### PR TITLE
ci: PR app artifacts + try-pr.sh for fast manual testing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,6 +58,18 @@ jobs:
       - name: Package app bundle
         run: ./scripts/package_app.sh release
 
+      - name: Zip app for artifact upload
+        # upload-artifact mangles symlinks/exec bits in .app bundles; ditto-zip
+        # first so the downloaded app keeps a valid signature.
+        run: ditto -c -k --sequesterRsrc --keepParent dist/localvoxtral.app dist/localvoxtral-app.zip
+
+      - name: Upload app artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: localvoxtral-app
+          path: dist/localvoxtral-app.zip
+          retention-days: 7
+
       - name: Smoke test packaged app launch
         run: |
           python3 - <<'PY'

--- a/scripts/try-pr.sh
+++ b/scripts/try-pr.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Download the CI-built app for a PR (or main) and launch it, for fast manual
+# testing of UI/behavior that automated tests can't cover. Runs on macOS; the
+# artifact is the exact bundle CI built and smoke-tested for that revision.
+#
+# Usage:
+#   ./scripts/try-pr.sh <pr-number>   # e.g. ./scripts/try-pr.sh 30
+#   ./scripts/try-pr.sh main          # latest green build of main
+#
+# Requires: gh (authenticated). Artifacts exist for CI runs made after the
+# artifact-upload step landed; use "gh run rerun <run-id>" on older PRs.
+
+if [[ "$(uname)" != "Darwin" ]]; then
+  echo "This script launches a macOS app bundle — run it on the Mac." >&2
+  exit 1
+fi
+
+TARGET="${1:?usage: $0 <pr-number|main>}"
+
+if [[ "$TARGET" == "main" ]]; then
+  RUN_ID="$(gh run list --workflow CI --branch main --status success --limit 1 \
+    --json databaseId --jq '.[0].databaseId')"
+else
+  HEAD_SHA="$(gh pr view "$TARGET" --json headRefOid --jq .headRefOid)"
+  RUN_ID="$(gh run list --workflow CI --commit "$HEAD_SHA" --status success --limit 1 \
+    --json databaseId --jq '.[0].databaseId')"
+fi
+
+if [[ -z "$RUN_ID" || "$RUN_ID" == "null" ]]; then
+  echo "No successful CI run found for '$TARGET' with a downloadable build." >&2
+  echo "If the PR predates artifact uploads, re-run its checks: gh pr checks $TARGET / gh run rerun" >&2
+  exit 1
+fi
+
+DEST="$(mktemp -d /tmp/localvoxtral-try.XXXXXX)"
+gh run download "$RUN_ID" -n localvoxtral-app -D "$DEST"
+ditto -x -k "$DEST/localvoxtral-app.zip" "$DEST/extracted"
+APP="$DEST/extracted/localvoxtral.app"
+xattr -cr "$APP" 2>/dev/null || true
+
+if pgrep -x localvoxtral >/dev/null 2>&1; then
+  echo "NOTE: another localvoxtral instance is running — quit it first to avoid"
+  echo "      two menu bar icons / hotkey conflicts."
+fi
+
+echo "Launching build of '$TARGET' (CI run $RUN_ID): $APP"
+open "$APP"


### PR DESCRIPTION
## What

- CI zips `dist/localvoxtral.app` (ditto, so signature/symlinks survive `upload-artifact`) and uploads it as artifact `localvoxtral-app` on every run, 7-day retention.
- `scripts/try-pr.sh <pr-number|main>` (macOS): finds the PR head's successful CI run, downloads the artifact, clears quarantine, warns about an already-running instance, and launches the app. One command from PR to running build for the manual UI checks that automated tests can't cover.

## Proof

- Unit suite unaffected (no source changes) — this PR's own CI run must show the `localvoxtral-app` artifact attached, which is the end-to-end proof of the workflow step.
- `bash -n scripts/try-pr.sh` clean; script exercised for the `main` target after merge.