### PR TITLE
Embed uv in the app bundle and add the pinned backend installer

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -96,6 +96,8 @@ Key subsystems:
 - Insertion: `TextInsertionService` (AX replace → Unicode CGEvents → Cmd+V)
 - Overlay: `OverlayBufferSessionCoordinator` (session + hold-before-dismiss
   timing), `OverlayBufferStateMachine`, `DictationOverlayController` (NSPanel)
+- Backends: catalog pinned to fork wheel releases; installer shells out to the
+  embedded `uv`; install root lives under Application Support.
 - Settings/config: `SettingsStore` (UserDefaults), `AppConfigStore` (TOML at
   `~/Library/Application Support/localvoxtral/config`)
 - Hotkey: `HotKeyManager` (Carbon, single global hotkey)

--- a/Sources/localvoxtral/Backends/BackendCatalog.swift
+++ b/Sources/localvoxtral/Backends/BackendCatalog.swift
@@ -1,0 +1,41 @@
+import Foundation
+
+struct ManagedBackendSpec: Equatable, Sendable {
+    let id: String
+    let displayName: String
+    let version: String
+    let requirementName: String
+    let wheelURL: URL
+    let wheelSHA256: String
+    let executableName: String
+    let pythonVersion: String
+    let port: Int
+}
+
+enum BackendCatalog {
+    static let voxmlx = ManagedBackendSpec(
+        id: "voxmlx",
+        displayName: "voxmlx",
+        version: "0.1.0",
+        requirementName: "voxmlx[server]",
+        wheelURL: URL(string: "https://github.com/T0mSIlver/voxmlx/releases/download/v0.1.0/voxmlx-0.1.0-py3-none-any.whl")!,
+        wheelSHA256: "028b39a51e6f5e4126b009fe0a316e68fe9215d500de970ea125a0ba550d8c83",
+        executableName: "voxmlx-serve",
+        pythonVersion: "3.12",
+        port: 8471
+    )
+
+    static let mlxLM = ManagedBackendSpec(
+        id: "mlx-lm",
+        displayName: "mlx-lm",
+        version: "0.31.3.post1",
+        requirementName: "mlx-lm",
+        wheelURL: URL(string: "https://github.com/T0mSIlver/mlx-lm/releases/download/v0.31.3.post1/mlx_lm-0.31.3.post1-py3-none-any.whl")!,
+        wheelSHA256: "05bcc1a66f5f3b1127e9eae9ed54f9ad046b12af97c0829632ecde70c6f3a87b",
+        executableName: "mlx_lm.server",
+        pythonVersion: "3.12",
+        port: 8472
+    )
+
+    static let all: [ManagedBackendSpec] = [voxmlx, mlxLM]
+}

--- a/Sources/localvoxtral/Backends/BackendInstallLayout.swift
+++ b/Sources/localvoxtral/Backends/BackendInstallLayout.swift
@@ -1,0 +1,48 @@
+import Foundation
+
+struct BackendInstallLayout: Equatable, Sendable {
+    let root: URL
+
+    init(root: URL? = nil) {
+        if let root {
+            self.root = root
+        } else {
+            let applicationSupport = FileManager.default.urls(
+                for: .applicationSupportDirectory,
+                in: .userDomainMask
+            ).first!
+            self.root = applicationSupport
+                .appendingPathComponent("localvoxtral", isDirectory: true)
+                .appendingPathComponent("backends", isDirectory: true)
+        }
+    }
+
+    var uvCache: URL {
+        root.appendingPathComponent("uv-cache", isDirectory: true)
+    }
+
+    var pythonInstalls: URL {
+        root.appendingPathComponent("python", isDirectory: true)
+    }
+
+    var tools: URL {
+        root.appendingPathComponent("tools", isDirectory: true)
+    }
+
+    var toolBin: URL {
+        root.appendingPathComponent("bin", isDirectory: true)
+    }
+
+    var downloads: URL {
+        root.appendingPathComponent("downloads", isDirectory: true)
+    }
+
+    var environment: [String: String] {
+        [
+            "UV_CACHE_DIR": uvCache.path,
+            "UV_PYTHON_INSTALL_DIR": pythonInstalls.path,
+            "UV_TOOL_DIR": tools.path,
+            "UV_TOOL_BIN_DIR": toolBin.path,
+        ]
+    }
+}

