### PR TITLE
Fix flaky managed download-progress tests: await the status mirror deterministically

### DIFF
--- a/Sources/localvoxtral/DictationViewModel+Session.swift
+++ b/Sources/localvoxtral/DictationViewModel+Session.swift
@@ -65,6 +65,7 @@ extension DictationViewModel {
                     if Task.isCancelled || self.managedStartupTaskID != startupTaskID {
                         return
                     }
+                    defer { self.debugManagedStatusMirrorEventSink?() }
                     guard (!needsManagedDictation || self.settings.dictationBackendMode == .managedLocal),
                           (!needsManagedPolishing
                               || (self.settings.llmPolishingEnabled

--- a/Sources/localvoxtral/DictationViewModel.swift
+++ b/Sources/localvoxtral/DictationViewModel.swift
@@ -322,6 +322,12 @@ final class DictationViewModel {
     var debugDeltaLogSink: ((DebugRealtimeDeltaLogRecord) -> Void)?
     @ObservationIgnored
     var debugSavedSessionRecordSink: ((DictationSessionRecord) -> Void)?
+    /// Test seam: invoked after the managed-startup status mirror finishes
+    /// handling each status update (including updates its guard skips), so
+    /// tests can await mirror processing deterministically instead of
+    /// guessing with `Task.yield()`.
+    @ObservationIgnored
+    var debugManagedStatusMirrorEventSink: (() -> Void)?
     @ObservationIgnored
     var debugMicrophoneAuthorizationStatusOverride: MicrophoneAuthorizationStatus?
     @ObservationIgnored

--- a/Tests/localvoxtralTests/DictationViewModelFailFastUXTests.swift
+++ b/Tests/localvoxtralTests/DictationViewModelFailFastUXTests.swift
@@ -353,11 +353,11 @@ final class DictationViewModelFailFastUXTests: XCTestCase {
         viewModel.startDictation()
         await backendManager.waitUntilEnsureStarted()
 
-        backendManager.emitStatus(
+        await emitStatusAndAwaitMirror(
+            backendManager, viewModel: viewModel,
             spec: BackendCatalog.voxmlx,
             status: .preparingModel(progress: ModelDownloadProgress(downloadedBytes: 36, totalBytes: 100))
         )
-        await Task.yield()
 
         XCTAssertEqual(viewModel.statusText, "Downloading dictation model (36%)...")
 
@@ -380,11 +380,11 @@ final class DictationViewModelFailFastUXTests: XCTestCase {
         viewModel.startDictation()
         await backendManager.waitUntilEnsureStarted()
 
-        backendManager.emitStatus(
+        await emitStatusAndAwaitMirror(
+            backendManager, viewModel: viewModel,
             spec: BackendCatalog.mlxLM,
             status: .preparingModel(progress: ModelDownloadProgress(downloadedBytes: 1, totalBytes: 4))
         )
-        await Task.yield()
 
         XCTAssertEqual(viewModel.statusText, "Downloading polishing model (25%)...")
 
@@ -1035,6 +1035,26 @@ final class DictationViewModelFailFastUXTests: XCTestCase {
         settings.polishingBackendMode = .externalURL
         settings.dictationOutputMode = outputMode
         return settings
+    }
+
+    /// Emits a fake backend status and suspends until the view model's
+    /// managed-startup status mirror has processed it. A bare `Task.yield()`
+    /// after `emitStatus` is a scheduling race: the mirror's `for await` loop
+    /// may not have run yet when the test asserts on `statusText` (flaked on
+    /// main, CI run 28752686491).
+    private func emitStatusAndAwaitMirror(
+        _ backendManager: FakeManagedBackendManager,
+        viewModel: DictationViewModel,
+        spec: ManagedBackendSpec,
+        status: ManagedBackendStatus
+    ) async {
+        await withCheckedContinuation { continuation in
+            viewModel.debugManagedStatusMirrorEventSink = {
+                viewModel.debugManagedStatusMirrorEventSink = nil
+                continuation.resume()
+            }
+            backendManager.emitStatus(spec: spec, status: status)
+        }
     }
 
     private func retainForTestProcessLifetime(_ viewModel: DictationViewModel) {


### PR DESCRIPTION
## What

CI on main went red on 8346e48 (a README-only commit): `DictationViewModelFailFastUXTests.testManagedStartupShowsPolishingModelDownloadProgress` flaked in run [28752686491](https://github.com/T0mSIlver/localvoxtral/actions/runs/28752686491).

Root cause: the test emits a fake `.preparingModel` status and then does a single `await Task.yield()` before asserting on `statusText`. The managed-startup status mirror is a separate `for await` loop task on the MainActor; one yield does not guarantee its iteration runs before the assertion, so the test can observe the initial "Installing polishing backend..." text instead of the download-progress text. `testManagedStartupShowsDictationModelDownloadProgress` has the identical race.

Fix: add a `debugManagedStatusMirrorEventSink` test seam (same pattern as `debugDeltaLogSink`) fired after the mirror handles each status update — including updates its guard skips — and make both tests suspend on it via `withCheckedContinuation` instead of yielding. No behavior change for the app; the seam is a no-op when unset.

The other two `Task.yield()` sites in this file guard negative assertions ("nothing further happened"), where a missed yield cannot produce a spurious red, so they are left alone.

## Proof

- Failing before (main, run 28752686491 attempt 1, on a commit that touched no Swift):
  ```
  DictationViewModelFailFastUXTests.swift:389: error: -[localvoxtralTests.DictationViewModelFailFastUXTests testManagedStartupShowsPolishingModelDownloadProgress] : XCTAssertEqual failed: ("Installing polishing backend...") is not equal to ("Downloading polishing model (25%)...")
  ```
- Passing after — `./scripts/remote-build.sh test --filter DictationViewModelFailFastUXTests`:
  ```
  Test Suite 'DictationViewModelFailFastUXTests' passed at 2026-07-06 17:26:48.092.
       Executed 56 tests, with 0 failures (0 unexpected) in 0.236 (0.239) seconds
  ```
- Stress: the same filtered suite run 10x consecutively on the build host — 10/10 green (`Executed 56 tests, with 0 failures` every run).
- Flakiness is nondeterministic so the pre-fix failure cannot be reproduced on demand; the CI log above is the failing-before evidence.
- Full CI (tiers 0-1) on this PR: see checks.

Note: today's additional CI reds (UI Smoke, rerun attempt 2, this PR's first CI attempt) were a separate infra issue — the Mac runner lost communication with GitHub exactly 10 minutes after job start ("The self-hosted runner lost communication with the server"), i.e. the host was sleeping. All were re-run once the host was back.
