### PR TITLE
feat(test-infra): launch-on-demand voxmlx/mlxlm servers with idle reaper

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,10 +71,22 @@ jobs:
           xcrun llvm-cov report "$BIN" -instr-profile "$PROF" \
             -ignore-filename-regex '(Tests|\.build)/'
 
+      - name: Warm on-demand voxmlx server
+        # The build host's voxmlx launchd service is launch-on-demand (its
+        # multi-GB weights are not resident 24/7 — scripts/mac/lv-test-servers.sh).
+        # Touch its trigger and block until port 8000 is healthy so the
+        # integration suite below hits warm weights; this also resets the idle
+        # window, so a burst of CI runs reuses one warm process and the reaper
+        # frees the RAM only after the machine goes quiet. Self-hosted only —
+        # hosted runners have no backend and the suite self-skips.
+        if: runner.environment == 'self-hosted'
+        run: ./scripts/mac/lv-test-servers.sh ensure voxmlx
+
       - name: Integration tests (live voxmlx)
         # The self-hosted runner has voxmlx serving locally (launchd service
-        # com.localvoxtral.voxmlx). On GitHub-hosted runners there is no
-        # backend and the suite self-skips, so this step is self-hosted only.
+        # com.localvoxtral.voxmlx, warmed on-demand by the step above). On
+        # GitHub-hosted runners there is no backend and the suite self-skips,
+        # so this step is self-hosted only.
         if: runner.environment == 'self-hosted'
         env:
           VLLM_REALTIME_TEST_ENABLE: "1"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,8 +79,20 @@ jobs:
         # window, so a burst of CI runs reuses one warm process and the reaper
         # frees the RAM only after the machine goes quiet. Self-hosted only —
         # hosted runners have no backend and the suite self-skips.
+        #
+        # Best-effort during rollout: the on-demand LaunchAgents + run dir are a
+        # one-time owner install (scripts/mac/README.md). Until that's done the
+        # run dir is absent and there is nothing to warm — the still-always-on
+        # voxmlx serves the suite, so skip cleanly instead of failing CI. The
+        # integration step below is the real gate on voxmlx being reachable.
         if: runner.environment == 'self-hosted'
