### PR TITLE
Bundled MLX Swift polishing engine replaces the managed mlx-lm wheel

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,13 +81,34 @@ jobs:
           VLLM_REALTIME_TEST_MODEL: T0mSIlver/Voxtral-Mini-4B-Realtime-2602-MLX-4bit
         run: swift test --filter RealtimeAPIVLLMIntegrationTests
 
+      - name: Polishing helper unit tests (PolishHelper package)
+        # Self-hosted only: hosted runners would pay a cold Cmlx C++ compile
+        # every fork PR. These tests are Metal-free (HTTP layer, router,
+        # cache locator, watchdog); the Metal path is covered below.
+        if: runner.environment == 'self-hosted'
+        run: swift test --package-path PolishHelper
+
       - name: Package app bundle
         # The self-hosted runner's keychain holds the stable localvoxtral-dev
         # signing cert, keeping TCC grants valid across builds; anywhere the
         # identity is absent (hosted runners), packaging falls back to ad-hoc.
+        # Hosted runners skip the bundled polishing helper (no MetalToolchain
+        # component + cold MLX C++ build would dominate fork-PR CI); every
+        # self-hosted lane (same-repo PRs, main, releases) builds it.
         env:
           LOCALVOXTRAL_CODESIGN_IDENTITY: localvoxtral-dev
+          LOCALVOXTRAL_SKIP_POLISHD: ${{ runner.environment == 'github-hosted' && '1' || '0' }}
         run: ./scripts/package_app.sh release
+
+      - name: Polishing helper integration (live model + eval baseline)
+        # Spawns the helper built by the packaging step with the real pinned
+        # model, drives the production polish request path, and asserts the
+        # shared eval baseline + parent-pid tether.
+        if: runner.environment == 'self-hosted'
+        env:
+          LOCALVOXTRAL_POLISHD_TEST_ENABLE: "1"
+          LOCALVOXTRAL_POLISHD_TEST_PATH: PolishHelper/.build/xcode/Build/Products/Release/localvoxtral-polishd
+        run: swift test --filter PolishHelperIntegrationTests
 
       - name: Zip app for artifact upload
         # upload-artifact mangles symlinks/exec bits in .app bundles; ditto-zip

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,7 +99,13 @@ jobs:
         run: |
           if ! xcrun metal --version >/dev/null 2>&1; then
             echo "Metal toolchain not active for $(whoami); installing component..."
-            xcodebuild -downloadComponent MetalToolchain
+            # The MobileAsset catalog fetch fails transiently (observed for
+            # both the builder and runner users on 2026-07-07) — retry.
+            for attempt in 1 2 3; do
+              xcodebuild -downloadComponent MetalToolchain && break
+              echo "catalog fetch failed (attempt $attempt); retrying in 10s..."
+              sleep 10
+            done
             xcrun metal --version
           fi
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -144,7 +144,14 @@ jobs:
           retention-days: 7
 
       - name: Zip dSYM for artifact upload
-        run: ditto -c -k --keepParent dist/localvoxtral.dSYM dist/localvoxtral-dSYM.zip
+        # Includes the polishing helper's dSYM when present (self-hosted
+        # lanes) — helper crashes (MLX C++/Metal) are the likeliest field
+        # crashes, and a dSYM that never leaves the runner symbolizes nothing.
+        run: |
+          ditto -c -k --keepParent dist/localvoxtral.dSYM dist/localvoxtral-dSYM.zip
+          if [[ -d dist/localvoxtral-polishd.dSYM ]]; then
+            ditto -c -k --keepParent dist/localvoxtral-polishd.dSYM dist/localvoxtral-polishd-dSYM.zip
+          fi
 
       - name: Upload dSYM artifact
         # Longer retention than the app: field crashes surface days after the
@@ -152,7 +159,9 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: localvoxtral-dsym
-          path: dist/localvoxtral-dSYM.zip
+          path: |
+            dist/localvoxtral-dSYM.zip
+            dist/localvoxtral-polishd-dSYM.zip
           retention-days: 30
 
       - name: Smoke test packaged app launch

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,6 +88,21 @@ jobs:
         if: runner.environment == 'self-hosted'
         run: swift test --package-path PolishHelper
 
+      - name: Ensure Metal toolchain
+        # Xcode 26 ships the Metal compiler as a separate component, and its
+        # activation is per-user — installing it for the SSH build user does
+        # not activate it for the runner user. Probe with a real invocation
+        # (`xcrun --find metal` succeeds even when the component is missing)
+        # and self-provision loudly; the asset is cached system-wide, so a
+        # re-activation here is quick.
+        if: runner.environment == 'self-hosted'
+        run: |
+          if ! xcrun metal --version >/dev/null 2>&1; then
+            echo "Metal toolchain not active for $(whoami); installing component..."
+            xcodebuild -downloadComponent MetalToolchain
+            xcrun metal --version
+          fi
+
       - name: Package app bundle
         # The self-hosted runner's keychain holds the stable localvoxtral-dev
         # signing cert, keeping TCC grants valid across builds; anywhere the

--- a/.github/workflows/mac-crashlog.yml
+++ b/.github/workflows/mac-crashlog.yml
@@ -32,7 +32,7 @@ jobs:
             defaults read com.localvoxtral.app "$key" 2>/dev/null || echo "<absent>"
           done
           echo "--- backend processes:"
-          pgrep -fl 'voxmlx-serve|mlx_lm' | sed "s|$HOME|~|g" || echo "none"
+          pgrep -fl 'voxmlx-serve|mlx_lm|localvoxtral-polishd' | sed "s|$HOME|~|g" || echo "none"
 
       - name: Recent localvoxtral app log (redacted)
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -129,6 +129,10 @@ jobs:
             "localvoxtral" "dist/localvoxtral-$TAG.dmg"
           ditto -c -k --keepParent \
             "dist/localvoxtral.dSYM" "dist/localvoxtral-$TAG.dSYM.zip"
