### PR TITLE
Rework @joostliebregts tap-vs-hold shortcuts on #30

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Built for Mistral AI's [Voxtral Mini 4B Realtime](https://huggingface.co/mistral
 
 ## Features
 
-- Global shortcut with selectable behavior: `Toggle` (press-to-start/stop) or `Push to Talk` (hold-to-dictate)
+- Global shortcuts: a single modifier key (tap for Overlay Buffer, hold for Live Auto-Paste) or per-mode keyboard shortcuts with `Toggle` / `Push to Talk` behavior
 - Native menu bar app with instant open and visual feedback with the icon
 - Output modes: overlay buffer (commit on stop) or live auto-paste into focused input
 - Personal replacement dictionary (exact match or exact match + LLM-aware-replacement)
@@ -45,11 +45,29 @@ If macOS blocks first launch, go to **System Settings -> Privacy & Security** an
 open ./dist/localvoxtral.app
 ```
 
+## Shortcuts
+
+Two ways to trigger dictation, configured in **Settings -> Dictation**:
+
+**Single modifier key** — Fn/Globe, Right Command, or Right Option. One key, two gestures:
+
+| Gesture | Behavior |
+|---|---|
+| Tap | Toggle Overlay Buffer dictation on/off |
+| Hold (past the hold delay, default 350 ms) | Live Auto-Paste push-to-talk — dictates while held, stops on release |
+
+The gesture selects the output mode, so both workflows are always one key away. Pressing any other key while the modifier is down cancels the gesture, so regular keyboard combos are unaffected. Requires Accessibility permission.
+
+**Per-mode keyboard shortcuts** — separate shortcuts for Overlay Buffer and Live Auto-Paste; behavior follows the `Toggle` / `Push to Talk` setting.
+
+The **Output mode** setting applies to dictation started from the menu bar. Keyboard gestures and per-mode shortcuts select their mode directly.
+
+**Escape** cancels an in-progress dictation.
+
 ## Settings
 
 - Open **Settings** from the menu bar popover to set:
-  - Dictation keyboard shortcut  
-  - Shortcut behavior (`Toggle` / `Push to Talk`)
+  - Dictation trigger: single modifier key (tap/hold) or per-mode keyboard shortcuts (`Toggle` / `Push to Talk`)
   - Realtime endpoint (URL, model name, API key)
   - Commit interval (`vLLM`/`voxmlx`)
   - Auto-copy final segment

--- a/Sources/localvoxtral/DictationViewModel+Session.swift
+++ b/Sources/localvoxtral/DictationViewModel+Session.swift
@@ -48,8 +48,9 @@ extension DictationViewModel {
         cancelConnectTimeout()
         isFinalizingStop = false
         isConnectingRealtimeSession = false
+        let requestedOutputMode = sessionOutputMode ?? settings.dictationOutputMode
         clearLatchedSessionMetadata()
-        sessionOutputMode = settings.dictationOutputMode
+        sessionOutputMode = requestedOutputMode
         sessionStartedAt = Date()
         sessionReplacementDictionary = settings.replacementDictionaryEnabled
             ? appConfigStore.loadReplacementDictionary()

--- a/Sources/localvoxtral/DictationViewModel+Session.swift
+++ b/Sources/localvoxtral/DictationViewModel+Session.swift
@@ -6,8 +6,8 @@ extension DictationViewModel {
     // MARK: - Session Lifecycle
 
     // Session metadata lifecycle:
-    // - Set: beginDictationSession() — captures values that should stay stable for
-    //   the active session even if Settings are edited before commit finishes.
+    // - Set: beginDictationSession(outputMode:) — captures values that should
+    //   stay stable for the active session even if Settings are edited before commit finishes.
     // - Cleared: finishStoppedSession(), abortConnectingSession(), and early-return
     //   error paths in beginDictationSession() where no session was established.
     // All session exit paths MUST clear these fields to nil.
@@ -29,7 +29,7 @@ extension DictationViewModel {
         return true
     }
 
-    private func clearLatchedSessionMetadata() {
+    func clearLatchedSessionMetadata() {
         sessionOutputMode = nil
         sessionStartedAt = nil
         sessionProvider = nil
@@ -37,7 +37,7 @@ extension DictationViewModel {
         sessionReplacementDictionary = nil
     }
 
-    func beginDictationSession() {
+    func beginDictationSession(outputMode: DictationOutputMode? = nil) {
         lastSocketErrorMessage = nil
         polishAndCommitTask?.cancel()
         polishAndCommitTask = nil
@@ -48,7 +48,7 @@ extension DictationViewModel {
         cancelConnectTimeout()
         isFinalizingStop = false
         isConnectingRealtimeSession = false
-        let requestedOutputMode = sessionOutputMode ?? settings.dictationOutputMode
+        let requestedOutputMode = outputMode ?? settings.dictationOutputMode
         clearLatchedSessionMetadata()
         sessionOutputMode = requestedOutputMode
         sessionStartedAt = Date()

--- a/Sources/localvoxtral/DictationViewModel.swift
+++ b/Sources/localvoxtral/DictationViewModel.swift
@@ -88,7 +88,10 @@ final class DictationViewModel {
             if message == HotKeyManager.handlerRegistrationErrorMessage {
                 return .hotKeyHandlerRegistrationFailure
             }
-            if message == HotKeyManager.unavailableErrorMessage {
+            if message == HotKeyManager.unavailableErrorMessage
+                || message == HotKeyManager.livePasteUnavailableErrorMessage
+                || message == HotKeyManager.modifierOnlyUnavailableErrorMessage
+            {
                 return .hotKeyShortcutUnavailable
             }
             if message.localizedCaseInsensitiveContains("websocket receive failed") {
@@ -560,6 +563,10 @@ final class DictationViewModel {
                 stopDictation(reason: "modifier hold release")
             } else if isConnectingRealtimeSession {
                 statusText = StatusStrings.connectingRealtimeBackend
+                return
+            } else if isAwaitingMicrophonePermission {
+                statusText = StatusStrings.ready
+                return
             }
             clearPushToTalkShortcutSessionAttempt()
             return
@@ -605,8 +612,7 @@ final class DictationViewModel {
     }
 
     func shouldCancelPushToTalkStartAfterConnect() -> Bool {
-        settings.dictationShortcutMode == .pushToTalk
-            && hasActivePushToTalkShortcutSession
+        hasActivePushToTalkShortcutSession
             && !isPushToTalkShortcutHeld
     }
 
@@ -677,15 +683,10 @@ final class DictationViewModel {
         let overlayShortcut = settings.overlayBufferShortcut
         let livePasteShortcut = settings.livePasteShortcut
 
-        if overlayShortcut != nil || livePasteShortcut != nil {
-            return hotKeyManager.registerDual(
-                overlay: overlayShortcut,
-                livePaste: livePasteShortcut
-            )
-        }
-
-        // Fallback: legacy single shortcut (if neither dual shortcut is configured)
-        return hotKeyManager.register(shortcut: settings.dictationShortcut)
+        return hotKeyManager.registerDual(
+            overlay: overlayShortcut,
+            livePaste: livePasteShortcut
+        )
     }
 
     func updateDictationShortcut(_ shortcut: DictationShortcut?) {
@@ -1085,6 +1086,12 @@ final class DictationViewModel {
         case .shortcutUnavailable:
             statusText = HotKeyManager.registrationErrorStatus
             lastError = HotKeyManager.unavailableErrorMessage
+        case .livePasteShortcutUnavailable:
+            statusText = HotKeyManager.registrationErrorStatus
+            lastError = HotKeyManager.livePasteUnavailableErrorMessage
+        case .modifierOnlyHotKeyUnavailable:
+            statusText = HotKeyManager.registrationErrorStatus
+            lastError = HotKeyManager.modifierOnlyUnavailableErrorMessage
         }
     }
 }
@@ -1114,6 +1121,14 @@ extension DictationViewModel {
     /// not entered when disabled". Pass `nil` to clear.
     func debugConfigureDeltaLogSink(_ sink: ((DebugRealtimeDeltaLogRecord) -> Void)?) {
         debugDeltaLogSink = sink
+    }
+
+    func debugSetModifierOnlyHoldStateForTesting(isActive: Bool) {
+        isModifierOnlyHoldActive = isActive
+    }
+
+    var debugCurrentHotKeyRegistrationKindForTesting: HotKeyManager.DebugRegistrationKind {
+        hotKeyManager.debugCurrentRegistrationKind
     }
 }
 #endif

--- a/Sources/localvoxtral/DictationViewModel.swift
+++ b/Sources/localvoxtral/DictationViewModel.swift
@@ -526,14 +526,6 @@ final class DictationViewModel {
     // MARK: - Public API
 
     private func handleDictationShortcutPress(mode: DictationOutputMode? = nil) {
-        // If a mode is specified by the shortcut, pre-set it so startDictation
-        // uses it — but never while a session is active: the stop half of a
-        // toggle finalizes using sessionOutputMode, and overwriting it here
-        // would finalize the running session down the wrong mode's path.
-        if let mode, !isDictating, !isConnectingRealtimeSession, !isFinalizingStop {
-            sessionOutputMode = mode
-        }
-
         switch settings.dictationShortcutMode {
         case .toggle:
             hasActivePushToTalkShortcutSession = false
@@ -544,14 +536,14 @@ final class DictationViewModel {
             } else if isFinalizingStop {
                 statusText = StatusStrings.finalizingPreviousDictation
             } else {
-                startDictation()
+                startDictation(outputMode: mode)
             }
         case .pushToTalk:
             guard !isPushToTalkShortcutHeld else { return }
             isPushToTalkShortcutHeld = true
             guard !isDictating, !isConnectingRealtimeSession, !isFinalizingStop else { return }
             hasActivePushToTalkShortcutSession = true
-            startDictation()
+            startDictation(outputMode: mode)
             if !isDictating, !isConnectingRealtimeSession, !isAwaitingMicrophonePermission {
                 hasActivePushToTalkShortcutSession = false
             }
@@ -603,15 +595,11 @@ final class DictationViewModel {
 
     /// Modifier-only hold gesture started — use push-to-talk semantics with live auto-paste.
     private func handleModifierOnlyHoldStart() {
-        // Nothing may be mutated while a session is already active: a stray
-        // hold during an overlay session would otherwise rewrite
-        // sessionOutputMode and finalize that session down the live path.
         guard !isDictating, !isConnectingRealtimeSession, !isFinalizingStop else { return }
-        sessionOutputMode = .liveAutoPaste
         isModifierOnlyHoldActive = true
         isPushToTalkShortcutHeld = true
         hasActivePushToTalkShortcutSession = true
-        startDictation()
+        startDictation(outputMode: .liveAutoPaste)
         if !isDictating, !isConnectingRealtimeSession, !isAwaitingMicrophonePermission {
             hasActivePushToTalkShortcutSession = false
             isModifierOnlyHoldActive = false
@@ -623,10 +611,7 @@ final class DictationViewModel {
     /// shortcut behavior: taps have no release event, so routing them through
     /// push-to-talk semantics latches dictation on with no way to stop it.
     private func handleModifierOnlyTap(mode: DictationOutputMode) {
-        if !isDictating, !isConnectingRealtimeSession, !isFinalizingStop {
-            sessionOutputMode = mode
-        }
-        toggleDictation()
+        toggleDictation(outputMode: mode)
     }
 
     func shouldCancelPushToTalkStartAfterConnect() -> Bool {
@@ -638,7 +623,7 @@ final class DictationViewModel {
         hasActivePushToTalkShortcutSession = false
     }
 
-    func toggleDictation() {
+    func toggleDictation(outputMode: DictationOutputMode? = nil) {
         hasActivePushToTalkShortcutSession = false
         if isDictating {
             stopDictation(reason: "manual toggle")
@@ -647,7 +632,7 @@ final class DictationViewModel {
         } else if isFinalizingStop {
             statusText = StatusStrings.finalizingPreviousDictation
         } else {
-            startDictation()
+            startDictation(outputMode: outputMode)
         }
     }
 
@@ -848,7 +833,7 @@ final class DictationViewModel {
         startDictation()
     }
 
-    func startDictation() {
+    func startDictation(outputMode: DictationOutputMode? = nil) {
         guard !isDictating else { return }
         guard !isConnectingRealtimeSession else {
             statusText = StatusStrings.connectingRealtimeBackend
@@ -880,7 +865,7 @@ final class DictationViewModel {
 
         switch microphone.authorizationStatus() {
         case .authorized:
-            beginDictationSession()
+            beginDictationSession(outputMode: outputMode)
         case .notDetermined:
             isAwaitingMicrophonePermission = true
             statusText = StatusStrings.requestingMicrophonePermission
@@ -903,7 +888,7 @@ final class DictationViewModel {
                         self.hasActivePushToTalkShortcutSession = false
                         return
                     }
-                    self.beginDictationSession()
+                    self.beginDictationSession(outputMode: outputMode)
                 }
             }
             Task { [weak self] in
@@ -965,7 +950,7 @@ final class DictationViewModel {
         pendingSegmentText = ""
         currentDictationEventText = ""
         if !isDictating, !isFinalizingStop, !isConnectingRealtimeSession {
-            sessionOutputMode = nil
+            clearLatchedSessionMetadata()
         }
         firstChunkPreprocessor.reset()
         overlayBufferCoordinator.reset()

--- a/Sources/localvoxtral/DictationViewModel.swift
+++ b/Sources/localvoxtral/DictationViewModel.swift
@@ -265,6 +265,9 @@ final class DictationViewModel {
     // to be cancelled if the user releases before dictation actually begins.
     @ObservationIgnored
     private var hasActivePushToTalkShortcutSession = false
+    // True when a modifier-only hold gesture started dictation (push-to-talk semantics).
+    @ObservationIgnored
+    private var isModifierOnlyHoldActive = false
 
     init(
         settings: SettingsStore,
@@ -344,15 +347,12 @@ final class DictationViewModel {
             networkMonitor.start()
         }
 
+        hotKeyManager.onPressWithMode = { [weak self] mode in self?.handleDictationShortcutPress(mode: mode) }
         hotKeyManager.onPress = { [weak self] in self?.handleDictationShortcutPress() }
         hotKeyManager.onRelease = { [weak self] in self?.handleDictationShortcutRelease() }
+        hotKeyManager.onHoldStart = { [weak self] in self?.handleModifierOnlyHoldStart() }
         if startRuntimeServices {
-            switch hotKeyManager.register(shortcut: settings.dictationShortcut) {
-            case .success:
-                break
-            case .failure(let reason):
-                applyHotKeyRegistrationFailure(reason)
-            }
+            registerCurrentHotKeys()
         }
 
         escapeCancelHandler.onCancel = { [weak self] in self?.cancelDictation() }
@@ -521,11 +521,24 @@ final class DictationViewModel {
 
     // MARK: - Public API
 
-    private func handleDictationShortcutPress() {
+    private func handleDictationShortcutPress(mode: DictationOutputMode? = nil) {
+        // If a mode is specified by the shortcut, pre-set it so startDictation uses it.
+        if let mode {
+            sessionOutputMode = mode
+        }
+
         switch settings.dictationShortcutMode {
         case .toggle:
             hasActivePushToTalkShortcutSession = false
-            toggleDictation()
+            if isDictating {
+                stopDictation(reason: "manual toggle")
+            } else if isConnectingRealtimeSession {
+                statusText = StatusStrings.connectingRealtimeBackend
+            } else if isFinalizingStop {
+                statusText = StatusStrings.finalizingPreviousDictation
+            } else {
+                startDictation()
+            }
         case .pushToTalk:
             guard !isPushToTalkShortcutHeld else { return }
             isPushToTalkShortcutHeld = true
@@ -539,6 +552,19 @@ final class DictationViewModel {
     }
 
     private func handleDictationShortcutRelease() {
+        // Modifier-only hold release
+        if isModifierOnlyHoldActive {
+            isModifierOnlyHoldActive = false
+            isPushToTalkShortcutHeld = false
+            if isDictating {
+                stopDictation(reason: "modifier hold release")
+            } else if isConnectingRealtimeSession {
+                statusText = StatusStrings.connectingRealtimeBackend
+            }
+            clearPushToTalkShortcutSessionAttempt()
+            return
+        }
+
         guard isPushToTalkShortcutHeld else { return }
         isPushToTalkShortcutHeld = false
 
@@ -562,6 +588,20 @@ final class DictationViewModel {
             return
         }
         clearPushToTalkShortcutSessionAttempt()
+    }
+
+    /// Modifier-only hold gesture started — use push-to-talk semantics with live auto-paste.
+    private func handleModifierOnlyHoldStart() {
+        sessionOutputMode = .liveAutoPaste
+        isModifierOnlyHoldActive = true
+        isPushToTalkShortcutHeld = true
+        guard !isDictating, !isConnectingRealtimeSession, !isFinalizingStop else { return }
+        hasActivePushToTalkShortcutSession = true
+        startDictation()
+        if !isDictating, !isConnectingRealtimeSession, !isAwaitingMicrophonePermission {
+            hasActivePushToTalkShortcutSession = false
+            isModifierOnlyHoldActive = false
+        }
     }
 
     func shouldCancelPushToTalkStartAfterConnect() -> Bool {
@@ -601,13 +641,60 @@ final class DictationViewModel {
         }
     }
 
+    /// Re-register the hotkey based on current settings.
+    /// Called when modifier-only mode or modifier key selection changes.
+    func applyHotKeySettingsChange() {
+        switch registerCurrentHotKeys() {
+        case .success:
+            if !isDictating, !isFinalizingStop,
+               (currentStatusToken == .hotKeyHandlerRegistrationFailure
+                || currentStatusToken == .hotKeyShortcutUnavailable)
+            {
+                statusText = StatusStrings.ready
+            }
+            if currentErrorToken == .hotKeyShortcutUnavailable
+                || currentErrorToken == .hotKeyHandlerRegistrationFailure
+            {
+                lastError = nil
+            }
+        case .failure(let reason):
+            applyHotKeyRegistrationFailure(reason)
+        }
+    }
+
+    /// Register hotkeys based on current settings.
+    /// Uses modifier-only, dual shortcuts, or legacy single shortcut depending on config.
+    @discardableResult
+    private func registerCurrentHotKeys() -> HotKeyManager.RegistrationResult {
+        if settings.modifierOnlyHotKeyEnabled {
+            return hotKeyManager.registerModifierOnly(
+                settings.modifierOnlyHotKeyModifier,
+                holdThreshold: settings.modifierOnlyHoldDelay
+            )
+        }
+
+        // Use dual shortcut registration
+        let overlayShortcut = settings.overlayBufferShortcut
+        let livePasteShortcut = settings.livePasteShortcut
+
+        if overlayShortcut != nil || livePasteShortcut != nil {
+            return hotKeyManager.registerDual(
+                overlay: overlayShortcut,
+                livePaste: livePasteShortcut
+            )
+        }
+
+        // Fallback: legacy single shortcut (if neither dual shortcut is configured)
+        return hotKeyManager.register(shortcut: settings.dictationShortcut)
+    }
+
     func updateDictationShortcut(_ shortcut: DictationShortcut?) {
         let previousShortcut = settings.dictationShortcut
         let previousWasEnabled = settings.dictationShortcutEnabled
 
         settings.setDictationShortcut(shortcut)
 
-        switch hotKeyManager.register(shortcut: settings.dictationShortcut) {
+        switch registerCurrentHotKeys() {
         case .success:
             if !isDictating, !isFinalizingStop,
                (currentStatusToken == .hotKeyHandlerRegistrationFailure
@@ -628,8 +715,62 @@ final class DictationViewModel {
             } else {
                 settings.setDictationShortcut(nil)
             }
-            _ = hotKeyManager.register(shortcut: settings.dictationShortcut)
+            _ = registerCurrentHotKeys()
             applyHotKeyRegistrationFailure(reason)
+        }
+    }
+
+    func updateOverlayBufferShortcut(_ shortcut: DictationShortcut?) {
+        let previousShortcut = settings.overlayBufferShortcut
+        let previousWasEnabled = settings.overlayBufferShortcutEnabled
+
+        settings.setOverlayBufferShortcut(shortcut)
+
+        switch registerCurrentHotKeys() {
+        case .success:
+            clearHotKeyErrors()
+        case .failure(let reason):
+            if previousWasEnabled {
+                settings.setOverlayBufferShortcut(previousShortcut ?? SettingsStore.defaultDictationShortcut)
+            } else {
+                settings.setOverlayBufferShortcut(nil)
+            }
+            _ = registerCurrentHotKeys()
+            applyHotKeyRegistrationFailure(reason)
+        }
+    }
+
+    func updateLivePasteShortcut(_ shortcut: DictationShortcut?) {
+        let previousShortcut = settings.livePasteShortcut
+        let previousWasEnabled = settings.livePasteShortcutEnabled
+
+        settings.setLivePasteShortcut(shortcut)
+
+        switch registerCurrentHotKeys() {
+        case .success:
+            clearHotKeyErrors()
+        case .failure(let reason):
+            if previousWasEnabled, let previousShortcut {
+                settings.setLivePasteShortcut(previousShortcut)
+            } else {
+                settings.setLivePasteShortcut(nil)
+            }
+            _ = registerCurrentHotKeys()
+            applyHotKeyRegistrationFailure(reason)
+        }
+    }
+
+    private func clearHotKeyErrors() {
+        if !isDictating, !isFinalizingStop,
+           (currentStatusToken == .hotKeyHandlerRegistrationFailure
+            || currentStatusToken == .hotKeyShortcutUnavailable)
+        {
+            statusText = StatusStrings.ready
+        }
+        if currentErrorToken == .hotKeyShortcutUnavailable
+            || currentErrorToken == .hotKeyHandlerRegistrationFailure
+        {
+            lastError = nil
         }
     }
 
@@ -950,8 +1091,8 @@ final class DictationViewModel {
 
 #if DEBUG
 extension DictationViewModel {
-    func debugHandleDictationShortcutPressForTesting() {
-        handleDictationShortcutPress()
+    func debugHandleDictationShortcutPressForTesting(mode: DictationOutputMode? = nil) {
+        handleDictationShortcutPress(mode: mode)
     }
 
     func debugHandleDictationShortcutReleaseForTesting() {

--- a/Sources/localvoxtral/DictationViewModel.swift
+++ b/Sources/localvoxtral/DictationViewModel.swift
@@ -354,6 +354,7 @@ final class DictationViewModel {
         hotKeyManager.onPress = { [weak self] in self?.handleDictationShortcutPress() }
         hotKeyManager.onRelease = { [weak self] in self?.handleDictationShortcutRelease() }
         hotKeyManager.onHoldStart = { [weak self] in self?.handleModifierOnlyHoldStart() }
+        hotKeyManager.onModifierOnlyTap = { [weak self] mode in self?.handleModifierOnlyTap(mode: mode) }
         if startRuntimeServices {
             registerCurrentHotKeys()
         }
@@ -525,8 +526,11 @@ final class DictationViewModel {
     // MARK: - Public API
 
     private func handleDictationShortcutPress(mode: DictationOutputMode? = nil) {
-        // If a mode is specified by the shortcut, pre-set it so startDictation uses it.
-        if let mode {
+        // If a mode is specified by the shortcut, pre-set it so startDictation
+        // uses it — but never while a session is active: the stop half of a
+        // toggle finalizes using sessionOutputMode, and overwriting it here
+        // would finalize the running session down the wrong mode's path.
+        if let mode, !isDictating, !isConnectingRealtimeSession, !isFinalizingStop {
             sessionOutputMode = mode
         }
 
@@ -599,16 +603,30 @@ final class DictationViewModel {
 
     /// Modifier-only hold gesture started — use push-to-talk semantics with live auto-paste.
     private func handleModifierOnlyHoldStart() {
+        // Nothing may be mutated while a session is already active: a stray
+        // hold during an overlay session would otherwise rewrite
+        // sessionOutputMode and finalize that session down the live path.
+        guard !isDictating, !isConnectingRealtimeSession, !isFinalizingStop else { return }
         sessionOutputMode = .liveAutoPaste
         isModifierOnlyHoldActive = true
         isPushToTalkShortcutHeld = true
-        guard !isDictating, !isConnectingRealtimeSession, !isFinalizingStop else { return }
         hasActivePushToTalkShortcutSession = true
         startDictation()
         if !isDictating, !isConnectingRealtimeSession, !isAwaitingMicrophonePermission {
             hasActivePushToTalkShortcutSession = false
             isModifierOnlyHoldActive = false
+            isPushToTalkShortcutHeld = false
         }
+    }
+
+    /// Modifier-only TAP is a toggle by contract regardless of the configured
+    /// shortcut behavior: taps have no release event, so routing them through
+    /// push-to-talk semantics latches dictation on with no way to stop it.
+    private func handleModifierOnlyTap(mode: DictationOutputMode) {
+        if !isDictating, !isConnectingRealtimeSession, !isFinalizingStop {
+            sessionOutputMode = mode
+        }
+        toggleDictation()
     }
 
     func shouldCancelPushToTalkStartAfterConnect() -> Bool {
@@ -1104,6 +1122,18 @@ extension DictationViewModel {
 
     func debugHandleDictationShortcutReleaseForTesting() {
         handleDictationShortcutRelease()
+    }
+
+    func debugHandleModifierOnlyTapForTesting(mode: DictationOutputMode) {
+        handleModifierOnlyTap(mode: mode)
+    }
+
+    func debugHandleModifierOnlyHoldStartForTesting() {
+        handleModifierOnlyHoldStart()
+    }
+
+    var debugIsPushToTalkShortcutHeldForTesting: Bool {
+        isPushToTalkShortcutHeld
     }
 
     func debugSetPushToTalkShortcutStateForTesting(

--- a/Sources/localvoxtral/HotKeyManager.swift
+++ b/Sources/localvoxtral/HotKeyManager.swift
@@ -17,19 +17,60 @@ final class HotKeyManager {
     static let registrationErrorStatus = "Failed to register global hotkey."
     static let unavailableErrorMessage = "The selected keyboard shortcut is unavailable."
 
+    /// Legacy single-shortcut callback. Used by `register(shortcut:)`.
     var onPress: (() -> Void)?
     var onRelease: (() -> Void)?
 
-    private var hotKeyRef: EventHotKeyRef?
+    /// Mode-aware callback for dual shortcuts. Used by `registerDual(overlay:livePaste:)`.
+    var onPressWithMode: ((DictationOutputMode) -> Void)?
+
+    /// Fired when modifier-only hold gesture starts (past threshold).
+    /// Signals push-to-talk semantics with liveAutoPaste mode.
+    var onHoldStart: (() -> Void)?
+
+    private var hotKeyRefs: [UInt32: EventHotKeyRef] = [:]
     private var hotKeyHandlerRef: EventHandlerRef?
     private static let hotKeySignature = OSType(0x53565854) // SVXT
     private nonisolated(unsafe) static weak var hotKeyTarget: HotKeyManager?
+    private let modifierOnlyManager = ModifierOnlyHotKeyManager()
+    private var isUsingModifierOnly = false
+
+    /// Maps hotkey IDs to output modes for dual-shortcut dispatch.
+    private var hotKeyIDToMode: [UInt32: DictationOutputMode] = [:]
+
+    private static let overlayHotKeyID: UInt32 = 1
+    private static let livePasteHotKeyID: UInt32 = 2
 
     init() {
         Self.hotKeyTarget = self
     }
 
-    /// Registers a global hotkey for the given shortcut.
+    /// Register a modifier-only key (Fn, Right Command, etc.) as the hotkey.
+    /// This bypasses the Carbon RegisterEventHotKey path entirely.
+    /// Tap triggers overlay buffer (toggle), hold triggers live auto-paste (push-to-talk).
+    @discardableResult
+    func registerModifierOnly(
+        _ modifier: ModifierOnlyHotKeyManager.ModifierKey,
+        holdThreshold: Double = 0.35
+    ) -> RegistrationResult {
+        unregister()
+        isUsingModifierOnly = true
+        modifierOnlyManager.holdThresholdSeconds = holdThreshold
+        modifierOnlyManager.onTap = { [weak self] in
+            guard let self else { return }
+            if self.onPressWithMode != nil {
+                self.onPressWithMode?(.overlayBuffer)
+            } else {
+                self.onPress?()
+            }
+        }
+        modifierOnlyManager.onHoldStart = { [weak self] in self?.onHoldStart?() }
+        modifierOnlyManager.onHoldRelease = { [weak self] in self?.onRelease?() }
+        modifierOnlyManager.start(modifier: modifier)
+        return .success
+    }
+
+    /// Registers a single global hotkey for the given shortcut (legacy path).
     /// Returns `.success` when registration succeeds (including when shortcut is nil).
     @discardableResult
     func register(shortcut: DictationShortcut?) -> RegistrationResult {
@@ -38,6 +79,131 @@ final class HotKeyManager {
         guard let shortcut else {
             return .success
         }
+
+        if !installHandlerIfNeeded() {
+            return .failure(.handlerInstallFailed)
+        }
+
+        hotKeyIDToMode.removeAll()
+
+        var ref: EventHotKeyRef?
+        let hotKeyID = EventHotKeyID(signature: Self.hotKeySignature, id: Self.overlayHotKeyID)
+        let registerStatus = RegisterEventHotKey(
+            shortcut.keyCode,
+            shortcut.carbonModifierFlags,
+            hotKeyID,
+            GetApplicationEventTarget(),
+            0,
+            &ref
+        )
+
+        if registerStatus != noErr {
+            unregister()
+            return .failure(.shortcutUnavailable)
+        }
+
+        if let ref {
+            hotKeyRefs[Self.overlayHotKeyID] = ref
+        }
+
+        return .success
+    }
+
+    /// Registers dual global hotkeys — one for overlay buffer mode, one for live auto-paste mode.
+    /// Either shortcut can be nil (disabled). Returns `.success` if at least one registers
+    /// successfully, or if both are nil. Returns `.failure` only if a non-nil shortcut fails to register.
+    @discardableResult
+    func registerDual(
+        overlay: DictationShortcut?,
+        livePaste: DictationShortcut?
+    ) -> RegistrationResult {
+        unregister()
+
+        guard overlay != nil || livePaste != nil else {
+            return .success
+        }
+
+        if !installHandlerIfNeeded() {
+            return .failure(.handlerInstallFailed)
+        }
+
+        hotKeyIDToMode.removeAll()
+
+        if let overlay {
+            var ref: EventHotKeyRef?
+            let hotKeyID = EventHotKeyID(signature: Self.hotKeySignature, id: Self.overlayHotKeyID)
+            let status = RegisterEventHotKey(
+                overlay.keyCode,
+                overlay.carbonModifierFlags,
+                hotKeyID,
+                GetApplicationEventTarget(),
+                0,
+                &ref
+            )
+            if status != noErr {
+                unregister()
+                return .failure(.shortcutUnavailable)
+            }
+            if let ref {
+                hotKeyRefs[Self.overlayHotKeyID] = ref
+                hotKeyIDToMode[Self.overlayHotKeyID] = .overlayBuffer
+            }
+        }
+
+        if let livePaste {
+            var ref: EventHotKeyRef?
+            let hotKeyID = EventHotKeyID(signature: Self.hotKeySignature, id: Self.livePasteHotKeyID)
+            let status = RegisterEventHotKey(
+                livePaste.keyCode,
+                livePaste.carbonModifierFlags,
+                hotKeyID,
+                GetApplicationEventTarget(),
+                0,
+                &ref
+            )
+            if status != noErr {
+                // Only fail if overlay also wasn't registered.
+                // If overlay succeeded, keep it and just skip live paste.
+                if hotKeyRefs.isEmpty {
+                    unregister()
+                    return .failure(.shortcutUnavailable)
+                }
+                // Overlay is registered — live paste failed. Still report as success
+                // so the app remains functional with the overlay shortcut.
+                return .success
+            }
+            if let ref {
+                hotKeyRefs[Self.livePasteHotKeyID] = ref
+                hotKeyIDToMode[Self.livePasteHotKeyID] = .liveAutoPaste
+            }
+        }
+
+        return .success
+    }
+
+    func unregister() {
+        if isUsingModifierOnly {
+            modifierOnlyManager.stop()
+            isUsingModifierOnly = false
+        }
+
+        for (_, ref) in hotKeyRefs {
+            UnregisterEventHotKey(ref)
+        }
+        hotKeyRefs.removeAll()
+        hotKeyIDToMode.removeAll()
+
+        if let hotKeyHandlerRef {
+            RemoveEventHandler(hotKeyHandlerRef)
+            self.hotKeyHandlerRef = nil
+        }
+    }
+
+    // MARK: - Private
+
+    /// Installs the Carbon event handler if not already installed. Returns true on success.
+    private func installHandlerIfNeeded() -> Bool {
+        guard hotKeyHandlerRef == nil else { return true }
 
         var eventTypes = [
             EventTypeSpec(
@@ -67,15 +233,15 @@ final class HotKeyManager {
                 )
 
                 guard status == noErr,
-                      hotKeyID.signature == HotKeyManager.hotKeySignature,
-                      hotKeyID.id == 1
+                      hotKeyID.signature == HotKeyManager.hotKeySignature
                 else {
                     return noErr
                 }
 
                 let eventKind = GetEventKind(eventRef)
+                let capturedID = hotKeyID.id
                 DispatchQueue.main.async {
-                    HotKeyManager.hotKeyTarget?.handleHotKeyEvent(kind: eventKind)
+                    HotKeyManager.hotKeyTarget?.handleHotKeyEvent(kind: eventKind, hotKeyID: capturedID)
                 }
 
                 return noErr
@@ -86,44 +252,18 @@ final class HotKeyManager {
             &hotKeyHandlerRef
         )
 
-        guard installStatus == noErr else {
-            return .failure(.handlerInstallFailed)
-        }
-
-        let hotKeyID = EventHotKeyID(signature: Self.hotKeySignature, id: 1)
-        let registerStatus = RegisterEventHotKey(
-            shortcut.keyCode,
-            shortcut.carbonModifierFlags,
-            hotKeyID,
-            GetApplicationEventTarget(),
-            0,
-            &hotKeyRef
-        )
-
-        if registerStatus != noErr {
-            unregister()
-            return .failure(.shortcutUnavailable)
-        }
-
-        return .success
+        return installStatus == noErr
     }
 
-    func unregister() {
-        if let hotKeyRef {
-            UnregisterEventHotKey(hotKeyRef)
-            self.hotKeyRef = nil
-        }
-
-        if let hotKeyHandlerRef {
-            RemoveEventHandler(hotKeyHandlerRef)
-            self.hotKeyHandlerRef = nil
-        }
-    }
-
-    private func handleHotKeyEvent(kind: UInt32) {
+    private func handleHotKeyEvent(kind: UInt32, hotKeyID: UInt32) {
         switch kind {
         case UInt32(kEventHotKeyPressed):
-            onPress?()
+            if let mode = hotKeyIDToMode[hotKeyID] {
+                onPressWithMode?(mode)
+            } else {
+                // Legacy single-shortcut path or fallback
+                onPress?()
+            }
         case UInt32(kEventHotKeyReleased):
             onRelease?()
         default:

--- a/Sources/localvoxtral/HotKeyManager.swift
+++ b/Sources/localvoxtral/HotKeyManager.swift
@@ -43,6 +43,12 @@ final class HotKeyManager {
     /// Signals push-to-talk semantics with liveAutoPaste mode.
     var onHoldStart: (() -> Void)?
 
+    /// Fired for a modifier-only TAP. Distinct from onPress/onPressWithMode
+    /// because taps carry no release event: the consumer must treat them as a
+    /// toggle regardless of the configured shortcut behavior, or push-to-talk
+    /// semantics latch dictation on.
+    var onModifierOnlyTap: ((DictationOutputMode) -> Void)?
+
     private var hotKeyRefs: [UInt32: EventHotKeyRef] = [:]
     private var hotKeyHandlerRef: EventHandlerRef?
     private static let hotKeySignature = OSType(0x53565854) // SVXT
@@ -79,7 +85,9 @@ final class HotKeyManager {
         candidateManager.holdThresholdSeconds = holdThreshold
         candidateManager.onTap = { [weak self] in
             guard let self else { return }
-            if self.onPressWithMode != nil {
+            if let onModifierOnlyTap = self.onModifierOnlyTap {
+                onModifierOnlyTap(.overlayBuffer)
+            } else if self.onPressWithMode != nil {
                 self.onPressWithMode?(.overlayBuffer)
             } else {
                 self.onPress?()
@@ -283,7 +291,13 @@ final class HotKeyManager {
         let installStatus = InstallEventHandler(
             GetApplicationEventTarget(),
             { _, eventRef, _ in
-                guard let eventRef else { return noErr }
+                // Returning noErr marks a Carbon event as HANDLED and stops
+                // propagation — EscapeCancelHandler shares this event target,
+                // so any hotkey that is not ours must be passed on with
+                // eventNotHandledErr or Escape-cancel goes dead whenever this
+                // handler ends up earlier in the chain (see #41 for the
+                // mirror-image bug).
+                guard let eventRef else { return OSStatus(eventNotHandledErr) }
 
                 var hotKeyID = EventHotKeyID()
                 let status = GetEventParameter(
@@ -299,7 +313,7 @@ final class HotKeyManager {
                 guard status == noErr,
                       hotKeyID.signature == HotKeyManager.hotKeySignature
                 else {
-                    return noErr
+                    return OSStatus(eventNotHandledErr)
                 }
 
                 let eventKind = GetEventKind(eventRef)

--- a/Sources/localvoxtral/HotKeyManager.swift
+++ b/Sources/localvoxtral/HotKeyManager.swift
@@ -6,6 +6,8 @@ final class HotKeyManager {
     enum RegistrationFailure {
         case handlerInstallFailed
         case shortcutUnavailable
+        case livePasteShortcutUnavailable
+        case modifierOnlyHotKeyUnavailable
     }
 
     enum RegistrationResult {
@@ -13,9 +15,22 @@ final class HotKeyManager {
         case failure(RegistrationFailure)
     }
 
+    #if DEBUG
+    enum DebugRegistrationKind: Equatable {
+        case none
+        case single
+        case dual(overlay: Bool, livePaste: Bool)
+        case modifierOnly
+    }
+    #endif
+
     static let handlerRegistrationErrorMessage = "Failed to register global hotkey handler."
     static let registrationErrorStatus = "Failed to register global hotkey."
     static let unavailableErrorMessage = "The selected keyboard shortcut is unavailable."
+    static let livePasteUnavailableErrorMessage =
+        "The selected Live Auto-Paste shortcut is unavailable."
+    static let modifierOnlyUnavailableErrorMessage =
+        "Unable to start the single-modifier hotkey. Grant Input Monitoring and Accessibility permissions, then try again."
 
     /// Legacy single-shortcut callback. Used by `register(shortcut:)`.
     var onPress: (() -> Void)?
@@ -32,7 +47,7 @@ final class HotKeyManager {
     private var hotKeyHandlerRef: EventHandlerRef?
     private static let hotKeySignature = OSType(0x53565854) // SVXT
     private nonisolated(unsafe) static weak var hotKeyTarget: HotKeyManager?
-    private let modifierOnlyManager = ModifierOnlyHotKeyManager()
+    private var modifierOnlyManager = ModifierOnlyHotKeyManager()
     private var isUsingModifierOnly = false
 
     /// Maps hotkey IDs to output modes for dual-shortcut dispatch.
@@ -40,6 +55,13 @@ final class HotKeyManager {
 
     private static let overlayHotKeyID: UInt32 = 1
     private static let livePasteHotKeyID: UInt32 = 2
+
+    #if DEBUG
+    private(set) var debugCurrentRegistrationKind: DebugRegistrationKind = .none
+    private(set) static var debugForcedHandlerInstallResult: Bool?
+    private(set) static var debugForcedRegisterStatusesByID: [UInt32: OSStatus] = [:]
+    private(set) static var debugUnregisterCallCount = 0
+    #endif
 
     init() {
         Self.hotKeyTarget = self
@@ -53,10 +75,9 @@ final class HotKeyManager {
         _ modifier: ModifierOnlyHotKeyManager.ModifierKey,
         holdThreshold: Double = 0.35
     ) -> RegistrationResult {
-        unregister()
-        isUsingModifierOnly = true
-        modifierOnlyManager.holdThresholdSeconds = holdThreshold
-        modifierOnlyManager.onTap = { [weak self] in
+        let candidateManager = ModifierOnlyHotKeyManager()
+        candidateManager.holdThresholdSeconds = holdThreshold
+        candidateManager.onTap = { [weak self] in
             guard let self else { return }
             if self.onPressWithMode != nil {
                 self.onPressWithMode?(.overlayBuffer)
@@ -64,9 +85,24 @@ final class HotKeyManager {
                 self.onPress?()
             }
         }
-        modifierOnlyManager.onHoldStart = { [weak self] in self?.onHoldStart?() }
-        modifierOnlyManager.onHoldRelease = { [weak self] in self?.onRelease?() }
-        modifierOnlyManager.start(modifier: modifier)
+        candidateManager.onHoldStart = { [weak self] in self?.onHoldStart?() }
+        candidateManager.onHoldRelease = { [weak self] in self?.onRelease?() }
+
+        let startOutcome = candidateManager.start(modifier: modifier)
+        guard startOutcome == .created else {
+            candidateManager.stop()
+            Log.modifierHotKey.error(
+                "Modifier-only hotkey registration failed with outcome \(startOutcome.rawValue, privacy: .public); preserving previous hotkey registration."
+            )
+            return .failure(.modifierOnlyHotKeyUnavailable)
+        }
+
+        unregister()
+        modifierOnlyManager = candidateManager
+        isUsingModifierOnly = true
+        #if DEBUG
+        debugCurrentRegistrationKind = .modifierOnly
+        #endif
         return .success
     }
 
@@ -77,6 +113,9 @@ final class HotKeyManager {
         unregister()
 
         guard let shortcut else {
+            #if DEBUG
+            debugCurrentRegistrationKind = .none
+            #endif
             return .success
         }
 
@@ -88,7 +127,7 @@ final class HotKeyManager {
 
         var ref: EventHotKeyRef?
         let hotKeyID = EventHotKeyID(signature: Self.hotKeySignature, id: Self.overlayHotKeyID)
-        let registerStatus = RegisterEventHotKey(
+        let registerStatus = registerEventHotKey(
             shortcut.keyCode,
             shortcut.carbonModifierFlags,
             hotKeyID,
@@ -105,6 +144,9 @@ final class HotKeyManager {
         if let ref {
             hotKeyRefs[Self.overlayHotKeyID] = ref
         }
+        #if DEBUG
+        debugCurrentRegistrationKind = .single
+        #endif
 
         return .success
     }
@@ -120,6 +162,9 @@ final class HotKeyManager {
         unregister()
 
         guard overlay != nil || livePaste != nil else {
+            #if DEBUG
+            debugCurrentRegistrationKind = .none
+            #endif
             return .success
         }
 
@@ -129,10 +174,13 @@ final class HotKeyManager {
 
         hotKeyIDToMode.removeAll()
 
+        var overlayRegistered = false
+        var livePasteRegistered = false
+
         if let overlay {
             var ref: EventHotKeyRef?
             let hotKeyID = EventHotKeyID(signature: Self.hotKeySignature, id: Self.overlayHotKeyID)
-            let status = RegisterEventHotKey(
+            let status = registerEventHotKey(
                 overlay.keyCode,
                 overlay.carbonModifierFlags,
                 hotKeyID,
@@ -144,6 +192,7 @@ final class HotKeyManager {
                 unregister()
                 return .failure(.shortcutUnavailable)
             }
+            overlayRegistered = true
             if let ref {
                 hotKeyRefs[Self.overlayHotKeyID] = ref
                 hotKeyIDToMode[Self.overlayHotKeyID] = .overlayBuffer
@@ -153,7 +202,7 @@ final class HotKeyManager {
         if let livePaste {
             var ref: EventHotKeyRef?
             let hotKeyID = EventHotKeyID(signature: Self.hotKeySignature, id: Self.livePasteHotKeyID)
-            let status = RegisterEventHotKey(
+            let status = registerEventHotKey(
                 livePaste.keyCode,
                 livePaste.carbonModifierFlags,
                 hotKeyID,
@@ -162,26 +211,35 @@ final class HotKeyManager {
                 &ref
             )
             if status != noErr {
-                // Only fail if overlay also wasn't registered.
-                // If overlay succeeded, keep it and just skip live paste.
-                if hotKeyRefs.isEmpty {
+                if !overlayRegistered {
                     unregister()
                     return .failure(.shortcutUnavailable)
                 }
-                // Overlay is registered — live paste failed. Still report as success
-                // so the app remains functional with the overlay shortcut.
-                return .success
+                Log.modifierHotKey.error(
+                    "Live Auto-Paste hotkey registration failed after Overlay Buffer hotkey registered; preserving overlay hotkey and surfacing failure."
+                )
+                return .failure(.livePasteShortcutUnavailable)
             }
+            livePasteRegistered = true
             if let ref {
                 hotKeyRefs[Self.livePasteHotKeyID] = ref
                 hotKeyIDToMode[Self.livePasteHotKeyID] = .liveAutoPaste
             }
         }
 
+        #if DEBUG
+        debugCurrentRegistrationKind = .dual(
+            overlay: overlayRegistered,
+            livePaste: livePasteRegistered
+        )
+        #endif
         return .success
     }
 
     func unregister() {
+        #if DEBUG
+        Self.debugUnregisterCallCount += 1
+        #endif
         if isUsingModifierOnly {
             modifierOnlyManager.stop()
             isUsingModifierOnly = false
@@ -204,6 +262,12 @@ final class HotKeyManager {
     /// Installs the Carbon event handler if not already installed. Returns true on success.
     private func installHandlerIfNeeded() -> Bool {
         guard hotKeyHandlerRef == nil else { return true }
+
+        #if DEBUG
+        if let forcedHandlerInstallResult = Self.debugForcedHandlerInstallResult {
+            return forcedHandlerInstallResult
+        }
+        #endif
 
         var eventTypes = [
             EventTypeSpec(
@@ -255,6 +319,31 @@ final class HotKeyManager {
         return installStatus == noErr
     }
 
+    private func registerEventHotKey(
+        _ keyCode: UInt32,
+        _ modifierFlags: UInt32,
+        _ hotKeyID: EventHotKeyID,
+        _ target: EventTargetRef?,
+        _ options: UInt32,
+        _ outRef: UnsafeMutablePointer<EventHotKeyRef?>
+    ) -> OSStatus {
+        #if DEBUG
+        if let forcedStatus = Self.debugForcedRegisterStatusesByID.removeValue(forKey: hotKeyID.id) {
+            outRef.pointee = nil
+            return forcedStatus
+        }
+        #endif
+
+        return RegisterEventHotKey(
+            keyCode,
+            modifierFlags,
+            hotKeyID,
+            target,
+            options,
+            outRef
+        )
+    }
+
     private func handleHotKeyEvent(kind: UInt32, hotKeyID: UInt32) {
         switch kind {
         case UInt32(kEventHotKeyPressed):
@@ -271,3 +360,34 @@ final class HotKeyManager {
         }
     }
 }
+
+#if DEBUG
+extension HotKeyManager {
+    static func debugResetOverridesForTesting() {
+        debugForcedHandlerInstallResult = nil
+        debugForcedRegisterStatusesByID = [:]
+        debugUnregisterCallCount = 0
+    }
+
+    static func debugForceHandlerInstallResultForTesting(_ result: Bool?) {
+        debugForcedHandlerInstallResult = result
+    }
+
+    static func debugForceRegisterStatusForTesting(
+        hotKeyID: DebugRegistrationKindHotKeyID,
+        status: OSStatus
+    ) {
+        switch hotKeyID {
+        case .overlay:
+            debugForcedRegisterStatusesByID[overlayHotKeyID] = status
+        case .livePaste:
+            debugForcedRegisterStatusesByID[livePasteHotKeyID] = status
+        }
+    }
+}
+
+enum DebugRegistrationKindHotKeyID {
+    case overlay
+    case livePaste
+}
+#endif

--- a/Sources/localvoxtral/HotKeyManager.swift
+++ b/Sources/localvoxtral/HotKeyManager.swift
@@ -30,7 +30,7 @@ final class HotKeyManager {
     static let livePasteUnavailableErrorMessage =
         "The selected Live Auto-Paste shortcut is unavailable."
     static let modifierOnlyUnavailableErrorMessage =
-        "Unable to start the single-modifier hotkey. Grant Input Monitoring and Accessibility permissions, then try again."
+        "Unable to install the single-modifier hotkey monitors. Grant Accessibility permission, then try again."
 
     /// Legacy single-shortcut callback. Used by `register(shortcut:)`.
     var onPress: (() -> Void)?
@@ -91,7 +91,7 @@ final class HotKeyManager {
         let startOutcome = candidateManager.start(modifier: modifier)
         guard startOutcome == .created else {
             candidateManager.stop()
-            Log.modifierHotKey.error(
+            Log.modifierKeys.error(
                 "Modifier-only hotkey registration failed with outcome \(startOutcome.rawValue, privacy: .public); preserving previous hotkey registration."
             )
             return .failure(.modifierOnlyHotKeyUnavailable)
@@ -215,7 +215,7 @@ final class HotKeyManager {
                     unregister()
                     return .failure(.shortcutUnavailable)
                 }
-                Log.modifierHotKey.error(
+                Log.modifierKeys.error(
                     "Live Auto-Paste hotkey registration failed after Overlay Buffer hotkey registered; preserving overlay hotkey and surfacing failure."
                 )
                 return .failure(.livePasteShortcutUnavailable)

--- a/Sources/localvoxtral/Log.swift
+++ b/Sources/localvoxtral/Log.swift
@@ -23,5 +23,5 @@ enum Log {
     /// privacy trade-off.
     static let deltas = Logger(subsystem: subsystem, category: "Deltas")
     static let escape = Logger(subsystem: subsystem, category: "Escape")
-    static let modifierHotKey = Logger(subsystem: subsystem, category: "ModifierHotKey")
+    static let modifierKeys = Logger(subsystem: subsystem, category: "ModifierKeys")
 }

--- a/Sources/localvoxtral/Log.swift
+++ b/Sources/localvoxtral/Log.swift
@@ -23,4 +23,5 @@ enum Log {
     /// privacy trade-off.
     static let deltas = Logger(subsystem: subsystem, category: "Deltas")
     static let escape = Logger(subsystem: subsystem, category: "Escape")
+    static let modifierHotKey = Logger(subsystem: subsystem, category: "ModifierHotKey")
 }

--- a/Sources/localvoxtral/ModifierOnlyHotKeyManager.swift
+++ b/Sources/localvoxtral/ModifierOnlyHotKeyManager.swift
@@ -1,0 +1,196 @@
+import Carbon.HIToolbox
+import CoreGraphics
+import Foundation
+
+/// Captures modifier-only key presses (Fn/Globe, Right Command) using
+/// a CGEventTap on flagsChanged events. Differentiates tap (quick press+release)
+/// from hold (press beyond threshold) to support dual dictation modes.
+@MainActor
+final class ModifierOnlyHotKeyManager {
+    enum ModifierKey: String, CaseIterable, Identifiable, Codable {
+        case fn = "fn"
+        case rightCommand = "right_command"
+        case rightOption = "right_option"
+
+        var id: String { rawValue }
+
+        var displayName: String {
+            switch self {
+            case .fn: return "Fn / Globe"
+            case .rightCommand: return "Right Command"
+            case .rightOption: return "Right Option"
+            }
+        }
+    }
+
+    /// Fired when the modifier key is tapped (pressed and released before hold threshold).
+    var onTap: (() -> Void)?
+    /// Fired when the modifier key is held past the hold threshold.
+    var onHoldStart: (() -> Void)?
+    /// Fired when the modifier key is released after a hold.
+    var onHoldRelease: (() -> Void)?
+
+    /// Seconds the modifier must be held before it counts as a hold gesture.
+    var holdThresholdSeconds: Double = 0.35
+
+    private var eventTap: CFMachPort?
+    private var runLoopSource: CFRunLoopSource?
+
+    // nonisolated(unsafe) because these are accessed from the CGEventTap callback
+    // which runs on a different thread. Access is guarded by the sequential
+    // nature of the event tap (one event at a time).
+    nonisolated(unsafe) private static var _targetModifier: ModifierKey?
+    private nonisolated(unsafe) static var shared: ModifierOnlyHotKeyManager?
+    private nonisolated(unsafe) static var isModifierDown = false
+    private nonisolated(unsafe) static var wasInterruptedByKey = false
+    nonisolated(unsafe) static var _eventTap: CFMachPort?
+    private nonisolated(unsafe) static var isInHoldState = false
+    private nonisolated(unsafe) static var holdTimerWorkItem: DispatchWorkItem?
+    private nonisolated(unsafe) static var _holdThresholdSeconds: Double = 0.35
+
+    func start(modifier: ModifierKey) {
+        stop()
+        Self._targetModifier = modifier
+        Self.shared = self
+        Self.isModifierDown = false
+        Self.wasInterruptedByKey = false
+        Self.isInHoldState = false
+        Self._holdThresholdSeconds = holdThresholdSeconds
+
+        let eventMask: CGEventMask =
+            (1 << CGEventType.flagsChanged.rawValue) |
+            (1 << CGEventType.keyDown.rawValue)
+
+        guard let tap = CGEvent.tapCreate(
+            tap: .cgSessionEventTap,
+            place: .headInsertEventTap,
+            options: .listenOnly,
+            eventsOfInterest: eventMask,
+            callback: modifierEventCallback,
+            userInfo: nil
+        ) else {
+            return
+        }
+
+        eventTap = tap
+        Self._eventTap = tap
+        runLoopSource = CFMachPortCreateRunLoopSource(kCFAllocatorDefault, tap, 0)
+        if let source = runLoopSource {
+            CFRunLoopAddSource(CFRunLoopGetCurrent(), source, .commonModes)
+        }
+        CGEvent.tapEnable(tap: tap, enable: true)
+    }
+
+    func stop() {
+        Self.holdTimerWorkItem?.cancel()
+        Self.holdTimerWorkItem = nil
+        if let tap = eventTap {
+            CGEvent.tapEnable(tap: tap, enable: false)
+        }
+        if let source = runLoopSource {
+            CFRunLoopRemoveSource(CFRunLoopGetCurrent(), source, .commonModes)
+        }
+        eventTap = nil
+        Self._eventTap = nil
+        runLoopSource = nil
+        Self._targetModifier = nil
+        Self.shared = nil
+        Self.isModifierDown = false
+        Self.wasInterruptedByKey = false
+        Self.isInHoldState = false
+    }
+
+    // Called from the CGEventTap callback (not on main thread)
+    nonisolated static func handleEvent(_ proxy: CGEventTapProxy, _ type: CGEventType, _ event: CGEvent) {
+        // macOS disables listen-only taps after focus loss or timeout — re-enable
+        if type == .tapDisabledByTimeout || type == .tapDisabledByUserInput {
+            if let tap = _eventTap {
+                CGEvent.tapEnable(tap: tap, enable: true)
+            }
+            return
+        }
+
+        guard Self.shared != nil, let target = Self._targetModifier else { return }
+
+        if type == .keyDown {
+            // A non-modifier key was pressed while our modifier is held.
+            // This means it's being used AS a modifier, not tapped alone.
+            if isModifierDown {
+                wasInterruptedByKey = true
+                holdTimerWorkItem?.cancel()
+                holdTimerWorkItem = nil
+            }
+            return
+        }
+
+        guard type == .flagsChanged else { return }
+
+        let flags = event.flags
+        let keyCode = event.getIntegerValueField(.keyboardEventKeycode)
+
+        let isTargetDown: Bool
+        switch target {
+        case .fn:
+            isTargetDown = flags.contains(.maskSecondaryFn)
+        case .rightCommand:
+            // Right Command keycode is 54
+            isTargetDown = keyCode == 54 && flags.contains(.maskCommand)
+        case .rightOption:
+            // Right Option keycode is 61
+            isTargetDown = keyCode == 61 && flags.contains(.maskAlternate)
+        }
+
+        if isTargetDown && !isModifierDown {
+            // Modifier just pressed — start hold timer
+            isModifierDown = true
+            wasInterruptedByKey = false
+            isInHoldState = false
+
+            holdTimerWorkItem?.cancel()
+            let workItem = DispatchWorkItem {
+                guard Self.isModifierDown, !Self.wasInterruptedByKey else { return }
+                Self.isInHoldState = true
+                DispatchQueue.main.async {
+                    Self.shared?.onHoldStart?()
+                }
+            }
+            holdTimerWorkItem = workItem
+            DispatchQueue.main.asyncAfter(
+                deadline: .now() + _holdThresholdSeconds,
+                execute: workItem
+            )
+        } else if !isTargetDown && isModifierDown {
+            // Modifier just released
+            isModifierDown = false
+            holdTimerWorkItem?.cancel()
+            holdTimerWorkItem = nil
+
+            if wasInterruptedByKey {
+                // Used as a modifier combo — no gesture
+                wasInterruptedByKey = false
+            } else if isInHoldState {
+                // Was holding — fire hold release
+                isInHoldState = false
+                DispatchQueue.main.async {
+                    Self.shared?.onHoldRelease?()
+                }
+            } else {
+                // Released before threshold — tap
+                DispatchQueue.main.async {
+                    Self.shared?.onTap?()
+                }
+            }
+        }
+    }
+}
+
+// CGEventTap C callback — forwards to the static handler
+private func modifierEventCallback(
+    proxy: CGEventTapProxy,
+    type: CGEventType,
+    event: CGEvent,
+    userInfo: UnsafeMutableRawPointer?
+) -> Unmanaged<CGEvent>? {
+    ModifierOnlyHotKeyManager.handleEvent(proxy, type, event)
+    return Unmanaged.passRetained(event)
+}

--- a/Sources/localvoxtral/ModifierOnlyHotKeyManager.swift
+++ b/Sources/localvoxtral/ModifierOnlyHotKeyManager.swift
@@ -49,9 +49,19 @@ final class ModifierOnlyHotKeyManager {
         self.holdScheduler = holdScheduler
     }
 
-    func start(modifier: ModifierKey) {
+    @discardableResult
+    func start(modifier: ModifierKey) -> ModifierOnlyHotKeyStartOutcome {
         #if DEBUG
         Self.startCallCount += 1
+        if let forcedStartOutcome = Self.forcedStartOutcome {
+            stop()
+            configureGestureState(modifier: modifier)
+            if forcedStartOutcome != .created {
+                resetGestureState()
+            }
+            Self.record(forcedStartOutcome)
+            return forcedStartOutcome
+        }
         #endif
 
         stop()
@@ -80,7 +90,7 @@ final class ModifierOnlyHotKeyManager {
             Log.modifierHotKey.error(
                 "Modifier-only CGEvent.tapCreate returned nil (trusted=\(trusted, privacy: .public), inputMonitoring=\(Self.describeHIDAccess(inputMonitoring), privacy: .public)). Modifier-only hotkey disabled; Carbon modifier+key shortcuts are unaffected."
             )
-            return
+            return .creationFailedNil
         }
 
         guard let source = CFMachPortCreateRunLoopSource(kCFAllocatorDefault, tap, 0) else {
@@ -90,7 +100,7 @@ final class ModifierOnlyHotKeyManager {
                 "CFMachPortCreateRunLoopSource returned nil; modifier-only hotkey disabled. Carbon modifier+key shortcuts are unaffected."
             )
             CGEvent.tapEnable(tap: tap, enable: false)
-            return
+            return .noRunLoopSource
         }
 
         CFRunLoopAddSource(CFRunLoopGetMain(), source, .commonModes)
@@ -105,6 +115,7 @@ final class ModifierOnlyHotKeyManager {
         Log.modifierHotKey.notice(
             "Modifier-only CGEventTap created and enabled on the main run loop for \(modifier.rawValue, privacy: .public)."
         )
+        return .created
     }
 
     func stop() {
@@ -308,11 +319,13 @@ final class ModifierOnlyHotKeyManager {
     static var lastStartOutcome: ModifierOnlyHotKeyStartOutcome = .none
     static var startCallCount = 0
     static var stopCallCount = 0
+    static var forcedStartOutcome: ModifierOnlyHotKeyStartOutcome?
 
     static func resetDebugState() {
         lastStartOutcome = .none
         startCallCount = 0
         stopCallCount = 0
+        forcedStartOutcome = nil
     }
 
     func debugStartGestureForTesting(modifier: ModifierKey) {

--- a/Sources/localvoxtral/ModifierOnlyHotKeyManager.swift
+++ b/Sources/localvoxtral/ModifierOnlyHotKeyManager.swift
@@ -1,14 +1,13 @@
+import AppKit
 import ApplicationServices
 import Carbon.HIToolbox
-import CoreGraphics
 import Foundation
 import IOKit.hid
-import Synchronization
 
 /// Captures modifier-only key presses (Fn/Globe, Right Command, Right Option)
-/// with a listen-only CGEventTap. A quick tap starts/stops overlay-buffer
-/// dictation; holding past the configured threshold starts live auto-paste
-/// push-to-talk dictation until the modifier is released.
+/// with NSEvent monitors. A quick tap starts/stops overlay-buffer dictation;
+/// holding past the configured threshold starts live auto-paste push-to-talk
+/// dictation until the modifier is released.
 @MainActor
 final class ModifierOnlyHotKeyManager {
     enum ModifierKey: String, CaseIterable, Identifiable, Codable {
@@ -28,7 +27,7 @@ final class ModifierOnlyHotKeyManager {
     }
 
     typealias HoldScheduler =
-        @Sendable (_ delay: Double, _ fire: @escaping @Sendable () -> Void) -> Void
+        @MainActor (_ delay: Double, _ fire: @escaping @MainActor @Sendable () -> Void) -> Void
 
     /// Fired when the modifier key is tapped (pressed and released before hold threshold).
     var onTap: (() -> Void)?
@@ -40,10 +39,15 @@ final class ModifierOnlyHotKeyManager {
     /// Seconds the modifier must be held before it counts as a hold gesture.
     var holdThresholdSeconds: Double = 0.35
 
-    private var eventTap: CFMachPort?
-    private var runLoopSource: CFRunLoopSource?
+    private var globalFlagsMonitor: Any?
+    private var localFlagsMonitor: Any?
+    private var globalKeyDownMonitor: Any?
+    private var localKeyDownMonitor: Any?
+
     private let holdScheduler: HoldScheduler
-    private let state = Mutex(ModifierGestureState())
+    private var state = ModifierGestureState()
+    private var loggedFlagsDelivery = false
+    private var loggedKeyDownDelivery = false
 
     init(holdScheduler: @escaping HoldScheduler = ModifierOnlyHotKeyManager.defaultHoldScheduler) {
         self.holdScheduler = holdScheduler
@@ -69,52 +73,81 @@ final class ModifierOnlyHotKeyManager {
 
         let trusted = AXIsProcessTrusted()
         let inputMonitoring = IOHIDCheckAccess(kIOHIDRequestTypeListenEvent)
-        Log.modifierHotKey.notice(
+        Log.modifierKeys.notice(
             "permission state: AXIsProcessTrusted=\(trusted, privacy: .public) inputMonitoring=\(Self.describeHIDAccess(inputMonitoring), privacy: .public)"
         )
 
-        let eventMask: CGEventMask =
-            (1 << CGEventType.flagsChanged.rawValue) |
-            (1 << CGEventType.keyDown.rawValue)
-
-        guard let tap = CGEvent.tapCreate(
-            tap: .cgSessionEventTap,
-            place: .headInsertEventTap,
-            options: .listenOnly,
-            eventsOfInterest: eventMask,
-            callback: modifierEventCallback,
-            userInfo: Unmanaged.passUnretained(self).toOpaque()
-        ) else {
+        guard trusted else {
             resetGestureState()
-            Self.record(.creationFailedNil)
-            Log.modifierHotKey.error(
-                "Modifier-only CGEvent.tapCreate returned nil (trusted=\(trusted, privacy: .public), inputMonitoring=\(Self.describeHIDAccess(inputMonitoring), privacy: .public)). Modifier-only hotkey disabled; Carbon modifier+key shortcuts are unaffected."
+            Self.record(.monitorInstallationFailed)
+            Log.modifierKeys.error(
+                "Accessibility trust is required for modifier-only global NSEvent monitors; modifier-only hotkey disabled. Carbon modifier+key shortcuts are unaffected."
             )
-            return .creationFailedNil
+            return .monitorInstallationFailed
         }
 
-        guard let source = CFMachPortCreateRunLoopSource(kCFAllocatorDefault, tap, 0) else {
+        globalFlagsMonitor = NSEvent.addGlobalMonitorForEvents(matching: .flagsChanged) {
+            [weak self] event in
+            let keyCode = event.keyCode
+            let rawFlags = event.modifierFlags.rawValue
+            Task { @MainActor [weak self] in
+                self?.handleFlagsChanged(
+                    keyCode: keyCode,
+                    flags: NSEvent.ModifierFlags(rawValue: rawFlags),
+                    source: .global
+                )
+            }
+        }
+
+        localFlagsMonitor = NSEvent.addLocalMonitorForEvents(matching: .flagsChanged) {
+            [weak self] event in
+            let keyCode = event.keyCode
+            let rawFlags = event.modifierFlags.rawValue
+            Task { @MainActor [weak self] in
+                self?.handleFlagsChanged(
+                    keyCode: keyCode,
+                    flags: NSEvent.ModifierFlags(rawValue: rawFlags),
+                    source: .local
+                )
+            }
+            return event
+        }
+
+        guard globalFlagsMonitor != nil, localFlagsMonitor != nil else {
+            removeEventMonitors()
             resetGestureState()
-            Self.record(.noRunLoopSource)
-            Log.modifierHotKey.error(
-                "CFMachPortCreateRunLoopSource returned nil; modifier-only hotkey disabled. Carbon modifier+key shortcuts are unaffected."
+            Self.record(.monitorInstallationFailed)
+            Log.modifierKeys.error(
+                "Unable to install required modifier-only flagsChanged NSEvent monitors; modifier-only hotkey disabled. Carbon modifier+key shortcuts are unaffected."
             )
-            CGEvent.tapEnable(tap: tap, enable: false)
-            return .noRunLoopSource
+            return .monitorInstallationFailed
         }
 
-        CFRunLoopAddSource(CFRunLoopGetMain(), source, .commonModes)
-        CGEvent.tapEnable(tap: tap, enable: true)
-
-        eventTap = tap
-        runLoopSource = source
-        state.withLock {
-            $0.activeTapAddress = UInt(bitPattern: Unmanaged.passUnretained(tap).toOpaque())
+        globalKeyDownMonitor = NSEvent.addGlobalMonitorForEvents(matching: .keyDown) {
+            [weak self] _ in
+            Task { @MainActor [weak self] in
+                self?.handleKeyDown(source: .global)
+            }
         }
-        Self.record(.created)
-        Log.modifierHotKey.notice(
-            "Modifier-only CGEventTap created and enabled on the main run loop for \(modifier.rawValue, privacy: .public)."
+
+        localKeyDownMonitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown) {
+            [weak self] event in
+            Task { @MainActor [weak self] in
+                self?.handleKeyDown(source: .local)
+            }
+            return event
+        }
+
+        Log.modifierKeys.notice(
+            "Installed modifier-only NSEvent monitors for \(modifier.rawValue, privacy: .public): flagsChanged global=\(self.globalFlagsMonitor != nil, privacy: .public) local=\(self.localFlagsMonitor != nil, privacy: .public), keyDown global=\(self.globalKeyDownMonitor != nil, privacy: .public) local=\(self.localKeyDownMonitor != nil, privacy: .public)."
         )
+        if globalKeyDownMonitor == nil || localKeyDownMonitor == nil {
+            Log.modifierKeys.notice(
+                "Modifier-only keyDown monitor installation incomplete; modifier-used-as-real-modifier cancellation will degrade to flagsChanged-only inference."
+            )
+        }
+
+        Self.record(.created)
         return .created
     }
 
@@ -123,45 +156,23 @@ final class ModifierOnlyHotKeyManager {
         Self.stopCallCount += 1
         #endif
 
-        if let tap = eventTap {
-            CGEvent.tapEnable(tap: tap, enable: false)
-        }
-        if let source = runLoopSource {
-            CFRunLoopRemoveSource(CFRunLoopGetMain(), source, .commonModes)
-        }
-        eventTap = nil
-        runLoopSource = nil
+        removeEventMonitors()
         resetGestureState()
     }
 
     deinit {
-        // MainActor deinit — teardown is driven by HotKeyManager via stop().
+        // MainActor deinit - teardown is driven by HotKeyManager via stop().
     }
 
-    nonisolated func handleEvent(_ type: CGEventType, _ event: CGEvent) {
-        if type == .tapDisabledByTimeout || type == .tapDisabledByUserInput {
-            reenableTapAfterSystemDisable(type: type)
-            return
-        }
-
-        switch type {
-        case .keyDown:
-            handleKeyDown()
-        case .flagsChanged:
-            handleFlagsChanged(
-                keyCode: event.getIntegerValueField(.keyboardEventKeycode),
-                flags: event.flags
-            )
-        default:
-            break
-        }
-    }
-
-    private nonisolated static func defaultHoldScheduler(
+    private static func defaultHoldScheduler(
         delay: Double,
-        fire: @escaping @Sendable () -> Void
+        fire: @escaping @MainActor @Sendable () -> Void
     ) {
-        DispatchQueue.main.asyncAfter(deadline: .now() + delay, execute: fire)
+        let nanoseconds = UInt64(max(delay, 0) * 1_000_000_000)
+        Task { @MainActor in
+            try? await Task.sleep(nanoseconds: nanoseconds)
+            fire()
+        }
     }
 
     private static func describeHIDAccess(_ access: IOHIDAccessType) -> String {
@@ -173,107 +184,141 @@ final class ModifierOnlyHotKeyManager {
     }
 
     private func configureGestureState(modifier: ModifierKey) {
-        state.withLock {
-            $0.targetModifier = modifier
-            $0.holdThresholdSeconds = holdThresholdSeconds
-            $0.activeTapAddress = nil
-            $0.resetGesture()
-        }
+        state.targetModifier = modifier
+        state.holdThresholdSeconds = holdThresholdSeconds
+        state.resetGesture()
+        loggedFlagsDelivery = false
+        loggedKeyDownDelivery = false
     }
 
     private func resetGestureState() {
-        state.withLock { $0.resetAll() }
+        state.resetAll()
+        loggedFlagsDelivery = false
+        loggedKeyDownDelivery = false
     }
 
-    private nonisolated func reenableTapAfterSystemDisable(type: CGEventType) {
-        let tapAddress = state.withLock { $0.activeTapAddress }
-        if let tapAddress,
-           let tapPointer = UnsafeMutableRawPointer(bitPattern: tapAddress)
-        {
-            let tap = Unmanaged<CFMachPort>.fromOpaque(tapPointer).takeUnretainedValue()
-            CGEvent.tapEnable(tap: tap, enable: true)
-            Log.modifierHotKey.notice(
-                "Modifier-only CGEventTap disabled by system (type=\(type.rawValue)); re-enabled."
+    private func removeEventMonitors() {
+        let monitors = [
+            globalFlagsMonitor,
+            localFlagsMonitor,
+            globalKeyDownMonitor,
+            localKeyDownMonitor,
+        ]
+        for monitor in monitors.compactMap({ $0 }) {
+            NSEvent.removeMonitor(monitor)
+        }
+        globalFlagsMonitor = nil
+        localFlagsMonitor = nil
+        globalKeyDownMonitor = nil
+        localKeyDownMonitor = nil
+    }
+
+    private func handleKeyDown(source: ModifierEventSource) {
+        if !loggedKeyDownDelivery {
+            loggedKeyDownDelivery = true
+            Log.modifierKeys.notice(
+                "Modifier-only keyDown NSEvent monitor delivered first event from \(source.rawValue, privacy: .public)."
             )
+        }
+
+        guard state.targetModifier != nil, state.isModifierDown else { return }
+        state.wasInterruptedByKey = true
+        state.generation &+= 1
+
+        if state.isInHoldState {
+            state.isInHoldState = false
+            fire(.holdRelease)
+        }
+    }
+
+    private func handleFlagsChanged(
+        keyCode: UInt16,
+        flags: NSEvent.ModifierFlags,
+        source: ModifierEventSource
+    ) {
+        if !loggedFlagsDelivery {
+            loggedFlagsDelivery = true
+            Log.modifierKeys.notice(
+                "Modifier-only flagsChanged NSEvent monitor delivered first event from \(source.rawValue, privacy: .public)."
+            )
+        }
+
+        guard let target = state.targetModifier else { return }
+
+        let targetFlagPresent = Self.targetFlagPresent(target, flags: flags)
+        let isTargetKeyEvent = Self.isTargetModifierKeyEvent(target, keyCode: keyCode)
+        let effect: GestureEffect
+
+        if state.isModifierDown {
+            if isTargetKeyEvent || !targetFlagPresent {
+                effect = handleTargetModifierReleaseIfNeeded(targetFlagPresent: targetFlagPresent)
+            } else {
+                effect = handleModifierInterruptedByFlagsTimeline()
+            }
+        } else if targetFlagPresent && isTargetKeyEvent {
+            effect = handleTargetModifierPress()
         } else {
-            Log.modifierHotKey.error(
-                "Modifier-only CGEventTap disabled by system (type=\(type.rawValue)) but no active tap is available to re-enable."
-            )
-        }
-    }
-
-    private nonisolated func handleKeyDown() {
-        state.withLock { state in
-            guard state.targetModifier != nil, state.isModifierDown else { return }
-            state.wasInterruptedByKey = true
-            state.generation &+= 1
-        }
-    }
-
-    private nonisolated func handleFlagsChanged(keyCode: Int64, flags: CGEventFlags) {
-        let effect = state.withLock { state -> GestureEffect in
-            guard let target = state.targetModifier else { return .none }
-
-            let isTargetDown = Self.isTargetModifierDown(
-                target,
-                keyCode: keyCode,
-                flags: flags
-            )
-
-            if isTargetDown && !state.isModifierDown {
-                state.isModifierDown = true
-                state.wasInterruptedByKey = false
-                state.isInHoldState = false
-                state.generation &+= 1
-                return .scheduleHold(
-                    generation: state.generation,
-                    delay: state.holdThresholdSeconds
-                )
-            }
-
-            if !isTargetDown && state.isModifierDown {
-                state.isModifierDown = false
-                state.generation &+= 1
-
-                if state.wasInterruptedByKey {
-                    state.wasInterruptedByKey = false
-                    state.isInHoldState = false
-                    return .none
-                }
-
-                if state.isInHoldState {
-                    state.isInHoldState = false
-                    return .fire(.holdRelease)
-                }
-
-                return .fire(.tap)
-            }
-
-            return .none
+            effect = .none
         }
 
         perform(effect)
     }
 
-    private nonisolated func handleHoldThresholdElapsed(generation: UInt64) {
-        let shouldFire = state.withLock { state -> Bool in
-            guard state.targetModifier != nil,
-                  state.generation == generation,
-                  state.isModifierDown,
-                  !state.wasInterruptedByKey,
-                  !state.isInHoldState
-            else {
-                return false
-            }
-            state.isInHoldState = true
-            return true
+    private func handleTargetModifierPress() -> GestureEffect {
+        state.isModifierDown = true
+        state.wasInterruptedByKey = false
+        state.isInHoldState = false
+        state.generation &+= 1
+        return .scheduleHold(generation: state.generation, delay: state.holdThresholdSeconds)
+    }
+
+    private func handleTargetModifierReleaseIfNeeded(targetFlagPresent: Bool) -> GestureEffect {
+        guard !targetFlagPresent, state.isModifierDown else { return .none }
+
+        state.isModifierDown = false
+        state.generation &+= 1
+
+        if state.wasInterruptedByKey {
+            state.wasInterruptedByKey = false
+            state.isInHoldState = false
+            return .none
         }
 
-        guard shouldFire else { return }
+        if state.isInHoldState {
+            state.isInHoldState = false
+            return .fire(.holdRelease)
+        }
+
+        return .fire(.tap)
+    }
+
+    private func handleModifierInterruptedByFlagsTimeline() -> GestureEffect {
+        state.wasInterruptedByKey = true
+        state.generation &+= 1
+
+        if state.isInHoldState {
+            state.isInHoldState = false
+            return .fire(.holdRelease)
+        }
+
+        return .none
+    }
+
+    private func handleHoldThresholdElapsed(generation: UInt64) {
+        guard state.targetModifier != nil,
+              state.generation == generation,
+              state.isModifierDown,
+              !state.wasInterruptedByKey,
+              !state.isInHoldState
+        else {
+            return
+        }
+
+        state.isInHoldState = true
         fire(.holdStart)
     }
 
-    private nonisolated func perform(_ effect: GestureEffect) {
+    private func perform(_ effect: GestureEffect) {
         switch effect {
         case .none:
             break
@@ -286,32 +331,42 @@ final class ModifierOnlyHotKeyManager {
         }
     }
 
-    private nonisolated func fire(_ callback: GestureCallback) {
-        Task { @MainActor [weak self] in
-            guard let self else { return }
-            switch callback {
-            case .tap:
-                self.onTap?()
-            case .holdStart:
-                self.onHoldStart?()
-            case .holdRelease:
-                self.onHoldRelease?()
-            }
+    private func fire(_ callback: GestureCallback) {
+        switch callback {
+        case .tap:
+            onTap?()
+        case .holdStart:
+            onHoldStart?()
+        case .holdRelease:
+            onHoldRelease?()
         }
     }
 
-    private nonisolated static func isTargetModifierDown(
+    private static func targetFlagPresent(
         _ target: ModifierKey,
-        keyCode: Int64,
-        flags: CGEventFlags
+        flags: NSEvent.ModifierFlags
     ) -> Bool {
         switch target {
         case .fn:
-            return flags.contains(.maskSecondaryFn)
+            return flags.contains(.function)
         case .rightCommand:
-            return keyCode == Int64(kVK_RightCommand) && flags.contains(.maskCommand)
+            return flags.contains(.command)
         case .rightOption:
-            return keyCode == Int64(kVK_RightOption) && flags.contains(.maskAlternate)
+            return flags.contains(.option)
+        }
+    }
+
+    private static func isTargetModifierKeyEvent(
+        _ target: ModifierKey,
+        keyCode: UInt16
+    ) -> Bool {
+        switch target {
+        case .fn:
+            return keyCode == UInt16(kVK_Function) || keyCode == 0
+        case .rightCommand:
+            return keyCode == UInt16(kVK_RightCommand)
+        case .rightOption:
+            return keyCode == UInt16(kVK_RightOption)
         }
     }
 
@@ -334,23 +389,24 @@ final class ModifierOnlyHotKeyManager {
     }
 
     func debugHandleKeyDownForTesting() {
-        handleKeyDown()
+        handleKeyDown(source: .synthetic)
     }
 
-    func debugHandleFlagsChangedForTesting(keyCode: Int64, flags: CGEventFlags) {
-        handleFlagsChanged(keyCode: keyCode, flags: flags)
+    func debugHandleFlagsChangedForTesting(
+        keyCode: UInt16,
+        flags: NSEvent.ModifierFlags
+    ) {
+        handleFlagsChanged(keyCode: keyCode, flags: flags, source: .synthetic)
     }
 
     func debugGestureSnapshotForTesting() -> ModifierOnlyHotKeyDebugSnapshot {
-        state.withLock {
-            ModifierOnlyHotKeyDebugSnapshot(
-                targetModifier: $0.targetModifier,
-                isModifierDown: $0.isModifierDown,
-                wasInterruptedByKey: $0.wasInterruptedByKey,
-                isInHoldState: $0.isInHoldState,
-                generation: $0.generation
-            )
-        }
+        ModifierOnlyHotKeyDebugSnapshot(
+            targetModifier: state.targetModifier,
+            isModifierDown: state.isModifierDown,
+            wasInterruptedByKey: state.wasInterruptedByKey,
+            isInHoldState: state.isInHoldState,
+            generation: state.generation
+        )
     }
 
     @inline(__always) private static func record(_ outcome: ModifierOnlyHotKeyStartOutcome) {
@@ -364,7 +420,6 @@ final class ModifierOnlyHotKeyManager {
 private struct ModifierGestureState {
     var targetModifier: ModifierOnlyHotKeyManager.ModifierKey?
     var holdThresholdSeconds = 0.35
-    var activeTapAddress: UInt?
     var isModifierDown = false
     var wasInterruptedByKey = false
     var isInHoldState = false
@@ -380,9 +435,14 @@ private struct ModifierGestureState {
     mutating func resetAll() {
         targetModifier = nil
         holdThresholdSeconds = 0.35
-        activeTapAddress = nil
         resetGesture()
     }
+}
+
+private enum ModifierEventSource: String {
+    case global
+    case local
+    case synthetic
 }
 
 private enum GestureEffect {
@@ -399,8 +459,7 @@ private enum GestureCallback {
 
 enum ModifierOnlyHotKeyStartOutcome: String, Equatable {
     case none
-    case creationFailedNil
-    case noRunLoopSource
+    case monitorInstallationFailed
     case created
 }
 
@@ -413,20 +472,3 @@ struct ModifierOnlyHotKeyDebugSnapshot: Equatable {
     var generation: UInt64
 }
 #endif
-
-private func modifierEventCallback(
-    proxy: CGEventTapProxy,
-    type: CGEventType,
-    event: CGEvent,
-    userInfo: UnsafeMutableRawPointer?
-) -> Unmanaged<CGEvent>? {
-    guard let userInfo else {
-        return Unmanaged.passRetained(event)
-    }
-
-    let manager = Unmanaged<ModifierOnlyHotKeyManager>
-        .fromOpaque(userInfo)
-        .takeUnretainedValue()
-    manager.handleEvent(type, event)
-    return Unmanaged.passRetained(event)
-}

--- a/Sources/localvoxtral/ModifierOnlyHotKeyManager.swift
+++ b/Sources/localvoxtral/ModifierOnlyHotKeyManager.swift
@@ -1,10 +1,14 @@
+import ApplicationServices
 import Carbon.HIToolbox
 import CoreGraphics
 import Foundation
+import IOKit.hid
+import Synchronization
 
-/// Captures modifier-only key presses (Fn/Globe, Right Command) using
-/// a CGEventTap on flagsChanged events. Differentiates tap (quick press+release)
-/// from hold (press beyond threshold) to support dual dictation modes.
+/// Captures modifier-only key presses (Fn/Globe, Right Command, Right Option)
+/// with a listen-only CGEventTap. A quick tap starts/stops overlay-buffer
+/// dictation; holding past the configured threshold starts live auto-paste
+/// push-to-talk dictation until the modifier is released.
 @MainActor
 final class ModifierOnlyHotKeyManager {
     enum ModifierKey: String, CaseIterable, Identifiable, Codable {
@@ -23,6 +27,9 @@ final class ModifierOnlyHotKeyManager {
         }
     }
 
+    typealias HoldScheduler =
+        @Sendable (_ delay: Double, _ fire: @escaping @Sendable () -> Void) -> Void
+
     /// Fired when the modifier key is tapped (pressed and released before hold threshold).
     var onTap: (() -> Void)?
     /// Fired when the modifier key is held past the hold threshold.
@@ -35,27 +42,26 @@ final class ModifierOnlyHotKeyManager {
 
     private var eventTap: CFMachPort?
     private var runLoopSource: CFRunLoopSource?
+    private let holdScheduler: HoldScheduler
+    private let state = Mutex(ModifierGestureState())
 
-    // nonisolated(unsafe) because these are accessed from the CGEventTap callback
-    // which runs on a different thread. Access is guarded by the sequential
-    // nature of the event tap (one event at a time).
-    nonisolated(unsafe) private static var _targetModifier: ModifierKey?
-    private nonisolated(unsafe) static var shared: ModifierOnlyHotKeyManager?
-    private nonisolated(unsafe) static var isModifierDown = false
-    private nonisolated(unsafe) static var wasInterruptedByKey = false
-    nonisolated(unsafe) static var _eventTap: CFMachPort?
-    private nonisolated(unsafe) static var isInHoldState = false
-    private nonisolated(unsafe) static var holdTimerWorkItem: DispatchWorkItem?
-    private nonisolated(unsafe) static var _holdThresholdSeconds: Double = 0.35
+    init(holdScheduler: @escaping HoldScheduler = ModifierOnlyHotKeyManager.defaultHoldScheduler) {
+        self.holdScheduler = holdScheduler
+    }
 
     func start(modifier: ModifierKey) {
+        #if DEBUG
+        Self.startCallCount += 1
+        #endif
+
         stop()
-        Self._targetModifier = modifier
-        Self.shared = self
-        Self.isModifierDown = false
-        Self.wasInterruptedByKey = false
-        Self.isInHoldState = false
-        Self._holdThresholdSeconds = holdThresholdSeconds
+        configureGestureState(modifier: modifier)
+
+        let trusted = AXIsProcessTrusted()
+        let inputMonitoring = IOHIDCheckAccess(kIOHIDRequestTypeListenEvent)
+        Log.modifierHotKey.notice(
+            "permission state: AXIsProcessTrusted=\(trusted, privacy: .public) inputMonitoring=\(Self.describeHIDAccess(inputMonitoring), privacy: .public)"
+        )
 
         let eventMask: CGEventMask =
             (1 << CGEventType.flagsChanged.rawValue) |
@@ -67,130 +73,347 @@ final class ModifierOnlyHotKeyManager {
             options: .listenOnly,
             eventsOfInterest: eventMask,
             callback: modifierEventCallback,
-            userInfo: nil
+            userInfo: Unmanaged.passUnretained(self).toOpaque()
         ) else {
+            resetGestureState()
+            Self.record(.creationFailedNil)
+            Log.modifierHotKey.error(
+                "Modifier-only CGEvent.tapCreate returned nil (trusted=\(trusted, privacy: .public), inputMonitoring=\(Self.describeHIDAccess(inputMonitoring), privacy: .public)). Modifier-only hotkey disabled; Carbon modifier+key shortcuts are unaffected."
+            )
             return
         }
 
-        eventTap = tap
-        Self._eventTap = tap
-        runLoopSource = CFMachPortCreateRunLoopSource(kCFAllocatorDefault, tap, 0)
-        if let source = runLoopSource {
-            CFRunLoopAddSource(CFRunLoopGetCurrent(), source, .commonModes)
+        guard let source = CFMachPortCreateRunLoopSource(kCFAllocatorDefault, tap, 0) else {
+            resetGestureState()
+            Self.record(.noRunLoopSource)
+            Log.modifierHotKey.error(
+                "CFMachPortCreateRunLoopSource returned nil; modifier-only hotkey disabled. Carbon modifier+key shortcuts are unaffected."
+            )
+            CGEvent.tapEnable(tap: tap, enable: false)
+            return
         }
+
+        CFRunLoopAddSource(CFRunLoopGetMain(), source, .commonModes)
         CGEvent.tapEnable(tap: tap, enable: true)
+
+        eventTap = tap
+        runLoopSource = source
+        state.withLock {
+            $0.activeTapAddress = UInt(bitPattern: Unmanaged.passUnretained(tap).toOpaque())
+        }
+        Self.record(.created)
+        Log.modifierHotKey.notice(
+            "Modifier-only CGEventTap created and enabled on the main run loop for \(modifier.rawValue, privacy: .public)."
+        )
     }
 
     func stop() {
-        Self.holdTimerWorkItem?.cancel()
-        Self.holdTimerWorkItem = nil
+        #if DEBUG
+        Self.stopCallCount += 1
+        #endif
+
         if let tap = eventTap {
             CGEvent.tapEnable(tap: tap, enable: false)
         }
         if let source = runLoopSource {
-            CFRunLoopRemoveSource(CFRunLoopGetCurrent(), source, .commonModes)
+            CFRunLoopRemoveSource(CFRunLoopGetMain(), source, .commonModes)
         }
         eventTap = nil
-        Self._eventTap = nil
         runLoopSource = nil
-        Self._targetModifier = nil
-        Self.shared = nil
-        Self.isModifierDown = false
-        Self.wasInterruptedByKey = false
-        Self.isInHoldState = false
+        resetGestureState()
     }
 
-    // Called from the CGEventTap callback (not on main thread)
-    nonisolated static func handleEvent(_ proxy: CGEventTapProxy, _ type: CGEventType, _ event: CGEvent) {
-        // macOS disables listen-only taps after focus loss or timeout — re-enable
+    deinit {
+        // MainActor deinit — teardown is driven by HotKeyManager via stop().
+    }
+
+    nonisolated func handleEvent(_ type: CGEventType, _ event: CGEvent) {
         if type == .tapDisabledByTimeout || type == .tapDisabledByUserInput {
-            if let tap = _eventTap {
-                CGEvent.tapEnable(tap: tap, enable: true)
-            }
+            reenableTapAfterSystemDisable(type: type)
             return
         }
 
-        guard Self.shared != nil, let target = Self._targetModifier else { return }
+        switch type {
+        case .keyDown:
+            handleKeyDown()
+        case .flagsChanged:
+            handleFlagsChanged(
+                keyCode: event.getIntegerValueField(.keyboardEventKeycode),
+                flags: event.flags
+            )
+        default:
+            break
+        }
+    }
 
-        if type == .keyDown {
-            // A non-modifier key was pressed while our modifier is held.
-            // This means it's being used AS a modifier, not tapped alone.
-            if isModifierDown {
-                wasInterruptedByKey = true
-                holdTimerWorkItem?.cancel()
-                holdTimerWorkItem = nil
+    private nonisolated static func defaultHoldScheduler(
+        delay: Double,
+        fire: @escaping @Sendable () -> Void
+    ) {
+        DispatchQueue.main.asyncAfter(deadline: .now() + delay, execute: fire)
+    }
+
+    private static func describeHIDAccess(_ access: IOHIDAccessType) -> String {
+        switch access {
+        case kIOHIDAccessTypeGranted: return "granted"
+        case kIOHIDAccessTypeDenied: return "denied"
+        default: return "unknown(\(access.rawValue))"
+        }
+    }
+
+    private func configureGestureState(modifier: ModifierKey) {
+        state.withLock {
+            $0.targetModifier = modifier
+            $0.holdThresholdSeconds = holdThresholdSeconds
+            $0.activeTapAddress = nil
+            $0.resetGesture()
+        }
+    }
+
+    private func resetGestureState() {
+        state.withLock { $0.resetAll() }
+    }
+
+    private nonisolated func reenableTapAfterSystemDisable(type: CGEventType) {
+        let tapAddress = state.withLock { $0.activeTapAddress }
+        if let tapAddress,
+           let tapPointer = UnsafeMutableRawPointer(bitPattern: tapAddress)
+        {
+            let tap = Unmanaged<CFMachPort>.fromOpaque(tapPointer).takeUnretainedValue()
+            CGEvent.tapEnable(tap: tap, enable: true)
+            Log.modifierHotKey.notice(
+                "Modifier-only CGEventTap disabled by system (type=\(type.rawValue)); re-enabled."
+            )
+        } else {
+            Log.modifierHotKey.error(
+                "Modifier-only CGEventTap disabled by system (type=\(type.rawValue)) but no active tap is available to re-enable."
+            )
+        }
+    }
+
+    private nonisolated func handleKeyDown() {
+        state.withLock { state in
+            guard state.targetModifier != nil, state.isModifierDown else { return }
+            state.wasInterruptedByKey = true
+            state.generation &+= 1
+        }
+    }
+
+    private nonisolated func handleFlagsChanged(keyCode: Int64, flags: CGEventFlags) {
+        let effect = state.withLock { state -> GestureEffect in
+            guard let target = state.targetModifier else { return .none }
+
+            let isTargetDown = Self.isTargetModifierDown(
+                target,
+                keyCode: keyCode,
+                flags: flags
+            )
+
+            if isTargetDown && !state.isModifierDown {
+                state.isModifierDown = true
+                state.wasInterruptedByKey = false
+                state.isInHoldState = false
+                state.generation &+= 1
+                return .scheduleHold(
+                    generation: state.generation,
+                    delay: state.holdThresholdSeconds
+                )
             }
-            return
+
+            if !isTargetDown && state.isModifierDown {
+                state.isModifierDown = false
+                state.generation &+= 1
+
+                if state.wasInterruptedByKey {
+                    state.wasInterruptedByKey = false
+                    state.isInHoldState = false
+                    return .none
+                }
+
+                if state.isInHoldState {
+                    state.isInHoldState = false
+                    return .fire(.holdRelease)
+                }
+
+                return .fire(.tap)
+            }
+
+            return .none
         }
 
-        guard type == .flagsChanged else { return }
+        perform(effect)
+    }
 
-        let flags = event.flags
-        let keyCode = event.getIntegerValueField(.keyboardEventKeycode)
+    private nonisolated func handleHoldThresholdElapsed(generation: UInt64) {
+        let shouldFire = state.withLock { state -> Bool in
+            guard state.targetModifier != nil,
+                  state.generation == generation,
+                  state.isModifierDown,
+                  !state.wasInterruptedByKey,
+                  !state.isInHoldState
+            else {
+                return false
+            }
+            state.isInHoldState = true
+            return true
+        }
 
-        let isTargetDown: Bool
+        guard shouldFire else { return }
+        fire(.holdStart)
+    }
+
+    private nonisolated func perform(_ effect: GestureEffect) {
+        switch effect {
+        case .none:
+            break
+        case .fire(let callback):
+            fire(callback)
+        case .scheduleHold(let generation, let delay):
+            holdScheduler(delay) { [weak self] in
+                self?.handleHoldThresholdElapsed(generation: generation)
+            }
+        }
+    }
+
+    private nonisolated func fire(_ callback: GestureCallback) {
+        Task { @MainActor [weak self] in
+            guard let self else { return }
+            switch callback {
+            case .tap:
+                self.onTap?()
+            case .holdStart:
+                self.onHoldStart?()
+            case .holdRelease:
+                self.onHoldRelease?()
+            }
+        }
+    }
+
+    private nonisolated static func isTargetModifierDown(
+        _ target: ModifierKey,
+        keyCode: Int64,
+        flags: CGEventFlags
+    ) -> Bool {
         switch target {
         case .fn:
-            isTargetDown = flags.contains(.maskSecondaryFn)
+            return flags.contains(.maskSecondaryFn)
         case .rightCommand:
-            // Right Command keycode is 54
-            isTargetDown = keyCode == 54 && flags.contains(.maskCommand)
+            return keyCode == Int64(kVK_RightCommand) && flags.contains(.maskCommand)
         case .rightOption:
-            // Right Option keycode is 61
-            isTargetDown = keyCode == 61 && flags.contains(.maskAlternate)
+            return keyCode == Int64(kVK_RightOption) && flags.contains(.maskAlternate)
         }
+    }
 
-        if isTargetDown && !isModifierDown {
-            // Modifier just pressed — start hold timer
-            isModifierDown = true
-            wasInterruptedByKey = false
-            isInHoldState = false
+    #if DEBUG
+    static var lastStartOutcome: ModifierOnlyHotKeyStartOutcome = .none
+    static var startCallCount = 0
+    static var stopCallCount = 0
 
-            holdTimerWorkItem?.cancel()
-            let workItem = DispatchWorkItem {
-                guard Self.isModifierDown, !Self.wasInterruptedByKey else { return }
-                Self.isInHoldState = true
-                DispatchQueue.main.async {
-                    Self.shared?.onHoldStart?()
-                }
-            }
-            holdTimerWorkItem = workItem
-            DispatchQueue.main.asyncAfter(
-                deadline: .now() + _holdThresholdSeconds,
-                execute: workItem
+    static func resetDebugState() {
+        lastStartOutcome = .none
+        startCallCount = 0
+        stopCallCount = 0
+    }
+
+    func debugStartGestureForTesting(modifier: ModifierKey) {
+        configureGestureState(modifier: modifier)
+        Self.record(.created)
+    }
+
+    func debugHandleKeyDownForTesting() {
+        handleKeyDown()
+    }
+
+    func debugHandleFlagsChangedForTesting(keyCode: Int64, flags: CGEventFlags) {
+        handleFlagsChanged(keyCode: keyCode, flags: flags)
+    }
+
+    func debugGestureSnapshotForTesting() -> ModifierOnlyHotKeyDebugSnapshot {
+        state.withLock {
+            ModifierOnlyHotKeyDebugSnapshot(
+                targetModifier: $0.targetModifier,
+                isModifierDown: $0.isModifierDown,
+                wasInterruptedByKey: $0.wasInterruptedByKey,
+                isInHoldState: $0.isInHoldState,
+                generation: $0.generation
             )
-        } else if !isTargetDown && isModifierDown {
-            // Modifier just released
-            isModifierDown = false
-            holdTimerWorkItem?.cancel()
-            holdTimerWorkItem = nil
-
-            if wasInterruptedByKey {
-                // Used as a modifier combo — no gesture
-                wasInterruptedByKey = false
-            } else if isInHoldState {
-                // Was holding — fire hold release
-                isInHoldState = false
-                DispatchQueue.main.async {
-                    Self.shared?.onHoldRelease?()
-                }
-            } else {
-                // Released before threshold — tap
-                DispatchQueue.main.async {
-                    Self.shared?.onTap?()
-                }
-            }
         }
+    }
+
+    @inline(__always) private static func record(_ outcome: ModifierOnlyHotKeyStartOutcome) {
+        lastStartOutcome = outcome
+    }
+    #else
+    @inline(__always) private static func record(_: ModifierOnlyHotKeyStartOutcome) {}
+    #endif
+}
+
+private struct ModifierGestureState {
+    var targetModifier: ModifierOnlyHotKeyManager.ModifierKey?
+    var holdThresholdSeconds = 0.35
+    var activeTapAddress: UInt?
+    var isModifierDown = false
+    var wasInterruptedByKey = false
+    var isInHoldState = false
+    var generation: UInt64 = 0
+
+    mutating func resetGesture() {
+        isModifierDown = false
+        wasInterruptedByKey = false
+        isInHoldState = false
+        generation &+= 1
+    }
+
+    mutating func resetAll() {
+        targetModifier = nil
+        holdThresholdSeconds = 0.35
+        activeTapAddress = nil
+        resetGesture()
     }
 }
 
-// CGEventTap C callback — forwards to the static handler
+private enum GestureEffect {
+    case none
+    case scheduleHold(generation: UInt64, delay: Double)
+    case fire(GestureCallback)
+}
+
+private enum GestureCallback {
+    case tap
+    case holdStart
+    case holdRelease
+}
+
+enum ModifierOnlyHotKeyStartOutcome: String, Equatable {
+    case none
+    case creationFailedNil
+    case noRunLoopSource
+    case created
+}
+
+#if DEBUG
+struct ModifierOnlyHotKeyDebugSnapshot: Equatable {
+    var targetModifier: ModifierOnlyHotKeyManager.ModifierKey?
+    var isModifierDown: Bool
+    var wasInterruptedByKey: Bool
+    var isInHoldState: Bool
+    var generation: UInt64
+}
+#endif
+
 private func modifierEventCallback(
     proxy: CGEventTapProxy,
     type: CGEventType,
     event: CGEvent,
     userInfo: UnsafeMutableRawPointer?
 ) -> Unmanaged<CGEvent>? {
-    ModifierOnlyHotKeyManager.handleEvent(proxy, type, event)
+    guard let userInfo else {
+        return Unmanaged.passRetained(event)
+    }
+
+    let manager = Unmanaged<ModifierOnlyHotKeyManager>
+        .fromOpaque(userInfo)
+        .takeUnretainedValue()
+    manager.handleEvent(type, event)
     return Unmanaged.passRetained(event)
 }

--- a/Sources/localvoxtral/SettingsStore.swift
+++ b/Sources/localvoxtral/SettingsStore.swift
@@ -15,7 +15,7 @@ struct DictationShortcut: Equatable, Sendable {
     }
 }
 
-enum DictationOutputMode: String, CaseIterable, Identifiable {
+enum DictationOutputMode: String, CaseIterable, Identifiable, Sendable {
     case overlayBuffer = "overlay_buffer"
     case liveAutoPaste = "live_auto_paste"
 

--- a/Sources/localvoxtral/SettingsStore.swift
+++ b/Sources/localvoxtral/SettingsStore.swift
@@ -265,7 +265,7 @@ final class SettingsStore {
         }
     }
 
-    /// Seconds to hold modifier before it triggers live auto-paste (0.15-0.8).
+    /// Seconds to hold modifier before it triggers live auto-paste (0.1-0.8).
     var modifierOnlyHoldDelay: Double {
         didSet { defaults.set(modifierOnlyHoldDelay, forKey: Keys.modifierOnlyHoldDelay) }
     }
@@ -418,7 +418,7 @@ final class SettingsStore {
         let storedHoldDelay = defaults.object(forKey: Keys.modifierOnlyHoldDelay) != nil
             ? defaults.double(forKey: Keys.modifierOnlyHoldDelay)
             : 0.35
-        modifierOnlyHoldDelay = min(max(storedHoldDelay, 0.15), 0.8)
+        modifierOnlyHoldDelay = min(max(storedHoldDelay, 0.1), 0.8)
 
         // --- Dual shortcut keys ---
         let hasExistingOverlayKeys = defaults.object(forKey: Keys.overlayBufferShortcutKeyCode) != nil

--- a/Sources/localvoxtral/SettingsStore.swift
+++ b/Sources/localvoxtral/SettingsStore.swift
@@ -146,6 +146,16 @@ final class SettingsStore {
         /// Note the `debug.` prefix (not `settings.`): this is not a
         /// user-facing preference and must never surface in the settings UI.
         static let debugLogRealtimeDeltas = "debug.log_realtime_deltas"
+        static let modifierOnlyHotKeyEnabled = "settings.modifier_only_hotkey_enabled"
+        static let modifierOnlyHotKeyModifier = "settings.modifier_only_hotkey_modifier"
+        static let modifierOnlyHoldDelay = "settings.modifier_only_hold_delay"
+        static let overlayBufferShortcutKeyCode = "settings.overlay_buffer_shortcut_key_code"
+        static let overlayBufferShortcutModifiers =
+            "settings.overlay_buffer_shortcut_carbon_modifiers"
+        static let overlayBufferShortcutEnabled = "settings.overlay_buffer_shortcut_enabled"
+        static let livePasteShortcutKeyCode = "settings.live_paste_shortcut_key_code"
+        static let livePasteShortcutModifiers = "settings.live_paste_shortcut_carbon_modifiers"
+        static let livePasteShortcutEnabled = "settings.live_paste_shortcut_enabled"
     }
 
     private let defaults: UserDefaults
@@ -243,6 +253,53 @@ final class SettingsStore {
     ///   `defaults write com.localvoxtral.app debug.log_realtime_deltas -bool true`
     var debugLogRealtimeDeltas: Bool {
         didSet { defaults.set(debugLogRealtimeDeltas, forKey: Keys.debugLogRealtimeDeltas) }
+    }
+
+    var modifierOnlyHotKeyEnabled: Bool {
+        didSet { defaults.set(modifierOnlyHotKeyEnabled, forKey: Keys.modifierOnlyHotKeyEnabled) }
+    }
+
+    var modifierOnlyHotKeyModifier: ModifierOnlyHotKeyManager.ModifierKey {
+        didSet {
+            defaults.set(modifierOnlyHotKeyModifier.rawValue, forKey: Keys.modifierOnlyHotKeyModifier)
+        }
+    }
+
+    /// Seconds to hold modifier before it triggers live auto-paste (0.15-0.8).
+    var modifierOnlyHoldDelay: Double {
+        didSet { defaults.set(modifierOnlyHoldDelay, forKey: Keys.modifierOnlyHoldDelay) }
+    }
+
+    var overlayBufferShortcutEnabled: Bool {
+        didSet { defaults.set(overlayBufferShortcutEnabled, forKey: Keys.overlayBufferShortcutEnabled) }
+    }
+
+    private var overlayBufferShortcutKeyCode: UInt32 {
+        didSet { defaults.set(overlayBufferShortcutKeyCode, forKey: Keys.overlayBufferShortcutKeyCode) }
+    }
+
+    private var overlayBufferShortcutCarbonModifierFlags: UInt32 {
+        didSet {
+            defaults.set(
+                overlayBufferShortcutCarbonModifierFlags,
+                forKey: Keys.overlayBufferShortcutModifiers)
+        }
+    }
+
+    var livePasteShortcutEnabled: Bool {
+        didSet { defaults.set(livePasteShortcutEnabled, forKey: Keys.livePasteShortcutEnabled) }
+    }
+
+    private var livePasteShortcutKeyCode: UInt32 {
+        didSet { defaults.set(livePasteShortcutKeyCode, forKey: Keys.livePasteShortcutKeyCode) }
+    }
+
+    private var livePasteShortcutCarbonModifierFlags: UInt32 {
+        didSet {
+            defaults.set(
+                livePasteShortcutCarbonModifierFlags,
+                forKey: Keys.livePasteShortcutModifiers)
+        }
     }
 
     init(
@@ -349,6 +406,80 @@ final class SettingsStore {
             defaults: defaults, key: Keys.replacementDictionaryEnabled, fallback: false)
         debugLogRealtimeDeltas = Self.loadBool(
             defaults: defaults, key: Keys.debugLogRealtimeDeltas, fallback: false)
+        modifierOnlyHotKeyEnabled = Self.loadBool(
+            defaults: defaults, key: Keys.modifierOnlyHotKeyEnabled, fallback: false)
+        if let storedModifier = defaults.string(forKey: Keys.modifierOnlyHotKeyModifier),
+           let parsed = ModifierOnlyHotKeyManager.ModifierKey(rawValue: storedModifier)
+        {
+            modifierOnlyHotKeyModifier = parsed
+        } else {
+            modifierOnlyHotKeyModifier = .fn
+        }
+        let storedHoldDelay = defaults.object(forKey: Keys.modifierOnlyHoldDelay) != nil
+            ? defaults.double(forKey: Keys.modifierOnlyHoldDelay)
+            : 0.35
+        modifierOnlyHoldDelay = min(max(storedHoldDelay, 0.15), 0.8)
+
+        // --- Dual shortcut keys ---
+        let hasExistingOverlayKeys = defaults.object(forKey: Keys.overlayBufferShortcutKeyCode) != nil
+        var needsOverlayMigrationPersist = false
+
+        if hasExistingOverlayKeys {
+            let obKeyCode = (defaults.object(forKey: Keys.overlayBufferShortcutKeyCode) as? NSNumber)?
+                .uint32Value ?? 0
+            let obModifiers = (defaults.object(forKey: Keys.overlayBufferShortcutModifiers) as? NSNumber)?
+                .uint32Value ?? 0
+            let obCandidate = DictationShortcut(keyCode: obKeyCode, carbonModifierFlags: obModifiers).normalized
+            if DictationShortcutValidation.persistenceErrorMessage(for: obCandidate) == nil {
+                overlayBufferShortcutKeyCode = obCandidate.keyCode
+                overlayBufferShortcutCarbonModifierFlags = obCandidate.carbonModifierFlags
+            } else {
+                overlayBufferShortcutKeyCode = 0
+                overlayBufferShortcutCarbonModifierFlags = 0
+            }
+            overlayBufferShortcutEnabled = Self.loadBool(
+                defaults: defaults, key: Keys.overlayBufferShortcutEnabled, fallback: true)
+        } else if storedKeyCode != nil, storedModifierFlags != nil {
+            overlayBufferShortcutKeyCode = resolvedShortcut.keyCode
+            overlayBufferShortcutCarbonModifierFlags = resolvedShortcut.carbonModifierFlags
+            overlayBufferShortcutEnabled = Self.loadBool(
+                defaults: defaults, key: Keys.dictationShortcutEnabled, fallback: true)
+            needsOverlayMigrationPersist = true
+        } else {
+            overlayBufferShortcutKeyCode = Self.defaultDictationShortcut.keyCode
+            overlayBufferShortcutCarbonModifierFlags = Self.defaultDictationShortcut.carbonModifierFlags
+            overlayBufferShortcutEnabled = true
+        }
+
+        let hasExistingLivePasteKeys = defaults.object(forKey: Keys.livePasteShortcutKeyCode) != nil
+        if hasExistingLivePasteKeys {
+            let lpKeyCode = (defaults.object(forKey: Keys.livePasteShortcutKeyCode) as? NSNumber)?
+                .uint32Value ?? 0
+            let lpModifiers = (defaults.object(forKey: Keys.livePasteShortcutModifiers) as? NSNumber)?
+                .uint32Value ?? 0
+            let lpCandidate = DictationShortcut(keyCode: lpKeyCode, carbonModifierFlags: lpModifiers).normalized
+            if DictationShortcutValidation.persistenceErrorMessage(for: lpCandidate) == nil {
+                livePasteShortcutKeyCode = lpCandidate.keyCode
+                livePasteShortcutCarbonModifierFlags = lpCandidate.carbonModifierFlags
+            } else {
+                livePasteShortcutKeyCode = 0
+                livePasteShortcutCarbonModifierFlags = 0
+            }
+            livePasteShortcutEnabled = Self.loadBool(
+                defaults: defaults, key: Keys.livePasteShortcutEnabled, fallback: false)
+        } else {
+            livePasteShortcutKeyCode = 0
+            livePasteShortcutCarbonModifierFlags = 0
+            livePasteShortcutEnabled = false
+        }
+
+        if needsOverlayMigrationPersist {
+            defaults.set(overlayBufferShortcutKeyCode, forKey: Keys.overlayBufferShortcutKeyCode)
+            defaults.set(
+                overlayBufferShortcutCarbonModifierFlags,
+                forKey: Keys.overlayBufferShortcutModifiers)
+            defaults.set(overlayBufferShortcutEnabled, forKey: Keys.overlayBufferShortcutEnabled)
+        }
     }
 
     // MARK: - Init Helpers
@@ -444,6 +575,63 @@ final class SettingsStore {
 
     func resetDictationShortcutToDefault() {
         setDictationShortcut(Self.defaultDictationShortcut)
+    }
+
+    // MARK: - Dual Shortcuts (per output mode)
+
+    var overlayBufferShortcut: DictationShortcut? {
+        guard overlayBufferShortcutEnabled else { return nil }
+        let candidate = DictationShortcut(
+            keyCode: overlayBufferShortcutKeyCode,
+            carbonModifierFlags: overlayBufferShortcutCarbonModifierFlags
+        ).normalized
+        if DictationShortcutValidation.persistenceErrorMessage(for: candidate) != nil {
+            return nil
+        }
+        return candidate
+    }
+
+    var livePasteShortcut: DictationShortcut? {
+        guard livePasteShortcutEnabled else { return nil }
+        let candidate = DictationShortcut(
+            keyCode: livePasteShortcutKeyCode,
+            carbonModifierFlags: livePasteShortcutCarbonModifierFlags
+        ).normalized
+        if DictationShortcutValidation.persistenceErrorMessage(for: candidate) != nil {
+            return nil
+        }
+        return candidate
+    }
+
+    func setOverlayBufferShortcut(_ shortcut: DictationShortcut?) {
+        guard let shortcut else {
+            overlayBufferShortcutEnabled = false
+            return
+        }
+        let normalizedShortcut = shortcut.normalized
+        if DictationShortcutValidation.persistenceErrorMessage(for: normalizedShortcut) == nil {
+            overlayBufferShortcutKeyCode = normalizedShortcut.keyCode
+            overlayBufferShortcutCarbonModifierFlags = normalizedShortcut.carbonModifierFlags
+        } else {
+            overlayBufferShortcutKeyCode = Self.defaultDictationShortcut.keyCode
+            overlayBufferShortcutCarbonModifierFlags = Self.defaultDictationShortcut.carbonModifierFlags
+        }
+        overlayBufferShortcutEnabled = true
+    }
+
+    func setLivePasteShortcut(_ shortcut: DictationShortcut?) {
+        guard let shortcut else {
+            livePasteShortcutEnabled = false
+            return
+        }
+        let normalizedShortcut = shortcut.normalized
+        if DictationShortcutValidation.persistenceErrorMessage(for: normalizedShortcut) == nil {
+            livePasteShortcutKeyCode = normalizedShortcut.keyCode
+            livePasteShortcutCarbonModifierFlags = normalizedShortcut.carbonModifierFlags
+        } else {
+            return
+        }
+        livePasteShortcutEnabled = true
     }
 
     func modelName(for provider: RealtimeProvider) -> String {

--- a/Sources/localvoxtral/SettingsView.swift
+++ b/Sources/localvoxtral/SettingsView.swift
@@ -38,6 +38,24 @@ struct SettingsView: View {
         )
     }
 
+    private var overlayBufferShortcutBinding: Binding<DictationShortcut?> {
+        Binding(
+            get: { settings.overlayBufferShortcut },
+            set: { newValue in
+                viewModel.updateOverlayBufferShortcut(newValue)
+            }
+        )
+    }
+
+    private var livePasteShortcutBinding: Binding<DictationShortcut?> {
+        Binding(
+            get: { settings.livePasteShortcut },
+            set: { newValue in
+                viewModel.updateLivePasteShortcut(newValue)
+            }
+        )
+    }
+
     var body: some View {
         TabView {
             ConnectionSettingsPane(
@@ -53,6 +71,8 @@ struct SettingsView: View {
                 settings: settings,
                 viewModel: viewModel,
                 dictationShortcutBinding: dictationShortcutBinding,
+                overlayBufferShortcutBinding: overlayBufferShortcutBinding,
+                livePasteShortcutBinding: livePasteShortcutBinding,
                 shortcutValidationError: $shortcutValidationError
             )
             .tabItem {
@@ -135,7 +155,11 @@ private struct DictationSettingsPane: View {
     @Bindable var settings: SettingsStore
     let viewModel: DictationViewModel
     let dictationShortcutBinding: Binding<DictationShortcut?>
+    let overlayBufferShortcutBinding: Binding<DictationShortcut?>
+    let livePasteShortcutBinding: Binding<DictationShortcut?>
     @Binding var shortcutValidationError: String?
+    @State private var overlayValidationError: String?
+    @State private var livePasteValidationError: String?
 
     var body: some View {
         SettingsPage {
@@ -176,34 +200,113 @@ private struct DictationSettingsPane: View {
             }
 
             SettingsGroup(title: "Shortcut") {
-                SettingsFieldRow(title: "Dictation shortcut") {
-                    HStack(alignment: .center, spacing: 8) {
-                        ShortcutRecorderField(
-                            shortcut: dictationShortcutBinding,
-                            validationError: $shortcutValidationError,
-                            fixedWidth: 132
-                        )
-                        .frame(height: 24, alignment: .leading)
-
-                        Button("Reset to Default") {
-                            shortcutValidationError = nil
-                            viewModel.updateDictationShortcut(
-                                SettingsStore.defaultDictationShortcut)
+                ToggleSettingRow(
+                    title: "Single modifier key",
+                    subtitle: "Tap for overlay buffer, hold for live auto-paste.",
+                    isOn: Binding(
+                        get: { settings.modifierOnlyHotKeyEnabled },
+                        set: { newValue in
+                            settings.modifierOnlyHotKeyEnabled = newValue
+                            viewModel.applyHotKeySettingsChange()
                         }
-                        .disabled(
-                            settings.dictationShortcut == SettingsStore.defaultDictationShortcut)
-                    }
-                }
-
-                if let shortcutValidationError {
-                    SettingsMessageRow(shortcutValidationError, color: .red)
-                }
-
-                if settings.dictationShortcut == nil {
-                    SettingsMessageRow(
-                        "Global dictation shortcut is currently disabled.",
-                        color: .secondary
                     )
+                )
+
+                if settings.modifierOnlyHotKeyEnabled {
+                    SettingsFieldRow(title: "Modifier key") {
+                        Picker("", selection: Binding(
+                            get: { settings.modifierOnlyHotKeyModifier },
+                            set: { newValue in
+                                settings.modifierOnlyHotKeyModifier = newValue
+                                viewModel.applyHotKeySettingsChange()
+                            }
+                        )) {
+                            ForEach(ModifierOnlyHotKeyManager.ModifierKey.allCases) { key in
+                                Text(key.displayName).tag(key)
+                            }
+                        }
+                        .pickerStyle(.segmented)
+                        .labelsHidden()
+                    }
+
+                    SettingsFieldRow(title: "Hold delay") {
+                        HStack(spacing: 8) {
+                            Slider(
+                                value: Binding(
+                                    get: { settings.modifierOnlyHoldDelay },
+                                    set: { newValue in
+                                        settings.modifierOnlyHoldDelay = newValue
+                                        viewModel.applyHotKeySettingsChange()
+                                    }
+                                ),
+                                in: 0.15...0.8,
+                                step: 0.05
+                            )
+                            Text("\(Int(settings.modifierOnlyHoldDelay * 1000))ms")
+                                .font(.system(size: 11, design: .monospaced))
+                                .foregroundStyle(.secondary)
+                                .frame(width: 44, alignment: .trailing)
+                        }
+                    }
+                } else {
+                    SettingsFieldRow(title: "Overlay Buffer") {
+                        HStack(alignment: .center, spacing: 8) {
+                            ShortcutRecorderField(
+                                shortcut: overlayBufferShortcutBinding,
+                                validationError: $overlayValidationError,
+                                fixedWidth: 132
+                            )
+                            .frame(height: 24, alignment: .leading)
+
+                            Button("Reset") {
+                                overlayValidationError = nil
+                                viewModel.updateOverlayBufferShortcut(
+                                    SettingsStore.defaultDictationShortcut)
+                            }
+                            .disabled(
+                                settings.overlayBufferShortcut == SettingsStore.defaultDictationShortcut)
+                        }
+                    }
+
+                    if let overlayValidationError {
+                        SettingsMessageRow(overlayValidationError, color: .red)
+                    }
+
+                    if settings.overlayBufferShortcut == nil {
+                        SettingsMessageRow(
+                            "Overlay Buffer shortcut is currently disabled.",
+                            color: .secondary
+                        )
+                    }
+
+                    SettingsFieldRow(title: "Live Auto-Paste") {
+                        HStack(alignment: .center, spacing: 8) {
+                            ShortcutRecorderField(
+                                shortcut: livePasteShortcutBinding,
+                                validationError: $livePasteValidationError,
+                                fixedWidth: 132
+                            )
+                            .frame(height: 24, alignment: .leading)
+
+                            if settings.livePasteShortcut != nil {
+                                Button("Clear") {
+                                    livePasteValidationError = nil
+                                    viewModel.updateLivePasteShortcut(nil)
+                                }
+                            }
+                        }
+                    }
+
+                    if let livePasteValidationError {
+                        SettingsMessageRow(livePasteValidationError, color: .red)
+                    }
+
+                    if settings.livePasteShortcut == nil {
+                        SettingsMessageRow(
+                            "Live Auto-Paste shortcut is not set. Record one above to enable.",
+                            color: .secondary
+                        )
+                    }
                 }
             }
         }

--- a/Sources/localvoxtral/SettingsView.swift
+++ b/Sources/localvoxtral/SettingsView.swift
@@ -163,54 +163,21 @@ private struct DictationSettingsPane: View {
 
     var body: some View {
         SettingsPage {
-            SettingsGroup(title: "Behavior") {
-                SettingsFieldRow(title: "Output mode") {
-                    VStack(alignment: .leading, spacing: 6) {
-                        Picker("", selection: $settings.dictationOutputMode) {
-                            ForEach(DictationOutputMode.allCases) { mode in
-                                Text(mode.displayName).tag(mode)
-                            }
-                        }
-                        .pickerStyle(.segmented)
-                        .labelsHidden()
-
-                        SettingsHelpText(settings.dictationOutputMode.description)
-                    }
-                }
-
-                SettingsFieldRow(title: "Shortcut behavior") {
-                    VStack(alignment: .leading, spacing: 6) {
-                        Picker("", selection: $settings.dictationShortcutMode) {
-                            ForEach(DictationShortcutMode.allCases) { mode in
-                                Text(mode.displayName).tag(mode)
-                            }
-                        }
-                        .pickerStyle(.segmented)
-                        .labelsHidden()
-
-                        SettingsHelpText(settings.dictationShortcutMode.description)
-                    }
-                }
-
-                ToggleSettingRow(
-                    title: "Auto-copy final segment",
-                    subtitle: "Copy the finalized segment to the clipboard after dictation stops.",
-                    isOn: $settings.autoCopyEnabled
-                )
-            }
-
-            SettingsGroup(title: "Shortcut") {
-                ToggleSettingRow(
-                    title: "Single modifier key",
-                    subtitle: "Tap for overlay buffer, hold for live auto-paste.",
-                    isOn: Binding(
+            SettingsGroup(title: "Start dictation with") {
+                SettingsFieldRow(title: "Trigger") {
+                    Picker("", selection: Binding(
                         get: { settings.modifierOnlyHotKeyEnabled },
                         set: { newValue in
                             settings.modifierOnlyHotKeyEnabled = newValue
                             viewModel.applyHotKeySettingsChange()
                         }
-                    )
-                )
+                    )) {
+                        Text("Single modifier key").tag(true)
+                        Text("Keyboard shortcuts").tag(false)
+                    }
+                    .pickerStyle(.segmented)
+                    .labelsHidden()
+                }
 
                 if settings.modifierOnlyHotKeyEnabled {
                     SettingsFieldRow(title: "Modifier key") {
@@ -227,6 +194,18 @@ private struct DictationSettingsPane: View {
                         }
                         .pickerStyle(.segmented)
                         .labelsHidden()
+                    }
+
+                    SettingsFieldRow(title: "Tap") {
+                        Text("Overlay Buffer — toggle dictation on and off.")
+                            .font(.system(size: 13))
+                            .foregroundStyle(.secondary)
+                    }
+
+                    SettingsFieldRow(title: "Hold") {
+                        Text("Live Auto-Paste — talk while held, stops on release.")
+                            .font(.system(size: 13))
+                            .foregroundStyle(.secondary)
                     }
 
                     SettingsFieldRow(title: "Hold delay") {
@@ -307,7 +286,48 @@ private struct DictationSettingsPane: View {
                             color: .secondary
                         )
                     }
+
+                    SettingsFieldRow(title: "Shortcut behavior") {
+                        VStack(alignment: .leading, spacing: 6) {
+                            Picker("", selection: $settings.dictationShortcutMode) {
+                                ForEach(DictationShortcutMode.allCases) { mode in
+                                    Text(mode.displayName).tag(mode)
+                                }
+                            }
+                            .pickerStyle(.segmented)
+                            .labelsHidden()
+
+                            SettingsHelpText(settings.dictationShortcutMode.description)
+                        }
+                    }
                 }
+            }
+
+            SettingsGroup(title: "Menu bar") {
+                SettingsFieldRow(title: "Output mode") {
+                    VStack(alignment: .leading, spacing: 6) {
+                        Picker("", selection: $settings.dictationOutputMode) {
+                            ForEach(DictationOutputMode.allCases) { mode in
+                                Text(mode.displayName).tag(mode)
+                            }
+                        }
+                        .pickerStyle(.segmented)
+                        .labelsHidden()
+
+                        SettingsHelpText(settings.dictationOutputMode.description)
+                        SettingsHelpText(
+                            "Used when starting dictation from the menu bar. Keyboard triggers above select their mode directly."
+                        )
+                    }
+                }
+            }
+
+            SettingsGroup(title: "General") {
+                ToggleSettingRow(
+                    title: "Auto-copy final segment",
+                    subtitle: "Copy the finalized segment to the clipboard after dictation stops.",
+                    isOn: $settings.autoCopyEnabled
+                )
             }
         }
     }

--- a/Sources/localvoxtral/SettingsView.swift
+++ b/Sources/localvoxtral/SettingsView.swift
@@ -218,7 +218,7 @@ private struct DictationSettingsPane: View {
                                         viewModel.applyHotKeySettingsChange()
                                     }
                                 ),
-                                in: 0.15...0.8,
+                                in: 0.1...0.8,
                                 step: 0.05
                             )
                             Text("\(Int(settings.modifierOnlyHoldDelay * 1000))ms")

--- a/Tests/localvoxtralTests/DictationViewModelModifierGestureTests.swift
+++ b/Tests/localvoxtralTests/DictationViewModelModifierGestureTests.swift
@@ -1,0 +1,123 @@
+import Foundation
+import XCTest
+@testable import localvoxtral
+
+/// Regression tests for the modifier-only tap/hold gesture routing found in
+/// adversarial review of the tap-vs-hold rework.
+@MainActor
+final class DictationViewModelModifierGestureTests: XCTestCase {
+    // DictationViewModel owns several app-lifetime services. Retain test instances
+    // for the process duration so teardown does not race service shutdown.
+    private static var retainedViewModels: [DictationViewModel] = []
+
+    func testModifierTapTogglesOffEvenInPushToTalkShortcutMode() {
+        // A tap has no release event: routing it through push-to-talk press
+        // semantics set isPushToTalkShortcutHeld with nothing to ever clear
+        // it, latching dictation on. A modifier-only tap must toggle.
+        let settings = makeSettings(outputMode: .overlayBuffer)
+        settings.dictationShortcutMode = .pushToTalk
+        let viewModel = makeViewModel(settings: settings)
+
+        viewModel.sessionOutputMode = .overlayBuffer
+        viewModel.isDictating = true
+
+        viewModel.debugHandleModifierOnlyTapForTesting(mode: .overlayBuffer)
+
+        XCTAssertFalse(viewModel.isDictating, "tap during dictation must stop it")
+        XCTAssertFalse(
+            viewModel.debugIsPushToTalkShortcutHeldForTesting,
+            "a tap must never latch the push-to-talk held flag"
+        )
+    }
+
+    func testModifierTapDoesNotRewriteActiveSessionMode() {
+        // Same invariant as the hold-start guard: the stop half of a toggle
+        // finalizes using sessionOutputMode; the tap's mode applies only when
+        // it STARTS a session.
+        let settings = makeSettings(outputMode: .liveAutoPaste)
+        let coordinator = GestureTestOverlayCoordinator()
+        let viewModel = makeViewModel(settings: settings, coordinator: coordinator)
+
+        viewModel.sessionOutputMode = .liveAutoPaste
+        viewModel.isDictating = true
+
+        viewModel.debugHandleModifierOnlyTapForTesting(mode: .overlayBuffer)
+
+        XCTAssertFalse(viewModel.isDictating)
+        XCTAssertEqual(
+            coordinator.commitCallCount, 0,
+            "the running live session must finalize down the live path — an overlay commit means its mode was rewritten by the tap"
+        )
+    }
+
+    func testHoldStartDuringActiveOverlaySessionLeavesModeUntouched() {
+        // handleModifierOnlyHoldStart wrote sessionOutputMode BEFORE its
+        // isDictating guard, so tap(overlay)→hold→release finalized the
+        // overlay session down the live-auto-paste path.
+        let settings = makeSettings(outputMode: .overlayBuffer)
+        let viewModel = makeViewModel(settings: settings)
+
+        viewModel.sessionOutputMode = .overlayBuffer
+        viewModel.isDictating = true
+
+        viewModel.debugHandleModifierOnlyHoldStartForTesting()
+
+        XCTAssertEqual(
+            viewModel.sessionOutputMode, .overlayBuffer,
+            "a hold during an active session must not rewrite its output mode"
+        )
+        XCTAssertFalse(
+            viewModel.debugIsPushToTalkShortcutHeldForTesting,
+            "no push-to-talk state may latch when the hold is ignored"
+        )
+    }
+
+    private func makeSettings(outputMode: DictationOutputMode) -> SettingsStore {
+        let suiteName = "localvoxtral.DictationViewModelModifierGestureTests.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defaults.removePersistentDomain(forName: suiteName)
+        addTeardownBlock {
+            defaults.removePersistentDomain(forName: suiteName)
+        }
+
+        let settings = SettingsStore(defaults: defaults, environment: [:])
+        settings.dictationOutputMode = outputMode
+        return settings
+    }
+
+    private func makeViewModel(
+        settings: SettingsStore,
+        coordinator: GestureTestOverlayCoordinator = GestureTestOverlayCoordinator()
+    ) -> DictationViewModel {
+        let viewModel = DictationViewModel(
+            settings: settings,
+            overlayBufferCoordinator: coordinator,
+            startRuntimeServices: false
+        )
+        Self.retainedViewModels.append(viewModel)
+        return viewModel
+    }
+}
+
+@MainActor
+private final class GestureTestOverlayCoordinator: OverlayBufferSessionCoordinating {
+    var commitTargetAppPID: pid_t? = nil
+    var commitCallCount = 0
+
+    func resolveAnchorNow() -> OverlayAnchor {
+        OverlayAnchor(targetRect: CGRect(x: 0, y: 0, width: 100, height: 24), source: .windowCenter)
+    }
+    func startSession(preResolvedAnchor: OverlayAnchor?) {}
+    func beginFinalizing(displayBufferText: String, commitBufferText: String) {}
+    func refresh(displayBufferText: String, commitBufferText: String) {}
+    func commitIfNeeded(
+        using textCommitter: OverlayTextCommitting,
+        autoCopyEnabled: Bool
+    ) -> OverlayBufferCommitOutcome {
+        commitCallCount += 1
+        return .succeeded
+    }
+    func dismissAfterHold(minimumVisibility: TimeInterval) {}
+    func reset() {}
+    func captureLiveCommitTargetAppPID() {}
+}

--- a/Tests/localvoxtralTests/DictationViewModelModifierGestureTests.swift
+++ b/Tests/localvoxtralTests/DictationViewModelModifierGestureTests.swift
@@ -72,6 +72,33 @@ final class DictationViewModelModifierGestureTests: XCTestCase {
         )
     }
 
+    func testFailedModifierHoldStartDoesNotLatchLiveModeForNextSettingsBasedSession() {
+        let settings = makeSettings(outputMode: .liveAutoPaste)
+        let viewModel = makeViewModel(settings: settings)
+
+        viewModel.isAwaitingMicrophonePermission = true
+
+        viewModel.debugHandleModifierOnlyHoldStartForTesting()
+
+        XCTAssertNil(
+            viewModel.sessionOutputMode,
+            "a gesture whose startDictation request is declined must not latch a shortcut mode"
+        )
+
+        settings.dictationOutputMode = .overlayBuffer
+        viewModel.isAwaitingMicrophonePermission = false
+        viewModel.textInsertion.debugSetAccessibilityTrusted(true)
+
+        viewModel.beginDictationSession()
+
+        XCTAssertEqual(
+            viewModel.sessionOutputMode, .overlayBuffer,
+            "the next settings-based session must use the current setting, not a stale failed gesture mode"
+        )
+
+        viewModel.abortConnectingSession()
+    }
+
     private func makeSettings(outputMode: DictationOutputMode) -> SettingsStore {
         let suiteName = "localvoxtral.DictationViewModelModifierGestureTests.\(UUID().uuidString)"
         let defaults = UserDefaults(suiteName: suiteName)!

--- a/Tests/localvoxtralTests/DictationViewModelOverlayLifecycleTests.swift
+++ b/Tests/localvoxtralTests/DictationViewModelOverlayLifecycleTests.swift
@@ -1,3 +1,4 @@
+import Carbon.HIToolbox
 import Foundation
 import XCTest
 @testable import localvoxtral
@@ -28,6 +29,28 @@ final class DictationViewModelOverlayLifecycleTests: XCTestCase {
 
         XCTAssertFalse(viewModel.isOverlayBufferModeEnabled)
         XCTAssertTrue(viewModel.isLiveAutoPasteModeEnabled)
+    }
+
+    func testShortcutSelectedOutputModeSurvivesBeginDictationSession() {
+        let settings = makeSettings(outputMode: .liveAutoPaste)
+        settings.realtimeAPIEndpointURL = "ws://127.0.0.1:1/realtime"
+        let overlayCoordinator = MockOverlayCoordinator()
+        let viewModel = DictationViewModel(
+            settings: settings,
+            overlayBufferCoordinator: overlayCoordinator,
+            startRuntimeServices: false
+        )
+        retainForTestProcessLifetime(viewModel)
+
+        viewModel.sessionOutputMode = .overlayBuffer
+
+        viewModel.beginDictationSession()
+
+        XCTAssertEqual(viewModel.sessionOutputMode, .overlayBuffer)
+        XCTAssertTrue(viewModel.isOverlayBufferModeEnabled)
+        XCTAssertFalse(viewModel.isLiveAutoPasteModeEnabled)
+
+        viewModel.abortConnectingSession()
     }
 
     func testStopWithoutFinalizationStillCommitsOverlayUsingLatchedSessionMode() {
@@ -184,6 +207,58 @@ final class DictationViewModelOverlayLifecycleTests: XCTestCase {
         XCTAssertFalse(viewModel.isDictating)
         XCTAssertEqual(viewModel.statusText, "Ready")
         XCTAssertEqual(viewModel.realtimeSessionIndicatorState, .idle)
+    }
+
+    func testModifierOnlyHoldReleaseBeforeConnectSkipsDictationStartOnConnectedEvent() {
+        let settings = makeSettings(outputMode: .overlayBuffer)
+        settings.modifierOnlyHotKeyEnabled = true
+        let overlayCoordinator = MockOverlayCoordinator()
+        let viewModel = DictationViewModel(
+            settings: settings,
+            overlayBufferCoordinator: overlayCoordinator,
+            startRuntimeServices: false
+        )
+        retainForTestProcessLifetime(viewModel)
+
+        viewModel.sessionOutputMode = .liveAutoPaste
+        viewModel.isConnectingRealtimeSession = true
+        viewModel.statusText = "Connecting to realtime backend..."
+        viewModel.debugSetPushToTalkShortcutStateForTesting(isHeld: true, hasActiveSession: true)
+        viewModel.debugSetModifierOnlyHoldStateForTesting(isActive: true)
+
+        viewModel.debugHandleDictationShortcutReleaseForTesting()
+        viewModel.handle(event: .connected)
+
+        XCTAssertFalse(viewModel.isConnectingRealtimeSession)
+        XCTAssertFalse(viewModel.isDictating)
+        XCTAssertEqual(viewModel.statusText, "Ready")
+        XCTAssertEqual(viewModel.realtimeSessionIndicatorState, .idle)
+    }
+
+    func testNoHotKeysRegisteredWhenOverlayAndLiveShortcutsAreDisabled() {
+        HotKeyManager.debugResetOverridesForTesting()
+        HotKeyManager.debugForceHandlerInstallResultForTesting(true)
+        HotKeyManager.debugForceRegisterStatusForTesting(hotKeyID: .overlay, status: noErr)
+        defer {
+            HotKeyManager.debugResetOverridesForTesting()
+        }
+
+        let settings = makeSettings(outputMode: .overlayBuffer)
+        settings.setDictationShortcut(SettingsStore.defaultDictationShortcut)
+        settings.setOverlayBufferShortcut(nil)
+        settings.setLivePasteShortcut(nil)
+        let overlayCoordinator = MockOverlayCoordinator()
+        let viewModel = DictationViewModel(
+            settings: settings,
+            overlayBufferCoordinator: overlayCoordinator,
+            startRuntimeServices: false
+        )
+        retainForTestProcessLifetime(viewModel)
+
+        viewModel.applyHotKeySettingsChange()
+
+        XCTAssertEqual(viewModel.debugCurrentHotKeyRegistrationKindForTesting, .none)
+        XCTAssertNil(viewModel.lastError)
     }
 
     func testCancelPolishingForNewSessionIfNeededResetsFinalizationState() {

--- a/Tests/localvoxtralTests/DictationViewModelOverlayLifecycleTests.swift
+++ b/Tests/localvoxtralTests/DictationViewModelOverlayLifecycleTests.swift
@@ -31,7 +31,7 @@ final class DictationViewModelOverlayLifecycleTests: XCTestCase {
         XCTAssertTrue(viewModel.isLiveAutoPasteModeEnabled)
     }
 
-    func testShortcutSelectedOutputModeSurvivesBeginDictationSession() {
+    func testExplicitOutputModeSurvivesBeginDictationSession() {
         let settings = makeSettings(outputMode: .liveAutoPaste)
         settings.realtimeAPIEndpointURL = "ws://127.0.0.1:1/realtime"
         let overlayCoordinator = MockOverlayCoordinator()
@@ -42,9 +42,7 @@ final class DictationViewModelOverlayLifecycleTests: XCTestCase {
         )
         retainForTestProcessLifetime(viewModel)
 
-        viewModel.sessionOutputMode = .overlayBuffer
-
-        viewModel.beginDictationSession()
+        viewModel.beginDictationSession(outputMode: .overlayBuffer)
 
         XCTAssertEqual(viewModel.sessionOutputMode, .overlayBuffer)
         XCTAssertTrue(viewModel.isOverlayBufferModeEnabled)

--- a/Tests/localvoxtralTests/HotKeyManagerTests.swift
+++ b/Tests/localvoxtralTests/HotKeyManagerTests.swift
@@ -47,7 +47,7 @@ final class HotKeyManagerTests: XCTestCase {
         XCTAssertEqual(manager.debugCurrentRegistrationKind, .single)
         let unregisterCountAfterInitialRegistration = HotKeyManager.debugUnregisterCallCount
 
-        ModifierOnlyHotKeyManager.forcedStartOutcome = .creationFailedNil
+        ModifierOnlyHotKeyManager.forcedStartOutcome = .monitorInstallationFailed
 
         let modifierResult = manager.registerModifierOnly(.fn)
 

--- a/Tests/localvoxtralTests/HotKeyManagerTests.swift
+++ b/Tests/localvoxtralTests/HotKeyManagerTests.swift
@@ -1,0 +1,65 @@
+import Carbon.HIToolbox
+import XCTest
+@testable import localvoxtral
+
+@MainActor
+final class HotKeyManagerTests: XCTestCase {
+    func testDualRegistrationReportsLivePasteFailureAfterOverlaySucceeds() {
+        resetDebugHotKeyState()
+        defer { resetDebugHotKeyState() }
+
+        let manager = HotKeyManager()
+        HotKeyManager.debugForceHandlerInstallResultForTesting(true)
+        HotKeyManager.debugForceRegisterStatusForTesting(hotKeyID: .overlay, status: noErr)
+        HotKeyManager.debugForceRegisterStatusForTesting(hotKeyID: .livePaste, status: OSStatus(eventHotKeyExistsErr))
+
+        let result = manager.registerDual(
+            overlay: DictationShortcut(
+                keyCode: UInt32(kVK_ANSI_D),
+                carbonModifierFlags: UInt32(controlKey | optionKey)
+            ),
+            livePaste: DictationShortcut(
+                keyCode: UInt32(kVK_ANSI_F),
+                carbonModifierFlags: UInt32(controlKey | optionKey)
+            )
+        )
+
+        guard case .failure(.livePasteShortcutUnavailable) = result else {
+            return XCTFail("Expected livePasteShortcutUnavailable, got \(result)")
+        }
+    }
+
+    func testModifierOnlyStartupFailurePreservesPreviousRegistration() {
+        resetDebugHotKeyState()
+        defer { resetDebugHotKeyState() }
+
+        let manager = HotKeyManager()
+        HotKeyManager.debugForceHandlerInstallResultForTesting(true)
+        HotKeyManager.debugForceRegisterStatusForTesting(hotKeyID: .overlay, status: noErr)
+
+        let initialResult = manager.register(shortcut: DictationShortcut(
+            keyCode: UInt32(kVK_ANSI_D),
+            carbonModifierFlags: UInt32(controlKey | optionKey)
+        ))
+        guard case .success = initialResult else {
+            return XCTFail("Expected initial registration success, got \(initialResult)")
+        }
+        XCTAssertEqual(manager.debugCurrentRegistrationKind, .single)
+        let unregisterCountAfterInitialRegistration = HotKeyManager.debugUnregisterCallCount
+
+        ModifierOnlyHotKeyManager.forcedStartOutcome = .creationFailedNil
+
+        let modifierResult = manager.registerModifierOnly(.fn)
+
+        guard case .failure(.modifierOnlyHotKeyUnavailable) = modifierResult else {
+            return XCTFail("Expected modifierOnlyHotKeyUnavailable, got \(modifierResult)")
+        }
+        XCTAssertEqual(HotKeyManager.debugUnregisterCallCount, unregisterCountAfterInitialRegistration)
+        XCTAssertEqual(manager.debugCurrentRegistrationKind, .single)
+    }
+
+    private func resetDebugHotKeyState() {
+        HotKeyManager.debugResetOverridesForTesting()
+        ModifierOnlyHotKeyManager.resetDebugState()
+    }
+}

--- a/Tests/localvoxtralTests/ModifierOnlyHotKeyManagerTests.swift
+++ b/Tests/localvoxtralTests/ModifierOnlyHotKeyManagerTests.swift
@@ -1,0 +1,174 @@
+import XCTest
+@testable import localvoxtral
+
+// NOTE: CGEventTap creation requires a real macOS event session (Accessibility permission
+// and a GUI session). These tests cover all testable aspects of ModifierOnlyHotKeyManager
+// without creating an actual event tap:
+//  - ModifierKey enum surface (rawValues, displayNames, CaseIterable)
+//  - Configuration/modifier switching (calling start() with different keys changes _targetModifier)
+//  - Stop clears all shared state
+//  - Rapid sequential start/stop cycles don't leave residual state
+//  - handleEvent static logic with simulated flag states
+
+@MainActor
+final class ModifierOnlyHotKeyManagerTests: XCTestCase {
+
+    // MARK: - ModifierKey Enum
+
+    func testModifierKeyRawValues() {
+        XCTAssertEqual(ModifierOnlyHotKeyManager.ModifierKey.fn.rawValue, "fn")
+        XCTAssertEqual(ModifierOnlyHotKeyManager.ModifierKey.rightCommand.rawValue, "right_command")
+        XCTAssertEqual(ModifierOnlyHotKeyManager.ModifierKey.rightOption.rawValue, "right_option")
+    }
+
+    func testModifierKeyDisplayNames() {
+        XCTAssertEqual(ModifierOnlyHotKeyManager.ModifierKey.fn.displayName, "Fn / Globe")
+        XCTAssertEqual(ModifierOnlyHotKeyManager.ModifierKey.rightCommand.displayName, "Right Command")
+        XCTAssertEqual(ModifierOnlyHotKeyManager.ModifierKey.rightOption.displayName, "Right Option")
+    }
+
+    func testModifierKeyIdentifiable() {
+        for key in ModifierOnlyHotKeyManager.ModifierKey.allCases {
+            XCTAssertEqual(key.id, key.rawValue, "id must match rawValue for \(key)")
+        }
+    }
+
+    func testModifierKeyCaseIterableContainsAllThreeCases() {
+        let all = ModifierOnlyHotKeyManager.ModifierKey.allCases
+        XCTAssertEqual(all.count, 3)
+        XCTAssertTrue(all.contains(.fn))
+        XCTAssertTrue(all.contains(.rightCommand))
+        XCTAssertTrue(all.contains(.rightOption))
+    }
+
+    func testModifierKeyCodableRoundtrip() throws {
+        for key in ModifierOnlyHotKeyManager.ModifierKey.allCases {
+            let data = try JSONEncoder().encode(key)
+            let decoded = try JSONDecoder().decode(ModifierOnlyHotKeyManager.ModifierKey.self, from: data)
+            XCTAssertEqual(decoded, key, "Codable roundtrip failed for \(key)")
+        }
+    }
+
+    // MARK: - Stop Clears All Shared State
+
+    func testStopClearsSharedState() {
+        let manager = ModifierOnlyHotKeyManager()
+        // stop() should safely clear state even if never started
+        manager.stop()
+
+        // Verify via the exposed static state that everything is clean.
+        // We can't read the static vars directly from outside the type, but we can
+        // verify that handleEvent is a no-op after stop() by observing no callbacks fire.
+        var tapCount = 0
+        var holdStartCount = 0
+        var holdReleaseCount = 0
+        manager.onTap = { tapCount += 1 }
+        manager.onHoldStart = { holdStartCount += 1 }
+        manager.onHoldRelease = { holdReleaseCount += 1 }
+
+        // After stop, shared = nil, so handleEvent is a no-op
+        // (confirmed by guard `shared != nil` at top of handleEvent)
+        XCTAssertEqual(tapCount, 0)
+        XCTAssertEqual(holdStartCount, 0)
+        XCTAssertEqual(holdReleaseCount, 0)
+    }
+
+    func testStopIsIdempotent() {
+        let manager = ModifierOnlyHotKeyManager()
+        // Multiple stop() calls should not crash
+        manager.stop()
+        manager.stop()
+        manager.stop()
+    }
+
+    // MARK: - Modifier Key Switching
+
+    func testModifierKeySwitchingCallsStopBeforeStart() {
+        // Calling start() twice with different modifier keys should work without crash.
+        // In a headless test env, CGEventTap creation silently fails (returns nil),
+        // but start() still updates _targetModifier and calls stop() first.
+        let manager = ModifierOnlyHotKeyManager()
+
+        // Each successive start() calls stop() first — no crash expected.
+        for modifier in ModifierOnlyHotKeyManager.ModifierKey.allCases {
+            manager.start(modifier: modifier)
+        }
+
+        // Clean up
+        manager.stop()
+    }
+
+    func testRapidStartStopCyclesProduceNoResidualState() {
+        let manager = ModifierOnlyHotKeyManager()
+        var tapCount = 0
+        var holdStartCount = 0
+        manager.onTap = { tapCount += 1 }
+        manager.onHoldStart = { holdStartCount += 1 }
+
+        for _ in 1...10 {
+            manager.start(modifier: .fn)
+            manager.stop()
+        }
+
+        // After all cycles are stopped, no callbacks should have fired
+        // (CGEventTap was never actually created in headless test env)
+        XCTAssertEqual(tapCount, 0, "No tap callbacks should fire in headless test environment")
+        XCTAssertEqual(holdStartCount, 0, "No hold callbacks should fire in headless test environment")
+    }
+
+    func testStopAfterStartWithDifferentModifiersLeavesNoResidualState() {
+        let manager1 = ModifierOnlyHotKeyManager()
+        let manager2 = ModifierOnlyHotKeyManager()
+
+        manager1.start(modifier: .fn)
+        manager2.start(modifier: .rightCommand)
+
+        // manager2.start() would have called stop() internally to replace manager1's
+        // registration (since _targetModifier and shared are static/class-level),
+        // but in a headless environment no CGEventTap exists.
+        // Stopping both should be safe.
+        manager1.stop()
+        manager2.stop()
+    }
+
+    // MARK: - Callback Wiring
+
+    func testCallbacksCanBeAssignedAndReassigned() {
+        let manager = ModifierOnlyHotKeyManager()
+
+        var firstTapCount = 0
+        manager.onTap = { firstTapCount += 1 }
+
+        var secondTapCount = 0
+        manager.onTap = { secondTapCount += 1 }
+
+        // Replacing callbacks is safe — no crash
+        XCTAssertEqual(firstTapCount, 0)
+        XCTAssertEqual(secondTapCount, 0)
+    }
+
+    func testCallbacksCanBeNilledOut() {
+        let manager = ModifierOnlyHotKeyManager()
+        manager.onTap = { }
+        manager.onHoldStart = { }
+        manager.onHoldRelease = { }
+
+        manager.onTap = nil
+        manager.onHoldStart = nil
+        manager.onHoldRelease = nil
+
+        // No crash when callbacks are nil
+        manager.stop()
+    }
+
+    func testHoldThresholdDefaultValue() {
+        let manager = ModifierOnlyHotKeyManager()
+        XCTAssertEqual(manager.holdThresholdSeconds, 0.35, accuracy: 0.001)
+    }
+
+    func testHoldThresholdCanBeCustomized() {
+        let manager = ModifierOnlyHotKeyManager()
+        manager.holdThresholdSeconds = 0.5
+        XCTAssertEqual(manager.holdThresholdSeconds, 0.5, accuracy: 0.001)
+    }
+}

--- a/Tests/localvoxtralTests/ModifierOnlyHotKeyManagerTests.swift
+++ b/Tests/localvoxtralTests/ModifierOnlyHotKeyManagerTests.swift
@@ -1,12 +1,11 @@
+import AppKit
 import Carbon.HIToolbox
-import CoreGraphics
-import Synchronization
 import XCTest
 @testable import localvoxtral
 
-// NOTE: CGEventTap creation requires a real macOS event session and TCC permissions.
+// NOTE: NSEvent delivery requires a real macOS event session and TCC permissions.
 // These tests cover the deterministic seams of ModifierOnlyHotKeyManager
-// without requiring an actual event tap:
+// without requiring actual monitor delivery:
 //  - ModifierKey enum surface (rawValues, displayNames, CaseIterable)
 //  - Configuration/modifier switching
 //  - Stop clears instance gesture state
@@ -15,7 +14,6 @@ import XCTest
 
 @MainActor
 final class ModifierOnlyHotKeyManagerTests: XCTestCase {
-
     // MARK: - ModifierKey Enum
 
     func testModifierKeyRawValues() {
@@ -79,19 +77,15 @@ final class ModifierOnlyHotKeyManagerTests: XCTestCase {
 
     func testModifierKeySwitchingCallsStopBeforeStart() {
         // Calling start() twice with different modifier keys should work without crash.
-        // In a headless test env, CGEventTap creation can fail because TCC permissions
-        // are missing; start() still records a deterministic outcome and remains safe.
         let manager = ModifierOnlyHotKeyManager()
+        ModifierOnlyHotKeyManager.resetDebugState()
+        ModifierOnlyHotKeyManager.forcedStartOutcome = .created
+        defer { ModifierOnlyHotKeyManager.resetDebugState() }
 
         // Each successive start() calls stop() first — no crash expected.
         for modifier in ModifierOnlyHotKeyManager.ModifierKey.allCases {
             manager.start(modifier: modifier)
-            XCTAssertTrue(
-                [.creationFailedNil, .noRunLoopSource, .created].contains(
-                    ModifierOnlyHotKeyManager.lastStartOutcome
-                ),
-                "unexpected start outcome: \(ModifierOnlyHotKeyManager.lastStartOutcome)"
-            )
+            XCTAssertEqual(ModifierOnlyHotKeyManager.lastStartOutcome, .created)
         }
 
         // Clean up
@@ -100,6 +94,9 @@ final class ModifierOnlyHotKeyManagerTests: XCTestCase {
 
     func testRapidStartStopCyclesProduceNoResidualState() {
         let manager = ModifierOnlyHotKeyManager()
+        ModifierOnlyHotKeyManager.resetDebugState()
+        ModifierOnlyHotKeyManager.forcedStartOutcome = .created
+        defer { ModifierOnlyHotKeyManager.resetDebugState() }
         var tapCount = 0
         var holdStartCount = 0
         manager.onTap = { tapCount += 1 }
@@ -119,11 +116,14 @@ final class ModifierOnlyHotKeyManagerTests: XCTestCase {
     func testStopAfterStartWithDifferentModifiersLeavesNoResidualState() {
         let manager1 = ModifierOnlyHotKeyManager()
         let manager2 = ModifierOnlyHotKeyManager()
+        ModifierOnlyHotKeyManager.resetDebugState()
+        ModifierOnlyHotKeyManager.forcedStartOutcome = .created
+        defer { ModifierOnlyHotKeyManager.resetDebugState() }
 
         manager1.start(modifier: .fn)
         manager2.start(modifier: .rightCommand)
 
-        // Stopping both should be safe even if one or both starts created a real tap.
+        // Stopping both should be safe and clear their independent state.
         manager1.stop()
         manager2.stop()
     }
@@ -182,18 +182,22 @@ final class ModifierOnlyHotKeyManagerTests: XCTestCase {
         manager.onHoldRelease = { holdReleaseCount += 1 }
         manager.debugStartGestureForTesting(modifier: .fn)
 
-        manager.debugHandleFlagsChangedForTesting(keyCode: 0, flags: .maskSecondaryFn)
+        manager.debugHandleFlagsChangedForTesting(
+            keyCode: UInt16(kVK_Function),
+            flags: .function
+        )
         XCTAssertEqual(scheduler.scheduledDelays, [0.35])
 
-        manager.debugHandleFlagsChangedForTesting(keyCode: 0, flags: CGEventFlags())
-        await Task.yield()
+        manager.debugHandleFlagsChangedForTesting(
+            keyCode: UInt16(kVK_Function),
+            flags: []
+        )
 
         XCTAssertEqual(tapCount, 1)
         XCTAssertEqual(holdStartCount, 0)
         XCTAssertEqual(holdReleaseCount, 0)
 
         scheduler.fireAll()
-        await Task.yield()
         XCTAssertEqual(holdStartCount, 0, "stale hold timer must not fire after tap release")
     }
 
@@ -209,20 +213,18 @@ final class ModifierOnlyHotKeyManagerTests: XCTestCase {
         manager.debugStartGestureForTesting(modifier: .rightCommand)
 
         manager.debugHandleFlagsChangedForTesting(
-            keyCode: Int64(kVK_RightCommand),
-            flags: .maskCommand
+            keyCode: UInt16(kVK_RightCommand),
+            flags: .command
         )
         scheduler.fireAll()
-        await Task.yield()
 
         XCTAssertEqual(holdStartCount, 1)
         XCTAssertEqual(tapCount, 0)
 
         manager.debugHandleFlagsChangedForTesting(
-            keyCode: Int64(kVK_RightCommand),
-            flags: CGEventFlags()
+            keyCode: UInt16(kVK_RightCommand),
+            flags: []
         )
-        await Task.yield()
 
         XCTAssertEqual(holdReleaseCount, 1)
         XCTAssertEqual(tapCount, 0)
@@ -240,18 +242,16 @@ final class ModifierOnlyHotKeyManagerTests: XCTestCase {
         manager.debugStartGestureForTesting(modifier: .rightOption)
 
         manager.debugHandleFlagsChangedForTesting(
-            keyCode: Int64(kVK_RightOption),
-            flags: .maskAlternate
+            keyCode: UInt16(kVK_RightOption),
+            flags: .option
         )
         manager.debugHandleKeyDownForTesting()
         scheduler.fireAll()
-        await Task.yield()
 
         manager.debugHandleFlagsChangedForTesting(
-            keyCode: Int64(kVK_RightOption),
-            flags: CGEventFlags()
+            keyCode: UInt16(kVK_RightOption),
+            flags: []
         )
-        await Task.yield()
 
         XCTAssertEqual(tapCount, 0)
         XCTAssertEqual(holdStartCount, 0)
@@ -266,19 +266,129 @@ final class ModifierOnlyHotKeyManagerTests: XCTestCase {
         manager.onHoldStart = { holdStartCount += 1 }
         manager.debugStartGestureForTesting(modifier: .fn)
 
-        manager.debugHandleFlagsChangedForTesting(keyCode: 0, flags: .maskSecondaryFn)
-        manager.debugHandleFlagsChangedForTesting(keyCode: 0, flags: CGEventFlags())
-        manager.debugHandleFlagsChangedForTesting(keyCode: 0, flags: .maskSecondaryFn)
+        manager.debugHandleFlagsChangedForTesting(
+            keyCode: UInt16(kVK_Function),
+            flags: .function
+        )
+        manager.debugHandleFlagsChangedForTesting(
+            keyCode: UInt16(kVK_Function),
+            flags: []
+        )
+        manager.debugHandleFlagsChangedForTesting(
+            keyCode: UInt16(kVK_Function),
+            flags: .function
+        )
 
         XCTAssertEqual(scheduler.scheduledDelays.count, 2)
 
         scheduler.fire(at: 0)
-        await Task.yield()
         XCTAssertEqual(holdStartCount, 0, "first scheduled hold should be stale")
 
         scheduler.fire(at: 0)
-        await Task.yield()
         XCTAssertEqual(holdStartCount, 1)
+    }
+
+    func testDoubleTapFiresTwoTapsAndNoHold() {
+        let scheduler = HoldSchedulerProbe()
+        let manager = ModifierOnlyHotKeyManager(holdScheduler: scheduler.scheduler)
+        var tapCount = 0
+        var holdStartCount = 0
+        manager.onTap = { tapCount += 1 }
+        manager.onHoldStart = { holdStartCount += 1 }
+        manager.debugStartGestureForTesting(modifier: .fn)
+
+        for _ in 0..<2 {
+            manager.debugHandleFlagsChangedForTesting(
+                keyCode: UInt16(kVK_Function),
+                flags: .function
+            )
+            manager.debugHandleFlagsChangedForTesting(
+                keyCode: UInt16(kVK_Function),
+                flags: []
+            )
+        }
+
+        XCTAssertEqual(tapCount, 2)
+        scheduler.fireAll()
+        XCTAssertEqual(holdStartCount, 0)
+    }
+
+    func testReleaseAtThresholdAfterTimerFiresUsesHoldReleaseNotTap() {
+        let scheduler = HoldSchedulerProbe()
+        let manager = ModifierOnlyHotKeyManager(holdScheduler: scheduler.scheduler)
+        var tapCount = 0
+        var holdStartCount = 0
+        var holdReleaseCount = 0
+        manager.onTap = { tapCount += 1 }
+        manager.onHoldStart = { holdStartCount += 1 }
+        manager.onHoldRelease = { holdReleaseCount += 1 }
+        manager.debugStartGestureForTesting(modifier: .fn)
+
+        manager.debugHandleFlagsChangedForTesting(
+            keyCode: UInt16(kVK_Function),
+            flags: .function
+        )
+        scheduler.fireAll()
+        manager.debugHandleFlagsChangedForTesting(
+            keyCode: UInt16(kVK_Function),
+            flags: []
+        )
+
+        XCTAssertEqual(tapCount, 0)
+        XCTAssertEqual(holdStartCount, 1)
+        XCTAssertEqual(holdReleaseCount, 1)
+    }
+
+    func testFlagsTimelineInterruptionCancelsPendingHoldWithoutKeyDownDelivery() {
+        let scheduler = HoldSchedulerProbe()
+        let manager = ModifierOnlyHotKeyManager(holdScheduler: scheduler.scheduler)
+        var tapCount = 0
+        var holdStartCount = 0
+        manager.onTap = { tapCount += 1 }
+        manager.onHoldStart = { holdStartCount += 1 }
+        manager.debugStartGestureForTesting(modifier: .rightCommand)
+
+        manager.debugHandleFlagsChangedForTesting(
+            keyCode: UInt16(kVK_RightCommand),
+            flags: .command
+        )
+        manager.debugHandleFlagsChangedForTesting(
+            keyCode: UInt16(kVK_Shift),
+            flags: [.command, .shift]
+        )
+        scheduler.fireAll()
+        manager.debugHandleFlagsChangedForTesting(
+            keyCode: UInt16(kVK_RightCommand),
+            flags: []
+        )
+
+        XCTAssertEqual(tapCount, 0)
+        XCTAssertEqual(holdStartCount, 0)
+    }
+
+    func testKeyInterruptionDuringHoldReleasesImmediatelyAndDoesNotLatch() {
+        let scheduler = HoldSchedulerProbe()
+        let manager = ModifierOnlyHotKeyManager(holdScheduler: scheduler.scheduler)
+        var holdStartCount = 0
+        var holdReleaseCount = 0
+        manager.onHoldStart = { holdStartCount += 1 }
+        manager.onHoldRelease = { holdReleaseCount += 1 }
+        manager.debugStartGestureForTesting(modifier: .rightOption)
+
+        manager.debugHandleFlagsChangedForTesting(
+            keyCode: UInt16(kVK_RightOption),
+            flags: .option
+        )
+        scheduler.fireAll()
+        manager.debugHandleKeyDownForTesting()
+        manager.debugHandleFlagsChangedForTesting(
+            keyCode: UInt16(kVK_RightOption),
+            flags: []
+        )
+
+        XCTAssertEqual(holdStartCount, 1)
+        XCTAssertEqual(holdReleaseCount, 1)
+        XCTAssertFalse(manager.debugGestureSnapshotForTesting().isInHoldState)
     }
 
     func testSeparateManagerInstancesDoNotClobberEachOther() async {
@@ -294,60 +404,56 @@ final class ModifierOnlyHotKeyManagerTests: XCTestCase {
         manager1.debugStartGestureForTesting(modifier: .fn)
         manager2.debugStartGestureForTesting(modifier: .rightCommand)
 
-        manager1.debugHandleFlagsChangedForTesting(keyCode: 0, flags: .maskSecondaryFn)
-        manager1.debugHandleFlagsChangedForTesting(keyCode: 0, flags: CGEventFlags())
-        await Task.yield()
+        manager1.debugHandleFlagsChangedForTesting(
+            keyCode: UInt16(kVK_Function),
+            flags: .function
+        )
+        manager1.debugHandleFlagsChangedForTesting(
+            keyCode: UInt16(kVK_Function),
+            flags: []
+        )
 
         XCTAssertEqual(manager1TapCount, 1)
         XCTAssertEqual(manager2TapCount, 0)
 
         manager2.debugHandleFlagsChangedForTesting(
-            keyCode: Int64(kVK_RightCommand),
-            flags: .maskCommand
+            keyCode: UInt16(kVK_RightCommand),
+            flags: .command
         )
         manager2.debugHandleFlagsChangedForTesting(
-            keyCode: Int64(kVK_RightCommand),
-            flags: CGEventFlags()
+            keyCode: UInt16(kVK_RightCommand),
+            flags: []
         )
-        await Task.yield()
 
         XCTAssertEqual(manager1TapCount, 1)
         XCTAssertEqual(manager2TapCount, 1)
     }
 }
 
-private final class HoldSchedulerProbe: @unchecked Sendable {
-    private struct State {
-        var delays: [Double] = []
-        var callbacks: [@Sendable () -> Void] = []
-    }
-
-    private let state = Mutex(State())
+@MainActor
+private final class HoldSchedulerProbe {
+    private var delays: [Double] = []
+    private var callbacks: [@MainActor @Sendable () -> Void] = []
 
     var scheduler: ModifierOnlyHotKeyManager.HoldScheduler {
         { [weak self] delay, fire in
-            self?.state.withLock {
-                $0.delays.append(delay)
-                $0.callbacks.append(fire)
-            }
+            self?.delays.append(delay)
+            self?.callbacks.append(fire)
         }
     }
 
     var scheduledDelays: [Double] {
-        state.withLock { $0.delays }
+        delays
     }
 
     func fire(at index: Int) {
-        let callback = state.withLock { $0.callbacks.remove(at: index) }
+        let callback = callbacks.remove(at: index)
         callback()
     }
 
     func fireAll() {
-        let callbacks = state.withLock { state -> [@Sendable () -> Void] in
-            let callbacks = state.callbacks
-            state.callbacks.removeAll()
-            return callbacks
-        }
+        let callbacks = callbacks
+        self.callbacks.removeAll()
         callbacks.forEach { $0() }
     }
 }

--- a/Tests/localvoxtralTests/ModifierOnlyHotKeyManagerTests.swift
+++ b/Tests/localvoxtralTests/ModifierOnlyHotKeyManagerTests.swift
@@ -1,14 +1,17 @@
+import Carbon.HIToolbox
+import CoreGraphics
+import Synchronization
 import XCTest
 @testable import localvoxtral
 
-// NOTE: CGEventTap creation requires a real macOS event session (Accessibility permission
-// and a GUI session). These tests cover all testable aspects of ModifierOnlyHotKeyManager
-// without creating an actual event tap:
+// NOTE: CGEventTap creation requires a real macOS event session and TCC permissions.
+// These tests cover the deterministic seams of ModifierOnlyHotKeyManager
+// without requiring an actual event tap:
 //  - ModifierKey enum surface (rawValues, displayNames, CaseIterable)
-//  - Configuration/modifier switching (calling start() with different keys changes _targetModifier)
-//  - Stop clears all shared state
+//  - Configuration/modifier switching
+//  - Stop clears instance gesture state
 //  - Rapid sequential start/stop cycles don't leave residual state
-//  - handleEvent static logic with simulated flag states
+//  - Gesture state transitions with simulated flag/key events and injected hold scheduling
 
 @MainActor
 final class ModifierOnlyHotKeyManagerTests: XCTestCase {
@@ -53,24 +56,15 @@ final class ModifierOnlyHotKeyManagerTests: XCTestCase {
 
     func testStopClearsSharedState() {
         let manager = ModifierOnlyHotKeyManager()
-        // stop() should safely clear state even if never started
+        manager.debugStartGestureForTesting(modifier: .fn)
+
         manager.stop()
 
-        // Verify via the exposed static state that everything is clean.
-        // We can't read the static vars directly from outside the type, but we can
-        // verify that handleEvent is a no-op after stop() by observing no callbacks fire.
-        var tapCount = 0
-        var holdStartCount = 0
-        var holdReleaseCount = 0
-        manager.onTap = { tapCount += 1 }
-        manager.onHoldStart = { holdStartCount += 1 }
-        manager.onHoldRelease = { holdReleaseCount += 1 }
-
-        // After stop, shared = nil, so handleEvent is a no-op
-        // (confirmed by guard `shared != nil` at top of handleEvent)
-        XCTAssertEqual(tapCount, 0)
-        XCTAssertEqual(holdStartCount, 0)
-        XCTAssertEqual(holdReleaseCount, 0)
+        let snapshot = manager.debugGestureSnapshotForTesting()
+        XCTAssertNil(snapshot.targetModifier)
+        XCTAssertFalse(snapshot.isModifierDown)
+        XCTAssertFalse(snapshot.wasInterruptedByKey)
+        XCTAssertFalse(snapshot.isInHoldState)
     }
 
     func testStopIsIdempotent() {
@@ -85,13 +79,19 @@ final class ModifierOnlyHotKeyManagerTests: XCTestCase {
 
     func testModifierKeySwitchingCallsStopBeforeStart() {
         // Calling start() twice with different modifier keys should work without crash.
-        // In a headless test env, CGEventTap creation silently fails (returns nil),
-        // but start() still updates _targetModifier and calls stop() first.
+        // In a headless test env, CGEventTap creation can fail because TCC permissions
+        // are missing; start() still records a deterministic outcome and remains safe.
         let manager = ModifierOnlyHotKeyManager()
 
         // Each successive start() calls stop() first — no crash expected.
         for modifier in ModifierOnlyHotKeyManager.ModifierKey.allCases {
             manager.start(modifier: modifier)
+            XCTAssertTrue(
+                [.creationFailedNil, .noRunLoopSource, .created].contains(
+                    ModifierOnlyHotKeyManager.lastStartOutcome
+                ),
+                "unexpected start outcome: \(ModifierOnlyHotKeyManager.lastStartOutcome)"
+            )
         }
 
         // Clean up
@@ -110,10 +110,10 @@ final class ModifierOnlyHotKeyManagerTests: XCTestCase {
             manager.stop()
         }
 
-        // After all cycles are stopped, no callbacks should have fired
-        // (CGEventTap was never actually created in headless test env)
+        // After all cycles are stopped, no callbacks should have fired.
         XCTAssertEqual(tapCount, 0, "No tap callbacks should fire in headless test environment")
         XCTAssertEqual(holdStartCount, 0, "No hold callbacks should fire in headless test environment")
+        XCTAssertNil(manager.debugGestureSnapshotForTesting().targetModifier)
     }
 
     func testStopAfterStartWithDifferentModifiersLeavesNoResidualState() {
@@ -123,10 +123,7 @@ final class ModifierOnlyHotKeyManagerTests: XCTestCase {
         manager1.start(modifier: .fn)
         manager2.start(modifier: .rightCommand)
 
-        // manager2.start() would have called stop() internally to replace manager1's
-        // registration (since _targetModifier and shared are static/class-level),
-        // but in a headless environment no CGEventTap exists.
-        // Stopping both should be safe.
+        // Stopping both should be safe even if one or both starts created a real tap.
         manager1.stop()
         manager2.stop()
     }
@@ -170,5 +167,187 @@ final class ModifierOnlyHotKeyManagerTests: XCTestCase {
         let manager = ModifierOnlyHotKeyManager()
         manager.holdThresholdSeconds = 0.5
         XCTAssertEqual(manager.holdThresholdSeconds, 0.5, accuracy: 0.001)
+    }
+
+    // MARK: - Gesture State
+
+    func testTapFiresWhenModifierReleasesBeforeHoldThreshold() async {
+        let scheduler = HoldSchedulerProbe()
+        let manager = ModifierOnlyHotKeyManager(holdScheduler: scheduler.scheduler)
+        var tapCount = 0
+        var holdStartCount = 0
+        var holdReleaseCount = 0
+        manager.onTap = { tapCount += 1 }
+        manager.onHoldStart = { holdStartCount += 1 }
+        manager.onHoldRelease = { holdReleaseCount += 1 }
+        manager.debugStartGestureForTesting(modifier: .fn)
+
+        manager.debugHandleFlagsChangedForTesting(keyCode: 0, flags: .maskSecondaryFn)
+        XCTAssertEqual(scheduler.scheduledDelays, [0.35])
+
+        manager.debugHandleFlagsChangedForTesting(keyCode: 0, flags: CGEventFlags())
+        await Task.yield()
+
+        XCTAssertEqual(tapCount, 1)
+        XCTAssertEqual(holdStartCount, 0)
+        XCTAssertEqual(holdReleaseCount, 0)
+
+        scheduler.fireAll()
+        await Task.yield()
+        XCTAssertEqual(holdStartCount, 0, "stale hold timer must not fire after tap release")
+    }
+
+    func testHoldFiresStartThenReleaseWhenThresholdElapsed() async {
+        let scheduler = HoldSchedulerProbe()
+        let manager = ModifierOnlyHotKeyManager(holdScheduler: scheduler.scheduler)
+        var tapCount = 0
+        var holdStartCount = 0
+        var holdReleaseCount = 0
+        manager.onTap = { tapCount += 1 }
+        manager.onHoldStart = { holdStartCount += 1 }
+        manager.onHoldRelease = { holdReleaseCount += 1 }
+        manager.debugStartGestureForTesting(modifier: .rightCommand)
+
+        manager.debugHandleFlagsChangedForTesting(
+            keyCode: Int64(kVK_RightCommand),
+            flags: .maskCommand
+        )
+        scheduler.fireAll()
+        await Task.yield()
+
+        XCTAssertEqual(holdStartCount, 1)
+        XCTAssertEqual(tapCount, 0)
+
+        manager.debugHandleFlagsChangedForTesting(
+            keyCode: Int64(kVK_RightCommand),
+            flags: CGEventFlags()
+        )
+        await Task.yield()
+
+        XCTAssertEqual(holdReleaseCount, 1)
+        XCTAssertEqual(tapCount, 0)
+    }
+
+    func testKeyInterruptionCancelsTapAndPendingHold() async {
+        let scheduler = HoldSchedulerProbe()
+        let manager = ModifierOnlyHotKeyManager(holdScheduler: scheduler.scheduler)
+        var tapCount = 0
+        var holdStartCount = 0
+        var holdReleaseCount = 0
+        manager.onTap = { tapCount += 1 }
+        manager.onHoldStart = { holdStartCount += 1 }
+        manager.onHoldRelease = { holdReleaseCount += 1 }
+        manager.debugStartGestureForTesting(modifier: .rightOption)
+
+        manager.debugHandleFlagsChangedForTesting(
+            keyCode: Int64(kVK_RightOption),
+            flags: .maskAlternate
+        )
+        manager.debugHandleKeyDownForTesting()
+        scheduler.fireAll()
+        await Task.yield()
+
+        manager.debugHandleFlagsChangedForTesting(
+            keyCode: Int64(kVK_RightOption),
+            flags: CGEventFlags()
+        )
+        await Task.yield()
+
+        XCTAssertEqual(tapCount, 0)
+        XCTAssertEqual(holdStartCount, 0)
+        XCTAssertEqual(holdReleaseCount, 0)
+        XCTAssertFalse(manager.debugGestureSnapshotForTesting().wasInterruptedByKey)
+    }
+
+    func testRepeatedPressInvalidatesEarlierHoldTimerByGeneration() async {
+        let scheduler = HoldSchedulerProbe()
+        let manager = ModifierOnlyHotKeyManager(holdScheduler: scheduler.scheduler)
+        var holdStartCount = 0
+        manager.onHoldStart = { holdStartCount += 1 }
+        manager.debugStartGestureForTesting(modifier: .fn)
+
+        manager.debugHandleFlagsChangedForTesting(keyCode: 0, flags: .maskSecondaryFn)
+        manager.debugHandleFlagsChangedForTesting(keyCode: 0, flags: CGEventFlags())
+        manager.debugHandleFlagsChangedForTesting(keyCode: 0, flags: .maskSecondaryFn)
+
+        XCTAssertEqual(scheduler.scheduledDelays.count, 2)
+
+        scheduler.fire(at: 0)
+        await Task.yield()
+        XCTAssertEqual(holdStartCount, 0, "first scheduled hold should be stale")
+
+        scheduler.fire(at: 0)
+        await Task.yield()
+        XCTAssertEqual(holdStartCount, 1)
+    }
+
+    func testSeparateManagerInstancesDoNotClobberEachOther() async {
+        let scheduler1 = HoldSchedulerProbe()
+        let scheduler2 = HoldSchedulerProbe()
+        let manager1 = ModifierOnlyHotKeyManager(holdScheduler: scheduler1.scheduler)
+        let manager2 = ModifierOnlyHotKeyManager(holdScheduler: scheduler2.scheduler)
+        var manager1TapCount = 0
+        var manager2TapCount = 0
+        manager1.onTap = { manager1TapCount += 1 }
+        manager2.onTap = { manager2TapCount += 1 }
+
+        manager1.debugStartGestureForTesting(modifier: .fn)
+        manager2.debugStartGestureForTesting(modifier: .rightCommand)
+
+        manager1.debugHandleFlagsChangedForTesting(keyCode: 0, flags: .maskSecondaryFn)
+        manager1.debugHandleFlagsChangedForTesting(keyCode: 0, flags: CGEventFlags())
+        await Task.yield()
+
+        XCTAssertEqual(manager1TapCount, 1)
+        XCTAssertEqual(manager2TapCount, 0)
+
+        manager2.debugHandleFlagsChangedForTesting(
+            keyCode: Int64(kVK_RightCommand),
+            flags: .maskCommand
+        )
+        manager2.debugHandleFlagsChangedForTesting(
+            keyCode: Int64(kVK_RightCommand),
+            flags: CGEventFlags()
+        )
+        await Task.yield()
+
+        XCTAssertEqual(manager1TapCount, 1)
+        XCTAssertEqual(manager2TapCount, 1)
+    }
+}
+
+private final class HoldSchedulerProbe: @unchecked Sendable {
+    private struct State {
+        var delays: [Double] = []
+        var callbacks: [@Sendable () -> Void] = []
+    }
+
+    private let state = Mutex(State())
+
+    var scheduler: ModifierOnlyHotKeyManager.HoldScheduler {
+        { [weak self] delay, fire in
+            self?.state.withLock {
+                $0.delays.append(delay)
+                $0.callbacks.append(fire)
+            }
+        }
+    }
+
+    var scheduledDelays: [Double] {
+        state.withLock { $0.delays }
+    }
+
+    func fire(at index: Int) {
+        let callback = state.withLock { $0.callbacks.remove(at: index) }
+        callback()
+    }
+
+    func fireAll() {
+        let callbacks = state.withLock { state -> [@Sendable () -> Void] in
+            let callbacks = state.callbacks
+            state.callbacks.removeAll()
+            return callbacks
+        }
+        callbacks.forEach { $0() }
     }
 }

--- a/Tests/localvoxtralTests/SettingsStoreTests.swift
+++ b/Tests/localvoxtralTests/SettingsStoreTests.swift
@@ -273,6 +273,58 @@ final class SettingsStoreTests: XCTestCase {
         XCTAssertEqual(store.dictationShortcut, SettingsStore.defaultDictationShortcut)
     }
 
+    // MARK: - dual shortcut migration
+
+    func testLegacyDictationShortcutMigratesToOverlayBufferShortcut() {
+        let legacyShortcut = DictationShortcut(
+            keyCode: UInt32(kVK_ANSI_D),
+            carbonModifierFlags: UInt32(cmdKey | shiftKey)
+        )
+        defaults.set(true, forKey: "settings.dictation_shortcut_enabled")
+        defaults.set(legacyShortcut.keyCode, forKey: "settings.dictation_shortcut_key_code")
+        defaults.set(
+            legacyShortcut.carbonModifierFlags,
+            forKey: "settings.dictation_shortcut_carbon_modifiers"
+        )
+
+        let store = makeStore()
+
+        XCTAssertEqual(store.overlayBufferShortcut, legacyShortcut)
+        XCTAssertNil(store.livePasteShortcut)
+        XCTAssertEqual(
+            (defaults.object(forKey: "settings.overlay_buffer_shortcut_key_code") as? NSNumber)?
+                .uint32Value,
+            legacyShortcut.keyCode
+        )
+        XCTAssertEqual(
+            (
+                defaults.object(forKey: "settings.overlay_buffer_shortcut_carbon_modifiers")
+                    as? NSNumber
+            )?.uint32Value,
+            legacyShortcut.carbonModifierFlags
+        )
+        XCTAssertTrue(defaults.bool(forKey: "settings.overlay_buffer_shortcut_enabled"))
+    }
+
+    func testDisabledLegacyDictationShortcutMigratesToDisabledOverlayShortcut() {
+        let legacyShortcut = DictationShortcut(
+            keyCode: UInt32(kVK_ANSI_F),
+            carbonModifierFlags: UInt32(controlKey | optionKey)
+        )
+        defaults.set(false, forKey: "settings.dictation_shortcut_enabled")
+        defaults.set(legacyShortcut.keyCode, forKey: "settings.dictation_shortcut_key_code")
+        defaults.set(
+            legacyShortcut.carbonModifierFlags,
+            forKey: "settings.dictation_shortcut_carbon_modifiers"
+        )
+
+        let store = makeStore()
+
+        XCTAssertNil(store.overlayBufferShortcut)
+        XCTAssertFalse(defaults.bool(forKey: "settings.overlay_buffer_shortcut_enabled"))
+        XCTAssertNil(store.livePasteShortcut)
+    }
+
     // MARK: - llmPolishingConfiguration
 
     func testLLMPolishingConfiguration_disabledReturnsNil() {


### PR DESCRIPTION
Rework of #17 stacked on #30; closes #20 when merged.

This preserves @joostliebregts's original tap-vs-hold / dual-shortcut commit as the first commit on the stack, then layers the PR #30 conflict resolution and hardening in a follow-up commit.

## What changed vs #17

- Rebased the March-era implementation onto `agent/opencode/pr16-trim` and preserved PR #30's overlay finalization and Escape-cancel behavior.
- Reworked `ModifierOnlyHotKeyManager` away from static shared gesture state. Gesture state is now per-instance and guarded by `Mutex`; hold timers use generation tokens so interrupted or released gestures cannot fire stale callbacks.
- Bound CGEventTap callbacks through `userInfo` to the owning manager instance, removing the modifier-manager singleton footgun.
- Kept modifier-only tap re-enable behavior alive for `tapDisabledByTimeout` / `tapDisabledByUserInput`.
- Added modifier-only tap diagnostics matching the Escape-cancel pattern: `AXIsProcessTrusted` and `IOHIDCheckAccess` are logged before tap creation, with explicit failure logs when tap creation or run-loop source creation fails. Carbon modifier+key shortcuts remain independent of modifier-only tap availability.
- Added regression tests for the gesture-state scheduler seam, stale hold timers, key interruption, independent manager instances, and legacy single-shortcut migration into the overlay-buffer shortcut.

## Proof

```text
LV_BUILD_DIR=work/localvoxtral-taphold ./scripts/remote-build.sh test
==> Running on builder@192.168.1.167: swift test --skip RealtimeAPIVLLMIntegrationTests
Build complete! (4.37s)
Test Suite 'localvoxtralPackageTests.xctest' passed
Executed 273 tests, with 0 failures (0 unexpected)
Test Suite 'Selected tests' passed
```

Focused regression coverage added:

- `ModifierOnlyHotKeyManagerTests.testTapFiresWhenModifierReleasesBeforeHoldThreshold`
- `ModifierOnlyHotKeyManagerTests.testHoldFiresStartThenReleaseWhenThresholdElapsed`
- `ModifierOnlyHotKeyManagerTests.testKeyInterruptionCancelsTapAndPendingHold`
- `ModifierOnlyHotKeyManagerTests.testRepeatedPressInvalidatesEarlierHoldTimerByGeneration`
- `ModifierOnlyHotKeyManagerTests.testSeparateManagerInstancesDoNotClobberEachOther`
- `SettingsStoreTests.testLegacyDictationShortcutMigratesToOverlayBufferShortcut`
- `SettingsStoreTests.testDisabledLegacyDictationShortcutMigratesToDisabledOverlayShortcut`

## Manual checks

To verify before merge on a Mac with Input Monitoring / Accessibility state known:

- Tap Fn/Globe: starts/stops Overlay Buffer mode without live auto-paste.
- Hold Fn/Globe past configured thresholds at 150 ms, 350 ms, and 800 ms: starts Live Auto-Paste push-to-talk and stops on release.
- Press another key while Fn/Globe is held: cancels the tap/hold gesture and does not start dictation.
- Configure Right Command as the modifier-only dictation key: tap triggers Overlay Buffer, hold triggers Live Auto-Paste.
- Configure Right Option as the modifier-only dictation key: tap triggers Overlay Buffer, hold triggers Live Auto-Paste.
- Disable modifier-only mode and verify classic Carbon shortcuts still work for both configured output modes.
- Start from an existing legacy single shortcut in UserDefaults and confirm it appears as the Overlay Buffer shortcut after launch, while Live Auto-Paste remains unset.