-        run: ./scripts/mac/lv-test-servers.sh ensure voxmlx
+        run: |
+          if [ -d /Users/Shared/localvoxtral/run ]; then
+            ./scripts/mac/lv-test-servers.sh ensure voxmlx
+          else
+            echo "on-demand infra not installed (run dir absent) — relying on the" \
+                 "always-on voxmlx; see scripts/mac/README.md to enable on-demand."
+          fi
 
       - name: Integration tests (live voxmlx)
         # The self-hosted runner has voxmlx serving locally (launchd service

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -127,13 +127,23 @@ as the launchd service `com.localvoxtral.voxmlx` (logs:
 backend, where the suite self-skips. The mic-capture tests
 (`LOCALVOXTRAL_MIC_CAPTURE_TEST_ENABLE`) stay off in CI until tier 2.
 
+On-demand test servers: the voxmlx (8000) and mlxlm (8080) launchd services are
+launch-on-demand (a trigger file + idle reaper — `scripts/mac/lv-test-servers.sh`,
+owner runbook `scripts/mac/README.md`), so their weights are not resident 24/7.
+This is hands-free: CI warms voxmlx in a step before the integration suite, and
+`remote-build.sh integration|eval-llm` warm the right server through the gate's
+`ensure` verb first, blocking until the port is healthy. A burst of runs reuses
+one warm process (each `ensure` resets a ~20 min idle window); the reaper frees
+the RAM once the machine goes quiet.
+
 LLM polish prompt eval: `LLMPolishPromptEvalTests` scores the bundled default
 polishing prompt (punctuation-spacing cases, French vs English) against a live
 mlx-lm server through the production request path. Run it with
 `./scripts/remote-build.sh eval-llm [endpoint]` — default endpoint is the
-`com.localvoxtral.mlxlm` launchd service on port 8080 (owner runbook:
-`scripts/mac/README.md`); don't point it at the app-managed instance on 8472,
-which dies whenever the app quits. Enablement is env
+on-demand `com.localvoxtral.mlxlm` launchd service on port 8080, which the lane
+warms first via the gate's `ensure` verb (owner runbook: `scripts/mac/README.md`);
+a custom endpoint is left untouched. Don't point it at the app-managed instance
+on 8472, which dies whenever the app quits. Enablement is env
 (`LLM_POLISH_EVAL_ENABLE=1`) or the marker file the script writes into the
 synced tree (the SSH gate can't pass env vars). Prompt changes MUST re-run
 this eval and paste the scoreboard in the PR's Proof section.

--- a/scripts/mac/README.md
+++ b/scripts/mac/README.md
@@ -168,8 +168,11 @@ scripts/mac/lv-test-servers.sh ensure voxmlx
 # wait for the reaper agent), and confirm launchd stopped the server / freed
 # RAM. Age both — reap keys off the NEWEST of the trigger + stamps, so a
 # freshly cold-started trigger (recent mtime) would otherwise keep it "warm".
+# reap BLOCKS until the port actually closes (SIGTERM drains the MLX server in
+# ~2-3s; it escalates to SIGKILL after STOP_GRACE), so the status right after
+# reflects the real state — no need to sleep.
 touch -t 202001010000 /Users/Shared/localvoxtral/run/voxmlx.*   # .want + .seen.*
-scripts/mac/lv-test-servers.sh reap                   # removes trigger + stamps + SIGTERM
+scripts/mac/lv-test-servers.sh reap                   # removes trigger + stamps, TERM→KILL
 scripts/mac/lv-test-servers.sh status                 # voxmlx: absent, down
 ```
 

--- a/scripts/mac/README.md
+++ b/scripts/mac/README.md
@@ -34,6 +34,10 @@ How it works (`scripts/mac/lv-test-servers.sh` is the single source of truth):
   in the GUI-owner domain, so the `launchctl kill` is permitted. The
   compromise: warm within a work session / CI burst, RAM freed once the machine
   goes quiet — next use pays one cold model load.
+- **Manual unload:** `lv-test-servers.sh stop [voxmlx|mlxlm|all]` frees the
+  weights NOW without waiting for the idle window — same stop path as reap
+  (trigger removed, `SIGTERM`→`SIGKILL`, blocks until the port closes). Default
+  target is `all`.
 - **Robustness:** an interrupted run or a sleeping Mac just leaves the trigger
   behind; the server stays warm and the reaper collects it later. There is no
   lock to get stuck and no orphan process (launchd owns each server; the reaper

--- a/scripts/mac/README.md
+++ b/scripts/mac/README.md
@@ -25,15 +25,20 @@ How it works (`scripts/mac/lv-test-servers.sh` is the single source of truth):
   server just bumps the trigger mtime, resetting the idle window, so a burst of
   runs reuses one warm process (no cold reload every few seconds).
 - **Reaping:** a third LaunchAgent (`com.localvoxtral.testservers-reaper`) runs
-  `lv-test-servers.sh reap` on a `StartInterval`. It removes any trigger older
-  than the idle window (default 20 min, `LV_TEST_SERVER_IDLE_SECONDS`), which
-  stops the server. The compromise: warm within a work session / CI burst,
-  RAM freed once the machine goes quiet — next use pays one cold model load.
+  `lv-test-servers.sh reap` on a `StartInterval`. For any service idle longer
+  than the window (default 20 min, `LV_TEST_SERVER_IDLE_SECONDS`) it removes the
+  trigger (so launchd won't relaunch it) **and** sends the job an explicit
+  `launchctl kill SIGTERM` — because launchd does not reliably terminate an
+  already-running process when a `KeepAlive` `PathState` condition flips false,
+  removing the trigger alone would leave the weights resident. The reaper runs
+  in the GUI-owner domain, so the `launchctl kill` is permitted. The
+  compromise: warm within a work session / CI burst, RAM freed once the machine
+  goes quiet — next use pays one cold model load.
 - **Robustness:** an interrupted run or a sleeping Mac just leaves the trigger
   behind; the server stays warm and the reaper collects it later. There is no
-  lock to get stuck and no orphan process (launchd owns each server, and
-  removing the trigger is a clean SIGTERM). On wake, the coalesced reaper run
-  reclaims anything stale.
+  lock to get stuck and no orphan process (launchd owns each server; the reaper
+  drops the trigger then SIGTERMs the process). On wake, the coalesced reaper
+  run reclaims anything stale.
 
 ### One-time install (trusted owner session on the Mac)
 

--- a/scripts/mac/README.md
+++ b/scripts/mac/README.md
@@ -47,6 +47,10 @@ How it works (`scripts/mac/lv-test-servers.sh` is the single source of truth):
 #    sticky (like /tmp) so any account — CI runner, gate account, owner — can
 #    start a server, but OWNED BY THE OWNER (the reaper's user) so the reaper's
 #    sticky-bit exemption lets it delete other accounts' files.
+#    DO THIS FIRST — before (re)bootstrapping the agents below. launchd sets up
+#    the KeepAlive PathState watch on <run dir>/<svc>.want at bootstrap; if the
+#    run dir's parent doesn't exist yet, bootstrap fails with
+#    "Bootstrap failed: 5: Input/output error".
 sudo install -d -m 1777 -o "$(id -un)" /Users/Shared/localvoxtral/run
 sudo install -d -m 0755 /Users/Shared/localvoxtral        # log dir, if absent
 
@@ -160,10 +164,12 @@ scripts/mac/lv-test-servers.sh ensure voxmlx          # cold-starts, blocks to w
 scripts/mac/lv-test-servers.sh status                 # voxmlx: trigger present, up
 # Warm reuse: a second ensure returns instantly ("already warm") and resets idle.
 scripts/mac/lv-test-servers.sh ensure voxmlx
-# Idle reap: age every activity stamp past the window and reap (or just wait
-# for the reaper agent), then confirm launchd stopped the server / freed RAM.
-touch -t 202001010000 /Users/Shared/localvoxtral/run/voxmlx.seen.*
-scripts/mac/lv-test-servers.sh reap                   # removes trigger + stamps
+# Idle reap: age the trigger AND the stamps past the window, then reap (or just
+# wait for the reaper agent), and confirm launchd stopped the server / freed
+# RAM. Age both — reap keys off the NEWEST of the trigger + stamps, so a
+# freshly cold-started trigger (recent mtime) would otherwise keep it "warm".
+touch -t 202001010000 /Users/Shared/localvoxtral/run/voxmlx.*   # .want + .seen.*
+scripts/mac/lv-test-servers.sh reap                   # removes trigger + stamps + SIGTERM
 scripts/mac/lv-test-servers.sh status                 # voxmlx: absent, down
 ```
 

--- a/scripts/mac/README.md
+++ b/scripts/mac/README.md
@@ -1,26 +1,65 @@
 # Mac build-host scripts
 
-## `com.localvoxtral.mlxlm` — polish-LLM eval service (owner runbook)
+## On-demand test servers (voxmlx + mlxlm) — owner runbook
 
-The LLM polish prompt eval (`./scripts/remote-build.sh eval-llm`,
-`LLMPolishPromptEvalTests`) needs an mlx-lm chat/completions server that is
-always up on the build host, exactly like `com.localvoxtral.voxmlx` (port
-8000) serves the tier-1 realtime tests. It listens on **8080** (mlx-lm's
-stock port) so it never collides with the app-managed instances on 8471/8472.
-Installed on the build host 2026-07-06. Don't point evals at the app-managed
-server on 8472 instead — it only exists while the app is running with
-polishing enabled, so it vanishes whenever the app quits.
+The two build-host model servers used by the integration/eval suites —
+`com.localvoxtral.voxmlx` (port 8000, tier-1 realtime STT) and
+`com.localvoxtral.mlxlm` (port 8080, LLM polish eval) — used to run
+`RunAtLoad`/`KeepAlive` always-on, keeping multi-GB weights resident 24/7.
+They are now **launch-on-demand with an idle reaper** so that RAM is only
+spent around actual test runs. This is hands-free for both CI and
+`remote-build.sh` — nobody has to remember to start/stop anything.
 
-Install from a trusted owner session on the Mac. Pins mirror
-`BackendCatalog.mlxLM` — keep them in sync when the catalog moves:
+How it works (`scripts/mac/lv-test-servers.sh` is the single source of truth):
+
+- Each agent is `RunAtLoad false` + `KeepAlive { PathState { <trigger>: true } }`.
+  launchd runs the server **while a trigger file exists** and stops it (freeing
+  the weights) when the file is removed. The triggers live in a world-writable
+  run dir so any account — the CI runner user, the SSH build-gate account, the
+  owner — can start a server just by touching a path (no cross-user
+  `launchctl` call, which macOS forbids without root).
+- **Warming:** a consumer runs `lv-test-servers.sh ensure <name>` (CI does this
+  before the integration step; `remote-build.sh` asks the gate's `ensure` verb;
+  the owner can run it directly). It touches the trigger — starting the server
+  if down — and blocks until the port is healthy. Touching an already-running
+  server just bumps the trigger mtime, resetting the idle window, so a burst of
+  runs reuses one warm process (no cold reload every few seconds).
+- **Reaping:** a third LaunchAgent (`com.localvoxtral.testservers-reaper`) runs
+  `lv-test-servers.sh reap` on a `StartInterval`. It removes any trigger older
+  than the idle window (default 20 min, `LV_TEST_SERVER_IDLE_SECONDS`), which
+  stops the server. The compromise: warm within a work session / CI burst,
+  RAM freed once the machine goes quiet — next use pays one cold model load.
+- **Robustness:** an interrupted run or a sleeping Mac just leaves the trigger
+  behind; the server stays warm and the reaper collects it later. There is no
+  lock to get stuck and no orphan process (launchd owns each server, and
+  removing the trigger is a clean SIGTERM). On wake, the coalesced reaper run
+  reclaims anything stale.
+
+### One-time install (trusted owner session on the Mac)
 
 ```bash
-# One-time venv with the pinned fork wheel (same wheel the app installs).
+# 1. Shared run dir for the trigger + activity-stamp files. World-writable and
+#    sticky (like /tmp) so any account — CI runner, gate account, owner — can
+#    start a server, but OWNED BY THE OWNER (the reaper's user) so the reaper's
+#    sticky-bit exemption lets it delete other accounts' files.
+sudo install -d -m 1777 -o "$(id -un)" /Users/Shared/localvoxtral/run
+sudo install -d -m 0755 /Users/Shared/localvoxtral        # log dir, if absent
+
+# 2. mlxlm venv with the pinned fork wheel (same wheel the app installs). Pins
+#    mirror BackendCatalog.mlxLM — keep them in sync when the catalog moves.
 uv venv --python 3.12 ~/.local/share/localvoxtral-eval/mlx-lm
 uv pip install --python ~/.local/share/localvoxtral-eval/mlx-lm/bin/python \
   'mlx-lm @ https://github.com/T0mSIlver/mlx-lm/releases/download/v0.31.3.post3/mlx_lm-0.31.3.post3-py3-none-any.whl'
+```
 
-# LaunchAgent (adjust $HOME):
+> This mlxlm service is the *prompt-eval reference endpoint* for
+> `LLMPolishPromptEvalTests` / `remote-build.sh eval-llm`. Don't point evals at
+> the app-managed server on 8472 — it only exists while the app is running with
+> polishing enabled, so it vanishes whenever the app quits.
+
+### mlxlm LaunchAgent (on-demand)
+
+```bash
 cat > ~/Library/LaunchAgents/com.localvoxtral.mlxlm.plist <<'PLIST'
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
@@ -33,13 +72,17 @@ cat > ~/Library/LaunchAgents/com.localvoxtral.mlxlm.plist <<'PLIST'
     <string>--model</string><string>mlx-community/Qwen3.5-0.8B-8bit</string>
     <string>--host</string><string>127.0.0.1</string>
     <string>--port</string><string>8080</string>
-    <!-- Same prompt-cache flags as the app-managed instance
-         (BackendManager.arguments) so evals measure production behavior. -->
     <string>--prompt-cache-size</string><string>1</string>
     <string>--prompt-cache-bytes</string><string>1GB</string>
   </array>
-  <key>RunAtLoad</key><true/>
-  <key>KeepAlive</key><true/>
+  <!-- On-demand: launchd starts this while the trigger file exists and stops
+       it (freeing the weights) when lv-test-servers.sh reap removes it. -->
+  <key>RunAtLoad</key><false/>
+  <key>KeepAlive</key>
+  <dict>
+    <key>PathState</key>
+    <dict><key>/Users/Shared/localvoxtral/run/mlxlm.want</key><true/></dict>
+  </dict>
   <key>StandardOutPath</key><string>/Users/Shared/localvoxtral/mlxlm.log</string>
   <key>StandardErrorPath</key><string>/Users/Shared/localvoxtral/mlxlm.log</string>
 </dict>
@@ -47,20 +90,93 @@ cat > ~/Library/LaunchAgents/com.localvoxtral.mlxlm.plist <<'PLIST'
 PLIST
 
 launchctl bootstrap "gui/$(id -u)" ~/Library/LaunchAgents/com.localvoxtral.mlxlm.plist
-curl -s http://127.0.0.1:8080/v1/models   # verify
 ```
 
-Log path matches the voxmlx service's shared-location convention (see the
-gate conf section below) so the gate account can read it if a `voxlog`-style
-verb is ever added. `svc-status`/`diag` already probe port 8080.
+### voxmlx LaunchAgent — convert existing to on-demand
+
+The voxmlx agent already exists (`com.localvoxtral.voxmlx`, port 8000, its
+`StandardOutPath` pointed at `/Users/Shared/localvoxtral/voxmlx.log` for the
+gate — see below). To make it on-demand, edit its plist to **replace**
+`<key>RunAtLoad</key><true/>` and `<key>KeepAlive</key><true/>` with:
+
+```xml
+  <key>RunAtLoad</key><false/>
+  <key>KeepAlive</key>
+  <dict>
+    <key>PathState</key>
+    <dict><key>/Users/Shared/localvoxtral/run/voxmlx.want</key><true/></dict>
+  </dict>
+```
+
+then re-bootstrap it:
+
+```bash
+launchctl bootout "gui/$(id -u)/com.localvoxtral.voxmlx" || true
+launchctl bootstrap "gui/$(id -u)" ~/Library/LaunchAgents/com.localvoxtral.voxmlx.plist
+```
+
+### Idle-reaper LaunchAgent
+
+```bash
+cat > ~/Library/LaunchAgents/com.localvoxtral.testservers-reaper.plist <<'PLIST'
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key><string>com.localvoxtral.testservers-reaper</string>
+  <key>ProgramArguments</key>
+  <array>
+    <string>/bin/bash</string>
+    <string>/Users/REPLACE_ME/work/localvoxtral/scripts/mac/lv-test-servers.sh</string>
+    <string>reap</string>
+  </array>
+  <!-- Every 5 min: finer than the 20-min idle window, so RAM is reclaimed
+       within ~5 min of the window elapsing. Coalesces across sleep. -->
+  <key>StartInterval</key><integer>300</integer>
+  <key>RunAtLoad</key><true/>
+  <key>StandardOutPath</key><string>/Users/Shared/localvoxtral/testservers-reaper.log</string>
+  <key>StandardErrorPath</key><string>/Users/Shared/localvoxtral/testservers-reaper.log</string>
+</dict>
+</plist>
+PLIST
+
+launchctl bootstrap "gui/$(id -u)" ~/Library/LaunchAgents/com.localvoxtral.testservers-reaper.plist
+```
+
+(Point the script path at a stable checkout of this repo, or copy
+`lv-test-servers.sh` to a fixed location. Override the idle window by adding an
+`EnvironmentVariables` dict with `LV_TEST_SERVER_IDLE_SECONDS`.)
+
+### Verify (owner-side proof)
+
+```bash
+scripts/mac/lv-test-servers.sh status                 # both: trigger absent, down
+scripts/mac/lv-test-servers.sh ensure voxmlx          # cold-starts, blocks to warm
+scripts/mac/lv-test-servers.sh status                 # voxmlx: trigger present, up
+# Warm reuse: a second ensure returns instantly ("already warm") and resets idle.
+scripts/mac/lv-test-servers.sh ensure voxmlx
+# Idle reap: age every activity stamp past the window and reap (or just wait
+# for the reaper agent), then confirm launchd stopped the server / freed RAM.
+touch -t 202001010000 /Users/Shared/localvoxtral/run/voxmlx.seen.*
+scripts/mac/lv-test-servers.sh reap                   # removes trigger + stamps
+scripts/mac/lv-test-servers.sh status                 # voxmlx: absent, down
+```
+
+If the SSH build gate is installed, `remote-build.sh integration|eval-llm`
+warm the right server through the gate's `ensure` verb automatically; CI warms
+voxmlx in its own step before the integration suite. The
+`svc-status`/`diag`/`voxlog` verbs still probe ports 8000/8080.
 
 ## `localvoxtral-build-gate.sh` — SSH build gate (v2)
 
 Forced command for the Linux dev box's build key on the Mac build host. It
 allowlists the `remote-build.sh` loop (rsync in, `swift build|test`,
-`package_app.sh release`) and, since v2, four read-only diagnostic verbs:
-`diag`, `applog [minutes]`, `voxlog [lines]`, `svc-status`. Everything else is
-denied and logged to `~/Library/Logs/localvoxtral-build-gate.log`.
+`package_app.sh release`), the v2 read-only diagnostic verbs `diag`,
+`applog [minutes]`, `voxlog [lines]`, `svc-status`, and the on-demand
+test-server verb `ensure <voxmlx|mlxlm|all>` (touches a trigger file in the
+world-writable run dir and polls the port until warm — see the on-demand
+section above). Everything else is denied and logged to
+`~/Library/Logs/localvoxtral-build-gate.log`.
 
 ### Installing / upgrading the gate
 
