### PR TITLE
Bump managed mlx-lm backend to 0.31.3.post3 (prompt-cache correctness fixes)

### DIFF
--- a/Sources/localvoxtral/Backends/BackendCatalog.swift
+++ b/Sources/localvoxtral/Backends/BackendCatalog.swift
@@ -45,10 +45,14 @@ enum BackendCatalog {
         // post2 pins transformers <5.13: 5.13.0 broke the string-keyed
         // AutoTokenizer.register call in mlx_lm/tokenizer_utils.py, so fresh
         // installs resolving latest transformers crashed mlx_lm.server at import.
-        version: "0.31.3.post2",
+        // post3 fixes prompt-cache correctness: reuse can no longer serve KV
+        // that doesn't match the request prefix (T0mSIlver/mlx-lm#2), and the
+        // server cache is actually LRU with one-token prefix hits fixed
+        // (T0mSIlver/mlx-lm#3).
+        version: "0.31.3.post3",
         requirementName: "mlx-lm",
-        wheelURL: URL(string: "https://github.com/T0mSIlver/mlx-lm/releases/download/v0.31.3.post2/mlx_lm-0.31.3.post2-py3-none-any.whl")!,
-        wheelSHA256: "61c49eba2e8651bded681f6d717a78fc635d768e487222530a2e239a58e47cdd",
+        wheelURL: URL(string: "https://github.com/T0mSIlver/mlx-lm/releases/download/v0.31.3.post3/mlx_lm-0.31.3.post3-py3-none-any.whl")!,
+        wheelSHA256: "13b0fe84eb7bcd92103b45e93a90a82be1cbf10cb089168b91e080c9bacb3177",
         executableName: "mlx_lm.server",
         pythonVersion: "3.12",
         port: 8472

--- a/scripts/mac/README.md
+++ b/scripts/mac/README.md
@@ -18,7 +18,7 @@ Install from a trusted owner session on the Mac. Pins mirror
 # One-time venv with the pinned fork wheel (same wheel the app installs).
 uv venv --python 3.12 ~/.local/share/localvoxtral-eval/mlx-lm
 uv pip install --python ~/.local/share/localvoxtral-eval/mlx-lm/bin/python \
-  'mlx-lm @ https://github.com/T0mSIlver/mlx-lm/releases/download/v0.31.3.post2/mlx_lm-0.31.3.post2-py3-none-any.whl'
+  'mlx-lm @ https://github.com/T0mSIlver/mlx-lm/releases/download/v0.31.3.post3/mlx_lm-0.31.3.post3-py3-none-any.whl'
 
 # LaunchAgent (adjust $HOME):
 cat > ~/Library/LaunchAgents/com.localvoxtral.mlxlm.plist <<'PLIST'


### PR DESCRIPTION
Bumps the managed `mlx-lm` backend wheel from `v0.31.3.post2` to [`v0.31.3.post3`](https://github.com/T0mSIlver/mlx-lm/releases/tag/v0.31.3.post3).

## What post3 fixes

- **Prompt-cache reuse can no longer serve KV that doesn't match the request prefix** (T0mSIlver/mlx-lm#2, filed upstream as ml-explore/mlx-lm#1494): a slid `ChunkedKVCache` window now reports itself non-trimmable, `fetch_nearest_cache` verifies every layer trimmed the full amount before reusing a longer entry, and `ConcatenateKVCache.trim` actually drops the trimmed KV. This is the mechanism class behind stale-system-prompt symptoms on long-lived servers — directly relevant to the polishing backend, which reuses a shared system prompt across calls.
- **The server prompt cache is actually LRU** (T0mSIlver/mlx-lm#3, upstream PR ml-explore/mlx-lm#1496): fetches refresh recency so the hot polishing system prompt can't be evicted while cold entries survive, and one-token cached prefixes are reachable.

## Changes

- `BackendCatalog.swift`: version, wheel URL, and `wheelSHA256` (verified against the downloaded release asset: `13b0fe84…`).
- `scripts/mac/README.md`: eval-venv install URL updated to the same wheel.

String-constant change only; prepared on a Linux box so `swift build` wasn't run here — covered by the `build-test` check.

## Proof

- ✅ [mlx-lm server test run against `v0.31.3.post3`](https://github.com/T0mSIlver/localvoxtral/actions/runs/28885157333) — **passed** on the self-hosted Apple Silicon runner: served `mlx-community/Qwen3.5-0.8B-8bit` from the release tag and probed chat completions twice, the second hitting the prompt-cache reuse path.
