### PR TITLE
Add one-command installer that survives macOS 26 unsigned-app scanning

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -116,6 +116,11 @@ jobs:
             -s scripts/dmg_settings.py \
             -D app=dist/localvoxtral.app \
             "localvoxtral" "dist/localvoxtral-$TAG.dmg"
+          (
+            cd dist
+            shasum -a 256 "localvoxtral-$TAG.zip" > "localvoxtral-$TAG.zip.sha256"
+            shasum -a 256 "localvoxtral-$TAG.dmg" > "localvoxtral-$TAG.dmg.sha256"
+          )
 
       - name: Tag (all gates green)
         run: |
@@ -133,4 +138,6 @@ jobs:
           generate_release_notes: true
           files: |
             dist/localvoxtral-${{ steps.meta.outputs.tag }}.zip
+            dist/localvoxtral-${{ steps.meta.outputs.tag }}.zip.sha256
             dist/localvoxtral-${{ steps.meta.outputs.tag }}.dmg
+            dist/localvoxtral-${{ steps.meta.outputs.tag }}.dmg.sha256

--- a/README.md
+++ b/README.md
@@ -32,11 +32,19 @@ Built for Mistral AI's [Voxtral Mini 4B Realtime](https://huggingface.co/mistral
 
 ## Quick start
 
-### Recommended: install from GitHub Releases (DMG)
+### Recommended: one-command installer
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/T0mSIlver/localvoxtral/main/scripts/install.sh | bash
+```
+
+This downloads the latest release, clears quarantine metadata, re-signs the app locally, installs it into `/Applications`, and opens it.
+
+### Manual install from GitHub Releases (DMG)
 
 Download the latest `.dmg` from [Releases](https://github.com/T0mSIlver/localvoxtral/releases/latest).
 
-Releases are ad-hoc signed (not notarized). Depending on macOS version, first launch is either blocked with an **Open Anyway** button in **System Settings -> Privacy & Security**, or reported as "damaged". In both cases this clears the quarantine flag and the app opens normally:
+Releases are ad-hoc signed (not notarized). On macOS 26, launching the raw downloaded app can hang on first launch unless you use the installer script above. On older macOS versions, first launch may instead be blocked with an **Open Anyway** button in **System Settings -> Privacy & Security**, or reported as "damaged". This clears the quarantine flag:
 
 ```bash
 xattr -cr /Applications/localvoxtral.app

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO="T0mSIlver/localvoxtral"
+APP_NAME="localvoxtral.app"
+INSTALL_PATH="/Applications/${APP_NAME}"
+VERSION="${LOCALVOXTRAL_VERSION:-latest}"
+DRYRUN="${LOCALVOXTRAL_INSTALL_DRYRUN:-0}"
+
+die() {
+  printf 'Error: %s\n' "$*" >&2
+  exit 1
+}
+
+step() {
+  printf '==> %s\n' "$*"
+}
+
+require_command() {
+  command -v "$1" >/dev/null 2>&1 || die "Missing required command: $1"
+}
+
+resolve_release_api_url() {
+  if [ "$VERSION" = "latest" ]; then
+    printf 'https://api.github.com/repos/%s/releases/latest\n' "$REPO"
+  else
+    printf 'https://api.github.com/repos/%s/releases/tags/%s\n' "$REPO" "$VERSION"
+  fi
+}
+
+resolve_zip_url() {
+  api_url="$(resolve_release_api_url)"
+  release_json="$(curl -fsSL "$api_url")" || die "Could not fetch GitHub release metadata from $api_url"
+  zip_urls="$(printf '%s\n' "$release_json" |
+    grep '"browser_download_url"[[:space:]]*:' |
+    sed -n 's/.*"browser_download_url"[[:space:]]*:[[:space:]]*"\([^"]*\.zip\)".*/\1/p' || true)"
+  zip_url="$(printf '%s\n' "$zip_urls" | sed -n '1p')"
+
+  [ -n "$zip_url" ] || die "No .zip asset found for release '${VERSION}'. Check https://github.com/${REPO}/releases"
+  printf '%s\n' "$zip_url"
+}
+
+require_command curl
+
+step "Resolving localvoxtral release zip"
+zip_url="$(resolve_zip_url)"
+printf 'Resolved zip: %s\n' "$zip_url"
+
+if [ "$DRYRUN" = "1" ]; then
+  step "Dry run requested; stopping before download and macOS install steps"
+  exit 0
+fi
+
+[ "$(uname -s)" = "Darwin" ] || die "This installer only runs on macOS. Set LOCALVOXTRAL_INSTALL_DRYRUN=1 to test release URL resolution elsewhere."
+
+require_command ditto
+require_command xattr
+require_command codesign
+require_command open
+
+tmp_dir="$(mktemp -d "${TMPDIR:-/tmp}/localvoxtral-install.XXXXXX")"
+cleanup() {
+  rm -rf "$tmp_dir"
+}
+trap cleanup EXIT
+
+zip_path="${tmp_dir}/localvoxtral.zip"
+
+step "Downloading release"
+curl -fL "$zip_url" -o "$zip_path" || die "Download failed: $zip_url"
+
+step "Extracting app bundle"
+ditto -x -k "$zip_path" "$tmp_dir" || die "Could not extract release zip"
+app_path="$(find "$tmp_dir" -type d -name "$APP_NAME" -prune -print | sed -n '1p')"
+[ -n "$app_path" ] || die "Extracted zip did not contain ${APP_NAME}"
+
+step "Clearing quarantine and local signing metadata"
+xattr -cr "$app_path" || die "Could not clear extended attributes from ${APP_NAME}"
+
+# macOS 26 can stall forever at _dyld_start while scanning downloaded foreign
+# ad-hoc-signed binaries. Re-signing locally outside /Applications avoids that
+# scan path. This should become unnecessary once releases are notarized.
+step "Re-signing app locally before it enters /Applications"
+codesign --force --deep --sign - "$app_path" || die "Local ad-hoc signing failed"
+
+if [ -d "$INSTALL_PATH" ]; then
+  step "Replacing existing app in /Applications"
+  osascript -e 'tell application "localvoxtral" to quit' >/dev/null 2>&1 || true
+  sleep 2
+  pkill -x localvoxtral >/dev/null 2>&1 || true
+  rm -rf "$INSTALL_PATH" || die "Could not remove existing ${INSTALL_PATH}. Close localvoxtral and retry."
+else
+  step "Installing app into /Applications"
+fi
+
+mv "$app_path" "$INSTALL_PATH" || die "Could not move ${APP_NAME} into /Applications. You may need to run this installer from an administrator account."
+
+step "Launching localvoxtral"
+open "$INSTALL_PATH" || die "Installed app but could not launch it from ${INSTALL_PATH}"
+
+step "Done"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -187,6 +187,9 @@ main() {
   step "Done"
 }
 
