### PR TITLE
build: stable codesign identity so TCC grants survive rebuilds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,6 +56,11 @@ jobs:
         run: swift test --filter RealtimeAPIVLLMIntegrationTests
 
       - name: Package app bundle
+        # The self-hosted runner's keychain holds the stable localvoxtral-dev
+        # signing cert, keeping TCC grants valid across builds; anywhere the
+        # identity is absent (hosted runners), packaging falls back to ad-hoc.
+        env:
+          LOCALVOXTRAL_CODESIGN_IDENTITY: localvoxtral-dev
         run: ./scripts/package_app.sh release
 
       - name: Zip app for artifact upload

--- a/scripts/package_app.sh
+++ b/scripts/package_app.sh
@@ -37,6 +37,15 @@ CONFIGURATION="${1:-release}"
 APP_VERSION="${2:-0.3.0}"
 BUILD_NUMBER="${3:-1}"
 
+# Sign with a stable identity when available so TCC grants (Accessibility)
+# survive rebuilds; ad-hoc signatures change every build and invalidate them.
+CODESIGN_IDENTITY="${LOCALVOXTRAL_CODESIGN_IDENTITY:--}"
+if [[ "$CODESIGN_IDENTITY" != "-" ]] \
+  && ! security find-identity -v -p codesigning 2>/dev/null | grep -q "$CODESIGN_IDENTITY"; then
+  echo "Signing identity '$CODESIGN_IDENTITY' not found in keychain; falling back to ad-hoc signing." >&2
+  CODESIGN_IDENTITY="-"
+fi
+
 if [[ "$CONFIGURATION" != "release" && "$CONFIGURATION" != "debug" ]]; then
   echo "Usage: ./scripts/package_app.sh [release|debug] [app-version] [build-number]"
   exit 1
@@ -202,10 +211,10 @@ PLIST
 chmod -R u+w "$APP_DIR"
 xattr -cr "$APP_DIR"
 
-# Ad-hoc sign the packaged app so Gatekeeper can evaluate a usable signature.
+# Sign the packaged app so Gatekeeper can evaluate a usable signature.
 # This does not replace Developer ID signing/notarization, but it avoids the
 # "no usable signature" path that breaks first-run open flows.
-if ! codesign --force --deep --sign - "$APP_DIR"; then
+if ! codesign --force --deep --sign "$CODESIGN_IDENTITY" "$APP_DIR"; then
   echo "Failed to code-sign packaged app bundle."
   exit 1
 fi

--- a/scripts/try-pr.sh
+++ b/scripts/try-pr.sh
@@ -45,5 +45,11 @@ if pgrep -x localvoxtral >/dev/null 2>&1; then
   echo "      two menu bar icons / hotkey conflicts."
 fi
 
-echo "Launching build of '$TARGET' (CI run $RUN_ID): $APP"
+SIGNER="$(codesign -dv "$APP" 2>&1 | grep -m1 '^Authority=' || echo 'Authority=ad-hoc')"
+echo "Launching build of '$TARGET' (CI run $RUN_ID, ${SIGNER}): $APP"
+if [[ "$SIGNER" == "Authority=ad-hoc" ]]; then
+  echo "NOTE: ad-hoc signed build — if text insertion fails, remove and re-add"
+  echo "      localvoxtral in System Settings > Privacy & Security > Accessibility"
+  echo "      (TCC grants don't survive ad-hoc signature changes)."
+fi
 open "$APP"


### PR DESCRIPTION
## What

- `package_app.sh`: signs with `$LOCALVOXTRAL_CODESIGN_IDENTITY` when that identity exists in the keychain; ad-hoc fallback (with a loud warning) otherwise — hosted runners and forks keep working unchanged.
- `ci.yml`: sets the identity to `localvoxtral-dev` (the self-hosted runner's local cert). Until the cert is created on the Mac, CI logs the fallback warning and behaves exactly as before.
- `try-pr.sh`: prints the build's signing authority and, for ad-hoc builds, explains the Accessibility re-grant workaround.

## Proof

- `remote-build.sh package` (no identity set → default path): `Packaged app: .../dist/localvoxtral.app` — behavior unchanged.
- This PR's CI run exercises the identity-missing fallback branch (cert not created yet); once the cert exists, runs sign with it and TCC grants persist across builds.