### PR TITLE
Fix #87: resolve app resources without patching generated sources; end-user launch smoke

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -144,13 +144,24 @@ jobs:
           path: dist/localvoxtral-dSYM.zip
           retention-days: 30
 
-      - name: Smoke test packaged app launch
+      - name: Smoke test packaged app launch (end-user simulation)
         run: |
-          python3 - <<'PY'
+          # Launch a COPY of the packaged app from outside the workspace with
+          # the workspace .build renamed away. A same-tree launch silently
+          # passes even when the binary's resource lookup depends on the
+          # builder's absolute .build path (SwiftPM's generated Bundle.module
+          # accessor falls back to it) — which crashes at launch on every
+          # OTHER machine. That masking shipped launch-broken artifacts (#87).
+          SMOKE_DIR="$(mktemp -d)"
+          ditto dist/localvoxtral.app "$SMOKE_DIR/localvoxtral.app"
+          mv .build .build.smoke-hidden
+          trap 'mv .build.smoke-hidden .build' EXIT
+          SMOKE_APP="$SMOKE_DIR/localvoxtral.app" python3 - <<'PY'
+          import os
           import subprocess
           import time
 
-          app_binary = "dist/localvoxtral.app/Contents/MacOS/localvoxtral"
+          app_binary = os.environ["SMOKE_APP"] + "/Contents/MacOS/localvoxtral"
           process = subprocess.Popen([app_binary])
           time.sleep(2)
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -165,9 +165,14 @@ this eval and paste the scoreboard in the PR's Proof section.
   (build, unit, live integration, packaging, smoke) and only then tags and
   publishes the GitHub release (.zip + .dmg). Never push release tags by
   hand; the pipeline owns them.
