### PR TITLE
Polish 0.4.2 install flow and DMG packaging

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -68,9 +68,14 @@ jobs:
             "dist/localvoxtral.app" \
             "$ZIP_PATH"
 
+          DMG_STAGING_DIR="$(mktemp -d)"
+          trap 'rm -rf "$DMG_STAGING_DIR"' EXIT
+          cp -R "dist/localvoxtral.app" "$DMG_STAGING_DIR/localvoxtral.app"
+          ln -s /Applications "$DMG_STAGING_DIR/Applications"
+
           hdiutil create \
             -volname "localvoxtral" \
-            -srcfolder "dist/localvoxtral.app" \
+            -srcfolder "$DMG_STAGING_DIR" \
             -ov \
             -format UDZO \
             "$DMG_PATH"

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ It keeps the loop simple: start dictation, speak, get text fast.
 Unlike Whisper-based tools that transcribe after you stop speaking, Voxtral Realtime streams text as audio arrives, so words appear while you're still talking.
 On Apple Silicon, `localvoxtral` + `voxmlx` provides a fully local path (audio + inference stay on-device), improving privacy and avoiding API costs.
 
-It connects to any OpenAI Realtime-compatible endpoint. Recommended backends are `voxmlx` (Apple Silicon, fully local) and `vLLM` (NVIDIA GPU). An `mlx-audio` backend is also supported but deprecated.
+It connects to any OpenAI Realtime-compatible endpoint. Recommended backends are `voxmlx` (Apple Silicon) and `vLLM` (NVIDIA GPU). An `mlx-audio` backend is also supported but deprecated.
 
 Built for Mistral AI's [Voxtral Mini 4B Realtime](https://huggingface.co/mistralai/Voxtral-Mini-4B-Realtime-2602) model, but it works with any OpenAI-compatible Realtime API backend.
 
@@ -28,7 +28,13 @@ Built for Mistral AI's [Voxtral Mini 4B Realtime](https://huggingface.co/mistral
 
 ## Quick start
 
-Build and run as an app bundle (recommended):
+### Recommended: install from GitHub Releases (DMG)
+
+Download the latest `.dmg` from [Releases](https://github.com/T0mSIlver/localvoxtral/releases/latest).
+
+If macOS blocks first launch, go to **System Settings -> Privacy & Security** and click **Open Anyway** for `localvoxtral`.
+
+### Alternatively, build from source as an app bundle
 
 ```bash
 ./scripts/package_app.sh release
@@ -46,21 +52,6 @@ open ./dist/localvoxtral.app
   - Transcription delay (`mlx-audio`)
   - Auto-paste into input field
   - Auto-copy final segment
-
-## UI
-
-<p>
-  <picture>
-    <source media="(prefers-color-scheme: dark)" srcset="assets/icons/menubar/MicIconTemplate@2x_dark-preview.png" />
-    <img src="assets/icons/menubar/MicIconTemplate@2x.png" alt="localvoxtral menubar icon" width="28" height="28" />
-  </picture>
-  Menubar icon
-</p>
-
-<p>
-  <img src="assets/settings.png" alt="localvoxtral settings view" width="320" />
-  <img src="assets/popover.png" alt="localvoxtral popover view" width="200" />
-</p>
 
 ## Tested setup
 
@@ -105,3 +96,18 @@ MLX_AUDIO_REALTIME_MAX_CHUNK_SECONDS=30 python -m mlx_audio.server --workers 1
   -  **done** ~~[mlx-audio framework](https://github.com/Blaizzy/mlx-audio) - thanks [Shreyas Karnik](https://github.com/shreyaskarnik)~~
   - **done** ~~[MLX](https://github.com/awni/voxmlx) - thanks [Awni Hannun](https://github.com/awni)~~
   - [Rust](https://github.com/TrevorS/voxtral-mini-realtime-rs) - thanks [TrevorS](https://github.com/TrevorS)
+
+## UI
+
+<p>
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="assets/icons/menubar/MicIconTemplate@2x_dark-preview.png" />
+    <img src="assets/icons/menubar/MicIconTemplate@2x.png" alt="localvoxtral menubar icon" width="28" height="28" />
+  </picture>
+  Menubar icon
+</p>
+
+<p>
+  <img src="assets/settings.png" alt="localvoxtral settings view" width="320" />
+  <img src="assets/popover.png" alt="localvoxtral popover view" width="200" />
+</p>

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -60,7 +60,11 @@ ditto -c -k --sequesterRsrc --keepParent "dist/localvoxtral.app" "$ARCHIVE_PATH"
 
 echo "Creating disk image $DMG_PATH..."
 rm -f "$DMG_PATH"
-hdiutil create -volname "localvoxtral" -srcfolder "dist/localvoxtral.app" -ov -format UDZO "$DMG_PATH"
+DMG_STAGING_DIR="$(mktemp -d "${TMPDIR:-/tmp}/localvoxtral-dmg.XXXXXX")"
+trap 'rm -rf "$DMG_STAGING_DIR"' EXIT
+cp -R "dist/localvoxtral.app" "$DMG_STAGING_DIR/localvoxtral.app"
+ln -s /Applications "$DMG_STAGING_DIR/Applications"
+hdiutil create -volname "localvoxtral" -srcfolder "$DMG_STAGING_DIR" -ov -format UDZO "$DMG_PATH"
 
 echo "Pushing main..."
 git push origin main


### PR DESCRIPTION
## Summary
- update DMG creation in local release script and GitHub release workflow to include an `Applications` shortcut inside the DMG
- simplify Quick Start to the release DMG path as the recommended install flow
- add a concise Gatekeeper note (`System Settings -> Privacy & Security -> Open Anyway`) for first launch if blocked

## Validation
- `bash -n scripts/release.sh`
- local DMG smoke test: mounted image contains `localvoxtral.app` and `Applications -> /Applications` symlink
