### PR TITLE
CI proof tooling: coverage summary, dSYM artifacts, on-demand ui-smoke, advisory format lint

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,18 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.swift]
+indent_style = space
+indent_size = 4
+
+[*.{yml,yaml,json}]
+indent_style = space
+indent_size = 2
+
+[Makefile]
+indent_style = tab

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -2,10 +2,14 @@
 
 ## `ci.yml`
 
-Every PR and push to main: build, unit tests, live voxmlx integration tests,
-app packaging, launch smoke test, and an installable app artifact
-(`localvoxtral-app`, fetch with `scripts/try-pr.sh`). Same-repo branches run
-on the self-hosted Mac runner; fork PRs run on GitHub-hosted macOS.
+Every PR and push to main: build, advisory format lint (`.swift-format`;
+flips to `--strict` after the one-shot tree reformat), unit tests with a
+coverage summary (`llvm-cov report` over Sources — visibility for the PR
+Proof section, not a gate), live voxmlx integration tests, app packaging,
+launch smoke test, an installable app artifact (`localvoxtral-app`, fetch
+with `scripts/try-pr.sh`), and a `localvoxtral-dsym` artifact (30-day
+retention) for symbolicating field crashes. Same-repo branches run on the
+self-hosted Mac runner; fork PRs run on GitHub-hosted macOS.
 
 ## `release.yml`
 
@@ -35,6 +39,9 @@ builds the styled DMG, verifies it with `hdiutil`, and uploads it for eyeballing
 ## `ui-smoke.yml`
 
 Nightly and manual-dispatch AX smoke drill on the self-hosted Mac runner.
+Also runs on same-repo PRs when the `needs-ui-smoke` label is added — the
+on-demand proof path for UI-affecting PRs (re-add the label to rerun after
+new pushes; fork PRs never reach the self-hosted runner, label or no label).
 It packages the app, launches a fresh menu bar instance, verifies the status
 item, checks that launch alone does not spawn managed backend processes, opens
 Settings from the status menu, selects the three settings tabs, checks the

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,12 +41,35 @@ jobs:
       - name: Build
         run: swift build
 
+      - name: Format lint (advisory)
+        # Advisory until the one-shot tree reformat lands: swift-format exits 0
+        # on findings without --strict. After the reformat, add --strict here
+        # to make style regressions block.
+        run: |
+          swift format lint --recursive --parallel Sources Tests Package.swift 2>&1 \
+            | tee format-lint.txt | tail -n 5
+          echo "format-lint findings: $(wc -l < format-lint.txt | tr -d ' ')"
+
       - name: Test (unit suite)
         # The integration suite needs a live inference backend and is exercised
         # manually; see CLAUDE.md.
         run: |
           swift test \
-            --skip RealtimeAPIVLLMIntegrationTests
+            --skip RealtimeAPIVLLMIntegrationTests \
+            --enable-code-coverage
+
+      - name: Coverage summary
+        # Visibility, not a gate: lets a PR's Proof section cite real coverage
+        # of the changed files instead of "a test exists".
+        run: |
+          set -euo pipefail
+          BIN="$(find .build -type f -name localvoxtralPackageTests -path '*.xctest/Contents/MacOS/*' | head -n 1)"
+          PROF="$(find .build -type f -name default.profdata -path '*debug*' | head -n 1)"
+          if [[ -z "$BIN" || -z "$PROF" ]]; then
+            echo "coverage data not found under .build"; exit 1
+          fi
+          xcrun llvm-cov report "$BIN" -instr-profile "$PROF" \
+            -ignore-filename-regex '(Tests|\.build)/'
 
       - name: Integration tests (live voxmlx)
         # The self-hosted runner has voxmlx serving locally (launchd service
@@ -77,6 +100,18 @@ jobs:
           name: localvoxtral-app
           path: dist/localvoxtral-app.zip
           retention-days: 7
