### PR TITLE
ci: one-command gate-then-tag release pipeline

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -1,37 +1,35 @@
-# Release Workflow Notes
+# Workflow Notes
+
+## `ci.yml`
+
+Every PR and push to main: build, unit tests, live voxmlx integration tests,
+app packaging, launch smoke test, and an installable app artifact
+(`localvoxtral-app`, fetch with `scripts/try-pr.sh`). Same-repo branches run
+on the self-hosted Mac runner; fork PRs run on GitHub-hosted macOS.
 
 ## `release.yml`
 
-This workflow publishes the macOS app zip to GitHub Releases.
-
-- Trigger (`push`): when a tag matching `v*.*.*` is pushed (for example `v0.3.0`)
-- Trigger (`workflow_dispatch`): manual run for an existing tag using the `tag` input
-
-Pipeline steps:
-
-1. Check out source (`push` ref or selected tag).
-2. Derive `tag` and `version` metadata (version is tag without the `v` prefix).
-3. Install Swift 6.2.
-4. Run `swift build -c release`.
-5. Run `swift test`.
-6. Package app bundle with:
-   - `./scripts/package_app.sh release <version> <github_run_number>`
-7. Zip app bundle to:
-   - `dist/localvoxtral-<tag>.zip`
-8. Create/update GitHub release for the tag and upload the zip asset.
-
-## Local release command
-
-Use this from repo root:
+One-command, gate-then-tag releases on the self-hosted runner:
 
 ```bash
-./scripts/release.sh vX.Y.Z
+./scripts/release.sh            # patch bump
+./scripts/release.sh minor      # or major, or an explicit X.Y.Z
 ```
 
-What it does:
+Pipeline: compute next version from the latest `v*` tag → release build →
+unit tests → live integration tests (voxmlx) → package app bundle → launch
+smoke test → zip + dmg → **create tag** → publish GitHub release with
+auto-generated notes and both artifacts.
 
-1. Verifies clean git state and `main` branch.
-2. Runs local build/tests.
-3. Packages and zips local app artifact.
-4. Pushes `main`.
-5. Creates and pushes the tag, which triggers `release.yml`.
+The tag is created only after every gate passes, so a failed release leaves
+no orphan tag. Releases are ad-hoc signed on purpose (a local signing cert
+means nothing on users' machines); proper distribution signing needs a
+Developer ID cert. Dispatch-only: pushing tags by hand no longer triggers a
+release.
+
+## `mlx-lm-test.yml`
+
+Manual-dispatch harness that installs `mlx_lm.server` from any ref of the
+T0mSIlver/mlx-lm fork on the self-hosted runner, serves the polishing model,
+and probes chat/completions through the prompt-cache path. Used to verify
+fork changes (MLX needs Apple Silicon).

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,108 +1,129 @@
 name: Release App
 
+# One-command releases: dispatch with a bump level (or explicit version) and
+# the pipeline gates, tags, packages, and publishes. The tag is created ONLY
+# after every gate passes — a failed release leaves no orphan tag behind.
+# Trigger from anywhere: ./scripts/release.sh minor   (wraps gh workflow run)
+
 on:
-  push:
-    tags:
-      - "v*.*.*"
   workflow_dispatch:
     inputs:
-      tag:
-        description: "Existing tag to publish (example: v0.3.0)"
-        required: true
+      bump:
+        description: "Version bump from the latest v* tag"
+        required: false
+        default: "patch"
+        type: choice
+        options: [patch, minor, major]
+      version:
+        description: "Explicit version (X.Y.Z) — overrides bump"
+        required: false
         type: string
 
 permissions:
   contents: write
 
-jobs:
-  build-and-release:
-    runs-on: macos-latest
-    steps:
-      - name: Checkout pushed ref
-        if: github.event_name != 'workflow_dispatch'
-        uses: actions/checkout@v4
+concurrency:
+  group: release
+  cancel-in-progress: false
 
-      - name: Checkout selected tag
-        if: github.event_name == 'workflow_dispatch'
+jobs:
+  release:
+    # Self-hosted for speed (warm build cache, live voxmlx for the integration
+    # gate). Releases stay ad-hoc signed: the runner's localvoxtral-dev cert
+    # is meaningless on users' machines, so we don't set the identity here.
+    runs-on: [self-hosted, macOS, ARM64]
+    timeout-minutes: 30
+    steps:
+      - name: Checkout main
         uses: actions/checkout@v4
         with:
-          ref: refs/tags/${{ github.event.inputs.tag }}
+          ref: main
+          fetch-depth: 0
 
-      - name: Derive release metadata
+      - name: Compute version
         id: meta
         run: |
-          if [[ "${GITHUB_EVENT_NAME}" == "workflow_dispatch" ]]; then
-            TAG="${{ github.event.inputs.tag }}"
+          set -euo pipefail
+          EXPLICIT="${{ inputs.version }}"
+          if [[ -n "$EXPLICIT" ]]; then
+            if [[ ! "$EXPLICIT" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+              echo "Invalid explicit version: $EXPLICIT (expected X.Y.Z)"; exit 1
+            fi
+            VERSION="$EXPLICIT"
           else
-            TAG="${GITHUB_REF_NAME}"
+            LATEST="$(git describe --tags --abbrev=0 --match 'v[0-9]*' 2>/dev/null || echo v0.0.0)"
+            BASE="${LATEST#v}"
+            IFS=. read -r MA MI PA <<< "$BASE"
+            case "${{ inputs.bump }}" in
+              major) VERSION="$((MA+1)).0.0" ;;
+              minor) VERSION="$MA.$((MI+1)).0" ;;
+              patch) VERSION="$MA.$MI.$((PA+1))" ;;
+              *) echo "Unknown bump"; exit 1 ;;
+            esac
           fi