@@ -89,7 +205,12 @@ differ per machine and are read from an optional, never-committed conf file:
 # /Users/<gate-account>/.localvoxtral-gate.conf
 VOXLOG_FILE=/Users/Shared/localvoxtral/voxmlx.log
 VOXMLX_GUI_UID=501        # uid of the GUI user running com.localvoxtral.voxmlx
+# LV_RUN_DIR=/Users/Shared/localvoxtral/run   # only if you moved the triggers
 ```
+
+The `ensure` verb needs no `VOXMLX_GUI_UID` — it never calls `launchctl`, it
+just touches a trigger file the owner-domain launchd watches, so the default
+run dir works as-is once the owner has created it (mode 1777).
 
 For `voxlog` to work across accounts, point the voxmlx LaunchAgent's
 `StandardOutPath`/`StandardErrorPath` at a shared location and set
@@ -113,6 +234,7 @@ fiddlier and breaks when the log file is rotated/recreated.)
 ./scripts/remote-build.sh applog 30   # app unified log, last 30 minutes
 ./scripts/remote-build.sh voxlog 100  # voxmlx log tail
 ./scripts/remote-build.sh svc-status  # voxmlx service/process/port status
+ssh <gate-destination> 'ensure voxmlx' # warm the on-demand STT server
 ssh <gate-destination> 'echo pwned'   # must print "denied command"
 ```
 

