### PR TITLE
Wire managed backends: lazy install/start on dictation, status UI, teardown

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -96,8 +96,10 @@ Key subsystems:
 - Insertion: `TextInsertionService` (AX replace → Unicode CGEvents → Cmd+V)
 - Overlay: `OverlayBufferSessionCoordinator` (session + hold-before-dismiss
   timing), `OverlayBufferStateMachine`, `DictationOverlayController` (NSPanel)
-- Backends: catalog pinned to fork wheel releases; installer shells out to the
-  embedded `uv`; install root lives under Application Support.
+- Backends: `BackendManager` lazily bootstraps app-managed local serving on
+  first dictation start; catalog pinned to fork wheel releases; installer
+  shells out to the embedded `uv`; supervisors spawn/health-check/stop the
+  managed processes; install root lives under Application Support.
 - Settings/config: `SettingsStore` (UserDefaults), `AppConfigStore` (TOML at
   `~/Library/Application Support/localvoxtral/config`)
 - Hotkey: `HotKeyManager` (Carbon, single global hotkey)

--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ The **Output mode** setting applies to dictation started from the menu bar. Keyb
 
 - Open **Settings** from the menu bar popover to set:
   - Dictation trigger: single modifier key (tap/hold) or per-mode keyboard shortcuts (`Toggle` / `Push to Talk`)
+  - Backend mode (`Managed local` / `External URL`)
   - Realtime endpoint (URL, model name, API key)
   - Auto-copy final segment
   - Output mode (`Overlay Buffer` / `Live Auto-Paste`)
@@ -79,9 +80,13 @@ The shared config directory lives at `~/Library/Application Support/localvoxtral
 
 ## Tested setup
 
+### Managed local (default)
+
+In Managed local mode, localvoxtral installs the pinned `voxmlx` and `mlx-lm` backend wheels automatically into `~/Library/Application Support/localvoxtral/backends` and starts them lazily on the first dictation request. App launch stays network-inert; downloads happen only when dictation starts in managed mode.
+
 In this tested setup, `vLLM` and `voxmlx` stream partial text fast enough for realtime dictation; latency and throughput will vary by hardware, model, and quantization.
 
-### voxmlx (recommended)
+### External URL: voxmlx
 
 [voxmlx](https://github.com/awni/voxmlx) OpenAI Realtime-compatible running on M1 Pro with a 4-bit quantized model. Use [this fork](https://github.com/T0mSIlver/voxmlx) which adds a WebSocket server that speaks the OpenAI Realtime API protocol and memory management optimizations.
 
@@ -91,7 +96,7 @@ uvx --from "git+https://github.com/T0mSIlver/voxmlx.git[server]" \
   voxmlx-serve --model T0mSIlver/Voxtral-Mini-4B-Realtime-2602-MLX-4bit
 ```
 
