### PR TITLE
feat: gradual DDC audio ducking fade-in with configurable duration

### DIFF
--- a/Sources/localvoxtral/AudioDuckingService.swift
+++ b/Sources/localvoxtral/AudioDuckingService.swift
@@ -1,0 +1,417 @@
+import AppKit
+import AudioToolbox
+import CoreAudio
+import Foundation
+import os
+
+/// Ducks audio when dictation starts and restores when it stops.
+///
+/// Uses a multi-strategy approach since not all audio output devices
+/// support software volume control (e.g. HDMI/DisplayPort monitors):
+///
+/// 1. Try CoreAudio VirtualMainVolume (headphones, built-in speakers)
+/// 2. Duck DDC monitor volume via BetterDisplay binary (when `useDDC` is true and BetterDisplay is installed)
+/// 3. Fall back to pausing common music apps (Spotify, Music) via NSAppleScript
+/// 4. Resume paused apps on unduck
+final class AudioDuckingService: @unchecked Sendable {
+    private let lock = NSLock()
+    private var _originalVolume: Float?
+    private var _duckedVolume: Float?
+    private var _fadeTask: Task<Void, Never>?
+    private var _pausedApps: [String] = []
+    private var _volumeControlAvailable = false
+    private var _ddcOriginalVolume: Float?
+    private var _ddcDuckedVolume: Float?
+    private var _ddcDucked = false
+    /// Incremented on every duck/unduck to cancel stale fade loops.
+    private var _fadeGeneration: Int = 0
+
+    // MARK: - DDC (BetterDisplay)
+
+    static let betterDisplayPath = "/Applications/BetterDisplay.app/Contents/MacOS/BetterDisplay"
+
+    static func isBetterDisplayInstalled() -> Bool {
+        FileManager.default.fileExists(atPath: betterDisplayPath)
+    }
+
+    /// Duck all DDC-capable monitor volumes to `targetFraction` of current.
+    /// Returns true if DDC ducking succeeded (at least one monitor responded).
+    @discardableResult
+    func duckViaDDC(to targetFraction: Float) -> Bool {
+        guard Self.isBetterDisplayInstalled() else { return false }
+
+        // Get current volume(s)
+        guard let current = runBetterDisplay(args: ["get", "-volume"]),
+              !current.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        else { return false }
+
+        // BetterDisplay returns comma-separated values for multiple monitors.
+        // Parse the first value to determine the original level.
+        let parts = current.trimmingCharacters(in: .whitespacesAndNewlines)
+            .split(separator: ",")
+            .compactMap { Float($0.trimmingCharacters(in: .whitespaces)) }
+        guard let firstVolume = parts.first, firstVolume > 0 else { return false }
+
+        // Use stored original if available (survives mid-fade re-ducks)
+        lock.lock()
+        let baseVolume = _ddcOriginalVolume ?? firstVolume
+        if _ddcOriginalVolume == nil {
+            _ddcOriginalVolume = firstVolume
+        }
+        lock.unlock()
+
+        let targetVolume = baseVolume * max(0.0, min(1.0, targetFraction))
+        let targetString = String(format: "%.4f", targetVolume)
+
+        guard runBetterDisplay(args: ["set", "-volume=\(targetString)"]) != nil else {
+            return false
+        }
+
+        lock.lock()
+        _ddcDuckedVolume = targetVolume
+        _ddcDucked = true
+        lock.unlock()
+        return true
+    }
+
+    /// Restore DDC monitor volume to what it was before ducking.
+    /// - Parameter fadeInDuration: Seconds over which to fade volume back up.
+    ///   DDC commands are slower than CoreAudio (process spawn per step),
+    ///   so we use ~15 steps regardless of duration.
+    func unduckViaDDC(fadeInDuration: TimeInterval = 1.5) {
+        lock.lock()
+        let original = _ddcOriginalVolume
+        let duckedVolume = _ddcDuckedVolume
+        // Don't clear _ddcOriginalVolume yet — if fade is cancelled by a new duck,
+        // the true original must survive. Cleared on fade completion only.
+        _ddcDuckedVolume = nil
+        _ddcDucked = false
+        _fadeGeneration += 1
+        let myGeneration = _fadeGeneration
+        lock.unlock()
+
+        guard let original, Self.isBetterDisplayInstalled() else { return }
+
+        let startVolume = duckedVolume ?? 0
+        let steps = 15
+        let stepInterval = fadeInDuration / Double(steps)
+
+        Log.ducking.info("unduck: strategy=DDC fade from \(startVolume) to \(original) over \(fadeInDuration)s (\(steps) steps)")
+
+        DispatchQueue.global(qos: .userInteractive).async { [weak self] in
+            for step in 1...steps {
+                // Bail if a new duck/unduck started
+                guard let self else { return }
+                self.lock.lock()
+                let stillCurrent = self._fadeGeneration == myGeneration
+                self.lock.unlock()
+                guard stillCurrent else {
+                    Log.ducking.info("unduck: DDC fade cancelled at step \(step)/\(steps)")
+                    return
+                }
+
+                let progress = Float(step) / Float(steps)
+                let eased = progress * progress * (3.0 - 2.0 * progress)
+                let volume = startVolume + (original - startVolume) * eased
+                let volumeString = String(format: "%.4f", volume)
+                _ = self.runBetterDisplay(args: ["set", "-volume=\(volumeString)"])
+                if step < steps {
+                    Thread.sleep(forTimeInterval: stepInterval)
+                }
+            }
+            // Fade completed — safe to clear the true original
+            if let self {
+                self.lock.lock()
+                if self._fadeGeneration == myGeneration {
+                    self._ddcOriginalVolume = nil
+                }
+                self.lock.unlock()
+            }
+            Log.ducking.info("unduck: DDC fade complete")
+        }
+    }
+
+    @discardableResult
+    private func runBetterDisplay(args: [String]) -> String? {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: Self.betterDisplayPath)
+        process.arguments = args
+
+        let pipe = Pipe()
+        process.standardOutput = pipe
+        process.standardError = Pipe()  // suppress stderr
+
+        process.launch()
+        process.waitUntilExit()
+
+        guard process.terminationStatus == 0 else { return nil }
+        let data = pipe.fileHandleForReading.readDataToEndOfFile()
+        return String(data: data, encoding: .utf8)
+    }
+
+    private static let defaultFadeDuration: TimeInterval = 0.3
+    private static let fadeStepInterval: TimeInterval = 0.03
+
+    private static let musicApps: [(name: String, pause: String, resume: String, state: String)] = [
+        ("Spotify",
+         "tell application \"Spotify\" to pause",
+         "tell application \"Spotify\" to play",
+         "tell application \"Spotify\" to player state as string"),
+        ("Music",
+         "tell application \"Music\" to pause",
+         "tell application \"Music\" to play",
+         "tell application \"Music\" to player state as string"),
+    ]
+
+    /// Duck audio to the target level.
+    ///
+    /// Strategy order:
+    /// 1. CoreAudio VirtualMainVolume (headphones, built-in speakers) — smooth fade
+    /// 2. DDC monitor volume via BetterDisplay (HDMI/DisplayPort) — when `useDDC` is true
+    /// 3. Pause music apps (Spotify, Music) — final fallback
+    func duck(to targetFraction: Float, useDDC: Bool = true) {
+        lock.lock()
+        _fadeTask?.cancel()
+        _fadeGeneration += 1 // cancel any in-progress fade
+        _pausedApps = []
+        _volumeControlAvailable = false
+        _duckedVolume = nil
+        _ddcDucked = false
+        // NOTE: _ddcOriginalVolume and _originalVolume are NOT cleared here.
+        // They persist across duck/unduck cycles so mid-fade re-ducks don't
+        // lose the true original volume. Cleared on fade completion only.
+
+        if let deviceID = defaultOutputDeviceID(),
+           let currentVolume = getVolume(deviceID: deviceID)
+        {
+            // Strategy 1: CoreAudio volume control works — use smooth fade
+            _volumeControlAvailable = true
+            if _originalVolume == nil {
+                _originalVolume = currentVolume
+            }
+            let baseVolume = _originalVolume ?? currentVolume
+            let targetVolume = baseVolume * max(0.0, min(1.0, targetFraction))
+            _duckedVolume = targetVolume
+            let startVolume = currentVolume
+            lock.unlock()
+
+            Log.ducking.info("duck: strategy=CoreAudio from=\(startVolume) to=\(targetVolume) device=\(deviceID)")
+
+            let task = Task.detached { [weak self] in
+                guard let self else { return }
+                await self.fadeVolume(
+                    deviceID: deviceID,
+                    from: startVolume,
+                    to: targetVolume
+                )
+            }
+
+            lock.lock()
+            _fadeTask = task
+            lock.unlock()
+        } else {
+            lock.unlock()
+            // Strategy 2: Try DDC via BetterDisplay
+            if useDDC, duckViaDDC(to: targetFraction) {
+                // DDC succeeded — nothing more to do
+            } else {
+                // Strategy 3: No volume control at all — pause music apps
+                pauseRunningMusicApps()
+            }
+        }
+    }
+
+    /// Restore volume or resume paused music apps.
+    /// - Parameter fadeInDuration: Duration in seconds for the volume fade-in.
+    ///   Longer values produce a gentler return (useful for AirPods after long sessions).
+    func unduck(fadeInDuration: TimeInterval = 1.5) {
+        lock.lock()
+        _fadeTask?.cancel()
+        _fadeGeneration += 1
+        let myGeneration = _fadeGeneration
+
+        if _volumeControlAvailable, let originalVolume = _originalVolume,
+           let deviceID = defaultOutputDeviceID()
+        {
+            // Reverse strategy 1: fade CoreAudio volume back up
+            let startVolume = _duckedVolume ?? getVolume(deviceID: deviceID) ?? originalVolume
+            // Don't clear _originalVolume yet — cleared on fade completion only.
+            _duckedVolume = nil
+            _volumeControlAvailable = false
+            lock.unlock()
+
+            Log.ducking.info(
+                "unduck: strategy=CoreAudio start=\(startVolume) end=\(originalVolume) duration=\(fadeInDuration)s"
+            )
+
+            setVolume(deviceID: deviceID, volume: startVolume)
+
+            let steps = max(1, Int(fadeInDuration / Self.fadeStepInterval))
+            let stepInterval = Self.fadeStepInterval
+            let capturedStart = startVolume
+            let capturedEnd = originalVolume
+            DispatchQueue.global(qos: .userInteractive).async { [weak self] in
+                for step in 1...steps {
+                    guard let self else { return }
+                    self.lock.lock()
+                    let stillCurrent = self._fadeGeneration == myGeneration
+                    self.lock.unlock()
+                    guard stillCurrent else { return }
+
+                    let progress = Float(step) / Float(steps)
+                    let eased = progress * progress * (3.0 - 2.0 * progress)
+                    let volume = capturedStart + (capturedEnd - capturedStart) * eased
+                    self.setVolume(deviceID: deviceID, volume: volume)
+                    Thread.sleep(forTimeInterval: stepInterval)
+                }
+                guard let self else { return }
+                self.setVolume(deviceID: deviceID, volume: capturedEnd)
+                self.lock.lock()
+                if self._fadeGeneration == myGeneration {
+                    self._originalVolume = nil
+                }
+                self.lock.unlock()
+            }
+        } else if _ddcDucked {
+            // Reverse strategy 2: restore DDC monitor volume with fade
+            _originalVolume = nil
+            _volumeControlAvailable = false
+            lock.unlock()
+            unduckViaDDC(fadeInDuration: fadeInDuration)
+        } else {
+            // Reverse strategy 3: resume paused music apps
+            Log.ducking.info("unduck: strategy=MusicApps (instant)")
+            _originalVolume = nil
+            _volumeControlAvailable = false
+            let appsToResume = _pausedApps
+            _pausedApps = []
+            lock.unlock()
+            resumeMusicApps(appsToResume)
+        }
+    }
+
+    func cancelFade() {
+        lock.lock()
+        _fadeTask?.cancel()
+        _fadeTask = nil
+        lock.unlock()
+    }
+
+    // MARK: - Music App Control
+
+    private func pauseRunningMusicApps() {
+        for app in Self.musicApps {
+            guard isAppRunning(app.name) else { continue }
+
+            if let state = runAppleScript(app.state),
+               state.lowercased().contains("playing")
+            {
+                _ = runAppleScript(app.pause)
+                lock.lock()
+                _pausedApps.append(app.name)
+                lock.unlock()
+            }
+        }
+    }
+
+    private func resumeMusicApps(_ apps: [String]) {
+        for appName in apps {
+            guard let app = Self.musicApps.first(where: { $0.name == appName }) else {
+                continue
+            }
+            guard isAppRunning(appName) else { continue }
+            _ = runAppleScript(app.resume)
+        }
+    }
+
+    private func isAppRunning(_ name: String) -> Bool {
+        NSWorkspace.shared.runningApplications.contains { app in
+            app.localizedName == name && !app.isTerminated
+        }
+    }
+
+    private func runAppleScript(_ source: String) -> String? {
+        let script = NSAppleScript(source: source)
+        var error: NSDictionary?
+        let result = script?.executeAndReturnError(&error)
+        return result?.stringValue
+    }
+
+    // MARK: - Volume Fade
+
+    private func fadeVolume(
+        deviceID: AudioDeviceID,
+        from startVolume: Float,
+        to endVolume: Float,
+        duration: TimeInterval = 0.3
+    ) async {
+        let stepDuration = Self.fadeStepInterval
+        let steps = max(1, Int(duration / stepDuration))
+
+        for step in 1...steps {
+            guard !Task.isCancelled else { return }
+
+            let progress = Float(step) / Float(steps)
+            let easedProgress = progress * progress * (3.0 - 2.0 * progress)
+            let volume = startVolume + (endVolume - startVolume) * easedProgress
+
+            setVolume(deviceID: deviceID, volume: volume)
+            try? await Task.sleep(for: .seconds(stepDuration))
+        }
+
+        if !Task.isCancelled {
+            setVolume(deviceID: deviceID, volume: endVolume)
+        }
+    }
+
+    // MARK: - CoreAudio
+
+    private func defaultOutputDeviceID() -> AudioDeviceID? {
+        var deviceID = AudioDeviceID(0)
+        var size = UInt32(MemoryLayout<AudioDeviceID>.size)
+        var address = AudioObjectPropertyAddress(
+            mSelector: kAudioHardwarePropertyDefaultOutputDevice,
+            mScope: kAudioObjectPropertyScopeGlobal,
+            mElement: kAudioObjectPropertyElementMain
+        )
+
+        let status = AudioObjectGetPropertyData(
+            AudioObjectID(kAudioObjectSystemObject),
+            &address, 0, nil, &size, &deviceID
+        )
+
+        guard status == noErr, deviceID != kAudioObjectUnknown else { return nil }
+        return deviceID
+    }
+
+    private func getVolume(deviceID: AudioDeviceID) -> Float? {
+        var volume: Float32 = 0
+        var size = UInt32(MemoryLayout<Float32>.size)
+        var address = AudioObjectPropertyAddress(
+            mSelector: kAudioHardwareServiceDeviceProperty_VirtualMainVolume,
+            mScope: kAudioObjectPropertyScopeOutput,
+            mElement: kAudioObjectPropertyElementMain
+        )
+
+        let status = AudioObjectGetPropertyData(
+            deviceID, &address, 0, nil, &size, &volume
+        )
+
+        guard status == noErr else { return nil }
+        return volume
+    }
+
+    private func setVolume(deviceID: AudioDeviceID, volume: Float) {
+        var mutableVolume = max(0.0, min(1.0, volume))
+        let size = UInt32(MemoryLayout<Float32>.size)
+        var address = AudioObjectPropertyAddress(
+            mSelector: kAudioHardwareServiceDeviceProperty_VirtualMainVolume,
+            mScope: kAudioObjectPropertyScopeOutput,
+            mElement: kAudioObjectPropertyElementMain
+        )
+
+        AudioObjectSetPropertyData(
+            deviceID, &address, 0, nil, size, &mutableVolume
+        )
+    }
+}

