### PR TITLE
dmg_settings: dmgbuild exec()s settings without __file__; use CWD-relative paths

### DIFF
--- a/scripts/dmg_settings.py
+++ b/scripts/dmg_settings.py
@@ -1,13 +1,14 @@
 from pathlib import Path
 
-
-repo_root = Path(__file__).resolve().parents[1]
+# dmgbuild exec()s this file without __file__ in the namespace, so paths must
+# be CWD-relative — both release.yml and dmg-test.yml invoke dmgbuild from the
+# repo root.
 app = defines.get("app", "dist/localvoxtral.app")
 
 format = "UDZO"
 files = [app]
 symlinks = {"Applications": "/Applications"}
-background = str(repo_root / "assets" / "dmg-background.png")
+background = str(Path("assets/dmg-background.png").resolve())
 
 window_rect = ((200, 200), (600, 400))
 icon_size = 128


### PR DESCRIPTION
## What
The first `dmg-test.yml` dispatch (run 28689213790) failed: `NameError: name '__file__' is not defined` — dmgbuild `exec()`s the settings file without `__file__` in the namespace. Paths are now CWD-relative (both workflows invoke dmgbuild from the repo root), resolved absolute at load time.

## Proof
- [x] Reproduced dmgbuild's load exactly (exec with `defines`, no `__file__`, from repo root) — settings now evaluate:
```
background = <repo>/assets/dmg-background.png
files = ['dist/localvoxtral.app']
```
- [x] `python3 -m py_compile scripts/dmg_settings.py` clean.
- [x] Re-dispatching `dmg-test.yml` after merge is the end-to-end proof — will link the run.
- The failed dispatch is exactly what dmg-test.yml exists for: the release pipeline never saw the broken path.