### PR TITLE
Stamp non-release builds with the git-described version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          # Full history + tags so package_app.sh can git-describe the
+          # artifact version (shallow clones can't, and fall back to 0.0.0-dev).
+          fetch-depth: 0
 
       - name: Setup Swift
         if: runner.environment == 'github-hosted'

--- a/scripts/package_app.sh
+++ b/scripts/package_app.sh
@@ -34,8 +34,14 @@ patch_local_resource_bundle_lookup() {
 }
 
 CONFIGURATION="${1:-release}"
-APP_VERSION="${2:-0.3.0}"
-BUILD_NUMBER="${3:-1}"
+# Default the version from git so About, crash reports, and diagnostics can
+# identify the exact build — every non-release build used to say "0.3.0".
+# Releases still pass an explicit version. Fallback covers trees without git
+# metadata (remote-build rsync excludes .git) and shallow clones without tags.
+GIT_VERSION="$(git describe --tags 2>/dev/null | sed 's/^v//')"
+GIT_BUILD_NUMBER="$(git rev-list --count HEAD 2>/dev/null)"
+APP_VERSION="${2:-${GIT_VERSION:-0.0.0-dev}}"
+BUILD_NUMBER="${3:-${GIT_BUILD_NUMBER:-1}}"
 
 # Sign with a stable identity when available so TCC grants (Accessibility)
 # survive rebuilds; ad-hoc signatures change every build and invalidate them.


### PR DESCRIPTION
## What

Every non-release build — the CI artifacts `try-pr.sh` serves, local dev packages — carried the hardcoded `0.3.0` default in About, crash reports, and diagnostics, making builds indistinguishable (it actively hurt during today's field debugging, and the owner spotted 0.3.0 in Settings). `package_app.sh` now defaults to `git describe --tags` (v-stripped, e.g. `0.7.1-26-g3db0651`) with the commit count as build number; releases keep passing explicit values. `ci.yml` checks out with `fetch-depth: 0` so the runner can describe. Trees without git metadata (remote-build's rsync excludes `.git`) fall back to `0.0.0-dev`.

## Proof

Derivation on this clone: `0.7.1-26-g3db0651` / build `126`; both the describe format and the `0.0.0-dev` fallback pass the script's existing version regex; `bash -n` clean. Verified end-to-end on this PR's own CI artifact: `CFBundleShortVersionString` = `0.7.1-28-g35925b1`.

- [ ] Owner spot-check: `try-pr.sh` this PR → About shows a real version instead of 0.3.0.
