### PR TITLE
Harden managed-backend lifecycle: live status mirroring, stale-failure retry fix, cancellable startup

### DIFF
--- a/Sources/localvoxtral/Backends/BackendManager.swift
+++ b/Sources/localvoxtral/Backends/BackendManager.swift
@@ -36,6 +36,13 @@ enum ManagedBackendManagerError: LocalizedError {
             return detail
         }
     }
+
+    var backendName: String {
+        switch self {
+        case .backendFailed(let name, _, _):
+            return name
+        }
+    }
 }
 
 @MainActor

--- a/Sources/localvoxtral/Backends/BackendManager.swift
+++ b/Sources/localvoxtral/Backends/BackendManager.swift
@@ -65,6 +65,8 @@ final class BackendManager: ManagedBackendManaging {
     @ObservationIgnored private var voxmlxSupervisor: (any ManagedBackendSupervising)?
     @ObservationIgnored private var mlxLMSupervisor: (any ManagedBackendSupervising)?
     @ObservationIgnored private var ensureReadyTask: Task<Void, Error>?
+    @ObservationIgnored private var voxmlxStateMirrorTask: Task<Void, Never>?
+    @ObservationIgnored private var mlxLMStateMirrorTask: Task<Void, Never>?
     #if DEBUG
     @ObservationIgnored var debugStatusChangeSink: ((ManagedBackendSpec, ManagedBackendStatus) -> Void)?
     #endif
@@ -115,6 +117,10 @@ final class BackendManager: ManagedBackendManaging {
     func stopAll() async {
         await voxmlxSupervisor?.stop()
         await mlxLMSupervisor?.stop()
+        voxmlxStateMirrorTask?.cancel()
+        voxmlxStateMirrorTask = nil
+        mlxLMStateMirrorTask?.cancel()
+        mlxLMStateMirrorTask = nil
         if voxmlxSupervisor != nil {
             voxmlxStatus = .stopped
         }
@@ -176,26 +182,15 @@ final class BackendManager: ManagedBackendManaging {
         let updates = supervisor.stateUpdates
         await supervisor.start()
 
-        switch supervisor.state {
-        case .running:
-            setStatus(.ready, for: spec)
-            return
-        case .failed(let message):
-            setStatus(.failed(message: message), for: spec)
-            throw ManagedBackendManagerError.backendFailed(name: spec.displayName, detail: message)
-        default:
-            break
-        }
-
         for await state in updates {
             switch state {
             case .launching, .waitingForReady, .restarting:
-                setStatus(.starting, for: spec)
+                mirrorSupervisorState(state, for: spec)
             case .running:
-                setStatus(.ready, for: spec)
+                mirrorSupervisorState(state, for: spec)
                 return
             case .failed(let message):
-                setStatus(.failed(message: message), for: spec)
+                mirrorSupervisorState(state, for: spec)
                 throw ManagedBackendManagerError.backendFailed(name: spec.displayName, detail: message)
             case .stopped:
                 let message = "\(spec.displayName) stopped before it became ready."
@@ -214,14 +209,22 @@ final class BackendManager: ManagedBackendManaging {
     private func supervisor(for spec: ManagedBackendSpec) -> any ManagedBackendSupervising {
         switch spec.id {
         case BackendCatalog.voxmlx.id:
-            if let voxmlxSupervisor { return voxmlxSupervisor }
+            if let voxmlxSupervisor {
+                startStateMirrorIfNeeded(supervisor: voxmlxSupervisor, spec: spec)
+                return voxmlxSupervisor
+            }
             let supervisor = supervisorFactory(configuration(for: spec))
             voxmlxSupervisor = supervisor
+            startStateMirrorIfNeeded(supervisor: supervisor, spec: spec)
             return supervisor
         case BackendCatalog.mlxLM.id:
-            if let mlxLMSupervisor { return mlxLMSupervisor }
+            if let mlxLMSupervisor {
+                startStateMirrorIfNeeded(supervisor: mlxLMSupervisor, spec: spec)
+                return mlxLMSupervisor
+            }
             let supervisor = supervisorFactory(configuration(for: spec))
             mlxLMSupervisor = supervisor
+            startStateMirrorIfNeeded(supervisor: supervisor, spec: spec)
             return supervisor
         default:
             preconditionFailure("Unknown managed backend '\(spec.id)'.")
@@ -234,7 +237,8 @@ final class BackendManager: ManagedBackendManaging {
             executableURL: layout.toolBin.appendingPathComponent(spec.executableName),
             arguments: arguments(for: spec),
             environment: processEnvironment(),
-            readinessURL: URL(string: "http://127.0.0.1:\(spec.port)/health")!
+            readinessURL: URL(string: "http://127.0.0.1:\(spec.port)/health")!,
+            readinessTimeout: readinessTimeout(for: spec)
         )
     }
 
@@ -272,18 +276,82 @@ final class BackendManager: ManagedBackendManaging {
                 environment[key] = value
             }
         }
+        // Deliberately leave Hugging Face cache variables unset: managed
+        // backends share the user's already-downloaded weights, while uninstall
+        // only owns the app-managed backends/ tree documented in README.
         environment.merge(layout.environment) { _, new in new }
         return environment
+    }
+
+    private func readinessTimeout(for spec: ManagedBackendSpec) -> Duration {
+        switch spec.id {
+        case BackendCatalog.voxmlx.id:
+            // First run downloads the model inside the server before /health
+            // responds; 600 s is too tight on slow links.
+            return .seconds(1800)
+        case BackendCatalog.mlxLM.id:
+            // First run downloads the polishing model inside the server before
+            // /health responds; 600 s is too tight on slow links.
+            return .seconds(1800)
+        default:
+            return .seconds(600)
+        }
     }
 
     private func isReady(_ spec: ManagedBackendSpec) -> Bool {
         switch spec.id {
         case BackendCatalog.voxmlx.id:
-            return voxmlxSupervisor?.state == .running || voxmlxStatus == .ready
+            return voxmlxSupervisor?.state == .running
         case BackendCatalog.mlxLM.id:
-            return mlxLMSupervisor?.state == .running || mlxLMStatus == .ready
+            return mlxLMSupervisor?.state == .running
         default:
             return false
+        }
+    }
+
+    private func startStateMirrorIfNeeded(
+        supervisor: any ManagedBackendSupervising,
+        spec: ManagedBackendSpec
+    ) {
+        switch spec.id {
+        case BackendCatalog.voxmlx.id:
+            guard voxmlxStateMirrorTask == nil else { return }
+            voxmlxStateMirrorTask = makeStateMirrorTask(supervisor: supervisor, spec: spec)
+        case BackendCatalog.mlxLM.id:
+            guard mlxLMStateMirrorTask == nil else { return }
+            mlxLMStateMirrorTask = makeStateMirrorTask(supervisor: supervisor, spec: spec)
+        default:
+            break
+        }
+    }
+
+    private func makeStateMirrorTask(
+        supervisor: any ManagedBackendSupervising,
+        spec: ManagedBackendSpec
+    ) -> Task<Void, Never> {
+        Task { @MainActor [weak self, supervisor, spec] in
+            for await state in supervisor.stateUpdates {
+                guard let self, !Task.isCancelled else { return }
+                self.mirrorSupervisorState(state, for: spec)
+            }
+        }
+    }
+
+    private func mirrorSupervisorState(
+        _ state: BackendProcessSupervisor.State,
+        for spec: ManagedBackendSpec
+    ) {
+        switch state {
+        case .idle:
+            break
+        case .launching, .waitingForReady, .restarting:
+            setStatus(.starting, for: spec)
+        case .running:
+            setStatus(.ready, for: spec)
+        case .failed(let message):
+            setStatus(.failed(message: message), for: spec)
+        case .stopped:
+            setStatus(.stopped, for: spec)
         }
     }
 

--- a/Sources/localvoxtral/Backends/BackendManager.swift
+++ b/Sources/localvoxtral/Backends/BackendManager.swift
@@ -8,7 +8,7 @@ enum ManagedBackendStatus: Equatable {
     case starting
     case ready
     case stopped
-    case failed(message: String)
+    case failed(summary: String, detail: String?)
 
     var requiresInstallProgressText: Bool {
         switch self {
@@ -21,12 +21,19 @@ enum ManagedBackendStatus: Equatable {
 }
 
 enum ManagedBackendManagerError: LocalizedError {
-    case backendFailed(name: String, detail: String)
+    case backendFailed(name: String, summary: String, detail: String?)
 
     var errorDescription: String? {
         switch self {
-        case .backendFailed(let name, let detail):
-            return "\(name) failed: \(detail)"
+        case .backendFailed(let name, let summary, _):
+            return "\(name) failed: \(summary)"
+        }
+    }
+
+    var technicalDetails: String? {
+        switch self {
+        case .backendFailed(_, _, let detail):
+            return detail
         }
     }
 }
@@ -136,7 +143,7 @@ final class BackendManager: ManagedBackendManaging {
         case BackendCatalog.mlxLM.id:
             return mlxLMStatus
         default:
-            return .failed(message: "Unknown managed backend '\(spec.id)'.")
+            return .failed(summary: "Unknown managed backend '\(spec.id)'.", detail: nil)
         }
     }
 
@@ -162,10 +169,11 @@ final class BackendManager: ManagedBackendManaging {
                 }
             } catch {
                 let detail = error.localizedDescription
-                setStatus(.failed(message: detail), for: spec)
+                setStatus(.failed(summary: detail, detail: nil), for: spec)
                 throw ManagedBackendManagerError.backendFailed(
                     name: spec.displayName,
-                    detail: detail
+                    summary: detail,
+                    detail: nil
                 )
             }
         }
@@ -189,21 +197,33 @@ final class BackendManager: ManagedBackendManaging {
             case .running:
                 mirrorSupervisorState(state, for: spec)
                 return
-            case .failed(let message):
+            case .failed(let summary, let detail):
                 mirrorSupervisorState(state, for: spec)
-                throw ManagedBackendManagerError.backendFailed(name: spec.displayName, detail: message)
+                throw ManagedBackendManagerError.backendFailed(
+                    name: spec.displayName,
+                    summary: summary,
+                    detail: detail
+                )
             case .stopped:
                 let message = "\(spec.displayName) stopped before it became ready."
-                setStatus(.failed(message: message), for: spec)
-                throw ManagedBackendManagerError.backendFailed(name: spec.displayName, detail: message)
+                setStatus(.failed(summary: message, detail: nil), for: spec)
+                throw ManagedBackendManagerError.backendFailed(
+                    name: spec.displayName,
+                    summary: message,
+                    detail: nil
+                )
             case .idle:
                 break
             }
         }
 
         let message = "\(spec.displayName) stopped reporting status before it became ready."
-        setStatus(.failed(message: message), for: spec)
-        throw ManagedBackendManagerError.backendFailed(name: spec.displayName, detail: message)
+        setStatus(.failed(summary: message, detail: nil), for: spec)
+        throw ManagedBackendManagerError.backendFailed(
+            name: spec.displayName,
+            summary: message,
+            detail: nil
+        )
     }
 
     private func supervisor(for spec: ManagedBackendSpec) -> any ManagedBackendSupervising {
@@ -348,8 +368,8 @@ final class BackendManager: ManagedBackendManaging {
             setStatus(.starting, for: spec)
         case .running:
             setStatus(.ready, for: spec)
-        case .failed(let message):
-            setStatus(.failed(message: message), for: spec)
+        case .failed(let summary, let detail):
+            setStatus(.failed(summary: summary, detail: detail), for: spec)
         case .stopped:
             setStatus(.stopped, for: spec)
         }

--- a/Sources/localvoxtral/Backends/BackendProcessSupervisor.swift
+++ b/Sources/localvoxtral/Backends/BackendProcessSupervisor.swift
@@ -20,12 +20,22 @@ final class BackendProcessSupervisor {
 
     private(set) var state: State
     private(set) var recentOutput: [String]
-    @ObservationIgnored var stateUpdates: AsyncStream<State>
+    @ObservationIgnored var stateUpdates: AsyncStream<State> {
+        let id = UUID()
+        let stream = AsyncStream<State>.makeStream(of: State.self)
+        stateContinuations[id] = stream.continuation
+        stream.continuation.onTermination = { @Sendable [weak self] _ in
+            Task { @MainActor [weak self] in
+                self?.stateContinuations[id] = nil
+            }
+        }
+        return stream.stream
+    }
 
     @ObservationIgnored private let configuration: BackendProcessConfiguration
     @ObservationIgnored private let probe: Probe
     @ObservationIgnored private let sleepFor: SleepClosure
-    @ObservationIgnored private let stateContinuation: AsyncStream<State>.Continuation
+    @ObservationIgnored private var stateContinuations: [UUID: AsyncStream<State>.Continuation] = [:]
 
     @ObservationIgnored private var supervisionTask: Task<Void, Never>?
     @ObservationIgnored private var currentProcess: Process?
@@ -52,10 +62,6 @@ final class BackendProcessSupervisor {
         self.sleepFor = sleepFor
         self.state = .idle
         self.recentOutput = []
-
-        let stream = AsyncStream<State>.makeStream(of: State.self)
-        self.stateUpdates = stream.stream
-        self.stateContinuation = stream.continuation
     }
 
     func start() async {
@@ -63,6 +69,7 @@ final class BackendProcessSupervisor {
         guard !isActiveState(state) else { return }
 
         stoppingIntentionally = false
+        transition(to: .launching)
         supervisionTask = Task { @MainActor [weak self] in
             guard let self else { return }
             await self.supervise()
@@ -112,7 +119,7 @@ final class BackendProcessSupervisor {
         var consecutiveFailures = 0
 
         while !stoppingIntentionally && !Task.isCancelled {
-            transition(to: .launching)
+            transitionIfNeeded(to: .launching)
 
             do {
                 try spawnProcess()
@@ -400,10 +407,17 @@ final class BackendProcessSupervisor {
 
     private func transition(to newState: State) {
         state = newState
-        stateContinuation.yield(newState)
+        for continuation in stateContinuations.values {
+            continuation.yield(newState)
+        }
         Log.backends.info(
             "\(self.configuration.name, privacy: .public) backend state \(String(describing: newState), privacy: .public)"
         )
+    }
+
+    private func transitionIfNeeded(to newState: State) {
+        guard state != newState else { return }
+        transition(to: newState)
     }
 
     private func stderrTailDescription() -> String {

--- a/Sources/localvoxtral/Backends/BackendProcessSupervisor.swift
+++ b/Sources/localvoxtral/Backends/BackendProcessSupervisor.swift
@@ -12,7 +12,7 @@ final class BackendProcessSupervisor {
         case running
         case restarting(attempt: Int)
         case stopped
-        case failed(message: String)
+        case failed(summary: String, detail: String?)
     }
 
     typealias Probe = @Sendable (URL) async -> Bool
@@ -110,7 +110,8 @@ final class BackendProcessSupervisor {
         guard !(await probe(configuration.readinessURL)) else {
             transition(
                 to: .failed(
-                    message: "\(configuration.name) port already in use; refusing to adopt an existing backend process."
+                    summary: "\(configuration.name) port already in use; refusing to adopt an existing backend process.",
+                    detail: nil
                 )
             )
             return
@@ -126,7 +127,8 @@ final class BackendProcessSupervisor {
             } catch {
                 transition(
                     to: .failed(
-                        message: "Failed to launch \(configuration.name): \(error.localizedDescription)"
+                        summary: "Failed to launch \(configuration.name): \(error.localizedDescription)",
+                        detail: nil
                     )
                 )
                 return
@@ -148,14 +150,15 @@ final class BackendProcessSupervisor {
                 consecutiveFailures += 1
 
             case .timedOut:
-                let stderrTail = stderrTailDescription()
+                let stderrTail = stderrTailDetail()
                 if let process = currentProcess {
                     await terminate(process: process, gracePeriod: configuration.terminationGracePeriod)
                 }
                 clearCurrentProcess()
                 transition(
                     to: .failed(
-                        message: "\(configuration.name) did not become ready before timeout.\(stderrTail)"
+                        summary: "\(configuration.name) did not become ready before timeout.",
+                        detail: stderrTail
                     )
                 )
                 return
@@ -169,7 +172,8 @@ final class BackendProcessSupervisor {
             if consecutiveFailures >= max(1, configuration.maxConsecutiveRestartFailures) {
                 transition(
                     to: .failed(
-                        message: "\(configuration.name) exited \(consecutiveFailures) consecutive times.\(stderrTailDescription())"
+                        summary: "\(configuration.name) exited \(consecutiveFailures) consecutive times.",
+                        detail: stderrTailDetail()
                     )
                 )
                 return
@@ -420,9 +424,9 @@ final class BackendProcessSupervisor {
         transition(to: newState)
     }
 
-    private func stderrTailDescription() -> String {
-        guard !recentErrorOutput.isEmpty else { return "" }
-        return " stderr: " + recentErrorOutput.suffix(5).joined(separator: "\n")
+    private func stderrTailDetail() -> String? {
+        guard !recentErrorOutput.isEmpty else { return nil }
+        return "stderr: " + recentErrorOutput.suffix(5).joined(separator: "\n")
     }
 
     private func backoffDuration(attempt: Int) -> Duration {

--- a/Sources/localvoxtral/DictationViewModel+Session.swift
+++ b/Sources/localvoxtral/DictationViewModel+Session.swift
@@ -109,14 +109,19 @@ extension DictationViewModel {
             ? String(describing: error)
             : error.localizedDescription
         let technicalDetails: String?
+        let popoverError: String
         if let managedError = error as? ManagedBackendManagerError {
             technicalDetails = normalizedFailureDetails(managedError.technicalDetails)
+            popoverError = "\(managedError.backendName) failed to start."
         } else {
             technicalDetails = summary
+            popoverError = "Managed backend failed to start."
         }
         let message = "Unable to start the managed dictation backend: \(summary)"
         statusText = "Managed backend failed."
-        lastError = message
+        // lastError renders in the menu-bar popover, which never shows long
+        // text (AGENTS.md); the full story goes to the alert and the log.
+        lastError = popoverError
         #if DEBUG
         debugLastConnectFailureTechnicalDetails = technicalDetails
         #endif

--- a/Sources/localvoxtral/DictationViewModel+Session.swift
+++ b/Sources/localvoxtral/DictationViewModel+Session.swift
@@ -105,18 +105,27 @@ extension DictationViewModel {
     }
 
     private func handleManagedBackendStartupFailure(_ error: Error) {
-        let detail = error.localizedDescription.trimmed.isEmpty
+        let summary = error.localizedDescription.trimmed.isEmpty
             ? String(describing: error)
             : error.localizedDescription
-        let message = "Unable to start the managed dictation backend: \(detail)"
+        let technicalDetails: String?
+        if let managedError = error as? ManagedBackendManagerError {
+            technicalDetails = normalizedFailureDetails(managedError.technicalDetails)
+        } else {
+            technicalDetails = summary
+        }
+        let message = "Unable to start the managed dictation backend: \(summary)"
         statusText = "Managed backend failed."
         lastError = message
-        logConnectionFailure(message: message, technicalDetails: detail)
+        #if DEBUG
+        debugLastConnectFailureTechnicalDetails = technicalDetails
+        #endif
+        logConnectionFailure(message: message, technicalDetails: technicalDetails)
         markRecentConnectionFailureIndicator()
         presentConnectionFailureAlert(
             title: "Managed Backend Failed",
             message: message,
-            technicalDetails: detail
+            technicalDetails: technicalDetails
         )
     }
 

--- a/Sources/localvoxtral/DictationViewModel+Session.swift
+++ b/Sources/localvoxtral/DictationViewModel+Session.swift
@@ -47,19 +47,41 @@ extension DictationViewModel {
         let includePolishing = settings.llmPolishingEnabled
         statusText = managedBackendStartupStatusText(includePolishing: includePolishing)
 
-        Task { @MainActor [weak self] in
+        managedStartupTask?.cancel()
+        let startupTaskID = UUID()
+        managedStartupTaskID = startupTaskID
+        managedStartupTask = Task { @MainActor [weak self, startupTaskID] in
             guard let self else { return }
+            defer {
+                if self.managedStartupTaskID == startupTaskID {
+                    self.managedStartupTask = nil
+                    self.managedStartupTaskID = nil
+                }
+            }
             do {
                 try await self.backendManager.ensureReady(includePolishing: includePolishing)
             } catch {
+                guard !Task.isCancelled else { return }
                 self.abortConnectingSession()
                 self.handleManagedBackendStartupFailure(error)
                 return
             }
 
-            guard !Task.isCancelled, self.isConnectingRealtimeSession else { return }
+            guard !Task.isCancelled,
+                  self.settings.backendMode == .managedLocal,
+                  self.isConnectingRealtimeSession
+            else { return }
             self.beginDictationSession(outputMode: outputMode)
         }
+    }
+
+    func cancelManagedStartupTask() {
+        // This cancels only the view-model caller. BackendManager owns and
+        // shares its in-flight ensureReady task, so another UI path may keep
+        // awaiting the same backend startup.
+        managedStartupTask?.cancel()
+        managedStartupTask = nil
+        managedStartupTaskID = nil
     }
 
     private func managedBackendStartupStatusText(includePolishing: Bool) -> String {

--- a/Sources/localvoxtral/DictationViewModel.swift
+++ b/Sources/localvoxtral/DictationViewModel.swift
@@ -190,6 +190,10 @@ final class DictationViewModel {
     @ObservationIgnored
     var commitTask: Task<Void, Never>?
     @ObservationIgnored
+    var managedStartupTask: Task<Void, Never>?
+    @ObservationIgnored
+    var managedStartupTaskID: UUID?
+    @ObservationIgnored
     var audioSendTask: Task<Void, Never>?
     @ObservationIgnored
     var stopFinalizationTask: Task<Void, Never>?
@@ -383,6 +387,8 @@ final class DictationViewModel {
         }
         lifecycleObservers.removeAll()
         commitTask?.cancel()
+        managedStartupTask?.cancel()
+        managedStartupTaskID = nil
         audioSendTask?.cancel()
         stopFinalizationTask?.cancel()
         connectTimeoutTask?.cancel()
@@ -427,6 +433,7 @@ final class DictationViewModel {
         ) { [weak self] _ in
             Task { @MainActor [weak self] in
                 guard let self else { return }
+                self.cancelManagedStartupTask()
                 if self.isDictating {
                     self.stopDictation(reason: "app terminating", finalizeRemainingAudio: false)
                 }
@@ -648,6 +655,7 @@ final class DictationViewModel {
     func cancelDictation() {
         guard isDictating || isFinalizingStop || isConnectingRealtimeSession else { return }
         wasCancelled = true
+        cancelManagedStartupTask()
         if isDictating {
             stopDictation(reason: "cancelled", finalizeRemainingAudio: false)
         } else if isConnectingRealtimeSession {
@@ -685,6 +693,11 @@ final class DictationViewModel {
         settings.backendMode = mode
 
         guard previousMode == .managedLocal, mode == .externalURL else { return }
+        cancelManagedStartupTask()
+        if isConnectingRealtimeSession {
+            abortConnectingSession()
+            statusText = StatusStrings.ready
+        }
         // Leaving managed mode means the app should no longer own local backend
         // processes. Polishing toggles are intentionally lighter-weight: if
         // mlx-lm is already running, it stays up until quit or a mode switch.

--- a/Sources/localvoxtral/SettingsView.swift
+++ b/Sources/localvoxtral/SettingsView.swift
@@ -236,8 +236,8 @@ private struct ManagedBackendStatusLabel: View {
             return "Ready"
         case .stopped:
             return "Stopped"
-        case .failed(let message):
-            return "Failed: \(message)"
+        case .failed(let summary, _):
+            return "Failed: \(summary)"
         }
     }
 

--- a/Sources/localvoxtral/StatusPopoverView.swift
+++ b/Sources/localvoxtral/StatusPopoverView.swift
@@ -159,11 +159,14 @@ struct StatusPopoverView: View {
     }
 
     // Same typography as the Status line so failure details read as part of
-    // the popover, not a styled callout.
+    // the popover, not a styled callout. The popover never shows long text
+    // (AGENTS.md): callers pass one short sentence, and the line limit here
+    // is the backstop for any path that slips a long string through.
     private func statusDetailView(_ detail: String) -> some View {
         Text(detail)
             .foregroundStyle(.secondary)
-            .lineLimit(nil)
+            .lineLimit(2)
+            .truncationMode(.tail)
             .fixedSize(horizontal: false, vertical: true)
             .frame(width: Self.contentWidth, alignment: .leading)
     }

--- a/Tests/localvoxtralTests/BackendManagerTests.swift
+++ b/Tests/localvoxtralTests/BackendManagerTests.swift
@@ -57,7 +57,7 @@ final class BackendManagerTests: XCTestCase {
             XCTAssertTrue(error.localizedDescription.contains("wheel unavailable"))
         }
 
-        XCTAssertEqual(manager.voxmlxStatus, .failed(message: "wheel unavailable"))
+        XCTAssertEqual(manager.voxmlxStatus, .failed(summary: "wheel unavailable", detail: nil))
     }
 
     func testPolishingFlagControlsWhetherMLXLMIsTouched() async throws {
@@ -133,10 +133,10 @@ final class BackendManagerTests: XCTestCase {
         XCTAssertEqual(manager.voxmlxStatus, .ready)
         XCTAssertEqual(supervisor.startCallCount, 1)
 
-        supervisor.emit(.failed(message: "process crashed after readiness"))
+        supervisor.emit(.failed(summary: "process crashed after readiness", detail: nil))
         await Task.yield()
 
-        XCTAssertEqual(manager.voxmlxStatus, .failed(message: "process crashed after readiness"))
+        XCTAssertEqual(manager.voxmlxStatus, .failed(summary: "process crashed after readiness", detail: nil))
 
         try await manager.ensureReady(includePolishing: false)
 
@@ -156,6 +156,42 @@ final class BackendManagerTests: XCTestCase {
         XCTAssertEqual(
             supervisorFactory.createdConfigurations.map(\.readinessTimeout),
             [.seconds(1800), .seconds(1800)]
+        )
+    }
+
+    func testSupervisorFailureErrorSplitsSummaryFromTechnicalDetails() async throws {
+        let marker = "FAKE_STDERR_TRACEBACK"
+        let installer = FakeBackendInstaller(needsInstall: [])
+        let supervisorFactory = FakeSupervisorFactory()
+        supervisorFactory.statesByName[BackendCatalog.voxmlx.displayName] = [.running]
+        supervisorFactory.statesByName[BackendCatalog.mlxLM.displayName] = [
+            .failed(
+                summary: "mlx-lm exited 5 consecutive times.",
+                detail: "stderr: Python traceback \(marker)"
+            ),
+        ]
+        let manager = makeManager(installer: installer, supervisorFactory: supervisorFactory)
+
+        do {
+            try await manager.ensureReady(includePolishing: true)
+            XCTFail("expected ensureReady to throw")
+        } catch let error as ManagedBackendManagerError {
+            XCTAssertEqual(
+                error.localizedDescription,
+                "mlx-lm failed: mlx-lm exited 5 consecutive times."
+            )
+            XCTAssertFalse(error.localizedDescription.contains(marker))
+            XCTAssertTrue(error.technicalDetails?.contains(marker) == true)
+        } catch {
+            XCTFail("expected ManagedBackendManagerError, got \(error)")
+        }
+
+        XCTAssertEqual(
+            manager.mlxLMStatus,
+            .failed(
+                summary: "mlx-lm exited 5 consecutive times.",
+                detail: "stderr: Python traceback \(marker)"
+            )
         )
     }
 

--- a/Tests/localvoxtralTests/BackendManagerTests.swift
+++ b/Tests/localvoxtralTests/BackendManagerTests.swift
@@ -122,6 +122,43 @@ final class BackendManagerTests: XCTestCase {
         XCTAssertEqual(manager.mlxLMStatus, .stopped)
     }
 
+    func testSupervisorStateMirrorMarksLaterFailureAndNextEnsureDoesNotShortCircuit() async throws {
+        let installer = FakeBackendInstaller(needsInstall: [])
+        let supervisorFactory = FakeSupervisorFactory()
+        supervisorFactory.statesByName[BackendCatalog.voxmlx.displayName] = [.running]
+        let manager = makeManager(installer: installer, supervisorFactory: supervisorFactory)
+
+        try await manager.ensureReady(includePolishing: false)
+        let supervisor = try XCTUnwrap(supervisorFactory.supervisors[BackendCatalog.voxmlx.displayName])
+        XCTAssertEqual(manager.voxmlxStatus, .ready)
+        XCTAssertEqual(supervisor.startCallCount, 1)
+
+        supervisor.emit(.failed(message: "process crashed after readiness"))
+        await Task.yield()
+
+        XCTAssertEqual(manager.voxmlxStatus, .failed(message: "process crashed after readiness"))
+
+        try await manager.ensureReady(includePolishing: false)
+
+        XCTAssertEqual(supervisor.startCallCount, 2)
+        XCTAssertEqual(manager.voxmlxStatus, .ready)
+    }
+
+    func testManagedBackendConfigurationsUseLongFirstRunReadinessTimeouts() async throws {
+        let installer = FakeBackendInstaller(needsInstall: [])
+        let supervisorFactory = FakeSupervisorFactory()
+        supervisorFactory.statesByName[BackendCatalog.voxmlx.displayName] = [.running]
+        supervisorFactory.statesByName[BackendCatalog.mlxLM.displayName] = [.running]
+        let manager = makeManager(installer: installer, supervisorFactory: supervisorFactory)
+
+        try await manager.ensureReady(includePolishing: true)
+
+        XCTAssertEqual(
+            supervisorFactory.createdConfigurations.map(\.readinessTimeout),
+            [.seconds(1800), .seconds(1800)]
+        )
+    }
+
     private func makeManager(
         installer: FakeBackendInstaller,
         supervisorFactory: FakeSupervisorFactory
@@ -215,32 +252,44 @@ private final class FakeSupervisorFactory {
 @MainActor
 private final class FakeBackendSupervisor: ManagedBackendSupervising {
     private let statesOnStart: [BackendProcessSupervisor.State]
-    private let stateContinuation: AsyncStream<BackendProcessSupervisor.State>.Continuation
+    private var stateContinuations: [UUID: AsyncStream<BackendProcessSupervisor.State>.Continuation] = [:]
 
     private(set) var state: BackendProcessSupervisor.State = .idle
-    let stateUpdates: AsyncStream<BackendProcessSupervisor.State>
+    var stateUpdates: AsyncStream<BackendProcessSupervisor.State> {
+        let id = UUID()
+        let stream = AsyncStream<BackendProcessSupervisor.State>.makeStream(of: BackendProcessSupervisor.State.self)
+        stateContinuations[id] = stream.continuation
+        stream.continuation.onTermination = { @Sendable [weak self] _ in
+            Task { @MainActor [weak self] in
+                self?.stateContinuations[id] = nil
+            }
+        }
+        return stream.stream
+    }
     private(set) var startCallCount = 0
     private(set) var stopCallCount = 0
 
     init(statesOnStart: [BackendProcessSupervisor.State]) {
         self.statesOnStart = statesOnStart
-        let stream = AsyncStream<BackendProcessSupervisor.State>.makeStream(of: BackendProcessSupervisor.State.self)
-        self.stateUpdates = stream.stream
-        self.stateContinuation = stream.continuation
     }
 
     func start() async {
         startCallCount += 1
         for state in statesOnStart {
-            self.state = state
-            stateContinuation.yield(state)
+            emit(state)
         }
     }
 
     func stop() async {
         stopCallCount += 1
-        state = .stopped
-        stateContinuation.yield(.stopped)
+        emit(.stopped)
+    }
+
+    func emit(_ state: BackendProcessSupervisor.State) {
+        self.state = state
+        for continuation in stateContinuations.values {
+            continuation.yield(state)
+        }
     }
 }
 

--- a/Tests/localvoxtralTests/BackendProcessSupervisorTests.swift
+++ b/Tests/localvoxtralTests/BackendProcessSupervisorTests.swift
@@ -231,6 +231,58 @@ final class BackendProcessSupervisorTests: XCTestCase {
         )
     }
 
+    func testRestartAfterFailureClearsStaleFailedStateSynchronouslyAndCanRun() async throws {
+        let directory = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let succeedMarker = directory.appendingPathComponent("succeed")
+        let readyMarker = directory.appendingPathComponent("ready")
+        let script = try writeScript(
+            in: directory,
+            name: "backend.sh",
+            body: """
+            #!/bin/sh
+            if [ -f "\(succeedMarker.path)" ]; then
+              touch "\(readyMarker.path)"
+              trap 'exit 0' TERM
+              while true; do sleep 1; done
+            fi
+            echo "intentional fast failure" >&2
+            exit 7
+            """
+        )
+        let supervisor = makeSupervisor(
+            executableURL: script,
+            readinessPollInterval: .milliseconds(1),
+            readinessTimeout: .seconds(5),
+            maxConsecutiveRestartFailures: 1,
+            probe: { _ in FileManager.default.fileExists(atPath: readyMarker.path) },
+            sleepFor: { _ in await Task.yield() }
+        )
+        let watcher = StateWatcher(stream: supervisor.stateUpdates)
+        defer { watcher.cancel() }
+
+        await supervisor.start()
+        let failedState = try await watcher.waitForState { state in
+            if case .failed = state { return true }
+            return false
+        }
+        guard case .failed = failedState else {
+            return XCTFail("expected failed state, got \(failedState)")
+        }
+
+        XCTAssertTrue(FileManager.default.createFile(atPath: succeedMarker.path, contents: Data()))
+        await supervisor.start()
+
+        XCTAssertNotEqual(supervisor.state, .failed(message: "intentional fast failure"))
+        if case .failed = supervisor.state {
+            XCTFail("start() must synchronously leave the stale failed state, got \(supervisor.state)")
+        }
+
+        _ = try await watcher.waitForState(.running)
+        await supervisor.stop()
+    }
+
     func testStopHonorsTERMWithoutRestarting() async throws {
         let directory = try makeTemporaryDirectory()
         defer { try? FileManager.default.removeItem(at: directory) }

--- a/Tests/localvoxtralTests/BackendProcessSupervisorTests.swift
+++ b/Tests/localvoxtralTests/BackendProcessSupervisorTests.swift
@@ -68,10 +68,11 @@ final class BackendProcessSupervisorTests: XCTestCase {
             return false
         }
 
-        guard case let .failed(message) = state else {
+        guard case let .failed(summary, detail) = state else {
             return XCTFail("expected failed state, got \(state)")
         }
-        XCTAssertTrue(message.contains("port already in use"))
+        XCTAssertTrue(summary.contains("port already in use"))
+        XCTAssertNil(detail)
         XCTAssertFalse(FileManager.default.fileExists(atPath: marker.path))
     }
 
@@ -108,10 +109,11 @@ final class BackendProcessSupervisorTests: XCTestCase {
             return false
         }
 
-        guard case let .failed(message) = state else {
+        guard case let .failed(summary, detail) = state else {
             return XCTFail("expected failed state, got \(state)")
         }
-        XCTAssertTrue(message.contains("did not become ready"))
+        XCTAssertTrue(summary.contains("did not become ready"))
+        XCTAssertNil(detail)
         if let pid = try readPID(from: pidFile) {
             XCTAssertFalse(isProcessRunning(pid))
         }
@@ -220,10 +222,12 @@ final class BackendProcessSupervisorTests: XCTestCase {
             return false
         }
 
-        guard case let .failed(message) = state else {
+        guard case let .failed(summary, optionalDetail) = state else {
             return XCTFail("expected failed state, got \(state)")
         }
-        XCTAssertTrue(message.contains("fatal backend failure"), message)
+        XCTAssertEqual(summary, "test-backend exited 3 consecutive times.")
+        let detail = try XCTUnwrap(optionalDetail)
+        XCTAssertTrue(detail.contains("fatal backend failure"), detail)
         XCTAssertEqual(try readCount(from: countFile), 3)
         XCTAssertEqual(
             sleeps.recordedDurations.filter { $0 >= .milliseconds(500) },
@@ -274,7 +278,7 @@ final class BackendProcessSupervisorTests: XCTestCase {
         XCTAssertTrue(FileManager.default.createFile(atPath: succeedMarker.path, contents: Data()))
         await supervisor.start()
 
-        XCTAssertNotEqual(supervisor.state, .failed(message: "intentional fast failure"))
+        XCTAssertNotEqual(supervisor.state, .failed(summary: "intentional fast failure", detail: nil))
         if case .failed = supervisor.state {
             XCTFail("start() must synchronously leave the stale failed state, got \(supervisor.state)")
         }

--- a/Tests/localvoxtralTests/DictationViewModelFailFastUXTests.swift
+++ b/Tests/localvoxtralTests/DictationViewModelFailFastUXTests.swift
@@ -265,7 +265,10 @@ final class DictationViewModelFailFastUXTests: XCTestCase {
 
         XCTAssertFalse(viewModel.isConnectingRealtimeSession)
         XCTAssertEqual(viewModel.statusText, "Managed backend failed.")
-        XCTAssertTrue(viewModel.lastError?.contains("voxmlx failed: missing wheel") == true)
+        // Popover rule (AGENTS.md): lastError is one short sentence; the full
+        // failure summary stays in the alert/log, not the popover. This fake
+        // is not a ManagedBackendManagerError, so the generic wording applies.
+        XCTAssertEqual(viewModel.lastError, "Managed backend failed to start.")
         XCTAssertEqual(viewModel.realtimeSessionIndicatorState, .recentFailure)
     }
 
@@ -291,7 +294,8 @@ final class DictationViewModelFailFastUXTests: XCTestCase {
         await viewModel.managedStartupTask?.value
 
         XCTAssertEqual(viewModel.statusText, "Managed backend failed.")
-        XCTAssertTrue(viewModel.lastError?.contains("mlx-lm failed: mlx-lm exited 5 consecutive times.") == true)
+        XCTAssertEqual(viewModel.lastError, "mlx-lm failed to start.")
+        XCTAssertFalse(viewModel.lastError?.contains("exited 5 consecutive times") == true)
         XCTAssertFalse(viewModel.lastError?.contains(marker) == true)
         XCTAssertTrue(viewModel.debugLastConnectFailureTechnicalDetails?.contains(marker) == true)
         XCTAssertEqual(viewModel.realtimeSessionIndicatorState, .recentFailure)

--- a/Tests/localvoxtralTests/DictationViewModelFailFastUXTests.swift
+++ b/Tests/localvoxtralTests/DictationViewModelFailFastUXTests.swift
@@ -282,6 +282,37 @@ final class DictationViewModelFailFastUXTests: XCTestCase {
         XCTAssertEqual(viewModel.statusText, "Invalid endpoint URL.")
     }
 
+    func testManagedStartupCancelledByModeSwitchDoesNotBeginSessionOrSurfaceError() async {
+        let backendManager = FakeManagedBackendManager()
+        backendManager.suspendEnsure = true
+        let viewModel = makeViewModel(outputMode: .overlayBuffer, backendManager: backendManager)
+        viewModel.settings.backendMode = .managedLocal
+        viewModel.settings.dictationShortcutMode = .pushToTalk
+        viewModel.settings.realtimeAPIEndpointURL = ""
+        viewModel.isShowingConnectionFailureAlert = true
+        viewModel.debugMicrophoneAuthorizationStatusOverride = .authorized
+        retainForTestProcessLifetime(viewModel)
+
+        viewModel.debugHandleDictationShortcutPressForTesting()
+        await backendManager.waitUntilEnsureStarted()
+
+        XCTAssertTrue(viewModel.isConnectingRealtimeSession)
+        XCTAssertNil(viewModel.sessionProvider)
+
+        viewModel.applyBackendModeChange(.externalURL)
+        viewModel.debugHandleDictationShortcutReleaseForTesting()
+        backendManager.resumeEnsure()
+        await Task.yield()
+        await Task.yield()
+
+        XCTAssertEqual(backendManager.ensureIncludePolishingCalls, [false])
+        XCTAssertNil(viewModel.sessionProvider)
+        XCTAssertFalse(viewModel.isDictating)
+        XCTAssertFalse(viewModel.isConnectingRealtimeSession)
+        XCTAssertNil(viewModel.lastError)
+        XCTAssertNotEqual(viewModel.statusText, "Invalid endpoint URL.")
+    }
+
     // MARK: - Helpers
 
     private func makeViewModel(

--- a/Tests/localvoxtralTests/DictationViewModelFailFastUXTests.swift
+++ b/Tests/localvoxtralTests/DictationViewModelFailFastUXTests.swift
@@ -259,7 +259,9 @@ final class DictationViewModelFailFastUXTests: XCTestCase {
         XCTAssertEqual(backendManager.ensureIncludePolishingCalls, [false])
 
         backendManager.resumeEnsure()
-        await Task.yield()
+        // A bare Task.yield() races the startup task's failure continuation
+        // (seen flaking in CI); await the tracked task instead.
+        await viewModel.managedStartupTask?.value
 
         XCTAssertFalse(viewModel.isConnectingRealtimeSession)
         XCTAssertEqual(viewModel.statusText, "Managed backend failed.")
@@ -302,7 +304,7 @@ final class DictationViewModelFailFastUXTests: XCTestCase {
         viewModel.applyBackendModeChange(.externalURL)
         viewModel.debugHandleDictationShortcutReleaseForTesting()
         backendManager.resumeEnsure()
-        await Task.yield()
+        await viewModel.managedStartupTask?.value
         await Task.yield()
 
         XCTAssertEqual(backendManager.ensureIncludePolishingCalls, [false])

--- a/Tests/localvoxtralTests/DictationViewModelFailFastUXTests.swift
+++ b/Tests/localvoxtralTests/DictationViewModelFailFastUXTests.swift
@@ -269,6 +269,34 @@ final class DictationViewModelFailFastUXTests: XCTestCase {
         XCTAssertEqual(viewModel.realtimeSessionIndicatorState, .recentFailure)
     }
 
+    func testManagedStartupFailureKeepsStderrOutOfLastErrorButPreservesTechnicalDetails() async {
+        let marker = "FAKE_STDERR_TRACEBACK"
+        let backendManager = FakeManagedBackendManager()
+        backendManager.ensureError = ManagedBackendManagerError.backendFailed(
+            name: "mlx-lm",
+            summary: "mlx-lm exited 5 consecutive times.",
+            detail: "stderr: Python traceback \(marker)"
+        )
+        backendManager.suspendEnsure = true
+        let viewModel = makeViewModel(outputMode: .overlayBuffer, backendManager: backendManager)
+        viewModel.settings.backendMode = .managedLocal
+        viewModel.isShowingConnectionFailureAlert = true
+        viewModel.debugMicrophoneAuthorizationStatusOverride = .authorized
+        retainForTestProcessLifetime(viewModel)
+
+        viewModel.startDictation()
+        await backendManager.waitUntilEnsureStarted()
+
+        backendManager.resumeEnsure()
+        await viewModel.managedStartupTask?.value
+
+        XCTAssertEqual(viewModel.statusText, "Managed backend failed.")
+        XCTAssertTrue(viewModel.lastError?.contains("mlx-lm failed: mlx-lm exited 5 consecutive times.") == true)
+        XCTAssertFalse(viewModel.lastError?.contains(marker) == true)
+        XCTAssertTrue(viewModel.debugLastConnectFailureTechnicalDetails?.contains(marker) == true)
+        XCTAssertEqual(viewModel.realtimeSessionIndicatorState, .recentFailure)
+    }
+
     func testStartDictationInExternalModeNeverTouchesManagedBackendManager() {
         let backendManager = FakeManagedBackendManager()
         let viewModel = makeViewModel(outputMode: .overlayBuffer, backendManager: backendManager)


### PR DESCRIPTION
## What
An adversarial deep review of the merged managed-backend subsystem found four confirmed defects that would surface during real first-run/E2E use. All fixed with regression tests:

1. **Stale `.ready` after a crash [high]**: the manager stopped observing supervisors once running, so a later crash left status lying at Ready and `isReady` skipped startup → websocket connect against a dead port. Now each supervisor gets a long-lived MainActor mirror task (supervisor `stateUpdates` became multicast — per-consumer streams with a MainActor continuation registry), and `isReady` consults **live** supervisor state only.
2. **Retry rethrows the previous failure [high]**: `start()` only scheduled the supervision task, so callers sampling state right after saw the old `.failed`. `start()` now transitions to `.launching` synchronously; the manager waits on the new run's stream instead of sampling once.
3. **First-run download vs readiness timeout [high]**: the model downloads inside the server before `/health` responds; 600 s could kill it mid-download on slow links. Managed backends now get 1800 s with explanatory comments.
4. **Uncancellable managed startup [high, partial]**: the dictation-start bootstrap task is now tracked and cancelled on dictation cancel, mode switch away from managed, and app termination — with a post-`ensureReady` guard (`!Task.isCancelled && backendMode == .managedLocal`) so backends can't start after the user left managed mode. The shared `ensureReady` task is deliberately not cancelled (other callers may await it); full cancellation through the installer is follow-up work.

Also documented: HF cache stays user-global **deliberately** (shares already-downloaded weights; the uninstall story covers `backends/` only).

## Proof
- [x] `LV_BUILD_DIR=work/localvoxtral-codex-hardening ./scripts/remote-build.sh test`
```
Executed 391 tests, with 0 failures (0 unexpected)
```
(main's 387 + 4 new regression tests: status follows a post-ready crash and ensureReady doesn't short-circuit; retry after failure observes non-failed state and recovers; mode-switch mid-bootstrap starts no session and fires no alert.)
- [x] Zero strict-concurrency warnings.

Review + fixes: codex (read-only reviewer, then fix worker); orchestrator verified diffs and reran the suite.

## Added during owner E2E (2026-07-04): short failure summaries in popover/settings

Live testing surfaced an mlx-lm crash-loop (see #59) whose multi-line Python traceback was rendered raw in the menu-bar popover and Settings. Owner call: those surfaces get a one-line summary; the full detail stays in the alert popup and logs.

- `BackendProcessSupervisor.State.failed` / `ManagedBackendStatus.failed` are now `failed(summary:detail:)` — summary is the short sentence ("mlx-lm exited 5 consecutive times."), detail carries the stderr tail.
- `ManagedBackendManagerError.backendFailed`: `localizedDescription` is short; new `technicalDetails` exposes the stderr tail.
- `handleManagedBackendStartupFailure`: the popover (`lastError`) shows one short sentence — "mlx-lm failed to start." (owner rule, now recorded in AGENTS.md: never anything long in the popover); the alert popup and log receive the full summary + stderr detail. Settings `ManagedBackendStatusLabel` renders the one-line summary. `StatusPopoverView.statusDetailView` gains a 2-line truncation backstop for any path that slips a long string through.

Regression tests: `testSupervisorFailureErrorSplitsSummaryFromTechnicalDetails` and `testManagedStartupFailureKeepsStderrOutOfLastErrorButPreservesTechnicalDetails` plant a `FAKE_STDERR_TRACEBACK` marker in the supervisor detail and assert `lastError` equals the short sentence (no summary chain, no marker) while the alert-facing `technicalDetails` include the marker.

```
Executed 393 tests, with 0 failures (0 unexpected)
```
