### PR TITLE
Release v0.5.1

### DIFF
--- a/Sources/localvoxtral/DictationOverlayView.swift
+++ b/Sources/localvoxtral/DictationOverlayView.swift
@@ -81,6 +81,7 @@ struct DictationOverlayView: View {
     let text: String
     let errorMessage: String?
     private let cornerRadius: CGFloat = 12
+    private let bodyFontSize: CGFloat = 13
 
     private var phaseTitle: String {
         switch phase {
@@ -100,6 +101,11 @@ struct DictationOverlayView: View {
         return trimmed.isEmpty ? "" : text
     }
 
+    private var minimumBodyTextHeight: CGFloat {
+        let font = NSFont.systemFont(ofSize: bodyFontSize)
+        return ceil(font.ascender - font.descender + font.leading)
+    }
+
     var body: some View {
         VStack(alignment: .leading, spacing: 8) {
             HStack(alignment: .center, spacing: 6) {
@@ -115,10 +121,14 @@ struct DictationOverlayView: View {
             .frame(height: 16)
 
             Text(displayText)
-                .font(.system(size: 13))
+                .font(.system(size: bodyFontSize))
                 .foregroundStyle(.primary)
                 .fixedSize(horizontal: false, vertical: true)
-                .frame(maxWidth: .infinity, alignment: .leading)
+                .frame(
+                    maxWidth: .infinity,
+                    minHeight: minimumBodyTextHeight,
+                    alignment: .topLeading
+                )
 
             if let errorMessage, !errorMessage.trimmed.isEmpty {
                 Text(errorMessage)

--- a/Sources/localvoxtral/DictationViewModel+RealtimeEvents.swift
+++ b/Sources/localvoxtral/DictationViewModel+RealtimeEvents.swift
@@ -25,6 +25,10 @@ extension DictationViewModel {
             handlePartialTranscriptEvent(delta, source: source)
         case .finalTranscript(let text):
             handleFinalTranscriptEvent(text, source: source)
+        case .transcriptionFinalized where source == .realtimeAPI:
+            handleTranscriptionFinalizedEvent()
+        case .transcriptionFinalized:
+            break
         case .error(let message):
             handleErrorEvent(message)
         }
@@ -173,6 +177,12 @@ extension DictationViewModel {
             copyLatestSegment(updateStatus: false)
         }
         refreshOverlayBufferSession()
+    }
+
+    private func handleTranscriptionFinalizedEvent() {
+        guard isFinalizingStop else { return }
+        debugLog("transcription finalized, disconnecting")
+        activeRealtimeClient().disconnect()
     }
 
     private func handleErrorEvent(_ message: String) {

--- a/Sources/localvoxtral/DictationViewModel+Session.swift
+++ b/Sources/localvoxtral/DictationViewModel+Session.swift
@@ -371,7 +371,9 @@ extension DictationViewModel {
         }
 
         if !shouldCommitOverlay || !didOverlayCommitFail {
-            overlayBufferCoordinator.reset()
+            overlayBufferCoordinator.dismissAfterHold(
+                minimumVisibility: TimingConstants.overlayFinalWordVisibilityMinimum
+            )
         }
 
         if currentErrorToken == .websocketReceiveFailed {

--- a/Sources/localvoxtral/DictationViewModel.swift
+++ b/Sources/localvoxtral/DictationViewModel.swift
@@ -211,14 +211,22 @@ final class DictationViewModel {
         }
 
         realtimeAPIClient.setEventHandler { [weak self] event in
-            Task { @MainActor [weak self] in
-                self?.handle(event: event, source: .realtimeAPI)
+            // Preserve callback order for back-to-back events (e.g. final transcript
+            // followed by transcription finalized) by routing through main-queue FIFO.
+            DispatchQueue.main.async { [weak self] in
+                guard let self else { return }
+                MainActor.assumeIsolated {
+                    self.handle(event: event, source: .realtimeAPI)
+                }
             }
         }
 
         mlxAudioRealtimeClient.setEventHandler { [weak self] event in
-            Task { @MainActor [weak self] in
-                self?.handle(event: event, source: .mlxAudio)
+            DispatchQueue.main.async { [weak self] in
+                guard let self else { return }
+                MainActor.assumeIsolated {
+                    self.handle(event: event, source: .mlxAudio)
+                }
             }
         }
 
@@ -762,9 +770,7 @@ final class DictationViewModel {
         textInsertion.refreshAccessibilityTrustState()
 
         let directInsertResult = textInsertion.insertText(segment)
-        if directInsertResult == .insertedByAccessibility
-            || directInsertResult == .insertedByKeyboardFallback
-        {
+        if directInsertResult.isSuccess {
             statusText = "Pasted latest segment."
             return
         }

--- a/Sources/localvoxtral/MlxAudioRealtimeWebSocketClient.swift
+++ b/Sources/localvoxtral/MlxAudioRealtimeWebSocketClient.swift
@@ -12,7 +12,6 @@ final class MlxAudioRealtimeWebSocketClient: BaseRealtimeWebSocketClient, @unche
         var sawStreamingDeltaForCurrentChunk = false
         var activeStreamingHypothesis = ""
         var pendingTranscriptionDelayMilliseconds: Int?
-        var delayedDisconnectWorkItem: DispatchWorkItem?
     }
 
     private enum TextSendAction: Sendable {
@@ -27,15 +26,8 @@ final class MlxAudioRealtimeWebSocketClient: BaseRealtimeWebSocketClient, @unche
         case dropped
     }
 
-    private enum DisconnectAction {
-        case none
-        case closeNow
-        case schedule(DispatchWorkItem)
-    }
-
     private let state = Mutex(State())
     private let streamingModeEnabled = true
-    private let finalizationGracePeriodSeconds: TimeInterval = 2.0
 
     let supportsPeriodicCommit = false
     var isConnected: Bool {
@@ -97,50 +89,6 @@ final class MlxAudioRealtimeWebSocketClient: BaseRealtimeWebSocketClient, @unche
         if shouldEmitDisconnected {
             debugLog("disconnect")
             emit(.disconnected)
-        }
-    }
-
-    func disconnectAfterFinalCommitIfNeeded() {
-        let action: DisconnectAction = state.withLock { s in
-            guard s.base.socketState != .disconnected else { return .none }
-            s.base.isUserInitiatedDisconnect = true
-
-            guard s.base.socketState == .connected, let task = s.base.webSocketTask else {
-                closeSocketLocked(&s, cancelTask: true, clearQueuedMessages: true)
-                return .closeNow
-            }
-
-            s.delayedDisconnectWorkItem?.cancel()
-            let workItem = DispatchWorkItem { [weak self] in
-                guard let self else { return }
-                let shouldEmit = self.state.withLock { s -> Bool in
-                    guard s.base.socketState != .disconnected, s.base.webSocketTask === task
-                    else { return false }
-                    self.closeSocketLocked(&s, cancelTask: true, clearQueuedMessages: true)
-                    return true
-                }
-                if shouldEmit {
-                    self.debugLog("disconnect after grace period")
-                    self.emit(.disconnected)
-                }
-            }
-
-            s.delayedDisconnectWorkItem = workItem
-            return .schedule(workItem)
-        }
-
-        switch action {
-        case .none:
-            return
-        case .closeNow:
-            debugLog("disconnect")
-            emit(.disconnected)
-        case .schedule(let workItem):
-            debugLog("waiting for mlx finalization before disconnect")
-            DispatchQueue.global(qos: .utility).asyncAfter(
-                deadline: .now() + finalizationGracePeriodSeconds,
-                execute: workItem
-            )
         }
     }
 
@@ -370,9 +318,6 @@ final class MlxAudioRealtimeWebSocketClient: BaseRealtimeWebSocketClient, @unche
     private func closeSocketLocked(
         _ s: inout State, cancelTask: Bool, clearQueuedMessages: Bool
     ) {
-        s.delayedDisconnectWorkItem?.cancel()
-        s.delayedDisconnectWorkItem = nil
-
         closeBaseStateLocked(&s.base, cancelTask: cancelTask)
 
         s.hasSentInitialConfiguration = false
@@ -395,7 +340,6 @@ extension MlxAudioRealtimeWebSocketClient {
         let pendingTextMessageCount: Int
         let pendingBinaryMessageCount: Int
         let hasSentInitialConfiguration: Bool
-        let hasDelayedDisconnectWorkItem: Bool
     }
 
     func debugPrimeConnectedStateForTesting(
@@ -409,7 +353,6 @@ extension MlxAudioRealtimeWebSocketClient {
             s.pendingTextMessages = ["pending-message"]
             s.pendingBinaryMessages = [Data([0x01, 0x02])]
             s.hasSentInitialConfiguration = true
-            s.delayedDisconnectWorkItem = DispatchWorkItem {}
         }
     }
 
@@ -425,8 +368,7 @@ extension MlxAudioRealtimeWebSocketClient {
                 isConnected: s.base.socketState == .connected,
                 pendingTextMessageCount: s.pendingTextMessages.count,
                 pendingBinaryMessageCount: s.pendingBinaryMessages.count,
-                hasSentInitialConfiguration: s.hasSentInitialConfiguration,
-                hasDelayedDisconnectWorkItem: s.delayedDisconnectWorkItem != nil
+                hasSentInitialConfiguration: s.hasSentInitialConfiguration
             )
         }
     }

--- a/Sources/localvoxtral/OverlayBufferSessionCoordinator.swift
+++ b/Sources/localvoxtral/OverlayBufferSessionCoordinator.swift
@@ -22,7 +22,7 @@ extension OverlayAnchorResolver: OverlayAnchorResolving {}
 protocol OverlayTextCommitting: AnyObject {
     var isAccessibilityTrusted: Bool { get }
 
-    func insertTextUsingAccessibilityOnly(_ text: String, preferredAppPID: pid_t?) -> Bool
+    func insertTextPrioritizingKeyboard(_ text: String, preferredAppPID: pid_t?) -> TextInsertResult
     func pasteUsingCommandV(_ text: String, preferredAppPID: pid_t?) -> Bool
 }
 
@@ -41,6 +41,7 @@ protocol OverlayBufferSessionCoordinating: AnyObject {
     func refresh(displayBufferText: String, commitBufferText: String)
     @discardableResult
     func commitIfNeeded(using textCommitter: OverlayTextCommitting, autoCopyEnabled: Bool) -> OverlayBufferCommitOutcome
+    func dismissAfterHold(minimumVisibility: TimeInterval)
     func reset()
 }
 
@@ -53,6 +54,8 @@ final class OverlayBufferSessionCoordinator: OverlayBufferSessionCoordinating {
     private var commitBufferText = ""
     private var liveCommitTargetAppPID: pid_t?
     private var finalizationCommitTargetAppPID: pid_t?
+    private var lastFinalizationContentUpdate: Date?
+    private var dismissTask: Task<Void, Never>?
 
     init(
         stateMachine: OverlayBufferStateMachine,
@@ -69,7 +72,10 @@ final class OverlayBufferSessionCoordinator: OverlayBufferSessionCoordinating {
     }
 
     func startSession(preResolvedAnchor: OverlayAnchor? = nil) {
+        dismissTask?.cancel()
+        dismissTask = nil
         commitBufferText = ""
+        lastFinalizationContentUpdate = nil
         finalizationCommitTargetAppPID = nil
         refreshLiveCommitTargetAppPID()
 
@@ -81,6 +87,9 @@ final class OverlayBufferSessionCoordinator: OverlayBufferSessionCoordinating {
 
     func beginFinalizing(displayBufferText: String, commitBufferText: String) {
         lockCommitTargetForFinalizationIfNeeded()
+        // Start the hold timer from the latest finalization-phase content update.
+        // beginFinalizing() itself updates visible overlay content.
+        lastFinalizationContentUpdate = Date()
         let anchor = anchorResolver.resolveAnchor()
 
         stateMachine.beginFinalizing(anchor: anchor)
@@ -97,6 +106,10 @@ final class OverlayBufferSessionCoordinator: OverlayBufferSessionCoordinating {
             refreshLiveCommitTargetAppPID()
         }
 
+        if stateMachine.phase == .finalizing {
+            lastFinalizationContentUpdate = Date()
+        }
+
         stateMachine.updateBuffer(text: displayBufferText, anchor: nil)
         self.commitBufferText = commitBufferText
         renderCurrentSnapshot()
@@ -110,18 +123,19 @@ final class OverlayBufferSessionCoordinator: OverlayBufferSessionCoordinating {
     ) -> OverlayBufferCommitOutcome {
         let commitText = OverlayBufferTextAssembler.insertionText(from: commitBufferText)
         guard !commitText.isEmpty else {
-            stateMachine.commitSucceeded()
-            renderCurrentSnapshot()
             Log.overlay.info("overlay commit skipped (empty buffer)")
             return .succeeded
         }
 
         let preferredPID = finalizationCommitTargetAppPID ?? liveCommitTargetAppPID
+        // Keep overlay commit aligned with live auto-paste behavior: try keyboard
+        // Unicode insertion first for web field compatibility, then AX, then Cmd+V.
+        let primaryResult = textCommitter.insertTextPrioritizingKeyboard(
+            commitText,
+            preferredAppPID: preferredPID
+        )
         let inserted =
-            textCommitter.insertTextUsingAccessibilityOnly(
-                commitText,
-                preferredAppPID: preferredPID
-            )
+            primaryResult.isSuccess
             || textCommitter.pasteUsingCommandV(
                 commitText,
                 preferredAppPID: preferredPID
@@ -131,8 +145,6 @@ final class OverlayBufferSessionCoordinator: OverlayBufferSessionCoordinating {
             if autoCopyEnabled {
                 copyToPasteboard(commitText)
             }
-            stateMachine.commitSucceeded()
-            renderCurrentSnapshot()
             Log.overlay.info("overlay commit succeeded")
             return .succeeded
         }
@@ -157,7 +169,37 @@ final class OverlayBufferSessionCoordinator: OverlayBufferSessionCoordinating {
         return .failed(message: failureMessage)
     }
 
+    func dismissAfterHold(minimumVisibility: TimeInterval) {
+        dismissTask?.cancel()
+        dismissTask = nil
+
+        let holdRemaining: TimeInterval
+        if let lastUpdate = lastFinalizationContentUpdate {
+            let elapsed = Date().timeIntervalSince(lastUpdate)
+            holdRemaining = max(0, minimumVisibility - elapsed)
+        } else {
+            holdRemaining = 0
+        }
+
+        guard holdRemaining > 0 else {
+            reset()
+            return
+        }
+
+        Log.overlay.info("holding overlay \(String(format: "%.2f", holdRemaining))s before dismiss")
+        dismissTask = Task { @MainActor [weak self] in
+            try? await Task.sleep(for: .seconds(holdRemaining))
+            guard let self, !Task.isCancelled else { return }
+            self.dismissTask = nil
+            Log.overlay.info("overlay hold elapsed, dismissing")
+            self.reset()
+        }
+    }
+
     func reset() {
+        dismissTask?.cancel()
+        dismissTask = nil
+        lastFinalizationContentUpdate = nil
         stateMachine.reset()
         commitBufferText = ""
         liveCommitTargetAppPID = nil

--- a/Sources/localvoxtral/OverlayBufferStateMachine.swift
+++ b/Sources/localvoxtral/OverlayBufferStateMachine.swift
@@ -95,10 +95,7 @@ enum OverlayBufferTextAssembler {
 // Valid state transitions:
 //   idle → buffering         (startSession)
 //   buffering → finalizing   (beginFinalizing)
-//   finalizing → idle        (commitSucceeded)
 //   finalizing → commitFailed (commitFailed)
-//   buffering/finalizing → idle (reset)
-//   commitFailed → idle      (reset)
 //   any → idle               (reset)
 @MainActor
 struct OverlayBufferStateMachine {
@@ -150,15 +147,6 @@ struct OverlayBufferStateMachine {
         if let anchor {
             self.anchor = anchor
         }
-    }
-
-    mutating func commitSucceeded() {
-        guard phase == .finalizing else {
-            let currentPhase = phase
-            Log.overlay.warning("commitSucceeded called but phase is \(String(describing: currentPhase)), not finalizing — ignoring")
-            return
-        }
-        reset()
     }
 
     mutating func commitFailed(error: String, anchor: OverlayAnchor?) {

--- a/Sources/localvoxtral/RealtimeAPIWebSocketClient.swift
+++ b/Sources/localvoxtral/RealtimeAPIWebSocketClient.swift
@@ -3,6 +3,16 @@ import Synchronization
 import os
 
 final class RealtimeAPIWebSocketClient: BaseRealtimeWebSocketClient, @unchecked Sendable, RealtimeClient {
+    /// Tracks stop-finalization commit coordination so we only emit
+    /// `.transcriptionFinalized` once the final commit response completes.
+    private enum FinalCommitCompletionGate {
+        /// No stop-finalization completion tracking is active.
+        case idle
+        /// Final commit has been sent and we are waiting for its
+        /// `transcription.done` to emit `.transcriptionFinalized`.
+        case awaitingFinalCommitTranscriptionDone
+    }
+
     private struct State {
         var base = BaseState()
         var pingTimer: DispatchSourceTimer?
@@ -12,6 +22,7 @@ final class RealtimeAPIWebSocketClient: BaseRealtimeWebSocketClient, @unchecked 
         var hasSentSessionUpdate = false
         var hasUncommittedAudio = false
         var isGenerationInProgress = false
+        var finalCommitCompletionGate: FinalCommitCompletionGate = .idle
         var pendingMessages: [String] = []
         var pendingModelName = ""
     }
@@ -64,6 +75,7 @@ final class RealtimeAPIWebSocketClient: BaseRealtimeWebSocketClient, @unchecked 
             s.hasSentSessionUpdate = false
             s.hasUncommittedAudio = false
             s.isGenerationInProgress = false
+            s.finalCommitCompletionGate = .idle
 
             task.resume()
         }
@@ -84,62 +96,6 @@ final class RealtimeAPIWebSocketClient: BaseRealtimeWebSocketClient, @unchecked 
         }
     }
 
-    func disconnectAfterFinalCommitIfNeeded() {
-        enum DisconnectAction {
-            case none
-            case closeNow
-            case sendFinalCommit(URLSessionWebSocketTask)
-        }
-
-        let action: DisconnectAction = state.withLock { s in
-            guard s.base.socketState != .disconnected else { return .none }
-            s.base.isUserInitiatedDisconnect = true
-
-            guard s.base.socketState == .connected,
-                  let webSocketTask = s.base.webSocketTask,
-                  (s.hasUncommittedAudio || s.isGenerationInProgress)
-            else {
-                closeSocketLocked(&s, cancelTask: true)
-                return .closeNow
-            }
-
-            s.hasUncommittedAudio = false
-            s.isGenerationInProgress = false
-            return .sendFinalCommit(webSocketTask)
-        }
-
-        switch action {
-        case .none:
-            return
-        case .closeNow:
-            debugLog("disconnect")
-            emit(.disconnected)
-        case .sendFinalCommit(let task):
-            debugLog("send final commit before disconnect")
-            let payload = #"{"type":"input_audio_buffer.commit","final":true}"#
-            task.send(.string(payload)) { [weak self] error in
-                guard let self else { return }
-                if let error {
-                    self.emit(.status(
-                        "Final commit send failed: \(self.describeSocketError(error))"))
-                }
-
-                let shouldEmitDisconnected: Bool = self.state.withLock { s in
-                    guard s.base.socketState != .disconnected, s.base.webSocketTask === task else {
-                        return false
-                    }
-                    self.closeSocketLocked(&s, cancelTask: true)
-                    return true
-                }
-
-                if shouldEmitDisconnected {
-                    self.debugLog("disconnect")
-                    self.emit(.disconnected)
-                }
-            }
-        }
-    }
-
     func sendAudioChunk(_ pcm16Data: Data) {
         guard !pcm16Data.isEmpty else { return }
         state.withLock { $0.hasUncommittedAudio = true }
@@ -152,30 +108,47 @@ final class RealtimeAPIWebSocketClient: BaseRealtimeWebSocketClient, @unchecked 
     }
 
     func sendCommit(final: Bool) {
-        let shouldCommit: Bool = state.withLock { s in
-            guard s.base.socketState != .disconnected else { return false }
+        enum CommitAction {
+            case none
+            case sendCommitFrame(final: Bool)
+        }
+
+        let action: CommitAction = state.withLock { s in
+            guard s.base.socketState != .disconnected else { return .none }
 
             if final {
-                let shouldSignalFinal = s.hasUncommittedAudio || s.isGenerationInProgress
+                switch s.finalCommitCompletionGate {
+                case .idle:
+                    break
+                case .awaitingFinalCommitTranscriptionDone:
+                    return .none
+                }
+
                 s.hasUncommittedAudio = false
-                s.isGenerationInProgress = false
-                return shouldSignalFinal
+                s.isGenerationInProgress = true
+                s.finalCommitCompletionGate = .awaitingFinalCommitTranscriptionDone
+                return .sendCommitFrame(final: true)
             }
 
-            guard s.hasUncommittedAudio else { return false }
-            guard !s.isGenerationInProgress else { return false }
+            guard s.finalCommitCompletionGate == .idle else { return .none }
+            guard s.hasUncommittedAudio else { return .none }
+            guard !s.isGenerationInProgress else { return .none }
             s.hasUncommittedAudio = false
             s.isGenerationInProgress = true
-            return true
+            return .sendCommitFrame(final: false)
         }
-        guard shouldCommit else { return }
 
-        var payload: [String: Any] = ["type": "input_audio_buffer.commit"]
-        if final {
-            payload["final"] = true
+        switch action {
+        case .none:
+            return
+        case .sendCommitFrame(let shouldMarkFinal):
+            var payload: [String: Any] = ["type": "input_audio_buffer.commit"]
+            if shouldMarkFinal {
+                payload["final"] = true
+            }
+            debugLog("send commit final=\(shouldMarkFinal)")
+            send(event: payload)
         }
-        debugLog("send commit final=\(final)")
-        send(event: payload)
     }
 
     // MARK: - JSON Event Handling
@@ -226,9 +199,30 @@ final class RealtimeAPIWebSocketClient: BaseRealtimeWebSocketClient, @unchecked 
         case "transcription.done",
             "response.audio_transcript.done",
             "conversation.item.input_audio_transcription.completed":
-            state.withLock { $0.isGenerationInProgress = false }
+            enum DoneAction {
+                case none
+                case emitTranscriptionFinalized
+            }
+
+            let doneAction: DoneAction = state.withLock { s in
+                s.isGenerationInProgress = false
+
+                switch s.finalCommitCompletionGate {
+                case .idle:
+                    return .none
+                case .awaitingFinalCommitTranscriptionDone:
+                    s.finalCommitCompletionGate = .idle
+                    return .emitTranscriptionFinalized
+                }
+            }
             if let text = findString(in: json, matching: ["text", "transcript", "delta"]) {
                 emit(.finalTranscript(text))
+            }
+            switch doneAction {
+            case .none:
+                break
+            case .emitTranscriptionFinalized:
+                emit(.transcriptionFinalized)
             }
         case "error":
             state.withLock { $0.isGenerationInProgress = false }
@@ -426,6 +420,7 @@ final class RealtimeAPIWebSocketClient: BaseRealtimeWebSocketClient, @unchecked 
         s.hasSentSessionUpdate = false
         s.hasUncommittedAudio = false
         s.isGenerationInProgress = false
+        s.finalCommitCompletionGate = .idle
         s.pendingMessages.removeAll(keepingCapacity: false)
         s.pendingModelName = ""
     }
@@ -494,6 +489,17 @@ extension RealtimeAPIWebSocketClient {
         task: URLSessionWebSocketTask, errorMessage: String?
     ) {
         handleTerminalSocketError(for: task, errorMessage: errorMessage)
+    }
+
+    func debugSetGenerationTrackingState(
+        hasUncommittedAudio: Bool,
+        isGenerationInProgress: Bool
+    ) {
+        state.withLock { s in
+            s.hasUncommittedAudio = hasUncommittedAudio
+            s.isGenerationInProgress = isGenerationInProgress
+            s.finalCommitCompletionGate = .idle
+        }
     }
 
     func debugStateSnapshot() -> DebugStateSnapshot {

--- a/Sources/localvoxtral/RealtimeClient.swift
+++ b/Sources/localvoxtral/RealtimeClient.swift
@@ -25,6 +25,7 @@ enum RealtimeEvent: Sendable {
     case status(String)
     case partialTranscript(String)
     case finalTranscript(String)
+    case transcriptionFinalized
     case error(String)
 }
 
@@ -35,7 +36,6 @@ protocol RealtimeClient: AnyObject {
     func setEventHandler(_ handler: @escaping @Sendable (RealtimeEvent) -> Void)
     func connect(configuration: RealtimeSessionConfiguration) throws
     func disconnect()
-    func disconnectAfterFinalCommitIfNeeded()
     func sendAudioChunk(_ pcm16Data: Data)
     func sendCommit(final: Bool)
 }

--- a/Sources/localvoxtral/TextInsertionService.swift
+++ b/Sources/localvoxtral/TextInsertionService.swift
@@ -7,13 +7,16 @@ import os
 enum TextInsertResult {
     case insertedByAccessibility
     case insertedByKeyboardFallback
-    case deferredByActiveModifiers
     case failed
-}
 
-enum KeyboardFallbackBehavior {
-    case always
-    case deferIfModifierActive
+    var isSuccess: Bool {
+        switch self {
+        case .insertedByAccessibility, .insertedByKeyboardFallback:
+            true
+        case .failed:
+            false
+        }
+    }
 }
 
 enum PreferredTextInsertionTargetPolicy {
@@ -92,7 +95,15 @@ final class TextInsertionService {
     private var insertionRetryTask: Task<Void, Never>?
     private var axInsertionSuccessCount = 0
     private var keyboardFallbackSuccessCount = 0
-    private var modifierDeferredInsertionCount = 0
+    private var activeModifierFallbackCount = 0
+#if DEBUG
+    @ObservationIgnored
+    private var debugUnicodePoster: ((String) -> Bool)?
+    @ObservationIgnored
+    private var debugModifierStateReader: (() -> Bool)?
+    @ObservationIgnored
+    private var debugAccessibilityInserter: ((String, pid_t?) -> Bool)?
+#endif
 
     static let accessibilityErrorMessage = AccessibilityTrustManager.errorMessage
 
@@ -121,46 +132,44 @@ final class TextInsertionService {
         return false
     }
 
-    func insertText(
+    func insertText(_ text: String) -> TextInsertResult {
+        guard !text.isEmpty else { return .insertedByAccessibility }
+        refreshAccessibilityTrustState()
+
+        if tryAccessibilityInsertion(text, preferredAppPID: nil) {
+            return .insertedByAccessibility
+        }
+        if tryKeyboardInsertion(
+            text,
+            preferredAppPID: nil,
+            requirePreferredTargetActivation: false
+        ) {
+            return .insertedByKeyboardFallback
+        }
+        return failedInsertionResult()
+    }
+
+    /// Inserts text by trying Unicode keyboard events first, then AX insertion.
+    /// Useful for realtime-style insertion paths where keyboard posting is more
+    /// reliable than AX in certain web fields.
+    func insertTextPrioritizingKeyboard(
         _ text: String,
-        keyboardFallbackBehavior: KeyboardFallbackBehavior = .always
+        preferredAppPID: pid_t? = nil
     ) -> TextInsertResult {
         guard !text.isEmpty else { return .insertedByAccessibility }
         refreshAccessibilityTrustState()
 
-        if keyboardFallbackBehavior == .deferIfModifierActive,
-           shouldSuppressKeyboardFallbackForActiveModifiers()
-        {
-            modifierDeferredInsertionCount += 1
-            return .deferredByActiveModifiers
-        }
-
-        if keyboardFallbackBehavior == .deferIfModifierActive,
-           postUnicodeTextEvents(text)
-        {
-            clearAccessibilityErrorIfNeeded()
-            keyboardFallbackSuccessCount += 1
+        if tryKeyboardInsertion(
+            text,
+            preferredAppPID: preferredAppPID,
+            requirePreferredTargetActivation: preferredAppPID != nil
+        ) {
             return .insertedByKeyboardFallback
         }
-
-        if insertTextUsingAccessibility(text) {
-            clearAccessibilityErrorIfNeeded()
-            axInsertionSuccessCount += 1
+        if tryAccessibilityInsertion(text, preferredAppPID: preferredAppPID) {
             return .insertedByAccessibility
         }
-
-        if postUnicodeTextEvents(text) {
-            clearAccessibilityErrorIfNeeded()
-            keyboardFallbackSuccessCount += 1
-            return .insertedByKeyboardFallback
-        }
-
-        if !isAccessibilityTrusted {
-            promptForAccessibilityPermissionIfNeeded()
-            setAccessibilityErrorIfNeeded()
-        }
-
-        return .failed
+        return failedInsertionResult()
     }
 
     func pasteUsingCommandV(_ text: String, preferredAppPID: pid_t? = nil) -> Bool {
@@ -208,16 +217,11 @@ final class TextInsertionService {
     func flushPendingRealtimeInsertion() {
         guard !pendingRealtimeInsertionText.isEmpty else { return }
 
-        let result = insertText(
-            pendingRealtimeInsertionText,
-            keyboardFallbackBehavior: .deferIfModifierActive
-        )
+        let result = insertTextPrioritizingKeyboard(pendingRealtimeInsertionText)
 
         switch result {
         case .insertedByAccessibility, .insertedByKeyboardFallback:
             pendingRealtimeInsertionText.removeAll(keepingCapacity: true)
-        case .deferredByActiveModifiers:
-            break
         case .failed:
             break
         }
@@ -258,15 +262,16 @@ final class TextInsertionService {
     func resetDiagnostics() {
         axInsertionSuccessCount = 0
         keyboardFallbackSuccessCount = 0
-        modifierDeferredInsertionCount = 0
+        activeModifierFallbackCount = 0
     }
 
     func logDiagnostics() {
-        let totalInsertions = axInsertionSuccessCount + keyboardFallbackSuccessCount + modifierDeferredInsertionCount
+        let totalInsertions =
+            axInsertionSuccessCount + keyboardFallbackSuccessCount + activeModifierFallbackCount
         guard totalInsertions > 0 else { return }
 
         Log.insertion.info(
-            "insertion-paths ax=\(self.axInsertionSuccessCount) keyboard_fallback=\(self.keyboardFallbackSuccessCount) deferred_modifiers=\(self.modifierDeferredInsertionCount)"
+            "insertion-paths ax=\(self.axInsertionSuccessCount) keyboard_fallback=\(self.keyboardFallbackSuccessCount) active_modifiers=\(self.activeModifierFallbackCount)"
         )
     }
 
@@ -282,10 +287,64 @@ final class TextInsertionService {
 
     // MARK: - Private
 
+    private func tryAccessibilityInsertion(
+        _ text: String,
+        preferredAppPID: pid_t?
+    ) -> Bool {
+        guard insertTextUsingAccessibility(text, preferredAppPID: preferredAppPID) else { return false }
+        clearAccessibilityErrorIfNeeded()
+        axInsertionSuccessCount += 1
+        return true
+    }
+
+    private func tryKeyboardInsertion(
+        _ text: String,
+        preferredAppPID: pid_t?,
+        requirePreferredTargetActivation: Bool
+    ) -> Bool {
+        let modifiersActive = hasActiveFallbackModifiers()
+        if modifiersActive {
+            activeModifierFallbackCount += 1
+        }
+
+        if requirePreferredTargetActivation,
+           !ensurePasteTargetIsActive(preferredAppPID: preferredAppPID)
+        {
+            return false
+        }
+
+        guard postUnicodeTextEvents(text) else {
+            if modifiersActive {
+                Log.insertion.debug("keyboard unicode insertion failed with active modifiers")
+            }
+            return false
+        }
+
+        if modifiersActive {
+            Log.insertion.debug("keyboard unicode insertion succeeded with active modifiers")
+        }
+        clearAccessibilityErrorIfNeeded()
+        keyboardFallbackSuccessCount += 1
+        return true
+    }
+
+    private func failedInsertionResult() -> TextInsertResult {
+        if !isAccessibilityTrusted {
+            promptForAccessibilityPermissionIfNeeded()
+            setAccessibilityErrorIfNeeded()
+        }
+        return .failed
+    }
+
     private func insertTextUsingAccessibility(
         _ text: String,
         preferredAppPID: pid_t? = nil
     ) -> Bool {
+#if DEBUG
+        if let debugAccessibilityInserter {
+            return debugAccessibilityInserter(text, preferredAppPID)
+        }
+#endif
         guard isAccessibilityTrusted else { return false }
         guard let focusedElement = resolvedAccessibilityInsertionTarget(
             preferredAppPID: preferredAppPID
@@ -446,6 +505,11 @@ final class TextInsertionService {
     }
 
     private func postUnicodeTextEvents(_ text: String) -> Bool {
+#if DEBUG
+        if let debugUnicodePoster {
+            return debugUnicodePoster(text)
+        }
+#endif
         guard !text.isEmpty,
               let source = CGEventSource(stateID: .combinedSessionState)
         else {
@@ -478,7 +542,12 @@ final class TextInsertionService {
         return didPostAnyEvent
     }
 
-    private func shouldSuppressKeyboardFallbackForActiveModifiers() -> Bool {
+    private func hasActiveFallbackModifiers() -> Bool {
+#if DEBUG
+        if let debugModifierStateReader {
+            return debugModifierStateReader()
+        }
+#endif
         let modifierKeyCodes: [CGKeyCode] = [
             54, // right command
             55, // left command
@@ -549,3 +618,33 @@ final class TextInsertionService {
         }
     }
 }
+
+#if DEBUG
+extension TextInsertionService {
+    struct DebugInsertionSnapshot {
+        let pendingRealtimeInsertionText: String
+        let axInsertionSuccessCount: Int
+        let keyboardFallbackSuccessCount: Int
+        let activeModifierFallbackCount: Int
+    }
+
+    func debugConfigureInsertionHooks(
+        unicodePoster: ((String) -> Bool)? = nil,
+        modifierStateReader: (() -> Bool)? = nil,
+        accessibilityInserter: ((String, pid_t?) -> Bool)? = nil
+    ) {
+        debugUnicodePoster = unicodePoster
+        debugModifierStateReader = modifierStateReader
+        debugAccessibilityInserter = accessibilityInserter
+    }
+
+    func debugInsertionSnapshot() -> DebugInsertionSnapshot {
+        DebugInsertionSnapshot(
+            pendingRealtimeInsertionText: pendingRealtimeInsertionText,
+            axInsertionSuccessCount: axInsertionSuccessCount,
+            keyboardFallbackSuccessCount: keyboardFallbackSuccessCount,
+            activeModifierFallbackCount: activeModifierFallbackCount
+        )
+    }
+}
+#endif

--- a/Sources/localvoxtral/TimingConstants.swift
+++ b/Sources/localvoxtral/TimingConstants.swift
@@ -40,6 +40,10 @@ enum TimingConstants {
     /// Interval at which the finalization loop polls for timeout/inactivity.
     static let finalizationPollInterval: TimeInterval = 0.1
 
+    /// Minimum time to keep the overlay visible after the most recent
+    /// finalization-time refresh before committing/hiding.
+    static let overlayFinalWordVisibilityMinimum: TimeInterval = 0.5
+
     // MARK: - Stop Finalization (mlx-audio path)
 
     /// Hard timeout for the stop-finalization phase on the mlx-audio path.

--- a/Tests/localvoxtralTests/DictationViewModelOverlayLifecycleTests.swift
+++ b/Tests/localvoxtralTests/DictationViewModelOverlayLifecycleTests.swift
@@ -52,7 +52,8 @@ final class DictationViewModelOverlayLifecycleTests: XCTestCase {
         XCTAssertEqual(overlayCoordinator.refreshCalls.last?.displayText, "hello world")
         XCTAssertEqual(overlayCoordinator.refreshCalls.last?.commitText, "hello\nworld")
         XCTAssertEqual(overlayCoordinator.commitCallCount, 1)
-        XCTAssertEqual(overlayCoordinator.resetCallCount, 1)
+        XCTAssertEqual(overlayCoordinator.dismissAfterHoldCallCount, 1)
+        XCTAssertEqual(overlayCoordinator.resetCallCount, 0)
         XCTAssertEqual(viewModel.statusText, "Ready")
         XCTAssertNil(viewModel.sessionOutputMode)
     }
@@ -80,6 +81,48 @@ final class DictationViewModelOverlayLifecycleTests: XCTestCase {
         XCTAssertEqual(viewModel.statusText, "Insert failed.")
         XCTAssertEqual(viewModel.lastError, "Unable to insert buffered text into the focused app.")
         XCTAssertNil(viewModel.sessionOutputMode)
+    }
+
+    func testTranscriptionFinalizedDisconnectsImmediatelyDuringFinalization() async {
+        let settings = makeSettings(outputMode: .overlayBuffer)
+        let overlayCoordinator = MockOverlayCoordinator()
+        let viewModel = DictationViewModel(
+            settings: settings,
+            overlayBufferCoordinator: overlayCoordinator,
+            startRuntimeServices: false
+        )
+        retainForTestProcessLifetime(viewModel)
+
+        let session = URLSession(configuration: .ephemeral)
+        let task = session.webSocketTask(with: URL(string: "ws://127.0.0.1:65535/test")!)
+        defer {
+            task.cancel()
+            session.invalidateAndCancel()
+        }
+
+        viewModel.activeClientSource = .realtimeAPI
+        viewModel.isFinalizingStop = true
+        viewModel.sessionOutputMode = .overlayBuffer
+        viewModel.realtimeAPIClient.debugPrimeConnectedStateForTesting(task: task)
+
+        viewModel.handle(event: .transcriptionFinalized, source: .realtimeAPI)
+
+        let timeoutAt = Date().addingTimeInterval(1.0)
+        while viewModel.isFinalizingStop, Date() < timeoutAt {
+            try? await Task.sleep(for: .milliseconds(10))
+        }
+
+        XCTAssertFalse(viewModel.isFinalizingStop)
+        XCTAssertNil(viewModel.activeClientSource)
+        XCTAssertEqual(viewModel.statusText, "Ready")
+        XCTAssertEqual(overlayCoordinator.commitCallCount, 1)
+        XCTAssertEqual(overlayCoordinator.dismissAfterHoldCallCount, 1)
+        XCTAssertEqual(
+            overlayCoordinator.lastDismissAfterHoldMinimumVisibility,
+            TimingConstants.overlayFinalWordVisibilityMinimum
+        )
+        XCTAssertEqual(overlayCoordinator.resetCallCount, 0)
+        XCTAssertFalse(viewModel.realtimeAPIClient.isConnected)
     }
 
     private func makeSettings(outputMode: DictationOutputMode) -> SettingsStore {
@@ -113,6 +156,8 @@ private final class MockOverlayCoordinator: OverlayBufferSessionCoordinating {
     var beginFinalizingCalls: [BufferCall] = []
     var refreshCalls: [BufferCall] = []
     var commitCallCount = 0
+    var dismissAfterHoldCallCount = 0
+    var lastDismissAfterHoldMinimumVisibility: TimeInterval?
     var resetCallCount = 0
 
     func resolveAnchorNow() -> OverlayAnchor {
@@ -144,6 +189,11 @@ private final class MockOverlayCoordinator: OverlayBufferSessionCoordinating {
     ) -> OverlayBufferCommitOutcome {
         commitCallCount += 1
         return commitOutcome
+    }
+
+    func dismissAfterHold(minimumVisibility: TimeInterval) {
+        dismissAfterHoldCallCount += 1
+        lastDismissAfterHoldMinimumVisibility = minimumVisibility
     }
 
     func reset() {

--- a/Tests/localvoxtralTests/MlxAudioTranscriptionTests.swift
+++ b/Tests/localvoxtralTests/MlxAudioTranscriptionTests.swift
@@ -335,6 +335,8 @@ final class MlxAudioTranscriptionIntegrationTests: XCTestCase {
                 finalCount += 1
                 allFinalTexts.append(text)
                 print("[\(formatTime(te.elapsed))] #\(i) FINAL[\(finalCount)]: \(text)")
+            case .transcriptionFinalized:
+                print("[\(formatTime(te.elapsed))] #\(i) TRANSCRIPTION FINALIZED")
             case .error(let msg):
                 print("[\(formatTime(te.elapsed))] #\(i) ERROR: \(msg)")
             }

--- a/Tests/localvoxtralTests/OverlayBufferSessionCoordinatorTests.swift
+++ b/Tests/localvoxtralTests/OverlayBufferSessionCoordinatorTests.swift
@@ -13,7 +13,7 @@ final class OverlayBufferSessionCoordinatorTests: XCTestCase {
             anchorResolver: anchorResolver
         )
         let committer = MockOverlayTextCommitter()
-        committer.insertResult = true
+        committer.insertResult = .insertedByAccessibility
 
         anchorResolver.focusedPID = 111
         coordinator.startSession()
@@ -44,7 +44,7 @@ final class OverlayBufferSessionCoordinatorTests: XCTestCase {
             anchorResolver: anchorResolver
         )
         let committer = MockOverlayTextCommitter()
-        committer.insertResult = true
+        committer.insertResult = .insertedByAccessibility
 
         anchorResolver.focusedPID = 111
         coordinator.startSession()
@@ -71,7 +71,7 @@ final class OverlayBufferSessionCoordinatorTests: XCTestCase {
             anchorResolver: anchorResolver
         )
         let committer = MockOverlayTextCommitter()
-        committer.insertResult = true
+        committer.insertResult = .insertedByAccessibility
 
         anchorResolver.focusedPID = 111
         coordinator.startSession()
@@ -115,7 +115,7 @@ final class OverlayBufferSessionCoordinatorTests: XCTestCase {
             anchorResolver: anchorResolver
         )
         let committer = MockOverlayTextCommitter()
-        committer.insertResult = false
+        committer.insertResult = .failed
         committer.pasteResult = false
         committer.isAccessibilityTrusted = true
 
@@ -145,7 +145,7 @@ final class OverlayBufferSessionCoordinatorTests: XCTestCase {
             anchorResolver: anchorResolver
         )
         let committer = MockOverlayTextCommitter()
-        committer.insertResult = true
+        committer.insertResult = .insertedByAccessibility
 
         anchorResolver.focusedPID = 111
         coordinator.startSession()
@@ -174,7 +174,7 @@ final class OverlayBufferSessionCoordinatorTests: XCTestCase {
             anchorResolver: anchorResolver
         )
         let committer = MockOverlayTextCommitter()
-        committer.insertResult = true
+        committer.insertResult = .insertedByAccessibility
 
         anchorResolver.focusedPID = 111
         coordinator.startSession()
@@ -187,6 +187,80 @@ final class OverlayBufferSessionCoordinatorTests: XCTestCase {
 
         XCTAssertEqual(outcome, .succeeded)
         XCTAssertEqual(committer.insertedTexts.first ?? "", "commit\nhello\nworld")
+    }
+
+    func testCommitSucceedsWhenKeyboardPrimaryPathSucceeds() {
+        let renderer = MockOverlayRenderer()
+        let anchorResolver = MockOverlayAnchorResolver()
+        let coordinator = OverlayBufferSessionCoordinator(
+            stateMachine: OverlayBufferStateMachine(),
+            renderer: renderer,
+            anchorResolver: anchorResolver
+        )
+        let committer = MockOverlayTextCommitter()
+        committer.insertResult = .insertedByKeyboardFallback
+        committer.pasteResult = false
+
+        anchorResolver.focusedPID = 111
+        coordinator.startSession()
+        coordinator.beginFinalizing(
+            displayBufferText: "hello",
+            commitBufferText: "hello"
+        )
+
+        let outcome = coordinator.commitIfNeeded(using: committer, autoCopyEnabled: false)
+
+        XCTAssertEqual(outcome, .succeeded)
+        XCTAssertEqual(committer.insertedTexts.count, 1)
+        XCTAssertTrue(committer.pastedTexts.isEmpty)
+    }
+
+    func testCommitFallsBackToCommandVWhenPrimaryInsertionFails() {
+        let renderer = MockOverlayRenderer()
+        let anchorResolver = MockOverlayAnchorResolver()
+        let coordinator = OverlayBufferSessionCoordinator(
+            stateMachine: OverlayBufferStateMachine(),
+            renderer: renderer,
+            anchorResolver: anchorResolver
+        )
+        let committer = MockOverlayTextCommitter()
+        committer.insertResult = .failed
+        committer.pasteResult = true
+
+        anchorResolver.focusedPID = 111
+        coordinator.startSession()
+        coordinator.beginFinalizing(
+            displayBufferText: "hello",
+            commitBufferText: "hello"
+        )
+
+        let outcome = coordinator.commitIfNeeded(using: committer, autoCopyEnabled: false)
+
+        XCTAssertEqual(outcome, .succeeded)
+        XCTAssertEqual(committer.insertedTexts.count, 1)
+        XCTAssertEqual(committer.pastedTexts.count, 1)
+    }
+
+    func testDismissAfterHoldWaitsFromBeginFinalizingWhenNoFinalRefreshArrives() async {
+        let renderer = MockOverlayRenderer()
+        let anchorResolver = MockOverlayAnchorResolver()
+        let coordinator = OverlayBufferSessionCoordinator(
+            stateMachine: OverlayBufferStateMachine(),
+            renderer: renderer,
+            anchorResolver: anchorResolver
+        )
+
+        coordinator.startSession()
+        coordinator.beginFinalizing(
+            displayBufferText: "hello",
+            commitBufferText: "hello"
+        )
+
+        coordinator.dismissAfterHold(minimumVisibility: 0.05)
+        XCTAssertEqual(renderer.hideCallCount, 0)
+
+        try? await Task.sleep(for: .milliseconds(120))
+        XCTAssertEqual(renderer.hideCallCount, 1)
     }
 }
 
@@ -224,7 +298,7 @@ private final class MockOverlayAnchorResolver: OverlayAnchorResolving {
 @MainActor
 private final class MockOverlayTextCommitter: OverlayTextCommitting {
     var isAccessibilityTrusted = true
-    var insertResult = false
+    var insertResult: TextInsertResult = .failed
     var pasteResult = false
 
     var insertedTexts: [String] = []
@@ -232,7 +306,7 @@ private final class MockOverlayTextCommitter: OverlayTextCommitting {
     var insertPreferredPIDs: [pid_t?] = []
     var pastePreferredPIDs: [pid_t?] = []
 
-    func insertTextUsingAccessibilityOnly(_ text: String, preferredAppPID: pid_t?) -> Bool {
+    func insertTextPrioritizingKeyboard(_ text: String, preferredAppPID: pid_t?) -> TextInsertResult {
         insertedTexts.append(text)
         insertPreferredPIDs.append(preferredAppPID)
         return insertResult

--- a/Tests/localvoxtralTests/OverlayBufferStateMachineTests.swift
+++ b/Tests/localvoxtralTests/OverlayBufferStateMachineTests.swift
@@ -4,7 +4,7 @@ import XCTest
 
 @MainActor
 final class OverlayBufferStateMachineTests: XCTestCase {
-    func testStateMachine_happyPathTransitionsToIdleAfterCommitSuccess() {
+    func testStateMachine_happyPathTransitionsToIdleAfterReset() {
         var machine = OverlayBufferStateMachine()
         let anchor = OverlayAnchor(targetRect: CGRect(x: 10, y: 20, width: 100, height: 40), source: .windowCenter)
 
@@ -17,7 +17,7 @@ final class OverlayBufferStateMachineTests: XCTestCase {
         machine.beginFinalizing(anchor: nil)
         XCTAssertEqual(machine.phase, .finalizing)
 
-        machine.commitSucceeded()
+        machine.reset()
         XCTAssertEqual(machine.phase, .idle)
         XCTAssertNil(machine.snapshot)
         XCTAssertEqual(machine.bufferText, "")

--- a/Tests/localvoxtralTests/RealtimeAPIVLLMIntegrationTests.swift
+++ b/Tests/localvoxtralTests/RealtimeAPIVLLMIntegrationTests.swift
@@ -182,7 +182,7 @@ final class RealtimeAPIVLLMIntegrationTests: XCTestCase {
         try await runHandshakeCycle(client: client, configuration: configuration)
     }
 
-    func testVLLMDisconnectAfterFinalCommitWithAudio() async throws {
+    func testVLLMDisconnectWithPendingAudio() async throws {
         let configuration = try integrationConfiguration()
         let client = RealtimeAPIWebSocketClient()
 
@@ -213,7 +213,7 @@ final class RealtimeAPIVLLMIntegrationTests: XCTestCase {
         await fulfillment(of: [connected, sessionReady], timeout: 20.0)
 
         client.sendAudioChunk(makeSineWavePCM16Chunk())
-        client.disconnectAfterFinalCommitIfNeeded()
+        client.disconnect()
 
         await fulfillment(of: [disconnected], timeout: 5.0)
         await fulfillment(of: [realtimeError], timeout: 0.5)

--- a/Tests/localvoxtralTests/TextInsertionServiceRealtimeInsertionTests.swift
+++ b/Tests/localvoxtralTests/TextInsertionServiceRealtimeInsertionTests.swift
@@ -1,0 +1,43 @@
+import XCTest
+@testable import localvoxtral
+
+#if DEBUG
+@MainActor
+final class TextInsertionServiceRealtimeInsertionTests: XCTestCase {
+    func testRealtimeFlush_activeModifiersAndKeyboardSuccess_clearsPendingText() {
+        let service = TextInsertionService()
+        service.debugConfigureInsertionHooks(
+            unicodePoster: { _ in true },
+            modifierStateReader: { true },
+            accessibilityInserter: { _, _ in false }
+        )
+
+        service.enqueueRealtimeInsertion("hello")
+
+        XCTAssertFalse(service.hasPendingInsertionText)
+        let snapshot = service.debugInsertionSnapshot()
+        XCTAssertEqual(snapshot.pendingRealtimeInsertionText, "")
+        XCTAssertEqual(snapshot.keyboardFallbackSuccessCount, 1)
+        XCTAssertEqual(snapshot.activeModifierFallbackCount, 1)
+        XCTAssertEqual(snapshot.axInsertionSuccessCount, 0)
+    }
+
+    func testRealtimeFlush_activeModifiersAndInsertionFailure_keepsPendingTextForRetry() {
+        let service = TextInsertionService()
+        service.debugConfigureInsertionHooks(
+            unicodePoster: { _ in false },
+            modifierStateReader: { true },
+            accessibilityInserter: { _, _ in false }
+        )
+
+        service.enqueueRealtimeInsertion("hello")
+
+        XCTAssertTrue(service.hasPendingInsertionText)
+        let snapshot = service.debugInsertionSnapshot()
+        XCTAssertEqual(snapshot.pendingRealtimeInsertionText, "hello")
+        XCTAssertEqual(snapshot.keyboardFallbackSuccessCount, 0)
+        XCTAssertEqual(snapshot.activeModifierFallbackCount, 1)
+        XCTAssertEqual(snapshot.axInsertionSuccessCount, 0)
+    }
+}
+#endif

--- a/Tests/localvoxtralTests/WebSocketClientLifecycleTests.swift
+++ b/Tests/localvoxtralTests/WebSocketClientLifecycleTests.swift
@@ -116,7 +116,6 @@ final class WebSocketClientLifecycleTests: XCTestCase {
         XCTAssertEqual(before.pendingTextMessageCount, 1)
         XCTAssertEqual(before.pendingBinaryMessageCount, 1)
         XCTAssertTrue(before.hasSentInitialConfiguration)
-        XCTAssertTrue(before.hasDelayedDisconnectWorkItem)
 
         client.debugHandleTerminalSocketErrorForTesting(task: task, errorMessage: "socket failed")
 
@@ -125,7 +124,6 @@ final class WebSocketClientLifecycleTests: XCTestCase {
         XCTAssertEqual(after.pendingTextMessageCount, 0)
         XCTAssertEqual(after.pendingBinaryMessageCount, 0)
         XCTAssertFalse(after.hasSentInitialConfiguration)
-        XCTAssertFalse(after.hasDelayedDisconnectWorkItem)
 
         let events = collector.snapshot()
         XCTAssertEqual(events.count, 2)
@@ -158,8 +156,6 @@ final class WebSocketClientLifecycleTests: XCTestCase {
         XCTAssertFalse(after.isConnected)
         XCTAssertEqual(after.pendingTextMessageCount, 0)
         XCTAssertEqual(after.pendingBinaryMessageCount, 0)
-        XCTAssertFalse(after.hasDelayedDisconnectWorkItem)
-
         let events = collector.snapshot()
         XCTAssertEqual(events.count, 1)
         guard case .disconnected = events[0] else {
@@ -269,6 +265,166 @@ final class WebSocketClientLifecycleTests: XCTestCase {
         XCTAssertEqual(message, "first error")
         guard case .disconnected = events[1] else {
             XCTFail("Expected .disconnected"); return
+        }
+    }
+
+    // MARK: - Transcription Finalization
+
+    func testRealtimeDoneEmitsTranscriptionFinalizedAfterFinalCommit() {
+        let client = RealtimeAPIWebSocketClient()
+        let collector = EventCollector()
+        client.setEventHandler { collector.append($0) }
+
+        let (session, task) = makeWebSocketTask()
+        defer {
+            task.cancel()
+            session.invalidateAndCancel()
+        }
+
+        client.debugPrimeConnectedStateForTesting(task: task)
+        client.debugSetGenerationTrackingState(hasUncommittedAudio: true, isGenerationInProgress: false)
+        client.sendCommit(final: true)
+        client.handle(json: ["type": "transcription.done", "text": "final text"])
+
+        let events = collector.snapshot()
+        XCTAssertEqual(events.count, 2)
+        guard case .finalTranscript(let text) = events[0] else {
+            XCTFail("Expected first event to be .finalTranscript")
+            return
+        }
+        XCTAssertEqual(text, "final text")
+        guard case .transcriptionFinalized = events[1] else {
+            XCTFail("Expected second event to be .transcriptionFinalized")
+            return
+        }
+    }
+
+    func testRealtimeDoneWithoutFinalCommitDoesNotEmitTranscriptionFinalized() {
+        let client = RealtimeAPIWebSocketClient()
+        let collector = EventCollector()
+        client.setEventHandler { collector.append($0) }
+
+        let (session, task) = makeWebSocketTask()
+        defer {
+            task.cancel()
+            session.invalidateAndCancel()
+        }
+
+        client.debugPrimeConnectedStateForTesting(task: task)
+        client.handle(json: ["type": "transcription.done"])
+
+        XCTAssertTrue(collector.snapshot().isEmpty)
+    }
+
+    func testRealtimeTranscriptionFinalizedEmitsOnlyOnceForRepeatedDone() {
+        let client = RealtimeAPIWebSocketClient()
+        let collector = EventCollector()
+        client.setEventHandler { collector.append($0) }
+
+        let (session, task) = makeWebSocketTask()
+        defer {
+            task.cancel()
+            session.invalidateAndCancel()
+        }
+
+        client.debugPrimeConnectedStateForTesting(task: task)
+        client.debugSetGenerationTrackingState(hasUncommittedAudio: true, isGenerationInProgress: false)
+        client.sendCommit(final: true)
+        client.handle(json: ["type": "transcription.done"])
+        client.handle(json: ["type": "transcription.done"])
+
+        let events = collector.snapshot()
+        XCTAssertEqual(events.count, 1)
+        guard case .transcriptionFinalized = events[0] else {
+            XCTFail("Expected only .transcriptionFinalized")
+            return
+        }
+    }
+
+    func testFinalCommitRequestedDuringInFlightGenerationFinalizesOnNextDone() {
+        let client = RealtimeAPIWebSocketClient()
+        let collector = EventCollector()
+        client.setEventHandler { collector.append($0) }
+
+        let (session, task) = makeWebSocketTask()
+        defer {
+            task.cancel()
+            session.invalidateAndCancel()
+        }
+
+        client.debugPrimeConnectedStateForTesting(task: task)
+        client.debugSetGenerationTrackingState(hasUncommittedAudio: true, isGenerationInProgress: true)
+
+        client.sendCommit(final: true)
+        client.handle(json: ["type": "transcription.done", "text": "in-flight complete"])
+
+        let events = collector.snapshot()
+        XCTAssertEqual(events.count, 2)
+        guard case .finalTranscript(let text) = events[0] else {
+            XCTFail("Expected first event to be .finalTranscript")
+            return
+        }
+        XCTAssertEqual(text, "in-flight complete")
+        guard case .transcriptionFinalized = events[1] else {
+            XCTFail("Expected second event to be .transcriptionFinalized on first done")
+            return
+        }
+    }
+
+    func testFinalCommitRequestedDuringInFlightGenerationWithoutUncommittedAudioFinalizesOnNextDone() {
+        let client = RealtimeAPIWebSocketClient()
+        let collector = EventCollector()
+        client.setEventHandler { collector.append($0) }
+
+        let (session, task) = makeWebSocketTask()
+        defer {
+            task.cancel()
+            session.invalidateAndCancel()
+        }
+
+        client.debugPrimeConnectedStateForTesting(task: task)
+        client.debugSetGenerationTrackingState(hasUncommittedAudio: false, isGenerationInProgress: true)
+
+        client.sendCommit(final: true)
+        client.handle(json: ["type": "transcription.done", "text": "in-flight complete"])
+
+        let events = collector.snapshot()
+        XCTAssertEqual(events.count, 2)
+        guard case .finalTranscript(let text) = events[0] else {
+            XCTFail("Expected first event to be .finalTranscript")
+            return
+        }
+        XCTAssertEqual(text, "in-flight complete")
+        guard case .transcriptionFinalized = events[1] else {
+            XCTFail("Expected second event to be .transcriptionFinalized on first done")
+            return
+        }
+    }
+
+    func testFinalCommitWithNoPendingAudioOrGenerationWaitsForDoneToFinalize() {
+        let client = RealtimeAPIWebSocketClient()
+        let collector = EventCollector()
+        client.setEventHandler { collector.append($0) }
+
+        let (session, task) = makeWebSocketTask()
+        defer {
+            task.cancel()
+            session.invalidateAndCancel()
+        }
+
+        client.debugPrimeConnectedStateForTesting(task: task)
+        client.debugSetGenerationTrackingState(hasUncommittedAudio: false, isGenerationInProgress: false)
+
+        client.sendCommit(final: true)
+        XCTAssertTrue(collector.snapshot().isEmpty)
+
+        client.handle(json: ["type": "transcription.done"])
+
+        let events = collector.snapshot()
+        XCTAssertEqual(events.count, 1)
+        guard case .transcriptionFinalized = events[0] else {
+            XCTFail("Expected .transcriptionFinalized after done")
+            return
         }
     }
 }


### PR DESCRIPTION
## Summary

This release tightens overlay-buffer finalization and makes real-time insertion more reliable under modifier-heavy usage.

### Major changes

- Hold and dismiss the overlay through the session coordinator while disconnecting on finalized transcript events so stop/finalize no longer races the last transcript commit.
- Move overlay commit and live insertion to keyboard-first paths with explicit fallback behavior, so insertion remains reliable when push-to-talk modifiers are active.
- Align realtime client finalization behavior around a final-commit state machine and add lifecycle tests for final-done handling, terminal-error cleanup, and insertion retry paths.

## Squash merge format

### Subject (fixed)

```text
Release v0.5.1 (#9)
```

### Body

```text
- Tighten overlay finalization timing and realtime insertion reliability.
- Route overlay hold/dismiss through the session coordinator and finalize on transcript done events to avoid dropping the last segment during stop/finalize races.
- Replace the prior arbitrary server-disconnect flow with deterministic done-event finalization so session teardown timing is predictable.
- Make live and final overlay insertion keyboard-first with modifier-aware fallbacks so push-to-talk sessions commit text consistently.
- Consolidate realtime final-commit lifecycle handling and expand tests around done-event finalization, terminal-error cleanup, and insertion retry coverage.
```

## Merge instructions

Please review and squash-merge this PR into `main` using the exact fixed subject + body above (or reply with edits and I will update the text for re-approval).