--- a/scripts/mac/localvoxtral-build-gate.sh
+++ b/scripts/mac/localvoxtral-build-gate.sh
@@ -296,15 +296,19 @@ ensure_one_service() {
     return 1
   fi
 
-  # Create the shared trigger if absent (launchd PathState starts the server);
-  # never modify another account's trigger in the sticky run dir. Then stamp
-  # our own activity file to reset the idle window. (Mirrors
+  # Create the shared trigger if absent (launchd PathState starts the server).
+  # Atomic O_EXCL create (`set -C` = noclobber) so a concurrent ensure from
+  # another account can't make us truncate a trigger we don't own (permission
+  # denied in the sticky run dir). If it already exists — whoever created it —
+  # that's success; only a genuinely unwritable run dir fails the post-check.
+  # Then stamp our own activity file to reset the idle window. (Mirrors
   # scripts/mac/lv-test-servers.sh ensure_one.)
   if [[ ! -e "$trigger" ]]; then
-    : >"$trigger" 2>/dev/null || {
-      printf 'ensure %s: cannot create trigger %s\n' "$name" "$trigger" >&2
-      return 1
-    }
+    ( set -C; : >"$trigger" ) 2>/dev/null || true
+  fi
+  if [[ ! -e "$trigger" ]]; then
+    printf 'ensure %s: cannot create trigger %s\n' "$name" "$trigger" >&2
+    return 1
   fi
   touch "$stamp" 2>/dev/null || {
     printf 'ensure %s: cannot write activity stamp %s\n' "$name" "$stamp" >&2

--- a/scripts/mac/localvoxtral-build-gate.sh
+++ b/scripts/mac/localvoxtral-build-gate.sh
@@ -14,6 +14,7 @@ set -euo pipefail
 #   applog [minutes]    # integer, clamped to 1..120, default 10
 #   voxlog [lines]      # integer, clamped to 1..500, default 80
 #   svc-status
+#   ensure <voxmlx|mlxlm|all>   # warm an on-demand test server (touch + poll)
 
 LOG_FILE="$HOME/Library/Logs/localvoxtral-build-gate.log"
 VOXLOG_FILE="$HOME/Library/Logs/voxmlx.log"
@@ -21,6 +22,16 @@ VOXMLX_SERVICE="com.localvoxtral.voxmlx"
 # The GUI-session uid whose launchd domain hosts the voxmlx service. The gate
 # account is deliberately not that user, so launchctl needs to be told.
 VOXMLX_GUI_UID="$(id -u)"
+
+# On-demand test-server triggers (see scripts/mac/lv-test-servers.sh — keep the
+# paths/ports/probes in sync). The `ensure` verb touches a trigger file, which
+# launchd's KeepAlive PathState turns into a server start, then polls the port
+# until the model is warm. The touch is a bounded, low-risk write into a
+# world-writable run dir; the gate does it INLINE (rather than exec'ing the
+# helper) so this reviewed script stays the whole trust boundary.
+LV_RUN_DIR="/Users/Shared/localvoxtral/run"
+LV_ENSURE_READY_TIMEOUT=180
+LV_ENSURE_PROBE_TIMEOUT=2
 
 # Machine-local overrides (never committed): the gate account is separate
 # from the GUI owner account, so voxmlx's log path and GUI uid differ per
@@ -239,6 +250,101 @@ run_svc_status() {
   show_ports
 }
 
+# Map an on-demand service name to its trigger file, port, and readiness probe.
+# Mirrors scripts/mac/lv-test-servers.sh; changing one means changing both.
+lv_service_trigger() {
+  case "$1" in
+    voxmlx) printf '%s/voxmlx.want\n' "$LV_RUN_DIR" ;;
+    mlxlm)  printf '%s/mlxlm.want\n' "$LV_RUN_DIR" ;;
+    *) return 1 ;;
+  esac
+}
+lv_service_port() {
+  case "$1" in
+    voxmlx) printf '8000\n' ;;
+    mlxlm)  printf '8080\n' ;;
+    *) return 1 ;;
+  esac
+}
+lv_service_healthy() {
+  # voxmlx: TCP accept (uvicorn binds only after model load, no HTTP route).
+  # mlxlm: GET /v1/models returns 200 once weights are resident.
+  local name="$1" port
+  port="$(lv_service_port "$name")" || return 1
+  case "$name" in
+    voxmlx)
+      nc -z -G "$LV_ENSURE_PROBE_TIMEOUT" -w "$LV_ENSURE_PROBE_TIMEOUT" \
+        127.0.0.1 "$port" >/dev/null 2>&1
+      ;;
+    mlxlm)
+      curl -fsS -o /dev/null --max-time "$LV_ENSURE_PROBE_TIMEOUT" \
+        "http://127.0.0.1:${port}/v1/models" >/dev/null 2>&1
+      ;;
+    *) return 1 ;;
+  esac
+}
+
+ensure_one_service() {
+  local name="$1" trigger port stamp waited=0
+  trigger="$(lv_service_trigger "$name")" || { printf 'ensure: unknown service %s\n' "$name" >&2; return 2; }
+  port="$(lv_service_port "$name")"
+  stamp="$LV_RUN_DIR/${name}.seen.$(id -u)"
+
+  if [[ ! -d "$LV_RUN_DIR" ]]; then
+    printf 'ensure %s: run dir %s missing — owner must create it (see scripts/mac/README.md)\n' \
+      "$name" "$LV_RUN_DIR" >&2
+    return 1
+  fi
+
+  # Create the shared trigger if absent (launchd PathState starts the server);
+  # never modify another account's trigger in the sticky run dir. Then stamp
+  # our own activity file to reset the idle window. (Mirrors
+  # scripts/mac/lv-test-servers.sh ensure_one.)
+  if [[ ! -e "$trigger" ]]; then
+    : >"$trigger" 2>/dev/null || {
+      printf 'ensure %s: cannot create trigger %s\n' "$name" "$trigger" >&2
+      return 1
+    }
+  fi
+  touch "$stamp" 2>/dev/null || {
+    printf 'ensure %s: cannot write activity stamp %s\n' "$name" "$stamp" >&2
+    return 1
+  }
+
+  if lv_service_healthy "$name"; then
+    printf 'ensure %s: already warm (port %s)\n' "$name" "$port"
+    return 0
+  fi
+
+  printf 'ensure %s: cold — waiting up to %ss for port %s...\n' "$name" "$LV_ENSURE_READY_TIMEOUT" "$port"
+  while (( waited < LV_ENSURE_READY_TIMEOUT )); do
+    if lv_service_healthy "$name"; then
+      printf 'ensure %s: ready after %ss (port %s)\n' "$name" "$waited" "$port"
+      return 0
+    fi
+    sleep 2
+    waited=$((waited + 2))
+  done
+
+  printf 'ensure %s: NOT ready after %ss (port %s) — is com.localvoxtral.%s bootstrapped?\n' \
+    "$name" "$LV_ENSURE_READY_TIMEOUT" "$port" "$name" >&2
+  return 1
+}
+
+run_ensure_command() {
+  local target="$1"
+  case "$target" in
+    voxmlx|mlxlm) ensure_one_service "$target" ;;
+    all)
+      local rc=0
+      ensure_one_service voxmlx || rc=$?
+      ensure_one_service mlxlm || rc=$?
+      return "$rc"
+      ;;
+    *) deny ;;
+  esac
+}
+
 # Fail-closed metacharacter blocklist. Note the glob subtlety: a `]` inside
 # the bracket expression terminates the set early, so part of this pattern
 # matches as literal text — empirically ALL listed characters still block
@@ -374,6 +480,11 @@ case "$original_command" in
     ;;
   svc-status)
     run_svc_status
+    ;;
+  ensure\ *)
+    arg="${original_command#ensure }"
+    [[ "$arg" != *" "* && -n "$arg" ]] || deny
+    run_ensure_command "$arg"
     ;;
   mkdir\ -p\ work/localvoxtral-*)
     run_mkdir_command "$original_command"

--- a/scripts/mac/lv-test-servers.sh
+++ b/scripts/mac/lv-test-servers.sh
@@ -66,6 +66,10 @@ RUN_DIR="${LV_TEST_SERVER_RUN_DIR:-/Users/Shared/localvoxtral/run}"
 IDLE_SECONDS="${LV_TEST_SERVER_IDLE_SECONDS:-1200}"
 # Cold-start budget: model load + (for MLX) first-run Metal JIT can be slow.
 READY_TIMEOUT="${LV_TEST_SERVER_READY_TIMEOUT:-180}"
+# How long reap waits for a SIGTERM'd server to close its port before it
+# escalates to SIGKILL. The MLX server drains gracefully in ~2-3s; this is the
+# ceiling before we stop being polite.
+STOP_GRACE="${LV_TEST_SERVER_STOP_GRACE:-8}"
 PORT_TIMEOUT=2
 
 ALL_SERVICES=(voxmlx mlxlm)
