### PR TITLE
test: inject pasteboard writes in overlay auto-copy tests

### DIFF
--- a/Sources/localvoxtral/OverlayBufferSessionCoordinator.swift
+++ b/Sources/localvoxtral/OverlayBufferSessionCoordinator.swift
@@ -50,6 +50,7 @@ protocol OverlayBufferSessionCoordinating: AnyObject {
 final class OverlayBufferSessionCoordinator: OverlayBufferSessionCoordinating {
     typealias DateProvider = () -> Date
     typealias SleepClosure = (Duration) async -> Void
+    typealias PasteboardWriter = (String) -> Void
 
     private var stateMachine: OverlayBufferStateMachine
     private let renderer: OverlayBufferRendering
@@ -57,6 +58,9 @@ final class OverlayBufferSessionCoordinator: OverlayBufferSessionCoordinating {
     // Injected time source so hold-before-dismiss timing is testable without wall-clock sleeps.
     private let now: DateProvider
     private let sleepFor: SleepClosure
+    // Injected so tests don't require a pasteboard server (headless CI users
+    // have none) and don't clobber the host session's clipboard.
+    private let copyToPasteboard: PasteboardWriter
 
     private var commitBufferText = ""
     private var liveCommitTargetAppPID: pid_t?
@@ -72,6 +76,11 @@ final class OverlayBufferSessionCoordinator: OverlayBufferSessionCoordinating {
         now: @escaping DateProvider = Date.init,
         sleepFor: @escaping SleepClosure = { duration in
             try? await Task.sleep(for: duration)
+        },
+        copyToPasteboard: @escaping PasteboardWriter = { text in
+            let pasteboard = NSPasteboard.general
+            pasteboard.clearContents()
+            pasteboard.setString(text, forType: .string)
         }
     ) {
         self.stateMachine = stateMachine
@@ -79,6 +88,7 @@ final class OverlayBufferSessionCoordinator: OverlayBufferSessionCoordinating {
         self.anchorResolver = anchorResolver
         self.now = now
         self.sleepFor = sleepFor
+        self.copyToPasteboard = copyToPasteboard
     }
 
     func resolveAnchorNow() -> OverlayAnchor {
@@ -267,11 +277,6 @@ final class OverlayBufferSessionCoordinator: OverlayBufferSessionCoordinating {
         }
     }
 
-    private func copyToPasteboard(_ text: String) {
-        let pasteboard = NSPasteboard.general
-        pasteboard.clearContents()
-        pasteboard.setString(text, forType: .string)
-    }
 }
 
 #if DEBUG

--- a/Tests/localvoxtralTests/OverlayBufferSessionCoordinatorTests.swift
+++ b/Tests/localvoxtralTests/OverlayBufferSessionCoordinatorTests.swift
@@ -38,10 +38,12 @@ final class OverlayBufferSessionCoordinatorTests: XCTestCase {
     func testCommitWithAutoCopyCopiesTextToPasteboard() {
         let renderer = MockOverlayRenderer()
         let anchorResolver = MockOverlayAnchorResolver()
+        var copiedTexts: [String] = []
         let coordinator = OverlayBufferSessionCoordinator(
             stateMachine: OverlayBufferStateMachine(),
             renderer: renderer,
-            anchorResolver: anchorResolver
+            anchorResolver: anchorResolver,
+            copyToPasteboard: { copiedTexts.append($0) }
         )
         let committer = MockOverlayTextCommitter()
         committer.insertResult = .insertedByAccessibility
@@ -53,22 +55,21 @@ final class OverlayBufferSessionCoordinatorTests: XCTestCase {
             commitBufferText: "copy me"
         )
 
-        let pasteboard = NSPasteboard.general
-        pasteboard.clearContents()
-
         let outcome = coordinator.commitIfNeeded(using: committer, autoCopyEnabled: true)
 
         XCTAssertEqual(outcome, .succeeded)
-        XCTAssertEqual(pasteboard.string(forType: .string), "copy me")
+        XCTAssertEqual(copiedTexts, ["copy me"])
     }
 
     func testCommitWithAutoCopyDisabledDoesNotCopyToPasteboard() {
         let renderer = MockOverlayRenderer()
         let anchorResolver = MockOverlayAnchorResolver()
+        var copiedTexts: [String] = []
         let coordinator = OverlayBufferSessionCoordinator(
             stateMachine: OverlayBufferStateMachine(),
             renderer: renderer,
-            anchorResolver: anchorResolver
+            anchorResolver: anchorResolver,
+            copyToPasteboard: { copiedTexts.append($0) }
         )
         let committer = MockOverlayTextCommitter()
         committer.insertResult = .insertedByAccessibility
@@ -80,15 +81,10 @@ final class OverlayBufferSessionCoordinatorTests: XCTestCase {
             commitBufferText: "do not copy"
         )
 
-        let pasteboard = NSPasteboard.general
-        pasteboard.clearContents()
-        pasteboard.setString("original", forType: .string)
-        let changeCount = pasteboard.changeCount
-
         let outcome = coordinator.commitIfNeeded(using: committer, autoCopyEnabled: false)
 
         XCTAssertEqual(outcome, .succeeded)
-        XCTAssertEqual(pasteboard.changeCount, changeCount)
+        XCTAssertTrue(copiedTexts.isEmpty)
     }
 
     func testResetHidesRenderer() {


### PR DESCRIPTION
## What

The overlay auto-copy tests used the real `NSPasteboard`, which fails under a headless CI user (no pasteboard server) and overwrote the logged-in user's clipboard with "copy me" on every CI run. `OverlayBufferSessionCoordinator` now takes an injected `copyToPasteboard:` closure (defaulting to the real pasteboard — production call site unchanged), same seam style as the existing `now:`/`sleepFor:` parameters, and the tests record writes into an array.

## Proof

- Regression demonstrated: before the fix, `remote-build.sh test` as the headless `builder` user failed with `XCTAssertEqual failed: ("nil") is not equal to ("Optional("copy me")")` in `testCommitWithAutoCopyCopiesTextToPasteboard`.
- After the fix, same environment: `Executed 208 tests, with 0 failures`
- Realtime integration: `Executed 7 tests, with 2 tests skipped and 0 failures ... in 16.0s`
- Packaging still green as builder: `Packaged app: .../dist/localvoxtral.app`