### PR TITLE
Harden release packaging and add DMG artifact

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,12 +58,22 @@ jobs:
       - name: Package app bundle
         run: ./scripts/package_app.sh release "${{ steps.meta.outputs.version }}" "${{ github.run_number }}"
 
-      - name: Archive app bundle
+      - name: Create release artifacts
         run: |
           mkdir -p dist
+          ZIP_PATH="dist/localvoxtral-${{ steps.meta.outputs.tag }}.zip"
+          DMG_PATH="dist/localvoxtral-${{ steps.meta.outputs.tag }}.dmg"
+
           ditto -c -k --sequesterRsrc --keepParent \
             "dist/localvoxtral.app" \
-            "dist/localvoxtral-${{ steps.meta.outputs.tag }}.zip"
+            "$ZIP_PATH"
+
+          hdiutil create \
+            -volname "localvoxtral" \
+            -srcfolder "dist/localvoxtral.app" \
+            -ov \
+            -format UDZO \
+            "$DMG_PATH"
 
       - name: Create GitHub release
         uses: softprops/action-gh-release@v2
@@ -71,4 +81,6 @@ jobs:
           tag_name: ${{ steps.meta.outputs.tag }}
           name: localvoxtral ${{ steps.meta.outputs.tag }}
           generate_release_notes: true
-          files: dist/localvoxtral-${{ steps.meta.outputs.tag }}.zip
+          files: |
+            dist/localvoxtral-${{ steps.meta.outputs.tag }}.zip
+            dist/localvoxtral-${{ steps.meta.outputs.tag }}.dmg

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -44,6 +44,7 @@ fi
 
 VERSION="${TAG#v}"
 ARCHIVE_PATH="dist/localvoxtral-${TAG}.zip"
+DMG_PATH="dist/localvoxtral-${TAG}.dmg"
 
 echo "Running build and tests..."
 swift build -c release
@@ -56,6 +57,10 @@ echo "Creating archive $ARCHIVE_PATH..."
 mkdir -p dist
 rm -f "$ARCHIVE_PATH"
 ditto -c -k --sequesterRsrc --keepParent "dist/localvoxtral.app" "$ARCHIVE_PATH"
+
+echo "Creating disk image $DMG_PATH..."
+rm -f "$DMG_PATH"
+hdiutil create -volname "localvoxtral" -srcfolder "dist/localvoxtral.app" -ov -format UDZO "$DMG_PATH"
 
 echo "Pushing main..."
 git push origin main


### PR DESCRIPTION
## Summary
- stop emitting partially signed app bundles in `package_app.sh` by removing ad-hoc/linker signatures and failing if an invalid signature remains
- keep release artifacts deterministic and avoid Gatekeeper "damaged" state caused by ignored signing errors
- publish a `.dmg` artifact in addition to `.zip` in the release workflow
- update `scripts/release.sh` to generate both zip and dmg locally before tag push

## Validation
- `bash -n scripts/package_app.sh scripts/release.sh`
- `./scripts/package_app.sh debug 0.4.1-dev 1`
- `codesign -dv dist/localvoxtral.app` (reports unsigned; no partial signature)
