### PR TITLE
fix: insert trailing-punctuation suffix when live deltas precede the final

### DIFF
--- a/Sources/localvoxtral/DictationViewModel+RealtimeEvents.swift
+++ b/Sources/localvoxtral/DictationViewModel+RealtimeEvents.swift
@@ -137,6 +137,13 @@ extension DictationViewModel {
         let finalizedSegment = resolvedFinalizedSegment(from: processedText)
         let hadLiveDelta = !pendingSegmentText.trimmed.isEmpty
             || !livePartialText.trimmed.isEmpty
+        // Text already typed into the field by the live partial path. Derived
+        // from the same state the `hadLiveDelta` guard reads (accumulated
+        // pending text, with live-partial text as fallback) so it cannot drift
+        // from a parallel bookkeeping. Captured before the reset below.
+        let liveInsertedText = pendingSegmentText.trimmed.isEmpty
+            ? livePartialText
+            : pendingSegmentText
         guard !finalizedSegment.isEmpty else {
             livePartialText = ""
             pendingSegmentText = ""
@@ -154,8 +161,23 @@ extension DictationViewModel {
         pendingSegmentText = ""
         statusText = activeStatusText
 
-        if !hadLiveDelta, isLiveAutoPasteModeEnabled {
-            textInsertion.enqueueRealtimeInsertion(finalizedSegment)
+        if isLiveAutoPasteModeEnabled {
+            if !hadLiveDelta {
+                // No partials were typed live: insert the whole segment.
+                textInsertion.enqueueRealtimeInsertion(finalizedSegment)
+            } else if let liveSuffix = TextMergingAlgorithms.livePasteExtensionSuffix(
+                finalText: processedText,
+                liveInsertedText: liveInsertedText
+            ) {
+                // Partials were already typed live and the final is a pure
+                // extension of them (e.g. a trailing "." that only arrived in
+                // the final): insert only the missing suffix so the trailing
+                // addition reaches the field without duplicating earlier text.
+                // When the final revises earlier content the helper returns nil
+                // and nothing is inserted — live mode cannot rewrite already
+                // typed text.
+                textInsertion.enqueueRealtimeInsertion(liveSuffix)
+            }
             if let accessibilityError = textInsertion.lastAccessibilityError {
                 lastError = accessibilityError
             }

--- a/Sources/localvoxtral/TextMergingAlgorithms.swift
+++ b/Sources/localvoxtral/TextMergingAlgorithms.swift
@@ -121,11 +121,18 @@ enum TextMergingAlgorithms {
         finalText: String,
         liveInsertedText: String
     ) -> String? {
-        guard !liveInsertedText.isEmpty, finalText.hasPrefix(liveInsertedText) else {
+        // The finalized-transcript path trims surrounding whitespace, so mirror
+        // that here: a final of "hello. " must type "." — never a dangling
+        // space the transcript itself discards.
+        let normalizedFinal = finalText.trimmed
+        guard !liveInsertedText.isEmpty, normalizedFinal.hasPrefix(liveInsertedText) else {
             return nil
         }
-        let startIndex = finalText.index(finalText.startIndex, offsetBy: liveInsertedText.count)
-        let suffix = String(finalText[startIndex...])
+        let startIndex = normalizedFinal.index(
+            normalizedFinal.startIndex,
+            offsetBy: liveInsertedText.count
+        )
+        let suffix = String(normalizedFinal[startIndex...])
         return suffix.isEmpty ? nil : suffix
     }
 

--- a/Sources/localvoxtral/TextMergingAlgorithms.swift
+++ b/Sources/localvoxtral/TextMergingAlgorithms.swift
@@ -103,6 +103,32 @@ enum TextMergingAlgorithms {
         return length
     }
 
+    /// Computes the missing suffix to type into the focused field when a final
+    /// transcript arrives after live partial deltas have already been inserted.
+    ///
+    /// Backends frequently deliver a trailing addition — typically the final
+    /// "." — only in the `.finalTranscript`, never as a partial delta. When the
+    /// final is a *pure extension* of the text already typed live
+    /// (`finalText == liveInsertedText + suffix`, using the same preprocessing
+    /// the live path applies on both sides), this returns exactly that suffix
+    /// so it can be appended to the field without duplicating earlier text.
+    ///
+    /// Returns nil when the final revises earlier content (not a pure
+    /// extension): live mode cannot rewrite already-typed text, so the caller
+    /// keeps today's behavior of inserting nothing. Also returns nil for an
+    /// empty suffix (final identical to the live text), making it a no-op.
+    static func livePasteExtensionSuffix(
+        finalText: String,
+        liveInsertedText: String
+    ) -> String? {
+        guard !liveInsertedText.isEmpty, finalText.hasPrefix(liveInsertedText) else {
+            return nil
+        }
+        let startIndex = finalText.index(finalText.startIndex, offsetBy: liveInsertedText.count)
+        let suffix = String(finalText[startIndex...])
+        return suffix.isEmpty ? nil : suffix
+    }
+
     static func stableWordBoundaryLength(in text: String, upTo rawLength: Int) -> Int {
         let length = min(max(0, rawLength), text.count)
         guard length > 0 else { return 0 }

--- a/Tests/localvoxtralTests/RealtimeAPILivePastePunctuationTests.swift
+++ b/Tests/localvoxtralTests/RealtimeAPILivePastePunctuationTests.swift
@@ -206,7 +206,7 @@ final class RealtimeAPILivePastePunctuationTests: XCTestCase {
         sendPartials(["you are", " right"], to: viewModel)
         XCTAssertEqual(insertedChunks, ["you are", " right"])
 
-        viewModel.handle(event: .finalTranscript("you are right, right?"), source: .realtimeAPI)
+        viewModel.handle(event: .finalTranscript("you are right, right?"))
 
         XCTAssertEqual(insertedChunks, ["you are", " right", ", right?"])
         XCTAssertEqual(viewModel.currentDictationEventText, "you are right, right?")
@@ -222,7 +222,7 @@ final class RealtimeAPILivePastePunctuationTests: XCTestCase {
         sendPartials(["sparisce"], to: viewModel)
         XCTAssertEqual(insertedChunks, ["sparisce"])
 
-        viewModel.handle(event: .finalTranscript("sparisci."), source: .realtimeAPI)
+        viewModel.handle(event: .finalTranscript("sparisci."))
 
         // The field keeps the live-typed text; no extra chunk is inserted.
         XCTAssertEqual(insertedChunks, ["sparisce"])
@@ -233,7 +233,7 @@ final class RealtimeAPILivePastePunctuationTests: XCTestCase {
         // No partials and an empty final: nothing is ever inserted.
         let viewModel = makeViewModel()
 
-        viewModel.handle(event: .finalTranscript(""), source: .realtimeAPI)
+        viewModel.handle(event: .finalTranscript(""))
 
         XCTAssertEqual(insertedChunks, [])
         XCTAssertEqual(viewModel.currentDictationEventText, "")
@@ -247,7 +247,7 @@ final class RealtimeAPILivePastePunctuationTests: XCTestCase {
         sendPartials(["sparisce"], to: viewModel)
         XCTAssertEqual(insertedChunks, ["sparisce"])
 
-        viewModel.handle(event: .finalTranscript("sparisce"), source: .realtimeAPI)
+        viewModel.handle(event: .finalTranscript("sparisce"))
 
         XCTAssertEqual(insertedChunks, ["sparisce"])
         XCTAssertEqual(viewModel.currentDictationEventText, "sparisce")

--- a/Tests/localvoxtralTests/RealtimeAPILivePastePunctuationTests.swift
+++ b/Tests/localvoxtralTests/RealtimeAPILivePastePunctuationTests.swift
@@ -180,19 +180,77 @@ final class RealtimeAPILivePastePunctuationTests: XCTestCase {
 
     // MARK: - Final transcript vs live deltas
 
-    func testFinalTranscriptDoesNotDoubleInsertWhenLiveDeltasAlreadyInserted() {
-        // When partials have already been typed live, the final transcript is
-        // folded into the running event text but is NOT re-inserted (avoids
-        // duplication). The live field therefore equals the partial stream.
+    func testFinalTranscriptInsertsTrailingPunctuationSuffixFromPureExtension() {
+        // Regression for the trailing-punctuation finding from issue #13's
+        // investigation: partials typed "sparisce" live, then the final
+        // delivers the trailing "." that never came as a partial delta. The
+        // final is a *pure extension* of the live-typed text, so the missing
+        // suffix (".") is inserted into the field — without duplicating the
+        // "sparisce" that is already there. Previously the `hadLiveDelta`
+        // guard skipped re-insertion entirely and the field ended "sparisce".
         let viewModel = makeViewModel()
         sendPartials(["sparisce"], to: viewModel)
         XCTAssertEqual(insertedChunks, ["sparisce"])
 
         viewModel.handle(event: .finalTranscript("sparisce."))
 
-        // No additional insertion beyond the live partial.
-        XCTAssertEqual(insertedChunks, ["sparisce"])
+        XCTAssertEqual(insertedChunks, ["sparisce", "."])
         XCTAssertEqual(viewModel.currentDictationEventText, "sparisce.")
+        XCTAssertEqual(viewModel.pendingSegmentText, "")
+    }
+
+    func testFinalTranscriptInsertsMultiCharSuffixFromPureExtension() {
+        // A multi-char trailing addition (", right?") that only arrives in the
+        // final is inserted as the missing suffix.
+        let viewModel = makeViewModel()
+        sendPartials(["you are", " right"], to: viewModel)
+        XCTAssertEqual(insertedChunks, ["you are", " right"])
+
+        viewModel.handle(event: .finalTranscript("you are right, right?"), source: .realtimeAPI)
+
+        XCTAssertEqual(insertedChunks, ["you are", " right", ", right?"])
+        XCTAssertEqual(viewModel.currentDictationEventText, "you are right, right?")
+        XCTAssertEqual(viewModel.pendingSegmentText, "")
+    }
+
+    func testFinalTranscriptThatRevisesLiveTextIsNotInserted() {
+        // When the final REVISES earlier content (not a pure extension — here
+        // the spelling "sparisce" is corrected to "sparisci"), live mode
+        // cannot rewrite already-typed text, so nothing extra is inserted.
+        // Today's behavior is preserved (issue #23's territory).
+        let viewModel = makeViewModel()
+        sendPartials(["sparisce"], to: viewModel)
+        XCTAssertEqual(insertedChunks, ["sparisce"])
+
+        viewModel.handle(event: .finalTranscript("sparisci."), source: .realtimeAPI)
+
+        // The field keeps the live-typed text; no extra chunk is inserted.
+        XCTAssertEqual(insertedChunks, ["sparisce"])
+        XCTAssertEqual(viewModel.pendingSegmentText, "")
+    }
+
+    func testEmptyFinalTranscriptWithNoLiveDeltasInsertsNothing() {
+        // No partials and an empty final: nothing is ever inserted.
+        let viewModel = makeViewModel()
+
+        viewModel.handle(event: .finalTranscript(""), source: .realtimeAPI)
+
+        XCTAssertEqual(insertedChunks, [])
+        XCTAssertEqual(viewModel.currentDictationEventText, "")
+        XCTAssertEqual(viewModel.pendingSegmentText, "")
+    }
+
+    func testFinalTranscriptIdenticalToLiveTextIsNoOp() {
+        // Final equals the already-typed live text: the missing suffix is
+        // empty, so nothing is inserted (no-op, no duplication).
+        let viewModel = makeViewModel()
+        sendPartials(["sparisce"], to: viewModel)
+        XCTAssertEqual(insertedChunks, ["sparisce"])
+
+        viewModel.handle(event: .finalTranscript("sparisce"), source: .realtimeAPI)
+
+        XCTAssertEqual(insertedChunks, ["sparisce"])
+        XCTAssertEqual(viewModel.currentDictationEventText, "sparisce")
         XCTAssertEqual(viewModel.pendingSegmentText, "")
     }
 }

--- a/Tests/localvoxtralTests/TextMergingAlgorithmsTests.swift
+++ b/Tests/localvoxtralTests/TextMergingAlgorithmsTests.swift
@@ -418,4 +418,82 @@ final class TextMergingAlgorithmsTests: XCTestCase {
         // Apostrophe glues (no leading space) so elisions like "l'acqua" form.
         XCTAssertTrue(TextMergingAlgorithms.shouldAvoidLeadingSpace(before: "'"))
     }
+
+    // MARK: - livePasteExtensionSuffix
+
+    func testLivePasteExtensionSuffix_trailingPeriod() {
+        // "sparisce" typed live, final "sparisce." is a pure extension → ".".
+        XCTAssertEqual(
+            TextMergingAlgorithms.livePasteExtensionSuffix(
+                finalText: "sparisce.",
+                liveInsertedText: "sparisce"
+            ),
+            "."
+        )
+    }
+
+    func testLivePasteExtensionSuffix_multiCharSuffix() {
+        // A multi-char trailing addition is returned verbatim.
+        XCTAssertEqual(
+            TextMergingAlgorithms.livePasteExtensionSuffix(
+                finalText: "you are right, right?",
+                liveInsertedText: "you are right"
+            ),
+            ", right?"
+        )
+    }
+
+    func testLivePasteExtensionSuffix_identicalReturnsNil() {
+        // Final equals the live text: empty suffix → no-op.
+        XCTAssertNil(
+            TextMergingAlgorithms.livePasteExtensionSuffix(
+                finalText: "sparisce",
+                liveInsertedText: "sparisce"
+            )
+        )
+    }
+
+    func testLivePasteExtensionSuffix_revisionReturnsNil() {
+        // The final revises earlier content (not a pure extension) → nil.
+        XCTAssertNil(
+            TextMergingAlgorithms.livePasteExtensionSuffix(
+                finalText: "sparisci.",
+                liveInsertedText: "sparisce"
+            )
+        )
+    }
+
+    func testLivePasteExtensionSuffix_finalShorterThanLiveReturnsNil() {
+        // The final is a prefix of the live text (contraction) → not a pure
+        // extension → nil.
+        XCTAssertNil(
+            TextMergingAlgorithms.livePasteExtensionSuffix(
+                finalText: "spari",
+                liveInsertedText: "sparisce"
+            )
+        )
+    }
+
+    func testLivePasteExtensionSuffix_emptyLiveReturnsNil() {
+        // No live text typed yet: the caller takes the whole-segment path, so a
+        // suffix must not be synthesized here.
+        XCTAssertNil(
+            TextMergingAlgorithms.livePasteExtensionSuffix(
+                finalText: "sparisce.",
+                liveInsertedText: ""
+            )
+        )
+    }
+
+    func testLivePasteExtensionSuffix_disjointReturnsNil() {
+        // Final carries only the punctuation (disjoint from the live word) →
+        // not a pure extension → nil (the whole-segment boundary join is a
+        // separate concern handled by resolvedFinalizedSegment).
+        XCTAssertNil(
+            TextMergingAlgorithms.livePasteExtensionSuffix(
+                finalText: ".",
+                liveInsertedText: "sparisce"
+            )
+        )
+    }
 }

--- a/Tests/localvoxtralTests/TextMergingAlgorithmsTests.swift
+++ b/Tests/localvoxtralTests/TextMergingAlgorithmsTests.swift
@@ -496,4 +496,32 @@ final class TextMergingAlgorithmsTests: XCTestCase {
             )
         )
     }
+
+    func testLivePasteExtensionSuffix_trailingWhitespaceInFinalIsNotTyped() {
+        // The finalized-transcript path trims trailing whitespace; the typed
+        // suffix must match, or the field diverges from the transcript.
+        XCTAssertEqual(
+            TextMergingAlgorithms.livePasteExtensionSuffix(
+                finalText: "sparisce. ",
+                liveInsertedText: "sparisce"
+            ),
+            "."
+        )
+        XCTAssertEqual(
+            TextMergingAlgorithms.livePasteExtensionSuffix(
+                finalText: "sparisce.\n",
+                liveInsertedText: "sparisce"
+            ),
+            "."
+        )
+    }
+
+    func testLivePasteExtensionSuffix_whitespaceOnlyExtensionReturnsNil() {
+        XCTAssertNil(
+            TextMergingAlgorithms.livePasteExtensionSuffix(
+                finalText: "sparisce ",
+                liveInsertedText: "sparisce"
+            )
+        )
+    }
 }


### PR DESCRIPTION
## What

In Live Auto-Paste + RealtimeAPI mode, partial deltas are typed live as they arrive. The final transcript frequently carries a trailing addition that never came as a partial delta (typically the final `.`). The `hadLiveDelta` guard in `handleFinalTranscriptEvent` skipped re-insertion entirely to avoid duplicating text, so that trailing addition never reached the target field — the field ended `sparisce` while the canonical event text said `sparisce.`.

Addresses the trailing-punctuation finding from #13's investigation (does **not** claim to fix #13 itself — the mid-word punctuation positioning analyzed there is a separate concern; the live path is append-only).

**Change:** when the final is a *pure extension* of what was already live-inserted (`final == liveInserted + suffix`, using the same preprocessing the live path applies on both sides), insert exactly the missing suffix. When the final *revises* earlier content (not a pure extension), keep today's behavior of inserting nothing — live mode cannot rewrite already-typed text (issue #23's territory).

The "already live-inserted" baseline is derived from the same state the `hadLiveDelta` guard reads (`pendingSegmentText`, with `livePartialText` fallback), captured before the segment reset, so it cannot drift from parallel bookkeeping. Both partials and finals go through `preprocessIncomingTranscriptChunk` (→ `FirstChunkPreprocessor`), so the prefix comparison is on equal footing.

### Note on a sanctioned test change

The pre-existing characterization test `testFinalTranscriptDoesNotDoubleInsertWhenLiveDeltasAlreadyInserted` asserted the **current (buggy)** behavior (`insertedChunks == ["sparisce"]` — the trailing `.` dropped). This PR changes intended behavior, so that assertion is updated to the correct one (`insertedChunks == ["sparisce", "."]`) and the test renamed. This is the sanctioned exception to the "never weaken a test" rule: the old assertion locked in the bug; the new one locks in the fix, and is stricter (it requires *more* correct output, not less). All other assertions in that test (`currentDictationEventText == "sparisce."`, `pendingSegmentText == ""`) are unchanged.

## Proof

- [x] Unit suite green — `./scripts/remote-build.sh test`
- [ ] Realtime integration green — not re-run; this change does not touch the websocket/audio path (tier 1 runs in CI on the self-hosted runner)
- [x] Bug fix: regression test added — failing run before the fix **and** passing run after (both below)
- [ ] UI change: n/a (logic-only change in the live-insertion path; no UI surface changed)

### Regression test — FAILING run (before the fix)

`LV_BUILD_DIR=work/localvoxtral-punct ./scripts/remote-build.sh test --filter RealtimeAPILivePastePunctuationTests` — against current/buggy source with the new regression tests added:

```
Test Case '-[localvoxtralTests.RealtimeAPILivePastePunctuationTests testFinalTranscriptInsertsMultiCharSuffixFromPureExtension]' started.
/Users/builder/work/localvoxtral-punct/Tests/localvoxtralTests/RealtimeAPILivePastePunctuationTests.swift:212: error: -[localvoxtralTests.RealtimeAPILivePastePunctuationTests testFinalTranscriptInsertsMultiCharSuffixFromPureExtension] : XCTAssertEqual failed: ("["you are", " right"]") is not equal to ("["you are", " right", ", right?"]")
Test Case '-[localvoxtralTests.RealtimeAPILivePastePunctuationTests testFinalTranscriptInsertsMultiCharSuffixFromPureExtension]' failed (0.058 seconds).
Test Case '-[localvoxtralTests.RealtimeAPILivePastePunctuationTests testFinalTranscriptInsertsTrailingPunctuationSuffixFromPureExtension]' started.
/Users/builder/work/localvoxtral-punct/Tests/localvoxtralTests/RealtimeAPILivePastePunctuationTests.swift:198: error: -[localvoxtralTests.RealtimeAPILivePastePunctuationTests testFinalTranscriptInsertsTrailingPunctuationSuffixFromPureExtension] : XCTAssertEqual failed: ("["sparisce"]") is not equal to ("["sparisce", "."]")
Test Case '-[localvoxtralTests.RealtimeAPILivePastePunctuationTests testFinalTranscriptInsertsTrailingPunctuationSuffixFromPureExtension]' failed (0.002 seconds).
	 Executed 16 tests, with 2 failures (0 unexpected) in 0.091 (0.092) seconds
```

### Regression test — PASSING run (after the fix)

Same command after the fix:

```
Test Case '-[localvoxtralTests.RealtimeAPILivePastePunctuationTests testEmptyFinalTranscriptWithNoLiveDeltasInsertsNothing]' passed (0.011 seconds).
Test Case '-[localvoxtralTests.RealtimeAPILivePastePunctuationTests testFinalTranscriptIdenticalToLiveTextIsNoOp]' passed (0.002 seconds).
Test Case '-[localvoxtralTests.RealtimeAPILivePastePunctuationTests testFinalTranscriptInsertsMultiCharSuffixFromPureExtension]' passed (0.002 seconds).
Test Case '-[localvoxtralTests.RealtimeAPILivePastePunctuationTests testFinalTranscriptInsertsTrailingPunctuationSuffixFromPureExtension]' passed (0.001 seconds).
Test Case '-[localvoxtralTests.RealtimeAPILivePastePunctuationTests testFinalTranscriptThatRevisesLiveTextIsNotInserted]' passed (0.001 seconds).
	 Executed 16 tests, with 0 failures (0 unexpected) in 0.032 (0.033) seconds
```

The new cases cover: pure-extension trailing `.` (core fix), multi-char suffix `, right?`, NOT-pure-extension revision (`sparisce` → `sparisci.` stays dropped), empty final (no-op), and final identical to live text (no-op). Pure-function coverage for `livePasteExtensionSuffix` is added to `TextMergingAlgorithmsTests` (7 cases).

### Full unit suite — green after the fix

`LV_BUILD_DIR=work/localvoxtral-punct ./scripts/remote-build.sh test`:

```
Test Suite 'localvoxtralPackageTests.xctest' passed at 2026-07-03 01:05:18.600.
	 Executed 242 tests, with 0 failures (0 unexpected) in 1.340 (1.351) seconds
```

### Strict-concurrency — warning-free

Forced recompile of the two changed source files; no `warning:`/`error:` emitted:

```
[3/7] Compiling localvoxtral TextMergingAlgorithms.swift
[5/7] Compiling localvoxtral DictationViewModel+RealtimeEvents.swift
=== no warning:/error: lines ===
```
