### PR TITLE
Remove the commit interval setting; fix commit cadence at 0.9s

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,6 @@ The **Output mode** setting applies to dictation started from the menu bar. Keyb
 - Open **Settings** from the menu bar popover to set:
   - Dictation trigger: single modifier key (tap/hold) or per-mode keyboard shortcuts (`Toggle` / `Push to Talk`)
   - Realtime endpoint (URL, model name, API key)
-  - Commit interval (`vLLM`/`voxmlx`)
   - Auto-copy final segment
   - Output mode (`Overlay Buffer` / `Live Auto-Paste`)
   - Replacement dictionary (overlay buffer output mode only)

--- a/Sources/localvoxtral/DictationViewModel+Session.swift
+++ b/Sources/localvoxtral/DictationViewModel+Session.swift
@@ -224,7 +224,7 @@ extension DictationViewModel {
         commitTask?.cancel()
         commitTask = nil
 
-        let interval = min(1.0, max(0.1, settings.commitIntervalSeconds))
+        let interval = TimingConstants.commitInterval
         let client = realtimeAPIClient
         guard client.supportsPeriodicCommit else { return }
         commitTask = Task(priority: .utility) {

--- a/Sources/localvoxtral/SettingsStore.swift
+++ b/Sources/localvoxtral/SettingsStore.swift
@@ -125,7 +125,6 @@ final class SettingsStore {
         static let realtimeAPIEndpointURL = "settings.realtime_api_endpoint_url"
         static let apiKey = "settings.api_key"
         static let realtimeAPIModelName = "settings.realtime_api_model_name"
-        static let commitIntervalSeconds = "settings.commit_interval_seconds"
         static let dictationOutputMode = "settings.dictation_output_mode"
         static let dictationShortcutMode = "settings.dictation_shortcut_mode"
         static let autoCopyEnabled = "settings.auto_copy_enabled"
@@ -179,10 +178,6 @@ final class SettingsStore {
 
     var realtimeAPIModelName: String {
         didSet { defaults.set(realtimeAPIModelName, forKey: Keys.realtimeAPIModelName) }
-    }
-
-    var commitIntervalSeconds: Double {
-        didSet { defaults.set(commitIntervalSeconds, forKey: Keys.commitIntervalSeconds) }
     }
 
     var autoCopyEnabled: Bool {
@@ -318,6 +313,10 @@ final class SettingsStore {
         // produce an invalid state.
         realtimeProvider = RealtimeProvider(rawValue: configuredProvider) ?? .realtimeAPI
 
+        // The commit interval setting was removed. Clean up stale persisted
+        // values so future defaults migrations do not preserve dead state.
+        defaults.removeObject(forKey: "settings.commit_interval_seconds")
+
         realtimeAPIEndpointURL = Self.loadString(
             defaults: defaults, key: Keys.realtimeAPIEndpointURL,
             envKey: "REALTIME_ENDPOINT", fallback: RealtimeProvider.realtimeAPI.defaultEndpoint,
@@ -335,12 +334,6 @@ final class SettingsStore {
             envKey: "REALTIME_MODEL", provider: .realtimeAPI,
             environment: environment
         )
-
-        let storedInterval = defaults.double(forKey: Keys.commitIntervalSeconds)
-        commitIntervalSeconds =
-            storedInterval > 0
-            ? min(max(storedInterval, 0.1), 1.0)
-            : 0.9
 
         autoCopyEnabled = Self.loadBool(
             defaults: defaults, key: Keys.autoCopyEnabled, fallback: false)

--- a/Sources/localvoxtral/SettingsView.swift
+++ b/Sources/localvoxtral/SettingsView.swift
@@ -125,28 +125,6 @@ private struct ConnectionSettingsPane: View {
                         .textFieldStyle(.roundedBorder)
                 }
             }
-
-            SettingsGroup(title: "Streaming") {
-                SettingsFieldRow(title: "Commit interval") {
-                    VStack(alignment: .leading, spacing: 6) {
-                        HStack(alignment: .firstTextBaseline, spacing: 12) {
-                            Slider(
-                                value: $settings.commitIntervalSeconds,
-                                in: 0.1...1.0,
-                                step: 0.1
-                            )
-                            Text(String(format: "%.2fs", settings.commitIntervalSeconds))
-                                .font(.callout.monospacedDigit())
-                                .foregroundStyle(.secondary)
-                                .frame(width: 48, alignment: .trailing)
-                        }
-
-                        SettingsHelpText(
-                            "How often finalized transcript chunks are requested from the realtime server."
-                        )
-                    }
-                }
-            }
         }
     }
 }

--- a/Sources/localvoxtral/TimingConstants.swift
+++ b/Sources/localvoxtral/TimingConstants.swift
@@ -10,6 +10,9 @@ enum TimingConstants {
     /// Interval at which buffered PCM chunks are drained and sent to the WebSocket.
     static let audioSendInterval: TimeInterval = 0.1
 
+    /// Fixed cadence for periodic realtime commits (was a user setting, removed).
+    static let commitInterval: TimeInterval = 0.9
+
     // MARK: - Connection
 
     /// How long to wait for a WebSocket to reach `.connected` before timing out.

--- a/Tests/localvoxtralTests/SettingsStoreTests.swift
+++ b/Tests/localvoxtralTests/SettingsStoreTests.swift
@@ -106,6 +106,14 @@ final class SettingsStoreTests: XCTestCase {
         XCTAssertEqual(store.realtimeProvider, .realtimeAPI)
     }
 
+    func testRemovedCommitIntervalSettingIsCleanedUp() {
+        defaults.set(0.5, forKey: "settings.commit_interval_seconds")
+
+        _ = makeStore()
+
+        XCTAssertNil(defaults.object(forKey: "settings.commit_interval_seconds"))
+    }
+
     // MARK: - effectiveModelName
 
     func testEffectiveModel_plainName() {


### PR DESCRIPTION
## What

Removes the user-facing **Commit interval** slider. The periodic realtime commit cadence becomes a fixed internal constant, `TimingConstants.commitInterval = 0.9` — the previous default, so behavior is unchanged for anyone who never touched the slider.

- `SettingsStore` drops `commitIntervalSeconds` (property, key, init clamp) and deletes the stale persisted `settings.commit_interval_seconds` key on init.
- The "Streaming" group is removed from the Connection settings pane.
- `DictationViewModel.restartCommitTask()` reads the constant.

This is standalone prep for the managed-backend work: the Connection pane is about to be reworked into a Managed local / External URL mode split, and a per-user streaming cadence knob doesn't earn its place there.

## Proof

- [x] Unit suite green — `LV_BUILD_DIR=work/localvoxtral-codex-commitint ./scripts/remote-build.sh test`
  ```
  Test Suite 'localvoxtralPackageTests.xctest' passed at 2026-07-04 00:55:11.592.
       Executed 315 tests, with 0 failures (0 unexpected) in 1.682 (1.700) seconds
  ```
- [x] Realtime integration green — `LV_BUILD_DIR=work/localvoxtral-codex-commitint ./scripts/remote-build.sh integration`
  ```
  Test Suite 'Selected tests' passed at 2026-07-04 00:56:12.003.
       Executed 7 tests, with 2 tests skipped and 0 failures (0 unexpected) in 16.556 (16.559) seconds
  ```
  (The 2 skips are the env-gated mic-capture tests, off by design in this tier.)
- [x] Settings-migration behavior is regression-tested: `testRemovedCommitIntervalSettingIsCleanedUp` seeds the legacy `settings.commit_interval_seconds` key and asserts `SettingsStore.init` removes it.
- [x] UI change: the change is pure removal of the Streaming group; **not hand-verified on a Mac in this PR** — the Connection pane gets reworked and hand-verified together in the upcoming backend-mode PR.
