### PR TITLE
test: characterize live auto-paste punctuation behavior (issue #13 investigation)

### DIFF
--- a/.agent-runs/issue13-punct/analysis.md
+++ b/.agent-runs/issue13-punct/analysis.md
@@ -1,0 +1,188 @@
+# Issue #13 — punctuation inserted mid-word / wrong position
+
+**Status:** NOT reproduced as a code defect in the merge / delta-boundary logic.
+**Outcome:** Added 23 characterization tests (11 pure-merge + 12 view-model
+event-path). No source change — the merge logic is provably not on the
+reporter's code path, and the live path is append-only. Hypotheses and the
+instrumentation needed to catch the real emission are below.
+
+## The report
+
+In **Live Auto-Paste** + **voxmlx** (Voxtral Mini 4B Realtime, 4-bit, Italian),
+streaming punctuation intermittently lands at the insertion cursor instead of
+the correct boundary (~1 in 10 runs):
+
+- `sparisce.` → `sparis.ce`
+- `al fondo,` → `al, fondo`
+
+The maintainer suspected the delta-merge boundary logic.
+
+## TL;DR of the trace
+
+For the reporter's exact configuration, the partial-transcript path through
+`DictationViewModel+RealtimeEvents.handlePartialTranscriptEvent` is
+**append-only**:
+
+```swift
+pendingSegmentText.append(processedDelta)        // raw append
+livePartialText   = pendingSegmentText
+if isLiveAutoPasteModeEnabled {
+    textInsertion.enqueueRealtimeInsertion(processedDelta)   // typed verbatim
+}
+```
+
+There is **no** `TextMergingAlgorithms` overlap/boundary merge on this path.
+`processedDelta` is only passed through `FirstChunkPreprocessor`, which trims
+leading whitespace from the *first* chunk of the session and is a no-op for
+every subsequent chunk. So whatever characters the delta stream delivers, in
+the order it delivers them, is exactly what is typed.
+
+The prime suspects named in the issue brief — `appendWithTailOverlap`,
+`appendWithoutOverlap`, `shouldAvoidLeadingSpace`,
+`stableWordBoundaryLength`, `normalizeTranscriptionFormatting` — are
+collectively reachable only from:
+
+- `MlxHypothesisStabilizer` (the **mlx-audio** path — out of scope, being
+  removed by another agent), and
+- `OverlayBufferStateMachine.mergedText` (the **overlay** display path).
+
+Neither runs for **Live Auto-Paste + RealtimeAPI**. They therefore cannot be
+the source of the reported symptom. `normalizedFinalizedSegment` /
+`appendToCurrentDictationEvent` (the only boundary logic that *is* on the
+RealtimeAPI path) only run on `.finalTranscript`, and a guard suppresses
+re-insertion whenever live deltas were already typed — so even they cannot
+splice punctuation into the live field (see "Final-transcript path" below).
+
+## What the new tests prove
+
+`Tests/localvoxtralTests/TextMergingAlgorithmsTests.swift` (Italian/punctuation
+block) — pure-function characterization. With left-to-right inputs the helpers
+produce the *correct* result every time:
+
+| Inputs | Result |
+|---|---|
+| `appendWithTailOverlap("sparisce", ".")` | `sparisce.` |
+| `appendWithTailOverlap("al fondo", ",")` | `al fondo,` |
+| `appendWithTailOverlap("al", "fondo,")` | `al fondo,` |
+| `appendWithTailOverlap("l", "'acqua")` | `l'acqua` |
+| `appendWithTailOverlap("un", "'altra")` | `un'altra` |
+| `appendWithTailOverlap("spari", "sparisce.")` | `sparisce.` (overlap) |
+| `normalizeTranscriptionFormatting("sparisce .")` | `sparisce.` |
+| `normalizeTranscriptionFormatting("al , fondo")` | `al, fondo` |
+| `normalizeTranscriptionFormatting("l' acqua")` | `l'acqua` |
+
+None of these relocate punctuation into a word.
+
+`Tests/localvoxtralTests/RealtimeAPILivePastePunctuationTests.swift` — drives
+the production `DictationViewModel.handle(event:source:)` for the RealtimeAPI
+path in Live Auto-Paste and captures every chunk
+`TextInsertionService` would type (via the `#if DEBUG`
+`debugConfigureInsertionHooks` seam). Key results:
+
+1. **Append-only is exact.** Deltas `["spar","isce","."]` produce
+   `insertedChunks == ["spar","isce","."]` and
+   `pendingSegmentText == "sparisce."`. Likewise `["al"," fondo",","]` →
+   `"al fondo,"` and elisions `["l","'acqua"]` → `"l'acqua"`.
+2. **Mid-word punctuation requires out-of-order delivery.** The *only* way the
+   live path yields `"sparis.ce"` is feeding deltas `["sparis",".","ce"]`
+   (punctuation before the rest of the word). The app types exactly what it
+   receives — it does not synthesize this ordering from a well-formed stream.
+   → The malformed output must originate *upstream* of the merge: in the order
+   the model/backend emits tokens.
+3. **`resolvedFinalizedSegment` never splices mid-word.** With pending
+   `"sparisce"` and final `"sparisce."` it returns `"sparisce."`; with
+   final `"."` only it returns `"sparisce ."` (space-joined, end of word);
+   disjoint words space-join. Punctuation always stays at a boundary.
+
+## Final-transcript path (a related, but different, finding)
+
+`handleFinalTranscriptEvent` computes
+`finalizedSegment = resolvedFinalizedSegment(...)` but only inserts it when no
+live delta preceded it:
+
+```swift
+let hadLiveDelta = !pendingSegmentText.trimmed.isEmpty || !livePartialText.trimmed.isEmpty
+...
+if !hadLiveDelta, isLiveAutoPasteModeEnabled {
+    textInsertion.enqueueRealtimeInsertion(finalizedSegment)
+}
+```
+
+Consequence: if a trailing period is delivered **only** in the `.finalTranscript`
+and never as a partial delta, it is *dropped* from the live field (the test
+`testFinalTranscriptDoesNotDoubleInsertWhenLiveDeltasAlreadyInserted` locks
+this in). That is a "missing trailing punctuation" behavior, **not** the
+reported "mid-word punctuation" symptom, so it is characterized but not
+changed here (changing it would risk double-insertion and is out of scope for
+this issue).
+
+## Why the symptom is ~1-in-10 and lands "at the insertion point"
+
+The phrase "lands at the insertion point" is the strongest clue: in an
+append-only pipeline, "the insertion point" is simply *wherever the cursor is
+when the punctuation delta arrives*. The cursor sits at the end of what was
+last typed. So the symptom is consistent with the punctuation delta arriving
+*before* the remainder of the word has been streamed/typed. Two realistic
+mechanisms (both upstream of our merge):
+
+1. **Periodic commits split a word across two generations.** The RealtimeAPI
+   client sends `input_audio_buffer.commit` every `commitIntervalSeconds`
+   (`DictationViewModel+Session.restartCommitTask`, 0.1–1.0 s). If a word
+   straddles a commit boundary, generation N can transcribe the head of the
+   word (and the model may emit trailing punctuation to "finish" it), while
+   generation N+1 transcribes the tail. The two generations' deltas are each
+   internally left-to-right, but *concatenated across the commit* they read as
+   `…sparis.` then `ce…`. The append-only path faithfully types that.
+   Non-final commits are skipped while a generation is in progress
+   (`sendCommit` checks `isGenerationInProgress`), but this does not prevent a
+   word from being split at the generation boundary itself.
+2. **Backend emission / Voxtral tokenization.** voxmlx/vLLM streaming may emit
+   a punctuation token detached from the word in a way that, combined with
+   timing of when our client receives frames, appears reordered. This is
+   inherently non-deterministic (~1-in-10) and matches the report.
+
+Mechanism (1) is the most likely and is *not* a merge bug — it is a
+consequence of periodic-commit segmentation interacting with an append-only
+live pipeline. A proper fix belongs at the commit/segmentation layer (e.g.,
+not committing mid-word, or reconciling head/tail across generations), not in
+`TextMergingAlgorithms`.
+
+## What I did NOT change (and why)
+
+- No edit to `TextMergingAlgorithms` — proven correct for the reported inputs
+  and not on the reported path.
+- No edit to `FirstChunkPreprocessor` — only touches the first chunk; cannot
+  reorder mid-stream.
+- No edit to `resolvedFinalizedSegment` — never splices mid-word.
+- No mlx-audio files touched (concurrent removal in flight).
+- No existing assertion weakened.
+
+## Instrumentation that would catch it live
+
+To confirm the upstream-emission hypothesis, capture (DEBUG-gated, off by
+default) the raw delta sequence the RealtimeAPI client emits, in arrival order:
+
+- In `RealtimeAPIWebSocketClient.handle(json:)` at the
+  `"transcription.delta"` / `"response.audio_transcript.delta"` branch, log
+  each emitted `.partialTranscript(delta)` with a monotonic sequence number
+  and the current commit-generation marker (`isGenerationInProgress` toggles).
+- Mirror the same log in `DictationViewModel.handlePartialTranscriptEvent`
+  right before `enqueueRealtimeInsertion`, including the running
+  `pendingSegmentText` length.
+
+With that trace from a reproducing run, the `sparis.ce` case will show either
+(a) a delta ordering like `sparis`, `.`, `ce` (emission/commit-split), or
+(b) something else that points at the insertion layer. `LOCALVOXTRAL_DEBUG=1`
+already gates `debugLog`; the additional structured delta log would slot in
+behind the same flag.
+
+## Verification
+
+```
+LV_BUILD_DIR=work/localvoxtral-issue13 ./scripts/remote-build.sh test
+→ Executed 231 tests, with 0 failures (0 unexpected) in 1.504 seconds
+```
+
+Baseline was 208 tests; this branch adds 23 (11 in TextMergingAlgorithmsTests,
+12 in the new RealtimeAPILivePastePunctuationTests), all green, no existing
+test modified.

--- a/Tests/localvoxtralTests/RealtimeAPILivePastePunctuationTests.swift
+++ b/Tests/localvoxtralTests/RealtimeAPILivePastePunctuationTests.swift
@@ -1,0 +1,219 @@
+import Foundation
+import XCTest
+@testable import localvoxtral
+
+// Characterization tests for issue #13 (punctuation inserted mid-word in Live
+// Auto-Paste + voxmlx). These drive the production RealtimeAPI event path
+// through DictationViewModel and capture exactly what TextInsertionService
+// would type into the focused field, via the `#if DEBUG` insertion hooks.
+//
+// They lock in two invariants that are central to the issue analysis:
+//   1. The RealtimeAPI partial-delta path is purely append-only: each
+//      `.partialTranscript` delta is appended to `pendingSegmentText` and
+//      forwarded verbatim to the insertion queue. There is no overlap/boundary
+//      merge on this path, so punctuation can only land where the deltas
+//      deliver it.
+//   2. `resolvedFinalizedSegment` (the only boundary logic on the RealtimeAPI
+//      path) never relocates punctuation into the middle of a word.
+#if DEBUG
+@MainActor
+final class RealtimeAPILivePastePunctuationTests: XCTestCase {
+    // DictationViewModel owns app-lifetime services; retain instances for the
+    // process duration so teardown does not race service shutdown.
+    private static var retainedViewModels: [DictationViewModel] = []
+
+    private var insertedChunks: [String] = []
+
+    private func makeViewModel() -> DictationViewModel {
+        let suiteName = "localvoxtral.RealtimeAPILivePastePunctuationTests.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defaults.removePersistentDomain(forName: suiteName)
+        addTeardownBlock {
+            defaults.removePersistentDomain(forName: suiteName)
+        }
+
+        let settings = SettingsStore(defaults: defaults, environment: [:])
+        settings.dictationOutputMode = .liveAutoPaste
+
+        let viewModel = DictationViewModel(
+            settings: settings,
+            overlayBufferCoordinator: MockOverlayCoordinator(),
+            startRuntimeServices: false
+        )
+        Self.retainedViewModels.append(viewModel)
+
+        // Configure the VM as an active Live Auto-Paste RealtimeAPI session so
+        // `handle(event:source:)` accepts and routes transcript events.
+        viewModel.activeClientSource = .realtimeAPI
+        viewModel.isDictating = true
+
+        // Capture every chunk the insertion service would type, and report
+        // success so the pending buffer drains synchronously each enqueue.
+        insertedChunks = []
+        viewModel.textInsertion.debugConfigureInsertionHooks(
+            unicodePoster: { [weak self] chunk in
+                self?.insertedChunks.append(chunk)
+                return true
+            },
+            modifierStateReader: { false },
+            accessibilityInserter: { _, _ in false }
+        )
+
+        return viewModel
+    }
+
+    private func sendPartials(_ deltas: [String], to viewModel: DictationViewModel) {
+        for delta in deltas {
+            viewModel.handle(event: .partialTranscript(delta), source: .realtimeAPI)
+        }
+    }
+
+    // MARK: - Append-only partial path
+
+    func testPartialDeltasAreInsertedVerbatimInArrivalOrder() {
+        // A realistic incremental delta stream for "sparisce." delivered
+        // left-to-right. The field must receive exactly these characters in
+        // this order.
+        let viewModel = makeViewModel()
+        sendPartials(["spar", "isce", "."], to: viewModel)
+
+        XCTAssertEqual(insertedChunks, ["spar", "isce", "."])
+        XCTAssertEqual(viewModel.pendingSegmentText, "sparisce.")
+        XCTAssertEqual(viewModel.livePartialText, "sparisce.")
+    }
+
+    func testPartialDeltasWholeWordThenPeriod_staysCorrect() {
+        // The model emitting the whole word then a detached period is the
+        // other common emission shape. It must still produce "sparisce.".
+        let viewModel = makeViewModel()
+        sendPartials(["sparisce", "."], to: viewModel)
+
+        XCTAssertEqual(insertedChunks, ["sparisce", "."])
+        XCTAssertEqual(viewModel.pendingSegmentText, "sparisce.")
+    }
+
+    func testPartialDeltasItalianPhraseWithComma_staysCorrect() {
+        // "al fondo," emitted as incremental deltas keeps the comma at the end.
+        let viewModel = makeViewModel()
+        sendPartials(["al", " fondo", ","], to: viewModel)
+
+        XCTAssertEqual(insertedChunks, ["al", " fondo", ","])
+        XCTAssertEqual(viewModel.pendingSegmentText, "al fondo,")
+    }
+
+    func testPartialDeltasItalianApostropheElision_staysCorrect() {
+        // Elisions ("l'acqua", "un'altra") must stream intact.
+        let viewModel = makeViewModel()
+        sendPartials(["l", "'acqua"], to: viewModel)
+        sendPartials([" un", "'altra"], to: viewModel)
+
+        XCTAssertEqual(insertedChunks, ["l", "'acqua", " un", "'altra"])
+        XCTAssertEqual(viewModel.pendingSegmentText, "l'acqua un'altra")
+    }
+
+    func testMidWordPunctuationOnlyOccursWhenDeltasDeliverItOutOfOrder() {
+        // This is the KEY characterization for issue #13: the ONLY way the
+        // append-only live path yields "sparis.ce" is if the delta stream
+        // itself delivers ".", then "ce" — i.e. punctuation arrives before the
+        // rest of the word. The app faithfully types what it receives; it does
+        // not synthesize this ordering from a well-formed stream.
+        let viewModel = makeViewModel()
+        sendPartials(["sparis", ".", "ce"], to: viewModel)
+
+        XCTAssertEqual(insertedChunks, ["sparis", ".", "ce"])
+        XCTAssertEqual(viewModel.pendingSegmentText, "sparis.ce")
+
+        // Conversely, the same characters in left-to-right order are correct:
+        let viewModel2 = makeViewModel()
+        sendPartials(["sparisce", "."], to: viewModel2)
+        XCTAssertEqual(viewModel2.pendingSegmentText, "sparisce.")
+    }
+
+    // MARK: - resolvedFinalizedSegment boundary logic
+
+    func testResolvedFinalizedSegment_finalExtendsPartialWithPeriod() {
+        // Partial streamed "sparisce", final delivers the trailing period:
+        // the resolved segment is the full "sparisce." — punctuation stays at
+        // the end, never mid-word.
+        let viewModel = makeViewModel()
+        viewModel.pendingSegmentText = "sparisce"
+
+        XCTAssertEqual(viewModel.resolvedFinalizedSegment(from: "sparisce."), "sparisce.")
+    }
+
+    func testResolvedFinalizedSegment_finalOnlyPunctuation_appendsWithSpace() {
+        // If the final carries only the punctuation, it appends after the
+        // buffered word (with a space, per the existing boundary rule) — it
+        // never splices into the word.
+        let viewModel = makeViewModel()
+        viewModel.pendingSegmentText = "sparisce"
+
+        XCTAssertEqual(viewModel.resolvedFinalizedSegment(from: "."), "sparisce .")
+    }
+
+    func testResolvedFinalizedSegment_emptyFinalReturnsPending() {
+        let viewModel = makeViewModel()
+        viewModel.pendingSegmentText = "al fondo"
+
+        XCTAssertEqual(viewModel.resolvedFinalizedSegment(from: ""), "al fondo")
+    }
+
+    func testResolvedFinalizedSegment_emptyPendingReturnsFinal() {
+        let viewModel = makeViewModel()
+
+        XCTAssertEqual(viewModel.resolvedFinalizedSegment(from: "al fondo,"), "al fondo,")
+    }
+
+    func testResolvedFinalizedSegment_disjointWordsJoinWithSpace() {
+        // "al" buffered, "fondo," final → "al fondo," (space-joined).
+        let viewModel = makeViewModel()
+        viewModel.pendingSegmentText = "al"
+
+        XCTAssertEqual(viewModel.resolvedFinalizedSegment(from: "fondo,"), "al fondo,")
+    }
+
+    func testResolvedFinalizedSegment_partialPrefixOfFinal_returnsFinal() {
+        let viewModel = makeViewModel()
+        viewModel.pendingSegmentText = "al fon"
+
+        XCTAssertEqual(viewModel.resolvedFinalizedSegment(from: "al fondo,"), "al fondo,")
+    }
+
+    // MARK: - Final transcript vs live deltas
+
+    func testFinalTranscriptDoesNotDoubleInsertWhenLiveDeltasAlreadyInserted() {
+        // When partials have already been typed live, the final transcript is
+        // folded into the running event text but is NOT re-inserted (avoids
+        // duplication). The live field therefore equals the partial stream.
+        let viewModel = makeViewModel()
+        sendPartials(["sparisce"], to: viewModel)
+        XCTAssertEqual(insertedChunks, ["sparisce"])
+
+        viewModel.handle(event: .finalTranscript("sparisce."), source: .realtimeAPI)
+
+        // No additional insertion beyond the live partial.
+        XCTAssertEqual(insertedChunks, ["sparisce"])
+        XCTAssertEqual(viewModel.currentDictationEventText, "sparisce.")
+        XCTAssertEqual(viewModel.pendingSegmentText, "")
+    }
+}
+
+@MainActor
+private final class MockOverlayCoordinator: OverlayBufferSessionCoordinating {
+    var commitOutcome: OverlayBufferCommitOutcome = .succeeded
+    var commitTargetAppPID: pid_t? = nil
+
+    func resolveAnchorNow() -> OverlayAnchor {
+        OverlayAnchor(targetRect: CGRect(x: 0, y: 0, width: 100, height: 24), source: .windowCenter)
+    }
+    func startSession(preResolvedAnchor: OverlayAnchor?) {}
+    func beginFinalizing(displayBufferText: String, commitBufferText: String) {}
+    func refresh(displayBufferText: String, commitBufferText: String) {}
+    func commitIfNeeded(
+        using textCommitter: OverlayTextCommitting,
+        autoCopyEnabled: Bool
+    ) -> OverlayBufferCommitOutcome { commitOutcome }
+    func dismissAfterHold(minimumVisibility: TimeInterval) {}
+    func reset() {}
+}
+#endif

--- a/Tests/localvoxtralTests/TextMergingAlgorithmsTests.swift
+++ b/Tests/localvoxtralTests/TextMergingAlgorithmsTests.swift
@@ -336,4 +336,86 @@ final class TextMergingAlgorithmsTests: XCTestCase {
         XCTAssertEqual(result.merged, existing)
         XCTAssertEqual(result.appendedDelta, "")
     }
+
+    // MARK: - Italian punctuation characterization (issue #13)
+    //
+    // These cases exercise the exact transformations that would be required to
+    // turn a well-formed stream into the reported malformed output
+    // ("sparis.ce", "al, fondo"). They assert the merge helpers produce the
+    // *correct* result, proving the malformed output does not originate in
+    // TextMergingAlgorithms when deltas are delivered in left-to-right order.
+
+    func testTailOverlap_periodGluesToWordEnd_italian() {
+        // "sparisce" + "." must produce "sparisce." — never "sparis.ce".
+        let result = TextMergingAlgorithms.appendWithTailOverlap(existing: "sparisce", incoming: ".")
+        XCTAssertEqual(result.merged, "sparisce.")
+        XCTAssertEqual(result.appendedDelta, ".")
+    }
+
+    func testTailOverlap_commaGluesToWordEnd_italian() {
+        // "al fondo" + "," must produce "al fondo," — the comma never jumps
+        // before "fondo".
+        let result = TextMergingAlgorithms.appendWithTailOverlap(existing: "al fondo", incoming: ",")
+        XCTAssertEqual(result.merged, "al fondo,")
+        XCTAssertEqual(result.appendedDelta, ",")
+    }
+
+    func testTailOverlap_wordThenSpaceWord_gluesWithSpace_italian() {
+        // "al" + "fondo," must produce "al fondo,".
+        let result = TextMergingAlgorithms.appendWithTailOverlap(existing: "al", incoming: "fondo,")
+        XCTAssertEqual(result.merged, "al fondo,")
+        XCTAssertEqual(result.appendedDelta, " fondo,")
+    }
+
+    func testTailOverlap_apostropheGluesToWord_italian() {
+        // "l" + "'acqua" must produce "l'acqua" (no leading space before ').
+        let result = TextMergingAlgorithms.appendWithTailOverlap(existing: "l", incoming: "'acqua")
+        XCTAssertEqual(result.merged, "l'acqua")
+        XCTAssertEqual(result.appendedDelta, "'acqua")
+    }
+
+    func testTailOverlap_apostropheGluesAfterArticle_italian() {
+        // "un" + "'altra" must produce "un'altra".
+        let result = TextMergingAlgorithms.appendWithTailOverlap(existing: "un", incoming: "'altra")
+        XCTAssertEqual(result.merged, "un'altra")
+        XCTAssertEqual(result.appendedDelta, "'altra")
+    }
+
+    func testTailOverlap_replayedGrowingWord_keepsOnlySuffix_italian() {
+        // Overlap merge when the incoming segment replays the prefix and grows:
+        // "spari" + "sparisce." → "sparisce." (the boundary stays at the end).
+        let result = TextMergingAlgorithms.appendWithTailOverlap(existing: "spari", incoming: "sparisce.")
+        XCTAssertEqual(result.merged, "sparisce.")
+        XCTAssertEqual(result.appendedDelta, "sce.")
+    }
+
+    func testNormalizeFormatting_compactsSpaceBeforePeriod_italian() {
+        // Tokenizer spacing artifact "sparisce ." must collapse to "sparisce.".
+        let normalized = TextMergingAlgorithms.normalizeTranscriptionFormatting("sparisce .")
+        XCTAssertEqual(normalized, "sparisce.")
+    }
+
+    func testNormalizeFormatting_compactsSpaceBeforeComma_italian() {
+        // "al , fondo" → "al, fondo" (no relocation of the comma into the word).
+        let normalized = TextMergingAlgorithms.normalizeTranscriptionFormatting("al , fondo")
+        XCTAssertEqual(normalized, "al, fondo")
+    }
+
+    func testNormalizeFormatting_apostropheElision_italian() {
+        // "l' acqua" → "l'acqua" (elision glues without splitting).
+        let normalized = TextMergingAlgorithms.normalizeTranscriptionFormatting("l' acqua")
+        XCTAssertEqual(normalized, "l'acqua")
+    }
+
+    func testNormalizeFormatting_preservesWordInternalPeriod_italian() {
+        // A legitimately mid-word period (abbreviation/url) must be preserved
+        // as-is — the normalizer never *inserts* punctuation into a word.
+        let normalized = TextMergingAlgorithms.normalizeTranscriptionFormatting("sparisce.al fondo")
+        XCTAssertEqual(normalized, "sparisce.al fondo")
+    }
+
+    func testAvoidLeadingSpace_apostrophe() {
+        // Apostrophe glues (no leading space) so elisions like "l'acqua" form.
+        XCTAssertTrue(TextMergingAlgorithms.shouldAvoidLeadingSpace(before: "'"))
+    }
 }


### PR DESCRIPTION
## What

Test-only. Outcome of the #13 investigation: the Live Auto-Paste + RealtimeAPI partial path is append-only — `TextMergingAlgorithms` never runs on it, so the merge logic cannot cause the reported mid-word punctuation. The app types deltas verbatim; reproducing `sparis.ce` requires the backend to deliver `["sparis", ".", "ce"]`, pointing at commit-boundary word-splitting or model emission upstream.

- +11 Italian/punctuation characterization tests in `TextMergingAlgorithmsTests` (apostrophes, punctuation-only deltas, reported sequences)
- +12 tests in new `RealtimeAPILivePastePunctuationTests` driving the production view-model event path via the `#if DEBUG` insertion hooks, including the proof that mid-word punctuation only occurs when deltas deliver it out of order
- Also characterizes (not fixes) a separate milder issue: a trailing period arriving only in `.finalTranscript` is dropped from the live field by the `hadLiveDelta` guard

No source changes. Addresses #13 (investigation), does not close it.

## Proof

- Unit suite: `Executed 231 tests, with 0 failures (0 unexpected)` (208 baseline + 23 new)
- No existing assertion weakened; no source file changed.