--- a/Sources/localvoxtral/Backends/BackendInstaller.swift
+++ b/Sources/localvoxtral/Backends/BackendInstaller.swift
@@ -1,0 +1,379 @@
+import CryptoKit
+import Foundation
+
+enum BackendInstallProgress: Equatable, Sendable {
+    case downloading(fraction: Double?)
+    case verifying
+    case installing(logLine: String)
+    case finished
+}
+
+enum BackendInstallError: LocalizedError, Sendable {
+    case uvNotFound
+    case downloadFailed(String)
+    case checksumMismatch(expected: String, actual: String)
+    case uvExited(code: Int32, stderrTail: String)
+    case executableMissing(URL)
+
+    var errorDescription: String? {
+        switch self {
+        case .uvNotFound:
+            return "Unable to find uv. Expected an embedded uv binary or Homebrew uv at /opt/homebrew/bin/uv or /usr/local/bin/uv."
+        case .downloadFailed(let message):
+            return "Backend wheel download failed: \(message)"
+        case .checksumMismatch(let expected, let actual):
+            return "Backend wheel checksum mismatch. Expected \(expected), got \(actual)."
+        case .uvExited(let code, let stderrTail):
+            return "uv exited with status \(code): \(stderrTail)"
+        case .executableMissing(let url):
+            return "Backend executable was not created by uv: \(url.path)"
+        }
+    }
+}
+
+struct BackendInstaller {
+    private let layout: BackendInstallLayout
+    private let uvLocator: any UVBinaryLocating
+    private let fileManager: FileManager
+
+    init(
+        layout: BackendInstallLayout = BackendInstallLayout(),
+        uvLocator: any UVBinaryLocating = UVBinaryLocator(),
+        fileManager: FileManager = .default
+    ) {
+        self.layout = layout
+        self.uvLocator = uvLocator
+        self.fileManager = fileManager
+    }
+
+    func installedVersion(of spec: ManagedBackendSpec) -> String? {
+        guard let marker = try? readInstalledMarker() else {
+            return nil
+        }
+        return marker[spec.id]
+    }
+
+    func needsInstallOrUpdate(_ spec: ManagedBackendSpec) -> Bool {
+        installedVersion(of: spec) != spec.version
+    }
+
+    func install(
+        _ spec: ManagedBackendSpec,
+        progress: @MainActor @Sendable @escaping (BackendInstallProgress) -> Void
+    ) async throws {
+        guard let uvURL = uvLocator.uvBinaryURL() else {
+            throw BackendInstallError.uvNotFound
+        }
+
+        try createLayoutDirectories()
+        let wheelURL = try await downloadWheel(for: spec, progress: progress)
+
+        await Self.report(.verifying, progress)
+        let actualSHA256 = try sha256Hex(for: wheelURL)
+        guard actualSHA256 == spec.wheelSHA256 else {
+            try? fileManager.removeItem(at: wheelURL)
+            throw BackendInstallError.checksumMismatch(
+                expected: spec.wheelSHA256,
+                actual: actualSHA256
+            )
+        }
+
+        let requirement = "\(spec.requirementName) @ \(wheelURL.absoluteString)"
+        let result = try await UVToolProcess.run(
+            uvURL: uvURL,
+            arguments: ["tool", "install", "--python", spec.pythonVersion, "--reinstall", requirement],
+            environment: processEnvironment(),
+            progress: progress
+        )
+        if result.exitCode != 0 {
+            throw BackendInstallError.uvExited(
+                code: result.exitCode,
+                stderrTail: result.stderrTail
+            )
+        }
+
+        let executableURL = layout.toolBin.appendingPathComponent(spec.executableName)
+        guard fileManager.isExecutableFile(atPath: executableURL.path) else {
+            throw BackendInstallError.executableMissing(executableURL)
+        }
+
+        try writeInstalledVersion(spec.version, for: spec.id)
+        await Self.report(.finished, progress)
+    }
+
+    private var installedMarkerURL: URL {
+        layout.root.appendingPathComponent("installed.json")
+    }
+
+    private func createLayoutDirectories() throws {
+        for directory in [layout.root, layout.uvCache, layout.pythonInstalls, layout.tools, layout.toolBin, layout.downloads] {
+            try fileManager.createDirectory(at: directory, withIntermediateDirectories: true)
+        }
+    }
+
+    private func readInstalledMarker() throws -> [String: String] {
+        guard fileManager.fileExists(atPath: installedMarkerURL.path) else {
+            return [:]
+        }
+        let data = try Data(contentsOf: installedMarkerURL)
+        return (try JSONSerialization.jsonObject(with: data) as? [String: String]) ?? [:]
+    }
+
+    private func writeInstalledVersion(_ version: String, for backendID: String) throws {
+        try fileManager.createDirectory(at: layout.root, withIntermediateDirectories: true)
+        var marker = try readInstalledMarker()
+        marker[backendID] = version
+        let data = try JSONSerialization.data(withJSONObject: marker, options: [.prettyPrinted, .sortedKeys])
+        try data.write(to: installedMarkerURL, options: .atomic)
+    }
+
+    private func processEnvironment() -> [String: String] {
+        let inherited = ProcessInfo.processInfo.environment
+        var environment: [String: String] = [:]
+        for key in ["PATH", "HOME"] {
+            if let value = inherited[key] {
+                environment[key] = value
+            }
+        }
+        environment.merge(layout.environment) { _, new in new }
+        return environment
+    }
+
+    private func downloadWheel(
+        for spec: ManagedBackendSpec,
+        progress: @MainActor @Sendable @escaping (BackendInstallProgress) -> Void
+    ) async throws -> URL {
+        await Self.report(.downloading(fraction: nil), progress)
+        let destination = layout.downloads.appendingPathComponent(spec.wheelURL.lastPathComponent)
+
+        if spec.wheelURL.isFileURL {
+            do {
+                if fileManager.fileExists(atPath: destination.path) {
+                    try fileManager.removeItem(at: destination)
+                }
+                try fileManager.copyItem(at: spec.wheelURL, to: destination)
+                await Self.report(.downloading(fraction: 1), progress)
+                return destination
+            } catch {
+                throw BackendInstallError.downloadFailed(error.localizedDescription)
+            }
+        }
+
+        do {
+            let (bytes, response) = try await URLSession.shared.bytes(from: spec.wheelURL)
+            let expectedLength = response.expectedContentLength
+            var data = Data()
+            var downloadedByteCount: Int64 = 0
+            var lastReportedBucket: Int64 = -1
+
+            for try await byte in bytes {
+                data.append(byte)
+                downloadedByteCount += 1
+                if expectedLength > 0 {
+                    let bucket = downloadedByteCount / 262_144
+                    if bucket != lastReportedBucket || downloadedByteCount == expectedLength {
+                        lastReportedBucket = bucket
+                        await Self.report(
+                            .downloading(
+                                fraction: min(1, Double(downloadedByteCount) / Double(expectedLength))
+                            ),
+                            progress
+                        )
+                    }
+                }
+            }
+            try data.write(to: destination, options: .atomic)
+            if expectedLength > 0 {
+                await Self.report(.downloading(fraction: 1), progress)
+            }
+            return destination
+        } catch let error as BackendInstallError {
+            throw error
+        } catch {
+            throw BackendInstallError.downloadFailed(error.localizedDescription)
+        }
+    }
+
+    private func sha256Hex(for url: URL) throws -> String {
+        let data = try Data(contentsOf: url)
+        let digest = SHA256.hash(data: data)
+        return digest.map { String(format: "%02x", $0) }.joined()
+    }
+
+    @MainActor
+    private static func report(
+        _ event: BackendInstallProgress,
+        _ progress: @MainActor @Sendable (BackendInstallProgress) -> Void
+    ) {
+        progress(event)
+    }
+}
+
+private struct UVToolProcessResult: Sendable {
+    let exitCode: Int32
+    let stderrTail: String
+}
+
+private final class UVToolProcess {
+    static func run(
+        uvURL: URL,
+        arguments: [String],
+        environment: [String: String],
+        progress: @MainActor @Sendable @escaping (BackendInstallProgress) -> Void
+    ) async throws -> UVToolProcessResult {
+        try await Task.detached {
+            try runSynchronously(
+                uvURL: uvURL,
+                arguments: arguments,
+                environment: environment,
+                progress: progress
+            )
+        }.value
+    }
+
+    private static func runSynchronously(
+        uvURL: URL,
+        arguments: [String],
+        environment: [String: String],
+        progress: @MainActor @Sendable @escaping (BackendInstallProgress) -> Void
+    ) throws -> UVToolProcessResult {
+        let process = Process()
+        process.executableURL = uvURL
+        process.arguments = arguments
+        process.environment = environment
+
+        let stdout = Pipe()
+        let stderr = Pipe()
+        process.standardOutput = stdout
+        process.standardError = stderr
+
+        let lineCollector = ProcessLineCollector(progress: progress)
+        let stdoutReader = PipeLineReader(fileHandle: stdout.fileHandleForReading) { line in
+            lineCollector.recordStdout(line)
+        }
+        let stderrReader = PipeLineReader(fileHandle: stderr.fileHandleForReading) { line in
+            lineCollector.recordStderr(line)
+        }
+
+        try process.run()
+        stdoutReader.start()
+        stderrReader.start()
+        process.waitUntilExit()
+        stdout.fileHandleForReading.closeFile()
+        stderr.fileHandleForReading.closeFile()
+        stdoutReader.waitUntilFinished()
+        stderrReader.waitUntilFinished()
+
+        return UVToolProcessResult(
+            exitCode: process.terminationStatus,
+            stderrTail: lineCollector.stderrTail()
+        )
+    }
+}
+
+private final class ProcessLineCollector: @unchecked Sendable {
+    private let lock = NSLock()
+    private let progress: @MainActor @Sendable (BackendInstallProgress) -> Void
+    private var stderrLines: [String] = []
+
+    init(progress: @MainActor @Sendable @escaping (BackendInstallProgress) -> Void) {
+        self.progress = progress
+    }
+
+    func recordStdout(_ line: String) {
+        emit(line)
+    }
+
+    func recordStderr(_ line: String) {
+        lock.lock()
+        stderrLines.append(line)
+        if stderrLines.count > 20 {
+            stderrLines.removeFirst(stderrLines.count - 20)
+        }
+        lock.unlock()
+        emit(line)
+    }
+
+    func stderrTail() -> String {
+        lock.lock()
+        defer { lock.unlock() }
+        return stderrLines.joined(separator: "\n")
+    }
+
+    private func emit(_ line: String) {
+        let semaphore = DispatchSemaphore(value: 0)
+        Task { @MainActor [progress] in
+            progress(.installing(logLine: line))
+            semaphore.signal()
+        }
+        semaphore.wait()
+    }
+}
+
+private final class PipeLineReader: @unchecked Sendable {
+    private let fileHandle: FileHandle
+    private let onLine: @Sendable (String) -> Void
+    private let state = PipeLineReaderState()
+    private var thread: Thread?
+
+    init(fileHandle: FileHandle, onLine: @Sendable @escaping (String) -> Void) {
+        self.fileHandle = fileHandle
+        self.onLine = onLine
+    }
+
+    func start() {
+        let fileHandle = fileHandle
+        let onLine = onLine
+        let state = state
+        let thread = Thread {
+            var buffer = Data()
+            while true {
+                let chunk = fileHandle.availableData
+                if chunk.isEmpty {
+                    break
+                }
+                buffer.append(chunk)
+                while let newlineIndex = buffer.firstIndex(of: 0x0A) {
+                    let lineData = buffer[..<newlineIndex]
+                    buffer.removeSubrange(...newlineIndex)
+                    if let line = String(data: lineData, encoding: .utf8), !line.isEmpty {
+                        onLine(line)
+                    }
+                }
+            }
+            if !buffer.isEmpty,
+               let line = String(data: buffer, encoding: .utf8),
+               !line.isEmpty
+            {
+                onLine(line)
+            }
+            state.markFinished()
+        }
+        self.thread = thread
+        thread.start()
+    }
+
+    func waitUntilFinished() {
+        state.waitUntilFinished()
+    }
+}
+
+private final class PipeLineReaderState: @unchecked Sendable {
+    private let condition = NSCondition()
+    private var isFinished = false
+
+    func markFinished() {
+        condition.lock()
+        isFinished = true
+        condition.signal()
+        condition.unlock()
+    }
+
+    func waitUntilFinished() {
+        condition.lock()
+        while !isFinished {
+            condition.wait()
+        }
+        condition.unlock()
+    }
+}

