### PR TITLE
polishd: OpenAI sampling overrides (top_p/top_k/min_p/presence_penalty) + recommended-sampling eval verdict

### DIFF
--- a/PolishHelper/Sources/PolishHelperCore/ChatCompletionAPI.swift
+++ b/PolishHelper/Sources/PolishHelperCore/ChatCompletionAPI.swift
@@ -7,6 +7,10 @@ public struct ChatCompletionRequest: Codable, Sendable {
     public var model: String?
     public var messages: [ChatCompletionMessage]
     public var temperature: Float?
+    public var topP: Float?
+    public var topK: Int?
+    public var minP: Float?
+    public var presencePenalty: Float?
     public var maxTokens: Int?
     public var stream: Bool?
 
@@ -14,6 +18,10 @@ public struct ChatCompletionRequest: Codable, Sendable {
         case model
         case messages
         case temperature
+        case topP = "top_p"
+        case topK = "top_k"
+        case minP = "min_p"
+        case presencePenalty = "presence_penalty"
         case maxTokens = "max_tokens"
         case stream
     }
@@ -22,14 +30,62 @@ public struct ChatCompletionRequest: Codable, Sendable {
         model: String? = nil,
         messages: [ChatCompletionMessage],
         temperature: Float? = nil,
+        topP: Float? = nil,
+        topK: Int? = nil,
+        minP: Float? = nil,
+        presencePenalty: Float? = nil,
         maxTokens: Int? = nil,
         stream: Bool? = nil
     ) {
         self.model = model
         self.messages = messages
         self.temperature = temperature
+        self.topP = topP
+        self.topK = topK
+        self.minP = minP
+        self.presencePenalty = presencePenalty
         self.maxTokens = maxTokens
         self.stream = stream
+    }
+
+    public var sampling: ChatSamplingParameters {
+        ChatSamplingParameters(
+            temperature: temperature,
+            topP: topP,
+            topK: topK,
+            minP: minP,
+            presencePenalty: presencePenalty,
+            maxTokens: maxTokens
+        )
+    }
+}
+
+/// The sampling knobs a request may override; nil fields keep the engine
+/// defaults (mlx-swift-lm's `GenerateParameters` — the model card's
+/// recommended values are deliberately NOT applied, matching the old
+/// mlx-lm engine's behavior).
+public struct ChatSamplingParameters: Equatable, Sendable {
+    public var temperature: Float?
+    public var topP: Float?
+    public var topK: Int?
+    public var minP: Float?
+    public var presencePenalty: Float?
+    public var maxTokens: Int?
+
+    public init(
+        temperature: Float? = nil,
+        topP: Float? = nil,
+        topK: Int? = nil,
+        minP: Float? = nil,
+        presencePenalty: Float? = nil,
+        maxTokens: Int? = nil
+    ) {
+        self.temperature = temperature
+        self.topP = topP
+        self.topK = topK
+        self.minP = minP
+        self.presencePenalty = presencePenalty
+        self.maxTokens = maxTokens
     }
 }
 

--- a/PolishHelper/Sources/PolishHelperCore/PolishModelHost.swift
+++ b/PolishHelper/Sources/PolishHelperCore/PolishModelHost.swift
@@ -8,8 +8,7 @@ import MLXLMCommon
 public protocol ChatResponding: Sendable {
     func respond(
         to messages: [ChatCompletionMessage],
-        temperature: Float?,
-        maxTokens: Int?
+        sampling: ChatSamplingParameters
     ) async throws -> String
 }
 