-### vLLM
+### External URL: vLLM
 
 [vllm](https://github.com/vllm-project/vllm) OpenAI Realtime-compatible server running on an NVIDIA RTX 3090, using the default settings recommended on the [Voxtral Mini 4B Realtime model page](https://huggingface.co/mistralai/Voxtral-Mini-4B-Realtime-2602).
 
@@ -102,7 +107,11 @@ vllm serve mistralai/Voxtral-Mini-4B-Realtime-2602 --compilation_config '{"cudag
 
 ## Tested setup (LLM polishing)
 
-### mlx-lm (recommended)
+### Managed local (default)
+
+When LLM polishing is enabled in Managed local mode, localvoxtral starts the pinned `mlx-lm` backend lazily and points polishing at its local chat completions endpoint.
+
+### External URL: mlx-lm
 
 `mlx_lm.server` on M1 Pro, running [Qwen3.5-0.8B in 8 bit](https://huggingface.co/mlx-community/Qwen3.5-0.8B-MLX-8bit) for local LLM polishing.
 Use [this fork](https://github.com/T0mSIlver/mlx-lm) which adds prompt caching optimizations.
@@ -122,7 +131,7 @@ With the default polishing prompts, prompt processing is roughly 286 ms (~50%) f
 ## Roadmap
 
 - [ ] Enhance the server connection UX
-- [ ] Drive `voxmlx-serve` (from the `voxmlx` fork) upstream and assess app-managed local serving (start/stop/config) in localvoxtral.
+- [x] Drive `voxmlx-serve` (from the `voxmlx` fork) upstream and assess app-managed local serving (start/stop/config) in localvoxtral.
 - [ ] Implement more of the on-device Voxtral Realtime integrations recommended in the model README:
   - [Pure C](https://github.com/antirez/voxtral.c) - thanks [Salvatore Sanfilippo](https://github.com/antirez)
   - **done** ~~[MLX](https://github.com/awni/voxmlx) - thanks [Awni Hannun](https://github.com/awni)~~

--- a/Sources/localvoxtral/Backends/BackendInstaller.swift
+++ b/Sources/localvoxtral/Backends/BackendInstaller.swift
@@ -31,7 +31,15 @@ enum BackendInstallError: LocalizedError, Sendable {
     }
 }
 
-struct BackendInstaller {
+protocol BackendInstalling: Sendable {
+    func needsInstallOrUpdate(_ spec: ManagedBackendSpec) -> Bool
+    func install(
+        _ spec: ManagedBackendSpec,
+        progress: @MainActor @Sendable @escaping (BackendInstallProgress) -> Void
+    ) async throws
+}
+
+struct BackendInstaller: BackendInstalling {
     private let layout: BackendInstallLayout
     private let uvLocator: any UVBinaryLocating
     private let fileManager: FileManager
@@ -208,6 +216,8 @@ struct BackendInstaller {
         progress(event)
     }
 }
+
+extension BackendInstaller: @unchecked Sendable {}
 
 private struct UVToolProcessResult: Sendable {
     let exitCode: Int32

--- a/Sources/localvoxtral/Backends/BackendManager.swift
+++ b/Sources/localvoxtral/Backends/BackendManager.swift
@@ -1,0 +1,303 @@
+import Darwin
+import Foundation
+import Observation
+
+enum ManagedBackendStatus: Equatable {
+    case notInstalled
+    case installing(progress: BackendInstallProgress)
+    case starting
+    case ready
+    case stopped
+    case failed(message: String)
+
+    var requiresInstallProgressText: Bool {
+        switch self {
+        case .notInstalled, .installing:
+            return true
+        case .starting, .ready, .stopped, .failed:
+            return false
+        }
+    }
+}
+
+enum ManagedBackendManagerError: LocalizedError {
+    case backendFailed(name: String, detail: String)
+
+    var errorDescription: String? {
+        switch self {
+        case .backendFailed(let name, let detail):
+            return "\(name) failed: \(detail)"
+        }
+    }
+}
+
+@MainActor
+protocol ManagedBackendSupervising: AnyObject {
+    var state: BackendProcessSupervisor.State { get }
+    var stateUpdates: AsyncStream<BackendProcessSupervisor.State> { get }
+
+    func start() async
+    func stop() async
+}
+
+extension BackendProcessSupervisor: ManagedBackendSupervising {}
+
+@MainActor
+protocol ManagedBackendManaging: AnyObject {
+    var voxmlxStatus: ManagedBackendStatus { get }
+    var mlxLMStatus: ManagedBackendStatus { get }
+
+    func ensureReady(includePolishing: Bool) async throws
+    func stopAll() async
+}
+
+@MainActor
+@Observable
+final class BackendManager: ManagedBackendManaging {
+    typealias SupervisorFactory = @MainActor (BackendProcessConfiguration) -> any ManagedBackendSupervising
+
+    private(set) var voxmlxStatus: ManagedBackendStatus
+    private(set) var mlxLMStatus: ManagedBackendStatus
+
+    @ObservationIgnored private let installer: any BackendInstalling
+    @ObservationIgnored private let layout: BackendInstallLayout
+    @ObservationIgnored private let supervisorFactory: SupervisorFactory
+    @ObservationIgnored private var voxmlxSupervisor: (any ManagedBackendSupervising)?
+    @ObservationIgnored private var mlxLMSupervisor: (any ManagedBackendSupervising)?
+    @ObservationIgnored private var ensureReadyTask: Task<Void, Error>?
+    #if DEBUG
+    @ObservationIgnored var debugStatusChangeSink: ((ManagedBackendSpec, ManagedBackendStatus) -> Void)?
+    #endif
+
+    init(
+        installer: any BackendInstalling = BackendInstaller(),
+        layout: BackendInstallLayout = BackendInstallLayout(),
+        supervisorFactory: @escaping SupervisorFactory = { configuration in
+            BackendProcessSupervisor(configuration: configuration)
+        }
+    ) {
+        self.installer = installer
+        self.layout = layout
+        self.supervisorFactory = supervisorFactory
+        self.voxmlxStatus = installer.needsInstallOrUpdate(BackendCatalog.voxmlx)
+            ? .notInstalled
+            : .stopped
+        self.mlxLMStatus = installer.needsInstallOrUpdate(BackendCatalog.mlxLM)
+            ? .notInstalled
+            : .stopped
+    }
+
+    func ensureReady(includePolishing: Bool) async throws {
+        while true {
+            if let ensureReadyTask {
+                try await ensureReadyTask.value
+                if includePolishing, !isReady(BackendCatalog.mlxLM) {
+                    continue
+                }
+                return
+            }
+
+            let task = Task { @MainActor in
+                try await self.performEnsureReady(includePolishing: includePolishing)
+            }
+            ensureReadyTask = task
+            do {
+                try await task.value
+                ensureReadyTask = nil
+                return
+            } catch {
+                ensureReadyTask = nil
+                throw error
+            }
+        }
+    }
+
+    func stopAll() async {
+        await voxmlxSupervisor?.stop()
+        await mlxLMSupervisor?.stop()
+        if voxmlxSupervisor != nil {
+            voxmlxStatus = .stopped
+        }
+        if mlxLMSupervisor != nil {
+            mlxLMStatus = .stopped
+        }
+    }
+
+    func status(for spec: ManagedBackendSpec) -> ManagedBackendStatus {
+        switch spec.id {
+        case BackendCatalog.voxmlx.id:
+            return voxmlxStatus
+        case BackendCatalog.mlxLM.id:
+            return mlxLMStatus
+        default:
+            return .failed(message: "Unknown managed backend '\(spec.id)'.")
+        }
+    }
+
+    private func performEnsureReady(includePolishing: Bool) async throws {
+        try await ensureReady(BackendCatalog.voxmlx)
+        if includePolishing {
+            try await ensureReady(BackendCatalog.mlxLM)
+        }
+    }
+
+    private func ensureReady(_ spec: ManagedBackendSpec) async throws {
+        if isReady(spec) {
+            setStatus(.ready, for: spec)
+            return
+        }
+
+        if installer.needsInstallOrUpdate(spec) {
+            setStatus(.installing(progress: .downloading(fraction: nil)), for: spec)
+            do {
+                try await installer.install(spec) { [weak self] progress in
+                    guard let self else { return }
+                    self.setStatus(.installing(progress: progress), for: spec)
+                }
+            } catch {
+                let detail = error.localizedDescription
+                setStatus(.failed(message: detail), for: spec)
+                throw ManagedBackendManagerError.backendFailed(
+                    name: spec.displayName,
+                    detail: detail
+                )
+            }
+        }
+
+        setStatus(.starting, for: spec)
+        let supervisor = supervisor(for: spec)
+        try await startAndWaitUntilReady(supervisor, spec: spec)
+    }
+
+    private func startAndWaitUntilReady(
+        _ supervisor: any ManagedBackendSupervising,
+        spec: ManagedBackendSpec
+    ) async throws {
+        let updates = supervisor.stateUpdates
+        await supervisor.start()
+
+        switch supervisor.state {
+        case .running:
+            setStatus(.ready, for: spec)
+            return
+        case .failed(let message):
+            setStatus(.failed(message: message), for: spec)
+            throw ManagedBackendManagerError.backendFailed(name: spec.displayName, detail: message)
+        default:
+            break
+        }
+
+        for await state in updates {
+            switch state {
+            case .launching, .waitingForReady, .restarting:
+                setStatus(.starting, for: spec)
+            case .running:
+                setStatus(.ready, for: spec)
+                return
+            case .failed(let message):
+                setStatus(.failed(message: message), for: spec)
+                throw ManagedBackendManagerError.backendFailed(name: spec.displayName, detail: message)
+            case .stopped:
+                let message = "\(spec.displayName) stopped before it became ready."
+                setStatus(.failed(message: message), for: spec)
+                throw ManagedBackendManagerError.backendFailed(name: spec.displayName, detail: message)
+            case .idle:
+                break
+            }
+        }
+
+        let message = "\(spec.displayName) stopped reporting status before it became ready."
+        setStatus(.failed(message: message), for: spec)
+        throw ManagedBackendManagerError.backendFailed(name: spec.displayName, detail: message)
+    }
+
+    private func supervisor(for spec: ManagedBackendSpec) -> any ManagedBackendSupervising {
+        switch spec.id {
+        case BackendCatalog.voxmlx.id:
+            if let voxmlxSupervisor { return voxmlxSupervisor }
+            let supervisor = supervisorFactory(configuration(for: spec))
+            voxmlxSupervisor = supervisor
+            return supervisor
+        case BackendCatalog.mlxLM.id:
+            if let mlxLMSupervisor { return mlxLMSupervisor }
+            let supervisor = supervisorFactory(configuration(for: spec))
+            mlxLMSupervisor = supervisor
+            return supervisor
+        default:
+            preconditionFailure("Unknown managed backend '\(spec.id)'.")
+        }
+    }
+
+    private func configuration(for spec: ManagedBackendSpec) -> BackendProcessConfiguration {
+        BackendProcessConfiguration(
+            name: spec.displayName,
+            executableURL: layout.toolBin.appendingPathComponent(spec.executableName),
+            arguments: arguments(for: spec),
+            environment: processEnvironment(),
+            readinessURL: URL(string: "http://127.0.0.1:\(spec.port)/health")!
+        )
+    }
+
+    private func arguments(for spec: ManagedBackendSpec) -> [String] {
+        let parentPID = "\(Darwin.getpid())"
+        switch spec.id {
+        case BackendCatalog.voxmlx.id:
+            return [
+                "--model",
+                SettingsStore.RealtimeProvider.realtimeAPI.defaultModelName,
+                "--port",
+                "\(spec.port)",
+                "--parent-pid",
+                parentPID,
+            ]
+        case BackendCatalog.mlxLM.id:
+            return [
+                "--model",
+                SettingsStore.defaultLLMPolishingModel,
+                "--port",
+                "\(spec.port)",
+                "--parent-pid",
+                parentPID,
+            ]
+        default:
+            return []
+        }
+    }
+
+    private func processEnvironment() -> [String: String] {
+        let inherited = ProcessInfo.processInfo.environment
+        var environment: [String: String] = [:]
+        for key in ["PATH", "HOME"] {
+            if let value = inherited[key] {
+                environment[key] = value
+            }
+        }
+        environment.merge(layout.environment) { _, new in new }
+        return environment
+    }
+
+    private func isReady(_ spec: ManagedBackendSpec) -> Bool {
+        switch spec.id {
+        case BackendCatalog.voxmlx.id:
+            return voxmlxSupervisor?.state == .running || voxmlxStatus == .ready
+        case BackendCatalog.mlxLM.id:
+            return mlxLMSupervisor?.state == .running || mlxLMStatus == .ready
+        default:
+            return false
+        }
+    }
+
+    private func setStatus(_ status: ManagedBackendStatus, for spec: ManagedBackendSpec) {
+        switch spec.id {
+        case BackendCatalog.voxmlx.id:
+            voxmlxStatus = status
+        case BackendCatalog.mlxLM.id:
+            mlxLMStatus = status
+        default:
+            break
+        }
+        #if DEBUG
+        debugStatusChangeSink?(spec, status)
+        #endif
+    }
+}

--- a/Sources/localvoxtral/Backends/ManagedBackendEndpoints.swift
+++ b/Sources/localvoxtral/Backends/ManagedBackendEndpoints.swift
@@ -2,12 +2,9 @@ import Foundation
 
 /// Fixed localhost endpoints for app-managed backends. Deliberately NOT
 /// 8000/8080 so a user-run server never collides with the managed ones.
-///
-/// NOTE: a parallel PR introduces `BackendCatalog` with the same ports; the
-/// wiring PR reconciles the duplication.
 enum ManagedBackendEndpoints {
-    static let voxmlxPort = 8471
-    static let mlxLMPort = 8472
-    static let realtimeURLString = "ws://127.0.0.1:8471/v1/realtime"
-    static let polishingURLString = "http://127.0.0.1:8472/v1/chat/completions"
+    static let voxmlxPort = BackendCatalog.voxmlx.port
+    static let mlxLMPort = BackendCatalog.mlxLM.port
+    static let realtimeURLString = "ws://127.0.0.1:\(voxmlxPort)/v1/realtime"
+    static let polishingURLString = "http://127.0.0.1:\(mlxLMPort)/v1/chat/completions"
 }

--- a/Sources/localvoxtral/DictationViewModel+Session.swift
+++ b/Sources/localvoxtral/DictationViewModel+Session.swift
@@ -37,6 +37,67 @@ extension DictationViewModel {
         sessionReplacementDictionary = nil
     }
 
+    func beginDictationAfterManagedBackendIfNeeded(outputMode: DictationOutputMode? = nil) {
+        guard settings.backendMode == .managedLocal else {
+            beginDictationSession(outputMode: outputMode)
+            return
+        }
+
+        isConnectingRealtimeSession = true
+        let includePolishing = settings.llmPolishingEnabled
+        statusText = managedBackendStartupStatusText(includePolishing: includePolishing)
+
+        Task { @MainActor [weak self] in
+            guard let self else { return }
+            do {
+                try await self.backendManager.ensureReady(includePolishing: includePolishing)
+            } catch {
+                self.abortConnectingSession()
+                self.handleManagedBackendStartupFailure(error)
+                return
+            }
+
+            guard !Task.isCancelled, self.isConnectingRealtimeSession else { return }
+            self.beginDictationSession(outputMode: outputMode)
+        }
+    }
+
+    private func managedBackendStartupStatusText(includePolishing: Bool) -> String {
+        if shouldShowManagedBackendInstallStatus(
+            voxmlxStatus: backendManager.voxmlxStatus,
+            mlxLMStatus: includePolishing ? backendManager.mlxLMStatus : nil
+        ) {
+            return "Installing dictation backend..."
+        }
+        return "Starting dictation backend - first run may download the model..."
+    }
+
+    private func shouldShowManagedBackendInstallStatus(
+        voxmlxStatus: ManagedBackendStatus,
+        mlxLMStatus: ManagedBackendStatus?
+    ) -> Bool {
+        if voxmlxStatus.requiresInstallProgressText {
+            return true
+        }
+        return mlxLMStatus?.requiresInstallProgressText == true
+    }
+
+    private func handleManagedBackendStartupFailure(_ error: Error) {
+        let detail = error.localizedDescription.trimmed.isEmpty
+            ? String(describing: error)
+            : error.localizedDescription
+        let message = "Unable to start the managed dictation backend: \(detail)"
+        statusText = "Managed backend failed."
+        lastError = message
+        logConnectionFailure(message: message, technicalDetails: detail)
+        markRecentConnectionFailureIndicator()
+        presentConnectionFailureAlert(
+            title: "Managed Backend Failed",
+            message: message,
+            technicalDetails: detail
+        )
+    }
+
     func beginDictationSession(outputMode: DictationOutputMode? = nil) {
         lastSocketErrorMessage = nil
         polishAndCommitTask?.cancel()

--- a/Sources/localvoxtral/DictationViewModel.swift
+++ b/Sources/localvoxtral/DictationViewModel.swift
@@ -176,6 +176,8 @@ final class DictationViewModel {
     @ObservationIgnored
     var appConfigStore: any AppConfigServing = AppConfigStore()
     @ObservationIgnored
+    let backendManager: any ManagedBackendManaging
+    @ObservationIgnored
     var sessionStore: DictationSessionStore?
     @ObservationIgnored
     let overlayBufferCoordinator: OverlayBufferSessionCoordinating
@@ -253,6 +255,8 @@ final class DictationViewModel {
     var debugDeltaLogSink: ((DebugRealtimeDeltaLogRecord) -> Void)?
     @ObservationIgnored
     var debugSavedSessionRecordSink: ((DictationSessionRecord) -> Void)?
+    @ObservationIgnored
+    var debugMicrophoneAuthorizationStatusOverride: MicrophoneAuthorizationStatus?
 
     @ObservationIgnored
     let debugLoggingEnabled = ProcessInfo.processInfo.environment["LOCALVOXTRAL_DEBUG"] == "1"
@@ -274,10 +278,12 @@ final class DictationViewModel {
 
     init(
         settings: SettingsStore,
+        backendManager: (any ManagedBackendManaging)? = nil,
         overlayBufferCoordinator: OverlayBufferSessionCoordinating? = nil,
         startRuntimeServices: Bool = true
     ) {
         self.settings = settings
+        self.backendManager = backendManager ?? BackendManager()
         self.managesRuntimeServices = startRuntimeServices
         if let overlayBufferCoordinator {
             self.overlayBufferCoordinator = overlayBufferCoordinator
@@ -420,8 +426,11 @@ final class DictationViewModel {
             queue: .main
         ) { [weak self] _ in
             Task { @MainActor [weak self] in
-                guard let self, self.isDictating else { return }
-                self.stopDictation(reason: "app terminating", finalizeRemainingAudio: false)
+                guard let self else { return }
+                if self.isDictating {
+                    self.stopDictation(reason: "app terminating", finalizeRemainingAudio: false)
+                }
+                await self.backendManager.stopAll()
             }
         }
 
@@ -671,6 +680,19 @@ final class DictationViewModel {
         }
     }
 
+    func applyBackendModeChange(_ mode: BackendMode) {
+        let previousMode = settings.backendMode
+        settings.backendMode = mode
+
+        guard previousMode == .managedLocal, mode == .externalURL else { return }
+        // Leaving managed mode means the app should no longer own local backend
+        // processes. Polishing toggles are intentionally lighter-weight: if
+        // mlx-lm is already running, it stays up until quit or a mode switch.
+        Task { @MainActor [backendManager] in
+            await backendManager.stopAll()
+        }
+    }
+
     /// Register hotkeys based on current settings.
     /// Uses modifier-only, dual shortcuts, or legacy single shortcut depending on config.
     @discardableResult
@@ -863,9 +885,9 @@ final class DictationViewModel {
         }
         lastError = nil
 
-        switch microphone.authorizationStatus() {
+        switch currentMicrophoneAuthorizationStatus() {
         case .authorized:
-            beginDictationSession(outputMode: outputMode)
+            beginDictationAfterManagedBackendIfNeeded(outputMode: outputMode)
         case .notDetermined:
             isAwaitingMicrophonePermission = true
             statusText = StatusStrings.requestingMicrophonePermission
@@ -888,7 +910,7 @@ final class DictationViewModel {
                         self.hasActivePushToTalkShortcutSession = false
                         return
                     }
-                    self.beginDictationSession(outputMode: outputMode)
+                    self.beginDictationAfterManagedBackendIfNeeded(outputMode: outputMode)
                 }
             }
             Task { [weak self] in
@@ -906,6 +928,15 @@ final class DictationViewModel {
             lastError = Self.microphoneDeniedMessage
             debugLog("microphone access denied or restricted")
         }
+    }
+
+    func currentMicrophoneAuthorizationStatus() -> MicrophoneAuthorizationStatus {
+        #if DEBUG
+        if let debugMicrophoneAuthorizationStatusOverride {
+            return debugMicrophoneAuthorizationStatusOverride
+        }
+        #endif
+        return microphone.authorizationStatus()
     }
 
     func stopDictation(reason: String = "unspecified", finalizeRemainingAudio: Bool = true) {

--- a/Sources/localvoxtral/SettingsStore.swift
+++ b/Sources/localvoxtral/SettingsStore.swift
@@ -193,7 +193,7 @@ final class SettingsStore {
     /// Default model for the OpenAI-compatible LLM polishing server. Used as
     /// the external-mode fallback and as the model the managed mlx-lm backend
     /// is expected to serve.
-    private static let defaultLLMPolishingModel = "mlx-community/Qwen3.5-0.8B-8bit"
+    static let defaultLLMPolishingModel = "mlx-community/Qwen3.5-0.8B-8bit"
 
     var realtimeProvider: RealtimeProvider {
         didSet { defaults.set(realtimeProvider.rawValue, forKey: Keys.realtimeProvider) }

--- a/Sources/localvoxtral/SettingsView.swift
+++ b/Sources/localvoxtral/SettingsView.swift
@@ -3,6 +3,7 @@ import SwiftUI
 struct SettingsView: View {
     @Bindable var settings: SettingsStore
     var viewModel: DictationViewModel
+    var backendManager: BackendManager
     @State private var shortcutValidationError: String?
 
     private var endpointBinding: Binding<String> {
@@ -60,6 +61,8 @@ struct SettingsView: View {
         TabView {
             ConnectionSettingsPane(
                 settings: settings,
+                viewModel: viewModel,
+                backendManager: backendManager,
                 endpointBinding: endpointBinding,
                 modelBinding: modelBinding
             )
@@ -104,15 +107,26 @@ private enum SettingsLayout {
 
 private struct ConnectionSettingsPane: View {
     @Bindable var settings: SettingsStore
+    let viewModel: DictationViewModel
+    let backendManager: BackendManager
     let endpointBinding: Binding<String>
     let modelBinding: Binding<String>
+
+    private var backendModeBinding: Binding<BackendMode> {
+        Binding(
+            get: { settings.backendMode },
+            set: { newValue in
+                viewModel.applyBackendModeChange(newValue)
+            }
+        )
+    }
 
     var body: some View {
         SettingsPage {
             SettingsGroup(title: "Backend") {
                 SettingsFieldRow(title: "Mode") {
                     VStack(alignment: .leading, spacing: 6) {
-                        Picker("", selection: $settings.backendMode) {
+                        Picker("", selection: backendModeBinding) {
                             ForEach(BackendMode.allCases) { mode in
                                 Text(mode.displayName).tag(mode)
                             }
@@ -141,29 +155,115 @@ private struct ConnectionSettingsPane: View {
                             .textFieldStyle(.roundedBorder)
                     }
                 case .managedLocal:
-                    ManagedBackendSettingsPlaceholder()
+                    ManagedBackendStatusRows(backendManager: backendManager)
                 }
             }
         }
     }
 }
 
-// TODO: the wiring PR replaces this static info with live install/run status
-// for the managed voxmlx + mlx-lm backends.
-private struct ManagedBackendSettingsPlaceholder: View {
+private struct ManagedBackendStatusRows: View {
+    let backendManager: BackendManager
+
     var body: some View {
-        SettingsFieldRow(title: "Dictation") {
+        ManagedBackendStatusRow(
+            title: "Dictation",
+            spec: BackendCatalog.voxmlx,
+            endpoint: ManagedBackendEndpoints.realtimeURLString,
+            status: backendManager.voxmlxStatus
+        )
+
+        ManagedBackendStatusRow(
+            title: "Polishing",
+            spec: BackendCatalog.mlxLM,
+            endpoint: ManagedBackendEndpoints.polishingURLString,
+            status: backendManager.mlxLMStatus
+        )
+    }
+}
+
+private struct ManagedBackendStatusRow: View {
+    let title: String
+    let spec: ManagedBackendSpec
+    let endpoint: String
+    let status: ManagedBackendStatus
+
+    var body: some View {
+        SettingsFieldRow(title: title) {
             VStack(alignment: .leading, spacing: 6) {
-                Text("voxmlx — \(ManagedBackendEndpoints.realtimeURLString)")
+                Text("\(spec.displayName) - \(endpoint)")
                     .font(.system(size: 12, weight: .medium, design: .monospaced))
 
-                SettingsHelpText("Backends are installed and started automatically.")
+                ManagedBackendStatusLabel(status: status)
             }
         }
+    }
+}
 
-        SettingsFieldRow(title: "Polishing") {
-            Text("mlx-lm — \(ManagedBackendEndpoints.polishingURLString)")
-                .font(.system(size: 12, weight: .medium, design: .monospaced))
+private struct ManagedBackendStatusLabel: View {
+    let status: ManagedBackendStatus
+
+    var body: some View {
+        HStack(spacing: 8) {
+            if case .installing(let progress) = status {
+                if let fraction = installFraction(from: progress) {
+                    ProgressView(value: fraction)
+                        .controlSize(.small)
+                        .frame(width: 54)
+                } else {
+                    ProgressView()
+                        .controlSize(.small)
+                        .frame(width: 54)
+                }
+            }
+
+            Text(statusText)
+                .font(.caption)
+                .foregroundStyle(statusColor)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+    }
+
+    private var statusText: String {
+        switch status {
+        case .notInstalled:
+            return "Not installed"
+        case .installing(let progress):
+            return installingText(progress)
+        case .starting:
+            return "Starting"
+        case .ready:
+            return "Ready"
+        case .stopped:
+            return "Stopped"
+        case .failed(let message):
+            return "Failed: \(message)"
+        }
+    }
+
+    private var statusColor: Color {
+        if case .failed = status {
+            return .red
+        }
+        return .secondary
+    }
+
+    private func installFraction(from progress: BackendInstallProgress) -> Double? {
+        guard case .downloading(let fraction) = progress else { return nil }
+        return fraction
+    }
+
+    private func installingText(_ progress: BackendInstallProgress) -> String {
+        switch progress {
+        case .downloading(let fraction):
+            guard let fraction else { return "Downloading" }
+            return "Downloading \(Int((fraction * 100).rounded()))%"
+        case .verifying:
+            return "Verifying"
+        case .installing(let logLine):
+            return logLine.trimmed.isEmpty ? "Installing" : "Installing: \(logLine)"
+        case .finished:
+            return "Installed"
         }
     }
 }
@@ -368,6 +468,8 @@ private struct TextProcessingSettingsPane: View {
                 if newValue, !wasEnabled {
                     viewModel.prepareLLMPolishingPromptAccessIfNeeded()
                 }
+                // Disabling polishing does not stop a managed mlx-lm process
+                // mid-run; it is stopped on quit or when switching to External URL.
             }
         )
     }

--- a/Sources/localvoxtral/localvoxtralApp.swift
+++ b/Sources/localvoxtral/localvoxtralApp.swift
@@ -4,12 +4,15 @@ import SwiftUI
 @main
 struct localvoxtralApp: App {
     @State private var settingsStore: SettingsStore
+    @State private var backendManager: BackendManager
     @State private var viewModel: DictationViewModel
 
     init() {
         let settings = SettingsStore()
+        let manager = BackendManager()
         settingsStore = settings
-        viewModel = DictationViewModel(settings: settings)
+        backendManager = manager
+        viewModel = DictationViewModel(settings: settings, backendManager: manager)
     }
 
     var body: some Scene {
@@ -83,7 +86,7 @@ struct localvoxtralApp: App {
         .menuBarExtraStyle(.menu)
 
         Settings {
-            SettingsView(settings: settingsStore, viewModel: viewModel)
+            SettingsView(settings: settingsStore, viewModel: viewModel, backendManager: backendManager)
                 .frame(minWidth: 560, idealWidth: 580, minHeight: 380, idealHeight: 420)
         }
         .defaultSize(width: 580, height: 420)

--- a/Tests/localvoxtralTests/BackendManagerTests.swift
+++ b/Tests/localvoxtralTests/BackendManagerTests.swift
@@ -1,0 +1,253 @@
+import Foundation
+import XCTest
+@testable import localvoxtral
+
+@MainActor
+final class BackendManagerTests: XCTestCase {
+    func testInstallThenStartHappyPathRecordsStatusSequence() async throws {
+        let installer = FakeBackendInstaller(needsInstall: [BackendCatalog.voxmlx.id])
+        let supervisorFactory = FakeSupervisorFactory()
+        supervisorFactory.statesByName[BackendCatalog.voxmlx.displayName] = [
+            .launching,
+            .waitingForReady,
+            .running,
+        ]
+        let manager = makeManager(installer: installer, supervisorFactory: supervisorFactory)
+        var voxmlxStatuses: [ManagedBackendStatus] = []
+        manager.debugStatusChangeSink = { spec, status in
+            guard spec.id == BackendCatalog.voxmlx.id else { return }
+            voxmlxStatuses.append(status)
+        }
+
+        try await manager.ensureReady(includePolishing: false)
+
+        XCTAssertEqual(installer.installCalls.map(\.id), [BackendCatalog.voxmlx.id])
+        XCTAssertEqual(manager.voxmlxStatus, .ready)
+        XCTAssertTrue(voxmlxStatuses.contains(.installing(progress: .downloading(fraction: nil))))
+        XCTAssertTrue(voxmlxStatuses.contains(.installing(progress: .verifying)))
+        XCTAssertTrue(voxmlxStatuses.contains(.starting))
+        XCTAssertEqual(voxmlxStatuses.last, .ready)
+    }
+
+    func testAlreadyInstalledSkipsInstaller() async throws {
+        let installer = FakeBackendInstaller(needsInstall: [])
+        let supervisorFactory = FakeSupervisorFactory()
+        supervisorFactory.statesByName[BackendCatalog.voxmlx.displayName] = [.running]
+        let manager = makeManager(installer: installer, supervisorFactory: supervisorFactory)
+
+        try await manager.ensureReady(includePolishing: false)
+
+        XCTAssertTrue(installer.installCalls.isEmpty)
+        XCTAssertEqual(supervisorFactory.createdConfigurations.map(\.name), [BackendCatalog.voxmlx.displayName])
+        XCTAssertEqual(manager.voxmlxStatus, .ready)
+    }
+
+    func testInstallFailureMarksBackendFailed() async {
+        let installer = FakeBackendInstaller(
+            needsInstall: [BackendCatalog.voxmlx.id],
+            installFailures: [BackendCatalog.voxmlx.id: FakeBackendError(message: "wheel unavailable")]
+        )
+        let manager = makeManager(installer: installer, supervisorFactory: FakeSupervisorFactory())
+
+        do {
+            try await manager.ensureReady(includePolishing: false)
+            XCTFail("expected ensureReady to throw")
+        } catch {
+            XCTAssertTrue(error.localizedDescription.contains("voxmlx"))
+            XCTAssertTrue(error.localizedDescription.contains("wheel unavailable"))
+        }
+
+        XCTAssertEqual(manager.voxmlxStatus, .failed(message: "wheel unavailable"))
+    }
+
+    func testPolishingFlagControlsWhetherMLXLMIsTouched() async throws {
+        let installer = FakeBackendInstaller(needsInstall: [])
+        let supervisorFactory = FakeSupervisorFactory()
+        supervisorFactory.statesByName[BackendCatalog.voxmlx.displayName] = [.running]
+        supervisorFactory.statesByName[BackendCatalog.mlxLM.displayName] = [.running]
+        let manager = makeManager(installer: installer, supervisorFactory: supervisorFactory)
+
+        try await manager.ensureReady(includePolishing: false)
+        XCTAssertEqual(supervisorFactory.createdConfigurations.map(\.name), [BackendCatalog.voxmlx.displayName])
+
+        try await manager.ensureReady(includePolishing: true)
+        XCTAssertEqual(
+            supervisorFactory.createdConfigurations.map(\.name),
+            [BackendCatalog.voxmlx.displayName, BackendCatalog.mlxLM.displayName]
+        )
+        XCTAssertEqual(manager.mlxLMStatus, .ready)
+    }
+
+    func testConcurrentEnsureReadyDoesNotDoubleInstall() async throws {
+        let installer = FakeBackendInstaller(
+            needsInstall: [BackendCatalog.voxmlx.id],
+            suspendInstalls: true
+        )
+        let supervisorFactory = FakeSupervisorFactory()
+        supervisorFactory.statesByName[BackendCatalog.voxmlx.displayName] = [.running]
+        let manager = makeManager(installer: installer, supervisorFactory: supervisorFactory)
+
+        let first = Task { @MainActor in
+            try await manager.ensureReady(includePolishing: false)
+        }
+        await installer.waitUntilInstallStarted()
+
+        let second = Task { @MainActor in
+            try await manager.ensureReady(includePolishing: false)
+        }
+        await Task.yield()
+
+        XCTAssertEqual(installer.installCalls.map(\.id), [BackendCatalog.voxmlx.id])
+        installer.resumeInstall()
+
+        try await first.value
+        try await second.value
+        XCTAssertEqual(installer.installCalls.map(\.id), [BackendCatalog.voxmlx.id])
+        XCTAssertEqual(manager.voxmlxStatus, .ready)
+    }
+
+    func testStopAllStopsBothSupervisors() async throws {
+        let installer = FakeBackendInstaller(needsInstall: [])
+        let supervisorFactory = FakeSupervisorFactory()
+        supervisorFactory.statesByName[BackendCatalog.voxmlx.displayName] = [.running]
+        supervisorFactory.statesByName[BackendCatalog.mlxLM.displayName] = [.running]
+        let manager = makeManager(installer: installer, supervisorFactory: supervisorFactory)
+
+        try await manager.ensureReady(includePolishing: true)
+        await manager.stopAll()
+
+        XCTAssertEqual(supervisorFactory.supervisors[BackendCatalog.voxmlx.displayName]?.stopCallCount, 1)
+        XCTAssertEqual(supervisorFactory.supervisors[BackendCatalog.mlxLM.displayName]?.stopCallCount, 1)
+        XCTAssertEqual(manager.voxmlxStatus, .stopped)
+        XCTAssertEqual(manager.mlxLMStatus, .stopped)
+    }
+
+    private func makeManager(
+        installer: FakeBackendInstaller,
+        supervisorFactory: FakeSupervisorFactory
+    ) -> BackendManager {
+        BackendManager(
+            installer: installer,
+            layout: BackendInstallLayout(root: URL(fileURLWithPath: "/tmp/localvoxtral-backend-manager-tests")),
+            supervisorFactory: { configuration in
+                supervisorFactory.makeSupervisor(configuration: configuration)
+            }
+        )
+    }
+}
+
+private final class FakeBackendInstaller: BackendInstalling, @unchecked Sendable {
+    private var needsInstall: Set<String>
+    private let installFailures: [String: Error]
+    private let suspendInstalls: Bool
+    private var installStartedContinuation: CheckedContinuation<Void, Never>?
+    private var installResumeContinuation: CheckedContinuation<Void, Never>?
+
+    private(set) var installCalls: [ManagedBackendSpec] = []
+
+    init(
+        needsInstall: Set<String>,
+        installFailures: [String: Error] = [:],
+        suspendInstalls: Bool = false
+    ) {
+        self.needsInstall = needsInstall
+        self.installFailures = installFailures
+        self.suspendInstalls = suspendInstalls
+    }
+
+    func needsInstallOrUpdate(_ spec: ManagedBackendSpec) -> Bool {
+        needsInstall.contains(spec.id)
+    }
+
+    func install(
+        _ spec: ManagedBackendSpec,
+        progress: @MainActor @Sendable @escaping (BackendInstallProgress) -> Void
+    ) async throws {
+        installCalls.append(spec)
+        installStartedContinuation?.resume()
+        installStartedContinuation = nil
+
+        if suspendInstalls {
+            await withCheckedContinuation { continuation in
+                installResumeContinuation = continuation
+            }
+        }
+
+        if let error = installFailures[spec.id] {
+            throw error
+        }
+
+        await progress(.verifying)
+        await progress(.installing(logLine: "installed \(spec.displayName)"))
+        await progress(.finished)
+        needsInstall.remove(spec.id)
+    }
+
+    func waitUntilInstallStarted() async {
+        guard installCalls.isEmpty else { return }
+        await withCheckedContinuation { continuation in
+            installStartedContinuation = continuation
+        }
+    }
+
+    func resumeInstall() {
+        installResumeContinuation?.resume()
+        installResumeContinuation = nil
+    }
+}
+
+@MainActor
+private final class FakeSupervisorFactory {
+    var statesByName: [String: [BackendProcessSupervisor.State]] = [:]
+    private(set) var createdConfigurations: [BackendProcessConfiguration] = []
+    private(set) var supervisors: [String: FakeBackendSupervisor] = [:]
+
+    func makeSupervisor(configuration: BackendProcessConfiguration) -> FakeBackendSupervisor {
+        createdConfigurations.append(configuration)
+        let supervisor = FakeBackendSupervisor(
+            statesOnStart: statesByName[configuration.name] ?? [.running]
+        )
+        supervisors[configuration.name] = supervisor
+        return supervisor
+    }
+}
+
+@MainActor
+private final class FakeBackendSupervisor: ManagedBackendSupervising {
+    private let statesOnStart: [BackendProcessSupervisor.State]
+    private let stateContinuation: AsyncStream<BackendProcessSupervisor.State>.Continuation
+
+    private(set) var state: BackendProcessSupervisor.State = .idle
+    let stateUpdates: AsyncStream<BackendProcessSupervisor.State>
+    private(set) var startCallCount = 0
+    private(set) var stopCallCount = 0
+
+    init(statesOnStart: [BackendProcessSupervisor.State]) {
+        self.statesOnStart = statesOnStart
+        let stream = AsyncStream<BackendProcessSupervisor.State>.makeStream(of: BackendProcessSupervisor.State.self)
+        self.stateUpdates = stream.stream
+        self.stateContinuation = stream.continuation
+    }
+
+    func start() async {
+        startCallCount += 1
+        for state in statesOnStart {
+            self.state = state
+            stateContinuation.yield(state)
+        }
+    }
+
+    func stop() async {
+        stopCallCount += 1
+        state = .stopped
+        stateContinuation.yield(.stopped)
+    }
+}
+
+private struct FakeBackendError: LocalizedError {
+    let message: String
+
+    var errorDescription: String? {
+        message
+    }
+}

--- a/Tests/localvoxtralTests/DictationViewModelFailFastUXTests.swift
+++ b/Tests/localvoxtralTests/DictationViewModelFailFastUXTests.swift
@@ -238,12 +238,60 @@ final class DictationViewModelFailFastUXTests: XCTestCase {
         viewModel.abortConnectingSession()
     }
 
+    // MARK: - Managed backend startup
+
+    func testStartDictationInManagedModeAwaitsBackendManagerAndSurfacesFailure() async {
+        let backendManager = FakeManagedBackendManager()
+        backendManager.ensureError = FakeManagedBackendFailure(message: "voxmlx failed: missing wheel")
+        backendManager.suspendEnsure = true
+        let viewModel = makeViewModel(outputMode: .overlayBuffer, backendManager: backendManager)
+        viewModel.settings.backendMode = .managedLocal
+        viewModel.isShowingConnectionFailureAlert = true
+        viewModel.debugMicrophoneAuthorizationStatusOverride = .authorized
+        retainForTestProcessLifetime(viewModel)
+
+        viewModel.startDictation()
+        await backendManager.waitUntilEnsureStarted()
+
+        XCTAssertTrue(viewModel.isConnectingRealtimeSession)
+        XCTAssertNil(viewModel.sessionProvider, "connection must not start until the managed backend is ready")
+        XCTAssertEqual(viewModel.statusText, "Installing dictation backend...")
+        XCTAssertEqual(backendManager.ensureIncludePolishingCalls, [false])
+
+        backendManager.resumeEnsure()
+        await Task.yield()
+
+        XCTAssertFalse(viewModel.isConnectingRealtimeSession)
+        XCTAssertEqual(viewModel.statusText, "Managed backend failed.")
+        XCTAssertTrue(viewModel.lastError?.contains("voxmlx failed: missing wheel") == true)
+        XCTAssertEqual(viewModel.realtimeSessionIndicatorState, .recentFailure)
+    }
+
+    func testStartDictationInExternalModeNeverTouchesManagedBackendManager() {
+        let backendManager = FakeManagedBackendManager()
+        let viewModel = makeViewModel(outputMode: .overlayBuffer, backendManager: backendManager)
+        viewModel.settings.backendMode = .externalURL
+        viewModel.settings.realtimeAPIEndpointURL = ""
+        viewModel.isShowingConnectionFailureAlert = true
+        viewModel.debugMicrophoneAuthorizationStatusOverride = .authorized
+        retainForTestProcessLifetime(viewModel)
+
+        viewModel.startDictation()
+
+        XCTAssertTrue(backendManager.ensureIncludePolishingCalls.isEmpty)
+        XCTAssertEqual(viewModel.statusText, "Invalid endpoint URL.")
+    }
+
     // MARK: - Helpers
 
-    private func makeViewModel(outputMode: DictationOutputMode) -> DictationViewModel {
+    private func makeViewModel(
+        outputMode: DictationOutputMode,
+        backendManager: (any ManagedBackendManaging)? = nil
+    ) -> DictationViewModel {
         let settings = makeSettings(outputMode: outputMode)
         let viewModel = DictationViewModel(
             settings: settings,
+            backendManager: backendManager,
             overlayBufferCoordinator: NoopOverlayCoordinator(),
             startRuntimeServices: false
         )
@@ -296,6 +344,63 @@ private final class NoopOverlayCoordinator: OverlayBufferSessionCoordinating {
     func dismissAfterHold(minimumVisibility: TimeInterval) {}
     func reset() {}
     func captureLiveCommitTargetAppPID() {}
+}
+
+@MainActor
+private final class FakeManagedBackendManager: ManagedBackendManaging {
+    var voxmlxStatus: ManagedBackendStatus = .notInstalled
+    var mlxLMStatus: ManagedBackendStatus = .notInstalled
+    var ensureError: Error?
+    var suspendEnsure = false
+    private(set) var ensureIncludePolishingCalls: [Bool] = []
+    private(set) var stopAllCallCount = 0
+    private var ensureStartedContinuation: CheckedContinuation<Void, Never>?
+    private var ensureResumeContinuation: CheckedContinuation<Void, Never>?
+
+    func ensureReady(includePolishing: Bool) async throws {
+        ensureIncludePolishingCalls.append(includePolishing)
+        ensureStartedContinuation?.resume()
+        ensureStartedContinuation = nil
+
+        if suspendEnsure {
+            await withCheckedContinuation { continuation in
+                ensureResumeContinuation = continuation
+            }
+        }
+
+        if let ensureError {
+            throw ensureError
+        }
+
+        voxmlxStatus = .ready
+        if includePolishing {
+            mlxLMStatus = .ready
+        }
+    }
+
+    func stopAll() async {
+        stopAllCallCount += 1
+    }
+
+    func waitUntilEnsureStarted() async {
+        guard ensureIncludePolishingCalls.isEmpty else { return }
+        await withCheckedContinuation { continuation in
+            ensureStartedContinuation = continuation
+        }
+    }
+
+    func resumeEnsure() {
+        ensureResumeContinuation?.resume()
+        ensureResumeContinuation = nil
+    }
+}
+
+private struct FakeManagedBackendFailure: LocalizedError {
+    let message: String
+
+    var errorDescription: String? {
+        message
+    }
 }
 
 extension DictationViewModel {


### PR DESCRIPTION
## What

The final integration PR of the managed-backend update — composes #44 (installer), #45 (backend mode), #47 (supervisor) into the working feature:

- **`BackendManager`** (`ManagedBackendManaging` protocol for DI): lazily installs (via `BackendInstaller`) and starts (via `BackendProcessSupervisor`) voxmlx — plus mlx-lm when polishing is enabled — exposing per-backend `ManagedBackendStatus` for the UI. Concurrent `ensureReady` calls share one in-flight task; already-ready backends are left alone.
- **Lazy bootstrap**: nothing installs, downloads, or spawns at app launch — the first dictation start in managed mode triggers it (CI's packaged-app launch smoke stays network-inert). Status text walks through "Installing dictation backend…" / "Starting dictation backend — first run may download the model…".
- **Failure surfacing** reuses the #36 fail-fast path (alert + status + connection-failure indicator) with the backend name and error detail.
- **Teardown**: backends stop on app termination (best-effort; `--parent-pid` in the spawn args is the hard-crash backstop) and when switching to External URL mode. Disabling polishing leaves an already-running mlx-lm up until quit — deliberate, documented in code.
- **Settings UI**: the managed placeholder from #45 is now live status per backend (endpoint, state, install progress, error text). Mode changes route through `applyBackendModeChange` so leaving managed mode stops the processes.
- Ports single-sourced: `ManagedBackendEndpoints` now derives from `BackendCatalog`.
- Spawn args: `voxmlx-serve --model <default> --port 8471 --parent-pid <pid>` / `mlx_lm.server --model <default> --port 8472 --parent-pid <pid>`, executables from the install layout, readiness = `GET /health`.

## Proof

- [x] Unit suite green on the rebased branch (post #44/#45/#47 squash-merges) — `LV_BUILD_DIR=work/localvoxtral-codex-wiring ./scripts/remote-build.sh test`
  ```
  Executed 384 tests, with 0 failures (0 unexpected)
  ```
  New `BackendManagerTests` (fake installer + fake supervisor factory): install-then-start status sequence, already-installed skips installer, install failure surfaces message, polishing flag gates mlx-lm, concurrent ensureReady doesn't double-install, stopAll. `DictationViewModelFailFastUXTests` additions: managed mode awaits ensureReady and surfaces its failure through the existing alert path; external mode never touches the manager.
- [x] Packaging green — `remote-build.sh package`: embedded uv present, bundle `satisfies its Designated Requirement`.
- [x] **UI/E2E hand-verification: NOT yet done — explicitly owed** (repo owner is release-gating this by hand):
  1. packaged app launch performs no install/spawn before first dictation;
  2. managed-mode first dictation installs voxmlx, starts it, connects, dictates;
  3. polishing path installs/starts mlx-lm lazily and polishes;
  4. settings rows show status/progress/errors correctly;
  5. switch to External URL stops managed processes;
  6. quit terminates both backends;
  7. live auto-paste + overlay buffer both work against the managed backend.
