### PR TITLE
Bump managed mlx-lm backend to 0.31.3.post4

### DIFF
--- a/Sources/localvoxtral/Backends/BackendCatalog.swift
+++ b/Sources/localvoxtral/Backends/BackendCatalog.swift
@@ -49,10 +49,16 @@ enum BackendCatalog {
         // that doesn't match the request prefix (T0mSIlver/mlx-lm#2), and the
         // server cache is actually LRU with one-token prefix hits fixed
         // (T0mSIlver/mlx-lm#3).
-        version: "0.31.3.post3",
+        // post4 corrects post3's slid-cache fix: post3 disabled trimming
+        // globally for a slid chunked cache, which silently corrupted
+        // speculative decoding (the draft-rewind path trims and ignores the
+        // result). post4 refuses arbitrary-prefix reuse in the server cache
+        // only, leaving the trim/rewind contract intact (ml-explore/mlx-lm#1502,
+        // #1503).
+        version: "0.31.3.post4",
         requirementName: "mlx-lm",
-        wheelURL: URL(string: "https://github.com/T0mSIlver/mlx-lm/releases/download/v0.31.3.post3/mlx_lm-0.31.3.post3-py3-none-any.whl")!,
-        wheelSHA256: "13b0fe84eb7bcd92103b45e93a90a82be1cbf10cb089168b91e080c9bacb3177",
+        wheelURL: URL(string: "https://github.com/T0mSIlver/mlx-lm/releases/download/v0.31.3.post4/mlx_lm-0.31.3.post4-py3-none-any.whl")!,
+        wheelSHA256: "d32d58c77b9e3a05b19748fad1ff6c26c67096a95ef88b6be990f9fed0d40bdf",
         executableName: "mlx_lm.server",
         pythonVersion: "3.12",
         port: 8472

--- a/scripts/mac/README.md
+++ b/scripts/mac/README.md
@@ -62,7 +62,7 @@ sudo install -d -m 0755 /Users/Shared/localvoxtral        # log dir, if absent
 #    mirror BackendCatalog.mlxLM — keep them in sync when the catalog moves.
 uv venv --python 3.12 ~/.local/share/localvoxtral-eval/mlx-lm
 uv pip install --python ~/.local/share/localvoxtral-eval/mlx-lm/bin/python \
-  'mlx-lm @ https://github.com/T0mSIlver/mlx-lm/releases/download/v0.31.3.post3/mlx_lm-0.31.3.post3-py3-none-any.whl'
+  'mlx-lm @ https://github.com/T0mSIlver/mlx-lm/releases/download/v0.31.3.post4/mlx_lm-0.31.3.post4-py3-none-any.whl'
 ```
 
 > This mlxlm service is the *prompt-eval reference endpoint* for


### PR DESCRIPTION
Bumps the managed **mlx-lm** polishing backend from `0.31.3.post3` to `0.31.3.post4`.

### Why
post3's prompt-cache fix made `ChunkedKVCache.is_trimmable()` return `False` once its window slid. But `is_trimmable`/`trim` are also on mlx-lm's speculative-decoding rewind path (`generate.py` `_rewind_cache`), which checks trimmability once at startup and then calls `trim_prompt_cache` on every draft rejection **ignoring the return value**. So once a llama4 chunked window slides past `attention_chunk_size`, those rewinds silently trim nothing and leave rejected KV resident — corrupting output.

post4 keeps `is_trimmable` truthful (a slid cache can still do the small suffix rewinds speculative decoding needs) and instead refuses arbitrary-*prefix* reuse inside the server's `LRUPromptCache.fetch_nearest_cache` only, leaving the global trim/rewind contract intact. It also closes a case post3's trim-count guard missed on its own (a shared prefix behind the attention-chunk boundary where the full trim succeeds).

Upstream PRs: ml-explore/mlx-lm#1502 + #1503. Fork release: [v0.31.3.post4](https://github.com/T0mSIlver/mlx-lm/releases/tag/v0.31.3.post4).

### Changes
- `BackendCatalog.swift`: `version`, `wheelURL`, and `wheelSHA256` → post4; comment explains the post3→post4 correction.
- `scripts/mac/README.md`: eval-harness install snippet → post4 wheel.

Wheel `mlx_lm-0.31.3.post4-py3-none-any.whl` is attached to the fork release; SHA256 `d32d58c7…d40bdf` verified against the uploaded asset, download URL returns 200.