-- `scripts/package_app.sh` intentionally patches SwiftPM-generated sources in
-  `.build/` (resource-bundle lookup for packaged .apps); the patches are
-  idempotent.
+- Packaged-app resource lookup: NEVER patch SwiftPM-generated DerivedSources
+  (the toolchain regenerates them clean on every build, silently reverting the
+  patch — shipped launch-broken artifacts, #87). App resources resolve at
+  runtime via `Bundle.localvoxtralResources` (`AppResourceBundle.swift`);
+  dependency checkouts (ShortcutRecorder) are still source-patched by
+  `package_app.sh` because checkouts persist across builds. CI's launch smoke
+  runs the packaged app COPIED outside the workspace with `.build` hidden —
+  same-tree launches mask exactly this class of breakage.
 
 ## Architecture map
 

--- a/Sources/localvoxtral/AppConfigStore.swift
+++ b/Sources/localvoxtral/AppConfigStore.swift
@@ -352,7 +352,7 @@ struct AppConfigStore: AppConfigServing {
 
     init(
         fileManager: FileManager = .default,
-        bundle: Bundle = .module,
+        bundle: Bundle = .localvoxtralResources,
         configDirectoryOverride: URL? = nil
     ) {
         self.fileManager = fileManager

--- a/Sources/localvoxtral/AppResourceBundle.swift
+++ b/Sources/localvoxtral/AppResourceBundle.swift
@@ -1,0 +1,27 @@
+import Foundation
+
+extension Bundle {
+    /// The app's SwiftPM resource bundle, resolved so it works BOTH in a
+    /// packaged .app and in dev contexts (`swift build/run/test`).
+    ///
+    /// `Bundle.module` cannot be used directly in a packaged app: SwiftPM's
+    /// generated accessor only checks the .app ROOT and the builder's
+    /// absolute `.build` path, while `package_app.sh` installs the bundle at
+    /// `Contents/Resources`. On any machine without that `.build` path the
+    /// accessor `fatalError`s at first touch — a launch crash that
+    /// same-machine CI smoke used to mask (#87). Patching the generated
+    /// accessor is not an option either: the toolchain regenerates it clean
+    /// on every build, silently reverting the patch (that was #87's root
+    /// cause). So resolve `Contents/Resources` first, and only fall back to
+    /// `Bundle.module` where its build-path candidate is actually valid
+    /// (dev builds and tests, which run out of `.build`).
+    static let localvoxtralResources: Bundle = {
+        if let url = Bundle.main.resourceURL?
+            .appendingPathComponent("localvoxtral_localvoxtral.bundle"),
+            let bundle = Bundle(url: url)
+        {
+            return bundle
+        }
+        return .module
+    }()
+}

--- a/scripts/package_app.sh
+++ b/scripts/package_app.sh
@@ -18,21 +18,6 @@ patch_shortcutrecorder_bundle_lookup() {
   perl -0pi -e 's/return SWIFTPM_MODULE_BUNDLE;/\/\/ localvoxtral packaged resources fallback\n    \/\/ Try the app bundle first — this avoids a TCC Desktop-access prompt when\n    \/\/ the .app resides anywhere under ~\/Desktop.\n    NSURL *resourceBundleURL = [[[NSBundle mainBundle] resourceURL]\n        URLByAppendingPathComponent:@"ShortcutRecorder_ShortcutRecorder.bundle"];\n    NSBundle *bundle = [NSBundle bundleWithURL:resourceBundleURL];\n    if (bundle)\n        return bundle;\n\n    \/\/ Fall back to the SPM-generated lookup (development builds).\n    bundle = SWIFTPM_MODULE_BUNDLE;\n    if (bundle)\n        return bundle;\n\n    return nil;/g' "$sr_common"
 }
 
-patch_local_resource_bundle_lookup() {
-  local configuration="$1"
-  local accessor
-  accessor="$(find "$ROOT_DIR/.build" -path "*/${configuration}/localvoxtral.build/DerivedSources/resource_bundle_accessor.swift" -print -quit 2>/dev/null || true)"
-  if [[ -z "$accessor" || ! -f "$accessor" ]]; then
-    return 1
-  fi
-
-  if grep -q "localvoxtral packaged resources fallback" "$accessor"; then
-    return 1
-  fi
-
-  perl -0pi -e 's/let preferredBundle = Bundle\(path: mainPath\)/\/\/ localvoxtral packaged resources fallback\n        let resourcePath = Bundle.main.resourceURL?.appendingPathComponent("localvoxtral_localvoxtral.bundle").path\n        let preferredBundle = resourcePath.flatMap(Bundle.init(path:)) ?? Bundle(path: mainPath)/g' "$accessor"
-}
-
 CONFIGURATION="${1:-release}"
 # Default the version from git so About, crash reports, and diagnostics can
 # identify the exact build — every non-release build used to say "0.3.0".
@@ -127,10 +112,14 @@ patch_shortcutrecorder_bundle_lookup
 # -g keeps DWARF in the object files so dsymutil can produce a dSYM below —
 # without it, field crash reports only symbolicate as well as the stripped
 # binary allows. It does not change optimization (-O still applies in release).
+# The app's OWN resource bundle needs no patching: Bundle.localvoxtralResources
+# (AppResourceBundle.swift) resolves Contents/Resources first at runtime. The
+# old approach — patching the generated resource_bundle_accessor.swift and
+# rebuilding — was silently reverted by the rebuild itself (the toolchain
+# regenerates DerivedSources every build) and shipped launch-broken artifacts
+# for days (#87). Never patch DerivedSources; only dependency checkouts (the
+# ShortcutRecorder patch above) persist across builds.
 swift build -c "$CONFIGURATION" --product localvoxtral -Xswiftc -g
-if patch_local_resource_bundle_lookup "$CONFIGURATION"; then
-  swift build -c "$CONFIGURATION" --product localvoxtral -Xswiftc -g
-fi
 
 BINARY_PATH="$(find "$ROOT_DIR/.build" -type f -path "*/${CONFIGURATION}/localvoxtral" | head -n 1)"
 if [[ -z "$BINARY_PATH" ]]; then


### PR DESCRIPTION
Fixes #87 — packaged apps crash at launch on any machine without the builder's `.build` directory, because `package_app.sh`'s resource-bundle patch is silently reverted by its own rebuild (the toolchain regenerates DerivedSources).

## What

1. **End-user-simulation launch smoke** (first commit, expected to fail CI as the fail-before proof): the smoke now launches a *copy* of the packaged app from outside the workspace with `.build` renamed away — the exact condition every non-builder machine is in.
2. **App-side resource resolution** (second commit): `Bundle.localvoxtralResources` tries `Bundle.main.resourceURL/localvoxtral_localvoxtral.bundle` (where `package_app.sh` actually installs it) before falling back to `Bundle.module` for dev/`swift run`/tests. `AppConfigStore`'s default bundle switches to it, and the fragile patch-and-rebuild machinery in `package_app.sh` is deleted.

## Proof

- Fail-before: this PR's first CI run (smoke-only commit) fails at the new smoke; field crashes SIGTRAP in `NSBundle.module` on probe runs (issue #87 has the full evidence chain, incl. the PATCH-AUDIT run showing the patch reverted by the rebuild).
- Pass-after: second commit turns the same smoke green.
- **Fail-before (public CI)**: [run 28975614776](https://github.com/T0mSIlver/localvoxtral/actions/runs/28975614776) — the smoke-only commit fails with the exact accessor crash:
  ```
  localvoxtral/resource_bundle_accessor.swift:12: Fatal error: could not load resource bundle: from /var/folders/.../localvoxtral.app/localvoxtral_localvoxtral.bundle or /Users/tom/actions-runner/_work/localvoxtral/localvoxtral/.build/arm64-apple-macosx/release/localvoxtral_localvoxtral.bundle
  packaged app exited during smoke test: -5
  ```
- **Pass-after**: [run 28975809316](https://github.com/T0mSIlver/localvoxtral/actions/runs/28975809316) — same smoke, green, with the resolver.
- Unit suite: `Executed 522 tests, with 2 tests skipped and 0 failures (0 unexpected)` (remote-build).
- Independent review: Codex (GPT-5.5 high) on the full diff — no actionable defects.

## Not in scope

ShortcutRecorder is already handled correctly: `package_app.sh` patches its lookup in the dependency **checkout source**, which persists across builds (the correction is noted on #87). Only the DerivedSources patch was structurally broken.
