### PR TITLE
ci: add PR CI and remote-build inner loop

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,71 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
+jobs:
+  build-test:
+    # Same-repo branches run on the self-hosted Mac (persistent workspace, warm
+    # incremental builds). Fork PRs run on GitHub-hosted macOS so untrusted code
+    # never executes on the build machine.
+    runs-on: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && fromJSON('["self-hosted", "macOS", "ARM64"]') || 'macos-latest' }}
+    timeout-minutes: 30
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Swift
+        if: runner.environment == 'github-hosted'
+        uses: swift-actions/setup-swift@v2
+        with:
+          swift-version: "6.2"
+
+      - name: Cache SwiftPM build
+        if: runner.environment == 'github-hosted'
+        uses: actions/cache@v4
+        with:
+          path: .build
+          key: swiftpm-${{ runner.os }}-${{ hashFiles('Package.resolved') }}
+          restore-keys: swiftpm-${{ runner.os }}-
+
+      - name: Build
+        run: swift build
+
+      - name: Test (unit suite)
+        # The two integration suites need a live inference backend and are
+        # exercised manually; see CLAUDE.md.
+        run: |
+          swift test \
+            --skip RealtimeAPIVLLMIntegrationTests \
+            --skip MlxAudioTranscriptionIntegrationTests
+
+      - name: Package app bundle
+        run: ./scripts/package_app.sh release
+
+      - name: Smoke test packaged app launch
+        run: |
+          python3 - <<'PY'
+          import subprocess
+          import time
+
+          app_binary = "dist/localvoxtral.app/Contents/MacOS/localvoxtral"
+          process = subprocess.Popen([app_binary])
+          time.sleep(2)
+
+          exit_code = process.poll()
+          if exit_code is not None:
+            raise SystemExit(f"packaged app exited during smoke test: {exit_code}")
+
+          process.terminate()
+          try:
+            process.wait(timeout=5)
+          except subprocess.TimeoutExpired:
+            process.kill()
+            process.wait(timeout=5)
+          PY

--- a/scripts/remote-build.sh
+++ b/scripts/remote-build.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Build/test this repo on the Mac build host. The app targets macOS, so on a
+# non-Mac dev box this is the compile/test inner loop: it rsyncs the working
+# tree (no commit needed) and runs the toolchain remotely over SSH.
+#
+# Usage:
+#   ./scripts/remote-build.sh [build|test|package|exec] [extra args...]
+#     build    swift build
+#     test     swift build + unit tests (default; skips live-backend suites)
+#     package  ./scripts/package_app.sh release
+#     exec     run the extra args verbatim in the remote work dir
+#
+# Examples:
+#   ./scripts/remote-build.sh
+#   ./scripts/remote-build.sh test --filter TextMergingAlgorithmsTests
+#   ./scripts/remote-build.sh exec swift test --list-tests
+#
+# Environment overrides:
+#   LV_BUILD_HOST  ssh destination            (default: tom@192.168.1.167)
+#   LV_BUILD_DIR   remote work dir, ~-relative (default: work/localvoxtral-remote)
+
+HOST="${LV_BUILD_HOST:-tom@192.168.1.167}"
+DIR="${LV_BUILD_DIR:-work/localvoxtral-remote}"
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+CMD="${1:-test}"
+if [[ $# -gt 0 ]]; then shift; fi
+
+UNIT_TEST_SKIPS=(--skip RealtimeAPIVLLMIntegrationTests --skip MlxAudioTranscriptionIntegrationTests)
+
+case "$CMD" in
+  build)   REMOTE_CMD=(swift build "$@") ;;
+  test)    REMOTE_CMD=(swift test "${UNIT_TEST_SKIPS[@]}" "$@") ;;
+  package) REMOTE_CMD=(./scripts/package_app.sh release "$@") ;;
+  exec)
+    if [[ $# -eq 0 ]]; then
+      echo "exec requires a command, e.g.: $0 exec swift test --list-tests" >&2
+      exit 1
+    fi
+    REMOTE_CMD=("$@")
+    ;;
+  *)
+    echo "Usage: $0 [build|test|package|exec] [extra args...]" >&2
+    exit 1
+    ;;
+esac
+
+echo "==> Syncing working tree to $HOST:$DIR"
+ssh "$HOST" "mkdir -p $(printf '%q' "$DIR")"
+# .build/ and dist/ are excluded from deletion too, so the remote incremental
+# build state survives between runs.
+rsync -az --delete \
+  --exclude '.git/' --exclude '.build/' --exclude 'dist/' \
+  "$ROOT_DIR/" "$HOST:$DIR/"
+
+echo "==> Running on $HOST: ${REMOTE_CMD[*]}"
+ssh "$HOST" "cd $(printf '%q' "$DIR") && $(printf '%q ' "${REMOTE_CMD[@]}")"


### PR DESCRIPTION
## What

- **`.github/workflows/ci.yml`** — the missing PR gate: build + unit tests + app packaging + launch smoke test on every PR and push to main.
  - Same-repo branches run on the self-hosted Mac runner (`self-hosted, macOS, ARM64`) with a persistent workspace for warm incremental builds.
  - **Fork PRs run on GitHub-hosted `macos-latest`** so untrusted code never executes on the self-hosted machine.
  - The two live-backend integration suites (`RealtimeAPIVLLMIntegrationTests`, `MlxAudioTranscriptionIntegrationTests`) are skipped; they remain manual.
- **`scripts/remote-build.sh`** — rsync the working tree to the Mac build host over SSH and build/test there; the compile inner loop for non-Mac dev boxes (no commit needed).

## Verification

- `remote-build.sh test` run end-to-end from a Linux box: 208 unit tests, 0 failures.
- This PR itself is the first live run of `ci.yml` on the self-hosted runner.