### PR TITLE
polishd: prompt-prefix KV cache reuse (system + instructions checkpointed, transcript prefilled per request)

### DIFF
--- a/PolishHelper/Sources/PolishHelperCore/PolishModelHost.swift
+++ b/PolishHelper/Sources/PolishHelperCore/PolishModelHost.swift
@@ -1,4 +1,5 @@
 import Foundation
+import MLX
 import MLXLLM
 import MLXLMCommon
 
@@ -23,12 +24,28 @@ public enum ChatRespondingError: Error, CustomStringConvertible {
     }
 }
 
-/// Loads the MLX model once and answers chat requests against it. Each
-/// request gets a fresh `ChatSession` (no cross-request history); the
-/// `ModelContainer` serializes concurrent generation internally.
+/// Loads the MLX model once and answers chat requests against it, reusing a
+/// KV-state checkpoint of the stable prompt prefix across requests.
+///
+/// Every polish request shares [system prompt, instructions user message] and
+/// varies only in the final transcript message, so the prefix's prefill work
+/// (the bulk of the prompt) is paid once and cloned per request via
+/// `KVCache.copy()`. Cloning — never trimming — is load-bearing: Qwen3.5 is
+/// hybrid linear-attention and its `MambaCache` layers cannot be trimmed, the
+/// same reason the previous mlx-lm engine only reused stored true prefixes
+/// for this model. The `ModelContainer` serializes concurrent requests.
 public final class MLXPolishModel: ChatResponding, @unchecked Sendable {
     private let container: ModelContainer
     private let defaultMaxTokens: Int
+
+    /// KV state for the templated stable prefix. `caches` is never mutated
+    /// after creation — each request extends a `copy()`. Only touched inside
+    /// `container.perform`, which serializes all access.
+    private struct PrefixSnapshot {
+        let prefixTokens: [Int]
+        let caches: [KVCache]
+    }
+    private var prefixSnapshot: PrefixSnapshot?
 
     private init(container: ModelContainer, defaultMaxTokens: Int) {
         self.container = container
@@ -55,19 +72,114 @@ public final class MLXPolishModel: ChatResponding, @unchecked Sendable {
         parameters.maxTokens = maxTokens ?? defaultMaxTokens
         // Deterministic sampling: identical requests must produce identical
         // output, like the previous engine's within-state behavior — the
-        // polish eval baseline and user experience both rely on it.
+        // polish eval baseline and user experience both rely on it. The
+        // sampler is seeded per request, so prefix-cache reuse does not
+        // change the sampled sequence for a given prompt.
         parameters.seed = 0
+        let generateParameters = parameters
 
-        let chat = try messages.map { message -> Chat.Message in
-            switch message.role {
-            case "system": .system(message.content)
-            case "user": .user(message.content)
-            case "assistant": .assistant(message.content)
-            default: throw ChatRespondingError.unknownRole(message.role)
+        let templateMessages = try messages.map { message -> [String: any Sendable] in
+            guard ["system", "user", "assistant"].contains(message.role) else {
+                throw ChatRespondingError.unknownRole(message.role)
             }
+            return ["role": message.role, "content": message.content]
+        }
+        let prefixMessageCount = PromptPrefixPlan.cacheablePrefix(of: messages)?.count
+
+        return try await container.perform { context in
+            let fullTokens = try context.tokenizer.applyChatTemplate(messages: templateMessages)
+            let (cache, promptTokens) = try self.promptState(
+                fullTokens: fullTokens,
+                templateMessages: templateMessages,
+                prefixMessageCount: prefixMessageCount,
+                context: context,
+                parameters: generateParameters
+            )
+
+            let input = LMInput(tokens: MLXArray(promptTokens))
+            let stream = try MLXLMCommon.generate(
+                input: input, cache: cache, parameters: generateParameters, context: context)
+            var output = ""
+            for await generation in stream {
+                if let chunk = generation.chunk {
+                    output += chunk
+                }
+            }
+            return output
+        }
+    }
+
+    /// The KV cache to generate on (nil for a fresh one) and the prompt
+    /// tokens still to prefill — the full prompt, or just the suffix past the
+    /// checkpointed prefix.
+    private func promptState(
+        fullTokens: [Int],
+        templateMessages: [[String: any Sendable]],
+        prefixMessageCount: Int?,
+        context: ModelContext,
+        parameters: GenerateParameters
+    ) throws -> ([KVCache]?, [Int]) {
+        guard let prefixMessageCount,
+            let prefixEncoder = context.tokenizer as? ChatPrefixEncoding
+        else {
+            return (nil, fullTokens)
         }
 
-        let session = ChatSession(container, generateParameters: parameters)
-        return try await session.respond(to: chat)
+        let prefixTokens = try prefixEncoder.encodeChatPrefix(
+            messages: Array(templateMessages.prefix(prefixMessageCount)))
+
+        switch PromptPrefixPlan.plan(fullTokens: fullTokens, cachedPrefixTokens: prefixTokens) {
+        case .fullPrefill:
+            // Template quirk guard: if the templated prefix is not a true
+            // token prefix of the full prompt, reuse would corrupt output —
+            // prefill everything instead and say so.
+            PolishdLog.info(
+                "prompt cache: templated prefix (\(prefixTokens.count) tokens) is not a "
+                    + "prefix of the prompt (\(fullTokens.count) tokens); full prefill")
+            return (nil, fullTokens)
+
+        case .reusePrefix(let suffixTokens):
+            if let snapshot = prefixSnapshot, snapshot.prefixTokens == prefixTokens {
+                PolishdLog.info(
+                    "prompt cache: hit — reusing \(prefixTokens.count) prefix tokens, "
+                        + "prefilling \(suffixTokens.count)")
+                return (snapshot.caches.map { $0.copy() }, suffixTokens)
+            }
+
+            let caches = try prefill(tokens: prefixTokens, context: context, parameters: parameters)
+            prefixSnapshot = PrefixSnapshot(prefixTokens: prefixTokens, caches: caches)
+            PolishdLog.info(
+                "prompt cache: checkpointed \(prefixTokens.count) prefix tokens; "
+                    + "prefilling \(suffixTokens.count)")
+            return (caches.map { $0.copy() }, suffixTokens)
+        }
+    }
+
+    /// Prefill `tokens` into a fresh cache WITHOUT sampling: `prepare`
+    /// consumes all full prefill windows, then the remaining tokens are
+    /// folded in with one forward pass whose logits are discarded. After
+    /// this the cache holds exactly `tokens`.
+    private func prefill(
+        tokens: [Int],
+        context: ModelContext,
+        parameters: GenerateParameters
+    ) throws -> [KVCache] {
+        let caches = context.model.newCache(parameters: parameters)
+        let input = LMInput(tokens: MLXArray(tokens))
+        switch try context.model.prepare(
+            input, cache: caches, windowSize: parameters.prefillStepSize)
+        {
+        case .tokens(let remaining):
+            withPreparedCache(caches, lengths: remaining.sequenceLengths) {
+                _ = context.model(
+                    remaining[text: .newAxis],
+                    cache: caches.isEmpty ? nil : caches,
+                    state: nil)
+            }
+        case .logits:
+            break
+        }
+        eval(caches)
+        return caches
     }
 }

--- a/PolishHelper/Sources/PolishHelperCore/PromptPrefixPlan.swift
+++ b/PolishHelper/Sources/PolishHelperCore/PromptPrefixPlan.swift
@@ -1,0 +1,46 @@
+import Foundation
+
+/// Prefix-cache planning for chat prompts: pure token/message math, no MLX,
+/// so it is unit-testable without Metal.
+///
+/// The reusable prefix is every message except the last — the polish request
+/// shape is [system, instructions user message, transcript user message],
+/// where only the transcript varies between requests. This mirrors the
+/// mlx-lm server's deliberate `messages[:-1]` cache segmentation, which is
+/// what made "system + first user cached, transcript not" work there.
+/// Qwen3.5's KV cache mixes in linear-attention state that cannot be
+/// trimmed, so reuse is only sound for a stored TRUE token prefix — hence
+/// the strict is-prefix check in ``plan(fullTokens:cachedPrefixTokens:)``
+/// instead of any longest-common-prefix trimming.
+public enum PromptPrefixPlan: Equatable, Sendable {
+    /// The cached prefix is a strict prefix of the full prompt: reuse the
+    /// snapshot's KV state and prefill only `suffixTokens`.
+    case reusePrefix(suffixTokens: [Int])
+    /// No usable prefix: prefill the full prompt from scratch.
+    case fullPrefill
+
+    /// The messages whose templated tokens are worth checkpointing: all but
+    /// the last (varying) one. Nil when there is nothing stable to cache.
+    public static func cacheablePrefix(
+        of messages: [ChatCompletionMessage]
+    ) -> [ChatCompletionMessage]? {
+        guard messages.count >= 2 else { return nil }
+        return Array(messages.dropLast())
+    }
+
+    /// Decide whether `cachedPrefixTokens` can serve as the already-prefilled
+    /// head of `fullTokens`. Requires a strict prefix with a non-empty
+    /// remainder (generation needs at least one fresh token to prefill).
+    public static func plan(
+        fullTokens: [Int],
+        cachedPrefixTokens: [Int]
+    ) -> PromptPrefixPlan {
+        guard !cachedPrefixTokens.isEmpty,
+            cachedPrefixTokens.count < fullTokens.count,
+            fullTokens.starts(with: cachedPrefixTokens)
+        else {
+            return .fullPrefill
+        }
+        return .reusePrefix(suffixTokens: Array(fullTokens.dropFirst(cachedPrefixTokens.count)))
+    }
+}

--- a/PolishHelper/Sources/PolishHelperCore/TransformersTokenizerLoader.swift
+++ b/PolishHelper/Sources/PolishHelperCore/TransformersTokenizerLoader.swift
@@ -15,6 +15,15 @@ public struct TransformersTokenizerLoader: TokenizerLoader {
     }
 }
 
+/// Templating a chat *prefix* — the messages before the varying final one —
+/// WITHOUT the generation prompt, so the result is a true token prefix of the
+/// full templated prompt and its KV state can be checkpointed for reuse.
+/// MLXLMCommon's `Tokenizer` protocol always adds the generation prompt, so
+/// this is a separate seam the prefix cache downcasts to.
+public protocol ChatPrefixEncoding {
+    func encodeChatPrefix(messages: [[String: any Sendable]]) throws -> [Int]
+}
+
 private struct TokenizerBridge: MLXLMCommon.Tokenizer {
     private let upstream: any Tokenizers.Tokenizer
 
@@ -51,6 +60,25 @@ private struct TokenizerBridge: MLXLMCommon.Tokenizer {
         do {
             return try upstream.applyChatTemplate(
                 messages: messages, tools: tools, additionalContext: additionalContext)
+        } catch Tokenizers.TokenizerError.missingChatTemplate {
+            throw MLXLMCommon.TokenizerError.missingChatTemplate
+        }
+    }
+}
+
+extension TokenizerBridge: ChatPrefixEncoding {
+    func encodeChatPrefix(messages: [[String: any Sendable]]) throws -> [Int] {
+        do {
+            // The full-control protocol requirement: the convenience
+            // overloads with defaulted addGenerationPrompt live on concrete
+            // tokenizers, not the existential.
+            return try upstream.applyChatTemplate(
+                messages: messages,
+                chatTemplate: nil,
+                addGenerationPrompt: false,
+                truncation: false,
+                maxLength: nil,
+                tools: nil)
         } catch Tokenizers.TokenizerError.missingChatTemplate {
             throw MLXLMCommon.TokenizerError.missingChatTemplate
         }

--- a/PolishHelper/Tests/PolishHelperCoreTests/PromptPrefixPlanTests.swift
+++ b/PolishHelper/Tests/PolishHelperCoreTests/PromptPrefixPlanTests.swift
@@ -1,0 +1,76 @@
+import XCTest
+
+@testable import PolishHelperCore
+
+final class PromptPrefixPlanTests: XCTestCase {
+
+    // MARK: - cacheablePrefix
+
+    func testCacheablePrefixDropsOnlyTheFinalMessage() {
+        let messages = [
+            ChatCompletionMessage(role: "system", content: "polish transcripts"),
+            ChatCompletionMessage(role: "user", content: "instructions"),
+            ChatCompletionMessage(role: "user", content: "the transcript"),
+        ]
+        XCTAssertEqual(
+            PromptPrefixPlan.cacheablePrefix(of: messages),
+            Array(messages.dropLast())
+        )
+    }
+
+    func testCacheablePrefixWithSystemPlusSingleUserCachesTheSystemMessage() {
+        let messages = [
+            ChatCompletionMessage(role: "system", content: "polish transcripts"),
+            ChatCompletionMessage(role: "user", content: "the transcript"),
+        ]
+        XCTAssertEqual(PromptPrefixPlan.cacheablePrefix(of: messages), [messages[0]])
+    }
+
+    func testCacheablePrefixIsNilWhenNothingStableExists() {
+        XCTAssertNil(PromptPrefixPlan.cacheablePrefix(of: []))
+        XCTAssertNil(
+            PromptPrefixPlan.cacheablePrefix(of: [
+                ChatCompletionMessage(role: "user", content: "the transcript")
+            ])
+        )
+    }
+
+    // MARK: - plan
+
+    func testPlanReusesStrictPrefixAndReturnsTheSuffix() {
+        XCTAssertEqual(
+            PromptPrefixPlan.plan(fullTokens: [1, 2, 3, 4, 5], cachedPrefixTokens: [1, 2, 3]),
+            .reusePrefix(suffixTokens: [4, 5])
+        )
+    }
+
+    func testPlanRejectsNonPrefixTokens() {
+        XCTAssertEqual(
+            PromptPrefixPlan.plan(fullTokens: [1, 2, 3, 4, 5], cachedPrefixTokens: [1, 9, 3]),
+            .fullPrefill
+        )
+    }
+
+    func testPlanRejectsPrefixEqualToFullPrompt() {
+        // Generation needs at least one fresh token to prefill, so an exact
+        // match cannot be served from the checkpoint.
+        XCTAssertEqual(
+            PromptPrefixPlan.plan(fullTokens: [1, 2, 3], cachedPrefixTokens: [1, 2, 3]),
+            .fullPrefill
+        )
+    }
+
+    func testPlanRejectsPrefixLongerThanPrompt() {
+        XCTAssertEqual(
+            PromptPrefixPlan.plan(fullTokens: [1, 2], cachedPrefixTokens: [1, 2, 3]),
+            .fullPrefill
+        )
+    }
+
+    func testPlanRejectsEmptyPrefix() {
+        XCTAssertEqual(
+            PromptPrefixPlan.plan(fullTokens: [1, 2, 3], cachedPrefixTokens: []),
+            .fullPrefill
+        )
+    }
+}

--- a/Tests/localvoxtralTests/PolishHelperIntegrationTests.swift
+++ b/Tests/localvoxtralTests/PolishHelperIntegrationTests.swift
@@ -181,7 +181,7 @@ final class PolishHelperIntegrationTests: XCTestCase {
         binary: URL,
         model: String,
         extraArguments: [String] = []
-    ) async throws -> (process: Process, port: UInt16) {
+    ) async throws -> (process: Process, port: UInt16, stderrLog: LineLog) {
         let process = Process()
         process.executableURL = binary
         process.arguments = ["--model", model, "--port", "0"] + extraArguments
@@ -227,7 +227,7 @@ final class PolishHelperIntegrationTests: XCTestCase {
             )
             throw XCTSkip("helper did not become ready")
         }
-        return (process, port)
+        return (process, port, stderrLog)
     }
 
     private final class LineLog: @unchecked Sendable {
@@ -244,6 +244,12 @@ final class PolishHelperIntegrationTests: XCTestCase {
             lock.lock()
             defer { lock.unlock() }
             return lines.suffix(count).joined(separator: "\n")
+        }
+
+        func countOfLines(containing substring: String) -> Int {
+            lock.lock()
+            defer { lock.unlock() }
+            return lines.count { $0.contains(substring) }
         }
     }
 
@@ -273,7 +279,7 @@ final class PolishHelperIntegrationTests: XCTestCase {
     func testHelperMatchesPolishEvalBaselineThroughProductionRequestPath() async throws {
         let (binary, model) = try helperConfiguration()
         try await ensureModelCached(model)
-        let (process, port) = try await launchHelper(binary: binary, model: model)
+        let (process, port, stderrLog) = try await launchHelper(binary: binary, model: model)
 
         let healthURL = URL(string: "http://127.0.0.1:\(port)/health")!
         let (_, healthResponse) = try await URLSession.shared.data(from: healthURL)
@@ -303,6 +309,25 @@ final class PolishHelperIntegrationTests: XCTestCase {
             "Bundled helper regressed required polish cases vs the mlx-lm baseline: \(result.failedRequiredCases.joined(separator: ", "))"
         )
 
+        // The prompt-prefix cache must actually engage: every eval request
+        // shares [system, instructions] and varies only the transcript
+        // message, so the first request checkpoints the prefix and the rest
+        // reuse it. A "full prefill" fallback line would mean the template
+        // boundary math broke and the cache silently turned itself off —
+        // fail loudly instead of shipping the perf regression.
+        XCTAssertEqual(
+            stderrLog.countOfLines(containing: "prompt cache: checkpointed"), 1,
+            "expected exactly one prefix checkpoint across the eval corpus"
+        )
+        XCTAssertGreaterThan(
+            stderrLog.countOfLines(containing: "prompt cache: hit"), 0,
+            "no request reused the prefix checkpoint"
+        )
+        XCTAssertEqual(
+            stderrLog.countOfLines(containing: "full prefill"), 0,
+            "prefix cache fell back to full prefill — templated prefix no longer a token prefix"
+        )
+
         XCTAssertTrue(process.isRunning)
         process.terminate()
     }
@@ -326,7 +351,7 @@ final class PolishHelperIntegrationTests: XCTestCase {
             }
         }
 
-        let (helper, _) = try await launchHelper(
+        let (helper, _, _) = try await launchHelper(
             binary: binary,
             model: model,
             extraArguments: ["--parent-pid", "\(decoyParent.processIdentifier)"]


### PR DESCRIPTION
## What

**Prompt-prefix KV cache reuse in `localvoxtral-polishd`** — the first deferred follow-up from #84 (the fork mlx-lm's ~50% prefill win). Matters little at 0.8B, but pays off directly when we move to larger polish models.

Every polish request shares `[system prompt, instructions user message]` and varies only the final transcript message (the app already splits the user prompt at the first placeholder for exactly this — `LLMPromptTemplates.renderedUserPrompts`). The helper now prefills that stable prefix once, keeps the KV state as an immutable checkpoint, and serves each request from a `KVCache.copy()` of it, prefilling only the transcript suffix.

**Why snapshot-and-copy, not trim-based LCP reuse:** Qwen3.5 is hybrid linear-attention; its `MambaCache` layers cannot be trimmed (inherit the no-op `trim`). This mirrors python mlx-lm exactly — there `ArraysCache.is_trimmable()` is false, so the fork server's cache never took its trim path for this model and relied on deliberately checkpointing the `messages[:-1]` boundary as a stored true prefix. This PR replicates that structure-aware design natively.

**Mechanics:**
- The prefix is templated with `addGenerationPrompt: false` via a new `ChatPrefixEncoding` seam on the tokenizer bridge (MLXLMCommon's `Tokenizer` protocol always appends the generation prompt, which would break prefix-ness).
- Runtime guard: the templated prefix must be a strict token prefix of the full prompt (`PromptPrefixPlan`, pure + unit-tested). Any template quirk falls back to a full prefill with a loud log line — never corrupt output.
- Checkpoint build is a sampling-free prefill (`model.prepare` for full windows + one logits-discarded forward pass); the snapshot is never mutated and rebuilds when the prefix messages change (e.g. user edits prompts).
- The seeded sampler is created per request, so determinism for identical requests is unchanged.
- `ModelContainer.perform` serializes requests, so the snapshot needs no extra locking.

**Also:** fixes the committed `PolishHelper/Package.resolved` (identity `jinja` → canonical `swift-jinja`; pins unchanged) — xcodebuild with `-disableAutomaticPackageResolution` rejected the file in any fresh workspace; CI only passed on warm runner state. That fix is also pushed to #84 directly.

## Proof

- [x] Helper unit suite (incl. new Metal-free `PromptPrefixPlanTests`) — `./scripts/remote-build.sh test --package-path PolishHelper`
  ```
  Executed 35 tests, with 0 failures (0 unexpected) in 0.109 (0.112) seconds
  ```
- [x] Root unit suite — `./scripts/remote-build.sh test`
  ```
  Executed 605 tests, with 2 tests skipped and 0 failures (0 unexpected) in 6.501 (6.532) seconds
  ```
- [x] Packaging with the corrected Package.resolved — `./scripts/remote-build.sh package` (bundles `localvoxtral-polishd`; previously failed in a fresh build dir with "dependencies were added: 'swift-jinja'").
- [x] Live integration + eval baseline — `./scripts/remote-build.sh integration-polishd`
  ```
  Test Case 'testHelperExitsWhenParentPIDDies' passed (2.007 seconds).
  Test Case 'testHelperMatchesPolishEvalBaselineThroughProductionRequestPath' passed (5.599 seconds).
  Executed 2 tests, with 0 failures (0 unexpected) in 7.606 (7.607) seconds

  == polishd (bundled MLX Swift helper) eval (model: mlx-community/Qwen3.5-0.8B-8bit) ==
  required: 7/7, known-hard passing: 3/7
  ```
  Same 10/14 score as #84's pre-cache baseline — cache reuse did not change polish behavior.
- [x] The cache is *asserted* to engage, not assumed: the eval-baseline test now requires the helper stderr to show exactly one `prompt cache: checkpointed` line, at least one `prompt cache: hit`, and zero `full prefill` fallbacks across the 14-case corpus. A template quirk that silently disables the cache fails the suite.
- [x] Indicative speedup: the same integration test ran 11.585s in #84's proof vs 5.599s here on the same host (includes helper launch + model load; not a controlled benchmark, but consistent with skipping the shared-prefix prefill on 13 of 14 requests).
- [x] No UI changes.

## Notes

- With larger models the win grows: the checkpoint amortizes the instructions prefix, and the per-request cost becomes transcript-length-bound.
- Snapshot memory: one extra KV copy of a few-hundred-token prefix for a 0.8B model — negligible; rebuilt (not accumulated) when prompts change.