-if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
+# BASH_SOURCE is unset when the script arrives on stdin (`curl ... | bash`),
+# and `set -u` turns that into a fatal unbound-variable error. Empty means
+# "not being sourced", so run main in that case too.
+if [[ "${BASH_SOURCE[0]:-}" == "" || "${BASH_SOURCE[0]:-}" == "$0" ]]; then
   main "$@"
 fi

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -6,6 +6,7 @@ APP_NAME="localvoxtral.app"
 INSTALL_PATH="/Applications/${APP_NAME}"
 VERSION="${LOCALVOXTRAL_VERSION:-latest}"
 DRYRUN="${LOCALVOXTRAL_INSTALL_DRYRUN:-0}"
+INSTALL_TMP_DIR=""
 
 die() {
   printf 'Error: %s\n' "$*" >&2
@@ -20,6 +21,12 @@ require_command() {
   command -v "$1" >/dev/null 2>&1 || die "Missing required command: $1"
 }
 
+cleanup() {
+  if [ -n "$INSTALL_TMP_DIR" ]; then
+    rm -rf "$INSTALL_TMP_DIR"
+  fi
+}
+
 resolve_release_api_url() {
   if [ "$VERSION" = "latest" ]; then
     printf 'https://api.github.com/repos/%s/releases/latest\n' "$REPO"
@@ -29,8 +36,25 @@ resolve_release_api_url() {
 }
 
 resolve_zip_url() {
+  local api_url http_code release_json release_json_file zip_url zip_urls
+
   api_url="$(resolve_release_api_url)"
-  release_json="$(curl -fsSL "$api_url")" || die "Could not fetch GitHub release metadata from $api_url"
+  release_json_file="$(mktemp "${TMPDIR:-/tmp}/localvoxtral-release.XXXXXX")"
+  http_code="$(curl -sSL -o "$release_json_file" -w '%{http_code}' "$api_url")" || {
+    rm -f "$release_json_file"
+    die "Could not fetch GitHub release metadata from $api_url"
+  }
+  release_json="$(cat "$release_json_file")"
+  rm -f "$release_json_file"
+
+  if [ "$http_code" = "403" ]; then
+    die "Could not fetch GitHub release metadata from $api_url (HTTP 403). GitHub may have rate-limited this client; wait and retry, or set LOCALVOXTRAL_VERSION to a direct release tag such as v1.2.3."
+  fi
+  case "$http_code" in
+    2*) ;;
+    *) die "Could not fetch GitHub release metadata from $api_url (HTTP $http_code)" ;;
+  esac
+
   zip_urls="$(printf '%s\n' "$release_json" |
     grep '"browser_download_url"[[:space:]]*:' |
     sed -n 's/.*"browser_download_url"[[:space:]]*:[[:space:]]*"\([^"]*\.zip\)".*/\1/p' || true)"
