### PR TITLE
ci: mlx-lm fork verification harness (workflow_dispatch)

### DIFF
--- a/.github/workflows/mlx-lm-test.yml
+++ b/.github/workflows/mlx-lm-test.yml
@@ -1,0 +1,73 @@
+name: mlx-lm server test
+
+# Manual verification harness for the T0mSIlver/mlx-lm fork (the LLM polishing
+# backend recommended in the README). Runs on the self-hosted Mac because MLX
+# needs Apple Silicon. Exercises the prompt-cache reuse path, which is where
+# the fork's patches live and where regressions crash the server thread.
+
+on:
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: "Git ref of T0mSIlver/mlx-lm to test (branch, tag, or SHA)"
+        required: true
+        default: "main"
+
+jobs:
+  serve-and-probe:
+    runs-on: [self-hosted, macOS, ARM64]
+    timeout-minutes: 15
+    steps:
+      - name: Start mlx_lm.server from ref
+        run: |
+          LOG=/tmp/mlx-lm-test-server.log
+          rm -f "$LOG"
+          ~/.local/bin/uvx --refresh --from \
+            "git+https://github.com/T0mSIlver/mlx-lm.git@${{ inputs.ref }}" \
+            mlx_lm.server \
+            --model mlx-community/Qwen3.5-0.8B-8bit \
+            --port 8081 \
+            --prompt-cache-size 1 \
+            --prompt-cache-bytes 1GB \
+            > "$LOG" 2>&1 &
+          echo $! > /tmp/mlx-lm-test-server.pid
+          for i in $(seq 1 60); do
+            if curl -s -o /dev/null http://127.0.0.1:8081/v1/models; then
+              echo "server up after ${i}s"; exit 0
+            fi
+            if ! kill -0 "$(cat /tmp/mlx-lm-test-server.pid)" 2>/dev/null; then
+              echo "server process died during startup"; cat "$LOG"; exit 1
+            fi
+            sleep 1
+          done
+          echo "server did not become ready"; cat "$LOG"; exit 1
+
+      - name: Probe chat completions (twice — second hits the prompt cache)
+        run: |
+          probe() {
+            curl -s --max-time 120 -X POST http://127.0.0.1:8081/v1/chat/completions \
+              -H 'Content-Type: application/json' \
+              -d '{"model":"mlx-community/Qwen3.5-0.8B-8bit","messages":[{"role":"system","content":"You clean up dictated text. Reply with only the cleaned text."},{"role":"user","content":"'"$1"'"}],"max_tokens":64,"temperature":0.3}'
+          }
+          for attempt in 1 2 3; do
+            RESP="$(probe "so um i think we should uh probably ship it $attempt")"
+            CONTENT="$(printf '%s' "$RESP" | python3 -c 'import json,sys; print(json.load(sys.stdin)["choices"][0]["message"]["content"])' 2>/dev/null || true)"
+            if [ -z "$CONTENT" ]; then
+              echo "probe $attempt returned no content. Raw: $RESP"
+              echo "--- server log ---"; cat /tmp/mlx-lm-test-server.log
+              exit 1
+            fi
+            echo "probe $attempt OK: $CONTENT"
+          done
+          # The reported crash killed the generate thread AFTER responding 200
+          # once — so also verify the server thread survived all probes.
+          if grep -q "Traceback\|RuntimeError" /tmp/mlx-lm-test-server.log; then
+            echo "server log contains a crash:"; cat /tmp/mlx-lm-test-server.log; exit 1
+          fi
+
+      - name: Stop server
+        if: always()
+        run: |
+          kill "$(cat /tmp/mlx-lm-test-server.pid)" 2>/dev/null || true
+          sleep 1
+          kill -9 "$(cat /tmp/mlx-lm-test-server.pid)" 2>/dev/null || true


### PR DESCRIPTION
## What

Manual-dispatch workflow that installs `mlx_lm.server` from any ref of the T0mSIlver/mlx-lm fork on the self-hosted Mac, serves Qwen3.5-0.8B-8bit on port 8081 with prompt caching enabled, probes /v1/chat/completions three times (exercising the prompt-cache reuse path where the fork's patches live), and fails on missing content or any Traceback/RuntimeError in the server log — including the currently-reported `There is no Stream(gpu, 0) in current thread` crash, which returned 200 once and then killed the generate thread.

Needed because MLX only runs on Apple Silicon: this is the verification loop for fixing the fork.

## Proof

- Workflow doesn't run on PRs (dispatch-only); this PR's CI proves the repo still builds. First dispatch against `main` of the fork will be the reproduction baseline (expected: FAIL with the reported crash); dispatch against the fix branch must PASS.