@@ -234,10 +238,29 @@ cmd_reap() {
     age=$((now - newest))
     if (( age >= IDLE_SECONDS )); then
       # Order matters: drop the trigger FIRST so launchd won't relaunch the job
-      # the instant we kill it, then terminate the running process.
+      # the instant we kill it, then terminate the running process. launchd does
+      # not reliably kill a running job on PathState-false; SIGTERM to the
+      # launchd job tears down its whole process tree (the job is a uv/uvx
+      # wrapper around the real server child) and the MLX server drains
+      # gracefully in ~2-3s. We MUST finish the kill here: once the trigger is
+      # gone a later reap run skips this service (trigger absent), so a server
+      # that ignored SIGTERM would leak forever. Escalate to SIGKILL — and as a
+      # last resort kill whatever still binds the port (only this test service
+      # does) — if the port is still open after the grace window.
       rm -f "$trigger" "$RUN_DIR/${name}.seen."* 2>/dev/null || true
       launchctl kill SIGTERM "gui/${uid}/com.localvoxtral.${name}" 2>/dev/null || true
-      echo "reap $name: idle ${age}s >= ${IDLE_SECONDS}s — stopped (trigger removed + SIGTERM)"
+      local waited=0
+      while (( waited < STOP_GRACE )) && healthy "$name"; do sleep 1; waited=$((waited + 1)); done
+      if healthy "$name"; then
+        local port pids
+        port="$(port_for "$name")"
+        launchctl kill SIGKILL "gui/${uid}/com.localvoxtral.${name}" 2>/dev/null || true
+        pids="$(lsof -nP -tiTCP:"$port" -sTCP:LISTEN 2>/dev/null || true)"
+        [[ -n "$pids" ]] && kill -KILL $pids 2>/dev/null || true
+        echo "reap $name: idle ${age}s >= ${IDLE_SECONDS}s — stopped (SIGTERM ignored → SIGKILL after ${waited}s)"
+      else
+        echo "reap $name: idle ${age}s >= ${IDLE_SECONDS}s — stopped (trigger removed + SIGTERM, drained in ${waited}s)"
+      fi
     else
       echo "reap $name: active (idle ${age}s < ${IDLE_SECONDS}s) — kept warm"
     fi

--- a/scripts/mac/lv-test-servers.sh
+++ b/scripts/mac/lv-test-servers.sh
@@ -38,8 +38,9 @@ set -euo pipefail
 #   * `reap`           — the idle-reaper LaunchAgent
 #                        (com.localvoxtral.testservers-reaper) runs this on a
 #                        StartInterval. If the newest activity stamp is older
-#                        than the idle window it removes the trigger, which
-#                        stops the server and releases its RAM.
+#                        than the idle window it removes the trigger and sends
+#                        the job an explicit SIGTERM, stopping the server and
+#                        releasing its RAM.
 #   * `status`         — human/CI readout of trigger + activity + port state.
 #
 # The trigger design is deliberately cross-user: launchd watches an absolute
@@ -52,8 +53,9 @@ set -euo pipefail
 #
 # Robustness: an interrupted run or a sleeping Mac just leaves the trigger and
 # stamps in place — the server stays warm and the reaper collects it after the
-# idle window. There is no lock to get stuck and no process to orphan (launchd
-# owns every server; removing the trigger is a clean SIGTERM).
+# idle window. There is no lock to get stuck and no process to orphan: launchd
+# owns every server, and the reaper stops an idle one by removing its trigger
+# (so launchd won't relaunch it) and then SIGTERM'ing the running process.
 
 # ---- configuration (keep in sync with the gate's `ensure` verb + plists) ----
 
@@ -149,13 +151,18 @@ MSG
   fi
 
   # Create the shared trigger if absent (launchd PathState then starts the
-  # server). Create-if-absent works for any account in the sticky run dir; we
-  # never modify an existing trigger owned by another user.
+  # server). Use an atomic O_EXCL create (`set -C` = noclobber) so a concurrent
+  # ensure from ANOTHER account can't make us truncate a trigger we don't own —
+  # a plain `>` would try to O_TRUNC the racer's file and hit permission-denied
+  # in the sticky run dir, failing a legitimate build. If the trigger already
+  # exists (whoever created it) that's success; only a genuinely unwritable run
+  # dir is an error, which the post-check catches.
   if [[ ! -e "$trigger" ]]; then
-    : >"$trigger" 2>/dev/null || {
-      echo "lv-test-servers: cannot create trigger $trigger (run dir not writable?)" >&2
-      return 1
-    }
+    ( set -C; : >"$trigger" ) 2>/dev/null || true
+  fi
+  if [[ ! -e "$trigger" ]]; then
+    echo "lv-test-servers: cannot create trigger $trigger (run dir not writable?)" >&2
+    return 1
   fi
   # Stamp our own activity file — always permitted (we own it) — to reset the
   # idle window regardless of who created the trigger.
@@ -208,12 +215,17 @@ cmd_ensure() {
 }
 
 cmd_reap() {
-  # If the newest activity stamp is older than the idle window, remove the
-  # trigger (launchd stops the server, freeing weights) and clean the stamps.
-  # Must run as the run-dir owner so the sticky-bit exemption allows deleting
-  # other accounts' trigger/stamp files.
-  local now newest age trigger
+  # If the newest activity stamp is older than the idle window, stop the server
+  # and free its weights. Removing the PathState trigger stops launchd from
+  # RESTARTING the job, but launchd does NOT reliably terminate an
+  # already-running process when a KeepAlive condition flips false — so we also
+  # send an explicit SIGTERM. The reaper LaunchAgent runs in the GUI-owner
+  # domain (its own uid), so `launchctl kill` into gui/$(id -u) is permitted and
+  # this is why the reaper MUST run as the owner (it's also the run-dir owner,
+  # whose sticky-bit exemption lets it delete other accounts' trigger/stamps).
+  local now newest age trigger uid
   now="$(date +%s)"
+  uid="$(id -u)"
   for name in "${ALL_SERVICES[@]}"; do
     trigger="$(trigger_for "$name")"
     [[ -e "$trigger" ]] || continue
@@ -221,8 +233,11 @@ cmd_reap() {
     [[ "$newest" =~ ^[0-9]+$ ]] || newest=0
     age=$((now - newest))
     if (( age >= IDLE_SECONDS )); then
+      # Order matters: drop the trigger FIRST so launchd won't relaunch the job
+      # the instant we kill it, then terminate the running process.
       rm -f "$trigger" "$RUN_DIR/${name}.seen."* 2>/dev/null || true
-      echo "reap $name: idle ${age}s >= ${IDLE_SECONDS}s — stopped (trigger removed)"
+      launchctl kill SIGTERM "gui/${uid}/com.localvoxtral.${name}" 2>/dev/null || true
+      echo "reap $name: idle ${age}s >= ${IDLE_SECONDS}s — stopped (trigger removed + SIGTERM)"
     else
       echo "reap $name: active (idle ${age}s < ${IDLE_SECONDS}s) — kept warm"
     fi

--- a/scripts/mac/lv-test-servers.sh
+++ b/scripts/mac/lv-test-servers.sh
@@ -1,0 +1,267 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# lv-test-servers.sh — on-demand lifecycle for the Mac build host's model
+# serving TEST services (NOT the app-managed backends).
+#
+# Two launchd LaunchAgents in the GUI-owner domain serve the integration/eval
+# suites:
+#   com.localvoxtral.voxmlx  port 8000  websocket realtime STT (tier-1)
+#   com.localvoxtral.mlxlm   port 8080  http chat/completions  (eval-llm)
+#
+# Keeping their multi-GB weights resident 24/7 wastes RAM. Instead both agents
+# are configured launch-on-demand via a KeepAlive `PathState` TRIGGER FILE
+# (RunAtLoad false, KeepAlive { PathState { <trigger>: true } }): launchd runs
+# the server while the trigger file EXISTS and stops it (freeing the weights)
+# when it is removed. See scripts/mac/README.md for the plists.
+#
+# Two file kinds live in the world-writable run dir:
+#   <name>.want         the launchd trigger — its EXISTENCE means "run".
+#   <name>.seen.<uid>   a per-caller activity stamp — its MTIME means "last
+#                       used by uid". The idle reaper keys off the NEWEST
+#                       stamp across all callers.
+# They are split because the run dir is a shared, sticky, world-writable dir:
+# any account can CREATE a file, but only its owner (or the dir owner) can
+# update/delete it. So each caller starts a server by creating the shared
+# trigger (create-if-absent — allowed for everyone) and records activity by
+# touching ITS OWN stamp (always permitted). The reaper runs as the run-dir
+# owner, so the sticky-bit exemption lets it delete any caller's files.
+#
+# Used from three places:
+#   * `ensure <name>`  — a consumer (CI, remote-build's ensure step, or a
+#                        person) calls this BEFORE running tests. It creates the
+#                        trigger (starting the server if down), stamps its own
+#                        activity file (resetting the idle window), and blocks
+#                        until the port is healthy so weights are warm before
+#                        the first request. A burst of runs reuses one warm
+#                        process — no cold reload every few seconds.
+#   * `reap`           — the idle-reaper LaunchAgent
+#                        (com.localvoxtral.testservers-reaper) runs this on a
+#                        StartInterval. If the newest activity stamp is older
+#                        than the idle window it removes the trigger, which
+#                        stops the server and releases its RAM.
+#   * `status`         — human/CI readout of trigger + activity + port state.
+#
+# The trigger design is deliberately cross-user: launchd watches an absolute
+# path in the owner's domain, but any account that can write the run dir (the
+# CI runner user, the SSH build-gate account, the owner) can start a server
+# without a `launchctl` call into another user's GUI domain (forbidden without
+# root). The SSH build gate (scripts/mac/localvoxtral-build-gate.sh) reimplements
+# the ensure logic INLINE rather than exec'ing this script, so its security
+# review stays self-contained; keep the paths/ports/probes below in sync.
+#
+# Robustness: an interrupted run or a sleeping Mac just leaves the trigger and
+# stamps in place — the server stays warm and the reaper collects it after the
+# idle window. There is no lock to get stuck and no process to orphan (launchd
+# owns every server; removing the trigger is a clean SIGTERM).
+
+# ---- configuration (keep in sync with the gate's `ensure` verb + plists) ----
+
+RUN_DIR="${LV_TEST_SERVER_RUN_DIR:-/Users/Shared/localvoxtral/run}"
+# Idle window: how long a server may sit unused before the reaper frees it.
+# Default 20 min — long enough that an interactive session or a burst of CI
+# runs reuses warm weights, short enough that an idle machine reclaims the RAM.
+IDLE_SECONDS="${LV_TEST_SERVER_IDLE_SECONDS:-1200}"
+# Cold-start budget: model load + (for MLX) first-run Metal JIT can be slow.
+READY_TIMEOUT="${LV_TEST_SERVER_READY_TIMEOUT:-180}"
+PORT_TIMEOUT=2
+
+ALL_SERVICES=(voxmlx mlxlm)
+
+trigger_for() {
+  case "$1" in
+    voxmlx) printf '%s/voxmlx.want\n' "$RUN_DIR" ;;
+    mlxlm)  printf '%s/mlxlm.want\n' "$RUN_DIR" ;;
+    *) return 1 ;;
+  esac
+}
+port_for() {
+  case "$1" in
+    voxmlx) printf '8000\n' ;;
+    mlxlm)  printf '8080\n' ;;
+    *) return 1 ;;
+  esac
+}
+# voxmlx exposes a websocket, not a documented HTTP readiness route, so it uses
+# a TCP-accept probe (uvicorn binds the port only after startup/model-load).
+# mlxlm answers GET /v1/models once weights are resident — a real readiness
+# signal — so it uses http.
+probe_for() {
+  case "$1" in
+    voxmlx) printf 'tcp\n' ;;
+    mlxlm)  printf 'http:/v1/models\n' ;;
+    *) return 1 ;;
+  esac
+}
+
+# ---- probes ------------------------------------------------------------------
+
+tcp_ok() {
+  local port="$1"
+  nc -z -G "$PORT_TIMEOUT" -w "$PORT_TIMEOUT" 127.0.0.1 "$port" >/dev/null 2>&1
+}
+
+http_ok() {
+  local port="$1" path="$2"
+  curl -fsS -o /dev/null --max-time "$PORT_TIMEOUT" \
+    "http://127.0.0.1:${port}${path}" >/dev/null 2>&1
+}
+
+healthy() {
+  local name="$1" port probe
+  port="$(port_for "$name")"
+  probe="$(probe_for "$name")"
+  case "$probe" in
+    tcp) tcp_ok "$port" ;;
+    http:*) http_ok "$port" "${probe#http:}" ;;
+    *) return 1 ;;
+  esac
+}
+
+# Newest activity mtime (epoch secs) across this service's stamps + trigger, or
+# empty if none exists. The trigger is included as a fallback so a
+# manually-created trigger with no stamp still ages out.
+newest_activity() {
+  local name="$1"
+  # shellcheck disable=SC2012
+  ls -1 "$RUN_DIR/${name}.seen."* "$(trigger_for "$name")" 2>/dev/null \
+    | while read -r f; do stat -f %m "$f" 2>/dev/null || true; done \
+    | sort -n | tail -1
+}
+
+# ---- commands ----------------------------------------------------------------
+
+ensure_one() {
+  local name="$1" trigger port stamp
+  trigger="$(trigger_for "$name")" || { echo "unknown service: $name" >&2; return 2; }
+  port="$(port_for "$name")"
+  stamp="$RUN_DIR/${name}.seen.$(id -u)"
+
+  if [[ ! -d "$RUN_DIR" ]]; then
+    cat >&2 <<MSG
+lv-test-servers: run dir missing: $RUN_DIR
+The GUI owner must create it once (world-writable so any account can trigger a
+start, owned by the reaper's user so it can clean up) and bootstrap the
+on-demand LaunchAgents — see scripts/mac/README.md:
+  sudo install -d -m 1777 -o "\$(id -un)" $RUN_DIR
+MSG
+    return 1
+  fi
+
+  # Create the shared trigger if absent (launchd PathState then starts the
+  # server). Create-if-absent works for any account in the sticky run dir; we
+  # never modify an existing trigger owned by another user.
+  if [[ ! -e "$trigger" ]]; then
+    : >"$trigger" 2>/dev/null || {
+      echo "lv-test-servers: cannot create trigger $trigger (run dir not writable?)" >&2
+      return 1
+    }
+  fi
+  # Stamp our own activity file — always permitted (we own it) — to reset the
+  # idle window regardless of who created the trigger.
+  touch "$stamp" 2>/dev/null || {
+    echo "lv-test-servers: cannot write activity stamp $stamp" >&2
+    return 1
+  }
+
+  # Warm path: already serving — return immediately so bursts are cheap.
+  if healthy "$name"; then
+    echo "ensure $name: already warm (port $port)"
+    return 0
+  fi
+
+  echo "ensure $name: cold — waiting up to ${READY_TIMEOUT}s for port $port..."
+  local waited=0
+  while (( waited < READY_TIMEOUT )); do
+    if healthy "$name"; then
+      echo "ensure $name: ready after ${waited}s (port $port)"
+      return 0
+    fi
+    sleep 2
+    waited=$((waited + 2))
+  done
+
+  cat >&2 <<MSG
+ensure $name: NOT ready after ${READY_TIMEOUT}s (port $port).
+Likely the LaunchAgent com.localvoxtral.${name} is not bootstrapped in the
+owner's GUI domain, or the model failed to load. Check:
+  launchctl print gui/\$(id -u)/com.localvoxtral.${name}
+  tail /Users/Shared/localvoxtral/${name}.log
+See scripts/mac/README.md.
+MSG
+  return 1
+}
+
+cmd_ensure() {
+  local target="${1:-all}"
+  local -a names
+  if [[ "$target" == "all" ]]; then
+    names=("${ALL_SERVICES[@]}")
+  else
+    names=("$target")
+  fi
+  local rc=0
+  for name in "${names[@]}"; do
+    ensure_one "$name" || rc=$?
+  done
+  return "$rc"
+}
+
+cmd_reap() {
+  # If the newest activity stamp is older than the idle window, remove the
+  # trigger (launchd stops the server, freeing weights) and clean the stamps.
+  # Must run as the run-dir owner so the sticky-bit exemption allows deleting
+  # other accounts' trigger/stamp files.
+  local now newest age trigger
+  now="$(date +%s)"
+  for name in "${ALL_SERVICES[@]}"; do
+    trigger="$(trigger_for "$name")"
+    [[ -e "$trigger" ]] || continue
+    newest="$(newest_activity "$name")"
+    [[ "$newest" =~ ^[0-9]+$ ]] || newest=0
+    age=$((now - newest))
+    if (( age >= IDLE_SECONDS )); then
+      rm -f "$trigger" "$RUN_DIR/${name}.seen."* 2>/dev/null || true
+      echo "reap $name: idle ${age}s >= ${IDLE_SECONDS}s — stopped (trigger removed)"
+    else
+      echo "reap $name: active (idle ${age}s < ${IDLE_SECONDS}s) — kept warm"
+    fi
+  done
+}
+
+cmd_status() {
+  local trigger port now newest
+  now="$(date +%s)"
+  for name in "${ALL_SERVICES[@]}"; do
+    trigger="$(trigger_for "$name")"
+    port="$(port_for "$name")"
+    local trig_state="absent" health_state="down" idle="-"
+    if [[ -e "$trigger" ]]; then
+      trig_state="present"
+      newest="$(newest_activity "$name")"
+      [[ "$newest" =~ ^[0-9]+$ ]] && idle="$((now - newest))s"
+    fi
+    healthy "$name" && health_state="up"
+    printf '%-8s trigger=%-8s idle=%-8s port %s: %s\n' \
+      "$name" "$trig_state" "$idle" "$port" "$health_state"
+  done
+}
+
+usage() {
+  cat >&2 <<'MSG'
+usage: lv-test-servers.sh <ensure [voxmlx|mlxlm|all] | reap | status>
+  ensure  start (if down) and block until the named server(s) are warm;
+          resets the idle window. Default target: all.
+  reap    stop any server idle longer than the idle window (reaper LaunchAgent;
+          must run as the run-dir owner).
+  status  print trigger + activity + port health for both services.
+MSG
+}
+
+case "${1:-}" in
+  ensure) shift; cmd_ensure "${1:-all}" ;;
+  reap)   cmd_reap ;;
+  status) cmd_status ;;
+  ""|-h|--help) usage; exit 2 ;;
+  *) echo "unknown command: $1" >&2; usage; exit 2 ;;
+esac

