### PR TITLE
Consolidate README around managed local; enable prompt caching in managed mlx-lm

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,8 @@ It keeps the loop simple: start dictation, speak, get text fast.
 Unlike Whisper-based tools that transcribe after you stop speaking, Voxtral Realtime streams text as audio arrives, so words appear while you're still talking.
 On Apple Silicon, `localvoxtral` + `voxmlx` + `mlx-lm` provides a fully local path (audio + inference + LLM polishing stay on-device), improving privacy and avoiding API costs.
 
-It connects to any OpenAI Realtime-compatible endpoint. Recommended backends are `voxmlx` (Apple Silicon) and `vLLM` (NVIDIA GPU).
-LLM Polishing connect to any OpenAI /chat/completions endpoint. The recommended backend is `mlx-lm` (Apple Silicon).
+On Apple Silicon the default **Managed local** mode runs everything for you: localvoxtral installs and manages `voxmlx` (dictation) and `mlx-lm` (LLM polishing) itself.
+**External URL** mode connects to any OpenAI Realtime-compatible endpoint you run yourself (e.g. `vLLM` on NVIDIA GPU), and LLM polishing to any OpenAI /chat/completions endpoint.
 
 Built for Mistral AI's [Voxtral Mini 4B Realtime](https://huggingface.co/mistralai/Voxtral-Mini-4B-Realtime-2602) model, but it works with any OpenAI-compatible Realtime API backend and model.
 
@@ -82,19 +82,11 @@ The shared config directory lives at `~/Library/Application Support/localvoxtral
 
 ### Managed local (default)
 
-In Managed local mode, localvoxtral installs the pinned `voxmlx` and `mlx-lm` backend wheels automatically into `~/Library/Application Support/localvoxtral/backends` and starts them lazily on the first dictation request. App launch stays network-inert; downloads happen only when dictation starts in managed mode.
+In Managed local mode, localvoxtral installs pinned wheel releases of the backends into `~/Library/Application Support/localvoxtral/backends` using an embedded [uv](https://github.com/astral-sh/uv), and starts them lazily on the first dictation request. App launch stays network-inert; downloads happen only when dictation starts. The managed processes exit with the app — even after a crash, via a parent-pid watchdog. Uninstalling the backends is deleting that one directory.
 
-In this tested setup, `vLLM` and `voxmlx` stream partial text fast enough for realtime dictation; latency and throughput will vary by hardware, model, and quantization.
+**Dictation — voxmlx.** [voxmlx](https://github.com/awni/voxmlx) running [Voxtral Mini 4B Realtime in 4-bit](https://huggingface.co/T0mSIlver/Voxtral-Mini-4B-Realtime-2602-MLX-4bit) on M1 Pro, streaming partial text fast enough for realtime dictation (latency and throughput vary by hardware, model, and quantization). The managed build is [this fork](https://github.com/T0mSIlver/voxmlx), which adds a WebSocket server that speaks the OpenAI Realtime API protocol, memory-management optimizations, and managed-launch support (readiness signal + parent-pid watchdog).
 
-### External URL: voxmlx
-
-[voxmlx](https://github.com/awni/voxmlx) OpenAI Realtime-compatible running on M1 Pro with a 4-bit quantized model. Use [this fork](https://github.com/T0mSIlver/voxmlx) which adds a WebSocket server that speaks the OpenAI Realtime API protocol and memory management optimizations.
-
-```bash
-# install uv once: https://docs.astral.sh/uv/getting-started/installation/
-uvx --from "git+https://github.com/T0mSIlver/voxmlx.git[server]" \
-  voxmlx-serve --model T0mSIlver/Voxtral-Mini-4B-Realtime-2602-MLX-4bit
-```
+**LLM polishing — mlx-lm.** When polishing is enabled, `mlx_lm.server` runs [Qwen3.5-0.8B in 8-bit](https://huggingface.co/mlx-community/Qwen3.5-0.8B-MLX-8bit) — a lightweight default that adds little overhead while remaining smart enough for reliable polishing. The managed build is [this fork](https://github.com/T0mSIlver/mlx-lm), which adds enhanced prompt caching (enabled by the managed launch): with the default polishing prompts, prompt processing is roughly 286 ms (~50%) faster on average on M1 Pro. On more powerful Apple Silicon the absolute savings will be lower because prompt processing is faster.
 
 ### External URL: vLLM
 
@@ -105,28 +97,7 @@ VLLM_DISABLE_COMPILE_CACHE=1
 vllm serve mistralai/Voxtral-Mini-4B-Realtime-2602 --compilation_config '{"cudagraph_mode": "PIECEWISE"}'
 ```
 