@@ -40,62 +64,129 @@ resolve_zip_url() {
   printf '%s\n' "$zip_url"
 }
 
-require_command curl
+fetch_checksum() {
+  local checksum_path checksum_url http_code
 
-step "Resolving localvoxtral release zip"
-zip_url="$(resolve_zip_url)"
-printf 'Resolved zip: %s\n' "$zip_url"
+  checksum_url="${1}.sha256"
+  checksum_path="$2"
 
-if [ "$DRYRUN" = "1" ]; then
-  step "Dry run requested; stopping before download and macOS install steps"
-  exit 0
-fi
+  http_code="$(curl -sSL -o "$checksum_path" -w '%{http_code}' "$checksum_url")" || {
+    rm -f "$checksum_path"
+    printf 'Warning: could not fetch checksum asset %s; continuing without checksum verification.\n' "$checksum_url" >&2
+    return 1
+  }
 
-[ "$(uname -s)" = "Darwin" ] || die "This installer only runs on macOS. Set LOCALVOXTRAL_INSTALL_DRYRUN=1 to test release URL resolution elsewhere."
-
-require_command ditto
-require_command xattr
-require_command codesign
-require_command open
-
-tmp_dir="$(mktemp -d "${TMPDIR:-/tmp}/localvoxtral-install.XXXXXX")"
-cleanup() {
-  rm -rf "$tmp_dir"
+  case "$http_code" in
+    2*) return 0 ;;
+    *)
+      rm -f "$checksum_path"
+      printf 'Warning: checksum asset %s is not available (HTTP %s); continuing without checksum verification.\n' "$checksum_url" "$http_code" >&2
+      return 1
+      ;;
+  esac
 }
-trap cleanup EXIT
 
-zip_path="${tmp_dir}/localvoxtral.zip"
+verify_zip_checksum() {
+  local checksum_path computed expected zip_path
 
-step "Downloading release"
-curl -fL "$zip_url" -o "$zip_path" || die "Download failed: $zip_url"
+  zip_path="$1"
+  checksum_path="$2"
 
-step "Extracting app bundle"
-ditto -x -k "$zip_path" "$tmp_dir" || die "Could not extract release zip"
-app_path="$(find "$tmp_dir" -type d -name "$APP_NAME" -prune -print | sed -n '1p')"
-[ -n "$app_path" ] || die "Extracted zip did not contain ${APP_NAME}"
+  [ -s "$checksum_path" ] || die "Checksum file is empty: $checksum_path"
+  expected="$(awk 'NR == 1 { print $1 }' "$checksum_path")"
+  [[ "$expected" =~ ^[[:xdigit:]]{64}$ ]] || die "Checksum file $checksum_path does not start with a valid SHA-256 digest"
 
-step "Clearing quarantine and local signing metadata"
-xattr -cr "$app_path" || die "Could not clear extended attributes from ${APP_NAME}"
+  require_command shasum
+  computed="$(shasum -a 256 "$zip_path" | awk '{ print $1 }')"
+  [ "$computed" = "$expected" ] || die "Checksum mismatch for downloaded zip: expected $expected, got $computed"
+}
 