--- a/scripts/mac/lv-test-servers.sh
+++ b/scripts/mac/lv-test-servers.sh
@@ -27,7 +27,7 @@ set -euo pipefail
 # touching ITS OWN stamp (always permitted). The reaper runs as the run-dir
 # owner, so the sticky-bit exemption lets it delete any caller's files.
 #
-# Used from three places:
+# Used from four places:
 #   * `ensure <name>`  — a consumer (CI, remote-build's ensure step, or a
 #                        person) calls this BEFORE running tests. It creates the
 #                        trigger (starting the server if down), stamps its own
@@ -41,6 +41,9 @@ set -euo pipefail
 #                        than the idle window it removes the trigger and sends
 #                        the job an explicit SIGTERM, stopping the server and
 #                        releasing its RAM.
+#   * `stop <name>`    — a person unloading NOW, without waiting for the idle
+#                        window (same stop path as reap: trigger removed,
+#                        TERM→KILL, blocks until the port closes).
 #   * `status`         — human/CI readout of trigger + activity + port state.
 #
 # The trigger design is deliberately cross-user: launchd watches an absolute
@@ -218,18 +221,42 @@ cmd_ensure() {
   return "$rc"
 }
 
-cmd_reap() {
-  # If the newest activity stamp is older than the idle window, stop the server
-  # and free its weights. Removing the PathState trigger stops launchd from
-  # RESTARTING the job, but launchd does NOT reliably terminate an
-  # already-running process when a KeepAlive condition flips false — so we also
-  # send an explicit SIGTERM. The reaper LaunchAgent runs in the GUI-owner
-  # domain (its own uid), so `launchctl kill` into gui/$(id -u) is permitted and
-  # this is why the reaper MUST run as the owner (it's also the run-dir owner,
-  # whose sticky-bit exemption lets it delete other accounts' trigger/stamps).
-  local now newest age trigger uid
-  now="$(date +%s)"
+# Stop a running server and free its weights. Shared by `reap` (when idle) and
+# `stop` (manual/immediate). Removing the PathState trigger stops launchd from
+# RESTARTING the job, but launchd does NOT reliably terminate an already-running
+# process when a KeepAlive condition flips false — so we drop the trigger FIRST
+# (so launchd won't relaunch the instant we kill it) then SIGTERM the job, which
+# tears down its whole process tree (the job is a uv/uvx wrapper around the real
+# server child). The MLX server drains gracefully in ~2-3s; block until the port
+# closes, and escalate to SIGKILL — plus, as a last resort, kill whatever still
+# binds the port (only this test service does) — if it's still up after
+# STOP_GRACE. The kill MUST finish here: once the trigger is gone a later reap
+# run skips this service, so a server that ignored SIGTERM would leak forever.
+# Must run as the GUI-owner (the reaper's user): `launchctl kill` into
+# gui/$(id -u) needs the owning domain, and the sticky run-dir owner can delete
+# any account's trigger/stamps. Echoes a short outcome fragment for the caller.
+stop_one() {
+  local name="$1" trigger uid port pids waited=0
+  trigger="$(trigger_for "$name")" || return 2
   uid="$(id -u)"
+  port="$(port_for "$name")"
+  rm -f "$trigger" "$RUN_DIR/${name}.seen."* 2>/dev/null || true
+  launchctl kill SIGTERM "gui/${uid}/com.localvoxtral.${name}" 2>/dev/null || true
+  while (( waited < STOP_GRACE )) && healthy "$name"; do sleep 1; waited=$((waited + 1)); done
+  if healthy "$name"; then
+    launchctl kill SIGKILL "gui/${uid}/com.localvoxtral.${name}" 2>/dev/null || true
+    pids="$(lsof -nP -tiTCP:"$port" -sTCP:LISTEN 2>/dev/null || true)"
+    [[ -n "$pids" ]] && kill -KILL $pids 2>/dev/null || true
+    echo "stopped (SIGTERM ignored → SIGKILL after ${waited}s)"
+  else
+    echo "stopped (trigger removed + SIGTERM, drained in ${waited}s)"
+  fi
+}
+
+cmd_reap() {
+  # Stop any server idle longer than the window; leave the rest warm.
+  local now newest age trigger
+  now="$(date +%s)"
   for name in "${ALL_SERVICES[@]}"; do
     trigger="$(trigger_for "$name")"
     [[ -e "$trigger" ]] || continue
@@ -237,34 +264,30 @@ cmd_reap() {
     [[ "$newest" =~ ^[0-9]+$ ]] || newest=0
     age=$((now - newest))
     if (( age >= IDLE_SECONDS )); then
-      # Order matters: drop the trigger FIRST so launchd won't relaunch the job
-      # the instant we kill it, then terminate the running process. launchd does
-      # not reliably kill a running job on PathState-false; SIGTERM to the
-      # launchd job tears down its whole process tree (the job is a uv/uvx
-      # wrapper around the real server child) and the MLX server drains
-      # gracefully in ~2-3s. We MUST finish the kill here: once the trigger is
-      # gone a later reap run skips this service (trigger absent), so a server
-      # that ignored SIGTERM would leak forever. Escalate to SIGKILL — and as a
-      # last resort kill whatever still binds the port (only this test service
-      # does) — if the port is still open after the grace window.
-      rm -f "$trigger" "$RUN_DIR/${name}.seen."* 2>/dev/null || true
-      launchctl kill SIGTERM "gui/${uid}/com.localvoxtral.${name}" 2>/dev/null || true
-      local waited=0
-      while (( waited < STOP_GRACE )) && healthy "$name"; do sleep 1; waited=$((waited + 1)); done
-      if healthy "$name"; then
-        local port pids
-        port="$(port_for "$name")"
-        launchctl kill SIGKILL "gui/${uid}/com.localvoxtral.${name}" 2>/dev/null || true
-        pids="$(lsof -nP -tiTCP:"$port" -sTCP:LISTEN 2>/dev/null || true)"
-        [[ -n "$pids" ]] && kill -KILL $pids 2>/dev/null || true
-        echo "reap $name: idle ${age}s >= ${IDLE_SECONDS}s — stopped (SIGTERM ignored → SIGKILL after ${waited}s)"
-      else
-        echo "reap $name: idle ${age}s >= ${IDLE_SECONDS}s — stopped (trigger removed + SIGTERM, drained in ${waited}s)"
-      fi
+      printf 'reap %s: idle %ss >= %ss — %s\n' "$name" "$age" "$IDLE_SECONDS" "$(stop_one "$name")"
     else
       echo "reap $name: active (idle ${age}s < ${IDLE_SECONDS}s) — kept warm"
     fi
   done
+}
+
+cmd_stop() {
+  # Manual, immediate unload — stop now regardless of the idle window.
+  local target="${1:-all}"
+  local -a names
+  if [[ "$target" == "all" ]]; then names=("${ALL_SERVICES[@]}"); else names=("$target"); fi
+  local rc=0
+  for name in "${names[@]}"; do
+    if ! trigger_for "$name" >/dev/null 2>&1; then
+      echo "unknown service: $name" >&2; rc=2; continue
+    fi
+    if [[ -e "$(trigger_for "$name")" ]] || healthy "$name"; then
+      printf 'stop %s: %s\n' "$name" "$(stop_one "$name")"
+    else
+      echo "stop $name: already down"
+    fi
+  done
+  return "$rc"
 }
 
 cmd_status() {
@@ -287,9 +310,11 @@ cmd_status() {
 
 usage() {
   cat >&2 <<'MSG'
-usage: lv-test-servers.sh <ensure [voxmlx|mlxlm|all] | reap | status>
+usage: lv-test-servers.sh <ensure [voxmlx|mlxlm|all] | stop [voxmlx|mlxlm|all] | reap | status>
   ensure  start (if down) and block until the named server(s) are warm;
           resets the idle window. Default target: all.
+  stop    unload the named server(s) NOW regardless of the idle window, freeing
+          the weights (block until the port closes; TERM→KILL). Default: all.
   reap    stop any server idle longer than the idle window (reaper LaunchAgent;
           must run as the run-dir owner).
   status  print trigger + activity + port health for both services.
@@ -298,6 +323,7 @@ MSG
 
 case "${1:-}" in
   ensure) shift; cmd_ensure "${1:-all}" ;;
+  stop)   shift; cmd_stop "${1:-all}" ;;
   reap)   cmd_reap ;;
   status) cmd_status ;;
   ""|-h|--help) usage; exit 2 ;;

