### PR TITLE
Fix default realtimeAPI endpoint port from 8080 to 8000

### DIFF
--- a/Sources/localvoxtral/SettingsStore.swift
+++ b/Sources/localvoxtral/SettingsStore.swift
@@ -126,7 +126,7 @@ final class SettingsStore {
         var defaultEndpoint: String {
             switch self {
             case .realtimeAPI:
-                return "ws://127.0.0.1:8080/v1/realtime"
+                return "ws://127.0.0.1:8000/v1/realtime"
             case .mlxAudio:
                 return "ws://127.0.0.1:8000/v1/audio/transcriptions/realtime"
             }


### PR DESCRIPTION
## Summary
- The `realtimeAPI` backend's default endpoint used port 8080, but both voxmlx and vLLM serve on port 8000 by default per the README instructions.
- Changed the default from `ws://127.0.0.1:8080/v1/realtime` to `ws://127.0.0.1:8000/v1/realtime`.

## Test plan
- [ ] Verify the Settings UI shows port 8000 for a fresh realtimeAPI backend selection
- [ ] Confirm connection works against a voxmlx or vLLM server on the default port

🤖 Generated with [Claude Code](https://claude.com/claude-code)