### PR TITLE
Secure-input session signals: error sound + menu bar warning icon

### DIFF
--- a/Sources/localvoxtral/DictationOverlayController.swift
+++ b/Sources/localvoxtral/DictationOverlayController.swift
@@ -83,7 +83,8 @@ final class DictationOverlayController {
         let initialView = DictationOverlayView(
             phase: .idle,
             text: "",
-            errorMessage: nil
+            errorMessage: nil,
+            secureInputActive: false
         )
         hostingView = TransparentHostingView(rootView: initialView)
         // Without this, NSHostingView probes the SwiftUI content at ∞×∞ and
@@ -127,7 +128,8 @@ final class DictationOverlayController {
         hostingView.rootView = DictationOverlayView(
             phase: snapshot.phase,
             text: snapshot.bufferText,
-            errorMessage: snapshot.errorMessage
+            errorMessage: snapshot.errorMessage,
+            secureInputActive: snapshot.secureInputActive
         )
 
         let contentHeight = Self.measureContentHeight(

--- a/Sources/localvoxtral/DictationOverlayView.swift
+++ b/Sources/localvoxtral/DictationOverlayView.swift
@@ -95,7 +95,12 @@ struct DictationOverlayView: View {
     private var phaseTitle: String {
         switch phase {
         case .buffering:
-            return secureInputActive ? "Listening (secure input)" : "Listening"
+            // Actionable, not just descriptive: the commit re-checks Secure
+            // Keyboard Entry at stop, so moving focus to a normal field
+            // before then gets a real insert instead of the clipboard.
+            return secureInputActive
+                ? "Secure input — select another field before finalizing"
+                : "Listening"
         case .finalizing:
             return secureInputActive ? "Finalizing (secure input)" : "Finalizing"
         case .commitFailed:

--- a/Sources/localvoxtral/DictationOverlayView.swift
+++ b/Sources/localvoxtral/DictationOverlayView.swift
@@ -80,20 +80,33 @@ struct DictationOverlayView: View {
     let phase: OverlayBufferPhase
     let text: String
     let errorMessage: String?
+    let secureInputActive: Bool
     private let cornerRadius: CGFloat = 12
     private let bodyFontSize: CGFloat = 13
+
+    /// Warning text needs explicit light/dark variants: system `.red` over
+    /// the translucent panel material washes out on light desktops.
+    static let warningColor = Color(nsColor: NSColor(name: nil) { appearance in
+        appearance.bestMatch(from: [.aqua, .darkAqua]) == .darkAqua
+            ? NSColor(srgbRed: 1.00, green: 0.48, blue: 0.44, alpha: 1.0)
+            : NSColor(srgbRed: 0.63, green: 0.07, blue: 0.05, alpha: 1.0)
+    })
 
     private var phaseTitle: String {
         switch phase {
         case .buffering:
-            return "Listening"
+            return secureInputActive ? "Listening (secure input)" : "Listening"
         case .finalizing:
-            return "Finalizing"
+            return secureInputActive ? "Finalizing (secure input)" : "Finalizing"
         case .commitFailed:
             return "Insert failed"
         case .idle:
             return "Ready"
         }
+    }
+
+    private var isSecureInputTitle: Bool {
+        secureInputActive && (phase == .buffering || phase == .finalizing)
     }
 
     private var displayText: String {
@@ -131,7 +144,7 @@ struct DictationOverlayView: View {
             HStack(alignment: .center, spacing: 6) {
                 Text(phaseTitle)
                     .font(.system(size: 11, weight: .semibold))
-                    .foregroundStyle(.secondary)
+                    .foregroundStyle(isSecureInputTitle ? Self.warningColor : Color.secondary)
                 if phase == .finalizing {
                     ProgressView()
                         .controlSize(.small)
@@ -179,7 +192,7 @@ struct DictationOverlayView: View {
             if let errorMessage, !errorMessage.trimmed.isEmpty {
                 Text(errorMessage)
                     .font(.system(size: 11))
-                    .foregroundStyle(.red)
+                    .foregroundStyle(Self.warningColor)
                     .fixedSize(horizontal: false, vertical: true)
                     .frame(maxWidth: .infinity, alignment: .leading)
             }
@@ -188,8 +201,10 @@ struct DictationOverlayView: View {
         .frame(minWidth: 400, idealWidth: 420, maxWidth: 540, alignment: .leading)
         .background(RoundedMaterialBackground(cornerRadius: cornerRadius))
         .overlay(
+            // Hairline must survive both appearances: pure white vanished
+            // against light desktops.
             RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
-                .strokeBorder(Color.white.opacity(0.25), lineWidth: 1)
+                .strokeBorder(Color.primary.opacity(0.25), lineWidth: 1)
         )
         .clipShape(RoundedRectangle(cornerRadius: cornerRadius, style: .continuous))
         .compositingGroup()

--- a/Sources/localvoxtral/DictationViewModel+Session.swift
+++ b/Sources/localvoxtral/DictationViewModel+Session.swift
@@ -791,9 +791,12 @@ extension DictationViewModel {
         setRealtimeIndicatorIdle()
         livePartialText = ""
         pendingSegmentText = ""
-        if case .failed = overlayCommitOutcome {
+        switch overlayCommitOutcome {
+        case .failed?:
             statusText = "Insert failed."
-        } else {
+        case .copiedToClipboard?:
+            statusText = StatusStrings.overlayCopiedToClipboard
+        default:
             statusText = "Ready"
         }
 
@@ -806,17 +809,26 @@ extension DictationViewModel {
             textInsertion.clearPendingText()
         }
 
-        let didOverlayCommitFail: Bool
-        if case .failed = overlayCommitOutcome {
-            didOverlayCommitFail = true
+        // Dismiss policy: a FAILED commit keeps its panel (the buffered text
+        // may exist nowhere else); the secure-input clipboard fallback shows
+        // its message for a readable hold and then dismisses — the text is
+        // safe on the clipboard, and a panel that outlives the session read
+        // as stuck in the field (owner feedback on #90).
+        let dismissVisibility: TimeInterval?
+        if !shouldCommitOverlay {
+            dismissVisibility = TimingConstants.overlayFinalWordVisibilityMinimum
         } else {
-            didOverlayCommitFail = false
+            switch overlayCommitOutcome {
+            case .failed?:
+                dismissVisibility = nil
+            case .copiedToClipboard?:
+                dismissVisibility = TimingConstants.overlayClipboardFallbackVisibility
+            default:
+                dismissVisibility = TimingConstants.overlayFinalWordVisibilityMinimum
+            }
         }
-
-        if !shouldCommitOverlay || !didOverlayCommitFail {
-            overlayBufferCoordinator.dismissAfterHold(
-                minimumVisibility: TimingConstants.overlayFinalWordVisibilityMinimum
-            )
+        if let dismissVisibility {
+            overlayBufferCoordinator.dismissAfterHold(minimumVisibility: dismissVisibility)
         }
 
         if currentErrorToken == .websocketReceiveFailed {
@@ -825,8 +837,8 @@ extension DictationViewModel {
         // The Secure Keyboard Entry warning describes state sampled at session
         // start; a finished session must not leave it wedged in the popover —
         // nor keep the menu bar warning icon lit. (A REFUSED live start never
-        // reaches this teardown, so its warning intentionally persists until
-        // the next session start clears it via the stale-warning path.)
+        // reaches this teardown; its icon clears when the shortcut release
+        // ends the attempt gesture, and the popover line at the next start.)
         if currentErrorToken == .secureKeyboardEntryActive {
             lastError = nil
         }

--- a/Sources/localvoxtral/DictationViewModel+Session.swift
+++ b/Sources/localvoxtral/DictationViewModel+Session.swift
@@ -198,6 +198,13 @@ extension DictationViewModel {
         cancelConnectTimeout()
         isFinalizingStop = false
         isConnectingRealtimeSession = false
+        // Every attempt starts with a fresh secure-input sample: a stale
+        // `true` from a previously refused start would keep the warning icon
+        // lit through an attempt that exits early for an unrelated reason
+        // (invalid endpoint, missing mic) and mask that failure (Codex
+        // review finding on #90). The refuse path / verdict apply below
+        // re-set it from the fresh sample.
+        sessionSecureInputActive = false
         let requestedOutputMode = outputMode ?? settings.dictationOutputMode
         clearLatchedSessionMetadata()
         sessionOutputMode = requestedOutputMode
@@ -267,8 +274,8 @@ extension DictationViewModel {
         // success), so a session would capture the mic and type into the
         // void. Refuse to start instead — the sound, menu bar icon, and
         // popover line (applied from the captured verdict) explain why, and
-        // they persist until the next session start because no session ran
-        // (#89 field feedback). Overlay Buffer proceeds: its pipeline still
+        // they persist until the next session attempt re-samples the state
+        // (no session ran, so the session-end clear never fires). Overlay Buffer proceeds: its pipeline still
         // produces text, and its commit re-checks secure input and falls
         // back to the clipboard.
         if isLiveAutoPasteModeEnabled,

--- a/Sources/localvoxtral/DictationViewModel+Session.swift
+++ b/Sources/localvoxtral/DictationViewModel+Session.swift
@@ -47,7 +47,7 @@ extension DictationViewModel {
     /// visible, and returns true when the start was refused. Overlay Buffer
     /// sessions are never refused: their pipeline still produces text and the
     /// commit falls back to the clipboard (#89 split behavior).
-    private func refuseLiveStartForSecureInputIfNeeded(
+    func refuseLiveStartForSecureInputIfNeeded(
         outputMode requestedOutputMode: DictationOutputMode
     ) -> Bool {
         guard requestedOutputMode == .liveAutoPaste,

--- a/Sources/localvoxtral/DictationViewModel+Session.swift
+++ b/Sources/localvoxtral/DictationViewModel+Session.swift
@@ -780,10 +780,12 @@ extension DictationViewModel {
             lastError = nil
         }
         // The Secure Keyboard Entry warning describes state sampled at session
-        // start; a finished session must not leave it wedged in the popover.
+        // start; a finished session must not leave it wedged in the popover —
+        // nor keep the menu bar warning icon lit.
         if currentErrorToken == .secureKeyboardEntryActive {
             lastError = nil
         }
+        sessionSecureInputActive = false
         firstChunkPreprocessor.reset()
     }
 

--- a/Sources/localvoxtral/DictationViewModel+Session.swift
+++ b/Sources/localvoxtral/DictationViewModel+Session.swift
@@ -136,6 +136,16 @@ extension DictationViewModel {
                   self.isConnectingRealtimeSession
             else { return }
             self.beginDictationSession(outputMode: outputMode)
+            // beginDictationSession re-checks secure input and may refuse
+            // HERE — long after the initiating gesture ended (a toggle tap
+            // ends immediately; a hold may release while the backend boots).
+            // With no gesture-end event left, the refusal signals would
+            // wedge (Codex finding, round 8). Mirror the refused-tap
+            // contract: the sound fired and the popover line stays; the
+            // icon and "Blocked" status end with the attempt.
+            if !self.isDictationAttemptGestureActive {
+                self.clearSecureInputRefusalSignalsIfAttemptEnded()
+            }
         }
     }
 

--- a/Sources/localvoxtral/DictationViewModel+Session.swift
+++ b/Sources/localvoxtral/DictationViewModel+Session.swift
@@ -37,8 +37,38 @@ extension DictationViewModel {
         sessionReplacementDictionary = nil
     }
 
+    /// Live Auto-Paste preflight for Secure Keyboard Entry: a live session
+    /// whose every synthetic keystroke would be swallowed SILENTLY (posting
+    /// reports success, delivery never happens) must not start — and must be
+    /// refused BEFORE managed-backend startup, or a cold backend would run a
+    /// lengthy install/download for a doomed session. Fires the refuse UX
+    /// (sound + menu bar icon + popover line, from a fresh verdict capture),
+    /// resets any overlay panel a prior failed commit intentionally left
+    /// visible, and returns true when the start was refused. Overlay Buffer
+    /// sessions are never refused: their pipeline still produces text and the
+    /// commit falls back to the clipboard (#89 split behavior).
+    private func refuseLiveStartForSecureInputIfNeeded(
+        outputMode requestedOutputMode: DictationOutputMode
+    ) -> Bool {
+        guard requestedOutputMode == .liveAutoPaste,
+              TerminalTargetDetector.isSecureKeyboardEntryEnabled()
+        else { return false }
+        captureSessionTargetVerdict()
+        applyPreCapturedSessionTargetVerdict()
+        statusText = StatusStrings.liveDictationBlockedBySecureInput
+        overlayBufferCoordinator.reset()
+        Log.target.warning(
+            "live dictation start refused: Secure Keyboard Entry is enabled"
+        )
+        clearLatchedSessionMetadata()
+        return true
+    }
+
     func beginDictationAfterManagedBackendIfNeeded(outputMode: DictationOutputMode? = nil) {
         let requestedOutputMode = outputMode ?? settings.dictationOutputMode
+        if refuseLiveStartForSecureInputIfNeeded(outputMode: requestedOutputMode) {
+            return
+        }
         let needsManagedDictation = settings.dictationBackendMode == .managedLocal
         let needsManagedPolishing = isManagedPolishingRequired(outputMode: requestedOutputMode)
 
@@ -268,27 +298,13 @@ extension DictationViewModel {
         // Same timing rationale as the anchor: sample the terminal-like
         // verdict and Secure Keyboard Entry state while the app the user
         // started dictation in is still frontmost, not after connect.
-        captureSessionTargetVerdict()
-        // Live Auto-Paste under Secure Keyboard Entry: every synthetic
-        // keystroke would be swallowed SILENTLY (posting still reports
-        // success), so a session would capture the mic and type into the
-        // void. Refuse to start instead — the sound, menu bar icon, and
-        // popover line (applied from the captured verdict) explain why, and
-        // they persist until the next session attempt re-samples the state
-        // (no session ran, so the session-end clear never fires). Overlay Buffer proceeds: its pipeline still
-        // produces text, and its commit re-checks secure input and falls
-        // back to the clipboard.
-        if isLiveAutoPasteModeEnabled,
-           preCapturedSessionTargetVerdict?.secureKeyboardEntryEnabled == true
-        {
-            applyPreCapturedSessionTargetVerdict()
-            statusText = StatusStrings.liveDictationBlockedBySecureInput
-            Log.target.warning(
-                "live dictation start refused: Secure Keyboard Entry is enabled"
-            )
-            clearLatchedSessionMetadata()
+        // Re-checked here as well as at the managed-backend entry: secure
+        // input may have turned ON while a cold backend was booting, and
+        // direct callers skip that entry point entirely.
+        if refuseLiveStartForSecureInputIfNeeded(outputMode: requestedOutputMode) {
             return
         }
+        captureSessionTargetVerdict()
         refreshInsertionScalarTracingForSession()
 
         audioChunkBuffer.clear()

--- a/Sources/localvoxtral/DictationViewModel+Session.swift
+++ b/Sources/localvoxtral/DictationViewModel+Session.swift
@@ -262,6 +262,26 @@ extension DictationViewModel {
         // verdict and Secure Keyboard Entry state while the app the user
         // started dictation in is still frontmost, not after connect.
         captureSessionTargetVerdict()
+        // Live Auto-Paste under Secure Keyboard Entry: every synthetic
+        // keystroke would be swallowed SILENTLY (posting still reports
+        // success), so a session would capture the mic and type into the
+        // void. Refuse to start instead — the sound, menu bar icon, and
+        // popover line (applied from the captured verdict) explain why, and
+        // they persist until the next session start because no session ran
+        // (#89 field feedback). Overlay Buffer proceeds: its pipeline still
+        // produces text, and its commit re-checks secure input and falls
+        // back to the clipboard.
+        if isLiveAutoPasteModeEnabled,
+           preCapturedSessionTargetVerdict?.secureKeyboardEntryEnabled == true
+        {
+            applyPreCapturedSessionTargetVerdict()
+            statusText = StatusStrings.liveDictationBlockedBySecureInput
+            Log.target.warning(
+                "live dictation start refused: Secure Keyboard Entry is enabled"
+            )
+            clearLatchedSessionMetadata()
+            return
+        }
         refreshInsertionScalarTracingForSession()
 
         audioChunkBuffer.clear()
@@ -781,7 +801,9 @@ extension DictationViewModel {
         }
         // The Secure Keyboard Entry warning describes state sampled at session
         // start; a finished session must not leave it wedged in the popover —
-        // nor keep the menu bar warning icon lit.
+        // nor keep the menu bar warning icon lit. (A REFUSED live start never
+        // reaches this teardown, so its warning intentionally persists until
+        // the next session start clears it via the stale-warning path.)
         if currentErrorToken == .secureKeyboardEntryActive {
             lastError = nil
         }
@@ -1215,6 +1237,12 @@ extension DictationViewModel {
         let anchor = preResolvedOverlayAnchor
         preResolvedOverlayAnchor = nil
         overlayBufferCoordinator.startSession(preResolvedAnchor: anchor)
+        if sessionSecureInputActive {
+            // The overlay is the surface the user is actually watching while
+            // buffering — warn there, not just in the (closed) popover. The
+            // commit re-checks secure input and falls back to the clipboard.
+            overlayBufferCoordinator.showSecureInputWarning()
+        }
     }
 
     func beginOverlayFinalization() {

--- a/Sources/localvoxtral/DictationViewModel.swift
+++ b/Sources/localvoxtral/DictationViewModel.swift
@@ -126,6 +126,7 @@ final class DictationViewModel {
         static let waitingForAccessibilityPermission = "Waiting for Accessibility permission."
         static let pasteBlockedByAccessibilityPermission = "Paste blocked by Accessibility permission."
         static let networkLostDictationStopped = "Network lost. Dictation stopped."
+        static let liveDictationBlockedBySecureInput = "Blocked: Secure Keyboard Entry is on."
         static let noNetworkConnection = "No network connection."
         static let microphoneAccessDenied = "Microphone access denied."
         static let finalizing = "Finalizing..."

--- a/Sources/localvoxtral/DictationViewModel.swift
+++ b/Sources/localvoxtral/DictationViewModel.swift
@@ -410,6 +410,12 @@ final class DictationViewModel {
     var debugManagedStatusMirrorEventSink: (() -> Void)?
     @ObservationIgnored
     var debugMicrophoneAuthorizationStatusOverride: MicrophoneAuthorizationStatus?
+    /// Test seam: replaces `microphone.requestAccess` in the session-start
+    /// permission gate so tests can hold and fire the grant continuation
+    /// deterministically (the real call shows a TCC prompt and touches the
+    /// microphone service).
+    @ObservationIgnored
+    var debugMicrophoneRequestAccessOverride: ((@escaping @Sendable (Bool) -> Void) -> Void)?
     @ObservationIgnored
     var debugHasRequestedStartupPermissions: Bool { hasRequestedStartupPermissions }
 
@@ -1306,7 +1312,7 @@ final class DictationViewModel {
             isAwaitingMicrophonePermission = true
             statusText = StatusStrings.requestingMicrophonePermission
             debugLog("microphone permission prompt requested")
-            microphone.requestAccess { [weak self] granted in
+            requestMicrophoneAccessForSessionStart { [weak self] granted in
                 Task { @MainActor [weak self] in
                     guard let self else { return }
                     self.isAwaitingMicrophonePermission = false
@@ -1325,6 +1331,15 @@ final class DictationViewModel {
                         return
                     }
                     self.beginDictationAfterManagedBackendIfNeeded(outputMode: outputMode)
+                    // The grant may land long after the initiating tap ended
+                    // (toggle taps have no release event). If secure input
+                    // turned on while the dialog was up, the entry point
+                    // above just refused — with no gesture-end event left,
+                    // the signals would wedge (Codex finding, round 9; same
+                    // shape as the managed-startup wedge in round 8).
+                    if !self.isDictationAttemptGestureActive {
+                        self.clearSecureInputRefusalSignalsIfAttemptEnded()
+                    }
                 }
             }
             Task { [weak self] in
@@ -1342,6 +1357,16 @@ final class DictationViewModel {
             lastError = Self.microphoneDeniedMessage
             debugLog("microphone access denied or restricted")
         }
+    }
+
+    private func requestMicrophoneAccessForSessionStart(
+        completion: @escaping @Sendable (Bool) -> Void
+    ) {
+        if let debugMicrophoneRequestAccessOverride {
+            debugMicrophoneRequestAccessOverride(completion)
+            return
+        }
+        microphone.requestAccess(completion: completion)
     }
 
     func currentMicrophoneAuthorizationStatus() -> MicrophoneAuthorizationStatus {

--- a/Sources/localvoxtral/DictationViewModel.swift
+++ b/Sources/localvoxtral/DictationViewModel.swift
@@ -790,6 +790,14 @@ final class DictationViewModel {
     /// push-to-talk semantics latches dictation on with no way to stop it.
     private func handleModifierOnlyTap(mode: DictationOutputMode) {
         toggleDictation(outputMode: mode)
+        // A tap has no release event (see the contract above), so a refused
+        // live start would latch the warning icon forever (Codex finding on
+        // #90). The tap IS the whole attempt gesture: if nothing started,
+        // end the refusal signals now — the sound already fired and the
+        // popover line keeps the explanation.
+        if !isDictating, !isConnectingRealtimeSession, !isAwaitingMicrophonePermission {
+            clearSecureInputRefusalSignalsIfAttemptEnded()
+        }
     }
 
     func shouldCancelPushToTalkStartAfterConnect() -> Bool {

--- a/Sources/localvoxtral/DictationViewModel.swift
+++ b/Sources/localvoxtral/DictationViewModel.swift
@@ -14,6 +14,10 @@ enum MenuBarIndicatorState: Equatable {
     case idle
     case connected
     case failure
+    /// Secure Keyboard Entry is swallowing this session's keystrokes — shown
+    /// with the failure icon because the menu bar is the only surface still
+    /// visible while the popover is closed during dictation (#89).
+    case secureInputWarning
 }
 
 /// A single raw realtime-delta log emission, captured before any
@@ -204,6 +208,12 @@ final class DictationViewModel {
     }
 
     var menuBarIndicatorState: MenuBarIndicatorState {
+        // Checked before .connected: the warning describes the session that
+        // is connected right now — its keystrokes are being swallowed, and
+        // the popover (where the text warning lives) is closed mid-dictation.
+        if currentErrorToken == .secureKeyboardEntryActive {
+            return .secureInputWarning
+        }
         switch realtimeSessionIndicatorState {
         case .connected:
             return .connected
@@ -216,6 +226,12 @@ final class DictationViewModel {
 
     let settings: SettingsStore
     let textInsertion = TextInsertionService()
+
+    /// Played once at session start when Secure Keyboard Entry is detected.
+    /// The popover is closed while dictating, so an audible cue is the only
+    /// immediate signal that keystrokes will be swallowed (#89). Test seam.
+    @ObservationIgnored
+    var secureInputWarningSound: () -> Void = { NSSound(named: "Basso")?.play() }
 
     // Services — internal so extension files can access them.
     @ObservationIgnored
@@ -1424,6 +1440,9 @@ final class DictationViewModel {
             if currentErrorToken != .accessibilityPermissionRequired {
                 lastError = Self.secureKeyboardEntryWarningMessage
             }
+            // Audible regardless of which warning owns the popover line: the
+            // session that just started will type nothing either way.
+            secureInputWarningSound()
             Log.target.warning(
                 "Secure Keyboard Entry is enabled at session start; synthetic keyboard events may be blocked."
             )

--- a/Sources/localvoxtral/DictationViewModel.swift
+++ b/Sources/localvoxtral/DictationViewModel.swift
@@ -790,14 +790,6 @@ final class DictationViewModel {
     /// push-to-talk semantics latches dictation on with no way to stop it.
     private func handleModifierOnlyTap(mode: DictationOutputMode) {
         toggleDictation(outputMode: mode)
-        // A tap has no release event (see the contract above), so a refused
-        // live start would latch the warning icon forever (Codex finding on
-        // #90). The tap IS the whole attempt gesture: if nothing started,
-        // end the refusal signals now — the sound already fired and the
-        // popover line keeps the explanation.
-        if !isDictating, !isConnectingRealtimeSession, !isAwaitingMicrophonePermission {
-            clearSecureInputRefusalSignalsIfAttemptEnded()
-        }
     }
 
     func shouldCancelPushToTalkStartAfterConnect() -> Bool {
@@ -811,6 +803,17 @@ final class DictationViewModel {
 
     func toggleDictation(outputMode: DictationOutputMode? = nil) {
         hasActivePushToTalkShortcutSession = false
+        defer {
+            // Toggle starts (modifier tap, popover button) have no release
+            // event, so a refused live start would latch the warning icon
+            // forever (Codex findings on #90, rounds 5-6). The tap/click IS
+            // the whole attempt gesture: if nothing started, end the refusal
+            // signals now — the sound already fired and the popover line
+            // keeps the explanation.
+            if !isDictating, !isConnectingRealtimeSession, !isAwaitingMicrophonePermission {
+                clearSecureInputRefusalSignalsIfAttemptEnded()
+            }
+        }
         if isDictating {
             stopDictation(reason: "manual toggle")
         } else if isConnectingRealtimeSession {
@@ -1261,6 +1264,16 @@ final class DictationViewModel {
         guard networkMonitor.isConnected else {
             statusText = StatusStrings.noNetworkConnection
             lastError = "Connect to a network before starting dictation."
+            return
+        }
+        // Refused BEFORE the microphone-authorization gate: a doomed live
+        // session must not trigger a mic permission prompt — and the mic
+        // gate's per-user TCC state must not decide whether the refusal
+        // fires at all (it did: the refusal lived only past this gate, and
+        // CI vs build-host permission differences flipped the behavior).
+        if refuseLiveStartForSecureInputIfNeeded(
+            outputMode: outputMode ?? settings.dictationOutputMode
+        ) {
             return
         }
         debugLog("startDictation requested")

--- a/Sources/localvoxtral/DictationViewModel.swift
+++ b/Sources/localvoxtral/DictationViewModel.swift
@@ -245,9 +245,15 @@ final class DictationViewModel {
 
     /// Ends the refused-start warning when no session is running: the icon
     /// (and the "Blocked" status line) return to normal, while `lastError`
-    /// keeps the one-line explanation in the popover.
+    /// keeps the one-line explanation in the popover. A stopped session that
+    /// is still finalizing/polishing is NOT an ended attempt — its text is
+    /// still headed for the clipboard fallback, and clearing here dropped
+    /// the icon to the yellow session state mid-polish (owner field feedback
+    /// on #90); session teardown owns that clear.
     func clearSecureInputRefusalSignalsIfAttemptEnded() {
-        guard !isDictating, !isConnectingRealtimeSession, sessionSecureInputActive else { return }
+        guard !isDictating, !isConnectingRealtimeSession, !isFinalizingStop,
+              sessionSecureInputActive
+        else { return }
         sessionSecureInputActive = false
         if statusText == StatusStrings.liveDictationBlockedBySecureInput {
             statusText = StatusStrings.ready

--- a/Sources/localvoxtral/DictationViewModel.swift
+++ b/Sources/localvoxtral/DictationViewModel.swift
@@ -211,7 +211,11 @@ final class DictationViewModel {
         // Checked before .connected: the warning describes the session that
         // is connected right now — its keystrokes are being swallowed, and
         // the popover (where the text warning lives) is closed mid-dictation.
-        if currentErrorToken == .secureKeyboardEntryActive {
+        // `sessionSecureInputActive` is tracked separately from `lastError`
+        // because the Accessibility warning deliberately outranks the
+        // secure-input POPOVER line — the icon must not vanish with it
+        // (Codex review finding on #90).
+        if sessionSecureInputActive || currentErrorToken == .secureKeyboardEntryActive {
             return .secureInputWarning
         }
         switch realtimeSessionIndicatorState {
@@ -226,6 +230,14 @@ final class DictationViewModel {
 
     let settings: SettingsStore
     let textInsertion = TextInsertionService()
+
+    /// Secure Keyboard Entry state sampled for the CURRENT session — drives
+    /// the menu bar warning icon independently of `lastError` (whose popover
+    /// line a higher-priority warning may own). Set when the session verdict
+    /// is applied; cleared at session end alongside the token-scoped
+    /// popover clear. Internal (not private(set)) because the session-end
+    /// clear lives in DictationViewModel+Session.swift.
+    var sessionSecureInputActive = false
 
     /// Played once at session start when Secure Keyboard Entry is detected.
     /// The popover is closed while dictating, so an audible cue is the only
@@ -1433,6 +1445,7 @@ final class DictationViewModel {
         )
         preCapturedSessionTargetVerdict = nil
         sessionTargetIsTerminalLike = verdict.decision.isTerminalLike
+        sessionSecureInputActive = verdict.secureKeyboardEntryEnabled
 
         if verdict.secureKeyboardEntryEnabled {
             // Never mask the Accessibility-trust warning — it explains a

--- a/Sources/localvoxtral/DictationViewModel.swift
+++ b/Sources/localvoxtral/DictationViewModel.swift
@@ -423,6 +423,14 @@ final class DictationViewModel {
     // Tracks physical key state so repeat key-down events do not retrigger actions.
     @ObservationIgnored
     private var isPushToTalkShortcutHeld = false
+
+    /// True while the user is still physically holding the dictation
+    /// shortcut/modifier — a release event is still coming, and it owns
+    /// ending the attempt's refusal signals. The managed-startup path in
+    /// DictationViewModel+Session.swift consults this: a secure-input
+    /// refusal that fires after backend boot may land with no gesture-end
+    /// event left to clear it.
+    var isDictationAttemptGestureActive: Bool { isPushToTalkShortcutHeld }
     // True only when a start attempt was initiated by push-to-talk and may still need
     // to be cancelled if the user releases before dictation actually begins.
     @ObservationIgnored

--- a/Sources/localvoxtral/DictationViewModel.swift
+++ b/Sources/localvoxtral/DictationViewModel.swift
@@ -127,6 +127,7 @@ final class DictationViewModel {
         static let pasteBlockedByAccessibilityPermission = "Paste blocked by Accessibility permission."
         static let networkLostDictationStopped = "Network lost. Dictation stopped."
         static let liveDictationBlockedBySecureInput = "Blocked: Secure Keyboard Entry is on."
+        static let overlayCopiedToClipboard = "Copied — paste it manually."
         static let noNetworkConnection = "No network connection."
         static let microphoneAccessDenied = "Microphone access denied."
         static let finalizing = "Finalizing..."
@@ -212,11 +213,13 @@ final class DictationViewModel {
         // Checked before .connected: the warning describes the session that
         // is connected right now — its keystrokes are being swallowed, and
         // the popover (where the text warning lives) is closed mid-dictation.
-        // `sessionSecureInputActive` is tracked separately from `lastError`
-        // because the Accessibility warning deliberately outranks the
-        // secure-input POPOVER line — the icon must not vanish with it
-        // (Codex review finding on #90).
-        if sessionSecureInputActive || currentErrorToken == .secureKeyboardEntryActive {
+        // Gated ONLY on the session-attempt flag, tracked separately from
+        // `lastError`: the Accessibility warning may own the popover line
+        // without hiding the icon (Codex finding), and the popover line may
+        // outlive the icon as the explanation after a refused-start gesture
+        // ends (owner field feedback — the icon must not stay lit after the
+        // modifier is released).
+        if sessionSecureInputActive {
             return .secureInputWarning
         }
         switch realtimeSessionIndicatorState {
@@ -239,6 +242,17 @@ final class DictationViewModel {
     /// popover clear. Internal (not private(set)) because the session-end
     /// clear lives in DictationViewModel+Session.swift.
     var sessionSecureInputActive = false
+
+    /// Ends the refused-start warning when no session is running: the icon
+    /// (and the "Blocked" status line) return to normal, while `lastError`
+    /// keeps the one-line explanation in the popover.
+    func clearSecureInputRefusalSignalsIfAttemptEnded() {
+        guard !isDictating, !isConnectingRealtimeSession, sessionSecureInputActive else { return }
+        sessionSecureInputActive = false
+        if statusText == StatusStrings.liveDictationBlockedBySecureInput {
+            statusText = StatusStrings.ready
+        }
+    }
 
     /// Played once at session start when Secure Keyboard Entry is detected.
     /// The popover is closed while dictating, so an audible cue is the only
@@ -708,6 +722,13 @@ final class DictationViewModel {
     }
 
     private func handleDictationShortcutRelease() {
+        // A REFUSED live start (secure input) resets the hold flags inside
+        // handleModifierOnlyHoldStart, so no branch below fires for it —
+        // this is the moment the user's attempt gesture ends, and the
+        // warning icon must end with it (owner field feedback on #90). The
+        // popover line stays as the explanation until the next start
+        // re-samples.
+        clearSecureInputRefusalSignalsIfAttemptEnded()
         // Modifier-only hold release
         if isModifierOnlyHoldActive {
             isModifierOnlyHoldActive = false

--- a/Sources/localvoxtral/OverlayBufferSessionCoordinator.swift
+++ b/Sources/localvoxtral/OverlayBufferSessionCoordinator.swift
@@ -31,6 +31,11 @@ extension TextInsertionService: OverlayTextCommitting {}
 enum OverlayBufferCommitOutcome: Equatable {
     case succeeded
     case failed(message: String)
+    /// Secure Keyboard Entry blocked synthetic insertion; the text was put on
+    /// the clipboard instead. Unlike `.failed` (whose panel persists so the
+    /// user can see text that may exist nowhere else), this panel is
+    /// dismissed after a readable hold — the words are safe.
+    case copiedToClipboard(message: String)
 }
 
 @MainActor
@@ -176,14 +181,18 @@ final class OverlayBufferSessionCoordinator: OverlayBufferSessionCoordinating {
         // only alternative — and show the failure state.
         if TerminalTargetDetector.isSecureKeyboardEntryEnabled() {
             copyToPasteboard(commitText)
-            let failureMessage = "Secure input blocked auto-paste — text copied, paste it manually."
+            let fallbackMessage = "Secure input blocked auto-paste — text copied, paste it manually."
             stateMachine.commitFailed(
-                error: failureMessage,
+                error: fallbackMessage,
                 anchor: anchorResolver.resolveAnchor()
             )
             renderCurrentSnapshot()
+            // The message is a fresh display change: anchor the dismiss hold
+            // to it so the stop flow's dismissAfterHold keeps it readable
+            // instead of measuring from the last buffered word.
+            lastOverlayDisplayTextChangeAt = now()
             Log.overlay.notice("overlay commit skipped: Secure Keyboard Entry active; text copied to clipboard")
-            return .failed(message: failureMessage)
+            return .copiedToClipboard(message: fallbackMessage)
         }
 
         let preferredPID = finalizationCommitTargetAppPID ?? liveCommitTargetAppPID

--- a/Sources/localvoxtral/OverlayBufferSessionCoordinator.swift
+++ b/Sources/localvoxtral/OverlayBufferSessionCoordinator.swift
@@ -254,9 +254,7 @@ final class OverlayBufferSessionCoordinator: OverlayBufferSessionCoordinating {
     }
 
     func showSecureInputWarning() {
-        stateMachine.setBufferingWarning(
-            "Secure input is on — auto-paste is blocked; the text will be copied at stop."
-        )
+        stateMachine.setSecureInputWarning()
         renderCurrentSnapshot()
     }
 

--- a/Sources/localvoxtral/OverlayBufferSessionCoordinator.swift
+++ b/Sources/localvoxtral/OverlayBufferSessionCoordinator.swift
@@ -67,7 +67,9 @@ extension OverlayBufferSessionCoordinating {
 final class OverlayBufferSessionCoordinator: OverlayBufferSessionCoordinating {
     typealias DateProvider = () -> Date
     typealias SleepClosure = (Duration) async -> Void
-    typealias PasteboardWriter = (String) -> Void
+    /// Returns whether the write landed — under secure input the clipboard
+    /// is the only preservation path, so a failed write must keep the panel.
+    typealias PasteboardWriter = (String) -> Bool
 
     private var stateMachine: OverlayBufferStateMachine
     private let renderer: OverlayBufferRendering
@@ -97,7 +99,7 @@ final class OverlayBufferSessionCoordinator: OverlayBufferSessionCoordinating {
         copyToPasteboard: @escaping PasteboardWriter = { text in
             let pasteboard = NSPasteboard.general
             pasteboard.clearContents()
-            pasteboard.setString(text, forType: .string)
+            return pasteboard.setString(text, forType: .string)
         }
     ) {
         self.stateMachine = stateMachine
@@ -180,7 +182,21 @@ final class OverlayBufferSessionCoordinator: OverlayBufferSessionCoordinating {
         // put the text on the clipboard unconditionally — losing it is the
         // only alternative — and show the failure state.
         if TerminalTargetDetector.isSecureKeyboardEntryEnabled() {
-            copyToPasteboard(commitText)
+            // The clipboard is the ONLY preservation path here: if the write
+            // fails, claiming "copied" and dismissing the panel would lose
+            // the transcript's last remaining copy — fall back to the
+            // persistent failure panel, which keeps the text visible.
+            guard copyToPasteboard(commitText) else {
+                let failureMessage =
+                    "Secure input blocked auto-paste and the clipboard copy failed — the text stays visible here."
+                stateMachine.commitFailed(
+                    error: failureMessage,
+                    anchor: anchorResolver.resolveAnchor()
+                )
+                renderCurrentSnapshot()
+                Log.overlay.error("overlay commit skipped: secure input active AND clipboard write failed")
+                return .failed(message: failureMessage)
+            }
             let fallbackMessage = "Secure input blocked auto-paste — text copied, paste it manually."
             stateMachine.commitFailed(
                 error: fallbackMessage,
@@ -211,7 +227,7 @@ final class OverlayBufferSessionCoordinator: OverlayBufferSessionCoordinating {
 
         if inserted {
             if autoCopyEnabled {
-                copyToPasteboard(commitText)
+                _ = copyToPasteboard(commitText)
             }
             Log.overlay.info("overlay commit succeeded")
             return .succeeded
@@ -225,7 +241,7 @@ final class OverlayBufferSessionCoordinator: OverlayBufferSessionCoordinating {
         }
 
         if autoCopyEnabled {
-            copyToPasteboard(commitText)
+            _ = copyToPasteboard(commitText)
         }
 
         stateMachine.commitFailed(

--- a/Sources/localvoxtral/OverlayBufferSessionCoordinator.swift
+++ b/Sources/localvoxtral/OverlayBufferSessionCoordinator.swift
@@ -49,6 +49,13 @@ protocol OverlayBufferSessionCoordinating: AnyObject {
     /// live replacement guard can re-target it even if focus moved.
     func captureLiveCommitTargetAppPID()
     var commitTargetAppPID: pid_t? { get }
+    /// Surfaces the Secure Keyboard Entry warning inside the overlay panel
+    /// while buffering. Defaulted so test doubles stay unchanged.
+    func showSecureInputWarning()
+}
+
+extension OverlayBufferSessionCoordinating {
+    func showSecureInputWarning() {}
 }
 
 @MainActor
@@ -159,6 +166,26 @@ final class OverlayBufferSessionCoordinator: OverlayBufferSessionCoordinating {
             return .succeeded
         }
 
+        // Re-check Secure Keyboard Entry AT COMMIT TIME (the session-start
+        // sample can be stale in both directions — a password prompt may have
+        // appeared or been dismissed while dictating). When it is active,
+        // synthetic insertion would be swallowed while REPORTING success
+        // (posting succeeds, delivery doesn't), the overlay would dismiss
+        // happily, and the words would be gone. Skip the doomed attempts,
+        // put the text on the clipboard unconditionally — losing it is the
+        // only alternative — and show the failure state.
+        if TerminalTargetDetector.isSecureKeyboardEntryEnabled() {
+            copyToPasteboard(commitText)
+            let failureMessage = "Secure input blocked auto-paste — text copied, paste it manually."
+            stateMachine.commitFailed(
+                error: failureMessage,
+                anchor: anchorResolver.resolveAnchor()
+            )
+            renderCurrentSnapshot()
+            Log.overlay.notice("overlay commit skipped: Secure Keyboard Entry active; text copied to clipboard")
+            return .failed(message: failureMessage)
+        }
+
         let preferredPID = finalizationCommitTargetAppPID ?? liveCommitTargetAppPID
         // Keep overlay commit aligned with live auto-paste behavior: try keyboard
         // Unicode insertion first for web field compatibility, then AX, then Cmd+V.
@@ -199,6 +226,13 @@ final class OverlayBufferSessionCoordinator: OverlayBufferSessionCoordinating {
         renderCurrentSnapshot()
         Log.overlay.info("overlay commit failed: \(failureMessage, privacy: .public)")
         return .failed(message: failureMessage)
+    }
+
+    func showSecureInputWarning() {
+        stateMachine.setBufferingWarning(
+            "Secure input is on — auto-paste is blocked; the text will be copied at stop."
+        )
+        renderCurrentSnapshot()
     }
 
     func dismissAfterHold(minimumVisibility: TimeInterval) {

--- a/Sources/localvoxtral/OverlayBufferStateMachine.swift
+++ b/Sources/localvoxtral/OverlayBufferStateMachine.swift
@@ -138,11 +138,11 @@ struct OverlayBufferStateMachine {
     }
 
     /// Marks the buffering session as running under Secure Keyboard Entry.
-    /// The overlay view folds this into the phase title ("Listening (secure
-    /// input)") rather than a separate warning sentence — a full sentence in
-    /// the panel read as clutter (owner feedback on #90). startSession resets
-    /// it; it persists through finalizing so the marker doesn't blink away
-    /// while the commit is still pending.
+    /// The overlay view folds this into the phase title (an actionable
+    /// "select another field" hint) rather than a separate warning sentence —
+    /// a warning line under the transcript read as clutter (owner feedback
+    /// on #90). startSession resets it; it persists through finalizing so
+    /// the marker doesn't blink away while the commit is still pending.
     mutating func setSecureInputWarning() {
         guard phase == .buffering else { return }
         secureInputActive = true

--- a/Sources/localvoxtral/OverlayBufferStateMachine.swift
+++ b/Sources/localvoxtral/OverlayBufferStateMachine.swift
@@ -103,12 +103,14 @@ struct OverlayBufferStateMachine {
         let phase: OverlayBufferPhase
         let bufferText: String
         let errorMessage: String?
+        let secureInputActive: Bool
         let anchor: OverlayAnchor
     }
 
     private(set) var phase: OverlayBufferPhase = .idle
     private(set) var bufferText = ""
     private(set) var errorMessage: String?
+    private(set) var secureInputActive = false
     private(set) var anchor: OverlayAnchor?
 
     var snapshot: Snapshot? {
@@ -117,6 +119,7 @@ struct OverlayBufferStateMachine {
             phase: phase,
             bufferText: bufferText,
             errorMessage: errorMessage,
+            secureInputActive: secureInputActive,
             anchor: anchor
         )
     }
@@ -130,15 +133,19 @@ struct OverlayBufferStateMachine {
         phase = .buffering
         bufferText = ""
         errorMessage = nil
+        secureInputActive = false
         self.anchor = anchor
     }
 
-    /// Shows a warning line while buffering, reusing the errorMessage surface
-    /// the overlay view and height measurement already render. startSession
-    /// resets it; commitFailed overwrites it with the commit outcome.
-    mutating func setBufferingWarning(_ message: String) {
+    /// Marks the buffering session as running under Secure Keyboard Entry.
+    /// The overlay view folds this into the phase title ("Listening (secure
+    /// input)") rather than a separate warning sentence — a full sentence in
+    /// the panel read as clutter (owner feedback on #90). startSession resets
+    /// it; it persists through finalizing so the marker doesn't blink away
+    /// while the commit is still pending.
+    mutating func setSecureInputWarning() {
         guard phase == .buffering else { return }
-        errorMessage = message
+        secureInputActive = true
     }
 
     mutating func updateBuffer(text: String, anchor: OverlayAnchor?) {
@@ -170,6 +177,7 @@ struct OverlayBufferStateMachine {
         phase = .idle
         bufferText = ""
         errorMessage = nil
+        secureInputActive = false
         anchor = nil
     }
 }

--- a/Sources/localvoxtral/OverlayBufferStateMachine.swift
+++ b/Sources/localvoxtral/OverlayBufferStateMachine.swift
@@ -133,6 +133,14 @@ struct OverlayBufferStateMachine {
         self.anchor = anchor
     }
 
+    /// Shows a warning line while buffering, reusing the errorMessage surface
+    /// the overlay view and height measurement already render. startSession
+    /// resets it; commitFailed overwrites it with the commit outcome.
+    mutating func setBufferingWarning(_ message: String) {
+        guard phase == .buffering else { return }
+        errorMessage = message
+    }
+
     mutating func updateBuffer(text: String, anchor: OverlayAnchor?) {
         guard phase == .buffering || phase == .finalizing else { return }
         bufferText = text

--- a/Sources/localvoxtral/TimingConstants.swift
+++ b/Sources/localvoxtral/TimingConstants.swift
@@ -48,4 +48,9 @@ enum TimingConstants {
     /// Minimum time to keep the overlay visible after the most recent
     /// visible overlay text update before committing/hiding.
     static let overlayFinalWordVisibilityMinimum: TimeInterval = 0.5
+
+    /// How long the overlay's secure-input clipboard-fallback message stays
+    /// readable before the panel dismisses itself (the text is already safe
+    /// on the clipboard, so the panel must not persist like a real failure).
+    static let overlayClipboardFallbackVisibility: TimeInterval = 4.0
 }

--- a/Sources/localvoxtral/localvoxtralApp.swift
+++ b/Sources/localvoxtral/localvoxtralApp.swift
@@ -36,6 +36,21 @@ struct localvoxtralApp: App {
                             "realtime-connected",
                             "localvoxtral, realtime session active"
                         )
+                    case .secureInputWarning:
+                        if let failureIcon = MenuBarIconAsset.failureIcon {
+                            return (
+                                failureIcon,
+                                .original,
+                                "secure-input-warning",
+                                "localvoxtral, Secure Keyboard Entry is blocking dictation typing"
+                            )
+                        }
+                        return (
+                            idleIcon,
+                            .template,
+                            "secure-input-warning",
+                            "localvoxtral, Secure Keyboard Entry is blocking dictation typing"
+                        )
                     case .failure:
                         if let failureIcon = MenuBarIconAsset.failureIcon {
                             return (
@@ -75,6 +90,9 @@ struct localvoxtralApp: App {
                 case .failure:
                     Label("localvoxtral", systemImage: "xmark.circle.fill")
                         .foregroundStyle(.red)
+                case .secureInputWarning:
+                    Label("localvoxtral", systemImage: "exclamationmark.triangle.fill")
+                        .foregroundStyle(.orange)
                 }
             }
         }

--- a/Tests/localvoxtralTests/DictationViewModelFailFastUXTests.swift
+++ b/Tests/localvoxtralTests/DictationViewModelFailFastUXTests.swift
@@ -1179,6 +1179,65 @@ final class DictationViewModelFailFastUXTests: XCTestCase {
         XCTAssertEqual(viewModel.statusText, DictationViewModel.StatusStrings.ready)
     }
 
+    func testDelayedSecureInputRefusalAfterMicPermissionGrantDoesNotWedgeTheIcon() async {
+        // Codex finding on #90 (round 9): same wedge as the managed-startup
+        // one (round 8) via the OTHER async continuation — the microphone
+        // permission dialog. A toggle tap starts with permission
+        // undetermined; secure input turns on while the dialog is up; the
+        // grant continuation re-enters the managed-backend entry point,
+        // which refuses with no gesture-end event left to clear the signals.
+        TerminalTargetDetector.debugFrontmostBundleIDOverride = { "com.apple.Terminal" }
+        TerminalTargetDetector.debugSecureEventInputOverride = { false } // off at press
+        addTeardownBlock {
+            TerminalTargetDetector.debugFrontmostBundleIDOverride = nil
+            TerminalTargetDetector.debugSecureEventInputOverride = nil
+        }
+
+        let backendManager = FakeManagedBackendManager()
+        let viewModel = makeViewModel(outputMode: .liveAutoPaste, backendManager: backendManager)
+        viewModel.settings.dictationBackendMode = .managedLocal
+        viewModel.isShowingConnectionFailureAlert = true
+        viewModel.debugMicrophoneAuthorizationStatusOverride = .notDetermined
+        var permissionCompletion: (@Sendable (Bool) -> Void)?
+        viewModel.debugMicrophoneRequestAccessOverride = { permissionCompletion = $0 }
+        var soundPlays = 0
+        viewModel.secureInputWarningSound = { soundPlays += 1 }
+        retainForTestProcessLifetime(viewModel)
+
+        // Toggle tap: the secure-input preflight passes, the mic gate parks
+        // the start behind the permission dialog, and the tap gesture ends.
+        viewModel.startDictation()
+        XCTAssertTrue(viewModel.isAwaitingMicrophonePermission)
+        guard let grantPermission = permissionCompletion else {
+            return XCTFail("the permission request must route through the test seam")
+        }
+
+        // Secure input turns on while the dialog is up; then the user grants.
+        TerminalTargetDetector.debugSecureEventInputOverride = { true }
+        grantPermission(true)
+        // The continuation hops to the main actor and runs synchronously to
+        // completion once started; drain the hop without wall-clock waits.
+        var spins = 0
+        while viewModel.isAwaitingMicrophonePermission, spins < 1_000 {
+            spins += 1
+            await Task.yield()
+        }
+
+        XCTAssertFalse(viewModel.isDictating, "the doomed live session is still refused")
+        XCTAssertTrue(backendManager.ensureCalls.isEmpty, "still no backend boot for a refused start")
+        XCTAssertEqual(soundPlays, 1, "the audible refusal cue fired")
+        XCTAssertEqual(
+            viewModel.lastError,
+            DictationViewModel.secureKeyboardEntryWarningMessage,
+            "the popover keeps the explanation"
+        )
+        XCTAssertNotEqual(
+            viewModel.menuBarIndicatorState, .secureInputWarning,
+            "no gesture-end event will ever come — the icon must not wedge"
+        )
+        XCTAssertEqual(viewModel.statusText, DictationViewModel.StatusStrings.ready)
+    }
+
     private func makeViewModel(
         outputMode: DictationOutputMode,
         backendManager: (any ManagedBackendManaging)? = nil

--- a/Tests/localvoxtralTests/DictationViewModelFailFastUXTests.swift
+++ b/Tests/localvoxtralTests/DictationViewModelFailFastUXTests.swift
@@ -1101,6 +1101,36 @@ final class DictationViewModelFailFastUXTests: XCTestCase {
 
     // MARK: - Helpers
 
+    func testLiveStartUnderSecureInputRefusesBeforeManagedBackendStartup() {
+        // Codex finding on #90 (round 3): the refusal used to run only inside
+        // beginDictationSession, AFTER ensureReady — a cold managed backend
+        // would start a lengthy install/download for a doomed live session.
+        TerminalTargetDetector.debugFrontmostBundleIDOverride = { "com.apple.Terminal" }
+        TerminalTargetDetector.debugSecureEventInputOverride = { true }
+        addTeardownBlock {
+            TerminalTargetDetector.debugFrontmostBundleIDOverride = nil
+            TerminalTargetDetector.debugSecureEventInputOverride = nil
+        }
+
+        let backendManager = FakeManagedBackendManager()
+        let viewModel = makeViewModel(outputMode: .liveAutoPaste, backendManager: backendManager)
+        viewModel.settings.dictationBackendMode = .managedLocal
+        viewModel.secureInputWarningSound = {}
+
+        viewModel.beginDictationAfterManagedBackendIfNeeded()
+
+        XCTAssertTrue(
+            backendManager.ensureCalls.isEmpty,
+            "no backend boot for a session that will be refused"
+        )
+        XCTAssertEqual(
+            viewModel.statusText,
+            DictationViewModel.StatusStrings.liveDictationBlockedBySecureInput
+        )
+        XCTAssertEqual(viewModel.menuBarIndicatorState, .secureInputWarning)
+        XCTAssertFalse(viewModel.isConnectingRealtimeSession)
+    }
+
     private func makeViewModel(
         outputMode: DictationOutputMode,
         backendManager: (any ManagedBackendManaging)? = nil

--- a/Tests/localvoxtralTests/DictationViewModelFailFastUXTests.swift
+++ b/Tests/localvoxtralTests/DictationViewModelFailFastUXTests.swift
@@ -1131,6 +1131,54 @@ final class DictationViewModelFailFastUXTests: XCTestCase {
         XCTAssertFalse(viewModel.isConnectingRealtimeSession)
     }
 
+    func testDelayedSecureInputRefusalAfterManagedStartupDoesNotWedgeTheIcon() async {
+        // Codex finding on #90 (round 8): secure input can turn ON while a
+        // managed backend boots. The refusal then fires from the startup
+        // task — after the initiating tap already ended — and no gesture-end
+        // event remains, so the red icon and "Blocked" status wedged until
+        // the next interaction. The startup path now ends the refusal
+        // signals itself when no gesture is still held.
+        TerminalTargetDetector.debugFrontmostBundleIDOverride = { "com.apple.Terminal" }
+        TerminalTargetDetector.debugSecureEventInputOverride = { false } // off at press
+        addTeardownBlock {
+            TerminalTargetDetector.debugFrontmostBundleIDOverride = nil
+            TerminalTargetDetector.debugSecureEventInputOverride = nil
+        }
+
+        let backendManager = FakeManagedBackendManager()
+        backendManager.suspendEnsure = true
+        let viewModel = makeViewModel(outputMode: .liveAutoPaste, backendManager: backendManager)
+        viewModel.settings.dictationBackendMode = .managedLocal
+        viewModel.isShowingConnectionFailureAlert = true
+        viewModel.debugMicrophoneAuthorizationStatusOverride = .authorized
+        var soundPlays = 0
+        viewModel.secureInputWarningSound = { soundPlays += 1 }
+        retainForTestProcessLifetime(viewModel)
+
+        viewModel.beginDictationAfterManagedBackendIfNeeded()
+        await backendManager.waitUntilEnsureStarted()
+        XCTAssertTrue(viewModel.isConnectingRealtimeSession, "preflight passed; backend boot in flight")
+
+        // The user focuses a password field while the backend boots; the
+        // initiating gesture is long over by the time startup completes.
+        TerminalTargetDetector.debugSecureEventInputOverride = { true }
+        backendManager.resumeEnsure()
+        await viewModel.managedStartupTask?.value
+
+        XCTAssertFalse(viewModel.isDictating, "the doomed live session is still refused")
+        XCTAssertEqual(soundPlays, 1, "the audible refusal cue fired")
+        XCTAssertEqual(
+            viewModel.lastError,
+            DictationViewModel.secureKeyboardEntryWarningMessage,
+            "the popover keeps the explanation"
+        )
+        XCTAssertNotEqual(
+            viewModel.menuBarIndicatorState, .secureInputWarning,
+            "no gesture-end event will ever come — the icon must not wedge"
+        )
+        XCTAssertEqual(viewModel.statusText, DictationViewModel.StatusStrings.ready)
+    }
+
     private func makeViewModel(
         outputMode: DictationOutputMode,
         backendManager: (any ManagedBackendManaging)? = nil

--- a/Tests/localvoxtralTests/OverlayBufferSessionCoordinatorTests.swift
+++ b/Tests/localvoxtralTests/OverlayBufferSessionCoordinatorTests.swift
@@ -35,8 +35,8 @@ final class OverlayBufferSessionCoordinatorTests: XCTestCase {
         // only place the words can survive, so the copy must be unconditional.
         let outcome = coordinator.commitIfNeeded(using: committer, autoCopyEnabled: false)
 
-        guard case .failed(let message) = outcome else {
-            return XCTFail("commit must report failure, got \(outcome)")
+        guard case .copiedToClipboard(let message) = outcome else {
+            return XCTFail("commit must report the clipboard fallback, got \(outcome)")
         }
         XCTAssertTrue(message.contains("copied"), "message tells the user where the text went")
         XCTAssertTrue(
@@ -45,6 +45,49 @@ final class OverlayBufferSessionCoordinatorTests: XCTestCase {
         )
         XCTAssertEqual(copiedTexts, ["secret words"])
         XCTAssertEqual(renderer.snapshots.compactMap { $0 }.last?.phase, .commitFailed)
+    }
+
+    func testClipboardFallbackPanelDismissesAfterReadableHold() async {
+        // Owner field feedback on #90: the fallback panel used to persist
+        // like a real failure. It must hold the message readable, then hide.
+        TerminalTargetDetector.debugSecureEventInputOverride = { true }
+        let renderer = MockOverlayRenderer()
+        var currentDate = Date(timeIntervalSince1970: 1_000)
+        var requestedSleeps: [Duration] = []
+        let coordinator = OverlayBufferSessionCoordinator(
+            stateMachine: OverlayBufferStateMachine(),
+            renderer: renderer,
+            anchorResolver: MockOverlayAnchorResolver(),
+            now: { currentDate },
+            sleepFor: { requestedSleeps.append($0) },
+            copyToPasteboard: { _ in }
+        )
+        let committer = MockOverlayTextCommitter()
+
+        coordinator.startSession()
+        coordinator.beginFinalizing(displayBufferText: "words", commitBufferText: "words")
+
+        // The user dictated a while ago; without re-anchoring the hold to the
+        // fallback message render, the elapsed time would swallow the whole
+        // visibility window and the message would flash away unread.
+        currentDate = currentDate.addingTimeInterval(10)
+        _ = coordinator.commitIfNeeded(using: committer, autoCopyEnabled: false)
+        XCTAssertEqual(renderer.hideCallCount, 0, "the fallback message is showing")
+
+        coordinator.dismissAfterHold(
+            minimumVisibility: TimingConstants.overlayClipboardFallbackVisibility
+        )
+        guard let dismissTask = coordinator.debugDismissTask else {
+            XCTFail("expected a pending dismiss hold task — the fallback panel must not persist")
+            return
+        }
+        await dismissTask.value
+
+        XCTAssertEqual(
+            requestedSleeps, [.seconds(TimingConstants.overlayClipboardFallbackVisibility)],
+            "the full visibility window, anchored to the message render"
+        )
+        XCTAssertEqual(renderer.hideCallCount, 1, "panel dismisses once the hold elapses")
     }
 
     func testCommitProceedsNormallyWhenSecureInputOff() {

--- a/Tests/localvoxtralTests/OverlayBufferSessionCoordinatorTests.swift
+++ b/Tests/localvoxtralTests/OverlayBufferSessionCoordinatorTests.swift
@@ -20,7 +20,7 @@ final class OverlayBufferSessionCoordinatorTests: XCTestCase {
             stateMachine: OverlayBufferStateMachine(),
             renderer: renderer,
             anchorResolver: anchorResolver,
-            copyToPasteboard: { copiedTexts.append($0) }
+            copyToPasteboard: { copiedTexts.append($0); return true }
         )
         let committer = MockOverlayTextCommitter()
         committer.insertResult = .insertedByAccessibility
@@ -60,7 +60,7 @@ final class OverlayBufferSessionCoordinatorTests: XCTestCase {
             anchorResolver: MockOverlayAnchorResolver(),
             now: { currentDate },
             sleepFor: { requestedSleeps.append($0) },
-            copyToPasteboard: { _ in }
+            copyToPasteboard: { _ in true }
         )
         let committer = MockOverlayTextCommitter()
 
@@ -90,6 +90,31 @@ final class OverlayBufferSessionCoordinatorTests: XCTestCase {
         XCTAssertEqual(renderer.hideCallCount, 1, "panel dismisses once the hold elapses")
     }
 
+    func testFailedClipboardWriteUnderSecureInputKeepsThePersistentPanel() {
+        // Codex finding on #90 (round 7): a failed pasteboard write must not
+        // claim "copied" and dismiss the transcript's only remaining copy.
+        TerminalTargetDetector.debugSecureEventInputOverride = { true }
+        let renderer = MockOverlayRenderer()
+        let coordinator = OverlayBufferSessionCoordinator(
+            stateMachine: OverlayBufferStateMachine(),
+            renderer: renderer,
+            anchorResolver: MockOverlayAnchorResolver(),
+            copyToPasteboard: { _ in false }
+        )
+        let committer = MockOverlayTextCommitter()
+
+        coordinator.startSession()
+        coordinator.beginFinalizing(displayBufferText: "words", commitBufferText: "words")
+        let outcome = coordinator.commitIfNeeded(using: committer, autoCopyEnabled: false)
+
+        guard case .failed(let message) = outcome else {
+            return XCTFail("must report a real failure, got \(outcome)")
+        }
+        XCTAssertFalse(message.contains("paste it manually"), "must not claim the text was copied")
+        XCTAssertTrue(committer.insertedTexts.isEmpty, "still no doomed synthetic attempts")
+        XCTAssertEqual(renderer.snapshots.compactMap { $0 }.last?.phase, .commitFailed)
+    }
+
     func testCommitProceedsNormallyWhenSecureInputOff() {
         TerminalTargetDetector.debugSecureEventInputOverride = { false }
         let renderer = MockOverlayRenderer()
@@ -99,7 +124,7 @@ final class OverlayBufferSessionCoordinatorTests: XCTestCase {
             stateMachine: OverlayBufferStateMachine(),
             renderer: renderer,
             anchorResolver: anchorResolver,
-            copyToPasteboard: { copiedTexts.append($0) }
+            copyToPasteboard: { copiedTexts.append($0); return true }
         )
         let committer = MockOverlayTextCommitter()
         committer.insertResult = .insertedByAccessibility
@@ -174,7 +199,7 @@ final class OverlayBufferSessionCoordinatorTests: XCTestCase {
             stateMachine: OverlayBufferStateMachine(),
             renderer: renderer,
             anchorResolver: anchorResolver,
-            copyToPasteboard: { copiedTexts.append($0) }
+            copyToPasteboard: { copiedTexts.append($0); return true }
         )
         let committer = MockOverlayTextCommitter()
         committer.insertResult = .insertedByAccessibility
@@ -200,7 +225,7 @@ final class OverlayBufferSessionCoordinatorTests: XCTestCase {
             stateMachine: OverlayBufferStateMachine(),
             renderer: renderer,
             anchorResolver: anchorResolver,
-            copyToPasteboard: { copiedTexts.append($0) }
+            copyToPasteboard: { copiedTexts.append($0); return true }
         )
         let committer = MockOverlayTextCommitter()
         committer.insertResult = .insertedByAccessibility

--- a/Tests/localvoxtralTests/OverlayBufferSessionCoordinatorTests.swift
+++ b/Tests/localvoxtralTests/OverlayBufferSessionCoordinatorTests.swift
@@ -4,6 +4,94 @@ import XCTest
 
 @MainActor
 final class OverlayBufferSessionCoordinatorTests: XCTestCase {
+    override func tearDown() async throws {
+        TerminalTargetDetector.debugSecureEventInputOverride = nil
+        try await super.tearDown()
+    }
+
+    // MARK: - Secure Keyboard Entry at commit time (#89)
+
+    func testCommitUnderSecureInputSkipsInsertionAndCopiesToClipboard() {
+        TerminalTargetDetector.debugSecureEventInputOverride = { true }
+        let renderer = MockOverlayRenderer()
+        let anchorResolver = MockOverlayAnchorResolver()
+        var copiedTexts: [String] = []
+        let coordinator = OverlayBufferSessionCoordinator(
+            stateMachine: OverlayBufferStateMachine(),
+            renderer: renderer,
+            anchorResolver: anchorResolver,
+            copyToPasteboard: { copiedTexts.append($0) }
+        )
+        let committer = MockOverlayTextCommitter()
+        committer.insertResult = .insertedByAccessibility
+
+        coordinator.startSession()
+        coordinator.beginFinalizing(
+            displayBufferText: "secret words",
+            commitBufferText: "secret words"
+        )
+
+        // Auto-copy OFF on purpose: under secure input the clipboard is the
+        // only place the words can survive, so the copy must be unconditional.
+        let outcome = coordinator.commitIfNeeded(using: committer, autoCopyEnabled: false)
+
+        guard case .failed(let message) = outcome else {
+            return XCTFail("commit must report failure, got \(outcome)")
+        }
+        XCTAssertTrue(message.contains("copied"), "message tells the user where the text went")
+        XCTAssertTrue(
+            committer.insertedTexts.isEmpty && committer.pastedTexts.isEmpty,
+            "synthetic insertion is never attempted — it would be swallowed while reporting success"
+        )
+        XCTAssertEqual(copiedTexts, ["secret words"])
+        XCTAssertEqual(renderer.snapshots.compactMap { $0 }.last?.phase, .commitFailed)
+    }
+
+    func testCommitProceedsNormallyWhenSecureInputOff() {
+        TerminalTargetDetector.debugSecureEventInputOverride = { false }
+        let renderer = MockOverlayRenderer()
+        let anchorResolver = MockOverlayAnchorResolver()
+        var copiedTexts: [String] = []
+        let coordinator = OverlayBufferSessionCoordinator(
+            stateMachine: OverlayBufferStateMachine(),
+            renderer: renderer,
+            anchorResolver: anchorResolver,
+            copyToPasteboard: { copiedTexts.append($0) }
+        )
+        let committer = MockOverlayTextCommitter()
+        committer.insertResult = .insertedByAccessibility
+
+        coordinator.startSession()
+        coordinator.beginFinalizing(
+            displayBufferText: "hello",
+            commitBufferText: "hello"
+        )
+
+        let outcome = coordinator.commitIfNeeded(using: committer, autoCopyEnabled: false)
+
+        XCTAssertEqual(outcome, .succeeded)
+        XCTAssertEqual(committer.insertedTexts, ["hello"])
+        XCTAssertTrue(copiedTexts.isEmpty)
+    }
+
+    func testShowSecureInputWarningRendersInsideTheOverlayWhileBuffering() {
+        let renderer = MockOverlayRenderer()
+        let coordinator = OverlayBufferSessionCoordinator(
+            stateMachine: OverlayBufferStateMachine(),
+            renderer: renderer,
+            anchorResolver: MockOverlayAnchorResolver()
+        )
+
+        coordinator.startSession()
+        coordinator.showSecureInputWarning()
+
+        XCTAssertEqual(renderer.snapshots.compactMap { $0 }.last?.phase, .buffering)
+        XCTAssertNotNil(
+            renderer.snapshots.compactMap { $0 }.last?.errorMessage,
+            "the warning must be visible in the overlay panel, not only the closed popover"
+        )
+    }
+
     func testCommitUsesPIDCapturedAtStopTime() {
         let renderer = MockOverlayRenderer()
         let anchorResolver = MockOverlayAnchorResolver()

--- a/Tests/localvoxtralTests/OverlayBufferSessionCoordinatorTests.swift
+++ b/Tests/localvoxtralTests/OverlayBufferSessionCoordinatorTests.swift
@@ -153,10 +153,15 @@ final class OverlayBufferSessionCoordinatorTests: XCTestCase {
         coordinator.startSession()
         coordinator.showSecureInputWarning()
 
-        XCTAssertEqual(renderer.snapshots.compactMap { $0 }.last?.phase, .buffering)
-        XCTAssertNotNil(
-            renderer.snapshots.compactMap { $0 }.last?.errorMessage,
-            "the warning must be visible in the overlay panel, not only the closed popover"
+        let rendered = renderer.snapshots.compactMap { $0 }.last
+        XCTAssertEqual(rendered?.phase, .buffering)
+        XCTAssertEqual(
+            rendered?.secureInputActive, true,
+            "the marker must be visible in the overlay panel, not only the closed popover"
+        )
+        XCTAssertNil(
+            rendered?.errorMessage,
+            "no separate warning sentence — the phase title carries it (owner feedback on #90)"
         )
     }
 

--- a/Tests/localvoxtralTests/OverlayBufferStateMachineTests.swift
+++ b/Tests/localvoxtralTests/OverlayBufferStateMachineTests.swift
@@ -4,6 +4,32 @@ import XCTest
 
 @MainActor
 final class OverlayBufferStateMachineTests: XCTestCase {
+    func testBufferingWarningShowsOnlyWhileBufferingAndResetsOnNewSession() {
+        var machine = OverlayBufferStateMachine()
+        let anchor = OverlayAnchor(
+            targetRect: CGRect(x: 0, y: 0, width: 80, height: 24),
+            source: .windowCenter
+        )
+
+        machine.setBufferingWarning("too early")
+        XCTAssertNil(machine.snapshot, "no session, no warning")
+
+        machine.startSession(anchor: anchor)
+        machine.setBufferingWarning("secure input on")
+        XCTAssertEqual(machine.snapshot?.errorMessage, "secure input on")
+
+        machine.beginFinalizing(anchor: nil)
+        machine.setBufferingWarning("too late")
+        XCTAssertEqual(
+            machine.snapshot?.errorMessage, "secure input on",
+            "finalizing keeps the buffering-time warning; commitFailed owns the surface next"
+        )
+
+        machine.reset()
+        machine.startSession(anchor: anchor)
+        XCTAssertNil(machine.snapshot?.errorMessage, "a new session starts clean")
+    }
+
     func testStateMachine_happyPathTransitionsToIdleAfterReset() {
         var machine = OverlayBufferStateMachine()
         let anchor = OverlayAnchor(targetRect: CGRect(x: 10, y: 20, width: 100, height: 40), source: .windowCenter)

--- a/Tests/localvoxtralTests/OverlayBufferStateMachineTests.swift
+++ b/Tests/localvoxtralTests/OverlayBufferStateMachineTests.swift
@@ -4,30 +4,40 @@ import XCTest
 
 @MainActor
 final class OverlayBufferStateMachineTests: XCTestCase {
-    func testBufferingWarningShowsOnlyWhileBufferingAndResetsOnNewSession() {
+    func testSecureInputMarkerSetsOnlyWhileBufferingAndResetsOnNewSession() {
         var machine = OverlayBufferStateMachine()
         let anchor = OverlayAnchor(
             targetRect: CGRect(x: 0, y: 0, width: 80, height: 24),
             source: .windowCenter
         )
 
-        machine.setBufferingWarning("too early")
-        XCTAssertNil(machine.snapshot, "no session, no warning")
+        machine.setSecureInputWarning()
+        XCTAssertNil(machine.snapshot, "no session, no marker")
 
         machine.startSession(anchor: anchor)
-        machine.setBufferingWarning("secure input on")
-        XCTAssertEqual(machine.snapshot?.errorMessage, "secure input on")
+        machine.setSecureInputWarning()
+        XCTAssertEqual(machine.snapshot?.secureInputActive, true)
+        XCTAssertNil(
+            machine.snapshot?.errorMessage,
+            "the marker lives in the phase title, not a warning line (owner feedback on #90)"
+        )
 
         machine.beginFinalizing(anchor: nil)
-        machine.setBufferingWarning("too late")
         XCTAssertEqual(
-            machine.snapshot?.errorMessage, "secure input on",
-            "finalizing keeps the buffering-time warning; commitFailed owns the surface next"
+            machine.snapshot?.secureInputActive, true,
+            "finalizing keeps the marker; commitFailed owns the surface next"
         )
 
         machine.reset()
         machine.startSession(anchor: anchor)
-        XCTAssertNil(machine.snapshot?.errorMessage, "a new session starts clean")
+        XCTAssertEqual(machine.snapshot?.secureInputActive, false, "a new session starts clean")
+
+        machine.beginFinalizing(anchor: nil)
+        machine.setSecureInputWarning()
+        XCTAssertEqual(
+            machine.snapshot?.secureInputActive, false,
+            "too late — the warning is sampled while buffering only"
+        )
     }
 
     func testStateMachine_happyPathTransitionsToIdleAfterReset() {

--- a/Tests/localvoxtralTests/TerminalTargetDetectorTests.swift
+++ b/Tests/localvoxtralTests/TerminalTargetDetectorTests.swift
@@ -471,6 +471,26 @@ final class TerminalTargetDetectorTests: XCTestCase {
         viewModel.isShowingConnectionFailureAlert = true
     }
 
+    func testRefusedLiveStartResetsStaleOverlayPanel() {
+        // Codex finding on #90 (round 3): a prior overlay commit failure
+        // intentionally leaves its panel visible until the NEXT session
+        // resets the coordinator — a refused live start must still perform
+        // that reset or the failed panel lingers indefinitely.
+        TerminalTargetDetector.debugFrontmostBundleIDOverride = { "com.apple.Terminal" }
+        TerminalTargetDetector.debugSecureEventInputOverride = { true }
+
+        let coordinator = TargetDetectorNoopOverlayCoordinator()
+        let viewModel = makeViewModel(outputMode: .liveAutoPaste, coordinator: coordinator)
+        Self.retainedViewModels.append(viewModel)
+        viewModel.secureInputWarningSound = {}
+
+        viewModel.beginDictationSession()
+
+        XCTAssertFalse(viewModel.isDictating)
+        XCTAssertGreaterThanOrEqual(coordinator.resetCallCount, 1)
+        viewModel.isShowingConnectionFailureAlert = true
+    }
+
     func testOverlaySessionStartProceedsUnderSecureInput() {
         TerminalTargetDetector.debugFrontmostBundleIDOverride = { "com.apple.Terminal" }
         TerminalTargetDetector.debugSecureEventInputOverride = { true }
@@ -494,7 +514,8 @@ final class TerminalTargetDetectorTests: XCTestCase {
 
     private func makeViewModel(
         outputMode: DictationOutputMode,
-        terminalAppBundleIDs: [String] = []
+        terminalAppBundleIDs: [String] = [],
+        coordinator: TargetDetectorNoopOverlayCoordinator = TargetDetectorNoopOverlayCoordinator()
     ) -> DictationViewModel {
         let suiteName = "localvoxtral.TerminalTargetDetectorTests.\(UUID().uuidString)"
         let defaults = UserDefaults(suiteName: suiteName)!
@@ -506,7 +527,7 @@ final class TerminalTargetDetectorTests: XCTestCase {
         settings.dictationOutputMode = outputMode
         let viewModel = DictationViewModel(
             settings: settings,
-            overlayBufferCoordinator: TargetDetectorNoopOverlayCoordinator(),
+            overlayBufferCoordinator: coordinator,
             startRuntimeServices: false
         )
         // Keep tests hermetic: capture reads the terminal-apps config through
@@ -564,6 +585,7 @@ private final class TargetDetectorNoopOverlayCoordinator: OverlayBufferSessionCo
         .succeeded
     }
     func dismissAfterHold(minimumVisibility: TimeInterval) {}
-    func reset() {}
+    private(set) var resetCallCount = 0
+    func reset() { resetCallCount += 1 }
     func captureLiveCommitTargetAppPID() {}
 }

--- a/Tests/localvoxtralTests/TerminalTargetDetectorTests.swift
+++ b/Tests/localvoxtralTests/TerminalTargetDetectorTests.swift
@@ -377,6 +377,41 @@ final class TerminalTargetDetectorTests: XCTestCase {
         )
     }
 
+    func testMenuBarSecureWarningSurvivesStopFinalizationAndPolish() {
+        // Owner field feedback on #90: dismissing a secure-input overlay
+        // session flashed the yellow session icon while LLM polishing ran —
+        // the gesture-end clear fired during stop finalization. The warning
+        // describes text that is still headed for the clipboard fallback;
+        // it must stay red until session teardown clears it.
+        TerminalTargetDetector.debugFrontmostBundleIDOverride = { "com.apple.Terminal" }
+        TerminalTargetDetector.debugSecureEventInputOverride = { true }
+
+        let viewModel = makeViewModel(outputMode: .overlayBuffer)
+        Self.retainedViewModels.append(viewModel)
+        viewModel.secureInputWarningSound = {}
+        viewModel.captureSessionTargetVerdict()
+        viewModel.applyPreCapturedSessionTargetVerdict()
+        viewModel.sessionOutputMode = .overlayBuffer
+
+        // The exact mid-dismiss state stopDictation leaves behind: dictation
+        // off, finalization (and the polish task) still running, indicator
+        // on the yellow session icon.
+        viewModel.isDictating = false
+        viewModel.isFinalizingStop = true
+        viewModel.setRealtimeIndicatorConnected()
+
+        viewModel.clearSecureInputRefusalSignalsIfAttemptEnded()
+        XCTAssertEqual(
+            viewModel.menuBarIndicatorState, .secureInputWarning,
+            "the release-time clear must not drop the warning to the session icon mid-polish"
+        )
+
+        // Once finalization actually ends, the gesture-end clear may act.
+        viewModel.isFinalizingStop = false
+        viewModel.clearSecureInputRefusalSignalsIfAttemptEnded()
+        XCTAssertNotEqual(viewModel.menuBarIndicatorState, .secureInputWarning)
+    }
+
     func testMenuBarSecureWarningClearsAtSessionEnd() {
         TerminalTargetDetector.debugFrontmostBundleIDOverride = { "com.apple.Terminal" }
         TerminalTargetDetector.debugSecureEventInputOverride = { true }

--- a/Tests/localvoxtralTests/TerminalTargetDetectorTests.swift
+++ b/Tests/localvoxtralTests/TerminalTargetDetectorTests.swift
@@ -398,6 +398,70 @@ final class TerminalTargetDetectorTests: XCTestCase {
         )
     }
 
+    // MARK: - Session start under Secure Keyboard Entry (#89 split behavior)
+
+    func testLiveSessionStartRefusedUnderSecureInput() {
+        TerminalTargetDetector.debugFrontmostBundleIDOverride = { "com.apple.Terminal" }
+        TerminalTargetDetector.debugSecureEventInputOverride = { true }
+
+        let viewModel = makeViewModel(outputMode: .liveAutoPaste)
+        Self.retainedViewModels.append(viewModel)
+        var soundPlays = 0
+        viewModel.secureInputWarningSound = { soundPlays += 1 }
+
+        viewModel.beginDictationSession()
+
+        XCTAssertFalse(viewModel.isDictating, "a live session that can only type into the void must not start")
+        XCTAssertFalse(viewModel.isConnectingRealtimeSession, "no socket attempt for a refused start")
+        XCTAssertEqual(viewModel.statusText, DictationViewModel.StatusStrings.liveDictationBlockedBySecureInput)
+        XCTAssertEqual(viewModel.lastError, DictationViewModel.secureKeyboardEntryWarningMessage)
+        XCTAssertEqual(viewModel.menuBarIndicatorState, .secureInputWarning)
+        XCTAssertEqual(soundPlays, 1)
+        // Suite hygiene: nothing here arms the connect timeout, but every test
+        // reaching beginDictationSession sets this flag by convention (PR #66).
+        viewModel.isShowingConnectionFailureAlert = true
+    }
+
+    func testRefusedStartWarningClearsAtNextSessionStartWithSecureInputOff() {
+        TerminalTargetDetector.debugFrontmostBundleIDOverride = { "com.apple.Terminal" }
+        TerminalTargetDetector.debugSecureEventInputOverride = { true }
+
+        let viewModel = makeViewModel(outputMode: .liveAutoPaste)
+        Self.retainedViewModels.append(viewModel)
+        viewModel.secureInputWarningSound = {}
+        viewModel.beginDictationSession()
+        XCTAssertEqual(viewModel.menuBarIndicatorState, .secureInputWarning)
+
+        // The password prompt is gone; the stale-warning path at the next
+        // capture/apply clears both the popover line and the icon.
+        TerminalTargetDetector.debugSecureEventInputOverride = { false }
+        viewModel.captureSessionTargetVerdict()
+        viewModel.applyPreCapturedSessionTargetVerdict()
+
+        XCTAssertNil(viewModel.lastError)
+        XCTAssertNotEqual(viewModel.menuBarIndicatorState, .secureInputWarning)
+        viewModel.isShowingConnectionFailureAlert = true
+    }
+
+    func testOverlaySessionStartProceedsUnderSecureInput() {
+        TerminalTargetDetector.debugFrontmostBundleIDOverride = { "com.apple.Terminal" }
+        TerminalTargetDetector.debugSecureEventInputOverride = { true }
+
+        let viewModel = makeViewModel(outputMode: .overlayBuffer)
+        Self.retainedViewModels.append(viewModel)
+        viewModel.secureInputWarningSound = {}
+
+        viewModel.beginDictationSession()
+
+        XCTAssertTrue(
+            viewModel.isConnectingRealtimeSession,
+            "overlay sessions proceed: the pipeline still produces text and the commit falls back to the clipboard"
+        )
+        // This path DOES arm the real 10s connect timeout (PR #66 rule).
+        viewModel.isShowingConnectionFailureAlert = true
+        viewModel.stopDictation(reason: "test", finalizeRemainingAudio: false)
+    }
+
     // MARK: - Fixture
 
     private func makeViewModel(

--- a/Tests/localvoxtralTests/TerminalTargetDetectorTests.swift
+++ b/Tests/localvoxtralTests/TerminalTargetDetectorTests.swift
@@ -371,12 +371,21 @@ final class TerminalTargetDetectorTests: XCTestCase {
             DictationViewModel.liveAutoPasteAccessibilityWarningMessage,
             "popover priority unchanged"
         )
+        XCTAssertEqual(
+            viewModel.menuBarIndicatorState, .secureInputWarning,
+            "the icon must not vanish just because another warning owns the popover line"
+        )
     }
 
     func testMenuBarSecureWarningClearsAtSessionEnd() {
+        TerminalTargetDetector.debugFrontmostBundleIDOverride = { "com.apple.Terminal" }
+        TerminalTargetDetector.debugSecureEventInputOverride = { true }
+
         let viewModel = makeViewModel(outputMode: .liveAutoPaste)
         Self.retainedViewModels.append(viewModel)
-        viewModel.lastError = DictationViewModel.secureKeyboardEntryWarningMessage
+        viewModel.secureInputWarningSound = {}
+        viewModel.captureSessionTargetVerdict()
+        viewModel.applyPreCapturedSessionTargetVerdict()
         viewModel.sessionOutputMode = .liveAutoPaste
         viewModel.isDictating = true
         XCTAssertEqual(viewModel.menuBarIndicatorState, .secureInputWarning)

--- a/Tests/localvoxtralTests/TerminalTargetDetectorTests.swift
+++ b/Tests/localvoxtralTests/TerminalTargetDetectorTests.swift
@@ -443,6 +443,34 @@ final class TerminalTargetDetectorTests: XCTestCase {
         viewModel.isShowingConnectionFailureAlert = true
     }
 
+    func testStaleSecureIconDoesNotMaskEarlyExitFailuresOnNextAttempt() {
+        // Codex finding on #90: refused start leaves the icon lit; a next
+        // attempt that exits early (missing mic) BEFORE the verdict capture
+        // must not keep reporting a secure-input warning that is now off.
+        TerminalTargetDetector.debugFrontmostBundleIDOverride = { "com.apple.Terminal" }
+        TerminalTargetDetector.debugSecureEventInputOverride = { true }
+
+        let viewModel = makeViewModel(outputMode: .liveAutoPaste)
+        Self.retainedViewModels.append(viewModel)
+        viewModel.secureInputWarningSound = {}
+        viewModel.beginDictationSession()
+        XCTAssertEqual(viewModel.menuBarIndicatorState, .secureInputWarning)
+
+        TerminalTargetDetector.debugSecureEventInputOverride = { false }
+        // Force the invalid-endpoint early exit, which happens BEFORE the
+        // verdict capture: custom backend mode with an empty endpoint URL.
+        viewModel.settings.dictationBackendMode = .externalURL
+        viewModel.settings.realtimeAPIEndpointURL = ""
+        viewModel.beginDictationSession()
+
+        XCTAssertNotEqual(
+            viewModel.menuBarIndicatorState, .secureInputWarning,
+            "the invalid-endpoint failure must not be masked by a stale secure-input icon"
+        )
+        XCTAssertFalse(viewModel.isDictating)
+        viewModel.isShowingConnectionFailureAlert = true
+    }
+
     func testOverlaySessionStartProceedsUnderSecureInput() {
         TerminalTargetDetector.debugFrontmostBundleIDOverride = { "com.apple.Terminal" }
         TerminalTargetDetector.debugSecureEventInputOverride = { true }

--- a/Tests/localvoxtralTests/TerminalTargetDetectorTests.swift
+++ b/Tests/localvoxtralTests/TerminalTargetDetectorTests.swift
@@ -538,6 +538,34 @@ final class TerminalTargetDetectorTests: XCTestCase {
         viewModel.isShowingConnectionFailureAlert = true
     }
 
+    func testRefusedModifierTapDoesNotLatchTheWarningIcon() {
+        // Codex finding on #90 (round 5): a modifier-only TAP has no release
+        // event, so a refused live start latched the icon until the next
+        // attempt. The tap is the whole gesture — signals end with it.
+        TerminalTargetDetector.debugFrontmostBundleIDOverride = { "com.apple.Terminal" }
+        TerminalTargetDetector.debugSecureEventInputOverride = { true }
+
+        let viewModel = makeViewModel(outputMode: .liveAutoPaste)
+        Self.retainedViewModels.append(viewModel)
+        var soundPlays = 0
+        viewModel.secureInputWarningSound = { soundPlays += 1 }
+
+        viewModel.debugHandleModifierOnlyTapForTesting(mode: .liveAutoPaste)
+
+        XCTAssertFalse(viewModel.isDictating, "start is refused under secure input")
+        XCTAssertEqual(soundPlays, 1, "the audible cue fired")
+        XCTAssertNotEqual(
+            viewModel.menuBarIndicatorState, .secureInputWarning,
+            "no release will ever come — the icon must not latch"
+        )
+        XCTAssertEqual(
+            viewModel.lastError,
+            DictationViewModel.secureKeyboardEntryWarningMessage,
+            "the popover keeps the explanation"
+        )
+        viewModel.isShowingConnectionFailureAlert = true
+    }
+
     func testClipboardFallbackOutcomeDismissesOverlayWithReadableHold() {
         // Owner field feedback on #90: the overlay stayed on after ending the
         // session when text was in the buffer — the clipboard fallback is not

--- a/Tests/localvoxtralTests/TerminalTargetDetectorTests.swift
+++ b/Tests/localvoxtralTests/TerminalTargetDetectorTests.swift
@@ -510,6 +510,75 @@ final class TerminalTargetDetectorTests: XCTestCase {
         viewModel.stopDictation(reason: "test", finalizeRemainingAudio: false)
     }
 
+    func testRefusedStartIconClearsWhenTheHoldGestureEnds() {
+        // Owner field feedback on #90: the icon stayed red after releasing
+        // the modifier. The release ends the attempt, so the icon (and the
+        // "Blocked" status) end with it; the popover line stays as the
+        // explanation.
+        TerminalTargetDetector.debugFrontmostBundleIDOverride = { "com.apple.Terminal" }
+        TerminalTargetDetector.debugSecureEventInputOverride = { true }
+
+        let viewModel = makeViewModel(outputMode: .liveAutoPaste)
+        Self.retainedViewModels.append(viewModel)
+        viewModel.secureInputWarningSound = {}
+
+        viewModel.debugHandleModifierOnlyHoldStartForTesting()
+        XCTAssertFalse(viewModel.isDictating, "start is refused under secure input")
+        XCTAssertEqual(viewModel.menuBarIndicatorState, .secureInputWarning)
+
+        viewModel.debugHandleDictationShortcutReleaseForTesting()
+
+        XCTAssertNotEqual(viewModel.menuBarIndicatorState, .secureInputWarning)
+        XCTAssertEqual(viewModel.statusText, DictationViewModel.StatusStrings.ready)
+        XCTAssertEqual(
+            viewModel.lastError,
+            DictationViewModel.secureKeyboardEntryWarningMessage,
+            "the popover keeps the explanation until the next start re-samples"
+        )
+        viewModel.isShowingConnectionFailureAlert = true
+    }
+
+    func testClipboardFallbackOutcomeDismissesOverlayWithReadableHold() {
+        // Owner field feedback on #90: the overlay stayed on after ending the
+        // session when text was in the buffer — the clipboard fallback is not
+        // a real failure and must not keep its panel like one.
+        let coordinator = TargetDetectorNoopOverlayCoordinator()
+        coordinator.commitOutcome = .copiedToClipboard(message: "copied")
+        let viewModel = makeViewModel(outputMode: .overlayBuffer, coordinator: coordinator)
+        Self.retainedViewModels.append(viewModel)
+        viewModel.sessionOutputMode = .overlayBuffer
+        viewModel.isDictating = true
+
+        viewModel.stopDictation(reason: "test", finalizeRemainingAudio: false)
+
+        XCTAssertEqual(
+            viewModel.statusText,
+            DictationViewModel.StatusStrings.overlayCopiedToClipboard,
+            "honest status instead of 'Insert failed.'"
+        )
+        XCTAssertEqual(
+            coordinator.dismissHoldVisibilities,
+            [TimingConstants.overlayClipboardFallbackVisibility],
+            "the panel dismisses after the readable hold instead of persisting"
+        )
+    }
+
+    func testFailedCommitOutcomeStillKeepsOverlayPanel() {
+        // The generic failure contract is unchanged: the buffered text may
+        // exist nowhere else, so the panel persists.
+        let coordinator = TargetDetectorNoopOverlayCoordinator()
+        coordinator.commitOutcome = .failed(message: "nope")
+        let viewModel = makeViewModel(outputMode: .overlayBuffer, coordinator: coordinator)
+        Self.retainedViewModels.append(viewModel)
+        viewModel.sessionOutputMode = .overlayBuffer
+        viewModel.isDictating = true
+
+        viewModel.stopDictation(reason: "test", finalizeRemainingAudio: false)
+
+        XCTAssertEqual(viewModel.statusText, "Insert failed.")
+        XCTAssertTrue(coordinator.dismissHoldVisibilities.isEmpty)
+    }
+
     // MARK: - Fixture
 
     private func makeViewModel(
@@ -578,13 +647,17 @@ private final class TargetDetectorNoopOverlayCoordinator: OverlayBufferSessionCo
     func startSession(preResolvedAnchor: OverlayAnchor?) {}
     func beginFinalizing(displayBufferText: String, commitBufferText: String) {}
     func refresh(displayBufferText: String, commitBufferText: String) {}
+    var commitOutcome: OverlayBufferCommitOutcome = .succeeded
     @discardableResult
     func commitIfNeeded(
         using textCommitter: OverlayTextCommitting, autoCopyEnabled: Bool
     ) -> OverlayBufferCommitOutcome {
-        .succeeded
+        commitOutcome
     }
-    func dismissAfterHold(minimumVisibility: TimeInterval) {}
+    private(set) var dismissHoldVisibilities: [TimeInterval] = []
+    func dismissAfterHold(minimumVisibility: TimeInterval) {
+        dismissHoldVisibilities.append(minimumVisibility)
+    }
     private(set) var resetCallCount = 0
     func reset() { resetCallCount += 1 }
     func captureLiveCommitTargetAppPID() {}

--- a/Tests/localvoxtralTests/TerminalTargetDetectorTests.swift
+++ b/Tests/localvoxtralTests/TerminalTargetDetectorTests.swift
@@ -316,6 +316,79 @@ final class TerminalTargetDetectorTests: XCTestCase {
         XCTAssertEqual(viewModel.lastError, "mlx-lm failed to start.")
     }
 
+    // MARK: - Secure Keyboard Entry signals: sound + menu bar icon (#89)
+
+    func testSecureInputWarningPlaysSoundAndDrivesMenuBarState() {
+        TerminalTargetDetector.debugFrontmostBundleIDOverride = { "com.apple.Terminal" }
+        TerminalTargetDetector.debugSecureEventInputOverride = { true }
+
+        let viewModel = makeViewModel(outputMode: .liveAutoPaste)
+        var soundPlays = 0
+        viewModel.secureInputWarningSound = { soundPlays += 1 }
+
+        viewModel.captureSessionTargetVerdict()
+        viewModel.applyPreCapturedSessionTargetVerdict()
+
+        XCTAssertEqual(soundPlays, 1, "one audible cue at session start")
+        XCTAssertEqual(
+            viewModel.menuBarIndicatorState, .secureInputWarning,
+            "the menu bar is the only visible surface while the popover is closed"
+        )
+    }
+
+    func testNoSecureInputSignalsWhenSecureInputOff() {
+        TerminalTargetDetector.debugFrontmostBundleIDOverride = { "com.apple.Terminal" }
+        TerminalTargetDetector.debugSecureEventInputOverride = { false }
+
+        let viewModel = makeViewModel(outputMode: .liveAutoPaste)
+        var soundPlays = 0
+        viewModel.secureInputWarningSound = { soundPlays += 1 }
+
+        viewModel.captureSessionTargetVerdict()
+        viewModel.applyPreCapturedSessionTargetVerdict()
+
+        XCTAssertEqual(soundPlays, 0)
+        XCTAssertNotEqual(viewModel.menuBarIndicatorState, .secureInputWarning)
+    }
+
+    func testSoundStillPlaysWhenAccessibilityWarningOwnsThePopoverLine() {
+        // The popover line is masked by the higher-priority warning, but the
+        // session still cannot type — the audible cue must not be masked.
+        TerminalTargetDetector.debugFrontmostBundleIDOverride = { "com.apple.Terminal" }
+        TerminalTargetDetector.debugSecureEventInputOverride = { true }
+
+        let viewModel = makeViewModel(outputMode: .liveAutoPaste)
+        viewModel.lastError = DictationViewModel.liveAutoPasteAccessibilityWarningMessage
+        var soundPlays = 0
+        viewModel.secureInputWarningSound = { soundPlays += 1 }
+
+        viewModel.captureSessionTargetVerdict()
+        viewModel.applyPreCapturedSessionTargetVerdict()
+
+        XCTAssertEqual(soundPlays, 1)
+        XCTAssertEqual(
+            viewModel.lastError,
+            DictationViewModel.liveAutoPasteAccessibilityWarningMessage,
+            "popover priority unchanged"
+        )
+    }
+
+    func testMenuBarSecureWarningClearsAtSessionEnd() {
+        let viewModel = makeViewModel(outputMode: .liveAutoPaste)
+        Self.retainedViewModels.append(viewModel)
+        viewModel.lastError = DictationViewModel.secureKeyboardEntryWarningMessage
+        viewModel.sessionOutputMode = .liveAutoPaste
+        viewModel.isDictating = true
+        XCTAssertEqual(viewModel.menuBarIndicatorState, .secureInputWarning)
+
+        viewModel.stopDictation(reason: "test", finalizeRemainingAudio: false)
+
+        XCTAssertNotEqual(
+            viewModel.menuBarIndicatorState, .secureInputWarning,
+            "icon reverts with the token-scoped clear at session end"
+        )
+    }
+
     // MARK: - Fixture
 
     private func makeViewModel(

--- a/Tests/localvoxtralTests/TerminalTargetDetectorTests.swift
+++ b/Tests/localvoxtralTests/TerminalTargetDetectorTests.swift
@@ -566,6 +566,27 @@ final class TerminalTargetDetectorTests: XCTestCase {
         viewModel.isShowingConnectionFailureAlert = true
     }
 
+    func testRefusedPopoverToggleStartDoesNotLatchTheWarningIcon() {
+        // Codex finding on #90 (round 6): the popover start button goes
+        // through toggleDictation with no release event either — same latch
+        // as the modifier tap.
+        TerminalTargetDetector.debugFrontmostBundleIDOverride = { "com.apple.Terminal" }
+        TerminalTargetDetector.debugSecureEventInputOverride = { true }
+
+        let viewModel = makeViewModel(outputMode: .liveAutoPaste)
+        Self.retainedViewModels.append(viewModel)
+        var soundPlays = 0
+        viewModel.secureInputWarningSound = { soundPlays += 1 }
+
+        viewModel.toggleDictation()
+
+        XCTAssertFalse(viewModel.isDictating)
+        XCTAssertEqual(soundPlays, 1)
+        XCTAssertNotEqual(viewModel.menuBarIndicatorState, .secureInputWarning)
+        XCTAssertEqual(viewModel.lastError, DictationViewModel.secureKeyboardEntryWarningMessage)
+        viewModel.isShowingConnectionFailureAlert = true
+    }
+
     func testClipboardFallbackOutcomeDismissesOverlayWithReadableHold() {
         // Owner field feedback on #90: the overlay stayed on after ending the
         // session when text was in the buffer — the clipboard fallback is not


### PR DESCRIPTION
Closes #89. Two parts, both driven by owner field-testing: the original signals (sound + icon), then the behavioral split after the field observation that the app kept running "as if healthy" in an error state — mic capturing, overlay buffering, and (worse) the overlay commit *reporting success* while secure input silently swallowed every synthetic keystroke (posting succeeds; delivery doesn't).

## What

**Signals (always fire when Secure Keyboard Entry is detected at session start):**
- `NSSound("Basso")` once — you find out after zero words, not a sentence. Plays even when the Accessibility warning owns the popover line. Injectable seam for tests.
- Menu bar icon: new `MenuBarIndicatorState.secureInputWarning` (failure asset / orange `exclamationmark.triangle.fill` fallback), tracked independently of `lastError` so higher-priority popover warnings can't hide it. Outranks `.connected`. Fresh-sampled at every attempt so it can never mask a later unrelated failure.

**Split behavior:**
- **Live Auto-Paste: refuses to start.** No mic, no socket, no managed-backend boot (the preflight runs before `ensureReady`, so a cold backend never runs a long install for a doomed session). Status line: "Blocked: Secure Keyboard Entry is on." The warning persists until the next attempt re-samples. A stale failed-commit overlay panel is reset on the refused start.
- **Overlay Buffer: proceeds** — the pipeline still produces text. The warning shows *inside the overlay panel* while buffering, and the commit **re-checks secure input at commit time**: skips the doomed synthetic attempts (which would falsely report success), copies the text to the clipboard **unconditionally** (losing the words is the only alternative), and shows the explicit failure state: "Secure input blocked auto-paste — text copied, paste it manually."

## Proof

- Suite: `Executed 593 tests, with 2 tests skipped and 0 failures (0 unexpected)` — 14 new tests across `TerminalTargetDetectorTests`, `OverlayBufferSessionCoordinatorTests`, `OverlayBufferStateMachineTests`, `DictationViewModelFailFastUXTests`.
- Codex (GPT-5.5 high), four rounds — three real P2s found and fixed, each pinned by a dedicated regression test:
  1. Icon vanished when the Accessibility warning owned the popover line → independent `sessionSecureInputActive` tracking.
  2. Stale icon masked unrelated early-exit failures on the next attempt → fresh sample per attempt.
  3. Refused start left a stale failed overlay panel onscreen + refusal ran after managed-backend boot → shared preflight before `ensureReady` + coordinator reset.
  Final verdict: "No actionable correctness regressions… covered by focused regression tests across live and overlay modes."

## Hand-verification (owner, via try-pr — UI/audio change)

- [ ] Ghostty `sudo -k && sudo true` (leave the password prompt up), **hold** (live): Basso immediately, warning icon in the menu bar, **no session starts** (no mic indicator, nothing typed), status "Blocked: Secure Keyboard Entry is on."
- [ ] Same prompt, **tap** (overlay): session runs, overlay shows the warning line while buffering; on stop the overlay shows the failure state and the text is on the clipboard — paste it manually.
- [ ] Cancel the prompt, dictate live again: no sound, normal icon, everything works; stale warning cleared.