-# macOS 26 can stall forever at _dyld_start while scanning downloaded foreign
-# ad-hoc-signed binaries. Re-signing locally outside /Applications avoids that
-# scan path. This should become unnecessary once releases are notarized.
-step "Re-signing app locally before it enters /Applications"
-codesign --force --deep --sign - "$app_path" || die "Local ad-hoc signing failed"
+install_app_bundle() {
+  local app_path old_path
 
-if [ -d "$INSTALL_PATH" ]; then
-  step "Replacing existing app in /Applications"
-  osascript -e 'tell application "localvoxtral" to quit' >/dev/null 2>&1 || true
-  sleep 2
-  pkill -x localvoxtral >/dev/null 2>&1 || true
-  rm -rf "$INSTALL_PATH" || die "Could not remove existing ${INSTALL_PATH}. Close localvoxtral and retry."
-else
-  step "Installing app into /Applications"
+  app_path="$1"
+
+  if [ -d "$INSTALL_PATH" ]; then
+    step "Replacing existing app in /Applications"
+    old_path="${INSTALL_PATH}.old.$$"
+    [ ! -e "$old_path" ] || die "Refusing to overwrite existing backup path: $old_path"
+    osascript -e 'tell application "localvoxtral" to quit' >/dev/null 2>&1 || true
+    sleep 2
+    pkill -x localvoxtral >/dev/null 2>&1 || true
+    mv "$INSTALL_PATH" "$old_path" || die "Could not move existing ${INSTALL_PATH} aside. Close localvoxtral and retry."
+    if mv "$app_path" "$INSTALL_PATH"; then
+      rm -rf "$old_path" || printf 'Warning: installed new app, but could not remove old app backup at %s\n' "$old_path" >&2
+    else
+      mv "$old_path" "$INSTALL_PATH" || printf 'Error: failed to restore previous app from %s to %s\n' "$old_path" "$INSTALL_PATH" >&2
+      die "Could not move ${APP_NAME} into /Applications. Previous install was restored if possible."
+    fi
+  else
+    step "Installing app into /Applications"
+    mv "$app_path" "$INSTALL_PATH" || die "Could not move ${APP_NAME} into /Applications. You may need to run this installer from an administrator account."
+  fi
+}
+
+main() {
+  local app_path checksum_path zip_path zip_url
+
+  require_command curl
+
+  step "Resolving localvoxtral release zip"
+  zip_url="$(resolve_zip_url)"
+  printf 'Resolved zip: %s\n' "$zip_url"
+
+  if [ "$DRYRUN" = "1" ]; then
+    step "Dry run requested; stopping before download and macOS install steps"
+    exit 0
+  fi
+
+  [ "$(uname -s)" = "Darwin" ] || die "This installer only runs on macOS. Set LOCALVOXTRAL_INSTALL_DRYRUN=1 to test release URL resolution elsewhere."
+
+  require_command ditto
+  require_command xattr
+  require_command codesign
+  require_command open
+
+  INSTALL_TMP_DIR="$(mktemp -d "${TMPDIR:-/tmp}/localvoxtral-install.XXXXXX")"
+  trap cleanup EXIT
+
+  zip_path="${INSTALL_TMP_DIR}/localvoxtral.zip"
+  checksum_path="${zip_path}.sha256"
+
+  step "Downloading release"
+  curl -fL "$zip_url" -o "$zip_path" || die "Download failed: $zip_url"
+
+  # The checksum comes from the same GitHub release as the zip. It protects
+  # against corruption or truncated downloads, not a compromised release account.
+  step "Checking release checksum"
+  if fetch_checksum "$zip_url" "$checksum_path"; then
+    verify_zip_checksum "$zip_path" "$checksum_path"
+  fi
+
+  step "Extracting app bundle"
+  ditto -x -k "$zip_path" "$INSTALL_TMP_DIR" || die "Could not extract release zip"
+  app_path="$(find "$INSTALL_TMP_DIR" -type d -name "$APP_NAME" -prune -print | sed -n '1p')"
+  [ -n "$app_path" ] || die "Extracted zip did not contain ${APP_NAME}"
+
+  step "Clearing quarantine and local signing metadata"
+  xattr -cr "$app_path" || die "Could not clear extended attributes from ${APP_NAME}"
+
+  # macOS 26 can stall forever at _dyld_start while scanning downloaded foreign
+  # ad-hoc-signed binaries. Re-signing locally outside /Applications avoids that
+  # scan path. This should become unnecessary once releases are notarized.
+  # --deep is deprecated but field-verified working on macOS 26.5 (2026-07-04);
+  # if Apple removes it, sign nested executables explicitly instead.
+  step "Re-signing app locally before it enters /Applications"
+  codesign --force --deep --sign - "$app_path" || die "Local ad-hoc signing failed"
+
+  install_app_bundle "$app_path"
+
+  step "Launching localvoxtral"
+  open "$INSTALL_PATH" || die "Installed app but could not launch it from ${INSTALL_PATH}"
+
+  step "Done"
+}
+
+if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
+  main "$@"
 fi