--- a/Sources/localvoxtral/DictationViewModel.swift
+++ b/Sources/localvoxtral/DictationViewModel.swift
@@ -144,6 +144,8 @@ final class DictationViewModel {
     @ObservationIgnored
     let mlxStabilizer = MlxHypothesisStabilizer()
     @ObservationIgnored
+    let audioDucker = AudioDuckingService()
+    @ObservationIgnored
     let overlayBufferCoordinator: OverlayBufferSessionCoordinating
     @ObservationIgnored
     var preResolvedOverlayAnchor: OverlayAnchor?
@@ -210,6 +212,9 @@ final class DictationViewModel {
     // to be cancelled if the user releases before dictation actually begins.
     @ObservationIgnored
     private var hasActivePushToTalkShortcutSession = false
+    // True when a modifier-only hold gesture started dictation (push-to-talk semantics).
+    @ObservationIgnored
+    private var isModifierOnlyHoldActive = false
 
     init(
         settings: SettingsStore,
@@ -292,15 +297,12 @@ final class DictationViewModel {
             networkMonitor.start()
         }
 
+        hotKeyManager.onPressWithMode = { [weak self] mode in self?.handleDictationShortcutPress(mode: mode) }
         hotKeyManager.onPress = { [weak self] in self?.handleDictationShortcutPress() }
         hotKeyManager.onRelease = { [weak self] in self?.handleDictationShortcutRelease() }
+        hotKeyManager.onHoldStart = { [weak self] in self?.handleModifierOnlyHoldStart() }
         if startRuntimeServices {
-            switch hotKeyManager.register(shortcut: settings.dictationShortcut) {
-            case .success:
-                break
-            case .failure(let reason):
-                applyHotKeyRegistrationFailure(reason)
-            }
+            registerCurrentHotKeys()
         }
 
         mlxStabilizer.onRealtimeInsertion = { [weak self] delta in
@@ -478,11 +480,24 @@ final class DictationViewModel {
 
     // MARK: - Public API
 
-    private func handleDictationShortcutPress() {
+    private func handleDictationShortcutPress(mode: DictationOutputMode? = nil) {
+        // If a mode is specified by the shortcut, pre-set it so startDictation uses it.
+        if let mode {
+            sessionOutputMode = mode
+        }
+
         switch settings.dictationShortcutMode {
         case .toggle:
             hasActivePushToTalkShortcutSession = false
-            toggleDictation()
+            if isDictating {
+                stopDictation(reason: "manual toggle")
+            } else if isConnectingRealtimeSession {
+                statusText = StatusStrings.connectingRealtimeBackend
+            } else if isFinalizingStop {
+                statusText = StatusStrings.finalizingPreviousDictation
+            } else {
+                startDictation()
+            }
         case .pushToTalk:
             guard !isPushToTalkShortcutHeld else { return }
             isPushToTalkShortcutHeld = true
@@ -496,6 +511,19 @@ final class DictationViewModel {
     }
 
     private func handleDictationShortcutRelease() {
+        // Modifier-only hold release
+        if isModifierOnlyHoldActive {
+            isModifierOnlyHoldActive = false
+            isPushToTalkShortcutHeld = false
+            if isDictating {
+                stopDictation(reason: "modifier hold release")
+            } else if isConnectingRealtimeSession {
+                statusText = StatusStrings.connectingRealtimeBackend
+            }
+            clearPushToTalkShortcutSessionAttempt()
+            return
+        }
+
         guard isPushToTalkShortcutHeld else { return }
         isPushToTalkShortcutHeld = false
 
@@ -521,6 +549,20 @@ final class DictationViewModel {
         clearPushToTalkShortcutSessionAttempt()
     }
 
+    /// Modifier-only hold gesture started — use push-to-talk semantics with live auto-paste.
+    private func handleModifierOnlyHoldStart() {
+        sessionOutputMode = .liveAutoPaste
+        isModifierOnlyHoldActive = true
+        isPushToTalkShortcutHeld = true
+        guard !isDictating, !isConnectingRealtimeSession, !isFinalizingStop else { return }
+        hasActivePushToTalkShortcutSession = true
+        startDictation()
+        if !isDictating, !isConnectingRealtimeSession, !isAwaitingMicrophonePermission {
+            hasActivePushToTalkShortcutSession = false
+            isModifierOnlyHoldActive = false
+        }
+    }
+
     func shouldCancelPushToTalkStartAfterConnect() -> Bool {
         settings.dictationShortcutMode == .pushToTalk
             && hasActivePushToTalkShortcutSession
@@ -544,13 +586,60 @@ final class DictationViewModel {
         }
     }
 
+    /// Re-register the hotkey based on current settings.
+    /// Called when modifier-only mode or modifier key selection changes.
+    func applyHotKeySettingsChange() {
+        switch registerCurrentHotKeys() {
+        case .success:
+            if !isDictating, !isFinalizingStop,
+               (currentStatusToken == .hotKeyHandlerRegistrationFailure
+                || currentStatusToken == .hotKeyShortcutUnavailable)
+            {
+                statusText = StatusStrings.ready
+            }
+            if currentErrorToken == .hotKeyShortcutUnavailable
+                || currentErrorToken == .hotKeyHandlerRegistrationFailure
+            {
+                lastError = nil
+            }
+        case .failure(let reason):
+            applyHotKeyRegistrationFailure(reason)
+        }
+    }
+
+    /// Register hotkeys based on current settings.
+    /// Uses modifier-only, dual shortcuts, or legacy single shortcut depending on config.
+    @discardableResult
+    private func registerCurrentHotKeys() -> HotKeyManager.RegistrationResult {
+        if settings.modifierOnlyHotKeyEnabled {
+            return hotKeyManager.registerModifierOnly(
+                settings.modifierOnlyHotKeyModifier,
+                holdThreshold: settings.modifierOnlyHoldDelay
+            )
+        }
+
+        // Use dual shortcut registration
+        let overlayShortcut = settings.overlayBufferShortcut
+        let livePasteShortcut = settings.livePasteShortcut
+
+        if overlayShortcut != nil || livePasteShortcut != nil {
+            return hotKeyManager.registerDual(
+                overlay: overlayShortcut,
+                livePaste: livePasteShortcut
+            )
+        }
+
+        // Fallback: legacy single shortcut (if neither dual shortcut is configured)
+        return hotKeyManager.register(shortcut: settings.dictationShortcut)
+    }
+
     func updateDictationShortcut(_ shortcut: DictationShortcut?) {
         let previousShortcut = settings.dictationShortcut
         let previousWasEnabled = settings.dictationShortcutEnabled
 
         settings.setDictationShortcut(shortcut)
 
-        switch hotKeyManager.register(shortcut: settings.dictationShortcut) {
+        switch registerCurrentHotKeys() {
         case .success:
             if !isDictating, !isFinalizingStop,
                (currentStatusToken == .hotKeyHandlerRegistrationFailure
@@ -571,8 +660,62 @@ final class DictationViewModel {
             } else {
                 settings.setDictationShortcut(nil)
             }
-            _ = hotKeyManager.register(shortcut: settings.dictationShortcut)
+            _ = registerCurrentHotKeys()
             applyHotKeyRegistrationFailure(reason)
+        }
+    }
+
+    func updateOverlayBufferShortcut(_ shortcut: DictationShortcut?) {
+        let previousShortcut = settings.overlayBufferShortcut
+        let previousWasEnabled = settings.overlayBufferShortcutEnabled
+
+        settings.setOverlayBufferShortcut(shortcut)
+
+        switch registerCurrentHotKeys() {
+        case .success:
+            clearHotKeyErrors()
+        case .failure(let reason):
+            if previousWasEnabled {
+                settings.setOverlayBufferShortcut(previousShortcut ?? SettingsStore.defaultDictationShortcut)
+            } else {
+                settings.setOverlayBufferShortcut(nil)
+            }
+            _ = registerCurrentHotKeys()
+            applyHotKeyRegistrationFailure(reason)
+        }
+    }
+
+    func updateLivePasteShortcut(_ shortcut: DictationShortcut?) {
+        let previousShortcut = settings.livePasteShortcut
+        let previousWasEnabled = settings.livePasteShortcutEnabled
+
+        settings.setLivePasteShortcut(shortcut)
+
+        switch registerCurrentHotKeys() {
+        case .success:
+            clearHotKeyErrors()
+        case .failure(let reason):
+            if previousWasEnabled, let previousShortcut {
+                settings.setLivePasteShortcut(previousShortcut)
+            } else {
+                settings.setLivePasteShortcut(nil)
+            }
+            _ = registerCurrentHotKeys()
+            applyHotKeyRegistrationFailure(reason)
+        }
+    }
+
+    private func clearHotKeyErrors() {
+        if !isDictating, !isFinalizingStop,
+           (currentStatusToken == .hotKeyHandlerRegistrationFailure
+            || currentStatusToken == .hotKeyShortcutUnavailable)
+        {
+            statusText = StatusStrings.ready
+        }
+        if currentErrorToken == .hotKeyShortcutUnavailable
+            || currentErrorToken == .hotKeyHandlerRegistrationFailure
+        {
+            lastError = nil
         }
     }
 
@@ -723,6 +866,7 @@ final class DictationViewModel {
         microphone.stop()
         flushBufferedAudio()
         isDictating = false
+        audioDucker.unduck(fadeInDuration: settings.audioDuckingFadeInDuration)
 
         guard finalizeRemainingAudio else {
             activeRealtimeClient().disconnect()
@@ -894,8 +1038,8 @@ final class DictationViewModel {
 
 #if DEBUG
 extension DictationViewModel {
-    func debugHandleDictationShortcutPressForTesting() {
-        handleDictationShortcutPress()
+    func debugHandleDictationShortcutPressForTesting(mode: DictationOutputMode? = nil) {
+        handleDictationShortcutPress(mode: mode)
     }
 
     func debugHandleDictationShortcutReleaseForTesting() {

--- a/Sources/localvoxtral/HotKeyManager.swift
+++ b/Sources/localvoxtral/HotKeyManager.swift
@@ -17,19 +17,60 @@ final class HotKeyManager {
     static let registrationErrorStatus = "Failed to register global hotkey."
     static let unavailableErrorMessage = "The selected keyboard shortcut is unavailable."
 
+    /// Legacy single-shortcut callback. Used by `register(shortcut:)`.
     var onPress: (() -> Void)?
     var onRelease: (() -> Void)?
 
-    private var hotKeyRef: EventHotKeyRef?
+    /// Mode-aware callback for dual shortcuts. Used by `registerDual(overlay:livePaste:)`.
+    var onPressWithMode: ((DictationOutputMode) -> Void)?
+
+    /// Fired when modifier-only hold gesture starts (past threshold).
+    /// Signals push-to-talk semantics with liveAutoPaste mode.
+    var onHoldStart: (() -> Void)?
+
+    private var hotKeyRefs: [UInt32: EventHotKeyRef] = [:]
     private var hotKeyHandlerRef: EventHandlerRef?
     private static let hotKeySignature = OSType(0x53565854) // SVXT
     private nonisolated(unsafe) static weak var hotKeyTarget: HotKeyManager?
+    private let modifierOnlyManager = ModifierOnlyHotKeyManager()
+    private var isUsingModifierOnly = false
+
+    /// Maps hotkey IDs to output modes for dual-shortcut dispatch.
+    private var hotKeyIDToMode: [UInt32: DictationOutputMode] = [:]
+
+    private static let overlayHotKeyID: UInt32 = 1
+    private static let livePasteHotKeyID: UInt32 = 2
 
     init() {
         Self.hotKeyTarget = self
     }
 
-    /// Registers a global hotkey for the given shortcut.
+    /// Register a modifier-only key (Fn, Right Command, etc.) as the hotkey.
+    /// This bypasses the Carbon RegisterEventHotKey path entirely.
+    /// Tap triggers overlay buffer (toggle), hold triggers live auto-paste (push-to-talk).
+    @discardableResult
+    func registerModifierOnly(
+        _ modifier: ModifierOnlyHotKeyManager.ModifierKey,
+        holdThreshold: Double = 0.35
+    ) -> RegistrationResult {
+        unregister()
+        isUsingModifierOnly = true
+        modifierOnlyManager.holdThresholdSeconds = holdThreshold
+        modifierOnlyManager.onTap = { [weak self] in
+            guard let self else { return }
+            if self.onPressWithMode != nil {
+                self.onPressWithMode?(.overlayBuffer)
+            } else {
+                self.onPress?()
+            }
+        }
+        modifierOnlyManager.onHoldStart = { [weak self] in self?.onHoldStart?() }
+        modifierOnlyManager.onHoldRelease = { [weak self] in self?.onRelease?() }
+        modifierOnlyManager.start(modifier: modifier)
+        return .success
+    }
+
+    /// Registers a single global hotkey for the given shortcut (legacy path).
     /// Returns `.success` when registration succeeds (including when shortcut is nil).
     @discardableResult
     func register(shortcut: DictationShortcut?) -> RegistrationResult {
@@ -38,6 +79,131 @@ final class HotKeyManager {
         guard let shortcut else {
             return .success
         }
+
+        if !installHandlerIfNeeded() {
+            return .failure(.handlerInstallFailed)
+        }
+
+        hotKeyIDToMode.removeAll()
+
+        var ref: EventHotKeyRef?
+        let hotKeyID = EventHotKeyID(signature: Self.hotKeySignature, id: Self.overlayHotKeyID)
+        let registerStatus = RegisterEventHotKey(
+            shortcut.keyCode,
+            shortcut.carbonModifierFlags,
+            hotKeyID,
+            GetApplicationEventTarget(),
+            0,
+            &ref
+        )
+
+        if registerStatus != noErr {
+            unregister()
+            return .failure(.shortcutUnavailable)
+        }
+
+        if let ref {
+            hotKeyRefs[Self.overlayHotKeyID] = ref
+        }
+
+        return .success
+    }
+
+    /// Registers dual global hotkeys — one for overlay buffer mode, one for live auto-paste mode.
+    /// Either shortcut can be nil (disabled). Returns `.success` if at least one registers
+    /// successfully, or if both are nil. Returns `.failure` only if a non-nil shortcut fails to register.
+    @discardableResult
+    func registerDual(
+        overlay: DictationShortcut?,
+        livePaste: DictationShortcut?
+    ) -> RegistrationResult {
+        unregister()
+
+        guard overlay != nil || livePaste != nil else {
+            return .success
+        }
+
+        if !installHandlerIfNeeded() {
+            return .failure(.handlerInstallFailed)
+        }
+
+        hotKeyIDToMode.removeAll()
+
+        if let overlay {
+            var ref: EventHotKeyRef?
+            let hotKeyID = EventHotKeyID(signature: Self.hotKeySignature, id: Self.overlayHotKeyID)
+            let status = RegisterEventHotKey(
+                overlay.keyCode,
+                overlay.carbonModifierFlags,
+                hotKeyID,
+                GetApplicationEventTarget(),
+                0,
+                &ref
+            )
+            if status != noErr {
+                unregister()
+                return .failure(.shortcutUnavailable)
+            }
+            if let ref {
+                hotKeyRefs[Self.overlayHotKeyID] = ref
+                hotKeyIDToMode[Self.overlayHotKeyID] = .overlayBuffer
+            }
+        }
+
+        if let livePaste {
+            var ref: EventHotKeyRef?
+            let hotKeyID = EventHotKeyID(signature: Self.hotKeySignature, id: Self.livePasteHotKeyID)
+            let status = RegisterEventHotKey(
+                livePaste.keyCode,
+                livePaste.carbonModifierFlags,
+                hotKeyID,
+                GetApplicationEventTarget(),
+                0,
+                &ref
+            )
+            if status != noErr {
+                // Only fail if overlay also wasn't registered.
+                // If overlay succeeded, keep it and just skip live paste.
+                if hotKeyRefs.isEmpty {
+                    unregister()
+                    return .failure(.shortcutUnavailable)
+                }
+                // Overlay is registered — live paste failed. Still report as success
+                // so the app remains functional with the overlay shortcut.
+                return .success
+            }
+            if let ref {
+                hotKeyRefs[Self.livePasteHotKeyID] = ref
+                hotKeyIDToMode[Self.livePasteHotKeyID] = .liveAutoPaste
+            }
+        }
+
+        return .success
+    }
+
+    func unregister() {
+        if isUsingModifierOnly {
+            modifierOnlyManager.stop()
+            isUsingModifierOnly = false
+        }
+
+        for (_, ref) in hotKeyRefs {
+            UnregisterEventHotKey(ref)
+        }
+        hotKeyRefs.removeAll()
+        hotKeyIDToMode.removeAll()
+
+        if let hotKeyHandlerRef {
+            RemoveEventHandler(hotKeyHandlerRef)
+            self.hotKeyHandlerRef = nil
+        }
+    }
+
+    // MARK: - Private
+
+    /// Installs the Carbon event handler if not already installed. Returns true on success.
+    private func installHandlerIfNeeded() -> Bool {
+        guard hotKeyHandlerRef == nil else { return true }
 
         var eventTypes = [
             EventTypeSpec(
@@ -67,15 +233,15 @@ final class HotKeyManager {
                 )
 
                 guard status == noErr,
-                      hotKeyID.signature == HotKeyManager.hotKeySignature,
-                      hotKeyID.id == 1
+                      hotKeyID.signature == HotKeyManager.hotKeySignature
                 else {
                     return noErr
                 }
 
                 let eventKind = GetEventKind(eventRef)
+                let capturedID = hotKeyID.id
                 DispatchQueue.main.async {
-                    HotKeyManager.hotKeyTarget?.handleHotKeyEvent(kind: eventKind)
+                    HotKeyManager.hotKeyTarget?.handleHotKeyEvent(kind: eventKind, hotKeyID: capturedID)
                 }
 
                 return noErr
@@ -86,44 +252,18 @@ final class HotKeyManager {
             &hotKeyHandlerRef
         )
 
-        guard installStatus == noErr else {
-            return .failure(.handlerInstallFailed)
-        }
-
-        let hotKeyID = EventHotKeyID(signature: Self.hotKeySignature, id: 1)
-        let registerStatus = RegisterEventHotKey(
-            shortcut.keyCode,
-            shortcut.carbonModifierFlags,
-            hotKeyID,
-            GetApplicationEventTarget(),
-            0,
-            &hotKeyRef
-        )
-
-        if registerStatus != noErr {
-            unregister()
-            return .failure(.shortcutUnavailable)
-        }
-
-        return .success
+        return installStatus == noErr
     }
 
-    func unregister() {
-        if let hotKeyRef {
-            UnregisterEventHotKey(hotKeyRef)
-            self.hotKeyRef = nil
-        }
-
-        if let hotKeyHandlerRef {
-            RemoveEventHandler(hotKeyHandlerRef)
-            self.hotKeyHandlerRef = nil
-        }
-    }
-
-    private func handleHotKeyEvent(kind: UInt32) {
+    private func handleHotKeyEvent(kind: UInt32, hotKeyID: UInt32) {
         switch kind {
         case UInt32(kEventHotKeyPressed):
-            onPress?()
+            if let mode = hotKeyIDToMode[hotKeyID] {
+                onPressWithMode?(mode)
+            } else {
+                // Legacy single-shortcut path or fallback
+                onPress?()
+            }
         case UInt32(kEventHotKeyReleased):
             onRelease?()
         default:

--- a/Sources/localvoxtral/Log.swift
+++ b/Sources/localvoxtral/Log.swift
@@ -15,4 +15,6 @@ enum Log {
     static let polishing = Logger(subsystem: subsystem, category: "Polishing")
     static let persistence = Logger(subsystem: subsystem, category: "Persistence")
     static let config = Logger(subsystem: subsystem, category: "Config")
+    static let ducking = Logger(subsystem: subsystem, category: "Ducking")
+    static let voiceAssistant = Logger(subsystem: subsystem, category: "voice-assistant")
 }

--- a/Sources/localvoxtral/ModifierOnlyHotKeyManager.swift
+++ b/Sources/localvoxtral/ModifierOnlyHotKeyManager.swift
@@ -1,0 +1,196 @@
+import Carbon.HIToolbox
+import CoreGraphics
+import Foundation
+
+/// Captures modifier-only key presses (Fn/Globe, Right Command) using
+/// a CGEventTap on flagsChanged events. Differentiates tap (quick press+release)
+/// from hold (press beyond threshold) to support dual dictation modes.
+@MainActor
+final class ModifierOnlyHotKeyManager {
+    enum ModifierKey: String, CaseIterable, Identifiable, Codable {
+        case fn = "fn"
+        case rightCommand = "right_command"
+        case rightOption = "right_option"
+
+        var id: String { rawValue }
+
+        var displayName: String {
+            switch self {
+            case .fn: return "Fn / Globe"
+            case .rightCommand: return "Right Command"
+            case .rightOption: return "Right Option"
+            }
+        }
+    }
+
+    /// Fired when the modifier key is tapped (pressed and released before hold threshold).
+    var onTap: (() -> Void)?
+    /// Fired when the modifier key is held past the hold threshold.
+    var onHoldStart: (() -> Void)?
+    /// Fired when the modifier key is released after a hold.
+    var onHoldRelease: (() -> Void)?
+
+    /// Seconds the modifier must be held before it counts as a hold gesture.
+    var holdThresholdSeconds: Double = 0.35
+
+    private var eventTap: CFMachPort?
+    private var runLoopSource: CFRunLoopSource?
+
+    // nonisolated(unsafe) because these are accessed from the CGEventTap callback
+    // which runs on a different thread. Access is guarded by the sequential
+    // nature of the event tap (one event at a time).
+    nonisolated(unsafe) private static var _targetModifier: ModifierKey?
+    private nonisolated(unsafe) static var shared: ModifierOnlyHotKeyManager?
+    private nonisolated(unsafe) static var isModifierDown = false
+    private nonisolated(unsafe) static var wasInterruptedByKey = false
+    nonisolated(unsafe) static var _eventTap: CFMachPort?
+    private nonisolated(unsafe) static var isInHoldState = false
+    private nonisolated(unsafe) static var holdTimerWorkItem: DispatchWorkItem?
+    private nonisolated(unsafe) static var _holdThresholdSeconds: Double = 0.35
+
+    func start(modifier: ModifierKey) {
+        stop()
+        Self._targetModifier = modifier
+        Self.shared = self
+        Self.isModifierDown = false
+        Self.wasInterruptedByKey = false
+        Self.isInHoldState = false
+        Self._holdThresholdSeconds = holdThresholdSeconds
+
+        let eventMask: CGEventMask =
+            (1 << CGEventType.flagsChanged.rawValue) |
+            (1 << CGEventType.keyDown.rawValue)
+
+        guard let tap = CGEvent.tapCreate(
+            tap: .cgSessionEventTap,
+            place: .headInsertEventTap,
+            options: .listenOnly,
+            eventsOfInterest: eventMask,
+            callback: modifierEventCallback,
+            userInfo: nil
+        ) else {
+            return
+        }
+
+        eventTap = tap
+        Self._eventTap = tap
+        runLoopSource = CFMachPortCreateRunLoopSource(kCFAllocatorDefault, tap, 0)
+        if let source = runLoopSource {
+            CFRunLoopAddSource(CFRunLoopGetCurrent(), source, .commonModes)
+        }
+        CGEvent.tapEnable(tap: tap, enable: true)
+    }
+
+    func stop() {
+        Self.holdTimerWorkItem?.cancel()
+        Self.holdTimerWorkItem = nil
+        if let tap = eventTap {
+            CGEvent.tapEnable(tap: tap, enable: false)
+        }
+        if let source = runLoopSource {
+            CFRunLoopRemoveSource(CFRunLoopGetCurrent(), source, .commonModes)
+        }
+        eventTap = nil
+        Self._eventTap = nil
+        runLoopSource = nil
+        Self._targetModifier = nil
+        Self.shared = nil
+        Self.isModifierDown = false
+        Self.wasInterruptedByKey = false
+        Self.isInHoldState = false
+    }
+
+    // Called from the CGEventTap callback (not on main thread)
+    nonisolated static func handleEvent(_ proxy: CGEventTapProxy, _ type: CGEventType, _ event: CGEvent) {
+        // macOS disables listen-only taps after focus loss or timeout — re-enable
+        if type == .tapDisabledByTimeout || type == .tapDisabledByUserInput {
+            if let tap = _eventTap {
+                CGEvent.tapEnable(tap: tap, enable: true)
+            }
+            return
+        }
+
+        guard Self.shared != nil, let target = Self._targetModifier else { return }
+
+        if type == .keyDown {
+            // A non-modifier key was pressed while our modifier is held.
+            // This means it's being used AS a modifier, not tapped alone.
+            if isModifierDown {
+                wasInterruptedByKey = true
+                holdTimerWorkItem?.cancel()
+                holdTimerWorkItem = nil
+            }
+            return
+        }
+
+        guard type == .flagsChanged else { return }
+
+        let flags = event.flags
+        let keyCode = event.getIntegerValueField(.keyboardEventKeycode)
+
+        let isTargetDown: Bool
+        switch target {
+        case .fn:
+            isTargetDown = flags.contains(.maskSecondaryFn)
+        case .rightCommand:
+            // Right Command keycode is 54
+            isTargetDown = keyCode == 54 && flags.contains(.maskCommand)
+        case .rightOption:
+            // Right Option keycode is 61
+            isTargetDown = keyCode == 61 && flags.contains(.maskAlternate)
+        }
+
+        if isTargetDown && !isModifierDown {
+            // Modifier just pressed — start hold timer
+            isModifierDown = true
+            wasInterruptedByKey = false
+            isInHoldState = false
+
+            holdTimerWorkItem?.cancel()
+            let workItem = DispatchWorkItem {
+                guard Self.isModifierDown, !Self.wasInterruptedByKey else { return }
+                Self.isInHoldState = true
+                DispatchQueue.main.async {
+                    Self.shared?.onHoldStart?()
+                }
+            }
+            holdTimerWorkItem = workItem
+            DispatchQueue.main.asyncAfter(
+                deadline: .now() + _holdThresholdSeconds,
+                execute: workItem
+            )
+        } else if !isTargetDown && isModifierDown {
+            // Modifier just released
+            isModifierDown = false
+            holdTimerWorkItem?.cancel()
+            holdTimerWorkItem = nil
+
+            if wasInterruptedByKey {
+                // Used as a modifier combo — no gesture
+                wasInterruptedByKey = false
+            } else if isInHoldState {
+                // Was holding — fire hold release
+                isInHoldState = false
+                DispatchQueue.main.async {
+                    Self.shared?.onHoldRelease?()
+                }
+            } else {
+                // Released before threshold — tap
+                DispatchQueue.main.async {
+                    Self.shared?.onTap?()
+                }
+            }
+        }
+    }
+}
+
+// CGEventTap C callback — forwards to the static handler
+private func modifierEventCallback(
+    proxy: CGEventTapProxy,
+    type: CGEventType,
+    event: CGEvent,
+    userInfo: UnsafeMutableRawPointer?
+) -> Unmanaged<CGEvent>? {
+    ModifierOnlyHotKeyManager.handleEvent(proxy, type, event)
+    return Unmanaged.passRetained(event)
+}

--- a/Sources/localvoxtral/SettingsStore.swift
+++ b/Sources/localvoxtral/SettingsStore.swift
@@ -165,6 +165,22 @@ final class SettingsStore {
         static let llmPolishingAPIKey = "settings.llm_polishing_api_key"
         static let llmPolishingModel = "settings.llm_polishing_model"
         static let replacementDictionaryEnabled = "settings.replacement_dictionary_enabled"
+        static let audioDuckingEnabled = "settings.audio_ducking_enabled"
+        static let audioDuckingLevel = "settings.audio_ducking_level"
+        static let audioDuckingUseDDC = "settings.audio_ducking_use_ddc"
+        static let audioDuckingFadeInDuration = "settings.audio_ducking_fade_in_duration"
+        static let modifierOnlyHotKeyEnabled = "settings.modifier_only_hotkey_enabled"
+        static let modifierOnlyHotKeyModifier = "settings.modifier_only_hotkey_modifier"
+        static let modifierOnlyHoldDelay = "settings.modifier_only_hold_delay"
+        static let overlayLastX = "settings.overlay_last_x"
+        static let overlayLastY = "settings.overlay_last_y"
+        static let overlayPositionSaved = "settings.overlay_position_saved"
+        static let overlayBufferShortcutKeyCode = "settings.overlay_buffer_shortcut_key_code"
+        static let overlayBufferShortcutModifiers = "settings.overlay_buffer_shortcut_carbon_modifiers"
+        static let overlayBufferShortcutEnabled = "settings.overlay_buffer_shortcut_enabled"
+        static let livePasteShortcutKeyCode = "settings.live_paste_shortcut_key_code"
+        static let livePasteShortcutModifiers = "settings.live_paste_shortcut_carbon_modifiers"
+        static let livePasteShortcutEnabled = "settings.live_paste_shortcut_enabled"
     }
 
     private let defaults: UserDefaults
@@ -261,6 +277,90 @@ final class SettingsStore {
     var replacementDictionaryEnabled: Bool {
         didSet {
             defaults.set(replacementDictionaryEnabled, forKey: Keys.replacementDictionaryEnabled)
+        }
+    }
+
+    var audioDuckingEnabled: Bool {
+        didSet { defaults.set(audioDuckingEnabled, forKey: Keys.audioDuckingEnabled) }
+    }
+
+    /// The fraction of current volume to duck to (0.0 = mute, 1.0 = no change).
+    /// For example, 0.2 means duck to 20% of the current volume.
+    var audioDuckingLevel: Double {
+        didSet {
+            defaults.set(
+                min(max(audioDuckingLevel, 0.0), 1.0),
+                forKey: Keys.audioDuckingLevel)
+        }
+    }
+
+    /// When true, duck HDMI/DisplayPort monitor volume via BetterDisplay DDC
+    /// instead of falling back to pausing music apps.
+    var audioDuckingUseDDC: Bool {
+        didSet { defaults.set(audioDuckingUseDDC, forKey: Keys.audioDuckingUseDDC) }
+    }
+
+    /// Duration in seconds for the volume fade-in after dictation stops (0.3–5.0).
+    var audioDuckingFadeInDuration: Double {
+        didSet { defaults.set(audioDuckingFadeInDuration, forKey: Keys.audioDuckingFadeInDuration) }
+    }
+
+    var modifierOnlyHotKeyEnabled: Bool {
+        didSet { defaults.set(modifierOnlyHotKeyEnabled, forKey: Keys.modifierOnlyHotKeyEnabled) }
+    }
+
+    var modifierOnlyHotKeyModifier: ModifierOnlyHotKeyManager.ModifierKey {
+        didSet {
+            defaults.set(modifierOnlyHotKeyModifier.rawValue, forKey: Keys.modifierOnlyHotKeyModifier)
+        }
+    }
+
+    /// Seconds to hold modifier before it triggers live auto-paste (0.15–0.8).
+    var modifierOnlyHoldDelay: Double {
+        didSet { defaults.set(modifierOnlyHoldDelay, forKey: Keys.modifierOnlyHoldDelay) }
+    }
+
+    var overlayLastX: Double {
+        didSet { defaults.set(overlayLastX, forKey: Keys.overlayLastX) }
+    }
+
+    var overlayLastY: Double {
+        didSet { defaults.set(overlayLastY, forKey: Keys.overlayLastY) }
+    }
+
+    var overlayPositionSaved: Bool {
+        didSet { defaults.set(overlayPositionSaved, forKey: Keys.overlayPositionSaved) }
+    }
+
+    var overlayBufferShortcutEnabled: Bool {
+        didSet { defaults.set(overlayBufferShortcutEnabled, forKey: Keys.overlayBufferShortcutEnabled) }
+    }
+
+    private var overlayBufferShortcutKeyCode: UInt32 {
+        didSet { defaults.set(overlayBufferShortcutKeyCode, forKey: Keys.overlayBufferShortcutKeyCode) }
+    }
+
+    private var overlayBufferShortcutCarbonModifierFlags: UInt32 {
+        didSet {
+            defaults.set(
+                overlayBufferShortcutCarbonModifierFlags,
+                forKey: Keys.overlayBufferShortcutModifiers)
+        }
+    }
+
+    var livePasteShortcutEnabled: Bool {
+        didSet { defaults.set(livePasteShortcutEnabled, forKey: Keys.livePasteShortcutEnabled) }
+    }
+
+    private var livePasteShortcutKeyCode: UInt32 {
+        didSet { defaults.set(livePasteShortcutKeyCode, forKey: Keys.livePasteShortcutKeyCode) }
+    }
+
+    private var livePasteShortcutCarbonModifierFlags: UInt32 {
+        didSet {
+            defaults.set(
+                livePasteShortcutCarbonModifierFlags,
+                forKey: Keys.livePasteShortcutModifiers)
         }
     }
 
@@ -388,6 +488,101 @@ final class SettingsStore {
         )
         replacementDictionaryEnabled = Self.loadBool(
             defaults: defaults, key: Keys.replacementDictionaryEnabled, fallback: false)
+        audioDuckingEnabled = Self.loadBool(
+            defaults: defaults, key: Keys.audioDuckingEnabled, fallback: false)
+        let storedDuckingLevel = defaults.object(forKey: Keys.audioDuckingLevel) != nil
+            ? defaults.double(forKey: Keys.audioDuckingLevel)
+            : 0.2
+        audioDuckingLevel = min(max(storedDuckingLevel, 0.0), 1.0)
+        audioDuckingUseDDC = Self.loadBool(
+            defaults: defaults, key: Keys.audioDuckingUseDDC, fallback: true)
+        let storedFadeIn = defaults.object(forKey: Keys.audioDuckingFadeInDuration) != nil
+            ? defaults.double(forKey: Keys.audioDuckingFadeInDuration)
+            : 1.5
+        audioDuckingFadeInDuration = min(max(storedFadeIn, 0.3), 5.0)
+        modifierOnlyHotKeyEnabled = Self.loadBool(
+            defaults: defaults, key: Keys.modifierOnlyHotKeyEnabled, fallback: false)
+        if let storedModifier = defaults.string(forKey: Keys.modifierOnlyHotKeyModifier),
+           let parsed = ModifierOnlyHotKeyManager.ModifierKey(rawValue: storedModifier)
+        {
+            modifierOnlyHotKeyModifier = parsed
+        } else {
+            modifierOnlyHotKeyModifier = .fn
+        }
+        let storedHoldDelay = defaults.object(forKey: Keys.modifierOnlyHoldDelay) != nil
+            ? defaults.double(forKey: Keys.modifierOnlyHoldDelay)
+            : 0.35
+        modifierOnlyHoldDelay = min(max(storedHoldDelay, 0.15), 0.8)
+        overlayLastX = defaults.double(forKey: Keys.overlayLastX)
+        overlayLastY = defaults.double(forKey: Keys.overlayLastY)
+        overlayPositionSaved = Self.loadBool(
+            defaults: defaults, key: Keys.overlayPositionSaved, fallback: false)
+
+        // --- Dual shortcut keys ---
+
+        // Check if overlay buffer shortcut keys already exist
+        let hasExistingOverlayKeys = defaults.object(forKey: Keys.overlayBufferShortcutKeyCode) != nil
+        var needsOverlayMigrationPersist = false
+
+        if hasExistingOverlayKeys {
+            // Load existing overlay buffer shortcut
+            let obKeyCode = (defaults.object(forKey: Keys.overlayBufferShortcutKeyCode) as? NSNumber)?
+                .uint32Value ?? 0
+            let obModifiers = (defaults.object(forKey: Keys.overlayBufferShortcutModifiers) as? NSNumber)?
+                .uint32Value ?? 0
+            let obCandidate = DictationShortcut(keyCode: obKeyCode, carbonModifierFlags: obModifiers).normalized
+            if DictationShortcutValidation.persistenceErrorMessage(for: obCandidate) == nil {
+                overlayBufferShortcutKeyCode = obCandidate.keyCode
+                overlayBufferShortcutCarbonModifierFlags = obCandidate.carbonModifierFlags
+            } else {
+                overlayBufferShortcutKeyCode = 0
+                overlayBufferShortcutCarbonModifierFlags = 0
+            }
+            overlayBufferShortcutEnabled = Self.loadBool(
+                defaults: defaults, key: Keys.overlayBufferShortcutEnabled, fallback: true)
+        } else if storedKeyCode != nil, storedModifierFlags != nil {
+            // Migration: copy legacy shortcut → overlay buffer shortcut
+            overlayBufferShortcutKeyCode = resolvedShortcut.keyCode
+            overlayBufferShortcutCarbonModifierFlags = resolvedShortcut.carbonModifierFlags
+            overlayBufferShortcutEnabled = Self.loadBool(
+                defaults: defaults, key: Keys.dictationShortcutEnabled, fallback: true)
+            needsOverlayMigrationPersist = true
+        } else {
+            // Fresh install — use default shortcut for overlay
+            overlayBufferShortcutKeyCode = Self.defaultDictationShortcut.keyCode
+            overlayBufferShortcutCarbonModifierFlags = Self.defaultDictationShortcut.carbonModifierFlags
+            overlayBufferShortcutEnabled = true
+        }
+
+        // Live paste shortcut — defaults to disabled/nil
+        let hasExistingLivePasteKeys = defaults.object(forKey: Keys.livePasteShortcutKeyCode) != nil
+        if hasExistingLivePasteKeys {
+            let lpKeyCode = (defaults.object(forKey: Keys.livePasteShortcutKeyCode) as? NSNumber)?
+                .uint32Value ?? 0
+            let lpModifiers = (defaults.object(forKey: Keys.livePasteShortcutModifiers) as? NSNumber)?
+                .uint32Value ?? 0
+            let lpCandidate = DictationShortcut(keyCode: lpKeyCode, carbonModifierFlags: lpModifiers).normalized
+            if DictationShortcutValidation.persistenceErrorMessage(for: lpCandidate) == nil {
+                livePasteShortcutKeyCode = lpCandidate.keyCode
+                livePasteShortcutCarbonModifierFlags = lpCandidate.carbonModifierFlags
+            } else {
+                livePasteShortcutKeyCode = 0
+                livePasteShortcutCarbonModifierFlags = 0
+            }
+            livePasteShortcutEnabled = Self.loadBool(
+                defaults: defaults, key: Keys.livePasteShortcutEnabled, fallback: false)
+        } else {
+            livePasteShortcutKeyCode = 0
+            livePasteShortcutCarbonModifierFlags = 0
+            livePasteShortcutEnabled = false
+        }
+
+        // Persist migrated overlay values after all stored properties are initialized
+        if needsOverlayMigrationPersist {
+            defaults.set(overlayBufferShortcutKeyCode, forKey: Keys.overlayBufferShortcutKeyCode)
+            defaults.set(overlayBufferShortcutCarbonModifierFlags, forKey: Keys.overlayBufferShortcutModifiers)
+            defaults.set(overlayBufferShortcutEnabled, forKey: Keys.overlayBufferShortcutEnabled)
+        }
     }
 
     // MARK: - Init Helpers
@@ -483,6 +678,71 @@ final class SettingsStore {
 
     func resetDictationShortcutToDefault() {
         setDictationShortcut(Self.defaultDictationShortcut)
+    }
+
+    // MARK: - Dual Shortcuts (per output mode)
+
+    var overlayBufferShortcut: DictationShortcut? {
+        guard overlayBufferShortcutEnabled else { return nil }
+
+        let candidate = DictationShortcut(
+            keyCode: overlayBufferShortcutKeyCode,
+            carbonModifierFlags: overlayBufferShortcutCarbonModifierFlags
+        ).normalized
+
+        if DictationShortcutValidation.persistenceErrorMessage(for: candidate) != nil {
+            return nil
+        }
+
+        return candidate
+    }
+
+    var livePasteShortcut: DictationShortcut? {
+        guard livePasteShortcutEnabled else { return nil }
+
+        let candidate = DictationShortcut(
+            keyCode: livePasteShortcutKeyCode,
+            carbonModifierFlags: livePasteShortcutCarbonModifierFlags
+        ).normalized
+
+        if DictationShortcutValidation.persistenceErrorMessage(for: candidate) != nil {
+            return nil
+        }
+
+        return candidate
+    }
+
+    func setOverlayBufferShortcut(_ shortcut: DictationShortcut?) {
+        guard let shortcut else {
+            overlayBufferShortcutEnabled = false
+            return
+        }
+
+        let normalizedShortcut = shortcut.normalized
+        if DictationShortcutValidation.persistenceErrorMessage(for: normalizedShortcut) == nil {
+            overlayBufferShortcutKeyCode = normalizedShortcut.keyCode
+            overlayBufferShortcutCarbonModifierFlags = normalizedShortcut.carbonModifierFlags
+        } else {
+            overlayBufferShortcutKeyCode = Self.defaultDictationShortcut.keyCode
+            overlayBufferShortcutCarbonModifierFlags = Self.defaultDictationShortcut.carbonModifierFlags
+        }
+        overlayBufferShortcutEnabled = true
+    }
+
+    func setLivePasteShortcut(_ shortcut: DictationShortcut?) {
+        guard let shortcut else {
+            livePasteShortcutEnabled = false
+            return
+        }
+
+        let normalizedShortcut = shortcut.normalized
+        if DictationShortcutValidation.persistenceErrorMessage(for: normalizedShortcut) == nil {
+            livePasteShortcutKeyCode = normalizedShortcut.keyCode
+            livePasteShortcutCarbonModifierFlags = normalizedShortcut.carbonModifierFlags
+        } else {
+            return
+        }
+        livePasteShortcutEnabled = true
     }
 
     func modelName(for provider: RealtimeProvider) -> String {

--- a/Sources/localvoxtral/SettingsView.swift
+++ b/Sources/localvoxtral/SettingsView.swift
@@ -62,6 +62,24 @@ struct SettingsView: View {
         )
     }
 
+    private var overlayBufferShortcutBinding: Binding<DictationShortcut?> {
+        Binding(
+            get: { settings.overlayBufferShortcut },
+            set: { newValue in
+                viewModel.updateOverlayBufferShortcut(newValue)
+            }
+        )
+    }
+
+    private var livePasteShortcutBinding: Binding<DictationShortcut?> {
+        Binding(
+            get: { settings.livePasteShortcut },
+            set: { newValue in
+                viewModel.updateLivePasteShortcut(newValue)
+            }
+        )
+    }
+
     var body: some View {
         TabView {
             ConnectionSettingsPane(
@@ -79,6 +97,8 @@ struct SettingsView: View {
                 settings: settings,
                 viewModel: viewModel,
                 dictationShortcutBinding: dictationShortcutBinding,
+                overlayBufferShortcutBinding: overlayBufferShortcutBinding,
+                livePasteShortcutBinding: livePasteShortcutBinding,
                 shortcutValidationError: $shortcutValidationError
             )
             .tabItem {
@@ -197,7 +217,11 @@ private struct DictationSettingsPane: View {
     @Bindable var settings: SettingsStore
     let viewModel: DictationViewModel
     let dictationShortcutBinding: Binding<DictationShortcut?>
+    let overlayBufferShortcutBinding: Binding<DictationShortcut?>
+    let livePasteShortcutBinding: Binding<DictationShortcut?>
     @Binding var shortcutValidationError: String?
+    @State private var overlayValidationError: String?
+    @State private var livePasteValidationError: String?
 
     var body: some View {
         SettingsPage {
@@ -235,37 +259,158 @@ private struct DictationSettingsPane: View {
                     subtitle: "Copy the finalized segment to the clipboard after dictation stops.",
                     isOn: $settings.autoCopyEnabled
                 )
+
+                ToggleSettingRow(
+                    title: "Audio ducking",
+                    subtitle: "Fade system volume down when dictation starts, restore when it stops.",
+                    isOn: $settings.audioDuckingEnabled
+                )
+
+                if settings.audioDuckingEnabled {
+                    SettingsFieldRow(title: "Duck to level") {
+                        VStack(alignment: .leading, spacing: 6) {
+                            HStack(alignment: .firstTextBaseline, spacing: 12) {
+                                Slider(
+                                    value: $settings.audioDuckingLevel,
+                                    in: 0.0...0.5,
+                                    step: 0.05
+                                )
+                                Text("\(Int(settings.audioDuckingLevel * 100))%")
+                                    .font(.callout.monospacedDigit())
+                                    .foregroundStyle(.secondary)
+                                    .frame(width: 48, alignment: .trailing)
+                            }
+
+                            SettingsHelpText(
+                                "Percentage of current volume to duck to. 0% = mute, 20% = quiet background."
+                            )
+                        }
+                    }
+
+                    SettingsFieldRow(title: "Fade-in duration") {
+                        HStack(spacing: 8) {
+                            Slider(
+                                value: $settings.audioDuckingFadeInDuration,
+                                in: 0.3...5.0,
+                                step: 0.1
+                            )
+                            Text(String(format: "%.1fs", settings.audioDuckingFadeInDuration))
+                                .font(.system(size: 11, design: .monospaced))
+                                .foregroundStyle(.secondary)
+                                .frame(width: 36, alignment: .trailing)
+                        }
+                    }
+                }
             }
 
             SettingsGroup(title: "Shortcut") {
-                SettingsFieldRow(title: "Dictation shortcut") {
-                    HStack(alignment: .center, spacing: 8) {
-                        ShortcutRecorderField(
-                            shortcut: dictationShortcutBinding,
-                            validationError: $shortcutValidationError,
-                            fixedWidth: 132
-                        )
-                        .frame(height: 24, alignment: .leading)
-
-                        Button("Reset to Default") {
-                            shortcutValidationError = nil
-                            viewModel.updateDictationShortcut(
-                                SettingsStore.defaultDictationShortcut)
+                ToggleSettingRow(
+                    title: "Single modifier key",
+                    subtitle: "Tap for overlay buffer, hold for live auto-paste.",
+                    isOn: Binding(
+                        get: { settings.modifierOnlyHotKeyEnabled },
+                        set: { newValue in
+                            settings.modifierOnlyHotKeyEnabled = newValue
+                            viewModel.applyHotKeySettingsChange()
                         }
-                        .disabled(
-                            settings.dictationShortcut == SettingsStore.defaultDictationShortcut)
-                    }
-                }
-
-                if let shortcutValidationError {
-                    SettingsMessageRow(shortcutValidationError, color: .red)
-                }
-
-                if settings.dictationShortcut == nil {
-                    SettingsMessageRow(
-                        "Global dictation shortcut is currently disabled.",
-                        color: .secondary
                     )
+                )
+
+                if settings.modifierOnlyHotKeyEnabled {
+                    SettingsFieldRow(title: "Modifier key") {
+                        Picker("", selection: Binding(
+                            get: { settings.modifierOnlyHotKeyModifier },
+                            set: { newValue in
+                                settings.modifierOnlyHotKeyModifier = newValue
+                                viewModel.applyHotKeySettingsChange()
+                            }
+                        )) {
+                            ForEach(ModifierOnlyHotKeyManager.ModifierKey.allCases) { key in
+                                Text(key.displayName).tag(key)
+                            }
+                        }
+                        .pickerStyle(.segmented)
+                        .labelsHidden()
+                    }
+
+                    SettingsFieldRow(title: "Hold delay") {
+                        HStack(spacing: 8) {
+                            Slider(
+                                value: Binding(
+                                    get: { settings.modifierOnlyHoldDelay },
+                                    set: { newValue in
+                                        settings.modifierOnlyHoldDelay = newValue
+                                        viewModel.applyHotKeySettingsChange()
+                                    }
+                                ),
+                                in: 0.15...0.8,
+                                step: 0.05
+                            )
+                            Text("\(Int(settings.modifierOnlyHoldDelay * 1000))ms")
+                                .font(.system(size: 11, design: .monospaced))
+                                .foregroundStyle(.secondary)
+                                .frame(width: 44, alignment: .trailing)
+                        }
+                    }
+                } else {
+                    SettingsFieldRow(title: "Overlay Buffer") {
+                        HStack(alignment: .center, spacing: 8) {
+                            ShortcutRecorderField(
+                                shortcut: overlayBufferShortcutBinding,
+                                validationError: $overlayValidationError,
+                                fixedWidth: 132
+                            )
+                            .frame(height: 24, alignment: .leading)
+
+                            Button("Reset") {
+                                overlayValidationError = nil
+                                viewModel.updateOverlayBufferShortcut(
+                                    SettingsStore.defaultDictationShortcut)
+                            }
+                            .disabled(
+                                settings.overlayBufferShortcut == SettingsStore.defaultDictationShortcut)
+                        }
+                    }
+
+                    if let overlayValidationError {
+                        SettingsMessageRow(overlayValidationError, color: .red)
+                    }
+
+                    if settings.overlayBufferShortcut == nil {
+                        SettingsMessageRow(
+                            "Overlay Buffer shortcut is currently disabled.",
+                            color: .secondary
+                        )
+                    }
+
+                    SettingsFieldRow(title: "Live Auto-Paste") {
+                        HStack(alignment: .center, spacing: 8) {
+                            ShortcutRecorderField(
+                                shortcut: livePasteShortcutBinding,
+                                validationError: $livePasteValidationError,
+                                fixedWidth: 132
+                            )
+                            .frame(height: 24, alignment: .leading)
+
+                            if settings.livePasteShortcut != nil {
+                                Button("Clear") {
+                                    livePasteValidationError = nil
+                                    viewModel.updateLivePasteShortcut(nil)
+                                }
+                            }
+                        }
+                    }
+
+                    if let livePasteValidationError {
+                        SettingsMessageRow(livePasteValidationError, color: .red)
+                    }
+
+                    if settings.livePasteShortcut == nil {
+                        SettingsMessageRow(
+                            "Live Auto-Paste shortcut is not set. Record one above to enable.",
+                            color: .secondary
+                        )
+                    }
                 }
             }
         }


### PR DESCRIPTION
Hey! I use localvoxtral with HDMI audio on a Mac Mini, so ducking goes through the DDC/BetterDisplay path. The instant volume restore after a long dictation session was pretty jarring (especially with headphones), so I added a gradual fade-in.

**Note:** This PR builds on #17 (tap-vs-hold gesture) because the DictationViewModel changes overlap. Can be reviewed independently but merges cleaner after #17.

## What it does

- **DDC fade-in**: Restores monitor volume gradually via BetterDisplay CLI in 15 steps (instead of instant)
- **CoreAudio fade-in**: Same gradual restore for headphones/built-in speakers via GCD loop
- **Fade duration setting**: Configurable 0.3–5.0s in Settings (default 1.5s)
- **Fade cancellation**: Generation counter cancels stale fades when new duck/unduck starts mid-fade
- **Volume drift prevention**: Duck target calculated from stored original volume, not mid-fade level. Rapid start/stop cycles no longer erode the base volume.

## How it works

- `AudioDuckingService` stores `_ddcOriginalVolume` / `_originalVolume` on first duck, clears only on fade completion
- `_fadeGeneration` counter incremented on every duck/unduck — fade loops bail if their generation is stale
- `duckViaDDC` uses `baseVolume = _ddcOriginalVolume ?? currentVolume` so mid-fade re-ducks still target the true original

## Test plan

- [ ] Dictate → stop → volume fades back gradually (not instant)
- [ ] Adjust fade-in slider in Settings → duration changes
- [ ] Rapid start/stop 5x → volume returns to original (no drift)
- [ ] Start new dictation while fade-in is running → fade cancels, volume ducks immediately
---

**Full disclosure:** I designed these features and found the bugs through daily use, but the code itself was written with Claude Code (AI pair programming). I'm not a software developer — more of a designer/thinker who vibe-codes. If the code quality isn't up to your standards or doesn't match your patterns, totally happy to iterate or just take it as inspiration.\n\n🤖 Generated with [Claude Code](https://claude.com/claude-code)