### PR TITLE
Fix macOS 26 launch hang: download pinned uv on first use instead of embedding it

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -98,8 +98,9 @@ Key subsystems:
   timing), `OverlayBufferStateMachine`, `DictationOverlayController` (NSPanel)
 - Backends: `BackendManager` lazily bootstraps app-managed local serving on
   first dictation start; catalog pinned to fork wheel releases; installer
-  shells out to the embedded `uv`; supervisors spawn/health-check/stop the
-  managed processes; install root lives under Application Support.
+  downloads a pinned `uv` on first use, then shells out to it; supervisors
+  spawn/health-check/stop the managed processes; install root lives under
+  Application Support.
 - Settings/config: `SettingsStore` (UserDefaults), `AppConfigStore` (TOML at
   `~/Library/Application Support/localvoxtral/config`)
 - Hotkey: `HotKeyManager` (Carbon, single global hotkey)

--- a/Sources/localvoxtral/Backends/BackendCatalog.swift
+++ b/Sources/localvoxtral/Backends/BackendCatalog.swift
@@ -12,6 +12,20 @@ struct ManagedBackendSpec: Equatable, Sendable {
     let port: Int
 }
 
+struct UVDistribution: Equatable, Sendable {
+    let version: String
+    let tarballURL: URL
+    let tarballSHA256: String
+    let archiveBinaryPath: String
+
+    static let pinned = UVDistribution(
+        version: "0.11.26",
+        tarballURL: URL(string: "https://github.com/astral-sh/uv/releases/download/0.11.26/uv-aarch64-apple-darwin.tar.gz")!,
+        tarballSHA256: "8f7fbf1708399b921857bce71e1d60f0d3ccf52a30caebc1c1a2f175dce13ab6",
+        archiveBinaryPath: "uv-aarch64-apple-darwin/uv"
+    )
+}
+
 enum BackendCatalog {
     static let voxmlx = ManagedBackendSpec(
         id: "voxmlx",

--- a/Sources/localvoxtral/Backends/BackendInstallLayout.swift
+++ b/Sources/localvoxtral/Backends/BackendInstallLayout.swift
@@ -21,6 +21,16 @@ struct BackendInstallLayout: Equatable, Sendable {
         root.appendingPathComponent("uv-cache", isDirectory: true)
     }
 
+    var uvBinaryDirectory: URL {
+        root
+            .appendingPathComponent("uv", isDirectory: true)
+            .appendingPathComponent(UVDistribution.pinned.version, isDirectory: true)
+    }
+
+    var managedUVBinary: URL {
+        uvBinaryDirectory.appendingPathComponent("uv")
+    }
+
     var pythonInstalls: URL {
         root.appendingPathComponent("python", isDirectory: true)
     }

--- a/Sources/localvoxtral/Backends/BackendInstaller.swift
+++ b/Sources/localvoxtral/Backends/BackendInstaller.swift
@@ -12,17 +12,20 @@ enum BackendInstallError: LocalizedError, Sendable {
     case uvNotFound
     case downloadFailed(String)
     case checksumMismatch(expected: String, actual: String)
+    case uvExtractionFailed(String)
     case uvExited(code: Int32, stderrTail: String)
     case executableMissing(URL)
 
     var errorDescription: String? {
         switch self {
         case .uvNotFound:
-            return "Unable to find uv. Expected an embedded uv binary or Homebrew uv at /opt/homebrew/bin/uv or /usr/local/bin/uv."
+            return "Unable to find or install uv. Expected managed uv or Homebrew uv at /opt/homebrew/bin/uv or /usr/local/bin/uv."
         case .downloadFailed(let message):
-            return "Backend wheel download failed: \(message)"
+            return "Download failed: \(message)"
         case .checksumMismatch(let expected, let actual):
-            return "Backend wheel checksum mismatch. Expected \(expected), got \(actual)."
+            return "Downloaded artifact checksum mismatch. Expected \(expected), got \(actual)."
+        case .uvExtractionFailed(let message):
+            return "uv archive extraction failed: \(message)"
         case .uvExited(let code, let stderrTail):
             return "uv exited with status \(code): \(stderrTail)"
         case .executableMissing(let url):
@@ -42,15 +45,18 @@ protocol BackendInstalling: Sendable {
 struct BackendInstaller: BackendInstalling {
     private let layout: BackendInstallLayout
     private let uvLocator: any UVBinaryLocating
+    private let uvDistribution: UVDistribution
     private let fileManager: FileManager
 
     init(
         layout: BackendInstallLayout = BackendInstallLayout(),
-        uvLocator: any UVBinaryLocating = UVBinaryLocator(),
+        uvLocator: (any UVBinaryLocating)? = nil,
+        uvDistribution: UVDistribution = .pinned,
         fileManager: FileManager = .default
     ) {
         self.layout = layout
-        self.uvLocator = uvLocator
+        self.uvLocator = uvLocator ?? UVBinaryLocator(layout: layout)
+        self.uvDistribution = uvDistribution
         self.fileManager = fileManager
     }
 
@@ -69,11 +75,8 @@ struct BackendInstaller: BackendInstalling {
         _ spec: ManagedBackendSpec,
         progress: @MainActor @Sendable @escaping (BackendInstallProgress) -> Void
     ) async throws {
-        guard let uvURL = uvLocator.uvBinaryURL() else {
-            throw BackendInstallError.uvNotFound
-        }
-
         try createLayoutDirectories()
+        let uvURL = try await resolveUVBinary(progress: progress)
         let wheelURL = try await downloadWheel(for: spec, progress: progress)
 
         await Self.report(.verifying, progress)
@@ -114,7 +117,15 @@ struct BackendInstaller: BackendInstalling {
     }
 
     private func createLayoutDirectories() throws {
-        for directory in [layout.root, layout.uvCache, layout.pythonInstalls, layout.tools, layout.toolBin, layout.downloads] {
+        for directory in [
+            layout.root,
+            layout.uvCache,
+            layout.uvBinaryDirectory,
+            layout.pythonInstalls,
+            layout.tools,
+            layout.toolBin,
+            layout.downloads,
+        ] {
             try fileManager.createDirectory(at: directory, withIntermediateDirectories: true)
         }
     }
@@ -147,19 +158,101 @@ struct BackendInstaller: BackendInstalling {
         return environment
     }
 
+    private func resolveUVBinary(
+        progress: @MainActor @Sendable @escaping (BackendInstallProgress) -> Void
+    ) async throws -> URL {
+        if let uvURL = uvLocator.uvBinaryURL() {
+            return uvURL
+        }
+
+        try await provisionManagedUV(progress: progress)
+        guard fileManager.isExecutableFile(atPath: layout.managedUVBinary.path) else {
+            throw BackendInstallError.uvNotFound
+        }
+        return layout.managedUVBinary
+    }
+
+    private func provisionManagedUV(
+        progress: @MainActor @Sendable @escaping (BackendInstallProgress) -> Void
+    ) async throws {
+        await Self.report(
+            .installing(logLine: "Downloading uv \(uvDistribution.version)"),
+            progress
+        )
+        let tarballURL = try await downloadArtifact(
+            from: uvDistribution.tarballURL,
+            to: layout.downloads.appendingPathComponent(uvDistribution.tarballURL.lastPathComponent),
+            progress: progress
+        )
+
+        await Self.report(.verifying, progress)
+        let actualSHA256 = try sha256Hex(for: tarballURL)
+        guard actualSHA256 == uvDistribution.tarballSHA256 else {
+            try? fileManager.removeItem(at: tarballURL)
+            throw BackendInstallError.checksumMismatch(
+                expected: uvDistribution.tarballSHA256,
+                actual: actualSHA256
+            )
+        }
+
+        await Self.report(
+            .installing(logLine: "Installing uv \(uvDistribution.version)"),
+            progress
+        )
+        let temporaryDirectory = fileManager.temporaryDirectory
+            .appendingPathComponent("localvoxtral-uv-\(UUID().uuidString)", isDirectory: true)
+        try fileManager.createDirectory(at: temporaryDirectory, withIntermediateDirectories: true)
+        defer {
+            try? fileManager.removeItem(at: temporaryDirectory)
+        }
+
+        let extractionResult = try await TarExtractionProcess.extract(
+            tarballURL: tarballURL,
+            destinationDirectory: temporaryDirectory,
+            memberPath: uvDistribution.archiveBinaryPath
+        )
+        guard extractionResult.exitCode == 0 else {
+            throw BackendInstallError.uvExtractionFailed(extractionResult.stderrTail)
+        }
+
+        let extractedUV = temporaryDirectory.appendingPathComponent(uvDistribution.archiveBinaryPath)
+        guard fileManager.fileExists(atPath: extractedUV.path) else {
+            throw BackendInstallError.uvExtractionFailed(
+                "Archive did not contain \(uvDistribution.archiveBinaryPath)."
+            )
+        }
+
+        if fileManager.fileExists(atPath: layout.managedUVBinary.path) {
+            try fileManager.removeItem(at: layout.managedUVBinary)
+        }
+        try fileManager.copyItem(at: extractedUV, to: layout.managedUVBinary)
+        try fileManager.setAttributes([.posixPermissions: 0o755], ofItemAtPath: layout.managedUVBinary.path)
+    }
+
     private func downloadWheel(
         for spec: ManagedBackendSpec,
         progress: @MainActor @Sendable @escaping (BackendInstallProgress) -> Void
     ) async throws -> URL {
-        await Self.report(.downloading(fraction: nil), progress)
-        let destination = layout.downloads.appendingPathComponent(spec.wheelURL.lastPathComponent)
+        try await downloadArtifact(
+            from: spec.wheelURL,
+            to: layout.downloads.appendingPathComponent(spec.wheelURL.lastPathComponent),
+            progress: progress
+        )
+    }
 
-        if spec.wheelURL.isFileURL {
+    private func downloadArtifact(
+        from sourceURL: URL,
+        to destination: URL,
+        progress: @MainActor @Sendable @escaping (BackendInstallProgress) -> Void
+    ) async throws -> URL {
+        await Self.report(.downloading(fraction: nil), progress)
+
+        if sourceURL.isFileURL {
             do {
                 if fileManager.fileExists(atPath: destination.path) {
                     try fileManager.removeItem(at: destination)
                 }
-                try fileManager.copyItem(at: spec.wheelURL, to: destination)
+                try fileManager.copyItem(at: sourceURL, to: destination)
                 await Self.report(.downloading(fraction: 1), progress)
                 return destination
             } catch {
@@ -168,7 +261,7 @@ struct BackendInstaller: BackendInstalling {
         }
 
         do {
-            let (bytes, response) = try await URLSession.shared.bytes(from: spec.wheelURL)
+            let (bytes, response) = try await URLSession.shared.bytes(from: sourceURL)
             let expectedLength = response.expectedContentLength
             var data = Data()
             var downloadedByteCount: Int64 = 0
@@ -222,6 +315,56 @@ extension BackendInstaller: @unchecked Sendable {}
 private struct UVToolProcessResult: Sendable {
     let exitCode: Int32
     let stderrTail: String
+}
+
+private struct TarExtractionProcessResult: Sendable {
+    let exitCode: Int32
+    let stderrTail: String
+}
+
+private final class TarExtractionProcess {
+    static func extract(
+        tarballURL: URL,
+        destinationDirectory: URL,
+        memberPath: String
+    ) async throws -> TarExtractionProcessResult {
+        try await Task.detached {
+            try extractSynchronously(
+                tarballURL: tarballURL,
+                destinationDirectory: destinationDirectory,
+                memberPath: memberPath
+            )
+        }.value
+    }
+
+    private static func extractSynchronously(
+        tarballURL: URL,
+        destinationDirectory: URL,
+        memberPath: String
+    ) throws -> TarExtractionProcessResult {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/tar")
+        process.arguments = [
+            "-xzf",
+            tarballURL.path,
+            "-C",
+            destinationDirectory.path,
+            memberPath,
+        ]
+
+        let stderr = Pipe()
+        process.standardError = stderr
+
+        try process.run()
+        process.waitUntilExit()
+
+        let stderrData = stderr.fileHandleForReading.readDataToEndOfFile()
+        let stderrText = String(data: stderrData, encoding: .utf8) ?? ""
+        return TarExtractionProcessResult(
+            exitCode: process.terminationStatus,
+            stderrTail: stderrText.trimmingCharacters(in: .whitespacesAndNewlines)
+        )
+    }
 }
 
 private final class UVToolProcess {

--- a/Sources/localvoxtral/Backends/UVBinaryLocator.swift
+++ b/Sources/localvoxtral/Backends/UVBinaryLocator.swift
@@ -5,15 +5,19 @@ protocol UVBinaryLocating: Sendable {
 }
 
 struct UVBinaryLocator: UVBinaryLocating {
+    private let layout: BackendInstallLayout
+
+    init(layout: BackendInstallLayout = BackendInstallLayout()) {
+        self.layout = layout
+    }
+
     func uvBinaryURL() -> URL? {
         let fileManager = FileManager.default
         let candidates = [
-            Bundle.main.executableURL?
-                .deletingLastPathComponent()
-                .appendingPathComponent("uv"),
+            layout.managedUVBinary,
             URL(fileURLWithPath: "/opt/homebrew/bin/uv"),
             URL(fileURLWithPath: "/usr/local/bin/uv"),
-        ].compactMap { $0 }
+        ]
 
         return candidates.first { url in
             fileManager.isExecutableFile(atPath: url.path)

--- a/Tests/localvoxtralTests/BackendInstallerTests.swift
+++ b/Tests/localvoxtralTests/BackendInstallerTests.swift
@@ -19,6 +19,13 @@ final class BackendInstallerTests: XCTestCase {
         let layout = BackendInstallLayout(root: root)
 
         XCTAssertEqual(layout.uvCache, root.appendingPathComponent("uv-cache", isDirectory: true))
+        XCTAssertEqual(
+            layout.uvBinaryDirectory,
+            root
+                .appendingPathComponent("uv", isDirectory: true)
+                .appendingPathComponent(UVDistribution.pinned.version, isDirectory: true)
+        )
+        XCTAssertEqual(layout.managedUVBinary, layout.uvBinaryDirectory.appendingPathComponent("uv"))
         XCTAssertEqual(layout.pythonInstalls, root.appendingPathComponent("python", isDirectory: true))
         XCTAssertEqual(layout.tools, root.appendingPathComponent("tools", isDirectory: true))
         XCTAssertEqual(layout.toolBin, root.appendingPathComponent("bin", isDirectory: true))
@@ -41,7 +48,7 @@ final class BackendInstallerTests: XCTestCase {
         )
         let capture = root.appendingPathComponent("uv-capture.txt")
         let fakeUV = try writeFakeUV(
-            in: root,
+            in: fakeUVDirectory(in: root),
             capture: capture,
             executableNameToCreate: spec.executableName,
             exitCode: 0,
@@ -77,6 +84,134 @@ final class BackendInstallerTests: XCTestCase {
         XCTAssertEqual(progressEvents.last, .finished)
     }
 
+    @MainActor
+    func testInstallProvisionsPinnedUVWhenLocatorFindsNothing() async throws {
+        let root = makeTemporaryDirectory()
+        let layout = BackendInstallLayout(root: root)
+        let wheel = try writeWheel(named: "voxmlx.whl", contents: "wheel-data")
+        let spec = makeSpec(
+            wheelURL: wheel,
+            wheelSHA256: try sha256Hex(for: wheel),
+            executableName: "voxmlx-serve"
+        )
+        let capture = root.appendingPathComponent("provisioned-uv-capture.txt")
+        let uvTarball = try writeUVTarball(
+            capture: capture,
+            executableNameToCreate: spec.executableName,
+            exitCode: 0,
+            stdoutLines: ["provisioned uv stdout"]
+        )
+        let uvDistribution = makeUVDistribution(
+            tarballURL: uvTarball,
+            tarballSHA256: try sha256Hex(for: uvTarball)
+        )
+        let installer = BackendInstaller(
+            layout: layout,
+            uvLocator: FakeUVLocator(url: nil),
+            uvDistribution: uvDistribution
+        )
+
+        var progressEvents: [BackendInstallProgress] = []
+        try await installer.install(spec) { event in
+            progressEvents.append(event)
+        }
+
+        let captureText = try String(contentsOf: capture, encoding: .utf8)
+        XCTAssertTrue(captureText.contains("ARGS:tool|install|--python|3.12|--reinstall|"))
+        XCTAssertTrue(captureText.contains("voxmlx[server] @ file://"))
+        XCTAssertTrue(FileManager.default.isExecutableFile(atPath: layout.managedUVBinary.path))
+        XCTAssertEqual(
+            layout.managedUVBinary.path,
+            root
+                .appendingPathComponent("uv", isDirectory: true)
+                .appendingPathComponent(UVDistribution.pinned.version, isDirectory: true)
+                .appendingPathComponent("uv")
+                .path
+        )
+        XCTAssertTrue(FileManager.default.isExecutableFile(atPath: layout.toolBin.appendingPathComponent(spec.executableName).path))
+        XCTAssertEqual(installer.installedVersion(of: spec), spec.version)
+        XCTAssertTrue(progressEvents.contains(.installing(logLine: "Downloading uv \(UVDistribution.pinned.version)")))
+        XCTAssertTrue(progressEvents.contains(.installing(logLine: "Installing uv \(UVDistribution.pinned.version)")))
+        XCTAssertTrue(progressEvents.contains(.installing(logLine: "provisioned uv stdout")))
+        XCTAssertEqual(progressEvents.last, .finished)
+    }
+
+    func testUVTarballChecksumMismatchDoesNotExtractOrInstallBackend() async throws {
+        let root = makeTemporaryDirectory()
+        let layout = BackendInstallLayout(root: root)
+        let wheel = try writeWheel(named: "voxmlx.whl", contents: "wheel-data")
+        let spec = makeSpec(
+            wheelURL: wheel,
+            wheelSHA256: try sha256Hex(for: wheel),
+            executableName: "voxmlx-serve"
+        )
+        let capture = root.appendingPathComponent("bad-uv-capture.txt")
+        let uvTarball = try writeUVTarball(
+            capture: capture,
+            executableNameToCreate: spec.executableName,
+            exitCode: 0
+        )
+        let uvDistribution = makeUVDistribution(
+            tarballURL: uvTarball,
+            tarballSHA256: String(repeating: "0", count: 64)
+        )
+        let installer = BackendInstaller(
+            layout: layout,
+            uvLocator: FakeUVLocator(url: nil),
+            uvDistribution: uvDistribution
+        )
+
+        do {
+            try await installer.install(spec) { _ in }
+            XCTFail("Expected uv checksum mismatch")
+        } catch BackendInstallError.checksumMismatch(let expected, let actual) {
+            XCTAssertEqual(expected, uvDistribution.tarballSHA256)
+            XCTAssertEqual(actual, try sha256Hex(for: uvTarball))
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+
+        XCTAssertFalse(FileManager.default.fileExists(atPath: capture.path))
+        XCTAssertFalse(FileManager.default.fileExists(atPath: layout.managedUVBinary.path))
+        XCTAssertFalse(FileManager.default.fileExists(atPath: layout.toolBin.appendingPathComponent(spec.executableName).path))
+        XCTAssertFalse(FileManager.default.fileExists(atPath: layout.downloads.appendingPathComponent(uvTarball.lastPathComponent).path))
+        XCTAssertNil(installer.installedVersion(of: spec))
+    }
+
+    func testLocatorFoundUVSkipsProvisioningDownload() async throws {
+        let root = makeTemporaryDirectory()
+        let layout = BackendInstallLayout(root: root)
+        let wheel = try writeWheel(named: "voxmlx.whl", contents: "wheel-data")
+        let spec = makeSpec(
+            wheelURL: wheel,
+            wheelSHA256: try sha256Hex(for: wheel),
+            executableName: "voxmlx-serve"
+        )
+        let capture = root.appendingPathComponent("existing-uv-capture.txt")
+        let fakeUV = try writeFakeUV(
+            in: fakeUVDirectory(in: root),
+            capture: capture,
+            executableNameToCreate: spec.executableName,
+            exitCode: 0
+        )
+        let uvDistribution = makeUVDistribution(
+            tarballURL: URL(fileURLWithPath: "/tmp/localvoxtral-missing-uv-fixture-\(UUID().uuidString).tar.gz"),
+            tarballSHA256: String(repeating: "0", count: 64)
+        )
+        let installer = BackendInstaller(
+            layout: layout,
+            uvLocator: FakeUVLocator(url: fakeUV),
+            uvDistribution: uvDistribution
+        )
+
+        try await installer.install(spec) { _ in }
+
+        let captureText = try String(contentsOf: capture, encoding: .utf8)
+        XCTAssertTrue(captureText.contains("ARGS:tool|install|--python|3.12|--reinstall|"))
+        XCTAssertFalse(FileManager.default.fileExists(atPath: layout.managedUVBinary.path))
+        XCTAssertEqual(installer.installedVersion(of: spec), spec.version)
+    }
+
     func testChecksumMismatchDeletesWheelAndDoesNotInvokeUV() async throws {
         let root = makeTemporaryDirectory()
         let layout = BackendInstallLayout(root: root)
@@ -88,7 +223,7 @@ final class BackendInstallerTests: XCTestCase {
         )
         let capture = root.appendingPathComponent("uv-capture.txt")
         let fakeUV = try writeFakeUV(
-            in: root,
+            in: fakeUVDirectory(in: root),
             capture: capture,
             executableNameToCreate: spec.executableName,
             exitCode: 0
@@ -123,7 +258,7 @@ final class BackendInstallerTests: XCTestCase {
             executableName: "voxmlx-serve"
         )
         let fakeUV = try writeFakeUV(
-            in: root,
+            in: fakeUVDirectory(in: root),
             capture: root.appendingPathComponent("uv-capture.txt"),
             executableNameToCreate: spec.executableName,
             exitCode: 7,
@@ -160,7 +295,7 @@ final class BackendInstallerTests: XCTestCase {
             executableName: "voxmlx-serve"
         )
         let fakeUV = try writeFakeUV(
-            in: root,
+            in: fakeUVDirectory(in: root),
             capture: root.appendingPathComponent("uv-capture.txt"),
             executableNameToCreate: nil,
             exitCode: 0
@@ -192,7 +327,7 @@ final class BackendInstallerTests: XCTestCase {
             executableName: "voxmlx-serve"
         )
         let fakeUV = try writeFakeUV(
-            in: root,
+            in: fakeUVDirectory(in: root),
             capture: root.appendingPathComponent("uv-capture.txt"),
             executableNameToCreate: spec.executableName,
             exitCode: 0
@@ -234,6 +369,10 @@ final class BackendInstallerTests: XCTestCase {
         return url
     }
 
+    private func fakeUVDirectory(in root: URL) -> URL {
+        root.appendingPathComponent("fake-uv-bin", isDirectory: true)
+    }
+
     private func writeFakeUV(
         in directory: URL,
         capture: URL,
@@ -242,6 +381,7 @@ final class BackendInstallerTests: XCTestCase {
         stderrLines: [String] = [],
         stdoutLines: [String] = []
     ) throws -> URL {
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
         let url = directory.appendingPathComponent("uv")
         let createExecutableBlock: String
         if let executableNameToCreate {
@@ -283,6 +423,53 @@ final class BackendInstallerTests: XCTestCase {
         return url
     }
 
+    private func writeUVTarball(
+        capture: URL,
+        executableNameToCreate: String?,
+        exitCode: Int,
+        stderrLines: [String] = [],
+        stdoutLines: [String] = []
+    ) throws -> URL {
+        let fixtureRoot = makeTemporaryDirectory()
+        let archiveDirectory = fixtureRoot.appendingPathComponent("uv-aarch64-apple-darwin", isDirectory: true)
+        try FileManager.default.createDirectory(at: archiveDirectory, withIntermediateDirectories: true)
+        _ = try writeFakeUV(
+            in: archiveDirectory,
+            capture: capture,
+            executableNameToCreate: executableNameToCreate,
+            exitCode: exitCode,
+            stderrLines: stderrLines,
+            stdoutLines: stdoutLines
+        )
+
+        let tarball = fixtureRoot.appendingPathComponent("uv-fixture-\(UUID().uuidString).tar.gz")
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/tar")
+        process.arguments = [
+            "-czf",
+            tarball.path,
+            "-C",
+            fixtureRoot.path,
+            "uv-aarch64-apple-darwin/uv",
+        ]
+
+        let stderr = Pipe()
+        process.standardError = stderr
+        try process.run()
+        process.waitUntilExit()
+
+        if process.terminationStatus != 0 {
+            let data = stderr.fileHandleForReading.readDataToEndOfFile()
+            let message = String(data: data, encoding: .utf8) ?? "tar exited \(process.terminationStatus)"
+            throw NSError(
+                domain: "BackendInstallerTests",
+                code: Int(process.terminationStatus),
+                userInfo: [NSLocalizedDescriptionKey: message]
+            )
+        }
+        return tarball
+    }
+
     private func makeSpec(
         version: String = "1.2.3",
         wheelURL: URL,
@@ -299,6 +486,18 @@ final class BackendInstallerTests: XCTestCase {
             executableName: executableName,
             pythonVersion: "3.12",
             port: 8471
+        )
+    }
+
+    private func makeUVDistribution(
+        tarballURL: URL,
+        tarballSHA256: String
+    ) -> UVDistribution {
+        UVDistribution(
+            version: UVDistribution.pinned.version,
+            tarballURL: tarballURL,
+            tarballSHA256: tarballSHA256,
+            archiveBinaryPath: UVDistribution.pinned.archiveBinaryPath
         )
     }
 

--- a/scripts/package_app.sh
+++ b/scripts/package_app.sh
@@ -33,44 +33,6 @@ patch_local_resource_bundle_lookup() {
   perl -0pi -e 's/let preferredBundle = Bundle\(path: mainPath\)/\/\/ localvoxtral packaged resources fallback\n        let resourcePath = Bundle.main.resourceURL?.appendingPathComponent("localvoxtral_localvoxtral.bundle").path\n        let preferredBundle = resourcePath.flatMap(Bundle.init(path:)) ?? Bundle(path: mainPath)/g' "$accessor"
 }
 
-embed_uv_binary() {
-  local uv_version="0.11.26"
-  local uv_archive_name="uv-${uv_version}-aarch64-apple-darwin.tar.gz"
-  local uv_url="https://github.com/astral-sh/uv/releases/download/${uv_version}/uv-aarch64-apple-darwin.tar.gz"
-  local uv_sha256="8f7fbf1708399b921857bce71e1d60f0d3ccf52a30caebc1c1a2f175dce13ab6"
-  local uv_dist_dir="$ROOT_DIR/.build/uv-dist"
-  local uv_tarball="$uv_dist_dir/$uv_archive_name"
-  local uv_destination="$APP_DIR/Contents/MacOS/uv"
-  local tmp_dir
-  local actual_sha256
-
-  echo "Embedding uv ${uv_version}..."
-  mkdir -p "$uv_dist_dir"
-  if [[ ! -f "$uv_tarball" ]]; then
-    echo "Downloading uv ${uv_version} from ${uv_url}"
-    curl -fL --retry 3 "$uv_url" -o "$uv_tarball"
-  else
-    echo "Using cached uv tarball: $uv_tarball"
-  fi
-
-  echo "Verifying uv ${uv_version} sha256..."
-  actual_sha256="$(shasum -a 256 "$uv_tarball" | awk '{print $1}')"
-  if [[ "$actual_sha256" != "$uv_sha256" ]]; then
-    rm -f "$uv_tarball"
-    echo "uv sha256 mismatch: expected $uv_sha256, got $actual_sha256"
-    exit 1
-  fi
-
-  tmp_dir="$(mktemp -d)"
-  tar -xzf "$uv_tarball" -C "$tmp_dir" "uv-aarch64-apple-darwin/uv"
-  install -m 755 "$tmp_dir/uv-aarch64-apple-darwin/uv" "$uv_destination"
-  rm -rf "$tmp_dir"
-
-  echo "Installed embedded uv: $uv_destination"
-  codesign --force --sign "$CODESIGN_IDENTITY" "$uv_destination"
-  echo "Signed embedded uv with identity: $CODESIGN_IDENTITY"
-}
-
 CONFIGURATION="${1:-release}"
 APP_VERSION="${2:-0.3.0}"
 BUILD_NUMBER="${3:-1}"
@@ -248,7 +210,6 @@ PLIST
 # because codesign rejects bundles containing that detritus.
 chmod -R u+w "$APP_DIR"
 xattr -cr "$APP_DIR"
-embed_uv_binary
 
 # Sign the packaged app so Gatekeeper can evaluate a usable signature.
 # This does not replace Developer ID signing/notarization, but it avoids the
@@ -265,4 +226,6 @@ fi
 touch "$APP_DIR"
 
 echo "Packaged app: $APP_DIR"
+echo "Contents/MacOS:"
+find "$APP_DIR/Contents/MacOS" -maxdepth 1 -type f -exec basename {} \; | sort | sed 's/^/  /'
 echo "Launch with: open \"$APP_DIR\""


### PR DESCRIPTION
## What

**Fixes v0.7.0 never launching on macOS 26.** Field-diagnosed on macOS 26.5: the embedded ~35 MB `uv` Mach-O at `Contents/MacOS/uv` makes the first-exec Gatekeeper/XProtect scan of the unsigned bundle run unbounded — the app hangs at `_dyld_start` with a 96 KB footprint forever. Quarantine is irrelevant (`xattr -cr` doesn't help; `gh`-downloaded copies stall identically). Removing uv from the bundle and re-signing the otherwise identical bundle → instant launch. (Two `sample` traces + the syspolicyd log trail in the session; v0.7.0 release notes now carry the known-issue warning.)

The fix: **uv leaves the bundle**. `BackendInstaller` provisions a pinned uv (0.11.26, sha256-pinned tarball) on first managed-mode use, with the same discipline as backend wheels: download via URLSession → sha256 verify (hard fail + delete, never extract unverified) → `tar` extract to a temp dir → install 0755 at a **versioned** path (`backends/uv/0.11.26/uv`, so future pin bumps re-download naturally). `UVBinaryLocator` prefers the managed copy, then Homebrew paths; the bundle lookup is gone. Nothing is lost — managed mode already required the network on first use for wheels + model weights.

## Proof

- [x] Unit suite green — `LV_BUILD_DIR=work/localvoxtral-codex-uvfix ./scripts/remote-build.sh test`
  ```
  Executed 387 tests, with 0 failures (0 unexpected)
  ```
  New `BackendInstallerTests`: provisioning happy path against a real `file://` tarball fixture (downloads, verifies, extracts, installs, and the backend install then uses *that* uv); tarball checksum mismatch → hard error, nothing extracted, backend install never proceeds; locator-found short-circuit → no download attempted.
- [x] Bundle is uv-free — `remote-build.sh package`:
  ```
  Contents/MacOS:
    localvoxtral
  ...satisfies its Designated Requirement
  ```
  (no embed step in the output; `package_app.sh` no longer has one)
- [x] Field verification pending on the actual release artifact: after v0.7.1 is cut, a browser-downloaded install on the macOS 26 machine that reproduced the hang must show the menu bar icon within seconds. This PR's description will be updated with that result.
