### PR TITLE
Fix racing assertion in supervisor crash-restart test

### DIFF
--- a/Tests/localvoxtralTests/BackendProcessSupervisorTests.swift
+++ b/Tests/localvoxtralTests/BackendProcessSupervisorTests.swift
@@ -165,6 +165,10 @@ final class BackendProcessSupervisorTests: XCTestCase {
         await supervisor.start()
 
         _ = try await watcher.waitForState(.restarting(attempt: 1))
+        // .restarting is emitted BEFORE the supervisor requests the backoff
+        // sleep; wait for the recorded sleep itself or this assertion races
+        // (seen once on the release-gate runner).
+        try await sleeps.waitUntilRecorded { $0 == .milliseconds(500) }
         XCTAssertEqual(
             sleeps.recordedDurations.filter { $0 == .milliseconds(500) },
             [.milliseconds(500)]
@@ -576,9 +580,37 @@ private final class ControlledSleep: @unchecked Sendable {
     private var durations: [Duration] = []
     private var continuations: [CheckedContinuation<Void, Never>] = []
     private var isReleased = false
+    private let recordedStream: AsyncStream<Duration>
+    private let recordedContinuation: AsyncStream<Duration>.Continuation
 
     init(shouldPause: @escaping @Sendable (Duration) -> Bool = { _ in true }) {
         self.shouldPause = shouldPause
+        (recordedStream, recordedContinuation) = AsyncStream.makeStream(of: Duration.self)
+    }
+
+    /// Waits until a sleep matching `matches` has been REQUESTED. State
+    /// transitions (e.g. `.restarting`) are emitted before the supervisor
+    /// calls `sleepFor`, so tests must synchronize on the recording itself
+    /// before asserting `recordedDurations`. Single consumer; yields are
+    /// buffered from init, so calls after the fact still see the sleep.
+    func waitUntilRecorded(
+        timeout: Duration = .seconds(5),
+        where matches: @escaping @Sendable (Duration) -> Bool
+    ) async throws {
+        try await withThrowingTaskGroup(of: Void.self) { group in
+            group.addTask {
+                for await duration in self.recordedStream where matches(duration) {
+                    return
+                }
+                throw WaitTimeout()
+            }
+            group.addTask {
+                try await Task.sleep(for: timeout)
+                throw WaitTimeout()
+            }
+            try await group.next()!
+            group.cancelAll()
+        }
     }
 
     var recordedDurations: [Duration] {
@@ -591,6 +623,9 @@ private final class ControlledSleep: @unchecked Sendable {
         await withCheckedContinuation { continuation in
             lock.lock()
             durations.append(duration)
+            // Yield after the append (still under the lock) so a waiter woken
+            // by this yield always observes the duration in recordedDurations.
+            recordedContinuation.yield(duration)
             guard !isReleased && shouldPause(duration) else {
                 lock.unlock()
                 continuation.resume()


### PR DESCRIPTION
## What
The 0.7.1 release run was aborted by its unit gate: `testCrashRestartsWithBackoffThenRunsWhenReady` asserted `recordedDurations` immediately after observing `.restarting(attempt: 1)` — but `BackendProcessSupervisor` emits that transition **before** calling `sleepFor` (BackendProcessSupervisor.swift:171 vs :174), so the assertion can race and see an empty list. Test-side fix only, using the file's existing task-group + `WaitTimeout` pattern: `ControlledSleep.waitUntilRecorded` (buffered AsyncStream, yielded after the append under the lock so a woken waiter always sees the recording) and the test synchronizes on the sleep being requested before asserting. No assertions weakened; the other two `recordedDurations` sites assert after states that causally follow their sleeps and are race-free.

## Proof
- [x] Regression shape: the failure was observed once on the release-gate runner (run 28690086338: `("[]") is not equal to ("[0.5 seconds]")`); the race window is real by code inspection (transition before sleep).
- [x] `BackendProcessSupervisorTests` 3× + full suite — `LV_BUILD_DIR=work/localvoxtral-testrace ./scripts/remote-build.sh test`:
```
Executed 7 tests, with 0 failures (0 unexpected) ×3
Executed 387 tests, with 0 failures (0 unexpected) in 4.300 (4.317) seconds
```