### PR TITLE
fix: dictation shortcut dead while escape-cancel armed

### DIFF
--- a/Sources/localvoxtral/EscapeCancelHandler.swift
+++ b/Sources/localvoxtral/EscapeCancelHandler.swift
@@ -144,7 +144,12 @@ final class EscapeCancelHandler {
         let installStatus = InstallEventHandler(
             GetApplicationEventTarget(),
             { _, eventRef, _ in
-                guard let eventRef else { return noErr }
+                // Returning noErr marks a Carbon event as HANDLED and stops
+                // propagation — HotKeyManager's handler shares this event
+                // target, so any hotkey that is not ours must be passed on
+                // with eventNotHandledErr or the dictation shortcut goes dead
+                // while Escape-cancel is armed.
+                guard let eventRef else { return OSStatus(eventNotHandledErr) }
 
                 var hotKeyID = EventHotKeyID()
                 let status = GetEventParameter(
@@ -161,7 +166,7 @@ final class EscapeCancelHandler {
                       hotKeyID.signature == EscapeCancelHandler.hotKeySignature,
                       hotKeyID.id == EscapeCancelHandler.hotKeyID
                 else {
-                    return noErr
+                    return OSStatus(eventNotHandledErr)
                 }
 
                 DispatchQueue.main.async {


### PR DESCRIPTION
## What

Regression from #30, found by the maintainer on-device: while dictating, the dictation shortcut no longer stopped the session — only Escape worked. The escape Carbon handler returned `noErr` for hotkey events that were not its own; Carbon treats that as "handled" and stops propagation, and since `HotKeyManager` shares `GetApplicationEventTarget()` (with the escape handler installed later, so called first), the dictation hotkey's events were swallowed for the whole session. Non-matching events now return `eventNotHandledErr` so they propagate.

## Proof

- Unit suite: `Executed 263 tests, with 0 failures` (the Carbon event chain itself isn't reachable headless — the decisive check is on-device: start dictation via shortcut, press the shortcut again → session stops; Escape still cancels).