### PR TITLE
Defuse leaked connect-timeout alert crashing headless test runs

### DIFF
--- a/Sources/localvoxtral/DictationViewModel+Session.swift
+++ b/Sources/localvoxtral/DictationViewModel+Session.swift
@@ -1044,6 +1044,14 @@ extension DictationViewModel {
         isShowingConnectionFailureAlert = true
         defer { isShowingConnectionFailureAlert = false }
 
+        // NSApp is nil in processes without an NSApplication (unit tests,
+        // headless tools); an alert cannot be presented there and force-
+        // unwrapping aborts the process (field flake: a leaked connect-timeout
+        // timer SIGTRAPed the test runner mid-suite).
+        guard NSApp != nil else {
+            Log.dictation.error("connection-failure alert skipped: no NSApplication in this process")
+            return
+        }
         NSApp.activate(ignoringOtherApps: true)
         let alert = NSAlert()
         alert.alertStyle = .warning

--- a/Tests/localvoxtralTests/DictationViewModelFailFastUXTests.swift
+++ b/Tests/localvoxtralTests/DictationViewModelFailFastUXTests.swift
@@ -247,6 +247,11 @@ final class DictationViewModelFailFastUXTests: XCTestCase {
         viewModel.settings.dictationBackendMode = .managedLocal
         viewModel.settings.polishingBackendMode = .managedLocal
         viewModel.settings.llmPolishingEnabled = true
+        // This test reaches beginDictationSession, which arms the real
+        // connect-timeout timer on a process-retained view model; without
+        // this suppression the timer's failure alert fires ~10s later inside
+        // whatever test is then running (field flake, 2026-07-05).
+        viewModel.isShowingConnectionFailureAlert = true
         viewModel.debugMicrophoneAuthorizationStatusOverride = .authorized
         retainForTestProcessLifetime(viewModel)
 


### PR DESCRIPTION
## What

`testStartDictationManagedBothWithPolishingEnabledRequestsBothBackends` (added with #62) reaches `beginDictationSession`, which arms the **real 10-second connect-timeout** on a process-retained view model — without the `isShowingConnectionFailureAlert` suppression its sibling tests use. The timer's failure alert then fires inside whatever test is running ~10 s later and crashes the runner at `NSApp.activate` (`NSApp` is nil under `swift test`):

```
DictationViewModel+Session.swift:1047: Fatal error: Unexpectedly found nil while implicitly unwrapping an Optional value
```

Main is green **only because the full suite currently finishes inside the 10-second blast window**; any branch that adds enough tests after the D-classes (e.g. #64's ~70) hits it deterministically — that's how it was found.

## Fix (both layers)

- The test sets the suppression flag like its siblings, with a comment explaining why it is load-bearing.
- `presentConnectionFailureAlert` no-ops with a log when the process has no `NSApplication` — an alert cannot be presented headlessly, and a leaked timer must never be able to SIGTRAP a test run again.

## Proof

Reproduced deterministically on the #64 branch (crash mid-`DictationViewModelOverlayLifecycleTests`, three consecutive runs); with this fix the #64 tree runs green (verified there before extracting this to main). This branch:

```
Executed 434 tests, with 0 failures (0 unexpected)
```

Known debt, out of scope: tests arming real wall-clock timers on retained view models predate this PR (no-wall-clock rule applies to new code).