### PR TITLE
Dev-loop tooling: per-worktree remote dirs, output capture, mac-health preflight, gate v2 runbook

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,13 +22,19 @@ is machine-local config, set once per clone (never committed):
 
 On a Mac, just `swift build` / `swift test`.
 
-When several agents work in parallel, each must set its own remote dir:
-`LV_BUILD_DIR=work/localvoxtral-<task> ./scripts/remote-build.sh ...`
+Before starting long remote work, `./scripts/mac-health.sh` — it fails fast
+with an actionable message when the Mac is asleep/unreachable instead of
+letting rsync hang or CI queue forever.
+
+Parallel agents are isolated automatically: the remote dir defaults to a
+per-worktree name derived from the local checkout path. `LV_BUILD_DIR`
+still overrides it when you need a specific dir.
 
 - An interrupted remote run can leave a stale SwiftPM lock in its remote dir —
   don't debug it, switch to a fresh `LV_BUILD_DIR`.
-- Never pipe a full test run only through grep: `tee` the raw output to a file
-  first, or a crash eats the failing test's name and you pay for reruns.
+- Every run's full remote output lands in `.build/last-remote.log`. Never pipe
+  the script itself through grep (a crash eats the failing test's name) — let
+  it print, then grep the log file.
 
 ## Hand-testing & field debugging (the fast loop)
 
@@ -64,7 +70,7 @@ Learned the hard way (2026-07-04) — use these instead of manual steps:
   (try-pr copy vs /Applications) before debugging its behavior — that
   confusion and theorize-first cost an hour on 2026-07-05. Deeper tools:
   `scripts/mac-diag.sh` on the Mac, Export Diagnostics… in Settings > About,
-  and (once the v2 gate is installed)
+  and (once the v2 gate is installed — owner runbook: `scripts/mac/README.md`)
   `./scripts/remote-build.sh diag|applog|voxlog|svc-status`.
 - **Pipes from child processes**: never read with
   `FileHandle.availableData` — it raises an uncatchable ObjC exception on

--- a/scripts/mac-health.sh
+++ b/scripts/mac-health.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+set -uo pipefail
+
+# Preflight for the Mac build loop: is the build host reachable, is the gate
+# answering, is voxmlx serving, and does CI look alive? Agents should run this
+# before long remote work so a sleeping Mac fails fast with an actionable
+# message instead of a hung rsync or a CI job queued forever.
+#
+# Exit code: 0 when the build loop is usable (SSH gate reachable), 1 otherwise.
+# voxmlx/CI problems are reported but only warn — unit builds still work
+# without them.
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+HOST="${LV_BUILD_HOST:-$(git -C "$ROOT_DIR" config --get localvoxtral.buildhost || true)}"
+
+if [[ -z "$HOST" ]]; then
+  echo "FAIL: no build host configured (git config localvoxtral.buildhost)" >&2
+  exit 1
+fi
+
+fail=0
+
+echo "== Mac build host: $HOST =="
+
+diag_output=""
+if diag_output="$(timeout 20 ssh -o ConnectTimeout=8 -o BatchMode=yes "$HOST" diag 2>&1)"; then
+  echo "OK: SSH gate reachable (gate v2)"
+  # Surface the two liveness signals agents actually branch on.
+  echo "$diag_output" | grep -A2 -- '-- port 8000 --' | sed 's/^/  /'
+  if echo "$diag_output" | grep -q 'Runner.Listener'; then
+    echo "  actions runner: process visible"
+  fi
+elif echo "$diag_output" | grep -qi 'denied command\|command not allowed'; then
+  echo "OK: SSH gate reachable (gate v1 — no diagnostics; install v2, see scripts/mac/README.md)"
+else
+  echo "FAIL: build host unreachable over SSH:" >&2
+  echo "$diag_output" | tail -3 | sed 's/^/  /' >&2
+  echo "  (Mac asleep, owner logged out, or IP changed — update 'git config localvoxtral.buildhost')" >&2
+  fail=1
+fi
+
+# CI recency is a best-effort proxy for "self-hosted runner online" — the
+# runners API needs a repo-admin token, which this box deliberately lacks.
+if command -v gh >/dev/null 2>&1; then
+  latest_run="$(gh run list --limit 1 --json status,conclusion,displayTitle,updatedAt \
+    --template '{{range .}}{{.status}}/{{.conclusion}} {{.updatedAt}} {{.displayTitle}}{{end}}' 2>/dev/null || true)"
+  if [[ -n "$latest_run" ]]; then
+    echo "CI:  latest run: $latest_run"
+    if [[ "$latest_run" == queued/* ]]; then
+      echo "WARN: latest CI run is queued — self-hosted runner may be offline" >&2
+    fi
+  else
+    echo "WARN: could not query CI runs via gh" >&2
+  fi
+fi
+
+exit "$fail"

--- a/scripts/mac/README.md
+++ b/scripts/mac/README.md
@@ -1,0 +1,71 @@
+# Mac build-host scripts
+
+## `localvoxtral-build-gate.sh` — SSH build gate (v2)
+
+Forced command for the Linux dev box's build key on the Mac build host. It
+allowlists the `remote-build.sh` loop (rsync in, `swift build|test`,
+`package_app.sh release`) and, since v2, four read-only diagnostic verbs:
+`diag`, `applog [minutes]`, `voxlog [lines]`, `svc-status`. Everything else is
+denied and logged to `~/Library/Logs/localvoxtral-build-gate.log`.
+
+### Installing / upgrading the gate
+
+Run from a trusted owner session on the Mac (not through the gate). With
+`GATE_ACCOUNT` set to the dedicated low-privilege account whose
+`authorized_keys` forces this script:
+
+```bash
+GATE_ACCOUNT=builder
+cd ~/work/localvoxtral && git pull
+sudo install -d -m 0755 -o "$GATE_ACCOUNT" "/Users/$GATE_ACCOUNT/bin"
+sudo install -m 0755 -o "$GATE_ACCOUNT" \
+  scripts/mac/localvoxtral-build-gate.sh \
+  "/Users/$GATE_ACCOUNT/bin/localvoxtral-build-gate.sh"
+```
+
+No `authorized_keys` change is needed — the entry already points at
+`$HOME/bin/localvoxtral-build-gate.sh`; this replaces the script in place.
+
+### Machine-local config (`~/.localvoxtral-gate.conf` in the gate account)
+
+The gate account is deliberately not the GUI owner account, so two things
+differ per machine and are read from an optional, never-committed conf file:
+
+```bash
+# /Users/<gate-account>/.localvoxtral-gate.conf
+VOXLOG_FILE=/Users/Shared/localvoxtral/voxmlx.log
+VOXMLX_GUI_UID=501        # uid of the GUI user running com.localvoxtral.voxmlx
+```
+
+For `voxlog` to work across accounts, point the voxmlx LaunchAgent's
+`StandardOutPath`/`StandardErrorPath` at a shared location and set
+`VOXLOG_FILE` to match:
+
+```bash
+sudo install -d -m 0755 -o "$(id -un)" /Users/Shared/localvoxtral
+# edit ~/Library/LaunchAgents/com.localvoxtral.voxmlx.plist: StandardOutPath +
+# StandardErrorPath -> /Users/Shared/localvoxtral/voxmlx.log, then:
+launchctl bootout "gui/$(id -u)/com.localvoxtral.voxmlx" || true
+launchctl bootstrap "gui/$(id -u)" ~/Library/LaunchAgents/com.localvoxtral.voxmlx.plist
+```
+
+(The alternative — ACL read grants on the owner's `~/Library/Logs` chain — is
+fiddlier and breaks when the log file is rotated/recreated.)
+
+### Verifying from the Linux box
+
+```bash
+./scripts/remote-build.sh diag        # versions, processes, ports, logs
+./scripts/remote-build.sh applog 30   # app unified log, last 30 minutes
+./scripts/remote-build.sh voxlog 100  # voxmlx log tail
+./scripts/remote-build.sh svc-status  # voxmlx service/process/port status
+ssh <gate-destination> 'echo pwned'   # must print "denied command"
+```
+
+Notes:
+
+- `applog` uses `log show`, which macOS may restrict for non-admin accounts.
+  If it returns nothing for the gate account, that's the cause — the crashlog
+  workflow (`mac-crashlog.yml`) runs as the runner user and is the fallback.
+- `svc-status` includes process and port sections because `launchctl print`
+  cannot read another user's GUI domain.

--- a/scripts/mac/localvoxtral-build-gate.sh
+++ b/scripts/mac/localvoxtral-build-gate.sh
@@ -7,11 +7,9 @@ set -euo pipefail
 # build-host SSH key. It keeps the existing build/test/package allowlist and
 # adds read-only diagnostics without granting an interactive shell.
 #
-# Gate v2 install notes:
-#   scp scripts/mac/localvoxtral-build-gate.sh <host>:bin/ && ssh <host> chmod +x bin/localvoxtral-build-gate.sh
-#
-# Run that from a trusted owner session, not through this gate. New diagnostic
-# verbs allowed through the gate:
+# Gate v2 install notes: see scripts/mac/README.md. Install from a trusted
+# owner session, not through this gate. New diagnostic verbs allowed through
+# the gate:
 #   diag
 #   applog [minutes]    # integer, clamped to 1..120, default 10
 #   voxlog [lines]      # integer, clamped to 1..500, default 80
@@ -20,6 +18,19 @@ set -euo pipefail
 LOG_FILE="$HOME/Library/Logs/localvoxtral-build-gate.log"
 VOXLOG_FILE="$HOME/Library/Logs/voxmlx.log"
 VOXMLX_SERVICE="com.localvoxtral.voxmlx"
+# The GUI-session uid whose launchd domain hosts the voxmlx service. The gate
+# account is deliberately not that user, so launchctl needs to be told.
+VOXMLX_GUI_UID="$(id -u)"
+
+# Machine-local overrides (never committed): the gate account is separate
+# from the GUI owner account, so voxmlx's log path and GUI uid differ per
+# machine. Anyone who can write this file can already replace the gate
+# script itself, so sourcing it adds no new trust.
+GATE_CONF="$HOME/.localvoxtral-gate.conf"
+if [[ -f "$GATE_CONF" ]]; then
+  # shellcheck source=/dev/null
+  source "$GATE_CONF"
+fi
 
 original_command="${SSH_ORIGINAL_COMMAND:-}"
 
@@ -71,7 +82,7 @@ clamp_integer() {
 }
 
 launchctl_target() {
-  printf 'gui/%s/%s\n' "$(id -u)" "$VOXMLX_SERVICE"
+  printf 'gui/%s/%s\n' "$VOXMLX_GUI_UID" "$VOXMLX_SERVICE"
 }
 
 show_versions() {
@@ -195,6 +206,11 @@ run_voxlog_command() {
 
 run_svc_status() {
   show_voxmlx_service 40
+  # launchctl can't read another user's GUI domain, so when the gate account
+  # is not the service owner the print above comes back empty — processes and
+  # ports still answer the question that matters: is voxmlx up and serving?
+  show_processes
+  show_ports
 }
 
 # Fail-closed metacharacter blocklist. Note the glob subtlety: a `]` inside

--- a/scripts/remote-build.sh
+++ b/scripts/remote-build.sh
@@ -26,11 +26,32 @@ set -euo pipefail
 # order:
 #   1. LV_BUILD_HOST env var (ssh destination, e.g. user@host or an ssh alias)
 #   2. git config localvoxtral.buildhost   (set once per clone, lives in .git/config)
-# Optional: LV_BUILD_DIR — remote work dir, ~-relative (default: work/localvoxtral-remote)
+# Optional: LV_BUILD_DIR — remote work dir, ~-relative. Defaults to a
+# per-worktree name derived from the local checkout path, so parallel agents
+# in separate worktrees never contend on remote build state or its SwiftPM
+# lock. The full remote output of every run is also written to
+# .build/last-remote.log, so a crash mid-run can never eat the failing test's
+# name (don't pipe this script straight into grep — grep the log file).
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 HOST="${LV_BUILD_HOST:-$(git -C "$ROOT_DIR" config --get localvoxtral.buildhost || true)}"
-DIR="${LV_BUILD_DIR:-work/localvoxtral-remote}"
+
+TREE_SLUG="$(basename "$ROOT_DIR" | tr '[:upper:]' '[:lower:]' | tr -c 'a-z0-9' '-')"
+TREE_SLUG="${TREE_SLUG%-}"
+TREE_HASH="$(printf '%s' "$ROOT_DIR" | md5sum | cut -c1-8)"
+DIR="${LV_BUILD_DIR:-work/localvoxtral-${TREE_SLUG}-${TREE_HASH}}"
+
+REMOTE_LOG="$ROOT_DIR/.build/last-remote.log"
+
+run_remote() {
+  local remote_command="$1"
+  local status=0
+  mkdir -p "$(dirname "$REMOTE_LOG")"
+  echo "==> Running on $HOST: $remote_command"
+  ssh "$HOST" "$remote_command" 2>&1 | tee "$REMOTE_LOG" || status=$?
+  echo "==> Full output: $REMOTE_LOG"
+  return "$status"
+}
 
 if [[ -z "$HOST" ]]; then
   cat >&2 <<'MSG'
@@ -66,20 +87,16 @@ case "$CMD" in
       echo "$CMD does not accept extra arguments" >&2
       exit 1
     fi
-    REMOTE_DIAG_CMD="$(quote_remote_command "$CMD")"
-    echo "==> Running on $HOST: $REMOTE_DIAG_CMD"
-    ssh "$HOST" "$REMOTE_DIAG_CMD"
-    exit 0
+    run_remote "$(quote_remote_command "$CMD")"
+    exit $?
     ;;
   applog|voxlog)
     if [[ $# -gt 1 ]]; then
       echo "$CMD accepts at most one numeric argument" >&2
       exit 1
     fi
-    REMOTE_DIAG_CMD="$(quote_remote_command "$CMD" "$@")"
-    echo "==> Running on $HOST: $REMOTE_DIAG_CMD"
-    ssh "$HOST" "$REMOTE_DIAG_CMD"
-    exit 0
+    run_remote "$(quote_remote_command "$CMD" "$@")"
+    exit $?
     ;;
 esac
 
@@ -115,5 +132,4 @@ rsync -az --delete \
   --exclude '.git/' --exclude '.build/' --exclude 'dist/' \
   "$ROOT_DIR/" "$HOST:$DIR/"
 
-echo "==> Running on $HOST: ${REMOTE_CMD[*]}"
-ssh "$HOST" "cd $(printf '%q' "$DIR") && $(printf '%q ' "${REMOTE_CMD[@]}")"
+run_remote "cd $(printf '%q' "$DIR") && $(printf '%q ' "${REMOTE_CMD[@]}")"


### PR DESCRIPTION
## What

Four dev-loop improvements so agents on the Linux box need less babysitting:

- **`remote-build.sh`: per-worktree remote dirs by default.** The remote work dir is now derived from the local checkout path (`work/localvoxtral-<slug>-<hash8>`), so parallel agents in separate worktrees never contend on remote build state or its SwiftPM lock. `LV_BUILD_DIR` still overrides.
- **`remote-build.sh`: full remote output always tee'd to `.build/last-remote.log`.** A crash mid-run can no longer eat the failing test's name because someone piped the run through grep — the raw log always exists.
- **`scripts/mac-health.sh` (new):** fail-fast preflight — SSH gate reachable (and v1 vs v2), voxmlx port from `diag` when available, latest CI run recency as a runner-online proxy (the runners API needs an admin token this box deliberately lacks).
- **Gate v2 fixes + install runbook (`scripts/mac/README.md`):** `voxlog`/`svc-status` assumed the gate runs as the service owner; the gate account is `builder`, so both came back empty. Added a machine-local `~/.localvoxtral-gate.conf` override (`VOXLOG_FILE`, `VOXMLX_GUI_UID`) and a process/port fallback in `svc-status`. The runbook documents install, the shared-log setup for `voxlog`, and verification.

AGENTS.md updated to match (auto dirs, log file, mac-health, runbook pointer).

## Proof

- Gate dispatch logic exercised locally with a 18-case harness (12 denials incl. metacharacter injection, 5 allows, conf-override + line clamp): `passed=18 failed=0`, all denials logged.
- Live run from a fresh worktree through the real (v1) gate on the build host — auto-derived dir accepted, cold build:
  ```
  ==> Syncing working tree to builder@192.168.1.167:work/localvoxtral-lv-tooling-a616b91b
  Build complete! (16.74s)
  ==> Full output: .build/last-remote.log
  ```
  `.build/last-remote.log` verified to contain the full remote output.
- `./scripts/mac-health.sh` live:
  ```
  OK: SSH gate reachable (gate v1 — no diagnostics; install v2, see scripts/mac/README.md)
  CI:  latest run: completed/success 2026-07-05T16:26:27Z Fail fast on managed backends: ...
  ```
- Gate v2's new verbs can only be end-to-end verified after the owner installs it on the Mac (runbook § Verifying) — the local harness covers the dispatch/validation logic.