### PR TITLE
feat: fail-fast UX for unreachable backend and missing Accessibility

### DIFF
--- a/Sources/localvoxtral/AccessibilityTrustManager.swift
+++ b/Sources/localvoxtral/AccessibilityTrustManager.swift
@@ -28,6 +28,10 @@ final class AccessibilityTrustManager {
     @ObservationIgnored private let now: DateProvider
     @ObservationIgnored private let pollingInterval: Duration
     @ObservationIgnored private let pollingTimeoutSeconds: TimeInterval
+    /// Test-only override of the trust verdict. When non-nil it is used in place
+    /// of `trustChecker()` so `refresh()` (called on the dictation-start path)
+    /// does not clobber the injected state. Always nil in release builds.
+    @ObservationIgnored private var debugTrustOverride: Bool?
 
     init(
         trustChecker: @escaping TrustChecker = { AXIsProcessTrusted() },
@@ -52,7 +56,7 @@ final class AccessibilityTrustManager {
 
     func refresh() {
         let wasTrusted = isTrusted
-        let trusted = trustChecker()
+        let trusted = debugTrustOverride ?? trustChecker()
         if isTrusted != trusted {
             isTrusted = trusted
         }
@@ -129,3 +133,14 @@ final class AccessibilityTrustManager {
         }
     }
 }
+
+#if DEBUG
+extension AccessibilityTrustManager {
+    /// Forces the trust verdict for tests, surviving subsequent `refresh()`
+    /// calls. Pass `nil` to restore the real `trustChecker`.
+    func debugSetTrustOverride(_ value: Bool?) {
+        debugTrustOverride = value
+        refresh()
+    }
+}
+#endif

--- a/Sources/localvoxtral/DictationViewModel+RealtimeEvents.swift
+++ b/Sources/localvoxtral/DictationViewModel+RealtimeEvents.swift
@@ -205,6 +205,10 @@ extension DictationViewModel {
             handleConnectFailure(reason: .socketError(message: message))
             return
         }
+        if isResolvingConnectTimeout {
+            handleConnectFailure(reason: .socketError(message: message))
+            return
+        }
         if !acceptsRealtimeEvents {
             statusText = "Ready"
             return

--- a/Sources/localvoxtral/DictationViewModel+RealtimeEvents.swift
+++ b/Sources/localvoxtral/DictationViewModel+RealtimeEvents.swift
@@ -53,7 +53,7 @@ extension DictationViewModel {
         cancelConnectTimeout()
         if isConnectingRealtimeSession {
             abortConnectingSession(disconnectSocket: false)
-            handleConnectFailure(reason: .socketError(message: lastError))
+            handleConnectFailure(reason: .socketError(message: lastSocketErrorMessage))
             return
         }
 
@@ -199,6 +199,7 @@ extension DictationViewModel {
     }
 
     private func handleErrorEvent(_ message: String) {
+        lastSocketErrorMessage = message
         if isConnectingRealtimeSession {
             abortConnectingSession()
             handleConnectFailure(reason: .socketError(message: message))

--- a/Sources/localvoxtral/DictationViewModel+RealtimeEvents.swift
+++ b/Sources/localvoxtral/DictationViewModel+RealtimeEvents.swift
@@ -53,12 +53,7 @@ extension DictationViewModel {
         cancelConnectTimeout()
         if isConnectingRealtimeSession {
             abortConnectingSession(disconnectSocket: false)
-            handleConnectFailure(
-                status: "Failed to connect.",
-                message: "Unable to establish realtime connection.",
-                technicalDetails: lastError?.trimmed.isEmpty == false
-                    ? lastError : nil
-            )
+            handleConnectFailure(reason: .socketError(message: lastError))
             return
         }
 
@@ -206,11 +201,7 @@ extension DictationViewModel {
     private func handleErrorEvent(_ message: String) {
         if isConnectingRealtimeSession {
             abortConnectingSession()
-            handleConnectFailure(
-                status: "Failed to connect.",
-                message: "Unable to establish realtime connection.",
-                technicalDetails: message
-            )
+            handleConnectFailure(reason: .socketError(message: message))
             return
         }
         if !acceptsRealtimeEvents {

--- a/Sources/localvoxtral/DictationViewModel+Session.swift
+++ b/Sources/localvoxtral/DictationViewModel+Session.swift
@@ -781,7 +781,6 @@ extension DictationViewModel {
         case .timedOut(let seconds):
             kind = .timedOut
             timeoutSeconds = seconds
-            rawError = connectTimeoutTechnicalDetails(timeoutSeconds: seconds)
 
         case .socketError(let message):
             kind = RealtimeConnectionFailureClassifier.classify(socketErrorMessage: message)
@@ -963,11 +962,6 @@ extension DictationViewModel {
         guard let value else { return nil }
         let trimmed = value.trimmed
         return trimmed.isEmpty ? nil : trimmed
-    }
-
-    private func connectTimeoutTechnicalDetails(timeoutSeconds: TimeInterval) -> String {
-        let endpoint = sanitizedRealtimeEndpointForLogging()
-        return "No connection response received in \(Int(timeoutSeconds)) seconds for endpoint \(endpoint)."
     }
 
     private func llmPolishingConnectionTechnicalDetails(_ details: String) -> String {

--- a/Sources/localvoxtral/DictationViewModel+Session.swift
+++ b/Sources/localvoxtral/DictationViewModel+Session.swift
@@ -38,6 +38,7 @@ extension DictationViewModel {
     }
 
     func beginDictationSession() {
+        lastSocketErrorMessage = nil
         polishAndCommitTask?.cancel()
         polishAndCommitTask = nil
         stopFinalizationTask?.cancel()
@@ -802,6 +803,9 @@ extension DictationViewModel {
         // Surface the actionable, endpoint-naming message as the primary error so
         // it is visible in the popover; keep the raw system error for logs/alert.
         lastError = description.message
+        #if DEBUG
+        debugLastConnectFailureTechnicalDetails = description.technicalDetails
+        #endif
         logConnectionFailure(
             message: description.message,
             technicalDetails: description.technicalDetails

--- a/Sources/localvoxtral/DictationViewModel+Session.swift
+++ b/Sources/localvoxtral/DictationViewModel+Session.swift
@@ -57,12 +57,7 @@ extension DictationViewModel {
 
         let provider = settings.realtimeProvider
         guard let endpoint = settings.resolvedWebSocketURL(for: provider) else {
-            let message = "Set a valid `ws://` or `wss://` endpoint for the selected backend in Settings."
-            handleConnectFailure(
-                status: "Invalid endpoint URL.",
-                message: message,
-                technicalDetails: "Settings value could not be normalized to a websocket endpoint URL."
-            )
+            handleConnectFailure(reason: .invalidEndpoint)
             clearLatchedSessionMetadata()
             return
         }
@@ -83,6 +78,27 @@ extension DictationViewModel {
         sessionProvider = provider
         sessionModelName = model
 
+        // Fail fast on Live Auto-Paste without Accessibility trust: transcribed
+        // text would have nowhere to go. Refresh trust once (the user may have
+        // just granted it), then warn + prompt before opening the socket. We do
+        // NOT abort — the keyboard-event fallback can still type into some apps,
+        // and the prompt's polling clears the warning once Accessibility lands.
+        // The warning is surfaced both as the status line and the red error in
+        // the popover, so it can't be missed before the user speaks.
+        let accessibilityBlockedAtStart: Bool
+        if isLiveAutoPasteModeEnabled, !textInsertion.isAccessibilityTrusted {
+            textInsertion.refreshAccessibilityTrustState()
+            accessibilityBlockedAtStart = !textInsertion.isAccessibilityTrusted
+        } else {
+            accessibilityBlockedAtStart = false
+        }
+        if accessibilityBlockedAtStart {
+            statusText = StatusStrings.pasteBlockedByAccessibilityPermission
+            lastError = Self.liveAutoPasteAccessibilityWarningMessage
+            textInsertion.requestAccessibilityPermissionIfNeeded()
+            debugLog("live auto-paste started without accessibility trust; surfacing warning")
+        }
+
         // Capture the AX anchor now, while the user's text field still has focus.
         // By the time the WebSocket connects and startOverlayBufferSession() runs,
         // our app may have taken focus and the original AX element will be gone.
@@ -101,7 +117,11 @@ extension DictationViewModel {
         textInsertion.resetDiagnostics()
 
         isConnectingRealtimeSession = true
-        statusText = "Connecting to realtime backend..."
+        // Keep the Accessibility warning as the status line when it applies, so
+        // the warning isn't clobbered by the generic "Connecting..." text.
+        if !accessibilityBlockedAtStart {
+            statusText = "Connecting to realtime backend..."
+        }
         debugLog(
             "beginDictationSession endpoint=\(endpoint.absoluteString) model=\(model) input=\(preferredInputID ?? "default")"
         )
@@ -115,11 +135,7 @@ extension DictationViewModel {
             scheduleConnectTimeout()
         } catch {
             abortConnectingSession(disconnectSocket: false)
-            handleConnectFailure(
-                status: "Failed to connect.",
-                message: "Unable to start the realtime connection.",
-                technicalDetails: error.localizedDescription
-            )
+            handleConnectFailure(reason: .connectThrew(rawError: error.localizedDescription))
             debugLog("beginDictationSession failed error=\(error.localizedDescription)")
         }
     }
@@ -663,12 +679,7 @@ extension DictationViewModel {
             guard let self, self.isConnectingRealtimeSession else { return }
 
             abortConnectingSession()
-            let message = "Could not connect to realtime backend within \(Int(timeout)) seconds."
-            handleConnectFailure(
-                status: "Connection timed out.",
-                message: message,
-                technicalDetails: connectTimeoutTechnicalDetails(timeoutSeconds: timeout)
-            )
+            handleConnectFailure(reason: .timedOut(timeoutSeconds: timeout))
         }
     }
 
@@ -734,16 +745,84 @@ extension DictationViewModel {
 
     // MARK: - Connection Failure
 
-    func handleConnectFailure(status: String, message: String, technicalDetails: String? = nil) {
-        let trimmedMessage = message.trimmed
-        let resolvedMessage = trimmedMessage.isEmpty ? "Unable to establish realtime connection." : trimmedMessage
-        let resolvedDetails = normalizedFailureDetails(technicalDetails)
+    /// Call-site context for a realtime backend connection failure. Each case
+    /// carries just enough information for `handleConnectFailure(reason:)` to
+    /// classify the failure and build a clear, endpoint-naming message via
+    /// `RealtimeConnectionFailureClassifier`.
+    enum RealtimeConnectFailureReason: Sendable {
+        /// The configured endpoint could not be resolved to a ws/wss URL.
+        case invalidEndpoint
+        /// `RealtimeClient.connect(_:)` threw synchronously.
+        case connectThrew(rawError: String)
+        /// The connect timeout fired before the socket opened.
+        case timedOut(timeoutSeconds: TimeInterval)
+        /// The socket emitted an `.error`/`.disconnected` event while connecting.
+        case socketError(message: String?)
+        /// The system network path was lost while opening the socket.
+        case networkLost
+    }
 
-        statusText = status
-        lastError = resolvedDetails ?? resolvedMessage
-        logConnectionFailure(message: resolvedMessage, technicalDetails: resolvedDetails)
+    func handleConnectFailure(reason: RealtimeConnectFailureReason) {
+        let endpointDescription = sanitizedRealtimeEndpointForMessage()
+
+        let kind: RealtimeConnectionFailureKind
+        var timeoutSeconds: TimeInterval? = nil
+        var rawError: String? = nil
+
+        switch reason {
+        case .invalidEndpoint:
+            kind = .invalidEndpoint
+
+        case .connectThrew(let errorText):
+            kind = classifyConnectError(errorText)
+            rawError = errorText.trimmed.isEmpty ? nil : errorText
+
+        case .timedOut(let seconds):
+            kind = .timedOut
+            timeoutSeconds = seconds
+            rawError = connectTimeoutTechnicalDetails(timeoutSeconds: seconds)
+
+        case .socketError(let message):
+            kind = RealtimeConnectionFailureClassifier.classify(socketErrorMessage: message)
+            if let message, !message.trimmed.isEmpty {
+                rawError = message
+            }
+        case .networkLost:
+            kind = .networkLost
+        }
+
+        let description = RealtimeConnectionFailureClassifier.describe(
+            kind: kind,
+            endpointDescription: endpointDescription,
+            timeoutSeconds: timeoutSeconds,
+            rawError: rawError
+        )
+
+        statusText = description.status
+        // Surface the actionable, endpoint-naming message as the primary error so
+        // it is visible in the popover; keep the raw system error for logs/alert.
+        lastError = description.message
+        logConnectionFailure(
+            message: description.message,
+            technicalDetails: description.technicalDetails
+        )
         markRecentConnectionFailureIndicator()
-        presentConnectionFailureAlert(message: resolvedMessage)
+        presentConnectionFailureAlert(
+            message: description.message,
+            technicalDetails: description.technicalDetails
+        )
+    }
+
+    private func classifyConnectError(_ rawError: String) -> RealtimeConnectionFailureKind {
+        let lowercased = rawError.lowercased()
+        if lowercased.contains("must use")
+            || lowercased.contains("ws://")
+            || lowercased.contains("wss://")
+            || lowercased.contains("endpoint must")
+        {
+            return .invalidEndpoint
+        }
+        return RealtimeConnectionFailureClassifier.classify(socketErrorMessage: rawError)
     }
 
     func handleLLMPolishingConnectionFailure(message: String, technicalDetails: String? = nil) {
@@ -767,7 +846,11 @@ extension DictationViewModel {
         )
     }
 
-    func presentConnectionFailureAlert(title: String = "Realtime Connection Failed", message: String) {
+    func presentConnectionFailureAlert(
+        title: String = "Realtime Connection Failed",
+        message: String,
+        technicalDetails: String? = nil
+    ) {
         guard !message.isEmpty else { return }
         guard !isShowingConnectionFailureAlert else { return }
 
@@ -778,7 +861,15 @@ extension DictationViewModel {
         let alert = NSAlert()
         alert.alertStyle = .warning
         alert.messageText = title
-        alert.informativeText = message
+        // Show the actionable message first; append the raw system error on a new
+        // line when present so a wrong port or NSError code is visible at a glance.
+        if let technicalDetails, !technicalDetails.trimmed.isEmpty,
+           technicalDetails.trimmed != message.trimmed
+        {
+            alert.informativeText = "\(message)\n\n\(technicalDetails)"
+        } else {
+            alert.informativeText = message
+        }
         if let appIcon = NSApplication.shared.applicationIconImage.copy() as? NSImage {
             appIcon.size = NSSize(width: 20, height: 20)
             alert.icon = appIcon
@@ -845,6 +936,13 @@ extension DictationViewModel {
             return "<invalid endpoint>"
         }
         return sanitizedURLForLogging(endpoint)
+    }
+
+    /// Sanitized resolved endpoint (scheme + host + port + path) for inclusion in
+    /// user-facing failure messages. Reuses the logging sanitizer so the message
+    /// and the log line always agree on what was attempted.
+    private func sanitizedRealtimeEndpointForMessage() -> String {
+        sanitizedRealtimeEndpointForLogging()
     }
 
     private func sanitizedLLMPolishingEndpointForLogging() -> String {

--- a/Sources/localvoxtral/DictationViewModel+Session.swift
+++ b/Sources/localvoxtral/DictationViewModel+Session.swift
@@ -679,14 +679,14 @@ extension DictationViewModel {
             try? await Task.sleep(for: .seconds(timeout))
             guard let self, self.isConnectingRealtimeSession else { return }
 
-            abortConnectingSession()
-            handleConnectFailure(reason: .timedOut(timeoutSeconds: timeout))
+            await self.resolveConnectTimeout(timeoutSeconds: timeout)
         }
     }
 
     func cancelConnectTimeout() {
         connectTimeoutTask?.cancel()
         connectTimeoutTask = nil
+        isResolvingConnectTimeout = false
     }
 
     func abortConnectingSession(disconnectSocket: Bool = true) {
@@ -761,6 +761,38 @@ extension DictationViewModel {
         case socketError(message: String?)
         /// The system network path was lost while opening the socket.
         case networkLost
+    }
+
+    func resolveConnectTimeout(
+        timeoutSeconds: TimeInterval,
+        sleepFor: (TimeInterval) async -> Void = DictationViewModel.sleepForConnectTimeoutSocketErrorGrace
+    ) async {
+        guard isConnectingRealtimeSession else { return }
+
+        if let lastSocketErrorMessage, !lastSocketErrorMessage.trimmed.isEmpty {
+            abortConnectingSession()
+            handleConnectFailure(reason: .socketError(message: lastSocketErrorMessage))
+            return
+        }
+
+        isResolvingConnectTimeout = true
+        await sleepFor(TimingConstants.connectTimeoutSocketErrorGrace)
+        isResolvingConnectTimeout = false
+
+        guard !Task.isCancelled, isConnectingRealtimeSession else { return }
+
+        if let lastSocketErrorMessage, !lastSocketErrorMessage.trimmed.isEmpty {
+            abortConnectingSession()
+            handleConnectFailure(reason: .socketError(message: lastSocketErrorMessage))
+            return
+        }
+
+        abortConnectingSession()
+        handleConnectFailure(reason: .timedOut(timeoutSeconds: timeoutSeconds))
+    }
+
+    private static func sleepForConnectTimeoutSocketErrorGrace(_ duration: TimeInterval) async {
+        try? await Task.sleep(for: .seconds(duration))
     }
 
     func handleConnectFailure(reason: RealtimeConnectFailureReason) {

--- a/Sources/localvoxtral/DictationViewModel.swift
+++ b/Sources/localvoxtral/DictationViewModel.swift
@@ -191,6 +191,8 @@ final class DictationViewModel {
     @ObservationIgnored
     var connectTimeoutTask: Task<Void, Never>?
     @ObservationIgnored
+    var isResolvingConnectTimeout = false
+    @ObservationIgnored
     var recentFailureResetTask: Task<Void, Never>?
     @ObservationIgnored
     var finalizationWatchdogTask: Task<Void, Never>?

--- a/Sources/localvoxtral/DictationViewModel.swift
+++ b/Sources/localvoxtral/DictationViewModel.swift
@@ -130,6 +130,14 @@ final class DictationViewModel {
     var livePartialText = ""
     var statusText = StatusStrings.ready
     var lastError: String?
+    // Raw message from the most recent websocket .error event this session.
+    // Kept separate from lastError, which holds user-facing UI state (e.g. the
+    // Accessibility warning) that must never leak into connection-failure details.
+    var lastSocketErrorMessage: String?
+    #if DEBUG
+    // Test seam: technicalDetails otherwise only reaches the log and the alert.
+    var debugLastConnectFailureTechnicalDetails: String?
+    #endif
     var lastFinalSegment = ""
     private(set) var availableInputDevices: [MicrophoneInputDevice] = []
     private(set) var selectedInputDeviceID = ""

--- a/Sources/localvoxtral/DictationViewModel.swift
+++ b/Sources/localvoxtral/DictationViewModel.swift
@@ -80,7 +80,9 @@ final class DictationViewModel {
 
         @MainActor
         static func from(_ message: String) -> ErrorToken {
-            if message == TextInsertionService.accessibilityErrorMessage {
+            if message == TextInsertionService.accessibilityErrorMessage
+                || message == DictationViewModel.liveAutoPasteAccessibilityWarningMessage
+            {
                 return .accessibilityPermissionRequired
             }
             if message == HotKeyManager.handlerRegistrationErrorMessage {
@@ -113,6 +115,12 @@ final class DictationViewModel {
 
     private static let microphoneDeniedMessage =
         "Grant microphone access in System Settings > Privacy & Security > Microphone."
+
+    /// Surfaced at dictation start (and in the popover) when Live Auto-Paste is
+    /// active but Accessibility isn't trusted — transcribed text would otherwise
+    /// land nowhere. Kept as a stable constant so `ErrorToken` can recognize it.
+    static let liveAutoPasteAccessibilityWarningMessage =
+        "Live Auto-Paste needs Accessibility access to type into other apps. Text won't appear until you enable it in System Settings > Privacy & Security > Accessibility."
 
     var isDictating = false
     var isFinalizingStop = false
@@ -308,6 +316,12 @@ final class DictationViewModel {
                    || self.currentStatusToken == .pasteBlockedByAccessibilityPermission)
             {
                 self.statusText = StatusStrings.ready
+            } else if self.isDictating,
+                self.currentStatusToken == .pasteBlockedByAccessibilityPermission
+            {
+                // Accessibility just landed mid-session: clear the stale warning
+                // so the menu bar / popover reflects that text will now arrive.
+                self.statusText = "Listening..."
             }
         }
 
@@ -479,12 +493,7 @@ final class DictationViewModel {
             debugLog("network lost")
             if isConnectingRealtimeSession {
                 abortConnectingSession()
-                let message = "Network connection was lost while connecting."
-                handleConnectFailure(
-                    status: StatusStrings.networkLostDictationStopped,
-                    message: message,
-                    technicalDetails: "Network path changed to unavailable while opening websocket."
-                )
+                handleConnectFailure(reason: .networkLost)
             } else if isDictating {
                 stopDictation(reason: "network lost", finalizeRemainingAudio: false)
                 statusText = StatusStrings.networkLostDictationStopped
@@ -895,6 +904,17 @@ final class DictationViewModel {
 
     var isLiveAutoPasteModeEnabled: Bool {
         activeOutputMode == .liveAutoPaste
+    }
+
+    /// Non-nil when Live Auto-Paste is the active output mode but Accessibility
+    /// isn't trusted — the condition under which transcribed text lands nowhere.
+    /// Used to surface a warning in the popover and at dictation start. Derived
+    /// from existing state; no new stored state.
+    var liveAutoPasteAccessibilityWarning: String? {
+        guard isLiveAutoPasteModeEnabled, !textInsertion.isAccessibilityTrusted else {
+            return nil
+        }
+        return Self.liveAutoPasteAccessibilityWarningMessage
     }
 
     private var activeOutputMode: DictationOutputMode {

--- a/Sources/localvoxtral/RealtimeConnectionFailure.swift
+++ b/Sources/localvoxtral/RealtimeConnectionFailure.swift
@@ -1,0 +1,167 @@
+import Foundation
+
+/// User-facing classification of a realtime backend connection failure.
+///
+/// The realtime backend can fail to connect in several distinct ways that each
+/// suggest a different user action (start the server, fix the port, fix DNS,
+/// reconnect to the network, fix the URL scheme). This enum captures the
+/// classification; `RealtimeConnectionFailureClassifier` maps it (plus the
+/// resolved endpoint) to the copy surfaced in the popover and failure alert.
+enum RealtimeConnectionFailureKind: Sendable, Equatable {
+    /// The configured endpoint could not be resolved to a valid ws/wss URL.
+    case invalidEndpoint
+    /// The host was reached but actively refused the connection (server not
+    /// running, wrong port, firewall refused).
+    case connectionRefused
+    /// The host itself could not be found or reached (DNS failure, host down,
+    /// unreachable network).
+    case hostUnreachable
+    /// The connection attempt did not complete within the connect timeout.
+    case timedOut
+    /// The system reported the network path was lost while opening the socket.
+    case networkLost
+    /// Any other failure (unexpected socket close, TLS error, etc.).
+    case unknown
+}
+
+/// Copy produced for a connection failure, ready to surface to the user.
+struct RealtimeConnectionFailureDescription: Sendable, Equatable {
+    /// Short status line (popover "Status:" + menu-bar context).
+    let status: String
+    /// Primary user-facing message. Always names the resolved endpoint when one
+    /// is known, so a wrong port is instantly visible.
+    let message: String
+    /// Raw technical/system error preserved for logs and the Console affordance.
+    let technicalDetails: String?
+}
+
+/// Pure mapping from a classified failure (+ endpoint) to user-facing copy.
+///
+/// Kept free of app state on purpose so the message construction is unit-testable
+/// without a view model or live socket.
+enum RealtimeConnectionFailureClassifier {
+    /// Placeholder used when the configured endpoint could not be resolved.
+    static let unknownEndpointDescription = "<unresolved endpoint>"
+
+    /// Describes a connection failure for the user.
+    /// - Parameters:
+    ///   - kind: Classified failure kind.
+    ///   - endpointDescription: Sanitized resolved endpoint string (scheme + host
+    ///     + port + path, no credentials/query). Pass `unknownEndpointDescription`
+    ///     when no endpoint could be resolved.
+    ///   - timeoutSeconds: Connect timeout, only meaningful for `.timedOut`.
+    ///   - rawError: Raw underlying error string (socket error / thrown error),
+    ///     surfaced as technical details. May be nil.
+    static func describe(
+        kind: RealtimeConnectionFailureKind,
+        endpointDescription: String,
+        timeoutSeconds: TimeInterval? = nil,
+        rawError: String?
+    ) -> RealtimeConnectionFailureDescription {
+        let endpoint = endpointDescription.trimmed.isEmpty
+            ? Self.unknownEndpointDescription
+            : endpointDescription
+
+        switch kind {
+        case .invalidEndpoint:
+            return RealtimeConnectionFailureDescription(
+                status: "Invalid endpoint URL.",
+                message: "Set a valid `ws://` or `wss://` endpoint for the selected backend in Settings.",
+                technicalDetails: rawError
+                    ?? "Settings value could not be normalized to a websocket endpoint URL."
+            )
+
+        case .connectionRefused:
+            return RealtimeConnectionFailureDescription(
+                status: "Connection refused.",
+                message: "Connection refused at \(endpoint). Make sure the backend is running and the port is correct.",
+                technicalDetails: rawError
+            )
+
+        case .hostUnreachable:
+            return RealtimeConnectionFailureDescription(
+                status: "Host unreachable.",
+                message: "Could not reach the backend host at \(endpoint). The host could not be found or the network can't reach it.",
+                technicalDetails: rawError
+            )
+
+        case .timedOut:
+            let seconds = max(1, Int(timeoutSeconds ?? 0.rounded()))
+            // The leading phrase is intentionally stable: existing regression
+            // tests assert on "No connection response received in <n> seconds".
+            return RealtimeConnectionFailureDescription(
+                status: "Connection timed out.",
+                message: "No connection response received in \(seconds) seconds at \(endpoint). The backend may be slow to start or unreachable.",
+                technicalDetails: rawError
+            )
+
+        case .networkLost:
+            // Matches DictationViewModel.StatusStrings.networkLostDictationStopped
+            // (kept verbatim so StatusToken mapping continues to recognize it).
+            return RealtimeConnectionFailureDescription(
+                status: "Network lost. Dictation stopped.",
+                message: "Network connection was lost while connecting to \(endpoint). Reconnect to a network and try again.",
+                technicalDetails: rawError
+                    ?? "Network path changed to unavailable while opening websocket."
+            )
+
+        case .unknown:
+            return RealtimeConnectionFailureDescription(
+                status: "Connection failed.",
+                message: "Could not connect to the realtime backend at \(endpoint). Check the endpoint in Settings and try again.",
+                technicalDetails: rawError
+            )
+        }
+    }
+
+    /// Classifies a raw socket/system error message string into a failure kind.
+    ///
+    /// `BaseRealtimeWebSocketClient.describeSocketError` formats errors as
+    /// `"<prefix> <localizedDescription> [<domain>:<code>] url=<url>"`, so the
+    /// NSError code is the most reliable signal. Localized-text fallbacks cover
+    /// transports that omit the structured code.
+    static func classify(socketErrorMessage message: String?) -> RealtimeConnectionFailureKind {
+        guard let message, !message.trimmed.isEmpty else {
+            return .unknown
+        }
+
+        if matches(any: [
+            ":-1001", "NSURLErrorTimedOut", "timed out", "timed out)"
+        ], in: message) {
+            return .timedOut
+        }
+
+        if matches(any: [
+            ":-1003", "NSURLErrorCannotFindHost", "could not find host",
+            "cannot find host", "nodename nor servname", "name resolution"
+        ], in: message) {
+            return .hostUnreachable
+        }
+
+        if matches(any: [
+            ":-1004", "NSURLErrorCannotConnectToHost", "connection refused",
+            "could not connect to the server", "cannot connect to host"
+        ], in: message) {
+            return .connectionRefused
+        }
+
+        if matches(any: [
+            ":-1005", ":-1009", "NSURLErrorNetworkConnectionLost",
+            "NSURLErrorNotConnectedToInternet", "network connection was lost",
+            "not connected to the internet", "internet connection appears to be offline"
+        ], in: message) {
+            return .networkLost
+        }
+
+        return .unknown
+    }
+
+    private static func matches(any candidates: [String], in message: String) -> Bool {
+        let lowercased = message.lowercased()
+        return candidates.contains { candidate in
+            // Match the candidate verbatim (preserves NSError code casing/symbols)
+            // or case-insensitively for natural-language phrases.
+            message.contains(candidate) || lowercased.contains(candidate.lowercased())
+        }
+    }
+}

--- a/Sources/localvoxtral/RealtimeConnectionFailure.swift
+++ b/Sources/localvoxtral/RealtimeConnectionFailure.swift
@@ -18,6 +18,9 @@ enum RealtimeConnectionFailureKind: Sendable, Equatable {
     case hostUnreachable
     /// The connection attempt did not complete within the connect timeout.
     case timedOut
+    /// The host/port accepted a connection but rejected the websocket upgrade,
+    /// usually because the configured path is not a realtime websocket route.
+    case endpointRejected
     /// The system reported the network path was lost while opening the socket.
     case networkLost
     /// Any other failure (unexpected socket close, TLS error, etc.).
@@ -103,6 +106,14 @@ enum RealtimeConnectionFailureClassifier {
                 technicalDetails: nil
             )
 
+        case .endpointRejected:
+            let message = "Endpoint path rejected by server at \(endpoint). Check the path."
+            return RealtimeConnectionFailureDescription(
+                status: "Endpoint path rejected.",
+                message: message,
+                technicalDetails: Self.technicalDetails(rawError, message: message)
+            )
+
         case .networkLost:
             // Matches DictationViewModel.StatusStrings.networkLostDictationStopped
             // (kept verbatim so StatusToken mapping continues to recognize it).
@@ -142,6 +153,16 @@ enum RealtimeConnectionFailureClassifier {
             ":-1001", "NSURLErrorTimedOut", "timed out", "timed out)"
         ], in: message) {
             return .timedOut
+        }
+
+        if matches(any: [
+            ":-1011", "NSURLErrorBadServerResponse", "bad server response",
+            "not a websocket", "not a web socket", "websocket upgrade",
+            "web socket upgrade", "expected http 101", "http 400",
+            "http 404", "http 426", "status code 400", "status code 404",
+            "status code 426"
+        ], in: message) {
+            return .endpointRejected
         }
 
         if matches(any: [

--- a/Sources/localvoxtral/RealtimeConnectionFailure.swift
+++ b/Sources/localvoxtral/RealtimeConnectionFailure.swift
@@ -64,52 +64,65 @@ enum RealtimeConnectionFailureClassifier {
 
         switch kind {
         case .invalidEndpoint:
+            let message = "Set a valid `ws://` or `wss://` endpoint for the selected backend in Settings."
             return RealtimeConnectionFailureDescription(
                 status: "Invalid endpoint URL.",
-                message: "Set a valid `ws://` or `wss://` endpoint for the selected backend in Settings.",
-                technicalDetails: rawError
-                    ?? "Settings value could not be normalized to a websocket endpoint URL."
+                message: message,
+                technicalDetails: Self.technicalDetails(
+                    rawError,
+                    fallback: "Settings value could not be normalized to a websocket endpoint URL.",
+                    message: message
+                )
             )
 
         case .connectionRefused:
+            let message = "Connection refused at \(endpoint). Make sure the backend is running and the port is correct."
             return RealtimeConnectionFailureDescription(
                 status: "Connection refused.",
-                message: "Connection refused at \(endpoint). Make sure the backend is running and the port is correct.",
-                technicalDetails: rawError
+                message: message,
+                technicalDetails: Self.technicalDetails(rawError, message: message)
             )
 
         case .hostUnreachable:
+            let message = "Could not reach the backend host at \(endpoint). The host could not be found or the network can't reach it."
             return RealtimeConnectionFailureDescription(
                 status: "Host unreachable.",
-                message: "Could not reach the backend host at \(endpoint). The host could not be found or the network can't reach it.",
-                technicalDetails: rawError
+                message: message,
+                technicalDetails: Self.technicalDetails(rawError, message: message)
             )
 
         case .timedOut:
-            let seconds = max(1, Int(timeoutSeconds ?? 0.rounded()))
+            let seconds = max(1, Int((timeoutSeconds ?? 0).rounded()))
+            let unit = seconds == 1 ? "second" : "seconds"
             // The leading phrase is intentionally stable: existing regression
-            // tests assert on "No connection response received in <n> seconds".
+            // tests assert on "No connection response received in <n> second(s)".
+            let message = "No connection response received in \(seconds) \(unit) at \(endpoint). The backend may be slow to start or unreachable."
             return RealtimeConnectionFailureDescription(
                 status: "Connection timed out.",
-                message: "No connection response received in \(seconds) seconds at \(endpoint). The backend may be slow to start or unreachable.",
-                technicalDetails: rawError
+                message: message,
+                technicalDetails: nil
             )
 
         case .networkLost:
             // Matches DictationViewModel.StatusStrings.networkLostDictationStopped
             // (kept verbatim so StatusToken mapping continues to recognize it).
+            let message = "Network connection was lost while connecting to \(endpoint). Reconnect to a network and try again."
             return RealtimeConnectionFailureDescription(
                 status: "Network lost. Dictation stopped.",
-                message: "Network connection was lost while connecting to \(endpoint). Reconnect to a network and try again.",
-                technicalDetails: rawError
-                    ?? "Network path changed to unavailable while opening websocket."
+                message: message,
+                technicalDetails: Self.technicalDetails(
+                    rawError,
+                    fallback: "Network path changed to unavailable while opening websocket.",
+                    message: message
+                )
             )
 
         case .unknown:
+            let message = "Could not connect to the realtime backend at \(endpoint). Check the endpoint in Settings and try again."
             return RealtimeConnectionFailureDescription(
                 status: "Connection failed.",
-                message: "Could not connect to the realtime backend at \(endpoint). Check the endpoint in Settings and try again.",
-                technicalDetails: rawError
+                message: message,
+                technicalDetails: Self.technicalDetails(rawError, message: message)
             )
         }
     }
@@ -163,5 +176,55 @@ enum RealtimeConnectionFailureClassifier {
             // or case-insensitively for natural-language phrases.
             message.contains(candidate) || lowercased.contains(candidate.lowercased())
         }
+    }
+
+    private static func technicalDetails(
+        _ rawError: String?,
+        fallback: String? = nil,
+        message: String
+    ) -> String? {
+        if let rawError {
+            let trimmed = rawError.trimmed
+            guard !trimmed.isEmpty else { return nil }
+            guard isDistinctTechnicalDetail(trimmed, from: message) else {
+                return nil
+            }
+            return trimmed
+        }
+        return fallback
+    }
+
+    private static func isDistinctTechnicalDetail(_ details: String, from message: String) -> Bool {
+        let normalizedDetails = normalizedForDetailComparison(details)
+        let normalizedMessage = normalizedForDetailComparison(message)
+        guard !normalizedDetails.isEmpty else { return false }
+        if normalizedDetails == normalizedMessage {
+            return false
+        }
+        if normalizedMessage.contains(normalizedDetails) {
+            return false
+        }
+        return true
+    }
+
+    private static func normalizedForDetailComparison(_ value: String) -> String {
+        let lowercased = value.lowercased()
+        var words: [String] = []
+        var current = ""
+
+        for scalar in lowercased.unicodeScalars {
+            if CharacterSet.alphanumerics.contains(scalar) {
+                current.unicodeScalars.append(scalar)
+            } else if !current.isEmpty {
+                words.append(current)
+                current.removeAll(keepingCapacity: true)
+            }
+        }
+
+        if !current.isEmpty {
+            words.append(current)
+        }
+
+        return words.joined(separator: " ")
     }
 }

--- a/Sources/localvoxtral/StatusPopoverView.swift
+++ b/Sources/localvoxtral/StatusPopoverView.swift
@@ -158,13 +158,14 @@ struct StatusPopoverView: View {
         .frame(width: Self.contentWidth, alignment: .leading)
     }
 
+    // Same typography as the Status line so failure details read as part of
+    // the popover, not a styled callout.
     private func statusDetailView(_ detail: String) -> some View {
         Text(detail)
-            .font(.caption)
             .foregroundStyle(.secondary)
             .lineLimit(nil)
             .fixedSize(horizontal: false, vertical: true)
-        .frame(width: Self.contentWidth, alignment: .leading)
+            .frame(width: Self.contentWidth, alignment: .leading)
     }
 
     private func openAccessibilitySettings() {

--- a/Sources/localvoxtral/StatusPopoverView.swift
+++ b/Sources/localvoxtral/StatusPopoverView.swift
@@ -68,6 +68,14 @@ struct StatusPopoverView: View {
 
             Divider()
 
+            // Prominent, single-source-of-truth "why can't I dictate right now"
+            // banner. Surfaces the Live Auto-Paste + Accessibility gap before the
+            // user speaks into the void; the affordance to fix it is right below.
+            if let warning = viewModel.liveAutoPasteAccessibilityWarning {
+                Text(warning)
+                    .foregroundStyle(.orange)
+            }
+
             Text("Status: \(viewModel.statusText)")
                 .foregroundStyle(.secondary)
 

--- a/Sources/localvoxtral/StatusPopoverView.swift
+++ b/Sources/localvoxtral/StatusPopoverView.swift
@@ -1,6 +1,33 @@
 import AppKit
 import SwiftUI
 
+struct StatusPopoverConnectionFailurePresenter {
+    static func detail(statusText: String, lastError: String?, endpoint: String) -> String? {
+        guard isConnectionFailureStatus(statusText) else { return nil }
+        if statusText != "Invalid endpoint URL.",
+           lastError?.contains(endpoint) != true
+        {
+            return nil
+        }
+        return "Endpoint: \(endpoint)"
+    }
+
+    private static func isConnectionFailureStatus(_ statusText: String) -> Bool {
+        switch statusText {
+        case "Invalid endpoint URL.",
+             "Connection refused.",
+             "Host unreachable.",
+             "Connection timed out.",
+             "Endpoint path rejected.",
+             "Network lost. Dictation stopped.",
+             "Connection failed.":
+            return true
+        default:
+            return false
+        }
+    }
+}
+
 struct StatusPopoverView: View {
     private static let contentWidth: CGFloat = 280
 
@@ -22,33 +49,12 @@ struct StatusPopoverView: View {
         return viewModel.isDictating ? "Stop Dictation" : "Start Dictation"
     }
 
-    private var connectionFailureSummary: (title: String, endpoint: String)? {
-        let endpoint = sanitizedRealtimeEndpointDescription
-        let title: String
-        switch viewModel.statusText {
-        case "Invalid endpoint URL.":
-            title = "Invalid endpoint URL"
-        case "Connection refused.":
-            title = "Connection refused"
-        case "Host unreachable.":
-            title = "Host unreachable"
-        case "Connection timed out.":
-            title = "Connection timed out"
-        case "Network lost. Dictation stopped.":
-            title = "Network lost"
-        case "Connection failed.":
-            title = "Connection failed"
-        default:
-            return nil
-        }
-
-        if viewModel.statusText != "Invalid endpoint URL.",
-           viewModel.lastError?.contains(endpoint) != true
-        {
-            return nil
-        }
-
-        return (title, endpoint)
+    private var connectionFailureDetail: String? {
+        StatusPopoverConnectionFailurePresenter.detail(
+            statusText: viewModel.statusText,
+            lastError: viewModel.lastError,
+            endpoint: sanitizedRealtimeEndpointDescription
+        )
     }
 
     private var sanitizedRealtimeEndpointDescription: String {
@@ -130,13 +136,10 @@ struct StatusPopoverView: View {
                 .fixedSize(horizontal: false, vertical: true)
                 .frame(width: Self.contentWidth, alignment: .leading)
 
-            if let connectionFailureSummary {
-                statusDetailView(
-                    title: connectionFailureSummary.title,
-                    detail: connectionFailureSummary.endpoint
-                )
+            if let connectionFailureDetail {
+                statusDetailView(connectionFailureDetail)
             } else if let lastError = viewModel.lastError {
-                statusDetailView(title: "Error", detail: lastError)
+                statusDetailView("Error: \(lastError)")
             }
 
             Divider()
@@ -155,22 +158,12 @@ struct StatusPopoverView: View {
         .frame(width: Self.contentWidth, alignment: .leading)
     }
 
-    private func statusDetailView(title: String, detail: String) -> some View {
-        HStack(alignment: .firstTextBaseline, spacing: 6) {
-            Circle()
-                .fill(.red)
-                .frame(width: 6, height: 6)
-            VStack(alignment: .leading, spacing: 2) {
-                Text(title)
-                    .font(.caption)
-                    .foregroundStyle(.primary)
-                Text(detail)
-                    .font(.caption2)
-                    .foregroundStyle(.secondary)
-                    .lineLimit(nil)
-                    .fixedSize(horizontal: false, vertical: true)
-            }
-        }
+    private func statusDetailView(_ detail: String) -> some View {
+        Text(detail)
+            .font(.caption)
+            .foregroundStyle(.secondary)
+            .lineLimit(nil)
+            .fixedSize(horizontal: false, vertical: true)
         .frame(width: Self.contentWidth, alignment: .leading)
     }
 

--- a/Sources/localvoxtral/StatusPopoverView.swift
+++ b/Sources/localvoxtral/StatusPopoverView.swift
@@ -2,6 +2,8 @@ import AppKit
 import SwiftUI
 
 struct StatusPopoverView: View {
+    private static let contentWidth: CGFloat = 280
+
     @Environment(\.openSettings) private var openSettings
 
     var viewModel: DictationViewModel
@@ -18,6 +20,49 @@ struct StatusPopoverView: View {
             return "Connecting..."
         }
         return viewModel.isDictating ? "Stop Dictation" : "Start Dictation"
+    }
+
+    private var connectionFailureSummary: (title: String, endpoint: String)? {
+        let endpoint = sanitizedRealtimeEndpointDescription
+        let title: String
+        switch viewModel.statusText {
+        case "Invalid endpoint URL.":
+            title = "Invalid endpoint URL"
+        case "Connection refused.":
+            title = "Connection refused"
+        case "Host unreachable.":
+            title = "Host unreachable"
+        case "Connection timed out.":
+            title = "Connection timed out"
+        case "Network lost. Dictation stopped.":
+            title = "Network lost"
+        case "Connection failed.":
+            title = "Connection failed"
+        default:
+            return nil
+        }
+
+        if viewModel.statusText != "Invalid endpoint URL.",
+           viewModel.lastError?.contains(endpoint) != true
+        {
+            return nil
+        }
+
+        return (title, endpoint)
+    }
+
+    private var sanitizedRealtimeEndpointDescription: String {
+        guard let endpoint = viewModel.settings.resolvedWebSocketURL(for: viewModel.settings.realtimeProvider) else {
+            return "<invalid endpoint>"
+        }
+        guard var components = URLComponents(url: endpoint, resolvingAgainstBaseURL: false) else {
+            return endpoint.absoluteString
+        }
+        components.user = nil
+        components.password = nil
+        components.query = nil
+        components.fragment = nil
+        return components.string ?? endpoint.absoluteString
     }
 
     var body: some View {
@@ -74,14 +119,24 @@ struct StatusPopoverView: View {
             if let warning = viewModel.liveAutoPasteAccessibilityWarning {
                 Text(warning)
                     .foregroundStyle(.orange)
+                    .lineLimit(nil)
+                    .fixedSize(horizontal: false, vertical: true)
+                    .frame(width: Self.contentWidth, alignment: .leading)
             }
 
             Text("Status: \(viewModel.statusText)")
                 .foregroundStyle(.secondary)
+                .lineLimit(nil)
+                .fixedSize(horizontal: false, vertical: true)
+                .frame(width: Self.contentWidth, alignment: .leading)
 
-            if let lastError = viewModel.lastError {
-                Text(lastError)
-                    .foregroundStyle(.red)
+            if let connectionFailureSummary {
+                statusDetailView(
+                    title: connectionFailureSummary.title,
+                    detail: connectionFailureSummary.endpoint
+                )
+            } else if let lastError = viewModel.lastError {
+                statusDetailView(title: "Error", detail: lastError)
             }
 
             Divider()
@@ -97,6 +152,26 @@ struct StatusPopoverView: View {
         .onReceive(NotificationCenter.default.publisher(for: NSApplication.didBecomeActiveNotification)) { _ in
             viewModel.refreshAccessibilityTrustState()
         }
+        .frame(width: Self.contentWidth, alignment: .leading)
+    }
+
+    private func statusDetailView(title: String, detail: String) -> some View {
+        HStack(alignment: .firstTextBaseline, spacing: 6) {
+            Circle()
+                .fill(.red)
+                .frame(width: 6, height: 6)
+            VStack(alignment: .leading, spacing: 2) {
+                Text(title)
+                    .font(.caption)
+                    .foregroundStyle(.primary)
+                Text(detail)
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+                    .lineLimit(nil)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+        }
+        .frame(width: Self.contentWidth, alignment: .leading)
     }
 
     private func openAccessibilitySettings() {

--- a/Sources/localvoxtral/TextInsertionService.swift
+++ b/Sources/localvoxtral/TextInsertionService.swift
@@ -1111,5 +1111,11 @@ extension TextInsertionService {
             await task.value
         }
     }
+
+    /// Forces the Accessibility trust verdict for tests. Pass `nil` to restore
+    /// the real `AXIsProcessTrusted()` checker.
+    func debugSetAccessibilityTrusted(_ trusted: Bool?) {
+        accessibilityTrust.debugSetTrustOverride(trusted)
+    }
 }
 #endif

--- a/Sources/localvoxtral/TimingConstants.swift
+++ b/Sources/localvoxtral/TimingConstants.swift
@@ -15,6 +15,11 @@ enum TimingConstants {
     /// How long to wait for a WebSocket to reach `.connected` before timing out.
     static let connectTimeout: TimeInterval = 1.0
 
+    /// Short grace after the app-level connect timeout fires before presenting
+    /// a timeout. This lets URLSession deliver a terminal socket error that
+    /// raced the timer, so refused ports are not mislabeled as silent timeouts.
+    static let connectTimeoutSocketErrorGrace: TimeInterval = 0.15
+
     /// Duration the "recent failure" indicator stays visible after a connection error.
     static let recentFailureIndicatorDuration: TimeInterval = 5.0
 

--- a/Tests/localvoxtralTests/DictationViewModelFailFastUXTests.swift
+++ b/Tests/localvoxtralTests/DictationViewModelFailFastUXTests.swift
@@ -55,7 +55,7 @@ final class DictationViewModelFailFastUXTests: XCTestCase {
         XCTAssertEqual(viewModel.statusText, "Connection timed out.")
         XCTAssertTrue(
             viewModel.lastError?.contains(
-                "No connection response received in \(Int(TimingConstants.connectTimeout)) seconds"
+                "No connection response received in \(Self.formattedTimeout(TimingConstants.connectTimeout))"
             ) == true
         )
         XCTAssertTrue(viewModel.lastError?.contains(endpoint) == true)
@@ -215,6 +215,11 @@ final class DictationViewModelFailFastUXTests: XCTestCase {
 
     private func retainForTestProcessLifetime(_ viewModel: DictationViewModel) {
         Self.retainedViewModels.append(viewModel)
+    }
+
+    private static func formattedTimeout(_ timeout: TimeInterval) -> String {
+        let seconds = max(1, Int(timeout.rounded()))
+        return "\(seconds) \(seconds == 1 ? "second" : "seconds")"
     }
 }
 

--- a/Tests/localvoxtralTests/DictationViewModelFailFastUXTests.swift
+++ b/Tests/localvoxtralTests/DictationViewModelFailFastUXTests.swift
@@ -1,0 +1,236 @@
+import Foundation
+import XCTest
+@testable import localvoxtral
+
+@MainActor
+final class DictationViewModelFailFastUXTests: XCTestCase {
+    // DictationViewModel owns several app-lifetime services. Retain test instances
+    // for the process duration so teardown does not race service shutdown.
+    private static var retainedViewModels: [DictationViewModel] = []
+
+    // MARK: - Backend connection failure messaging
+
+    func testSocketConnectionRefusedSurfacesRefusedStatusAndEndpoint() {
+        let viewModel = makeViewModel(outputMode: .liveAutoPaste)
+        viewModel.isShowingConnectionFailureAlert = true
+        retainForTestProcessLifetime(viewModel)
+
+        let endpoint = viewModel.sanitizedRealtimeEndpointForMessageReference()
+        XCTAssertTrue(endpoint.contains("ws://"), "sanity: endpoint resolved, got \(endpoint)")
+
+        viewModel.handleConnectFailure(
+            reason: .socketError(
+                message: "WebSocket failed: [NSURLErrorDomain:-1004] url=ws://127.0.0.1:8000/v1/realtime"
+            )
+        )
+
+        XCTAssertEqual(viewModel.statusText, "Connection refused.")
+        XCTAssertNotNil(viewModel.lastError)
+        XCTAssertTrue(viewModel.lastError?.contains(endpoint) == true, "lastError should name the endpoint")
+        XCTAssertEqual(viewModel.realtimeSessionIndicatorState, .recentFailure)
+    }
+
+    func testSocketHostUnreachableSurfacesDistinctStatus() {
+        let viewModel = makeViewModel(outputMode: .liveAutoPaste)
+        viewModel.isShowingConnectionFailureAlert = true
+        retainForTestProcessLifetime(viewModel)
+
+        viewModel.handleConnectFailure(
+            reason: .socketError(message: "WebSocket failed: [NSURLErrorDomain:-1003] url=ws://x/realtime")
+        )
+
+        XCTAssertEqual(viewModel.statusText, "Host unreachable.")
+        XCTAssertNotNil(viewModel.lastError)
+    }
+
+    func testTimeoutReasonKeepsStableStatusAndEndpointPhrase() {
+        let viewModel = makeViewModel(outputMode: .overlayBuffer)
+        viewModel.isShowingConnectionFailureAlert = true
+        retainForTestProcessLifetime(viewModel)
+
+        let endpoint = viewModel.sanitizedRealtimeEndpointForMessageReference()
+
+        viewModel.handleConnectFailure(reason: .timedOut(timeoutSeconds: TimingConstants.connectTimeout))
+
+        XCTAssertEqual(viewModel.statusText, "Connection timed out.")
+        XCTAssertTrue(
+            viewModel.lastError?.contains(
+                "No connection response received in \(Int(TimingConstants.connectTimeout)) seconds"
+            ) == true
+        )
+        XCTAssertTrue(viewModel.lastError?.contains(endpoint) == true)
+    }
+
+    func testInvalidEndpointReasonSurfacesSettingsGuidance() {
+        let viewModel = makeViewModel(outputMode: .liveAutoPaste)
+        viewModel.isShowingConnectionFailureAlert = true
+        retainForTestProcessLifetime(viewModel)
+
+        viewModel.handleConnectFailure(reason: .invalidEndpoint)
+
+        XCTAssertEqual(viewModel.statusText, "Invalid endpoint URL.")
+        XCTAssertTrue(viewModel.lastError?.contains("Settings") == true)
+    }
+
+    func testNetworkLostReasonSurfacesNetworkLostStatus() {
+        let viewModel = makeViewModel(outputMode: .liveAutoPaste)
+        viewModel.isShowingConnectionFailureAlert = true
+        retainForTestProcessLifetime(viewModel)
+
+        viewModel.handleConnectFailure(reason: .networkLost)
+
+        XCTAssertEqual(viewModel.statusText, "Network lost. Dictation stopped.")
+        XCTAssertNotNil(viewModel.lastError)
+    }
+
+    // MARK: - Accessibility gate at dictation start
+
+    func testLiveAutoPasteWarningPresentIffNotTrusted() {
+        let viewModel = makeViewModel(outputMode: .liveAutoPaste)
+        retainForTestProcessLifetime(viewModel)
+
+        viewModel.textInsertion.debugSetAccessibilityTrusted(false)
+        XCTAssertEqual(
+            viewModel.liveAutoPasteAccessibilityWarning,
+            DictationViewModel.liveAutoPasteAccessibilityWarningMessage
+        )
+
+        viewModel.textInsertion.debugSetAccessibilityTrusted(true)
+        XCTAssertNil(viewModel.liveAutoPasteAccessibilityWarning)
+    }
+
+    func testOverlayModeNeverShowsLiveAutoPasteWarning() {
+        let viewModel = makeViewModel(outputMode: .overlayBuffer)
+        retainForTestProcessLifetime(viewModel)
+
+        viewModel.textInsertion.debugSetAccessibilityTrusted(false)
+        XCTAssertNil(viewModel.liveAutoPasteAccessibilityWarning)
+    }
+
+    func testWarningIsRecognizedAsAccessibilityErrorToken() {
+        // Ensures the existing onAccessibilityTrustChanged callback (which clears
+        // lastError when currentErrorToken == .accessibilityPermissionRequired)
+        // will clear the warning once Accessibility lands.
+        let token = DictationViewModel.ErrorToken.from(
+            DictationViewModel.liveAutoPasteAccessibilityWarningMessage
+        )
+        XCTAssertEqual(token, .accessibilityPermissionRequired)
+    }
+
+    func testBeginDictationSessionSurfacesAccessibilityWarningInLiveMode() {
+        let viewModel = makeViewModel(outputMode: .liveAutoPaste)
+        // Point at a closed port so the async connect fails fast and does not
+        // hit a real backend. The AX warning is asserted synchronously, before
+        // any connect result can race back.
+        viewModel.settings.realtimeAPIEndpointURL = "ws://127.0.0.1:65535/realtime"
+        viewModel.isShowingConnectionFailureAlert = true
+        viewModel.textInsertion.debugSetAccessibilityTrusted(false)
+        retainForTestProcessLifetime(viewModel)
+
+        viewModel.beginDictationSession()
+
+        // Fail-fast warning surfaces at start and is not clobbered by the
+        // generic "Connecting..." status.
+        XCTAssertEqual(viewModel.statusText, "Paste blocked by Accessibility permission.")
+        XCTAssertEqual(viewModel.lastError, DictationViewModel.liveAutoPasteAccessibilityWarningMessage)
+        XCTAssertTrue(viewModel.isConnectingRealtimeSession, "session still proceeds so AX can be granted mid-session")
+
+        viewModel.abortConnectingSession()
+    }
+
+    func testBeginDictationSessionSkipsAccessibilityWarningWhenTrustedInLiveMode() {
+        let viewModel = makeViewModel(outputMode: .liveAutoPaste)
+        viewModel.settings.realtimeAPIEndpointURL = "ws://127.0.0.1:65535/realtime"
+        viewModel.isShowingConnectionFailureAlert = true
+        viewModel.textInsertion.debugSetAccessibilityTrusted(true)
+        retainForTestProcessLifetime(viewModel)
+
+        viewModel.beginDictationSession()
+
+        XCTAssertEqual(viewModel.statusText, "Connecting to realtime backend...")
+        XCTAssertNil(viewModel.lastError)
+
+        viewModel.abortConnectingSession()
+    }
+
+    func testBeginDictationSessionSkipsAccessibilityWarningInOverlayMode() {
+        let viewModel = makeViewModel(outputMode: .overlayBuffer)
+        viewModel.settings.realtimeAPIEndpointURL = "ws://127.0.0.1:65535/realtime"
+        viewModel.isShowingConnectionFailureAlert = true
+        viewModel.textInsertion.debugSetAccessibilityTrusted(false)
+        retainForTestProcessLifetime(viewModel)
+
+        viewModel.beginDictationSession()
+
+        XCTAssertEqual(viewModel.statusText, "Connecting to realtime backend...")
+        XCTAssertNil(viewModel.lastError)
+
+        viewModel.abortConnectingSession()
+    }
+
+    // MARK: - Helpers
+
+    private func makeViewModel(outputMode: DictationOutputMode) -> DictationViewModel {
+        let settings = makeSettings(outputMode: outputMode)
+        let viewModel = DictationViewModel(
+            settings: settings,
+            overlayBufferCoordinator: NoopOverlayCoordinator(),
+            startRuntimeServices: false
+        )
+        return viewModel
+    }
+
+    private func makeSettings(outputMode: DictationOutputMode) -> SettingsStore {
+        let suiteName = "localvoxtral.DictationViewModelFailFastUXTests.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defaults.removePersistentDomain(forName: suiteName)
+        addTeardownBlock {
+            defaults.removePersistentDomain(forName: suiteName)
+        }
+        let settings = SettingsStore(defaults: defaults, environment: [:])
+        settings.dictationOutputMode = outputMode
+        return settings
+    }
+
+    private func retainForTestProcessLifetime(_ viewModel: DictationViewModel) {
+        Self.retainedViewModels.append(viewModel)
+    }
+}
+
+// MARK: - Test-only accessors and doubles
+
+@MainActor
+private final class NoopOverlayCoordinator: OverlayBufferSessionCoordinating {
+    var commitTargetAppPID: pid_t? = nil
+
+    func resolveAnchorNow() -> OverlayAnchor {
+        OverlayAnchor(targetRect: .zero, source: .windowCenter)
+    }
+    func startSession(preResolvedAnchor: OverlayAnchor?) {}
+    func beginFinalizing(displayBufferText: String, commitBufferText: String) {}
+    func refresh(displayBufferText: String, commitBufferText: String) {}
+    @discardableResult
+    func commitIfNeeded(using textCommitter: OverlayTextCommitting, autoCopyEnabled: Bool) -> OverlayBufferCommitOutcome {
+        .succeeded
+    }
+    func dismissAfterHold(minimumVisibility: TimeInterval) {}
+    func reset() {}
+}
+
+extension DictationViewModel {
+    /// Test-only access to the sanitized endpoint used in user-facing messages.
+    @MainActor
+    fileprivate func sanitizedRealtimeEndpointForMessageReference() -> String {
+        // Mirrors the private sanitizedRealtimeEndpointForMessage() for assertions.
+        let endpoint = settings.resolvedWebSocketURL(for: settings.realtimeProvider)
+        guard let endpoint else { return "<invalid endpoint>" }
+        guard var components = URLComponents(url: endpoint, resolvingAgainstBaseURL: false) else {
+            return endpoint.absoluteString
+        }
+        components.user = nil
+        components.password = nil
+        components.query = nil
+        components.fragment = nil
+        return components.string ?? endpoint.absoluteString
+    }
+}

--- a/Tests/localvoxtralTests/DictationViewModelFailFastUXTests.swift
+++ b/Tests/localvoxtralTests/DictationViewModelFailFastUXTests.swift
@@ -61,6 +61,43 @@ final class DictationViewModelFailFastUXTests: XCTestCase {
         XCTAssertTrue(viewModel.lastError?.contains(endpoint) == true)
     }
 
+    func testRefusedSocketErrorDuringTimeoutResolutionWinsOverTimeout() async {
+        let viewModel = makeViewModel(outputMode: .liveAutoPaste)
+        viewModel.isShowingConnectionFailureAlert = true
+        viewModel.isConnectingRealtimeSession = true
+        viewModel.statusText = "Connecting to realtime backend..."
+        retainForTestProcessLifetime(viewModel)
+
+        await viewModel.resolveConnectTimeout(timeoutSeconds: TimingConstants.connectTimeout) { _ in
+            viewModel.handle(
+                event: .error(
+                    "WebSocket failed: The operation couldn't be completed. [NSURLErrorDomain:-1004] url=ws://127.0.0.1:8001/v1/realtimeaa"
+                )
+            )
+        }
+
+        XCTAssertFalse(viewModel.isConnectingRealtimeSession)
+        XCTAssertEqual(viewModel.statusText, "Connection refused.")
+        XCTAssertTrue(viewModel.lastError?.contains("Connection refused") == true)
+        XCTAssertFalse(viewModel.lastError?.contains("No connection response received") == true)
+        XCTAssertEqual(viewModel.realtimeSessionIndicatorState, .recentFailure)
+    }
+
+    func testEndpointRejectedSocketErrorSurfacesPathStatus() {
+        let viewModel = makeViewModel(outputMode: .liveAutoPaste)
+        viewModel.isShowingConnectionFailureAlert = true
+        retainForTestProcessLifetime(viewModel)
+
+        viewModel.handleConnectFailure(
+            reason: .socketError(
+                message: "WebSocket failed: bad server response [NSURLErrorDomain:-1011] url=ws://127.0.0.1:8000/v1/realtimeaa"
+            )
+        )
+
+        XCTAssertEqual(viewModel.statusText, "Endpoint path rejected.")
+        XCTAssertTrue(viewModel.lastError?.contains("Check the path") == true)
+    }
+
     func testInvalidEndpointReasonSurfacesSettingsGuidance() {
         let viewModel = makeViewModel(outputMode: .liveAutoPaste)
         viewModel.isShowingConnectionFailureAlert = true
@@ -81,6 +118,19 @@ final class DictationViewModelFailFastUXTests: XCTestCase {
 
         XCTAssertEqual(viewModel.statusText, "Network lost. Dictation stopped.")
         XCTAssertNotNil(viewModel.lastError)
+    }
+
+    func testConnectionFailurePopoverDetailDoesNotRepeatStatusText() {
+        let status = "Connection refused."
+        let endpoint = "ws://127.0.0.1:8001/v1/realtimeaa"
+        let detail = StatusPopoverConnectionFailurePresenter.detail(
+            statusText: status,
+            lastError: "Connection refused at \(endpoint). Make sure the backend is running and the port is correct.",
+            endpoint: endpoint
+        )
+
+        XCTAssertEqual(detail, "Endpoint: \(endpoint)")
+        XCTAssertFalse(detail?.contains(status) == true)
     }
 
     // MARK: - Accessibility gate at dictation start

--- a/Tests/localvoxtralTests/DictationViewModelFailFastUXTests.swift
+++ b/Tests/localvoxtralTests/DictationViewModelFailFastUXTests.swift
@@ -166,10 +166,9 @@ final class DictationViewModelFailFastUXTests: XCTestCase {
         retainForTestProcessLifetime(viewModel)
 
         viewModel.lastError = DictationViewModel.liveAutoPasteAccessibilityWarningMessage
-        viewModel.activeClientSource = .realtimeAPI
         viewModel.isConnectingRealtimeSession = true
 
-        viewModel.handle(event: .disconnected, source: .realtimeAPI)
+        viewModel.handle(event: .disconnected)
 
         XCTAssertFalse(
             viewModel.debugLastConnectFailureTechnicalDetails?.contains("Accessibility") == true,
@@ -291,6 +290,7 @@ private final class NoopOverlayCoordinator: OverlayBufferSessionCoordinating {
     }
     func dismissAfterHold(minimumVisibility: TimeInterval) {}
     func reset() {}
+    func captureLiveCommitTargetAppPID() {}
 }
 
 extension DictationViewModel {

--- a/Tests/localvoxtralTests/DictationViewModelFailFastUXTests.swift
+++ b/Tests/localvoxtralTests/DictationViewModelFailFastUXTests.swift
@@ -107,6 +107,27 @@ final class DictationViewModelFailFastUXTests: XCTestCase {
         XCTAssertNil(viewModel.liveAutoPasteAccessibilityWarning)
     }
 
+    func testErrorlessDisconnectDoesNotLeakUIErrorIntoFailureDetails() {
+        // A handshake that closes without a websocket .error event classifies
+        // from lastSocketErrorMessage (nil here), never from lastError, which
+        // may hold unrelated UI state such as the Accessibility warning.
+        let viewModel = makeViewModel(outputMode: .liveAutoPaste)
+        viewModel.isShowingConnectionFailureAlert = true
+        retainForTestProcessLifetime(viewModel)
+
+        viewModel.lastError = DictationViewModel.liveAutoPasteAccessibilityWarningMessage
+        viewModel.activeClientSource = .realtimeAPI
+        viewModel.isConnectingRealtimeSession = true
+
+        viewModel.handle(event: .disconnected, source: .realtimeAPI)
+
+        XCTAssertFalse(
+            viewModel.debugLastConnectFailureTechnicalDetails?.contains("Accessibility") == true,
+            "failure details must not embed the AX warning, got: \(viewModel.debugLastConnectFailureTechnicalDetails ?? "nil")"
+        )
+        XCTAssertEqual(viewModel.realtimeSessionIndicatorState, .recentFailure)
+    }
+
     func testWarningIsRecognizedAsAccessibilityErrorToken() {
         // Ensures the existing onAccessibilityTrustChanged callback (which clears
         // lastError when currentErrorToken == .accessibilityPermissionRequired)

--- a/Tests/localvoxtralTests/DictationViewModelOverlayLifecycleTests.swift
+++ b/Tests/localvoxtralTests/DictationViewModelOverlayLifecycleTests.swift
@@ -157,7 +157,7 @@ final class DictationViewModelOverlayLifecycleTests: XCTestCase {
         XCTAssertNotNil(viewModel.lastError)
         XCTAssertTrue(
             viewModel.lastError?.contains(
-                "No connection response received in \(Int(TimingConstants.connectTimeout)) seconds"
+                "No connection response received in \(Self.formattedTimeout(TimingConstants.connectTimeout))"
             ) == true
         )
     }
@@ -902,6 +902,11 @@ final class DictationViewModelOverlayLifecycleTests: XCTestCase {
 
     private func retainForTestProcessLifetime(_ viewModel: DictationViewModel) {
         Self.retainedViewModels.append(viewModel)
+    }
+
+    private static func formattedTimeout(_ timeout: TimeInterval) -> String {
+        let seconds = max(1, Int(timeout.rounded()))
+        return "\(seconds) \(seconds == 1 ? "second" : "seconds")"
     }
 }
 

--- a/Tests/localvoxtralTests/RealtimeConnectionFailureTests.swift
+++ b/Tests/localvoxtralTests/RealtimeConnectionFailureTests.swift
@@ -108,8 +108,29 @@ final class RealtimeConnectionFailureTests: XCTestCase {
         )
         XCTAssertEqual(description.status, "Connection timed out.")
         // Stable phrase asserted by existing timeout regression test:
-        XCTAssertTrue(description.message.contains("No connection response received in 1 seconds"))
+        XCTAssertTrue(description.message.contains("No connection response received in 1 second"))
+        XCTAssertFalse(description.message.contains("1 seconds"))
         XCTAssertTrue(description.message.contains(endpoint))
+    }
+
+    func testDescribeTimedOutPluralizesMultipleSeconds() {
+        let description = RealtimeConnectionFailureClassifier.describe(
+            kind: .timedOut,
+            endpointDescription: endpoint,
+            timeoutSeconds: 3.0,
+            rawError: nil
+        )
+        XCTAssertTrue(description.message.contains("No connection response received in 3 seconds"))
+    }
+
+    func testDescribeTimedOutOmitsDuplicateTechnicalDetails() {
+        let description = RealtimeConnectionFailureClassifier.describe(
+            kind: .timedOut,
+            endpointDescription: endpoint,
+            timeoutSeconds: 1.0,
+            rawError: "No connection response received in 1 seconds for endpoint \(endpoint)."
+        )
+        XCTAssertNil(description.technicalDetails)
     }
 
     func testDescribeInvalidEndpointDoesNotRequireEndpoint() {
@@ -152,6 +173,36 @@ final class RealtimeConnectionFailureTests: XCTestCase {
             rawError: nil
         )
         XCTAssertTrue(description.message.contains(RealtimeConnectionFailureClassifier.unknownEndpointDescription))
+    }
+
+    func testDescribeOmitsTechnicalDetailsThatDuplicateMessageForAllKinds() {
+        let cases: [(RealtimeConnectionFailureKind, TimeInterval?)] = [
+            (.invalidEndpoint, nil),
+            (.connectionRefused, nil),
+            (.hostUnreachable, nil),
+            (.timedOut, 2.0),
+            (.networkLost, nil),
+            (.unknown, nil),
+        ]
+
+        for (kind, timeoutSeconds) in cases {
+            let baseline = RealtimeConnectionFailureClassifier.describe(
+                kind: kind,
+                endpointDescription: endpoint,
+                timeoutSeconds: timeoutSeconds,
+                rawError: nil
+            )
+            let withDuplicateDetails = RealtimeConnectionFailureClassifier.describe(
+                kind: kind,
+                endpointDescription: endpoint,
+                timeoutSeconds: timeoutSeconds,
+                rawError: baseline.message
+            )
+            XCTAssertNil(
+                withDuplicateDetails.technicalDetails,
+                "\(kind) should omit details that repeat the user-facing message"
+            )
+        }
     }
 
     // MARK: - Divergence guard

--- a/Tests/localvoxtralTests/RealtimeConnectionFailureTests.swift
+++ b/Tests/localvoxtralTests/RealtimeConnectionFailureTests.swift
@@ -1,0 +1,169 @@
+import Foundation
+import XCTest
+@testable import localvoxtral
+
+@MainActor
+final class RealtimeConnectionFailureTests: XCTestCase {
+
+    // MARK: - classify(socketErrorMessage:)
+
+    func testClassifyNilOrEmptyIsUnknown() {
+        XCTAssertEqual(RealtimeConnectionFailureClassifier.classify(socketErrorMessage: nil), .unknown)
+        XCTAssertEqual(RealtimeConnectionFailureClassifier.classify(socketErrorMessage: ""), .unknown)
+        XCTAssertEqual(
+            RealtimeConnectionFailureClassifier.classify(socketErrorMessage: "   "), .unknown
+        )
+    }
+
+    func testClassifiesConnectionRefusedByNSURLErrorCode() {
+        let message = "WebSocket failed: The operation couldn't be completed. [NSURLErrorDomain:-1004] url=ws://127.0.0.1:8000/v1/realtime"
+        XCTAssertEqual(
+            RealtimeConnectionFailureClassifier.classify(socketErrorMessage: message), .connectionRefused
+        )
+    }
+
+    func testClassifiesHostUnreachableByNSURLErrorCode() {
+        let message = "WebSocket failed: Could not find host. [NSURLErrorDomain:-1003] url=ws://missing-host:8000/realtime"
+        XCTAssertEqual(
+            RealtimeConnectionFailureClassifier.classify(socketErrorMessage: message), .hostUnreachable
+        )
+    }
+
+    func testClassifiesTimedOutByNSURLErrorCode() {
+        let message = "WebSocket failed: The request timed out. [NSURLErrorDomain:-1001] url=ws://10.0.0.5:8000/realtime"
+        XCTAssertEqual(
+            RealtimeConnectionFailureClassifier.classify(socketErrorMessage: message), .timedOut
+        )
+    }
+
+    func testClassifiesNetworkLostByNSURLErrorCodes() {
+        XCTAssertEqual(
+            RealtimeConnectionFailureClassifier.classify(
+                socketErrorMessage: "lost [NSURLErrorDomain:-1005] url=ws://x/realtime"
+            ), .networkLost
+        )
+        XCTAssertEqual(
+            RealtimeConnectionFailureClassifier.classify(
+                socketErrorMessage: "offline [NSURLErrorDomain:-1009] url=ws://x/realtime"
+            ), .networkLost
+        )
+    }
+
+    func testClassifiesLocalizedPhrasesWhenErrorCodeAbsent() {
+        XCTAssertEqual(
+            RealtimeConnectionFailureClassifier.classify(socketErrorMessage: "connection refused"), .connectionRefused
+        )
+        XCTAssertEqual(
+            RealtimeConnectionFailureClassifier.classify(socketErrorMessage: "Could not connect to the server."), .connectionRefused
+        )
+        XCTAssertEqual(
+            RealtimeConnectionFailureClassifier.classify(socketErrorMessage: "Could not find host."), .hostUnreachable
+        )
+        XCTAssertEqual(
+            RealtimeConnectionFailureClassifier.classify(socketErrorMessage: "The request timed out."), .timedOut
+        )
+        XCTAssertEqual(
+            RealtimeConnectionFailureClassifier.classify(socketErrorMessage: "Internet connection appears to be offline."), .networkLost
+        )
+    }
+
+    func testClassifiesUnknownForUnrecognizedMessages() {
+        XCTAssertEqual(
+            RealtimeConnectionFailureClassifier.classify(socketErrorMessage: "WebSocket closed (1011)."), .unknown
+        )
+    }
+
+    // MARK: - describe(kind:endpointDescription:...)
+
+    private let endpoint = "ws://127.0.0.1:8000/v1/realtime"
+
+    func testDescribeConnectionRefusedNamesEndpoint() {
+        let description = RealtimeConnectionFailureClassifier.describe(
+            kind: .connectionRefused,
+            endpointDescription: endpoint,
+            rawError: "refused [NSURLErrorDomain:-1004]"
+        )
+        XCTAssertEqual(description.status, "Connection refused.")
+        XCTAssertTrue(description.message.contains(endpoint), "message should name the endpoint")
+        XCTAssertTrue(description.message.localizedCaseInsensitiveContains("refused"))
+        XCTAssertEqual(description.technicalDetails, "refused [NSURLErrorDomain:-1004]")
+    }
+
+    func testDescribeHostUnreachableNamesEndpoint() {
+        let description = RealtimeConnectionFailureClassifier.describe(
+            kind: .hostUnreachable,
+            endpointDescription: "ws://missing-host:8000/realtime",
+            rawError: nil
+        )
+        XCTAssertEqual(description.status, "Host unreachable.")
+        XCTAssertTrue(description.message.contains("ws://missing-host:8000/realtime"))
+    }
+
+    func testDescribeTimedOutKeepsStablePhraseAndNamesEndpoint() {
+        let description = RealtimeConnectionFailureClassifier.describe(
+            kind: .timedOut,
+            endpointDescription: endpoint,
+            timeoutSeconds: 1.0,
+            rawError: nil
+        )
+        XCTAssertEqual(description.status, "Connection timed out.")
+        // Stable phrase asserted by existing timeout regression test:
+        XCTAssertTrue(description.message.contains("No connection response received in 1 seconds"))
+        XCTAssertTrue(description.message.contains(endpoint))
+    }
+
+    func testDescribeInvalidEndpointDoesNotRequireEndpoint() {
+        let description = RealtimeConnectionFailureClassifier.describe(
+            kind: .invalidEndpoint,
+            endpointDescription: "",
+            rawError: nil
+        )
+        XCTAssertEqual(description.status, "Invalid endpoint URL.")
+        XCTAssertTrue(description.message.contains("Settings"))
+        XCTAssertNotNil(description.technicalDetails)
+    }
+
+    func testDescribeNetworkLostMatchesStatusTokenString() {
+        let description = RealtimeConnectionFailureClassifier.describe(
+            kind: .networkLost,
+            endpointDescription: endpoint,
+            rawError: nil
+        )
+        // Must equal StatusStrings.networkLostDictationStopped so the menu-bar /
+        // popover status token mapping still recognizes it.
+        XCTAssertEqual(description.status, "Network lost. Dictation stopped.")
+        XCTAssertTrue(description.message.contains(endpoint))
+    }
+
+    func testDescribeUnknownNamesEndpoint() {
+        let description = RealtimeConnectionFailureClassifier.describe(
+            kind: .unknown,
+            endpointDescription: endpoint,
+            rawError: "some error"
+        )
+        XCTAssertEqual(description.status, "Connection failed.")
+        XCTAssertTrue(description.message.contains(endpoint))
+    }
+
+    func testDescribeFallsBackToPlaceholderForEmptyEndpoint() {
+        let description = RealtimeConnectionFailureClassifier.describe(
+            kind: .connectionRefused,
+            endpointDescription: "  ",
+            rawError: nil
+        )
+        XCTAssertTrue(description.message.contains(RealtimeConnectionFailureClassifier.unknownEndpointDescription))
+    }
+
+    // MARK: - Divergence guard
+
+    func testNetworkLostStatusMatchesStatusStringsConstant() {
+        // Guards against the hardcoded classifier string drifting from
+        // DictationViewModel.StatusStrings.networkLostDictationStopped.
+        let description = RealtimeConnectionFailureClassifier.describe(
+            kind: .networkLost,
+            endpointDescription: endpoint,
+            rawError: nil
+        )
+        XCTAssertEqual(description.status, DictationViewModel.StatusStrings.networkLostDictationStopped)
+    }
+}

--- a/Tests/localvoxtralTests/RealtimeConnectionFailureTests.swift
+++ b/Tests/localvoxtralTests/RealtimeConnectionFailureTests.swift
@@ -49,6 +49,13 @@ final class RealtimeConnectionFailureTests: XCTestCase {
         )
     }
 
+    func testClassifiesEndpointRejectedByBadServerResponse() {
+        let message = "WebSocket failed: The operation couldn't be completed. [NSURLErrorDomain:-1011] url=ws://127.0.0.1:8000/v1/realtimeaa"
+        XCTAssertEqual(
+            RealtimeConnectionFailureClassifier.classify(socketErrorMessage: message), .endpointRejected
+        )
+    }
+
     func testClassifiesLocalizedPhrasesWhenErrorCodeAbsent() {
         XCTAssertEqual(
             RealtimeConnectionFailureClassifier.classify(socketErrorMessage: "connection refused"), .connectionRefused
@@ -61,6 +68,9 @@ final class RealtimeConnectionFailureTests: XCTestCase {
         )
         XCTAssertEqual(
             RealtimeConnectionFailureClassifier.classify(socketErrorMessage: "The request timed out."), .timedOut
+        )
+        XCTAssertEqual(
+            RealtimeConnectionFailureClassifier.classify(socketErrorMessage: "WebSocket upgrade failed with HTTP 404."), .endpointRejected
         )
         XCTAssertEqual(
             RealtimeConnectionFailureClassifier.classify(socketErrorMessage: "Internet connection appears to be offline."), .networkLost
@@ -123,6 +133,19 @@ final class RealtimeConnectionFailureTests: XCTestCase {
         XCTAssertTrue(description.message.contains("No connection response received in 3 seconds"))
     }
 
+    func testDescribeEndpointRejectedNamesPathGuidance() {
+        let description = RealtimeConnectionFailureClassifier.describe(
+            kind: .endpointRejected,
+            endpointDescription: endpoint,
+            rawError: "bad server response [NSURLErrorDomain:-1011]"
+        )
+
+        XCTAssertEqual(description.status, "Endpoint path rejected.")
+        XCTAssertTrue(description.message.contains(endpoint))
+        XCTAssertTrue(description.message.localizedCaseInsensitiveContains("check the path"))
+        XCTAssertEqual(description.technicalDetails, "bad server response [NSURLErrorDomain:-1011]")
+    }
+
     func testDescribeTimedOutOmitsDuplicateTechnicalDetails() {
         let description = RealtimeConnectionFailureClassifier.describe(
             kind: .timedOut,
@@ -181,6 +204,7 @@ final class RealtimeConnectionFailureTests: XCTestCase {
             (.connectionRefused, nil),
             (.hostUnreachable, nil),
             (.timedOut, 2.0),
+            (.endpointRejected, nil),
             (.networkLost, nil),
             (.unknown, nil),
         ]


### PR DESCRIPTION
## What

Two common failure modes that previously degraded into **confusing silence** now **fail fast** with clear, actionable feedback routed through the popover status + red error and the menu-bar "recent failure" indicator.

**1. Realtime backend not reachable.** Before, every connect failure funneled through `handleConnectFailure(status:"Failed to connect.", message:"Unable to establish realtime connection.", technicalDetails: <raw socket error>)`. The user-facing *message* (shown in the modal alert) was generic and named neither the failure kind nor the endpoint; only `lastError` carried the raw socket text. Now:
- New pure `RealtimeConnectionFailureClassifier` maps socket errors (`NSURLError` codes `-1004/-1003/-1001/-1005/-1009` + localized phrases) to a kind: **connection refused / host unreachable / timed out / network lost / invalid endpoint / unknown**.
- It produces status + message copy that **always names the resolved endpoint** (scheme+host+port+path), so a wrong port is instantly visible.
- `handleConnectFailure` is refactored to take a `RealtimeConnectFailureReason` and funnel **every** call site (timeout, socket `.error`/`.disconnected`, `connect()` throw, invalid endpoint, network lost) through the single classifier.
- The modal alert now appends the raw system error (with the NSError code) beneath the actionable message.

**2. Accessibility permission missing (Live Auto-Paste).** Before, in Live Auto-Paste mode without AX trust the user could speak a whole paragraph that landed nowhere — the AX error only surfaced late, on the first failed insertion. Now:
- At **dictation start** (`beginDictationSession`), if Live Auto-Paste is active without AX trust, a warning is shown **both** as the status line (`Paste blocked by Accessibility permission.`) **and** the red `lastError`, and it is **not** clobbered by the generic "Connecting..." status. The existing "Enable Accessibility…" affordance + System Settings prompt fire immediately.
- The session still **proceeds** (keyboard-event fallback may work for some apps, and once the user grants AX the prompt's polling clears the warning mid-session). `ErrorToken` recognizes the warning so the existing trust-changed callback clears it.
- The popover also shows the warning **before** starting (orange banner) via the new derived `liveAutoPasteAccessibilityWarning`.

Scope kept tight: failure-communication only, no settings-UX redesign, no new stored view-model state (the warning is derived from existing output-mode + AX-trust state). Matches the `@MainActor`/`@Observable` + pure-function conventions.

## Proof

- [x] Unit suite green — `LV_BUILD_DIR=work/localvoxtral-failfast ./scripts/remote-build.sh test`
  ```
  Test Suite 'localvoxtralPackageTests' passed …
  Executed 257 tests, with 0 failures (0 unexpected) in 1.354 (1.366) seconds
  ```
  (Baseline was 231; +26 new tests. Strict-concurrency **warning-free** — `grep -i warning:` on the build output returns nothing.)

- [x] Realtime integration green — `VLLM_REALTIME_TEST_ENABLE=1 ./scripts/remote-build.sh integration`
  ```
  Test Suite 'RealtimeAPIVLLMIntegrationTests' passed …
  Executed 7 tests, with 2 tests skipped and 0 failures (0 unexpected) in 15.808 (15.811) seconds
  ```
  Includes `testVLLMProcessesSpokenSyntheticAudio_meetsExpectedAccuracy` (real inference through the production websocket client) — confirms the connect/handshake path is intact.

- [x] Bug fix: regression test added — failing run **before** the fix and passing run **after**.

  AX-gate regression (`testBeginDictationSessionSurfacesAccessibilityWarningInLiveMode`), with the gate block reverted to simulate pre-fix behavior:
  ```
  BEFORE (gate reverted):
  /…/DictationViewModelFailFastUXTests.swift:134: error: XCTAssertEqual failed:
    ("Connecting to realtime backend...") is not equal to ("Paste blocked by Accessibility permission.")
  /…/DictationViewModelFailFastUXTests.swift:135: error: XCTAssertEqual failed:
    ("nil") is not equal to ("Optional(\"Live Auto-Paste needs Accessibility access …\")")
  Test Case '…testBeginDictationSessionSurfacesAccessibilityWarningInLiveMode' failed (0.100 seconds)

  AFTER (fix applied):
  Test Case '…testBeginDictationSessionSurfacesAccessibilityWarningInLiveMode' passed (0.002 seconds)
  Executed 11 tests, with 0 failures (0 unexpected)
  ```
  Backend-classification regressions cover the mapping end-to-end through the view model, e.g. `testSocketConnectionRefusedSurfacesRefusedStatusAndEndpoint` asserts `statusText == "Connection refused."` and that `lastError` names the resolved endpoint — previously `statusText` was the generic `"Failed to connect."` (see `handleConnectFailure(reason:)` diff). The pure classifier mapping is covered by `RealtimeConnectionFailureTests` (15 tests).

- [ ] UI change: manual checks — see the manual-check list below (to be performed by the maintainer on macOS).

## Manual checks (UI-affecting — for the maintainer on a Mac)

Backend (start from a clean state each time; reopen the popover after each attempt):
1. **Connection refused:** stop voxmlx (`launchctl bootout gui/$(id -u) ~/Library/LaunchAgents/com.localvoxtral.voxmlx.plist` or kill the process). Hit the dictation hotkey. Within ~1s the menu-bar icon turns into the failure indicator and the popover shows `Status: Connection refused.` + red `Connection refused at ws://127.0.0.1:8000/v1/realtime. Make sure the backend is running and the port is correct.` A modal alert shows the same message + the raw `[NSURLErrorDomain:-1004]` error.
2. **Wrong port:** in Settings set the endpoint to `ws://127.0.0.1:12345/v1/realtime`, hit hotkey. Popover shows `Connection refused at ws://127.0.0.1:12345/v1/realtime` (the wrong port is right there in the message).
3. **Host unreachable:** set endpoint to `ws://nonexistent-host-xyz:8000/v1/realtime`, hit hotkey. Popover shows `Status: Host unreachable.` + `Could not reach the backend host at ws://nonexistent-host-xyz:8000/…`.
4. **Timed out:** point the endpoint at a black-holed IP (e.g. `ws://10.255.255.1/v1/realtime`) so the TCP handshake hangs. Hit hotkey. After `connectTimeout` (~1s) the popover shows `Status: Connection timed out.` + `No connection response received in 1 seconds at ws://10.255.255.1/v1/realtime…`.
5. **Invalid endpoint:** set endpoint to `notaurl`, hit hotkey. Popover shows `Status: Invalid endpoint URL.` + `Set a valid ws:// or wss:// endpoint for the selected backend in Settings.`
6. **Happy path:** restart voxmlx, hit hotkey. Status goes `Connecting… → Listening…`, no failure indicator.

Accessibility (Live Auto-Paste mode):
7. With AX **not** granted for localvoxtral, set output mode to Live Auto-Paste and open the popover **before** starting: an orange banner reads `Live Auto-Paste needs Accessibility access to type into other apps. Text won't appear until you enable it in System Settings > Privacy & Security > Accessibility.` and the `Enable Accessibility…` button is shown.
8. Hit the hotkey (still no AX). Status reads `Paste blocked by Accessibility permission.` and the red warning persists into the session (not overwritten by "Listening…"). The System Settings Accessibility pane opens.
9. Toggle localvoxtral on in System Settings ▸ Privacy & Security ▸ Accessibility. Within the poll window the warning clears and dictation inserts normally.
10. Switch output mode to **Overlay Buffer**, revoke AX, hit hotkey: no Live Auto-Paste warning is shown (overlay capture needs no AX at start; commit-time failure handling is unchanged).