-          if [[ ! "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+([.-][0-9A-Za-z.-]+)?$ ]]; then
-            echo "Unsupported tag format: $TAG"
-            exit 1
+          TAG="v$VERSION"
+          if git rev-parse -q --verify "refs/tags/$TAG" >/dev/null \
+             || git ls-remote --tags origin "refs/tags/$TAG" | grep -q .; then
+            echo "Tag already exists: $TAG"; exit 1
           fi
-          VERSION="${TAG#v}"
-          echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
-          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+          echo "Releasing $TAG from $(git rev-parse --short HEAD)"
 
-      - name: Setup Swift
-        uses: swift-actions/setup-swift@v2
-        with:
-          swift-version: "6.2"
-
-      - name: Build
+      - name: Gate — build
         run: swift build -c release
 
-      - name: Test
-        run: swift test
+      - name: Gate — unit tests
+        run: |
+          swift test \
+            --skip RealtimeAPIVLLMIntegrationTests
 
-      - name: Package app bundle
+      - name: Gate — live integration (voxmlx)
+        env:
+          VLLM_REALTIME_TEST_ENABLE: "1"
+          VLLM_REALTIME_TEST_MODEL: T0mSIlver/Voxtral-Mini-4B-Realtime-2602-MLX-4bit
+        run: swift test --filter RealtimeAPIVLLMIntegrationTests
+
+      - name: Gate — package app bundle
         run: ./scripts/package_app.sh release "${{ steps.meta.outputs.version }}" "${{ github.run_number }}"
 
-      - name: Smoke test packaged app launch
+      - name: Gate — packaged app launch smoke test
         run: |
           python3 - <<'PY'
-          import subprocess
-          import time
-
-          app_binary = "dist/localvoxtral.app/Contents/MacOS/localvoxtral"
-          process = subprocess.Popen([app_binary])
+          import subprocess, time
+          process = subprocess.Popen(["dist/localvoxtral.app/Contents/MacOS/localvoxtral"])
           time.sleep(2)
-
-          exit_code = process.poll()
-          if exit_code is not None:
-            raise SystemExit(f"packaged app exited during smoke test: {exit_code}")
-
+          if process.poll() is not None:
+              raise SystemExit(f"packaged app exited during smoke test: {process.returncode}")
           process.terminate()
           try:
-            process.wait(timeout=5)
+              process.wait(timeout=5)
           except subprocess.TimeoutExpired:
-            process.kill()
-            process.wait(timeout=5)
+              process.kill(); process.wait(timeout=5)
           PY
 
-      - name: Create release artifacts
+      - name: Create release artifacts (zip + dmg)
         run: |
-          mkdir -p dist
-          ZIP_PATH="dist/localvoxtral-${{ steps.meta.outputs.tag }}.zip"
-          DMG_PATH="dist/localvoxtral-${{ steps.meta.outputs.tag }}.dmg"
-
+          set -euo pipefail
+          TAG="${{ steps.meta.outputs.tag }}"
           ditto -c -k --sequesterRsrc --keepParent \
-            "dist/localvoxtral.app" \
-            "$ZIP_PATH"
-
+            "dist/localvoxtral.app" "dist/localvoxtral-$TAG.zip"
           DMG_STAGING_DIR="$(mktemp -d)"
           trap 'rm -rf "$DMG_STAGING_DIR"' EXIT
           cp -R "dist/localvoxtral.app" "$DMG_STAGING_DIR/localvoxtral.app"
           ln -s /Applications "$DMG_STAGING_DIR/Applications"
+          hdiutil create -volname "localvoxtral" -srcfolder "$DMG_STAGING_DIR" \
+            -ov -format UDZO "dist/localvoxtral-$TAG.dmg"
 
-          hdiutil create \
-            -volname "localvoxtral" \
-            -srcfolder "$DMG_STAGING_DIR" \
-            -ov \
-            -format UDZO \
-            "$DMG_PATH"
+      - name: Tag (all gates green)
+        run: |
+          TAG="${{ steps.meta.outputs.tag }}"
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git tag -a "$TAG" -m "localvoxtral $TAG"
+          git push origin "$TAG"
 
-      - name: Create GitHub release
+      - name: Publish GitHub release
         uses: softprops/action-gh-release@v2
         with:
           tag_name: ${{ steps.meta.outputs.tag }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -66,8 +66,11 @@ backend, where the suite self-skips. The mic-capture tests
   GitHub-hosted macOS. Never move fork-PR jobs to the self-hosted runner — it
   is a personal machine.
 - Watch a PR's checks with `gh pr checks <n> --watch`.
-- Releases: push a `v*.*.*` tag (or `./scripts/release.sh vX.Y.Z` from main),
-  which triggers `release.yml` → GitHub Release with .zip + .dmg.
+- Releases: `./scripts/release.sh [patch|minor|major|X.Y.Z]` from any machine
+  with gh — dispatches `release.yml` on the self-hosted runner, which gates
+  (build, unit, live integration, packaging, smoke) and only then tags and
+  publishes the GitHub release (.zip + .dmg). Never push release tags by
+  hand; the pipeline owns them.
 - `scripts/package_app.sh` intentionally patches SwiftPM-generated sources in
   `.build/` (resource-bundle lookup for packaged .apps); the patches are
   idempotent.

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,78 +1,36 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-cd "$ROOT_DIR"
+# One-command release from any machine with gh. Dispatches the Release App
+# workflow, which gates (build, unit tests, live integration, packaging,
+# launch smoke) on the self-hosted Mac runner and only then tags, builds the
+# DMG/zip, and publishes the GitHub release. A failed release leaves no tag.
+#
+# Usage:
+#   ./scripts/release.sh            # patch bump (v0.6.1 -> v0.6.2)
+#   ./scripts/release.sh minor      # v0.6.1 -> v0.7.0
+#   ./scripts/release.sh major      # v0.6.1 -> v1.0.0
+#   ./scripts/release.sh 1.2.3      # explicit version
 
-TAG="${1:-}"
-if [[ -z "$TAG" ]]; then
-  echo "Usage: ./scripts/release.sh v0.3.0"
-  exit 1
-fi
+ARG="${1:-patch}"
 
-if [[ ! "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+([.-][0-9A-Za-z.-]+)?$ ]]; then
-  echo "Invalid tag: $TAG"
-  echo "Expected semantic tag like v0.3.0"
-  exit 1
-fi
+case "$ARG" in
+  patch|minor|major)
+    FIELD="bump"; VALUE="$ARG" ;;
+  *)
+    if [[ "$ARG" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+      FIELD="version"; VALUE="$ARG"
+    else
+      echo "Usage: $0 [patch|minor|major|X.Y.Z]" >&2
+      exit 1
+    fi
+    ;;
+esac
 
-if [[ -n "$(git status --porcelain)" ]]; then
-  echo "Working tree is not clean. Commit or stash changes first."
-  exit 1
-fi
-
-CURRENT_BRANCH="$(git branch --show-current)"
-if [[ "$CURRENT_BRANCH" != "main" ]]; then
-  echo "Release must run from main. Current branch: $CURRENT_BRANCH"
-  exit 1
-fi
-
-if ! git remote get-url origin >/dev/null 2>&1; then
-  echo "Missing origin remote."
-  exit 1
-fi
-
-if git rev-parse -q --verify "refs/tags/$TAG" >/dev/null; then
-  echo "Tag already exists locally: $TAG"
-  exit 1
-fi
-
-if git ls-remote --tags origin "refs/tags/$TAG" | grep -q .; then
-  echo "Tag already exists on origin: $TAG"
-  exit 1
-fi
-
-VERSION="${TAG#v}"
-ARCHIVE_PATH="dist/localvoxtral-${TAG}.zip"
-DMG_PATH="dist/localvoxtral-${TAG}.dmg"
-
-echo "Running build and tests..."
-swift build -c release
-swift test
-
-echo "Packaging app..."
-./scripts/package_app.sh release "$VERSION" 1
-
-echo "Creating archive $ARCHIVE_PATH..."
-mkdir -p dist
-rm -f "$ARCHIVE_PATH"
-ditto -c -k --sequesterRsrc --keepParent "dist/localvoxtral.app" "$ARCHIVE_PATH"
-
-echo "Creating disk image $DMG_PATH..."
-rm -f "$DMG_PATH"
-DMG_STAGING_DIR="$(mktemp -d "${TMPDIR:-/tmp}/localvoxtral-dmg.XXXXXX")"
-trap 'rm -rf "$DMG_STAGING_DIR"' EXIT
-cp -R "dist/localvoxtral.app" "$DMG_STAGING_DIR/localvoxtral.app"
-ln -s /Applications "$DMG_STAGING_DIR/Applications"
-hdiutil create -volname "localvoxtral" -srcfolder "$DMG_STAGING_DIR" -ov -format UDZO "$DMG_PATH"
-
-echo "Pushing main..."
-git push origin main
-
-echo "Tagging and pushing $TAG..."
-git tag -a "$TAG" -m "Release $TAG"
-git push origin "$TAG"
-
-echo "Published $TAG"
-echo "GitHub Actions will build and publish the release artifact from this tag."
-echo "Release page: https://github.com/T0mSIlver/localvoxtral/releases/tag/$TAG"
+echo "Dispatching release ($FIELD=$VALUE)..."
+gh workflow run "Release App" -f "$FIELD=$VALUE"
+sleep 5
+RUN_ID="$(gh run list --workflow "Release App" --limit 1 --json databaseId --jq '.[0].databaseId')"
+echo "Watching run $RUN_ID (Ctrl+C detaches; the release continues remotely)"
+gh run watch "$RUN_ID" --exit-status
+echo "Done. Release page: https://github.com/T0mSIlver/localvoxtral/releases/latest"


### PR DESCRIPTION
## What

- **`release.yml` rebuilt**: `workflow_dispatch` with `bump` (patch/minor/major) or explicit `version`. Runs on the self-hosted runner: version computation → release build → unit tests → **live voxmlx integration** → packaging → launch smoke → zip+dmg → **tag created only after all gates pass** → GitHub release with auto-generated notes. No more orphan tags from red release builds; ad-hoc signing kept deliberately for distribution parity.
- **`scripts/release.sh`**: thin dispatcher — `./scripts/release.sh minor` from any machine with gh, watches the run. No local Mac build required anymore.
- Docs: workflows README + AGENTS.md shipping section.

## Proof

- YAML validated; `bash -n` clean on the dispatcher.
- The workflow itself is dispatch-only and can only be truly exercised by cutting a release — the first real dispatch (proposed: v0.6.2 from current main) is the end-to-end proof.