### PR TITLE
fix: remove wall-clock dependence from overlay hold-before-dismiss timing tests

### DIFF
--- a/Sources/localvoxtral/OverlayBufferSessionCoordinator.swift
+++ b/Sources/localvoxtral/OverlayBufferSessionCoordinator.swift
@@ -48,9 +48,15 @@ protocol OverlayBufferSessionCoordinating: AnyObject {
 
 @MainActor
 final class OverlayBufferSessionCoordinator: OverlayBufferSessionCoordinating {
+    typealias DateProvider = () -> Date
+    typealias SleepClosure = (Duration) async -> Void
+
     private var stateMachine: OverlayBufferStateMachine
     private let renderer: OverlayBufferRendering
     private let anchorResolver: OverlayAnchorResolving
+    // Injected time source so hold-before-dismiss timing is testable without wall-clock sleeps.
+    private let now: DateProvider
+    private let sleepFor: SleepClosure
 
     private var commitBufferText = ""
     private var liveCommitTargetAppPID: pid_t?
@@ -62,11 +68,17 @@ final class OverlayBufferSessionCoordinator: OverlayBufferSessionCoordinating {
     init(
         stateMachine: OverlayBufferStateMachine,
         renderer: OverlayBufferRendering,
-        anchorResolver: OverlayAnchorResolving
+        anchorResolver: OverlayAnchorResolving,
+        now: @escaping DateProvider = Date.init,
+        sleepFor: @escaping SleepClosure = { duration in
+            try? await Task.sleep(for: duration)
+        }
     ) {
         self.stateMachine = stateMachine
         self.renderer = renderer
         self.anchorResolver = anchorResolver
+        self.now = now
+        self.sleepFor = sleepFor
     }
 
     func resolveAnchorNow() -> OverlayAnchor {
@@ -180,7 +192,7 @@ final class OverlayBufferSessionCoordinator: OverlayBufferSessionCoordinating {
 
         let holdRemaining: TimeInterval
         if let lastUpdate = lastOverlayDisplayTextChangeAt {
-            let elapsed = Date().timeIntervalSince(lastUpdate)
+            let elapsed = now().timeIntervalSince(lastUpdate)
             holdRemaining = max(0, minimumVisibility - elapsed)
         } else {
             holdRemaining = 0
@@ -193,8 +205,9 @@ final class OverlayBufferSessionCoordinator: OverlayBufferSessionCoordinating {
 
         Log.overlay.info("holding overlay \(String(format: "%.2f", holdRemaining))s before dismiss")
         dismissTask = Task { @MainActor [weak self] in
-            try? await Task.sleep(for: .seconds(holdRemaining))
-            guard let self, !Task.isCancelled else { return }
+            guard let self else { return }
+            await self.sleepFor(.seconds(holdRemaining))
+            guard !Task.isCancelled else { return }
             self.dismissTask = nil
             Log.overlay.info("overlay hold elapsed, dismissing")
             self.reset()
@@ -226,7 +239,7 @@ final class OverlayBufferSessionCoordinator: OverlayBufferSessionCoordinating {
         newOverlayDisplayText: String
     ) {
         guard previousOverlayDisplayText != newOverlayDisplayText else { return }
-        lastOverlayDisplayTextChangeAt = Date()
+        lastOverlayDisplayTextChangeAt = now()
     }
 
     private func lockCommitTargetForFinalizationIfNeeded() {
@@ -260,3 +273,11 @@ final class OverlayBufferSessionCoordinator: OverlayBufferSessionCoordinating {
         pasteboard.setString(text, forType: .string)
     }
 }
+
+#if DEBUG
+extension OverlayBufferSessionCoordinator {
+    /// Exposes the pending hold task so tests can await dismissal deterministically
+    /// instead of polling wall-clock time.
+    var debugDismissTask: Task<Void, Never>? { dismissTask }
+}
+#endif

--- a/Tests/localvoxtralTests/OverlayBufferSessionCoordinatorTests.swift
+++ b/Tests/localvoxtralTests/OverlayBufferSessionCoordinatorTests.swift
@@ -244,10 +244,14 @@ final class OverlayBufferSessionCoordinatorTests: XCTestCase {
     func testDismissAfterHoldWaitsFromBeginFinalizingWhenNoFinalRefreshArrives() async {
         let renderer = MockOverlayRenderer()
         let anchorResolver = MockOverlayAnchorResolver()
+        let currentDate = Date(timeIntervalSince1970: 1_000)
+        var requestedSleeps: [Duration] = []
         let coordinator = OverlayBufferSessionCoordinator(
             stateMachine: OverlayBufferStateMachine(),
             renderer: renderer,
-            anchorResolver: anchorResolver
+            anchorResolver: anchorResolver,
+            now: { currentDate },
+            sleepFor: { requestedSleeps.append($0) }
         )
 
         coordinator.startSession()
@@ -259,20 +263,27 @@ final class OverlayBufferSessionCoordinatorTests: XCTestCase {
         coordinator.dismissAfterHold(minimumVisibility: 0.05)
         XCTAssertEqual(renderer.hideCallCount, 0)
 
-        let didHide = await waitUntil(timeout: .milliseconds(300)) {
-            renderer.hideCallCount == 1
+        guard let dismissTask = coordinator.debugDismissTask else {
+            XCTFail("expected a pending dismiss hold task")
+            return
         }
-        XCTAssertTrue(didHide)
+        await dismissTask.value
+
+        XCTAssertEqual(requestedSleeps, [.seconds(0.05)])
         XCTAssertEqual(renderer.hideCallCount, 1)
     }
 
-    func testDismissAfterHoldIsImmediateWhenTextWasAlreadyStaleBeforeFinalizing() async {
+    func testDismissAfterHoldIsImmediateWhenTextWasAlreadyStaleBeforeFinalizing() {
         let renderer = MockOverlayRenderer()
         let anchorResolver = MockOverlayAnchorResolver()
+        var currentDate = Date(timeIntervalSince1970: 1_000)
+        var requestedSleeps: [Duration] = []
         let coordinator = OverlayBufferSessionCoordinator(
             stateMachine: OverlayBufferStateMachine(),
             renderer: renderer,
-            anchorResolver: anchorResolver
+            anchorResolver: anchorResolver,
+            now: { currentDate },
+            sleepFor: { requestedSleeps.append($0) }
         )
 
         coordinator.startSession()
@@ -280,7 +291,7 @@ final class OverlayBufferSessionCoordinatorTests: XCTestCase {
             displayBufferText: "hello",
             commitBufferText: "hello"
         )
-        try? await Task.sleep(for: .milliseconds(80))
+        currentDate.addTimeInterval(0.08)
 
         coordinator.beginFinalizing(
             displayBufferText: "hello",
@@ -289,15 +300,21 @@ final class OverlayBufferSessionCoordinatorTests: XCTestCase {
         coordinator.dismissAfterHold(minimumVisibility: 0.05)
 
         XCTAssertEqual(renderer.hideCallCount, 1)
+        XCTAssertTrue(requestedSleeps.isEmpty)
+        XCTAssertNil(coordinator.debugDismissTask)
     }
 
-    func testDismissAfterHoldUnchangedFinalizingRefreshDoesNotExtendHold() async {
+    func testDismissAfterHoldUnchangedFinalizingRefreshDoesNotExtendHold() {
         let renderer = MockOverlayRenderer()
         let anchorResolver = MockOverlayAnchorResolver()
+        var currentDate = Date(timeIntervalSince1970: 1_000)
+        var requestedSleeps: [Duration] = []
         let coordinator = OverlayBufferSessionCoordinator(
             stateMachine: OverlayBufferStateMachine(),
             renderer: renderer,
-            anchorResolver: anchorResolver
+            anchorResolver: anchorResolver,
+            now: { currentDate },
+            sleepFor: { requestedSleeps.append($0) }
         )
 
         coordinator.startSession()
@@ -305,7 +322,7 @@ final class OverlayBufferSessionCoordinatorTests: XCTestCase {
             displayBufferText: "hello",
             commitBufferText: "hello"
         )
-        try? await Task.sleep(for: .milliseconds(80))
+        currentDate.addTimeInterval(0.08)
 
         coordinator.refresh(
             displayBufferText: "hello",
@@ -314,15 +331,21 @@ final class OverlayBufferSessionCoordinatorTests: XCTestCase {
         coordinator.dismissAfterHold(minimumVisibility: 0.05)
 
         XCTAssertEqual(renderer.hideCallCount, 1)
+        XCTAssertTrue(requestedSleeps.isEmpty)
+        XCTAssertNil(coordinator.debugDismissTask)
     }
 
     func testDismissAfterHoldChangedFinalizingRefreshExtendsHold() async {
         let renderer = MockOverlayRenderer()
         let anchorResolver = MockOverlayAnchorResolver()
+        var currentDate = Date(timeIntervalSince1970: 1_000)
+        var requestedSleeps: [Duration] = []
         let coordinator = OverlayBufferSessionCoordinator(
             stateMachine: OverlayBufferStateMachine(),
             renderer: renderer,
-            anchorResolver: anchorResolver
+            anchorResolver: anchorResolver,
+            now: { currentDate },
+            sleepFor: { requestedSleeps.append($0) }
         )
 
         coordinator.startSession()
@@ -330,6 +353,9 @@ final class OverlayBufferSessionCoordinatorTests: XCTestCase {
             displayBufferText: "hello",
             commitBufferText: "hello"
         )
+        // Even when the hold from beginFinalizing has already elapsed, a
+        // finalizing refresh that changes the visible text restarts the hold.
+        currentDate.addTimeInterval(0.08)
         coordinator.refresh(
             displayBufferText: "hello world",
             commitBufferText: "hello world"
@@ -338,27 +364,14 @@ final class OverlayBufferSessionCoordinatorTests: XCTestCase {
         coordinator.dismissAfterHold(minimumVisibility: 0.05)
         XCTAssertEqual(renderer.hideCallCount, 0)
 
-        let didHide = await waitUntil(timeout: .milliseconds(300)) {
-            renderer.hideCallCount == 1
+        guard let dismissTask = coordinator.debugDismissTask else {
+            XCTFail("expected a pending dismiss hold task")
+            return
         }
-        XCTAssertTrue(didHide)
+        await dismissTask.value
+
+        XCTAssertEqual(requestedSleeps, [.seconds(0.05)])
         XCTAssertEqual(renderer.hideCallCount, 1)
-    }
-
-    private func waitUntil(
-        timeout: Duration,
-        pollInterval: Duration = .milliseconds(10),
-        condition: @escaping @MainActor () -> Bool
-    ) async -> Bool {
-        let clock = ContinuousClock()
-        let deadline = clock.now + timeout
-
-        while !condition() {
-            guard clock.now < deadline else { return false }
-            try? await Task.sleep(for: pollInterval)
-        }
-
-        return true
     }
 }
 


### PR DESCRIPTION
## Problem

The `dismissAfterHold` hold-timing logic in `OverlayBufferSessionCoordinator` used raw `Date()` and real `Task.sleep`, and its four tests relied on real 80ms sleeps, a 50ms hold window, and a 300ms polling `waitUntil` helper. Under CI load these timing margins are a known flakiness risk.

## Change

- **`Sources/localvoxtral/OverlayBufferSessionCoordinator.swift`**: inject a time source via init parameters `now: () -> Date` and `sleepFor: (Duration) async -> Void`, following the exact DI pattern already used by `AccessibilityTrustManager`. Both the hold-remaining computation and the display-text-change timestamp now use the injected clock. Defaults are `Date.init` and `try? await Task.sleep(for:)`, so production behavior is unchanged (the sole production call site passes neither). A `#if DEBUG` `debugDismissTask` accessor exposes the pending hold task so tests can await dismissal deterministically.
- **`Tests/localvoxtralTests/OverlayBufferSessionCoordinatorTests.swift`**: the four `dismissAfterHold` tests now advance a fake clock and record requested sleep durations instead of sleeping/polling. No real time dependence remains: the "immediate" cases assert synchronously, and the "hold" cases await the exposed dismiss task and assert the exact requested hold duration. The `waitUntil` polling helper is deleted. The changed-refresh test now verifies a stronger property: a visible-text change during finalizing restarts the full hold even after the original hold window has already elapsed.

`TimingConstants` and `DictationViewModelOverlayLifecycleTests` were checked: the lifecycle tests use a spy coordinator and never touch real hold timing, so no changes were needed there.

## Verification

- Full unit suite via `remote-build.sh test`: 208 tests, 0 failures.
- `OverlayBufferSessionCoordinatorTests` + `DictationViewModelOverlayLifecycleTests` run 5 times in a row: 31 tests, 0 failures on every run.
- Build is warning-free under Swift 6.2 strict concurrency.