### PR TITLE
Add BackendProcessSupervisor for managed backend lifecycles

### DIFF
--- a/Sources/localvoxtral/Backends/BackendProcessConfiguration.swift
+++ b/Sources/localvoxtral/Backends/BackendProcessConfiguration.swift
@@ -1,0 +1,13 @@
+import Foundation
+
+struct BackendProcessConfiguration: Sendable {
+    var name: String
+    var executableURL: URL
+    var arguments: [String]
+    var environment: [String: String]
+    var readinessURL: URL
+    var readinessPollInterval: Duration = .milliseconds(500)
+    var readinessTimeout: Duration = .seconds(600)
+    var terminationGracePeriod: Duration = .seconds(5)
+    var maxConsecutiveRestartFailures: Int = 5
+}

--- a/Sources/localvoxtral/Backends/BackendProcessSupervisor.swift
+++ b/Sources/localvoxtral/Backends/BackendProcessSupervisor.swift
@@ -1,0 +1,431 @@
+import Darwin
+import Foundation
+import Observation
+
+@MainActor
+@Observable
+final class BackendProcessSupervisor {
+    enum State: Equatable, Sendable {
+        case idle
+        case launching
+        case waitingForReady
+        case running
+        case restarting(attempt: Int)
+        case stopped
+        case failed(message: String)
+    }
+
+    typealias Probe = @Sendable (URL) async -> Bool
+    typealias SleepClosure = @Sendable (Duration) async throws -> Void
+
+    private(set) var state: State
+    private(set) var recentOutput: [String]
+    @ObservationIgnored var stateUpdates: AsyncStream<State>
+
+    @ObservationIgnored private let configuration: BackendProcessConfiguration
+    @ObservationIgnored private let probe: Probe
+    @ObservationIgnored private let sleepFor: SleepClosure
+    @ObservationIgnored private let stateContinuation: AsyncStream<State>.Continuation
+
+    @ObservationIgnored private var supervisionTask: Task<Void, Never>?
+    @ObservationIgnored private var currentProcess: Process?
+    @ObservationIgnored private var currentProcessID: pid_t?
+    @ObservationIgnored private var currentProcessExited = false
+    @ObservationIgnored private var currentTerminationStatus: Int32?
+    @ObservationIgnored private var processExitContinuation: CheckedContinuation<Int32, Never>?
+    @ObservationIgnored private var stdoutPipe: Pipe?
+    @ObservationIgnored private var stderrPipe: Pipe?
+    @ObservationIgnored private var stdoutPartial = ""
+    @ObservationIgnored private var stderrPartial = ""
+    @ObservationIgnored private var recentErrorOutput: [String] = []
+    @ObservationIgnored private var stoppingIntentionally = false
+
+    init(
+        configuration: BackendProcessConfiguration,
+        probe: @escaping Probe = BackendProcessSupervisor.defaultProbe,
+        sleepFor: @escaping SleepClosure = { duration in
+            try await Task.sleep(for: duration)
+        }
+    ) {
+        self.configuration = configuration
+        self.probe = probe
+        self.sleepFor = sleepFor
+        self.state = .idle
+        self.recentOutput = []
+
+        let stream = AsyncStream<State>.makeStream(of: State.self)
+        self.stateUpdates = stream.stream
+        self.stateContinuation = stream.continuation
+    }
+
+    func start() async {
+        guard supervisionTask == nil else { return }
+        guard !isActiveState(state) else { return }
+
+        stoppingIntentionally = false
+        supervisionTask = Task { @MainActor [weak self] in
+            guard let self else { return }
+            await self.supervise()
+        }
+    }
+
+    func stop() async {
+        stoppingIntentionally = true
+        supervisionTask?.cancel()
+
+        if let process = currentProcess {
+            await terminate(process: process, gracePeriod: configuration.terminationGracePeriod)
+        }
+
+        clearCurrentProcess()
+        supervisionTask = nil
+        transition(to: .stopped)
+    }
+
+    private static func defaultProbe(url: URL) async -> Bool {
+        var request = URLRequest(url: url)
+        request.httpMethod = "GET"
+        request.timeoutInterval = 2
+
+        do {
+            let (_, response) = try await URLSession.shared.data(for: request)
+            return (response as? HTTPURLResponse)?.statusCode == 200
+        } catch {
+            return false
+        }
+    }
+
+    private func supervise() async {
+        defer {
+            supervisionTask = nil
+        }
+
+        guard !(await probe(configuration.readinessURL)) else {
+            transition(
+                to: .failed(
+                    message: "\(configuration.name) port already in use; refusing to adopt an existing backend process."
+                )
+            )
+            return
+        }
+
+        var consecutiveFailures = 0
+
+        while !stoppingIntentionally && !Task.isCancelled {
+            transition(to: .launching)
+
+            do {
+                try spawnProcess()
+            } catch {
+                transition(
+                    to: .failed(
+                        message: "Failed to launch \(configuration.name): \(error.localizedDescription)"
+                    )
+                )
+                return
+            }
+
+            transition(to: .waitingForReady)
+            let readinessOutcome = await waitForReadiness()
+
+            switch readinessOutcome {
+            case .ready:
+                consecutiveFailures = 0
+                transition(to: .running)
+                _ = await waitForCurrentProcessExit()
+                guard !stoppingIntentionally && !Task.isCancelled else { return }
+                consecutiveFailures += 1
+
+            case .exited:
+                guard !stoppingIntentionally && !Task.isCancelled else { return }
+                consecutiveFailures += 1
+
+            case .timedOut:
+                let stderrTail = stderrTailDescription()
+                if let process = currentProcess {
+                    await terminate(process: process, gracePeriod: configuration.terminationGracePeriod)
+                }
+                clearCurrentProcess()
+                transition(
+                    to: .failed(
+                        message: "\(configuration.name) did not become ready before timeout.\(stderrTail)"
+                    )
+                )
+                return
+
+            case .cancelled:
+                return
+            }
+
+            clearCurrentProcess()
+
+            if consecutiveFailures >= max(1, configuration.maxConsecutiveRestartFailures) {
+                transition(
+                    to: .failed(
+                        message: "\(configuration.name) exited \(consecutiveFailures) consecutive times.\(stderrTailDescription())"
+                    )
+                )
+                return
+            }
+
+            transition(to: .restarting(attempt: consecutiveFailures))
+
+            do {
+                try await sleepFor(backoffDuration(attempt: consecutiveFailures))
+            } catch {
+                return
+            }
+        }
+    }
+
+    private enum ReadinessOutcome {
+        case ready
+        case exited
+        case timedOut
+        case cancelled
+    }
+
+    private func waitForReadiness() async -> ReadinessOutcome {
+        var elapsed: Duration = .zero
+
+        while !stoppingIntentionally && !Task.isCancelled {
+            if currentProcessExited || currentProcess?.isRunning == false {
+                return .exited
+            }
+
+            if await probe(configuration.readinessURL) {
+                return .ready
+            }
+
+            do {
+                try await sleepFor(configuration.readinessPollInterval)
+            } catch {
+                return .cancelled
+            }
+            await Task.yield()
+
+            elapsed += configuration.readinessPollInterval
+            if currentProcessExited || currentProcess?.isRunning == false {
+                return .exited
+            }
+            if elapsed >= configuration.readinessTimeout {
+                return .timedOut
+            }
+        }
+
+        return .cancelled
+    }
+
+    private func spawnProcess() throws {
+        clearCurrentProcess()
+
+        let process = Process()
+        process.executableURL = configuration.executableURL
+        process.arguments = configuration.arguments
+        process.environment = configuration.environment
+
+        let stdoutPipe = Pipe()
+        let stderrPipe = Pipe()
+        process.standardOutput = stdoutPipe
+        process.standardError = stderrPipe
+
+        attachOutputReader(to: stdoutPipe, source: "stdout")
+        attachOutputReader(to: stderrPipe, source: "stderr")
+
+        process.terminationHandler = { terminatedProcess in
+            let pid = terminatedProcess.processIdentifier
+            let status = terminatedProcess.terminationStatus
+            Task { @MainActor [weak self] in
+                self?.handleProcessExit(pid: pid, status: status)
+            }
+        }
+
+        try process.run()
+
+        currentProcess = process
+        currentProcessID = process.processIdentifier
+        currentProcessExited = false
+        currentTerminationStatus = nil
+        self.stdoutPipe = stdoutPipe
+        self.stderrPipe = stderrPipe
+
+        Log.backends.info(
+            "\(self.configuration.name, privacy: .public) backend launched pid=\(process.processIdentifier, privacy: .public)"
+        )
+    }
+
+    private func attachOutputReader(to pipe: Pipe, source: String) {
+        pipe.fileHandleForReading.readabilityHandler = { [weak self] fileHandle in
+            let data = fileHandle.availableData
+            guard !data.isEmpty else {
+                fileHandle.readabilityHandler = nil
+                return
+            }
+
+            Task { @MainActor [weak self] in
+                self?.appendOutput(data: data, source: source)
+            }
+        }
+    }
+
+    private func appendOutput(data: Data, source: String) {
+        let text = String(data: data, encoding: .utf8) ?? String(decoding: data, as: UTF8.self)
+        var buffer = (source == "stderr" ? stderrPartial : stdoutPartial) + text
+        let endsWithNewline = buffer.hasSuffix("\n")
+        var pieces = buffer.split(separator: "\n", omittingEmptySubsequences: false).map(String.init)
+
+        if endsWithNewline {
+            buffer = ""
+            _ = pieces.popLast()
+        } else {
+            buffer = pieces.popLast() ?? ""
+        }
+
+        if source == "stderr" {
+            stderrPartial = buffer
+        } else {
+            stdoutPartial = buffer
+        }
+
+        for piece in pieces {
+            appendOutputLine(piece, source: source)
+        }
+    }
+
+    private func appendOutputLine(_ rawLine: String, source: String) {
+        let line = rawLine.trimmingCharacters(in: .newlines)
+        guard !line.isEmpty else { return }
+
+        let formatted = "[\(configuration.name) \(source)] \(line)"
+        recentOutput.append(formatted)
+        if recentOutput.count > 40 {
+            recentOutput.removeFirst(recentOutput.count - 40)
+        }
+
+        if source == "stderr" {
+            recentErrorOutput.append(line)
+            if recentErrorOutput.count > 20 {
+                recentErrorOutput.removeFirst(recentErrorOutput.count - 20)
+            }
+        }
+
+        Log.backends.info("\(formatted, privacy: .public)")
+    }
+
+    private func handleProcessExit(pid: pid_t, status: Int32) {
+        guard currentProcessID == pid else { return }
+
+        flushOutputPartials()
+        currentProcessExited = true
+        currentTerminationStatus = status
+        let continuation = processExitContinuation
+        processExitContinuation = nil
+        continuation?.resume(returning: status)
+
+        Log.backends.info(
+            "\(self.configuration.name, privacy: .public) backend exited pid=\(pid, privacy: .public) status=\(status, privacy: .public)"
+        )
+    }
+
+    private func waitForCurrentProcessExit() async -> Int32 {
+        if currentProcessExited {
+            return currentTerminationStatus ?? 0
+        }
+
+        return await withCheckedContinuation { continuation in
+            processExitContinuation = continuation
+        }
+    }
+
+    private func terminate(process: Process, gracePeriod: Duration) async {
+        guard process.isRunning else { return }
+
+        process.terminate()
+
+        var elapsed: Duration = .zero
+        let sleepSlice = minDuration(.milliseconds(100), gracePeriod)
+        while process.isRunning && elapsed < gracePeriod {
+            do {
+                try await sleepFor(sleepSlice)
+            } catch {
+                break
+            }
+            await Task.yield()
+            elapsed += sleepSlice
+        }
+
+        if process.isRunning {
+            Darwin.kill(process.processIdentifier, SIGKILL)
+        }
+
+        var killElapsed: Duration = .zero
+        while process.isRunning && killElapsed < .seconds(1) {
+            do {
+                try await sleepFor(.milliseconds(10))
+            } catch {
+                break
+            }
+            await Task.yield()
+            killElapsed += .milliseconds(10)
+        }
+    }
+
+    private func clearCurrentProcess() {
+        flushOutputPartials()
+        stdoutPipe?.fileHandleForReading.readabilityHandler = nil
+        stderrPipe?.fileHandleForReading.readabilityHandler = nil
+        let continuation = processExitContinuation
+        processExitContinuation = nil
+        continuation?.resume(returning: currentTerminationStatus ?? 0)
+        stdoutPipe = nil
+        stderrPipe = nil
+        currentProcess = nil
+        currentProcessID = nil
+        currentProcessExited = false
+        currentTerminationStatus = nil
+        stdoutPartial = ""
+        stderrPartial = ""
+    }
+
+    private func flushOutputPartials() {
+        if !stdoutPartial.isEmpty {
+            appendOutputLine(stdoutPartial, source: "stdout")
+            stdoutPartial = ""
+        }
+        if !stderrPartial.isEmpty {
+            appendOutputLine(stderrPartial, source: "stderr")
+            stderrPartial = ""
+        }
+    }
+
+    private func transition(to newState: State) {
+        state = newState
+        stateContinuation.yield(newState)
+        Log.backends.info(
+            "\(self.configuration.name, privacy: .public) backend state \(String(describing: newState), privacy: .public)"
+        )
+    }
+
+    private func stderrTailDescription() -> String {
+        guard !recentErrorOutput.isEmpty else { return "" }
+        return " stderr: " + recentErrorOutput.suffix(5).joined(separator: "\n")
+    }
+
+    private func backoffDuration(attempt: Int) -> Duration {
+        let seconds = min(30.0, 0.5 * pow(2.0, Double(max(0, attempt - 1))))
+        return .seconds(seconds)
+    }
+
+    private func minDuration(_ lhs: Duration, _ rhs: Duration) -> Duration {
+        lhs <= rhs ? lhs : rhs
+    }
+
+    private func isActiveState(_ state: State) -> Bool {
+        switch state {
+        case .launching, .waitingForReady, .running, .restarting:
+            return true
+        case .idle, .stopped, .failed:
+            return false
+        }
+    }
+}

