### PR TITLE
build: use identity certificate for persistent Accessibility permission

### DIFF
--- a/scripts/package_app.sh
+++ b/scripts/package_app.sh
@@ -202,10 +202,14 @@ PLIST
 chmod -R u+w "$APP_DIR"
 xattr -cr "$APP_DIR"
 
-# Ad-hoc sign the packaged app so Gatekeeper can evaluate a usable signature.
-# This does not replace Developer ID signing/notarization, but it avoids the
-# "no usable signature" path that breaks first-run open flows.
-if ! codesign --force --deep --sign - "$APP_DIR"; then
+# Sign with persistent identity so Accessibility permission survives rebuilds.
+# Falls back to ad-hoc signing if the localvoxtral-dev cert is not installed.
+SIGN_IDENTITY="localvoxtral-dev"
+if ! security find-identity -p codesigning -v 2>/dev/null | grep -q "$SIGN_IDENTITY"; then
+  echo "Warning: Certificate '$SIGN_IDENTITY' not found — using ad-hoc signing (AX permission will reset)"
+  SIGN_IDENTITY="-"
+fi
+if ! codesign --force --deep --sign "$SIGN_IDENTITY" "$APP_DIR"; then
   echo "Failed to code-sign packaged app bundle."
   exit 1
 fi


### PR DESCRIPTION
Hey! Small build script improvement. During development, every rebuild changes the ad-hoc code signature, which makes macOS remove the app from the Accessibility trusted list. You have to manually re-add it every single time — pretty annoying when iterating fast.

## What it does

The build script now looks for a self-signed certificate called `localvoxtral-dev` in Keychain. If found, it signs with that identity instead of ad-hoc. Same identity = same code signature requirement = macOS keeps the Accessibility permission across rebuilds.

Falls back to ad-hoc signing if the cert isn't installed (no breaking change).

## Setup (one-time)

If you want to use this, create the cert once:

\`\`\`bash
# Generate cert
openssl req -x509 -newkey rsa:2048 -nodes \
  -keyout /tmp/lv.key -out /tmp/lv.crt -days 3650 \
  -subj "/CN=localvoxtral-dev" \
  -addext "keyUsage=digitalSignature" \
  -addext "extendedKeyUsage=codeSigning"

# Import to Keychain
openssl pkcs12 -export -out /tmp/lv.p12 -inkey /tmp/lv.key -in /tmp/lv.crt -passout pass:tmp -legacy
security import /tmp/lv.p12 -k ~/Library/Keychains/login.keychain-db -P tmp -T /usr/bin/codesign
security add-trusted-cert -d -r trustRoot -p codeSign -k ~/Library/Keychains/login.keychain-db /tmp/lv.crt
rm /tmp/lv.key /tmp/lv.crt /tmp/lv.p12
\`\`\`

Or skip it entirely — the script falls back to ad-hoc signing automatically.

## Test plan

- [ ] Build without cert installed → ad-hoc signing (same as before)
- [ ] Install cert, build → signed with localvoxtral-dev identity
- [ ] Rebuild after granting AX → permission persists
---

**Full disclosure:** I designed these features and found the bugs through daily use, but the code itself was written with Claude Code (AI pair programming). I'm not a software developer — more of a designer/thinker who vibe-codes. If the code quality isn't up to your standards or doesn't match your patterns, totally happy to iterate or just take it as inspiration.\n\n🤖 Generated with [Claude Code](https://claude.com/claude-code)