### PR TITLE
Fail fast on managed backends: eager launch + readiness-driven menu bar icon

### DIFF
--- a/Sources/localvoxtral/DictationViewModel+Session.swift
+++ b/Sources/localvoxtral/DictationViewModel+Session.swift
@@ -40,9 +40,7 @@ extension DictationViewModel {
     func beginDictationAfterManagedBackendIfNeeded(outputMode: DictationOutputMode? = nil) {
         let requestedOutputMode = outputMode ?? settings.dictationOutputMode
         let needsManagedDictation = settings.dictationBackendMode == .managedLocal
-        let needsManagedPolishing = requestedOutputMode == .overlayBuffer
-            && settings.llmPolishingEnabled
-            && settings.polishingBackendMode == .managedLocal
+        let needsManagedPolishing = isManagedPolishingRequired(outputMode: requestedOutputMode)
 
         guard needsManagedDictation || needsManagedPolishing else {
             beginDictationSession(outputMode: outputMode)

--- a/Sources/localvoxtral/DictationViewModel.swift
+++ b/Sources/localvoxtral/DictationViewModel.swift
@@ -399,6 +399,7 @@ final class DictationViewModel {
 
         textInsertion.onAccessibilityTrustChanged = { [weak self] in
             guard let self else { return }
+            self.retryModifierOnlyHotKeyRegistrationIfNeeded()
             if self.currentErrorToken == .accessibilityPermissionRequired {
                 self.lastError = nil
             }
@@ -760,6 +761,23 @@ final class DictationViewModel {
         case .failure(let reason):
             applyHotKeyRegistrationFailure(reason)
         }
+    }
+
+    /// Modifier-only NSEvent monitors require Accessibility trust, and
+    /// `AXIsProcessTrusted()` can transiently report false at cold launch even
+    /// with a persisted grant (field-hit 2026-07-05: launch-time registration
+    /// died and the shortcut stayed dead until the user touched the modifier
+    /// setting). Once trust lands, re-register — but never churn a live
+    /// registration.
+    private func retryModifierOnlyHotKeyRegistrationIfNeeded() {
+        guard settings.modifierOnlyHotKeyEnabled,
+              textInsertion.isAccessibilityTrusted,
+              !hotKeyManager.isModifierOnlyRegistrationActive
+        else { return }
+        Log.modifierKeys.notice(
+            "Accessibility trust granted; retrying modifier-only hotkey registration."
+        )
+        applyHotKeySettingsChange()
     }
 
     func applyDictationBackendModeChange(_ mode: BackendMode) {

--- a/Sources/localvoxtral/DictationViewModel.swift
+++ b/Sources/localvoxtral/DictationViewModel.swift
@@ -10,6 +10,12 @@ enum RealtimeSessionIndicatorState {
     case recentFailure
 }
 
+enum MenuBarIndicatorState: Equatable {
+    case idle
+    case connected
+    case failure
+}
+
 /// A single raw realtime-delta log emission, captured before any
 /// merge/preprocess/insertion processing. Mirrors what `Log.deltas` records
 /// when `SettingsStore.debugLogRealtimeDeltas` is on; surfaced through the
@@ -164,6 +170,31 @@ final class DictationViewModel {
         guard let lastError else { return nil }
         return ErrorToken.from(lastError)
     }
+    var requiredManagedBackendsReady: Bool {
+        guard settings.onboardingCompleted else { return true }
+        if settings.dictationBackendMode == .managedLocal,
+           !isReady(backendManager.voxmlxStatus)
+        {
+            return false
+        }
+        if isManagedPolishingRequired(outputMode: settings.dictationOutputMode),
+           !isReady(backendManager.mlxLMStatus)
+        {
+            return false
+        }
+        return true
+    }
+
+    var menuBarIndicatorState: MenuBarIndicatorState {
+        switch realtimeSessionIndicatorState {
+        case .connected:
+            return .connected
+        case .recentFailure:
+            return .failure
+        case .idle:
+            return requiredManagedBackendsReady ? .idle : .failure
+        }
+    }
 
     let settings: SettingsStore
     let textInsertion = TextInsertionService()
@@ -210,9 +241,13 @@ final class DictationViewModel {
     // off in Managed local mode. Kept awaitable so tests can await the shutdown.
     @ObservationIgnored
     var polishingShutdownTask: Task<Void, Never>?
-    // Eagerly installs/downloads/starts managed mlx-lm when the polishing
-    // toggle turns on, so the user watches inline progress in Settings
-    // instead of waiting for the next dictation. Kept awaitable for tests.
+    // Eagerly installs/downloads/starts required managed backends so the user
+    // watches inline progress in Settings instead of waiting for dictation.
+    // One slot per backend (mirroring BackendManager's per-backend single-flight
+    // rationale): a polishing toggle/mode flip must never cancel an in-flight
+    // voxmlx warmup, and vice versa. Kept awaitable for tests.
+    @ObservationIgnored
+    var dictationWarmupTask: Task<Void, Never>?
     @ObservationIgnored
     var polishingWarmupTask: Task<Void, Never>?
     @ObservationIgnored
@@ -401,7 +436,7 @@ final class DictationViewModel {
             refreshMicrophoneInputs()
             registerLifecycleObservers()
             requestStartupPermissionsIfNeeded()
-            warmUpPolishingAtLaunchIfNeeded()
+            warmUpManagedBackendsAtLaunchIfNeeded()
         }
     }
 
@@ -415,6 +450,7 @@ final class DictationViewModel {
         managedStartupTask?.cancel()
         managedStartupTaskID = nil
         polishingShutdownTask?.cancel()
+        dictationWarmupTask?.cancel()
         polishingWarmupTask?.cancel()
         audioSendTask?.cancel()
         stopFinalizationTask?.cancel()
@@ -723,14 +759,21 @@ final class DictationViewModel {
         let previousMode = settings.dictationBackendMode
         settings.dictationBackendMode = mode
 
-        guard previousMode == .managedLocal, mode == .externalURL else { return }
-        cancelManagedStartupTask()
-        if isConnectingRealtimeSession {
-            abortConnectingSession()
-            statusText = StatusStrings.ready
+        if previousMode == .externalURL, mode == .managedLocal {
+            startManagedBackendWarmup(dictation: true, polishing: false)
+            return
         }
-        Task { @MainActor [backendManager] in
-            await backendManager.stopDictation()
+
+        if previousMode == .managedLocal, mode == .externalURL {
+            cancelManagedStartupTask()
+            dictationWarmupTask?.cancel()
+            if isConnectingRealtimeSession {
+                abortConnectingSession()
+                statusText = StatusStrings.ready
+            }
+            Task { @MainActor [backendManager] in
+                await backendManager.stopDictation()
+            }
         }
     }
 
@@ -738,11 +781,38 @@ final class DictationViewModel {
         let previousMode = settings.polishingBackendMode
         settings.polishingBackendMode = mode
 
-        guard previousMode == .managedLocal, mode == .externalURL else { return }
-        cancelManagedStartupTask()
-        polishingWarmupTask?.cancel()
-        Task { @MainActor [backendManager] in
-            await backendManager.stopPolishing()
+        if previousMode == .externalURL, mode == .managedLocal {
+            if isManagedPolishingRequired(outputMode: settings.dictationOutputMode) {
+                startPolishingWarmup()
+            }
+            return
+        }
+
+        if previousMode == .managedLocal, mode == .externalURL {
+            cancelManagedStartupTask()
+            polishingWarmupTask?.cancel()
+            Task { @MainActor [backendManager] in
+                await backendManager.stopPolishing()
+            }
+        }
+    }
+
+    func applyDictationOutputModeChange(_ mode: DictationOutputMode) {
+        let previousMode = settings.dictationOutputMode
+        settings.dictationOutputMode = mode
+
+        guard previousMode != mode else { return }
+        if mode == .overlayBuffer, isManagedPolishingRequired(outputMode: mode) {
+            startPolishingWarmup()
+        } else if previousMode == .overlayBuffer,
+                  mode == .liveAutoPaste,
+                  settings.polishingBackendMode == .managedLocal
+        {
+            polishingWarmupTask?.cancel()
+            polishingShutdownTask?.cancel()
+            polishingShutdownTask = Task { @MainActor [backendManager] in
+                await backendManager.stopPolishing()
+            }
         }
     }
 
@@ -756,7 +826,7 @@ final class DictationViewModel {
     func llmPolishingEnabledDidChange(_ enabled: Bool) {
         guard settings.polishingBackendMode == .managedLocal else { return }
         polishingShutdownTask?.cancel()
-        if enabled {
+        if enabled, settings.dictationOutputMode == .overlayBuffer {
             startPolishingWarmup()
         } else {
             polishingWarmupTask?.cancel()
@@ -766,28 +836,46 @@ final class DictationViewModel {
         }
     }
 
-    func warmUpPolishingAtLaunchIfNeeded() {
-        // Mirrors the dictation-time gate in
-        // beginDictationAfterManagedBackendIfNeeded: polishing only ever runs
-        // in Overlay Buffer, so a persisted enabled flag must not spawn
-        // mlx-lm on a Live Auto-Paste launch.
-        guard settings.llmPolishingEnabled,
-              settings.polishingBackendMode == .managedLocal,
-              settings.dictationOutputMode == .overlayBuffer
-        else { return }
+    func warmUpManagedBackendsAtLaunchIfNeeded() {
+        guard settings.onboardingCompleted else {
+            Log.backends.info("launch managed backend warmup skipped until onboarding completes")
+            return
+        }
 
-        startPolishingWarmup()
+        let needsDictation = settings.dictationBackendMode == .managedLocal
+        let needsPolishing = isManagedPolishingRequired(outputMode: settings.dictationOutputMode)
+        startManagedBackendWarmup(dictation: needsDictation, polishing: needsPolishing)
     }
 
     func startPolishingWarmup() {
-        polishingWarmupTask?.cancel()
-        // Owner-specified UX (field-hit 2026-07-04): enabling polishing or
-        // launching with it already enabled eagerly installs/downloads/starts
-        // the managed backend, with progress rendered inline in Endpoints.
-        // Failures land in mlxLMStatus; dictation-time ensureReady remains the
+        startManagedBackendWarmup(dictation: false, polishing: true)
+    }
+
+    func startManagedBackendWarmup(dictation: Bool, polishing: Bool) {
+        guard dictation || polishing else { return }
+        guard settings.onboardingCompleted else {
+            Log.backends.info("managed backend warmup skipped until onboarding completes")
+            return
+        }
+
+        // Owner-specified UX: required managed backends install/download/start
+        // eagerly, with progress rendered inline in Endpoints.
+        // Failures land in the manager statuses; dictation-time ensureReady remains the
         // backstop and retry path.
-        polishingWarmupTask = Task { @MainActor [backendManager] in
-            try? await backendManager.ensureReady(dictation: false, polishing: true)
+        Log.backends.info(
+            "managed backend warmup requested dictation=\(dictation, privacy: .public) polishing=\(polishing, privacy: .public)"
+        )
+        if dictation {
+            dictationWarmupTask?.cancel()
+            dictationWarmupTask = Task { @MainActor [backendManager] in
+                try? await backendManager.ensureReady(dictation: true, polishing: false)
+            }
+        }
+        if polishing {
+            polishingWarmupTask?.cancel()
+            polishingWarmupTask = Task { @MainActor [backendManager] in
+                try? await backendManager.ensureReady(dictation: false, polishing: true)
+            }
         }
     }
 
@@ -1286,8 +1374,21 @@ final class DictationViewModel {
         return Self.liveAutoPasteAccessibilityWarningMessage
     }
 
+    func isManagedPolishingRequired(outputMode: DictationOutputMode) -> Bool {
+        outputMode == .overlayBuffer
+            && settings.llmPolishingEnabled
+            && settings.polishingBackendMode == .managedLocal
+    }
+
     private var activeOutputMode: DictationOutputMode {
         sessionOutputMode ?? settings.dictationOutputMode
+    }
+
+    private func isReady(_ status: ManagedBackendStatus) -> Bool {
+        if case .ready = status {
+            return true
+        }
+        return false
     }
 
     func debugLog(_ message: String) {

--- a/Sources/localvoxtral/DictationViewModel.swift
+++ b/Sources/localvoxtral/DictationViewModel.swift
@@ -239,8 +239,14 @@ final class DictationViewModel {
     var managedStartupTaskID: UUID?
     // Stops the managed mlx-lm (polishing) process when LLM polishing is turned
     // off in Managed local mode. Kept awaitable so tests can await the shutdown.
+    // Shutdown tasks are tracked (never fire-and-forget) so a warmup requested
+    // right after a stop can cancel a still-queued stop and serialize behind a
+    // running one — otherwise a stale stop lands after the fresh warmup and
+    // kills the backend the settings now require.
     @ObservationIgnored
     var polishingShutdownTask: Task<Void, Never>?
+    @ObservationIgnored
+    var dictationShutdownTask: Task<Void, Never>?
     // Eagerly installs/downloads/starts required managed backends so the user
     // watches inline progress in Settings instead of waiting for dictation.
     // One slot per backend (mirroring BackendManager's per-backend single-flight
@@ -450,6 +456,7 @@ final class DictationViewModel {
         managedStartupTask?.cancel()
         managedStartupTaskID = nil
         polishingShutdownTask?.cancel()
+        dictationShutdownTask?.cancel()
         dictationWarmupTask?.cancel()
         polishingWarmupTask?.cancel()
         audioSendTask?.cancel()
@@ -765,13 +772,16 @@ final class DictationViewModel {
         }
 
         if previousMode == .managedLocal, mode == .externalURL {
+            Log.backends.info("dictation backend mode switched to external; stopping managed voxmlx")
             cancelManagedStartupTask()
             dictationWarmupTask?.cancel()
             if isConnectingRealtimeSession {
                 abortConnectingSession()
                 statusText = StatusStrings.ready
             }
-            Task { @MainActor [backendManager] in
+            dictationShutdownTask?.cancel()
+            dictationShutdownTask = Task { @MainActor [backendManager] in
+                guard !Task.isCancelled else { return }
                 await backendManager.stopDictation()
             }
         }
@@ -789,9 +799,12 @@ final class DictationViewModel {
         }
 
         if previousMode == .managedLocal, mode == .externalURL {
+            Log.backends.info("polishing backend mode switched to external; stopping managed mlx-lm")
             cancelManagedStartupTask()
             polishingWarmupTask?.cancel()
-            Task { @MainActor [backendManager] in
+            polishingShutdownTask?.cancel()
+            polishingShutdownTask = Task { @MainActor [backendManager] in
+                guard !Task.isCancelled else { return }
                 await backendManager.stopPolishing()
             }
         }
@@ -808,9 +821,11 @@ final class DictationViewModel {
                   mode == .liveAutoPaste,
                   settings.polishingBackendMode == .managedLocal
         {
+            Log.backends.info("output mode switched to Live Auto-Paste; stopping managed mlx-lm")
             polishingWarmupTask?.cancel()
             polishingShutdownTask?.cancel()
             polishingShutdownTask = Task { @MainActor [backendManager] in
+                guard !Task.isCancelled else { return }
                 await backendManager.stopPolishing()
             }
         }
@@ -829,8 +844,10 @@ final class DictationViewModel {
         if enabled, settings.dictationOutputMode == .overlayBuffer {
             startPolishingWarmup()
         } else {
+            Log.backends.info("polishing disabled; stopping managed mlx-lm")
             polishingWarmupTask?.cancel()
             polishingShutdownTask = Task { @MainActor [backendManager] in
+                guard !Task.isCancelled else { return }
                 await backendManager.stopPolishing()
             }
         }
@@ -865,15 +882,27 @@ final class DictationViewModel {
         Log.backends.info(
             "managed backend warmup requested dictation=\(dictation, privacy: .public) polishing=\(polishing, privacy: .public)"
         )
+        // A stop decided just before this warmup must not land on the fresh
+        // process: cancel the shutdown if it hasn't run yet, and serialize the
+        // warmup behind it if it has (rapid managed→external→managed or
+        // polishing off→on flips race the async stop otherwise).
         if dictation {
             dictationWarmupTask?.cancel()
+            let pendingShutdown = dictationShutdownTask
+            dictationShutdownTask = nil
+            pendingShutdown?.cancel()
             dictationWarmupTask = Task { @MainActor [backendManager] in
+                await pendingShutdown?.value
                 try? await backendManager.ensureReady(dictation: true, polishing: false)
             }
         }
         if polishing {
             polishingWarmupTask?.cancel()
+            let pendingShutdown = polishingShutdownTask
+            polishingShutdownTask = nil
+            pendingShutdown?.cancel()
             polishingWarmupTask = Task { @MainActor [backendManager] in
+                await pendingShutdown?.value
                 try? await backendManager.ensureReady(dictation: false, polishing: true)
             }
         }

--- a/Sources/localvoxtral/HotKeyManager.swift
+++ b/Sources/localvoxtral/HotKeyManager.swift
@@ -56,6 +56,11 @@ final class HotKeyManager {
     private var modifierOnlyManager = ModifierOnlyHotKeyManager()
     private var isUsingModifierOnly = false
 
+    /// True while a modifier-only registration is installed. Lets the view
+    /// model retry a launch-time registration that failed because
+    /// Accessibility trust had not landed yet, without churning a live one.
+    var isModifierOnlyRegistrationActive: Bool { isUsingModifierOnly }
+
     /// Maps hotkey IDs to output modes for dual-shortcut dispatch.
     private var hotKeyIDToMode: [UInt32: DictationOutputMode] = [:]
 

--- a/Sources/localvoxtral/SettingsView.swift
+++ b/Sources/localvoxtral/SettingsView.swift
@@ -361,6 +361,11 @@ private struct ManagedBackendStatusLabel: View {
 
     var body: some View {
         HStack(spacing: 8) {
+            Circle()
+                .fill(statusColor)
+                .frame(width: 8, height: 8)
+                .accessibilityHidden(true)
+
             if case .installing(let progress) = status {
                 if let fraction = installFraction(from: progress) {
                     ProgressView(value: fraction)
@@ -385,7 +390,7 @@ private struct ManagedBackendStatusLabel: View {
 
             Text(statusText)
                 .font(.caption)
-                .foregroundStyle(statusColor)
+                .foregroundStyle(.primary)
                 .fixedSize(horizontal: false, vertical: true)
         }
     }
@@ -410,10 +415,16 @@ private struct ManagedBackendStatusLabel: View {
     }
 
     private var statusColor: Color {
-        if case .failed = status {
+        switch status {
+        case .ready:
+            return .green
+        case .installing, .preparingModel, .starting:
+            return .orange
+        case .failed:
             return .red
+        case .notInstalled, .stopped:
+            return .secondary
         }
-        return .secondary
     }
 
     private func installFraction(from progress: BackendInstallProgress) -> Double? {
@@ -462,6 +473,15 @@ private struct DictationSettingsPane: View {
     let overlayBufferShortcutBinding: Binding<DictationShortcut?>
     let livePasteShortcutBinding: Binding<DictationShortcut?>
     @Binding var shortcutValidationError: String?
+
+    private var dictationOutputModeBinding: Binding<DictationOutputMode> {
+        Binding(
+            get: { settings.dictationOutputMode },
+            set: { newValue in
+                viewModel.applyDictationOutputModeChange(newValue)
+            }
+        )
+    }
     @State private var overlayValidationError: String?
     @State private var livePasteValidationError: String?
 
@@ -610,7 +630,7 @@ private struct DictationSettingsPane: View {
             SettingsGroup(title: "Menu bar") {
                 SettingsFieldRow(title: "Output mode") {
                     VStack(alignment: .leading, spacing: 6) {
-                        Picker("", selection: $settings.dictationOutputMode) {
+                        Picker("", selection: dictationOutputModeBinding) {
                             ForEach(DictationOutputMode.allCases) { mode in
                                 Text(mode.displayName).tag(mode)
                             }

--- a/Sources/localvoxtral/localvoxtralApp.swift
+++ b/Sources/localvoxtral/localvoxtralApp.swift
@@ -10,7 +10,7 @@ struct localvoxtralApp: App {
             StatusPopoverView(viewModel: appDelegate.viewModel)
         } label: {
             let viewModel = appDelegate.viewModel
-            let state = viewModel.realtimeSessionIndicatorState
+            let state = viewModel.menuBarIndicatorState
             if let idleIcon = MenuBarIconAsset.idleIcon {
                 let iconConfiguration: (
                     icon: NSImage,
@@ -36,20 +36,24 @@ struct localvoxtralApp: App {
                             "realtime-connected",
                             "localvoxtral, realtime session active"
                         )
-                    case .recentFailure:
+                    case .failure:
                         if let failureIcon = MenuBarIconAsset.failureIcon {
                             return (
                                 failureIcon,
                                 .original,
                                 "realtime-failed",
-                                "localvoxtral, realtime connection failed recently"
+                                viewModel.realtimeSessionIndicatorState == .recentFailure
+                                    ? "localvoxtral, realtime connection failed recently"
+                                    : "localvoxtral, dictation backend not ready"
                             )
                         }
                         return (
                             idleIcon,
                             .template,
                             "realtime-failed",
-                            "localvoxtral, realtime connection failed recently"
+                            viewModel.realtimeSessionIndicatorState == .recentFailure
+                                ? "localvoxtral, realtime connection failed recently"
+                                : "localvoxtral, dictation backend not ready"
                         )
                     }
                 }()
@@ -68,7 +72,7 @@ struct localvoxtralApp: App {
                 case .connected:
                     Label("localvoxtral", systemImage: "checkmark.circle.fill")
                         .foregroundStyle(.green)
-                case .recentFailure:
+                case .failure:
                     Label("localvoxtral", systemImage: "xmark.circle.fill")
                         .foregroundStyle(.red)
                 }

--- a/Sources/localvoxtral/localvoxtralApp.swift
+++ b/Sources/localvoxtral/localvoxtralApp.swift
@@ -134,7 +134,13 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             backendManager: backendManager,
             openEndpointsSettings: { [weak self] in self?.openEndpointsSettings() }
         )
-        controller.onFinished = { [weak self] in self?.onboardingController = nil }
+        controller.onFinished = { [weak self] in
+            self?.onboardingController = nil
+            // First launch skips the eager warmup (the wizard owns bootstrap);
+            // once the wizard is done — finished or skipped — start whatever
+            // required managed backends it didn't already start.
+            self?.viewModel.warmUpManagedBackendsAtLaunchIfNeeded()
+        }
         onboardingController = controller
         controller.present()
     }

--- a/Tests/localvoxtralTests/DictationViewModelFailFastUXTests.swift
+++ b/Tests/localvoxtralTests/DictationViewModelFailFastUXTests.swift
@@ -525,21 +525,78 @@ final class DictationViewModelFailFastUXTests: XCTestCase {
         XCTAssertEqual(backendManager.stopAllCallCount, 0)
     }
 
-    func testModeSwitchesToManagedStartNoBackends() async {
+    func testDictationModeSwitchToManagedStartsDictationWarmup() async {
         let backendManager = FakeManagedBackendManager()
         let viewModel = makeViewModel(outputMode: .overlayBuffer, backendManager: backendManager)
         viewModel.settings.dictationBackendMode = .externalURL
-        viewModel.settings.polishingBackendMode = .externalURL
+        viewModel.settings.onboardingCompleted = true
         retainForTestProcessLifetime(viewModel)
 
         viewModel.applyDictationBackendModeChange(.managedLocal)
-        viewModel.applyPolishingBackendModeChange(.managedLocal)
-        await Task.yield()
+        await viewModel.dictationWarmupTask?.value
 
-        XCTAssertTrue(backendManager.ensureCalls.isEmpty)
+        XCTAssertEqual(backendManager.ensureCalls, [.init(dictation: true, polishing: false)])
         XCTAssertEqual(backendManager.stopDictationCallCount, 0)
         XCTAssertEqual(backendManager.stopPolishingCallCount, 0)
         XCTAssertEqual(backendManager.stopAllCallCount, 0)
+    }
+
+    func testLLMPolishingDisabledDoesNotCancelInFlightDictationWarmup() async {
+        let backendManager = FakeManagedBackendManager()
+        backendManager.suspendEnsure = true
+        let viewModel = makeViewModel(outputMode: .overlayBuffer, backendManager: backendManager)
+        viewModel.settings.dictationBackendMode = .externalURL
+        viewModel.settings.polishingBackendMode = .managedLocal
+        viewModel.settings.llmPolishingEnabled = true
+        viewModel.settings.onboardingCompleted = true
+        retainForTestProcessLifetime(viewModel)
+
+        viewModel.applyDictationBackendModeChange(.managedLocal)
+        await backendManager.waitUntilEnsureStarted()
+
+        // Turning polishing off must stop mlx-lm only — the voxmlx warmup keeps
+        // its own task slot and must survive (regression: a shared slot let this
+        // cancel the in-flight dictation warmup).
+        viewModel.llmPolishingEnabledDidChange(false)
+        await viewModel.polishingShutdownTask?.value
+
+        XCTAssertEqual(viewModel.dictationWarmupTask?.isCancelled, false)
+        backendManager.resumeEnsure()
+        await viewModel.dictationWarmupTask?.value
+
+        XCTAssertEqual(backendManager.ensureCalls, [.init(dictation: true, polishing: false)])
+        XCTAssertEqual(backendManager.stopPolishingCallCount, 1)
+        XCTAssertEqual(backendManager.stopDictationCallCount, 0)
+    }
+
+    func testPolishingModeSwitchToManagedStartsPolishingWarmupWhenRequired() async {
+        let backendManager = FakeManagedBackendManager()
+        let viewModel = makeViewModel(outputMode: .overlayBuffer, backendManager: backendManager)
+        viewModel.settings.polishingBackendMode = .externalURL
+        viewModel.settings.llmPolishingEnabled = true
+        viewModel.settings.onboardingCompleted = true
+        retainForTestProcessLifetime(viewModel)
+
+        viewModel.applyPolishingBackendModeChange(.managedLocal)
+        await viewModel.polishingWarmupTask?.value
+
+        XCTAssertEqual(backendManager.ensureCalls, [.init(dictation: false, polishing: true)])
+        XCTAssertEqual(backendManager.stopPolishingCallCount, 0)
+    }
+
+    func testPolishingModeSwitchToManagedDoesNotWarmUpWhenPolishingUnavailable() async {
+        let backendManager = FakeManagedBackendManager()
+        let viewModel = makeViewModel(outputMode: .liveAutoPaste, backendManager: backendManager)
+        viewModel.settings.polishingBackendMode = .externalURL
+        viewModel.settings.llmPolishingEnabled = true
+        viewModel.settings.onboardingCompleted = true
+        retainForTestProcessLifetime(viewModel)
+
+        viewModel.applyPolishingBackendModeChange(.managedLocal)
+        await viewModel.polishingWarmupTask?.value
+
+        XCTAssertTrue(backendManager.ensureCalls.isEmpty)
+        XCTAssertNil(viewModel.polishingWarmupTask)
     }
 
     // MARK: - LLM polishing enable toggle stops managed mlx-lm
@@ -575,6 +632,7 @@ final class DictationViewModelFailFastUXTests: XCTestCase {
         let backendManager = FakeManagedBackendManager()
         let viewModel = makeViewModel(outputMode: .overlayBuffer, backendManager: backendManager)
         viewModel.settings.polishingBackendMode = .managedLocal
+        viewModel.settings.onboardingCompleted = true
         retainForTestProcessLifetime(viewModel)
 
         viewModel.llmPolishingEnabledDidChange(true)
@@ -593,6 +651,7 @@ final class DictationViewModelFailFastUXTests: XCTestCase {
         let backendManager = FakeManagedBackendManager()
         let viewModel = makeViewModel(outputMode: .overlayBuffer, backendManager: backendManager)
         viewModel.settings.polishingBackendMode = .externalURL
+        viewModel.settings.onboardingCompleted = true
         retainForTestProcessLifetime(viewModel)
 
         viewModel.llmPolishingEnabledDidChange(true)
@@ -607,6 +666,7 @@ final class DictationViewModelFailFastUXTests: XCTestCase {
         backendManager.suspendEnsure = true
         let viewModel = makeViewModel(outputMode: .overlayBuffer, backendManager: backendManager)
         viewModel.settings.polishingBackendMode = .managedLocal
+        viewModel.settings.onboardingCompleted = true
         retainForTestProcessLifetime(viewModel)
 
         viewModel.llmPolishingEnabledDidChange(true)
@@ -622,60 +682,267 @@ final class DictationViewModelFailFastUXTests: XCTestCase {
         XCTAssertEqual(backendManager.stopPolishingCallCount, 1)
     }
 
-    func testWarmUpPolishingAtLaunchIfNeededEnabledManagedWarmsUpPolishingOnly() async {
+    func testDictationOutputModeSwitchToLiveStopsManagedPolishing() async {
         let backendManager = FakeManagedBackendManager()
         let viewModel = makeViewModel(outputMode: .overlayBuffer, backendManager: backendManager)
         viewModel.settings.polishingBackendMode = .managedLocal
         viewModel.settings.llmPolishingEnabled = true
         retainForTestProcessLifetime(viewModel)
 
-        viewModel.warmUpPolishingAtLaunchIfNeeded()
+        viewModel.applyDictationOutputModeChange(.liveAutoPaste)
+        await viewModel.polishingShutdownTask?.value
+
+        XCTAssertEqual(viewModel.settings.dictationOutputMode, .liveAutoPaste)
+        XCTAssertEqual(backendManager.stopPolishingCallCount, 1)
+        XCTAssertTrue(backendManager.ensureCalls.isEmpty)
+    }
+
+    func testDictationOutputModeSwitchToOverlayWarmsUpManagedPolishingWhenEnabled() async {
+        let backendManager = FakeManagedBackendManager()
+        let viewModel = makeViewModel(outputMode: .liveAutoPaste, backendManager: backendManager)
+        viewModel.settings.polishingBackendMode = .managedLocal
+        viewModel.settings.llmPolishingEnabled = true
+        viewModel.settings.onboardingCompleted = true
+        retainForTestProcessLifetime(viewModel)
+
+        viewModel.applyDictationOutputModeChange(.overlayBuffer)
+        await viewModel.polishingWarmupTask?.value
+
+        XCTAssertEqual(viewModel.settings.dictationOutputMode, .overlayBuffer)
+        XCTAssertEqual(backendManager.ensureCalls, [.init(dictation: false, polishing: true)])
+        XCTAssertEqual(backendManager.stopPolishingCallCount, 0)
+    }
+
+    func testWarmUpManagedBackendsAtLaunchIfNeededManagedDictationAndPolishingRequestsBoth() async {
+        let backendManager = FakeManagedBackendManager()
+        let viewModel = makeViewModel(outputMode: .overlayBuffer, backendManager: backendManager)
+        viewModel.settings.dictationBackendMode = .managedLocal
+        viewModel.settings.polishingBackendMode = .managedLocal
+        viewModel.settings.llmPolishingEnabled = true
+        viewModel.settings.onboardingCompleted = true
+        retainForTestProcessLifetime(viewModel)
+
+        viewModel.warmUpManagedBackendsAtLaunchIfNeeded()
+        await viewModel.dictationWarmupTask?.value
+        await viewModel.polishingWarmupTask?.value
+
+        // Per-backend warmup slots: two independent ensure requests, one per
+        // backend, so neither can cancel the other later.
+        XCTAssertEqual(backendManager.ensureCalls.count, 2)
+        XCTAssertTrue(backendManager.ensureCalls.contains(.init(dictation: true, polishing: false)))
+        XCTAssertTrue(backendManager.ensureCalls.contains(.init(dictation: false, polishing: true)))
+        XCTAssertEqual(backendManager.stopPolishingCallCount, 0)
+    }
+
+    func testWarmUpManagedBackendsAtLaunchIfNeededManagedDictationOnlyRequestsDictationOnly() async {
+        let backendManager = FakeManagedBackendManager()
+        let viewModel = makeViewModel(outputMode: .liveAutoPaste, backendManager: backendManager)
+        viewModel.settings.dictationBackendMode = .managedLocal
+        viewModel.settings.polishingBackendMode = .managedLocal
+        viewModel.settings.llmPolishingEnabled = true
+        viewModel.settings.onboardingCompleted = true
+        retainForTestProcessLifetime(viewModel)
+
+        viewModel.warmUpManagedBackendsAtLaunchIfNeeded()
+        await viewModel.dictationWarmupTask?.value
+
+        XCTAssertEqual(backendManager.ensureCalls, [.init(dictation: true, polishing: false)])
+        XCTAssertNil(viewModel.polishingWarmupTask)
+    }
+
+    func testWarmUpManagedBackendsAtLaunchIfNeededOnboardingIncompleteDoesNotWarmUp() async {
+        let backendManager = FakeManagedBackendManager()
+        let viewModel = makeViewModel(outputMode: .overlayBuffer, backendManager: backendManager)
+        viewModel.settings.dictationBackendMode = .managedLocal
+        viewModel.settings.polishingBackendMode = .managedLocal
+        viewModel.settings.llmPolishingEnabled = true
+        viewModel.settings.onboardingCompleted = false
+        retainForTestProcessLifetime(viewModel)
+
+        viewModel.warmUpManagedBackendsAtLaunchIfNeeded()
+        await viewModel.polishingWarmupTask?.value
+
+        XCTAssertTrue(backendManager.ensureCalls.isEmpty)
+        XCTAssertNil(viewModel.dictationWarmupTask)
+        XCTAssertNil(viewModel.polishingWarmupTask)
+    }
+
+    func testWarmUpManagedBackendsAtLaunchIfNeededExternalModesDoNotWarmUp() async {
+        let backendManager = FakeManagedBackendManager()
+        let viewModel = makeViewModel(outputMode: .overlayBuffer, backendManager: backendManager)
+        viewModel.settings.dictationBackendMode = .externalURL
+        viewModel.settings.polishingBackendMode = .externalURL
+        viewModel.settings.llmPolishingEnabled = true
+        viewModel.settings.onboardingCompleted = true
+        retainForTestProcessLifetime(viewModel)
+
+        viewModel.warmUpManagedBackendsAtLaunchIfNeeded()
+        await viewModel.polishingWarmupTask?.value
+
+        XCTAssertTrue(backendManager.ensureCalls.isEmpty)
+        XCTAssertNil(viewModel.dictationWarmupTask)
+        XCTAssertNil(viewModel.polishingWarmupTask)
+    }
+
+    func testWarmUpManagedBackendsAtLaunchIfNeededEnabledManagedWarmsUpPolishingOnly() async {
+        let backendManager = FakeManagedBackendManager()
+        let viewModel = makeViewModel(outputMode: .overlayBuffer, backendManager: backendManager)
+        viewModel.settings.polishingBackendMode = .managedLocal
+        viewModel.settings.llmPolishingEnabled = true
+        viewModel.settings.onboardingCompleted = true
+        retainForTestProcessLifetime(viewModel)
+
+        viewModel.warmUpManagedBackendsAtLaunchIfNeeded()
         await viewModel.polishingWarmupTask?.value
 
         XCTAssertEqual(backendManager.ensureCalls, [.init(dictation: false, polishing: true)])
         XCTAssertEqual(backendManager.stopPolishingCallCount, 0)
     }
 
-    func testWarmUpPolishingAtLaunchIfNeededDisabledDoesNotWarmUp() async {
+    func testWarmUpManagedBackendsAtLaunchIfNeededDisabledDoesNotWarmUp() async {
         let backendManager = FakeManagedBackendManager()
         let viewModel = makeViewModel(outputMode: .overlayBuffer, backendManager: backendManager)
         viewModel.settings.polishingBackendMode = .managedLocal
         viewModel.settings.llmPolishingEnabled = false
+        viewModel.settings.onboardingCompleted = true
         retainForTestProcessLifetime(viewModel)
 
-        viewModel.warmUpPolishingAtLaunchIfNeeded()
+        viewModel.warmUpManagedBackendsAtLaunchIfNeeded()
         await viewModel.polishingWarmupTask?.value
 
         XCTAssertTrue(backendManager.ensureCalls.isEmpty)
         XCTAssertNil(viewModel.polishingWarmupTask)
     }
 
-    func testWarmUpPolishingAtLaunchIfNeededLiveAutoPasteDoesNotWarmUp() async {
+    func testWarmUpManagedBackendsAtLaunchIfNeededLiveAutoPasteDoesNotWarmUpPolishing() async {
         let backendManager = FakeManagedBackendManager()
         let viewModel = makeViewModel(outputMode: .liveAutoPaste, backendManager: backendManager)
         viewModel.settings.polishingBackendMode = .managedLocal
         viewModel.settings.llmPolishingEnabled = true
+        viewModel.settings.onboardingCompleted = true
         retainForTestProcessLifetime(viewModel)
 
-        viewModel.warmUpPolishingAtLaunchIfNeeded()
+        viewModel.warmUpManagedBackendsAtLaunchIfNeeded()
         await viewModel.polishingWarmupTask?.value
 
         XCTAssertTrue(backendManager.ensureCalls.isEmpty)
         XCTAssertNil(viewModel.polishingWarmupTask)
     }
 
-    func testWarmUpPolishingAtLaunchIfNeededExternalModeDoesNotWarmUp() async {
+    func testWarmUpManagedBackendsAtLaunchIfNeededExternalPolishingModeDoesNotWarmUpPolishing() async {
         let backendManager = FakeManagedBackendManager()
         let viewModel = makeViewModel(outputMode: .overlayBuffer, backendManager: backendManager)
         viewModel.settings.polishingBackendMode = .externalURL
         viewModel.settings.llmPolishingEnabled = true
+        viewModel.settings.onboardingCompleted = true
         retainForTestProcessLifetime(viewModel)
 
-        viewModel.warmUpPolishingAtLaunchIfNeeded()
+        viewModel.warmUpManagedBackendsAtLaunchIfNeeded()
         await viewModel.polishingWarmupTask?.value
 
         XCTAssertTrue(backendManager.ensureCalls.isEmpty)
         XCTAssertNil(viewModel.polishingWarmupTask)
+    }
+
+    // MARK: - Menu bar backend readiness indicator
+
+    func testMenuBarIndicatorShowsFailureWhenManagedDictationBackendIsNotReady() {
+        let backendManager = FakeManagedBackendManager()
+        backendManager.voxmlxStatus = .starting
+        let viewModel = makeViewModel(outputMode: .overlayBuffer, backendManager: backendManager)
+        viewModel.settings.dictationBackendMode = .managedLocal
+        viewModel.settings.polishingBackendMode = .externalURL
+        viewModel.settings.onboardingCompleted = true
+        retainForTestProcessLifetime(viewModel)
+
+        XCTAssertFalse(viewModel.requiredManagedBackendsReady)
+        XCTAssertEqual(viewModel.menuBarIndicatorState, .failure)
+    }
+
+    func testMenuBarIndicatorShowsIdleWhenRequiredManagedBackendsAreReady() {
+        let backendManager = FakeManagedBackendManager()
+        backendManager.voxmlxStatus = .ready
+        backendManager.mlxLMStatus = .ready
+        let viewModel = makeViewModel(outputMode: .overlayBuffer, backendManager: backendManager)
+        viewModel.settings.dictationBackendMode = .managedLocal
+        viewModel.settings.polishingBackendMode = .managedLocal
+        viewModel.settings.llmPolishingEnabled = true
+        viewModel.settings.onboardingCompleted = true
+        retainForTestProcessLifetime(viewModel)
+
+        XCTAssertTrue(viewModel.requiredManagedBackendsReady)
+        XCTAssertEqual(viewModel.menuBarIndicatorState, .idle)
+    }
+
+    func testMenuBarIndicatorShowsIdleForExternalModesEvenWhenManagedBackendsAreStopped() {
+        let backendManager = FakeManagedBackendManager()
+        backendManager.voxmlxStatus = .stopped
+        backendManager.mlxLMStatus = .failed(summary: "mlx-lm failed to start.", detail: "trace")
+        let viewModel = makeViewModel(outputMode: .overlayBuffer, backendManager: backendManager)
+        viewModel.settings.dictationBackendMode = .externalURL
+        viewModel.settings.polishingBackendMode = .externalURL
+        viewModel.settings.llmPolishingEnabled = true
+        viewModel.settings.onboardingCompleted = true
+        retainForTestProcessLifetime(viewModel)
+
+        XCTAssertTrue(viewModel.requiredManagedBackendsReady)
+        XCTAssertEqual(viewModel.menuBarIndicatorState, .idle)
+    }
+
+    func testMenuBarIndicatorShowsFailureWhenRequiredManagedPolishingBackendFailed() {
+        let backendManager = FakeManagedBackendManager()
+        backendManager.voxmlxStatus = .ready
+        backendManager.mlxLMStatus = .failed(summary: "mlx-lm failed to start.", detail: "trace")
+        let viewModel = makeViewModel(outputMode: .overlayBuffer, backendManager: backendManager)
+        viewModel.settings.dictationBackendMode = .externalURL
+        viewModel.settings.polishingBackendMode = .managedLocal
+        viewModel.settings.llmPolishingEnabled = true
+        viewModel.settings.onboardingCompleted = true
+        retainForTestProcessLifetime(viewModel)
+
+        XCTAssertFalse(viewModel.requiredManagedBackendsReady)
+        XCTAssertEqual(viewModel.menuBarIndicatorState, .failure)
+    }
+
+    func testMenuBarIndicatorIgnoresManagedBackendReadinessUntilOnboardingCompletes() {
+        let backendManager = FakeManagedBackendManager()
+        backendManager.voxmlxStatus = .notInstalled
+        backendManager.mlxLMStatus = .notInstalled
+        let viewModel = makeViewModel(outputMode: .overlayBuffer, backendManager: backendManager)
+        viewModel.settings.dictationBackendMode = .managedLocal
+        viewModel.settings.polishingBackendMode = .managedLocal
+        viewModel.settings.llmPolishingEnabled = true
+        viewModel.settings.onboardingCompleted = false
+        retainForTestProcessLifetime(viewModel)
+
+        XCTAssertTrue(viewModel.requiredManagedBackendsReady)
+        XCTAssertEqual(viewModel.menuBarIndicatorState, .idle)
+    }
+
+    func testMenuBarIndicatorSessionConnectedWinsOverUnreadyManagedBackend() {
+        let backendManager = FakeManagedBackendManager()
+        backendManager.voxmlxStatus = .starting
+        let viewModel = makeViewModel(outputMode: .overlayBuffer, backendManager: backendManager)
+        viewModel.settings.dictationBackendMode = .managedLocal
+        viewModel.settings.onboardingCompleted = true
+        viewModel.realtimeSessionIndicatorState = .connected
+        retainForTestProcessLifetime(viewModel)
+
+        XCTAssertFalse(viewModel.requiredManagedBackendsReady)
+        XCTAssertEqual(viewModel.menuBarIndicatorState, .connected)
+    }
+
+    func testMenuBarIndicatorRecentFailureWinsOverReadyManagedBackends() {
+        let backendManager = FakeManagedBackendManager()
+        backendManager.voxmlxStatus = .ready
+        let viewModel = makeViewModel(outputMode: .overlayBuffer, backendManager: backendManager)
+        viewModel.settings.dictationBackendMode = .managedLocal
+        viewModel.settings.onboardingCompleted = true
+        viewModel.realtimeSessionIndicatorState = .recentFailure
+        retainForTestProcessLifetime(viewModel)
+
+        XCTAssertTrue(viewModel.requiredManagedBackendsReady)
+        XCTAssertEqual(viewModel.menuBarIndicatorState, .failure)
     }
 
     func testReRunOnboardingResetsFlagAndInvokesPresenter() {

--- a/Tests/localvoxtralTests/DictationViewModelFailFastUXTests.swift
+++ b/Tests/localvoxtralTests/DictationViewModelFailFastUXTests.swift
@@ -569,6 +569,50 @@ final class DictationViewModelFailFastUXTests: XCTestCase {
         XCTAssertEqual(backendManager.stopDictationCallCount, 0)
     }
 
+    func testDictationModeFlipBackToManagedSerializesWarmupBehindPendingStop() async {
+        let backendManager = FakeManagedBackendManager()
+        backendManager.suspendStopDictation = true
+        let viewModel = makeViewModel(outputMode: .overlayBuffer, backendManager: backendManager)
+        viewModel.settings.dictationBackendMode = .managedLocal
+        viewModel.settings.polishingBackendMode = .externalURL
+        viewModel.settings.onboardingCompleted = true
+        retainForTestProcessLifetime(viewModel)
+
+        viewModel.applyDictationBackendModeChange(.externalURL)
+        await backendManager.waitForStopDictationCallCount(1)
+
+        // Flip back while the stop is still executing: the warmup must wait for
+        // the stop to finish, or the stale stop kills the fresh voxmlx process
+        // (review finding on rapid managed→external→managed flips).
+        viewModel.applyDictationBackendModeChange(.managedLocal)
+        await Task.yield()
+        XCTAssertTrue(backendManager.ensureCalls.isEmpty)
+
+        backendManager.resumeStopDictation()
+        await viewModel.dictationWarmupTask?.value
+
+        XCTAssertEqual(backendManager.ensureCalls, [.init(dictation: true, polishing: false)])
+        XCTAssertEqual(backendManager.stopDictationCallCount, 1)
+    }
+
+    func testPolishingToggleOffThenOnCancelsQueuedStop() async {
+        let backendManager = FakeManagedBackendManager()
+        let viewModel = makeViewModel(outputMode: .overlayBuffer, backendManager: backendManager)
+        viewModel.settings.polishingBackendMode = .managedLocal
+        viewModel.settings.llmPolishingEnabled = true
+        viewModel.settings.onboardingCompleted = true
+        retainForTestProcessLifetime(viewModel)
+
+        // Off then immediately on: the queued stop must never run, or it lands
+        // after the warmup and stops the mlx-lm the settings now require.
+        viewModel.llmPolishingEnabledDidChange(false)
+        viewModel.llmPolishingEnabledDidChange(true)
+        await viewModel.polishingWarmupTask?.value
+
+        XCTAssertEqual(backendManager.ensureCalls, [.init(dictation: false, polishing: true)])
+        XCTAssertEqual(backendManager.stopPolishingCallCount, 0)
+    }
+
     func testPolishingModeSwitchToManagedStartsPolishingWarmupWhenRequired() async {
         let backendManager = FakeManagedBackendManager()
         let viewModel = makeViewModel(outputMode: .overlayBuffer, backendManager: backendManager)
@@ -1047,6 +1091,7 @@ private final class FakeManagedBackendManager: ManagedBackendManaging {
     }
     var ensureError: Error?
     var suspendEnsure = false
+    var suspendStopDictation = false
     private(set) var ensureCalls: [EnsureCall] = []
     private(set) var stopAllCallCount = 0
     private(set) var stopDictationCallCount = 0
@@ -1054,6 +1099,7 @@ private final class FakeManagedBackendManager: ManagedBackendManaging {
     private var ensureStartedContinuation: CheckedContinuation<Void, Never>?
     private var ensureResumeContinuation: CheckedContinuation<Void, Never>?
     private var stopDictationContinuation: CheckedContinuation<Void, Never>?
+    private var stopDictationResumeContinuation: CheckedContinuation<Void, Never>?
     private var stopPolishingContinuation: CheckedContinuation<Void, Never>?
 
     func ensureReady(dictation: Bool, polishing: Bool) async throws {
@@ -1087,6 +1133,12 @@ private final class FakeManagedBackendManager: ManagedBackendManaging {
         stopDictationCallCount += 1
         stopDictationContinuation?.resume()
         stopDictationContinuation = nil
+
+        if suspendStopDictation {
+            await withCheckedContinuation { continuation in
+                stopDictationResumeContinuation = continuation
+            }
+        }
     }
 
     func stopPolishing() async {
@@ -1124,6 +1176,11 @@ private final class FakeManagedBackendManager: ManagedBackendManaging {
     func resumeEnsure() {
         ensureResumeContinuation?.resume()
         ensureResumeContinuation = nil
+    }
+
+    func resumeStopDictation() {
+        stopDictationResumeContinuation?.resume()
+        stopDictationResumeContinuation = nil
     }
 
     func waitForStopDictationCallCount(_ expected: Int) async {

--- a/Tests/localvoxtralTests/DictationViewModelModifierGestureTests.swift
+++ b/Tests/localvoxtralTests/DictationViewModelModifierGestureTests.swift
@@ -99,6 +99,66 @@ final class DictationViewModelModifierGestureTests: XCTestCase {
         viewModel.abortConnectingSession()
     }
 
+    func testAccessibilityTrustArrivalRetriesFailedModifierOnlyRegistration() {
+        // Launch-time modifier-only registration fails while AXIsProcessTrusted()
+        // is transiently false (cold-launch TCC race, field-hit 2026-07-05).
+        // When trust lands, the trust-change hook must re-register instead of
+        // leaving the shortcut dead until the user touches the modifier setting.
+        ModifierOnlyHotKeyManager.resetDebugState()
+        defer { ModifierOnlyHotKeyManager.resetDebugState() }
+
+        let settings = makeSettings(outputMode: .overlayBuffer)
+        settings.modifierOnlyHotKeyEnabled = true
+        // Force the failure BEFORE the view model exists: on an AX-trusted
+        // test host, init's trust refresh already fires the retry hook, and a
+        // real registration there would break the "dead at launch" premise.
+        ModifierOnlyHotKeyManager.forcedStartOutcome = .monitorInstallationFailed
+        let viewModel = makeViewModel(settings: settings)
+        viewModel.textInsertion.debugSetAccessibilityTrusted(false)
+
+        viewModel.applyHotKeySettingsChange()
+        XCTAssertNotEqual(
+            viewModel.debugCurrentHotKeyRegistrationKindForTesting, .modifierOnly,
+            "sanity: the launch-time registration attempt must have failed"
+        )
+
+        ModifierOnlyHotKeyManager.forcedStartOutcome = .created
+        viewModel.textInsertion.debugSetAccessibilityTrusted(true)
+
+        XCTAssertEqual(
+            viewModel.debugCurrentHotKeyRegistrationKindForTesting, .modifierOnly,
+            "trust arrival must re-register the modifier-only hotkey"
+        )
+        XCTAssertNil(
+            viewModel.lastError,
+            "a healed registration must clear the stale hotkey error"
+        )
+    }
+
+    func testAccessibilityTrustArrivalDoesNotChurnLiveModifierOnlyRegistration() {
+        ModifierOnlyHotKeyManager.resetDebugState()
+        defer { ModifierOnlyHotKeyManager.resetDebugState() }
+
+        let settings = makeSettings(outputMode: .overlayBuffer)
+        settings.modifierOnlyHotKeyEnabled = true
+        // Forced before init so an AX-trusted test host cannot install real
+        // NSEvent monitors through the init-time trust refresh.
+        ModifierOnlyHotKeyManager.forcedStartOutcome = .created
+        let viewModel = makeViewModel(settings: settings)
+        viewModel.textInsertion.debugSetAccessibilityTrusted(false)
+
+        viewModel.applyHotKeySettingsChange()
+        XCTAssertEqual(viewModel.debugCurrentHotKeyRegistrationKindForTesting, .modifierOnly)
+        let startCallsAfterRegistration = ModifierOnlyHotKeyManager.startCallCount
+
+        viewModel.textInsertion.debugSetAccessibilityTrusted(true)
+
+        XCTAssertEqual(
+            ModifierOnlyHotKeyManager.startCallCount, startCallsAfterRegistration,
+            "trust arrival must not re-register a modifier-only hotkey that is already live"
+        )
+    }
+
     private func makeSettings(outputMode: DictationOutputMode) -> SettingsStore {
         let suiteName = "localvoxtral.DictationViewModelModifierGestureTests.\(UUID().uuidString)"
         let defaults = UserDefaults(suiteName: suiteName)!

--- a/scripts/ui-smoke.sh
+++ b/scripts/ui-smoke.sh
@@ -471,13 +471,17 @@ assert_tab "Dictation" "Start dictation with"
 assert_tab "Text Processing" "Replacements"
 assert_tab "About" "Diagnostics"
 
+# The launch phase forces external URL modes (managed mode now eagerly spawns
+# at launch), so the Endpoints pane renders endpoint configuration fields, not
+# the managed status rows. Managed-row AX coverage would need a second launch
+# that tolerates the eager spawn.
 select_tab "Endpoints" >/dev/null 2>&1 || true
 sleep 0.5
-if [[ "$(window_has_static_text "voxmlx - ws://127.0.0.1:8471/v1/realtime" 2>/dev/null || true)" == "found" ]] \
-  && [[ "$(window_has_static_text "mlx-lm - http://127.0.0.1:8472/v1/chat/completions" 2>/dev/null || true)" == "found" ]]; then
-  record_pass "Managed-mode Endpoints pane shows dictation and polishing backend rows."
+if [[ "$(window_has_static_text "Endpoint" 2>/dev/null || true)" == "found" ]] \
+  && [[ "$(window_has_static_text "API key" 2>/dev/null || true)" == "found" ]]; then
+  record_pass "External-mode Endpoints pane shows endpoint configuration fields."
 else
-  record_fail "Managed-mode Endpoints pane did not show both expected backend rows."
+  record_fail "External-mode Endpoints pane did not show endpoint configuration fields."
 fi
 
 quit_app

--- a/scripts/ui-smoke.sh
+++ b/scripts/ui-smoke.sh
@@ -9,7 +9,7 @@ set -uo pipefail
 # There is no app-code hook for a separate suite/domain, and NSUserDefaults
 # command-line overrides do not move standard defaults to an isolated suite.
 # This script therefore snapshots that defaults domain, forces only the smoke
-# test's required managed-mode setting, and restores the snapshot on exit.
+# test's required external-mode setting, and restores the snapshot on exit.
 
 APP_PATH="${1:-dist/localvoxtral.app}"
 APP_PROCESS="localvoxtral"
@@ -239,18 +239,17 @@ if ! snapshot_defaults; then
   print_summary
   exit 1
 fi
-if ! defaults write "$BUNDLE_ID" settings.dictation_backend_mode -string managed_local \
-  || ! defaults write "$BUNDLE_ID" settings.polishing_backend_mode -string managed_local \
+if ! defaults write "$BUNDLE_ID" settings.dictation_backend_mode -string external_url \
+  || ! defaults write "$BUNDLE_ID" settings.polishing_backend_mode -string external_url \
   || ! defaults write "$BUNDLE_ID" settings.llm_polishing_enabled -bool false \
   || ! defaults write "$BUNDLE_ID" settings.onboarding_completed -bool true; then
-  record_fail "Could not force managed backend mode and completed onboarding in defaults."
+  record_fail "Could not force external backend mode and completed onboarding in defaults."
   print_summary
   exit 1
 fi
-# llm_polishing_enabled is forced false so the launch invariant below tests
-# pure lazy bootstrap: with it enabled (managed + Overlay Buffer) the app now
-# intentionally warms up mlx-lm at launch, and the invariant would then hinge
-# on whatever toggle state the owner's persisted defaults happen to hold.
+# Backend modes are forced external so the launch invariant below tests that
+# externally managed servers are never spawned by the app. Managed local mode
+# now intentionally launches required backends eagerly at app start.
 # onboarding_completed is forced true so the first-launch wizard never appears
 # and the launch invariants below (menu-bar item, no backend spawned) hold. A
 # dedicated wizard smoke would need a second launch with the flag false plus AX
@@ -259,7 +258,7 @@ fi
 # TODO(tier-2): add a wizard-appears smoke by launching once with
 # settings.onboarding_completed=false and asserting the "Welcome to localvoxtral"
 # window, then completing it.
-record_pass "Defaults domain snapshot captured and smoke run forced to managed mode with onboarding completed."
+record_pass "Defaults domain snapshot captured and smoke run forced to external mode with onboarding completed."
 
 # Managed backends are Python entry-point processes, so match the full
 # command line (-f). The runner legitimately hosts a voxmlx-serve launchd
@@ -339,9 +338,9 @@ fi
 stop_backend_sampler
 NEW_BACKEND_PIDS="$(comm -13 <(printf '%s\n' "$BASELINE_BACKEND_PIDS" | sed '/^$/d') <(sampled_backend_pids) 2>/dev/null || true)"
 if [[ -n "$NEW_BACKEND_PIDS" ]]; then
-  record_fail "App launch spawned managed backend process(es) — lazy-bootstrap invariant violated. New pids: $NEW_BACKEND_PIDS"
+  record_fail "App launch spawned managed backend process(es) in external mode. New pids: $NEW_BACKEND_PIDS"
 else
-  record_pass "No managed backend process spawned by app launch, including transient samples."
+  record_pass "No managed backend process spawned by app launch in external mode, including transient samples."
 fi
 
 open_status_menu() {


### PR DESCRIPTION
## What

Fail fast on voxmlx / mlx-lm availability instead of discovering a dead backend on the first dictation attempt:

- **Eager launch at app start.** Required managed backends now start as soon as the app launches: voxmlx whenever dictation mode is Managed local, mlx-lm under the existing polishing gate (enabled + managed + Overlay Buffer). On first launch the onboarding wizard still owns bootstrap; the eager warmup fires when the wizard finishes (or is skipped). Warmups also fire on backend-mode, polishing-toggle and output-mode changes, so any "required but not running" state always has a self-heal in flight; dictation-time `ensureReady` remains the backstop.
- **Per-backend warmup slots.** The launch/toggle warmup used to share one task slot; a polishing toggle or mode flip could cancel an in-flight voxmlx warmup (and vice versa), stranding it in `stopped` with a red icon and no self-heal. Same lesson as BackendManager's per-backend single-flight (field-hit 2026-07-04) — each backend now warms in its own slot.
- **Stops serialize with warmups.** Stop tasks are tracked per backend with a cancellation guard; a warmup requested right after a stop cancels a still-queued stop and waits for a running one, so rapid managed→external→managed or polishing off→on flips can't let the stale stop kill the fresh process.
- **Readiness-driven menu bar icon.** New derived `menuBarIndicatorState`: the failure icon shows whenever a required managed backend isn't `.ready` — including while installing/downloading/starting; red deliberately means "can't dictate yet" per the owner's spec, even during a normal first-run download (reviewer flagged the tradeoff; decision noted here). Session states still win, and the not-ready case gets its own accessibility label. External URL modes contribute no requirement (no endpoint probing infra — deliberately out of scope).
- **Endpoints pane.** Managed status rows get a colored readiness dot (green ready / orange in-progress / red failed / gray stopped). Group structure unchanged per the settings-pane rule.
- **ui-smoke launch drill updated.** The lazy-bootstrap invariant this PR retires is replaced: the drill now forces external URL modes, asserts "external mode spawns nothing at launch", and its Endpoints content check now expects the external-mode fields.

Note for review: `testModeSwitchesToManagedStartNoBackends` asserted the old lazy behavior and was replaced by `testDictationModeSwitchToManagedStartsDictationWarmup` (asserts the new eager behavior). This is the requested behavior flip, not a weakened test.

Reviewed pre-merge by two independent agent reviews (opus + codex). Findings addressed in the second commit: warmup/stop races (both reviewers, regression-tested below), stranded managed-mode ui-smoke assertion, missing post-onboarding warmup trigger, stop-side lifecycle logging. Accepted as-is: red icon during normal warmup (owner-specified), redundant idempotent `stopPolishing()` on overlay→live with polishing already off.

## Proof

- [x] Unit suite green — `LV_BUILD_DIR=work/localvoxtral-failfast ./scripts/remote-build.sh test` (after review fixes)

  ```
  Executed 513 tests, with 0 failures (0 unexpected) in 6.615 (6.647) seconds
  ```

- [x] New behavior: menu-bar readiness derivation — failing run with backend readiness disabled in `menuBarIndicatorState`, passing run with production logic:

  ```
  error: ...testMenuBarIndicatorShowsFailureWhenManagedDictationBackendIsNotReady] : XCTAssertEqual failed: ("idle") is not equal to ("failure")
  Executed 1 test, with 1 failure (0 unexpected) in 0.108 (0.108) seconds
  ```
  ```
  Test Case '...testMenuBarIndicatorShowsFailureWhenManagedDictationBackendIsNotReady]' passed (0.015 seconds).
  Executed 1 test, with 0 failures (0 unexpected) in 0.015 (0.016) seconds
  ```

- [x] Bug fix (warmup cross-cancellation): `testLLMPolishingDisabledDoesNotCancelInFlightDictationWarmup` — failing against the shared-slot behavior, passing with per-backend slots:

  ```
  error: ...testLLMPolishingDisabledDoesNotCancelInFlightDictationWarmup] : XCTAssertEqual failed: ("nil") is not equal to ("Optional(false)")
  ```
  ```
  Executed 54 tests, with 0 failures (0 unexpected) in 0.336 (0.339) seconds   # full DictationViewModelFailFastUXTests class
  ```

- [x] Bug fix (stop-vs-warmup races, review findings): `testDictationModeFlipBackToManagedSerializesWarmupBehindPendingStop` and `testPolishingToggleOffThenOnCancelsQueuedStop` — failing with the fix neutralized (no serialization / no cancellation guard), passing with it:

  ```
  error: ...testDictationModeFlipBackToManagedSerializesWarmupBehindPendingStop] : XCTAssertTrue failed
  error: ...testPolishingToggleOffThenOnCancelsQueuedStop] : XCTAssertEqual failed: ("1") is not equal to ("0")
  ```
  ```
  Executed 513 tests, with 0 failures (0 unexpected)   # full suite with fixes restored
  ```

- [x] Bug fix (found hand-testing this PR): modifier-only shortcut dead after cold launch. Unified log (mac-crashlog) showed `AXIsProcessTrusted=false` at launch → `registerModifierOnly` gave up permanently; the settings flip re-registered once trust had landed. Fixed by retrying registration on the Accessibility trust-change hook. Regression test `testAccessibilityTrustArrivalRetriesFailedModifierOnlyRegistration` — failing without the retry hook, passing with it:

  ```
  error: ...testAccessibilityTrustArrivalRetriesFailedModifierOnlyRegistration] : XCTAssertEqual failed: ("none") is not equal to ("modifierOnly") - trust arrival must re-register the modifier-only hotkey
  ```
  ```
  Executed 515 tests, with 0 failures (0 unexpected)   # full suite with the fix
  ```

- [ ] UI change, to verify by hand via try-pr.sh: menu bar icon is red from launch until voxmlx reports ready, flips to the idle icon when ready; Endpoints rows show the colored dot; with polishing enabled, killing mlx-lm mid-run turns the icon red and the Endpoints row shows the failure. ui-smoke.yml (nightly) covers the updated external-mode launch invariant + Endpoints fields assertion.