-## Tested setup (LLM polishing)
-
-### Managed local (default)
-
-When LLM polishing is enabled in Managed local mode, localvoxtral starts the pinned `mlx-lm` backend lazily and points polishing at its local chat completions endpoint.
-
-### External URL: mlx-lm
-
-`mlx_lm.server` on M1 Pro, running [Qwen3.5-0.8B in 8 bit](https://huggingface.co/mlx-community/Qwen3.5-0.8B-MLX-8bit) for local LLM polishing.
-Use [this fork](https://github.com/T0mSIlver/mlx-lm) which adds prompt caching optimizations.
-Qwen3.5-0.8B is a lightweight default that adds little overhead while remaining smart enough for reliable polishing.
-
-```bash
-# install uv once: https://docs.astral.sh/uv/getting-started/installation/
-# use prompt caching to avoid reprocessing the full conversation on every request
-uvx --from "git+https://github.com/T0mSIlver/mlx-lm.git" mlx_lm.server \
-  --model mlx-community/Qwen3.5-0.8B-8bit \
-  --prompt-cache-size 1 \
-  --prompt-cache-bytes 1GB
-```
-
-With the default polishing prompts, prompt processing is roughly 286 ms (~50%) faster on average on M1 Pro with my fork's enhanced prompt caching. On more powerful Apple Silicon, the absolute ms savings will likely be lower because prompt processing is faster.
+Any other OpenAI Realtime-compatible endpoint works the same way — set it (plus model name and API key if needed) in **Settings → Connection** with backend mode `External URL`.
 
 ## Roadmap
 
@@ -138,6 +109,8 @@ With the default polishing prompts, prompt processing is roughly 286 ms (~50%) f
   - [Rust](https://github.com/TrevorS/voxtral-mini-realtime-rs) - thanks [TrevorS](https://github.com/TrevorS)
 
 ## UI
+
+<!-- Regenerate the screenshots below with ./scripts/capture-readme-assets.sh (run on a Mac; demo.gif is manual). -->
 
 <p>
   <picture>

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ The shared config directory lives at `~/Library/Application Support/localvoxtral
 
 ### Managed local (default)
 
-In Managed local mode, localvoxtral installs pinned wheel releases of the backends into `~/Library/Application Support/localvoxtral/backends` using an embedded [uv](https://github.com/astral-sh/uv), and starts them lazily on the first dictation request. App launch stays network-inert; downloads happen only when dictation starts. The managed processes exit with the app — even after a crash, via a parent-pid watchdog. Uninstalling the backends is deleting that one directory.
+In Managed local mode, localvoxtral installs pinned wheel releases of the backends into `~/Library/Application Support/localvoxtral/backends` using a pinned [uv](https://github.com/astral-sh/uv) it downloads on first use, and starts them lazily on the first dictation request. App launch stays network-inert; downloads happen only when dictation starts. The managed processes exit with the app — even after a crash, via a parent-pid watchdog. Uninstalling the backends is deleting that one directory.
 
 **Dictation — voxmlx.** [voxmlx](https://github.com/awni/voxmlx) running [Voxtral Mini 4B Realtime in 4-bit](https://huggingface.co/T0mSIlver/Voxtral-Mini-4B-Realtime-2602-MLX-4bit) on M1 Pro, streaming partial text fast enough for realtime dictation (latency and throughput vary by hardware, model, and quantization). The managed build is [this fork](https://github.com/T0mSIlver/voxmlx), which adds a WebSocket server that speaks the OpenAI Realtime API protocol, memory-management optimizations, and managed-launch support (readiness signal + parent-pid watchdog).
 

--- a/Sources/localvoxtral/Backends/BackendManager.swift
+++ b/Sources/localvoxtral/Backends/BackendManager.swift
@@ -251,6 +251,9 @@ final class BackendManager: ManagedBackendManaging {
                 parentPID,
             ]
         case BackendCatalog.mlxLM.id:
+            // Prompt caching avoids reprocessing the full polishing prompt on
+            // every request — the mlx-lm fork's main optimization (~50% faster
+            // prompt processing on M1 Pro with the default prompts).
             return [
                 "--model",
                 SettingsStore.defaultLLMPolishingModel,
@@ -258,6 +261,10 @@ final class BackendManager: ManagedBackendManaging {
                 "\(spec.port)",
                 "--parent-pid",
                 parentPID,
+                "--prompt-cache-size",
+                "1",
+                "--prompt-cache-bytes",
+                "1GB",
             ]
         default:
             return []

--- a/Tests/localvoxtralTests/BackendManagerTests.swift
+++ b/Tests/localvoxtralTests/BackendManagerTests.swift
@@ -76,6 +76,17 @@ final class BackendManagerTests: XCTestCase {
             [BackendCatalog.voxmlx.displayName, BackendCatalog.mlxLM.displayName]
         )
         XCTAssertEqual(manager.mlxLMStatus, .ready)
+
+        let mlxLMArguments = try XCTUnwrap(
+            supervisorFactory.createdConfigurations
+                .first { $0.name == BackendCatalog.mlxLM.displayName }?
+                .arguments
+        )
+        // The managed server must run with the fork's prompt caching enabled;
+        // the README's polishing-latency claim depends on these flags.
+        XCTAssertTrue(mlxLMArguments.contains("--prompt-cache-size"))
+        XCTAssertTrue(mlxLMArguments.contains("--prompt-cache-bytes"))
+        XCTAssertTrue(mlxLMArguments.contains("--parent-pid"))
     }
 
     func testConcurrentEnsureReadyDoesNotDoubleInstall() async throws {

--- a/scripts/capture-readme-assets.sh
+++ b/scripts/capture-readme-assets.sh
@@ -1,0 +1,145 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Regenerate the README screenshots:
+#   assets/popover.png                     (menu bar menu)
+#   assets/settings-realtime-endpoint.png  (Settings > Realtime Endpoint)
+#   assets/settings-dictation.png          (Settings > Dictation)
+#   assets/settings-text-processing.png    (Settings > Text Processing)
+#
+# Run ON A MAC from the repo root:
+#   ./scripts/capture-readme-assets.sh [path/to/localvoxtral.app]
+# Default app: dist/localvoxtral.app (build it with ./scripts/package_app.sh).
+#
+# One-time TCC grants required for the terminal you run this from
+# (System Settings > Privacy & Security):
+#   - Accessibility    (System Events drives the menu and settings tabs)
+#   - Screen Recording (screencapture -l reads window contents)
+#
+# demo.gif is not automated — record it by hand.
+
+if [[ "$(uname)" != "Darwin" ]]; then
+  echo "This script drives a macOS app — run it on the Mac." >&2
+  exit 1
+fi
+
+APP_PATH="${1:-dist/localvoxtral.app}"
+APP_PROCESS="localvoxtral"
+ASSETS_DIR="assets"
+TAB_NAMES=("Realtime Endpoint" "Dictation" "Text Processing")
+TAB_FILES=("settings-realtime-endpoint.png" "settings-dictation.png" "settings-text-processing.png")
+
+[[ -d "$APP_PATH" ]] || { echo "App bundle not found: $APP_PATH (build with ./scripts/package_app.sh)" >&2; exit 1; }
+[[ -d "$ASSETS_DIR" ]] || { echo "Run from the repo root ($ASSETS_DIR/ not found)." >&2; exit 1; }
+
+# --- window-id helper -------------------------------------------------------
+# Prints the CGWindowID of the largest on-screen window owned by <pid> whose
+# window layer is >= <min-layer> (0 = normal windows, 100+ = open menus).
+HELPER="$(mktemp -t lv-windowid).swift"
+trap 'rm -f "$HELPER"' EXIT
+cat > "$HELPER" <<'SWIFT'
+import CoreGraphics
+import Foundation
+
+guard CommandLine.arguments.count >= 3,
+      let pid = Int(CommandLine.arguments[1]),
+      let minLayer = Int(CommandLine.arguments[2])
+else { exit(2) }
+
+let windows = CGWindowListCopyWindowInfo([.optionOnScreenOnly], kCGNullWindowID) as? [[String: Any]] ?? []
+var best: (id: Int, area: Double)?
+for window in windows {
+    guard let ownerPID = window[kCGWindowOwnerPID as String] as? Int, ownerPID == pid,
+          let layer = window[kCGWindowLayer as String] as? Int, layer >= minLayer,
+          minLayer > 0 || layer == 0,
+          let id = window[kCGWindowNumber as String] as? Int,
+          let bounds = window[kCGWindowBounds as String] as? [String: Double],
+          let width = bounds["Width"], let height = bounds["Height"]
+    else { continue }
+    let area = width * height
+    if area > 10_000, area > (best?.area ?? 0) { best = (id, area) }
+}
+guard let best else { exit(1) }
+print(best.id)
+SWIFT
+
+window_id() { # <pid> <min-layer>
+  swift "$HELPER" "$1" "$2" 2>/dev/null
+}
+
+wait_for_window() { # <pid> <min-layer> [timeout-seconds]
+  local deadline=$((SECONDS + ${3:-10}))
+  while ((SECONDS < deadline)); do
+    if id="$(window_id "$1" "$2")"; then echo "$id"; return 0; fi
+    sleep 0.3
+  done
+  return 1
+}
+
+# --- launch a fresh instance ------------------------------------------------
+if pgrep -xq "$APP_PROCESS"; then
+  echo "Quitting running $APP_PROCESS instance..."
+  osascript -e "tell application \"$APP_PROCESS\" to quit" >/dev/null 2>&1 || pkill -x "$APP_PROCESS" || true
+  sleep 1
+fi
+open "$APP_PATH"
+for _ in $(seq 1 20); do pgrep -xq "$APP_PROCESS" && break; sleep 0.5; done
+APP_PID="$(pgrep -xn "$APP_PROCESS")"
+sleep 2 # let the status item settle
+
+open_status_menu() {
+  # Clicking a menu bar item blocks System Events while the menu tracks, so
+  # fire it with "ignoring application responses" and give it time to open.
+  osascript >/dev/null <<OSA
+tell application "System Events" to tell process "$APP_PROCESS"
+  ignoring application responses
+    click menu bar item 1 of menu bar 2
+  end ignoring
+end tell
+OSA
+  sleep 1
+}
+
+dismiss_menu() {
+  osascript -e 'tell application "System Events" to key code 53' >/dev/null # Escape
+  sleep 0.5
+}
+
+# --- 1. menu ("popover") shot -----------------------------------------------
+echo "Capturing $ASSETS_DIR/popover.png"
+open_status_menu
+if MENU_ID="$(wait_for_window "$APP_PID" 100 5)"; then
+  screencapture -o -x -l "$MENU_ID" "$ASSETS_DIR/popover.png"
+  dismiss_menu
+else
+  dismiss_menu
+  echo "WARNING: could not find the open menu window; skipped popover.png" >&2
+fi
+
+# --- 2. settings tabs ---------------------------------------------------------
+echo "Opening Settings..."
+open_status_menu
+osascript >/dev/null <<OSA
+tell application "System Events" to tell process "$APP_PROCESS"
+  click menu item "Settings…" of menu 1 of menu bar item 1 of menu bar 2
+end tell
+OSA
+SETTINGS_ID="$(wait_for_window "$APP_PID" 0 10)" || { echo "Settings window never appeared." >&2; exit 1; }
+sleep 1
+
+for i in "${!TAB_NAMES[@]}"; do
+  tab="${TAB_NAMES[$i]}"
+  out="$ASSETS_DIR/${TAB_FILES[$i]}"
+  echo "Capturing $out"
+  osascript >/dev/null <<OSA
+tell application "System Events" to tell process "$APP_PROCESS"
+  click button "$tab" of toolbar 1 of window 1
+end tell
+OSA
+  sleep 1
+  SETTINGS_ID="$(window_id "$APP_PID" 0)" || { echo "Lost the settings window." >&2; exit 1; }
+  screencapture -o -x -l "$SETTINGS_ID" "$out"
+done
+
+osascript -e "tell application \"$APP_PROCESS\" to quit" >/dev/null 2>&1 || true
+echo "Done. Review with: open $ASSETS_DIR"

--- a/scripts/capture-readme-assets.sh
+++ b/scripts/capture-readme-assets.sh
@@ -44,12 +44,12 @@ import CoreGraphics
 
 var ok = true
 if !AXIsProcessTrusted() {
-    print("MISSING Accessibility: System Settings > Privacy & Security > Accessibility — enable the terminal app you are running this from, then rerun.")
+    print("MISSING Accessibility: System Settings > Privacy & Security > Accessibility — enable the app that launched this script (your terminal, or the CI runner app for workflow runs), then rerun.")
     ok = false
 }
 if !CGPreflightScreenCaptureAccess() {
     _ = CGRequestScreenCaptureAccess()
-    print("MISSING Screen Recording: System Settings > Privacy & Security > Screen Recording — enable the terminal app you are running this from, then rerun.")
+    print("MISSING Screen Recording: System Settings > Privacy & Security > Screen Recording — enable the app that launched this script (your terminal, or the CI runner app for workflow runs), then rerun.")
     ok = false
 }
 exit(ok ? 0 : 1)
@@ -60,7 +60,20 @@ swift "$PREFLIGHT" || exit 1
 # Prints the CGWindowID of the largest on-screen window owned by <pid> whose
 # window layer is >= <min-layer> (0 = normal windows, 100+ = open menus).
 HELPER="$(mktemp -t lv-windowid).swift"
-trap 'rm -f "$HELPER" "$PREFLIGHT"' EXIT
+# Cleanup must also quit the app we launch below: with set -e, any failed
+# capture step would otherwise strand a localvoxtral instance (and possibly
+# an open menu) in the GUI session, poisoning the next run.
+LAUNCHED_APP=0
+cleanup() {
+  rm -f "$HELPER" "$PREFLIGHT"
+  if [[ "$LAUNCHED_APP" == 1 ]]; then
+    osascript -e 'tell application "System Events" to key code 53' >/dev/null 2>&1 || true
+    osascript -e "tell application \"$APP_PROCESS\" to quit" >/dev/null 2>&1 || true
+    sleep 1
+    pkill -x "$APP_PROCESS" >/dev/null 2>&1 || true
+  fi
+}
+trap cleanup EXIT INT TERM HUP
 cat > "$HELPER" <<'SWIFT'
 import CoreGraphics
 import Foundation
@@ -103,9 +116,16 @@ wait_for_window() { # <pid> <min-layer> [timeout-seconds]
 # --- launch a fresh instance ------------------------------------------------
 if pgrep -xq "$APP_PROCESS"; then
   echo "Quitting running $APP_PROCESS instance..."
-  osascript -e "tell application \"$APP_PROCESS\" to quit" >/dev/null 2>&1 || pkill -x "$APP_PROCESS" || true
+  osascript -e "tell application \"$APP_PROCESS\" to quit" >/dev/null 2>&1 || true
+  for _ in $(seq 1 10); do pgrep -xq "$APP_PROCESS" || break; sleep 0.5; done
+  pkill -x "$APP_PROCESS" >/dev/null 2>&1 || true
   sleep 1
 fi
+if pgrep -xq "$APP_PROCESS"; then
+  echo "A previous $APP_PROCESS instance refuses to quit; captures would show stale state. Aborting." >&2
+  exit 1
+fi
+LAUNCHED_APP=1
 open "$APP_PATH"
 for _ in $(seq 1 20); do pgrep -xq "$APP_PROCESS" && break; sleep 0.5; done
 APP_PID="$(pgrep -xn "$APP_PROCESS")"

--- a/scripts/capture-readme-assets.sh
+++ b/scripts/capture-readme-assets.sh
@@ -32,11 +32,35 @@ TAB_FILES=("settings-realtime-endpoint.png" "settings-dictation.png" "settings-t
 [[ -d "$APP_PATH" ]] || { echo "App bundle not found: $APP_PATH (build with ./scripts/package_app.sh)" >&2; exit 1; }
 [[ -d "$ASSETS_DIR" ]] || { echo "Run from the repo root ($ASSETS_DIR/ not found)." >&2; exit 1; }
 
+# --- permission preflight ----------------------------------------------------
+# System Events needs Accessibility; screencapture -l needs Screen Recording.
+# Without them the failures are cryptic (error 1002) or silent (empty grabs),
+# so check both up front and say exactly what to enable.
+PREFLIGHT="$(mktemp -t lv-preflight).swift"
+trap 'rm -f "$PREFLIGHT"' EXIT
+cat > "$PREFLIGHT" <<'SWIFT'
+import ApplicationServices
+import CoreGraphics
+
+var ok = true
+if !AXIsProcessTrusted() {
+    print("MISSING Accessibility: System Settings > Privacy & Security > Accessibility — enable the terminal app you are running this from, then rerun.")
+    ok = false
+}
+if !CGPreflightScreenCaptureAccess() {
+    _ = CGRequestScreenCaptureAccess()
+    print("MISSING Screen Recording: System Settings > Privacy & Security > Screen Recording — enable the terminal app you are running this from, then rerun.")
+    ok = false
+}
+exit(ok ? 0 : 1)
+SWIFT
+swift "$PREFLIGHT" || exit 1
+
 # --- window-id helper -------------------------------------------------------
 # Prints the CGWindowID of the largest on-screen window owned by <pid> whose
 # window layer is >= <min-layer> (0 = normal windows, 100+ = open menus).
 HELPER="$(mktemp -t lv-windowid).swift"
-trap 'rm -f "$HELPER"' EXIT
+trap 'rm -f "$HELPER" "$PREFLIGHT"' EXIT
 cat > "$HELPER" <<'SWIFT'
 import CoreGraphics
 import Foundation


### PR DESCRIPTION
## What

Post-0.7.0 README consolidation plus one behavior fix the docs depend on:

- **README**: the voxmlx and mlx-lm details (models, forks, performance notes) now live in the **Managed local** section — the "External URL: voxmlx" and the whole "Tested setup (LLM polishing)" external section are gone, since managed mode runs those exact forks automatically. External URL docs are now just vLLM plus a generic "any OpenAI Realtime-compatible endpoint" note. Intro rewritten to lead with managed mode.
- **Fix — managed mlx-lm now runs with prompt caching** (`--prompt-cache-size 1 --prompt-cache-bytes 1GB`): the external instructions always passed these, but the managed spawn didn't, so managed polishing silently missed the fork's main optimization (~50% faster prompt processing on M1 Pro). The README's performance claim in the managed section depends on this.
- **New `scripts/capture-readme-assets.sh`**: regenerates the README screenshots (menu + all three settings tabs) on a Mac — drives the UI via System Events, resolves window IDs via an embedded CoreGraphics helper, captures with `screencapture -l`. Needs Accessibility + Screen Recording grants for the invoking terminal; `demo.gif` stays manual. A README comment points at it.

## Proof

- [x] Unit suite green — `LV_BUILD_DIR=work/localvoxtral-readme ./scripts/remote-build.sh test`
  ```
  Executed 384 tests, with 0 failures (0 unexpected) in 3.699 (3.715) seconds
  ```
  `testPolishingFlagControlsWhetherMLXLMIsTouched` now also asserts the mlx-lm spawn arguments include the prompt-cache flags (fails on the previous arguments).
- [ ] **Screenshots in `assets/` are still the pre-0.7.0 ones.** To refresh before merge, on the Mac from this branch:
  ```bash
  ./scripts/package_app.sh release
  ./scripts/capture-readme-assets.sh
  git add assets && git commit -m "Refresh README screenshots" && git push
  ```
  The script is macOS-GUI-only and could not be executed from the Linux orchestrator — first run may need the two TCC grants and a retry.
- [x] No app UI change (spawn args + docs only).
