### PR TITLE
feat: opt-in raw realtime delta logging (issue #13 instrumentation)

### DIFF
--- a/Sources/localvoxtral/DictationViewModel+RealtimeEvents.swift
+++ b/Sources/localvoxtral/DictationViewModel+RealtimeEvents.swift
@@ -5,6 +5,13 @@ extension DictationViewModel {
     // MARK: - Realtime Event Routing
 
     func handle(event: RealtimeEvent) {
+        // Instrument the raw, pre-processing delta stream first. This is the
+        // single choke point where every realtime event arrives on the main
+        // actor; logging here captures exactly what the backend delivered
+        // before FirstChunkPreprocessor / merge / insertion touch it. No-op
+        // unless the hidden `debug.log_realtime_deltas` toggle is set.
+        logRawRealtimeEventIfEnabled(event)
+
         switch event {
         case .connected:
             handleConnectedEvent()
@@ -261,6 +268,73 @@ extension DictationViewModel {
 
     private func preprocessIncomingTranscriptChunk(_ chunk: String) -> String {
         firstChunkPreprocessor.preprocess(chunk)
+    }
+
+    // MARK: - Raw Delta Logging (issue #13 instrumentation)
+
+    /// Emit the raw payload of every received realtime event to `Log.deltas`
+    /// (notice level) BEFORE any processing, when the hidden
+    /// `SettingsStore.debugLogRealtimeDeltas` toggle is on. Each event within
+    /// a session carries a monotonic `sequence` that resets when a new session
+    /// connects, so the arrival order of deltas is unambiguous in the log.
+    ///
+    /// Partial/final transcript payloads are logged via `.debugDescription` so
+    /// the exact characters — including any leading/trailing/inner whitespace
+    /// and the punctuation placement under investigation — are visible, and
+    /// marked `.public` (see `debugLogRealtimeDeltas` docs for the privacy
+    /// rationale). No-op when the toggle is off.
+    private func logRawRealtimeEventIfEnabled(_ event: RealtimeEvent) {
+        guard settings.debugLogRealtimeDeltas else { return }
+
+        // A new realtime session starts the per-session sequence over.
+        if case .connected = event {
+            realtimeDeltaLogSequence = 0
+        }
+
+        let sequence = realtimeDeltaLogSequence
+        realtimeDeltaLogSequence &+= 1
+
+        switch event {
+        case .connected:
+            Log.deltas.notice(
+                "[delta-log seq=\(sequence)] session boundary: connected")
+            emitDeltaLogRecord(.sessionConnected, sequence: sequence, payload: nil)
+        case .disconnected:
+            Log.deltas.notice(
+                "[delta-log seq=\(sequence)] session boundary: disconnected")
+            emitDeltaLogRecord(.sessionDisconnected, sequence: sequence, payload: nil)
+        case .partialTranscript(let delta):
+            Log.deltas.notice(
+                "[delta-log seq=\(sequence)] partial delta: \(delta.debugDescription, privacy: .public)")
+            emitDeltaLogRecord(.partialDelta, sequence: sequence, payload: delta)
+        case .finalTranscript(let text):
+            Log.deltas.notice(
+                "[delta-log seq=\(sequence)] final transcript: \(text.debugDescription, privacy: .public)")
+            emitDeltaLogRecord(.finalTranscript, sequence: sequence, payload: text)
+        case .status(let message):
+            Log.deltas.notice(
+                "[delta-log seq=\(sequence)] status: \(message, privacy: .public)")
+            emitDeltaLogRecord(.status, sequence: sequence, payload: message)
+        case .error(let message):
+            Log.deltas.notice(
+                "[delta-log seq=\(sequence)] error: \(message, privacy: .public)")
+            emitDeltaLogRecord(.error, sequence: sequence, payload: message)
+        case .transcriptionFinalized:
+            Log.deltas.notice(
+                "[delta-log seq=\(sequence)] transcription finalized")
+            emitDeltaLogRecord(.transcriptionFinalized, sequence: sequence, payload: nil)
+        }
+    }
+
+    /// Mirror the delta-log emission to the `#if DEBUG` test sink. Defined on
+    /// the main type (the sink is invoked inline from production code, like
+    /// `TextInsertionService`'s `debugUnicodePoster`), so no compile-time DEBUG
+    /// guard is needed here: the sink is nil in release builds.
+    private func emitDeltaLogRecord(
+        _ kind: DebugRealtimeDeltaLogRecord.Kind, sequence: Int, payload: String?
+    ) {
+        debugDeltaLogSink?(
+            DebugRealtimeDeltaLogRecord(kind: kind, sequence: sequence, payload: payload))
     }
 
     // MARK: - Finalized Segment Resolution

--- a/Sources/localvoxtral/DictationViewModel.swift
+++ b/Sources/localvoxtral/DictationViewModel.swift
@@ -9,6 +9,30 @@ enum RealtimeSessionIndicatorState {
     case recentFailure
 }
 
+/// A single raw realtime-delta log emission, captured before any
+/// merge/preprocess/insertion processing. Mirrors what `Log.deltas` records
+/// when `SettingsStore.debugLogRealtimeDeltas` is on; surfaced through the
+/// `#if DEBUG` `debugDeltaLogSink` seam for instrumentation tests.
+///
+/// `payload` is the exact, unprocessed string the backend delivered (quoted in
+/// the actual log via `.debugDescription` so whitespace is visible); it is nil
+/// for events that carry no string payload (session boundaries, finalized).
+struct DebugRealtimeDeltaLogRecord: Equatable, Sendable {
+    enum Kind: String, Sendable {
+        case sessionConnected = "session.connected"
+        case sessionDisconnected = "session.disconnected"
+        case partialDelta = "partial"
+        case finalTranscript = "final"
+        case status = "status"
+        case error = "error"
+        case transcriptionFinalized = "finalized"
+    }
+
+    let kind: Kind
+    let sequence: Int
+    let payload: String?
+}
+
 @MainActor
 @Observable
 final class DictationViewModel {
@@ -184,6 +208,22 @@ final class DictationViewModel {
     var sessionModelName: String?
     @ObservationIgnored
     var firstChunkPreprocessor = FirstChunkPreprocessor()
+
+    // Per-session sequence counter for the opt-in raw-delta log
+    // (`SettingsStore.debugLogRealtimeDeltas`). Reset to 0 when a new realtime
+    // session connects. Only mutated inside the gated logging path, so a value
+    // of 0 while events are flowing proves the toggle is off. Internal so the
+    // realtime-events extension can read/advance it.
+    @ObservationIgnored
+    var realtimeDeltaLogSequence = 0
+
+    /// `#if DEBUG` test seam mirroring the raw-delta log emissions. Only
+    /// invoked when `SettingsStore.debugLogRealtimeDeltas` is on (i.e. inside
+    /// the same gated path that calls `Log.deltas`), so "sink not called when
+    /// disabled" proves the logging call path was not entered. The record is
+    /// the exact pre-processing payload the Logger would emit.
+    @ObservationIgnored
+    var debugDeltaLogSink: ((DebugRealtimeDeltaLogRecord) -> Void)?
 
     @ObservationIgnored
     let debugLoggingEnabled = ProcessInfo.processInfo.environment["LOCALVOXTRAL_DEBUG"] == "1"
@@ -868,6 +908,15 @@ extension DictationViewModel {
     ) {
         isPushToTalkShortcutHeld = isHeld
         hasActivePushToTalkShortcutSession = hasActiveSession
+    }
+
+    /// Install a sink that receives every raw-delta log emission captured by
+    /// `logRawRealtimeEventIfEnabled`. Only fires when
+    /// `SettingsStore.debugLogRealtimeDeltas` is on (same gated path as
+    /// `Log.deltas`), so it doubles as an observation point for "logging path
+    /// not entered when disabled". Pass `nil` to clear.
+    func debugConfigureDeltaLogSink(_ sink: ((DebugRealtimeDeltaLogRecord) -> Void)?) {
+        debugDeltaLogSink = sink
     }
 }
 #endif

--- a/Sources/localvoxtral/Log.swift
+++ b/Sources/localvoxtral/Log.swift
@@ -15,4 +15,9 @@ enum Log {
     static let polishing = Logger(subsystem: subsystem, category: "Polishing")
     static let persistence = Logger(subsystem: subsystem, category: "Persistence")
     static let config = Logger(subsystem: subsystem, category: "Config")
+    /// Opt-in raw realtime delta instrumentation for issue #13. Emits at notice
+    /// level so it is visible by default under `log stream` / Console. Gated by
+    /// `SettingsStore.debugLogRealtimeDeltas`; see that property's docs for the
+    /// privacy trade-off.
+    static let deltas = Logger(subsystem: subsystem, category: "Deltas")
 }

--- a/Sources/localvoxtral/SettingsStore.swift
+++ b/Sources/localvoxtral/SettingsStore.swift
@@ -139,6 +139,13 @@ final class SettingsStore {
         static let llmPolishingAPIKey = "settings.llm_polishing_api_key"
         static let llmPolishingModel = "settings.llm_polishing_model"
         static let replacementDictionaryEnabled = "settings.replacement_dictionary_enabled"
+        /// Hidden debug toggle (no UI). When true, every received realtime
+        /// event's raw payload is logged to the `Deltas` category before any
+        /// merge/preprocess/insertion processing — instrumentation for
+        /// diagnosing issue #13 (mid-word punctuation in Live Auto-Paste).
+        /// Note the `debug.` prefix (not `settings.`): this is not a
+        /// user-facing preference and must never surface in the settings UI.
+        static let debugLogRealtimeDeltas = "debug.log_realtime_deltas"
     }
 
     private let defaults: UserDefaults
@@ -220,6 +227,22 @@ final class SettingsStore {
         didSet {
             defaults.set(replacementDictionaryEnabled, forKey: Keys.replacementDictionaryEnabled)
         }
+    }
+
+    /// Hidden debug flag for issue #13 instrumentation. Default false. When
+    /// enabled, `DictationViewModel` logs the exact payload of every received
+    /// realtime event (partial deltas quoted so whitespace is visible, final
+    /// transcripts, and session boundaries) to `Log.deltas` (notice level)
+    /// BEFORE any merge/preprocess/insertion processing.
+    ///
+    /// Privacy: this logs dictated content in cleartext. That is the explicit
+    /// purpose of an opt-in debug flag, so payloads are marked `.public` to
+    /// make whitespace and punctuation visible in `log stream` / Console. Only
+    /// enable it for a capture you intend to share; leave it off otherwise.
+    /// There is no UI for this setting — it is toggled via `defaults`:
+    ///   `defaults write com.localvoxtral.app debug.log_realtime_deltas -bool true`
+    var debugLogRealtimeDeltas: Bool {
+        didSet { defaults.set(debugLogRealtimeDeltas, forKey: Keys.debugLogRealtimeDeltas) }
     }
 
     init(
@@ -324,6 +347,8 @@ final class SettingsStore {
         )
         replacementDictionaryEnabled = Self.loadBool(
             defaults: defaults, key: Keys.replacementDictionaryEnabled, fallback: false)
+        debugLogRealtimeDeltas = Self.loadBool(
+            defaults: defaults, key: Keys.debugLogRealtimeDeltas, fallback: false)
     }
 
     // MARK: - Init Helpers

--- a/Tests/localvoxtralTests/DictationViewModelDeltaLoggingTests.swift
+++ b/Tests/localvoxtralTests/DictationViewModelDeltaLoggingTests.swift
@@ -1,0 +1,194 @@
+import Foundation
+import XCTest
+@testable import localvoxtral
+
+// Tests for the issue #13 raw-delta instrumentation: when the hidden
+// `debug.log_realtime_deltas` toggle is on, `DictationViewModel` must log the
+// exact, pre-processing payload of every received realtime event (partial
+// deltas quoted so whitespace/punctuation is visible, final transcripts, and
+// session boundaries) with a per-session sequence number — BEFORE any
+// merge/preprocess/insertion processing. When off, the logging call path must
+// not be entered at all.
+//
+// OSLog output can't be captured in-process, so we observe through the
+// `#if DEBUG` `debugConfigureDeltaLogSink` seam, which is invoked from the
+// same gated path as `Log.deltas`. The sink records mirror what is logged.
+#if DEBUG
+@MainActor
+final class DictationViewModelDeltaLoggingTests: XCTestCase {
+    // DictationViewModel owns app-lifetime services; retain instances for the
+    // process duration so teardown does not race service shutdown.
+    private static var retainedViewModels: [DictationViewModel] = []
+
+    private var captured: [DebugRealtimeDeltaLogRecord] = []
+
+    /// Build a ViewModel whose delta-log sink captures every emission in
+    /// arrival order. `enableDeltaLogging` controls the toggle so each test
+    /// pins the exact state under test.
+    private func makeViewModel(enableDeltaLogging: Bool) -> DictationViewModel {
+        let suiteName = "localvoxtral.DictationViewModelDeltaLoggingTests.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defaults.removePersistentDomain(forName: suiteName)
+        addTeardownBlock {
+            defaults.removePersistentDomain(forName: suiteName)
+        }
+
+        let settings = SettingsStore(defaults: defaults, environment: [:])
+        settings.debugLogRealtimeDeltas = enableDeltaLogging
+
+        let viewModel = DictationViewModel(
+            settings: settings,
+            overlayBufferCoordinator: MockOverlayCoordinator(),
+            startRuntimeServices: false
+        )
+        Self.retainedViewModels.append(viewModel)
+
+        captured = []
+        viewModel.debugConfigureDeltaLogSink { [weak self] record in
+            self?.captured.append(record)
+        }
+
+        return viewModel
+    }
+
+    // MARK: - Toggle off: logging path not entered
+
+    func testDeltaLogging_disabled_neverEmitsAndDoesNotAdvanceSequence() {
+        // With the toggle off, sending a full mix of events must not enter the
+        // logging path at all: the sink receives nothing AND the per-session
+        // sequence counter (only ever mutated inside the gated path) stays 0.
+        // The two assertions together prove "no logging call path is hit".
+        let viewModel = makeViewModel(enableDeltaLogging: false)
+
+        viewModel.handle(event: .connected)
+        viewModel.handle(event: .partialTranscript("spar"))
+        viewModel.handle(event: .partialTranscript("isce"))
+        viewModel.handle(event: .partialTranscript("."))
+        viewModel.handle(event: .finalTranscript("sparisce."))
+        viewModel.handle(event: .transcriptionFinalized)
+        viewModel.handle(event: .disconnected)
+
+        XCTAssertTrue(captured.isEmpty, "sink must not fire when toggle is off")
+        XCTAssertEqual(
+            viewModel.realtimeDeltaLogSequence, 0,
+            "sequence counter must not advance when toggle is off")
+    }
+
+    // MARK: - Toggle on: exact payloads + arrival order + sequence
+
+    func testDeltaLogging_enabled_capturesPartialDeltasInArrivalOrderWithExactPayloads() {
+        // The core of issue #13: capture the EXACT delta string the backend
+        // delivered, in arrival order, before any processing. The mid-word
+        // punctuation case ("sparis", ".", "ce") is precisely what we need to
+        // see upstream; the app must record it verbatim.
+        let viewModel = makeViewModel(enableDeltaLogging: true)
+
+        viewModel.handle(event: .partialTranscript("sparis"))
+        viewModel.handle(event: .partialTranscript("."))
+        viewModel.handle(event: .partialTranscript("ce"))
+
+        XCTAssertEqual(captured.count, 3)
+        XCTAssertEqual(captured[0].kind, .partialDelta)
+        XCTAssertEqual(captured[0].sequence, 0)
+        XCTAssertEqual(captured[0].payload, "sparis")
+        XCTAssertEqual(captured[1].kind, .partialDelta)
+        XCTAssertEqual(captured[1].sequence, 1)
+        XCTAssertEqual(captured[1].payload, ".")
+        XCTAssertEqual(captured[2].kind, .partialDelta)
+        XCTAssertEqual(captured[2].sequence, 2)
+        XCTAssertEqual(captured[2].payload, "ce")
+    }
+
+    func testDeltaLogging_enabled_capturesWhitespaceExactly() {
+        // Punctuation placement isn't the only thing to verify — leading,
+        // inner, and trailing whitespace must survive to the log so a reviewer
+        // can see it in the capture. The sink holds the raw string; the Logger
+        // quotes it via `.debugDescription` (verified in source).
+        let viewModel = makeViewModel(enableDeltaLogging: true)
+
+        let exact = "  lead\u{00a0}space\ntrail\t"
+        viewModel.handle(event: .partialTranscript(exact))
+
+        XCTAssertEqual(captured.count, 1)
+        XCTAssertEqual(captured[0].payload, exact)
+    }
+
+    func testDeltaLogging_enabled_capturesFinalTranscriptFinalizedAndBoundaries() {
+        // A realistic single-session flow: connect, partial, final, finalized.
+        // Each event is captured with a monotonic per-session sequence.
+        let viewModel = makeViewModel(enableDeltaLogging: true)
+
+        viewModel.handle(event: .connected)
+        viewModel.handle(event: .partialTranscript("hi"))
+        viewModel.handle(event: .finalTranscript("hi."))
+        viewModel.handle(event: .transcriptionFinalized)
+        viewModel.handle(event: .disconnected)
+
+        XCTAssertEqual(
+            captured.map(\.kind),
+            [.sessionConnected, .partialDelta, .finalTranscript, .transcriptionFinalized,
+                .sessionDisconnected])
+        XCTAssertEqual(captured.map(\.sequence), [0, 1, 2, 3, 4])
+        XCTAssertEqual(captured[0].payload, nil, "connected has no string payload")
+        XCTAssertEqual(captured[1].payload, "hi")
+        XCTAssertEqual(captured[2].payload, "hi.")
+        XCTAssertEqual(captured[3].payload, nil, "finalized has no string payload")
+        XCTAssertEqual(captured[4].payload, nil, "disconnected has no string payload")
+    }
+
+    func testDeltaLogging_enabled_sequenceResetsWhenNewSessionConnects() {
+        // The sequence is per-session: a fresh `.connected` boundary must reset
+        // it to 0 so a reviewer can correlate delta order within one session.
+        let viewModel = makeViewModel(enableDeltaLogging: true)
+
+        // Session 1.
+        viewModel.handle(event: .connected)            // seq 0 (reset)
+        viewModel.handle(event: .partialTranscript("a"))  // seq 1
+        viewModel.handle(event: .partialTranscript("b"))  // seq 2
+        // Session 2 begins — sequence must reset.
+        viewModel.handle(event: .connected)            // seq 0 (reset)
+        viewModel.handle(event: .partialTranscript("c"))  // seq 1
+
+        let connectedRecords = captured.filter { $0.kind == .sessionConnected }
+        XCTAssertEqual(connectedRecords.map(\.sequence), [0, 0])
+
+        let partialRecords = captured.filter { $0.kind == .partialDelta }
+        XCTAssertEqual(partialRecords.map(\.sequence), [1, 2, 1])
+        XCTAssertEqual(partialRecords.map(\.payload), ["a", "b", "c"])
+    }
+
+    func testDeltaLogging_enabled_capturesStatusAndErrorPayloads() {
+        // Status/error events also carry payloads worth capturing during a
+        // debugging session.
+        let viewModel = makeViewModel(enableDeltaLogging: true)
+
+        viewModel.handle(event: .status("Session ready."))
+        viewModel.handle(event: .error("rate limited"))
+
+        XCTAssertEqual(captured.count, 2)
+        XCTAssertEqual(captured[0].kind, .status)
+        XCTAssertEqual(captured[0].payload, "Session ready.")
+        XCTAssertEqual(captured[1].kind, .error)
+        XCTAssertEqual(captured[1].payload, "rate limited")
+    }
+}
+
+@MainActor
+private final class MockOverlayCoordinator: OverlayBufferSessionCoordinating {
+    var commitOutcome: OverlayBufferCommitOutcome = .succeeded
+    var commitTargetAppPID: pid_t? = nil
+
+    func resolveAnchorNow() -> OverlayAnchor {
+        OverlayAnchor(targetRect: CGRect(x: 0, y: 0, width: 100, height: 24), source: .windowCenter)
+    }
+    func startSession(preResolvedAnchor: OverlayAnchor?) {}
+    func beginFinalizing(displayBufferText: String, commitBufferText: String) {}
+    func refresh(displayBufferText: String, commitBufferText: String) {}
+    func commitIfNeeded(
+        using textCommitter: OverlayTextCommitting,
+        autoCopyEnabled: Bool
+    ) -> OverlayBufferCommitOutcome { commitOutcome }
+    func dismissAfterHold(minimumVisibility: TimeInterval) {}
+    func reset() {}
+}
+#endif

--- a/Tests/localvoxtralTests/SettingsStoreTests.swift
+++ b/Tests/localvoxtralTests/SettingsStoreTests.swift
@@ -329,4 +329,31 @@ final class SettingsStoreTests: XCTestCase {
         XCTAssertTrue(reloadedStore.replacementDictionaryEnabled)
     }
 
+    // MARK: - debugLogRealtimeDeltas (issue #13 instrumentation)
+
+    func testDebugLogRealtimeDeltas_defaultsToFalse() {
+        // The hidden instrumentation toggle must be off by default so no
+        // dictated content is ever logged unless explicitly opted in.
+        let store = makeStore()
+
+        XCTAssertFalse(store.debugLogRealtimeDeltas)
+    }
+
+    func testDebugLogRealtimeDeltas_persistsAcrossReloadUnderDocumentedKey() {
+        // The reporter enables capture via `defaults write com.localvoxtral.app
+        // debug.log_realtime_deltas -bool true`. Verify the round-trips under
+        // exactly that key and survives a store reload.
+        defaults.set(true, forKey: "debug.log_realtime_deltas")
+
+        let store = makeStore()
+        XCTAssertTrue(store.debugLogRealtimeDeltas)
+
+        // And a set through the property must persist under the same key.
+        store.debugLogRealtimeDeltas = false
+        XCTAssertEqual(defaults.bool(forKey: "debug.log_realtime_deltas"), false)
+
+        let reloadedStore = makeStore()
+        XCTAssertFalse(reloadedStore.debugLogRealtimeDeltas)
+    }
+
 }


### PR DESCRIPTION
## What

Opt-in instrumentation for **issue #13** (punctuation landing mid-word in Live Auto-Paste + voxmlx). The investigation (locked in by `RealtimeAPILivePastePunctuationTests`) proved the app types deltas verbatim on the append-only path — so the corruption must already be present in the delta **sequence** the backend delivers. This PR gives the reporter a way to capture that raw sequence from one bad run.

Changes (all gated behind a hidden toggle, default off, **no UI**):

- **`SettingsStore`**: new hidden bool `debugLogRealtimeDeltas`, persisted under key `debug.log_realtime_deltas` (note the `debug.` prefix, not `settings.` — this is not a user-facing preference). Default `false`. Loaded the same way as the other bool settings.
- **`Log`**: new os.Log category `Deltas` (subsystem `com.localvoxtral`), emitted at **notice** level so it's visible by default in `log stream` / Console.
- **`DictationViewModel`**: at the top of `handle(event:)` — the single choke point where every realtime event arrives on the main actor — log the event's exact payload **before** any `FirstChunkPreprocessor` / merge / insertion processing. Partial + final transcript payloads are quoted via `.debugDescription` so leading/inner/trailing whitespace and punctuation placement are visible. Each event carries a **per-session sequence number** that resets when a new session connects, so arrival order is unambiguous. When the toggle is off, `logRawRealtimeEventIfEnabled(_:)` returns at its first `guard` and no further work is done.

This is a **no-op when disabled** — there is no change to the realtime/merge/insertion paths, which is why the integration suite and the existing characterization tests are untouched.

### How a reporter captures a bad run

Enable (the packaged app's defaults domain is `com.localvoxtral.app`, i.e. `UserDefaults.standard` whose domain is the bundle id):

```
defaults write com.localvoxtral.app debug.log_realtime_deltas -bool true
```

Restart the app (the toggle is read at `SettingsStore` init), reproduce the dictation, then capture:

```
log stream --predicate 'subsystem == "com.localvoxtral" AND category == "Deltas"'
```

Disable afterwards:

```
defaults delete com.localvoxtral.app debug.log_realtime_deltas
```

### Privacy

This logs dictated content **in cleartext**, and payloads are marked `.privacy: .public`. That is a conscious choice — it is the explicit purpose of an opt-in debug flag (whitespace and punctuation must be visible to diagnose #13, and `.public` prevents the unified logging system from redacting them). The default is off and there is no UI, so no content is logged unless a user deliberately enables it for a capture they intend to share. This is called out in the code comments on `debugLogRealtimeDeltas` and `logRawRealtimeEventIfEnabled(_:)`.

Refs #13 (instrumentation only — does not change dictation behavior).

## Proof

- [x] Unit suite green — `LV_BUILD_DIR=work/localvoxtral-deltalog ./scripts/remote-build.sh test`:
  ```
  Executed 246 tests, with 0 failures (0 unexpected) in 1.362 (1.373) seconds
  ```
  Zero compiler warnings (Swift 6.2 strict concurrency).
- [ ] Realtime integration — N/A. This change adds only logging behind an off-by-default toggle; the realtime/merge/insertion paths are unchanged, so `RealtimeAPIVLLMIntegrationTests` is not a meaningful proof target here. It remains green on CI.
- [ ] Bug fix regression test — N/A (instrumentation, not a behavior fix). New tests below demonstrate the instrumentation behaves as intended.
- [ ] UI change — N/A (no UI; hidden toggle only).

### Toggle is read correctly (default off + round-trip under the documented defaults key)

`SettingsStoreTests`:
```
testDebugLogRealtimeDeltas_defaultsToFalse  … passed
testDebugLogRealtimeDeltas_persistsAcrossReloadUnderDocumentedKey  … passed
```
The second writes `defaults write … debug.log_realtime_deltas true`, reloads the store, and asserts the bool round-trips under exactly the key documented above.

### When disabled, the logging call path is not entered

`DictationViewModelDeltaLoggingTests.testDeltaLogging_disabled_neverEmitsAndDoesNotAdvanceSequence` sends a full event mix (connect, partials, final, finalized, disconnect) with the toggle off and asserts both that the debug sink **never fires** and that `realtimeDeltaLogSequence` **stays 0** (the counter is only ever mutated inside the gated path). Together these prove no logging work happens when disabled.

### When enabled, exact payloads + arrival order + sequence are captured

```
DictationViewModelDeltaLoggingTests:
  testDeltaLogging_disabled_neverEmitsAndDoesNotAdvanceSequence  … passed
  testDeltaLogging_enabled_capturesPartialDeltasInArrivalOrderWithExactPayloads  … passed
  testDeltaLogging_enabled_capturesWhitespaceExactly  … passed
  testDeltaLogging_enabled_capturesFinalTranscriptFinalizedAndBoundaries  … passed
  testDeltaLogging_enabled_sequenceResetsWhenNewSessionConnects  … passed
  testDeltaLogging_enabled_capturesStatusAndErrorPayloads  … passed
```

`testDeltaLogging_enabled_capturesPartialDeltasInArrivalOrderWithExactPayloads` feeds the exact mid-word-punctuation delta stream from the issue (`["sparis", ".", "ce"]`) and asserts the captured records are `partial("sparis", seq=0)`, `partial(".", seq=1)`, `partial("ce", seq=2)` — i.e. the instrumentation would surface that punctuation arrived before the rest of the word. `testDeltaLogging_enabled_capturesWhitespaceExactly` asserts leading/inner/trailing whitespace (incl. a non-breaking space and a tab/newline) survives to the captured payload. `…sequenceResetsWhenNewSessionConnects` proves the sequence resets to 0 on a fresh `connected` boundary.

OSLog output cannot be captured in-process in a unit test, so observation is via the existing-style `#if DEBUG` sink (`debugConfigureDeltaLogSink`), invoked from the same gated path as `Log.deltas`. The sink records mirror exactly what is logged (kind, sequence, exact payload string); the Logger quoting via `.debugDescription` is verified in source.
