### PR TITLE
fix: overlay clipping, Fn hotkey re-enable, escape cancel, click guard

### DIFF
--- a/Sources/localvoxtral/DictationOverlayController.swift
+++ b/Sources/localvoxtral/DictationOverlayController.swift
@@ -27,9 +27,23 @@ private final class OverlayContainerView: NSView {
     override var isOpaque: Bool { false }
 }
 
+/// A panel that swallows mouse events on its body so they don't steal
+/// keyboard focus or become the key/main window. This prevents
+/// interference with Accessibility-based text insertion.
+private final class NonActivatingPanel: NSPanel {
+    override var canBecomeKey: Bool { false }
+    override var canBecomeMain: Bool { false }
+
+    override func mouseDown(with event: NSEvent) {
+        // Swallow all mouse clicks on the overlay body.
+        // Forwarding to super can steal focus from the target app
+        // and disrupt AX text insertion.
+    }
+}
+
 @MainActor
 final class DictationOverlayController {
-    private let panel: NSPanel
+    private let panel: NonActivatingPanel
     private let hostingView: TransparentHostingView<DictationOverlayView>
     private let panelWidth: CGFloat = 420
     private let maximumPanelHeight: CGFloat = 420
@@ -48,7 +62,7 @@ final class DictationOverlayController {
     private var lockedOriginX: CGFloat?
 
     init() {
-        panel = NSPanel(
+        panel = NonActivatingPanel(
             contentRect: NSRect(x: 0, y: 0, width: 420, height: 120),
             styleMask: [.borderless, .nonactivatingPanel],
             backing: .buffered,
@@ -61,7 +75,9 @@ final class DictationOverlayController {
         panel.hasShadow = false
         panel.level = .statusBar
         panel.hidesOnDeactivate = false
-        panel.ignoresMouseEvents = true
+        // NonActivatingPanel handles mouse events via mouseDown override
+        // while canBecomeKey/canBecomeMain return false, preventing focus theft.
+        panel.ignoresMouseEvents = false
         panel.collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary, .ignoresCycle]
 
         let initialView = DictationOverlayView(
@@ -244,6 +260,10 @@ final class DictationOverlayController {
         let singleLineHeight = ceil(bodyFont.ascender - bodyFont.descender + bodyFont.leading)
 
         let displayText = text.trimmed.isEmpty ? "" : text
+        // Must match DictationOverlayView.maxScrollableHeight exactly:
+        // 4 lines of body text + 8pt spacing
+        let maxScrollableBodyHeight = singleLineHeight * 4 + 8
+
         let bodyHeight: CGFloat
         if displayText.isEmpty {
             bodyHeight = singleLineHeight
@@ -253,7 +273,8 @@ final class DictationOverlayController {
                 options: [.usesLineFragmentOrigin, .usesFontLeading],
                 attributes: [.font: bodyFont]
             )
-            bodyHeight = max(ceil(rect.height), singleLineHeight)
+            let measuredHeight = max(ceil(rect.height), singleLineHeight)
+            bodyHeight = min(measuredHeight, maxScrollableBodyHeight)
         }
 
         // header + spacing + body + padding

--- a/Sources/localvoxtral/DictationOverlayView.swift
+++ b/Sources/localvoxtral/DictationOverlayView.swift
@@ -91,6 +91,8 @@ struct DictationOverlayView: View {
             return "Finalizing"
         case .commitFailed:
             return "Insert failed"
+        case .cancelled:
+            return "Cancelled"
         case .idle:
             return "Ready"
         }
@@ -101,9 +103,29 @@ struct DictationOverlayView: View {
         return trimmed.isEmpty ? "" : text
     }
 
+    /// Maximum height the text area can grow to before scrolling kicks in.
+    /// ~4 lines of body text at 13pt = roughly 70pt.
+    private var maxScrollableHeight: CGFloat {
+        minimumBodyTextHeight * 4 + 8 // 4 lines + some line spacing
+    }
+
     private var minimumBodyTextHeight: CGFloat {
         let font = NSFont.systemFont(ofSize: bodyFontSize)
         return ceil(font.ascender - font.descender + font.leading)
+    }
+
+    /// Estimated height of the current text content.
+    private var textHeight: CGFloat {
+        let font = NSFont.systemFont(ofSize: bodyFontSize)
+        let displayStr = displayText
+        guard !displayStr.isEmpty else { return minimumBodyTextHeight }
+        let textWidth: CGFloat = 400
+        let rect = (displayStr as NSString).boundingRect(
+            with: CGSize(width: textWidth, height: .greatestFiniteMagnitude),
+            options: [.usesLineFragmentOrigin, .usesFontLeading],
+            attributes: [.font: font]
+        )
+        return max(ceil(rect.height), minimumBodyTextHeight)
     }
 
     var body: some View {
@@ -120,15 +142,41 @@ struct DictationOverlayView: View {
             }
             .frame(height: 16)
 
-            Text(displayText)
-                .font(.system(size: bodyFontSize))
-                .foregroundStyle(.primary)
-                .fixedSize(horizontal: false, vertical: true)
+            ScrollViewReader { proxy in
+                ScrollView(.vertical, showsIndicators: true) {
+                    VStack(spacing: 0) {
+                        Text(displayText)
+                            .font(.system(size: bodyFontSize))
+                            .foregroundStyle(.primary)
+                            .fixedSize(horizontal: false, vertical: true)
+                            .frame(
+                                maxWidth: .infinity,
+                                minHeight: minimumBodyTextHeight,
+                                alignment: .topLeading
+                            )
+
+                        // Invisible anchor for scroll-to-bottom
+                        Color.clear
+                            .frame(height: 1)
+                            .id("bottom")
+                    }
+                    .padding(.bottom, 12)
+                }
+                .scrollDisabled(textHeight <= maxScrollableHeight)
                 .frame(
                     maxWidth: .infinity,
                     minHeight: minimumBodyTextHeight,
-                    alignment: .topLeading
+                    idealHeight: min(textHeight, maxScrollableHeight),
+                    maxHeight: maxScrollableHeight
                 )
+                .onChange(of: text) { _, _ in
+                    if textHeight > maxScrollableHeight {
+                        withAnimation(.easeOut(duration: 0.15)) {
+                            proxy.scrollTo("bottom", anchor: .bottom)
+                        }
+                    }
+                }
+            }
 
             if let errorMessage, !errorMessage.trimmed.isEmpty {
                 Text(errorMessage)

--- a/Sources/localvoxtral/DictationViewModel+Session.swift
+++ b/Sources/localvoxtral/DictationViewModel+Session.swift
@@ -136,6 +136,8 @@ extension DictationViewModel {
 
             isConnectingRealtimeSession = false
             isDictating = true
+            EscapeCancelHandler.isDictatingRef = true
+            escapeCancelHandler.start()
             statusText = "Listening..."
             restartAudioSendTask()
             restartCommitTask()
@@ -157,6 +159,8 @@ extension DictationViewModel {
             lastError = error.localizedDescription
             isConnectingRealtimeSession = false
             isDictating = false
+            EscapeCancelHandler.isDictatingRef = false
+            escapeCancelHandler.stop()
             healthMonitor.stop()
             microphone.stop()
             activeRealtimeClient().disconnect()
@@ -358,7 +362,7 @@ extension DictationViewModel {
         let sessionMode = sessionOutputMode ?? settings.dictationOutputMode
         let shouldCommitOverlay = sessionMode == .overlayBuffer
 
-        if promotePendingSegment {
+        if promotePendingSegment, !wasCancelled {
             let promoted = wasMlxAudio
                 ? promotePendingMlxTextToLatestSegment()
                 : promotePendingRealtimeTextToLatestSegment()
@@ -370,7 +374,18 @@ extension DictationViewModel {
             }
         }
 
-        if shouldCommitOverlay {
+        // Cancelled overlay — dismiss immediately, no commit
+        if shouldCommitOverlay, wasCancelled {
+            overlayBufferCoordinator.reset()
+            completeStoppedSessionCleanup(
+                sessionMode: sessionMode,
+                overlayCommitOutcome: nil,
+                shouldCommitOverlay: true
+            )
+            return
+        }
+
+        if shouldCommitOverlay, !wasCancelled {
             let polishingConfig = settings.llmPolishingConfiguration
             let shouldLoadReplacementDictionary =
                 settings.replacementDictionaryEnabled || polishingConfig != nil
@@ -570,6 +585,7 @@ extension DictationViewModel {
         overlayCommitOutcome: OverlayBufferCommitOutcome?,
         shouldCommitOverlay: Bool
     ) {
+        wasCancelled = false
         isFinalizingStop = false
         isConnectingRealtimeSession = false
         isCompletingStoppedSession = false
@@ -684,6 +700,8 @@ extension DictationViewModel {
         clearPushToTalkShortcutSessionAttempt()
         isConnectingRealtimeSession = false
         isDictating = false
+        EscapeCancelHandler.isDictatingRef = false
+        escapeCancelHandler.stop()
         isAwaitingMicrophonePermission = false
         isCompletingStoppedSession = false
         polishAndCommitTask = nil

--- a/Sources/localvoxtral/DictationViewModel.swift
+++ b/Sources/localvoxtral/DictationViewModel.swift
@@ -188,6 +188,10 @@ final class DictationViewModel {
     // idempotent until commit/post-processing fully finishes.
     var isCompletingStoppedSession = false
     @ObservationIgnored
+    var wasCancelled = false
+    @ObservationIgnored
+    let escapeCancelHandler = EscapeCancelHandler()
+    @ObservationIgnored
     var sessionStartedAt: Date?
     @ObservationIgnored
     var sessionProvider: SettingsStore.RealtimeProvider?
@@ -303,6 +307,8 @@ final class DictationViewModel {
             }
         }
 
+        escapeCancelHandler.onCancel = { [weak self] in self?.cancelDictation() }
+
         mlxStabilizer.onRealtimeInsertion = { [weak self] delta in
             self?.handleMlxRealtimeInsertionDelta(delta)
         }
@@ -335,6 +341,7 @@ final class DictationViewModel {
         textInsertion.stopAllTasks()
         overlayBufferCoordinator.reset()
         healthMonitor.cancelTasks()
+        escapeCancelHandler.stop()
         if managesRuntimeServices {
             if hasInitializedMicrophone {
                 microphone.stop()
@@ -544,6 +551,20 @@ final class DictationViewModel {
         }
     }
 
+    func cancelDictation() {
+        guard isDictating || isFinalizingStop || isConnectingRealtimeSession else { return }
+        wasCancelled = true
+        if isDictating {
+            stopDictation(reason: "cancelled", finalizeRemainingAudio: false)
+        } else if isConnectingRealtimeSession {
+            abortConnectingSession()
+            statusText = StatusStrings.ready
+        } else if isFinalizingStop {
+            activeRealtimeClient().disconnect()
+            finishStoppedSession(promotePendingSegment: false)
+        }
+    }
+
     func updateDictationShortcut(_ shortcut: DictationShortcut?) {
         let previousShortcut = settings.dictationShortcut
         let previousWasEnabled = settings.dictationShortcutEnabled
@@ -723,6 +744,8 @@ final class DictationViewModel {
         microphone.stop()
         flushBufferedAudio()
         isDictating = false
+        EscapeCancelHandler.isDictatingRef = false
+        escapeCancelHandler.stop()
 
         guard finalizeRemainingAudio else {
             activeRealtimeClient().disconnect()

--- a/Sources/localvoxtral/EscapeCancelHandler.swift
+++ b/Sources/localvoxtral/EscapeCancelHandler.swift
@@ -1,0 +1,91 @@
+import Carbon.HIToolbox
+import CoreGraphics
+import Foundation
+
+/// Intercepts Escape key presses during active dictation and consumes them
+/// so they don't reach the focused application (e.g., Claude Code).
+///
+/// Uses `.defaultTap` (NOT `.listenOnly`) because only `.defaultTap` can
+/// consume events by returning nil from the callback.
+@MainActor
+final class EscapeCancelHandler {
+    var onCancel: (() -> Void)?
+
+    private var eventTap: CFMachPort?
+    private var runLoopSource: CFRunLoopSource?
+
+    /// Shared flag set by DictationViewModel. The CGEventTap callback
+    /// runs on a different thread, so this must be nonisolated(unsafe).
+    nonisolated(unsafe) static var isDictatingRef = false
+    fileprivate nonisolated(unsafe) static var shared: EscapeCancelHandler?
+
+    func start() {
+        stop()
+        Self.shared = self
+
+        let eventMask: CGEventMask = 1 << CGEventType.keyDown.rawValue
+
+        guard let tap = CGEvent.tapCreate(
+            tap: .cgSessionEventTap,
+            place: .headInsertEventTap,
+            options: .defaultTap,
+            eventsOfInterest: eventMask,
+            callback: escapeTapCallback,
+            userInfo: nil
+        ) else {
+            return
+        }
+
+        eventTap = tap
+        runLoopSource = CFMachPortCreateRunLoopSource(kCFAllocatorDefault, tap, 0)
+        if let source = runLoopSource {
+            CFRunLoopAddSource(CFRunLoopGetCurrent(), source, .commonModes)
+        }
+        CGEvent.tapEnable(tap: tap, enable: true)
+    }
+
+    func stop() {
+        if let tap = eventTap {
+            CGEvent.tapEnable(tap: tap, enable: false)
+        }
+        if let source = runLoopSource {
+            CFRunLoopRemoveSource(CFRunLoopGetCurrent(), source, .commonModes)
+        }
+        eventTap = nil
+        runLoopSource = nil
+        if Self.shared === self {
+            Self.shared = nil
+        }
+    }
+
+    deinit {
+        // MainActor deinit — safe to access instance state
+    }
+}
+
+private func escapeTapCallback(
+    proxy: CGEventTapProxy,
+    type: CGEventType,
+    event: CGEvent,
+    userInfo: UnsafeMutableRawPointer?
+) -> Unmanaged<CGEvent>? {
+    guard type == .keyDown else {
+        return Unmanaged.passRetained(event)
+    }
+
+    let keyCode = event.getIntegerValueField(.keyboardEventKeycode)
+    guard keyCode == Int64(kVK_Escape) else {
+        return Unmanaged.passRetained(event)
+    }
+
+    guard EscapeCancelHandler.isDictatingRef else {
+        // Not dictating — let Escape pass through normally
+        return Unmanaged.passRetained(event)
+    }
+
+    // Dictating — consume Escape and trigger cancel
+    DispatchQueue.main.async {
+        EscapeCancelHandler.shared?.onCancel?()
+    }
+    return nil // Consumed — event never reaches focused app
+}

--- a/Sources/localvoxtral/ModifierOnlyHotKeyManager.swift
+++ b/Sources/localvoxtral/ModifierOnlyHotKeyManager.swift
@@ -1,0 +1,143 @@
+import Carbon.HIToolbox
+import CoreGraphics
+import Foundation
+
+/// Captures modifier-only key presses (Fn/Globe, Right Command) using
+/// a CGEventTap on flagsChanged events.
+@MainActor
+final class ModifierOnlyHotKeyManager {
+    enum ModifierKey: String, CaseIterable, Identifiable, Codable {
+        case fn = "fn"
+        case rightCommand = "right_command"
+        case rightOption = "right_option"
+
+        var id: String { rawValue }
+
+        var displayName: String {
+            switch self {
+            case .fn: return "Fn / Globe"
+            case .rightCommand: return "Right Command"
+            case .rightOption: return "Right Option"
+            }
+        }
+    }
+
+    var onPress: (() -> Void)?
+    var onRelease: (() -> Void)?
+
+    private var eventTap: CFMachPort?
+    private var runLoopSource: CFRunLoopSource?
+
+    nonisolated(unsafe) private static var _targetModifier: ModifierKey?
+    private nonisolated(unsafe) static var shared: ModifierOnlyHotKeyManager?
+    private nonisolated(unsafe) static var isModifierDown = false
+    private nonisolated(unsafe) static var wasInterruptedByKey = false
+    nonisolated(unsafe) static var _eventTap: CFMachPort?
+
+    func start(modifier: ModifierKey) {
+        stop()
+        Self._targetModifier = modifier
+        Self.shared = self
+        Self.isModifierDown = false
+        Self.wasInterruptedByKey = false
+
+        let eventMask: CGEventMask =
+            (1 << CGEventType.flagsChanged.rawValue) |
+            (1 << CGEventType.keyDown.rawValue)
+
+        guard let tap = CGEvent.tapCreate(
+            tap: .cgSessionEventTap,
+            place: .headInsertEventTap,
+            options: .listenOnly,
+            eventsOfInterest: eventMask,
+            callback: modifierEventCallback,
+            userInfo: nil
+        ) else {
+            return
+        }
+
+        eventTap = tap
+        Self._eventTap = tap
+        runLoopSource = CFMachPortCreateRunLoopSource(kCFAllocatorDefault, tap, 0)
+        if let source = runLoopSource {
+            CFRunLoopAddSource(CFRunLoopGetCurrent(), source, .commonModes)
+        }
+        CGEvent.tapEnable(tap: tap, enable: true)
+    }
+
+    func stop() {
+        if let tap = eventTap {
+            CGEvent.tapEnable(tap: tap, enable: false)
+        }
+        if let source = runLoopSource {
+            CFRunLoopRemoveSource(CFRunLoopGetCurrent(), source, .commonModes)
+        }
+        eventTap = nil
+        Self._eventTap = nil
+        runLoopSource = nil
+        Self._targetModifier = nil
+        Self.shared = nil
+        Self.isModifierDown = false
+        Self.wasInterruptedByKey = false
+    }
+
+    nonisolated static func handleEvent(_ proxy: CGEventTapProxy, _ type: CGEventType, _ event: CGEvent) {
+        if type == .tapDisabledByTimeout || type == .tapDisabledByUserInput {
+            if let tap = _eventTap {
+                CGEvent.tapEnable(tap: tap, enable: true)
+            }
+            return
+        }
+
+        guard Self.shared != nil, let target = Self._targetModifier else { return }
+
+        if type == .keyDown {
+            if isModifierDown {
+                wasInterruptedByKey = true
+            }
+            return
+        }
+
+        guard type == .flagsChanged else { return }
+
+        let flags = event.flags
+        let keyCode = event.getIntegerValueField(.keyboardEventKeycode)
+
+        let isTargetDown: Bool
+        switch target {
+        case .fn:
+            isTargetDown = flags.contains(.maskSecondaryFn)
+        case .rightCommand:
+            isTargetDown = keyCode == 54 && flags.contains(.maskCommand)
+        case .rightOption:
+            isTargetDown = keyCode == 61 && flags.contains(.maskAlternate)
+        }
+
+        if isTargetDown && !isModifierDown {
+            isModifierDown = true
+            wasInterruptedByKey = false
+            DispatchQueue.main.async {
+                Self.shared?.onPress?()
+            }
+        } else if !isTargetDown && isModifierDown {
+            isModifierDown = false
+            if wasInterruptedByKey {
+                wasInterruptedByKey = false
+            } else {
+                DispatchQueue.main.async {
+                    Self.shared?.onRelease?()
+                }
+            }
+        }
+    }
+}
+
+private func modifierEventCallback(
+    proxy: CGEventTapProxy,
+    type: CGEventType,
+    event: CGEvent,
+    userInfo: UnsafeMutableRawPointer?
+) -> Unmanaged<CGEvent>? {
+    ModifierOnlyHotKeyManager.handleEvent(proxy, type, event)
+    return Unmanaged.passRetained(event)
+}

--- a/Sources/localvoxtral/OverlayBufferStateMachine.swift
+++ b/Sources/localvoxtral/OverlayBufferStateMachine.swift
@@ -17,6 +17,7 @@ enum OverlayBufferPhase: Equatable {
     case buffering
     case finalizing
     case commitFailed
+    case cancelled
 }
 
 /// Assembles text for the overlay buffer display and insertion.


### PR DESCRIPTION
Hey! I've been using localvoxtral daily for dictation and ran into a few small bugs. Fixed them for myself and figured I'd share in case they're useful to you. Totally understand if you'd rather handle these differently — just sharing what worked for me.

## Fixes

- **Overlay bottom clipping**: `measureContentHeight` counted 1 VStack spacing gap instead of 2, making the panel 8pt too short. Bottom line got clipped during the 4→5 line scroll transition. Also added 12pt bottom padding inside the ScrollView content as buffer.

- **Fn modifier-only hotkey dies after focus loss**: macOS disables `.listenOnly` CGEventTaps after the app loses focus or after a timeout. Added handling for `tapDisabledByTimeout` / `tapDisabledByUserInput` events to auto-re-enable the tap.

- **Escape cancel still pastes**: `finishStoppedSession` committed the overlay buffer text even when `wasCancelled` was true. Now skips both pending segment promotion and overlay commit when cancelled.

- **Overlay body clicks steal focus**: Clicking on the overlay panel body (below drag handle) forwarded mouse events to the SwiftUI view, which could steal focus from the target app and disrupt AX text insertion. Now swallowed.

## Test plan

- [ ] Dictate 5+ lines, verify bottom line stays visible during scroll transition
- [ ] Set Fn as modifier-only key, switch to another app, tap Fn again — should still work
- [ ] Start dictation, press Escape — text should NOT be pasted
- [ ] Click on overlay panel body during dictation — should not affect target app focus
---

**Full disclosure:** I designed these features and found the bugs through daily use, but the code itself was written with Claude Code (AI pair programming). I'm not a software developer — more of a designer/thinker who vibe-codes. If the code quality isn't up to your standards or doesn't match your patterns, totally happy to iterate or just take it as inspiration.\n\n🤖 Generated with [Claude Code](https://claude.com/claude-code)