### PR TITLE
Add local-first diagnostics: mac-diag.sh and Export Diagnostics menu item

### DIFF
--- a/Sources/localvoxtral/Backends/BackendManager.swift
+++ b/Sources/localvoxtral/Backends/BackendManager.swift
@@ -35,6 +35,9 @@ enum ManagedBackendManagerError: LocalizedError {
 protocol ManagedBackendSupervising: AnyObject {
     var state: BackendProcessSupervisor.State { get }
     var stateUpdates: AsyncStream<BackendProcessSupervisor.State> { get }
+    /// Ring buffer of recent stdout/stderr lines (capped by the supervisor).
+    /// Surfaced for local diagnostics export only.
+    var recentOutput: [String] { get }
 
     func start() async
     func stop() async
@@ -49,6 +52,10 @@ protocol ManagedBackendManaging: AnyObject {
 
     func ensureReady(includePolishing: Bool) async throws
     func stopAll() async
+    /// Recent supervisor output lines for the given backend, or empty if the
+    /// supervisor has not been created yet (backend never started). For local
+    /// diagnostics export only.
+    func recentOutput(for spec: ManagedBackendSpec) -> [String]
 }
 
 @MainActor
@@ -131,6 +138,17 @@ final class BackendManager: ManagedBackendManaging {
             return mlxLMStatus
         default:
             return .failed(message: "Unknown managed backend '\(spec.id)'.")
+        }
+    }
+
+    func recentOutput(for spec: ManagedBackendSpec) -> [String] {
+        switch spec.id {
+        case BackendCatalog.voxmlx.id:
+            return voxmlxSupervisor?.recentOutput ?? []
+        case BackendCatalog.mlxLM.id:
+            return mlxLMSupervisor?.recentOutput ?? []
+        default:
+            return []
         }
     }
 

--- a/Sources/localvoxtral/DiagnosticsExporter.swift
+++ b/Sources/localvoxtral/DiagnosticsExporter.swift
@@ -112,6 +112,8 @@ enum DiagnosticsExporter {
         let headerFormatter = makeHeaderFormatter()
         lines.append("localvoxtral diagnostics")
         lines.append("generated: \(headerFormatter.string(from: now))")
+        lines.append("This file was generated locally and is never uploaded anywhere.")
+        lines.append("Review it before sharing — backend process output below is verbatim.")
         lines.append("")
 
         lines.append("== App ==")
@@ -168,8 +170,15 @@ enum DiagnosticsExporter {
         now: Date
     ) throws -> URL {
         let filenameFormatter = makeFilenameFormatter()
-        let filename = "\(filenamePrefix)\(filenameFormatter.string(from: now))\(filenameSuffix)"
-        let destination = directory.appendingPathComponent(filename)
+        let stem = "\(filenamePrefix)\(filenameFormatter.string(from: now))"
+        // Second-precision timestamps can collide on rapid re-export; never
+        // silently overwrite an earlier report.
+        var destination = directory.appendingPathComponent(stem + filenameSuffix)
+        var attempt = 2
+        while FileManager.default.fileExists(atPath: destination.path), attempt <= 100 {
+            destination = directory.appendingPathComponent("\(stem)-\(attempt)\(filenameSuffix)")
+            attempt += 1
+        }
         let report = makeReport(snapshot: snapshot, now: now)
         // `atomic: true` so a partial write never leaves a misleading file.
         try report.write(to: destination, atomically: true, encoding: .utf8)

--- a/Sources/localvoxtral/DiagnosticsExporter.swift
+++ b/Sources/localvoxtral/DiagnosticsExporter.swift
@@ -1,0 +1,228 @@
+import Foundation
+
+/// Local-first diagnostics export. Produces a single readable text report of
+/// the app's runtime configuration and managed-backend state so the owner can
+/// debug field issues fast — without any phone-home telemetry.
+///
+/// Privacy is the core product promise, so the exporter is built so secrets
+/// can never enter the output:
+/// - `DiagnosticsSnapshot` only carries non-secret value fields. API keys are
+///   reduced to booleans ("is one set?") at snapshot-build time and the key
+///   values are never copied into the snapshot.
+/// - Endpoints are scrubbed of embedded credentials (userinfo/query/fragment).
+/// - Dictated content / transcript stores are never read here.
+struct DiagnosticsSnapshot: Sendable, Equatable {
+    var appVersion: String
+    var appBuild: String
+    var bundleIdentifier: String
+    var osVersion: String
+    var backendMode: String
+    var realtimeEndpoint: String
+    var realtimeModel: String
+    var hasRealtimeAPIKey: Bool
+    var polishingSummary: String
+    var hasPolishingAPIKey: Bool
+    var voxmlxStatus: String
+    var mlxLMStatus: String
+    var voxmlxRecentOutput: [String]
+    var mlxLMRecentOutput: [String]
+}
+
+enum DiagnosticsExporter {
+    /// Filename prefix + format for the on-disk report. Timestamp is colons-free
+    /// so it is safe in filenames on all filesystems.
+    static let filenamePrefix = "localvoxtral-diagnostics-"
+    static let filenameSuffix = ".txt"
+
+    // Formatters are created per-call (not as `static let`) because DateFormatter
+    // is non-Sendable and Swift 6.2 strict concurrency forbids shared static
+    // mutable-ish state. A diagnostics export runs rarely, so this is cheap.
+
+    private static func makeFilenameFormatter() -> DateFormatter {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyy-MM-dd'T'HH-mm-ss"
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.timeZone = TimeZone(identifier: "UTC")
+        return formatter
+    }
+
+    private static func makeHeaderFormatter() -> DateFormatter {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ssZZZZZ"
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.timeZone = TimeZone(identifier: "UTC")
+        return formatter
+    }
+
+    // MARK: - Snapshot building (reads live types; @MainActor)
+
+    /// Builds a redacted snapshot from the live app state. This is the security
+    /// boundary: it decides exactly what (non-secret) information leaves the app.
+    @MainActor
+    static func makeSnapshot(
+        settings: SettingsStore,
+        voxmlxStatus: ManagedBackendStatus,
+        mlxLMStatus: ManagedBackendStatus,
+        voxmlxRecentOutput: [String],
+        mlxLMRecentOutput: [String],
+        bundle: Bundle = .main,
+        processInfo: ProcessInfo = .processInfo
+    ) -> DiagnosticsSnapshot {
+        let info = bundle.infoDictionary
+        let appVersion = (info?["CFBundleShortVersionString"] as? String) ?? "unknown"
+        let appBuild = (info?["CFBundleVersion"] as? String) ?? "unknown"
+        let bundleIdentifier = bundle.bundleIdentifier ?? "unknown"
+
+        let realtimeEndpoint = sanitizedEndpointDescription(
+            from: settings.resolvedWebSocketURL(for: settings.realtimeProvider)
+        )
+        let realtimeModel = settings.effectiveModelName(for: settings.realtimeProvider)
+
+        let polishingSummary: String
+        if let polishing = settings.llmPolishingConfiguration {
+            polishingSummary = sanitizedEndpointDescription(from: polishing.endpointURL)
+        } else {
+            polishingSummary = "<disabled>"
+        }
+
+        return DiagnosticsSnapshot(
+            appVersion: appVersion,
+            appBuild: appBuild,
+            bundleIdentifier: bundleIdentifier,
+            osVersion: processInfo.operatingSystemVersionString,
+            backendMode: settings.backendMode.displayName,
+            realtimeEndpoint: realtimeEndpoint,
+            realtimeModel: realtimeModel,
+            hasRealtimeAPIKey: !settings.apiKey.trimmed.isEmpty,
+            polishingSummary: polishingSummary,
+            hasPolishingAPIKey: !settings.llmPolishingAPIKey.trimmed.isEmpty,
+            voxmlxStatus: describe(voxmlxStatus),
+            mlxLMStatus: describe(mlxLMStatus),
+            voxmlxRecentOutput: voxmlxRecentOutput,
+            mlxLMRecentOutput: mlxLMRecentOutput
+        )
+    }
+
+    // MARK: - Report rendering (pure)
+
+    /// Renders the snapshot as a single readable text report. `now` is an
+    /// injected clock seam (no `Date()` here) so tests are deterministic.
+    static func makeReport(snapshot: DiagnosticsSnapshot, now: Date) -> String {
+        var lines: [String] = []
+        let headerFormatter = makeHeaderFormatter()
+        lines.append("localvoxtral diagnostics")
+        lines.append("generated: \(headerFormatter.string(from: now))")
+        lines.append("")
+
+        lines.append("== App ==")
+        lines.append("version: \(snapshot.appVersion) (build \(snapshot.appBuild))")
+        lines.append("bundle id: \(snapshot.bundleIdentifier)")
+        lines.append("")
+
+        lines.append("== OS ==")
+        lines.append(snapshot.osVersion)
+        lines.append("")
+
+        lines.append("== Backend configuration ==")
+        lines.append("mode: \(snapshot.backendMode)")
+        lines.append("realtime endpoint: \(snapshot.realtimeEndpoint)")
+        lines.append("realtime model: \(snapshot.realtimeModel)")
+        lines.append("realtime API key: \(snapshot.hasRealtimeAPIKey ? "set" : "not set")")
+        lines.append("LLM polishing: \(snapshot.polishingSummary)")
+        lines.append("LLM polishing API key: \(snapshot.hasPolishingAPIKey ? "set" : "not set")")
+        lines.append("")
+
+        lines.append("== Managed backend status ==")
+        lines.append("voxmlx: \(snapshot.voxmlxStatus)")
+        lines.append("mlx-lm: \(snapshot.mlxLMStatus)")
+        lines.append("")
+
+        lines.append("== Managed backend recent output ==")
+        if snapshot.voxmlxRecentOutput.isEmpty && snapshot.mlxLMRecentOutput.isEmpty {
+            lines.append("(no supervisor output captured)")
+        } else {
+            if !snapshot.voxmlxRecentOutput.isEmpty {
+                lines.append("-- voxmlx --")
+                lines.append(contentsOf: snapshot.voxmlxRecentOutput)
+            }
+            if !snapshot.mlxLMRecentOutput.isEmpty {
+                lines.append("-- mlx-lm --")
+                lines.append(contentsOf: snapshot.mlxLMRecentOutput)
+            }
+        }
+
+        lines.append("")
+        lines.append("== end of diagnostics ==")
+        return lines.joined(separator: "\n")
+    }
+
+    // MARK: - File writing (injectable destination + clock)
+
+    /// Writes the report to `directory` as
+    /// `localvoxtral-diagnostics-<timestamp>.txt`, where `<timestamp>` is
+    /// derived from the injected `now`. Returns the written file URL.
+    @discardableResult
+    static func writeReport(
+        snapshot: DiagnosticsSnapshot,
+        to directory: URL,
+        now: Date
+    ) throws -> URL {
+        let filenameFormatter = makeFilenameFormatter()
+        let filename = "\(filenamePrefix)\(filenameFormatter.string(from: now))\(filenameSuffix)"
+        let destination = directory.appendingPathComponent(filename)
+        let report = makeReport(snapshot: snapshot, now: now)
+        // `atomic: true` so a partial write never leaves a misleading file.
+        try report.write(to: destination, atomically: true, encoding: .utf8)
+        return destination
+    }
+
+    // MARK: - Helpers
+
+    /// Returns a credential-free description of an endpoint URL. Userinfo,
+    /// query, and fragment are stripped so embedded tokens can never leak.
+    static func sanitizedEndpointDescription(from url: URL?) -> String {
+        guard let url else { return "<invalid endpoint>" }
+        guard var components = URLComponents(url: url, resolvingAgainstBaseURL: false) else {
+            return url.absoluteString
+        }
+        components.user = nil
+        components.password = nil
+        components.query = nil
+        components.fragment = nil
+        return components.string ?? url.absoluteString
+    }
+
+    /// Human-readable, single-line description of a managed-backend status.
+    static func describe(_ status: ManagedBackendStatus) -> String {
+        switch status {
+        case .notInstalled:
+            return "not installed"
+        case .installing(let progress):
+            return "installing (\(describe(progress)))"
+        case .starting:
+            return "starting"
+        case .ready:
+            return "ready"
+        case .stopped:
+            return "stopped"
+        case .failed(let message):
+            return "failed: \(message)"
+        }
+    }
+
+    private static func describe(_ progress: BackendInstallProgress) -> String {
+        switch progress {
+        case .downloading(let fraction):
+            if let fraction {
+                return String(format: "downloading %.0f%%", fraction * 100)
+            }
+            return "downloading"
+        case .verifying:
+            return "verifying"
+        case .installing(let logLine):
+            return "installing: \(logLine)"
+        case .finished:
+            return "finished"
+        }
+    }
+}

--- a/Sources/localvoxtral/Log.swift
+++ b/Sources/localvoxtral/Log.swift
@@ -25,4 +25,5 @@ enum Log {
     static let deltas = Logger(subsystem: subsystem, category: "Deltas")
     static let escape = Logger(subsystem: subsystem, category: "Escape")
     static let modifierKeys = Logger(subsystem: subsystem, category: "ModifierKeys")
+    static let diagnostics = Logger(subsystem: subsystem, category: "Diagnostics")
 }

--- a/Sources/localvoxtral/StatusPopoverView.swift
+++ b/Sources/localvoxtral/StatusPopoverView.swift
@@ -110,6 +110,10 @@ struct StatusPopoverView: View {
                 openSettings()
             }
 
+            Button("Export Diagnostics…") {
+                exportDiagnostics()
+            }
+
             if !viewModel.isAccessibilityTrusted {
                 Button("Enable Accessibility…") {
                     viewModel.requestAccessibilityPermission()
@@ -173,5 +177,39 @@ struct StatusPopoverView: View {
             return
         }
         NSWorkspace.shared.open(url)
+    }
+
+    /// Writes a local-first diagnostics report to the Desktop. The report
+    /// contains only non-secret configuration/status (no API keys, no dictated
+    /// content). See `DiagnosticsExporter` for the redaction boundary.
+    private func exportDiagnostics() {
+        let backendManager = viewModel.backendManager
+        let snapshot = DiagnosticsExporter.makeSnapshot(
+            settings: viewModel.settings,
+            voxmlxStatus: backendManager.voxmlxStatus,
+            mlxLMStatus: backendManager.mlxLMStatus,
+            voxmlxRecentOutput: backendManager.recentOutput(for: BackendCatalog.voxmlx),
+            mlxLMRecentOutput: backendManager.recentOutput(for: BackendCatalog.mlxLM)
+        )
+
+        guard let desktop = FileManager.default.urls(
+            for: .desktopDirectory,
+            in: .userDomainMask
+        ).first else {
+            Log.diagnostics.error("diagnostics export failed: Desktop directory unavailable")
+            return
+        }
+
+        do {
+            let writtenURL = try DiagnosticsExporter.writeReport(
+                snapshot: snapshot,
+                to: desktop,
+                now: Date()
+            )
+            Log.diagnostics.info("diagnostics exported: \(writtenURL.path, privacy: .public)")
+            NSWorkspace.shared.activateFileViewerSelecting([writtenURL])
+        } catch {
+            Log.diagnostics.error("diagnostics export failed: \(error.localizedDescription, privacy: .public)")
+        }
     }
 }

--- a/Sources/localvoxtral/StatusPopoverView.swift
+++ b/Sources/localvoxtral/StatusPopoverView.swift
@@ -200,16 +200,24 @@ struct StatusPopoverView: View {
             return
         }
 
-        do {
-            let writtenURL = try DiagnosticsExporter.writeReport(
-                snapshot: snapshot,
-                to: desktop,
-                now: Date()
-            )
-            Log.diagnostics.info("diagnostics exported: \(writtenURL.path, privacy: .public)")
-            NSWorkspace.shared.activateFileViewerSelecting([writtenURL])
-        } catch {
-            Log.diagnostics.error("diagnostics export failed: \(error.localizedDescription, privacy: .public)")
+        // Snapshot is built on the MainActor above; rendering and the file
+        // write happen off-main so a slow/iCloud-backed Desktop can never
+        // beachball the menu bar app.
+        let exportedAt = Date()
+        Task.detached(priority: .utility) {
+            do {
+                let writtenURL = try DiagnosticsExporter.writeReport(
+                    snapshot: snapshot,
+                    to: desktop,
+                    now: exportedAt
+                )
+                Log.diagnostics.info("diagnostics exported: \(writtenURL.path, privacy: .public)")
+                await MainActor.run {
+                    NSWorkspace.shared.activateFileViewerSelecting([writtenURL])
+                }
+            } catch {
+                Log.diagnostics.error("diagnostics export failed: \(error.localizedDescription, privacy: .public)")
+            }
         }
     }
 }

--- a/Tests/localvoxtralTests/BackendManagerTests.swift
+++ b/Tests/localvoxtralTests/BackendManagerTests.swift
@@ -219,6 +219,7 @@ private final class FakeBackendSupervisor: ManagedBackendSupervising {
 
     private(set) var state: BackendProcessSupervisor.State = .idle
     let stateUpdates: AsyncStream<BackendProcessSupervisor.State>
+    var recentOutput: [String] = []
     private(set) var startCallCount = 0
     private(set) var stopCallCount = 0
 

--- a/Tests/localvoxtralTests/DiagnosticsExporterTests.swift
+++ b/Tests/localvoxtralTests/DiagnosticsExporterTests.swift
@@ -1,0 +1,218 @@
+import Foundation
+import XCTest
+@testable import localvoxtral
+
+@MainActor
+final class DiagnosticsExporterTests: XCTestCase {
+    private var defaultsSuiteName = ""
+    private var defaults: UserDefaults!
+    private var tempDirectory: URL!
+
+    override func setUp() async throws {
+        try await super.setUp()
+        defaultsSuiteName = "localvoxtral.DiagnosticsExporterTests.\(UUID().uuidString)"
+        defaults = UserDefaults(suiteName: defaultsSuiteName)
+        defaults.removePersistentDomain(forName: defaultsSuiteName)
+        tempDirectory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("DiagnosticsExporterTests.\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: tempDirectory, withIntermediateDirectories: true)
+    }
+
+    override func tearDown() async throws {
+        try? FileManager.default.removeItem(at: tempDirectory)
+        defaults?.removePersistentDomain(forName: defaultsSuiteName)
+        defaults = nil
+        defaultsSuiteName = ""
+        try await super.tearDown()
+    }
+
+    // MARK: - Helpers
+
+    private func makeStore() -> SettingsStore {
+        SettingsStore(defaults: defaults, environment: [:])
+    }
+
+    /// A store in external-URL mode with a user-entered endpoint, so the
+    /// exporter surfaces the user endpoint (the path where a stray API key or
+    /// embedded credential could otherwise leak).
+    private func makeExternalStore(endpoint: String = "ws://127.0.0.1:8000/v1/realtime") -> SettingsStore {
+        let store = makeStore()
+        store.backendMode = .externalURL
+        store.realtimeProvider = .realtimeAPI
+        store.realtimeAPIEndpointURL = endpoint
+        return store
+    }
+
+    private func makeSnapshot(
+        settings: SettingsStore,
+        voxmlxStatus: ManagedBackendStatus = .notInstalled,
+        mlxLMStatus: ManagedBackendStatus = .notInstalled,
+        voxmlxRecentOutput: [String] = [],
+        mlxLMRecentOutput: [String] = []
+    ) -> DiagnosticsSnapshot {
+        DiagnosticsExporter.makeSnapshot(
+            settings: settings,
+            voxmlxStatus: voxmlxStatus,
+            mlxLMStatus: mlxLMStatus,
+            voxmlxRecentOutput: voxmlxRecentOutput,
+            mlxLMRecentOutput: mlxLMRecentOutput
+        )
+    }
+
+    // MARK: - Section presence
+
+    func testReportContainsExpectedSections() {
+        let store = makeExternalStore()
+        let snapshot = makeSnapshot(settings: store)
+        let report = DiagnosticsExporter.makeReport(snapshot: snapshot, now: Date())
+
+        XCTAssertTrue(report.contains("localvoxtral diagnostics"))
+        XCTAssertTrue(report.contains("== App =="))
+        XCTAssertTrue(report.contains("== OS =="))
+        XCTAssertTrue(report.contains("== Backend configuration =="))
+        XCTAssertTrue(report.contains("== Managed backend status =="))
+        XCTAssertTrue(report.contains("== Managed backend recent output =="))
+        XCTAssertTrue(report.contains("mode: External URL"))
+        XCTAssertTrue(report.contains("realtime endpoint: ws://127.0.0.1:8000/v1/realtime"))
+        XCTAssertTrue(report.contains("realtime API key: not set"))
+        XCTAssertTrue(report.contains("LLM polishing: <disabled>"))
+        XCTAssertTrue(report.contains("voxmlx: not installed"))
+        XCTAssertTrue(report.contains("mlx-lm: not installed"))
+    }
+
+    func testReportIncludesSupervisorOutputWhenPresent() {
+        let store = makeExternalStore()
+        let snapshot = makeSnapshot(
+            settings: store,
+            voxmlxRecentOutput: ["[voxmlx stdout] INFO started", "[voxmlx stderr] listening"],
+            mlxLMRecentOutput: ["[mlx-lm stdout] ready"]
+        )
+        let report = DiagnosticsExporter.makeReport(snapshot: snapshot, now: Date())
+
+        XCTAssertTrue(report.contains("-- voxmlx --"))
+        XCTAssertTrue(report.contains("[voxmlx stdout] INFO started"))
+        XCTAssertTrue(report.contains("[voxmlx stderr] listening"))
+        XCTAssertTrue(report.contains("-- mlx-lm --"))
+        XCTAssertTrue(report.contains("[mlx-lm stdout] ready"))
+    }
+
+    // MARK: - API key redaction (the core privacy property)
+
+    func testReportExcludesRealtimeAPIKeyValueWhenSet() {
+        let store = makeExternalStore()
+        store.apiKey = "sk-test-DO-NOT-LEAK-REALTIME-7c9f"
+
+        let snapshot = makeSnapshot(settings: store)
+        let report = DiagnosticsExporter.makeReport(snapshot: snapshot, now: Date())
+
+        // The key value must never appear, but its presence is reported as a boolean.
+        XCTAssertFalse(report.contains("sk-test-DO-NOT-LEAK-REALTIME-7c9f"))
+        XCTAssertTrue(report.contains("realtime API key: set"))
+    }
+
+    func testReportExcludesPolishingAPIKeyValueWhenSet() {
+        let store = makeExternalStore()
+        store.llmPolishingEnabled = true
+        store.llmPolishingEndpointURL = "http://127.0.0.1:8080/v1/chat/completions"
+        store.llmPolishingAPIKey = "polish-DO-NOT-LEAK-9a4b"
+
+        let snapshot = makeSnapshot(settings: store)
+        let report = DiagnosticsExporter.makeReport(snapshot: snapshot, now: Date())
+
+        XCTAssertFalse(report.contains("polish-DO-NOT-LEAK-9a4b"))
+        XCTAssertTrue(report.contains("LLM polishing API key: set"))
+    }
+
+    func testReportExcludesEmbeddedEndpointCredentials() {
+        let store = makeExternalStore(
+            endpoint: "ws://alice:hunter2@127.0.0.1:8000/v1/realtime?token=sekret-fragment#frag"
+        )
+
+        let snapshot = makeSnapshot(settings: store)
+        let report = DiagnosticsExporter.makeReport(snapshot: snapshot, now: Date())
+
+        XCTAssertFalse(report.contains("alice"))
+        XCTAssertFalse(report.contains("hunter2"))
+        XCTAssertFalse(report.contains("sekret"))
+        XCTAssertFalse(report.contains("frag"))
+        XCTAssertTrue(report.contains("127.0.0.1:8000"))
+    }
+
+    func testSanitizedEndpointDescriptionStripsCredentials() {
+        let url = URL(string: "wss://user:pass@example.com:9000/path?token=x#section")!
+        XCTAssertEqual(
+            DiagnosticsExporter.sanitizedEndpointDescription(from: url),
+            "wss://example.com:9000/path"
+        )
+    }
+
+    func testSanitizedEndpointDescriptionHandlesNil() {
+        XCTAssertEqual(DiagnosticsExporter.sanitizedEndpointDescription(from: nil), "<invalid endpoint>")
+    }
+
+    // MARK: - Status rendering
+
+    func testDescribeStatusVariants() {
+        XCTAssertEqual(DiagnosticsExporter.describe(.ready), "ready")
+        XCTAssertEqual(DiagnosticsExporter.describe(.starting), "starting")
+        XCTAssertEqual(DiagnosticsExporter.describe(.stopped), "stopped")
+        XCTAssertEqual(DiagnosticsExporter.describe(.notInstalled), "not installed")
+        XCTAssertEqual(DiagnosticsExporter.describe(.failed(message: "boom")), "failed: boom")
+        XCTAssertTrue(DiagnosticsExporter.describe(.installing(progress: .verifying)).contains("installing"))
+        XCTAssertTrue(DiagnosticsExporter.describe(.installing(progress: .downloading(fraction: 0.5))).contains("50%"))
+    }
+
+    // MARK: - File writing: injected directory + injected timestamp
+
+    func testWriteReportUsesInjectedDirectoryAndTimestamp() throws {
+        let store = makeExternalStore()
+        let snapshot = makeSnapshot(settings: store)
+
+        // Fixed injected clock — UTC 2025-07-04T13:02:05 — so the filename is
+        // fully determined by the seam, not wall-clock.
+        var components = DateComponents()
+        components.year = 2025
+        components.month = 7
+        components.day = 4
+        components.hour = 13
+        components.minute = 2
+        components.second = 5
+        components.timeZone = TimeZone(identifier: "UTC")
+        let now = Calendar(identifier: .gregorian).date(from: components)!
+
+        let writtenURL = try DiagnosticsExporter.writeReport(
+            snapshot: snapshot,
+            to: tempDirectory,
+            now: now
+        )
+
+        let expectedFilename = "localvoxtral-diagnostics-2025-07-04T13-02-05.txt"
+        XCTAssertEqual(writtenURL.lastPathComponent, expectedFilename)
+        XCTAssertEqual(writtenURL.deletingLastPathComponent(), tempDirectory)
+        XCTAssertTrue(FileManager.default.fileExists(atPath: writtenURL.path))
+
+        let content = try String(contentsOf: writtenURL, encoding: .utf8)
+        XCTAssertTrue(content.contains("localvoxtral diagnostics"))
+        XCTAssertTrue(content.contains("== Backend configuration =="))
+        // Must be written under the injected temp dir, never the real Desktop.
+        XCTAssertFalse(writtenURL.path.contains("Desktop"))
+    }
+
+    func testWriteReportContentMatchesMakeReport() throws {
+        let store = makeExternalStore()
+        let snapshot = makeSnapshot(
+            settings: store,
+            voxmlxRecentOutput: ["[voxmlx stdout] up"]
+        )
+        let now = Date(timeIntervalSince1970: 1_750_000_000)
+
+        let writtenURL = try DiagnosticsExporter.writeReport(
+            snapshot: snapshot,
+            to: tempDirectory,
+            now: now
+        )
+        let onDisk = try String(contentsOf: writtenURL, encoding: .utf8)
+        let direct = DiagnosticsExporter.makeReport(snapshot: snapshot, now: now)
+        XCTAssertEqual(onDisk, direct)
+    }
+}

--- a/Tests/localvoxtralTests/DictationViewModelFailFastUXTests.swift
+++ b/Tests/localvoxtralTests/DictationViewModelFailFastUXTests.swift
@@ -382,6 +382,10 @@ private final class FakeManagedBackendManager: ManagedBackendManaging {
         stopAllCallCount += 1
     }
 
+    func recentOutput(for spec: ManagedBackendSpec) -> [String] {
+        []
+    }
+
     func waitUntilEnsureStarted() async {
         guard ensureIncludePolishingCalls.isEmpty else { return }
         await withCheckedContinuation { continuation in

--- a/scripts/mac-diag.sh
+++ b/scripts/mac-diag.sh
@@ -25,6 +25,17 @@ VOXMLX_LAUNCHD_LABEL="com.localvoxtral.voxmlx"
 # nc connect timeout (seconds) so a down port does not hang the report.
 PORT_TIMEOUT=2
 
+# Runs a command under a wall-clock bound when a timeout binary exists
+# (log show can be slow over ssh); degrades to unbounded otherwise.
+bounded() {
+  local secs="$1"; shift
+  if command -v timeout >/dev/null 2>&1; then
+    timeout "$secs" "$@"
+  else
+    "$@"
+  fi
+}
+
 print_header() {
   printf '\n=== %s ===\n' "$1"
 }
@@ -111,10 +122,11 @@ fi
 
 print_header "Process state"
 for proc in localvoxtral voxmlx-serve mlx_lm.server; do
-  matches="$(pgrep -fl "$proc" 2>/dev/null || true)"
-  if [[ -n "$matches" ]]; then
-    printf '[%s] running:\n' "$proc"
-    printf '%s\n' "$matches"
+  # PIDs only — full command lines (pgrep -fl) could leak flags such as API
+  # keys from user-run backend invocations.
+  pids="$(pgrep -f "$proc" 2>/dev/null | tr '\n' ' ' || true)"
+  if [[ -n "$pids" ]]; then
+    print_kv "$proc" "running (pids: ${pids})"
   else
     print_kv "$proc" "not running"
   fi
@@ -144,8 +156,10 @@ dump_file "${BACKENDS_ROOT}/installed.json"
 # --- Recent app logs (default level only — never raises verbosity) --------
 
 print_header "Recent app logs (last 10m, default level, last 80 lines)"
-app_logs="$(log show \
-  --predicate 'process == "localvoxtral"' \
+# Excludes the opt-in Deltas category, which logs dictated content in
+# cleartext when debug.log_realtime_deltas is enabled.
+app_logs="$(bounded 30 log show \
+  --predicate 'process == "localvoxtral" AND NOT (category == "Deltas")' \
   --last 10m \
   --style compact 2>&1 | tail -80 || true)"
 if [[ -z "$app_logs" ]]; then
@@ -157,7 +171,7 @@ fi
 # --- syspolicyd errors (macOS 26 launch-stall class) ----------------------
 
 print_header "syspolicyd errors/rejections (last 10m, last 20 lines)"
-syspolicy_logs="$(log show \
+syspolicy_logs="$(bounded 30 log show \
   --predicate 'process == "syspolicyd"' \
   --last 10m \
   --style compact 2>&1 | grep -iE 'error|reject' | tail -20 || true)"

--- a/scripts/mac-diag.sh
+++ b/scripts/mac-diag.sh
@@ -1,0 +1,179 @@
+#!/usr/bin/env bash
+# mac-diag.sh — local-first diagnostics snapshot for localvoxtral.
+#
+# Prints a single readable report to stdout. Designed to run over ssh and to
+# be piped to a file:  ssh mac-host 'bash -s' < scripts/mac-diag.sh > diag.txt
+#
+# It has NO dependency on the app's Swift sources — only standard macOS tools.
+#
+# Privacy: this script NEVER reads dictated content or transcript stores and
+# NEVER raises log verbosity. The unified-log sections use the default level
+# (the app only logs dictated text under an opt-in hidden debug flag). Missing
+# artifacts are reported as "absent", never as errors.
+
+# No `set -e`: a diagnostic snapshot must keep going when a probe fails.
+set -uo pipefail
+
+APP_NAME="localvoxtral"
+APP_BUNDLE_ID="com.localvoxtral.app"
+APP_DIR="/Applications/${APP_NAME}.app"
+INFO_PLIST="${APP_DIR}/Contents/Info.plist"
+BACKENDS_ROOT="${HOME}/Library/Application Support/${APP_NAME}/backends"
+VOXMLX_LOG="${HOME}/Library/Logs/voxmlx.log"
+VOXMLX_LAUNCHD_LABEL="com.localvoxtral.voxmlx"
+
+# nc connect timeout (seconds) so a down port does not hang the report.
+PORT_TIMEOUT=2
+
+print_header() {
+  printf '\n=== %s ===\n' "$1"
+}
+
+print_kv() {
+  printf '%-22s %s\n' "$1:" "$2"
+}
+
+run_section_raw() {
+  # Print a section header then the captured stdout+stderr of the remaining
+  # args. A nonzero exit is tolerated (the command's failure / stderr is often
+  # itself the signal, e.g. launchctl on a missing service). Empty output is
+  # reported as "absent" so the report shape stays stable.
+  local title="$1"
+  shift
+  print_header "$title"
+  local out
+  out="$("$@" 2>&1)" || true
+  if [[ -z "$out" ]]; then
+    printf '(absent)\n'
+  else
+    printf '%s\n' "$out"
+  fi
+}
+
+check_port() {
+  local port="$1"
+  local label="$2"
+  if nc -z -G "$PORT_TIMEOUT" -w "$PORT_TIMEOUT" 127.0.0.1 "$port" >/dev/null 2>&1; then
+    print_kv "127.0.0.1:${port} (${label})" "OPEN"
+  else
+    print_kv "127.0.0.1:${port} (${label})" "closed/unreachable"
+  fi
+}
+
+dump_dir_listing() {
+  local path="$1"
+  if [[ -d "$path" ]]; then
+    # -1 so each entry is on its own line; head keeps the report bounded.
+    ls -1 "$path" 2>&1 | head -40
+  else
+    printf '(directory absent: %s)\n' "$path"
+  fi
+}
+
+dump_file() {
+  local path="$1"
+  if [[ -f "$path" ]]; then
+    cat "$path"
+  else
+    printf '(file absent: %s)\n' "$path"
+  fi
+}
+
+# --- Report header --------------------------------------------------------
+
+printf 'localvoxtral diagnostics snapshot\n'
+printf 'generated: %s\n' "$(date -u '+%Y-%m-%dT%H:%M:%SZ')"
+printf 'host: %s\n' "$(hostname 2>/dev/null || echo unknown)"
+printf 'user: %s (uid=%s)\n' "$(id -F 2>/dev/null || id -un)" "$(id -u)"
+
+# --- Versions -------------------------------------------------------------
+
+print_header "Versions (system + app)"
+sw_vers 2>&1 || printf '(sw_vers failed)\n'
+
+if [[ -f "$INFO_PLIST" ]]; then
+  app_version="$(/usr/libexec/PlistBuddy -c 'Print :CFBundleShortVersionString' "$INFO_PLIST" 2>/dev/null || echo unknown)"
+  app_build="$(/usr/libexec/PlistBuddy -c 'Print :CFBundleVersion' "$INFO_PLIST" 2>/dev/null || echo unknown)"
+  print_kv "app version" "${app_version}"
+  print_kv "app build" "${app_build}"
+  print_kv "app bundle id" "${APP_BUNDLE_ID}"
+else
+  print_kv "app" "not installed at ${APP_DIR}"
+fi
+
+# Code signature tag (TeamIdentifier / Authority) — useful for TCC debugging.
+if [[ -d "$APP_DIR" ]]; then
+  print_header "App code signature (${APP_DIR})"
+  codesign -dv "$APP_DIR" 2>&1 | head -20 || printf '(codesign failed)\n'
+fi
+
+# --- Process state --------------------------------------------------------
+
+print_header "Process state"
+for proc in localvoxtral voxmlx-serve mlx_lm.server; do
+  matches="$(pgrep -fl "$proc" 2>/dev/null || true)"
+  if [[ -n "$matches" ]]; then
+    printf '[%s] running:\n' "$proc"
+    printf '%s\n' "$matches"
+  else
+    print_kv "$proc" "not running"
+  fi
+done
+
+# --- Ports ----------------------------------------------------------------
+
+print_header "Local ports (127.0.0.1)"
+check_port 8000 "user/external realtime"
+check_port 8471 "managed voxmlx"
+check_port 8472 "managed mlx-lm"
+
+# --- launchd --------------------------------------------------------------
+
+run_section_raw "launchd: ${VOXMLX_LAUNCHD_LABEL}" \
+  launchctl print "gui/$(id -u)/${VOXMLX_LAUNCHD_LABEL}"
+
+# --- Managed install state ------------------------------------------------
+
+print_header "Managed install state (Application Support)"
+print_header "backends root (${BACKENDS_ROOT})"
+dump_dir_listing "$BACKENDS_ROOT"
+print_header "backends bin/"
+dump_dir_listing "${BACKENDS_ROOT}/bin"
+dump_file "${BACKENDS_ROOT}/installed.json"
+
+# --- Recent app logs (default level only — never raises verbosity) --------
+
+print_header "Recent app logs (last 10m, default level, last 80 lines)"
+app_logs="$(log show \
+  --predicate 'process == "localvoxtral"' \
+  --last 10m \
+  --style compact 2>&1 | tail -80 || true)"
+if [[ -z "$app_logs" ]]; then
+  printf '(no log lines in the last 10m)\n'
+else
+  printf '%s\n' "$app_logs"
+fi
+
+# --- syspolicyd errors (macOS 26 launch-stall class) ----------------------
+
+print_header "syspolicyd errors/rejections (last 10m, last 20 lines)"
+syspolicy_logs="$(log show \
+  --predicate 'process == "syspolicyd"' \
+  --last 10m \
+  --style compact 2>&1 | grep -iE 'error|reject' | tail -20 || true)"
+if [[ -z "$syspolicy_logs" ]]; then
+  printf '(no syspolicyd error/reject lines in the last 10m)\n'
+else
+  printf '%s\n' "$syspolicy_logs"
+fi
+
+# --- Backend logs ---------------------------------------------------------
+
+print_header "voxmlx log (last 20 lines)"
+if [[ -f "$VOXMLX_LOG" ]]; then
+  tail -20 "$VOXMLX_LOG" 2>&1 || printf '(could not read %s)\n' "$VOXMLX_LOG"
+else
+  printf '(absent: %s)\n' "$VOXMLX_LOG"
+fi
+
+printf '\n=== end of diagnostics ===\n'


### PR DESCRIPTION
## What
The privacy-compatible answer to "telemetry": nothing phones home, but field issues become one command to capture.
- `scripts/mac-diag.sh`: single readable snapshot over ssh or locally — versions, signature info, process/port/launchd state, managed install state, recent app logs, recent syspolicyd errors (the macOS 26 launch-stall class), voxmlx.log tail. Never touches dictated content.
- **Export Diagnostics…** in the status menu → timestamped report on the Desktop: app/OS versions, backend mode + endpoints, managed backend statuses, supervisor output ring buffers.
- `DiagnosticsExporter` is the security boundary and is built so secrets cannot enter the output: API keys are reduced to booleans at snapshot-build time (values never copied), endpoints are scrubbed of userinfo/query/fragment, transcript stores are never read. Timestamp and destination are injected (no wall clock in tests, per repo rules).
- `ManagedBackendManaging`/`ManagedBackendSupervising` gain a read-only `recentOutput` surface (additive; fakes updated).

## Proof
- [x] Unit suite green — `LV_BUILD_DIR=work/localvoxtral-oc-diag ./scripts/remote-build.sh test`
```
Executed 397 tests, with 0 failures (0 unexpected) in 4.234 (4.250) seconds
```
10 new `DiagnosticsExporterTests` incl.: a set API key's value never appears in the report; expected sections present; injected timestamp/directory respected.
- [x] `bash -n scripts/mac-diag.sh` clean.
- [ ] UI change (one new menu item): **not hand-verified** — click Export Diagnostics… once and check the Desktop file reads sanely.

Worker: opencode (GLM-5.2); orchestrator reviewed the full diff and ran the verification.

## Adversarial review outcome (post-open)

A codex read-only reviewer ran against this PR; all confirmed findings fixed in the follow-up commit, re-verified at 397/0:
- **[high]** `mac-diag.sh` log capture now excludes the `Deltas` category (which logs dictated content in cleartext when the hidden `debug.log_realtime_deltas` flag is on) — the report can no longer capture transcripts.
- **[high]** process listing is PID-only (`pgrep -fl` printed full command lines, which could leak API-key flags from user-run backends).
- **[med]** report generation/writing moved off the main actor (a slow/iCloud Desktop can't beachball the menu bar app).
- **[med→documented]** backend `recentOutput` stays verbatim but the report header now says review-before-sharing (default backend logs contain no transcript content; dropping the section would gut its debugging value).
- **[low]** filename uniquing on rapid re-export; `log show` bounded by `timeout` where available.