--- a/Sources/localvoxtral/Log.swift
+++ b/Sources/localvoxtral/Log.swift
@@ -15,6 +15,7 @@ enum Log {
     static let polishing = Logger(subsystem: subsystem, category: "Polishing")
     static let persistence = Logger(subsystem: subsystem, category: "Persistence")
     static let config = Logger(subsystem: subsystem, category: "Config")
+    static let backends = Logger(subsystem: subsystem, category: "Backends")
     static let replacements = Logger(subsystem: subsystem, category: "Replacements")
     static let corrector = Logger(subsystem: subsystem, category: "Corrector")
     /// Opt-in raw realtime delta instrumentation for issue #13. Emits at notice

--- a/Tests/localvoxtralTests/BackendProcessSupervisorTests.swift
+++ b/Tests/localvoxtralTests/BackendProcessSupervisorTests.swift
@@ -1,0 +1,654 @@
+import Darwin
+import Foundation
+import Synchronization
+import XCTest
+@testable import localvoxtral
+
+@MainActor
+final class BackendProcessSupervisorTests: XCTestCase {
+    func testHappyPathWaitsForReadinessThenRuns() async throws {
+        let directory = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let script = try writeScript(
+            in: directory,
+            name: "backend.sh",
+            body: """
+            #!/bin/sh
+            trap 'exit 0' TERM
+            while true; do sleep 1; done
+            """
+        )
+        let probe = LockedValue(false)
+        let sleeps = ControlledSleep { $0 == .milliseconds(500) }
+        let supervisor = makeSupervisor(
+            executableURL: script,
+            probe: { _ in probe.value },
+            sleepFor: { duration in try await sleeps.sleep(duration) }
+        )
+        let watcher = StateWatcher(stream: supervisor.stateUpdates)
+        defer { watcher.cancel() }
+
+        await supervisor.start()
+
+        _ = try await watcher.waitForState(.waitingForReady)
+        probe.value = true
+        sleeps.resumeAll()
+
+        _ = try await watcher.waitForState(.running)
+        await supervisor.stop()
+    }
+
+    func testPreStartProbeTrueFailsWithoutSpawning() async throws {
+        let directory = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let marker = directory.appendingPathComponent("spawned")
+        let script = try writeScript(
+            in: directory,
+            name: "backend.sh",
+            body: """
+            #!/bin/sh
+            touch "\(marker.path)"
+            sleep 10
+            """
+        )
+        let supervisor = makeSupervisor(
+            executableURL: script,
+            probe: { _ in true },
+            sleepFor: { _ in }
+        )
+        let watcher = StateWatcher(stream: supervisor.stateUpdates)
+        defer { watcher.cancel() }
+
+        await supervisor.start()
+
+        let state = try await watcher.waitForState { state in
+            if case .failed = state { return true }
+            return false
+        }
+
+        guard case let .failed(message) = state else {
+            return XCTFail("expected failed state, got \(state)")
+        }
+        XCTAssertTrue(message.contains("port already in use"))
+        XCTAssertFalse(FileManager.default.fileExists(atPath: marker.path))
+    }
+
+    func testReadinessTimeoutFailsAndTerminatesChild() async throws {
+        let directory = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let pidFile = directory.appendingPathComponent("pid")
+        let script = try writeScript(
+            in: directory,
+            name: "backend.sh",
+            body: """
+            #!/bin/sh
+            echo $$ > "\(pidFile.path)"
+            trap 'exit 0' TERM
+            while true; do sleep 1; done
+            """
+        )
+        let sleeps = RecordingSleep()
+        let supervisor = makeSupervisor(
+            executableURL: script,
+            readinessPollInterval: .milliseconds(1),
+            readinessTimeout: .milliseconds(2),
+            terminationGracePeriod: .milliseconds(1),
+            probe: { _ in false },
+            sleepFor: { duration in try await sleeps.sleep(duration) }
+        )
+        let watcher = StateWatcher(stream: supervisor.stateUpdates)
+        defer { watcher.cancel() }
+
+        await supervisor.start()
+        let state = try await watcher.waitForState { state in
+            if case .failed = state { return true }
+            return false
+        }
+
+        guard case let .failed(message) = state else {
+            return XCTFail("expected failed state, got \(state)")
+        }
+        XCTAssertTrue(message.contains("did not become ready"))
+        if let pid = try readPID(from: pidFile) {
+            XCTAssertFalse(isProcessRunning(pid))
+        }
+    }
+
+    func testCrashRestartsWithBackoffThenRunsWhenReady() async throws {
+        let directory = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let countFile = directory.appendingPathComponent("count")
+        let marker = directory.appendingPathComponent("crashed-once")
+        let script = try writeScript(
+            in: directory,
+            name: "backend.sh",
+            body: """
+            #!/bin/sh
+            count=0
+            if [ -f "\(countFile.path)" ]; then
+              count=$(cat "\(countFile.path)")
+            fi
+            count=$((count + 1))
+            echo "$count" > "\(countFile.path)"
+            if [ "$count" -eq 1 ]; then
+              touch "\(marker.path)"
+              echo "first crash" >&2
+              exit 2
+            fi
+            trap 'exit 0' TERM
+            while true; do sleep 1; done
+            """
+        )
+        let probe = LockedValue(false)
+        let sleeps = ControlledSleep { $0 == .milliseconds(500) }
+        let countFilePath = countFile.path
+        let supervisor = makeSupervisor(
+            executableURL: script,
+            readinessPollInterval: .milliseconds(10),
+            readinessTimeout: .seconds(600),
+            maxConsecutiveRestartFailures: 5,
+            probe: { _ in
+                guard probe.value else { return false }
+                let text = (try? String(contentsOfFile: countFilePath, encoding: .utf8)) ?? ""
+                let count = Int(text.trimmingCharacters(in: .whitespacesAndNewlines)) ?? 0
+                return count >= 2
+            },
+            sleepFor: { duration in try await sleeps.sleep(duration) }
+        )
+        let watcher = StateWatcher(stream: supervisor.stateUpdates)
+        defer { watcher.cancel() }
+
+        await supervisor.start()
+
+        _ = try await watcher.waitForState(.restarting(attempt: 1))
+        XCTAssertEqual(
+            sleeps.recordedDurations.filter { $0 == .milliseconds(500) },
+            [.milliseconds(500)]
+        )
+        XCTAssertTrue(FileManager.default.fileExists(atPath: marker.path))
+
+        probe.value = true
+        sleeps.resumeAll()
+
+        _ = try await watcher.waitForState(.running)
+        XCTAssertEqual(try readCount(from: countFile), 2)
+        await supervisor.stop()
+    }
+
+    func testMaxFailuresFailsWithStderrTail() async throws {
+        let directory = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let countFile = directory.appendingPathComponent("count")
+        let script = try writeScript(
+            in: directory,
+            name: "backend.sh",
+            body: """
+            #!/bin/sh
+            count=0
+            if [ -f "\(countFile.path)" ]; then
+              count=$(cat "\(countFile.path)")
+            fi
+            count=$((count + 1))
+            echo "$count" > "\(countFile.path)"
+            echo "fatal backend failure $count" >&2
+            exit 7
+            """
+        )
+        let sleeps = SpawnAwareRecordingSleep(countFile: countFile)
+        let supervisor = makeSupervisor(
+            executableURL: script,
+            readinessPollInterval: .milliseconds(10),
+            maxConsecutiveRestartFailures: 3,
+            probe: { _ in false },
+            sleepFor: { duration in try await sleeps.sleep(duration) }
+        )
+        let watcher = StateWatcher(stream: supervisor.stateUpdates)
+        defer { watcher.cancel() }
+
+        await supervisor.start()
+        let state = try await watcher.waitForState { state in
+            if case .failed = state { return true }
+            return false
+        }
+
+        guard case let .failed(message) = state else {
+            return XCTFail("expected failed state, got \(state)")
+        }
+        XCTAssertTrue(message.contains("fatal backend failure"), message)
+        XCTAssertEqual(try readCount(from: countFile), 3)
+        XCTAssertEqual(
+            sleeps.recordedDurations.filter { $0 >= .milliseconds(500) },
+            [.milliseconds(500), .seconds(1)]
+        )
+    }
+
+    func testStopHonorsTERMWithoutRestarting() async throws {
+        let directory = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let termMarker = directory.appendingPathComponent("term")
+        let readyMarker = directory.appendingPathComponent("ready")
+        let script = try writeScript(
+            in: directory,
+            name: "backend.sh",
+            body: """
+            #!/bin/sh
+            trap 'touch "\(termMarker.path)"; exit 0' TERM
+            touch "\(readyMarker.path)"
+            while true; do sleep 1 & wait $!; done
+            """
+        )
+        let probe = LockedValue(false)
+        let sleeps = TerminationAwareSleep(termMarker: termMarker, readyMarker: readyMarker)
+        let supervisor = makeSupervisor(
+            executableURL: script,
+            readinessPollInterval: .milliseconds(10),
+            readinessTimeout: .seconds(600),
+            probe: { _ in
+                probe.value && FileManager.default.fileExists(atPath: readyMarker.path)
+            },
+            sleepFor: { duration in try await sleeps.sleep(duration) }
+        )
+        let watcher = StateWatcher(stream: supervisor.stateUpdates)
+        defer { watcher.cancel() }
+
+        await supervisor.start()
+        _ = try await watcher.waitForState(.waitingForReady)
+        probe.value = true
+        sleeps.resumeAll()
+        _ = try await watcher.waitForState(.running)
+
+        await supervisor.stop()
+
+        _ = try await watcher.waitForState(.stopped)
+        XCTAssertTrue(FileManager.default.fileExists(atPath: termMarker.path))
+        XCTAssertFalse(watcher.containsState(.restarting(attempt: 1)))
+    }
+
+    func testStopEscalatesToKILLWhenTERMIsIgnored() async throws {
+        let directory = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let pidFile = directory.appendingPathComponent("pid")
+        let script = try writeScript(
+            in: directory,
+            name: "backend.sh",
+            body: """
+            #!/bin/sh
+            echo $$ > "\(pidFile.path)"
+            trap '' TERM
+            while true; do sleep 1; done
+            """
+        )
+        let probe = LockedValue(false)
+        let sleeps = ControlledSleep()
+        let supervisor = makeSupervisor(
+            executableURL: script,
+            terminationGracePeriod: .milliseconds(2),
+            probe: { _ in probe.value },
+            sleepFor: { duration in try await sleeps.sleep(duration) }
+        )
+        let watcher = StateWatcher(stream: supervisor.stateUpdates)
+        defer { watcher.cancel() }
+
+        await supervisor.start()
+        _ = try await watcher.waitForState(.waitingForReady)
+        probe.value = true
+        sleeps.resumeAll()
+        _ = try await watcher.waitForState(.running)
+
+        await supervisor.stop()
+
+        _ = try await watcher.waitForState(.stopped)
+        XCTAssertTrue(sleeps.recordedDurations.contains(.milliseconds(2)))
+        if let pid = try readPID(from: pidFile) {
+            XCTAssertFalse(isProcessRunning(pid))
+        }
+    }
+
+    private func makeSupervisor(
+        executableURL: URL,
+        readinessPollInterval: Duration = .milliseconds(500),
+        readinessTimeout: Duration = .seconds(5),
+        terminationGracePeriod: Duration = .milliseconds(100),
+        maxConsecutiveRestartFailures: Int = 5,
+        probe: @escaping @Sendable (URL) async -> Bool,
+        sleepFor: @escaping @Sendable (Duration) async throws -> Void
+    ) -> BackendProcessSupervisor {
+        BackendProcessSupervisor(
+            configuration: BackendProcessConfiguration(
+                name: "test-backend",
+                executableURL: executableURL,
+                arguments: [],
+                environment: ProcessInfo.processInfo.environment,
+                readinessURL: URL(string: "http://127.0.0.1:9/ready")!,
+                readinessPollInterval: readinessPollInterval,
+                readinessTimeout: readinessTimeout,
+                terminationGracePeriod: terminationGracePeriod,
+                maxConsecutiveRestartFailures: maxConsecutiveRestartFailures
+            ),
+            probe: probe,
+            sleepFor: sleepFor
+        )
+    }
+
+    private func makeTemporaryDirectory() throws -> URL {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("BackendProcessSupervisorTests-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        return directory
+    }
+
+    private func writeScript(in directory: URL, name: String, body: String) throws -> URL {
+        let url = directory.appendingPathComponent(name)
+        try body.write(to: url, atomically: true, encoding: .utf8)
+        XCTAssertEqual(chmod(url.path, 0o755), 0)
+        return url
+    }
+
+    private func readPID(from url: URL) throws -> pid_t? {
+        guard FileManager.default.fileExists(atPath: url.path) else { return nil }
+        let text = try String(contentsOf: url, encoding: .utf8)
+        return pid_t(text.trimmingCharacters(in: .whitespacesAndNewlines))
+    }
+
+    private func readCount(from url: URL) throws -> Int {
+        let text = try String(contentsOf: url, encoding: .utf8)
+        return Int(text.trimmingCharacters(in: .whitespacesAndNewlines)) ?? 0
+    }
+
+    private func isProcessRunning(_ pid: pid_t) -> Bool {
+        Darwin.kill(pid, 0) == 0
+    }
+}
+
+private final class StateWatcher: @unchecked Sendable {
+    private let storage = Mutex(Storage())
+    private var task: Task<Void, Never>?
+
+    init(stream: AsyncStream<BackendProcessSupervisor.State>) {
+        task = Task {
+            for await state in stream {
+                self.record(state)
+            }
+        }
+    }
+
+    func waitForState(
+        _ expectedState: BackendProcessSupervisor.State,
+        timeout: Duration = .seconds(5)
+    ) async throws -> BackendProcessSupervisor.State {
+        try await waitForState(timeout: timeout) { $0 == expectedState }
+    }
+
+    func waitForState(
+        timeout: Duration = .seconds(5),
+        matching predicate: @escaping @Sendable (BackendProcessSupervisor.State) -> Bool
+    ) async throws -> BackendProcessSupervisor.State {
+        try await withThrowingTaskGroup(of: BackendProcessSupervisor.State.self) { group in
+            group.addTask {
+                try await self.wait(matching: predicate)
+            }
+            group.addTask {
+                try await Task.sleep(for: timeout)
+                throw WaitTimeout()
+            }
+
+            let result = try await group.next()!
+            group.cancelAll()
+            return result
+        }
+    }
+
+    func containsState(_ state: BackendProcessSupervisor.State) -> Bool {
+        storage.withLock { $0.states.contains(state) }
+    }
+
+    func cancel() {
+        task?.cancel()
+        task = nil
+    }
+
+    private func record(_ state: BackendProcessSupervisor.State) {
+        let continuationsToResume = storage.withLock { storage in
+            storage.states.append(state)
+
+            var remaining: [Waiter] = []
+            var continuations: [CheckedContinuation<BackendProcessSupervisor.State, Error>] = []
+            for waiter in storage.waiters {
+                if waiter.predicate(state) {
+                    continuations.append(waiter.continuation)
+                } else {
+                    remaining.append(waiter)
+                }
+            }
+            storage.waiters = remaining
+            return continuations
+        }
+
+        for continuation in continuationsToResume {
+            continuation.resume(returning: state)
+        }
+    }
+
+    private func wait(
+        matching predicate: @escaping @Sendable (BackendProcessSupervisor.State) -> Bool
+    ) async throws -> BackendProcessSupervisor.State {
+        if let state = storage.withLock({ $0.states.first(where: predicate) }) {
+            return state
+        }
+
+        let id = UUID()
+        return try await withTaskCancellationHandler {
+            try await withCheckedThrowingContinuation { continuation in
+                let state: BackendProcessSupervisor.State? = storage.withLock { storage in
+                    if let state = storage.states.first(where: predicate) {
+                        return state
+                    }
+                    storage.waiters.append(
+                        Waiter(id: id, predicate: predicate, continuation: continuation)
+                    )
+                    return nil
+                }
+                if let state {
+                    continuation.resume(returning: state)
+                }
+            }
+        } onCancel: {
+            let continuation = storage.withLock { storage in
+                guard let index = storage.waiters.firstIndex(where: { $0.id == id }) else {
+                    return nil as CheckedContinuation<BackendProcessSupervisor.State, Error>?
+                }
+                return storage.waiters.remove(at: index).continuation
+            }
+            continuation?.resume(throwing: CancellationError())
+        }
+    }
+
+    private struct Waiter: Sendable {
+        var id: UUID
+        var predicate: @Sendable (BackendProcessSupervisor.State) -> Bool
+        var continuation: CheckedContinuation<BackendProcessSupervisor.State, Error>
+    }
+
+    private struct Storage: Sendable {
+        var states: [BackendProcessSupervisor.State] = []
+        var waiters: [Waiter] = []
+    }
+}
+
+private struct WaitTimeout: Error {}
+
+private final class LockedValue<Value>: @unchecked Sendable {
+    private let lock = NSLock()
+    private var storage: Value
+
+    init(_ value: Value) {
+        storage = value
+    }
+
+    var value: Value {
+        get {
+            lock.lock()
+            defer { lock.unlock() }
+            return storage
+        }
+        set {
+            lock.lock()
+            storage = newValue
+            lock.unlock()
+        }
+    }
+}
+
+private final class RecordingSleep: @unchecked Sendable {
+    private let durations = LockedValue<[Duration]>([])
+
+    var recordedDurations: [Duration] {
+        durations.value
+    }
+
+    func sleep(_ duration: Duration) async throws {
+        var recorded = durations.value
+        recorded.append(duration)
+        durations.value = recorded
+        await Task.yield()
+    }
+}
+
+private final class SpawnAwareRecordingSleep: @unchecked Sendable {
+    private let durations = LockedValue<[Duration]>([])
+    private let countFile: URL
+    private let lastObservedCount = LockedValue(0)
+    private let awaitingNextSpawn = LockedValue(true)
+
+    init(countFile: URL) {
+        self.countFile = countFile
+    }
+
+    var recordedDurations: [Duration] {
+        durations.value
+    }
+
+    func sleep(_ duration: Duration) async throws {
+        var recorded = durations.value
+        recorded.append(duration)
+        durations.value = recorded
+
+        guard duration == .milliseconds(10) else {
+            awaitingNextSpawn.value = true
+            await Task.yield()
+            return
+        }
+
+        guard awaitingNextSpawn.value else {
+            await Task.yield()
+            return
+        }
+
+        while !Task.isCancelled {
+            let count = currentCount()
+            if count > lastObservedCount.value {
+                lastObservedCount.value = count
+                awaitingNextSpawn.value = false
+                return
+            }
+            await Task.yield()
+        }
+
+        throw CancellationError()
+    }
+
+    private func currentCount() -> Int {
+        guard let text = try? String(contentsOf: countFile, encoding: .utf8) else { return 0 }
+        return Int(text.trimmingCharacters(in: .whitespacesAndNewlines)) ?? 0
+    }
+}
+
+private final class ControlledSleep: @unchecked Sendable {
+    private let lock = NSLock()
+    private let shouldPause: @Sendable (Duration) -> Bool
+    private var durations: [Duration] = []
+    private var continuations: [CheckedContinuation<Void, Never>] = []
+    private var isReleased = false
+
+    init(shouldPause: @escaping @Sendable (Duration) -> Bool = { _ in true }) {
+        self.shouldPause = shouldPause
+    }
+
+    var recordedDurations: [Duration] {
+        lock.lock()
+        defer { lock.unlock() }
+        return durations
+    }
+
+    func sleep(_ duration: Duration) async throws {
+        await withCheckedContinuation { continuation in
+            lock.lock()
+            durations.append(duration)
+            guard !isReleased && shouldPause(duration) else {
+                lock.unlock()
+                continuation.resume()
+                return
+            }
+            continuations.append(continuation)
+            lock.unlock()
+        }
+    }
+
+    func resumeAll() {
+        lock.lock()
+        isReleased = true
+        let pending = continuations
+        continuations.removeAll()
+        lock.unlock()
+
+        for continuation in pending {
+            continuation.resume()
+        }
+    }
+}
+
+private final class TerminationAwareSleep: @unchecked Sendable {
+    private let controlledSleep = ControlledSleep()
+    private let termMarker: URL
+    private let readyMarker: URL
+
+    init(termMarker: URL, readyMarker: URL) {
+        self.termMarker = termMarker
+        self.readyMarker = readyMarker
+    }
+
+    func sleep(_ duration: Duration) async throws {
+        if duration == .milliseconds(10) {
+            for _ in 0 ..< 1_000 {
+                if FileManager.default.fileExists(atPath: readyMarker.path) {
+                    return
+                }
+                await Task.yield()
+            }
+            return
+        }
+
+        if duration == .milliseconds(100) {
+            for _ in 0 ..< 1_000 {
+                if FileManager.default.fileExists(atPath: termMarker.path) {
+                    return
+                }
+                await Task.yield()
+            }
+            return
+        }
+
+        try await controlledSleep.sleep(duration)
+    }
+
+    func resumeAll() {
+        controlledSleep.resumeAll()
+    }
+}


### PR DESCRIPTION
## What

Adds `BackendProcessSupervisor` — the child-process lifecycle half of the managed-backend update (infra only; nothing spawns real backends until the wiring PR):

- Spawns a configured backend (`BackendProcessConfiguration`: executable, args, env, readiness URL, timing knobs) as a child `Process`, streams stdout/stderr into a ring buffer + the new `Log.backends` category.
- **Readiness** = polling `GET /health` for HTTP 200 via an injected `probe` seam; generous default timeout (600 s) because a first run downloads model weights inside the server. Elapsed time is counted in slept intervals — no wall clock.
- **Refuses to adopt strangers**: if the readiness URL is already healthy before spawn, it fails with "port already in use" instead of silently attaching to an unknown process on a managed port.
- **Crash-restart** with exponential backoff (0.5 s → 30 s cap) and a consecutive-failure cap surfacing the stderr tail; a successful readiness pass resets the counter. Intentional `stop()` marks state first so no restart races the teardown.
- **Stop** = SIGTERM → grace period → SIGKILL, with bounded post-KILL waiting (avoids an indefinite `Process.isRunning`/termination-handler race).
- Timing/probing injected in the `OverlayBufferSessionCoordinator` seam style (`sleepFor:`/`probe:`); state observable via `@Observable` + an `AsyncStream<State>` for tests and the upcoming status UI.

Sibling PRs: #44 (installer), #45 (backend mode). The wiring PR composes all three (spawn with `--parent-pid`, stop on app quit, status UI).

## Proof

- [x] Unit suite green after rebase onto current main (#37 + #43 in) — `LV_BUILD_DIR=work/localvoxtral-codex-procsup-final ./scripts/remote-build.sh test`
  ```
  Executed 356 tests, with 0 failures (0 unexpected) in 2.435 (2.450) seconds
  ```
  New `BackendProcessSupervisorTests` drive real `/bin/sh` fake backends through the injected seams: happy path, port-already-in-use (nothing spawned), readiness timeout, crash → backoff sequence → recovery, max-consecutive-failures with stderr surfaced, TERM-honoring stop, and TERM-ignoring → KILL escalation. No wall-clock waits — transitions awaited on `stateUpdates`.
- [x] Not a bug fix; no UI change (nothing user-reachable in this PR).