--- a/Sources/localvoxtral/Backends/UVBinaryLocator.swift
+++ b/Sources/localvoxtral/Backends/UVBinaryLocator.swift
@@ -1,0 +1,22 @@
+import Foundation
+
+protocol UVBinaryLocating: Sendable {
+    func uvBinaryURL() -> URL?
+}
+
+struct UVBinaryLocator: UVBinaryLocating {
+    func uvBinaryURL() -> URL? {
+        let fileManager = FileManager.default
+        let candidates = [
+            Bundle.main.executableURL?
+                .deletingLastPathComponent()
+                .appendingPathComponent("uv"),
+            URL(fileURLWithPath: "/opt/homebrew/bin/uv"),
+            URL(fileURLWithPath: "/usr/local/bin/uv"),
+        ].compactMap { $0 }
+
+        return candidates.first { url in
+            fileManager.isExecutableFile(atPath: url.path)
+        }
+    }
+}

--- a/Tests/localvoxtralTests/BackendInstallerTests.swift
+++ b/Tests/localvoxtralTests/BackendInstallerTests.swift
@@ -1,0 +1,319 @@
+import CryptoKit
+import Foundation
+import XCTest
+@testable import localvoxtral
+
+final class BackendInstallerTests: XCTestCase {
+    private var temporaryDirectories: [URL] = []
+
+    override func tearDown() {
+        for directory in temporaryDirectories {
+            try? FileManager.default.removeItem(at: directory)
+        }
+        temporaryDirectories.removeAll()
+        super.tearDown()
+    }
+
+    func testLayoutComputesExpectedDirectoriesAndEnvironment() throws {
+        let root = makeTemporaryDirectory()
+        let layout = BackendInstallLayout(root: root)
+
+        XCTAssertEqual(layout.uvCache, root.appendingPathComponent("uv-cache", isDirectory: true))
+        XCTAssertEqual(layout.pythonInstalls, root.appendingPathComponent("python", isDirectory: true))
+        XCTAssertEqual(layout.tools, root.appendingPathComponent("tools", isDirectory: true))
+        XCTAssertEqual(layout.toolBin, root.appendingPathComponent("bin", isDirectory: true))
+        XCTAssertEqual(layout.downloads, root.appendingPathComponent("downloads", isDirectory: true))
+        XCTAssertEqual(layout.environment["UV_CACHE_DIR"], layout.uvCache.path)
+        XCTAssertEqual(layout.environment["UV_PYTHON_INSTALL_DIR"], layout.pythonInstalls.path)
+        XCTAssertEqual(layout.environment["UV_TOOL_DIR"], layout.tools.path)
+        XCTAssertEqual(layout.environment["UV_TOOL_BIN_DIR"], layout.toolBin.path)
+    }
+
+    @MainActor
+    func testInstallHappyPathInvokesUVWithExpectedArgumentsEnvironmentAndWritesMarker() async throws {
+        let root = makeTemporaryDirectory()
+        let layout = BackendInstallLayout(root: root)
+        let wheel = try writeWheel(named: "voxmlx fixture.whl", contents: "wheel-data")
+        let spec = makeSpec(
+            wheelURL: wheel,
+            wheelSHA256: try sha256Hex(for: wheel),
+            executableName: "voxmlx-serve"
+        )
+        let capture = root.appendingPathComponent("uv-capture.txt")
+        let fakeUV = try writeFakeUV(
+            in: root,
+            capture: capture,
+            executableNameToCreate: spec.executableName,
+            exitCode: 0,
+            stderrLines: ["uv stderr line"],
+            stdoutLines: ["uv stdout line"]
+        )
+        let installer = BackendInstaller(
+            layout: layout,
+            uvLocator: FakeUVLocator(url: fakeUV)
+        )
+
+        var progressEvents: [BackendInstallProgress] = []
+        try await installer.install(spec) { event in
+            progressEvents.append(event)
+        }
+
+        let captureText = try String(contentsOf: capture, encoding: .utf8)
+        XCTAssertTrue(captureText.contains("ARGS:tool|install|--python|3.12|--reinstall|"))
+        XCTAssertTrue(captureText.contains("voxmlx[server] @ file://"))
+        XCTAssertTrue(captureText.contains("/downloads/voxmlx%20fixture.whl"))
+        XCTAssertTrue(captureText.contains("UV_CACHE_DIR=\(layout.uvCache.path)"))
+        XCTAssertTrue(captureText.contains("UV_PYTHON_INSTALL_DIR=\(layout.pythonInstalls.path)"))
+        XCTAssertTrue(captureText.contains("UV_TOOL_DIR=\(layout.tools.path)"))
+        XCTAssertTrue(captureText.contains("UV_TOOL_BIN_DIR=\(layout.toolBin.path)"))
+        XCTAssertTrue(FileManager.default.isExecutableFile(atPath: layout.toolBin.appendingPathComponent(spec.executableName).path))
+        XCTAssertEqual(installer.installedVersion(of: spec), spec.version)
+        XCTAssertFalse(installer.needsInstallOrUpdate(spec))
+        XCTAssertTrue(progressEvents.contains(.downloading(fraction: nil)))
+        XCTAssertTrue(progressEvents.contains(.downloading(fraction: 1)))
+        XCTAssertTrue(progressEvents.contains(.verifying))
+        XCTAssertTrue(progressEvents.contains(.installing(logLine: "uv stdout line")))
+        XCTAssertTrue(progressEvents.contains(.installing(logLine: "uv stderr line")))
+        XCTAssertEqual(progressEvents.last, .finished)
+    }
+
+    func testChecksumMismatchDeletesWheelAndDoesNotInvokeUV() async throws {
+        let root = makeTemporaryDirectory()
+        let layout = BackendInstallLayout(root: root)
+        let wheel = try writeWheel(named: "bad.whl", contents: "bad-wheel")
+        let spec = makeSpec(
+            wheelURL: wheel,
+            wheelSHA256: String(repeating: "0", count: 64),
+            executableName: "voxmlx-serve"
+        )
+        let capture = root.appendingPathComponent("uv-capture.txt")
+        let fakeUV = try writeFakeUV(
+            in: root,
+            capture: capture,
+            executableNameToCreate: spec.executableName,
+            exitCode: 0
+        )
+        let installer = BackendInstaller(
+            layout: layout,
+            uvLocator: FakeUVLocator(url: fakeUV)
+        )
+
+        do {
+            try await installer.install(spec) { _ in }
+            XCTFail("Expected checksum mismatch")
+        } catch BackendInstallError.checksumMismatch(let expected, let actual) {
+            XCTAssertEqual(expected, spec.wheelSHA256)
+            XCTAssertEqual(actual, try sha256Hex(for: wheel))
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+
+        XCTAssertFalse(FileManager.default.fileExists(atPath: capture.path))
+        XCTAssertFalse(FileManager.default.fileExists(atPath: layout.downloads.appendingPathComponent(wheel.lastPathComponent).path))
+        XCTAssertNil(installer.installedVersion(of: spec))
+    }
+
+    func testUVFailureCarriesStderrTailAndDoesNotWriteMarker() async throws {
+        let root = makeTemporaryDirectory()
+        let layout = BackendInstallLayout(root: root)
+        let wheel = try writeWheel(named: "voxmlx.whl", contents: "wheel-data")
+        let spec = makeSpec(
+            wheelURL: wheel,
+            wheelSHA256: try sha256Hex(for: wheel),
+            executableName: "voxmlx-serve"
+        )
+        let fakeUV = try writeFakeUV(
+            in: root,
+            capture: root.appendingPathComponent("uv-capture.txt"),
+            executableNameToCreate: spec.executableName,
+            exitCode: 7,
+            stderrLines: (1...25).map { "stderr-\($0)" }
+        )
+        let installer = BackendInstaller(
+            layout: layout,
+            uvLocator: FakeUVLocator(url: fakeUV)
+        )
+
+        do {
+            try await installer.install(spec) { _ in }
+            XCTFail("Expected uv failure")
+        } catch BackendInstallError.uvExited(let code, let stderrTail) {
+            XCTAssertEqual(code, 7)
+            let tailLines = stderrTail.split(separator: "\n").map(String.init)
+            XCTAssertFalse(tailLines.contains("stderr-1"))
+            XCTAssertTrue(tailLines.contains("stderr-6"))
+            XCTAssertTrue(tailLines.contains("stderr-25"))
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+
+        XCTAssertNil(installer.installedVersion(of: spec))
+    }
+
+    func testExecutableMissingAfterSuccessfulUVRunThrowsAndDoesNotWriteMarker() async throws {
+        let root = makeTemporaryDirectory()
+        let layout = BackendInstallLayout(root: root)
+        let wheel = try writeWheel(named: "voxmlx.whl", contents: "wheel-data")
+        let spec = makeSpec(
+            wheelURL: wheel,
+            wheelSHA256: try sha256Hex(for: wheel),
+            executableName: "voxmlx-serve"
+        )
+        let fakeUV = try writeFakeUV(
+            in: root,
+            capture: root.appendingPathComponent("uv-capture.txt"),
+            executableNameToCreate: nil,
+            exitCode: 0
+        )
+        let installer = BackendInstaller(
+            layout: layout,
+            uvLocator: FakeUVLocator(url: fakeUV)
+        )
+
+        do {
+            try await installer.install(spec) { _ in }
+            XCTFail("Expected missing executable")
+        } catch BackendInstallError.executableMissing(let url) {
+            XCTAssertEqual(url, layout.toolBin.appendingPathComponent(spec.executableName))
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+
+        XCTAssertNil(installer.installedVersion(of: spec))
+    }
+
+    func testInstalledVersionAndNeedsInstallOrUpdateRoundTrip() async throws {
+        let root = makeTemporaryDirectory()
+        let layout = BackendInstallLayout(root: root)
+        let wheel = try writeWheel(named: "voxmlx.whl", contents: "wheel-data")
+        let spec = makeSpec(
+            wheelURL: wheel,
+            wheelSHA256: try sha256Hex(for: wheel),
+            executableName: "voxmlx-serve"
+        )
+        let fakeUV = try writeFakeUV(
+            in: root,
+            capture: root.appendingPathComponent("uv-capture.txt"),
+            executableNameToCreate: spec.executableName,
+            exitCode: 0
+        )
+        let installer = BackendInstaller(
+            layout: layout,
+            uvLocator: FakeUVLocator(url: fakeUV)
+        )
+
+        XCTAssertNil(installer.installedVersion(of: spec))
+        XCTAssertTrue(installer.needsInstallOrUpdate(spec))
+
+        try await installer.install(spec) { _ in }
+
+        XCTAssertEqual(installer.installedVersion(of: spec), spec.version)
+        XCTAssertFalse(installer.needsInstallOrUpdate(spec))
+
+        let newerSpec = makeSpec(
+            version: "9.9.9",
+            wheelURL: wheel,
+            wheelSHA256: try sha256Hex(for: wheel),
+            executableName: "voxmlx-serve"
+        )
+        XCTAssertTrue(installer.needsInstallOrUpdate(newerSpec))
+    }
+
+    private func makeTemporaryDirectory() -> URL {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("localvoxtral-backend-tests-\(UUID().uuidString)", isDirectory: true)
+        try! FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        temporaryDirectories.append(directory)
+        return directory
+    }
+
+    private func writeWheel(named name: String, contents: String) throws -> URL {
+        let directory = makeTemporaryDirectory()
+        let url = directory.appendingPathComponent(name)
+        try contents.data(using: .utf8)!.write(to: url)
+        return url
+    }
+
+    private func writeFakeUV(
+        in directory: URL,
+        capture: URL,
+        executableNameToCreate: String?,
+        exitCode: Int,
+        stderrLines: [String] = [],
+        stdoutLines: [String] = []
+    ) throws -> URL {
+        let url = directory.appendingPathComponent("uv")
+        let createExecutableBlock: String
+        if let executableNameToCreate {
+            createExecutableBlock = """
+            mkdir -p "$UV_TOOL_BIN_DIR"
+            touch "$UV_TOOL_BIN_DIR/\(executableNameToCreate)"
+            chmod +x "$UV_TOOL_BIN_DIR/\(executableNameToCreate)"
+            """
+        } else {
+            createExecutableBlock = ":"
+        }
+        let stderrBlock = stderrLines.map { "echo '\($0)' >&2" }.joined(separator: "\n")
+        let stdoutBlock = stdoutLines.map { "echo '\($0)'" }.joined(separator: "\n")
+        let script = """
+        #!/usr/bin/env bash
+        set -euo pipefail
+        {
+          printf 'ARGS:'
+          joined=''
+          for arg in "$@"; do
+            if [[ -n "$joined" ]]; then
+              joined="${joined}|"
+            fi
+            joined="${joined}${arg}"
+          done
+          printf '%s\\n' "$joined"
+          printf 'UV_CACHE_DIR=%s\\n' "$UV_CACHE_DIR"
+          printf 'UV_PYTHON_INSTALL_DIR=%s\\n' "$UV_PYTHON_INSTALL_DIR"
+          printf 'UV_TOOL_DIR=%s\\n' "$UV_TOOL_DIR"
+          printf 'UV_TOOL_BIN_DIR=%s\\n' "$UV_TOOL_BIN_DIR"
+        } > "\(capture.path)"
+        \(stdoutBlock)
+        \(stderrBlock)
+        \(createExecutableBlock)
+        exit \(exitCode)
+        """
+        try script.data(using: .utf8)!.write(to: url)
+        try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: url.path)
+        return url
+    }
+
+    private func makeSpec(
+        version: String = "1.2.3",
+        wheelURL: URL,
+        wheelSHA256: String,
+        executableName: String
+    ) -> ManagedBackendSpec {
+        ManagedBackendSpec(
+            id: "voxmlx",
+            displayName: "voxmlx",
+            version: version,
+            requirementName: "voxmlx[server]",
+            wheelURL: wheelURL,
+            wheelSHA256: wheelSHA256,
+            executableName: executableName,
+            pythonVersion: "3.12",
+            port: 8471
+        )
+    }
+
+    private func sha256Hex(for url: URL) throws -> String {
+        let data = try Data(contentsOf: url)
+        return SHA256.hash(data: data)
+            .map { String(format: "%02x", $0) }
+            .joined()
+    }
+}
+
+private struct FakeUVLocator: UVBinaryLocating {
+    let url: URL?
+
+    func uvBinaryURL() -> URL? {
+        url
+    }
+}

--- a/scripts/package_app.sh
+++ b/scripts/package_app.sh
@@ -33,6 +33,44 @@ patch_local_resource_bundle_lookup() {
   perl -0pi -e 's/let preferredBundle = Bundle\(path: mainPath\)/\/\/ localvoxtral packaged resources fallback\n        let resourcePath = Bundle.main.resourceURL?.appendingPathComponent("localvoxtral_localvoxtral.bundle").path\n        let preferredBundle = resourcePath.flatMap(Bundle.init(path:)) ?? Bundle(path: mainPath)/g' "$accessor"
 }
 
+embed_uv_binary() {
+  local uv_version="0.11.26"
+  local uv_archive_name="uv-${uv_version}-aarch64-apple-darwin.tar.gz"
+  local uv_url="https://github.com/astral-sh/uv/releases/download/${uv_version}/uv-aarch64-apple-darwin.tar.gz"
+  local uv_sha256="8f7fbf1708399b921857bce71e1d60f0d3ccf52a30caebc1c1a2f175dce13ab6"
+  local uv_dist_dir="$ROOT_DIR/.build/uv-dist"
+  local uv_tarball="$uv_dist_dir/$uv_archive_name"
+  local uv_destination="$APP_DIR/Contents/MacOS/uv"
+  local tmp_dir
+  local actual_sha256
+
+  echo "Embedding uv ${uv_version}..."
+  mkdir -p "$uv_dist_dir"
+  if [[ ! -f "$uv_tarball" ]]; then
+    echo "Downloading uv ${uv_version} from ${uv_url}"
+    curl -fL --retry 3 "$uv_url" -o "$uv_tarball"
+  else
+    echo "Using cached uv tarball: $uv_tarball"
+  fi
+
+  echo "Verifying uv ${uv_version} sha256..."
+  actual_sha256="$(shasum -a 256 "$uv_tarball" | awk '{print $1}')"
+  if [[ "$actual_sha256" != "$uv_sha256" ]]; then
+    rm -f "$uv_tarball"
+    echo "uv sha256 mismatch: expected $uv_sha256, got $actual_sha256"
+    exit 1
+  fi
+
+  tmp_dir="$(mktemp -d)"
+  tar -xzf "$uv_tarball" -C "$tmp_dir" "uv-aarch64-apple-darwin/uv"
+  install -m 755 "$tmp_dir/uv-aarch64-apple-darwin/uv" "$uv_destination"
+  rm -rf "$tmp_dir"
+
+  echo "Installed embedded uv: $uv_destination"
+  codesign --force --sign "$CODESIGN_IDENTITY" "$uv_destination"
+  echo "Signed embedded uv with identity: $CODESIGN_IDENTITY"
+}
+
 CONFIGURATION="${1:-release}"
 APP_VERSION="${2:-0.3.0}"
 BUILD_NUMBER="${3:-1}"
@@ -210,6 +248,7 @@ PLIST
 # because codesign rejects bundles containing that detritus.
 chmod -R u+w "$APP_DIR"
 xattr -cr "$APP_DIR"
+embed_uv_binary
 
 # Sign the packaged app so Gatekeeper can evaluate a usable signature.
 # This does not replace Developer ID signing/notarization, but it avoids the


### PR DESCRIPTION
## What

Infrastructure for app-managed local backends (step 1 of the managed-backend update — no UI, no lifecycle wiring yet):

- **`package_app.sh` embeds uv 0.11.26** at `Contents/MacOS/uv`: downloads the `aarch64-apple-darwin` tarball (cached under `.build/uv-dist/`, `curl -fL --retry 3`), hard-fails on sha256 mismatch, and signs the binary explicitly before the whole-bundle sign (`--deep` is unreliable for extra Mach-Os).
- **`BackendCatalog`** — pinned specs for the two fork releases: [voxmlx v0.1.0](https://github.com/T0mSIlver/voxmlx/releases/tag/v0.1.0) (port 8471) and [mlx-lm v0.31.3.post1](https://github.com/T0mSIlver/mlx-lm/releases/tag/v0.31.3.post1) (port 8472) — wheel URL + sha256 + executable name + python version each. Both releases ship `--parent-pid` self-exit watchdogs for the upcoming supervisor.
- **`BackendInstaller`** — downloads the wheel with URLSession, verifies sha256 in-app (uv is never invoked on an unverified wheel), then `uv tool install --python 3.12 --reinstall "<name> @ file://<wheel>"` with `UV_CACHE_DIR`/`UV_PYTHON_INSTALL_DIR`/`UV_TOOL_DIR`/`UV_TOOL_BIN_DIR` all under `~/Library/Application Support/localvoxtral/backends/` — fully self-contained, uninstall = delete one directory. Streams uv output as progress, records installed versions in `installed.json`, verifies the expected executable exists post-install.
- **`UVBinaryLocator`** — embedded uv first, then Homebrew/`/usr/local` fallbacks for dev builds.

Sibling PRs (in flight): backend-mode setting, `BackendProcessSupervisor`. A final wiring PR integrates everything; nothing in this PR is reachable from the UI yet.

## Proof

- [x] Unit suite green — `LV_BUILD_DIR=work/localvoxtral-codex-backends ./scripts/remote-build.sh test`
  ```
  Executed 320 tests, with 0 failures (0 unexpected) in 2.868 (2.884) seconds
  ```
  including 6 new `BackendInstallerTests` driven by a fake `uv` script (argv/env capture, checksum-mismatch never invokes uv, stderr-tail surfacing, marker round-trip).
- [x] Packaging green with the embed step — `LV_BUILD_DIR=work/localvoxtral-codex-backends ./scripts/remote-build.sh package`
  ```
  Embedding uv 0.11.26...
  Verifying uv 0.11.26 sha256...
  Installed embedded uv: .../dist/localvoxtral.app/Contents/MacOS/uv
  Signed embedded uv with identity: -
  .../dist/localvoxtral.app: satisfies its Designated Requirement
  ```
- [x] Not a bug fix; no UI change (no user-visible behavior in this PR).

Reviewer notes: progress lines are relayed to the MainActor via a semaphore-gated hop in `ProcessLineCollector` (ordered, but serializes the pipe reader behind the main thread — fine for one install at a time); `uv` runs inside `Task.detached` with a blocking `waitUntilExit` (occupies one executor thread for the install duration — acceptable for this use, flagged for future cleanup).