@@ -62,14 +61,25 @@ public final class MLXPolishModel: ChatResponding, @unchecked Sendable {
 
     public func respond(
         to messages: [ChatCompletionMessage],
-        temperature: Float?,
-        maxTokens: Int?
+        sampling: ChatSamplingParameters
     ) async throws -> String {
         var parameters = GenerateParameters()
-        if let temperature {
+        if let temperature = sampling.temperature {
             parameters.temperature = temperature
         }
-        parameters.maxTokens = maxTokens ?? defaultMaxTokens
+        if let topP = sampling.topP {
+            parameters.topP = topP
+        }
+        if let topK = sampling.topK {
+            parameters.topK = topK
+        }
+        if let minP = sampling.minP {
+            parameters.minP = minP
+        }
+        if let presencePenalty = sampling.presencePenalty {
+            parameters.presencePenalty = presencePenalty
+        }
+        parameters.maxTokens = sampling.maxTokens ?? defaultMaxTokens
         // Deterministic sampling: identical requests must produce identical
         // output, like the previous engine's within-state behavior — the
         // polish eval baseline and user experience both rely on it. The

--- a/PolishHelper/Sources/PolishHelperCore/PolishdRouter.swift
+++ b/PolishHelper/Sources/PolishHelperCore/PolishdRouter.swift
@@ -42,8 +42,7 @@ public struct PolishdRouter: Sendable {
             let start = ContinuousClock.now
             let content = try await responder.respond(
                 to: completion.messages,
-                temperature: completion.temperature,
-                maxTokens: completion.maxTokens
+                sampling: completion.sampling
             )
             let elapsed = start.duration(to: .now)
             PolishdLog.info("chat.completion ok in \(elapsed)")

--- a/PolishHelper/Tests/PolishHelperCoreTests/PolishdRouterTests.swift
+++ b/PolishHelper/Tests/PolishHelperCoreTests/PolishdRouterTests.swift
@@ -4,7 +4,7 @@ import XCTest
 
 private final class StubResponder: ChatResponding, @unchecked Sendable {
     let result: Result<String, Error>
-    private(set) var received: (messages: [ChatCompletionMessage], temperature: Float?, maxTokens: Int?)?
+    private(set) var received: (messages: [ChatCompletionMessage], sampling: ChatSamplingParameters)?
 
     init(result: Result<String, Error> = .success("polished")) {
         self.result = result
@@ -12,10 +12,9 @@ private final class StubResponder: ChatResponding, @unchecked Sendable {
 
     func respond(
         to messages: [ChatCompletionMessage],
-        temperature: Float?,
-        maxTokens: Int?
+        sampling: ChatSamplingParameters
     ) async throws -> String {
-        received = (messages, temperature, maxTokens)
+        received = (messages, sampling)
         return try result.get()
     }
 }
@@ -52,8 +51,31 @@ final class PolishdRouterTests: XCTestCase {
         XCTAssertEqual(decoded.model, "x")
         XCTAssertEqual(responder.received?.messages.count, 3)
         XCTAssertEqual(responder.received?.messages[1].content, "raw one")
-        XCTAssertEqual(responder.received?.temperature, 0.3)
-        XCTAssertNil(responder.received?.maxTokens)
+        XCTAssertEqual(responder.received?.sampling.temperature, 0.3)
+        XCTAssertNil(responder.received?.sampling.maxTokens)
+    }
+
+    func testChatCompletionRoundTripsSamplingOverrides() async throws {
+        let responder = StubResponder()
+        let router = PolishdRouter(responder: responder, modelName: "test-model")
+        let response = await router.handle(
+            chatRequest(
+                """
+                {"temperature": 1.0, "top_p": 0.95, "top_k": 20, "min_p": 0.05,
+                 "presence_penalty": 2.0, "max_tokens": 64,
+                 "messages": [{"role": "user", "content": "raw"}]}
+                """
+            )
+        )
+
+        XCTAssertEqual(response.status, 200)
+        XCTAssertEqual(
+            responder.received?.sampling,
+            ChatSamplingParameters(
+                temperature: 1.0, topP: 0.95, topK: 20, minP: 0.05,
+                presencePenalty: 2.0, maxTokens: 64
+            )
+        )
     }
 
     func testStreamingIsRejected() async {

--- a/Tests/localvoxtralTests/LLMPolishEvalSupport.swift
+++ b/Tests/localvoxtralTests/LLMPolishEvalSupport.swift
@@ -177,7 +177,7 @@ enum LLMPolishEvalSupport {
 
     static func runCase(
         _ evalCase: LLMPolishEvalCase,
-        service: LLMPolishingService,
+        service: any LLMPolishingServicing,
         templates: LLMPromptTemplates,
         configuration: LLMPolishingConfiguration
     ) async -> (failures: [String], output: String) {
@@ -241,7 +241,7 @@ enum LLMPolishEvalSupport {
     /// Runs the full corpus and returns the printable scoreboard plus the
     /// required-case failures the caller must assert on.
     static func runScoreboard(
-        service: LLMPolishingService,
+        service: any LLMPolishingServicing,
         templates: LLMPromptTemplates,
         configuration: LLMPolishingConfiguration
     ) async -> ScoreboardResult {

--- a/Tests/localvoxtralTests/PolishHelperIntegrationTests.swift
+++ b/Tests/localvoxtralTests/PolishHelperIntegrationTests.swift
@@ -332,6 +332,42 @@ final class PolishHelperIntegrationTests: XCTestCase {
         process.terminate()
     }
 
+    /// EXPERIMENT (2026-07-09, print-only — no score assertions): run the
+    /// same corpus with the Qwen3.5 model card's recommended non-thinking
+    /// text sampling (temperature 1.0, top_p 1.0, top_k 20, min_p 0,
+    /// presence_penalty 2.0) instead of the production temperature-0.3
+    /// request, to test the hypothesis that the recommended set — tuned for
+    /// open-ended generation — hurts a copy-editing task where the output
+    /// should mostly repeat the input (presence_penalty penalizes exactly
+    /// that repetition). Compare this scoreboard against the baseline test's.
+    func testEvalScoreboardWithQwenRecommendedSampling() async throws {
+        let (binary, model) = try helperConfiguration()
+        try await ensureModelCached(model)
+        let (process, port, _) = try await launchHelper(binary: binary, model: model)
+
+        let configuration = LLMPolishingConfiguration(
+            endpointURL: URL(string: "http://127.0.0.1:\(port)/v1/chat/completions")!,
+            apiKey: "",
+            model: model
+        )
+        let (templates, cleanup) = try LLMPolishEvalSupport.defaultPromptTemplates()
+        addTeardownBlock { cleanup() }
+
+        let result = await LLMPolishEvalSupport.runScoreboard(
+            service: QwenRecommendedSamplingPolishingService(),
+            templates: templates,
+            configuration: configuration
+        )
+        LLMPolishEvalSupport.printScoreboard(
+            result,
+            configuration: configuration,
+            header: "polishd EXPERIMENT: Qwen recommended non-thinking sampling (temp 1.0, top_k 20, presence 2.0)"
+        )
+
+        XCTAssertTrue(process.isRunning)
+        process.terminate()
+    }
+
     /// The memory-contract proof: when the process that passed --parent-pid
     /// dies, the helper exits on its own (freeing all model memory), exactly
     /// like the old fork's Python watchdog.
@@ -363,5 +399,57 @@ final class PolishHelperIntegrationTests: XCTestCase {
         decoyParent.terminate()
         await fulfillment(of: [helperExited], timeout: 30)
         XCTAssertFalse(helper.isRunning)
+    }
+}
+
+/// The production request with the sampling fields swapped for the Qwen3.5
+/// model card's recommended non-thinking text values. Request/response
+/// handling mirrors `LLMPolishingService.polish`.
+private struct QwenRecommendedSamplingPolishingService: LLMPolishingServicing {
+    func polish(
+        request: LLMPolishingRequest,
+        configuration: LLMPolishingConfiguration
+    ) async throws -> LLMPolishingResult {
+        var urlRequest = URLRequest(url: configuration.endpointURL)
+        urlRequest.httpMethod = "POST"
+        urlRequest.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        urlRequest.timeoutInterval = 60
+
+        let messages = [["role": "system", "content": request.systemPrompt]]
+            + request.userPrompts.map { ["role": "user", "content": $0] }
+        let body: [String: Any] = [
+            "model": configuration.model,
+            "messages": messages,
+            "temperature": 1.0,
+            "top_p": 1.0,
+            "top_k": 20,
+            "min_p": 0.0,
+            "presence_penalty": 2.0,
+        ]
+        urlRequest.httpBody = try JSONSerialization.data(withJSONObject: body)
+
+        let (data, response) = try await URLSession.shared.data(for: urlRequest)
+        guard let httpResponse = response as? HTTPURLResponse,
+            (200..<300).contains(httpResponse.statusCode)
+        else {
+            throw LLMPolishingError.requestFailed(
+                statusCode: (response as? HTTPURLResponse)?.statusCode ?? -1,
+                body: String(decoding: data.prefix(500), as: UTF8.self)
+            )
+        }
+
+        guard let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+            let choices = json["choices"] as? [[String: Any]],
+            let message = choices.first?["message"] as? [String: Any],
+            let content = message["content"] as? String
+        else {
+            throw LLMPolishingError.invalidResponse
+        }
+
+        return LLMPolishingResult(
+            rawText: request.inputText,
+            polishedText: content.trimmingCharacters(in: .whitespacesAndNewlines),
+            durationSeconds: 0
+        )
     }
 }


### PR DESCRIPTION
## What

**`localvoxtral-polishd` accepts OpenAI sampling overrides** (`top_p`, `top_k`, `min_p`, `presence_penalty`) in the chat/completions request body, mapped into `GenerateParameters` via a new `ChatSamplingParameters` seam. Absent fields keep engine defaults, so behavior is unchanged for every existing caller — the model card's recommended values are deliberately NOT applied by default, matching the old mlx-lm engine.

Why now: this is the prerequisite seam for the model picker (#96) — per-model sampling defaults ride the request body from the app's catalog, keeping the engine generic and model-agnostic.

**Experiment included** (print-only, non-gating): `testEvalScoreboardWithQwenRecommendedSampling` runs the shared eval corpus through the production request path with Qwen3.5's card-recommended non-thinking sampling (temp 1.0, top_p 1.0, top_k 20, min_p 0, presence_penalty 2.0) for comparison against the temp-0.3 baseline.

**Experiment verdict — recommended sampling is WORSE for polishing at 0.8B:**

| | required | known-hard |
|---|---|---|
| baseline (temp 0.3, deterministic) | **7/7** | 3/7 |
| Qwen recommended (temp 1.0, top_k 20, presence 2.0) | **5/7** | 3/7 |

The two new failures are semantic corruption, not spacing wobbles: `en-comma-extra-space` mangles quoting (`"Well," I think…"`), and `en-accented-word-question` rewrites "café" → "coffee". Presence-penalty 2.0 + temp 1.0 actively fight verbatim transcript reproduction. Conclusion: engine defaults stay; per-model overrides are opt-in data for the picker catalog, to be re-evaluated per model.

## Proof

- [x] Helper unit suite (incl. new `PolishdRouterTests` sampling decode cases) — `./scripts/remote-build.sh test --package-path PolishHelper`
  ```
  Executed 36 tests, with 0 failures (0 unexpected) in 0.119 (0.121) seconds
  ```
- [x] Root unit suite — `./scripts/remote-build.sh test`
  ```
  Executed 605 tests, with 2 tests skipped and 0 failures (0 unexpected) in 6.500 (6.534) seconds
  ```
- [x] Packaging — `./scripts/remote-build.sh package` (bundles the helper, exit 0).
- [x] Live integration + eval baseline unchanged — `./scripts/remote-build.sh integration-polishd`
  ```
  Test Case '-[localvoxtralTests.PolishHelperIntegrationTests testEvalScoreboardWithQwenRecommendedSampling]' passed (4.095 seconds).
  Test Case '-[localvoxtralTests.PolishHelperIntegrationTests testHelperExitsWhenParentPIDDies]' passed (1.227 seconds).
  Test Case '-[localvoxtralTests.PolishHelperIntegrationTests testHelperMatchesPolishEvalBaselineThroughProductionRequestPath]' passed (3.890 seconds).

  == polishd (bundled MLX Swift helper) eval (model: mlx-community/Qwen3.5-0.8B-8bit) ==
  == required: 7/7, known-hard passing: 3/7 ==

  == polishd EXPERIMENT: Qwen recommended non-thinking sampling (temp 1.0, top_k 20, presence 2.0) ==
  == required: 5/7, known-hard passing: 3/7 ==
  ```
  Baseline identical to #84/#93 (10/14): overrides absent ⇒ behavior unchanged, asserted through the production request path.
- No UI changes.
