### PR TITLE
Pin managed mlx-lm to 0.31.3.post2: transformers 5.13.0 crashes mlx_lm.server at import

### DIFF
--- a/Sources/localvoxtral/Backends/BackendCatalog.swift
+++ b/Sources/localvoxtral/Backends/BackendCatalog.swift
@@ -42,10 +42,13 @@ enum BackendCatalog {
     static let mlxLM = ManagedBackendSpec(
         id: "mlx-lm",
         displayName: "mlx-lm",
-        version: "0.31.3.post1",
+        // post2 pins transformers <5.13: 5.13.0 broke the string-keyed
+        // AutoTokenizer.register call in mlx_lm/tokenizer_utils.py, so fresh
+        // installs resolving latest transformers crashed mlx_lm.server at import.
+        version: "0.31.3.post2",
         requirementName: "mlx-lm",
-        wheelURL: URL(string: "https://github.com/T0mSIlver/mlx-lm/releases/download/v0.31.3.post1/mlx_lm-0.31.3.post1-py3-none-any.whl")!,
-        wheelSHA256: "05bcc1a66f5f3b1127e9eae9ed54f9ad046b12af97c0829632ecde70c6f3a87b",
+        wheelURL: URL(string: "https://github.com/T0mSIlver/mlx-lm/releases/download/v0.31.3.post2/mlx_lm-0.31.3.post2-py3-none-any.whl")!,
+        wheelSHA256: "61c49eba2e8651bded681f6d717a78fc635d768e487222530a2e239a58e47cdd",
         executableName: "mlx_lm.server",
         pythonVersion: "3.12",
         port: 8472


### PR DESCRIPTION
## What

Bump the managed mlx-lm pin to **v0.31.3.post2**, whose only change is `transformers>=5.7.0,<5.13` (release: https://github.com/T0mSIlver/mlx-lm/releases/tag/v0.31.3.post2).

## Why

Field failure on the owner's machine (fresh managed install today): mlx-lm crash-looped 5× at import with

```
File ".../transformers/models/auto/auto_factory.py", line 680, in register
    if key.__module__.startswith("transformers."):
AttributeError: 'str' object has no attribute '__module__'
```

Root cause: `mlx_lm/tokenizer_utils.py` registers its `NewlineTokenizer` with a **string** key (`AutoTokenizer.register("NewlineTokenizer", ...)`), and the wheel pinned `transformers>=5.7.0` with **no upper bound** — so `uv tool install` resolves whatever transformers is newest *on the day each user first installs*. transformers **5.13.0** (current latest) made string keys fatal. Installs from a few days ago got ≤5.12 and work; fresh installs are broken. Upstream `ml-explore/mlx-lm` main has the same unguarded call as of today, so there was no fix to cherry-pick — the fork now carries the bound.

voxmlx is not affected: it does not depend on transformers at all.

## Proof

Empirical bisect on Linux (py3.12, replicating the exact `tokenizer_utils.py` registration):

```
5.7.0: OK   5.8.0: OK   5.9.0: OK   5.10.0: OK   5.11.0: OK   5.12.0: OK
5.13.0: BROKEN ('str' object has no attribute '__module__')   <- current latest
```

post2 wheel metadata + fresh-env resolution through the wheel:

```
Version: 0.31.3.post2
Requires-Dist: transformers<5.13,>=5.7.0

resolved transformers 5.12.1
5.12.1: OK
```

Reinstall trigger for already-broken installs: `BackendInstaller.needsInstallOrUpdate` compares the install-marker version against `spec.version`, so the `post1 -> post2` bump forces a reinstall on next managed start — covered by the existing `BackendInstallerTests` version-bump case (`XCTAssertTrue(installer.needsInstallOrUpdate(newerSpec))`).

Unit suite on the build host:

```
Executed 387 tests, with 0 failures (0 unexpected) in 4.370 (4.389) seconds
```

- [ ] **Owner verification (macOS)**: on the machine that hit the crash, update to a build containing this pin, start dictation with polishing enabled — mlx-lm reinstalls as post2 and reaches ready.

## Notes

The unbounded transitive resolve is a class of failure, not a one-off: managed installs resolve deps at install time per machine. Full lockfile-style pinning of the tool environments (constraints baked into the catalog) is a follow-up candidate on the roadmap.