+
+      - name: Zip dSYM for artifact upload
+        run: ditto -c -k --keepParent dist/localvoxtral.dSYM dist/localvoxtral-dSYM.zip
+
+      - name: Upload dSYM artifact
+        # Longer retention than the app: field crashes surface days after the
+        # try-pr build that produced them.
+        uses: actions/upload-artifact@v4
+        with:
+          name: localvoxtral-dsym
+          path: dist/localvoxtral-dSYM.zip
+          retention-days: 30
 
       - name: Smoke test packaged app launch
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -127,6 +127,8 @@ jobs:
             -s scripts/dmg_settings.py \
             -D app=dist/localvoxtral.app \
             "localvoxtral" "dist/localvoxtral-$TAG.dmg"
+          ditto -c -k --keepParent \
+            "dist/localvoxtral.dSYM" "dist/localvoxtral-$TAG.dSYM.zip"
           (
             cd dist
             shasum -a 256 "localvoxtral-$TAG.zip" > "localvoxtral-$TAG.zip.sha256"
@@ -153,3 +155,4 @@ jobs:
             dist/localvoxtral-${{ steps.meta.outputs.tag }}.zip.sha256
             dist/localvoxtral-${{ steps.meta.outputs.tag }}.dmg
             dist/localvoxtral-${{ steps.meta.outputs.tag }}.dmg.sha256
+            dist/localvoxtral-${{ steps.meta.outputs.tag }}.dSYM.zip

--- a/.github/workflows/ui-smoke.yml
+++ b/.github/workflows/ui-smoke.yml
@@ -4,6 +4,10 @@ on:
   workflow_dispatch:
   schedule:
     - cron: "0 4 * * *"
+  # UI-affecting PRs get automated proof on demand: add the needs-ui-smoke
+  # label (re-add it to rerun after new pushes).
+  pull_request:
+    types: [labeled]
 
 concurrency:
   group: ui-smoke-${{ github.ref }}
@@ -11,6 +15,12 @@ concurrency:
 
 jobs:
   ui-smoke:
+    # Same security invariant as ci.yml: fork PRs must never reach the
+    # self-hosted runner, label or no label.
+    if: >-
+      github.event_name != 'pull_request' ||
+      (github.event.label.name == 'needs-ui-smoke' &&
+       github.event.pull_request.head.repo.full_name == github.repository)
     runs-on: [self-hosted, macOS, ARM64]
     timeout-minutes: 20
     steps:

--- a/.swift-format
+++ b/.swift-format
@@ -1,0 +1,5 @@
+{
+  "version": 1,
+  "indentation": { "spaces": 4 },
+  "lineLength": 120
+}

--- a/scripts/package_app.sh
+++ b/scripts/package_app.sh
@@ -38,8 +38,12 @@ CONFIGURATION="${1:-release}"
 # identify the exact build — every non-release build used to say "0.3.0".
 # Releases still pass an explicit version. Fallback covers trees without git
 # metadata (remote-build rsync excludes .git) and shallow clones without tags.
-GIT_VERSION="$(git describe --tags 2>/dev/null | sed 's/^v//')"
-GIT_BUILD_NUMBER="$(git rev-list --count HEAD 2>/dev/null)"
+# `|| true` because trees without git metadata (remote-build rsync excludes
+# .git) make git exit 128, which pipefail+set -e turns into a silent death
+# before the first echo — the fallback below never got a chance (broke
+# `remote-build.sh package` when #67 introduced git-derived versions).
+GIT_VERSION="$(git describe --tags 2>/dev/null | sed 's/^v//' || true)"
+GIT_BUILD_NUMBER="$(git rev-list --count HEAD 2>/dev/null || true)"
 APP_VERSION="${2:-${GIT_VERSION:-0.0.0-dev}}"
 BUILD_NUMBER="${3:-${GIT_BUILD_NUMBER:-1}}"
 
@@ -92,9 +96,12 @@ done
 swift package resolve >/dev/null
 patch_shortcutrecorder_bundle_lookup
 
-swift build -c "$CONFIGURATION" --product localvoxtral
+# -g keeps DWARF in the object files so dsymutil can produce a dSYM below —
+# without it, field crash reports only symbolicate as well as the stripped
+# binary allows. It does not change optimization (-O still applies in release).
+swift build -c "$CONFIGURATION" --product localvoxtral -Xswiftc -g
 if patch_local_resource_bundle_lookup "$CONFIGURATION"; then
-  swift build -c "$CONFIGURATION" --product localvoxtral
+  swift build -c "$CONFIGURATION" --product localvoxtral -Xswiftc -g
 fi
 
 BINARY_PATH="$(find "$ROOT_DIR/.build" -type f -path "*/${CONFIGURATION}/localvoxtral" | head -n 1)"
@@ -102,6 +109,13 @@ if [[ -z "$BINARY_PATH" ]]; then
   echo "Unable to find built localvoxtral binary under .build."
   exit 1
 fi
+
+# Collect debug symbols while the object files still exist; CI uploads the
+# dSYM so crashes from any distributed build can be symbolicated later.
+DSYM_PATH="$ROOT_DIR/dist/localvoxtral.dSYM"
+mkdir -p "$ROOT_DIR/dist"
+rm -rf "$DSYM_PATH"
+dsymutil "$BINARY_PATH" -o "$DSYM_PATH"
 
 APP_DIR="$ROOT_DIR/dist/localvoxtral.app"
 rm -rf "$APP_DIR"
@@ -232,6 +246,8 @@ fi
 touch "$APP_DIR"
 
 echo "Packaged app: $APP_DIR"
+echo "Debug symbols: $DSYM_PATH"
+dwarfdump --uuid "$DSYM_PATH" 2>/dev/null | head -n 1 || true
 echo "Contents/MacOS:"
 find "$APP_DIR/Contents/MacOS" -maxdepth 1 -type f -exec basename {} \; | sort | sed 's/^/  /'
 echo "Launch with: open \"$APP_DIR\""


### PR DESCRIPTION
## What

- **Coverage visibility**: the unit suite runs with `--enable-code-coverage` and a new step prints the `llvm-cov report` summary over `Sources/` — PR Proof sections can cite real coverage of changed files. Visibility only, no threshold gate.
- **dSYM artifacts**: `package_app.sh` builds with `-Xswiftc -g` (does not change `-O`) and runs `dsymutil` → `dist/localvoxtral.dSYM`. `ci.yml` uploads it (`localvoxtral-dsym`, 30-day retention — field crashes surface days after the try-pr build); `release.yml` attaches `localvoxtral-<tag>.dSYM.zip` to releases.
- **Bug fix (found while proving the above)**: `remote-build.sh package` has been broken since #67 — in a tree without `.git` (rsync excludes it), `git describe` exits 128 and `set -euo pipefail` killed the script *silently* before the intended `0.0.0-dev` fallback could apply. Fixed with `|| true` inside the substitutions.
- **On-demand UI proof**: `ui-smoke.yml` now also triggers when the `needs-ui-smoke` label is added to a same-repo PR. Fork PRs can never reach the self-hosted runner (label event still checks `head.repo`).
- **Format config + advisory lint**: `.swift-format` tuned to the existing style (4-space indent, 120 cols) + `.editorconfig`. CI prints lint findings but stays green (swift-format only fails with `--strict`). Blocking enforcement needs a one-shot tree reformat first — measured at ~2,250 findings (mostly continuation-line indentation), which would conflict with in-flight PRs, so that's a separate owner-scheduled change.

## Proof

- **Packaging bug**, minimal repro (Linux, non-git dir): `set -euo pipefail; V="$(git describe --tags 2>/dev/null | sed 's/^v//')"` → `exit=128`, nothing printed. With `|| true` → `exit=0`, fallback applies.
- **Before fix**: `LV_BUILD_DIR=work/localvoxtral-ci-proof ./scripts/remote-build.sh package` → `exit=128` with zero remote output. **After fix**, same command:
  ```
  Packaged app: /Users/builder/work/localvoxtral-ci-proof/dist/localvoxtral.app
  Debug symbols: /Users/builder/work/localvoxtral-ci-proof/dist/localvoxtral.dSYM
  UUID: A30F4BDF-FA3A-351E-8F2B-50903CB10727 (arm64) .../DWARF/localvoxtral
  ```
  (exit=0 — real DWARF in the dSYM, not an empty shell)
- Workflow YAML validated; this PR's own CI run exercises the coverage + lint + dSYM-artifact steps end-to-end.
- Label trigger: adding `needs-ui-smoke` to this PR should start a UI Smoke run — will verify after opening.
- Lint baseline measured with the Swift 6.2 toolchain: 2,250 findings under the tuned config (1,941 Indentation) vs 23,775 under defaults.