-
-mv "$app_path" "$INSTALL_PATH" || die "Could not move ${APP_NAME} into /Applications. You may need to run this installer from an administrator account."
-
-step "Launching localvoxtral"
-open "$INSTALL_PATH" || die "Installed app but could not launch it from ${INSTALL_PATH}"
-
-step "Done"


### PR DESCRIPTION
## What
`scripts/install.sh`, curl-pipeable: resolves the latest (or `LOCALVOXTRAL_VERSION`-pinned) release zip via the GitHub API, downloads, extracts, `xattr -cr`, **re-signs locally with an ad-hoc identity while still in the temp dir** — the exact sequence field-proven today to make the app launch on macOS 26, where foreign ad-hoc signatures stall forever at `_dyld_start` — then replaces /Applications/localvoxtral.app and opens it. README Quick start now leads with the one-liner; the DMG path stays as manual fallback with an honest warning. The re-sign step becomes unnecessary once releases are notarized (roadmap #1).

## Proof
- [x] `bash -n` clean; `LOCALVOXTRAL_INSTALL_DRYRUN=1 bash scripts/install.sh` on Linux resolves the real asset:
```
Resolved zip: https://github.com/T0mSIlver/localvoxtral/releases/download/v0.7.1/localvoxtral-v0.7.1.zip
```
- [ ] **Owner verification owed (macOS)**: run the one-liner from the PR branch on the machine where v0.7.1 hangs:
```
curl -fsSL https://raw.githubusercontent.com/T0mSIlver/localvoxtral/lane/install/scripts/install.sh | bash
```
Expect: installs and the menu bar icon appears within seconds. That run is the regression proof for the macOS 26 launch bug.

## Adversarial review outcome (post-open)

An opencode (GLM-5.2) read-only shell/security reviewer ran against this PR — no high-severity findings; fixes applied in the follow-up commit:
- **[med]** integrity check: `release.yml` now publishes `.zip.sha256`/`.dmg.sha256` assets and the installer verifies the zip when the asset exists (warns and continues for older releases). Stated honestly in-script: same-source checksums protect against corruption, not a compromised release account — notarization remains the real answer.
- **[low]** rename-then-replace install: a failed `mv` can no longer leave the user with *no* app (old copy restored on failure); also closes the app-respawn-vs-`rm` race.
- **[low]** GitHub API 403 now prints a rate-limit hint instead of a generic error.
- **[low]** `codesign --deep` deprecation noted in-script (field-verified working on macOS 26.5, 2026-07-04).


## Field-found bug: `curl | bash` unbound variable (fixed in bd70f3a)

First real invocation on the owner's Mac failed:
```
bash: line 190: BASH_SOURCE[0]: unbound variable
```
`BASH_SOURCE` is unset when the script arrives on stdin (the curl-pipe path — the primary install path), and `set -u` made the source-guard fatal. All prior verification had executed the script as a file, where `BASH_SOURCE[0]` is set.

Fail-then-pass, both on the piped path:
```
$ git show HEAD~1:scripts/install.sh | LOCALVOXTRAL_INSTALL_DRYRUN=1 bash
bash: line 190: BASH_SOURCE[0]: unbound variable   # exit 1

$ cat scripts/install.sh | LOCALVOXTRAL_INSTALL_DRYRUN=1 bash
==> Resolving localvoxtral release zip
Resolved zip: https://github.com/T0mSIlver/localvoxtral/releases/download/v0.7.1/localvoxtral-v0.7.1.zip
==> Dry run requested; stopping before download and macOS install steps
```
Direct-execution and `source` (must not run `main`) modes re-verified alongside.
