### PR TITLE
Fix SIGABRT during managed-backend install: pipe reads must never use availableData

### DIFF
--- a/Sources/localvoxtral/Backends/BackendInstaller.swift
+++ b/Sources/localvoxtral/Backends/BackendInstaller.swift
@@ -466,23 +466,31 @@ private final class ProcessLineCollector: @unchecked Sendable {
 // Internal (not private) so the crash regression tests can drive it directly.
 final class PipeLineReader: @unchecked Sendable {
     private let fileHandle: FileHandle
+    // Captured once while the handle is known-valid; the read loop uses the
+    // raw descriptor so no NSFileHandle method can raise mid-read.
+    private let descriptor: Int32
     private let onLine: @Sendable (String) -> Void
     private let state = PipeLineReaderState()
     private var thread: Thread?
 
     init(fileHandle: FileHandle, onLine: @Sendable @escaping (String) -> Void) {
         self.fileHandle = fileHandle
+        self.descriptor = fileHandle.fileDescriptor
         self.onLine = onLine
     }
 
     func start() {
+        let descriptor = descriptor
         let fileHandle = fileHandle
         let onLine = onLine
         let state = state
         let thread = Thread {
+            // Retain the FileHandle for the loop's lifetime so the descriptor
+            // is not closed-and-reused underneath the reads.
+            withExtendedLifetime(fileHandle) {}
             var buffer = Data()
             while true {
-                let chunk = fileHandle.availableData
+                let chunk = POSIXPipeRead.nextChunk(fromDescriptor: descriptor)
                 if chunk.isEmpty {
                     break
                 }

--- a/Sources/localvoxtral/Backends/BackendInstaller.swift
+++ b/Sources/localvoxtral/Backends/BackendInstaller.swift
@@ -463,7 +463,8 @@ private final class ProcessLineCollector: @unchecked Sendable {
     }
 }
 
-private final class PipeLineReader: @unchecked Sendable {
+// Internal (not private) so the crash regression tests can drive it directly.
+final class PipeLineReader: @unchecked Sendable {
     private let fileHandle: FileHandle
     private let onLine: @Sendable (String) -> Void
     private let state = PipeLineReaderState()

--- a/Sources/localvoxtral/Backends/BackendProcessSupervisor.swift
+++ b/Sources/localvoxtral/Backends/BackendProcessSupervisor.swift
@@ -266,8 +266,13 @@ final class BackendProcessSupervisor {
     }
 
     private func attachOutputReader(to pipe: Pipe, source: String) {
+        // Capture the raw descriptor while the handle is known-valid;
+        // availableData inside the handler can raise an uncatchable ObjC
+        // exception if cleanup() closes the pipe while a callback is in
+        // flight (same abort class as the PipeLineReader field crash).
+        let descriptor = pipe.fileHandleForReading.fileDescriptor
         pipe.fileHandleForReading.readabilityHandler = { [weak self] fileHandle in
-            let data = fileHandle.availableData
+            let data = POSIXPipeRead.nextChunk(fromDescriptor: descriptor)
             guard !data.isEmpty else {
                 fileHandle.readabilityHandler = nil
                 return

--- a/Sources/localvoxtral/Backends/POSIXPipeRead.swift
+++ b/Sources/localvoxtral/Backends/POSIXPipeRead.swift
@@ -1,0 +1,31 @@
+import Foundation
+
+/// Reads pipe data with POSIX `read(2)` instead of `FileHandle.availableData`.
+///
+/// `availableData` raises an Objective-C `NSFileHandleOperationException` when
+/// the descriptor errors or closes mid-read. That exception is uncatchable
+/// from Swift, so it aborts the whole app — field-hit as a SIGABRT in
+/// `PipeLineReader` during a managed mlx-lm install. `read(2)` reports the
+/// same conditions as return values instead, which callers can treat as EOF.
+enum POSIXPipeRead {
+    /// Blocks until data is available, then returns it. Returns empty Data on
+    /// EOF *or any read error* — for a pipe reader both mean "stop reading".
+    static func nextChunk(fromDescriptor descriptor: Int32) -> Data {
+        var buffer = [UInt8](repeating: 0, count: 64 * 1024)
+        while true {
+            let count = buffer.withUnsafeMutableBytes { pointer in
+                read(descriptor, pointer.baseAddress, pointer.count)
+            }
+            if count > 0 {
+                return Data(bytes: buffer, count: count)
+            }
+            if count == 0 {
+                return Data()
+            }
+            if errno == EINTR {
+                continue
+            }
+            return Data()
+        }
+    }
+}

--- a/Tests/localvoxtralTests/BackendInstallerTests.swift
+++ b/Tests/localvoxtralTests/BackendInstallerTests.swift
@@ -1,5 +1,6 @@
 import CryptoKit
 import Foundation
+import Synchronization
 import XCTest
 @testable import localvoxtral
 
@@ -514,5 +515,38 @@ private struct FakeUVLocator: UVBinaryLocating {
 
     func uvBinaryURL() -> URL? {
         url
+    }
+}
+
+// MARK: - PipeLineReader crash regression (field SIGABRT 2026-07-04)
+//
+// FileHandle.availableData raises an uncatchable ObjC
+// NSFileHandleOperationException when the descriptor errors mid-read, which
+// aborts the whole app. Field-hit during a managed mlx-lm install. The reader
+// must treat read errors as EOF and finish cleanly instead.
+final class PipeLineReaderCrashRegressionTests: XCTestCase {
+    func testReaderFinishesCleanlyWhenDescriptorIsNotReadable() {
+        // A write-only descriptor makes read(2) fail with EBADF immediately —
+        // the same failure availableData turns into a process abort.
+        let writeOnly = FileHandle(forWritingAtPath: "/dev/null")!
+        defer { try? writeOnly.close() }
+
+        let reader = PipeLineReader(fileHandle: writeOnly) { _ in }
+        reader.start()
+        reader.waitUntilFinished()
+        // Reaching here without SIGABRT is the assertion.
+    }
+
+    func testReaderDeliversLinesThenFinishesOnEOF() {
+        let pipe = Pipe()
+        let lines = Mutex<[String]>([])
+        let reader = PipeLineReader(fileHandle: pipe.fileHandleForReading) { line in
+            lines.withLock { $0.append(line) }
+        }
+        reader.start()
+        pipe.fileHandleForWriting.write(Data("alpha\nbeta\n".utf8))
+        try? pipe.fileHandleForWriting.close()
+        reader.waitUntilFinished()
+        XCTAssertEqual(lines.withLock { $0 }, ["alpha", "beta"])
     }
 }


### PR DESCRIPTION
## What

Managed-backend pipe reads no longer use `FileHandle.availableData`. `PipeLineReader` (installer output) and the supervisor's `readabilityHandler` now capture the raw descriptor once and read with POSIX `read(2)`, treating any error as EOF.

## Why

Owner's fresh-bootstrap E2E today: **the app crashed (SIGABRT) while installing/starting mlx-lm**. Crash report (fetched via the new `mac-crashlog.yml` dispatch workflow):

```
exception: EXC_CRASH SIGABRT — abort() called
10 Foundation  _NSFileHandleRaiseOperationExceptionWhileReading
11 Foundation  -[NSConcreteFileHandle availableData]
12 localvoxtral  closure #1 in PipeLineReader.start() (BackendInstaller.swift:484)
```

`availableData` raises an Objective-C `NSFileHandleOperationException` when the descriptor errors or closes mid-read. ObjC exceptions are uncatchable from Swift, so the whole app aborts. The supervisor's `readabilityHandler` had the identical latent abort (cleanup() closing the pipe while a callback is in flight).

## Proof

Regression test crashes the runner at the test-only commit (`d535061`, first commit of this PR) with the exact field stack:

```
3   Foundation      -[NSConcreteFileHandle availableData] + 312
4   localvoxtralPackageTests   $s12localvoxtral14PipeLineReaderC5startyyFyyYbcfU_ + 320
libc++abi: terminating due to uncaught exception of type NSException
```

Same tests at the fix commit:

```
Test Case 'testReaderDeliversLinesThenFinishesOnEOF' passed (0.001 seconds).
Test Case 'testReaderFinishesCleanlyWhenDescriptorIsNotReadable' passed (0.000 seconds).
```

Full suite:

```
Executed 395 tests, with 0 failures (0 unexpected) in 4.561 (4.577) seconds
```

- [ ] **Owner verification (macOS)**: rerun the fresh-bootstrap E2E (Step 1 of the plan) — mlx-lm installs and starts without the app dying.
