### PR TITLE
Release v0.5.3

### DIFF
--- a/Sources/localvoxtral/DictationViewModel+RealtimeEvents.swift
+++ b/Sources/localvoxtral/DictationViewModel+RealtimeEvents.swift
@@ -38,11 +38,18 @@ extension DictationViewModel {
 
     private func handleConnectedEvent() {
         cancelConnectTimeout()
-        setRealtimeIndicatorConnected()
         if isConnectingRealtimeSession {
+            if shouldCancelPushToTalkStartAfterConnect() {
+                abortConnectingSession()
+                setRealtimeIndicatorIdle()
+                statusText = "Ready"
+                return
+            }
+            setRealtimeIndicatorConnected()
             startAudioCaptureAfterConnection()
             return
         }
+        setRealtimeIndicatorConnected()
         statusText = activeStatusText
     }
 

--- a/Sources/localvoxtral/DictationViewModel+Session.swift
+++ b/Sources/localvoxtral/DictationViewModel+Session.swift
@@ -411,6 +411,7 @@ extension DictationViewModel {
         cancelConnectTimeout()
         finalizationWatchdogTask?.cancel()
         finalizationWatchdogTask = nil
+        clearPushToTalkShortcutSessionAttempt()
         isConnectingRealtimeSession = false
         isDictating = false
         isAwaitingMicrophonePermission = false

--- a/Sources/localvoxtral/DictationViewModel.swift
+++ b/Sources/localvoxtral/DictationViewModel.swift
@@ -476,8 +476,10 @@ final class DictationViewModel {
         guard hasActivePushToTalkShortcutSession else { return }
 
         if isConnectingRealtimeSession {
-            abortConnectingSession()
-            statusText = StatusStrings.ready
+            // Keep the connection attempt alive so timeout/errors surface to the user
+            // instead of silently resetting to Ready on key release.
+            statusText = StatusStrings.connectingRealtimeBackend
+            return
         } else if isDictating {
             stopDictation(reason: "push-to-talk release")
         } else if isAwaitingMicrophonePermission {
@@ -486,6 +488,16 @@ final class DictationViewModel {
             statusText = StatusStrings.ready
             return
         }
+        clearPushToTalkShortcutSessionAttempt()
+    }
+
+    func shouldCancelPushToTalkStartAfterConnect() -> Bool {
+        settings.dictationShortcutMode == .pushToTalk
+            && hasActivePushToTalkShortcutSession
+            && !isPushToTalkShortcutHeld
+    }
+
+    func clearPushToTalkShortcutSessionAttempt() {
         hasActivePushToTalkShortcutSession = false
     }
 
@@ -840,3 +852,23 @@ final class DictationViewModel {
         }
     }
 }
+
+#if DEBUG
+extension DictationViewModel {
+    func debugHandleDictationShortcutPressForTesting() {
+        handleDictationShortcutPress()
+    }
+
+    func debugHandleDictationShortcutReleaseForTesting() {
+        handleDictationShortcutRelease()
+    }
+
+    func debugSetPushToTalkShortcutStateForTesting(
+        isHeld: Bool,
+        hasActiveSession: Bool
+    ) {
+        isPushToTalkShortcutHeld = isHeld
+        hasActivePushToTalkShortcutSession = hasActiveSession
+    }
+}
+#endif

--- a/Sources/localvoxtral/TimingConstants.swift
+++ b/Sources/localvoxtral/TimingConstants.swift
@@ -16,7 +16,7 @@ enum TimingConstants {
     // MARK: - Connection
 
     /// How long to wait for a WebSocket to reach `.connected` before timing out.
-    static let connectTimeout: TimeInterval = 2.0
+    static let connectTimeout: TimeInterval = 1.0
 
     /// Duration the "recent failure" indicator stays visible after a connection error.
     static let recentFailureIndicatorDuration: TimeInterval = 5.0

--- a/Tests/localvoxtralTests/DictationViewModelOverlayLifecycleTests.swift
+++ b/Tests/localvoxtralTests/DictationViewModelOverlayLifecycleTests.swift
@@ -125,6 +125,71 @@ final class DictationViewModelOverlayLifecycleTests: XCTestCase {
         XCTAssertFalse(viewModel.realtimeAPIClient.isConnected)
     }
 
+    func testPushToTalkReleaseWhileConnectingStillSurfacesTimeoutFailure() async {
+        let settings = makeSettings(outputMode: .liveAutoPaste)
+        settings.dictationShortcutMode = .pushToTalk
+        let overlayCoordinator = MockOverlayCoordinator()
+        let viewModel = DictationViewModel(
+            settings: settings,
+            overlayBufferCoordinator: overlayCoordinator,
+            startRuntimeServices: false
+        )
+        retainForTestProcessLifetime(viewModel)
+
+        // Prevent NSAlert from blocking test execution when the timeout path presents.
+        viewModel.isShowingConnectionFailureAlert = true
+        viewModel.isConnectingRealtimeSession = true
+        viewModel.statusText = "Connecting to realtime backend..."
+        viewModel.debugSetPushToTalkShortcutStateForTesting(isHeld: true, hasActiveSession: true)
+        viewModel.scheduleConnectTimeout()
+
+        viewModel.debugHandleDictationShortcutReleaseForTesting()
+
+        XCTAssertTrue(viewModel.isConnectingRealtimeSession)
+        XCTAssertEqual(viewModel.statusText, "Connecting to realtime backend...")
+
+        let timeoutAt = Date().addingTimeInterval(TimingConstants.connectTimeout + 1.0)
+        while viewModel.isConnectingRealtimeSession, Date() < timeoutAt {
+            try? await Task.sleep(for: .milliseconds(10))
+        }
+
+        XCTAssertFalse(viewModel.isConnectingRealtimeSession)
+        XCTAssertEqual(viewModel.statusText, "Connection timed out.")
+        XCTAssertEqual(viewModel.realtimeSessionIndicatorState, .recentFailure)
+        XCTAssertNotNil(viewModel.lastError)
+        XCTAssertTrue(
+            viewModel.lastError?.contains(
+                "No connection response received in \(Int(TimingConstants.connectTimeout)) seconds"
+            ) == true
+        )
+    }
+
+    func testPushToTalkReleaseBeforeConnectSkipsDictationStartOnConnectedEvent() {
+        let settings = makeSettings(outputMode: .liveAutoPaste)
+        settings.dictationShortcutMode = .pushToTalk
+        let overlayCoordinator = MockOverlayCoordinator()
+        let viewModel = DictationViewModel(
+            settings: settings,
+            overlayBufferCoordinator: overlayCoordinator,
+            startRuntimeServices: false
+        )
+        retainForTestProcessLifetime(viewModel)
+
+        viewModel.activeClientSource = .realtimeAPI
+        viewModel.isConnectingRealtimeSession = true
+        viewModel.statusText = "Connecting to realtime backend..."
+        viewModel.debugSetPushToTalkShortcutStateForTesting(isHeld: true, hasActiveSession: true)
+
+        viewModel.debugHandleDictationShortcutReleaseForTesting()
+        viewModel.handle(event: .connected, source: .realtimeAPI)
+
+        XCTAssertFalse(viewModel.isConnectingRealtimeSession)
+        XCTAssertFalse(viewModel.isDictating)
+        XCTAssertNil(viewModel.activeClientSource)
+        XCTAssertEqual(viewModel.statusText, "Ready")
+        XCTAssertEqual(viewModel.realtimeSessionIndicatorState, .idle)
+    }
+
     private func makeSettings(outputMode: DictationOutputMode) -> SettingsStore {
         let suiteName = "localvoxtral.DictationViewModelOverlayLifecycleTests.\(UUID().uuidString)"
         let defaults = UserDefaults(suiteName: suiteName)!


### PR DESCRIPTION
## Summary

- Keeps push-to-talk connection attempts alive on key release so connection timeout/failure is surfaced instead of silently resetting to Ready.
- Prevents dictation from starting if the push-to-talk key is already released when the websocket connect event arrives.
- Reduces realtime connection timeout from 2s to 1s for faster failure feedback.
- Adds overlay lifecycle tests covering both release-during-connect and release-before-connect paths.

## Squash Merge Instructions

Use this exact squash subject:

`Release v0.5.3 (#11)`

Use this squash body:

- Keep push-to-talk connection attempts alive until timeout/error so failed connects are visible to the user.
- Cancel push-to-talk startup on late connect events when the key was already released.
- Reduce realtime connect timeout from 2s to 1s to shorten failure feedback.
- Add lifecycle tests for push-to-talk release behavior around connection start.

## Review Request

Please review this release PR and squash merge using the subject/body above.
