### PR TITLE
Gate diag: redact process command lines, connect-test ports, voxlog/applog diagnosability

### DIFF
--- a/scripts/mac/README.md
+++ b/scripts/mac/README.md
@@ -64,8 +64,13 @@ ssh <gate-destination> 'echo pwned'   # must print "denied command"
 
 Notes:
 
-- `applog` uses `log show`, which macOS may restrict for non-admin accounts.
-  If it returns nothing for the gate account, that's the cause — the crashlog
-  workflow (`mac-crashlog.yml`) runs as the runner user and is the fallback.
+- `applog` uses `log show`, which is restricted for non-admin accounts
+  (confirmed on macOS 26: "Could not open local log store: Operation not
+  permitted" for the gate account). The crashlog workflow
+  (`mac-crashlog.yml`) runs as the runner user and is the fallback.
 - `svc-status` includes process and port sections because `launchctl print`
-  cannot read another user's GUI domain.
+  cannot read another user's GUI domain. Port checks are connect tests
+  (`nc -z`) — `lsof` only sees the gate account's own sockets.
+- Process listings deliberately print pid/user/executable only, never full
+  command lines: other users' cmdlines can embed secrets (env assignments in
+  remote-ssh invocations), and diag output flows into agent transcripts.

--- a/scripts/mac/localvoxtral-build-gate.sh
+++ b/scripts/mac/localvoxtral-build-gate.sh
@@ -112,7 +112,7 @@ show_versions() {
 
 show_processes() {
   section "Processes"
-  local process pattern
+  local process pattern pids
   for process in localvoxtral voxmlx-serve mlx_lm.server; do
     printf -- '-- %s --\n' "$process"
     if command -v pgrep >/dev/null 2>&1; then
@@ -121,7 +121,17 @@ show_processes() {
         voxmlx-serve) pattern='(^|/)voxmlx-serve( |$)' ;;
         mlx_lm.server) pattern='(^|/)mlx_lm[.]server( |$)' ;;
       esac
-      pgrep -fl "$pattern" 2>&1 || printf 'not running\n'
+      # pid/user/executable only — NEVER full command lines: other users'
+      # cmdlines can carry secrets in embedded env assignments (a Zed
+      # remote-ssh cmdline leaked a GitHub PAT through diag, 2026-07-05),
+      # and this output flows into agent transcripts and logs.
+      pids="$(pgrep -f "$pattern" 2>/dev/null || true)"
+      if [[ -n "$pids" ]]; then
+        # shellcheck disable=SC2086
+        ps -o pid=,user=,comm= -p $pids 2>/dev/null || printf 'pids: %s\n' "$pids"
+      else
+        printf 'not running\n'
+      fi
     else
       printf 'pgrep: not found\n'
     fi
@@ -133,10 +143,16 @@ show_ports() {
   local port
   for port in 8000 8471 8472; do
     printf -- '-- port %s --\n' "$port"
-    if command -v lsof >/dev/null 2>&1; then
+    # Connect test first: lsof only sees this account's sockets, so it
+    # reported "no listener" while another user's voxmlx was serving.
+    if command -v nc >/dev/null 2>&1; then
+      if nc -z -w 2 127.0.0.1 "$port" >/dev/null 2>&1; then
+        printf 'listening (connect test)\n'
+      else
+        printf 'no listener (connect test)\n'
+      fi
+    elif command -v lsof >/dev/null 2>&1; then
       lsof -nP -iTCP:"$port" -sTCP:LISTEN 2>&1 || printf 'no listener\n'
-    elif command -v nc >/dev/null 2>&1; then
-      nc -vz 127.0.0.1 "$port" 2>&1 || printf 'no listener\n'
     else
       printf 'lsof/nc: not found\n'
     fi
@@ -159,6 +175,9 @@ show_voxlog() {
 
   section "voxmlx.log"
   if [[ -f "$VOXLOG_FILE" ]]; then
+    # Size/mtime line so an empty file is distinguishable from a missing one
+    # when diagnosing remotely.
+    ls -l "$VOXLOG_FILE" 2>/dev/null || true
     tail -n "$lines" "$VOXLOG_FILE" 2>&1 || true
   else
     printf '%s: not found\n' "$VOXLOG_FILE"
@@ -168,13 +187,18 @@ show_voxlog() {
 show_applog() {
   local minutes="$1"
   local tail_lines="${2:-}"
+  local output
 
   section "localvoxtral unified log"
   if command -v log >/dev/null 2>&1; then
+    output="$(log show --style compact --last "${minutes}m" --predicate 'process == "localvoxtral"' 2>&1 || true)"
     if [[ -n "$tail_lines" ]]; then
-      (log show --style compact --last "${minutes}m" --predicate 'process == "localvoxtral"' 2>&1 || true) | tail -n "$tail_lines"
+      printf '%s\n' "$output" | tail -n "$tail_lines"
     else
-      log show --style compact --last "${minutes}m" --predicate 'process == "localvoxtral"'
+      printf '%s\n' "$output"
+    fi
+    if [[ "$output" == *"not permitted"* ]]; then
+      printf '(unified log access is restricted for this account — dispatch mac-crashlog.yml for app logs)\n'
     fi
   else
     printf 'log: not found\n'


### PR DESCRIPTION
## What

First live run of gate v2 (installed today) surfaced three defects in the diagnostic verbs:

1. **Secret leak (the reason this PR exists):** `pgrep -fl` prints full command lines of *any* matching process. A Zed remote-ssh process on the build host embeds a GitHub PAT in its command line (`env 'GITHUB_TOKEN=…'`), and the `localvoxtral` pattern matched its `cd …/localvoxtral &&` — the PAT landed verbatim in `diag`/`svc-status` output, which flows into agent transcripts and logs. Process sections now print `pid user executable` only (`ps -o pid=,user=,comm=`). The leaked token is being rotated.
2. **False "no listener":** `lsof` only sees the gate account's own sockets, so it reported port 8000 down while the owner's voxmlx was demonstrably serving. Port checks are now `nc -z -w 2` connect tests (account-independent truth).
3. **Diagnosability:** `voxlog` prints the log file's `ls -l` line so empty-vs-missing is distinguishable remotely; `applog` appends a hint pointing at `mac-crashlog.yml` when the unified log store is restricted (confirmed on macOS 26: non-admin gets "Operation not permitted").

## Proof

- Leak regression test: spawned a process whose cmdline matches the `localvoxtral` pattern and contains `FAKE_SECRET_TOKEN_ABC123`; ran `svc-status` through the gate script → `PASS: no secret in output`, listing shows `pid user comm` only.
- Full 18-case dispatch harness (12 denials incl. metacharacter injection, allows, clamps, conf override) re-run against the updated script: `passed=18 failed=0`.
- `bash -n` clean. Live verification of the new output happens on the next gate reinstall (owner step, same one-liner as the runbook).

## Field evidence (from the live run that found this)

- `diag`/`svc-status`/`voxlog` verbs work end-to-end through the installed v2 gate; denial probe correctly rejected (`denied command`, exit 126).
- `applog`: "Could not open local log store: Operation not permitted" → documented + hint added.
- Port 8000 "no listener" via lsof while `voxmlx-serve` pid 13067 was serving → fixed by connect test.