### PR TITLE
Match local defaults to backend serving ports

### DIFF
--- a/Sources/localvoxtral/SettingsStore.swift
+++ b/Sources/localvoxtral/SettingsStore.swift
@@ -126,7 +126,7 @@ final class SettingsStore {
         var defaultEndpoint: String {
             switch self {
             case .realtimeAPI:
-                return "ws://127.0.0.1:8080/v1/realtime"
+                return "ws://127.0.0.1:8000/v1/realtime"
             case .mlxAudio:
                 return "ws://127.0.0.1:8000/v1/audio/transcriptions/realtime"
             }
@@ -373,7 +373,7 @@ final class SettingsStore {
         llmPolishingEndpointURL = Self.loadString(
             defaults: defaults, key: Keys.llmPolishingEndpointURL,
             envKey: "LLM_POLISHING_ENDPOINT",
-            fallback: "http://127.0.0.1:8000/v1/chat/completions",
+            fallback: "http://127.0.0.1:8080/v1/chat/completions",
             environment: environment
         )
         llmPolishingAPIKey = Self.loadString(

--- a/Sources/localvoxtral/SettingsView.swift
+++ b/Sources/localvoxtral/SettingsView.swift
@@ -324,7 +324,7 @@ private struct TextProcessingSettingsPane: View {
                 if settings.llmPolishingEnabled {
                     SettingsFieldRow(title: "Endpoint") {
                         TextField(
-                            "http://127.0.0.1:8000/v1/chat/completions",
+                            "http://127.0.0.1:8080/v1/chat/completions",
                             text: $settings.llmPolishingEndpointURL
                         )
                         .textFieldStyle(.roundedBorder)

--- a/Tests/localvoxtralTests/SettingsStoreTests.swift
+++ b/Tests/localvoxtralTests/SettingsStoreTests.swift
@@ -143,6 +143,17 @@ final class SettingsStoreTests: XCTestCase {
         )
     }
 
+    func testRealtimeProviderDefaultEndpointsMatchToolDefaults() {
+        XCTAssertEqual(
+            SettingsStore.RealtimeProvider.realtimeAPI.defaultEndpoint,
+            "ws://127.0.0.1:8000/v1/realtime"
+        )
+        XCTAssertEqual(
+            SettingsStore.RealtimeProvider.mlxAudio.defaultEndpoint,
+            "ws://127.0.0.1:8000/v1/audio/transcriptions/realtime"
+        )
+    }
+
     // MARK: - dictationOutputMode
 
     func testDictationOutputMode_defaultsToOverlayBuffer() {
@@ -285,6 +296,12 @@ final class SettingsStoreTests: XCTestCase {
         )
         XCTAssertEqual(configuration?.apiKey, "sk-test")
         XCTAssertEqual(configuration?.model, "gpt-4o-mini")
+    }
+
+    func testLLMPolishingEndpointDefaultsToMLXLMPort() {
+        let store = makeStore()
+
+        XCTAssertEqual(store.llmPolishingEndpointURL, "http://127.0.0.1:8080/v1/chat/completions")
     }
 
     // MARK: - replacementDictionaryEnabled


### PR DESCRIPTION
## Summary
- change the default realtime API endpoint to port 8000 to match vLLM and voxmlx defaults
- change the default LLM polishing endpoint and settings placeholder to port 8080 to match mlx-lm and avoid colliding with realtime serving
- add settings tests that lock the default endpoint values

## Testing
- Not run locally: the current worktree contains unrelated in-progress files that break package compilation before tests start (`SettingsScreenshotGenerator.swift` references `SettingsView.Tab`).