+          # Helper dSYM: MLX C++/Metal crashes in the polishing helper are
+          # the likeliest field crashes; releases must carry its symbols.
+          ditto -c -k --keepParent \
+            "dist/localvoxtral-polishd.dSYM" "dist/localvoxtral-polishd-$TAG.dSYM.zip"
           (
             cd dist
             shasum -a 256 "localvoxtral-$TAG.zip" > "localvoxtral-$TAG.zip.sha256"
@@ -156,3 +160,4 @@ jobs:
             dist/localvoxtral-${{ steps.meta.outputs.tag }}.dmg
             dist/localvoxtral-${{ steps.meta.outputs.tag }}.dmg.sha256
             dist/localvoxtral-${{ steps.meta.outputs.tag }}.dSYM.zip
+            dist/localvoxtral-polishd-${{ steps.meta.outputs.tag }}.dSYM.zip

--- a/.gitignore
+++ b/.gitignore
@@ -16,5 +16,7 @@ DerivedData/
 .agent-runs/
 .opencode/
 
-# Transient enable marker written by remote-build.sh eval-llm
+# Transient enable markers written by remote-build.sh eval-llm /
+# integration-polishd
 /.llm-polish-eval-enable.json
+/.polishd-integration-enable.json

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .DS_Store
 /.build
+/PolishHelper/.build
 /Packages
 xcuserdata/
 DerivedData/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -130,8 +130,9 @@ This is a real app with daily users. Nothing ships on "it compiles".
 
 | Tier | What | When | Cost |
 |---|---|---|---|
-| 0 | Unit suite (200+ tests) + packaging + launch smoke | every PR/push, CI | ~1 min |
+| 0 | Unit suite (500+ tests) + PolishHelper unit suite + packaging + launch smoke | every PR/push, CI (helper unit suite: self-hosted lanes only) | ~1 min |
 | 1 | `RealtimeAPIVLLMIntegrationTests` vs live local voxmlx: real inference through the production websocket client, word-accuracy asserted | every PR/push on the self-hosted runner; locally via `remote-build.sh integration` | ~20 s |
+| 1 | `PolishHelperIntegrationTests`: the packaged polishing helper vs the real pinned model — production request path, shared eval baseline, parent-pid tether | every PR/push on the self-hosted runner (after packaging); locally via `remote-build.sh integration-polishd` | ~15 s warm |
 | 2 | `ui-smoke.yml` AX smoke drill (status item, settings tabs, lazy managed-backend launch invariant); dictation-with-audio remains future work | nightly + manual on the self-hosted GUI runner | — |
 
 Tier 1 details: the suite is env-gated (`VLLM_REALTIME_TEST_ENABLE=1`) and

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,9 +17,23 @@ is machine-local config, set once per clone (never committed):
 ./scripts/remote-build.sh                 # build + unit tests
 ./scripts/remote-build.sh test --filter TextMergingAlgorithmsTests
 ./scripts/remote-build.sh integration     # realtime pipeline vs live voxmlx
-./scripts/remote-build.sh eval-llm        # default polish prompt eval vs live mlx-lm
-./scripts/remote-build.sh package         # build the .app bundle
+./scripts/remote-build.sh eval-llm        # default polish prompt eval vs a live chat/completions server
+./scripts/remote-build.sh package         # build the .app bundle (also builds the polishing helper)
+./scripts/remote-build.sh integration-polishd  # bundled polish helper vs real model + eval baseline (run package first)
+./scripts/remote-build.sh build --package-path PolishHelper   # helper package alone
+./scripts/remote-build.sh test  --package-path PolishHelper   # helper unit tests (Metal-free)
 ```
+
+The polishing helper (`PolishHelper/`, product `localvoxtral-polishd`) is a
+SEPARATE SwiftPM package so the root build never compiles the MLX C++ core.
+Two hard rules learned setting it up: (1) `swift build` of the helper
+compiles but CANNOT produce working Metal kernels — only the xcodebuild lane
+in `package_app.sh` can (aggregate scheme `PolishHelper`); a swift-build
+binary fails at runtime loading the metallib. (2) On Xcode 26+ the Metal
+compiler is a separate ~700 MB component — one-time host setup is
+`xcodebuild -downloadComponent MetalToolchain` (the catalog fetch fails
+transiently sometimes; retry). `xcrun --find metal` succeeding does NOT mean
+the toolchain is installed; only invoking `metal` proves it.
 
 On a Mac, just `swift build` / `swift test`.
 
@@ -129,14 +143,18 @@ backend, where the suite self-skips. The mic-capture tests
 
 LLM polish prompt eval: `LLMPolishPromptEvalTests` scores the bundled default
 polishing prompt (punctuation-spacing cases, French vs English) against a live
-mlx-lm server through the production request path. Run it with
+chat/completions server through the production request path. Run it with
 `./scripts/remote-build.sh eval-llm [endpoint]` — default endpoint is the
 `com.localvoxtral.mlxlm` launchd service on port 8080 (owner runbook:
 `scripts/mac/README.md`); don't point it at the app-managed instance on 8472,
 which dies whenever the app quits. Enablement is env
 (`LLM_POLISH_EVAL_ENABLE=1`) or the marker file the script writes into the
 synced tree (the SSH gate can't pass env vars). Prompt changes MUST re-run
-this eval and paste the scoreboard in the PR's Proof section.
+this eval and paste the scoreboard in the PR's Proof section. The corpus +
+scorer live in `LLMPolishEvalSupport`, shared with
+`PolishHelperIntegrationTests` (`remote-build.sh integration-polishd`), which
+holds the bundled MLX Swift polishing helper to the same baseline — engine or
+model-pin changes MUST run that one too.
 
 ## CI / shipping
 
@@ -191,7 +209,11 @@ Key subsystems:
 - Settings/config: `SettingsStore` (UserDefaults), `AppConfigStore` (TOML at
   `~/Library/Application Support/localvoxtral/config`)
 - Hotkey: `HotKeyManager` (Carbon, single global hotkey)
-- LLM polish: `LLMPolishingService` (chat/completions)
+- LLM polish: `LLMPolishingService` (chat/completions client) → in managed
+  mode, the bundled `localvoxtral-polishd` helper (`PolishHelper/` package:
+  MLX Swift inference + a minimal loopback OpenAI server + parent-pid
+  watchdog), supervised like any managed backend on port 8472. Replaced the
+  uv-installed mlx-lm fork wheel (upstream mlx-lm unmaintained, 2026-07).
 
 ## Conventions
 

--- a/PolishHelper/Package.resolved
+++ b/PolishHelper/Package.resolved
@@ -10,15 +10,6 @@
       }
     },
     {
-      "identity": "jinja",
-      "kind": "remoteSourceControl",
-      "location": "https://github.com/huggingface/swift-jinja.git",
-      "state": {
-        "revision": "0b67ecb79139f6addef8699eff3622808aa6c7dc",
-        "version": "2.3.6"
-      }
-    },
-    {
       "identity": "mlx-swift",
       "kind": "remoteSourceControl",
       "location": "https://github.com/ml-explore/mlx-swift",
@@ -79,6 +70,15 @@
       "state": {
         "revision": "b721959445b617d0bf03910b2b4aced345fd93bf",
         "version": "0.9.0"
+      }
+    },
+    {
+      "identity": "swift-jinja",
+      "kind": "remoteSourceControl",
+      "location": "https://github.com/huggingface/swift-jinja.git",
+      "state": {
+        "revision": "0b67ecb79139f6addef8699eff3622808aa6c7dc",
+        "version": "2.3.6"
       }
     },
     {

--- a/PolishHelper/Package.resolved
+++ b/PolishHelper/Package.resolved
@@ -1,0 +1,140 @@
+{
+  "pins": [
+    {
+      "identity": "eventsource",
+      "kind": "remoteSourceControl",
+      "location": "https://github.com/mattt/EventSource.git",
+      "state": {
+        "revision": "a3a85a85214caf642abaa96ae664e4c772a59f6e",
+        "version": "1.4.1"
+      }
+    },
+    {
+      "identity": "jinja",
+      "kind": "remoteSourceControl",
+      "location": "https://github.com/huggingface/swift-jinja.git",
+      "state": {
+        "revision": "0b67ecb79139f6addef8699eff3622808aa6c7dc",
+        "version": "2.3.6"
+      }
+    },
+    {
+      "identity": "mlx-swift",
+      "kind": "remoteSourceControl",
+      "location": "https://github.com/ml-explore/mlx-swift",
+      "state": {
+        "revision": "dc43e62d7055353c7f99fa071a4e71d29dfddc44",
+        "version": "0.31.4"
+      }
+    },
+    {
+      "identity": "mlx-swift-lm",
+      "kind": "remoteSourceControl",
+      "location": "https://github.com/ml-explore/mlx-swift-lm.git",
+      "state": {
+        "revision": "bd4b7434e6bdb588c7ef55706ff8904cb7fd4c57",
+        "version": "3.31.4"
+      }
+    },
+    {
+      "identity": "swift-asn1",
+      "kind": "remoteSourceControl",
+      "location": "https://github.com/apple/swift-asn1.git",
+      "state": {
+        "revision": "a9a5efd40eaf558a2bcd48d64b1d1646be686008",
+        "version": "1.7.1"
+      }
+    },
+    {
+      "identity": "swift-atomics",
+      "kind": "remoteSourceControl",
+      "location": "https://github.com/apple/swift-atomics.git",
+      "state": {
+        "revision": "0442cb5a3f98ab802acb777929fdb446bda11a34",
+        "version": "1.3.1"
+      }
+    },
+    {
+      "identity": "swift-collections",
+      "kind": "remoteSourceControl",
+      "location": "https://github.com/apple/swift-collections.git",
+      "state": {
+        "revision": "a0cb0954ecb21e4e31b0070e6ed5674e8556685a",
+        "version": "1.6.0"
+      }
+    },
+    {
+      "identity": "swift-crypto",
+      "kind": "remoteSourceControl",
+      "location": "https://github.com/apple/swift-crypto.git",
+      "state": {
+        "revision": "1b6b2e274e85105bfa155183145a1dcfd63331f1",
+        "version": "4.5.0"
+      }
+    },
+    {
+      "identity": "swift-huggingface",
+      "kind": "remoteSourceControl",
+      "location": "https://github.com/huggingface/swift-huggingface.git",
+      "state": {
+        "revision": "b721959445b617d0bf03910b2b4aced345fd93bf",
+        "version": "0.9.0"
+      }
+    },
+    {
+      "identity": "swift-nio",
+      "kind": "remoteSourceControl",
+      "location": "https://github.com/apple/swift-nio.git",
+      "state": {
+        "revision": "cd3e1152083706d77b223fb29110e590efcc70c0",
+        "version": "2.101.2"
+      }
+    },
+    {
+      "identity": "swift-numerics",
+      "kind": "remoteSourceControl",
+      "location": "https://github.com/apple/swift-numerics",
+      "state": {
+        "revision": "0c0290ff6b24942dadb83a929ffaaa1481df04a2",
+        "version": "1.1.1"
+      }
+    },
+    {
+      "identity": "swift-syntax",
+      "kind": "remoteSourceControl",
+      "location": "https://github.com/swiftlang/swift-syntax.git",
+      "state": {
+        "revision": "79e4b74a295b6eb74a8b585e3a39d29e70c1dbd1",
+        "version": "603.0.2"
+      }
+    },
+    {
+      "identity": "swift-system",
+      "kind": "remoteSourceControl",
+      "location": "https://github.com/apple/swift-system.git",
+      "state": {
+        "revision": "38cd4aaf65feb0ef9bad77d330014f0f256577f5",
+        "version": "1.7.3"
+      }
+    },
+    {
+      "identity": "swift-transformers",
+      "kind": "remoteSourceControl",
+      "location": "https://github.com/huggingface/swift-transformers.git",
+      "state": {
+        "revision": "2fa33e1f5e7131a7fc64c28e6d161dcec0d24820",
+        "version": "1.3.3"
+      }
+    },
+    {
+      "identity": "yyjson",
+      "kind": "remoteSourceControl",
+      "location": "https://github.com/ibireme/yyjson.git",
+      "state": {
+        "revision": "8b4a38dc994a110abaec8a400615567bd996105f",
+        "version": "0.12.0"
+      }
+    }
+  ],
+  "version": 2
+}

--- a/PolishHelper/Package.swift
+++ b/PolishHelper/Package.swift
@@ -1,0 +1,38 @@
+// swift-tools-version: 6.1
+import PackageDescription
+
+// Standalone package (not part of the root localvoxtral package) so the main
+// app's `swift build` / `swift test` loop never compiles the MLX C++ core.
+// SwiftPM command-line builds of this package produce a binary that cannot
+// load Metal kernels at runtime (mlx-swift compiles its metallib only under
+// Xcode's build system) — that's fine for unit tests, which stay Metal-free.
+// The shippable helper is built with xcodebuild by scripts/package_app.sh.
+let package = Package(
+    name: "PolishHelper",
+    platforms: [.macOS(.v15)],
+    products: [
+        .executable(name: "localvoxtral-polishd", targets: ["localvoxtral-polishd"])
+    ],
+    dependencies: [
+        .package(url: "https://github.com/ml-explore/mlx-swift-lm.git", exact: "3.31.4"),
+        .package(url: "https://github.com/huggingface/swift-transformers.git", from: "1.3.0"),
+    ],
+    targets: [
+        .target(
+            name: "PolishHelperCore",
+            dependencies: [
+                .product(name: "MLXLLM", package: "mlx-swift-lm"),
+                .product(name: "MLXLMCommon", package: "mlx-swift-lm"),
+                .product(name: "Tokenizers", package: "swift-transformers"),
+            ]
+        ),
+        .executableTarget(
+            name: "localvoxtral-polishd",
+            dependencies: ["PolishHelperCore"]
+        ),
+        .testTarget(
+            name: "PolishHelperCoreTests",
+            dependencies: ["PolishHelperCore"]
+        ),
+    ]
+)

--- a/PolishHelper/Sources/PolishHelperCore/ChatCompletionAPI.swift
+++ b/PolishHelper/Sources/PolishHelperCore/ChatCompletionAPI.swift
@@ -1,0 +1,97 @@
+import Foundation
+
+/// Wire types for the OpenAI chat-completions subset the app's
+/// `LLMPolishingService` actually sends and reads. Streaming is deliberately
+/// unsupported (the polish path is a single non-streaming request).
+public struct ChatCompletionRequest: Codable, Sendable {
+    public var model: String?
+    public var messages: [ChatCompletionMessage]
+    public var temperature: Float?
+    public var maxTokens: Int?
+    public var stream: Bool?
+
+    enum CodingKeys: String, CodingKey {
+        case model
+        case messages
+        case temperature
+        case maxTokens = "max_tokens"
+        case stream
+    }
+
+    public init(
+        model: String? = nil,
+        messages: [ChatCompletionMessage],
+        temperature: Float? = nil,
+        maxTokens: Int? = nil,
+        stream: Bool? = nil
+    ) {
+        self.model = model
+        self.messages = messages
+        self.temperature = temperature
+        self.maxTokens = maxTokens
+        self.stream = stream
+    }
+}
+
+public struct ChatCompletionMessage: Codable, Sendable, Equatable {
+    public var role: String
+    public var content: String
+
+    public init(role: String, content: String) {
+        self.role = role
+        self.content = content
+    }
+}
+
+public struct ChatCompletionResponse: Codable, Sendable {
+    public struct Choice: Codable, Sendable {
+        public var index: Int
+        public var message: ChatCompletionMessage
+        public var finishReason: String
+
+        enum CodingKeys: String, CodingKey {
+            case index
+            case message
+            case finishReason = "finish_reason"
+        }
+
+        public init(index: Int, message: ChatCompletionMessage, finishReason: String) {
+            self.index = index
+            self.message = message
+            self.finishReason = finishReason
+        }
+    }
+
+    public var id: String
+    public var object: String
+    public var created: Int
+    public var model: String
+    public var choices: [Choice]
+
+    public init(id: String, created: Int, model: String, content: String) {
+        self.id = id
+        self.object = "chat.completion"
+        self.created = created
+        self.model = model
+        self.choices = [
+            Choice(
+                index: 0,
+                message: ChatCompletionMessage(role: "assistant", content: content),
+                finishReason: "stop"
+            )
+        ]
+    }
+}
+
+public struct ChatCompletionErrorResponse: Codable, Sendable {
+    public struct ErrorBody: Codable, Sendable {
+        public var message: String
+        public var type: String
+    }
+
+    public var error: ErrorBody
+
+    public init(message: String, type: String) {
+        self.error = ErrorBody(message: message, type: type)
+    }
+}

--- a/PolishHelper/Sources/PolishHelperCore/HFCacheModelLocator.swift
+++ b/PolishHelper/Sources/PolishHelperCore/HFCacheModelLocator.swift
@@ -1,0 +1,79 @@
+import Foundation
+
+/// Resolves a Hugging Face repo id (e.g. "mlx-community/Qwen3.5-0.8B-8bit")
+/// to a local snapshot directory in the shared HF hub cache. The app
+/// pre-downloads models there via `HFModelDownloader` (which deliberately
+/// leaves the HF cache env unset so weights are shared with other tools);
+/// this helper never downloads — a missing model is a hard, actionable error.
+public enum HFCacheModelLocator {
+    public enum LocatorError: Error, CustomStringConvertible {
+        case modelNotCached(repoID: String, searched: URL)
+        case noUsableSnapshot(repoID: String, searched: URL)
+
+        public var description: String {
+            switch self {
+            case .modelNotCached(let repoID, let searched):
+                "model \(repoID) not found in HF cache at \(searched.path); download it first"
+            case .noUsableSnapshot(let repoID, let searched):
+                "model \(repoID) has no snapshot containing config.json under \(searched.path)"
+            }
+        }
+    }
+
+    /// Mirrors huggingface_hub's cache-root resolution: HF_HUB_CACHE, then
+    /// HF_HOME/hub, then ~/.cache/huggingface/hub.
+    public static func defaultCacheRoot(
+        environment: [String: String] = ProcessInfo.processInfo.environment,
+        home: URL = FileManager.default.homeDirectoryForCurrentUser
+    ) -> URL {
+        if let hubCache = environment["HF_HUB_CACHE"], !hubCache.isEmpty {
+            return URL(filePath: hubCache)
+        }
+        if let hfHome = environment["HF_HOME"], !hfHome.isEmpty {
+            return URL(filePath: hfHome).appending(path: "hub")
+        }
+        return home.appending(path: ".cache/huggingface/hub")
+    }
+
+    public static func locate(repoID: String, cacheRoot: URL) throws -> URL {
+        let repoDir = cacheRoot.appending(path: "models--" + repoID.replacingOccurrences(of: "/", with: "--"))
+        let snapshotsDir = repoDir.appending(path: "snapshots")
+        let fileManager = FileManager.default
+        guard fileManager.fileExists(atPath: snapshotsDir.path) else {
+            throw LocatorError.modelNotCached(repoID: repoID, searched: cacheRoot)
+        }
+
+        // Prefer the revision recorded for the main ref; otherwise fall back
+        // to the most recently modified snapshot that actually has a config.
+        let mainRef = repoDir.appending(path: "refs/main")
+        if let revision = try? String(contentsOf: mainRef, encoding: .utf8)
+            .trimmingCharacters(in: .whitespacesAndNewlines),
+            !revision.isEmpty
+        {
+            let candidate = snapshotsDir.appending(path: revision)
+            if fileManager.fileExists(atPath: candidate.appending(path: "config.json").path) {
+                return candidate
+            }
+        }
+
+        let snapshots = (try? fileManager.contentsOfDirectory(
+            at: snapshotsDir,
+            includingPropertiesForKeys: [.contentModificationDateKey]
+        )) ?? []
+        let usable = snapshots
+            .filter { fileManager.fileExists(atPath: $0.appending(path: "config.json").path) }
+            .sorted { lhs, rhs in
+                let lhsDate =
+                    (try? lhs.resourceValues(forKeys: [.contentModificationDateKey])
+                        .contentModificationDate) ?? .distantPast
+                let rhsDate =
+                    (try? rhs.resourceValues(forKeys: [.contentModificationDateKey])
+                        .contentModificationDate) ?? .distantPast
+                return lhsDate > rhsDate
+            }
+        guard let newest = usable.first else {
+            throw LocatorError.noUsableSnapshot(repoID: repoID, searched: snapshotsDir)
+        }
+        return newest
+    }
+}

--- a/PolishHelper/Sources/PolishHelperCore/HTTPMessage.swift
+++ b/PolishHelper/Sources/PolishHelperCore/HTTPMessage.swift
@@ -1,0 +1,104 @@
+import Foundation
+
+public struct HTTPRequest: Sendable, Equatable {
+    public var method: String
+    public var path: String
+    public var body: Data
+
+    public init(method: String, path: String, body: Data = Data()) {
+        self.method = method
+        self.path = path
+        self.body = body
+    }
+}
+
+public struct HTTPResponse: Sendable {
+    public var status: Int
+    public var body: Data
+    public var contentType: String
+
+    public init(status: Int, body: Data, contentType: String = "application/json") {
+        self.status = status
+        self.body = body
+        self.contentType = contentType
+    }
+
+    public static func json(_ status: Int, _ value: some Encodable) -> HTTPResponse {
+        let body = (try? JSONEncoder().encode(value)) ?? Data("{}".utf8)
+        return HTTPResponse(status: status, body: body)
+    }
+
+    var reasonPhrase: String {
+        switch status {
+        case 200: "OK"
+        case 400: "Bad Request"
+        case 404: "Not Found"
+        case 405: "Method Not Allowed"
+        case 500: "Internal Server Error"
+        default: "Response"
+        }
+    }
+
+    public func serialized() -> Data {
+        var head = "HTTP/1.1 \(status) \(reasonPhrase)\r\n"
+        head += "Content-Type: \(contentType)\r\n"
+        head += "Content-Length: \(body.count)\r\n"
+        head += "Connection: close\r\n\r\n"
+        return Data(head.utf8) + body
+    }
+}
+
+public enum HTTPParseError: Error, Equatable {
+    case malformedRequestLine
+    case bodyTooLarge(limit: Int)
+}
+
+/// Incremental HTTP/1.1 request parser: feed it chunks as they arrive on the
+/// socket, get a complete request back once the head and declared body are in.
+/// Pure value type so it is trivially unit-testable without sockets.
+public struct HTTPRequestAccumulator: Sendable {
+    public static let maxBodyBytes = 8 << 20
+
+    private var buffer = Data()
+    private var head: (method: String, path: String, contentLength: Int)?
+
+    public init() {}
+
+    public mutating func append(_ chunk: Data) throws -> HTTPRequest? {
+        buffer.append(chunk)
+
+        if head == nil {
+            guard let headEnd = buffer.range(of: Data("\r\n\r\n".utf8)) else {
+                return nil
+            }
+            let headData = buffer.subdata(in: buffer.startIndex ..< headEnd.lowerBound)
+            guard let headText = String(data: headData, encoding: .utf8) else {
+                throw HTTPParseError.malformedRequestLine
+            }
+            let lines = headText.components(separatedBy: "\r\n")
+            let requestLine = lines[0].split(separator: " ")
+            guard requestLine.count == 3 else {
+                throw HTTPParseError.malformedRequestLine
+            }
+            var contentLength = 0
+            for line in lines.dropFirst() {
+                let parts = line.split(separator: ":", maxSplits: 1)
+                guard parts.count == 2 else { continue }
+                if parts[0].trimmingCharacters(in: .whitespaces).lowercased() == "content-length" {
+                    contentLength = Int(parts[1].trimmingCharacters(in: .whitespaces)) ?? 0
+                }
+            }
+            guard contentLength <= Self.maxBodyBytes else {
+                throw HTTPParseError.bodyTooLarge(limit: Self.maxBodyBytes)
+            }
+            head = (String(requestLine[0]), String(requestLine[1]), contentLength)
+            buffer.removeSubrange(buffer.startIndex ..< headEnd.upperBound)
+        }
+
+        guard let head, buffer.count >= head.contentLength else {
+            return nil
+        }
+        let body = buffer.prefix(head.contentLength)
+        return HTTPRequest(method: head.method, path: head.path, body: Data(body))
+    }
+}

--- a/PolishHelper/Sources/PolishHelperCore/HTTPMessage.swift
+++ b/PolishHelper/Sources/PolishHelperCore/HTTPMessage.swift
@@ -50,7 +50,9 @@ public struct HTTPResponse: Sendable {
 
 public enum HTTPParseError: Error, Equatable {
     case malformedRequestLine
+    case invalidContentLength
     case bodyTooLarge(limit: Int)
+    case headTooLarge(limit: Int)
 }
 
 /// Incremental HTTP/1.1 request parser: feed it chunks as they arrive on the
@@ -58,6 +60,7 @@ public enum HTTPParseError: Error, Equatable {
 /// Pure value type so it is trivially unit-testable without sockets.
 public struct HTTPRequestAccumulator: Sendable {
     public static let maxBodyBytes = 8 << 20
+    public static let maxHeadBytes = 64 << 10
 
     private var buffer = Data()
     private var head: (method: String, path: String, contentLength: Int)?
@@ -69,6 +72,12 @@ public struct HTTPRequestAccumulator: Sendable {
 
         if head == nil {
             guard let headEnd = buffer.range(of: Data("\r\n\r\n".utf8)) else {
+                // Bound what a peer can make us buffer while it withholds the
+                // blank line — real clients send a complete head in one or two
+                // segments.
+                guard buffer.count <= Self.maxHeadBytes else {
+                    throw HTTPParseError.headTooLarge(limit: Self.maxHeadBytes)
+                }
                 return nil
             }
             let headData = buffer.subdata(in: buffer.startIndex ..< headEnd.lowerBound)
@@ -85,7 +94,14 @@ public struct HTTPRequestAccumulator: Sendable {
                 let parts = line.split(separator: ":", maxSplits: 1)
                 guard parts.count == 2 else { continue }
                 if parts[0].trimmingCharacters(in: .whitespaces).lowercased() == "content-length" {
-                    contentLength = Int(parts[1].trimmingCharacters(in: .whitespaces)) ?? 0
+                    guard let parsed = Int(parts[1].trimmingCharacters(in: .whitespaces)),
+                        parsed >= 0
+                    else {
+                        // A negative value would trap in prefix(_:) below;
+                        // reject the request instead of crashing the helper.
+                        throw HTTPParseError.invalidContentLength
+                    }
+                    contentLength = parsed
                 }
             }
             guard contentLength <= Self.maxBodyBytes else {

--- a/PolishHelper/Sources/PolishHelperCore/HTTPServer.swift
+++ b/PolishHelper/Sources/PolishHelperCore/HTTPServer.swift
@@ -1,0 +1,117 @@
+import Foundation
+import Network
+import Synchronization
+
+/// Minimal loopback-only HTTP/1.1 server: one request per connection,
+/// `Connection: close` semantics. This is deliberately not a general web
+/// server — it exists to expose /health and /v1/chat/completions to the
+/// supervising app on 127.0.0.1.
+public final class HTTPServer: @unchecked Sendable {
+    public typealias Handler = @Sendable (HTTPRequest) async -> HTTPResponse
+
+    private let listener: NWListener
+    private let handler: Handler
+    private let queue = DispatchQueue(label: "localvoxtral.polishd.http")
+    private let started = Mutex(false)
+
+    /// Pass port 0 to bind an ephemeral port (tests); read `boundPort` after
+    /// `start()` returns.
+    public init(port: UInt16, handler: @escaping Handler) throws {
+        let parameters = NWParameters.tcp
+        parameters.allowLocalEndpointReuse = true
+        parameters.requiredLocalEndpoint = NWEndpoint.hostPort(
+            host: .ipv4(.loopback),
+            port: NWEndpoint.Port(rawValue: port) ?? .any
+        )
+        self.listener = try NWListener(using: parameters)
+        self.handler = handler
+    }
+
+    public var boundPort: UInt16 {
+        listener.port?.rawValue ?? 0
+    }
+
+    public func start() async throws {
+        listener.newConnectionHandler = { [weak self] connection in
+            self?.accept(connection)
+        }
+        try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
+            listener.stateUpdateHandler = { [weak self, started] state in
+                let alreadyStarted = started.withLock { value in
+                    let previous = value
+                    value = true
+                    return previous
+                }
+                switch state {
+                case .ready:
+                    if !alreadyStarted { continuation.resume() }
+                case .failed(let error), .waiting(let error):
+                    if !alreadyStarted { continuation.resume(throwing: error) }
+                    self?.listener.cancel()
+                default:
+                    // Non-terminal transition before ready; keep waiting.
+                    started.withLock { $0 = alreadyStarted }
+                }
+            }
+            listener.start(queue: queue)
+        }
+    }
+
+    public func stop() {
+        listener.cancel()
+    }
+
+    private func accept(_ connection: NWConnection) {
+        connection.start(queue: queue)
+        receive(on: connection, accumulator: HTTPRequestAccumulator())
+    }
+
+    private func receive(on connection: NWConnection, accumulator: HTTPRequestAccumulator) {
+        connection.receive(minimumIncompleteLength: 1, maximumLength: 1 << 16) {
+            [weak self] data, _, isComplete, error in
+            guard let self else {
+                connection.cancel()
+                return
+            }
+            var accumulator = accumulator
+            if let data, !data.isEmpty {
+                do {
+                    if let request = try accumulator.append(data) {
+                        self.respond(to: request, on: connection)
+                        return
+                    }
+                } catch {
+                    self.send(
+                        HTTPResponse.json(
+                            400,
+                            ChatCompletionErrorResponse(
+                                message: "malformed request: \(error)", type: "invalid_request_error"
+                            )
+                        ),
+                        on: connection
+                    )
+                    return
+                }
+            }
+            if error != nil || isComplete {
+                connection.cancel()
+                return
+            }
+            self.receive(on: connection, accumulator: accumulator)
+        }
+    }
+
+    private func respond(to request: HTTPRequest, on connection: NWConnection) {
+        Task { [handler] in
+            let response = await handler(request)
+            self.send(response, on: connection)
+        }
+    }
+
+    private func send(_ response: HTTPResponse, on connection: NWConnection) {
+        connection.send(
+            content: response.serialized(),
+            completion: .contentProcessed { _ in connection.cancel() }
+        )
+    }
+}

--- a/PolishHelper/Sources/PolishHelperCore/HTTPServer.swift
+++ b/PolishHelper/Sources/PolishHelperCore/HTTPServer.swift
@@ -13,6 +13,13 @@ public final class HTTPServer: @unchecked Sendable {
     private let handler: Handler
     private let queue = DispatchQueue(label: "localvoxtral.polishd.http")
 
+    /// Called when the listener reaches a terminal state AFTER serving began.
+    /// The supervised helper passes `{ exit(1) }`: a dead listener in a live
+    /// process is invisible to the supervisor (it only watches process exit),
+    /// so dying loudly is the only way to get restarted. Defaults to nil
+    /// (tests just observe the stopped server).
+    public var onListenerFailure: (@Sendable (Error) -> Void)?
+
     /// Pass port 0 to bind an ephemeral port (tests); read `boundPort` after
     /// `start()` returns.
     public init(port: UInt16, handler: @escaping Handler) throws {
@@ -41,8 +48,18 @@ public final class HTTPServer: @unchecked Sendable {
                 case .ready:
                     resumeOnce.run { continuation.resume() }
                 case .failed(let error), .waiting(let error):
-                    resumeOnce.run { continuation.resume(throwing: error) }
+                    // Pre-ready: fail start(). Post-ready: the listener died
+                    // under us — cancel and escalate, because a supervised
+                    // helper with a dead port must exit to be restarted.
+                    let wasPreReady = resumeOnce.run { continuation.resume(throwing: error) }
                     self?.listener.cancel()
+                    if !wasPreReady {
+                        self?.onListenerFailure?(error)
+                    }
+                case .cancelled:
+                    // A stop() racing start() must not leave the caller
+                    // suspended forever.
+                    resumeOnce.run { continuation.resume(throwing: CancellationError()) }
                 default:
                     break
                 }
@@ -52,18 +69,20 @@ public final class HTTPServer: @unchecked Sendable {
     }
 
     /// A continuation may be resumed exactly once, but the listener can emit
-    /// `.waiting` and later `.ready` (or several failures) — this collapses
-    /// them to the first terminal transition.
+    /// several terminal transitions — this collapses them to the first.
+    /// `run` returns whether THIS call was the first (i.e. the body ran).
     private final class ResumeOnce: Sendable {
         private let resumed = Mutex(false)
 
-        func run(_ body: () -> Void) {
+        @discardableResult
+        func run(_ body: () -> Void) -> Bool {
             let first = resumed.withLock { value in
                 let previous = value
                 value = true
                 return !previous
             }
             if first { body() }
+            return first
         }
     }
 

--- a/PolishHelper/Sources/PolishHelperCore/HTTPServer.swift
+++ b/PolishHelper/Sources/PolishHelperCore/HTTPServer.swift
@@ -12,7 +12,6 @@ public final class HTTPServer: @unchecked Sendable {
     private let listener: NWListener
     private let handler: Handler
     private let queue = DispatchQueue(label: "localvoxtral.polishd.http")
-    private let started = Mutex(false)
 
     /// Pass port 0 to bind an ephemeral port (tests); read `boundPort` after
     /// `start()` returns.
@@ -35,25 +34,36 @@ public final class HTTPServer: @unchecked Sendable {
         listener.newConnectionHandler = { [weak self] connection in
             self?.accept(connection)
         }
+        let resumeOnce = ResumeOnce()
         try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
-            listener.stateUpdateHandler = { [weak self, started] state in
-                let alreadyStarted = started.withLock { value in
-                    let previous = value
-                    value = true
-                    return previous
-                }
+            listener.stateUpdateHandler = { [weak self] state in
                 switch state {
                 case .ready:
-                    if !alreadyStarted { continuation.resume() }
+                    resumeOnce.run { continuation.resume() }
                 case .failed(let error), .waiting(let error):
-                    if !alreadyStarted { continuation.resume(throwing: error) }
+                    resumeOnce.run { continuation.resume(throwing: error) }
                     self?.listener.cancel()
                 default:
-                    // Non-terminal transition before ready; keep waiting.
-                    started.withLock { $0 = alreadyStarted }
+                    break
                 }
             }
             listener.start(queue: queue)
+        }
+    }
+
+    /// A continuation may be resumed exactly once, but the listener can emit
+    /// `.waiting` and later `.ready` (or several failures) — this collapses
+    /// them to the first terminal transition.
+    private final class ResumeOnce: Sendable {
+        private let resumed = Mutex(false)
+
+        func run(_ body: () -> Void) {
+            let first = resumed.withLock { value in
+                let previous = value
+                value = true
+                return !previous
+            }
+            if first { body() }
         }
     }
 

--- a/PolishHelper/Sources/PolishHelperCore/ParentProcessWatchdog.swift
+++ b/PolishHelper/Sources/PolishHelperCore/ParentProcessWatchdog.swift
@@ -1,0 +1,31 @@
+import Foundation
+
+/// Exits the helper when the supervising app dies, so a crashed or killed app
+/// can never leave an orphaned model holding memory. This reproduces the
+/// `--parent-pid` watchdog the mlx-lm fork implemented on the Python side.
+public final class ParentProcessWatchdog: @unchecked Sendable {
+    private let source: DispatchSourceProcess
+    private let onParentExit: @Sendable () -> Void
+
+    public init(parentPID: pid_t, onParentExit: @escaping @Sendable () -> Void) {
+        self.onParentExit = onParentExit
+        self.source = DispatchSource.makeProcessSource(
+            identifier: parentPID,
+            eventMask: .exit,
+            queue: DispatchQueue(label: "localvoxtral.polishd.watchdog")
+        )
+        source.setEventHandler { onParentExit() }
+        source.activate()
+
+        // The kqueue registration only fires for a live process; if the
+        // parent died between spawn and here, catch it with a direct probe
+        // (registered-then-probed, so there is no gap).
+        if kill(parentPID, 0) != 0 && errno == ESRCH {
+            onParentExit()
+        }
+    }
+
+    deinit {
+        source.cancel()
+    }
+}

--- a/PolishHelper/Sources/PolishHelperCore/ParentProcessWatchdog.swift
+++ b/PolishHelper/Sources/PolishHelperCore/ParentProcessWatchdog.swift
@@ -1,10 +1,12 @@
 import Foundation
+import Synchronization
 
 /// Exits the helper when the supervising app dies, so a crashed or killed app
 /// can never leave an orphaned model holding memory. This reproduces the
 /// `--parent-pid` watchdog the mlx-lm fork implemented on the Python side.
 public final class ParentProcessWatchdog: @unchecked Sendable {
     private let source: DispatchSourceProcess
+    private let fired = Mutex(false)
     private let onParentExit: @Sendable () -> Void
 
     public init(parentPID: pid_t, onParentExit: @escaping @Sendable () -> Void) {
@@ -14,15 +16,26 @@ public final class ParentProcessWatchdog: @unchecked Sendable {
             eventMask: .exit,
             queue: DispatchQueue(label: "localvoxtral.polishd.watchdog")
         )
-        source.setEventHandler { onParentExit() }
+        source.setEventHandler { [weak self] in self?.fireOnce() }
         source.activate()
 
         // The kqueue registration only fires for a live process; if the
         // parent died between spawn and here, catch it with a direct probe
-        // (registered-then-probed, so there is no gap).
+        // (registered-then-probed, so there is no gap). Some libdispatch
+        // versions ALSO simulate the exit event for an already-dead pid —
+        // `fireOnce` collapses the two paths to a single callback.
         if kill(parentPID, 0) != 0 && errno == ESRCH {
-            onParentExit()
+            fireOnce()
         }
+    }
+
+    private func fireOnce() {
+        let first = fired.withLock { value in
+            let previous = value
+            value = true
+            return !previous
+        }
+        if first { onParentExit() }
     }
 
     deinit {

--- a/PolishHelper/Sources/PolishHelperCore/PolishModelHost.swift
+++ b/PolishHelper/Sources/PolishHelperCore/PolishModelHost.swift
@@ -53,6 +53,10 @@ public final class MLXPolishModel: ChatResponding, @unchecked Sendable {
             parameters.temperature = temperature
         }
         parameters.maxTokens = maxTokens ?? defaultMaxTokens
+        // Deterministic sampling: identical requests must produce identical
+        // output, like the previous engine's within-state behavior — the
+        // polish eval baseline and user experience both rely on it.
+        parameters.seed = 0
 
         let chat = try messages.map { message -> Chat.Message in
             switch message.role {

--- a/PolishHelper/Sources/PolishHelperCore/PolishModelHost.swift
+++ b/PolishHelper/Sources/PolishHelperCore/PolishModelHost.swift
@@ -1,0 +1,69 @@
+import Foundation
+import MLXLLM
+import MLXLMCommon
+
+/// The seam between the HTTP layer and inference: the router talks to this
+/// protocol so it can be unit-tested with a stub, no Metal required.
+public protocol ChatResponding: Sendable {
+    func respond(
+        to messages: [ChatCompletionMessage],
+        temperature: Float?,
+        maxTokens: Int?
+    ) async throws -> String
+}
+
+public enum ChatRespondingError: Error, CustomStringConvertible {
+    case unknownRole(String)
+
+    public var description: String {
+        switch self {
+        case .unknownRole(let role):
+            "unsupported message role: \(role)"
+        }
+    }
+}
+
+/// Loads the MLX model once and answers chat requests against it. Each
+/// request gets a fresh `ChatSession` (no cross-request history); the
+/// `ModelContainer` serializes concurrent generation internally.
+public final class MLXPolishModel: ChatResponding, @unchecked Sendable {
+    private let container: ModelContainer
+    private let defaultMaxTokens: Int
+
+    private init(container: ModelContainer, defaultMaxTokens: Int) {
+        self.container = container
+        self.defaultMaxTokens = defaultMaxTokens
+    }
+
+    public static func load(directory: URL, defaultMaxTokens: Int) async throws -> MLXPolishModel {
+        let container = try await LLMModelFactory.shared.loadContainer(
+            from: directory,
+            using: TransformersTokenizerLoader()
+        )
+        return MLXPolishModel(container: container, defaultMaxTokens: defaultMaxTokens)
+    }
+
+    public func respond(
+        to messages: [ChatCompletionMessage],
+        temperature: Float?,
+        maxTokens: Int?
+    ) async throws -> String {
+        var parameters = GenerateParameters()
+        if let temperature {
+            parameters.temperature = temperature
+        }
+        parameters.maxTokens = maxTokens ?? defaultMaxTokens
+
+        let chat = try messages.map { message -> Chat.Message in
+            switch message.role {
+            case "system": .system(message.content)
+            case "user": .user(message.content)
+            case "assistant": .assistant(message.content)
+            default: throw ChatRespondingError.unknownRole(message.role)
+            }
+        }
+
+        let session = ChatSession(container, generateParameters: parameters)
+        return try await session.respond(to: chat)
+    }
+}

--- a/PolishHelper/Sources/PolishHelperCore/PolishdRouter.swift
+++ b/PolishHelper/Sources/PolishHelperCore/PolishdRouter.swift
@@ -1,0 +1,86 @@
+import Foundation
+
+/// Routes the two endpoints the app's supervisor and polish client use:
+/// GET /health (readiness probe) and POST /v1/chat/completions.
+public struct PolishdRouter: Sendable {
+    private let responder: any ChatResponding
+    private let modelName: String
+
+    public init(responder: any ChatResponding, modelName: String) {
+        self.responder = responder
+        self.modelName = modelName
+    }
+
+    public func handle(_ request: HTTPRequest) async -> HTTPResponse {
+        switch (request.method, request.path) {
+        case ("GET", "/health"):
+            return .json(200, ["status": "ok"])
+        case ("POST", "/v1/chat/completions"):
+            return await handleChatCompletion(request)
+        case (_, "/health"), (_, "/v1/chat/completions"):
+            return errorResponse(405, "method not allowed", type: "invalid_request_error")
+        default:
+            return errorResponse(404, "not found: \(request.path)", type: "invalid_request_error")
+        }
+    }
+
+    private func handleChatCompletion(_ request: HTTPRequest) async -> HTTPResponse {
+        let completion: ChatCompletionRequest
+        do {
+            completion = try JSONDecoder().decode(ChatCompletionRequest.self, from: request.body)
+        } catch {
+            return errorResponse(400, "invalid JSON body: \(error)", type: "invalid_request_error")
+        }
+        if completion.stream == true {
+            return errorResponse(400, "streaming is not supported", type: "invalid_request_error")
+        }
+        guard !completion.messages.isEmpty else {
+            return errorResponse(400, "messages must not be empty", type: "invalid_request_error")
+        }
+
+        do {
+            let start = ContinuousClock.now
+            let content = try await responder.respond(
+                to: completion.messages,
+                temperature: completion.temperature,
+                maxTokens: completion.maxTokens
+            )
+            let elapsed = start.duration(to: .now)
+            PolishdLog.info("chat.completion ok in \(elapsed)")
+            let response = ChatCompletionResponse(
+                id: "polishd-\(UUID().uuidString)",
+                created: Int(Date().timeIntervalSince1970),
+                model: completion.model ?? modelName,
+                content: content
+            )
+            return .json(200, response)
+        } catch let error as ChatRespondingError {
+            return errorResponse(400, "\(error)", type: "invalid_request_error")
+        } catch {
+            PolishdLog.error("chat.completion failed: \(error)")
+            return errorResponse(500, "generation failed: \(error)", type: "server_error")
+        }
+    }
+
+    private func errorResponse(_ status: Int, _ message: String, type: String) -> HTTPResponse {
+        .json(status, ChatCompletionErrorResponse(message: message, type: type))
+    }
+}
+
+/// stderr logging: the supervising app captures the helper's output into the
+/// diagnostics ring buffer, so failures here stay visible in exports.
+public enum PolishdLog {
+    public static func info(_ message: String) {
+        emit("info", message)
+    }
+
+    public static func error(_ message: String) {
+        emit("error", message)
+    }
+
+    private static func emit(_ level: String, _ message: String) {
+        let stamp = ISO8601DateFormatter().string(from: Date())
+        fputs("\(stamp) [\(level)] \(message)\n", stderr)
+        fflush(stderr)
+    }
+}

--- a/PolishHelper/Sources/PolishHelperCore/TransformersTokenizerLoader.swift
+++ b/PolishHelper/Sources/PolishHelperCore/TransformersTokenizerLoader.swift
@@ -1,0 +1,58 @@
+import Foundation
+import MLXLMCommon
+import Tokenizers
+
+/// Hand-written equivalent of mlx-swift-lm's `#huggingFaceTokenizerLoader()`
+/// macro expansion (Libraries/MLXHuggingFaceMacros). Using the macro would
+/// pull swift-syntax + swift-huggingface into the build for two trivial
+/// bridge types; we only ever load tokenizers from a local directory.
+public struct TransformersTokenizerLoader: TokenizerLoader {
+    public init() {}
+
+    public func load(from directory: URL) async throws -> any MLXLMCommon.Tokenizer {
+        let upstream = try await Tokenizers.AutoTokenizer.from(modelFolder: directory)
+        return TokenizerBridge(upstream)
+    }
+}
+
+private struct TokenizerBridge: MLXLMCommon.Tokenizer {
+    private let upstream: any Tokenizers.Tokenizer
+
+    init(_ upstream: any Tokenizers.Tokenizer) {
+        self.upstream = upstream
+    }
+
+    func encode(text: String, addSpecialTokens: Bool) -> [Int] {
+        upstream.encode(text: text, addSpecialTokens: addSpecialTokens)
+    }
+
+    // swift-transformers uses `decode(tokens:)` instead of `decode(tokenIds:)`.
+    func decode(tokenIds: [Int], skipSpecialTokens: Bool) -> String {
+        upstream.decode(tokens: tokenIds, skipSpecialTokens: skipSpecialTokens)
+    }
+
+    func convertTokenToId(_ token: String) -> Int? {
+        upstream.convertTokenToId(token)
+    }
+
+    func convertIdToToken(_ id: Int) -> String? {
+        upstream.convertIdToToken(id)
+    }
+
+    var bosToken: String? { upstream.bosToken }
+    var eosToken: String? { upstream.eosToken }
+    var unknownToken: String? { upstream.unknownToken }
+
+    func applyChatTemplate(
+        messages: [[String: any Sendable]],
+        tools: [[String: any Sendable]]?,
+        additionalContext: [String: any Sendable]?
+    ) throws -> [Int] {
+        do {
+            return try upstream.applyChatTemplate(
+                messages: messages, tools: tools, additionalContext: additionalContext)
+        } catch Tokenizers.TokenizerError.missingChatTemplate {
+            throw MLXLMCommon.TokenizerError.missingChatTemplate
+        }
+    }
+}

--- a/PolishHelper/Sources/localvoxtral-polishd/PolishdMain.swift
+++ b/PolishHelper/Sources/localvoxtral-polishd/PolishdMain.swift
@@ -86,12 +86,17 @@ struct PolishdMain {
     }
 
     static func run(options: Options) async throws {
+        // Retained for the whole process lifetime — deinit cancels the kqueue
+        // source, so a discarded watchdog silently never fires (integration
+        // test testHelperExitsWhenParentPIDDies caught exactly that).
+        var watchdog: ParentProcessWatchdog?
         if let parentPID = options.parentPID {
-            _ = ParentProcessWatchdog(parentPID: parentPID) {
+            watchdog = ParentProcessWatchdog(parentPID: parentPID) {
                 PolishdLog.info("parent \(parentPID) exited; shutting down")
                 exit(0)
             }
         }
+        defer { withExtendedLifetime(watchdog) {} }
 
         let modelDirectory: URL
         if let path = options.modelDirectory {

--- a/PolishHelper/Sources/localvoxtral-polishd/PolishdMain.swift
+++ b/PolishHelper/Sources/localvoxtral-polishd/PolishdMain.swift
@@ -130,6 +130,13 @@ struct PolishdMain {
         let server = try HTTPServer(port: options.port) { request in
             await router.handle(request)
         }
+        // A dead listener in a live process is invisible to the supervisor
+        // (it only watches process exit + /health during startup) — exit so
+        // it restarts us.
+        server.onListenerFailure = { error in
+            PolishdLog.error("listener failed after ready: \(error); exiting for restart")
+            exit(1)
+        }
         try await server.start()
         PolishdLog.info("ready on 127.0.0.1:\(server.boundPort)")
 

--- a/PolishHelper/Sources/localvoxtral-polishd/PolishdMain.swift
+++ b/PolishHelper/Sources/localvoxtral-polishd/PolishdMain.swift
@@ -1,0 +1,139 @@
+import Foundation
+import MLX
+import PolishHelperCore
+
+/// localvoxtral's bundled polishing engine: loads a local MLX model and
+/// serves the OpenAI chat-completions subset on loopback. Spawned and
+/// supervised by the app (BackendProcessSupervisor); /health only answers
+/// once the model is loaded, matching the mlx_lm.server readiness contract.
+@main
+struct PolishdMain {
+    struct Options {
+        var modelID: String?
+        var modelDirectory: String?
+        var port: UInt16 = 8472
+        var parentPID: pid_t?
+        var defaultMaxTokens = 2048
+        var cacheLimitMB = 64
+    }
+
+    static func main() async {
+        do {
+            try await run(options: try parse(arguments: Array(CommandLine.arguments.dropFirst())))
+        } catch {
+            PolishdLog.error("\(error)")
+            exit(1)
+        }
+    }
+
+    static func parse(arguments: [String]) throws -> Options {
+        var options = Options()
+        var iterator = arguments.makeIterator()
+        func value(for flag: String) throws -> String {
+            guard let next = iterator.next() else {
+                throw OptionError.missingValue(flag)
+            }
+            return next
+        }
+        while let flag = iterator.next() {
+            switch flag {
+            case "--model": options.modelID = try value(for: flag)
+            case "--model-dir": options.modelDirectory = try value(for: flag)
+            case "--port":
+                guard let port = UInt16(try value(for: flag)) else {
+                    throw OptionError.invalidValue(flag)
+                }
+                options.port = port
+            case "--parent-pid":
+                guard let pid = pid_t(try value(for: flag)) else {
+                    throw OptionError.invalidValue(flag)
+                }
+                options.parentPID = pid
+            case "--default-max-tokens":
+                guard let tokens = Int(try value(for: flag)), tokens > 0 else {
+                    throw OptionError.invalidValue(flag)
+                }
+                options.defaultMaxTokens = tokens
+            case "--cache-limit-mb":
+                guard let limit = Int(try value(for: flag)), limit >= 0 else {
+                    throw OptionError.invalidValue(flag)
+                }
+                options.cacheLimitMB = limit
+            default:
+                throw OptionError.unknownFlag(flag)
+            }
+        }
+        guard options.modelID != nil || options.modelDirectory != nil else {
+            throw OptionError.missingModel
+        }
+        return options
+    }
+
+    enum OptionError: Error, CustomStringConvertible {
+        case missingValue(String)
+        case invalidValue(String)
+        case unknownFlag(String)
+        case missingModel
+
+        var description: String {
+            switch self {
+            case .missingValue(let flag): "missing value for \(flag)"
+            case .invalidValue(let flag): "invalid value for \(flag)"
+            case .unknownFlag(let flag): "unknown flag: \(flag)"
+            case .missingModel: "one of --model <hf-repo-id> or --model-dir <path> is required"
+            }
+        }
+    }
+
+    static func run(options: Options) async throws {
+        if let parentPID = options.parentPID {
+            _ = ParentProcessWatchdog(parentPID: parentPID) {
+                PolishdLog.info("parent \(parentPID) exited; shutting down")
+                exit(0)
+            }
+        }
+
+        let modelDirectory: URL
+        if let path = options.modelDirectory {
+            modelDirectory = URL(filePath: path)
+        } else if let repoID = options.modelID {
+            modelDirectory = try HFCacheModelLocator.locate(
+                repoID: repoID,
+                cacheRoot: HFCacheModelLocator.defaultCacheRoot()
+            )
+        } else {
+            throw OptionError.missingModel
+        }
+
+        // Keep the recycling cache small: the polish model is <1 GB and the
+        // helper idles between dictations — without a limit, freed buffers
+        // linger as process footprint up to MLX's default (1.5x working set).
+        Memory.cacheLimit = options.cacheLimitMB << 20
+
+        PolishdLog.info("loading model from \(modelDirectory.path)")
+        let loadStart = ContinuousClock.now
+        let model = try await MLXPolishModel.load(
+            directory: modelDirectory,
+            defaultMaxTokens: options.defaultMaxTokens
+        )
+        PolishdLog.info("model loaded in \(loadStart.duration(to: .now)); \(memorySummary())")
+
+        let router = PolishdRouter(
+            responder: model,
+            modelName: options.modelID ?? modelDirectory.lastPathComponent
+        )
+        let server = try HTTPServer(port: options.port) { request in
+            await router.handle(request)
+        }
+        try await server.start()
+        PolishdLog.info("ready on 127.0.0.1:\(server.boundPort)")
+
+        while true {
+            try await Task.sleep(for: .seconds(3600))
+        }
+    }
+
+    static func memorySummary() -> String {
+        "active \(Memory.activeMemory >> 20) MiB, cache \(Memory.cacheMemory >> 20) MiB"
+    }
+}

--- a/PolishHelper/Tests/PolishHelperCoreTests/HFCacheModelLocatorTests.swift
+++ b/PolishHelper/Tests/PolishHelperCoreTests/HFCacheModelLocatorTests.swift
@@ -1,0 +1,96 @@
+import XCTest
+
+@testable import PolishHelperCore
+
+final class HFCacheModelLocatorTests: XCTestCase {
+    private var cacheRoot: URL!
+
+    override func setUpWithError() throws {
+        cacheRoot = FileManager.default.temporaryDirectory
+            .appending(path: "hf-cache-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: cacheRoot, withIntermediateDirectories: true)
+    }
+
+    override func tearDownWithError() throws {
+        try FileManager.default.removeItem(at: cacheRoot)
+    }
+
+    private func makeSnapshot(repo: String, revision: String, withConfig: Bool = true) throws -> URL {
+        let snapshot = cacheRoot
+            .appending(path: "models--" + repo.replacingOccurrences(of: "/", with: "--"))
+            .appending(path: "snapshots/\(revision)")
+        try FileManager.default.createDirectory(at: snapshot, withIntermediateDirectories: true)
+        if withConfig {
+            try Data("{}".utf8).write(to: snapshot.appending(path: "config.json"))
+        }
+        return snapshot
+    }
+
+    private func writeMainRef(repo: String, revision: String) throws {
+        let refs = cacheRoot
+            .appending(path: "models--" + repo.replacingOccurrences(of: "/", with: "--"))
+            .appending(path: "refs")
+        try FileManager.default.createDirectory(at: refs, withIntermediateDirectories: true)
+        try Data("\(revision)\n".utf8).write(to: refs.appending(path: "main"))
+    }
+
+    func testResolvesSnapshotNamedByMainRef() throws {
+        let repo = "mlx-community/Qwen3.5-0.8B-8bit"
+        _ = try makeSnapshot(repo: repo, revision: "old")
+        let wanted = try makeSnapshot(repo: repo, revision: "abc123")
+        try writeMainRef(repo: repo, revision: "abc123")
+
+        let located = try HFCacheModelLocator.locate(repoID: repo, cacheRoot: cacheRoot)
+        XCTAssertEqual(located.standardizedFileURL, wanted.standardizedFileURL)
+    }
+
+    func testFallsBackToNewestSnapshotWithConfigWhenRefMissing() throws {
+        let repo = "org/model"
+        _ = try makeSnapshot(repo: repo, revision: "no-config", withConfig: false)
+        let usable = try makeSnapshot(repo: repo, revision: "usable")
+
+        let located = try HFCacheModelLocator.locate(repoID: repo, cacheRoot: cacheRoot)
+        XCTAssertEqual(located.standardizedFileURL, usable.standardizedFileURL)
+    }
+
+    func testMissingModelThrowsActionableError() {
+        XCTAssertThrowsError(
+            try HFCacheModelLocator.locate(repoID: "org/absent", cacheRoot: cacheRoot)
+        ) { error in
+            guard case HFCacheModelLocator.LocatorError.modelNotCached(let repoID, _) = error else {
+                return XCTFail("unexpected error: \(error)")
+            }
+            XCTAssertEqual(repoID, "org/absent")
+        }
+    }
+
+    func testSnapshotsWithoutConfigThrow() throws {
+        let repo = "org/broken"
+        _ = try makeSnapshot(repo: repo, revision: "x", withConfig: false)
+        XCTAssertThrowsError(
+            try HFCacheModelLocator.locate(repoID: repo, cacheRoot: cacheRoot)
+        ) { error in
+            guard case HFCacheModelLocator.LocatorError.noUsableSnapshot = error else {
+                return XCTFail("unexpected error: \(error)")
+            }
+        }
+    }
+
+    func testCacheRootResolutionRespectsEnvOverrides() {
+        let home = URL(filePath: "/Users/x")
+        XCTAssertEqual(
+            HFCacheModelLocator.defaultCacheRoot(environment: [:], home: home).path,
+            "/Users/x/.cache/huggingface/hub"
+        )
+        XCTAssertEqual(
+            HFCacheModelLocator.defaultCacheRoot(environment: ["HF_HOME": "/hf"], home: home).path,
+            "/hf/hub"
+        )
+        XCTAssertEqual(
+            HFCacheModelLocator.defaultCacheRoot(
+                environment: ["HF_HUB_CACHE": "/direct", "HF_HOME": "/hf"], home: home
+            ).path,
+            "/direct"
+        )
+    }
+}

--- a/PolishHelper/Tests/PolishHelperCoreTests/HTTPMessageTests.swift
+++ b/PolishHelper/Tests/PolishHelperCoreTests/HTTPMessageTests.swift
@@ -49,6 +49,34 @@ final class HTTPMessageTests: XCTestCase {
         }
     }
 
+    func testNegativeContentLengthIsRejectedNotTrapped() {
+        // Regression: Int("-1") parses, and buffer.prefix(-1) traps — a local
+        // peer could crash the helper with one malformed request.
+        var accumulator = HTTPRequestAccumulator()
+        let raw = "POST /x HTTP/1.1\r\nContent-Length: -1\r\n\r\n"
+        XCTAssertThrowsError(try accumulator.append(Data(raw.utf8))) { error in
+            XCTAssertEqual(error as? HTTPParseError, .invalidContentLength)
+        }
+    }
+
+    func testNonNumericContentLengthIsRejected() {
+        var accumulator = HTTPRequestAccumulator()
+        let raw = "POST /x HTTP/1.1\r\nContent-Length: abc\r\n\r\n"
+        XCTAssertThrowsError(try accumulator.append(Data(raw.utf8))) { error in
+            XCTAssertEqual(error as? HTTPParseError, .invalidContentLength)
+        }
+    }
+
+    func testEndlessHeadWithoutBlankLineIsBounded() {
+        // A peer streaming header bytes forever must not grow memory
+        // unboundedly while we wait for \r\n\r\n.
+        var accumulator = HTTPRequestAccumulator()
+        let filler = Data(repeating: UInt8(ascii: "a"), count: HTTPRequestAccumulator.maxHeadBytes + 1)
+        XCTAssertThrowsError(try accumulator.append(filler)) { error in
+            XCTAssertEqual(error as? HTTPParseError, .headTooLarge(limit: HTTPRequestAccumulator.maxHeadBytes))
+        }
+    }
+
     func testResponseSerializationIncludesLengthAndClose() {
         let response = HTTPResponse(status: 200, body: Data("{\"a\":1}".utf8))
         let text = String(decoding: response.serialized(), as: UTF8.self)

--- a/PolishHelper/Tests/PolishHelperCoreTests/HTTPMessageTests.swift
+++ b/PolishHelper/Tests/PolishHelperCoreTests/HTTPMessageTests.swift
@@ -1,0 +1,60 @@
+import XCTest
+
+@testable import PolishHelperCore
+
+final class HTTPMessageTests: XCTestCase {
+    func testParsesRequestDeliveredInOneChunk() throws {
+        var accumulator = HTTPRequestAccumulator()
+        let raw = "POST /v1/chat/completions HTTP/1.1\r\nHost: x\r\nContent-Length: 4\r\n\r\nbody"
+        let request = try accumulator.append(Data(raw.utf8))
+        XCTAssertEqual(request, HTTPRequest(method: "POST", path: "/v1/chat/completions", body: Data("body".utf8)))
+    }
+
+    func testParsesRequestDeliveredBytewise() throws {
+        var accumulator = HTTPRequestAccumulator()
+        let raw = "POST /x HTTP/1.1\r\ncontent-length: 5\r\n\r\nhello"
+        var request: HTTPRequest?
+        for byte in Data(raw.utf8) {
+            XCTAssertNil(request)
+            request = try accumulator.append(Data([byte]))
+        }
+        XCTAssertEqual(request, HTTPRequest(method: "POST", path: "/x", body: Data("hello".utf8)))
+    }
+
+    func testParsesGetWithoutBody() throws {
+        var accumulator = HTTPRequestAccumulator()
+        let request = try accumulator.append(Data("GET /health HTTP/1.1\r\nHost: x\r\n\r\n".utf8))
+        XCTAssertEqual(request, HTTPRequest(method: "GET", path: "/health"))
+    }
+
+    func testHeaderNamesAreCaseInsensitiveAndBodyWaitsForAllBytes() throws {
+        var accumulator = HTTPRequestAccumulator()
+        XCTAssertNil(try accumulator.append(Data("POST /x HTTP/1.1\r\nCONTENT-LENGTH: 6\r\n\r\nabc".utf8)))
+        let request = try accumulator.append(Data("def".utf8))
+        XCTAssertEqual(request?.body, Data("abcdef".utf8))
+    }
+
+    func testMalformedRequestLineThrows() {
+        var accumulator = HTTPRequestAccumulator()
+        XCTAssertThrowsError(try accumulator.append(Data("NONSENSE\r\n\r\n".utf8))) { error in
+            XCTAssertEqual(error as? HTTPParseError, .malformedRequestLine)
+        }
+    }
+
+    func testOversizedBodyIsRejectedUpFront() {
+        var accumulator = HTTPRequestAccumulator()
+        let raw = "POST /x HTTP/1.1\r\nContent-Length: \(HTTPRequestAccumulator.maxBodyBytes + 1)\r\n\r\n"
+        XCTAssertThrowsError(try accumulator.append(Data(raw.utf8))) { error in
+            XCTAssertEqual(error as? HTTPParseError, .bodyTooLarge(limit: HTTPRequestAccumulator.maxBodyBytes))
+        }
+    }
+
+    func testResponseSerializationIncludesLengthAndClose() {
+        let response = HTTPResponse(status: 200, body: Data("{\"a\":1}".utf8))
+        let text = String(decoding: response.serialized(), as: UTF8.self)
+        XCTAssertTrue(text.hasPrefix("HTTP/1.1 200 OK\r\n"))
+        XCTAssertTrue(text.contains("Content-Length: 7\r\n"))
+        XCTAssertTrue(text.contains("Connection: close\r\n"))
+        XCTAssertTrue(text.hasSuffix("\r\n\r\n{\"a\":1}"))
+    }
+}

--- a/PolishHelper/Tests/PolishHelperCoreTests/HTTPServerTests.swift
+++ b/PolishHelper/Tests/PolishHelperCoreTests/HTTPServerTests.swift
@@ -1,0 +1,57 @@
+import XCTest
+
+@testable import PolishHelperCore
+
+final class HTTPServerTests: XCTestCase {
+    func testServesRequestsOverLoopback() async throws {
+        let server = try HTTPServer(port: 0) { request in
+            if request.method == "GET" && request.path == "/health" {
+                return .json(200, ["status": "ok"])
+            }
+            return HTTPResponse(status: 200, body: request.body)
+        }
+        try await server.start()
+        defer { server.stop() }
+        let port = server.boundPort
+        XCTAssertNotEqual(port, 0)
+
+        // GET round-trip.
+        let healthURL = URL(string: "http://127.0.0.1:\(port)/health")!
+        let (healthBody, healthResponse) = try await URLSession.shared.data(from: healthURL)
+        XCTAssertEqual((healthResponse as? HTTPURLResponse)?.statusCode, 200)
+        XCTAssertEqual(
+            try JSONDecoder().decode([String: String].self, from: healthBody),
+            ["status": "ok"]
+        )
+
+        // POST round-trip: the body comes back verbatim (echo handler).
+        var post = URLRequest(url: URL(string: "http://127.0.0.1:\(port)/echo")!)
+        post.httpMethod = "POST"
+        post.httpBody = Data("payload-bytes".utf8)
+        let (echoBody, echoResponse) = try await URLSession.shared.data(for: post)
+        XCTAssertEqual((echoResponse as? HTTPURLResponse)?.statusCode, 200)
+        XCTAssertEqual(echoBody, Data("payload-bytes".utf8))
+    }
+
+    func testConcurrentRequestsAllComplete() async throws {
+        let server = try HTTPServer(port: 0) { request in
+            HTTPResponse(status: 200, body: request.body)
+        }
+        try await server.start()
+        defer { server.stop() }
+        let port = server.boundPort
+
+        try await withThrowingTaskGroup(of: Void.self) { group in
+            for index in 0..<8 {
+                group.addTask {
+                    var post = URLRequest(url: URL(string: "http://127.0.0.1:\(port)/echo")!)
+                    post.httpMethod = "POST"
+                    post.httpBody = Data("request-\(index)".utf8)
+                    let (body, _) = try await URLSession.shared.data(for: post)
+                    XCTAssertEqual(body, Data("request-\(index)".utf8))
+                }
+            }
+            try await group.waitForAll()
+        }
+    }
+}

--- a/PolishHelper/Tests/PolishHelperCoreTests/ParentProcessWatchdogTests.swift
+++ b/PolishHelper/Tests/PolishHelperCoreTests/ParentProcessWatchdogTests.swift
@@ -1,0 +1,37 @@
+import XCTest
+
+@testable import PolishHelperCore
+
+final class ParentProcessWatchdogTests: XCTestCase {
+    func testFiresWhenObservedProcessExits() throws {
+        // /bin/cat with an open stdin pipe blocks until we terminate it, so
+        // the exit event is entirely under the test's control (no sleeps).
+        let process = Process()
+        process.executableURL = URL(filePath: "/bin/cat")
+        process.standardInput = Pipe()
+        try process.run()
+
+        let fired = expectation(description: "watchdog fired")
+        let watchdog = ParentProcessWatchdog(parentPID: process.processIdentifier) {
+            fired.fulfill()
+        }
+        _ = watchdog
+
+        process.terminate()
+        wait(for: [fired], timeout: 10)
+    }
+
+    func testFiresImmediatelyWhenProcessIsAlreadyDead() throws {
+        let process = Process()
+        process.executableURL = URL(filePath: "/usr/bin/true")
+        try process.run()
+        process.waitUntilExit()
+
+        let fired = expectation(description: "watchdog fired for dead pid")
+        let watchdog = ParentProcessWatchdog(parentPID: process.processIdentifier) {
+            fired.fulfill()
+        }
+        _ = watchdog
+        wait(for: [fired], timeout: 10)
+    }
+}

--- a/PolishHelper/Tests/PolishHelperCoreTests/PolishdRouterTests.swift
+++ b/PolishHelper/Tests/PolishHelperCoreTests/PolishdRouterTests.swift
@@ -1,0 +1,106 @@
+import XCTest
+
+@testable import PolishHelperCore
+
+private final class StubResponder: ChatResponding, @unchecked Sendable {
+    let result: Result<String, Error>
+    private(set) var received: (messages: [ChatCompletionMessage], temperature: Float?, maxTokens: Int?)?
+
+    init(result: Result<String, Error> = .success("polished")) {
+        self.result = result
+    }
+
+    func respond(
+        to messages: [ChatCompletionMessage],
+        temperature: Float?,
+        maxTokens: Int?
+    ) async throws -> String {
+        received = (messages, temperature, maxTokens)
+        return try result.get()
+    }
+}
+
+final class PolishdRouterTests: XCTestCase {
+    private func chatRequest(_ json: String) -> HTTPRequest {
+        HTTPRequest(method: "POST", path: "/v1/chat/completions", body: Data(json.utf8))
+    }
+
+    func testHealthAnswersOK() async {
+        let router = PolishdRouter(responder: StubResponder(), modelName: "m")
+        let response = await router.handle(HTTPRequest(method: "GET", path: "/health"))
+        XCTAssertEqual(response.status, 200)
+    }
+
+    func testChatCompletionRoundTripsContentAndParameters() async throws {
+        let responder = StubResponder(result: .success("cleaned text"))
+        let router = PolishdRouter(responder: responder, modelName: "test-model")
+        let response = await router.handle(
+            chatRequest(
+                """
+                {"model": "x", "temperature": 0.3,
+                 "messages": [{"role": "system", "content": "sys"},
+                              {"role": "user", "content": "raw one"},
+                              {"role": "user", "content": "raw two"}]}
+                """
+            )
+        )
+
+        XCTAssertEqual(response.status, 200)
+        let decoded = try JSONDecoder().decode(ChatCompletionResponse.self, from: response.body)
+        XCTAssertEqual(decoded.choices.first?.message.content, "cleaned text")
+        XCTAssertEqual(decoded.choices.first?.finishReason, "stop")
+        XCTAssertEqual(decoded.model, "x")
+        XCTAssertEqual(responder.received?.messages.count, 3)
+        XCTAssertEqual(responder.received?.messages[1].content, "raw one")
+        XCTAssertEqual(responder.received?.temperature, 0.3)
+        XCTAssertNil(responder.received?.maxTokens)
+    }
+
+    func testStreamingIsRejected() async {
+        let router = PolishdRouter(responder: StubResponder(), modelName: "m")
+        let response = await router.handle(
+            chatRequest("{\"stream\": true, \"messages\": [{\"role\": \"user\", \"content\": \"x\"}]}")
+        )
+        XCTAssertEqual(response.status, 400)
+    }
+
+    func testEmptyMessagesRejected() async {
+        let router = PolishdRouter(responder: StubResponder(), modelName: "m")
+        let response = await router.handle(chatRequest("{\"messages\": []}"))
+        XCTAssertEqual(response.status, 400)
+    }
+
+    func testInvalidJSONRejected() async {
+        let router = PolishdRouter(responder: StubResponder(), modelName: "m")
+        let response = await router.handle(chatRequest("{nope"))
+        XCTAssertEqual(response.status, 400)
+    }
+
+    func testUnknownRoleSurfacesAsBadRequest() async {
+        let responder = StubResponder(result: .failure(ChatRespondingError.unknownRole("tool")))
+        let router = PolishdRouter(responder: responder, modelName: "m")
+        let response = await router.handle(
+            chatRequest("{\"messages\": [{\"role\": \"tool\", \"content\": \"x\"}]}")
+        )
+        XCTAssertEqual(response.status, 400)
+    }
+
+    func testGenerationFailureSurfacesAsServerError() async throws {
+        struct Boom: Error {}
+        let router = PolishdRouter(responder: StubResponder(result: .failure(Boom())), modelName: "m")
+        let response = await router.handle(
+            chatRequest("{\"messages\": [{\"role\": \"user\", \"content\": \"x\"}]}")
+        )
+        XCTAssertEqual(response.status, 500)
+        let decoded = try JSONDecoder().decode(ChatCompletionErrorResponse.self, from: response.body)
+        XCTAssertEqual(decoded.error.type, "server_error")
+    }
+
+    func testUnknownPathIs404AndWrongMethodIs405() async {
+        let router = PolishdRouter(responder: StubResponder(), modelName: "m")
+        let notFound = await router.handle(HTTPRequest(method: "GET", path: "/nope"))
+        XCTAssertEqual(notFound.status, 404)
+        let wrongMethod = await router.handle(HTTPRequest(method: "GET", path: "/v1/chat/completions"))
+        XCTAssertEqual(wrongMethod.status, 405)
+    }
+}

--- a/README.md
+++ b/README.md
@@ -88,12 +88,12 @@ The shared config directory lives at `~/Library/Application Support/localvoxtral
 
 ## Under the hood
 
-In **Managed local** mode (the default), localvoxtral installs, launches, and supervises two inference engines for you — no terminal required:
+In **Managed local** mode (the default), localvoxtral launches and supervises two inference engines for you — no terminal required:
 
 - **Dictation — [voxmlx](https://github.com/T0mSIlver/voxmlx)** streaming [Voxtral Mini 4B Realtime in 4-bit](https://huggingface.co/T0mSIlver/Voxtral-Mini-4B-Realtime-2602-MLX-4bit). localvoxtral ships a tuned build that adds a native OpenAI Realtime WebSocket server and memory-management optimizations for long dictation sessions.
-- **Polishing — [mlx-lm](https://github.com/T0mSIlver/mlx-lm)** running [Qwen3.5-0.8B in 8-bit](https://huggingface.co/mlx-community/Qwen3.5-0.8B-MLX-8bit), a lightweight model that cleans up transcripts with negligible overhead. The tuned build adds enhanced prompt caching that roughly halves prompt-processing time for each polishing call.
+- **Polishing — a bundled native engine** built on Apple's [MLX Swift](https://github.com/ml-explore/mlx-swift-lm), running [Qwen3.5-0.8B in 8-bit](https://huggingface.co/mlx-community/Qwen3.5-0.8B-8bit), a lightweight model that cleans up transcripts with negligible overhead. It ships inside the app — nothing to install — and runs as a supervised helper process, so turning polishing off frees its memory immediately.
 
-Engines install from pinned, checksum-verified releases into `~/Library/Application Support/localvoxtral`, never outlive the app (a watchdog stops them even after a crash), and uninstall by deleting that one folder.
+The dictation engine installs from pinned, checksum-verified releases into `~/Library/Application Support/localvoxtral`; the polishing engine ships inside the app bundle. Neither ever outlives the app (a watchdog stops them even after a crash); uninstalling means deleting the app and that one folder.
 
 Prefer your own hardware? Dictation and polishing each switch independently to **External URL** mode in **Settings → Endpoints** — any OpenAI Realtime-compatible server works for dictation, any chat-completions server for polishing.
 

--- a/Sources/localvoxtral/Backends/BackendCatalog.swift
+++ b/Sources/localvoxtral/Backends/BackendCatalog.swift
@@ -1,14 +1,21 @@
 import Foundation
 
+/// How a managed backend's executable gets onto the user's Mac.
+enum BackendInstallKind: Equatable, Sendable {
+    /// Installed at runtime: pinned wheel via a pinned uv into the app-managed
+    /// backends/ tree under Application Support.
+    case uvWheel(wheelURL: URL, wheelSHA256: String, requirementName: String, pythonVersion: String)
+    /// Ships inside the .app bundle (Contents/MacOS); nothing to install or
+    /// update at runtime — the app's own update cycle owns it.
+    case bundledExecutable
+}
+
 struct ManagedBackendSpec: Equatable, Sendable {
     let id: String
     let displayName: String
     let version: String
-    let requirementName: String
-    let wheelURL: URL
-    let wheelSHA256: String
+    let installKind: BackendInstallKind
     let executableName: String
-    let pythonVersion: String
     let port: Int
 }
 
@@ -31,30 +38,28 @@ enum BackendCatalog {
         id: "voxmlx",
         displayName: "voxmlx",
         version: "0.1.0",
-        requirementName: "voxmlx[server]",
-        wheelURL: URL(string: "https://github.com/T0mSIlver/voxmlx/releases/download/v0.1.0/voxmlx-0.1.0-py3-none-any.whl")!,
-        wheelSHA256: "028b39a51e6f5e4126b009fe0a316e68fe9215d500de970ea125a0ba550d8c83",
+        installKind: .uvWheel(
+            wheelURL: URL(string: "https://github.com/T0mSIlver/voxmlx/releases/download/v0.1.0/voxmlx-0.1.0-py3-none-any.whl")!,
+            wheelSHA256: "028b39a51e6f5e4126b009fe0a316e68fe9215d500de970ea125a0ba550d8c83",
+            requirementName: "voxmlx[server]",
+            pythonVersion: "3.12"
+        ),
         executableName: "voxmlx-serve",
-        pythonVersion: "3.12",
         port: 8471
     )
 
+    /// The polishing engine: localvoxtral-polishd (MLX Swift, see PolishHelper/),
+    /// bundled inside the .app. It replaced the uv-installed mlx-lm fork wheel:
+    /// upstream mlx-lm went unmaintained and the fork existed to carry fixes
+    /// (transformers pins, prompt-cache correctness, parent-pid watchdog) that
+    /// the Swift helper now owns directly. Swift symbols keep the historical
+    /// `mlxLM` name to keep that mechanical rename out of the functional diff.
     static let mlxLM = ManagedBackendSpec(
-        id: "mlx-lm",
-        displayName: "mlx-lm",
-        // post2 pins transformers <5.13: 5.13.0 broke the string-keyed
-        // AutoTokenizer.register call in mlx_lm/tokenizer_utils.py, so fresh
-        // installs resolving latest transformers crashed mlx_lm.server at import.
-        // post3 fixes prompt-cache correctness: reuse can no longer serve KV
-        // that doesn't match the request prefix (T0mSIlver/mlx-lm#2), and the
-        // server cache is actually LRU with one-token prefix hits fixed
-        // (T0mSIlver/mlx-lm#3).
-        version: "0.31.3.post3",
-        requirementName: "mlx-lm",
-        wheelURL: URL(string: "https://github.com/T0mSIlver/mlx-lm/releases/download/v0.31.3.post3/mlx_lm-0.31.3.post3-py3-none-any.whl")!,
-        wheelSHA256: "13b0fe84eb7bcd92103b45e93a90a82be1cbf10cb089168b91e080c9bacb3177",
-        executableName: "mlx_lm.server",
-        pythonVersion: "3.12",
+        id: "polishd",
+        displayName: "Polishing engine",
+        version: "bundled",
+        installKind: .bundledExecutable,
+        executableName: "localvoxtral-polishd",
         port: 8472
     )
 

--- a/Sources/localvoxtral/Backends/BackendInstaller.swift
+++ b/Sources/localvoxtral/Backends/BackendInstaller.swift
@@ -68,31 +68,42 @@ struct BackendInstaller: BackendInstalling {
     }
 
     func needsInstallOrUpdate(_ spec: ManagedBackendSpec) -> Bool {
-        installedVersion(of: spec) != spec.version
+        switch spec.installKind {
+        case .uvWheel:
+            return installedVersion(of: spec) != spec.version
+        case .bundledExecutable:
+            // Ships inside the .app; the app's own update cycle owns it.
+            return false
+        }
     }
 
     func install(
         _ spec: ManagedBackendSpec,
         progress: @MainActor @Sendable @escaping (BackendInstallProgress) -> Void
     ) async throws {
+        guard case .uvWheel(let specWheelURL, let wheelSHA256, let requirementName, let pythonVersion) =
+            spec.installKind
+        else {
+            preconditionFailure("install called for bundled backend '\(spec.id)'.")
+        }
         try createLayoutDirectories()
         let uvURL = try await resolveUVBinary(progress: progress)
-        let wheelURL = try await downloadWheel(for: spec, progress: progress)
+        let wheelURL = try await downloadWheel(from: specWheelURL, progress: progress)
 
         await Self.report(.verifying, progress)
         let actualSHA256 = try sha256Hex(for: wheelURL)
-        guard actualSHA256 == spec.wheelSHA256 else {
+        guard actualSHA256 == wheelSHA256 else {
             try? fileManager.removeItem(at: wheelURL)
             throw BackendInstallError.checksumMismatch(
-                expected: spec.wheelSHA256,
+                expected: wheelSHA256,
                 actual: actualSHA256
             )
         }
 
-        let requirement = "\(spec.requirementName) @ \(wheelURL.absoluteString)"
+        let requirement = "\(requirementName) @ \(wheelURL.absoluteString)"
         let result = try await UVToolProcess.run(
             uvURL: uvURL,
-            arguments: ["tool", "install", "--python", spec.pythonVersion, "--reinstall", requirement],
+            arguments: ["tool", "install", "--python", pythonVersion, "--reinstall", requirement],
             environment: processEnvironment(),
             progress: progress
         )
@@ -230,12 +241,12 @@ struct BackendInstaller: BackendInstalling {
     }
 
     private func downloadWheel(
-        for spec: ManagedBackendSpec,
+        from wheelURL: URL,
         progress: @MainActor @Sendable @escaping (BackendInstallProgress) -> Void
     ) async throws -> URL {
         try await downloadArtifact(
-            from: spec.wheelURL,
-            to: layout.downloads.appendingPathComponent(spec.wheelURL.lastPathComponent),
+            from: wheelURL,
+            to: layout.downloads.appendingPathComponent(wheelURL.lastPathComponent),
             progress: progress
         )
     }

--- a/Sources/localvoxtral/Backends/BackendManager.swift
+++ b/Sources/localvoxtral/Backends/BackendManager.swift
@@ -290,7 +290,10 @@ final class BackendManager: ManagedBackendManaging {
             return
         }
 
-        if installer.needsInstallOrUpdate(spec) {
+        // Structural, not just data-driven: a bundled backend must never enter
+        // the uv install path regardless of what an installer claims (the real
+        // installer preconditionFailures on bundled installs).
+        if case .uvWheel = spec.installKind, installer.needsInstallOrUpdate(spec) {
             setStatus(.installing(progress: .downloading(fraction: nil)), for: spec)
             do {
                 try await installer.install(spec) { [weak self] progress in
@@ -430,18 +433,16 @@ final class BackendManager: ManagedBackendManaging {
         case .uvWheel:
             return layout.toolBin.appendingPathComponent(spec.executableName)
         case .bundledExecutable:
-            #if DEBUG
-            // Integration tests point the manager at a freshly built helper.
-            if let override = ProcessInfo.processInfo
-                .environment["LOCALVOXTRAL_POLISHD_PATH"], !override.isEmpty
-            {
-                return URL(fileURLWithPath: override)
-            }
-            #endif
+            // Packaged app: Contents/MacOS next to the main binary (that is
+            // where package_app.sh copies the helper). Integration tests
+            // spawn the helper binary directly and never route through here.
             if let auxiliary = Bundle.main.url(forAuxiliaryExecutable: spec.executableName) {
                 return auxiliary
             }
             // Dev runs outside a packaged bundle: sibling of the main binary.
+            // (`swift run` has no bundled helper — managed polishing fails at
+            // spawn with a visible supervisor error there; use a packaged
+            // build for hand-testing polishing.)
             return (Bundle.main.executableURL ?? URL(fileURLWithPath: CommandLine.arguments[0]))
                 .deletingLastPathComponent()
                 .appendingPathComponent(spec.executableName)

--- a/Sources/localvoxtral/Backends/BackendManager.swift
+++ b/Sources/localvoxtral/Backends/BackendManager.swift
@@ -417,12 +417,35 @@ final class BackendManager: ManagedBackendManaging {
     private func configuration(for spec: ManagedBackendSpec) -> BackendProcessConfiguration {
         BackendProcessConfiguration(
             name: spec.displayName,
-            executableURL: layout.toolBin.appendingPathComponent(spec.executableName),
+            executableURL: executableURL(for: spec),
             arguments: arguments(for: spec),
             environment: processEnvironment(),
             readinessURL: URL(string: "http://127.0.0.1:\(spec.port)/health")!,
             readinessTimeout: readinessTimeout(for: spec)
         )
+    }
+
+    private func executableURL(for spec: ManagedBackendSpec) -> URL {
+        switch spec.installKind {
+        case .uvWheel:
+            return layout.toolBin.appendingPathComponent(spec.executableName)
+        case .bundledExecutable:
+            #if DEBUG
+            // Integration tests point the manager at a freshly built helper.
+            if let override = ProcessInfo.processInfo
+                .environment["LOCALVOXTRAL_POLISHD_PATH"], !override.isEmpty
+            {
+                return URL(fileURLWithPath: override)
+            }
+            #endif
+            if let auxiliary = Bundle.main.url(forAuxiliaryExecutable: spec.executableName) {
+                return auxiliary
+            }
+            // Dev runs outside a packaged bundle: sibling of the main binary.
+            return (Bundle.main.executableURL ?? URL(fileURLWithPath: CommandLine.arguments[0]))
+                .deletingLastPathComponent()
+                .appendingPathComponent(spec.executableName)
+        }
     }
 
     private func arguments(for spec: ManagedBackendSpec) -> [String] {
@@ -438,9 +461,6 @@ final class BackendManager: ManagedBackendManaging {
                 parentPID,
             ]
         case BackendCatalog.mlxLM.id:
-            // Prompt caching avoids reprocessing the full polishing prompt on
-            // every request — the mlx-lm fork's main optimization (~50% faster
-            // prompt processing on M1 Pro with the default prompts).
             return [
                 "--model",
                 SettingsStore.defaultLLMPolishingModel,
@@ -448,10 +468,6 @@ final class BackendManager: ManagedBackendManaging {
                 "\(spec.port)",
                 "--parent-pid",
                 parentPID,
-                "--prompt-cache-size",
-                "1",
-                "--prompt-cache-bytes",
-                "1GB",
             ]
         default:
             return []
@@ -461,7 +477,11 @@ final class BackendManager: ManagedBackendManaging {
     private func modelPreparationRequest(for spec: ManagedBackendSpec) -> ModelPreparationRequest {
         // Keep these include patterns in sync with:
         // - /home/dev/work/voxmlx/voxmlx/weights.py download_model
-        // - /home/dev/work/mlx-lm/mlx_lm/utils.py _download
+        // - PolishHelper's loader (MLXLLM loadContainer + AutoTokenizer):
+        //   config.json, generation_config.json, model*.safetensors,
+        //   tokenizer.json/tokenizer_config.json, chat template *.jinja —
+        //   the list below is a superset kept identical to the old mlx-lm
+        //   one so existing HF snapshots stay valid.
         switch spec.id {
         case BackendCatalog.voxmlx.id:
             return ModelPreparationRequest(
@@ -521,9 +541,10 @@ final class BackendManager: ManagedBackendManaging {
             // responds; 600 s is too tight on slow links.
             return .seconds(1800)
         case BackendCatalog.mlxLM.id:
-            // First run downloads the polishing model inside the server before
-            // /health responds; 600 s is too tight on slow links.
-            return .seconds(1800)
+            // Model weights are downloaded by prepareModel before the helper
+            // spawns; /health waits only on model load + first Metal JIT
+            // compile (seconds, not minutes).
+            return .seconds(300)
         default:
             return .seconds(600)
         }

--- a/Sources/localvoxtral/DiagnosticsExporter.swift
+++ b/Sources/localvoxtral/DiagnosticsExporter.swift
@@ -139,7 +139,7 @@ enum DiagnosticsExporter {
 
         lines.append("== Managed backend status ==")
         lines.append("voxmlx: \(snapshot.voxmlxStatus)")
-        lines.append("mlx-lm: \(snapshot.mlxLMStatus)")
+        lines.append("polishing engine (localvoxtral-polishd): \(snapshot.mlxLMStatus)")
         lines.append("")
 
         lines.append("== Managed backend recent output ==")
@@ -151,7 +151,7 @@ enum DiagnosticsExporter {
                 lines.append(contentsOf: snapshot.voxmlxRecentOutput)
             }
             if !snapshot.mlxLMRecentOutput.isEmpty {
-                lines.append("-- mlx-lm --")
+                lines.append("-- localvoxtral-polishd --")
                 lines.append(contentsOf: snapshot.mlxLMRecentOutput)
             }
         }

--- a/Sources/localvoxtral/Onboarding/OnboardingBootstrapDriving.swift
+++ b/Sources/localvoxtral/Onboarding/OnboardingBootstrapDriving.swift
@@ -5,7 +5,7 @@ import Foundation
 enum OnboardingItemID: String, CaseIterable, Identifiable, Sendable {
     /// voxmlx + the Voxtral realtime dictation model.
     case dictation
-    /// mlx-lm + the LLM polishing model.
+    /// The bundled polishing engine's LLM model.
     case polishing
 
     var id: String { rawValue }
@@ -25,7 +25,7 @@ enum OnboardingItemID: String, CaseIterable, Identifiable, Sendable {
         case .dictation:
             return "voxmlx + the Voxtral realtime model"
         case .polishing:
-            return "mlx-lm + the polishing LLM"
+            return "the polishing LLM (bundled engine)"
         }
     }
 }

--- a/Sources/localvoxtral/Onboarding/OnboardingWizardView.swift
+++ b/Sources/localvoxtral/Onboarding/OnboardingWizardView.swift
@@ -198,7 +198,7 @@ private struct DownloadsPage: View {
                     Text("Also set up LLM polishing")
                         .font(.system(size: 13, weight: .medium))
                     Text(
-                        "Downloads mlx-lm + a small polishing model. You can decline and turn it on later in Settings."
+                        "Downloads a small polishing model for the built-in engine. You can decline and turn it on later in Settings."
                     )
                     .font(.caption)
                     .foregroundStyle(.secondary)

--- a/Sources/localvoxtral/SettingsStore.swift
+++ b/Sources/localvoxtral/SettingsStore.swift
@@ -92,7 +92,7 @@ enum BackendMode: String, CaseIterable, Identifiable {
     var polishingDescription: String {
         switch self {
         case .managedLocal:
-            return "Installs and runs mlx-lm on this Mac."
+            return "Runs the bundled polishing engine on this Mac."
         case .externalURL:
             return "Use an OpenAI-compatible chat completions endpoint you run yourself."
         }

--- a/Tests/localvoxtralTests/BackendInstallerTests.swift
+++ b/Tests/localvoxtralTests/BackendInstallerTests.swift
@@ -238,7 +238,7 @@ final class BackendInstallerTests: XCTestCase {
             try await installer.install(spec) { _ in }
             XCTFail("Expected checksum mismatch")
         } catch BackendInstallError.checksumMismatch(let expected, let actual) {
-            XCTAssertEqual(expected, spec.wheelSHA256)
+            XCTAssertEqual(expected, String(repeating: "0", count: 64))
             XCTAssertEqual(actual, try sha256Hex(for: wheel))
         } catch {
             XCTFail("Unexpected error: \(error)")
@@ -353,6 +353,18 @@ final class BackendInstallerTests: XCTestCase {
             executableName: "voxmlx-serve"
         )
         XCTAssertTrue(installer.needsInstallOrUpdate(newerSpec))
+    }
+
+    func testBundledBackendNeverNeedsInstallOrUpdate() {
+        // The polishing helper ships inside the .app: even with no
+        // installed.json marker at all, ensureReady must never route it
+        // through the uv install path.
+        let installer = BackendInstaller(
+            layout: BackendInstallLayout(root: makeTemporaryDirectory())
+        )
+        XCTAssertEqual(BackendCatalog.mlxLM.installKind, .bundledExecutable)
+        XCTAssertFalse(installer.needsInstallOrUpdate(BackendCatalog.mlxLM))
+        XCTAssertNil(installer.installedVersion(of: BackendCatalog.mlxLM))
     }
 
     private func makeTemporaryDirectory() -> URL {
@@ -481,11 +493,13 @@ final class BackendInstallerTests: XCTestCase {
             id: "voxmlx",
             displayName: "voxmlx",
             version: version,
-            requirementName: "voxmlx[server]",
-            wheelURL: wheelURL,
-            wheelSHA256: wheelSHA256,
+            installKind: .uvWheel(
+                wheelURL: wheelURL,
+                wheelSHA256: wheelSHA256,
+                requirementName: "voxmlx[server]",
+                pythonVersion: "3.12"
+            ),
             executableName: executableName,
-            pythonVersion: "3.12",
             port: 8471
         )
     }

--- a/Tests/localvoxtralTests/BackendManagerTests.swift
+++ b/Tests/localvoxtralTests/BackendManagerTests.swift
@@ -93,16 +93,25 @@ final class BackendManagerTests: XCTestCase {
         )
         XCTAssertEqual(manager.mlxLMStatus, .ready)
 
-        let mlxLMArguments = try XCTUnwrap(
+        let mlxLMConfiguration = try XCTUnwrap(
             supervisorFactory.createdConfigurations
-                .first { $0.name == BackendCatalog.mlxLM.displayName }?
-                .arguments
+                .first { $0.name == BackendCatalog.mlxLM.displayName }
         )
-        // The managed server must run with the fork's prompt caching enabled;
-        // the README's polishing-latency claim depends on these flags.
-        XCTAssertTrue(mlxLMArguments.contains("--prompt-cache-size"))
-        XCTAssertTrue(mlxLMArguments.contains("--prompt-cache-bytes"))
-        XCTAssertTrue(mlxLMArguments.contains("--parent-pid"))
+        // The bundled helper owns prompt handling internally; the supervisor
+        // contract is model id + port + parent-pid tethering.
+        XCTAssertTrue(mlxLMConfiguration.arguments.contains("--parent-pid"))
+        XCTAssertEqual(
+            mlxLMConfiguration.arguments.prefix(2),
+            ["--model", SettingsStore.defaultLLMPolishingModel]
+        )
+        XCTAssertFalse(mlxLMConfiguration.arguments.contains("--prompt-cache-size"))
+        // The bundled executable resolves next to the app binary, never from
+        // the uv tools tree.
+        XCTAssertEqual(
+            mlxLMConfiguration.executableURL.lastPathComponent,
+            BackendCatalog.mlxLM.executableName
+        )
+        XCTAssertFalse(mlxLMConfiguration.executableURL.path.contains("backends"))
     }
 
     func testPolishingOnlyEnsureReadyDoesNotTouchVoxmlx() async throws {
@@ -239,7 +248,9 @@ final class BackendManagerTests: XCTestCase {
 
         XCTAssertEqual(
             supervisorFactory.createdConfigurations.map(\.readinessTimeout),
-            [.seconds(1800), .seconds(1800)]
+            // voxmlx still downloads its model inside the server on first run;
+            // the bundled polishing helper only loads pre-downloaded weights.
+            [.seconds(1800), .seconds(300)]
         )
     }
 
@@ -428,8 +439,8 @@ final class BackendManagerTests: XCTestCase {
         supervisorFactory.statesByName[BackendCatalog.voxmlx.displayName] = [.running]
         supervisorFactory.statesByName[BackendCatalog.mlxLM.displayName] = [
             .failed(
-                summary: "mlx-lm exited 5 consecutive times.",
-                detail: "stderr: Python traceback \(marker)"
+                summary: "polishd exited 5 consecutive times.",
+                detail: "stderr: traceback \(marker)"
             ),
         ]
         let manager = makeManager(installer: installer, supervisorFactory: supervisorFactory)
@@ -440,7 +451,7 @@ final class BackendManagerTests: XCTestCase {
         } catch let error as ManagedBackendManagerError {
             XCTAssertEqual(
                 error.localizedDescription,
-                "mlx-lm failed: mlx-lm exited 5 consecutive times."
+                "Polishing engine failed: polishd exited 5 consecutive times."
             )
             XCTAssertFalse(error.localizedDescription.contains(marker))
             XCTAssertTrue(error.technicalDetails?.contains(marker) == true)
@@ -451,8 +462,8 @@ final class BackendManagerTests: XCTestCase {
         XCTAssertEqual(
             manager.mlxLMStatus,
             .failed(
-                summary: "mlx-lm exited 5 consecutive times.",
-                detail: "stderr: Python traceback \(marker)"
+                summary: "polishd exited 5 consecutive times.",
+                detail: "stderr: traceback \(marker)"
             )
         )
     }

--- a/Tests/localvoxtralTests/BackendManagerTests.swift
+++ b/Tests/localvoxtralTests/BackendManagerTests.swift
@@ -114,6 +114,22 @@ final class BackendManagerTests: XCTestCase {
         XCTAssertFalse(mlxLMConfiguration.executableURL.path.contains("backends"))
     }
 
+    func testBundledPolishingBackendNeverEntersInstallPathEvenIfInstallerClaimsNeed() async throws {
+        // The guard must be structural (installKind), not data-driven: even a
+        // (mis)configured installer that claims the bundled backend needs an
+        // install must never be invoked for it — the real installer traps on
+        // bundled installs.
+        let installer = FakeBackendInstaller(needsInstall: [BackendCatalog.mlxLM.id])
+        let supervisorFactory = FakeSupervisorFactory()
+        supervisorFactory.statesByName[BackendCatalog.mlxLM.displayName] = [.running]
+        let manager = makeManager(installer: installer, supervisorFactory: supervisorFactory)
+
+        try await manager.ensureReady(dictation: false, polishing: true)
+
+        XCTAssertTrue(installer.installCalls.isEmpty)
+        XCTAssertEqual(manager.mlxLMStatus, .ready)
+    }
+
     func testPolishingOnlyEnsureReadyDoesNotTouchVoxmlx() async throws {
         let installer = FakeBackendInstaller(needsInstall: [])
         let modelPreparer = FakeModelPreparer()

--- a/Tests/localvoxtralTests/DiagnosticsExporterTests.swift
+++ b/Tests/localvoxtralTests/DiagnosticsExporterTests.swift
@@ -79,7 +79,7 @@ final class DiagnosticsExporterTests: XCTestCase {
         XCTAssertTrue(report.contains("realtime API key: not set"))
         XCTAssertTrue(report.contains("LLM polishing: <disabled>"))
         XCTAssertTrue(report.contains("voxmlx: not installed"))
-        XCTAssertTrue(report.contains("mlx-lm: not installed"))
+        XCTAssertTrue(report.contains("polishing engine (localvoxtral-polishd): not installed"))
     }
 
     func testReportIncludesSupervisorOutputWhenPresent() {
@@ -94,7 +94,7 @@ final class DiagnosticsExporterTests: XCTestCase {
         XCTAssertTrue(report.contains("-- voxmlx --"))
         XCTAssertTrue(report.contains("[voxmlx stdout] INFO started"))
         XCTAssertTrue(report.contains("[voxmlx stderr] listening"))
-        XCTAssertTrue(report.contains("-- mlx-lm --"))
+        XCTAssertTrue(report.contains("-- localvoxtral-polishd --"))
         XCTAssertTrue(report.contains("[mlx-lm stdout] ready"))
     }
 

--- a/Tests/localvoxtralTests/LLMPolishEvalSupport.swift
+++ b/Tests/localvoxtralTests/LLMPolishEvalSupport.swift
@@ -1,0 +1,295 @@
+import Foundation
+import XCTest
+
+@testable import localvoxtral
+
+/// The polish-prompt eval corpus + scoring, shared verbatim between
+/// `LLMPolishPromptEvalTests` (scores a live chat/completions endpoint,
+/// enabled via remote-build.sh eval-llm) and `PolishHelperIntegrationTests`
+/// (scores the bundled localvoxtral-polishd helper it spawns itself). One
+/// corpus, one scorer — an engine swap that changes polish behavior must
+/// show up as the same required-case failures in both suites.
+struct LLMPolishEvalCase {
+    let id: String
+    let input: String
+    /// Full expected output, compared by normalized whole-string
+    /// equality. Set on required cases — their outputs are
+    /// deterministic, and equality (unlike substring needles) also
+    /// rejects prepended labels like "Corrected: …" that the prompt
+    /// forbids. Nil on known-hard cases, which use the needles below.
+    let expectedText: String?
+    /// Substrings that must appear in the normalized output.
+    let mustContain: [String]
+    /// Substrings that must NOT appear in the normalized output.
+    let mustNotContain: [String]
+
+    init(
+        id: String,
+        input: String,
+        expectedText: String? = nil,
+        mustContain: [String] = [],
+        mustNotContain: [String] = []
+    ) {
+        self.id = id
+        self.input = input
+        self.expectedText = expectedText
+        self.mustContain = mustContain
+        self.mustNotContain = mustNotContain
+    }
+}
+
+enum LLMPolishEvalSupport {
+    /// Guard against the polisher rewriting instead of cleaning: letters/
+    /// digits-only word accuracy between input and output must stay high.
+    static let requiredWordAccuracy = 0.7
+
+    /// Sentences the pinned default model fixed in EVERY server state
+    /// observed on 2026-07-06: a warm app-managed instance, a fresh
+    /// com.localvoxtral.mlxlm service, and that service in a later state.
+    /// mlx_lm.server answers identically for identical requests within one
+    /// server state, but a handful of borderline cases were seen flipping
+    /// deterministically BETWEEN states (suspected prompt-cache influence
+    /// on logits — see the stale-cache issue on the mlx-lm fork), so only
+    /// cases stable across all states qualify as required. Every one of
+    /// these MUST pass; a failure means the default prompt (or the model
+    /// pin, or the engine) regressed. Comparison is done on normalized
+    /// text (narrow no-break and no-break spaces unified to a plain space,
+    /// runs of spaces collapsed, lowercased), so a typographically correct
+    /// French narrow no-break space counts as the required space.
+    static let requiredCases: [LLMPolishEvalCase] = [
+        // French — space before ":" must be inserted when missing.
+        LLMPolishEvalCase(
+            id: "fr-colon-missing-space",
+            input: "Voici le plan: on commence demain matin.",
+            expectedText: "Voici le plan : on commence demain matin."
+        ),
+        // French — already correct, must be preserved (no over-correction).
+        LLMPolishEvalCase(
+            id: "fr-already-correct",
+            input: "Où est la gare ?",
+            expectedText: "Où est la gare ?"
+        ),
+        // English — stray space before punctuation must be removed.
+        LLMPolishEvalCase(
+            id: "en-question-extra-space",
+            input: "Are you coming to the meeting tomorrow ?",
+            expectedText: "Are you coming to the meeting tomorrow?"
+        ),
+        LLMPolishEvalCase(
+            id: "en-comma-extra-space",
+            input: "Well , I think we should try again.",
+            expectedText: "Well, I think we should try again."
+        ),
+        LLMPolishEvalCase(
+            id: "en-accented-word-question",
+            input: "Did you enjoy the café ?",
+            expectedText: "Did you enjoy the café?"
+        ),
+        LLMPolishEvalCase(
+            id: "en-multi-questions",
+            input: "Is it ready ? Can we ship it ?",
+            expectedText: "Is it ready? Can we ship it?"
+        ),
+        // English — already correct, must be preserved.
+        LLMPolishEvalCase(
+            id: "en-already-correct",
+            input: "What time is it? It is already late!",
+            expectedText: "What time is it? It is already late!"
+        ),
+    ]
+
+    /// Cases the pinned 0.8B model cannot do reliably. Two flavors:
+    /// never-pass cases (a probe battery showed the model cannot even
+    /// perceive the error — it answers "the spacing is correct" when asked
+    /// yes/no with the rule stated in the question) and state-dependent
+    /// wobblers that flip between server states (see `requiredCases` doc).
+    /// Tracked and printed but NOT asserted, so the suites stay
+    /// deterministic-green while these serve as the acceptance list for a
+    /// future fine-tune or model-pin bump: promote one to `requiredCases`
+    /// only after it passes across server restarts and prompt-cache
+    /// configurations.
+    static let knownHardCases: [LLMPolishEvalCase] = [
+        LLMPolishEvalCase(
+            id: "fr-question-missing-space",
+            input: "Tu viens demain?",
+            mustContain: ["demain ?"],
+            mustNotContain: ["demain?"]
+        ),
+        LLMPolishEvalCase(
+            id: "en-exclamation-extra-space",
+            input: "That demo was really impressive !",
+            mustContain: ["impressive!"],
+            mustNotContain: ["impressive !"]
+        ),
+        LLMPolishEvalCase(
+            id: "fr-exclamation-missing-space",
+            input: "C'est vraiment génial!",
+            mustContain: ["génial !"],
+            mustNotContain: ["génial!"]
+        ),
+        LLMPolishEvalCase(
+            id: "fr-semicolon-missing-space",
+            input: "Il pleut beaucoup; on reste à la maison.",
+            mustContain: ["beaucoup ;"],
+            mustNotContain: ["beaucoup;"]
+        ),
+        LLMPolishEvalCase(
+            id: "fr-multi-sentence",
+            input: "Quelle heure est-il? Il est déjà tard!",
+            mustContain: ["est-il ?", "tard !"],
+            mustNotContain: ["est-il?", "tard!"]
+        ),
+        LLMPolishEvalCase(
+            id: "fr-proper-noun-question",
+            input: "As-tu déjà testé localvoxtral?",
+            mustContain: ["localvoxtral ?"],
+            mustNotContain: ["localvoxtral?"]
+        ),
+        LLMPolishEvalCase(
+            id: "en-colon-extra-space",
+            input: "Here is the plan : we ship the fix tomorrow.",
+            mustContain: ["plan:"],
+            mustNotContain: ["plan :"]
+        ),
+    ]
+
+    /// The bundled default templates, loaded through the production config
+    /// path (a fresh override directory gets seeded with the bundled files).
+    /// The caller owns cleanup of the returned directory.
+    static func defaultPromptTemplates() throws -> (LLMPromptTemplates, cleanup: () -> Void) {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("lv-polish-eval-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        let templates = AppConfigStore(configDirectoryOverride: directory).loadLLMPromptTemplates()
+        return (templates, { try? FileManager.default.removeItem(at: directory) })
+    }
+
+    /// Unifies the space variants a correct French typography can use
+    /// (U+202F narrow no-break, U+00A0 no-break) with a plain space,
+    /// collapses runs, and lowercases, so assertions accept any of them.
+    static func normalized(_ text: String) -> String {
+        text
+            .replacingOccurrences(of: "\u{202F}", with: " ")
+            .replacingOccurrences(of: "\u{00A0}", with: " ")
+            .replacingOccurrences(of: " +", with: " ", options: .regularExpression)
+            .lowercased()
+    }
+
+    static func runCase(
+        _ evalCase: LLMPolishEvalCase,
+        service: LLMPolishingService,
+        templates: LLMPromptTemplates,
+        configuration: LLMPolishingConfiguration
+    ) async -> (failures: [String], output: String) {
+        let request = LLMPolishingRequest(
+            inputText: evalCase.input,
+            systemPrompt: templates.systemContent,
+            userPrompts: templates.renderedUserPrompts(
+                inputText: evalCase.input,
+                replacementDictionary: ""
+            )
+        )
+
+        var caseFailures: [String] = []
+        var outputForLog = "<no output>"
+        do {
+            let result = try await service.polish(request: request, configuration: configuration)
+            outputForLog = result.polishedText
+            let output = normalized(result.polishedText)
+
+            if let expectedText = evalCase.expectedText {
+                // Whole-output equality: substring needles would false-pass
+                // outputs with prepended labels ("Corrected: …") or trailing
+                // commentary that the prompt forbids.
+                if output != normalized(expectedText) {
+                    caseFailures.append("expected \"\(expectedText)\"")
+                }
+            } else {
+                for needle in evalCase.mustContain where !output.contains(normalized(needle)) {
+                    caseFailures.append("missing \"\(needle)\"")
+                }
+                for needle in evalCase.mustNotContain where output.contains(normalized(needle)) {
+                    caseFailures.append("still contains \"\(needle)\"")
+                }
+
+                let wordAccuracy = IntegrationTestSupport.wordAccuracy(
+                    expected: evalCase.input,
+                    actual: result.polishedText
+                )
+                if wordAccuracy < requiredWordAccuracy {
+                    caseFailures.append(
+                        "word accuracy \(String(format: "%.2f", wordAccuracy)) < \(requiredWordAccuracy) (rewrote the text)"
+                    )
+                }
+            }
+        } catch {
+            caseFailures.append("request failed: \(error.localizedDescription)")
+        }
+
+        // Keep each output on one physical line — the model can (and does)
+        // emit newlines, and multi-line entries hide the tail of the output
+        // when the log is grepped.
+        return (caseFailures, outputForLog.replacingOccurrences(of: "\n", with: "\\n"))
+    }
+
+    struct ScoreboardResult {
+        var lines: [String] = []
+        var failedRequiredCases: [String] = []
+        var passingHardCases: [String] = []
+    }
+
+    /// Runs the full corpus and returns the printable scoreboard plus the
+    /// required-case failures the caller must assert on.
+    static func runScoreboard(
+        service: LLMPolishingService,
+        templates: LLMPromptTemplates,
+        configuration: LLMPolishingConfiguration
+    ) async -> ScoreboardResult {
+        var result = ScoreboardResult()
+
+        for evalCase in requiredCases {
+            let (failures, output) = await runCase(
+                evalCase, service: service, templates: templates, configuration: configuration
+            )
+            if failures.isEmpty {
+                result.lines.append("PASS \(evalCase.id)")
+            } else {
+                result.lines.append(
+                    "FAIL \(evalCase.id): \(failures.joined(separator: "; ")) — output: \(output)"
+                )
+                result.failedRequiredCases.append(evalCase.id)
+            }
+        }
+
+        for evalCase in knownHardCases {
+            let (failures, output) = await runCase(
+                evalCase, service: service, templates: templates, configuration: configuration
+            )
+            if failures.isEmpty {
+                result.lines.append(
+                    "PASS \(evalCase.id) (known-hard — promote only if stable across server restarts)"
+                )
+                result.passingHardCases.append(evalCase.id)
+            } else {
+                result.lines.append("XFAIL \(evalCase.id) (known-hard) — output: \(output)")
+            }
+        }
+
+        return result
+    }
+
+    static func printScoreboard(
+        _ result: ScoreboardResult,
+        configuration: LLMPolishingConfiguration,
+        header: String
+    ) {
+        print(
+            """
+            == \(header) (model: \(configuration.model), endpoint: \(configuration.endpointURL)) ==
+            \(result.lines.joined(separator: "\n"))
+            == required: \(requiredCases.count - result.failedRequiredCases.count)/\(requiredCases.count), \
+            known-hard passing: \(result.passingHardCases.count)/\(knownHardCases.count) ==
+            """
+        )
+    }
+}

--- a/Tests/localvoxtralTests/LLMPolishPromptEvalTests.swift
+++ b/Tests/localvoxtralTests/LLMPolishPromptEvalTests.swift
@@ -1,15 +1,19 @@
 import Foundation
 import XCTest
+
 @testable import localvoxtral
 
-/// Eval harness for the DEFAULT LLM polishing prompt against a live mlx-lm
-/// (or any chat/completions) server. It builds requests exactly the way
+/// Eval harness for the DEFAULT LLM polishing prompt against a live
+/// chat/completions server. It builds requests exactly the way
 /// `DictationViewModel+Session` does — bundled default templates through
 /// `AppConfigStore`, `renderedUserPrompts`, the production
 /// `LLMPolishingService` — and scores a table of tricky punctuation-spacing
 /// sentences the prompt must fix (French: one space before ?, !, :, ; —
 /// English: none). Voxtral sometimes emits the wrong convention; the polish
 /// pass is the fix, and this suite is the regression net for the prompt.
+/// The corpus + scorer live in `LLMPolishEvalSupport`, shared with
+/// `PolishHelperIntegrationTests` so the bundled engine is held to the
+/// same baseline.
 ///
 /// Enablement (both channels result in the same configuration):
 /// - env: LLM_POLISH_EVAL_ENABLE=1, optional LLM_POLISH_EVAL_ENDPOINT /
@@ -31,149 +35,6 @@ final class LLMPolishPromptEvalTests: XCTestCase {
     private static let apiKeyEnv = "LLM_POLISH_EVAL_API_KEY"
     private static let markerFileName = ".llm-polish-eval-enable.json"
     private static let defaultEndpoint = "http://127.0.0.1:8080/v1/chat/completions"
-
-    /// Guard against the polisher rewriting instead of cleaning: letters/
-    /// digits-only word accuracy between input and output must stay high.
-    private static let requiredWordAccuracy = 0.7
-
-    private struct EvalCase {
-        let id: String
-        let input: String
-        /// Full expected output, compared by normalized whole-string
-        /// equality. Set on required cases — their outputs are
-        /// deterministic, and equality (unlike substring needles) also
-        /// rejects prepended labels like "Corrected: …" that the prompt
-        /// forbids. Nil on known-hard cases, which use the needles below.
-        let expectedText: String?
-        /// Substrings that must appear in the normalized output.
-        let mustContain: [String]
-        /// Substrings that must NOT appear in the normalized output.
-        let mustNotContain: [String]
-
-        init(
-            id: String,
-            input: String,
-            expectedText: String? = nil,
-            mustContain: [String] = [],
-            mustNotContain: [String] = []
-        ) {
-            self.id = id
-            self.input = input
-            self.expectedText = expectedText
-            self.mustContain = mustContain
-            self.mustNotContain = mustNotContain
-        }
-    }
-
-    /// Sentences the pinned default model fixed in EVERY server state
-    /// observed on 2026-07-06: a warm app-managed instance, a fresh
-    /// com.localvoxtral.mlxlm service, and that service in a later state.
-    /// mlx_lm.server answers identically for identical requests within one
-    /// server state, but a handful of borderline cases were seen flipping
-    /// deterministically BETWEEN states (suspected prompt-cache influence
-    /// on logits — see the stale-cache issue on the mlx-lm fork), so only
-    /// cases stable across all states qualify as required. Every one of
-    /// these MUST pass; a failure means the default prompt (or the model
-    /// pin, or the server) regressed. Comparison is done on normalized
-    /// text (narrow no-break and no-break spaces unified to a plain space,
-    /// runs of spaces collapsed, lowercased), so a typographically correct
-    /// French narrow no-break space counts as the required space.
-    private static let requiredCases: [EvalCase] = [
-        // French — space before ":" must be inserted when missing.
-        EvalCase(
-            id: "fr-colon-missing-space",
-            input: "Voici le plan: on commence demain matin.",
-            expectedText: "Voici le plan : on commence demain matin."
-        ),
-        // French — already correct, must be preserved (no over-correction).
-        EvalCase(
-            id: "fr-already-correct",
-            input: "Où est la gare ?",
-            expectedText: "Où est la gare ?"
-        ),
-        // English — stray space before punctuation must be removed.
-        EvalCase(
-            id: "en-question-extra-space",
-            input: "Are you coming to the meeting tomorrow ?",
-            expectedText: "Are you coming to the meeting tomorrow?"
-        ),
-        EvalCase(
-            id: "en-comma-extra-space",
-            input: "Well , I think we should try again.",
-            expectedText: "Well, I think we should try again."
-        ),
-        EvalCase(
-            id: "en-accented-word-question",
-            input: "Did you enjoy the café ?",
-            expectedText: "Did you enjoy the café?"
-        ),
-        EvalCase(
-            id: "en-multi-questions",
-            input: "Is it ready ? Can we ship it ?",
-            expectedText: "Is it ready? Can we ship it?"
-        ),
-        // English — already correct, must be preserved.
-        EvalCase(
-            id: "en-already-correct",
-            input: "What time is it? It is already late!",
-            expectedText: "What time is it? It is already late!"
-        ),
-    ]
-
-    /// Cases the pinned 0.8B model cannot do reliably. Two flavors:
-    /// never-pass cases (a probe battery showed the model cannot even
-    /// perceive the error — it answers "the spacing is correct" when asked
-    /// yes/no with the rule stated in the question) and state-dependent
-    /// wobblers that flip between server states (see `requiredCases` doc).
-    /// Tracked and printed but NOT asserted, so the suite stays
-    /// deterministic-green while these serve as the acceptance list for a
-    /// future fine-tune or model-pin bump: promote one to `requiredCases`
-    /// only after it passes across server restarts and prompt-cache
-    /// configurations.
-    private static let knownHardCases: [EvalCase] = [
-        EvalCase(
-            id: "fr-question-missing-space",
-            input: "Tu viens demain?",
-            mustContain: ["demain ?"],
-            mustNotContain: ["demain?"]
-        ),
-        EvalCase(
-            id: "en-exclamation-extra-space",
-            input: "That demo was really impressive !",
-            mustContain: ["impressive!"],
-            mustNotContain: ["impressive !"]
-        ),
-        EvalCase(
-            id: "fr-exclamation-missing-space",
-            input: "C'est vraiment génial!",
-            mustContain: ["génial !"],
-            mustNotContain: ["génial!"]
-        ),
-        EvalCase(
-            id: "fr-semicolon-missing-space",
-            input: "Il pleut beaucoup; on reste à la maison.",
-            mustContain: ["beaucoup ;"],
-            mustNotContain: ["beaucoup;"]
-        ),
-        EvalCase(
-            id: "fr-multi-sentence",
-            input: "Quelle heure est-il? Il est déjà tard!",
-            mustContain: ["est-il ?", "tard !"],
-            mustNotContain: ["est-il?", "tard!"]
-        ),
-        EvalCase(
-            id: "fr-proper-noun-question",
-            input: "As-tu déjà testé localvoxtral?",
-            mustContain: ["localvoxtral ?"],
-            mustNotContain: ["localvoxtral?"]
-        ),
-        EvalCase(
-            id: "en-colon-extra-space",
-            input: "Here is the plan : we ship the fix tomorrow.",
-            mustContain: ["plan:"],
-            mustNotContain: ["plan :"]
-        ),
-    ]
 
     private struct MarkerConfig: Decodable {
         let endpoint: String?
@@ -245,135 +106,26 @@ final class LLMPolishPromptEvalTests: XCTestCase {
         }
     }
 
-    /// The bundled default templates, loaded through the production config
-    /// path (a fresh override directory gets seeded with the bundled files).
-    private func defaultPromptTemplates() throws -> LLMPromptTemplates {
-        let directory = FileManager.default.temporaryDirectory
-            .appendingPathComponent("lv-polish-eval-\(UUID().uuidString)", isDirectory: true)
-        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
-        addTeardownBlock {
-            try? FileManager.default.removeItem(at: directory)
-        }
-        return AppConfigStore(configDirectoryOverride: directory).loadLLMPromptTemplates()
-    }
-
-    /// Unifies the space variants a correct French typography can use
-    /// (U+202F narrow no-break, U+00A0 no-break) with a plain space,
-    /// collapses runs, and lowercases, so assertions accept any of them.
-    private func normalized(_ text: String) -> String {
-        text
-            .replacingOccurrences(of: "\u{202F}", with: " ")
-            .replacingOccurrences(of: "\u{00A0}", with: " ")
-            .replacingOccurrences(of: " +", with: " ", options: .regularExpression)
-            .lowercased()
-    }
-
-    private func runCase(
-        _ evalCase: EvalCase,
-        service: LLMPolishingService,
-        templates: LLMPromptTemplates,
-        configuration: LLMPolishingConfiguration
-    ) async -> (failures: [String], output: String) {
-        let request = LLMPolishingRequest(
-            inputText: evalCase.input,
-            systemPrompt: templates.systemContent,
-            userPrompts: templates.renderedUserPrompts(
-                inputText: evalCase.input,
-                replacementDictionary: ""
-            )
-        )
-
-        var caseFailures: [String] = []
-        var outputForLog = "<no output>"
-        do {
-            let result = try await service.polish(request: request, configuration: configuration)
-            outputForLog = result.polishedText
-            let output = normalized(result.polishedText)
-
-            if let expectedText = evalCase.expectedText {
-                // Whole-output equality: substring needles would false-pass
-                // outputs with prepended labels ("Corrected: …") or trailing
-                // commentary that the prompt forbids.
-                if output != normalized(expectedText) {
-                    caseFailures.append("expected \"\(expectedText)\"")
-                }
-            } else {
-                for needle in evalCase.mustContain where !output.contains(normalized(needle)) {
-                    caseFailures.append("missing \"\(needle)\"")
-                }
-                for needle in evalCase.mustNotContain where output.contains(normalized(needle)) {
-                    caseFailures.append("still contains \"\(needle)\"")
-                }
-
-                let wordAccuracy = IntegrationTestSupport.wordAccuracy(
-                    expected: evalCase.input,
-                    actual: result.polishedText
-                )
-                if wordAccuracy < Self.requiredWordAccuracy {
-                    caseFailures.append(
-                        "word accuracy \(String(format: "%.2f", wordAccuracy)) < \(Self.requiredWordAccuracy) (rewrote the text)"
-                    )
-                }
-            }
-        } catch {
-            caseFailures.append("request failed: \(error.localizedDescription)")
-        }
-
-        // Keep each output on one physical line — the model can (and does)
-        // emit newlines, and multi-line entries hide the tail of the output
-        // when the log is grepped.
-        return (caseFailures, outputForLog.replacingOccurrences(of: "\n", with: "\\n"))
-    }
-
     func testDefaultPromptFixesPunctuationSpacing() async throws {
         let configuration = try evalConfiguration()
-        let templates = try defaultPromptTemplates()
+        let (templates, cleanup) = try LLMPolishEvalSupport.defaultPromptTemplates()
+        addTeardownBlock { cleanup() }
         let service = LLMPolishingService()
 
-        var scoreboard: [String] = []
-        var failedRequiredCases: [String] = []
-        var passingHardCases: [String] = []
-
-        for evalCase in Self.requiredCases {
-            let (failures, output) = await runCase(
-                evalCase, service: service, templates: templates, configuration: configuration
-            )
-            if failures.isEmpty {
-                scoreboard.append("PASS \(evalCase.id)")
-            } else {
-                scoreboard.append(
-                    "FAIL \(evalCase.id): \(failures.joined(separator: "; ")) — output: \(output)"
-                )
-                failedRequiredCases.append(evalCase.id)
-            }
-        }
-
-        for evalCase in Self.knownHardCases {
-            let (failures, output) = await runCase(
-                evalCase, service: service, templates: templates, configuration: configuration
-            )
-            if failures.isEmpty {
-                scoreboard.append(
-                    "PASS \(evalCase.id) (known-hard — promote only if stable across server restarts)"
-                )
-                passingHardCases.append(evalCase.id)
-            } else {
-                scoreboard.append("XFAIL \(evalCase.id) (known-hard) — output: \(output)")
-            }
-        }
-
-        print(
-            """
-            == LLM polish prompt eval (model: \(configuration.model), endpoint: \(configuration.endpointURL)) ==
-            \(scoreboard.joined(separator: "\n"))
-            == required: \(Self.requiredCases.count - failedRequiredCases.count)/\(Self.requiredCases.count), \
-            known-hard passing: \(passingHardCases.count)/\(Self.knownHardCases.count) ==
-            """
+        let result = await LLMPolishEvalSupport.runScoreboard(
+            service: service,
+            templates: templates,
+            configuration: configuration
+        )
+        LLMPolishEvalSupport.printScoreboard(
+            result,
+            configuration: configuration,
+            header: "LLM polish prompt eval"
         )
 
         XCTAssertTrue(
-            failedRequiredCases.isEmpty,
-            "Default polish prompt regressed on required punctuation-spacing cases: \(failedRequiredCases.joined(separator: ", "))"
+            result.failedRequiredCases.isEmpty,
+            "Default polish prompt regressed on required punctuation-spacing cases: \(result.failedRequiredCases.joined(separator: ", "))"
         )
     }
 }

--- a/Tests/localvoxtralTests/PolishHelperIntegrationTests.swift
+++ b/Tests/localvoxtralTests/PolishHelperIntegrationTests.swift
@@ -86,10 +86,16 @@ final class PolishHelperIntegrationTests: XCTestCase {
         return (binary, model?.isEmpty == false ? model! : SettingsStore.defaultLLMPolishingModel)
     }
 
+    private struct ModelProvisioningError: Error, CustomStringConvertible {
+        let description: String
+    }
+
     /// The helper never downloads (missing model = hard error by design), so
     /// the suite provisions the shared HF cache itself when the model is
     /// absent — the same cache layout + include patterns as the app's
     /// HFModelDownloader, idempotent, ~0.9 GB once per build host/user.
+    /// Provisioning failures are test FAILURES, not skips: this suite only
+    /// runs when explicitly enabled, and a green skip would hide broken infra.
     private func ensureModelCached(_ repoID: String) async throws {
         let cacheRoot = FileManager.default.homeDirectoryForCurrentUser
             .appendingPathComponent(".cache/huggingface/hub")
@@ -97,12 +103,18 @@ final class PolishHelperIntegrationTests: XCTestCase {
             "models--" + repoID.replacingOccurrences(of: "/", with: "--")
         )
         let snapshotsDir = repoDir.appendingPathComponent("snapshots")
-        if let snapshots = try? FileManager.default.contentsOfDirectory(atPath: snapshotsDir.path),
-           snapshots.contains(where: { snapshot in
-               FileManager.default.fileExists(
-                   atPath: snapshotsDir.appendingPathComponent("\(snapshot)/config.json").path
-               )
-           })
+
+        // Completeness marker is refs/main, which is written LAST below (and
+        // is what HFCacheModelLocator prefers). Keying on config.json alone
+        // would let a cancelled half-download (config present, weights
+        // missing) poison the cache into a permanently-failing suite.
+        let mainRef = repoDir.appendingPathComponent("refs/main")
+        if let revision = try? String(contentsOf: mainRef, encoding: .utf8)
+            .trimmingCharacters(in: .whitespacesAndNewlines),
+            !revision.isEmpty,
+            FileManager.default.fileExists(
+                atPath: snapshotsDir.appendingPathComponent("\(revision)/config.json").path
+            )
         {
             return
         }
@@ -116,7 +128,9 @@ final class PolishHelperIntegrationTests: XCTestCase {
         let apiURL = URL(string: "https://huggingface.co/api/models/\(repoID)/revision/main")!
         let (infoData, infoResponse) = try await URLSession.shared.data(from: apiURL)
         guard (infoResponse as? HTTPURLResponse)?.statusCode == 200 else {
-            throw XCTSkip("HF API unreachable for \(repoID); cannot provision model")
+            throw ModelProvisioningError(
+                description: "HF API unreachable for \(repoID): \(infoResponse)"
+            )
         }
         let info = try JSONDecoder().decode(RepoInfo.self, from: infoData)
 
@@ -128,7 +142,9 @@ final class PolishHelperIntegrationTests: XCTestCase {
         let wanted = info.siblings.map(\.rfilename).filter { name in
             patterns.contains { fnmatch($0, name, 0) == 0 }
         }
-        XCTAssertFalse(wanted.isEmpty, "HF listing for \(repoID) matched no files")
+        guard !wanted.isEmpty else {
+            throw ModelProvisioningError(description: "HF listing for \(repoID) matched no files")
+        }
 
         let snapshotDir = snapshotsDir.appendingPathComponent(info.sha)
         try FileManager.default.createDirectory(
@@ -145,14 +161,14 @@ final class PolishHelperIntegrationTests: XCTestCase {
             )!
             let (temporary, response) = try await URLSession.shared.download(from: source)
             guard (response as? HTTPURLResponse)?.statusCode == 200 else {
-                throw XCTSkip("download failed for \(name): \(response)")
+                throw ModelProvisioningError(description: "download failed for \(name): \(response)")
             }
             try FileManager.default.moveItem(at: temporary, to: destination)
         }
 
         let refsDir = repoDir.appendingPathComponent("refs")
         try FileManager.default.createDirectory(at: refsDir, withIntermediateDirectories: true)
-        try Data("\(info.sha)\n".utf8).write(to: refsDir.appendingPathComponent("main"))
+        try Data("\(info.sha)\n".utf8).write(to: mainRef)
         print("polishd integration: model provisioned (\(wanted.count) files)")
     }
 
@@ -165,7 +181,7 @@ final class PolishHelperIntegrationTests: XCTestCase {
         binary: URL,
         model: String,
         extraArguments: [String] = []
-    ) throws -> (process: Process, port: UInt16) {
+    ) async throws -> (process: Process, port: UInt16) {
         let process = Process()
         process.executableURL = binary
         process.arguments = ["--model", model, "--port", "0"] + extraArguments
@@ -198,7 +214,7 @@ final class PolishHelperIntegrationTests: XCTestCase {
             }
         }
 
-        wait(for: [readyOrExited], timeout: Self.readyTimeout)
+        await fulfillment(of: [readyOrExited], timeout: Self.readyTimeout)
         guard let port = portBox.get() else {
             let status = process.isRunning
                 ? "still running, no ready line after \(Int(Self.readyTimeout))s"
@@ -257,7 +273,7 @@ final class PolishHelperIntegrationTests: XCTestCase {
     func testHelperMatchesPolishEvalBaselineThroughProductionRequestPath() async throws {
         let (binary, model) = try helperConfiguration()
         try await ensureModelCached(model)
-        let (process, port) = try launchHelper(binary: binary, model: model)
+        let (process, port) = try await launchHelper(binary: binary, model: model)
 
         let healthURL = URL(string: "http://127.0.0.1:\(port)/health")!
         let (_, healthResponse) = try await URLSession.shared.data(from: healthURL)
@@ -310,7 +326,7 @@ final class PolishHelperIntegrationTests: XCTestCase {
             }
         }
 
-        let (helper, _) = try launchHelper(
+        let (helper, _) = try await launchHelper(
             binary: binary,
             model: model,
             extraArguments: ["--parent-pid", "\(decoyParent.processIdentifier)"]

--- a/Tests/localvoxtralTests/PolishHelperIntegrationTests.swift
+++ b/Tests/localvoxtralTests/PolishHelperIntegrationTests.swift
@@ -1,0 +1,222 @@
+import Foundation
+import XCTest
+
+@testable import localvoxtral
+
+/// Integration tests for the bundled MLX Swift polishing helper
+/// (localvoxtral-polishd): spawn the real xcodebuild-built binary with the
+/// real pinned model, drive it through the production `LLMPolishingService`,
+/// and hold it to the same eval baseline as the old mlx-lm server
+/// (`LLMPolishEvalSupport`). Also proves the parent-PID tether end to end.
+///
+/// Enablement (needs a Metal-capable Mac with the model in the HF cache and
+/// a helper binary from `./scripts/remote-build.sh package`):
+/// - env: LOCALVOXTRAL_POLISHD_TEST_ENABLE=1, optional
+///   LOCALVOXTRAL_POLISHD_TEST_PATH / LOCALVOXTRAL_POLISHD_TEST_MODEL
+/// - marker file `.polishd-integration-enable.json` at the repo root,
+///   written by `./scripts/remote-build.sh integration-polishd` (the build
+///   gate pins env prefixes per-command, so enablement travels in the tree).
+@MainActor
+final class PolishHelperIntegrationTests: XCTestCase {
+    private static let enableEnv = "LOCALVOXTRAL_POLISHD_TEST_ENABLE"
+    private static let pathEnv = "LOCALVOXTRAL_POLISHD_TEST_PATH"
+    private static let modelEnv = "LOCALVOXTRAL_POLISHD_TEST_MODEL"
+    private static let markerFileName = ".polishd-integration-enable.json"
+    private static let defaultHelperPath =
+        "PolishHelper/.build/xcode/Build/Products/Release/localvoxtral-polishd"
+
+    /// Generous because the first request after a cold Metal JIT cache can
+    /// pay kernel-compilation time on top of model load.
+    private static let readyTimeout: TimeInterval = 300
+
+    private struct MarkerConfig: Decodable {
+        let helperPath: String?
+        let model: String?
+    }
+
+    private var repoRoot: URL {
+        URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent() // localvoxtralTests
+            .deletingLastPathComponent() // Tests
+            .deletingLastPathComponent() // repo root
+    }
+
+    private func helperConfiguration() throws -> (binary: URL, model: String) {
+        let env = ProcessInfo.processInfo.environment
+        var helperPath: String?
+        var model: String?
+
+        if env[Self.enableEnv] == "1" {
+            helperPath = env[Self.pathEnv]
+            model = env[Self.modelEnv]
+        } else {
+            let markerURL = repoRoot.appendingPathComponent(Self.markerFileName)
+            guard FileManager.default.fileExists(atPath: markerURL.path) else {
+                throw XCTSkip(
+                    """
+                    Polishing-helper integration tests are disabled.
+                    Enable with \(Self.enableEnv)=1 (optional \(Self.pathEnv), \
+                    \(Self.modelEnv)) or run \
+                    ./scripts/remote-build.sh integration-polishd from the dev box
+                    (after a `package` run has built the helper).
+                    """
+                )
+            }
+            let marker = try JSONDecoder().decode(
+                MarkerConfig.self,
+                from: Data(contentsOf: markerURL)
+            )
+            helperPath = marker.helperPath
+            model = marker.model
+        }
+
+        let resolvedPath = helperPath?.isEmpty == false ? helperPath! : Self.defaultHelperPath
+        let binary = resolvedPath.hasPrefix("/")
+            ? URL(fileURLWithPath: resolvedPath)
+            : repoRoot.appendingPathComponent(resolvedPath)
+        guard FileManager.default.isExecutableFile(atPath: binary.path) else {
+            XCTFail(
+                """
+                Helper binary missing at \(binary.path).
+                Build it first: ./scripts/remote-build.sh package
+                """
+            )
+            throw XCTSkip("helper binary missing")
+        }
+        return (binary, model?.isEmpty == false ? model! : SettingsStore.defaultLLMPolishingModel)
+    }
+
+    /// Spawns the helper and waits for its stderr readiness line
+    /// ("ready on 127.0.0.1:<port>"), which carries the ephemeral port when
+    /// launched with --port 0. Event-driven via the same descriptor-safe
+    /// PipeLineReader the app's installer uses (never
+    /// FileHandle.availableData — PR #60).
+    private func launchHelper(
+        binary: URL,
+        model: String,
+        extraArguments: [String] = []
+    ) throws -> (process: Process, port: UInt16) {
+        let process = Process()
+        process.executableURL = binary
+        process.arguments = ["--model", model, "--port", "0"] + extraArguments
+
+        let stderr = Pipe()
+        process.standardError = stderr
+        let ready = expectation(description: "helper reported ready")
+        let portBox = PortBox()
+        let reader = PipeLineReader(fileHandle: stderr.fileHandleForReading) { line in
+            if let range = line.range(of: "ready on 127.0.0.1:"),
+               let port = UInt16(line[range.upperBound...].prefix(while: \.isNumber))
+            {
+                if portBox.set(port) {
+                    ready.fulfill()
+                }
+            }
+        }
+
+        try process.run()
+        reader.start()
+        addTeardownBlock {
+            if process.isRunning {
+                process.terminate()
+            }
+        }
+
+        wait(for: [ready], timeout: Self.readyTimeout)
+        guard let port = portBox.get() else {
+            throw XCTSkip("helper never reported a port")
+        }
+        return (process, port)
+    }
+
+    private final class PortBox: @unchecked Sendable {
+        private let lock = NSLock()
+        private var port: UInt16?
+
+        func set(_ value: UInt16) -> Bool {
+            lock.lock()
+            defer { lock.unlock() }
+            guard port == nil else { return false }
+            port = value
+            return true
+        }
+
+        func get() -> UInt16? {
+            lock.lock()
+            defer { lock.unlock() }
+            return port
+        }
+    }
+
+    /// The parity proof: /health answers, and the production polish request
+    /// path scores the SAME eval corpus the mlx-lm server was held to. A
+    /// required-case failure here means the engine swap changed polish
+    /// behavior — investigate before shipping, do not relax the corpus.
+    func testHelperMatchesPolishEvalBaselineThroughProductionRequestPath() async throws {
+        let (binary, model) = try helperConfiguration()
+        let (process, port) = try launchHelper(binary: binary, model: model)
+
+        let healthURL = URL(string: "http://127.0.0.1:\(port)/health")!
+        let (_, healthResponse) = try await URLSession.shared.data(from: healthURL)
+        XCTAssertEqual((healthResponse as? HTTPURLResponse)?.statusCode, 200)
+
+        let configuration = LLMPolishingConfiguration(
+            endpointURL: URL(string: "http://127.0.0.1:\(port)/v1/chat/completions")!,
+            apiKey: "",
+            model: model
+        )
+        let (templates, cleanup) = try LLMPolishEvalSupport.defaultPromptTemplates()
+        addTeardownBlock { cleanup() }
+
+        let result = await LLMPolishEvalSupport.runScoreboard(
+            service: LLMPolishingService(),
+            templates: templates,
+            configuration: configuration
+        )
+        LLMPolishEvalSupport.printScoreboard(
+            result,
+            configuration: configuration,
+            header: "polishd (bundled MLX Swift helper) eval"
+        )
+
+        XCTAssertTrue(
+            result.failedRequiredCases.isEmpty,
+            "Bundled helper regressed required polish cases vs the mlx-lm baseline: \(result.failedRequiredCases.joined(separator: ", "))"
+        )
+
+        XCTAssertTrue(process.isRunning)
+        process.terminate()
+    }
+
+    /// The memory-contract proof: when the process that passed --parent-pid
+    /// dies, the helper exits on its own (freeing all model memory), exactly
+    /// like the old fork's Python watchdog.
+    func testHelperExitsWhenParentPIDDies() async throws {
+        let (binary, model) = try helperConfiguration()
+
+        // A stand-in "app" process the test fully controls: /bin/cat with an
+        // open stdin pipe blocks until terminated.
+        let decoyParent = Process()
+        decoyParent.executableURL = URL(fileURLWithPath: "/bin/cat")
+        decoyParent.standardInput = Pipe()
+        try decoyParent.run()
+        addTeardownBlock {
+            if decoyParent.isRunning {
+                decoyParent.terminate()
+            }
+        }
+
+        let (helper, _) = try launchHelper(
+            binary: binary,
+            model: model,
+            extraArguments: ["--parent-pid", "\(decoyParent.processIdentifier)"]
+        )
+
+        let helperExited = expectation(description: "helper exited after parent death")
+        helper.terminationHandler = { _ in helperExited.fulfill() }
+
+        decoyParent.terminate()
+        await fulfillment(of: [helperExited], timeout: 30)
+        XCTAssertFalse(helper.isRunning)
+    }
+}

--- a/Tests/localvoxtralTests/PolishHelperIntegrationTests.swift
+++ b/Tests/localvoxtralTests/PolishHelperIntegrationTests.swift
@@ -86,6 +86,76 @@ final class PolishHelperIntegrationTests: XCTestCase {
         return (binary, model?.isEmpty == false ? model! : SettingsStore.defaultLLMPolishingModel)
     }
 
+    /// The helper never downloads (missing model = hard error by design), so
+    /// the suite provisions the shared HF cache itself when the model is
+    /// absent — the same cache layout + include patterns as the app's
+    /// HFModelDownloader, idempotent, ~0.9 GB once per build host/user.
+    private func ensureModelCached(_ repoID: String) async throws {
+        let cacheRoot = FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent(".cache/huggingface/hub")
+        let repoDir = cacheRoot.appendingPathComponent(
+            "models--" + repoID.replacingOccurrences(of: "/", with: "--")
+        )
+        let snapshotsDir = repoDir.appendingPathComponent("snapshots")
+        if let snapshots = try? FileManager.default.contentsOfDirectory(atPath: snapshotsDir.path),
+           snapshots.contains(where: { snapshot in
+               FileManager.default.fileExists(
+                   atPath: snapshotsDir.appendingPathComponent("\(snapshot)/config.json").path
+               )
+           })
+        {
+            return
+        }
+
+        print("polishd integration: downloading \(repoID) into \(cacheRoot.path)")
+        struct RepoInfo: Decodable {
+            struct Sibling: Decodable { let rfilename: String }
+            let sha: String
+            let siblings: [Sibling]
+        }
+        let apiURL = URL(string: "https://huggingface.co/api/models/\(repoID)/revision/main")!
+        let (infoData, infoResponse) = try await URLSession.shared.data(from: apiURL)
+        guard (infoResponse as? HTTPURLResponse)?.statusCode == 200 else {
+            throw XCTSkip("HF API unreachable for \(repoID); cannot provision model")
+        }
+        let info = try JSONDecoder().decode(RepoInfo.self, from: infoData)
+
+        // Same include patterns as BackendManager.modelPreparationRequest.
+        let patterns = [
+            "*.json", "model*.safetensors", "*.py", "tokenizer.model",
+            "*.tiktoken", "tiktoken.model", "*.txt", "*.jsonl", "*.jinja",
+        ]
+        let wanted = info.siblings.map(\.rfilename).filter { name in
+            patterns.contains { fnmatch($0, name, 0) == 0 }
+        }
+        XCTAssertFalse(wanted.isEmpty, "HF listing for \(repoID) matched no files")
+
+        let snapshotDir = snapshotsDir.appendingPathComponent(info.sha)
+        try FileManager.default.createDirectory(
+            at: snapshotDir, withIntermediateDirectories: true
+        )
+        for name in wanted {
+            let destination = snapshotDir.appendingPathComponent(name)
+            if FileManager.default.fileExists(atPath: destination.path) { continue }
+            try FileManager.default.createDirectory(
+                at: destination.deletingLastPathComponent(), withIntermediateDirectories: true
+            )
+            let source = URL(
+                string: "https://huggingface.co/\(repoID)/resolve/\(info.sha)/\(name)"
+            )!
+            let (temporary, response) = try await URLSession.shared.download(from: source)
+            guard (response as? HTTPURLResponse)?.statusCode == 200 else {
+                throw XCTSkip("download failed for \(name): \(response)")
+            }
+            try FileManager.default.moveItem(at: temporary, to: destination)
+        }
+
+        let refsDir = repoDir.appendingPathComponent("refs")
+        try FileManager.default.createDirectory(at: refsDir, withIntermediateDirectories: true)
+        try Data("\(info.sha)\n".utf8).write(to: refsDir.appendingPathComponent("main"))
+        print("polishd integration: model provisioned (\(wanted.count) files)")
+    }
+
     /// Spawns the helper and waits for its stderr readiness line
     /// ("ready on 127.0.0.1:<port>"), which carries the ephemeral port when
     /// launched with --port 0. Event-driven via the same descriptor-safe
@@ -102,17 +172,23 @@ final class PolishHelperIntegrationTests: XCTestCase {
 
         let stderr = Pipe()
         process.standardError = stderr
-        let ready = expectation(description: "helper reported ready")
+        // Fulfilled on the ready line OR on early exit, so a crashing helper
+        // fails in seconds with its stderr instead of a 300 s silent timeout.
+        let readyOrExited = expectation(description: "helper ready or exited")
+        readyOrExited.assertForOverFulfill = false
         let portBox = PortBox()
+        let stderrLog = LineLog()
         let reader = PipeLineReader(fileHandle: stderr.fileHandleForReading) { line in
+            stderrLog.append(line)
             if let range = line.range(of: "ready on 127.0.0.1:"),
                let port = UInt16(line[range.upperBound...].prefix(while: \.isNumber))
             {
                 if portBox.set(port) {
-                    ready.fulfill()
+                    readyOrExited.fulfill()
                 }
             }
         }
+        process.terminationHandler = { _ in readyOrExited.fulfill() }
 
         try process.run()
         reader.start()
@@ -122,11 +198,37 @@ final class PolishHelperIntegrationTests: XCTestCase {
             }
         }
 
-        wait(for: [ready], timeout: Self.readyTimeout)
+        wait(for: [readyOrExited], timeout: Self.readyTimeout)
         guard let port = portBox.get() else {
-            throw XCTSkip("helper never reported a port")
+            let status = process.isRunning
+                ? "still running, no ready line after \(Int(Self.readyTimeout))s"
+                : "exited with status \(process.terminationStatus)"
+            XCTFail(
+                """
+                Helper failed to become ready (\(status)). stderr tail:
+                \(stderrLog.tail(30))
+                """
+            )
+            throw XCTSkip("helper did not become ready")
         }
         return (process, port)
+    }
+
+    private final class LineLog: @unchecked Sendable {
+        private let lock = NSLock()
+        private var lines: [String] = []
+
+        func append(_ line: String) {
+            lock.lock()
+            lines.append(line)
+            lock.unlock()
+        }
+
+        func tail(_ count: Int) -> String {
+            lock.lock()
+            defer { lock.unlock() }
+            return lines.suffix(count).joined(separator: "\n")
+        }
     }
 
     private final class PortBox: @unchecked Sendable {
@@ -154,6 +256,7 @@ final class PolishHelperIntegrationTests: XCTestCase {
     /// behavior — investigate before shipping, do not relax the corpus.
     func testHelperMatchesPolishEvalBaselineThroughProductionRequestPath() async throws {
         let (binary, model) = try helperConfiguration()
+        try await ensureModelCached(model)
         let (process, port) = try launchHelper(binary: binary, model: model)
 
         let healthURL = URL(string: "http://127.0.0.1:\(port)/health")!
@@ -193,6 +296,7 @@ final class PolishHelperIntegrationTests: XCTestCase {
     /// like the old fork's Python watchdog.
     func testHelperExitsWhenParentPIDDies() async throws {
         let (binary, model) = try helperConfiguration()
+        try await ensureModelCached(model)
 
         // A stand-in "app" process the test fully controls: /bin/cat with an
         // open stdin pipe blocks until terminated.

--- a/scripts/mac-diag.sh
+++ b/scripts/mac-diag.sh
@@ -121,7 +121,7 @@ fi
 # --- Process state --------------------------------------------------------
 
 print_header "Process state"
-for proc in localvoxtral voxmlx-serve mlx_lm.server; do
+for proc in localvoxtral voxmlx-serve mlx_lm.server localvoxtral-polishd; do
   # PIDs only — full command lines (pgrep -fl) could leak flags such as API
   # keys from user-run backend invocations.
   pids="$(pgrep -f "$proc" 2>/dev/null | tr '\n' ' ' || true)"
@@ -137,7 +137,7 @@ done
 print_header "Local ports (127.0.0.1)"
 check_port 8000 "user/external realtime"
 check_port 8471 "managed voxmlx"
-check_port 8472 "managed mlx-lm"
+check_port 8472 "managed polishing engine (localvoxtral-polishd)"
 
 # --- launchd --------------------------------------------------------------
 

--- a/scripts/mac/README.md
+++ b/scripts/mac/README.md
@@ -12,11 +12,13 @@ xcodebuild -downloadComponent MetalToolchain
 xcodebuild -showComponent MetalToolchain   # expect "Status: installed"
 ```
 
-Installed on the build host 2026-07-07. Gotchas: the catalog fetch fails
-transiently sometimes ("Failed fetching catalog for assetType") — just retry;
-and `xcrun --find metal` succeeds even when the component is missing (the
-shim exists), so only an actual invocation (`xcrun metal --version`) proves
-it works. Runs as a normal user, no sudo needed.
+Installed on the build host 2026-07-07 (builder user; ci.yml self-provisions
+it for the runner user, since activation is PER-USER even though the asset
+lands system-wide). Gotchas: the catalog fetch fails transiently sometimes
+("Failed fetching catalog for assetType") — just retry; and `xcrun --find
+metal` succeeds even when the component is missing (the shim exists), so
+only an actual invocation (`xcrun metal --version`) proves it works. Runs
+as a normal user, no sudo needed.
 
 ## `com.localvoxtral.mlxlm` — polish-LLM eval service (owner runbook)
 

--- a/scripts/mac/README.md
+++ b/scripts/mac/README.md
@@ -1,6 +1,31 @@
 # Mac build-host scripts
 
+## Metal toolchain (Xcode 26+) — required for packaging
+
+`package_app.sh` builds the bundled polishing helper (`PolishHelper/`,
+MLX Swift) with xcodebuild, which compiles Metal kernels. On Xcode 26+ the
+Metal compiler is a separate ~700 MB component that is NOT installed with
+Xcode; one-time setup per build host:
+
+```bash
+xcodebuild -downloadComponent MetalToolchain
+xcodebuild -showComponent MetalToolchain   # expect "Status: installed"
+```
+
+Installed on the build host 2026-07-07. Gotchas: the catalog fetch fails
+transiently sometimes ("Failed fetching catalog for assetType") — just retry;
+and `xcrun --find metal` succeeds even when the component is missing (the
+shim exists), so only an actual invocation (`xcrun metal --version`) proves
+it works. Runs as a normal user, no sudo needed.
+
 ## `com.localvoxtral.mlxlm` — polish-LLM eval service (owner runbook)
+
+> Since the bundled MLX Swift helper replaced the app-managed mlx-lm wheel
+> (2026-07), this service is the *prompt-eval reference endpoint* only — the
+> app no longer installs or runs mlx-lm, and production-engine parity is
+> covered by `./scripts/remote-build.sh integration-polishd` instead. The
+> `--prompt-cache-*` flags below are mlx-lm-specific and no longer mirror
+> app behavior.
 
 The LLM polish prompt eval (`./scripts/remote-build.sh eval-llm`,
 `LLMPolishPromptEvalTests`) needs an mlx-lm chat/completions server that is

--- a/scripts/package_app.sh
+++ b/scripts/package_app.sh
@@ -226,6 +226,76 @@ cat > "$APP_DIR/Contents/Info.plist" <<PLIST
 </plist>
 PLIST
 
+# --- Bundled polishing helper (localvoxtral-polishd, PolishHelper/) --------
+# MUST build with xcodebuild: SwiftPM CLI cannot compile mlx-swift's Metal
+# kernels (mlx-swift README), producing a binary that fails at runtime with
+# "Failed to load the default metallib". Xcode's build system compiles the
+# kernels into the mlx-swift_Cmlx resource bundle, which we ship alongside.
+# A real invocation, not `xcrun --find`: on Xcode 26+ the metal shim exists
+# even when the toolchain component is missing, and only fails when executed.
+# One-time host provision (owner runbook: scripts/mac/README.md):
+#   xcodebuild -downloadComponent MetalToolchain
+# The catalog fetch can fail transiently — retry before concluding.
+if ! xcrun metal --version >/dev/null 2>&1; then
+  echo "Metal toolchain not available. On Xcode 26+ it is a separate component:"
+  echo "  xcodebuild -downloadComponent MetalToolchain"
+  echo "(catalog fetch can fail transiently; retry once before debugging)"
+  exit 1
+fi
+
+HELPER_DERIVED_DATA="$ROOT_DIR/PolishHelper/.build/xcode"
+HELPER_BUILD_LOG="$ROOT_DIR/PolishHelper/.build/xcodebuild.log"
+mkdir -p "$ROOT_DIR/PolishHelper/.build"
+echo "Building polishing helper (xcodebuild; full log: $HELPER_BUILD_LOG)"
+(
+  cd "$ROOT_DIR/PolishHelper"
+  # Xcode generates a single aggregate scheme named after the package; the
+  # localvoxtral-polishd product binary lands in Build/Products/Release.
+  xcodebuild \
+    -scheme PolishHelper \
+    -destination 'platform=macOS,arch=arm64' \
+    -configuration Release \
+    -derivedDataPath "$HELPER_DERIVED_DATA" \
+    build > "$HELPER_BUILD_LOG" 2>&1
+) || {
+  echo "Polishing helper xcodebuild failed; last 40 log lines:"
+  tail -n 40 "$HELPER_BUILD_LOG"
+  exit 1
+}
+
+HELPER_PRODUCTS_DIR="$HELPER_DERIVED_DATA/Build/Products/Release"
+HELPER_BINARY="$HELPER_PRODUCTS_DIR/localvoxtral-polishd"
+if [[ ! -f "$HELPER_BINARY" ]]; then
+  echo "Polishing helper build reported success but produced no binary at:"
+  echo "  $HELPER_BINARY"
+  tail -n 40 "$HELPER_BUILD_LOG"
+  exit 1
+fi
+
+cp "$HELPER_BINARY" "$APP_DIR/Contents/MacOS/localvoxtral-polishd"
+chmod +x "$APP_DIR/Contents/MacOS/localvoxtral-polishd"
+
+# The helper's resource bundles (Metal kernels + tokenizer resources) must be
+# reachable from the app bundle's Resources; the Cmlx C++ lookup resolves
+# mlx-swift_Cmlx.bundle relative to the running process's main bundle.
+while IFS= read -r helper_bundle; do
+  cp -R "$helper_bundle" "$APP_DIR/Contents/Resources/$(basename "$helper_bundle")"
+done < <(find "$HELPER_PRODUCTS_DIR" -maxdepth 1 -type d -name "*.bundle" -print)
+
+if [[ ! -d "$APP_DIR/Contents/Resources/mlx-swift_Cmlx.bundle" ]]; then
+  echo "mlx-swift_Cmlx.bundle missing from helper build products; the helper"
+  echo "would abort at runtime loading Metal kernels."
+  exit 1
+fi
+
+# Helper dSYM for field crash symbolication, next to the app's own.
+HELPER_DSYM_SOURCE="$HELPER_PRODUCTS_DIR/localvoxtral-polishd.dSYM"
+if [[ -d "$HELPER_DSYM_SOURCE" ]]; then
+  rm -rf "$ROOT_DIR/dist/localvoxtral-polishd.dSYM"
+  cp -R "$HELPER_DSYM_SOURCE" "$ROOT_DIR/dist/localvoxtral-polishd.dSYM"
+fi
+# ---------------------------------------------------------------------------
+
 # Remove filesystem metadata from copied assets (e.g. FinderInfo/resource fork)
 # because codesign rejects bundles containing that detritus.
 chmod -R u+w "$APP_DIR"

--- a/scripts/package_app.sh
+++ b/scripts/package_app.sh
@@ -238,6 +238,9 @@ PLIST
 if [[ "${LOCALVOXTRAL_SKIP_POLISHD:-0}" == "1" ]]; then
   echo "WARNING: skipping polishing helper (LOCALVOXTRAL_SKIP_POLISHD=1);"
   echo "this bundle cannot run Managed local polishing."
+  # A stale helper dSYM from a previous non-skip run would be wrong-UUID
+  # symbolication bait next to this helper-less bundle.
+  rm -rf "$ROOT_DIR/dist/localvoxtral-polishd.dSYM"
 else
 
 # A real invocation, not `xcrun --find`: on Xcode 26+ the metal shim exists
@@ -260,11 +263,15 @@ echo "Building polishing helper (xcodebuild; full log: $HELPER_BUILD_LOG)"
   cd "$ROOT_DIR/PolishHelper"
   # Xcode generates a single aggregate scheme named after the package; the
   # localvoxtral-polishd product binary lands in Build/Products/Release.
+  # -disableAutomaticPackageResolution: the committed Package.resolved is the
+  # contract — if a manifest edit invalidates it, fail loudly instead of
+  # silently re-resolving to floating versions that never get committed.
   xcodebuild \
     -scheme PolishHelper \
     -destination 'platform=macOS,arch=arm64' \
     -configuration Release \
     -derivedDataPath "$HELPER_DERIVED_DATA" \
+    -disableAutomaticPackageResolution \
     build > "$HELPER_BUILD_LOG" 2>&1
 ) || {
   echo "Polishing helper xcodebuild failed; last 40 log lines:"
@@ -297,12 +304,18 @@ if [[ ! -d "$APP_DIR/Contents/Resources/mlx-swift_Cmlx.bundle" ]]; then
   exit 1
 fi
 
-# Helper dSYM for field crash symbolication, next to the app's own.
+# Helper dSYM for field crash symbolication, next to the app's own. Missing
+# dSYM is a hard error: helper crashes (MLX C++/Metal) are the likeliest
+# field crashes now, and a silent skip would degrade symbolication without
+# any signal.
 HELPER_DSYM_SOURCE="$HELPER_PRODUCTS_DIR/localvoxtral-polishd.dSYM"
-if [[ -d "$HELPER_DSYM_SOURCE" ]]; then
-  rm -rf "$ROOT_DIR/dist/localvoxtral-polishd.dSYM"
-  cp -R "$HELPER_DSYM_SOURCE" "$ROOT_DIR/dist/localvoxtral-polishd.dSYM"
+if [[ ! -d "$HELPER_DSYM_SOURCE" ]]; then
+  echo "Polishing helper dSYM missing at $HELPER_DSYM_SOURCE — the Release"
+  echo "config should always emit one (DWARF with dSYM)."
+  exit 1
 fi
+rm -rf "$ROOT_DIR/dist/localvoxtral-polishd.dSYM"
+cp -R "$HELPER_DSYM_SOURCE" "$ROOT_DIR/dist/localvoxtral-polishd.dSYM"
 
 fi # LOCALVOXTRAL_SKIP_POLISHD
 # ---------------------------------------------------------------------------

--- a/scripts/package_app.sh
+++ b/scripts/package_app.sh
@@ -231,6 +231,15 @@ PLIST
 # kernels (mlx-swift README), producing a binary that fails at runtime with
 # "Failed to load the default metallib". Xcode's build system compiles the
 # kernels into the mlx-swift_Cmlx resource bundle, which we ship alongside.
+#
+# LOCALVOXTRAL_SKIP_POLISHD=1 skips this stage — for GitHub-hosted fork-PR
+# runners only, where the MetalToolchain download + cold Cmlx C++ build would
+# dominate CI time. A bundle built this way has no Managed local polishing.
+if [[ "${LOCALVOXTRAL_SKIP_POLISHD:-0}" == "1" ]]; then
+  echo "WARNING: skipping polishing helper (LOCALVOXTRAL_SKIP_POLISHD=1);"
+  echo "this bundle cannot run Managed local polishing."
+else
+
 # A real invocation, not `xcrun --find`: on Xcode 26+ the metal shim exists
 # even when the toolchain component is missing, and only fails when executed.
 # One-time host provision (owner runbook: scripts/mac/README.md):
@@ -294,6 +303,8 @@ if [[ -d "$HELPER_DSYM_SOURCE" ]]; then
   rm -rf "$ROOT_DIR/dist/localvoxtral-polishd.dSYM"
   cp -R "$HELPER_DSYM_SOURCE" "$ROOT_DIR/dist/localvoxtral-polishd.dSYM"
 fi
+
+fi # LOCALVOXTRAL_SKIP_POLISHD
 # ---------------------------------------------------------------------------
 
 # Remove filesystem metadata from copied assets (e.g. FinderInfo/resource fork)

--- a/scripts/remote-build.sh
+++ b/scripts/remote-build.sh
@@ -6,10 +6,14 @@ set -euo pipefail
 # tree (no commit needed) and runs the toolchain remotely over SSH.
 #
 # Usage:
-#   ./scripts/remote-build.sh [build|test|integration|eval-llm|package|exec|diag|applog|voxlog|svc-status] [extra args...]
+#   ./scripts/remote-build.sh [build|test|integration|integration-polishd|eval-llm|package|exec|diag|applog|voxlog|svc-status] [extra args...]
 #     build        swift build
 #     test         swift build + unit tests (default; skips live-backend suites)
 #     integration  realtime pipeline tests against the live voxmlx service
+#     integration-polishd
+#                  spawn the bundled polishing helper (built by `package`)
+#                  with the real model and score it against the polish eval
+#                  baseline + parent-pid tether
 #     eval-llm     default-polish-prompt eval against a live mlx-lm server;
 #                  optional arg = chat/completions endpoint (default
 #                  http://127.0.0.1:8080/v1/chat/completions, the
@@ -104,7 +108,8 @@ case "$CMD" in
     ;;
 esac
 
-UNIT_TEST_SKIPS=(--skip RealtimeAPIVLLMIntegrationTests --skip LLMPolishPromptEvalTests)
+UNIT_TEST_SKIPS=(--skip RealtimeAPIVLLMIntegrationTests --skip LLMPolishPromptEvalTests
+  --skip PolishHelperIntegrationTests)
 
 case "$CMD" in
   build)   REMOTE_CMD=(swift build "$@") ;;
@@ -113,6 +118,22 @@ case "$CMD" in
     REMOTE_CMD=(env VLLM_REALTIME_TEST_ENABLE=1
       VLLM_REALTIME_TEST_MODEL=T0mSIlver/Voxtral-Mini-4B-Realtime-2602-MLX-4bit
       swift test --filter RealtimeAPIVLLMIntegrationTests "$@")
+    ;;
+  integration-polishd)
+    # Same marker-through-the-tree pattern as eval-llm (the gate pins env
+    # prefixes per-command). Requires a helper binary from a prior
+    # `./scripts/remote-build.sh package` run — the remote PolishHelper/.build
+    # tree survives rsync (excluded from --delete).
+    if [[ $# -ne 0 ]]; then
+      echo "integration-polishd does not accept extra arguments" >&2
+      exit 1
+    fi
+    POLISHD_MARKER="$ROOT_DIR/.polishd-integration-enable.json"
+    trap 'rm -f "$POLISHD_MARKER"' EXIT
+    printf '{"helperPath": "%s"}\n' \
+      "PolishHelper/.build/xcode/Build/Products/Release/localvoxtral-polishd" \
+      >"$POLISHD_MARKER"
+    REMOTE_CMD=(swift test --filter PolishHelperIntegrationTests)
     ;;
   eval-llm)
     # Enablement travels as a gitignored marker file inside the synced tree
@@ -139,7 +160,7 @@ case "$CMD" in
     REMOTE_CMD=("$@")
     ;;
   *)
-    echo "Usage: $0 [build|test|integration|eval-llm|package|exec|diag|applog|voxlog|svc-status] [extra args...]" >&2
+    echo "Usage: $0 [build|test|integration|integration-polishd|eval-llm|package|exec|diag|applog|voxlog|svc-status] [extra args...]" >&2
     exit 1
     ;;
 esac

--- a/scripts/ui-smoke.sh
+++ b/scripts/ui-smoke.sh
@@ -130,7 +130,7 @@ quit_app() {
 }
 
 managed_backend_pids() {
-  pgrep -f 'voxmlx-serve|mlx_lm\.server' 2>/dev/null | sort || true
+  pgrep -f 'voxmlx-serve|mlx_lm\.server|localvoxtral-polishd' 2>/dev/null | sort || true
 }
 
 start_backend_sampler() {


### PR DESCRIPTION
## What

**Replaces the managed mlx-lm Python wheel with a bundled MLX Swift polishing engine** (`localvoxtral-polishd`).

Why: upstream mlx-lm is effectively unmaintained (no release since 2026-04-22, 263 open PRs, the lead maintainer left Apple in February) and every fix we need lives in our fork wheel. Apple's maintenance attention moved to MLX Swift (`ml-explore/mlx-swift-lm`, active releases, Qwen3.5 support). This PR moves polishing onto it and deletes the Python/uv/wheel layer for that backend.

**New `PolishHelper/` package → `localvoxtral-polishd`**: MLXLLM inference + a minimal loopback OpenAI chat/completions server (`/health`, `/v1/chat/completions`) + kqueue parent-PID watchdog. Ships inside the .app (Contents/MacOS), supervised by the existing `BackendProcessSupervisor` on port 8472, same readiness contract as `mlx_lm.server` (`/health` answers only once the model is loaded). Deterministic generation (seeded sampling) so identical requests give identical output, like the old engine's within-state behavior.

**Deliberately a helper process, not in-process inference:** MLX Metal failures abort the host app uncatchably (ml-explore/mlx#3390 — C++ exception thrown inside a libdispatch completion queue), the same failure class as our PR #60 FileHandle crash. Out-of-process keeps a GPU OOM from killing dictation mid-sentence, and keeps the memory contract trivial: every existing stop trigger (polishing disabled, switch to External URL, overlay trigger removed, app quit) still frees all model memory by killing the process.

**Root app:** `ManagedBackendSpec` gains `installKind` (`uvWheel` | `bundledExecutable`). The polishing spec is now bundled — no uv/wheel install step, executable resolves next to the app binary, readiness timeout 1800s → 300s (weights are pre-downloaded by `prepareModel`; the helper never downloads, missing model is a hard actionable error). ensureReady single-flight, stop triggers, status flow, Settings/onboarding/diagnostics seams: unchanged. The `LLMPolishingServicing` HTTP seam is untouched, so the overlay-lifecycle suite runs as-is. Fork patches accounted for: transformers pin → gone (no Python); parent-PID watchdog → native kqueue; prompt caching → deferred follow-up (below).

**Build & packaging:**
- `PolishHelper/` is a separate SwiftPM package so the root `swift build`/`swift test` loop never compiles the MLX C++ core. Helper unit tests are Metal-free: `./scripts/remote-build.sh test --package-path PolishHelper`.
- The shippable helper MUST be built by xcodebuild (SwiftPM CLI cannot compile mlx-swift's Metal kernels); `package_app.sh` owns that lane and bundles `mlx-swift_Cmlx.bundle` (metallib) + tokenizer resources into Contents/Resources, plus a helper dSYM in dist/.
- One-time build-host provision: `xcodebuild -downloadComponent MetalToolchain` (~700 MB; **done on the build host 2026-07-07**, runbook added to `scripts/mac/README.md`). Gotcha: `xcrun --find metal` succeeds even without the component — only invoking `metal` proves it; the catalog fetch fails transiently, retry.
- Deps pinned via committed `PolishHelper/Package.resolved` (mlx-swift-lm 3.31.4 exact, mlx-swift 0.31.4, swift-transformers 1.3.3). All MIT/Apache-2.0, no copyleft.
- CI: helper unit tests + live-model integration on self-hosted lanes; fork PRs skip the helper (`LOCALVOXTRAL_SKIP_POLISHD=1`) to avoid the MetalToolchain download + cold MLX C++ build on hosted runners.
- New lane: `./scripts/remote-build.sh integration-polishd` — spawns the packaged helper with the real pinned model and holds it to the shared eval baseline (corpus factored into `LLMPolishEvalSupport`, used unchanged by `LLMPolishPromptEvalTests`).

## Proof

- [x] Unit suite green — `./scripts/remote-build.sh test`
  ```
  Executed 523 tests, with 2 tests skipped and 0 failures (0 unexpected) in 6.119 (6.149) seconds
  ```
- [x] Helper unit suite green — `./scripts/remote-build.sh test --package-path PolishHelper`
  ```
  Executed 24 tests, with 0 failures (0 unexpected) in 0.112 (0.114) seconds
  ```
- [x] Packaging with bundled helper — `./scripts/remote-build.sh package`
  ```
  Contents/MacOS:
    localvoxtral
    localvoxtral-polishd
  dist/localvoxtral.app: valid on disk
  dist/localvoxtral.app: satisfies its Designated Requirement
  ```
- [x] Helper integration + eval baseline — `./scripts/remote-build.sh integration-polishd`
  ```
  Test Case 'testHelperExitsWhenParentPIDDies' passed (2.172 seconds).
  Test Case 'testHelperMatchesPolishEvalBaselineThroughProductionRequestPath' passed (11.585 seconds).
  Executed 2 tests, with 0 failures (0 unexpected) in 13.757 (13.757) seconds

  == polishd (bundled MLX Swift helper) eval (model: mlx-community/Qwen3.5-0.8B-8bit) ==
  required: 7/7, known-hard passing: 3/7
  ```
  Same-day reference run against the mlx-lm eval service (`./scripts/remote-build.sh eval-llm`, port 8080):
  ```
  == LLM polish prompt eval (model: mlx-community/Qwen3.5-0.8B-8bit, endpoint: http://127.0.0.1:8080/v1/chat/completions) ==
  required: 7/7, known-hard passing: 3/7
  ```
  Identical scores (10/14); the known-hard mix differs slightly (helper passes en-exclamation-extra-space, mlx-lm passes fr-semicolon-missing-space) — the corpus documents these as state-dependent wobblers, which is why only required cases are asserted.
- [x] Bug fix regression (parent-PID tether): the first live run caught the watchdog being deinit'd immediately (`_ =` discard cancels the kqueue source). Failing before:
  ```
  error: testHelperExitsWhenParentPIDDies : Asynchronous wait failed: Exceeded timeout of 30 seconds,
  with unfulfilled expectations: "helper exited after parent death".  (81.826 seconds)
  ```
  Passing after the retain fix:
  ```
  Test Case 'testHelperExitsWhenParentPIDDies' passed (2.172 seconds).
  ```
- [x] Realtime integration untouched by this PR (voxmlx path unchanged); CI runs it as tier 1 on this branch.
- [x] UI change: Settings copy only ("Runs the bundled polishing engine on this Mac.", status row shows "Polishing engine"); no group-structure changes. Not yet hand-verified — try-pr.sh after CI builds the artifact.

## Deferred follow-ups

- Prompt-cache reuse in the helper (the fork's ~50% prefill win). `ChatSession` has first-class cache save/trim, but Qwen3.5 is hybrid linear-attention (CacheList) — verify trim/persistence before relying on it. Note the full 14-case eval runs in ~12s including model load, ~0.5s/request warm, so latency is already acceptable.
- Mechanical rename of the `mlxLM*` Swift symbols (kept, to keep this diff reviewable).
- Cleanup of the orphaned uv-installed mlx-lm tool on existing user Macs.
- Retire `.github/workflows/mlx-lm-test.yml` (mlx-lm server harness).
- `com.localvoxtral.mlxlm` eval service stays as the prompt-eval reference endpoint (runbook note added).