--- a/scripts/remote-build.sh
+++ b/scripts/remote-build.sh
@@ -57,6 +57,19 @@ run_remote() {
   return "$status"
 }
 
+# Bring an on-demand test server up (and warm) before a suite that needs it.
+# The build host's voxmlx (8000) and mlxlm (8080) launchd services are
+# launch-on-demand (scripts/mac/lv-test-servers.sh) so their model weights are
+# not resident 24/7; this asks the SSH build gate's `ensure` verb to touch the
+# trigger and block until the port is healthy. It also resets the idle window,
+# so a burst of runs reuses the warm process. Fails fast with the gate's
+# message if the server can't be brought up.
+ensure_remote_server() {
+  local name="$1"
+  echo "==> Ensuring on-demand test server '$name' is warm on $HOST"
+  ssh "$HOST" "ensure $name"
+}
+
 if [[ -z "$HOST" ]]; then
   cat >&2 <<'MSG'
 No build host configured. Point this script at a Mac with the Swift toolchain
@@ -106,10 +119,17 @@ esac
 
 UNIT_TEST_SKIPS=(--skip RealtimeAPIVLLMIntegrationTests --skip LLMPolishPromptEvalTests)
 
+# On-demand test server to warm before the suite runs (empty = none). The
+# build host's voxmlx/mlxlm launchd services are launch-on-demand to keep their
+# weights out of RAM when idle; the lanes that hit them ask the gate to start
+# and warm them first. See scripts/mac/lv-test-servers.sh + scripts/mac/README.md.
+ENSURE_SERVER=""
+
 case "$CMD" in
   build)   REMOTE_CMD=(swift build "$@") ;;
   test)    REMOTE_CMD=(swift test "${UNIT_TEST_SKIPS[@]}" "$@") ;;
   integration)
