### PR TITLE
Terminal-safe live dictation: target detection, hold-back replacements, newline/tab sanitization

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ Open **Settings** from the menu bar popover:
 - **General** — permission status for Microphone and Accessibility (with grant buttons), copy-final-segment toggle, and Re-run Setup
 - **Endpoints** — Dictation and Polishing sections; each switches independently between `Managed local` (status row with inline install/download progress) and `External URL` (endpoint URL, model name, API key)
 - **Dictation** — the trigger (single modifier key with tap/hold gestures, or per-mode keyboard shortcuts with `Toggle` / `Push to Talk`) and the menu-bar output mode
-- **Text Processing** — exact-match replacements toggle and the shared config folder (`replacement_dictionary.toml`, `llm_system_prompt.toml`, `llm_user_prompt.toml`)
+- **Text Processing** — exact-match replacements toggle and the shared config folder (`replacement_dictionary.toml`, `llm_system_prompt.toml`, `llm_user_prompt.toml`, `terminal_apps.toml` — extra apps to treat as terminals, e.g. ones that embed one)
 - **About** — version, link to this repository, and Export Diagnostics (writes a redacted local report to the Desktop)
 
 The shared config directory lives at `~/Library/Application Support/localvoxtral/config`.

--- a/Sources/localvoxtral/AppConfigStore.swift
+++ b/Sources/localvoxtral/AppConfigStore.swift
@@ -4,6 +4,7 @@ protocol AppConfigServing {
     func configDirectoryURL() -> URL
     func loadReplacementDictionary() -> ReplacementDictionary
     func loadLLMPromptTemplates() -> LLMPromptTemplates
+    func loadTerminalAppBundleIDs() -> [String]
 }
 
 struct ReplacementEntry: Equatable, Sendable {
@@ -329,6 +330,7 @@ struct AppConfigStore: AppConfigServing {
         case replacementDictionary
         case llmSystemPrompt
         case llmUserPrompt
+        case terminalApps
 
         var fileName: String {
             switch self {
@@ -338,6 +340,8 @@ struct AppConfigStore: AppConfigServing {
                 return "llm_system_prompt.toml"
             case .llmUserPrompt:
                 return "llm_user_prompt.toml"
+            case .terminalApps:
+                return "terminal_apps.toml"
             }
         }
 
@@ -408,6 +412,25 @@ struct AppConfigStore: AppConfigServing {
             userPrompt = defaultTemplates.userContent
         }
         return LLMPromptTemplates(systemContent: systemPrompt, userContent: userPrompt)
+    }
+
+    /// User-listed bundle IDs to treat as terminals, on top of
+    /// `TerminalTargetDetector`'s built-in allowlist. Any read/parse failure
+    /// falls back to an empty list (the built-in detection still applies).
+    func loadTerminalAppBundleIDs() -> [String] {
+        let file = ConfigFile.terminalApps
+        let url = userConfigURL(for: file)
+
+        do {
+            ensureConfigFilesExist(at: resolvedConfigDirectoryURL())
+            let data = try Data(contentsOf: url)
+            return try Self.parseTerminalApps(data: data, fileName: file.fileName)
+        } catch {
+            Log.config.error(
+                "Terminal apps config fallback to empty list: \(error.localizedDescription, privacy: .public)"
+            )
+            return []
+        }
     }
 
     private func loadPromptContent(file: ConfigFile, fallback: String) -> String {
@@ -637,6 +660,62 @@ struct AppConfigStore: AppConfigServing {
 
         try finalizeCurrentEntry()
         return ReplacementDictionary(entries: entries)
+    }
+
+    private static func parseTerminalApps(
+        data: Data,
+        fileName: String
+    ) throws -> [String] {
+        guard let text = String(data: data, encoding: .utf8) else {
+            throw AppConfigError.invalidFile(fileName: fileName, reason: "File is not valid UTF-8.")
+        }
+
+        let normalizedText = text.replacingOccurrences(of: "\r\n", with: "\n")
+        let rawLines = normalizedText.components(separatedBy: "\n")
+
+        var bundleIDs: [String]?
+        var lineIndex = 0
+
+        while lineIndex < rawLines.count {
+            let line = uncommented(rawLines[lineIndex]).trimmed
+            lineIndex += 1
+
+            guard !line.isEmpty else { continue }
+            guard bundleIDs == nil else {
+                throw AppConfigError.invalidFile(
+                    fileName: fileName,
+                    reason: "Only a single bundle_ids assignment is supported."
+                )
+            }
+
+            let components = line.split(separator: "=", maxSplits: 1, omittingEmptySubsequences: false)
+            guard components.count == 2, String(components[0]).trimmed == "bundle_ids" else {
+                throw AppConfigError.invalidFile(
+                    fileName: fileName,
+                    reason: "Expected `bundle_ids = [...]` near `\(line)`."
+                )
+            }
+
+            var value = String(components[1]).trimmed
+            while !hasBalancedSquareBrackets(in: value) {
+                guard lineIndex < rawLines.count else {
+                    throw AppConfigError.invalidFile(
+                        fileName: fileName,
+                        reason: "Unterminated bundle_ids array."
+                    )
+                }
+                value += "\n" + uncommented(rawLines[lineIndex]).trimmed
+                lineIndex += 1
+            }
+
+            bundleIDs = try parseStringArray(
+                value,
+                fileName: fileName,
+                fieldName: "bundle_ids"
+            ).map { $0.trimmed }.filter { !$0.isEmpty }
+        }
+
+        return bundleIDs ?? []
     }
 
     private static func parsePromptTemplate(

--- a/Sources/localvoxtral/DictationViewModel+Session.swift
+++ b/Sources/localvoxtral/DictationViewModel+Session.swift
@@ -258,6 +258,11 @@ extension DictationViewModel {
             ? overlayBufferCoordinator.resolveAnchorNow()
             : nil
 
+        // Same timing rationale as the anchor: sample the terminal-like
+        // verdict and Secure Keyboard Entry state while the app the user
+        // started dictation in is still frontmost, not after connect.
+        captureSessionTargetVerdict()
+
         audioChunkBuffer.clear()
         livePartialText = ""
         pendingSegmentText = ""
@@ -303,7 +308,7 @@ extension DictationViewModel {
             isConnectingRealtimeSession = false
             isDictating = true
             escapeCancelHandler.start()
-            refreshSessionTargetVerdictAtSessionStart()
+            applyPreCapturedSessionTargetVerdict()
             statusText = "Listening..."
             restartAudioSendTask()
             restartCommitTask()
@@ -767,6 +772,11 @@ extension DictationViewModel {
         }
 
         if currentErrorToken == .websocketReceiveFailed {
+            lastError = nil
+        }
+        // The Secure Keyboard Entry warning describes state sampled at session
+        // start; a finished session must not leave it wedged in the popover.
+        if currentErrorToken == .secureKeyboardEntryActive {
             lastError = nil
         }
         firstChunkPreprocessor.reset()

--- a/Sources/localvoxtral/DictationViewModel+Session.swift
+++ b/Sources/localvoxtral/DictationViewModel+Session.swift
@@ -303,6 +303,7 @@ extension DictationViewModel {
             isConnectingRealtimeSession = false
             isDictating = true
             escapeCancelHandler.start()
+            refreshSessionTargetVerdictAtSessionStart()
             statusText = "Listening..."
             restartAudioSendTask()
             restartCommitTask()

--- a/Sources/localvoxtral/DictationViewModel+Session.swift
+++ b/Sources/localvoxtral/DictationViewModel+Session.swift
@@ -262,6 +262,7 @@ extension DictationViewModel {
         // verdict and Secure Keyboard Entry state while the app the user
         // started dictation in is still frontmost, not after connect.
         captureSessionTargetVerdict()
+        refreshInsertionScalarTracingForSession()
 
         audioChunkBuffer.clear()
         livePartialText = ""

--- a/Sources/localvoxtral/DictationViewModel+Session.swift
+++ b/Sources/localvoxtral/DictationViewModel+Session.swift
@@ -715,7 +715,10 @@ extension DictationViewModel {
             textInsertion.endLiveReplacementSession()
             return
         }
-        guard settings.replacementDictionaryEnabled else {
+        // Terminal-like targets always begin a live session even with the
+        // dictionary disabled: the hold-back stream's newline/tab sanitization
+        // must protect the terminal regardless of replacements.
+        guard settings.replacementDictionaryEnabled || sessionTargetIsTerminalLike else {
             textInsertion.endLiveReplacementSession()
             return
         }
@@ -725,10 +728,7 @@ extension DictationViewModel {
         textInsertion.beginLiveReplacementSession(
             dictionary: dictionary,
             preferredAppPID: overlayBufferCoordinator.commitTargetAppPID,
-            // Terminal-target detection (TerminalTargetDetector, built in a
-            // sibling change) is wired here by the orchestrator; until then
-            // every live target takes the non-terminal strategy selection.
-            isTerminalLikeTarget: false
+            isTerminalLikeTarget: sessionTargetIsTerminalLike
         )
     }
 

--- a/Sources/localvoxtral/DictationViewModel+Session.swift
+++ b/Sources/localvoxtral/DictationViewModel+Session.swift
@@ -718,7 +718,11 @@ extension DictationViewModel {
         let dictionary = replacementDictionaryForCurrentSession()
         textInsertion.beginLiveReplacementSession(
             dictionary: dictionary,
-            preferredAppPID: overlayBufferCoordinator.commitTargetAppPID
+            preferredAppPID: overlayBufferCoordinator.commitTargetAppPID,
+            // Terminal-target detection (TerminalTargetDetector, built in a
+            // sibling change) is wired here by the orchestrator; until then
+            // every live target takes the non-terminal strategy selection.
+            isTerminalLikeTarget: false
         )
     }
 

--- a/Sources/localvoxtral/DictationViewModel.swift
+++ b/Sources/localvoxtral/DictationViewModel.swift
@@ -83,6 +83,7 @@ final class DictationViewModel {
         case hotKeyHandlerRegistrationFailure
         case hotKeyShortcutUnavailable
         case websocketReceiveFailed
+        case secureKeyboardEntryActive
         case other
 
         @MainActor
@@ -91,6 +92,9 @@ final class DictationViewModel {
                 || message == DictationViewModel.liveAutoPasteAccessibilityWarningMessage
             {
                 return .accessibilityPermissionRequired
+            }
+            if message == DictationViewModel.secureKeyboardEntryWarningMessage {
+                return .secureKeyboardEntryActive
             }
             if message == HotKeyManager.handlerRegistrationErrorMessage {
                 return .hotKeyHandlerRegistrationFailure
@@ -241,6 +245,19 @@ final class DictationViewModel {
     let overlayBufferCoordinator: OverlayBufferSessionCoordinating
     @ObservationIgnored
     var preResolvedOverlayAnchor: OverlayAnchor?
+
+    /// Terminal-like verdict + Secure Keyboard Entry state sampled in
+    /// `beginDictationSession` BEFORE the socket opens — same reason as
+    /// `preResolvedOverlayAnchor` above: the user may focus another app while
+    /// the backend connects, and the session must record the app dictation
+    /// was started in. Consumed (and cleared) once audio capture starts.
+    @ObservationIgnored
+    var preCapturedSessionTargetVerdict: SessionTargetVerdict?
+
+    struct SessionTargetVerdict: Equatable, Sendable {
+        let decision: TerminalTargetDetector.Decision
+        let secureKeyboardEntryEnabled: Bool
+    }
     @ObservationIgnored
     private let hotKeyManager = HotKeyManager()
 
@@ -1362,18 +1379,42 @@ final class DictationViewModel {
         }
     }
 
-    /// Computes and stores the terminal-like verdict for the app focused right
-    /// now, and warns (without blocking) when Secure Keyboard Entry would
-    /// swallow synthetic keystrokes. Called at each dictation session start.
-    /// Lives in this file (not +Session) so the setter stays private(set).
-    func refreshSessionTargetVerdictAtSessionStart() {
-        let decision = TerminalTargetDetector.detectCurrentTarget()
-        sessionTargetIsTerminalLike = decision.isTerminalLike
-        if TerminalTargetDetector.isSecureKeyboardEntryEnabled() {
-            lastError = Self.secureKeyboardEntryWarningMessage
+    /// Samples the terminal-like verdict and Secure Keyboard Entry state for
+    /// the app focused right now. Called from `beginDictationSession` before
+    /// the socket opens (see `preCapturedSessionTargetVerdict`).
+    func captureSessionTargetVerdict() {
+        preCapturedSessionTargetVerdict = SessionTargetVerdict(
+            decision: TerminalTargetDetector.detectCurrentTarget(),
+            secureKeyboardEntryEnabled: TerminalTargetDetector.isSecureKeyboardEntryEnabled()
+        )
+    }
+
+    /// Consumes the verdict captured at `beginDictationSession` time once
+    /// audio capture starts, and warns (without blocking) when Secure
+    /// Keyboard Entry would swallow synthetic keystrokes. Lives in this file
+    /// (not +Session) so `sessionTargetIsTerminalLike` stays private(set).
+    func applyPreCapturedSessionTargetVerdict() {
+        // Fallback probe covers paths that reach audio start without a
+        // capture (should not happen; keeps the verdict defined regardless).
+        let verdict = preCapturedSessionTargetVerdict ?? SessionTargetVerdict(
+            decision: TerminalTargetDetector.detectCurrentTarget(),
+            secureKeyboardEntryEnabled: TerminalTargetDetector.isSecureKeyboardEntryEnabled()
+        )
+        preCapturedSessionTargetVerdict = nil
+        sessionTargetIsTerminalLike = verdict.decision.isTerminalLike
+
+        if verdict.secureKeyboardEntryEnabled {
+            // Never mask the Accessibility-trust warning — it explains a
+            // total insertion failure, which outranks a secure-input maybe.
+            if currentErrorToken != .accessibilityPermissionRequired {
+                lastError = Self.secureKeyboardEntryWarningMessage
+            }
             Log.target.warning(
                 "Secure Keyboard Entry is enabled at session start; synthetic keyboard events may be blocked."
             )
+        } else if currentErrorToken == .secureKeyboardEntryActive {
+            // Stale warning from an earlier session; secure input is off now.
+            lastError = nil
         }
     }
 

--- a/Sources/localvoxtral/DictationViewModel.swift
+++ b/Sources/localvoxtral/DictationViewModel.swift
@@ -1382,6 +1382,20 @@ final class DictationViewModel {
     /// Samples the terminal-like verdict and Secure Keyboard Entry state for
     /// the app focused right now. Called from `beginDictationSession` before
     /// the socket opens (see `preCapturedSessionTargetVerdict`).
+    /// Opt-in field diagnostic: scalar tracing of posted keyboard chunks is
+    /// enabled per session by the presence of the `insertion_scalar_trace`
+    /// marker file in the shared config folder (same gate pattern as the
+    /// eval-llm marker). Called at each dictation session start.
+    func refreshInsertionScalarTracingForSession() {
+        let markerURL = appConfigStore.configDirectoryURL()
+            .appendingPathComponent("insertion_scalar_trace", isDirectory: false)
+        let enabled = FileManager.default.fileExists(atPath: markerURL.path)
+        if enabled, !textInsertion.isScalarTracingEnabled {
+            Log.insertion.notice("scalar-trace enabled for this session (marker file present)")
+        }
+        textInsertion.isScalarTracingEnabled = enabled
+    }
+
     func captureSessionTargetVerdict() {
         let userBundleIDs = Set(appConfigStore.loadTerminalAppBundleIDs())
         preCapturedSessionTargetVerdict = SessionTargetVerdict(

--- a/Sources/localvoxtral/DictationViewModel.swift
+++ b/Sources/localvoxtral/DictationViewModel.swift
@@ -132,6 +132,13 @@ final class DictationViewModel {
     static let liveAutoPasteAccessibilityWarningMessage =
         "Live Auto-Paste needs Accessibility access to type into other apps. Text won't appear until you enable it in System Settings > Privacy & Security > Accessibility."
 
+    /// Surfaced at dictation start when macOS Secure Keyboard Entry is active
+    /// (e.g. Ghostty around password prompts): it blocks synthetic keyboard
+    /// events, so dictated text may silently land nowhere. Warn only — the
+    /// session still runs. One short sentence (popover copy rule).
+    static let secureKeyboardEntryWarningMessage =
+        "Secure Keyboard Entry is on; dictated text may not appear."
+
     var isDictating = false
     var isFinalizingStop = false
     var isConnectingRealtimeSession = false
@@ -149,6 +156,13 @@ final class DictationViewModel {
     var debugLastConnectFailureTechnicalDetails: String?
     #endif
     var lastFinalSegment = ""
+
+    /// Whether the app focused at the most recent session start behaves like
+    /// a terminal emulator (bundle allowlist, AX-writability heuristic
+    /// fallback). Refreshed at each session start; live replacement strategy
+    /// and future per-app behaviors key off it. See `TerminalTargetDetector`.
+    private(set) var sessionTargetIsTerminalLike = false
+
     private(set) var availableInputDevices: [MicrophoneInputDevice] = []
     private(set) var selectedInputDeviceID = ""
 
@@ -1345,6 +1359,21 @@ final class DictationViewModel {
         let status = currentMicrophoneAuthorizationStatus()
         if microphoneAuthorizationStatus != status {
             microphoneAuthorizationStatus = status
+        }
+    }
+
+    /// Computes and stores the terminal-like verdict for the app focused right
+    /// now, and warns (without blocking) when Secure Keyboard Entry would
+    /// swallow synthetic keystrokes. Called at each dictation session start.
+    /// Lives in this file (not +Session) so the setter stays private(set).
+    func refreshSessionTargetVerdictAtSessionStart() {
+        let decision = TerminalTargetDetector.detectCurrentTarget()
+        sessionTargetIsTerminalLike = decision.isTerminalLike
+        if TerminalTargetDetector.isSecureKeyboardEntryEnabled() {
+            lastError = Self.secureKeyboardEntryWarningMessage
+            Log.target.warning(
+                "Secure Keyboard Entry is enabled at session start; synthetic keyboard events may be blocked."
+            )
         }
     }
 

--- a/Sources/localvoxtral/DictationViewModel.swift
+++ b/Sources/localvoxtral/DictationViewModel.swift
@@ -1383,8 +1383,9 @@ final class DictationViewModel {
     /// the app focused right now. Called from `beginDictationSession` before
     /// the socket opens (see `preCapturedSessionTargetVerdict`).
     func captureSessionTargetVerdict() {
+        let userBundleIDs = Set(appConfigStore.loadTerminalAppBundleIDs())
         preCapturedSessionTargetVerdict = SessionTargetVerdict(
-            decision: TerminalTargetDetector.detectCurrentTarget(),
+            decision: TerminalTargetDetector.detectCurrentTarget(userBundleIDs: userBundleIDs),
             secureKeyboardEntryEnabled: TerminalTargetDetector.isSecureKeyboardEntryEnabled()
         )
     }

--- a/Sources/localvoxtral/LiveHoldBackReplacementStream.swift
+++ b/Sources/localvoxtral/LiveHoldBackReplacementStream.swift
@@ -22,10 +22,17 @@ import Foundation
 /// `lookbackStart(before:)` word segmentation, so a released prefix can
 /// never be reached by a correction the embedded corrector produces later.
 ///
-/// Newline policy (terminal targets): a typed newline can act as Enter and
-/// submit a prompt mid-dictation. When `sanitizesNewlines` is on, released
-/// text collapses each newline run — together with adjacent spaces/tabs —
-/// into a single space, including runs that span release boundaries.
+/// Newline/tab policy (terminal targets): a typed newline can act as Enter
+/// and submit a prompt mid-dictation, and a typed Tab can trigger shell
+/// completion UI — both mutate terminal state. When `sanitizesNewlines` is
+/// on, every whitespace run containing a newline or tab — including all
+/// adjacent spaces/tabs on BOTH sides of it — collapses to exactly one
+/// space, even when the run spans release boundaries or ends in the flushed
+/// remainder. To decide a run's fate, trailing spaces/tabs are buffered
+/// until the next non-whitespace character (or the remainder flush); plain
+/// space runs are then re-emitted verbatim, so no dictated text is ever
+/// dropped. Collapse runs at the very start of the session produce no
+/// leading space.
 struct LiveHoldBackReplacementStream {
     private var corrector: LiveReplacementCorrector
     private let sanitizesNewlines: Bool
@@ -33,11 +40,15 @@ struct LiveHoldBackReplacementStream {
     /// typing. Everything before this offset is immutable by construction.
     private var releasedCharacterCount = 0
 
-    // Newline sanitization state, persisted across releases so whitespace
+    // Newline/tab sanitization state, persisted across releases so whitespace
     // runs spanning chunk boundaries still collapse to a single space.
-    // Starts "as if a space was emitted" so leading newlines are dropped.
+    // Starts "as if a space was emitted" so leading collapse runs are
+    // dropped. `pendingPlainSpaces` buffers spaces whose run fate (verbatim
+    // vs collapsed) is not yet known; `pendingRunNeedsCollapse` marks the
+    // current whitespace run as containing a newline or tab.
     private var lastEmittedCharacterWasSpace = true
-    private var isAbsorbingCollapsedWhitespace = false
+    private var pendingPlainSpaces = ""
+    private var pendingRunNeedsCollapse = false
 
     init(dictionary: ReplacementDictionary, sanitizesNewlines: Bool) {
         corrector = LiveReplacementCorrector(dictionary: dictionary)
@@ -66,7 +77,13 @@ struct LiveHoldBackReplacementStream {
         if let correction = corrector.finalUnboundedCorrection() {
             corrector.apply(correction)
         }
-        return release(upTo: corrector.correctedText.count)
+        var output = release(upTo: corrector.correctedText.count)
+        if sanitizesNewlines {
+            // End of session decides the fate of a still-buffered trailing
+            // whitespace run.
+            emitPendingWhitespaceRun(into: &output)
+        }
+        return output
     }
 
     // MARK: - Private
@@ -122,30 +139,47 @@ struct LiveHoldBackReplacementStream {
         return sanitizesNewlines ? sanitizingNewlines(in: released) : released
     }
 
-    /// Collapses each newline run (with adjacent spaces/tabs) into a single
-    /// space without ever producing double spaces, tracking state across
+    /// Collapses every whitespace run containing a newline or tab — with all
+    /// adjacent spaces/tabs on both sides — into a single space, without ever
+    /// producing double spaces. Trailing spaces are buffered (not emitted)
+    /// until the next non-whitespace character or the remainder flush decides
+    /// whether the run stays verbatim or collapses; state persists across
     /// release boundaries.
     private mutating func sanitizingNewlines(in text: String) -> String {
         var output = ""
         output.reserveCapacity(text.count)
 
         for character in text {
-            if character.isNewline {
-                isAbsorbingCollapsedWhitespace = true
-                if !lastEmittedCharacterWasSpace {
-                    output.append(" ")
-                    lastEmittedCharacterWasSpace = true
+            if character.isNewline || character == "\t" {
+                pendingRunNeedsCollapse = true
+                pendingPlainSpaces = ""
+                continue
+            }
+            if character == " " {
+                if !pendingRunNeedsCollapse {
+                    pendingPlainSpaces.append(" ")
                 }
                 continue
             }
-            if isAbsorbingCollapsedWhitespace, character == " " || character == "\t" {
-                continue
-            }
-            isAbsorbingCollapsedWhitespace = false
+            emitPendingWhitespaceRun(into: &output)
             output.append(character)
-            lastEmittedCharacterWasSpace = character == " " || character == "\t"
+            lastEmittedCharacterWasSpace = false
         }
 
         return output
+    }
+
+    private mutating func emitPendingWhitespaceRun(into output: inout String) {
+        if pendingRunNeedsCollapse {
+            if !lastEmittedCharacterWasSpace {
+                output.append(" ")
+                lastEmittedCharacterWasSpace = true
+            }
+        } else if !pendingPlainSpaces.isEmpty {
+            output.append(pendingPlainSpaces)
+            lastEmittedCharacterWasSpace = true
+        }
+        pendingPlainSpaces = ""
+        pendingRunNeedsCollapse = false
     }
 }

--- a/Sources/localvoxtral/LiveHoldBackReplacementStream.swift
+++ b/Sources/localvoxtral/LiveHoldBackReplacementStream.swift
@@ -1,0 +1,151 @@
+import Foundation
+
+/// Applies replacement-dictionary rules to Live Auto-Paste text BEFORE it is
+/// typed into the target app.
+///
+/// The post-typing `LiveReplacementCorrector` path erases already-typed text
+/// with backspaces and retypes it, verified by a caret guard. Some targets
+/// can never satisfy that guard: terminals expose a screen-grid cursor over
+/// the whole scrollback (field bug 2026-07-06 — the guard armed, the first
+/// correction timed out, and the corrector stood down for the session), and
+/// targets without a readable caret used to receive blind, unverified
+/// backspaces. This stream replaces both cases: transcript text is held back
+/// until it can no longer participate in a future rule match, replacements
+/// are applied to the held text, and only corrected text is ever released
+/// for typing — no backspaces, ever.
+///
+/// Hold-back policy: the trailing partial word (no whitespace after it yet)
+/// plus the last `maxRuleWordCount - 1` complete words stay held, because
+/// they could still be part of a rule match that only completes with future
+/// text. Single-word dictionaries therefore release with zero hold beyond
+/// the trailing partial word. The policy mirrors the corrector's own
+/// `lookbackStart(before:)` word segmentation, so a released prefix can
+/// never be reached by a correction the embedded corrector produces later.
+///
+/// Newline policy (terminal targets): a typed newline can act as Enter and
+/// submit a prompt mid-dictation. When `sanitizesNewlines` is on, released
+/// text collapses each newline run — together with adjacent spaces/tabs —
+/// into a single space, including runs that span release boundaries.
+struct LiveHoldBackReplacementStream {
+    private var corrector: LiveReplacementCorrector
+    private let sanitizesNewlines: Bool
+    /// Character offset into `corrector.correctedText` already released for
+    /// typing. Everything before this offset is immutable by construction.
+    private var releasedCharacterCount = 0
+
+    // Newline sanitization state, persisted across releases so whitespace
+    // runs spanning chunk boundaries still collapse to a single space.
+    // Starts "as if a space was emitted" so leading newlines are dropped.
+    private var lastEmittedCharacterWasSpace = true
+    private var isAbsorbingCollapsedWhitespace = false
+
+    init(dictionary: ReplacementDictionary, sanitizesNewlines: Bool) {
+        corrector = LiveReplacementCorrector(dictionary: dictionary)
+        self.sanitizesNewlines = sanitizesNewlines
+    }
+
+    var ruleCount: Int {
+        corrector.ruleCount
+    }
+
+    /// Ingests the next stabilized transcript chunk and returns the text that
+    /// is now safe to type, with dictionary replacements already applied (and
+    /// newlines sanitized when the policy is on).
+    mutating func ingest(_ text: String) -> String {
+        guard !text.isEmpty else { return "" }
+        corrector.recordInsertedText(text)
+        applyCompletedBoundaryCorrections()
+        return release(upTo: safeReleaseLimit())
+    }
+
+    /// Session stop: applies a final unbounded-word match (mirroring
+    /// `completedBoundaryCorrectedText(_:dictionary:includeFinalUnboundedWord:)`)
+    /// and releases everything still held.
+    mutating func flushRemainder() -> String {
+        applyCompletedBoundaryCorrections()
+        if let correction = corrector.finalUnboundedCorrection() {
+            corrector.apply(correction)
+        }
+        return release(upTo: corrector.correctedText.count)
+    }
+
+    // MARK: - Private
+
+    private mutating func applyCompletedBoundaryCorrections() {
+        while let correction = corrector.nextCompletedBoundaryCorrection() {
+            corrector.apply(correction)
+        }
+    }
+
+    /// The largest character offset into the corrected text that no future
+    /// correction can modify. Corrections end at a future word boundary and
+    /// reach back at most `maxRuleWordCount` whitespace-separated words from
+    /// it, so the trailing partial word plus the `maxRuleWordCount - 1`
+    /// complete words before it must stay held.
+    private func safeReleaseLimit() -> Int {
+        guard corrector.hasRules else {
+            return corrector.correctedText.count
+        }
+
+        let characters = Array(corrector.correctedText)
+        var offset = characters.count
+
+        // Hold the trailing partial word (punctuation does not complete a
+        // word here: "def" in "abc def." could still grow into "def.x").
+        while offset > 0, !LiveReplacementCorrector.isWhitespace(characters[offset - 1]) {
+            offset -= 1
+        }
+
+        // Hold the last (maxRuleWordCount - 1) complete words: they may be
+        // the leading words of a multi-word match that completes later.
+        var wordsToHold = corrector.maxRuleWordCount - 1
+        while wordsToHold > 0, offset > 0 {
+            while offset > 0, LiveReplacementCorrector.isWhitespace(characters[offset - 1]) {
+                offset -= 1
+            }
+            while offset > 0, !LiveReplacementCorrector.isWhitespace(characters[offset - 1]) {
+                offset -= 1
+            }
+            wordsToHold -= 1
+        }
+
+        return max(offset, releasedCharacterCount)
+    }
+
+    private mutating func release(upTo limit: Int) -> String {
+        guard limit > releasedCharacterCount else { return "" }
+        let text = corrector.correctedText
+        let start = text.index(text.startIndex, offsetBy: releasedCharacterCount)
+        let end = text.index(text.startIndex, offsetBy: limit)
+        releasedCharacterCount = limit
+        let released = String(text[start ..< end])
+        return sanitizesNewlines ? sanitizingNewlines(in: released) : released
+    }
+
+    /// Collapses each newline run (with adjacent spaces/tabs) into a single
+    /// space without ever producing double spaces, tracking state across
+    /// release boundaries.
+    private mutating func sanitizingNewlines(in text: String) -> String {
+        var output = ""
+        output.reserveCapacity(text.count)
+
+        for character in text {
+            if character.isNewline {
+                isAbsorbingCollapsedWhitespace = true
+                if !lastEmittedCharacterWasSpace {
+                    output.append(" ")
+                    lastEmittedCharacterWasSpace = true
+                }
+                continue
+            }
+            if isAbsorbingCollapsedWhitespace, character == " " || character == "\t" {
+                continue
+            }
+            isAbsorbingCollapsedWhitespace = false
+            output.append(character)
+            lastEmittedCharacterWasSpace = character == " " || character == "\t"
+        }
+
+        return output
+    }
+}

--- a/Sources/localvoxtral/LiveReplacementCorrector.swift
+++ b/Sources/localvoxtral/LiveReplacementCorrector.swift
@@ -1,9 +1,7 @@
 import Foundation
 
 struct LiveReplacementCorrection: Sendable {
-    let erasedText: String
     let replacementText: String
-    let backspaceCount: Int
 
     fileprivate let startOffset: Int
     fileprivate let endOffset: Int
@@ -14,7 +12,6 @@ struct LiveReplacementCorrector {
     private let maxKeyWordCount: Int
     private var typedText = ""
     private var scanOffset = 0
-    private(set) var isStandingDown = false
 
     init(dictionary: ReplacementDictionary) {
         let rules = dictionary.liveReplacementRules()
@@ -64,16 +61,12 @@ struct LiveReplacementCorrector {
     }
 
     mutating func recordInsertedText(_ text: String) {
-        guard !text.isEmpty, !isStandingDown else { return }
+        guard !text.isEmpty else { return }
         typedText.append(text)
     }
 
-    mutating func standDown() {
-        isStandingDown = true
-    }
-
     mutating func nextCompletedBoundaryCorrection() -> LiveReplacementCorrection? {
-        guard !isStandingDown, !rules.isEmpty, !typedText.isEmpty else { return nil }
+        guard !rules.isEmpty, !typedText.isEmpty else { return nil }
 
         while scanOffset < typedText.count {
             let characters = Array(typedText)
@@ -116,7 +109,7 @@ struct LiveReplacementCorrector {
     }
 
     mutating func finalUnboundedCorrection() -> LiveReplacementCorrection? {
-        guard !isStandingDown, !rules.isEmpty, !typedText.isEmpty else { return nil }
+        guard !rules.isEmpty, !typedText.isEmpty else { return nil }
         let characters = Array(typedText)
         guard let last = characters.last, !Self.isCompletionBoundary(last) else { return nil }
         scanOffset = characters.count
@@ -127,7 +120,6 @@ struct LiveReplacementCorrector {
     }
 
     mutating func apply(_ correction: LiveReplacementCorrection) {
-        guard !isStandingDown else { return }
         let startIndex = typedText.index(typedText.startIndex, offsetBy: correction.startOffset)
         let endIndex = typedText.index(typedText.startIndex, offsetBy: correction.endOffset)
         typedText.replaceSubrange(startIndex ..< endIndex, with: correction.replacementText)
@@ -162,22 +154,10 @@ struct LiveReplacementCorrector {
                 let matchStartOffset = lookbackStartOffset + matchStartDelta
                 let boundaryStart = typedText.index(typedText.startIndex, offsetBy: wordEndOffset)
                 let boundaryEnd = typedText.index(typedText.startIndex, offsetBy: boundaryEndOffset)
-                let erasedStart = typedText.index(
-                    typedText.startIndex,
-                    offsetBy: matchStartOffset
-                )
-                let erasedText = String(typedText[erasedStart ..< boundaryEnd])
                 let boundaryText = String(typedText[boundaryStart ..< boundaryEnd])
 
                 return LiveReplacementCorrection(
-                    erasedText: erasedText,
                     replacementText: rule.replaceWith + boundaryText,
-                    // Keyboard backspace is counted by grapheme so composed
-                    // characters are erased as users expect in native fields.
-                    // Some web/Electron controls delete by UTF-16 unit instead;
-                    // the next caret-guard check catches that mismatch and
-                    // disables further live corrections for the session.
-                    backspaceCount: erasedText.count,
                     startOffset: matchStartOffset,
                     endOffset: boundaryEndOffset
                 )

--- a/Sources/localvoxtral/LiveReplacementCorrector.swift
+++ b/Sources/localvoxtral/LiveReplacementCorrector.swift
@@ -30,6 +30,19 @@ struct LiveReplacementCorrector {
         rules.count
     }
 
+    /// The corrected text accumulated so far (inserted text with applied
+    /// corrections). `LiveHoldBackReplacementStream` releases stable prefixes
+    /// of this text for typing.
+    var correctedText: String {
+        typedText
+    }
+
+    /// The maximum whitespace-separated word count across all rules — the
+    /// lookback window corrections can reach back into.
+    var maxRuleWordCount: Int {
+        maxKeyWordCount
+    }
+
     static func completedBoundaryCorrectedText(
         _ text: String,
         dictionary: ReplacementDictionary,
@@ -206,7 +219,11 @@ struct LiveReplacementCorrector {
         isWhitespace(character) || isPunctuation(character)
     }
 
-    private static func isWhitespace(_ character: Character) -> Bool {
+    // Internal (not private): `LiveHoldBackReplacementStream` computes its
+    // hold-back window with the exact same word segmentation as
+    // `lookbackStart(before:)` so its released prefix can never be reached by
+    // a future correction.
+    static func isWhitespace(_ character: Character) -> Bool {
         character.unicodeScalars.allSatisfy {
             CharacterSet.whitespacesAndNewlines.contains($0)
         }

--- a/Sources/localvoxtral/Log.swift
+++ b/Sources/localvoxtral/Log.swift
@@ -24,6 +24,9 @@ enum Log {
     /// privacy trade-off.
     static let deltas = Logger(subsystem: subsystem, category: "Deltas")
     static let escape = Logger(subsystem: subsystem, category: "Escape")
+    /// Session-start target detection: terminal-like verdicts and Secure
+    /// Keyboard Entry warnings (see `TerminalTargetDetector`).
+    static let target = Logger(subsystem: subsystem, category: "Target")
     static let modifierKeys = Logger(subsystem: subsystem, category: "ModifierKeys")
     static let diagnostics = Logger(subsystem: subsystem, category: "Diagnostics")
 }

--- a/Sources/localvoxtral/Resources/Config/terminal_apps.toml
+++ b/Sources/localvoxtral/Resources/Config/terminal_apps.toml
@@ -1,0 +1,17 @@
+# Apps localvoxtral should treat as terminals, in addition to the built-in
+# list (Terminal, iTerm2, Ghostty, Warp, WezTerm, kitty, Alacritty, Hyper,
+# Tabby, Rio).
+#
+# Terminal targets get terminal-safe live dictation: dictionary replacements
+# apply before text is typed (no backspace corrections), and newlines/tabs
+# are typed as spaces so nothing submits a prompt or triggers completion
+# mid-dictation. Add an app here when it embeds a terminal localvoxtral
+# doesn't detect on its own (agent managers, IDE-like apps).
+#
+# Find an app's bundle ID from any terminal:
+#   osascript -e 'id of app "AppName"'
+#
+# Example:
+# bundle_ids = ["com.cmuxterm.app", "com.microsoft.VSCode"]
+
+bundle_ids = []

--- a/Sources/localvoxtral/Resources/Config/terminal_apps.toml
+++ b/Sources/localvoxtral/Resources/Config/terminal_apps.toml
@@ -12,6 +12,6 @@
 #   osascript -e 'id of app "AppName"'
 #
 # Example:
-# bundle_ids = ["com.cmuxterm.app", "com.microsoft.VSCode"]
+# bundle_ids = ["com.microsoft.VSCode", "com.example.myterminal"]
 
 bundle_ids = []

--- a/Sources/localvoxtral/TerminalTargetDetector.swift
+++ b/Sources/localvoxtral/TerminalTargetDetector.swift
@@ -70,6 +70,9 @@ enum TerminalTargetDetector {
         "co.zeit.hyper",            // Hyper
         "org.tabby",                // Tabby (electron-builder appId)
         "com.raphaelamorim.rio",    // Rio (misc/osx Info.plist)
+        "com.cmuxterm.app",         // cmux (field-verified bundle id, 2026-07-07;
+                                    // its AX value reads writable, so the probe
+                                    // can never identify it — allowlist or bust)
     ]
 
     /// Prefix matches for apps that ship channel-suffixed bundle IDs.

--- a/Sources/localvoxtral/TerminalTargetDetector.swift
+++ b/Sources/localvoxtral/TerminalTargetDetector.swift
@@ -12,8 +12,11 @@ import Carbon
 enum TerminalTargetDetector {
     /// Why the verdict was reached; logged at session start.
     enum Reason: String, Sendable {
-        /// The frontmost app's bundle ID is on the terminal allowlist.
+        /// The frontmost app's bundle ID is on the built-in terminal allowlist.
         case bundleMatch = "bundle-match"
+        /// The frontmost app's bundle ID is in the user's terminal_apps.toml
+        /// list (apps that embed a terminal the built-in detection misses).
+        case userBundleMatch = "user-bundle-match"
         /// Unknown bundle, Accessibility trust present, and confirmed that
         /// nothing has AX focus.
         case axProbeNoFocusedElement = "ax-probe-no-focus"
@@ -82,17 +85,22 @@ enum TerminalTargetDetector {
         return terminalBundleIDPrefixes.contains { bundleID.hasPrefix($0) }
     }
 
-    /// Core decision: allowlist first; for unknown bundles fall back to the
+    /// Core decision: built-in allowlist first, then the user's
+    /// terminal_apps.toml bundle IDs; for unknown bundles fall back to the
     /// AX probe — a confirmed-missing focused element or a confirmed
     /// unsettable value attribute read as terminal-like, while an
     /// inconclusive probe does not. The probe closure is only invoked when
-    /// the bundle is unknown.
+    /// the bundle is unknown to both lists.
     static func decision(
         forBundleID bundleID: String?,
+        userBundleIDs: Set<String> = [],
         focusedElementProbe: () -> FocusedElementProbe
     ) -> Decision {
         if isTerminalLikeBundleID(bundleID) {
             return Decision(isTerminalLike: true, reason: .bundleMatch)
+        }
+        if let bundleID, userBundleIDs.contains(bundleID) {
+            return Decision(isTerminalLike: true, reason: .userBundleMatch)
         }
         switch focusedElementProbe() {
         case .noFocusedElement:
@@ -109,9 +117,9 @@ enum TerminalTargetDetector {
     /// Live verdict for the app focused right now, logged loudly (one line
     /// per session start) so field logs always show what the session decided
     /// and why.
-    static func detectCurrentTarget() -> Decision {
+    static func detectCurrentTarget(userBundleIDs: Set<String> = []) -> Decision {
         let bundleID = currentFrontmostBundleID()
-        let verdict = decision(forBundleID: bundleID) {
+        let verdict = decision(forBundleID: bundleID, userBundleIDs: userBundleIDs) {
             probeFocusedElementLive()
         }
         Log.target.notice(

--- a/Sources/localvoxtral/TerminalTargetDetector.swift
+++ b/Sources/localvoxtral/TerminalTargetDetector.swift
@@ -14,14 +14,21 @@ enum TerminalTargetDetector {
     enum Reason: String, Sendable {
         /// The frontmost app's bundle ID is on the terminal allowlist.
         case bundleMatch = "bundle-match"
-        /// Unknown bundle and no focused AX element could be read.
+        /// Unknown bundle, Accessibility trust present, and confirmed that
+        /// nothing has AX focus.
         case axProbeNoFocusedElement = "ax-probe-no-focus"
-        /// Unknown bundle and the focused element's kAXValueAttribute is not
-        /// settable — behaves like a terminal grid, not a text field.
+        /// Unknown bundle and the focused element's kAXValueAttribute is
+        /// confirmed not settable — behaves like a terminal grid, not a
+        /// text field.
         case axProbeValueNotSettable = "ax-probe-unsettable"
         /// Unknown bundle but the focused element accepts AX value writes —
         /// an ordinary text field.
         case axProbeValueSettable = "ax-probe-writable"
+        /// Unknown bundle and the probe could not tell: Accessibility trust
+        /// missing, or a transient AX error (.cannotComplete, .apiDisabled,
+        /// ...). Distinct from "confirmed writable" so field logs show the
+        /// difference.
+        case axProbeUnavailable = "ax-probe-unavailable"
     }
 
     struct Decision: Equatable, Sendable {
@@ -33,9 +40,17 @@ enum TerminalTargetDetector {
     /// settability. Injectable in DEBUG so decision logic is testable
     /// without live AX.
     enum FocusedElementProbe: Equatable, Sendable {
+        /// Trusted and confirmed: nothing has AX focus.
         case noFocusedElement
+        /// Confirmed (status == .success): the value attribute is read-only.
         case valueNotSettable
+        /// Confirmed (status == .success): the value attribute is writable.
         case valueSettable
+        /// The probe could not tell — Accessibility trust missing or a
+        /// transient AX failure. Never treated as terminal-like: a false
+        /// negative is mild (callers have independent fallbacks), a false
+        /// positive would change behavior in ordinary apps on AX flakiness.
+        case probeUnavailable
     }
 
     /// Exact bundle IDs of known terminal emulators (verified against each
@@ -68,9 +83,10 @@ enum TerminalTargetDetector {
     }
 
     /// Core decision: allowlist first; for unknown bundles fall back to the
-    /// AX probe — a missing focused element or an unsettable value attribute
-    /// both read as terminal-like. The probe closure is only invoked when the
-    /// bundle is unknown.
+    /// AX probe — a confirmed-missing focused element or a confirmed
+    /// unsettable value attribute read as terminal-like, while an
+    /// inconclusive probe does not. The probe closure is only invoked when
+    /// the bundle is unknown.
     static func decision(
         forBundleID bundleID: String?,
         focusedElementProbe: () -> FocusedElementProbe
@@ -85,6 +101,8 @@ enum TerminalTargetDetector {
             return Decision(isTerminalLike: true, reason: .axProbeValueNotSettable)
         case .valueSettable:
             return Decision(isTerminalLike: false, reason: .axProbeValueSettable)
+        case .probeUnavailable:
+            return Decision(isTerminalLike: false, reason: .axProbeUnavailable)
         }
     }
 
@@ -124,22 +142,50 @@ enum TerminalTargetDetector {
         return NSWorkspace.shared.frontmostApplication?.bundleIdentifier
     }
 
+    /// Reads AX focus directly (not via `SystemAccessibilityFocus`, which
+    /// discards the AXError) because the decision must distinguish
+    /// "confirmed nothing focused" from "the read itself failed".
     private static func probeFocusedElementLive() -> FocusedElementProbe {
         #if DEBUG
         if let override = debugFocusedElementProbeOverride {
             return override()
         }
         #endif
-        guard let (element, _) = SystemAccessibilityFocus.focusedElement() else {
+        // Without Accessibility trust every AX read fails; that says nothing
+        // about the target.
+        guard AXIsProcessTrusted() else { return .probeUnavailable }
+
+        let systemWideElement = AXUIElementCreateSystemWide()
+        var focusedObject: AnyObject?
+        let focusStatus = AXUIElementCopyAttributeValue(
+            systemWideElement,
+            kAXFocusedUIElementAttribute as CFString,
+            &focusedObject
+        )
+        switch focusStatus {
+        case .success:
+            break
+        case .noValue:
+            // Trusted and confirmed: nothing has AX focus.
+            return .noFocusedElement
+        default:
+            // Transient AX failure (.cannotComplete, .apiDisabled, ...).
+            return .probeUnavailable
+        }
+        guard let focusedObject,
+              CFGetTypeID(focusedObject) == AXUIElementGetTypeID()
+        else {
             return .noFocusedElement
         }
+
+        let element = unsafeDowncast(focusedObject, to: AXUIElement.self)
         var settable = DarwinBoolean(false)
-        let status = AXUIElementIsAttributeSettable(
+        let settableStatus = AXUIElementIsAttributeSettable(
             element,
             kAXValueAttribute as CFString,
             &settable
         )
-        guard status == .success else { return .valueNotSettable }
+        guard settableStatus == .success else { return .probeUnavailable }
         return settable.boolValue ? .valueSettable : .valueNotSettable
     }
 

--- a/Sources/localvoxtral/TerminalTargetDetector.swift
+++ b/Sources/localvoxtral/TerminalTargetDetector.swift
@@ -1,0 +1,153 @@
+import AppKit
+import ApplicationServices
+import Carbon
+
+/// Decides whether the focused dictation target behaves like a terminal
+/// emulator. Terminals accept synthetic keyboard events but reject AX value
+/// writes, and their AX "caret" (when readable at all) is a screen-grid
+/// cursor whose position never matches text-field caret arithmetic — so the
+/// live replacement strategy (and future per-app behaviors) key off this
+/// verdict, computed once per dictation session at session start.
+@MainActor
+enum TerminalTargetDetector {
+    /// Why the verdict was reached; logged at session start.
+    enum Reason: String, Sendable {
+        /// The frontmost app's bundle ID is on the terminal allowlist.
+        case bundleMatch = "bundle-match"
+        /// Unknown bundle and no focused AX element could be read.
+        case axProbeNoFocusedElement = "ax-probe-no-focus"
+        /// Unknown bundle and the focused element's kAXValueAttribute is not
+        /// settable — behaves like a terminal grid, not a text field.
+        case axProbeValueNotSettable = "ax-probe-unsettable"
+        /// Unknown bundle but the focused element accepts AX value writes —
+        /// an ordinary text field.
+        case axProbeValueSettable = "ax-probe-writable"
+    }
+
+    struct Decision: Equatable, Sendable {
+        let isTerminalLike: Bool
+        let reason: Reason
+    }
+
+    /// Result of probing the focused AX element for kAXValueAttribute
+    /// settability. Injectable in DEBUG so decision logic is testable
+    /// without live AX.
+    enum FocusedElementProbe: Equatable, Sendable {
+        case noFocusedElement
+        case valueNotSettable
+        case valueSettable
+    }
+
+    /// Exact bundle IDs of known terminal emulators (verified against each
+    /// app's shipped Info.plist / build config). VS Code and Cursor are
+    /// deliberately absent: their editor surfaces are AX-writable, and their
+    /// integrated terminals are left to the AX heuristic.
+    private static let terminalBundleIDs: Set<String> = [
+        "com.apple.Terminal",       // Terminal.app
+        "com.googlecode.iterm2",    // iTerm2
+        "com.mitchellh.ghostty",    // Ghostty
+        "com.github.wez.wezterm",   // WezTerm
+        "net.kovidgoyal.kitty",     // kitty
+        "org.alacritty",            // Alacritty
+        "co.zeit.hyper",            // Hyper
+        "org.tabby",                // Tabby (electron-builder appId)
+        "com.raphaelamorim.rio",    // Rio (misc/osx Info.plist)
+    ]
+
+    /// Prefix matches for apps that ship channel-suffixed bundle IDs.
+    /// Warp uses dev.warp.Warp-Stable / -Preview / -Dev per release channel.
+    private static let terminalBundleIDPrefixes: [String] = [
+        "dev.warp.Warp",
+    ]
+
+    /// Pure allowlist check: exact match first, then known channel prefixes.
+    static func isTerminalLikeBundleID(_ bundleID: String?) -> Bool {
+        guard let bundleID, !bundleID.isEmpty else { return false }
+        if terminalBundleIDs.contains(bundleID) { return true }
+        return terminalBundleIDPrefixes.contains { bundleID.hasPrefix($0) }
+    }
+
+    /// Core decision: allowlist first; for unknown bundles fall back to the
+    /// AX probe — a missing focused element or an unsettable value attribute
+    /// both read as terminal-like. The probe closure is only invoked when the
+    /// bundle is unknown.
+    static func decision(
+        forBundleID bundleID: String?,
+        focusedElementProbe: () -> FocusedElementProbe
+    ) -> Decision {
+        if isTerminalLikeBundleID(bundleID) {
+            return Decision(isTerminalLike: true, reason: .bundleMatch)
+        }
+        switch focusedElementProbe() {
+        case .noFocusedElement:
+            return Decision(isTerminalLike: true, reason: .axProbeNoFocusedElement)
+        case .valueNotSettable:
+            return Decision(isTerminalLike: true, reason: .axProbeValueNotSettable)
+        case .valueSettable:
+            return Decision(isTerminalLike: false, reason: .axProbeValueSettable)
+        }
+    }
+
+    /// Live verdict for the app focused right now, logged loudly (one line
+    /// per session start) so field logs always show what the session decided
+    /// and why.
+    static func detectCurrentTarget() -> Decision {
+        let bundleID = currentFrontmostBundleID()
+        let verdict = decision(forBundleID: bundleID) {
+            probeFocusedElementLive()
+        }
+        Log.target.notice(
+            "Session target verdict: terminalLike=\(verdict.isTerminalLike, privacy: .public) reason=\(verdict.reason.rawValue, privacy: .public) bundle=\(bundleID ?? "<none>", privacy: .public)"
+        )
+        return verdict
+    }
+
+    /// True when macOS Secure Keyboard Entry is active (e.g. Ghostty around
+    /// password prompts, or enabled manually in Terminal.app/iTerm2). It
+    /// blocks synthetic keyboard events, so dictated text silently lands
+    /// nowhere — callers warn, never block.
+    static func isSecureKeyboardEntryEnabled() -> Bool {
+        #if DEBUG
+        if let override = debugSecureEventInputOverride {
+            return override()
+        }
+        #endif
+        return IsSecureEventInputEnabled()
+    }
+
+    private static func currentFrontmostBundleID() -> String? {
+        #if DEBUG
+        if let override = debugFrontmostBundleIDOverride {
+            return override()
+        }
+        #endif
+        return NSWorkspace.shared.frontmostApplication?.bundleIdentifier
+    }
+
+    private static func probeFocusedElementLive() -> FocusedElementProbe {
+        #if DEBUG
+        if let override = debugFocusedElementProbeOverride {
+            return override()
+        }
+        #endif
+        guard let (element, _) = SystemAccessibilityFocus.focusedElement() else {
+            return .noFocusedElement
+        }
+        var settable = DarwinBoolean(false)
+        let status = AXUIElementIsAttributeSettable(
+            element,
+            kAXValueAttribute as CFString,
+            &settable
+        )
+        guard status == .success else { return .valueNotSettable }
+        return settable.boolValue ? .valueSettable : .valueNotSettable
+    }
+
+    #if DEBUG
+    // Test seams: the live AX/NSWorkspace/Carbon reads are not exercisable
+    // from unit tests (mirrors the debugConfigureInsertionHooks pattern).
+    static var debugFrontmostBundleIDOverride: (() -> String?)?
+    static var debugFocusedElementProbeOverride: (() -> FocusedElementProbe)?
+    static var debugSecureEventInputOverride: (() -> Bool)?
+    #endif
+}

--- a/Sources/localvoxtral/TextInsertionService.swift
+++ b/Sources/localvoxtral/TextInsertionService.swift
@@ -113,6 +113,13 @@ final class TextInsertionService {
     private var liveReplacementCorrectionTask: Task<Void, Never>?
     @ObservationIgnored
     private var pendingFinalLiveReplacementFlush = false
+    /// The correction the deferred task is currently working on, with the
+    /// phase it has reached — consulted at teardown so an abandoned
+    /// correction whose backspaces were already posted gets its erased text
+    /// restored instead of staying silently deleted from the target.
+    @ObservationIgnored
+    private var inFlightLiveReplacementCorrectionState:
+        (correction: LiveReplacementCorrection, phase: LiveReplacementCorrectionPhase)?
     private let liveReplacementCaretSettleInterval: Duration = .milliseconds(10)
     private let liveReplacementCaretSettleAttemptCount = 15
 
@@ -356,6 +363,7 @@ final class TextInsertionService {
         liveReplacementCorrectionTask = nil
         isLiveReplacementCorrectionInFlight = false
         pendingFinalLiveReplacementFlush = false
+        inFlightLiveReplacementCorrectionState = nil
         accessibilityTrust.stopTasks()
     }
 
@@ -443,13 +451,60 @@ final class TextInsertionService {
     }
 
     func endLiveReplacementSession() {
+        // Session stop can land while a deferred correction is in flight
+        // (the production stop flow runs flushFinalLiveReplacementCorrections
+        // and this teardown in the same MainActor turn, so the correction
+        // task never gets to finish — pre-existing on the guarded path).
+        // Abandoning that correction must not eat text:
+        // - if its backspaces were already posted, the erased text is
+        //   retyped raw (the correction itself is skipped);
+        // - a final flush that queued behind the in-flight correction is
+        //   drained synchronously here — the task it was deferred to is
+        //   being cancelled, so the flag would otherwise never fire and the
+        //   queued text would be silently dropped.
+        let hadQueuedFinalFlush = pendingFinalLiveReplacementFlush
+        let abandonedCorrection = inFlightLiveReplacementCorrectionState
+        let sessionDictionary = liveGuardedSessionDictionary
+
         liveReplacementCorrectionTask?.cancel()
         liveReplacementCorrectionTask = nil
         isLiveReplacementCorrectionInFlight = false
         pendingFinalLiveReplacementFlush = false
+        inFlightLiveReplacementCorrectionState = nil
         liveSessionSpan = nil
         liveReplacementCorrector = nil
         liveGuardedSessionDictionary = nil
+
+        if let abandonedCorrection, abandonedCorrection.phase == .backspacePosted {
+            // Best-effort: if the restore cannot post, the keyboard path is
+            // broken and teardown proceeds regardless.
+            if postUnicodeTextEvents(abandonedCorrection.correction.erasedText) {
+                Log.corrector.notice(
+                    "corrector teardown restored erased text chars=\(abandonedCorrection.correction.erasedText.count, privacy: .public)"
+                )
+            }
+        }
+
+        if hadQueuedFinalFlush {
+            // Route the queued text through a hold-back stream so dictionary
+            // replacements still apply to it (the corrector is already torn
+            // down above, so no backspaces can be posted). A converted or
+            // pure hold-back session drains its own stream; a guarded
+            // session gets a fresh, empty one for the queued text.
+            if liveHoldBackStream == nil, let sessionDictionary {
+                liveHoldBackStream = LiveHoldBackReplacementStream(
+                    dictionary: sessionDictionary,
+                    sanitizesNewlines: false
+                )
+            }
+            if liveHoldBackStream != nil {
+                Log.corrector.notice("corrector teardown drained queued final flush")
+                flushLiveHoldBackStream(releaseRemainder: true)
+            } else {
+                flushPendingRealtimeInsertion()
+            }
+        }
+
         liveHoldBackStream = nil
         // pendingHoldBackReleasedText intentionally survives: the session
         // cleanup path reads hasPendingInsertionText to surface lost text
@@ -582,14 +637,16 @@ final class TextInsertionService {
             return .stopped
         }
 
+        // From here on the correction's backspaces are posted: any bail-out
+        // must restore the erased text before converting.
         guard let expectedErasedCaret = expectedErasedCaretLocation(for: correction) else {
-            convertLiveReplacementCorrectionsToHoldBack(reason: "caret unavailable")
+            restoreErasedTextThenConvertToHoldBack(correction, reason: "caret unavailable")
             return .stopped
         }
 
         switch currentCaretSettlement(expectedLocation: expectedErasedCaret) {
         case .unavailable:
-            convertLiveReplacementCorrectionsToHoldBack(reason: "caret unavailable")
+            restoreErasedTextThenConvertToHoldBack(correction, reason: "caret unavailable")
             return .stopped
         case .mismatched:
             beginDeferredLiveReplacementCorrection(correction, phase: .backspacePosted)
@@ -647,6 +704,7 @@ final class TextInsertionService {
     ) {
         guard !isLiveReplacementCorrectionInFlight else { return }
         isLiveReplacementCorrectionInFlight = true
+        inFlightLiveReplacementCorrectionState = (correction, phase)
         liveReplacementCorrectionTask = Task { @MainActor [weak self] in
             await self?.completeDeferredLiveReplacementCorrection(correction, startingAt: phase)
         }
@@ -683,16 +741,19 @@ final class TextInsertionService {
                 return
             }
             currentPhase = .backspacePosted
+            inFlightLiveReplacementCorrectionState = (correction, .backspacePosted)
         }
 
         if currentPhase == .backspacePosted {
+            // The correction's backspaces are posted: any bail-out must
+            // restore the erased text before converting.
             guard let expectedErasedCaret = expectedErasedCaretLocation(for: correction) else {
-                convertLiveReplacementCorrectionsToHoldBack(reason: "caret unavailable")
+                restoreErasedTextThenConvertToHoldBack(correction, reason: "caret unavailable")
                 finishDeferredLiveReplacementCorrection()
                 return
             }
             guard await waitForLiveReplacementCaret(expectedLocation: expectedErasedCaret) else {
-                convertLiveReplacementCorrectionsToHoldBack(reason: "tracked caret diverged")
+                restoreErasedTextThenConvertToHoldBack(correction, reason: "tracked caret diverged")
                 finishDeferredLiveReplacementCorrection()
                 return
             }
@@ -733,6 +794,7 @@ final class TextInsertionService {
     private func finishDeferredLiveReplacementCorrection() {
         liveReplacementCorrectionTask = nil
         isLiveReplacementCorrectionInFlight = false
+        inFlightLiveReplacementCorrectionState = nil
         let shouldFlushFinalCorrection = pendingFinalLiveReplacementFlush
         pendingFinalLiveReplacementFlush = false
 
@@ -779,12 +841,17 @@ final class TextInsertionService {
     /// - "no valid rules" (session start): nothing to convert to — TRUE
     ///   STAND-DOWN (logged directly, never reaches this path).
     ///
-    /// The failed correction stays abandoned exactly as a stand-down would
-    /// leave it: its text is already typed raw in the target and NO
-    /// backspaces are ever posted after conversion. The fresh stream starts
-    /// EMPTY — accepted trade-off: a rule match spanning the conversion
-    /// boundary (words typed before + words after) will not apply. Newline
-    /// sanitization stays OFF because the target was not terminal-detected.
+    /// The failed correction is abandoned: NO backspaces are ever posted
+    /// after conversion. When the failure happens BEFORE its backspaces were
+    /// posted, its text is already typed raw in the target and stays raw.
+    /// When the failure happens AFTER its backspaces were posted (the
+    /// matched text is erased from the target), callers must go through
+    /// `restoreErasedTextThenConvertToHoldBack` so the erased text is
+    /// retyped raw first — conversion must never eat typed text. The fresh
+    /// stream starts EMPTY — accepted trade-off: a rule match spanning the
+    /// conversion boundary (words typed before + words after) will not
+    /// apply. Newline sanitization stays OFF because the target was not
+    /// terminal-detected.
     ///
     /// Deferred-correction state (`isLiveReplacementCorrectionInFlight`,
     /// `liveReplacementCorrectionTask`, `pendingFinalLiveReplacementFlush`)
@@ -817,6 +884,27 @@ final class TextInsertionService {
         Log.corrector.notice(
             "corrector convert strategy=holdback reason=\(reason, privacy: .public)"
         )
+    }
+
+    /// Conversion after the failed correction's backspaces were already
+    /// posted: the matched text has been erased from the target, so it is
+    /// retyped raw BEFORE converting — otherwise conversion would silently
+    /// lose the user's typed text (codex review finding, 2026-07-07). If the
+    /// restore itself cannot post, the keyboard path is broken and the
+    /// session truly stands down instead (same recovery as the existing
+    /// `postReplacementAndRecordLiveReplacementCorrection` failure path).
+    private func restoreErasedTextThenConvertToHoldBack(
+        _ correction: LiveReplacementCorrection,
+        reason: String
+    ) {
+        guard postUnicodeTextEvents(correction.erasedText) else {
+            standDownLiveReplacementCorrections(reason: "keyboard correction failed")
+            return
+        }
+        Log.corrector.notice(
+            "corrector restored erased text before convert chars=\(correction.erasedText.count, privacy: .public)"
+        )
+        convertLiveReplacementCorrectionsToHoldBack(reason: reason)
     }
 
     private func standDownLiveReplacementCorrections(reason: String) {

--- a/Sources/localvoxtral/TextInsertionService.swift
+++ b/Sources/localvoxtral/TextInsertionService.swift
@@ -116,6 +116,17 @@ final class TextInsertionService {
     private let liveReplacementCaretSettleInterval: Duration = .milliseconds(10)
     private let liveReplacementCaretSettleAttemptCount = 15
 
+    // Hold-back strategy for targets where post-typing backspace corrections
+    // cannot be verified (terminals, caret-less targets): replacements are
+    // applied BEFORE typing and no backspaces are ever posted. Mutually
+    // exclusive with `liveReplacementCorrector`.
+    @ObservationIgnored
+    private var liveHoldBackStream: LiveHoldBackReplacementStream?
+    /// Stream-released (already corrected/sanitized) text whose insertion
+    /// failed; retried as-is and never re-ingested into the stream.
+    @ObservationIgnored
+    private var pendingHoldBackReleasedText = ""
+
     private struct LiveSessionSpan: Sendable {
         var startCaretLocation: Int
         var insertedUTF16Length: Int
@@ -151,11 +162,12 @@ final class TextInsertionService {
     static let accessibilityErrorMessage = AccessibilityTrustManager.errorMessage
 
     var hasPendingInsertionText: Bool {
-        !pendingRealtimeInsertionText.isEmpty
+        !pendingRealtimeInsertionText.isEmpty || !pendingHoldBackReleasedText.isEmpty
     }
 
     func drainPendingInsertionText() -> String {
-        let text = pendingRealtimeInsertionText
+        let text = pendingHoldBackReleasedText + pendingRealtimeInsertionText
+        pendingHoldBackReleasedText = ""
         pendingRealtimeInsertionText = ""
         return text
     }
@@ -258,6 +270,11 @@ final class TextInsertionService {
     }
 
     func flushPendingRealtimeInsertion() {
+        if liveHoldBackStream != nil {
+            flushLiveHoldBackStream(releaseRemainder: false)
+            return
+        }
+
         guard !pendingRealtimeInsertionText.isEmpty else { return }
         guard !isLiveReplacementCorrectionInFlight else { return }
 
@@ -288,7 +305,7 @@ final class TextInsertionService {
                 guard !Task.isCancelled else { break }
                 guard let self else { break }
                 guard isDictating() else { continue }
-                guard !self.pendingRealtimeInsertionText.isEmpty else { continue }
+                guard self.hasPendingInsertionText else { continue }
                 self.flushPendingRealtimeInsertion()
             }
         }
@@ -339,6 +356,7 @@ final class TextInsertionService {
 
     func clearPendingText() {
         pendingRealtimeInsertionText = ""
+        pendingHoldBackReleasedText = ""
     }
 
     // MARK: - Live Auto-Paste Replacement Tracking
@@ -349,36 +367,63 @@ final class TextInsertionService {
         isTerminalLikeTarget: Bool = false
     ) {
         didLogLiveReplacementStandDown = false
+        liveReplacementCorrector = nil
+        liveSessionSpan = nil
+        liveHoldBackStream = nil
+        pendingHoldBackReleasedText = ""
+
         let entryCount = dictionary?.entries.count ?? 0
-        liveReplacementCorrector = dictionary.map { LiveReplacementCorrector(dictionary: $0) }
-        let ruleCount = liveReplacementCorrector?.ruleCount ?? 0
-        if liveReplacementCorrector?.hasRules == false {
-            liveReplacementCorrector = nil
+        let corrector = dictionary.map { LiveReplacementCorrector(dictionary: $0) }
+        let ruleCount = corrector?.ruleCount ?? 0
+
+        if isTerminalLikeTarget {
+            // Terminals expose a screen-grid caret over the whole scrollback
+            // buffer, so post-typing backspace corrections can never be
+            // verified there (field bug 2026-07-06: the caret guard armed,
+            // the first correction timed out, and the corrector stood down).
+            // Replacements are applied before typing instead, and newlines
+            // are collapsed so a typed newline can never act as Enter and
+            // submit a prompt mid-dictation.
+            liveHoldBackStream = LiveHoldBackReplacementStream(
+                dictionary: dictionary ?? ReplacementDictionary(entries: []),
+                sanitizesNewlines: true
+            )
+            Log.corrector.notice(
+                "corrector armed strategy=holdback reason=terminal entries=\(entryCount, privacy: .public) rules=\(ruleCount, privacy: .public) newline_sanitize=on"
+            )
+            return
         }
 
-        guard liveReplacementCorrector != nil else {
+        guard let dictionary, let corrector, corrector.hasRules else {
             if entryCount > 0 {
                 Log.corrector.notice(
                     "corrector stand-down reason=no valid rules entries=\(entryCount, privacy: .public)"
                 )
             }
-            liveSessionSpan = nil
             return
         }
 
         if let caretLocation = readCurrentCaretLocation(preferredAppPID: preferredAppPID) {
+            liveReplacementCorrector = corrector
             liveSessionSpan = LiveSessionSpan(
                 startCaretLocation: caretLocation,
                 insertedUTF16Length: 0,
                 preferredAppPID: preferredAppPID
             )
             Log.corrector.notice(
-                "corrector armed entries=\(entryCount, privacy: .public) rules=\(ruleCount, privacy: .public) caret_guard=on"
+                "corrector armed strategy=guarded-corrector entries=\(entryCount, privacy: .public) rules=\(ruleCount, privacy: .public) caret_guard=on"
             )
         } else {
-            liveSessionSpan = nil
+            // No readable caret means backspace corrections cannot be
+            // verified — and unverified backspaces are never posted into a
+            // target whose state we cannot observe. Hold text back and apply
+            // replacements before typing instead.
+            liveHoldBackStream = LiveHoldBackReplacementStream(
+                dictionary: dictionary,
+                sanitizesNewlines: false
+            )
             Log.corrector.notice(
-                "corrector armed entries=\(entryCount, privacy: .public) rules=\(ruleCount, privacy: .public) caret_guard=off reason=caret unavailable"
+                "corrector armed strategy=holdback reason=caret-unavailable entries=\(entryCount, privacy: .public) rules=\(ruleCount, privacy: .public) newline_sanitize=off"
             )
         }
     }
@@ -397,10 +442,18 @@ final class TextInsertionService {
         pendingFinalLiveReplacementFlush = false
         liveSessionSpan = nil
         liveReplacementCorrector = nil
+        liveHoldBackStream = nil
+        // pendingHoldBackReleasedText intentionally survives: the session
+        // cleanup path reads hasPendingInsertionText to surface lost text
+        // before calling clearPendingText().
         didLogLiveReplacementStandDown = false
     }
 
     func flushFinalLiveReplacementCorrections() {
+        if liveHoldBackStream != nil {
+            flushLiveHoldBackStream(releaseRemainder: true)
+            return
+        }
         if isLiveReplacementCorrectionInFlight {
             pendingFinalLiveReplacementFlush = true
             return
@@ -409,6 +462,43 @@ final class TextInsertionService {
     }
 
     // MARK: - Private
+
+    /// Hold-back flush path: pending raw transcript text is ingested into the
+    /// stream and only what the stream releases (already corrected, already
+    /// sanitized) is typed. Text still held by the stream is neither typed
+    /// nor retried until the stream releases it — the retry task only ever
+    /// retypes `pendingHoldBackReleasedText`, so held text cannot be
+    /// double-inserted.
+    private func flushLiveHoldBackStream(releaseRemainder: Bool) {
+        guard var stream = liveHoldBackStream else { return }
+
+        let rawText = pendingRealtimeInsertionText
+        pendingRealtimeInsertionText.removeAll(keepingCapacity: true)
+        var releasedText = pendingHoldBackReleasedText
+        pendingHoldBackReleasedText = ""
+
+        if !rawText.isEmpty {
+            releasedText += stream.ingest(rawText)
+        }
+        if releaseRemainder {
+            releasedText += stream.flushRemainder()
+        }
+        liveHoldBackStream = stream
+
+        guard !releasedText.isEmpty else { return }
+
+        switch insertTextPrioritizingKeyboard(releasedText) {
+        case .insertedByAccessibility, .insertedByKeyboardFallback:
+            break
+        case .failed:
+            // Keep the released text verbatim for the retry task; it must
+            // never be re-ingested into the stream.
+            pendingHoldBackReleasedText = releasedText
+            Log.corrector.notice(
+                "corrector holdback release failed chars=\(releasedText.count, privacy: .public) queued_for_retry=1"
+            )
+        }
+    }
 
     private func recordSuccessfulLiveInsertion(
         text: String,
@@ -452,7 +542,12 @@ final class TextInsertionService {
     ) -> LiveReplacementCorrectionResult {
         guard liveReplacementCorrector != nil else { return .stopped }
         guard liveSessionSpan != nil else {
-            return postUnguardedLiveReplacementCorrection(correction)
+            // The guarded corrector never runs without an armed caret guard
+            // (caret-less sessions use the hold-back stream instead), so a
+            // missing span mid-session means the session state was torn down.
+            // Never post unverified backspaces.
+            standDownLiveReplacementCorrections(reason: "caret guard unavailable")
+            return .stopped
         }
         guard let expectedInsertedCaret = expectedLiveReplacementCaretLocation() else {
             standDownLiveReplacementCorrections(reason: "caret unavailable")
@@ -469,16 +564,6 @@ final class TextInsertionService {
         case .matched:
             return postBackspaceAndFinishLiveReplacementCorrection(correction)
         }
-    }
-
-    private func postUnguardedLiveReplacementCorrection(
-        _ correction: LiveReplacementCorrection
-    ) -> LiveReplacementCorrectionResult {
-        guard postBackspaceEvents(count: correction.backspaceCount) else {
-            standDownLiveReplacementCorrections(reason: "keyboard correction failed")
-            return .stopped
-        }
-        return postReplacementAndRecordLiveReplacementCorrection(correction)
     }
 
     private func postBackspaceAndFinishLiveReplacementCorrection(
@@ -1101,6 +1186,10 @@ extension TextInsertionService {
 
     var debugLiveReplacementCorrectorIsActive: Bool {
         liveReplacementCorrector?.isStandingDown == false
+    }
+
+    var debugLiveHoldBackStreamIsActive: Bool {
+        liveHoldBackStream != nil
     }
 
     var debugLiveReplacementCorrectionIsInFlight: Bool {

--- a/Sources/localvoxtral/TextInsertionService.swift
+++ b/Sources/localvoxtral/TextInsertionService.swift
@@ -345,7 +345,8 @@ final class TextInsertionService {
 
     func beginLiveReplacementSession(
         dictionary: ReplacementDictionary?,
-        preferredAppPID: pid_t?
+        preferredAppPID: pid_t?,
+        isTerminalLikeTarget: Bool = false
     ) {
         didLogLiveReplacementStandDown = false
         let entryCount = dictionary?.entries.count ?? 0

--- a/Sources/localvoxtral/TextInsertionService.swift
+++ b/Sources/localvoxtral/TextInsertionService.swift
@@ -103,78 +103,29 @@ final class TextInsertionService {
     private var keyboardFallbackSuccessCount = 0
     private var activeModifierFallbackCount = 0
 
-    // Optional guard for Live Auto-Paste streaming replacements. When the
-    // target exposes a caret location, track where our typed session text
-    // should end; if the caret diverges, corrections stand down for the rest
-    // of the session.
-    @ObservationIgnored
-    private var liveSessionSpan: LiveSessionSpan?
-    @ObservationIgnored
-    private var liveReplacementCorrector: LiveReplacementCorrector?
-    @ObservationIgnored
-    private var didLogLiveReplacementStandDown = false
-    @ObservationIgnored
-    private var isLiveReplacementCorrectionInFlight = false
-    @ObservationIgnored
-    private var liveReplacementCorrectionTask: Task<Void, Never>?
-    @ObservationIgnored
-    private var pendingFinalLiveReplacementFlush = false
-    /// The correction the deferred task is currently working on, with the
-    /// phase it has reached — consulted at teardown so an abandoned
-    /// correction whose backspaces were already posted gets its erased text
-    /// restored instead of staying silently deleted from the target.
-    @ObservationIgnored
-    private var inFlightLiveReplacementCorrectionState:
-        (correction: LiveReplacementCorrection, phase: LiveReplacementCorrectionPhase)?
-    private let liveReplacementCaretSettleInterval: Duration = .milliseconds(10)
-    private let liveReplacementCaretSettleAttemptCount = 15
-
-    // Hold-back strategy for targets where post-typing backspace corrections
-    // cannot be verified (terminals, caret-less targets): replacements are
-    // applied BEFORE typing and no backspaces are ever posted. Mutually
-    // exclusive with `liveReplacementCorrector`.
+    // Live Auto-Paste streaming replacements apply the dictionary to
+    // transcript text BEFORE it is typed, via a hold-back stream: text is
+    // held until it can no longer participate in a rule match, replacements
+    // are applied to the held text, and only corrected text is ever released
+    // for typing. No caret reads, no backspaces — the post-typing backspace
+    // corrector was removed (it could never win the race against async
+    // CGEvent delivery and produced zero successful field corrections). Nil
+    // when no replacement applies (dictionary disabled / no rules /
+    // non-terminal with no rules); transcript text is then typed directly.
     @ObservationIgnored
     private var liveHoldBackStream: LiveHoldBackReplacementStream?
     /// Stream-released (already corrected/sanitized) text whose insertion
     /// failed; retried as-is and never re-ingested into the stream.
     @ObservationIgnored
     private var pendingHoldBackReleasedText = ""
-    /// The session dictionary, retained while the guarded corrector is armed
-    /// so a caret-related stand-down can convert the session to a fresh
-    /// hold-back stream instead of giving up on replacements.
-    @ObservationIgnored
-    private var liveGuardedSessionDictionary: ReplacementDictionary?
-
-    private struct LiveSessionSpan: Sendable {
-        var startCaretLocation: Int
-        var insertedUTF16Length: Int
-        let preferredAppPID: pid_t?
-    }
-
-    private enum LiveReplacementCorrectionPhase: Equatable, Sendable {
-        case insertedTextPosted
-        case backspacePosted
-    }
-
-    private enum LiveReplacementCorrectionResult {
-        case applied
-        case waiting
-        case stopped
-    }
 
 #if DEBUG
     @ObservationIgnored
     private var debugUnicodePoster: ((String) -> Bool)?
     @ObservationIgnored
-    private var debugBackspacePoster: ((Int) -> Bool)?
-    @ObservationIgnored
     private var debugModifierStateReader: (() -> Bool)?
     @ObservationIgnored
     private var debugAccessibilityInserter: ((String, pid_t?) -> Bool)?
-    @ObservationIgnored
-    private var debugCaretLocationReader: ((pid_t?) -> Int?)?
-    @ObservationIgnored
-    private var debugLiveReplacementSettleSleep: (() async -> Void)?
 #endif
 
     static let accessibilityErrorMessage = AccessibilityTrustManager.errorMessage
@@ -288,28 +239,21 @@ final class TextInsertionService {
     }
 
     func flushPendingRealtimeInsertion() {
+        // Replacement-active sessions route all transcript text through the
+        // hold-back stream (replacements applied before typing). Sessions with
+        // no active stream (dictionary disabled / no rules) type directly.
         if liveHoldBackStream != nil {
             flushLiveHoldBackStream(releaseRemainder: false)
             return
         }
 
         guard !pendingRealtimeInsertionText.isEmpty else { return }
-        guard !isLiveReplacementCorrectionInFlight else { return }
 
         let insertedText = pendingRealtimeInsertionText
-        let result = insertTextPrioritizingKeyboard(insertedText)
-
-        switch result {
+        switch insertTextPrioritizingKeyboard(insertedText) {
         case .insertedByAccessibility, .insertedByKeyboardFallback:
             pendingRealtimeInsertionText.removeAll(keepingCapacity: true)
-            recordSuccessfulLiveInsertion(
-                text: insertedText,
-                result: result
-            )
         case .failed:
-            standDownLiveReplacementCorrections(
-                reason: "realtime insertion failed"
-            )
             break
         }
     }
@@ -365,11 +309,6 @@ final class TextInsertionService {
     func stopAllTasks() {
         insertionRetryTask?.cancel()
         insertionRetryTask = nil
-        liveReplacementCorrectionTask?.cancel()
-        liveReplacementCorrectionTask = nil
-        isLiveReplacementCorrectionInFlight = false
-        pendingFinalLiveReplacementFlush = false
-        inFlightLiveReplacementCorrectionState = nil
         accessibilityTrust.stopTasks()
     }
 
@@ -385,25 +324,19 @@ final class TextInsertionService {
         preferredAppPID: pid_t?,
         isTerminalLikeTarget: Bool = false
     ) {
-        didLogLiveReplacementStandDown = false
-        liveReplacementCorrector = nil
-        liveSessionSpan = nil
-        liveGuardedSessionDictionary = nil
         liveHoldBackStream = nil
         pendingHoldBackReleasedText = ""
 
         let entryCount = dictionary?.entries.count ?? 0
-        let corrector = dictionary.map { LiveReplacementCorrector(dictionary: $0) }
-        let ruleCount = corrector?.ruleCount ?? 0
+        let ruleCount = dictionary.map { LiveReplacementCorrector(dictionary: $0).ruleCount } ?? 0
 
         if isTerminalLikeTarget {
             // Terminals expose a screen-grid caret over the whole scrollback
-            // buffer, so post-typing backspace corrections can never be
-            // verified there (field bug 2026-07-06: the caret guard armed,
-            // the first correction timed out, and the corrector stood down).
-            // Replacements are applied before typing instead, and newlines
-            // are collapsed so a typed newline can never act as Enter and
-            // submit a prompt mid-dictation.
+            // buffer, so replacements are always applied before typing and a
+            // typed newline/tab is collapsed to a space — it can never act as
+            // Enter and submit a prompt (or trigger completion) mid-dictation.
+            // The hold-back stream is armed even with no rules so the newline
+            // sanitization still runs.
             liveHoldBackStream = LiveHoldBackReplacementStream(
                 dictionary: dictionary ?? ReplacementDictionary(entries: []),
                 sanitizesNewlines: true
@@ -414,7 +347,11 @@ final class TextInsertionService {
             return
         }
 
-        guard let dictionary, let corrector, corrector.hasRules else {
+        // Non-terminal: with no valid rules there is nothing to correct, so
+        // text is typed directly (no hold-back delay). With rules, apply them
+        // before typing via the same stream (newline sanitization off — a
+        // real editor should keep the user's newlines).
+        guard let dictionary, LiveReplacementCorrector(dictionary: dictionary).hasRules else {
             if entryCount > 0 {
                 Log.corrector.notice(
                     "corrector stand-down reason=no valid rules entries=\(entryCount, privacy: .public)"
@@ -423,111 +360,34 @@ final class TextInsertionService {
             return
         }
 
-        if let caretLocation = readCurrentCaretLocation(preferredAppPID: preferredAppPID) {
-            liveReplacementCorrector = corrector
-            liveGuardedSessionDictionary = dictionary
-            liveSessionSpan = LiveSessionSpan(
-                startCaretLocation: caretLocation,
-                insertedUTF16Length: 0,
-                preferredAppPID: preferredAppPID
-            )
-            Log.corrector.notice(
-                "corrector armed strategy=guarded-corrector entries=\(entryCount, privacy: .public) rules=\(ruleCount, privacy: .public) caret_guard=on"
-            )
-        } else {
-            // No readable caret means backspace corrections cannot be
-            // verified — and unverified backspaces are never posted into a
-            // target whose state we cannot observe. Hold text back and apply
-            // replacements before typing instead.
-            liveHoldBackStream = LiveHoldBackReplacementStream(
-                dictionary: dictionary,
-                sanitizesNewlines: false
-            )
-            Log.corrector.notice(
-                "corrector armed strategy=holdback reason=caret-unavailable entries=\(entryCount, privacy: .public) rules=\(ruleCount, privacy: .public) newline_sanitize=off"
-            )
-        }
-    }
-
-    /// Accumulates the UTF-16 length of text successfully inserted during the
-    /// session. Kept as a narrow test hook for the caret guard bookkeeping.
-    func recordSuccessfulLiveInsertion(utf16Length: Int) {
-        guard utf16Length > 0 else { return }
-        liveSessionSpan?.insertedUTF16Length += utf16Length
+        liveHoldBackStream = LiveHoldBackReplacementStream(
+            dictionary: dictionary,
+            sanitizesNewlines: false
+        )
+        Log.corrector.notice(
+            "corrector armed strategy=holdback entries=\(entryCount, privacy: .public) rules=\(ruleCount, privacy: .public) newline_sanitize=off"
+        )
     }
 
     func endLiveReplacementSession() {
-        // Session stop can land while a deferred correction is in flight
-        // (the production stop flow runs flushFinalLiveReplacementCorrections
-        // and this teardown in the same MainActor turn, so the correction
-        // task never gets to finish — pre-existing on the guarded path).
-        // Abandoning that correction must not eat text:
-        // - if its backspaces were already posted, the erased text is
-        //   retyped raw (the correction itself is skipped);
-        // - a final flush that queued behind the in-flight correction is
-        //   drained synchronously here — the task it was deferred to is
-        //   being cancelled, so the flag would otherwise never fire and the
-        //   queued text would be silently dropped.
-        let hadQueuedFinalFlush = pendingFinalLiveReplacementFlush
-        let abandonedCorrection = inFlightLiveReplacementCorrectionState
-        let sessionDictionary = liveGuardedSessionDictionary
-
-        liveReplacementCorrectionTask?.cancel()
-        liveReplacementCorrectionTask = nil
-        isLiveReplacementCorrectionInFlight = false
-        pendingFinalLiveReplacementFlush = false
-        inFlightLiveReplacementCorrectionState = nil
-        liveSessionSpan = nil
-        liveReplacementCorrector = nil
-        liveGuardedSessionDictionary = nil
-
-        if let abandonedCorrection, abandonedCorrection.phase == .backspacePosted {
-            // Best-effort: if the restore cannot post, the keyboard path is
-            // broken and teardown proceeds regardless.
-            if postUnicodeTextEvents(abandonedCorrection.correction.erasedText) {
-                Log.corrector.notice(
-                    "corrector teardown restored erased text chars=\(abandonedCorrection.correction.erasedText.count, privacy: .public)"
-                )
-            }
+        // Teardown: flush any text the stream is still holding so a stopped
+        // session never drops its trailing word(s). Idempotent with the
+        // production stop flow, which calls flushFinalLiveReplacementCorrections
+        // first — a second remainder flush releases nothing (already at the
+        // end) and only retries text whose insertion had failed.
+        if liveHoldBackStream != nil {
+            flushLiveHoldBackStream(releaseRemainder: true)
         }
-
-        if hadQueuedFinalFlush {
-            // Route the queued text through a hold-back stream so dictionary
-            // replacements still apply to it (the corrector is already torn
-            // down above, so no backspaces can be posted). A converted or
-            // pure hold-back session drains its own stream; a guarded
-            // session gets a fresh, empty one for the queued text.
-            if liveHoldBackStream == nil, let sessionDictionary {
-                liveHoldBackStream = LiveHoldBackReplacementStream(
-                    dictionary: sessionDictionary,
-                    sanitizesNewlines: false
-                )
-            }
-            if liveHoldBackStream != nil {
-                Log.corrector.notice("corrector teardown drained queued final flush")
-                flushLiveHoldBackStream(releaseRemainder: true)
-            } else {
-                flushPendingRealtimeInsertion()
-            }
-        }
-
         liveHoldBackStream = nil
         // pendingHoldBackReleasedText intentionally survives: the session
         // cleanup path reads hasPendingInsertionText to surface lost text
         // before calling clearPendingText().
-        didLogLiveReplacementStandDown = false
     }
 
     func flushFinalLiveReplacementCorrections() {
-        if liveHoldBackStream != nil {
-            flushLiveHoldBackStream(releaseRemainder: true)
-            return
-        }
-        if isLiveReplacementCorrectionInFlight {
-            pendingFinalLiveReplacementFlush = true
-            return
-        }
-        processLiveReplacementCorrections(includeFinalUnboundedWord: true)
+        // Session stop: release the whole held tail with replacements applied.
+        guard liveHoldBackStream != nil else { return }
+        flushLiveHoldBackStream(releaseRemainder: true)
     }
 
     // MARK: - Private
@@ -565,361 +425,6 @@ final class TextInsertionService {
             pendingHoldBackReleasedText = releasedText
             Log.corrector.notice(
                 "corrector holdback release failed chars=\(releasedText.count, privacy: .public) queued_for_retry=1"
-            )
-        }
-    }
-
-    private func recordSuccessfulLiveInsertion(
-        text: String,
-        result: TextInsertResult
-    ) {
-        recordSuccessfulLiveInsertion(utf16Length: (text as NSString).length)
-
-        guard liveReplacementCorrector != nil else { return }
-        guard result == .insertedByKeyboardFallback else {
-            standDownLiveReplacementCorrections(
-                reason: "realtime insertion did not use the keyboard path"
-            )
-            return
-        }
-
-        liveReplacementCorrector?.recordInsertedText(text)
-        processLiveReplacementCorrections(includeFinalUnboundedWord: false)
-    }
-
-    private func processLiveReplacementCorrections(includeFinalUnboundedWord: Bool) {
-        guard !isLiveReplacementCorrectionInFlight else { return }
-
-        while let correction = liveReplacementCorrector?.nextCompletedBoundaryCorrection() {
-            switch applyOrDeferLiveReplacementCorrection(correction) {
-            case .applied:
-                continue
-            case .waiting, .stopped:
-                return
-            }
-        }
-
-        if includeFinalUnboundedWord,
-           let correction = liveReplacementCorrector?.finalUnboundedCorrection()
-        {
-            _ = applyOrDeferLiveReplacementCorrection(correction)
-        }
-    }
-
-    private func applyOrDeferLiveReplacementCorrection(
-        _ correction: LiveReplacementCorrection
-    ) -> LiveReplacementCorrectionResult {
-        guard liveReplacementCorrector != nil else { return .stopped }
-        guard liveSessionSpan != nil else {
-            // The guarded corrector never runs without an armed caret guard
-            // (caret-less sessions use the hold-back stream instead), so a
-            // missing span mid-session means the caret guard is gone. Never
-            // post unverified backspaces — convert to pre-typing replacements.
-            convertLiveReplacementCorrectionsToHoldBack(reason: "caret guard unavailable")
-            return .stopped
-        }
-        guard let expectedInsertedCaret = expectedLiveReplacementCaretLocation() else {
-            convertLiveReplacementCorrectionsToHoldBack(reason: "caret unavailable")
-            return .stopped
-        }
-
-        switch currentCaretSettlement(expectedLocation: expectedInsertedCaret) {
-        case .unavailable:
-            convertLiveReplacementCorrectionsToHoldBack(reason: "caret unavailable")
-            return .stopped
-        case .mismatched:
-            beginDeferredLiveReplacementCorrection(correction, phase: .insertedTextPosted)
-            return .waiting
-        case .matched:
-            return postBackspaceAndFinishLiveReplacementCorrection(correction)
-        }
-    }
-
-    private func postBackspaceAndFinishLiveReplacementCorrection(
-        _ correction: LiveReplacementCorrection
-    ) -> LiveReplacementCorrectionResult {
-        guard postBackspaceEvents(count: correction.backspaceCount) else {
-            standDownLiveReplacementCorrections(reason: "keyboard correction failed")
-            return .stopped
-        }
-
-        // From here on the correction's backspaces are posted: any bail-out
-        // must restore the erased text before converting.
-        guard let expectedErasedCaret = expectedErasedCaretLocation(for: correction) else {
-            restoreErasedTextThenConvertToHoldBack(correction, reason: "caret unavailable")
-            return .stopped
-        }
-
-        switch currentCaretSettlement(expectedLocation: expectedErasedCaret) {
-        case .unavailable:
-            restoreErasedTextThenConvertToHoldBack(correction, reason: "caret unavailable")
-            return .stopped
-        case .mismatched:
-            beginDeferredLiveReplacementCorrection(correction, phase: .backspacePosted)
-            return .waiting
-        case .matched:
-            return postReplacementAndRecordLiveReplacementCorrection(correction)
-        }
-    }
-
-    private func postReplacementAndRecordLiveReplacementCorrection(
-        _ correction: LiveReplacementCorrection
-    ) -> LiveReplacementCorrectionResult {
-        guard postUnicodeTextEvents(correction.replacementText) else {
-            _ = postUnicodeTextEvents(correction.erasedText)
-            standDownLiveReplacementCorrections(reason: "keyboard correction failed")
-            return .stopped
-        }
-
-        liveReplacementCorrector?.apply(correction)
-        liveSessionSpan?.insertedUTF16Length +=
-            (correction.replacementText as NSString).length - (correction.erasedText as NSString).length
-        Log.corrector.notice(
-            "corrector correction posted erased_chars=\(correction.erasedText.count, privacy: .public) replacement_chars=\(correction.replacementText.count, privacy: .public)"
-        )
-        return .applied
-    }
-
-    private enum CaretSettlement {
-        case matched
-        case mismatched
-        case unavailable
-    }
-
-    private func currentCaretSettlement(expectedLocation: Int) -> CaretSettlement {
-        guard let span = liveSessionSpan else { return .unavailable }
-        guard let caretLocation = readCurrentCaretLocation(preferredAppPID: span.preferredAppPID) else {
-            return .unavailable
-        }
-        return caretLocation == expectedLocation ? .matched : .mismatched
-    }
-
-    private func expectedLiveReplacementCaretLocation() -> Int? {
-        guard let span = liveSessionSpan else { return nil }
-        return span.startCaretLocation + span.insertedUTF16Length
-    }
-
-    private func expectedErasedCaretLocation(for correction: LiveReplacementCorrection) -> Int? {
-        guard let expectedInsertedCaret = expectedLiveReplacementCaretLocation() else { return nil }
-        return expectedInsertedCaret - (correction.erasedText as NSString).length
-    }
-
-    private func beginDeferredLiveReplacementCorrection(
-        _ correction: LiveReplacementCorrection,
-        phase: LiveReplacementCorrectionPhase
-    ) {
-        guard !isLiveReplacementCorrectionInFlight else { return }
-        isLiveReplacementCorrectionInFlight = true
-        inFlightLiveReplacementCorrectionState = (correction, phase)
-        liveReplacementCorrectionTask = Task { @MainActor [weak self] in
-            await self?.completeDeferredLiveReplacementCorrection(correction, startingAt: phase)
-        }
-    }
-
-    private func completeDeferredLiveReplacementCorrection(
-        _ correction: LiveReplacementCorrection,
-        startingAt phase: LiveReplacementCorrectionPhase
-    ) async {
-        guard liveReplacementCorrector != nil else {
-            finishDeferredLiveReplacementCorrection()
-            return
-        }
-
-        var currentPhase = phase
-        if currentPhase == .insertedTextPosted {
-            guard let expectedInsertedCaret = expectedLiveReplacementCaretLocation() else {
-                convertLiveReplacementCorrectionsToHoldBack(reason: "caret unavailable")
-                finishDeferredLiveReplacementCorrection()
-                return
-            }
-            guard await waitForLiveReplacementCaret(expectedLocation: expectedInsertedCaret) else {
-                // The field case (cmux, 2026-07-07): the correction's caret
-                // math never matches a terminal grid. The failed correction's
-                // text is already typed raw and stays raw; all FUTURE text
-                // flows through a fresh hold-back stream.
-                convertLiveReplacementCorrectionsToHoldBack(reason: "tracked caret diverged")
-                finishDeferredLiveReplacementCorrection()
-                return
-            }
-            guard postBackspaceEvents(count: correction.backspaceCount) else {
-                standDownLiveReplacementCorrections(reason: "keyboard correction failed")
-                finishDeferredLiveReplacementCorrection()
-                return
-            }
-            currentPhase = .backspacePosted
-            inFlightLiveReplacementCorrectionState = (correction, .backspacePosted)
-        }
-
-        if currentPhase == .backspacePosted {
-            // The correction's backspaces are posted: any bail-out must
-            // restore the erased text before converting.
-            guard let expectedErasedCaret = expectedErasedCaretLocation(for: correction) else {
-                restoreErasedTextThenConvertToHoldBack(correction, reason: "caret unavailable")
-                finishDeferredLiveReplacementCorrection()
-                return
-            }
-            guard await waitForLiveReplacementCaret(expectedLocation: expectedErasedCaret) else {
-                restoreErasedTextThenConvertToHoldBack(correction, reason: "tracked caret diverged")
-                finishDeferredLiveReplacementCorrection()
-                return
-            }
-        }
-
-        _ = postReplacementAndRecordLiveReplacementCorrection(correction)
-        finishDeferredLiveReplacementCorrection()
-    }
-
-    private func waitForLiveReplacementCaret(expectedLocation: Int) async -> Bool {
-        for _ in 0 ..< liveReplacementCaretSettleAttemptCount {
-            await sleepForLiveReplacementCaretSettleInterval()
-            switch currentCaretSettlement(expectedLocation: expectedLocation) {
-            case .matched:
-                return true
-            case .mismatched:
-                continue
-            case .unavailable:
-                return false
-            }
-        }
-        Log.corrector.notice(
-            "corrector settle timeout expected_utf16=\(expectedLocation, privacy: .public)"
-        )
-        return false
-    }
-
-    private func sleepForLiveReplacementCaretSettleInterval() async {
-#if DEBUG
-        if let debugLiveReplacementSettleSleep {
-            await debugLiveReplacementSettleSleep()
-            return
-        }
-#endif
-        try? await Task.sleep(for: liveReplacementCaretSettleInterval)
-    }
-
-    private func finishDeferredLiveReplacementCorrection() {
-        liveReplacementCorrectionTask = nil
-        isLiveReplacementCorrectionInFlight = false
-        inFlightLiveReplacementCorrectionState = nil
-        let shouldFlushFinalCorrection = pendingFinalLiveReplacementFlush
-        pendingFinalLiveReplacementFlush = false
-
-        if liveHoldBackStream != nil {
-            // The deferred correction converted the session to the hold-back
-            // stream mid-flight. Text queued while the correction was in
-            // flight — and a final flush requested during it — must flow into
-            // the stream exactly once, never back into the guarded path.
-            flushLiveHoldBackStream(releaseRemainder: shouldFlushFinalCorrection)
-            return
-        }
-
-        processLiveReplacementCorrections(includeFinalUnboundedWord: shouldFlushFinalCorrection)
-        flushPendingRealtimeInsertion()
-    }
-
-    /// Converts a guarded-corrector session to the hold-back stream after a
-    /// caret-related failure, instead of disabling replacements for the rest
-    /// of the session. Field bug (owner's Mac, 2026-07-07): cmux
-    /// (`com.cmuxterm.app`) hosts a terminal but reports a WRITABLE focused
-    /// AX value, so it is honestly classified non-terminal; the guarded
-    /// corrector armed with caret_guard=on, the first correction's caret
-    /// math never matched the terminal grid, and after "stand-down
-    /// reason=tracked caret diverged" replacements were silently dead.
-    /// Undetected terminal-hosts will keep appearing, so a caret-related
-    /// stand-down now converts.
-    ///
-    /// Stand-down reason classification (every call site):
-    /// - "tracked caret diverged", "caret unavailable", "caret guard
-    ///   unavailable": caret VERIFICATION broke, but typing still works —
-    ///   CONVERT. The hold-back stream needs no caret: it applies
-    ///   replacements before typing and never posts backspaces.
-    /// - "keyboard correction failed": Unicode/backspace key events cannot
-    ///   post; the hold-back stream types with the same Unicode events, so
-    ///   conversion cannot help — TRUE STAND-DOWN.
-    /// - "realtime insertion failed": no insertion path works at all — TRUE
-    ///   STAND-DOWN.
-    /// - "realtime insertion did not use the keyboard path": the raw chunk
-    ///   landed via AX replace, so backspace-count math is unsafe. The
-    ///   hold-back stream would technically work (it is insertion-path
-    ///   agnostic), but this is not the field failure mode and mixed
-    ///   AX/keyboard sessions keep the proven stand-down behavior — TRUE
-    ///   STAND-DOWN.
-    /// - "no valid rules" (session start): nothing to convert to — TRUE
-    ///   STAND-DOWN (logged directly, never reaches this path).
-    ///
-    /// The failed correction is abandoned: NO backspaces are ever posted
-    /// after conversion. When the failure happens BEFORE its backspaces were
-    /// posted, its text is already typed raw in the target and stays raw.
-    /// When the failure happens AFTER its backspaces were posted (the
-    /// matched text is erased from the target), callers must go through
-    /// `restoreErasedTextThenConvertToHoldBack` so the erased text is
-    /// retyped raw first — conversion must never eat typed text. The fresh
-    /// stream starts EMPTY — accepted trade-off: a rule match spanning the
-    /// conversion boundary (words typed before + words after) will not
-    /// apply. Newline sanitization stays OFF because the target was not
-    /// terminal-detected.
-    ///
-    /// Deferred-correction state (`isLiveReplacementCorrectionInFlight`,
-    /// `liveReplacementCorrectionTask`, `pendingFinalLiveReplacementFlush`)
-    /// is deliberately NOT touched here: every deferred conversion site runs
-    /// inside the correction task and calls
-    /// `finishDeferredLiveReplacementCorrection()` immediately after, which
-    /// resets that state and routes text queued during the defer into the
-    /// stream exactly once; synchronous sites can only be reached with no
-    /// correction in flight.
-    private func convertLiveReplacementCorrectionsToHoldBack(reason: String) {
-        guard liveReplacementCorrector != nil,
-              let dictionary = liveGuardedSessionDictionary
-        else {
-            // No armed guarded session (or no dictionary to rebuild from):
-            // fall back to the plain stand-down.
-            standDownLiveReplacementCorrections(reason: reason)
-            return
-        }
-
-        // Tear down the guarded machinery so nothing can post backspaces or
-        // re-enter the guarded path for the rest of the session.
-        liveReplacementCorrector = nil
-        liveSessionSpan = nil
-        liveGuardedSessionDictionary = nil
-
-        liveHoldBackStream = LiveHoldBackReplacementStream(
-            dictionary: dictionary,
-            sanitizesNewlines: false
-        )
-        Log.corrector.notice(
-            "corrector convert strategy=holdback reason=\(reason, privacy: .public)"
-        )
-    }
-
-    /// Conversion after the failed correction's backspaces were already
-    /// posted: the matched text has been erased from the target, so it is
-    /// retyped raw BEFORE converting — otherwise conversion would silently
-    /// lose the user's typed text (codex review finding, 2026-07-07). If the
-    /// restore itself cannot post, the keyboard path is broken and the
-    /// session truly stands down instead (same recovery as the existing
-    /// `postReplacementAndRecordLiveReplacementCorrection` failure path).
-    private func restoreErasedTextThenConvertToHoldBack(
-        _ correction: LiveReplacementCorrection,
-        reason: String
-    ) {
-        guard postUnicodeTextEvents(correction.erasedText) else {
-            standDownLiveReplacementCorrections(reason: "keyboard correction failed")
-            return
-        }
-        Log.corrector.notice(
-            "corrector restored erased text before convert chars=\(correction.erasedText.count, privacy: .public)"
-        )
-        convertLiveReplacementCorrectionsToHoldBack(reason: reason)
-    }
-
-    private func standDownLiveReplacementCorrections(reason: String) {
-        guard liveReplacementCorrector != nil else { return }
-        liveReplacementCorrector?.standDown()
-        if !didLogLiveReplacementStandDown {
-            didLogLiveReplacementStandDown = true
-            Log.corrector.notice(
-                "corrector stand-down reason=\(reason, privacy: .public)"
             )
         }
     }
@@ -1143,76 +648,7 @@ final class TextInsertionService {
 
     // MARK: - Caret Guard
 
-    /// Reads the caret location (UTF-16 offset) of the focused text element,
-    /// used as an optional divergence guard for Live Auto-Paste corrections.
-    private func readCurrentCaretLocation(preferredAppPID: pid_t?) -> Int? {
-#if DEBUG
-        if let debugCaretLocationReader {
-            return debugCaretLocationReader(preferredAppPID)
-        }
-#endif
-        guard isAccessibilityTrusted,
-              let element = resolvedAccessibilityInsertionTarget(preferredAppPID: preferredAppPID)
-        else {
-            return nil
-        }
-        return readSelectedTextRangeLocation(in: element)
-    }
-
     // MARK: - Low-level AX Helpers
-
-    private func readSelectedTextRangeLocation(in element: AXUIElement) -> Int? {
-        var rangeObject: CFTypeRef?
-        let status = AXUIElementCopyAttributeValue(
-            element, kAXSelectedTextRangeAttribute as CFString, &rangeObject
-        )
-        guard status == .success,
-              let rangeObject,
-              CFGetTypeID(rangeObject) == AXValueGetTypeID()
-        else {
-            return nil
-        }
-        let rangeValue = unsafeDowncast(rangeObject, to: AXValue.self)
-        guard AXValueGetType(rangeValue) == .cfRange else { return nil }
-        var range = CFRange()
-        guard AXValueGetValue(rangeValue, .cfRange, &range) else { return nil }
-        return range.location
-    }
-
-    private func postBackspaceEvents(count: Int) -> Bool {
-#if DEBUG
-        if let debugBackspacePoster {
-            return debugBackspacePoster(count)
-        }
-#endif
-        guard count > 0 else { return true }
-        guard let source = CGEventSource(stateID: .combinedSessionState) else {
-            return false
-        }
-
-        for _ in 0 ..< count {
-            guard let keyDown = CGEvent(
-                keyboardEventSource: source,
-                virtualKey: 51,
-                keyDown: true
-            ),
-                  let keyUp = CGEvent(
-                    keyboardEventSource: source,
-                    virtualKey: 51,
-                    keyDown: false
-                  )
-            else {
-                return false
-            }
-
-            keyDown.flags = []
-            keyUp.flags = []
-            keyDown.post(tap: .cgAnnotatedSessionEventTap)
-            keyUp.post(tap: .cgAnnotatedSessionEventTap)
-        }
-
-        return true
-    }
 
     private func postUnicodeTextEvents(_ text: String) -> Bool {
 #if DEBUG
@@ -1352,18 +788,12 @@ extension TextInsertionService {
 
     func debugConfigureInsertionHooks(
         unicodePoster: ((String) -> Bool)? = nil,
-        backspacePoster: ((Int) -> Bool)? = nil,
         modifierStateReader: (() -> Bool)? = nil,
-        accessibilityInserter: ((String, pid_t?) -> Bool)? = nil,
-        caretLocationReader: ((pid_t?) -> Int?)? = nil,
-        liveReplacementSettleSleep: (() async -> Void)? = nil
+        accessibilityInserter: ((String, pid_t?) -> Bool)? = nil
     ) {
         debugUnicodePoster = unicodePoster
-        debugBackspacePoster = backspacePoster
         debugModifierStateReader = modifierStateReader
         debugAccessibilityInserter = accessibilityInserter
-        debugCaretLocationReader = caretLocationReader
-        debugLiveReplacementSettleSleep = liveReplacementSettleSleep
     }
 
     func debugInsertionSnapshot() -> DebugInsertionSnapshot {
@@ -1375,28 +805,8 @@ extension TextInsertionService {
         )
     }
 
-    /// Test-only accessor for the live session span bookkeeping.
-    func debugLiveSessionSpanSnapshot() -> (startCaret: Int, insertedLength: Int)? {
-        guard let span = liveSessionSpan else { return nil }
-        return (span.startCaretLocation, span.insertedUTF16Length)
-    }
-
-    var debugLiveReplacementCorrectorIsActive: Bool {
-        liveReplacementCorrector?.isStandingDown == false
-    }
-
     var debugLiveHoldBackStreamIsActive: Bool {
         liveHoldBackStream != nil
-    }
-
-    var debugLiveReplacementCorrectionIsInFlight: Bool {
-        isLiveReplacementCorrectionInFlight
-    }
-
-    func debugWaitForLiveReplacementCorrectionTasks() async {
-        while let task = liveReplacementCorrectionTask {
-            await task.value
-        }
     }
 
     /// Forces the Accessibility trust verdict for tests. Pass `nil` to restore

--- a/Sources/localvoxtral/TextInsertionService.swift
+++ b/Sources/localvoxtral/TextInsertionService.swift
@@ -91,6 +91,12 @@ final class TextInsertionService {
         set { accessibilityTrust.onTrustChanged = newValue }
     }
 
+    /// Opt-in field diagnostic: when the marker file
+    /// `insertion_scalar_trace` exists in the shared config folder, every
+    /// UTF-16 chunk posted as keyboard events is hex-logged (see
+    /// `postUnicodeTextEvents`). Set once per session at session start.
+    var isScalarTracingEnabled = false
+
     private var pendingRealtimeInsertionText = ""
     private var insertionRetryTask: Task<Void, Never>?
     private var axInsertionSuccessCount = 0
@@ -1227,6 +1233,18 @@ final class TextInsertionService {
         for i in stride(from: 0, to: utf16.count, by: chunkSize) {
             let end = min(i + chunkSize, utf16.count)
             var chunk = Array(utf16[i ..< end])
+
+            if isScalarTracingEnabled {
+                // Opt-in field diagnostic (marker file in the config folder):
+                // logs the exact UTF-16 units handed to keyboardSetUnicodeString,
+                // chunk boundaries included, so pipeline corruption (e.g. a
+                // split surrogate pair) is visible in the unified log. The hex
+                // IS transcript content — hence opt-in and privacy: .public.
+                let hex = chunk.map { String(format: "%04X", $0) }.joined(separator: " ")
+                Log.insertion.notice(
+                    "scalar-trace chunk[\(i, privacy: .public)..<\(end, privacy: .public)]: \(hex, privacy: .public)"
+                )
+            }
 
             guard let keyDown = CGEvent(keyboardEventSource: source, virtualKey: 0, keyDown: true),
                   let keyUp = CGEvent(keyboardEventSource: source, virtualKey: 0, keyDown: false)

--- a/Sources/localvoxtral/TextInsertionService.swift
+++ b/Sources/localvoxtral/TextInsertionService.swift
@@ -126,6 +126,11 @@ final class TextInsertionService {
     /// failed; retried as-is and never re-ingested into the stream.
     @ObservationIgnored
     private var pendingHoldBackReleasedText = ""
+    /// The session dictionary, retained while the guarded corrector is armed
+    /// so a caret-related stand-down can convert the session to a fresh
+    /// hold-back stream instead of giving up on replacements.
+    @ObservationIgnored
+    private var liveGuardedSessionDictionary: ReplacementDictionary?
 
     private struct LiveSessionSpan: Sendable {
         var startCaretLocation: Int
@@ -369,6 +374,7 @@ final class TextInsertionService {
         didLogLiveReplacementStandDown = false
         liveReplacementCorrector = nil
         liveSessionSpan = nil
+        liveGuardedSessionDictionary = nil
         liveHoldBackStream = nil
         pendingHoldBackReleasedText = ""
 
@@ -405,6 +411,7 @@ final class TextInsertionService {
 
         if let caretLocation = readCurrentCaretLocation(preferredAppPID: preferredAppPID) {
             liveReplacementCorrector = corrector
+            liveGuardedSessionDictionary = dictionary
             liveSessionSpan = LiveSessionSpan(
                 startCaretLocation: caretLocation,
                 insertedUTF16Length: 0,
@@ -442,6 +449,7 @@ final class TextInsertionService {
         pendingFinalLiveReplacementFlush = false
         liveSessionSpan = nil
         liveReplacementCorrector = nil
+        liveGuardedSessionDictionary = nil
         liveHoldBackStream = nil
         // pendingHoldBackReleasedText intentionally survives: the session
         // cleanup path reads hasPendingInsertionText to surface lost text
@@ -544,19 +552,19 @@ final class TextInsertionService {
         guard liveSessionSpan != nil else {
             // The guarded corrector never runs without an armed caret guard
             // (caret-less sessions use the hold-back stream instead), so a
-            // missing span mid-session means the session state was torn down.
-            // Never post unverified backspaces.
-            standDownLiveReplacementCorrections(reason: "caret guard unavailable")
+            // missing span mid-session means the caret guard is gone. Never
+            // post unverified backspaces — convert to pre-typing replacements.
+            convertLiveReplacementCorrectionsToHoldBack(reason: "caret guard unavailable")
             return .stopped
         }
         guard let expectedInsertedCaret = expectedLiveReplacementCaretLocation() else {
-            standDownLiveReplacementCorrections(reason: "caret unavailable")
+            convertLiveReplacementCorrectionsToHoldBack(reason: "caret unavailable")
             return .stopped
         }
 
         switch currentCaretSettlement(expectedLocation: expectedInsertedCaret) {
         case .unavailable:
-            standDownLiveReplacementCorrections(reason: "caret unavailable")
+            convertLiveReplacementCorrectionsToHoldBack(reason: "caret unavailable")
             return .stopped
         case .mismatched:
             beginDeferredLiveReplacementCorrection(correction, phase: .insertedTextPosted)
@@ -575,13 +583,13 @@ final class TextInsertionService {
         }
 
         guard let expectedErasedCaret = expectedErasedCaretLocation(for: correction) else {
-            standDownLiveReplacementCorrections(reason: "caret unavailable")
+            convertLiveReplacementCorrectionsToHoldBack(reason: "caret unavailable")
             return .stopped
         }
 
         switch currentCaretSettlement(expectedLocation: expectedErasedCaret) {
         case .unavailable:
-            standDownLiveReplacementCorrections(reason: "caret unavailable")
+            convertLiveReplacementCorrectionsToHoldBack(reason: "caret unavailable")
             return .stopped
         case .mismatched:
             beginDeferredLiveReplacementCorrection(correction, phase: .backspacePosted)
@@ -656,12 +664,16 @@ final class TextInsertionService {
         var currentPhase = phase
         if currentPhase == .insertedTextPosted {
             guard let expectedInsertedCaret = expectedLiveReplacementCaretLocation() else {
-                standDownLiveReplacementCorrections(reason: "caret unavailable")
+                convertLiveReplacementCorrectionsToHoldBack(reason: "caret unavailable")
                 finishDeferredLiveReplacementCorrection()
                 return
             }
             guard await waitForLiveReplacementCaret(expectedLocation: expectedInsertedCaret) else {
-                standDownLiveReplacementCorrections(reason: "tracked caret diverged")
+                // The field case (cmux, 2026-07-07): the correction's caret
+                // math never matches a terminal grid. The failed correction's
+                // text is already typed raw and stays raw; all FUTURE text
+                // flows through a fresh hold-back stream.
+                convertLiveReplacementCorrectionsToHoldBack(reason: "tracked caret diverged")
                 finishDeferredLiveReplacementCorrection()
                 return
             }
@@ -675,12 +687,12 @@ final class TextInsertionService {
 
         if currentPhase == .backspacePosted {
             guard let expectedErasedCaret = expectedErasedCaretLocation(for: correction) else {
-                standDownLiveReplacementCorrections(reason: "caret unavailable")
+                convertLiveReplacementCorrectionsToHoldBack(reason: "caret unavailable")
                 finishDeferredLiveReplacementCorrection()
                 return
             }
             guard await waitForLiveReplacementCaret(expectedLocation: expectedErasedCaret) else {
-                standDownLiveReplacementCorrections(reason: "tracked caret diverged")
+                convertLiveReplacementCorrectionsToHoldBack(reason: "tracked caret diverged")
                 finishDeferredLiveReplacementCorrection()
                 return
             }
@@ -724,8 +736,87 @@ final class TextInsertionService {
         let shouldFlushFinalCorrection = pendingFinalLiveReplacementFlush
         pendingFinalLiveReplacementFlush = false
 
+        if liveHoldBackStream != nil {
+            // The deferred correction converted the session to the hold-back
+            // stream mid-flight. Text queued while the correction was in
+            // flight — and a final flush requested during it — must flow into
+            // the stream exactly once, never back into the guarded path.
+            flushLiveHoldBackStream(releaseRemainder: shouldFlushFinalCorrection)
+            return
+        }
+
         processLiveReplacementCorrections(includeFinalUnboundedWord: shouldFlushFinalCorrection)
         flushPendingRealtimeInsertion()
+    }
+
+    /// Converts a guarded-corrector session to the hold-back stream after a
+    /// caret-related failure, instead of disabling replacements for the rest
+    /// of the session. Field bug (owner's Mac, 2026-07-07): cmux
+    /// (`com.cmuxterm.app`) hosts a terminal but reports a WRITABLE focused
+    /// AX value, so it is honestly classified non-terminal; the guarded
+    /// corrector armed with caret_guard=on, the first correction's caret
+    /// math never matched the terminal grid, and after "stand-down
+    /// reason=tracked caret diverged" replacements were silently dead.
+    /// Undetected terminal-hosts will keep appearing, so a caret-related
+    /// stand-down now converts.
+    ///
+    /// Stand-down reason classification (every call site):
+    /// - "tracked caret diverged", "caret unavailable", "caret guard
+    ///   unavailable": caret VERIFICATION broke, but typing still works —
+    ///   CONVERT. The hold-back stream needs no caret: it applies
+    ///   replacements before typing and never posts backspaces.
+    /// - "keyboard correction failed": Unicode/backspace key events cannot
+    ///   post; the hold-back stream types with the same Unicode events, so
+    ///   conversion cannot help — TRUE STAND-DOWN.
+    /// - "realtime insertion failed": no insertion path works at all — TRUE
+    ///   STAND-DOWN.
+    /// - "realtime insertion did not use the keyboard path": the raw chunk
+    ///   landed via AX replace, so backspace-count math is unsafe. The
+    ///   hold-back stream would technically work (it is insertion-path
+    ///   agnostic), but this is not the field failure mode and mixed
+    ///   AX/keyboard sessions keep the proven stand-down behavior — TRUE
+    ///   STAND-DOWN.
+    /// - "no valid rules" (session start): nothing to convert to — TRUE
+    ///   STAND-DOWN (logged directly, never reaches this path).
+    ///
+    /// The failed correction stays abandoned exactly as a stand-down would
+    /// leave it: its text is already typed raw in the target and NO
+    /// backspaces are ever posted after conversion. The fresh stream starts
+    /// EMPTY — accepted trade-off: a rule match spanning the conversion
+    /// boundary (words typed before + words after) will not apply. Newline
+    /// sanitization stays OFF because the target was not terminal-detected.
+    ///
+    /// Deferred-correction state (`isLiveReplacementCorrectionInFlight`,
+    /// `liveReplacementCorrectionTask`, `pendingFinalLiveReplacementFlush`)
+    /// is deliberately NOT touched here: every deferred conversion site runs
+    /// inside the correction task and calls
+    /// `finishDeferredLiveReplacementCorrection()` immediately after, which
+    /// resets that state and routes text queued during the defer into the
+    /// stream exactly once; synchronous sites can only be reached with no
+    /// correction in flight.
+    private func convertLiveReplacementCorrectionsToHoldBack(reason: String) {
+        guard liveReplacementCorrector != nil,
+              let dictionary = liveGuardedSessionDictionary
+        else {
+            // No armed guarded session (or no dictionary to rebuild from):
+            // fall back to the plain stand-down.
+            standDownLiveReplacementCorrections(reason: reason)
+            return
+        }
+
+        // Tear down the guarded machinery so nothing can post backspaces or
+        // re-enter the guarded path for the rest of the session.
+        liveReplacementCorrector = nil
+        liveSessionSpan = nil
+        liveGuardedSessionDictionary = nil
+
+        liveHoldBackStream = LiveHoldBackReplacementStream(
+            dictionary: dictionary,
+            sanitizesNewlines: false
+        )
+        Log.corrector.notice(
+            "corrector convert strategy=holdback reason=\(reason, privacy: .public)"
+        )
     }
 
     private func standDownLiveReplacementCorrections(reason: String) {

--- a/Tests/localvoxtralTests/AppConfigStoreTests.swift
+++ b/Tests/localvoxtralTests/AppConfigStoreTests.swift
@@ -35,10 +35,67 @@ final class AppConfigStoreTests: XCTestCase {
                 atPath: configDirectory.appendingPathComponent("llm_user_prompt.toml").path
             )
         )
+        XCTAssertTrue(
+            FileManager.default.fileExists(
+                atPath: configDirectory.appendingPathComponent("terminal_apps.toml").path
+            )
+        )
 
         let templates = store.loadLLMPromptTemplates()
         XCTAssertFalse(templates.systemContent.trimmed.isEmpty)
         XCTAssertFalse(templates.userContent.trimmed.isEmpty)
+        // Bundled terminal_apps template ships an empty list.
+        XCTAssertEqual(store.loadTerminalAppBundleIDs(), [])
+    }
+
+    func testTerminalAppsConfigParsesBundleIDs() throws {
+        let directory = makeTemporaryConfigDirectory()
+        try write(
+            """
+            # apps that embed a terminal
+            bundle_ids = [
+                "com.cmuxterm.app", # agent manager
+                "com.microsoft.VSCode",
+                "  ",
+            ]
+            """,
+            named: "terminal_apps.toml",
+            in: directory
+        )
+        let store = AppConfigStore(configDirectoryOverride: directory)
+
+        XCTAssertEqual(
+            store.loadTerminalAppBundleIDs(),
+            ["com.cmuxterm.app", "com.microsoft.VSCode"]
+        )
+    }
+
+    func testInvalidTerminalAppsConfigFallsBackToEmptyList() throws {
+        let directory = makeTemporaryConfigDirectory()
+        try write(
+            """
+            bundle_ids = ["com.cmuxterm.app"
+            """,
+            named: "terminal_apps.toml",
+            in: directory
+        )
+        let store = AppConfigStore(configDirectoryOverride: directory)
+
+        XCTAssertEqual(store.loadTerminalAppBundleIDs(), [])
+    }
+
+    func testTerminalAppsConfigRejectsUnsupportedKeys() throws {
+        let directory = makeTemporaryConfigDirectory()
+        try write(
+            """
+            apps = ["com.cmuxterm.app"]
+            """,
+            named: "terminal_apps.toml",
+            in: directory
+        )
+        let store = AppConfigStore(configDirectoryOverride: directory)
+
+        XCTAssertEqual(store.loadTerminalAppBundleIDs(), [])
     }
 
     func testInvalidReplacementDictionaryFallsBackToBundledDefault() throws {

--- a/Tests/localvoxtralTests/DictationViewModelFailFastUXTests.swift
+++ b/Tests/localvoxtralTests/DictationViewModelFailFastUXTests.swift
@@ -1112,6 +1112,10 @@ final class DictationViewModelFailFastUXTests: XCTestCase {
             overlayBufferCoordinator: NoopOverlayCoordinator(),
             startRuntimeServices: false
         )
+        // Keep tests hermetic: session start reads config (terminal apps,
+        // replacement dictionary) through the store — never the real
+        // config directory.
+        viewModel.appConfigStore = FailFastHermeticConfigStore()
         return viewModel
     }
 
@@ -1164,6 +1168,24 @@ final class DictationViewModelFailFastUXTests: XCTestCase {
 }
 
 // MARK: - Test-only accessors and doubles
+
+private final class FailFastHermeticConfigStore: AppConfigServing {
+    func configDirectoryURL() -> URL {
+        FileManager.default.temporaryDirectory
+    }
+
+    func loadReplacementDictionary() -> ReplacementDictionary {
+        ReplacementDictionary(entries: [])
+    }
+
+    func loadLLMPromptTemplates() -> LLMPromptTemplates {
+        LLMPromptTemplates(systemContent: "system", userContent: "{{input_text}}")
+    }
+
+    func loadTerminalAppBundleIDs() -> [String] {
+        []
+    }
+}
 
 @MainActor
 private final class NoopOverlayCoordinator: OverlayBufferSessionCoordinating {

--- a/Tests/localvoxtralTests/DictationViewModelLiveReplacementCorrectorTests.swift
+++ b/Tests/localvoxtralTests/DictationViewModelLiveReplacementCorrectorTests.swift
@@ -198,17 +198,18 @@ final class DictationViewModelLiveReplacementCorrectorTests: XCTestCase {
     }
 
     func testUserAllowlistedBundleSelectsHoldBack() {
-        // cmux field case: the app reports a writable AX value, so detection
-        // needs the user's terminal_apps.toml entry to classify it — and the
-        // session must then behave exactly like a built-in terminal.
+        // The original cmux field case (writable AX value, only the user's
+        // terminal_apps.toml entry can classify it) — cmux itself is built-in
+        // now, so an unknown stand-in keeps the user path exercised. The
+        // session must behave exactly like a built-in terminal.
         TerminalTargetDetector.debugFocusedElementProbeOverride = { .valueSettable }
         let harness = makeHarness(
             dictionary: voxtralDictionary,
             configStore: MockAppConfigStore(
                 replacementDictionary: voxtralDictionary,
-                terminalAppBundleIDs: ["com.cmuxterm.app"]
+                terminalAppBundleIDs: ["com.example.myterminal"]
             ),
-            frontmostBundleID: "com.cmuxterm.app"
+            frontmostBundleID: "com.example.myterminal"
         )
 
         harness.viewModel.handle(event: .partialTranscript("voxtral "))
@@ -216,6 +217,25 @@ final class DictationViewModelLiveReplacementCorrectorTests: XCTestCase {
 
         XCTAssertEqual(harness.field.value, "localvoxtral ")
         XCTAssertEqual(harness.typed.value.joined(), "localvoxtral ")
+    }
+
+    func testCmuxIsTerminalLikeViaBuiltInAllowlist() {
+        // cmux graduated from the user allowlist to built-in (owner request,
+        // 2026-07-08): terminal behavior with zero config, even though its AX
+        // value reads writable.
+        TerminalTargetDetector.debugFocusedElementProbeOverride = { .valueSettable }
+        let harness = makeHarness(
+            dictionary: voxtralDictionary,
+            frontmostBundleID: "com.cmuxterm.app"
+        )
+
+        harness.viewModel.handle(event: .partialTranscript("voxtral\nls "))
+        stop(harness.viewModel)
+
+        XCTAssertEqual(
+            harness.field.value, "localvoxtral ls ",
+            "replacement applied AND the newline sanitized — full terminal treatment with zero config"
+        )
     }
 
     // MARK: - Harness

--- a/Tests/localvoxtralTests/DictationViewModelLiveReplacementCorrectorTests.swift
+++ b/Tests/localvoxtralTests/DictationViewModelLiveReplacementCorrectorTests.swift
@@ -13,6 +13,13 @@ final class DictationViewModelLiveReplacementCorrectorTests: XCTestCase {
 
     private static var retainedViewModels: [DictationViewModel] = []
 
+    override func tearDown() async throws {
+        TerminalTargetDetector.debugFrontmostBundleIDOverride = nil
+        TerminalTargetDetector.debugFocusedElementProbeOverride = nil
+        TerminalTargetDetector.debugSecureEventInputOverride = nil
+        try await super.tearDown()
+    }
+
     func testCorrectsWordCompletedAcrossDeltaBoundaries() {
         let harness = makeHarness(
             dictionary: ReplacementDictionary(entries: [
@@ -357,6 +364,71 @@ final class DictationViewModelLiveReplacementCorrectorTests: XCTestCase {
         XCTAssertEqual(harness.events.value, [.type("voxtral ")])
     }
 
+    // MARK: - Terminal target wiring (TerminalTargetDetector → hold-back strategy)
+
+    /// End-to-end regression for the field bug (2026-07-06): a terminal with a
+    /// READABLE grid caret armed the guarded corrector, which then diverged and
+    /// stood down — replacements never applied. With the detector wired, the
+    /// terminal verdict must select the hold-back strategy: replacement applied
+    /// before typing, zero backspace events.
+    func testTerminalVerdictSelectsHoldBackAndAppliesReplacementWithoutBackspaces() {
+        let harness = makeHarness(
+            dictionary: ReplacementDictionary(entries: [
+                ReplacementEntry(replaceWith: "localvoxtral", matches: ["voxtral"]),
+            ]),
+            caretLocationReader: { _ in 0 },
+            frontmostBundleID: "com.mitchellh.ghostty"
+        )
+
+        harness.viewModel.handle(event: .partialTranscript("voxtral "))
+        harness.viewModel.isDictating = false
+        harness.viewModel.isFinalizingStop = true
+        harness.viewModel.finishStoppedSession(promotePendingSegment: false)
+
+        XCTAssertEqual(harness.field.value, "localvoxtral ")
+        XCTAssertFalse(harness.events.value.contains {
+            if case .backspace = $0 { return true }
+            return false
+        })
+    }
+
+    func testTerminalVerdictWithDictionaryDisabledStillSanitizesNewlines() {
+        let harness = makeHarness(
+            dictionaryEnabled: false,
+            frontmostBundleID: "com.mitchellh.ghostty"
+        )
+
+        harness.viewModel.handle(event: .partialTranscript("ls -la\nnext "))
+        harness.viewModel.isDictating = false
+        harness.viewModel.isFinalizingStop = true
+        harness.viewModel.finishStoppedSession(promotePendingSegment: false)
+
+        XCTAssertEqual(harness.field.value, "ls -la next ")
+        XCTAssertFalse(harness.events.value.contains {
+            if case .backspace = $0 { return true }
+            return false
+        })
+    }
+
+    func testNonTerminalVerdictKeepsGuardedCorrector() {
+        TerminalTargetDetector.debugFocusedElementProbeOverride = { .valueSettable }
+        let harness = makeHarness(
+            dictionary: ReplacementDictionary(entries: [
+                ReplacementEntry(replaceWith: "localvoxtral", matches: ["voxtral"]),
+            ]),
+            frontmostBundleID: "com.example.editor"
+        )
+
+        harness.viewModel.handle(event: .partialTranscript("voxtral "))
+
+        XCTAssertEqual(harness.field.value, "localvoxtral ")
+        XCTAssertEqual(harness.events.value, [
+            .type("voxtral "),
+            .backspace(8),
+            .type("localvoxtral "),
+        ])
+    }
+
     private func makeHarness(
         dictionaryEnabled: Bool = true,
         dictionary: ReplacementDictionary = ReplacementDictionary(entries: []),
@@ -366,7 +438,8 @@ final class DictationViewModelLiveReplacementCorrectorTests: XCTestCase {
         caretLocationReader: ((pid_t?) -> Int?)? = nil,
         unicodePoster: ((String) -> Bool)? = nil,
         backspacePoster: ((Int) -> Bool)? = nil,
-        liveReplacementSettleSleep: (() async -> Void)? = nil
+        liveReplacementSettleSleep: (() async -> Void)? = nil,
+        frontmostBundleID: String? = nil
     ) -> (
         viewModel: DictationViewModel,
         field: TestField,
@@ -411,6 +484,13 @@ final class DictationViewModelLiveReplacementCorrectorTests: XCTestCase {
             caretLocationReader: caretLocationReader ?? { _ in (field.value as NSString).length },
             liveReplacementSettleSleep: liveReplacementSettleSleep
         )
+
+        if let frontmostBundleID {
+            TerminalTargetDetector.debugFrontmostBundleIDOverride = { frontmostBundleID }
+            TerminalTargetDetector.debugSecureEventInputOverride = { false }
+            viewModel.captureSessionTargetVerdict()
+            viewModel.applyPreCapturedSessionTargetVerdict()
+        }
 
         viewModel.sessionOutputMode = .liveAutoPaste
         viewModel.isDictating = true

--- a/Tests/localvoxtralTests/DictationViewModelLiveReplacementCorrectorTests.swift
+++ b/Tests/localvoxtralTests/DictationViewModelLiveReplacementCorrectorTests.swift
@@ -79,6 +79,9 @@ final class DictationViewModelLiveReplacementCorrectorTests: XCTestCase {
     // dropped it at stop; nothing was replaced. The hold-back stream applies it
     // on the stop flush.
     func testFinalWordOnlyReplacementIsAppliedAtStop() {
+        // Writable AX value → deterministically classified non-terminal,
+        // independent of whether the CI host has Accessibility trust.
+        TerminalTargetDetector.debugFocusedElementProbeOverride = { .valueSettable }
         let harness = makeHarness(
             dictionary: voxtralDictionary,
             frontmostBundleID: "com.example.editor"
@@ -112,6 +115,7 @@ final class DictationViewModelLiveReplacementCorrectorTests: XCTestCase {
     }
 
     func testWhitespaceBoundaryReleasesCorrectedTextInRegularEditor() {
+        TerminalTargetDetector.debugFocusedElementProbeOverride = { .valueSettable }
         let harness = makeHarness(
             dictionary: voxtralDictionary,
             frontmostBundleID: "com.example.editor"
@@ -126,6 +130,7 @@ final class DictationViewModelLiveReplacementCorrectorTests: XCTestCase {
     }
 
     func testNonTerminalSessionUsesHoldBackStream() {
+        TerminalTargetDetector.debugFocusedElementProbeOverride = { .valueSettable }
         let harness = makeHarness(
             dictionary: voxtralDictionary,
             frontmostBundleID: "com.example.editor"

--- a/Tests/localvoxtralTests/DictationViewModelLiveReplacementCorrectorTests.swift
+++ b/Tests/localvoxtralTests/DictationViewModelLiveReplacementCorrectorTests.swift
@@ -192,7 +192,10 @@ final class DictationViewModelLiveReplacementCorrectorTests: XCTestCase {
         XCTAssertTrue(harness.viewModel.textInsertion.debugLiveReplacementCorrectorIsActive)
     }
 
-    func testCorrectorStillAppliesWhenInitialCaretIsUnavailable() {
+    // Replaces the retired unguarded-correction test: a session without a
+    // readable caret used to post blind backspaces; it now applies
+    // replacements before typing via the hold-back stream instead.
+    func testCaretUnavailableSessionAppliesReplacementBeforeTypingWithoutBackspaces() {
         let harness = makeHarness(
             dictionary: ReplacementDictionary(entries: [
                 ReplacementEntry(replaceWith: "localvoxtral", matches: ["voxtral"]),
@@ -204,11 +207,9 @@ final class DictationViewModelLiveReplacementCorrectorTests: XCTestCase {
 
         XCTAssertEqual(harness.field.value, "localvoxtral ")
         XCTAssertEqual(harness.events.value, [
-            .type("voxtral "),
-            .backspace(8),
             .type("localvoxtral "),
         ])
-        XCTAssertTrue(harness.viewModel.textInsertion.debugLiveReplacementCorrectorIsActive)
+        XCTAssertTrue(harness.viewModel.textInsertion.debugLiveHoldBackStreamIsActive)
     }
 
     func testDeltasArrivingDuringInFlightCorrectionAreBufferedUntilAfterCorrection() async {

--- a/Tests/localvoxtralTests/DictationViewModelLiveReplacementCorrectorTests.swift
+++ b/Tests/localvoxtralTests/DictationViewModelLiveReplacementCorrectorTests.swift
@@ -4,13 +4,14 @@ import XCTest
 @testable import localvoxtral
 
 #if DEBUG
+/// End-to-end Live Auto-Paste replacement behavior at the view-model level.
+/// Every target applies dictionary replacements BEFORE typing through the
+/// hold-back stream: matched words are released already corrected, no target
+/// ever receives a backspace, and a word held at session stop is flushed with
+/// its replacement applied (the 2026-07-08 field regression — a final-word
+/// replacement was deferred by the old guarded corrector and dropped at stop).
 @MainActor
 final class DictationViewModelLiveReplacementCorrectorTests: XCTestCase {
-    private enum InsertionEvent: Equatable {
-        case type(String)
-        case backspace(Int)
-    }
-
     private static var retainedViewModels: [DictationViewModel] = []
 
     override func tearDown() async throws {
@@ -22,21 +23,18 @@ final class DictationViewModelLiveReplacementCorrectorTests: XCTestCase {
 
     func testCorrectsWordCompletedAcrossDeltaBoundaries() {
         let harness = makeHarness(
-            dictionary: ReplacementDictionary(entries: [
-                ReplacementEntry(replaceWith: "localvoxtral", matches: ["voxtral"]),
-            ])
+            dictionary: voxtralDictionary
         )
 
         harness.viewModel.handle(event: .partialTranscript("vox"))
+        XCTAssertEqual(harness.typed.value, [], "partial word stays held until a boundary")
         harness.viewModel.handle(event: .partialTranscript("tral "))
 
         XCTAssertEqual(harness.field.value, "localvoxtral ")
-        XCTAssertEqual(harness.events.value, [
-            .type("vox"),
-            .type("tral "),
-            .backspace(8),
-            .type("localvoxtral "),
-        ])
+        XCTAssertEqual(
+            harness.typed.value, ["localvoxtral "],
+            "the corrected word is released once its boundary arrives — no raw type, no backspace"
+        )
         XCTAssertEqual(harness.viewModel.pendingSegmentText, "voxtral ")
     }
 
@@ -49,305 +47,100 @@ final class DictationViewModelLiveReplacementCorrectorTests: XCTestCase {
 
         harness.viewModel.handle(event: .partialTranscript("local "))
         harness.viewModel.handle(event: .partialTranscript("voxtral "))
+        // A two-word rule holds the last complete word back — it could begin
+        // another match — so the corrected text is released on the stop flush.
+        XCTAssertEqual(harness.typed.value, [], "the last complete word stays held for a multi-word rule")
+
+        stop(harness.viewModel)
 
         XCTAssertEqual(harness.field.value, "localvoxtral ")
-        XCTAssertEqual(harness.events.value, [
-            .type("local "),
-            .type("voxtral "),
-            .backspace(14),
-            .type("localvoxtral "),
-        ])
+        XCTAssertEqual(harness.typed.value.joined(), "localvoxtral ")
     }
 
     func testCorrectsFinalUnboundedWordOnStopFlush() {
         let harness = makeHarness(
-            dictionary: ReplacementDictionary(entries: [
-                ReplacementEntry(replaceWith: "localvoxtral", matches: ["voxtral"]),
-            ])
+            dictionary: voxtralDictionary
         )
 
         harness.viewModel.handle(event: .partialTranscript("voxtral"))
         harness.viewModel.handle(event: .finalTranscript("voxtral"))
-        harness.viewModel.isDictating = false
-        harness.viewModel.isFinalizingStop = true
-        harness.viewModel.finishStoppedSession(promotePendingSegment: false)
+        XCTAssertEqual(harness.typed.value, [], "the unbounded final word stays held until stop")
+
+        stop(harness.viewModel)
 
         XCTAssertEqual(harness.field.value, "localvoxtral")
-        XCTAssertEqual(harness.events.value, [
-            .type("voxtral"),
-            .backspace(7),
-            .type("localvoxtral"),
-        ])
+        XCTAssertEqual(harness.typed.value, ["localvoxtral"])
         XCTAssertEqual(harness.viewModel.currentDictationEventText, "voxtral")
     }
 
-    func testFinalTranscriptSuffixCanCompleteAndCorrectWordBeforeStop() {
+    // The exact field regression (2026-07-08), end to end: a short dictation
+    // whose ONLY replacement is the final word, with no trailing whitespace.
+    // The old guarded corrector deferred it waiting for the caret to settle and
+    // dropped it at stop; nothing was replaced. The hold-back stream applies it
+    // on the stop flush.
+    func testFinalWordOnlyReplacementIsAppliedAtStop() {
         let harness = makeHarness(
-            dictionary: ReplacementDictionary(entries: [
-                ReplacementEntry(replaceWith: "localvoxtral", matches: ["voxtral"]),
-            ])
+            dictionary: voxtralDictionary,
+            frontmostBundleID: "com.example.editor"
         )
 
-        harness.viewModel.handle(event: .partialTranscript("voxtral"))
-        harness.viewModel.handle(event: .finalTranscript("voxtral."))
+        harness.viewModel.handle(event: .partialTranscript("vox"))
+        harness.viewModel.handle(event: .finalTranscript("voxtral"))
+        XCTAssertEqual(harness.typed.value, [])
 
-        XCTAssertEqual(harness.field.value, "localvoxtral.")
-        XCTAssertEqual(harness.events.value, [
-            .type("voxtral"),
-            .type("."),
-            .backspace(8),
-            .type("localvoxtral."),
-        ])
-        XCTAssertEqual(harness.viewModel.currentDictationEventText, "voxtral.")
+        stop(harness.viewModel)
+
+        XCTAssertEqual(
+            harness.field.value, "localvoxtral",
+            "the only replacement in the session — the final word — must not be dropped at stop"
+        )
+        XCTAssertEqual(harness.typed.value, ["localvoxtral"])
     }
 
     func testNoMatchWordsAreUntouched() {
         let harness = makeHarness(
-            dictionary: ReplacementDictionary(entries: [
-                ReplacementEntry(replaceWith: "localvoxtral", matches: ["voxtral"]),
-            ])
+            dictionary: voxtralDictionary
         )
 
         harness.viewModel.handle(event: .partialTranscript("hello "))
 
         XCTAssertEqual(harness.field.value, "hello ")
-        XCTAssertEqual(harness.events.value, [.type("hello ")])
+        XCTAssertEqual(
+            harness.typed.value, ["hello "],
+            "a completed non-matching word is released promptly, unchanged"
+        )
     }
 
-    func testCorrectorDefersWhenCaretHasNotSettled() async {
-        let field = TestField("")
-        let events = Box<[InsertionEvent]>([])
+    func testWhitespaceBoundaryReleasesCorrectedTextInRegularEditor() {
         let harness = makeHarness(
-            dictionary: ReplacementDictionary(entries: [
-                ReplacementEntry(replaceWith: "localvoxtral", matches: ["voxtral"]),
-            ]),
-            field: field,
-            events: events,
-            caretLocationReader: { _ in
-                if field.value.isEmpty { return 0 }
-                return max(0, (field.value as NSString).length - 1)
-            },
-            liveReplacementSettleSleep: {}
+            dictionary: voxtralDictionary,
+            frontmostBundleID: "com.example.editor"
         )
 
-        harness.viewModel.handle(event: .partialTranscript("voxtral "))
+        // A newline is a whitespace boundary: it completes the word and, in a
+        // regular (non-terminal) editor, is preserved verbatim.
+        harness.viewModel.handle(event: .partialTranscript("voxtral\n"))
 
-        XCTAssertEqual(harness.field.value, "voxtral ")
-        XCTAssertTrue(harness.viewModel.textInsertion.debugLiveReplacementCorrectionIsInFlight)
-
-        await harness.viewModel.textInsertion.debugWaitForLiveReplacementCorrectionTasks()
+        XCTAssertEqual(harness.field.value, "localvoxtral\n")
+        XCTAssertEqual(harness.typed.value, ["localvoxtral\n"])
     }
 
-    func testCorrectorStandsDownAfterCaretSettleTimeout() async {
-        let field = TestField("")
-        let events = Box<[InsertionEvent]>([])
+    func testNonTerminalSessionUsesHoldBackStream() {
         let harness = makeHarness(
-            dictionary: ReplacementDictionary(entries: [
-                ReplacementEntry(replaceWith: "localvoxtral", matches: ["voxtral"]),
-            ]),
-            field: field,
-            events: events,
-            caretLocationReader: { _ in
-                if field.value.isEmpty { return 0 }
-                return max(0, (field.value as NSString).length - 1)
-            },
-            liveReplacementSettleSleep: {}
+            dictionary: voxtralDictionary,
+            frontmostBundleID: "com.example.editor"
         )
-
-        harness.viewModel.handle(event: .partialTranscript("voxtral "))
-        await harness.viewModel.textInsertion.debugWaitForLiveReplacementCorrectionTasks()
-
-        XCTAssertEqual(harness.field.value, "voxtral ")
-        XCTAssertEqual(harness.events.value, [
-            .type("voxtral "),
-        ])
-        XCTAssertFalse(harness.viewModel.textInsertion.debugLiveReplacementCorrectorIsActive)
-    }
-
-    func testCorrectorWaitsForLaggedCaretAndThenCorrects() async {
-        let field = TestField("")
-        var staleReadsRemaining = 3
-        let harness = makeHarness(
-            dictionary: ReplacementDictionary(entries: [
-                ReplacementEntry(replaceWith: "localvoxtral", matches: ["voxtral"]),
-            ]),
-            field: field,
-            caretLocationReader: { _ in
-                let currentLocation = (field.value as NSString).length
-                guard currentLocation > 0, staleReadsRemaining > 0 else {
-                    return currentLocation
-                }
-                staleReadsRemaining -= 1
-                return 0
-            },
-            liveReplacementSettleSleep: {}
-        )
-
-        harness.viewModel.handle(event: .partialTranscript("voxtral "))
-
-        XCTAssertEqual(harness.field.value, "voxtral ")
-        XCTAssertTrue(harness.viewModel.textInsertion.debugLiveReplacementCorrectionIsInFlight)
-
-        await harness.viewModel.textInsertion.debugWaitForLiveReplacementCorrectionTasks()
-
-        XCTAssertEqual(harness.field.value, "localvoxtral ")
-        XCTAssertEqual(harness.events.value, [
-            .type("voxtral "),
-            .backspace(8),
-            .type("localvoxtral "),
-        ])
-        XCTAssertTrue(harness.viewModel.textInsertion.debugLiveReplacementCorrectorIsActive)
-    }
-
-    // Replaces the retired unguarded-correction test: a session without a
-    // readable caret used to post blind backspaces; it now applies
-    // replacements before typing via the hold-back stream instead.
-    func testCaretUnavailableSessionAppliesReplacementBeforeTypingWithoutBackspaces() {
-        let harness = makeHarness(
-            dictionary: ReplacementDictionary(entries: [
-                ReplacementEntry(replaceWith: "localvoxtral", matches: ["voxtral"]),
-            ]),
-            caretLocationReader: { _ in nil }
-        )
-
-        harness.viewModel.handle(event: .partialTranscript("voxtral "))
-
-        XCTAssertEqual(harness.field.value, "localvoxtral ")
-        XCTAssertEqual(harness.events.value, [
-            .type("localvoxtral "),
-        ])
         XCTAssertTrue(harness.viewModel.textInsertion.debugLiveHoldBackStreamIsActive)
-    }
-
-    func testDeltasArrivingDuringInFlightCorrectionAreBufferedUntilAfterCorrection() async {
-        let field = TestField("")
-        var staleReadsRemaining = 3
-        let harness = makeHarness(
-            dictionary: ReplacementDictionary(entries: [
-                ReplacementEntry(replaceWith: "localvoxtral", matches: ["voxtral"]),
-            ]),
-            field: field,
-            caretLocationReader: { _ in
-                let currentLocation = (field.value as NSString).length
-                guard currentLocation > 0, staleReadsRemaining > 0 else {
-                    return currentLocation
-                }
-                staleReadsRemaining -= 1
-                return 0
-            },
-            liveReplacementSettleSleep: {}
-        )
-
-        harness.viewModel.handle(event: .partialTranscript("voxtral "))
-        harness.viewModel.textInsertion.enqueueRealtimeInsertion("next ")
-
-        XCTAssertEqual(harness.field.value, "voxtral ")
-        XCTAssertEqual(harness.events.value, [.type("voxtral ")])
-
-        await harness.viewModel.textInsertion.debugWaitForLiveReplacementCorrectionTasks()
-
-        XCTAssertEqual(harness.field.value, "localvoxtral next ")
-        XCTAssertEqual(harness.events.value, [
-            .type("voxtral "),
-            .backspace(8),
-            .type("localvoxtral "),
-            .type("next "),
-        ])
-    }
-
-    func testFailedReplacementRetypesOriginalTextBeforeStandingDown() {
-        let field = TestField("")
-        let events = Box<[InsertionEvent]>([])
-        var replacementFailuresRemaining = 1
-        let harness = makeHarness(
-            dictionary: ReplacementDictionary(entries: [
-                ReplacementEntry(replaceWith: "localvoxtral", matches: ["voxtral"]),
-            ]),
-            field: field,
-            events: events,
-            unicodePoster: { chunk in
-                if chunk == "localvoxtral ", replacementFailuresRemaining > 0 {
-                    replacementFailuresRemaining -= 1
-                    return false
-                }
-                events.value.append(.type(chunk))
-                field.value.append(chunk)
-                return true
-            }
-        )
 
         harness.viewModel.handle(event: .partialTranscript("voxtral "))
 
-        XCTAssertEqual(harness.field.value, "voxtral ")
-        XCTAssertEqual(harness.events.value, [
-            .type("voxtral "),
-            .backspace(8),
-            .type("voxtral "),
-        ])
-        XCTAssertFalse(harness.viewModel.textInsertion.debugLiveReplacementCorrectorIsActive)
-        XCTAssertEqual(replacementFailuresRemaining, 0)
-    }
-
-    func testBackspaceCountUsesGraphemeCountForEmojiMatch() {
-        let harness = makeHarness(
-            dictionary: ReplacementDictionary(entries: [
-                ReplacementEntry(replaceWith: "developer", matches: ["👩‍💻"]),
-            ])
-        )
-
-        harness.viewModel.handle(event: .partialTranscript("👩‍💻 "))
-
-        XCTAssertEqual(harness.field.value, "developer ")
-        XCTAssertEqual(harness.events.value, [
-            .type("👩‍💻 "),
-            .backspace(2),
-            .type("developer "),
-        ])
-    }
-
-    func testShorterReplacementPreservesBoundary() {
-        let harness = makeHarness(
-            dictionary: ReplacementDictionary(entries: [
-                ReplacementEntry(replaceWith: "-", matches: ["dash"]),
-            ])
-        )
-
-        harness.viewModel.handle(event: .partialTranscript("dash,"))
-
-        XCTAssertEqual(harness.field.value, "-,")
-        XCTAssertEqual(harness.events.value, [
-            .type("dash,"),
-            .backspace(5),
-            .type("-,"),
-        ])
-    }
-
-    func testBoundaryCharactersArePreserved() {
-        let cases: [(String, String)] = [
-            ("voxtral,", "localvoxtral,"),
-            ("voxtral.", "localvoxtral."),
-            ("voxtral\n", "localvoxtral\n"),
-        ]
-
-        for (input, expected) in cases {
-            let harness = makeHarness(
-                dictionary: ReplacementDictionary(entries: [
-                    ReplacementEntry(replaceWith: "localvoxtral", matches: ["voxtral"]),
-                ])
-            )
-
-            harness.viewModel.handle(event: .partialTranscript(input))
-
-            XCTAssertEqual(harness.field.value, expected)
-            XCTAssertEqual(harness.events.value.last, .type(expected))
-        }
+        XCTAssertEqual(harness.field.value, "localvoxtral ")
+        XCTAssertEqual(harness.typed.value, ["localvoxtral "])
     }
 
     func testReplacementDictionarySettingOffLeavesLivePathUntouchedAndDoesNotLoadDictionary() {
         let configStore = MockAppConfigStore(
-            replacementDictionary: ReplacementDictionary(entries: [
-                ReplacementEntry(replaceWith: "localvoxtral", matches: ["voxtral"]),
-            ])
+            replacementDictionary: voxtralDictionary
         )
         let harness = makeHarness(
             dictionaryEnabled: false,
@@ -355,41 +148,36 @@ final class DictationViewModelLiveReplacementCorrectorTests: XCTestCase {
         )
 
         harness.viewModel.handle(event: .partialTranscript("voxtral "))
-        harness.viewModel.isDictating = false
-        harness.viewModel.isFinalizingStop = true
-        harness.viewModel.finishStoppedSession(promotePendingSegment: false)
+        stop(harness.viewModel)
 
         XCTAssertEqual(configStore.loadReplacementDictionaryCallCount, 0)
+        XCTAssertFalse(
+            harness.viewModel.textInsertion.debugLiveHoldBackStreamIsActive,
+            "dictionary off in a non-terminal target types directly, no hold-back"
+        )
         XCTAssertEqual(harness.field.value, "voxtral ")
-        XCTAssertEqual(harness.events.value, [.type("voxtral ")])
+        XCTAssertEqual(harness.typed.value, ["voxtral "])
     }
 
     // MARK: - Terminal target wiring (TerminalTargetDetector → hold-back strategy)
 
     /// End-to-end regression for the field bug (2026-07-06): a terminal with a
     /// READABLE grid caret armed the guarded corrector, which then diverged and
-    /// stood down — replacements never applied. With the detector wired, the
-    /// terminal verdict must select the hold-back strategy: replacement applied
-    /// before typing, zero backspace events.
-    func testTerminalVerdictSelectsHoldBackAndAppliesReplacementWithoutBackspaces() {
+    /// stood down — replacements never applied. The terminal verdict now selects
+    /// the hold-back stream: replacement applied before typing.
+    func testTerminalVerdictSelectsHoldBackAndAppliesReplacement() {
         let harness = makeHarness(
-            dictionary: ReplacementDictionary(entries: [
-                ReplacementEntry(replaceWith: "localvoxtral", matches: ["voxtral"]),
-            ]),
-            caretLocationReader: { _ in 0 },
+            dictionary: voxtralDictionary,
             frontmostBundleID: "com.mitchellh.ghostty"
         )
 
         harness.viewModel.handle(event: .partialTranscript("voxtral "))
-        harness.viewModel.isDictating = false
-        harness.viewModel.isFinalizingStop = true
-        harness.viewModel.finishStoppedSession(promotePendingSegment: false)
+        stop(harness.viewModel)
 
         XCTAssertEqual(harness.field.value, "localvoxtral ")
-        XCTAssertFalse(harness.events.value.contains {
-            if case .backspace = $0 { return true }
-            return false
-        })
+        // The terminal sanitizer buffers the trailing space until stop, so the
+        // release may arrive as more than one chunk — assert the joined text.
+        XCTAssertEqual(harness.typed.value.joined(), "localvoxtral ")
     }
 
     func testTerminalVerdictWithDictionaryDisabledStillSanitizesNewlines() {
@@ -399,15 +187,9 @@ final class DictationViewModelLiveReplacementCorrectorTests: XCTestCase {
         )
 
         harness.viewModel.handle(event: .partialTranscript("ls -la\nnext "))
-        harness.viewModel.isDictating = false
-        harness.viewModel.isFinalizingStop = true
-        harness.viewModel.finishStoppedSession(promotePendingSegment: false)
+        stop(harness.viewModel)
 
         XCTAssertEqual(harness.field.value, "ls -la next ")
-        XCTAssertFalse(harness.events.value.contains {
-            if case .backspace = $0 { return true }
-            return false
-        })
     }
 
     func testUserAllowlistedBundleSelectsHoldBack() {
@@ -416,47 +198,33 @@ final class DictationViewModelLiveReplacementCorrectorTests: XCTestCase {
         // session must then behave exactly like a built-in terminal.
         TerminalTargetDetector.debugFocusedElementProbeOverride = { .valueSettable }
         let harness = makeHarness(
-            dictionary: ReplacementDictionary(entries: [
-                ReplacementEntry(replaceWith: "localvoxtral", matches: ["voxtral"]),
-            ]),
+            dictionary: voxtralDictionary,
             configStore: MockAppConfigStore(
-                replacementDictionary: ReplacementDictionary(entries: [
-                    ReplacementEntry(replaceWith: "localvoxtral", matches: ["voxtral"]),
-                ]),
+                replacementDictionary: voxtralDictionary,
                 terminalAppBundleIDs: ["com.cmuxterm.app"]
             ),
             frontmostBundleID: "com.cmuxterm.app"
         )
 
         harness.viewModel.handle(event: .partialTranscript("voxtral "))
-        harness.viewModel.isDictating = false
-        harness.viewModel.isFinalizingStop = true
-        harness.viewModel.finishStoppedSession(promotePendingSegment: false)
+        stop(harness.viewModel)
 
         XCTAssertEqual(harness.field.value, "localvoxtral ")
-        XCTAssertFalse(harness.events.value.contains {
-            if case .backspace = $0 { return true }
-            return false
-        })
+        XCTAssertEqual(harness.typed.value.joined(), "localvoxtral ")
     }
 
-    func testNonTerminalVerdictKeepsGuardedCorrector() {
-        TerminalTargetDetector.debugFocusedElementProbeOverride = { .valueSettable }
-        let harness = makeHarness(
-            dictionary: ReplacementDictionary(entries: [
-                ReplacementEntry(replaceWith: "localvoxtral", matches: ["voxtral"]),
-            ]),
-            frontmostBundleID: "com.example.editor"
-        )
+    // MARK: - Harness
 
-        harness.viewModel.handle(event: .partialTranscript("voxtral "))
-
-        XCTAssertEqual(harness.field.value, "localvoxtral ")
-        XCTAssertEqual(harness.events.value, [
-            .type("voxtral "),
-            .backspace(8),
-            .type("localvoxtral "),
+    private var voxtralDictionary: ReplacementDictionary {
+        ReplacementDictionary(entries: [
+            ReplacementEntry(replaceWith: "localvoxtral", matches: ["voxtral"]),
         ])
+    }
+
+    private func stop(_ viewModel: DictationViewModel) {
+        viewModel.isDictating = false
+        viewModel.isFinalizingStop = true
+        viewModel.finishStoppedSession(promotePendingSegment: false)
     }
 
     private func makeHarness(
@@ -464,16 +232,13 @@ final class DictationViewModelLiveReplacementCorrectorTests: XCTestCase {
         dictionary: ReplacementDictionary = ReplacementDictionary(entries: []),
         configStore: MockAppConfigStore? = nil,
         field: TestField = TestField(""),
-        events: Box<[InsertionEvent]> = Box([]),
-        caretLocationReader: ((pid_t?) -> Int?)? = nil,
+        typed: Box<[String]> = Box([]),
         unicodePoster: ((String) -> Bool)? = nil,
-        backspacePoster: ((Int) -> Bool)? = nil,
-        liveReplacementSettleSleep: (() async -> Void)? = nil,
         frontmostBundleID: String? = nil
     ) -> (
         viewModel: DictationViewModel,
         field: TestField,
-        events: Box<[InsertionEvent]>
+        typed: Box<[String]>
     ) {
         let suiteName = "localvoxtral.DictationViewModelLiveReplacementCorrectorTests.\(UUID().uuidString)"
         let defaults = UserDefaults(suiteName: suiteName)!
@@ -496,23 +261,12 @@ final class DictationViewModelLiveReplacementCorrectorTests: XCTestCase {
 
         viewModel.textInsertion.debugConfigureInsertionHooks(
             unicodePoster: unicodePoster ?? { chunk in
-                events.value.append(.type(chunk))
+                typed.value.append(chunk)
                 field.value.append(chunk)
                 return true
             },
-            backspacePoster: backspacePoster ?? { count in
-                events.value.append(.backspace(count))
-                for _ in 0 ..< count {
-                    if !field.value.isEmpty {
-                        field.value.removeLast()
-                    }
-                }
-                return true
-            },
             modifierStateReader: { false },
-            accessibilityInserter: { _, _ in false },
-            caretLocationReader: caretLocationReader ?? { _ in (field.value as NSString).length },
-            liveReplacementSettleSleep: liveReplacementSettleSleep
+            accessibilityInserter: { _, _ in false }
         )
 
         if let frontmostBundleID {
@@ -526,7 +280,7 @@ final class DictationViewModelLiveReplacementCorrectorTests: XCTestCase {
         viewModel.isDictating = true
         viewModel.configureLiveAutoPasteReplacementCorrectorForSession()
 
-        return (viewModel, field, events)
+        return (viewModel, field, typed)
     }
 }
 

--- a/Tests/localvoxtralTests/DictationViewModelLiveReplacementCorrectorTests.swift
+++ b/Tests/localvoxtralTests/DictationViewModelLiveReplacementCorrectorTests.swift
@@ -410,6 +410,36 @@ final class DictationViewModelLiveReplacementCorrectorTests: XCTestCase {
         })
     }
 
+    func testUserAllowlistedBundleSelectsHoldBack() {
+        // cmux field case: the app reports a writable AX value, so detection
+        // needs the user's terminal_apps.toml entry to classify it — and the
+        // session must then behave exactly like a built-in terminal.
+        TerminalTargetDetector.debugFocusedElementProbeOverride = { .valueSettable }
+        let harness = makeHarness(
+            dictionary: ReplacementDictionary(entries: [
+                ReplacementEntry(replaceWith: "localvoxtral", matches: ["voxtral"]),
+            ]),
+            configStore: MockAppConfigStore(
+                replacementDictionary: ReplacementDictionary(entries: [
+                    ReplacementEntry(replaceWith: "localvoxtral", matches: ["voxtral"]),
+                ]),
+                terminalAppBundleIDs: ["com.cmuxterm.app"]
+            ),
+            frontmostBundleID: "com.cmuxterm.app"
+        )
+
+        harness.viewModel.handle(event: .partialTranscript("voxtral "))
+        harness.viewModel.isDictating = false
+        harness.viewModel.isFinalizingStop = true
+        harness.viewModel.finishStoppedSession(promotePendingSegment: false)
+
+        XCTAssertEqual(harness.field.value, "localvoxtral ")
+        XCTAssertFalse(harness.events.value.contains {
+            if case .backspace = $0 { return true }
+            return false
+        })
+    }
+
     func testNonTerminalVerdictKeepsGuardedCorrector() {
         TerminalTargetDetector.debugFocusedElementProbeOverride = { .valueSettable }
         let harness = makeHarness(
@@ -541,10 +571,15 @@ private final class MockOverlayCoordinator: OverlayBufferSessionCoordinating {
 
 private final class MockAppConfigStore: AppConfigServing {
     private let replacementDictionary: ReplacementDictionary
+    private let terminalAppBundleIDs: [String]
     private(set) var loadReplacementDictionaryCallCount = 0
 
-    init(replacementDictionary: ReplacementDictionary) {
+    init(
+        replacementDictionary: ReplacementDictionary,
+        terminalAppBundleIDs: [String] = []
+    ) {
         self.replacementDictionary = replacementDictionary
+        self.terminalAppBundleIDs = terminalAppBundleIDs
     }
 
     func configDirectoryURL() -> URL {
@@ -558,6 +593,10 @@ private final class MockAppConfigStore: AppConfigServing {
 
     func loadLLMPromptTemplates() -> LLMPromptTemplates {
         LLMPromptTemplates(systemContent: "{{input_text}}", userContent: "{{input_text}}")
+    }
+
+    func loadTerminalAppBundleIDs() -> [String] {
+        terminalAppBundleIDs
     }
 }
 #endif

--- a/Tests/localvoxtralTests/DictationViewModelModifierGestureTests.swift
+++ b/Tests/localvoxtralTests/DictationViewModelModifierGestureTests.swift
@@ -181,8 +181,30 @@ final class DictationViewModelModifierGestureTests: XCTestCase {
             overlayBufferCoordinator: coordinator,
             startRuntimeServices: false
         )
+        // Keep tests hermetic: session start reads config (terminal apps,
+        // replacement dictionary) through the store — never the real
+        // config directory.
+        viewModel.appConfigStore = GestureTestHermeticConfigStore()
         Self.retainedViewModels.append(viewModel)
         return viewModel
+    }
+}
+
+private final class GestureTestHermeticConfigStore: AppConfigServing {
+    func configDirectoryURL() -> URL {
+        FileManager.default.temporaryDirectory
+    }
+
+    func loadReplacementDictionary() -> ReplacementDictionary {
+        ReplacementDictionary(entries: [])
+    }
+
+    func loadLLMPromptTemplates() -> LLMPromptTemplates {
+        LLMPromptTemplates(systemContent: "system", userContent: "{{input_text}}")
+    }
+
+    func loadTerminalAppBundleIDs() -> [String] {
+        []
     }
 }
 

--- a/Tests/localvoxtralTests/DictationViewModelOverlayLifecycleTests.swift
+++ b/Tests/localvoxtralTests/DictationViewModelOverlayLifecycleTests.swift
@@ -1097,6 +1097,10 @@ private final class MockAppConfigStore: AppConfigServing {
         loadLLMPromptTemplatesCallCount += 1
         return promptTemplates
     }
+
+    func loadTerminalAppBundleIDs() -> [String] {
+        []
+    }
 }
 
 private struct BufferCall {

--- a/Tests/localvoxtralTests/LiveHoldBackReplacementStreamTests.swift
+++ b/Tests/localvoxtralTests/LiveHoldBackReplacementStreamTests.swift
@@ -1,0 +1,148 @@
+import XCTest
+@testable import localvoxtral
+
+final class LiveHoldBackReplacementStreamTests: XCTestCase {
+    private func makeStream(
+        entries: [ReplacementEntry],
+        sanitizesNewlines: Bool = false
+    ) -> LiveHoldBackReplacementStream {
+        LiveHoldBackReplacementStream(
+            dictionary: ReplacementDictionary(entries: entries),
+            sanitizesNewlines: sanitizesNewlines
+        )
+    }
+
+    private var voxtralEntry: ReplacementEntry {
+        ReplacementEntry(replaceWith: "localvoxtral", matches: ["voxtral"])
+    }
+
+    // MARK: - Replacement + hold-back policy
+
+    func testSingleWordRuleReleasesPromptlyAtWordBoundary() {
+        var stream = makeStream(entries: [voxtralEntry])
+        XCTAssertEqual(stream.ingest("voxtral "), "localvoxtral ")
+    }
+
+    func testTrailingPartialWordIsHeldAcrossChunks() {
+        var stream = makeStream(entries: [voxtralEntry])
+        XCTAssertEqual(stream.ingest("vox"), "")
+        XCTAssertEqual(stream.ingest("tral"), "")
+        XCTAssertEqual(stream.ingest(" "), "localvoxtral ")
+    }
+
+    func testNonMatchingTextReleasesWithZeroExtraHold() {
+        var stream = makeStream(entries: [voxtralEntry])
+        XCTAssertEqual(stream.ingest("hello world "), "hello world ")
+    }
+
+    func testMultiWordRuleSpanningIngestChunksMatches() {
+        var stream = makeStream(entries: [
+            ReplacementEntry(replaceWith: "localvoxtral", matches: ["local voxtral"]),
+        ])
+        XCTAssertEqual(stream.ingest("local "), "")
+        XCTAssertEqual(stream.ingest("voxtral "), "")
+        XCTAssertEqual(stream.ingest("rocks "), "localvoxtral ")
+        XCTAssertEqual(stream.flushRemainder(), "rocks ")
+    }
+
+    func testMultiWordRuleHoldsBackPossiblePrefixWords() {
+        var stream = makeStream(entries: [
+            ReplacementEntry(replaceWith: "Claude Code", matches: ["cloud code"]),
+        ])
+        // "cloud" alone must not be released: it could be the first word of
+        // the two-word match that only completes with the next chunk.
+        XCTAssertEqual(stream.ingest("use cloud "), "use ")
+        // Once the match applies, everything but the trailing complete word
+        // (a possible prefix of the next two-word match) is released.
+        XCTAssertEqual(stream.ingest("code "), "Claude ")
+        XCTAssertEqual(stream.flushRemainder(), "Code ")
+    }
+
+    func testPunctuationBoundaryCompletesMatchButHoldsUntilWhitespace() {
+        var stream = makeStream(entries: [voxtralEntry])
+        // "voxtral." could still grow into a different word ("voxtral.x"),
+        // so it stays held until whitespace or the final flush.
+        XCTAssertEqual(stream.ingest("voxtral."), "")
+        XCTAssertEqual(stream.ingest(" "), "localvoxtral. ")
+    }
+
+    func testFlushRemainderAppliesFinalUnboundedWordMatch() {
+        var stream = makeStream(entries: [voxtralEntry])
+        XCTAssertEqual(stream.ingest("voxtral"), "")
+        XCTAssertEqual(stream.flushRemainder(), "localvoxtral")
+    }
+
+    func testEmojiGraphemeMatchIsReplaced() {
+        var stream = makeStream(entries: [
+            ReplacementEntry(replaceWith: "developer", matches: ["👩‍💻"]),
+        ])
+        XCTAssertEqual(stream.ingest("👩‍💻 "), "developer ")
+    }
+
+    func testNoRulesReleasesEverythingImmediately() {
+        var stream = makeStream(entries: [])
+        XCTAssertEqual(stream.ingest("partial-word-no-boundary"), "partial-word-no-boundary")
+        XCTAssertEqual(stream.flushRemainder(), "")
+    }
+
+    func testEmptyAndWhitespaceOnlyIngest() {
+        var stream = makeStream(entries: [voxtralEntry])
+        XCTAssertEqual(stream.ingest(""), "")
+        XCTAssertEqual(stream.ingest("   "), "   ")
+        XCTAssertEqual(stream.flushRemainder(), "")
+    }
+
+    func testFlushRemainderOnEmptyStreamIsEmpty() {
+        var stream = makeStream(entries: [voxtralEntry])
+        XCTAssertEqual(stream.flushRemainder(), "")
+    }
+
+    // MARK: - Newline sanitization
+
+    func testNewlineIsCollapsedToSingleSpace() {
+        var stream = makeStream(entries: [voxtralEntry], sanitizesNewlines: true)
+        XCTAssertEqual(stream.ingest("hello\nworld "), "hello world ")
+    }
+
+    func testNewlineRunWithAdjacentSpacesProducesNoDoubleSpace() {
+        var stream = makeStream(entries: [voxtralEntry], sanitizesNewlines: true)
+        XCTAssertEqual(stream.ingest("hello \n\n world "), "hello world ")
+    }
+
+    func testNewlineCollapseSpansReleaseBoundaries() {
+        var stream = makeStream(entries: [voxtralEntry], sanitizesNewlines: true)
+        XCTAssertEqual(stream.ingest("hello\n"), "hello ")
+        XCTAssertEqual(stream.ingest("\n world "), "world ")
+    }
+
+    func testLeadingNewlinesAreDropped() {
+        var stream = makeStream(entries: [voxtralEntry], sanitizesNewlines: true)
+        XCTAssertEqual(stream.ingest("\n\nhello "), "hello ")
+    }
+
+    func testCarriageReturnsAreSanitized() {
+        var stream = makeStream(entries: [voxtralEntry], sanitizesNewlines: true)
+        XCTAssertEqual(stream.ingest("a\r\nb\rc "), "a b c ")
+    }
+
+    func testFlushedRemainderIsSanitized() {
+        var stream = makeStream(
+            entries: [ReplacementEntry(replaceWith: "localvoxtral", matches: ["local voxtral"])],
+            sanitizesNewlines: true
+        )
+        // Two-word rule holds everything back so the newline reaches the
+        // remainder flush; sanitization must still apply there.
+        XCTAssertEqual(stream.ingest("run\nit"), "")
+        XCTAssertEqual(stream.flushRemainder(), "run it")
+    }
+
+    func testSanitizationOffPreservesNewlines() {
+        var stream = makeStream(entries: [voxtralEntry], sanitizesNewlines: false)
+        XCTAssertEqual(stream.ingest("hello\nworld "), "hello\nworld ")
+    }
+
+    func testReplacementAndSanitizationCompose() {
+        var stream = makeStream(entries: [voxtralEntry], sanitizesNewlines: true)
+        XCTAssertEqual(stream.ingest("voxtral\nrocks "), "localvoxtral rocks ")
+    }
+}

--- a/Tests/localvoxtralTests/LiveHoldBackReplacementStreamTests.swift
+++ b/Tests/localvoxtralTests/LiveHoldBackReplacementStreamTests.swift
@@ -99,30 +99,83 @@ final class LiveHoldBackReplacementStreamTests: XCTestCase {
 
     // MARK: - Newline sanitization
 
+    // Trailing spaces are buffered until the next non-whitespace character
+    // (or the remainder flush) decides whether their run collapses, so the
+    // sanitize-ON assertions below check ingest and flush outputs jointly.
+
     func testNewlineIsCollapsedToSingleSpace() {
         var stream = makeStream(entries: [voxtralEntry], sanitizesNewlines: true)
-        XCTAssertEqual(stream.ingest("hello\nworld "), "hello world ")
+        XCTAssertEqual(stream.ingest("hello\nworld "), "hello world")
+        XCTAssertEqual(stream.flushRemainder(), " ")
     }
 
     func testNewlineRunWithAdjacentSpacesProducesNoDoubleSpace() {
         var stream = makeStream(entries: [voxtralEntry], sanitizesNewlines: true)
-        XCTAssertEqual(stream.ingest("hello \n\n world "), "hello world ")
+        XCTAssertEqual(stream.ingest("hello \n\n world "), "hello world")
+        XCTAssertEqual(stream.flushRemainder(), " ")
     }
 
     func testNewlineCollapseSpansReleaseBoundaries() {
         var stream = makeStream(entries: [voxtralEntry], sanitizesNewlines: true)
-        XCTAssertEqual(stream.ingest("hello\n"), "hello ")
-        XCTAssertEqual(stream.ingest("\n world "), "world ")
+        XCTAssertEqual(stream.ingest("hello\n"), "hello")
+        XCTAssertEqual(stream.ingest("\n world "), " world")
+        XCTAssertEqual(stream.flushRemainder(), " ")
     }
 
     func testLeadingNewlinesAreDropped() {
         var stream = makeStream(entries: [voxtralEntry], sanitizesNewlines: true)
-        XCTAssertEqual(stream.ingest("\n\nhello "), "hello ")
+        XCTAssertEqual(stream.ingest("\n\nhello "), "hello")
+        XCTAssertEqual(stream.flushRemainder(), " ")
     }
 
     func testCarriageReturnsAreSanitized() {
         var stream = makeStream(entries: [voxtralEntry], sanitizesNewlines: true)
-        XCTAssertEqual(stream.ingest("a\r\nb\rc "), "a b c ")
+        XCTAssertEqual(stream.ingest("a\r\nb\rc "), "a b c")
+        XCTAssertEqual(stream.flushRemainder(), " ")
+    }
+
+    func testTabBeforeNewlineCollapsesToSingleSpace() {
+        var stream = makeStream(entries: [voxtralEntry], sanitizesNewlines: true)
+        // The tab precedes the newline: the whole run (tab + newline) must
+        // still collapse to exactly one space.
+        XCTAssertEqual(stream.ingest("cmd\t\nnext "), "cmd next")
+        XCTAssertEqual(stream.flushRemainder(), " ")
+    }
+
+    func testSpacesBeforeNewlineAcrossChunksCollapse() {
+        var stream = makeStream(entries: [voxtralEntry], sanitizesNewlines: true)
+        // The spaces are buffered at the chunk edge; the newline arriving in
+        // the next chunk retroactively collapses the whole run.
+        XCTAssertEqual(stream.ingest("cmd "), "cmd")
+        XCTAssertEqual(stream.ingest("\nls "), " ls")
+        XCTAssertEqual(stream.flushRemainder(), " ")
+    }
+
+    func testStandaloneTabCollapsesToSingleSpace() {
+        var stream = makeStream(entries: [voxtralEntry], sanitizesNewlines: true)
+        // A synthetic Tab keystroke triggers shell completion UI — same
+        // terminal-state hazard class as Enter.
+        XCTAssertEqual(stream.ingest("a\tb "), "a b")
+        XCTAssertEqual(stream.flushRemainder(), " ")
+    }
+
+    func testTabRunCollapsesToSingleSpace() {
+        var stream = makeStream(entries: [voxtralEntry], sanitizesNewlines: true)
+        XCTAssertEqual(stream.ingest("a\t\tb "), "a b")
+        XCTAssertEqual(stream.flushRemainder(), " ")
+    }
+
+    func testWhitespaceHeldAtChunkEdgeIsReleasedIntactWhenNoNewlineFollows() {
+        var stream = makeStream(entries: [voxtralEntry], sanitizesNewlines: true)
+        XCTAssertEqual(stream.ingest("cmd "), "cmd")
+        XCTAssertEqual(stream.ingest("ls "), " ls")
+        XCTAssertEqual(stream.flushRemainder(), " ")
+    }
+
+    func testPlainSpaceRunsAreReemittedVerbatim() {
+        var stream = makeStream(entries: [voxtralEntry], sanitizesNewlines: true)
+        XCTAssertEqual(stream.ingest("a  b "), "a  b")
+        XCTAssertEqual(stream.flushRemainder(), " ")
     }
 
     func testFlushedRemainderIsSanitized() {
@@ -141,8 +194,14 @@ final class LiveHoldBackReplacementStreamTests: XCTestCase {
         XCTAssertEqual(stream.ingest("hello\nworld "), "hello\nworld ")
     }
 
+    func testSanitizationOffPreservesTabs() {
+        var stream = makeStream(entries: [voxtralEntry], sanitizesNewlines: false)
+        XCTAssertEqual(stream.ingest("a\tb "), "a\tb ")
+    }
+
     func testReplacementAndSanitizationCompose() {
         var stream = makeStream(entries: [voxtralEntry], sanitizesNewlines: true)
-        XCTAssertEqual(stream.ingest("voxtral\nrocks "), "localvoxtral rocks ")
+        XCTAssertEqual(stream.ingest("voxtral\nrocks "), "localvoxtral rocks")
+        XCTAssertEqual(stream.flushRemainder(), " ")
     }
 }

--- a/Tests/localvoxtralTests/TerminalTargetDetectorTests.swift
+++ b/Tests/localvoxtralTests/TerminalTargetDetectorTests.swift
@@ -1,0 +1,180 @@
+import Foundation
+import XCTest
+@testable import localvoxtral
+
+@MainActor
+final class TerminalTargetDetectorTests: XCTestCase {
+    override func tearDown() async throws {
+        TerminalTargetDetector.debugFrontmostBundleIDOverride = nil
+        TerminalTargetDetector.debugFocusedElementProbeOverride = nil
+        TerminalTargetDetector.debugSecureEventInputOverride = nil
+        try await super.tearDown()
+    }
+
+    // MARK: - Bundle allowlist (pure)
+
+    func testAllowlistMatchesKnownTerminalBundleIDs() {
+        let knownTerminals = [
+            "com.apple.Terminal",
+            "com.googlecode.iterm2",
+            "com.mitchellh.ghostty",
+            "dev.warp.Warp-Stable",
+            "com.github.wez.wezterm",
+            "net.kovidgoyal.kitty",
+            "org.alacritty",
+            "co.zeit.hyper",
+            "org.tabby",
+            "com.raphaelamorim.rio",
+        ]
+        for bundleID in knownTerminals {
+            XCTAssertTrue(
+                TerminalTargetDetector.isTerminalLikeBundleID(bundleID),
+                "\(bundleID) should be terminal-like"
+            )
+        }
+    }
+
+    func testAllowlistMatchesWarpChannelVariants() {
+        for bundleID in ["dev.warp.Warp-Preview", "dev.warp.Warp-Dev", "dev.warp.Warp-Beta"] {
+            XCTAssertTrue(
+                TerminalTargetDetector.isTerminalLikeBundleID(bundleID),
+                "\(bundleID) should match the Warp prefix"
+            )
+        }
+    }
+
+    func testAllowlistRejectsUnknownNilAndEditorBundleIDs() {
+        XCTAssertFalse(TerminalTargetDetector.isTerminalLikeBundleID(nil))
+        XCTAssertFalse(TerminalTargetDetector.isTerminalLikeBundleID(""))
+        // VS Code/Cursor editors are AX-writable — never allowlisted.
+        XCTAssertFalse(TerminalTargetDetector.isTerminalLikeBundleID("com.microsoft.VSCode"))
+        XCTAssertFalse(TerminalTargetDetector.isTerminalLikeBundleID("com.todesktop.230313mzl4w4u92"))
+        XCTAssertFalse(TerminalTargetDetector.isTerminalLikeBundleID("com.apple.Safari"))
+        // Prefix matching must not fire on unrelated dev.warp-ish strings.
+        XCTAssertFalse(TerminalTargetDetector.isTerminalLikeBundleID("dev.warp"))
+        XCTAssertFalse(TerminalTargetDetector.isTerminalLikeBundleID("dev.warplike.Other"))
+    }
+
+    // MARK: - Decision logic (injected AX probe)
+
+    func testUnknownBundleWithUnsettableValueIsTerminalLike() {
+        let decision = TerminalTargetDetector.decision(forBundleID: "com.example.unknown") {
+            .valueNotSettable
+        }
+        XCTAssertTrue(decision.isTerminalLike)
+        XCTAssertEqual(decision.reason, .axProbeValueNotSettable)
+    }
+
+    func testUnknownBundleWithMissingFocusedElementIsTerminalLike() {
+        let decision = TerminalTargetDetector.decision(forBundleID: "com.example.unknown") {
+            .noFocusedElement
+        }
+        XCTAssertTrue(decision.isTerminalLike)
+        XCTAssertEqual(decision.reason, .axProbeNoFocusedElement)
+    }
+
+    func testUnknownBundleWithSettableValueIsNotTerminalLike() {
+        let decision = TerminalTargetDetector.decision(forBundleID: "com.example.unknown") {
+            .valueSettable
+        }
+        XCTAssertFalse(decision.isTerminalLike)
+        XCTAssertEqual(decision.reason, .axProbeValueSettable)
+    }
+
+    func testAllowlistedBundleIsTerminalLikeWithoutProbing() {
+        let decision = TerminalTargetDetector.decision(forBundleID: "com.mitchellh.ghostty") {
+            XCTFail("AX probe must not run for allowlisted bundles")
+            return .valueSettable
+        }
+        XCTAssertTrue(decision.isTerminalLike)
+        XCTAssertEqual(decision.reason, .bundleMatch)
+    }
+
+    func testDetectCurrentTargetUsesInjectedSeams() {
+        TerminalTargetDetector.debugFrontmostBundleIDOverride = { "com.example.unknown" }
+        TerminalTargetDetector.debugFocusedElementProbeOverride = { .valueNotSettable }
+        let decision = TerminalTargetDetector.detectCurrentTarget()
+        XCTAssertTrue(decision.isTerminalLike)
+        XCTAssertEqual(decision.reason, .axProbeValueNotSettable)
+
+        TerminalTargetDetector.debugFocusedElementProbeOverride = { .valueSettable }
+        XCTAssertFalse(TerminalTargetDetector.detectCurrentTarget().isTerminalLike)
+    }
+
+    // MARK: - Session-start wiring + Secure Keyboard Entry warning
+
+    func testSessionStartStoresTerminalVerdictAndWarnsOnSecureKeyboardEntry() {
+        TerminalTargetDetector.debugFrontmostBundleIDOverride = { "com.apple.Terminal" }
+        TerminalTargetDetector.debugFocusedElementProbeOverride = {
+            XCTFail("AX probe must not run for allowlisted bundles")
+            return .valueSettable
+        }
+        TerminalTargetDetector.debugSecureEventInputOverride = { true }
+
+        let viewModel = makeViewModel()
+        XCTAssertFalse(viewModel.sessionTargetIsTerminalLike)
+
+        viewModel.refreshSessionTargetVerdictAtSessionStart()
+
+        XCTAssertTrue(viewModel.sessionTargetIsTerminalLike)
+        XCTAssertEqual(
+            viewModel.lastError,
+            DictationViewModel.secureKeyboardEntryWarningMessage
+        )
+    }
+
+    func testSessionStartWithoutSecureInputLeavesNoWarningAndRefreshesVerdict() {
+        TerminalTargetDetector.debugFrontmostBundleIDOverride = { "com.apple.Terminal" }
+        TerminalTargetDetector.debugSecureEventInputOverride = { false }
+
+        let viewModel = makeViewModel()
+        viewModel.refreshSessionTargetVerdictAtSessionStart()
+        XCTAssertTrue(viewModel.sessionTargetIsTerminalLike)
+        XCTAssertNil(viewModel.lastError)
+
+        // A later session against an ordinary writable text field resets the verdict.
+        TerminalTargetDetector.debugFrontmostBundleIDOverride = { "com.example.editor" }
+        TerminalTargetDetector.debugFocusedElementProbeOverride = { .valueSettable }
+        viewModel.refreshSessionTargetVerdictAtSessionStart()
+        XCTAssertFalse(viewModel.sessionTargetIsTerminalLike)
+        XCTAssertNil(viewModel.lastError)
+    }
+
+    // MARK: - Fixture
+
+    private func makeViewModel() -> DictationViewModel {
+        let suiteName = "localvoxtral.TerminalTargetDetectorTests.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defaults.removePersistentDomain(forName: suiteName)
+        addTeardownBlock {
+            defaults.removePersistentDomain(forName: suiteName)
+        }
+        let settings = SettingsStore(defaults: defaults, environment: [:])
+        return DictationViewModel(
+            settings: settings,
+            overlayBufferCoordinator: TargetDetectorNoopOverlayCoordinator(),
+            startRuntimeServices: false
+        )
+    }
+}
+
+@MainActor
+private final class TargetDetectorNoopOverlayCoordinator: OverlayBufferSessionCoordinating {
+    var commitTargetAppPID: pid_t? = nil
+
+    func resolveAnchorNow() -> OverlayAnchor {
+        OverlayAnchor(targetRect: .zero, source: .windowCenter)
+    }
+    func startSession(preResolvedAnchor: OverlayAnchor?) {}
+    func beginFinalizing(displayBufferText: String, commitBufferText: String) {}
+    func refresh(displayBufferText: String, commitBufferText: String) {}
+    @discardableResult
+    func commitIfNeeded(
+        using textCommitter: OverlayTextCommitting, autoCopyEnabled: Bool
+    ) -> OverlayBufferCommitOutcome {
+        .succeeded
+    }
+    func dismissAfterHold(minimumVisibility: TimeInterval) {}
+    func reset() {}
+    func captureLiveCommitTargetAppPID() {}
+}

--- a/Tests/localvoxtralTests/TerminalTargetDetectorTests.swift
+++ b/Tests/localvoxtralTests/TerminalTargetDetectorTests.swift
@@ -4,6 +4,10 @@ import XCTest
 
 @MainActor
 final class TerminalTargetDetectorTests: XCTestCase {
+    // DictationViewModel owns app-lifetime services. Retain test instances for
+    // the process duration so teardown does not race service shutdown.
+    private static var retainedViewModels: [DictationViewModel] = []
+
     override func tearDown() async throws {
         TerminalTargetDetector.debugFrontmostBundleIDOverride = nil
         TerminalTargetDetector.debugFocusedElementProbeOverride = nil
@@ -81,6 +85,16 @@ final class TerminalTargetDetectorTests: XCTestCase {
         XCTAssertEqual(decision.reason, .axProbeValueSettable)
     }
 
+    func testUnknownBundleWithUnavailableProbeIsNotTerminalLike() {
+        // AX trust missing / transient AX errors must not flip ordinary apps
+        // terminal-like — "couldn't tell" is distinct from "confirmed grid".
+        let decision = TerminalTargetDetector.decision(forBundleID: "com.example.unknown") {
+            .probeUnavailable
+        }
+        XCTAssertFalse(decision.isTerminalLike)
+        XCTAssertEqual(decision.reason, .axProbeUnavailable)
+    }
+
     func testAllowlistedBundleIsTerminalLikeWithoutProbing() {
         let decision = TerminalTargetDetector.decision(forBundleID: "com.mitchellh.ghostty") {
             XCTFail("AX probe must not run for allowlisted bundles")
@@ -101,48 +115,125 @@ final class TerminalTargetDetectorTests: XCTestCase {
         XCTAssertFalse(TerminalTargetDetector.detectCurrentTarget().isTerminalLike)
     }
 
-    // MARK: - Session-start wiring + Secure Keyboard Entry warning
+    // MARK: - Capture-at-begin / consume-at-audio-start lifecycle
 
-    func testSessionStartStoresTerminalVerdictAndWarnsOnSecureKeyboardEntry() {
+    func testBeginDictationSessionCapturesVerdictBeforeConnect() {
+        // Pins the wiring: the verdict must be sampled inside
+        // beginDictationSession (before the socket opens), like
+        // preResolvedOverlayAnchor. Overlay mode avoids the live-auto-paste
+        // accessibility fail-fast path (no TCC prompt on the runner).
         TerminalTargetDetector.debugFrontmostBundleIDOverride = { "com.apple.Terminal" }
-        TerminalTargetDetector.debugFocusedElementProbeOverride = {
-            XCTFail("AX probe must not run for allowlisted bundles")
-            return .valueSettable
-        }
         TerminalTargetDetector.debugSecureEventInputOverride = { true }
 
-        let viewModel = makeViewModel()
-        XCTAssertFalse(viewModel.sessionTargetIsTerminalLike)
+        let viewModel = makeViewModel(outputMode: .overlayBuffer)
+        viewModel.settings.realtimeAPIEndpointURL = "ws://127.0.0.1:1/realtime"
+        viewModel.isShowingConnectionFailureAlert = true
+        Self.retainedViewModels.append(viewModel)
 
-        viewModel.refreshSessionTargetVerdictAtSessionStart()
+        viewModel.beginDictationSession(outputMode: .overlayBuffer)
+
+        XCTAssertEqual(
+            viewModel.preCapturedSessionTargetVerdict,
+            DictationViewModel.SessionTargetVerdict(
+                decision: .init(isTerminalLike: true, reason: .bundleMatch),
+                secureKeyboardEntryEnabled: true
+            )
+        )
+
+        viewModel.abortConnectingSession()
+    }
+
+    func testApplyConsumesPreCapturedVerdictInsteadOfReprobing() {
+        // Capture with the terminal frontmost and secure input on...
+        TerminalTargetDetector.debugFrontmostBundleIDOverride = { "com.mitchellh.ghostty" }
+        TerminalTargetDetector.debugSecureEventInputOverride = { true }
+
+        let viewModel = makeViewModel(outputMode: .liveAutoPaste)
+        viewModel.captureSessionTargetVerdict()
+
+        // ...then simulate a focus switch during connect: live state now says
+        // an ordinary writable app with secure input off. The session must
+        // keep the captured values, not reprobe.
+        TerminalTargetDetector.debugFrontmostBundleIDOverride = { "com.example.editor" }
+        TerminalTargetDetector.debugFocusedElementProbeOverride = { .valueSettable }
+        TerminalTargetDetector.debugSecureEventInputOverride = { false }
+
+        viewModel.applyPreCapturedSessionTargetVerdict()
 
         XCTAssertTrue(viewModel.sessionTargetIsTerminalLike)
         XCTAssertEqual(
             viewModel.lastError,
             DictationViewModel.secureKeyboardEntryWarningMessage
         )
+        XCTAssertNil(viewModel.preCapturedSessionTargetVerdict, "capture is consumed once")
     }
 
-    func testSessionStartWithoutSecureInputLeavesNoWarningAndRefreshesVerdict() {
+    // MARK: - Secure Keyboard Entry warning lifecycle
+
+    func testSecureWarningDoesNotClobberAccessibilityWarning() {
+        TerminalTargetDetector.debugFrontmostBundleIDOverride = { "com.apple.Terminal" }
+        TerminalTargetDetector.debugSecureEventInputOverride = { true }
+
+        let viewModel = makeViewModel(outputMode: .liveAutoPaste)
+        viewModel.lastError = DictationViewModel.liveAutoPasteAccessibilityWarningMessage
+
+        viewModel.captureSessionTargetVerdict()
+        viewModel.applyPreCapturedSessionTargetVerdict()
+
+        XCTAssertEqual(
+            viewModel.lastError,
+            DictationViewModel.liveAutoPasteAccessibilityWarningMessage,
+            "the Accessibility-trust warning outranks the secure-input warning"
+        )
+        XCTAssertTrue(viewModel.sessionTargetIsTerminalLike, "verdict still applies")
+    }
+
+    func testStaleSecureWarningClearedAtNextSessionStartWhenSecureInputOff() {
+        // Regression: the warning used to wedge in lastError forever.
         TerminalTargetDetector.debugFrontmostBundleIDOverride = { "com.apple.Terminal" }
         TerminalTargetDetector.debugSecureEventInputOverride = { false }
 
-        let viewModel = makeViewModel()
-        viewModel.refreshSessionTargetVerdictAtSessionStart()
-        XCTAssertTrue(viewModel.sessionTargetIsTerminalLike)
-        XCTAssertNil(viewModel.lastError)
+        let viewModel = makeViewModel(outputMode: .liveAutoPaste)
+        viewModel.lastError = DictationViewModel.secureKeyboardEntryWarningMessage
 
-        // A later session against an ordinary writable text field resets the verdict.
-        TerminalTargetDetector.debugFrontmostBundleIDOverride = { "com.example.editor" }
-        TerminalTargetDetector.debugFocusedElementProbeOverride = { .valueSettable }
-        viewModel.refreshSessionTargetVerdictAtSessionStart()
-        XCTAssertFalse(viewModel.sessionTargetIsTerminalLike)
+        viewModel.captureSessionTargetVerdict()
+        viewModel.applyPreCapturedSessionTargetVerdict()
+
+        XCTAssertNil(viewModel.lastError, "stale warning cleared once secure input is off")
+        XCTAssertTrue(viewModel.sessionTargetIsTerminalLike)
+    }
+
+    func testSecureWarningClearedAtSessionEnd() {
+        // Regression: session end must release the warning (mirrors the
+        // websocketReceiveFailed clearing), not leave it in the popover.
+        let viewModel = makeViewModel(outputMode: .liveAutoPaste)
+        Self.retainedViewModels.append(viewModel)
+        viewModel.lastError = DictationViewModel.secureKeyboardEntryWarningMessage
+        viewModel.sessionOutputMode = .liveAutoPaste
+        viewModel.isDictating = true
+
+        viewModel.stopDictation(reason: "test", finalizeRemainingAudio: false)
+
         XCTAssertNil(viewModel.lastError)
+        XCTAssertEqual(viewModel.statusText, "Ready")
+    }
+
+    func testSessionEndKeepsUnrelatedErrors() {
+        // The session-end clear is token-scoped: other errors must survive.
+        let viewModel = makeViewModel(outputMode: .liveAutoPaste)
+        Self.retainedViewModels.append(viewModel)
+        viewModel.lastError = "mlx-lm failed to start."
+        viewModel.sessionOutputMode = .liveAutoPaste
+        viewModel.isDictating = true
+
+        viewModel.stopDictation(reason: "test", finalizeRemainingAudio: false)
+
+        XCTAssertEqual(viewModel.lastError, "mlx-lm failed to start.")
     }
 
     // MARK: - Fixture
 
-    private func makeViewModel() -> DictationViewModel {
+    private func makeViewModel(outputMode: DictationOutputMode) -> DictationViewModel {
         let suiteName = "localvoxtral.TerminalTargetDetectorTests.\(UUID().uuidString)"
         let defaults = UserDefaults(suiteName: suiteName)!
         defaults.removePersistentDomain(forName: suiteName)
@@ -150,6 +241,7 @@ final class TerminalTargetDetectorTests: XCTestCase {
             defaults.removePersistentDomain(forName: suiteName)
         }
         let settings = SettingsStore(defaults: defaults, environment: [:])
+        settings.dictationOutputMode = outputMode
         return DictationViewModel(
             settings: settings,
             overlayBufferCoordinator: TargetDetectorNoopOverlayCoordinator(),

--- a/Tests/localvoxtralTests/TerminalTargetDetectorTests.swift
+++ b/Tests/localvoxtralTests/TerminalTargetDetectorTests.swift
@@ -163,6 +163,39 @@ final class TerminalTargetDetectorTests: XCTestCase {
         XCTAssertFalse(unconfigured.sessionTargetIsTerminalLike)
     }
 
+    // MARK: - Insertion scalar tracing (marker-file gate)
+
+    func testScalarTracingFollowsMarkerFilePresence() throws {
+        let configDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("lv-scalar-trace-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: configDir, withIntermediateDirectories: true)
+        addTeardownBlock {
+            try? FileManager.default.removeItem(at: configDir)
+        }
+
+        let viewModel = makeViewModel(outputMode: .liveAutoPaste)
+        viewModel.appConfigStore = TargetDetectorMockConfigStore(
+            terminalAppBundleIDs: [],
+            configDirectory: configDir
+        )
+
+        viewModel.refreshInsertionScalarTracingForSession()
+        XCTAssertFalse(viewModel.textInsertion.isScalarTracingEnabled)
+
+        FileManager.default.createFile(
+            atPath: configDir.appendingPathComponent("insertion_scalar_trace").path,
+            contents: nil
+        )
+        viewModel.refreshInsertionScalarTracingForSession()
+        XCTAssertTrue(viewModel.textInsertion.isScalarTracingEnabled)
+
+        try FileManager.default.removeItem(
+            at: configDir.appendingPathComponent("insertion_scalar_trace")
+        )
+        viewModel.refreshInsertionScalarTracingForSession()
+        XCTAssertFalse(viewModel.textInsertion.isScalarTracingEnabled, "tracing must disarm when the marker is removed")
+    }
+
     // MARK: - Capture-at-begin / consume-at-audio-start lifecycle
 
     func testBeginDictationSessionCapturesVerdictBeforeConnect() {
@@ -309,13 +342,18 @@ final class TerminalTargetDetectorTests: XCTestCase {
 
 private final class TargetDetectorMockConfigStore: AppConfigServing {
     private let terminalAppBundleIDs: [String]
+    private let configDirectory: URL
 
-    init(terminalAppBundleIDs: [String]) {
+    init(
+        terminalAppBundleIDs: [String],
+        configDirectory: URL = FileManager.default.temporaryDirectory
+    ) {
         self.terminalAppBundleIDs = terminalAppBundleIDs
+        self.configDirectory = configDirectory
     }
 
     func configDirectoryURL() -> URL {
-        FileManager.default.temporaryDirectory
+        configDirectory
     }
 
     func loadReplacementDictionary() -> ReplacementDictionary {

--- a/Tests/localvoxtralTests/TerminalTargetDetectorTests.swift
+++ b/Tests/localvoxtralTests/TerminalTargetDetectorTests.swift
@@ -29,6 +29,7 @@ final class TerminalTargetDetectorTests: XCTestCase {
             "co.zeit.hyper",
             "org.tabby",
             "com.raphaelamorim.rio",
+            "com.cmuxterm.app",
         ]
         for bundleID in knownTerminals {
             XCTAssertTrue(
@@ -118,9 +119,11 @@ final class TerminalTargetDetectorTests: XCTestCase {
     // MARK: - User allowlist (terminal_apps.toml)
 
     func testUserBundleIDIsTerminalLikeWithoutProbing() {
+        // A bundle NOT in the built-in list: cmux graduated to built-in, so it
+        // can no longer exercise the user-allowlist path.
         let decision = TerminalTargetDetector.decision(
-            forBundleID: "com.cmuxterm.app",
-            userBundleIDs: ["com.cmuxterm.app"]
+            forBundleID: "com.example.myterminal",
+            userBundleIDs: ["com.example.myterminal"]
         ) {
             XCTFail("AX probe must not run for user-allowlisted bundles")
             return .valueSettable
@@ -141,16 +144,17 @@ final class TerminalTargetDetectorTests: XCTestCase {
     }
 
     func testCaptureUsesUserTerminalAppsFromConfigStore() {
-        // The field case (2026-07-07): cmux hosts a terminal but reports a
-        // writable AX value, so only the user's terminal_apps.toml entry can
-        // classify it.
-        TerminalTargetDetector.debugFrontmostBundleIDOverride = { "com.cmuxterm.app" }
+        // The original cmux field case (2026-07-07): a terminal host with a
+        // writable AX value that only the user's terminal_apps.toml entry can
+        // classify. cmux itself is built-in now, so an unknown stand-in keeps
+        // this capture path exercised.
+        TerminalTargetDetector.debugFrontmostBundleIDOverride = { "com.example.myterminal" }
         TerminalTargetDetector.debugFocusedElementProbeOverride = { .valueSettable }
         TerminalTargetDetector.debugSecureEventInputOverride = { false }
 
         let viewModel = makeViewModel(
             outputMode: .liveAutoPaste,
-            terminalAppBundleIDs: ["com.cmuxterm.app"]
+            terminalAppBundleIDs: ["com.example.myterminal"]
         )
         viewModel.captureSessionTargetVerdict()
         viewModel.applyPreCapturedSessionTargetVerdict()

--- a/Tests/localvoxtralTests/TerminalTargetDetectorTests.swift
+++ b/Tests/localvoxtralTests/TerminalTargetDetectorTests.swift
@@ -115,6 +115,54 @@ final class TerminalTargetDetectorTests: XCTestCase {
         XCTAssertFalse(TerminalTargetDetector.detectCurrentTarget().isTerminalLike)
     }
 
+    // MARK: - User allowlist (terminal_apps.toml)
+
+    func testUserBundleIDIsTerminalLikeWithoutProbing() {
+        let decision = TerminalTargetDetector.decision(
+            forBundleID: "com.cmuxterm.app",
+            userBundleIDs: ["com.cmuxterm.app"]
+        ) {
+            XCTFail("AX probe must not run for user-allowlisted bundles")
+            return .valueSettable
+        }
+        XCTAssertTrue(decision.isTerminalLike)
+        XCTAssertEqual(decision.reason, .userBundleMatch)
+    }
+
+    func testUserBundleIDDoesNotOverrideBuiltInReason() {
+        let decision = TerminalTargetDetector.decision(
+            forBundleID: "com.mitchellh.ghostty",
+            userBundleIDs: ["com.mitchellh.ghostty"]
+        ) {
+            XCTFail("AX probe must not run for allowlisted bundles")
+            return .valueSettable
+        }
+        XCTAssertEqual(decision.reason, .bundleMatch)
+    }
+
+    func testCaptureUsesUserTerminalAppsFromConfigStore() {
+        // The field case (2026-07-07): cmux hosts a terminal but reports a
+        // writable AX value, so only the user's terminal_apps.toml entry can
+        // classify it.
+        TerminalTargetDetector.debugFrontmostBundleIDOverride = { "com.cmuxterm.app" }
+        TerminalTargetDetector.debugFocusedElementProbeOverride = { .valueSettable }
+        TerminalTargetDetector.debugSecureEventInputOverride = { false }
+
+        let viewModel = makeViewModel(
+            outputMode: .liveAutoPaste,
+            terminalAppBundleIDs: ["com.cmuxterm.app"]
+        )
+        viewModel.captureSessionTargetVerdict()
+        viewModel.applyPreCapturedSessionTargetVerdict()
+        XCTAssertTrue(viewModel.sessionTargetIsTerminalLike)
+
+        // Without the config entry the same app stays non-terminal.
+        let unconfigured = makeViewModel(outputMode: .liveAutoPaste)
+        unconfigured.captureSessionTargetVerdict()
+        unconfigured.applyPreCapturedSessionTargetVerdict()
+        XCTAssertFalse(unconfigured.sessionTargetIsTerminalLike)
+    }
+
     // MARK: - Capture-at-begin / consume-at-audio-start lifecycle
 
     func testBeginDictationSessionCapturesVerdictBeforeConnect() {
@@ -233,7 +281,10 @@ final class TerminalTargetDetectorTests: XCTestCase {
 
     // MARK: - Fixture
 
-    private func makeViewModel(outputMode: DictationOutputMode) -> DictationViewModel {
+    private func makeViewModel(
+        outputMode: DictationOutputMode,
+        terminalAppBundleIDs: [String] = []
+    ) -> DictationViewModel {
         let suiteName = "localvoxtral.TerminalTargetDetectorTests.\(UUID().uuidString)"
         let defaults = UserDefaults(suiteName: suiteName)!
         defaults.removePersistentDomain(forName: suiteName)
@@ -242,11 +293,41 @@ final class TerminalTargetDetectorTests: XCTestCase {
         }
         let settings = SettingsStore(defaults: defaults, environment: [:])
         settings.dictationOutputMode = outputMode
-        return DictationViewModel(
+        let viewModel = DictationViewModel(
             settings: settings,
             overlayBufferCoordinator: TargetDetectorNoopOverlayCoordinator(),
             startRuntimeServices: false
         )
+        // Keep tests hermetic: capture reads the terminal-apps config through
+        // the store, which must never touch the real config directory here.
+        viewModel.appConfigStore = TargetDetectorMockConfigStore(
+            terminalAppBundleIDs: terminalAppBundleIDs
+        )
+        return viewModel
+    }
+}
+
+private final class TargetDetectorMockConfigStore: AppConfigServing {
+    private let terminalAppBundleIDs: [String]
+
+    init(terminalAppBundleIDs: [String]) {
+        self.terminalAppBundleIDs = terminalAppBundleIDs
+    }
+
+    func configDirectoryURL() -> URL {
+        FileManager.default.temporaryDirectory
+    }
+
+    func loadReplacementDictionary() -> ReplacementDictionary {
+        ReplacementDictionary(entries: [])
+    }
+
+    func loadLLMPromptTemplates() -> LLMPromptTemplates {
+        LLMPromptTemplates(systemContent: "system", userContent: "{{input_text}}")
+    }
+
+    func loadTerminalAppBundleIDs() -> [String] {
+        terminalAppBundleIDs
     }
 }
 

--- a/Tests/localvoxtralTests/TextInsertionServiceLiveStrategyTests.swift
+++ b/Tests/localvoxtralTests/TextInsertionServiceLiveStrategyTests.swift
@@ -1,0 +1,62 @@
+import XCTest
+@testable import localvoxtral
+
+#if DEBUG
+/// Live Auto-Paste replacement strategy selection at session start:
+/// terminal-like targets and caret-less targets must apply replacements
+/// BEFORE typing (hold-back stream, zero backspaces), while readable-caret
+/// regular targets keep the guarded backspace corrector.
+@MainActor
+final class TextInsertionServiceLiveStrategyTests: XCTestCase {
+    // Field repro (owner's Mac, 2026-07-06): dictating into a terminal
+    // (Ghostty, Claude Code TUI) with one replacement entry. The terminal
+    // exposes a READABLE AX caret, but it is a screen-grid cursor over the
+    // whole scrollback buffer, so it can never match the tracked session
+    // span. The first correction attempt timed out ("corrector settle
+    // timeout") and the corrector stood down for the whole session
+    // ("stand-down reason=tracked caret diverged") — replacement entries
+    // never applied in terminals.
+    func testTerminalLikeSessionAppliesReplacementWithoutBackspaces() async {
+        let service = TextInsertionService()
+        var typedChunks: [String] = []
+        var backspaceEvents: [Int] = []
+        service.debugConfigureInsertionHooks(
+            unicodePoster: { chunk in
+                typedChunks.append(chunk)
+                return true
+            },
+            backspacePoster: { count in
+                backspaceEvents.append(count)
+                return true
+            },
+            modifierStateReader: { false },
+            accessibilityInserter: { _, _ in false },
+            // Terminal grid caret: readable, but pinned to a screen position
+            // that never matches startCaret + insertedUTF16Length.
+            caretLocationReader: { _ in 4242 },
+            liveReplacementSettleSleep: {}
+        )
+
+        service.beginLiveReplacementSession(
+            dictionary: ReplacementDictionary(entries: [
+                ReplacementEntry(replaceWith: "localvoxtral", matches: ["voxtral"]),
+            ]),
+            preferredAppPID: nil,
+            isTerminalLikeTarget: true
+        )
+
+        service.enqueueRealtimeInsertion("vox")
+        service.enqueueRealtimeInsertion("tral ")
+        await service.debugWaitForLiveReplacementCorrectionTasks()
+        service.flushFinalLiveReplacementCorrections()
+        await service.debugWaitForLiveReplacementCorrectionTasks()
+
+        XCTAssertEqual(
+            backspaceEvents, [],
+            "terminal-safe live sessions must never post backspace events"
+        )
+        XCTAssertEqual(typedChunks.joined(), "localvoxtral ")
+        service.endLiveReplacementSession()
+    }
+}
+#endif

--- a/Tests/localvoxtralTests/TextInsertionServiceLiveStrategyTests.swift
+++ b/Tests/localvoxtralTests/TextInsertionServiceLiveStrategyTests.swift
@@ -212,14 +212,18 @@ final class TextInsertionServiceLiveStrategyTests: XCTestCase {
             "failed release must stay pending so the retry task retries it"
         )
 
-        // Simulates the periodic retry task's call.
+        // Simulates the periodic retry task's call. The trailing space is
+        // buffered by the sanitizer until the final flush decides its fate.
         service.flushPendingRealtimeInsertion()
 
         XCTAssertEqual(
-            typed.value, ["localvoxtral "],
+            typed.value, ["localvoxtral"],
             "retried release must be typed exactly once, never re-ingested"
         )
         XCTAssertFalse(service.hasPendingInsertionText)
+
+        service.flushFinalLiveReplacementCorrections()
+        XCTAssertEqual(typed.value.joined(), "localvoxtral ")
         service.endLiveReplacementSession()
     }
 

--- a/Tests/localvoxtralTests/TextInsertionServiceLiveStrategyTests.swift
+++ b/Tests/localvoxtralTests/TextInsertionServiceLiveStrategyTests.swift
@@ -58,5 +58,224 @@ final class TextInsertionServiceLiveStrategyTests: XCTestCase {
         XCTAssertEqual(typedChunks.joined(), "localvoxtral ")
         service.endLiveReplacementSession()
     }
+
+    func testTerminalLikeSessionSanitizesNewlinesInReleasedText() {
+        let harness = makeServiceHarness(caretLocationReader: { _ in 4242 })
+        harness.service.beginLiveReplacementSession(
+            dictionary: voxtralDictionary,
+            preferredAppPID: nil,
+            isTerminalLikeTarget: true
+        )
+
+        harness.service.enqueueRealtimeInsertion("run\n\nthe tests ")
+        harness.service.flushFinalLiveReplacementCorrections()
+
+        XCTAssertEqual(harness.typed.value.joined(), "run the tests ")
+        XCTAssertEqual(harness.backspaces.value, [])
+    }
+
+    func testTerminalLikeSessionSanitizesNewlinesInFlushedRemainder() {
+        let harness = makeServiceHarness(caretLocationReader: { _ in 4242 })
+        harness.service.beginLiveReplacementSession(
+            dictionary: ReplacementDictionary(entries: [
+                ReplacementEntry(replaceWith: "localvoxtral", matches: ["local voxtral"]),
+            ]),
+            preferredAppPID: nil,
+            isTerminalLikeTarget: true
+        )
+
+        // The two-word rule holds everything back, so the newline is still
+        // held at session stop and must be sanitized on the remainder flush.
+        harness.service.enqueueRealtimeInsertion("run\nit")
+        XCTAssertEqual(harness.typed.value, [])
+        harness.service.flushFinalLiveReplacementCorrections()
+
+        XCTAssertEqual(harness.typed.value.joined(), "run it")
+        XCTAssertEqual(harness.backspaces.value, [])
+    }
+
+    func testTerminalLikeSessionWithoutDictionaryStillSanitizesNewlines() {
+        let harness = makeServiceHarness(caretLocationReader: { _ in 4242 })
+        harness.service.beginLiveReplacementSession(
+            dictionary: nil,
+            preferredAppPID: nil,
+            isTerminalLikeTarget: true
+        )
+
+        harness.service.enqueueRealtimeInsertion("git status\n")
+        harness.service.flushFinalLiveReplacementCorrections()
+
+        XCTAssertEqual(harness.typed.value.joined(), "git status ")
+        XCTAssertEqual(harness.backspaces.value, [])
+    }
+
+    func testCaretUnreadableSessionAppliesReplacementWithoutBackspaces() {
+        let harness = makeServiceHarness(caretLocationReader: { _ in nil })
+        harness.service.beginLiveReplacementSession(
+            dictionary: voxtralDictionary,
+            preferredAppPID: nil,
+            isTerminalLikeTarget: false
+        )
+        XCTAssertTrue(harness.service.debugLiveHoldBackStreamIsActive)
+
+        harness.service.enqueueRealtimeInsertion("vox")
+        harness.service.enqueueRealtimeInsertion("tral ")
+        harness.service.flushFinalLiveReplacementCorrections()
+
+        XCTAssertEqual(harness.typed.value.joined(), "localvoxtral ")
+        XCTAssertEqual(
+            harness.backspaces.value, [],
+            "caret-unreadable sessions must never post unverified backspaces"
+        )
+    }
+
+    func testCaretUnreadableNonTerminalSessionPreservesNewlines() {
+        let harness = makeServiceHarness(caretLocationReader: { _ in nil })
+        harness.service.beginLiveReplacementSession(
+            dictionary: voxtralDictionary,
+            preferredAppPID: nil,
+            isTerminalLikeTarget: false
+        )
+
+        harness.service.enqueueRealtimeInsertion("voxtral\nrocks ")
+        harness.service.flushFinalLiveReplacementCorrections()
+
+        XCTAssertEqual(harness.typed.value.joined(), "localvoxtral\nrocks ")
+    }
+
+    func testCaretReadableNonTerminalSessionStillUsesGuardedCorrector() {
+        let field = FakeCaretField()
+        let harness = makeServiceHarness(
+            field: field,
+            caretLocationReader: { _ in (field.value as NSString).length }
+        )
+        harness.service.beginLiveReplacementSession(
+            dictionary: voxtralDictionary,
+            preferredAppPID: nil,
+            isTerminalLikeTarget: false
+        )
+        XCTAssertFalse(harness.service.debugLiveHoldBackStreamIsActive)
+        XCTAssertTrue(harness.service.debugLiveReplacementCorrectorIsActive)
+
+        harness.service.enqueueRealtimeInsertion("voxtral ")
+
+        // Existing behavior preserved exactly: type raw, then backspace and
+        // retype under the caret guard.
+        XCTAssertEqual(harness.typed.value, ["voxtral ", "localvoxtral "])
+        XCTAssertEqual(harness.backspaces.value, [8])
+        XCTAssertEqual(field.value, "localvoxtral ")
+    }
+
+    func testHeldTextIsTypedOnFinalFlush() {
+        let harness = makeServiceHarness(caretLocationReader: { _ in 4242 })
+        harness.service.beginLiveReplacementSession(
+            dictionary: voxtralDictionary,
+            preferredAppPID: nil,
+            isTerminalLikeTarget: true
+        )
+
+        harness.service.enqueueRealtimeInsertion("voxtral")
+        XCTAssertEqual(harness.typed.value, [], "partial word must stay held")
+
+        harness.service.flushFinalLiveReplacementCorrections()
+        XCTAssertEqual(harness.typed.value, ["localvoxtral"])
+        XCTAssertEqual(harness.backspaces.value, [])
+    }
+
+    func testFailedHoldBackReleaseIsRetriedWithoutDuplication() {
+        let typed = Box<[String]>([])
+        let failuresRemaining = Box(1)
+        let service = TextInsertionService()
+        service.debugConfigureInsertionHooks(
+            unicodePoster: { chunk in
+                if failuresRemaining.value > 0 {
+                    failuresRemaining.value -= 1
+                    return false
+                }
+                typed.value.append(chunk)
+                return true
+            },
+            modifierStateReader: { false },
+            accessibilityInserter: { _, _ in false },
+            caretLocationReader: { _ in 4242 }
+        )
+        service.beginLiveReplacementSession(
+            dictionary: voxtralDictionary,
+            preferredAppPID: nil,
+            isTerminalLikeTarget: true
+        )
+
+        service.enqueueRealtimeInsertion("voxtral ")
+        XCTAssertEqual(typed.value, [])
+        XCTAssertTrue(
+            service.hasPendingInsertionText,
+            "failed release must stay pending so the retry task retries it"
+        )
+
+        // Simulates the periodic retry task's call.
+        service.flushPendingRealtimeInsertion()
+
+        XCTAssertEqual(
+            typed.value, ["localvoxtral "],
+            "retried release must be typed exactly once, never re-ingested"
+        )
+        XCTAssertFalse(service.hasPendingInsertionText)
+        service.endLiveReplacementSession()
+    }
+
+    // MARK: - Harness
+
+    private var voxtralDictionary: ReplacementDictionary {
+        ReplacementDictionary(entries: [
+            ReplacementEntry(replaceWith: "localvoxtral", matches: ["voxtral"]),
+        ])
+    }
+
+    private func makeServiceHarness(
+        field: FakeCaretField? = nil,
+        caretLocationReader: @escaping (pid_t?) -> Int?
+    ) -> (
+        service: TextInsertionService,
+        typed: Box<[String]>,
+        backspaces: Box<[Int]>
+    ) {
+        let service = TextInsertionService()
+        let typed = Box<[String]>([])
+        let backspaces = Box<[Int]>([])
+        service.debugConfigureInsertionHooks(
+            unicodePoster: { chunk in
+                typed.value.append(chunk)
+                field?.value.append(chunk)
+                return true
+            },
+            backspacePoster: { count in
+                backspaces.value.append(count)
+                if let field {
+                    for _ in 0 ..< count where !field.value.isEmpty {
+                        field.value.removeLast()
+                    }
+                }
+                return true
+            },
+            modifierStateReader: { false },
+            accessibilityInserter: { _, _ in false },
+            caretLocationReader: caretLocationReader,
+            liveReplacementSettleSleep: {}
+        )
+        return (service, typed, backspaces)
+    }
+}
+
+@MainActor
+private final class FakeCaretField {
+    var value = ""
+}
+
+private final class Box<Value> {
+    var value: Value
+
+    init(_ value: Value) {
+        self.value = value
+    }
 }
 #endif

--- a/Tests/localvoxtralTests/TextInsertionServiceLiveStrategyTests.swift
+++ b/Tests/localvoxtralTests/TextInsertionServiceLiveStrategyTests.swift
@@ -2,81 +2,56 @@ import XCTest
 @testable import localvoxtral
 
 #if DEBUG
-/// Live Auto-Paste replacement strategy selection at session start:
-/// terminal-like targets and caret-less targets must apply replacements
-/// BEFORE typing (hold-back stream, zero backspaces), while readable-caret
-/// regular targets keep the guarded backspace corrector.
+/// Live Auto-Paste replacement behavior. Every target — terminal or regular
+/// editor — applies dictionary replacements BEFORE typing, through the
+/// hold-back stream. The post-typing backspace corrector was removed: it read
+/// the target's caret synchronously right after posting keystrokes the app had
+/// not processed yet, so corrections deferred and were dropped at session stop
+/// — zero successful corrections in the field (logs, 2026-07-08). No target
+/// ever receives a backspace event; there is no backspace hook to assert on.
 @MainActor
 final class TextInsertionServiceLiveStrategyTests: XCTestCase {
     // Field repro (owner's Mac, 2026-07-06): dictating into a terminal
-    // (Ghostty, Claude Code TUI) with one replacement entry. The terminal
-    // exposes a READABLE AX caret, but it is a screen-grid cursor over the
-    // whole scrollback buffer, so it can never match the tracked session
-    // span. The first correction attempt timed out ("corrector settle
-    // timeout") and the corrector stood down for the whole session
-    // ("stand-down reason=tracked caret diverged") — replacement entries
-    // never applied in terminals.
-    func testTerminalLikeSessionAppliesReplacementWithoutBackspaces() async {
-        let service = TextInsertionService()
-        var typedChunks: [String] = []
-        var backspaceEvents: [Int] = []
-        service.debugConfigureInsertionHooks(
-            unicodePoster: { chunk in
-                typedChunks.append(chunk)
-                return true
-            },
-            backspacePoster: { count in
-                backspaceEvents.append(count)
-                return true
-            },
-            modifierStateReader: { false },
-            accessibilityInserter: { _, _ in false },
-            // Terminal grid caret: readable, but pinned to a screen position
-            // that never matches startCaret + insertedUTF16Length.
-            caretLocationReader: { _ in 4242 },
-            liveReplacementSettleSleep: {}
-        )
+    // (Ghostty, Claude Code TUI) with one replacement entry. Replacements are
+    // applied before typing, so the whole matched word is corrected with no
+    // backspaces.
+    func testTerminalLikeSessionAppliesReplacementBeforeTyping() {
+        let typed = Box<[String]>([])
+        let service = makeService(capturing: typed)
 
         service.beginLiveReplacementSession(
-            dictionary: ReplacementDictionary(entries: [
-                ReplacementEntry(replaceWith: "localvoxtral", matches: ["voxtral"]),
-            ]),
+            dictionary: voxtralDictionary,
             preferredAppPID: nil,
             isTerminalLikeTarget: true
         )
 
         service.enqueueRealtimeInsertion("vox")
         service.enqueueRealtimeInsertion("tral ")
-        await service.debugWaitForLiveReplacementCorrectionTasks()
         service.flushFinalLiveReplacementCorrections()
-        await service.debugWaitForLiveReplacementCorrectionTasks()
 
-        XCTAssertEqual(
-            backspaceEvents, [],
-            "terminal-safe live sessions must never post backspace events"
-        )
-        XCTAssertEqual(typedChunks.joined(), "localvoxtral ")
+        XCTAssertEqual(typed.value.joined(), "localvoxtral ")
         service.endLiveReplacementSession()
     }
 
     func testTerminalLikeSessionSanitizesNewlinesInReleasedText() {
-        let harness = makeServiceHarness(caretLocationReader: { _ in 4242 })
-        harness.service.beginLiveReplacementSession(
+        let typed = Box<[String]>([])
+        let service = makeService(capturing: typed)
+        service.beginLiveReplacementSession(
             dictionary: voxtralDictionary,
             preferredAppPID: nil,
             isTerminalLikeTarget: true
         )
 
-        harness.service.enqueueRealtimeInsertion("run\n\nthe tests ")
-        harness.service.flushFinalLiveReplacementCorrections()
+        service.enqueueRealtimeInsertion("run\n\nthe tests ")
+        service.flushFinalLiveReplacementCorrections()
 
-        XCTAssertEqual(harness.typed.value.joined(), "run the tests ")
-        XCTAssertEqual(harness.backspaces.value, [])
+        XCTAssertEqual(typed.value.joined(), "run the tests ")
     }
 
     func testTerminalLikeSessionSanitizesNewlinesInFlushedRemainder() {
-        let harness = makeServiceHarness(caretLocationReader: { _ in 4242 })
-        harness.service.beginLiveReplacementSession(
+        let typed = Box<[String]>([])
+        let service = makeService(capturing: typed)
+        service.beginLiveReplacementSession(
             dictionary: ReplacementDictionary(entries: [
                 ReplacementEntry(replaceWith: "localvoxtral", matches: ["local voxtral"]),
             ]),
@@ -86,100 +61,179 @@ final class TextInsertionServiceLiveStrategyTests: XCTestCase {
 
         // The two-word rule holds everything back, so the newline is still
         // held at session stop and must be sanitized on the remainder flush.
-        harness.service.enqueueRealtimeInsertion("run\nit")
-        XCTAssertEqual(harness.typed.value, [])
-        harness.service.flushFinalLiveReplacementCorrections()
+        service.enqueueRealtimeInsertion("run\nit")
+        XCTAssertEqual(typed.value, [])
+        service.flushFinalLiveReplacementCorrections()
 
-        XCTAssertEqual(harness.typed.value.joined(), "run it")
-        XCTAssertEqual(harness.backspaces.value, [])
+        XCTAssertEqual(typed.value.joined(), "run it")
     }
 
     func testTerminalLikeSessionWithoutDictionaryStillSanitizesNewlines() {
-        let harness = makeServiceHarness(caretLocationReader: { _ in 4242 })
-        harness.service.beginLiveReplacementSession(
+        let typed = Box<[String]>([])
+        let service = makeService(capturing: typed)
+        service.beginLiveReplacementSession(
             dictionary: nil,
             preferredAppPID: nil,
             isTerminalLikeTarget: true
         )
+        XCTAssertTrue(
+            service.debugLiveHoldBackStreamIsActive,
+            "terminals arm the stream even with no rules so newline sanitization runs"
+        )
 
-        harness.service.enqueueRealtimeInsertion("git status\n")
-        harness.service.flushFinalLiveReplacementCorrections()
+        service.enqueueRealtimeInsertion("git status\n")
+        service.flushFinalLiveReplacementCorrections()
 
-        XCTAssertEqual(harness.typed.value.joined(), "git status ")
-        XCTAssertEqual(harness.backspaces.value, [])
+        XCTAssertEqual(typed.value.joined(), "git status ")
     }
 
-    func testCaretUnreadableSessionAppliesReplacementWithoutBackspaces() {
-        let harness = makeServiceHarness(caretLocationReader: { _ in nil })
-        harness.service.beginLiveReplacementSession(
+    func testNonTerminalSessionAppliesReplacementBeforeTyping() {
+        let typed = Box<[String]>([])
+        let service = makeService(capturing: typed)
+        service.beginLiveReplacementSession(
             dictionary: voxtralDictionary,
             preferredAppPID: nil,
             isTerminalLikeTarget: false
         )
-        XCTAssertTrue(harness.service.debugLiveHoldBackStreamIsActive)
+        XCTAssertTrue(service.debugLiveHoldBackStreamIsActive)
 
-        harness.service.enqueueRealtimeInsertion("vox")
-        harness.service.enqueueRealtimeInsertion("tral ")
-        harness.service.flushFinalLiveReplacementCorrections()
+        service.enqueueRealtimeInsertion("vox")
+        service.enqueueRealtimeInsertion("tral ")
+        service.flushFinalLiveReplacementCorrections()
 
-        XCTAssertEqual(harness.typed.value.joined(), "localvoxtral ")
+        XCTAssertEqual(typed.value.joined(), "localvoxtral ")
+    }
+
+    func testNonTerminalSessionPreservesNewlines() {
+        let typed = Box<[String]>([])
+        let service = makeService(capturing: typed)
+        service.beginLiveReplacementSession(
+            dictionary: voxtralDictionary,
+            preferredAppPID: nil,
+            isTerminalLikeTarget: false
+        )
+
+        service.enqueueRealtimeInsertion("voxtral\nrocks ")
+        service.flushFinalLiveReplacementCorrections()
+
         XCTAssertEqual(
-            harness.backspaces.value, [],
-            "caret-unreadable sessions must never post unverified backspaces"
+            typed.value.joined(), "localvoxtral\nrocks ",
+            "a regular editor must keep the user's newlines"
         )
     }
 
-    func testCaretUnreadableNonTerminalSessionPreservesNewlines() {
-        let harness = makeServiceHarness(caretLocationReader: { _ in nil })
-        harness.service.beginLiveReplacementSession(
+    // MARK: - The regression: final-word-only replacement at stop
+
+    // The exact field failure (2026-07-08): a short dictation whose ONLY
+    // replacement is the final word, with no trailing whitespace. The old
+    // guarded corrector deferred this correction waiting for the caret to
+    // settle and dropped it when the session stopped — nothing was replaced,
+    // in every app. The hold-back stream applies it on the remainder flush.
+    func testFinalWordOnlyReplacementIsAppliedAtStopNonTerminal() {
+        let typed = Box<[String]>([])
+        let service = makeService(capturing: typed)
+        service.beginLiveReplacementSession(
             dictionary: voxtralDictionary,
             preferredAppPID: nil,
             isTerminalLikeTarget: false
         )
 
-        harness.service.enqueueRealtimeInsertion("voxtral\nrocks ")
-        harness.service.flushFinalLiveReplacementCorrections()
+        // Streams as a partial word with NO trailing boundary, then stop.
+        service.enqueueRealtimeInsertion("vox")
+        service.enqueueRealtimeInsertion("tral")
+        XCTAssertEqual(typed.value, [], "the trailing partial word stays held until stop")
 
-        XCTAssertEqual(harness.typed.value.joined(), "localvoxtral\nrocks ")
+        service.flushFinalLiveReplacementCorrections()
+        XCTAssertEqual(
+            typed.value.joined(), "localvoxtral",
+            "the final word's replacement must be applied on stop, not dropped"
+        )
+        service.endLiveReplacementSession()
     }
 
-    func testCaretReadableNonTerminalSessionStillUsesGuardedCorrector() {
-        let field = FakeCaretField()
-        let harness = makeServiceHarness(
-            field: field,
-            caretLocationReader: { _ in (field.value as NSString).length }
-        )
-        harness.service.beginLiveReplacementSession(
+    // Codex-required invariant: after stop, the text emitted for the whole
+    // session equals the dictionary applied to the full raw transcript. Proves
+    // no fresh-empty-stream teardown bug and no dropped tail.
+    func testStopEmittedTextEqualsDictionaryAppliedToFullRawText() {
+        let rawDeltas = ["je ", "porte ", "une ", "vox", "tral ", "et ", "un ", "voxtral"]
+        let expected = "je porte une localvoxtral et un localvoxtral"
+
+        for terminalLike in [false, true] {
+            let typed = Box<[String]>([])
+            let service = makeService(capturing: typed)
+            service.beginLiveReplacementSession(
+                dictionary: voxtralDictionary,
+                preferredAppPID: nil,
+                isTerminalLikeTarget: terminalLike
+            )
+            for delta in rawDeltas {
+                service.enqueueRealtimeInsertion(delta)
+            }
+            service.flushFinalLiveReplacementCorrections()
+            XCTAssertEqual(
+                typed.value.joined(), expected,
+                "emitted text must equal the dictionary applied to the full raw text (terminalLike=\(terminalLike))"
+            )
+            service.endLiveReplacementSession()
+        }
+    }
+
+    // Teardown safety: even if a caller reaches endLiveReplacementSession
+    // without an explicit final flush first, the held tail is not dropped.
+    func testEndSessionFlushesHeldTailWithoutExplicitFinalFlush() {
+        let typed = Box<[String]>([])
+        let service = makeService(capturing: typed)
+        service.beginLiveReplacementSession(
             dictionary: voxtralDictionary,
             preferredAppPID: nil,
             isTerminalLikeTarget: false
         )
-        XCTAssertFalse(harness.service.debugLiveHoldBackStreamIsActive)
-        XCTAssertTrue(harness.service.debugLiveReplacementCorrectorIsActive)
 
-        harness.service.enqueueRealtimeInsertion("voxtral ")
+        service.enqueueRealtimeInsertion("voxtral")
+        XCTAssertEqual(typed.value, [])
 
-        // Existing behavior preserved exactly: type raw, then backspace and
-        // retype under the caret guard.
-        XCTAssertEqual(harness.typed.value, ["voxtral ", "localvoxtral "])
-        XCTAssertEqual(harness.backspaces.value, [8])
-        XCTAssertEqual(field.value, "localvoxtral ")
+        service.endLiveReplacementSession()
+        XCTAssertEqual(
+            typed.value.joined(), "localvoxtral",
+            "teardown must flush the held tail rather than drop it"
+        )
+    }
+
+    func testNonTerminalNoRulesTypesDirectlyWithoutHoldBack() {
+        let typed = Box<[String]>([])
+        let service = makeService(capturing: typed)
+        service.beginLiveReplacementSession(
+            dictionary: ReplacementDictionary(entries: []),
+            preferredAppPID: nil,
+            isTerminalLikeTarget: false
+        )
+        XCTAssertFalse(
+            service.debugLiveHoldBackStreamIsActive,
+            "a non-terminal target with no rules must type directly (zero hold-back delay)"
+        )
+
+        // No hold-back: each partial word is typed immediately, unheld.
+        service.enqueueRealtimeInsertion("hello")
+        XCTAssertEqual(typed.value, ["hello"])
+        service.enqueueRealtimeInsertion(" world")
+        XCTAssertEqual(typed.value.joined(), "hello world")
+        service.endLiveReplacementSession()
     }
 
     func testHeldTextIsTypedOnFinalFlush() {
-        let harness = makeServiceHarness(caretLocationReader: { _ in 4242 })
-        harness.service.beginLiveReplacementSession(
+        let typed = Box<[String]>([])
+        let service = makeService(capturing: typed)
+        service.beginLiveReplacementSession(
             dictionary: voxtralDictionary,
             preferredAppPID: nil,
             isTerminalLikeTarget: true
         )
 
-        harness.service.enqueueRealtimeInsertion("voxtral")
-        XCTAssertEqual(harness.typed.value, [], "partial word must stay held")
+        service.enqueueRealtimeInsertion("voxtral")
+        XCTAssertEqual(typed.value, [], "partial word must stay held")
 
-        harness.service.flushFinalLiveReplacementCorrections()
-        XCTAssertEqual(harness.typed.value, ["localvoxtral"])
-        XCTAssertEqual(harness.backspaces.value, [])
+        service.flushFinalLiveReplacementCorrections()
+        XCTAssertEqual(typed.value, ["localvoxtral"])
     }
 
     func testFailedHoldBackReleaseIsRetriedWithoutDuplication() {
@@ -196,8 +250,7 @@ final class TextInsertionServiceLiveStrategyTests: XCTestCase {
                 return true
             },
             modifierStateReader: { false },
-            accessibilityInserter: { _, _ in false },
-            caretLocationReader: { _ in 4242 }
+            accessibilityInserter: { _, _ in false }
         )
         service.beginLiveReplacementSession(
             dictionary: voxtralDictionary,
@@ -227,405 +280,6 @@ final class TextInsertionServiceLiveStrategyTests: XCTestCase {
         service.endLiveReplacementSession()
     }
 
-    // MARK: - Mid-session conversion (guarded corrector → hold-back stream)
-
-    // Field repro (owner's Mac, 2026-07-07): cmux (com.cmuxterm.app) hosts a
-    // terminal but reports a WRITABLE focused AX value, so it is honestly
-    // classified non-terminal and the guarded corrector arms with
-    // caret_guard=on. The terminal grid caret never matches the tracked
-    // session span, the first correction times out its settle attempts
-    // ("stand-down reason=tracked caret diverged"), and replacements used to
-    // go silently dead for the rest of the session. The session must instead
-    // CONVERT to the hold-back stream and keep applying replacements to all
-    // future text — with zero backspace events after the conversion point.
-    func testCaretDivergenceConvertsToHoldBackAndKeepsApplyingReplacements() async {
-        // Terminal-grid style caret: readable, but pinned to a location that
-        // never matches startCaret + insertedUTF16Length.
-        let harness = makeServiceHarness(caretLocationReader: { _ in 4242 })
-        harness.service.beginLiveReplacementSession(
-            dictionary: voxtralDictionary,
-            preferredAppPID: nil,
-            isTerminalLikeTarget: false
-        )
-        XCTAssertTrue(harness.service.debugLiveReplacementCorrectorIsActive)
-        XCTAssertFalse(harness.service.debugLiveHoldBackStreamIsActive)
-
-        // First rule match: typed raw, then the deferred correction exhausts
-        // its settle attempts against the diverged caret.
-        harness.service.enqueueRealtimeInsertion("voxtral ")
-        await harness.service.debugWaitForLiveReplacementCorrectionTasks()
-
-        XCTAssertTrue(
-            harness.service.debugLiveHoldBackStreamIsActive,
-            "caret divergence must convert the session to the hold-back stream"
-        )
-        XCTAssertFalse(harness.service.debugLiveReplacementCorrectorIsActive)
-        XCTAssertEqual(
-            harness.typed.value, ["voxtral "],
-            "the failed correction's text is already typed raw and stays raw"
-        )
-
-        // Second rule match after conversion: applied BEFORE typing.
-        harness.service.enqueueRealtimeInsertion("voxtral ")
-        harness.service.flushFinalLiveReplacementCorrections()
-
-        XCTAssertEqual(harness.typed.value.joined(), "voxtral localvoxtral ")
-        XCTAssertEqual(
-            harness.backspaces.value, [],
-            "no backspace events may ever be posted after conversion"
-        )
-        harness.service.endLiveReplacementSession()
-    }
-
-    func testKeyboardFailureStandDownDoesNotConvertToHoldBack() {
-        let typed = Box<[String]>([])
-        let backspaceAttempts = Box<[Int]>([])
-        let field = FakeCaretField()
-        let service = TextInsertionService()
-        service.debugConfigureInsertionHooks(
-            unicodePoster: { chunk in
-                typed.value.append(chunk)
-                field.value.append(chunk)
-                return true
-            },
-            backspacePoster: { count in
-                backspaceAttempts.value.append(count)
-                return false
-            },
-            modifierStateReader: { false },
-            accessibilityInserter: { _, _ in false },
-            caretLocationReader: { _ in (field.value as NSString).length },
-            liveReplacementSettleSleep: {}
-        )
-        service.beginLiveReplacementSession(
-            dictionary: voxtralDictionary,
-            preferredAppPID: nil,
-            isTerminalLikeTarget: false
-        )
-
-        // Caret settles correctly, but the backspace key events cannot post.
-        service.enqueueRealtimeInsertion("voxtral ")
-
-        XCTAssertEqual(backspaceAttempts.value, [8])
-        XCTAssertFalse(
-            service.debugLiveHoldBackStreamIsActive,
-            "keyboard-posting failure must stay a true stand-down: the hold-back stream could not type either"
-        )
-        XCTAssertFalse(service.debugLiveReplacementCorrectorIsActive)
-
-        // Further dictation types raw: no corrections, no stream, no more
-        // backspace attempts.
-        service.enqueueRealtimeInsertion("voxtral ")
-        service.flushFinalLiveReplacementCorrections()
-
-        XCTAssertEqual(typed.value.joined(), "voxtral voxtral ")
-        XCTAssertEqual(backspaceAttempts.value, [8])
-        XCTAssertFalse(service.debugLiveHoldBackStreamIsActive)
-        service.endLiveReplacementSession()
-    }
-
-    func testConversionDuringDeferredCorrectionRoutesQueuedTextThroughStreamOnce() async {
-        let harness = makeServiceHarness(caretLocationReader: { _ in 4242 })
-        harness.service.beginLiveReplacementSession(
-            dictionary: ReplacementDictionary(entries: [
-                ReplacementEntry(replaceWith: "localvoxtral", matches: ["voxtral"]),
-                ReplacementEntry(replaceWith: "chai", matches: ["tea"]),
-            ]),
-            preferredAppPID: nil,
-            isTerminalLikeTarget: false
-        )
-
-        harness.service.enqueueRealtimeInsertion("voxtral ")
-        XCTAssertTrue(harness.service.debugLiveReplacementCorrectionIsInFlight)
-
-        // Queued while the failing correction is still in flight: must flow
-        // into the converted stream exactly once (no drop, no double-type).
-        harness.service.enqueueRealtimeInsertion("tea")
-        XCTAssertEqual(harness.typed.value, ["voxtral "])
-
-        await harness.service.debugWaitForLiveReplacementCorrectionTasks()
-
-        XCTAssertTrue(harness.service.debugLiveHoldBackStreamIsActive)
-        XCTAssertFalse(harness.service.debugLiveReplacementCorrectionIsInFlight)
-        XCTAssertFalse(
-            harness.service.hasPendingInsertionText,
-            "queued text must be ingested into the stream, not left pending"
-        )
-        XCTAssertEqual(
-            harness.typed.value, ["voxtral "],
-            "the trailing partial word stays held by the stream, never typed raw"
-        )
-
-        harness.service.flushFinalLiveReplacementCorrections()
-        XCTAssertEqual(harness.typed.value, ["voxtral ", "chai"])
-        XCTAssertEqual(
-            harness.backspaces.value, [],
-            "no backspaces after conversion, even when the failed correction was mid-defer"
-        )
-        harness.service.endLiveReplacementSession()
-    }
-
-    func testFinalFlushRequestedDuringDeferredCorrectionFlushesConvertedStream() async {
-        let harness = makeServiceHarness(caretLocationReader: { _ in 4242 })
-        harness.service.beginLiveReplacementSession(
-            dictionary: ReplacementDictionary(entries: [
-                ReplacementEntry(replaceWith: "localvoxtral", matches: ["voxtral"]),
-                ReplacementEntry(replaceWith: "chai", matches: ["tea"]),
-            ]),
-            preferredAppPID: nil,
-            isTerminalLikeTarget: false
-        )
-
-        harness.service.enqueueRealtimeInsertion("voxtral ")
-        harness.service.enqueueRealtimeInsertion("tea")
-        // Session stop while the failing correction is still in flight.
-        harness.service.flushFinalLiveReplacementCorrections()
-        XCTAssertEqual(harness.typed.value, ["voxtral "])
-
-        await harness.service.debugWaitForLiveReplacementCorrectionTasks()
-
-        XCTAssertEqual(
-            harness.typed.value, ["voxtral ", "chai"],
-            "the queued final flush must release the converted stream's remainder"
-        )
-        XCTAssertEqual(harness.backspaces.value, [])
-        harness.service.endLiveReplacementSession()
-    }
-
-    func testCaretBecomingUnavailableMidSessionConvertsToHoldBack() {
-        let caretReads = Box(0)
-        // Caret readable at session start (arms the guarded corrector), then
-        // unreadable for every later verification.
-        let harness = makeServiceHarness(caretLocationReader: { _ in
-            caretReads.value += 1
-            return caretReads.value == 1 ? 0 : nil
-        })
-        harness.service.beginLiveReplacementSession(
-            dictionary: voxtralDictionary,
-            preferredAppPID: nil,
-            isTerminalLikeTarget: false
-        )
-        XCTAssertTrue(harness.service.debugLiveReplacementCorrectorIsActive)
-
-        harness.service.enqueueRealtimeInsertion("voxtral ")
-
-        XCTAssertTrue(
-            harness.service.debugLiveHoldBackStreamIsActive,
-            "a caret that becomes unavailable mid-session must convert, not stand down"
-        )
-        XCTAssertEqual(harness.typed.value, ["voxtral "])
-
-        harness.service.enqueueRealtimeInsertion("voxtral ")
-        harness.service.flushFinalLiveReplacementCorrections()
-
-        XCTAssertEqual(harness.typed.value.joined(), "voxtral localvoxtral ")
-        XCTAssertEqual(harness.backspaces.value, [])
-        harness.service.endLiveReplacementSession()
-    }
-
-    // MARK: - Post-backspace conversion must restore erased text (codex review, 2026-07-07)
-
-    // The caret matches initially, so the correction's backspaces post and
-    // ERASE the matched text — and only then the erased-caret verification
-    // fails. Converting without retyping correction.erasedText loses the
-    // user's typed text from the target app. The erased text must be
-    // restored raw before converting, and a later rule match must still
-    // apply through the converted stream.
-    func testPostBackspaceCaretLossRestoresErasedTextBeforeConverting() {
-        let field = FakeCaretField()
-        // begin → 0 (arms guard), inserted-caret check → 8 (matched, so
-        // backspaces post), erased-caret check → nil (caret lost).
-        let caretScript = Box<[Int?]>([0, 8, nil])
-        let harness = makeServiceHarness(
-            field: field,
-            caretLocationReader: { _ in
-                caretScript.value.isEmpty ? nil : caretScript.value.removeFirst()
-            }
-        )
-        harness.service.beginLiveReplacementSession(
-            dictionary: voxtralDictionary,
-            preferredAppPID: nil,
-            isTerminalLikeTarget: false
-        )
-
-        harness.service.enqueueRealtimeInsertion("voxtral ")
-
-        XCTAssertEqual(harness.backspaces.value, [8])
-        XCTAssertEqual(
-            field.value, "voxtral ",
-            "the erased text must be restored before converting"
-        )
-        XCTAssertTrue(harness.service.debugLiveHoldBackStreamIsActive)
-
-        harness.service.enqueueRealtimeInsertion("voxtral ")
-        harness.service.flushFinalLiveReplacementCorrections()
-
-        XCTAssertEqual(
-            field.value, "voxtral localvoxtral ",
-            "all dictated text must be present in the target after conversion"
-        )
-        XCTAssertEqual(harness.backspaces.value, [8], "no backspaces after conversion")
-        harness.service.endLiveReplacementSession()
-    }
-
-    func testDeferredPostBackspaceTimeoutRestoresErasedTextBeforeConverting() async {
-        let field = FakeCaretField()
-        // begin → 0, inserted-caret check → 7 (mismatch, defers), settle
-        // wait → 8 (matched, backspaces post), then 5 forever: the
-        // erased-caret wait (expected 0) times out → tracked caret diverged
-        // AFTER the erase.
-        let caretScript = Box<[Int?]>([0, 7, 8])
-        let harness = makeServiceHarness(
-            field: field,
-            caretLocationReader: { _ in
-                caretScript.value.isEmpty ? 5 : caretScript.value.removeFirst()
-            }
-        )
-        harness.service.beginLiveReplacementSession(
-            dictionary: voxtralDictionary,
-            preferredAppPID: nil,
-            isTerminalLikeTarget: false
-        )
-
-        harness.service.enqueueRealtimeInsertion("voxtral ")
-        XCTAssertTrue(harness.service.debugLiveReplacementCorrectionIsInFlight)
-        await harness.service.debugWaitForLiveReplacementCorrectionTasks()
-
-        XCTAssertEqual(harness.backspaces.value, [8])
-        XCTAssertEqual(
-            field.value, "voxtral ",
-            "the deferred post-backspace timeout must restore the erased text before converting"
-        )
-        XCTAssertTrue(harness.service.debugLiveHoldBackStreamIsActive)
-
-        harness.service.enqueueRealtimeInsertion("voxtral ")
-        harness.service.flushFinalLiveReplacementCorrections()
-
-        XCTAssertEqual(field.value, "voxtral localvoxtral ")
-        XCTAssertEqual(harness.backspaces.value, [8])
-        harness.service.endLiveReplacementSession()
-    }
-
-    func testPostBackspaceRestoreFailureStandsDownWithoutConverting() {
-        let typed = Box<[String]>([])
-        let backspaces = Box<[Int]>([])
-        let failNextUnicodePost = Box(false)
-        let caretScript = Box<[Int?]>([0, 8, nil])
-        let service = TextInsertionService()
-        service.debugConfigureInsertionHooks(
-            unicodePoster: { chunk in
-                if failNextUnicodePost.value {
-                    failNextUnicodePost.value = false
-                    return false
-                }
-                typed.value.append(chunk)
-                return true
-            },
-            backspacePoster: { count in
-                backspaces.value.append(count)
-                // The restore attempt right after these backspaces fails:
-                // the keyboard path is broken.
-                failNextUnicodePost.value = true
-                return true
-            },
-            modifierStateReader: { false },
-            accessibilityInserter: { _, _ in false },
-            caretLocationReader: { _ in
-                caretScript.value.isEmpty ? nil : caretScript.value.removeFirst()
-            },
-            liveReplacementSettleSleep: {}
-        )
-        service.beginLiveReplacementSession(
-            dictionary: voxtralDictionary,
-            preferredAppPID: nil,
-            isTerminalLikeTarget: false
-        )
-
-        service.enqueueRealtimeInsertion("voxtral ")
-
-        XCTAssertEqual(backspaces.value, [8])
-        XCTAssertFalse(
-            service.debugLiveHoldBackStreamIsActive,
-            "a failed restore means the keyboard path is broken: true stand-down, no conversion"
-        )
-        XCTAssertFalse(service.debugLiveReplacementCorrectorIsActive)
-
-        service.enqueueRealtimeInsertion("next ")
-        service.flushFinalLiveReplacementCorrections()
-        XCTAssertEqual(typed.value, ["voxtral ", "next "])
-        XCTAssertEqual(backspaces.value, [8])
-        service.endLiveReplacementSession()
-    }
-
-    // MARK: - Session stop during an in-flight correction (codex review, 2026-07-07)
-
-    // Production stop ordering: finishStoppedSession calls
-    // flushFinalLiveReplacementCorrections() and then (same MainActor turn)
-    // completeStoppedSessionCleanup() -> endLiveReplacementSession(). When a
-    // deferred correction is in flight, the final flush is queued behind a
-    // task that teardown immediately cancels — pre-existing on the guarded
-    // path: the queued text was dropped and reported as failed pending text.
-    // Teardown must drain it instead, with replacements applied.
-    func testSessionStopDuringInFlightCorrectionDrainsQueuedTextInsteadOfDroppingIt() {
-        let harness = makeServiceHarness(caretLocationReader: { _ in 4242 })
-        harness.service.beginLiveReplacementSession(
-            dictionary: ReplacementDictionary(entries: [
-                ReplacementEntry(replaceWith: "localvoxtral", matches: ["voxtral"]),
-                ReplacementEntry(replaceWith: "chai", matches: ["tea"]),
-            ]),
-            preferredAppPID: nil,
-            isTerminalLikeTarget: false
-        )
-
-        harness.service.enqueueRealtimeInsertion("voxtral ")
-        XCTAssertTrue(harness.service.debugLiveReplacementCorrectionIsInFlight)
-        harness.service.enqueueRealtimeInsertion("tea")
-
-        // Production ordering: both calls in the same turn, the deferred
-        // task never gets to run.
-        harness.service.flushFinalLiveReplacementCorrections()
-        harness.service.endLiveReplacementSession()
-
-        XCTAssertEqual(
-            harness.typed.value, ["voxtral ", "chai"],
-            "text queued behind the cancelled correction must be drained with replacements applied"
-        )
-        XCTAssertFalse(harness.service.hasPendingInsertionText)
-        XCTAssertEqual(harness.backspaces.value, [])
-    }
-
-    func testSessionStopDuringBackspacePostedCorrectionRestoresErasedText() {
-        let field = FakeCaretField()
-        // begin → 0, inserted-caret check → 8 (matched, backspaces post),
-        // erased-caret check → 7 (mismatch, defers at .backspacePosted).
-        let caretScript = Box<[Int?]>([0, 8, 7])
-        let harness = makeServiceHarness(
-            field: field,
-            caretLocationReader: { _ in
-                caretScript.value.isEmpty ? 7 : caretScript.value.removeFirst()
-            }
-        )
-        harness.service.beginLiveReplacementSession(
-            dictionary: voxtralDictionary,
-            preferredAppPID: nil,
-            isTerminalLikeTarget: false
-        )
-
-        harness.service.enqueueRealtimeInsertion("voxtral ")
-        XCTAssertTrue(harness.service.debugLiveReplacementCorrectionIsInFlight)
-        XCTAssertEqual(field.value, "", "the correction's backspaces erased the text")
-
-        // Production stop ordering, same turn.
-        harness.service.flushFinalLiveReplacementCorrections()
-        harness.service.endLiveReplacementSession()
-
-        XCTAssertEqual(
-            field.value, "voxtral ",
-            "teardown must restore text erased by the abandoned correction"
-        )
-        XCTAssertEqual(harness.backspaces.value, [8])
-    }
-
     // MARK: - Harness
 
     private var voxtralDictionary: ReplacementDictionary {
@@ -634,44 +288,18 @@ final class TextInsertionServiceLiveStrategyTests: XCTestCase {
         ])
     }
 
-    private func makeServiceHarness(
-        field: FakeCaretField? = nil,
-        caretLocationReader: @escaping (pid_t?) -> Int?
-    ) -> (
-        service: TextInsertionService,
-        typed: Box<[String]>,
-        backspaces: Box<[Int]>
-    ) {
+    private func makeService(capturing typed: Box<[String]>) -> TextInsertionService {
         let service = TextInsertionService()
-        let typed = Box<[String]>([])
-        let backspaces = Box<[Int]>([])
         service.debugConfigureInsertionHooks(
             unicodePoster: { chunk in
                 typed.value.append(chunk)
-                field?.value.append(chunk)
-                return true
-            },
-            backspacePoster: { count in
-                backspaces.value.append(count)
-                if let field {
-                    for _ in 0 ..< count where !field.value.isEmpty {
-                        field.value.removeLast()
-                    }
-                }
                 return true
             },
             modifierStateReader: { false },
-            accessibilityInserter: { _, _ in false },
-            caretLocationReader: caretLocationReader,
-            liveReplacementSettleSleep: {}
+            accessibilityInserter: { _, _ in false }
         )
-        return (service, typed, backspaces)
+        return service
     }
-}
-
-@MainActor
-private final class FakeCaretField {
-    var value = ""
 }
 
 private final class Box<Value> {

--- a/Tests/localvoxtralTests/TextInsertionServiceLiveStrategyTests.swift
+++ b/Tests/localvoxtralTests/TextInsertionServiceLiveStrategyTests.swift
@@ -227,6 +227,202 @@ final class TextInsertionServiceLiveStrategyTests: XCTestCase {
         service.endLiveReplacementSession()
     }
 
+    // MARK: - Mid-session conversion (guarded corrector → hold-back stream)
+
+    // Field repro (owner's Mac, 2026-07-07): cmux (com.cmuxterm.app) hosts a
+    // terminal but reports a WRITABLE focused AX value, so it is honestly
+    // classified non-terminal and the guarded corrector arms with
+    // caret_guard=on. The terminal grid caret never matches the tracked
+    // session span, the first correction times out its settle attempts
+    // ("stand-down reason=tracked caret diverged"), and replacements used to
+    // go silently dead for the rest of the session. The session must instead
+    // CONVERT to the hold-back stream and keep applying replacements to all
+    // future text — with zero backspace events after the conversion point.
+    func testCaretDivergenceConvertsToHoldBackAndKeepsApplyingReplacements() async {
+        // Terminal-grid style caret: readable, but pinned to a location that
+        // never matches startCaret + insertedUTF16Length.
+        let harness = makeServiceHarness(caretLocationReader: { _ in 4242 })
+        harness.service.beginLiveReplacementSession(
+            dictionary: voxtralDictionary,
+            preferredAppPID: nil,
+            isTerminalLikeTarget: false
+        )
+        XCTAssertTrue(harness.service.debugLiveReplacementCorrectorIsActive)
+        XCTAssertFalse(harness.service.debugLiveHoldBackStreamIsActive)
+
+        // First rule match: typed raw, then the deferred correction exhausts
+        // its settle attempts against the diverged caret.
+        harness.service.enqueueRealtimeInsertion("voxtral ")
+        await harness.service.debugWaitForLiveReplacementCorrectionTasks()
+
+        XCTAssertTrue(
+            harness.service.debugLiveHoldBackStreamIsActive,
+            "caret divergence must convert the session to the hold-back stream"
+        )
+        XCTAssertFalse(harness.service.debugLiveReplacementCorrectorIsActive)
+        XCTAssertEqual(
+            harness.typed.value, ["voxtral "],
+            "the failed correction's text is already typed raw and stays raw"
+        )
+
+        // Second rule match after conversion: applied BEFORE typing.
+        harness.service.enqueueRealtimeInsertion("voxtral ")
+        harness.service.flushFinalLiveReplacementCorrections()
+
+        XCTAssertEqual(harness.typed.value.joined(), "voxtral localvoxtral ")
+        XCTAssertEqual(
+            harness.backspaces.value, [],
+            "no backspace events may ever be posted after conversion"
+        )
+        harness.service.endLiveReplacementSession()
+    }
+
+    func testKeyboardFailureStandDownDoesNotConvertToHoldBack() {
+        let typed = Box<[String]>([])
+        let backspaceAttempts = Box<[Int]>([])
+        let field = FakeCaretField()
+        let service = TextInsertionService()
+        service.debugConfigureInsertionHooks(
+            unicodePoster: { chunk in
+                typed.value.append(chunk)
+                field.value.append(chunk)
+                return true
+            },
+            backspacePoster: { count in
+                backspaceAttempts.value.append(count)
+                return false
+            },
+            modifierStateReader: { false },
+            accessibilityInserter: { _, _ in false },
+            caretLocationReader: { _ in (field.value as NSString).length },
+            liveReplacementSettleSleep: {}
+        )
+        service.beginLiveReplacementSession(
+            dictionary: voxtralDictionary,
+            preferredAppPID: nil,
+            isTerminalLikeTarget: false
+        )
+
+        // Caret settles correctly, but the backspace key events cannot post.
+        service.enqueueRealtimeInsertion("voxtral ")
+
+        XCTAssertEqual(backspaceAttempts.value, [8])
+        XCTAssertFalse(
+            service.debugLiveHoldBackStreamIsActive,
+            "keyboard-posting failure must stay a true stand-down: the hold-back stream could not type either"
+        )
+        XCTAssertFalse(service.debugLiveReplacementCorrectorIsActive)
+
+        // Further dictation types raw: no corrections, no stream, no more
+        // backspace attempts.
+        service.enqueueRealtimeInsertion("voxtral ")
+        service.flushFinalLiveReplacementCorrections()
+
+        XCTAssertEqual(typed.value.joined(), "voxtral voxtral ")
+        XCTAssertEqual(backspaceAttempts.value, [8])
+        XCTAssertFalse(service.debugLiveHoldBackStreamIsActive)
+        service.endLiveReplacementSession()
+    }
+
+    func testConversionDuringDeferredCorrectionRoutesQueuedTextThroughStreamOnce() async {
+        let harness = makeServiceHarness(caretLocationReader: { _ in 4242 })
+        harness.service.beginLiveReplacementSession(
+            dictionary: ReplacementDictionary(entries: [
+                ReplacementEntry(replaceWith: "localvoxtral", matches: ["voxtral"]),
+                ReplacementEntry(replaceWith: "chai", matches: ["tea"]),
+            ]),
+            preferredAppPID: nil,
+            isTerminalLikeTarget: false
+        )
+
+        harness.service.enqueueRealtimeInsertion("voxtral ")
+        XCTAssertTrue(harness.service.debugLiveReplacementCorrectionIsInFlight)
+
+        // Queued while the failing correction is still in flight: must flow
+        // into the converted stream exactly once (no drop, no double-type).
+        harness.service.enqueueRealtimeInsertion("tea")
+        XCTAssertEqual(harness.typed.value, ["voxtral "])
+
+        await harness.service.debugWaitForLiveReplacementCorrectionTasks()
+
+        XCTAssertTrue(harness.service.debugLiveHoldBackStreamIsActive)
+        XCTAssertFalse(harness.service.debugLiveReplacementCorrectionIsInFlight)
+        XCTAssertFalse(
+            harness.service.hasPendingInsertionText,
+            "queued text must be ingested into the stream, not left pending"
+        )
+        XCTAssertEqual(
+            harness.typed.value, ["voxtral "],
+            "the trailing partial word stays held by the stream, never typed raw"
+        )
+
+        harness.service.flushFinalLiveReplacementCorrections()
+        XCTAssertEqual(harness.typed.value, ["voxtral ", "chai"])
+        XCTAssertEqual(
+            harness.backspaces.value, [],
+            "no backspaces after conversion, even when the failed correction was mid-defer"
+        )
+        harness.service.endLiveReplacementSession()
+    }
+
+    func testFinalFlushRequestedDuringDeferredCorrectionFlushesConvertedStream() async {
+        let harness = makeServiceHarness(caretLocationReader: { _ in 4242 })
+        harness.service.beginLiveReplacementSession(
+            dictionary: ReplacementDictionary(entries: [
+                ReplacementEntry(replaceWith: "localvoxtral", matches: ["voxtral"]),
+                ReplacementEntry(replaceWith: "chai", matches: ["tea"]),
+            ]),
+            preferredAppPID: nil,
+            isTerminalLikeTarget: false
+        )
+
+        harness.service.enqueueRealtimeInsertion("voxtral ")
+        harness.service.enqueueRealtimeInsertion("tea")
+        // Session stop while the failing correction is still in flight.
+        harness.service.flushFinalLiveReplacementCorrections()
+        XCTAssertEqual(harness.typed.value, ["voxtral "])
+
+        await harness.service.debugWaitForLiveReplacementCorrectionTasks()
+
+        XCTAssertEqual(
+            harness.typed.value, ["voxtral ", "chai"],
+            "the queued final flush must release the converted stream's remainder"
+        )
+        XCTAssertEqual(harness.backspaces.value, [])
+        harness.service.endLiveReplacementSession()
+    }
+
+    func testCaretBecomingUnavailableMidSessionConvertsToHoldBack() {
+        let caretReads = Box(0)
+        // Caret readable at session start (arms the guarded corrector), then
+        // unreadable for every later verification.
+        let harness = makeServiceHarness(caretLocationReader: { _ in
+            caretReads.value += 1
+            return caretReads.value == 1 ? 0 : nil
+        })
+        harness.service.beginLiveReplacementSession(
+            dictionary: voxtralDictionary,
+            preferredAppPID: nil,
+            isTerminalLikeTarget: false
+        )
+        XCTAssertTrue(harness.service.debugLiveReplacementCorrectorIsActive)
+
+        harness.service.enqueueRealtimeInsertion("voxtral ")
+
+        XCTAssertTrue(
+            harness.service.debugLiveHoldBackStreamIsActive,
+            "a caret that becomes unavailable mid-session must convert, not stand down"
+        )
+        XCTAssertEqual(harness.typed.value, ["voxtral "])
+
+        harness.service.enqueueRealtimeInsertion("voxtral ")
+        harness.service.flushFinalLiveReplacementCorrections()
+
+        XCTAssertEqual(harness.typed.value.joined(), "voxtral localvoxtral ")
+        XCTAssertEqual(harness.backspaces.value, [])
+        harness.service.endLiveReplacementSession()
+    }
+
     // MARK: - Harness
 
     private var voxtralDictionary: ReplacementDictionary {

--- a/Tests/localvoxtralTests/TextInsertionServiceLiveStrategyTests.swift
+++ b/Tests/localvoxtralTests/TextInsertionServiceLiveStrategyTests.swift
@@ -423,6 +423,209 @@ final class TextInsertionServiceLiveStrategyTests: XCTestCase {
         harness.service.endLiveReplacementSession()
     }
 
+    // MARK: - Post-backspace conversion must restore erased text (codex review, 2026-07-07)
+
+    // The caret matches initially, so the correction's backspaces post and
+    // ERASE the matched text — and only then the erased-caret verification
+    // fails. Converting without retyping correction.erasedText loses the
+    // user's typed text from the target app. The erased text must be
+    // restored raw before converting, and a later rule match must still
+    // apply through the converted stream.
+    func testPostBackspaceCaretLossRestoresErasedTextBeforeConverting() {
+        let field = FakeCaretField()
+        // begin → 0 (arms guard), inserted-caret check → 8 (matched, so
+        // backspaces post), erased-caret check → nil (caret lost).
+        let caretScript = Box<[Int?]>([0, 8, nil])
+        let harness = makeServiceHarness(
+            field: field,
+            caretLocationReader: { _ in
+                caretScript.value.isEmpty ? nil : caretScript.value.removeFirst()
+            }
+        )
+        harness.service.beginLiveReplacementSession(
+            dictionary: voxtralDictionary,
+            preferredAppPID: nil,
+            isTerminalLikeTarget: false
+        )
+
+        harness.service.enqueueRealtimeInsertion("voxtral ")
+
+        XCTAssertEqual(harness.backspaces.value, [8])
+        XCTAssertEqual(
+            field.value, "voxtral ",
+            "the erased text must be restored before converting"
+        )
+        XCTAssertTrue(harness.service.debugLiveHoldBackStreamIsActive)
+
+        harness.service.enqueueRealtimeInsertion("voxtral ")
+        harness.service.flushFinalLiveReplacementCorrections()
+
+        XCTAssertEqual(
+            field.value, "voxtral localvoxtral ",
+            "all dictated text must be present in the target after conversion"
+        )
+        XCTAssertEqual(harness.backspaces.value, [8], "no backspaces after conversion")
+        harness.service.endLiveReplacementSession()
+    }
+
+    func testDeferredPostBackspaceTimeoutRestoresErasedTextBeforeConverting() async {
+        let field = FakeCaretField()
+        // begin → 0, inserted-caret check → 7 (mismatch, defers), settle
+        // wait → 8 (matched, backspaces post), then 5 forever: the
+        // erased-caret wait (expected 0) times out → tracked caret diverged
+        // AFTER the erase.
+        let caretScript = Box<[Int?]>([0, 7, 8])
+        let harness = makeServiceHarness(
+            field: field,
+            caretLocationReader: { _ in
+                caretScript.value.isEmpty ? 5 : caretScript.value.removeFirst()
+            }
+        )
+        harness.service.beginLiveReplacementSession(
+            dictionary: voxtralDictionary,
+            preferredAppPID: nil,
+            isTerminalLikeTarget: false
+        )
+
+        harness.service.enqueueRealtimeInsertion("voxtral ")
+        XCTAssertTrue(harness.service.debugLiveReplacementCorrectionIsInFlight)
+        await harness.service.debugWaitForLiveReplacementCorrectionTasks()
+
+        XCTAssertEqual(harness.backspaces.value, [8])
+        XCTAssertEqual(
+            field.value, "voxtral ",
+            "the deferred post-backspace timeout must restore the erased text before converting"
+        )
+        XCTAssertTrue(harness.service.debugLiveHoldBackStreamIsActive)
+
+        harness.service.enqueueRealtimeInsertion("voxtral ")
+        harness.service.flushFinalLiveReplacementCorrections()
+
+        XCTAssertEqual(field.value, "voxtral localvoxtral ")
+        XCTAssertEqual(harness.backspaces.value, [8])
+        harness.service.endLiveReplacementSession()
+    }
+
+    func testPostBackspaceRestoreFailureStandsDownWithoutConverting() {
+        let typed = Box<[String]>([])
+        let backspaces = Box<[Int]>([])
+        let failNextUnicodePost = Box(false)
+        let caretScript = Box<[Int?]>([0, 8, nil])
+        let service = TextInsertionService()
+        service.debugConfigureInsertionHooks(
+            unicodePoster: { chunk in
+                if failNextUnicodePost.value {
+                    failNextUnicodePost.value = false
+                    return false
+                }
+                typed.value.append(chunk)
+                return true
+            },
+            backspacePoster: { count in
+                backspaces.value.append(count)
+                // The restore attempt right after these backspaces fails:
+                // the keyboard path is broken.
+                failNextUnicodePost.value = true
+                return true
+            },
+            modifierStateReader: { false },
+            accessibilityInserter: { _, _ in false },
+            caretLocationReader: { _ in
+                caretScript.value.isEmpty ? nil : caretScript.value.removeFirst()
+            },
+            liveReplacementSettleSleep: {}
+        )
+        service.beginLiveReplacementSession(
+            dictionary: voxtralDictionary,
+            preferredAppPID: nil,
+            isTerminalLikeTarget: false
+        )
+
+        service.enqueueRealtimeInsertion("voxtral ")
+
+        XCTAssertEqual(backspaces.value, [8])
+        XCTAssertFalse(
+            service.debugLiveHoldBackStreamIsActive,
+            "a failed restore means the keyboard path is broken: true stand-down, no conversion"
+        )
+        XCTAssertFalse(service.debugLiveReplacementCorrectorIsActive)
+
+        service.enqueueRealtimeInsertion("next ")
+        service.flushFinalLiveReplacementCorrections()
+        XCTAssertEqual(typed.value, ["voxtral ", "next "])
+        XCTAssertEqual(backspaces.value, [8])
+        service.endLiveReplacementSession()
+    }
+
+    // MARK: - Session stop during an in-flight correction (codex review, 2026-07-07)
+
+    // Production stop ordering: finishStoppedSession calls
+    // flushFinalLiveReplacementCorrections() and then (same MainActor turn)
+    // completeStoppedSessionCleanup() -> endLiveReplacementSession(). When a
+    // deferred correction is in flight, the final flush is queued behind a
+    // task that teardown immediately cancels — pre-existing on the guarded
+    // path: the queued text was dropped and reported as failed pending text.
+    // Teardown must drain it instead, with replacements applied.
+    func testSessionStopDuringInFlightCorrectionDrainsQueuedTextInsteadOfDroppingIt() {
+        let harness = makeServiceHarness(caretLocationReader: { _ in 4242 })
+        harness.service.beginLiveReplacementSession(
+            dictionary: ReplacementDictionary(entries: [
+                ReplacementEntry(replaceWith: "localvoxtral", matches: ["voxtral"]),
+                ReplacementEntry(replaceWith: "chai", matches: ["tea"]),
+            ]),
+            preferredAppPID: nil,
+            isTerminalLikeTarget: false
+        )
+
+        harness.service.enqueueRealtimeInsertion("voxtral ")
+        XCTAssertTrue(harness.service.debugLiveReplacementCorrectionIsInFlight)
+        harness.service.enqueueRealtimeInsertion("tea")
+
+        // Production ordering: both calls in the same turn, the deferred
+        // task never gets to run.
+        harness.service.flushFinalLiveReplacementCorrections()
+        harness.service.endLiveReplacementSession()
+
+        XCTAssertEqual(
+            harness.typed.value, ["voxtral ", "chai"],
+            "text queued behind the cancelled correction must be drained with replacements applied"
+        )
+        XCTAssertFalse(harness.service.hasPendingInsertionText)
+        XCTAssertEqual(harness.backspaces.value, [])
+    }
+
+    func testSessionStopDuringBackspacePostedCorrectionRestoresErasedText() {
+        let field = FakeCaretField()
+        // begin → 0, inserted-caret check → 8 (matched, backspaces post),
+        // erased-caret check → 7 (mismatch, defers at .backspacePosted).
+        let caretScript = Box<[Int?]>([0, 8, 7])
+        let harness = makeServiceHarness(
+            field: field,
+            caretLocationReader: { _ in
+                caretScript.value.isEmpty ? 7 : caretScript.value.removeFirst()
+            }
+        )
+        harness.service.beginLiveReplacementSession(
+            dictionary: voxtralDictionary,
+            preferredAppPID: nil,
+            isTerminalLikeTarget: false
+        )
+
+        harness.service.enqueueRealtimeInsertion("voxtral ")
+        XCTAssertTrue(harness.service.debugLiveReplacementCorrectionIsInFlight)
+        XCTAssertEqual(field.value, "", "the correction's backspaces erased the text")
+
+        // Production stop ordering, same turn.
+        harness.service.flushFinalLiveReplacementCorrections()
+        harness.service.endLiveReplacementSession()
+
+        XCTAssertEqual(
+            field.value, "voxtral ",
+            "teardown must restore text erased by the abandoned correction"
+        )
+        XCTAssertEqual(harness.backspaces.value, [8])
+    }
+
     // MARK: - Harness
 
     private var voxtralDictionary: ReplacementDictionary {


### PR DESCRIPTION
## What

Live Auto-Paste replacement-dictionary entries never applied reliably. The default (non-terminal) path typed text raw, then tried to **backspace and retype** each replacement, gated by reading the target's AX caret. But synthetic CGEvents reach the target *asynchronously*, so the synchronous caret read never matched immediately — every correction deferred waiting for the caret to settle, and a short dictation ended (tearing the deferred task down) before it did. Field logs show **zero** successful corrections across a whole session (crashlog run 28959033459, 2026-07-08): replacements silently did nothing in every non-terminal app. Terminals were worse still — a screen-grid caret can *never* match, so they timed out and stood down.

This PR makes live dictation replacement reliable everywhere by applying replacements **before** typing, for **every** target.

- **`TerminalTargetDetector`** — per-session verdict (bundle-ID allowlist: Terminal.app, iTerm2, Ghostty, Warp incl. channel variants, WezTerm, kitty, Alacritty, Hyper, Tabby, Rio; user `terminal_apps.toml` allowlist; AX-writability probe fallback for unknown apps). Captured in `beginDictationSession` *before* the socket opens (focus can drift during connect). Transient AX failures read as "unavailable", not terminal-like.
- **`LiveHoldBackReplacementStream`** — the sole live-replacement strategy. Text is held back to the trailing partial word + (max rule word count − 1) complete words, corrected, then released. **No caret reads, no backspaces, ever.** Embeds `LiveReplacementCorrector` for matching (no duplicated rule logic).
- **Strategy selection** at live session start: terminal-like → hold-back **with** newline/tab sanitization (a typed `\n` submits an agent prompt, a typed `\t` triggers shell completion — both collapse to a space); non-terminal with rules → hold-back **without** sanitization (a regular editor keeps its newlines); non-terminal with no rules → type directly (zero hold-back delay). Terminal targets arm sanitization even with the dictionary disabled.
- **The guarded backspace corrector is deleted** — along with the deferred-correction task, caret-settle polling, adaptive guarded→hold-back conversion, unguarded blind-backspace path, and the now-dead corrector stand-down / erased-text / backspace-count API. **Net −1228 lines.**
- **Secure Keyboard Entry warning** — one-line popover warning at session start when `IsSecureEventInputEnabled()` (blocks synthetic keystrokes; auto-enabled by Ghostty around password prompts), token-scoped so it never clobbers higher-priority errors and clears at session end.
- Strategy/verdict decisions logged per session (`Log.corrector`, `Log.target`).

Both the original terminal work and this hold-back-everywhere change were independently reviewed (Codex, GPT-5.5 high); all findings fixed.

### Tradeoff (accepted — already true for terminals)

Hold-back can't type a word until it sees the boundary proving it can't be part of a rule match, so the trailing partial word — or up to `maxRuleWordCount` words for a multi-word rule — appears one boundary later, flushed on the next word or on stop. Imperceptible next to "no replacement at all", and it's what terminals already did.

## Proof

Field evidence, guarded path, before this change (crashlog run 28959033459 — every non-terminal session armed then produced **zero** `correction posted`, only `teardown drained` / `restored erased text`):
```
18:21:36 corrector armed strategy=guarded-corrector entries=1 rules=1 caret_guard=on
18:21:39 corrector teardown drained queued final flush          # no "correction posted"
18:22:04 corrector armed strategy=guarded-corrector ...
18:22:08 corrector teardown restored erased text chars=9        # correction abandoned
```
(`grep -c "correction posted"` across the whole run: **0**.)

- [x] **Regression — the exact field bug** (final-word-only replacement, no trailing whitespace) now applied on stop, at both the service and view-model level:
```
TextInsertionServiceLiveStrategyTests testFinalWordOnlyReplacementIsAppliedAtStopNonTerminal passed (0.002s)
DictationViewModelLiveReplacementCorrectorTests testFinalWordOnlyReplacementIsAppliedAtStop passed (0.004s)
```
Fail-before is documented by the (now-deleted) `testCorrectorStandsDownAfterCaretSettleTimeout`, which asserted the field stayed **uncorrected** ("voxtral ") once the caret diverged — the drop, encoded as the old expected behavior.
- [x] **Invariant** — after stop, emitted text == dictionary applied to the full raw transcript (no dropped tail, no fresh-empty-stream bug), asserted for terminal and non-terminal:
```
testStopEmittedTextEqualsDictionaryAppliedToFullRawText passed (0.003s)
testEndSessionFlushesHeldTailWithoutExplicitFinalFlush passed (0.002s)
```
- [x] Stream matrix (pre-existing `LiveHoldBackReplacementStreamTests`, 26 tests): multi-word rule spanning ingest chunks, punctuation boundary, emoji grapheme, newline/tab sanitization on/off, replacement+sanitization compose.
- [x] Unit suite green — `./scripts/remote-build.sh` (578 tests, 2 env-gated skips, **0 failures, 0 warnings**):
```
Executed 578 tests, with 2 tests skipped and 0 failures (0 unexpected) in 6.185 (6.219) seconds
```
- [x] Hand-verification — done twice over: owner field test (2026-07-08, all scenarios, "great") and the automated E2E probe ([run 28974870442](https://github.com/T0mSIlver/localvoxtral/actions/runs/28974870442), TextEdit + Ghostty, real TTS audio + hold gesture — see the probe comment below):
  - **Regular editor (e.g. TextEdit)**: the replacement lands (no backspace flicker); the last word appears on the next word/stop. Log shows `strategy=holdback newline_sanitize=off`.
  - **Ghostty / Claude Code**: replacement lands, newlines collapse to spaces. Log shows `strategy=holdback reason=terminal`.
  - **cmux** (writable AX): now in the **built-in allowlist** (owner request after field-testing) — zero-config sessions get full terminal treatment: replacements AND newline/tab sanitization, log `strategy=holdback reason=terminal newline_sanitize=on`. The user allowlist (`terminal_apps.toml`) remains for other undetectable terminal hosts.

