### PR TITLE
Add backend mode setting: managed local vs external URL (vLLM / OpenAI)

### DIFF
--- a/Sources/localvoxtral/Backends/ManagedBackendEndpoints.swift
+++ b/Sources/localvoxtral/Backends/ManagedBackendEndpoints.swift
@@ -1,0 +1,13 @@
+import Foundation
+
+/// Fixed localhost endpoints for app-managed backends. Deliberately NOT
+/// 8000/8080 so a user-run server never collides with the managed ones.
+///
+/// NOTE: a parallel PR introduces `BackendCatalog` with the same ports; the
+/// wiring PR reconciles the duplication.
+enum ManagedBackendEndpoints {
+    static let voxmlxPort = 8471
+    static let mlxLMPort = 8472
+    static let realtimeURLString = "ws://127.0.0.1:8471/v1/realtime"
+    static let polishingURLString = "http://127.0.0.1:8472/v1/chat/completions"
+}

--- a/Sources/localvoxtral/SettingsStore.swift
+++ b/Sources/localvoxtral/SettingsStore.swift
@@ -65,6 +65,31 @@ enum DictationShortcutMode: String, CaseIterable, Identifiable {
     }
 }
 
+enum BackendMode: String, CaseIterable, Identifiable {
+    case managedLocal = "managed_local"
+    case externalURL = "external_url"
+
+    var id: String { rawValue }
+
+    var displayName: String {
+        switch self {
+        case .managedLocal:
+            return "Managed local"
+        case .externalURL:
+            return "External URL"
+        }
+    }
+
+    var description: String {
+        switch self {
+        case .managedLocal:
+            return "localvoxtral installs and runs the dictation and polishing backends on this Mac automatically."
+        case .externalURL:
+            return "Connect to a vLLM or OpenAI-compatible realtime endpoint you run yourself."
+        }
+    }
+}
+
 enum DictationShortcutValidation {
     static let allowedModifierFlagsMask = UInt32(cmdKey | optionKey | shiftKey | controlKey)
 
@@ -113,7 +138,7 @@ final class SettingsStore {
 
         var id: String { rawValue }
 
-        var displayName: String { "vLLM/voxmlx" }
+        var displayName: String { "vLLM / OpenAI" }
 
         var defaultEndpoint: String { "ws://127.0.0.1:8000/v1/realtime" }
 
@@ -125,6 +150,7 @@ final class SettingsStore {
         static let realtimeAPIEndpointURL = "settings.realtime_api_endpoint_url"
         static let apiKey = "settings.api_key"
         static let realtimeAPIModelName = "settings.realtime_api_model_name"
+        static let backendMode = "settings.backend_mode"
         static let dictationOutputMode = "settings.dictation_output_mode"
         static let dictationShortcutMode = "settings.dictation_shortcut_mode"
         static let autoCopyEnabled = "settings.auto_copy_enabled"
@@ -164,8 +190,17 @@ final class SettingsStore {
         carbonModifierFlags: UInt32(optionKey)
     )
 
+    /// Default model for the OpenAI-compatible LLM polishing server. Used as
+    /// the external-mode fallback and as the model the managed mlx-lm backend
+    /// is expected to serve.
+    private static let defaultLLMPolishingModel = "mlx-community/Qwen3.5-0.8B-8bit"
+
     var realtimeProvider: RealtimeProvider {
         didSet { defaults.set(realtimeProvider.rawValue, forKey: Keys.realtimeProvider) }
+    }
+
+    var backendMode: BackendMode {
+        didSet { defaults.set(backendMode.rawValue, forKey: Keys.backendMode) }
     }
 
     var realtimeAPIEndpointURL: String {
@@ -303,6 +338,30 @@ final class SettingsStore {
     ) {
         self.defaults = defaults
 
+        // Resolve backend mode. Order matters:
+        // 1. An explicit stored preference always wins.
+        // 2. Otherwise an existing user — one who has already configured an
+        //    endpoint via defaults or the REALTIME_ENDPOINT env var — keeps
+        //    their working external setup rather than being silently switched
+        //    to managed local.
+        // 3. A fresh install defaults to managed local.
+        // The resolved value is persisted immediately so the one-time
+        // heuristic in step 2 only ever runs once.
+        let resolvedBackendMode: BackendMode
+        if let storedBackendMode = defaults.string(forKey: Keys.backendMode),
+            let parsedBackendMode = BackendMode(rawValue: storedBackendMode)
+        {
+            resolvedBackendMode = parsedBackendMode
+        } else if defaults.string(forKey: Keys.realtimeAPIEndpointURL) != nil
+            || environment["REALTIME_ENDPOINT"] != nil
+        {
+            resolvedBackendMode = .externalURL
+        } else {
+            resolvedBackendMode = .managedLocal
+        }
+        backendMode = resolvedBackendMode
+        defaults.set(resolvedBackendMode.rawValue, forKey: Keys.backendMode)
+
         let configuredProvider = Self.loadString(
             defaults: defaults, key: Keys.realtimeProvider,
             envKey: "REALTIME_PROVIDER", fallback: RealtimeProvider.realtimeAPI.rawValue,
@@ -392,7 +451,7 @@ final class SettingsStore {
         )
         llmPolishingModel = Self.loadString(
             defaults: defaults, key: Keys.llmPolishingModel,
-            envKey: "LLM_POLISHING_MODEL", fallback: "mlx-community/Qwen3.5-0.8B-8bit",
+            envKey: "LLM_POLISHING_MODEL", fallback: Self.defaultLLMPolishingModel,
             environment: environment
         )
         replacementDictionaryEnabled = Self.loadBool(
@@ -513,7 +572,10 @@ final class SettingsStore {
     }
 
     var trimmedAPIKey: String {
-        apiKey.trimmed
+        // `trimmedAPIKey` is only ever used as the realtime connection bearer
+        // token (see RealtimeAPIWebSocketClient, which omits the Authorization
+        // header when it is empty). Managed local servers need no key.
+        backendMode == .managedLocal ? "" : apiKey.trimmed
     }
 
     var effectiveModelName: String {
@@ -632,6 +694,11 @@ final class SettingsStore {
     }
 
     func effectiveModelName(for provider: RealtimeProvider) -> String {
+        if backendMode == .managedLocal {
+            // Managed mode always serves the managed default model; a
+            // user-typed override in external-mode fields is ignored.
+            return RealtimeProvider.realtimeAPI.defaultModelName
+        }
         let normalized = Self.normalizedModelName(from: modelName(for: provider))
         return normalized.isEmpty ? provider.defaultModelName : normalized
     }
@@ -645,6 +712,9 @@ final class SettingsStore {
     }
 
     func resolvedWebSocketURL(for provider: RealtimeProvider) -> URL? {
+        if backendMode == .managedLocal {
+            return URL(string: ManagedBackendEndpoints.realtimeURLString)
+        }
         let trimmed = endpointURL(for: provider).trimmed
         guard !trimmed.isEmpty else { return nil }
 
@@ -689,6 +759,15 @@ final class SettingsStore {
 
     var llmPolishingConfiguration: LLMPolishingConfiguration? {
         guard llmPolishingEnabled else { return nil }
+        if backendMode == .managedLocal {
+            guard let url = URL(string: ManagedBackendEndpoints.polishingURLString)
+            else { return nil }
+            return LLMPolishingConfiguration(
+                endpointURL: url,
+                apiKey: "",
+                model: Self.defaultLLMPolishingModel
+            )
+        }
         let trimmedEndpoint = llmPolishingEndpointURL.trimmed
         guard !trimmedEndpoint.isEmpty, let url = URL(string: trimmedEndpoint) else { return nil }
         guard
@@ -703,7 +782,7 @@ final class SettingsStore {
             endpointURL: url,
             apiKey: llmPolishingAPIKey.trimmed,
             model: llmPolishingModel.trimmed.isEmpty
-                ? "mlx-community/Qwen3.5-0.8B-8bit"
+                ? Self.defaultLLMPolishingModel
                 : llmPolishingModel.trimmed
         )
     }

--- a/Sources/localvoxtral/SettingsView.swift
+++ b/Sources/localvoxtral/SettingsView.swift
@@ -110,21 +110,60 @@ private struct ConnectionSettingsPane: View {
     var body: some View {
         SettingsPage {
             SettingsGroup(title: "Backend") {
-                SettingsFieldRow(title: "Realtime endpoint") {
-                    TextField(settings.endpointPlaceholder, text: endpointBinding)
-                        .textFieldStyle(.roundedBorder)
+                SettingsFieldRow(title: "Mode") {
+                    VStack(alignment: .leading, spacing: 6) {
+                        Picker("", selection: $settings.backendMode) {
+                            ForEach(BackendMode.allCases) { mode in
+                                Text(mode.displayName).tag(mode)
+                            }
+                        }
+                        .pickerStyle(.segmented)
+                        .labelsHidden()
+
+                        SettingsHelpText(settings.backendMode.description)
+                    }
                 }
 
-                SettingsFieldRow(title: "Model") {
-                    TextField(settings.modelPlaceholder, text: modelBinding)
-                        .textFieldStyle(.roundedBorder)
-                }
+                switch settings.backendMode {
+                case .externalURL:
+                    SettingsFieldRow(title: "Realtime endpoint") {
+                        TextField(settings.endpointPlaceholder, text: endpointBinding)
+                            .textFieldStyle(.roundedBorder)
+                    }
 
-                SettingsFieldRow(title: "API key") {
-                    SecureField("Required for remote providers", text: $settings.apiKey)
-                        .textFieldStyle(.roundedBorder)
+                    SettingsFieldRow(title: "Model") {
+                        TextField(settings.modelPlaceholder, text: modelBinding)
+                            .textFieldStyle(.roundedBorder)
+                    }
+
+                    SettingsFieldRow(title: "API key") {
+                        SecureField("Required for remote providers", text: $settings.apiKey)
+                            .textFieldStyle(.roundedBorder)
+                    }
+                case .managedLocal:
+                    ManagedBackendSettingsPlaceholder()
                 }
             }
+        }
+    }
+}
+
+// TODO: the wiring PR replaces this static info with live install/run status
+// for the managed voxmlx + mlx-lm backends.
+private struct ManagedBackendSettingsPlaceholder: View {
+    var body: some View {
+        SettingsFieldRow(title: "Dictation") {
+            VStack(alignment: .leading, spacing: 6) {
+                Text("voxmlx — \(ManagedBackendEndpoints.realtimeURLString)")
+                    .font(.system(size: 12, weight: .medium, design: .monospaced))
+
+                SettingsHelpText("Backends are installed and started automatically.")
+            }
+        }
+
+        SettingsFieldRow(title: "Polishing") {
+            Text("mlx-lm — \(ManagedBackendEndpoints.polishingURLString)")
+                .font(.system(size: 12, weight: .medium, design: .monospaced))
         }
     }
 }

--- a/Tests/localvoxtralTests/DictationViewModelFailFastUXTests.swift
+++ b/Tests/localvoxtralTests/DictationViewModelFailFastUXTests.swift
@@ -258,6 +258,11 @@ final class DictationViewModelFailFastUXTests: XCTestCase {
             defaults.removePersistentDomain(forName: suiteName)
         }
         let settings = SettingsStore(defaults: defaults, environment: [:])
+        // These tests exercise connection-failure UX against a user-configured
+        // external endpoint (a closed port). Pin external mode so that the
+        // configured realtimeAPIEndpointURL is honored rather than overridden
+        // by the managed-local default.
+        settings.backendMode = .externalURL
         settings.dictationOutputMode = outputMode
         return settings
     }

--- a/Tests/localvoxtralTests/DictationViewModelOverlayLifecycleTests.swift
+++ b/Tests/localvoxtralTests/DictationViewModelOverlayLifecycleTests.swift
@@ -649,6 +649,12 @@ final class DictationViewModelOverlayLifecycleTests: XCTestCase {
         let settings = makeSettings(outputMode: .overlayBuffer)
         settings.llmPolishingEnabled = true
         settings.llmPolishingEndpointURL = "not a url"
+        // This test exercises external-mode endpoint validation (an invalid
+        // URL surfaces a config error before polishing runs). Pin external
+        // mode so the configured endpoint is validated; managed mode ignores
+        // the user-typed endpoint and is covered at the SettingsStore level
+        // (testLLMPolishingConfiguration_managedLocal_*).
+        settings.backendMode = .externalURL
 
         let overlayCoordinator = MockOverlayCoordinator()
         let viewModel = DictationViewModel(

--- a/Tests/localvoxtralTests/SettingsStoreTests.swift
+++ b/Tests/localvoxtralTests/SettingsStoreTests.swift
@@ -33,6 +33,7 @@ final class SettingsStoreTests: XCTestCase {
         let store = makeStore()
         store.realtimeAPIEndpointURL = "ws://127.0.0.1:8000/v1/realtime"
         store.realtimeProvider = .realtimeAPI
+        store.backendMode = .externalURL
         XCTAssertEqual(store.resolvedWebSocketURL?.absoluteString, "ws://127.0.0.1:8000/v1/realtime")
     }
 
@@ -40,6 +41,7 @@ final class SettingsStoreTests: XCTestCase {
         let store = makeStore()
         store.realtimeAPIEndpointURL = "wss://example.com/realtime"
         store.realtimeProvider = .realtimeAPI
+        store.backendMode = .externalURL
         XCTAssertEqual(store.resolvedWebSocketURL?.absoluteString, "wss://example.com/realtime")
     }
 
@@ -47,6 +49,7 @@ final class SettingsStoreTests: XCTestCase {
         let store = makeStore()
         store.realtimeAPIEndpointURL = "http://localhost:8000/v1/realtime"
         store.realtimeProvider = .realtimeAPI
+        store.backendMode = .externalURL
         XCTAssertEqual(store.resolvedWebSocketURL?.absoluteString, "ws://localhost:8000/v1/realtime")
     }
 
@@ -54,6 +57,7 @@ final class SettingsStoreTests: XCTestCase {
         let store = makeStore()
         store.realtimeAPIEndpointURL = "https://example.com/realtime"
         store.realtimeProvider = .realtimeAPI
+        store.backendMode = .externalURL
         XCTAssertEqual(store.resolvedWebSocketURL?.absoluteString, "wss://example.com/realtime")
     }
 
@@ -61,6 +65,7 @@ final class SettingsStoreTests: XCTestCase {
         let store = makeStore()
         store.realtimeAPIEndpointURL = "myhost:9000/path"
         store.realtimeProvider = .realtimeAPI
+        store.backendMode = .externalURL
         XCTAssertEqual(store.resolvedWebSocketURL?.absoluteString, "ws://myhost:9000/path")
     }
 
@@ -68,6 +73,7 @@ final class SettingsStoreTests: XCTestCase {
         let store = makeStore()
         store.realtimeAPIEndpointURL = ""
         store.realtimeProvider = .realtimeAPI
+        store.backendMode = .externalURL
         XCTAssertNil(store.resolvedWebSocketURL)
     }
 
@@ -75,6 +81,7 @@ final class SettingsStoreTests: XCTestCase {
         let store = makeStore()
         store.realtimeAPIEndpointURL = "   \n  "
         store.realtimeProvider = .realtimeAPI
+        store.backendMode = .externalURL
         XCTAssertNil(store.resolvedWebSocketURL)
     }
 
@@ -82,6 +89,7 @@ final class SettingsStoreTests: XCTestCase {
         let store = makeStore()
         store.realtimeAPIEndpointURL = "  ws://example.com  "
         store.realtimeProvider = .realtimeAPI
+        store.backendMode = .externalURL
         XCTAssertEqual(store.resolvedWebSocketURL?.absoluteString, "ws://example.com")
     }
 
@@ -114,12 +122,174 @@ final class SettingsStoreTests: XCTestCase {
         XCTAssertNil(defaults.object(forKey: "settings.commit_interval_seconds"))
     }
 
+    // MARK: - backendMode migration
+
+    func testBackendMode_freshDefaults_defaultToManagedLocal() {
+        let store = makeStore()
+
+        XCTAssertEqual(store.backendMode, .managedLocal)
+    }
+
+    func testBackendMode_freshDefaults_persistsManagedLocalImmediately() {
+        // The migration heuristic must persist its resolved value on first
+        // init so it only ever runs once (a second store on the same defaults
+        // must not re-derive from endpoint/env state).
+        _ = makeStore()
+
+        XCTAssertEqual(
+            defaults.string(forKey: "settings.backend_mode"),
+            BackendMode.managedLocal.rawValue
+        )
+    }
+
+    func testBackendMode_persistedEndpointKey_migratesToExternalURL() {
+        // An existing user who has already configured a realtime endpoint
+        // keeps their working external setup.
+        defaults.set(
+            "ws://127.0.0.1:8000/v1/realtime",
+            forKey: "settings.realtime_api_endpoint_url"
+        )
+
+        let store = makeStore()
+
+        XCTAssertEqual(store.backendMode, .externalURL)
+    }
+
+    func testBackendMode_realtimeEndpointEnv_migratesToExternalURL() {
+        // The REALTIME_ENDPOINT env var is also evidence of a pre-existing
+        // external setup (e.g. launched from a wrapper script).
+        let store = SettingsStore(
+            defaults: defaults,
+            environment: ["REALTIME_ENDPOINT": "ws://example.com/realtime"]
+        )
+
+        XCTAssertEqual(store.backendMode, .externalURL)
+    }
+
+    func testBackendMode_explicitStoredValueWinsOverEndpointHeuristic() {
+        // An explicit stored preference beats the endpoint/env heuristic in
+        // both directions. Here a persisted endpoint would normally select
+        // external, but an explicit managed_local preference must win.
+        defaults.set(
+            "ws://127.0.0.1:8000/v1/realtime",
+            forKey: "settings.realtime_api_endpoint_url"
+        )
+        defaults.set("managed_local", forKey: "settings.backend_mode")
+
+        let store = makeStore()
+
+        XCTAssertEqual(store.backendMode, .managedLocal)
+    }
+
+    func testBackendMode_externalURL_roundTripsAcrossReload() {
+        let store = makeStore()
+        store.backendMode = .externalURL
+
+        XCTAssertEqual(
+            defaults.string(forKey: "settings.backend_mode"),
+            "external_url"
+        )
+
+        let reloadedStore = makeStore()
+        XCTAssertEqual(reloadedStore.backendMode, .externalURL)
+    }
+
+    func testBackendMode_managedLocal_roundTripsAcrossReload() {
+        let store = makeStore()
+        store.backendMode = .managedLocal
+
+        let reloadedStore = makeStore()
+        XCTAssertEqual(reloadedStore.backendMode, .managedLocal)
+    }
+
+    // MARK: - backendMode-dependent resolution
+
+    func testResolvedWebSocketURL_managedLocal_returnsManagedEndpoint() {
+        // A fresh store is managed; the user-typed endpoint must be ignored.
+        let store = makeStore()
+        store.realtimeAPIEndpointURL = "ws://example.com/realtime"
+
+        XCTAssertEqual(
+            store.resolvedWebSocketURL?.absoluteString,
+            ManagedBackendEndpoints.realtimeURLString
+        )
+    }
+
+    func testEffectiveModelName_managedLocal_returnsManagedDefaultIgnoringOverride() {
+        let store = makeStore()
+        store.realtimeAPIModelName = "user-typed-override"
+
+        XCTAssertEqual(
+            store.effectiveModelName,
+            SettingsStore.RealtimeProvider.realtimeAPI.defaultModelName
+        )
+    }
+
+    func testTrimmedAPIKey_managedLocal_isEmpty() {
+        // Managed local servers need no bearer token; trimmedAPIKey is only
+        // the realtime connection bearer token.
+        let store = makeStore()
+        store.apiKey = "sk-managed-should-be-ignored"
+
+        XCTAssertEqual(store.trimmedAPIKey, "")
+    }
+
+    func testTrimmedAPIKey_externalURL_returnsApiKey() {
+        let store = makeStore()
+        store.backendMode = .externalURL
+        store.apiKey = "  sk-external  "
+
+        XCTAssertEqual(store.trimmedAPIKey, "sk-external")
+    }
+
+    func testLLMPolishingConfiguration_managedLocal_returnsManagedEndpointAndEmptyKey() {
+        let store = makeStore()
+        store.llmPolishingEnabled = true
+        // User-tuned polishing fields must be ignored in managed mode.
+        store.llmPolishingEndpointURL = "https://api.openai.com/v1/chat/completions"
+        store.llmPolishingAPIKey = "sk-ignored"
+        store.llmPolishingModel = "gpt-4o-mini"
+
+        let configuration = store.llmPolishingConfiguration
+        XCTAssertEqual(
+            configuration?.endpointURL.absoluteString,
+            ManagedBackendEndpoints.polishingURLString
+        )
+        XCTAssertEqual(configuration?.apiKey, "")
+        XCTAssertEqual(configuration?.model, "mlx-community/Qwen3.5-0.8B-8bit")
+    }
+
+    func testLLMPolishingConfiguration_managedLocal_disabledReturnsNil() {
+        let store = makeStore()
+        store.llmPolishingEnabled = false
+
+        XCTAssertNil(store.llmPolishingConfiguration)
+    }
+
+    func testLLMPolishingConfiguration_externalURL_usesConfiguredEndpoint() {
+        let store = makeStore()
+        store.backendMode = .externalURL
+        store.llmPolishingEnabled = true
+        store.llmPolishingEndpointURL = "https://api.openai.com/v1/chat/completions"
+        store.llmPolishingAPIKey = "sk-test"
+        store.llmPolishingModel = "gpt-4o-mini"
+
+        let configuration = store.llmPolishingConfiguration
+        XCTAssertEqual(
+            configuration?.endpointURL.absoluteString,
+            "https://api.openai.com/v1/chat/completions"
+        )
+        XCTAssertEqual(configuration?.apiKey, "sk-test")
+        XCTAssertEqual(configuration?.model, "gpt-4o-mini")
+    }
+
     // MARK: - effectiveModelName
 
     func testEffectiveModel_plainName() {
         let store = makeStore()
         store.realtimeAPIModelName = "my-model"
         store.realtimeProvider = .realtimeAPI
+        store.backendMode = .externalURL
         XCTAssertEqual(store.effectiveModelName, "my-model")
     }
 
@@ -127,6 +297,7 @@ final class SettingsStoreTests: XCTestCase {
         let store = makeStore()
         store.realtimeAPIModelName = "  my-model  "
         store.realtimeProvider = .realtimeAPI
+        store.backendMode = .externalURL
         XCTAssertEqual(store.effectiveModelName, "my-model")
     }
 
@@ -134,6 +305,7 @@ final class SettingsStoreTests: XCTestCase {
         let store = makeStore()
         store.realtimeAPIModelName = "junk-line\nactual-model"
         store.realtimeProvider = .realtimeAPI
+        store.backendMode = .externalURL
         XCTAssertEqual(store.effectiveModelName, "actual-model")
     }
 
@@ -141,6 +313,7 @@ final class SettingsStoreTests: XCTestCase {
         let store = makeStore()
         store.realtimeAPIModelName = "some prefix model-name"
         store.realtimeProvider = .realtimeAPI
+        store.backendMode = .externalURL
         XCTAssertEqual(store.effectiveModelName, "model-name")
     }
 
@@ -148,6 +321,7 @@ final class SettingsStoreTests: XCTestCase {
         let store = makeStore()
         store.realtimeAPIModelName = ""
         store.realtimeProvider = .realtimeAPI
+        store.backendMode = .externalURL
         XCTAssertEqual(
             store.effectiveModelName,
             SettingsStore.RealtimeProvider.realtimeAPI.defaultModelName
@@ -158,6 +332,7 @@ final class SettingsStoreTests: XCTestCase {
         let store = makeStore()
         store.realtimeAPIModelName = "   \n  "
         store.realtimeProvider = .realtimeAPI
+        store.backendMode = .externalURL
         XCTAssertEqual(
             store.effectiveModelName,
             SettingsStore.RealtimeProvider.realtimeAPI.defaultModelName
@@ -347,6 +522,7 @@ final class SettingsStoreTests: XCTestCase {
         let store = makeStore()
         store.llmPolishingEnabled = true
         store.llmPolishingEndpointURL = "not a url"
+        store.backendMode = .externalURL
 
         XCTAssertNil(store.llmPolishingConfiguration)
     }
@@ -357,6 +533,7 @@ final class SettingsStoreTests: XCTestCase {
         store.llmPolishingEndpointURL = "https://api.openai.com/v1/chat/completions"
         store.llmPolishingAPIKey = "  sk-test  "
         store.llmPolishingModel = "  gpt-4o-mini  "
+        store.backendMode = .externalURL
 
         let configuration = store.llmPolishingConfiguration
         XCTAssertEqual(


### PR DESCRIPTION
## What

Adds the **backend mode** setting — the user-facing half of the managed-backend update:

- **Managed local** (fresh-install default): the app will run voxmlx + mlx-lm itself on dedicated ports (`ws://127.0.0.1:8471/v1/realtime`, `http://127.0.0.1:8472/v1/chat/completions` — deliberately not 8000/8080 so a user-run server never collides). In this mode `SettingsStore` resolves the managed endpoints/models, ignores user-typed overrides, and sends no bearer token (`trimmedAPIKey` is only consumed by `RealtimeAPIWebSocketClient`, which omits the Authorization header when empty — verified).
- **External URL**: existing behavior, relabeled "vLLM / OpenAI" (voxmlx is now the managed path).
- **Migration** (runs once, then persists): explicit stored mode wins → else a previously persisted endpoint key or `REALTIME_ENDPOINT` env keeps existing users in external mode → else fresh installs default to managed.
- Connection pane: mode segmented picker; external shows the endpoint/model/key fields; managed shows a static placeholder (endpoints + "installed and started automatically") that the wiring PR replaces with live install/run status.

Sibling PRs: #44 (installer infra), supervisor (in flight). Nothing launches backends yet — **do not cut a release until the wiring PR lands**, since fresh installs now default to managed mode with nothing serving.

## Proof

- [x] Unit suite green after rebasing onto main with #37 and #43 merged (conflicts in `SettingsStore.Keys` and `SettingsStoreTests` resolved as straight unions) — `LV_BUILD_DIR=work/localvoxtral-oc-backendmode ./scripts/remote-build.sh test`
  ```
  Executed 363 tests, with 0 failures (0 unexpected) in 1.754 (1.769) seconds
  ```
  13 new `SettingsStoreTests`: full migration matrix (fresh → managed + persisted immediately; stored endpoint key → external; `REALTIME_ENDPOINT` env → external; explicit stored mode wins), both-mode round-trips, and mode-dependent `resolvedWebSocketURL` / `effectiveModelName` / `trimmedAPIKey` / `llmPolishingConfiguration`.
- [x] Two existing test files needed external mode pinned (`DictationViewModelFailFastUXTests`, one `DictationViewModelOverlayLifecycleTests` case): they exercise user-configured-endpoint failure UX, which managed mode intentionally bypasses. Comments in place; no assertions weakened; managed-mode equivalents covered at the SettingsStore level.
- [x] UI change: Connection pane gains the mode picker / managed placeholder — **not hand-verified on a Mac in this PR**; the wiring PR replaces the placeholder with live status and hand-verifies the whole pane.