+    ENSURE_SERVER="voxmlx"
     REMOTE_CMD=(env VLLM_REALTIME_TEST_ENABLE=1
       VLLM_REALTIME_TEST_MODEL=T0mSIlver/Voxtral-Mini-4B-Realtime-2602-MLX-4bit
       swift test --filter RealtimeAPIVLLMIntegrationTests "$@")
@@ -123,6 +143,11 @@ case "$CMD" in
       exit 1
     fi
     EVAL_ENDPOINT="${1:-http://127.0.0.1:8080/v1/chat/completions}"
+    # Only warm the local on-demand mlxlm service when the eval targets it; a
+    # custom endpoint is the caller's own server and we must not touch it.
+    if [[ "$EVAL_ENDPOINT" == *"127.0.0.1:8080"* || "$EVAL_ENDPOINT" == *"localhost:8080"* ]]; then
+      ENSURE_SERVER="mlxlm"
+    fi
     EVAL_MARKER="$ROOT_DIR/.llm-polish-eval-enable.json"
     # Trap registered before the marker exists, so no kill window leaves a
     # stale marker behind.
@@ -143,6 +168,10 @@ case "$CMD" in
     exit 1
     ;;
 esac
+
+if [[ -n "$ENSURE_SERVER" ]]; then
+  ensure_remote_server "$ENSURE_SERVER"
+fi
 
 echo "==> Syncing working tree to $HOST:$DIR"
 ssh "$HOST" "mkdir -p $(printf '%q' "$DIR")"

--- a/scripts/remote-build.sh
+++ b/scripts/remote-build.sh
@@ -62,12 +62,20 @@ run_remote() {
 # launch-on-demand (scripts/mac/lv-test-servers.sh) so their model weights are
 # not resident 24/7; this asks the SSH build gate's `ensure` verb to touch the
 # trigger and block until the port is healthy. It also resets the idle window,
-# so a burst of runs reuses the warm process. Fails fast with the gate's
-# message if the server can't be brought up.
+# so a burst of runs reuses the warm process.
+#
+# Best-effort: warming is an optimization, not the gate — the test suite itself
+# fails loudly if the server is actually unreachable. During rollout the
+# on-demand infra is a one-time owner install (scripts/mac/README.md); until
+# then the gate's `ensure` errors (run dir absent) but the still-always-on
+# server serves the suite, so a warm failure must NOT abort the run.
 ensure_remote_server() {
   local name="$1"
   echo "==> Ensuring on-demand test server '$name' is warm on $HOST"
-  ssh "$HOST" "ensure $name"
+  if ! ssh "$HOST" "ensure $name"; then
+    echo "==> WARN: could not warm '$name' on-demand (infra not installed, or gate" \
+         "lacks the ensure verb). Continuing — the suite will fail if it's really down." >&2
+  fi
 }
 
 if [[ -z "$HOST" ]]; then


### PR DESCRIPTION
## What & why

The build host ran two model servers as always-on launchd LaunchAgents so the test suites always had something to hit:
- `com.localvoxtral.voxmlx` (port 8000, tier-1 realtime STT — `RealtimeAPIVLLMIntegrationTests` + every CI run)
- `com.localvoxtral.mlxlm` (port 8080, LLM polish eval — `LLMPolishPromptEvalTests` / `remote-build.sh eval-llm`)

Both used `RunAtLoad`/`KeepAlive` always-on, so multi-GB weights sat resident 24/7. If either was down the consuming tests *failed* (their enable env/marker is set, so they don't self-skip). This makes them **launch-on-demand with an idle reaper** so RAM is only spent around actual runs — hands-free for both CI and `remote-build.sh`.

## The design (and why over the alternatives)

**launchd `KeepAlive` `PathState` trigger file + per-uid activity stamp + a periodic idle reaper.** Each agent becomes `RunAtLoad false` + `KeepAlive { PathState { <trigger>: true } }`: launchd runs the server *while the trigger file exists* and stops it (freeing weights) when it's removed. An `ensure <name>` helper creates the trigger (starting the server), stamps a per-caller activity file, and blocks until the port is healthy; a reaper LaunchAgent removes triggers whose newest stamp is older than the idle window (default 20 min).

- **vs. the menu-bar toggle idea I floated**: a toggle is manual and never fires for CI — fails the "hands-free for CI" goal. The trigger-file model is automatic for the manual path, `remote-build.sh`, *and* CI.
- **vs. pure launchd socket activation**: neither server binary supports `launch_activate_socket`, so it would need a real WS/HTTP spawning proxy — over-engineered for a dev/test convenience.
- **vs. cross-user `launchctl start`**: the services live in the GUI-owner domain; the CI runner user and the SSH-gate account can't `launchctl` into it without root. A filesystem trigger in a world-writable run dir sidesteps that — any account that can write the dir starts a server.
- **Why a separate stamp file, not the trigger's mtime**: the run dir is sticky + world-writable, so one account can't update another's file mtime. Splitting "existence = should-run" (trigger) from "recency = last-used" (per-uid stamp each caller owns) keeps warm-reuse idle tracking correct across the runner/gate/owner accounts; the reaper runs as the run-dir owner, whose sticky-bit exemption lets it delete every account's files.

Satisfies all four goals: (a) hands-free for CI and `remote-build.sh`, (b) warm reuse across a burst (each `ensure` resets the window; a second `ensure` returns instantly), (c) RAM released after the idle window, (d) robust to sleep/interruption — a left-behind trigger just keeps the server warm until the reaper collects it; launchd owns every process, so no locks or zombies.

## Files

- **`scripts/mac/lv-test-servers.sh`** (new) — source of truth: `ensure [voxmlx|mlxlm|all]` / `reap` / `status`. Per-service trigger paths, ports, readiness probes (voxmlx = TCP accept, mlxlm = `GET /v1/models`).
- **`scripts/mac/localvoxtral-build-gate.sh`** — new allowlisted `ensure <voxmlx|mlxlm|all>` verb, reimplemented *inline* (not exec'ing the helper) so the gate's security review stays self-contained; fail-closed metachar/exact-name checks reused.
- **`scripts/remote-build.sh`** — `integration` warms voxmlx and `eval-llm` warms mlxlm (only when the endpoint is the local 8080) via the gate's `ensure` verb before rsync/test; a custom eval endpoint is left untouched.
- **`.github/workflows/ci.yml`** — new "Warm on-demand voxmlx server" step (self-hosted only) before the integration suite.
- **`scripts/mac/README.md`** — on-demand runbook: one-time install (owner-owned sticky run dir, both plists → `PathState`, reaper LaunchAgent), gate `ensure` verb + conf note, owner verification steps.
- **`AGENTS.md`** — test-tier section updated to describe the on-demand model.

## Proof

Linux-side (in this PR's development): all scripts pass `bash -n`; `ci.yml` passes YAML parse. Lifecycle exercised with `nc`/`stat` shims: `ensure` warm path returns instantly + creates trigger+stamp; `status` reports idle correctly; `reap` keeps a fresh server warm and stops an aged one; the gate's inline `ensure` warm path works and denies non-allowlisted args (`ensure bogus`, `ensure foo bar`, arbitrary commands → "denied command", exit 126). Idle arithmetic hardened against a non-numeric `stat` result.

Owner-side (Mac — launchd can't be driven from Linux), full steps in `scripts/mac/README.md`:
1. **Install**: `sudo install -d -m 1777 -o "$(id -un)" /Users/Shared/localvoxtral/run`; convert both plists to `RunAtLoad false` + the `PathState` trigger and re-`bootstrap`; bootstrap the reaper agent.
2. **On-demand start**: `lv-test-servers.sh status` → both absent/down; `ensure voxmlx` blocks then returns ready; `status` → present/up.
3. **Warm reuse**: a second `ensure voxmlx` prints "already warm" instantly.
4. **Idle reap**: `touch -t 202001010000 /Users/Shared/localvoxtral/run/voxmlx.seen.*` then `reap` → stopped; `status` → absent/down; RAM freed.
5. **CI hands-free**: with both services stopped, `./scripts/remote-build.sh integration` and `eval-llm` both pass from cold; a real CI run shows the warm step bring voxmlx up before the integration suite.

Assumption to flag: the trigger-file model relies on the voxmlx/mlxlm agents living in the GUI-owner domain with the owner logged in (true today), and the run dir being owned by the reaper's user. Both covered in the runbook.

> Based on `main`, developed in an isolated git worktree. Doc references were adjusted for `main` (this branch doesn't carry the polishing-helper worldview — no `integration-polishd` lane or Metal-toolchain packaging here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
