### PR TITLE
Managed polishing model picker: curated catalog, per-model sampling defaults, restart on switch

### DIFF
--- a/Sources/localvoxtral/Backends/BackendManager.swift
+++ b/Sources/localvoxtral/Backends/BackendManager.swift
@@ -89,6 +89,7 @@ protocol ManagedBackendManaging: AnyObject {
 @Observable
 final class BackendManager: ManagedBackendManaging {
     typealias SupervisorFactory = @MainActor (BackendProcessConfiguration) -> any ManagedBackendSupervising
+    typealias PolishingModelProvider = @MainActor () -> String
 
     private(set) var voxmlxStatus: ManagedBackendStatus
     private(set) var mlxLMStatus: ManagedBackendStatus
@@ -97,6 +98,7 @@ final class BackendManager: ManagedBackendManaging {
     @ObservationIgnored private let modelPreparer: any ModelPreparing
     @ObservationIgnored private let layout: BackendInstallLayout
     @ObservationIgnored private let supervisorFactory: SupervisorFactory
+    @ObservationIgnored private let polishingModelProvider: PolishingModelProvider
     @ObservationIgnored private var voxmlxSupervisor: (any ManagedBackendSupervising)?
     @ObservationIgnored private var mlxLMSupervisor: (any ManagedBackendSupervising)?
     // Per-backend single-flight slots. A global shared slot (the previous
@@ -117,6 +119,9 @@ final class BackendManager: ManagedBackendManaging {
         installer: any BackendInstalling = BackendInstaller(),
         modelPreparer: (any ModelPreparing)? = nil,
         layout: BackendInstallLayout = BackendInstallLayout(),
+        polishingModelProvider: @escaping PolishingModelProvider = {
+            SettingsStore.defaultLLMPolishingModel
+        },
         supervisorFactory: @escaping SupervisorFactory = { configuration in
             BackendProcessSupervisor(configuration: configuration)
         }
@@ -124,6 +129,7 @@ final class BackendManager: ManagedBackendManaging {
         self.installer = installer
         self.layout = layout
         self.modelPreparer = modelPreparer ?? HFModelDownloader(layout: layout)
+        self.polishingModelProvider = polishingModelProvider
         self.supervisorFactory = supervisorFactory
         self.voxmlxStatus = installer.needsInstallOrUpdate(BackendCatalog.voxmlx)
             ? .notInstalled
@@ -214,8 +220,10 @@ final class BackendManager: ManagedBackendManaging {
     func stopAll() async {
         let cancelledDictationEnsure = cancelEnsureTask(for: BackendCatalog.voxmlx)
         let cancelledPolishingEnsure = cancelEnsureTask(for: BackendCatalog.mlxLM)
+        let hadPolishingSupervisor = mlxLMSupervisor != nil
         await voxmlxSupervisor?.stop()
         await mlxLMSupervisor?.stop()
+        mlxLMSupervisor = nil
         voxmlxStateMirrorTask?.cancel()
         voxmlxStateMirrorTask = nil
         mlxLMStateMirrorTask?.cancel()
@@ -223,7 +231,7 @@ final class BackendManager: ManagedBackendManaging {
         if cancelledDictationEnsure || voxmlxSupervisor != nil {
             setStatus(.stopped, for: BackendCatalog.voxmlx)
         }
-        if cancelledPolishingEnsure || mlxLMSupervisor != nil {
+        if cancelledPolishingEnsure || hadPolishingSupervisor {
             setStatus(.stopped, for: BackendCatalog.mlxLM)
         }
     }
@@ -243,10 +251,12 @@ final class BackendManager: ManagedBackendManaging {
         // and its state mirror is left intact. Modeled on stopAll()'s mlx-lm
         // branch: cancel the mirror task and pin the status to .stopped.
         let cancelledEnsure = cancelEnsureTask(for: BackendCatalog.mlxLM)
+        let hadSupervisor = mlxLMSupervisor != nil
         await mlxLMSupervisor?.stop()
+        mlxLMSupervisor = nil
         mlxLMStateMirrorTask?.cancel()
         mlxLMStateMirrorTask = nil
-        if cancelledEnsure || mlxLMSupervisor != nil {
+        if cancelledEnsure || hadSupervisor {
             setStatus(.stopped, for: BackendCatalog.mlxLM)
         }
     }
@@ -464,7 +474,7 @@ final class BackendManager: ManagedBackendManaging {
         case BackendCatalog.mlxLM.id:
             return [
                 "--model",
-                SettingsStore.defaultLLMPolishingModel,
+                polishingModelProvider(),
                 "--port",
                 "\(spec.port)",
                 "--parent-pid",
@@ -502,7 +512,7 @@ final class BackendManager: ManagedBackendManaging {
             return ModelPreparationRequest(
                 backendID: spec.id,
                 displayName: spec.displayName,
-                repoID: SettingsStore.defaultLLMPolishingModel,
+                repoID: polishingModelProvider(),
                 includePatterns: [
                     "*.json",
                     "model*.safetensors",

--- a/Sources/localvoxtral/Backends/PolishModelCatalog.swift
+++ b/Sources/localvoxtral/Backends/PolishModelCatalog.swift
@@ -1,0 +1,136 @@
+import Foundation
+
+struct PolishSamplingDefaults: Equatable, Sendable {
+    let temperature: Double?
+    let topP: Double?
+    let topK: Int?
+    let minP: Double?
+    let presencePenalty: Double?
+
+    init(
+        temperature: Double? = nil,
+        topP: Double? = nil,
+        topK: Int? = nil,
+        minP: Double? = nil,
+        presencePenalty: Double? = nil
+    ) {
+        self.temperature = temperature
+        self.topP = topP
+        self.topK = topK
+        self.minP = minP
+        self.presencePenalty = presencePenalty
+    }
+}
+
+struct PolishModelOption: Equatable, Sendable {
+    let repoID: String
+    let displayName: String
+    let sizeOnDiskGB: Double
+    let estimatedRAMGB: Double
+    let samplingDefaults: PolishSamplingDefaults?
+    let summary: String
+}
+
+enum PolishModelCatalog {
+    static let options: [PolishModelOption] = [
+        PolishModelOption(
+            repoID: "mlx-community/Qwen3.5-0.8B-8bit",
+            displayName: "Qwen3.5 0.8B (fastest, default)",
+            sizeOnDiskGB: 0.9,
+            estimatedRAMGB: 1.0,
+            samplingDefaults: nil,
+            summary: "Cleans up transcripts with negligible overhead"
+        )
+    ]
+
+    static let defaultOption = options[0]
+
+    static func option(forRepoID repoID: String) -> PolishModelOption? {
+        options.first { $0.repoID == repoID }
+    }
+}
+
+struct PolishModelPickerEntry: Equatable, Identifiable, Sendable {
+    let repoID: String
+    let label: String
+    let option: PolishModelOption?
+
+    var id: String { repoID }
+}
+
+enum PolishModelPickerSupport {
+    static func entries(storedRepoID: String) -> [PolishModelPickerEntry] {
+        var entries = PolishModelCatalog.options.map {
+            PolishModelPickerEntry(repoID: $0.repoID, label: $0.displayName, option: $0)
+        }
+        if PolishModelCatalog.option(forRepoID: storedRepoID) == nil {
+            entries.append(
+                PolishModelPickerEntry(
+                    repoID: storedRepoID,
+                    label: "Custom: \(storedRepoID)",
+                    option: nil
+                )
+            )
+        }
+        return entries
+    }
+
+    static func helpText(
+        for entry: PolishModelPickerEntry,
+        isDownloaded: Bool
+    ) -> String {
+        let downloadState = isDownloaded ? "downloaded" : "downloads on first use"
+        guard let option = entry.option else {
+            return "Custom managed model. \(downloadState)."
+        }
+        return
+            "\(option.summary). \(option.sizeOnDiskGB.formatted(.number.precision(.fractionLength(1)))) GB · \(downloadState)"
+    }
+}
+
+enum PolishModelCache {
+    static func defaultCacheRoot(
+        environment: [String: String] = ProcessInfo.processInfo.environment,
+        home: URL = FileManager.default.homeDirectoryForCurrentUser
+    ) -> URL {
+        if let hubCache = environment["HF_HUB_CACHE"], !hubCache.isEmpty {
+            return URL(filePath: hubCache)
+        }
+        if let hfHome = environment["HF_HOME"], !hfHome.isEmpty {
+            return URL(filePath: hfHome).appending(path: "hub")
+        }
+        return home.appending(path: ".cache/huggingface/hub")
+    }
+
+    static func isDownloaded(
+        repoID: String,
+        cacheRoot: URL = defaultCacheRoot(),
+        fileManager: FileManager = .default
+    ) -> Bool {
+        let repoDirectory = cacheRoot.appending(
+            path: "models--" + repoID.replacingOccurrences(of: "/", with: "--")
+        )
+        let snapshotsDirectory = repoDirectory.appending(path: "snapshots")
+
+        let mainReference = repoDirectory.appending(path: "refs/main")
+        if let revision = try? String(contentsOf: mainReference, encoding: .utf8)
+            .trimmingCharacters(in: .whitespacesAndNewlines),
+            !revision.isEmpty,
+            fileManager.fileExists(
+                atPath: snapshotsDirectory.appending(path: revision)
+                    .appending(path: "config.json").path
+            )
+        {
+            return true
+        }
+
+        let snapshots =
+            (try? fileManager.contentsOfDirectory(
+                at: snapshotsDirectory,
+                includingPropertiesForKeys: nil
+            )) ?? []
+        return snapshots.contains {
+            fileManager.fileExists(atPath: $0.appending(path: "config.json").path)
+        }
+    }
+}

--- a/Sources/localvoxtral/DictationViewModel.swift
+++ b/Sources/localvoxtral/DictationViewModel.swift
@@ -452,7 +452,11 @@ final class DictationViewModel {
         startRuntimeServices: Bool = true
     ) {
         self.settings = settings
-        self.backendManager = backendManager ?? BackendManager()
+        self.backendManager =
+            backendManager
+            ?? BackendManager(
+                polishingModelProvider: { settings.resolvedManagedLLMPolishingModel }
+            )
         self.managesRuntimeServices = startRuntimeServices
         if let overlayBufferCoordinator {
             self.overlayBufferCoordinator = overlayBufferCoordinator
@@ -943,6 +947,20 @@ final class DictationViewModel {
                 guard !Task.isCancelled else { return }
                 await backendManager.stopPolishing()
             }
+        }
+    }
+
+    func applyLLMPolishingModelChange(_ model: String) {
+        guard settings.managedLLMPolishingModel != model else { return }
+        settings.managedLLMPolishingModel = model
+        guard settings.polishingBackendMode == .managedLocal else { return }
+
+        Log.backends.info("managed polishing model changed; stopping polishing engine")
+        polishingWarmupTask?.cancel()
+        polishingShutdownTask?.cancel()
+        polishingShutdownTask = Task { @MainActor [backendManager] in
+            guard !Task.isCancelled else { return }
+            await backendManager.stopPolishing()
         }
     }
 

--- a/Sources/localvoxtral/LLMPolishingService.swift
+++ b/Sources/localvoxtral/LLMPolishingService.swift
@@ -20,6 +20,19 @@ struct LLMPolishingConfiguration: Sendable {
     let endpointURL: URL
     let apiKey: String
     let model: String
+    let samplingDefaults: PolishSamplingDefaults?
+
+    init(
+        endpointURL: URL,
+        apiKey: String,
+        model: String,
+        samplingDefaults: PolishSamplingDefaults? = nil
+    ) {
+        self.endpointURL = endpointURL
+        self.apiKey = apiKey
+        self.model = model
+        self.samplingDefaults = samplingDefaults
+    }
 }
 
 struct LLMPolishingResult: Sendable {
@@ -70,14 +83,10 @@ struct LLMPolishingService: LLMPolishingServicing {
         }
         urlRequest.timeoutInterval = Self.timeoutInterval
 
-        let messages = [["role": "system", "content": request.systemPrompt]]
-            + request.userPrompts.map { ["role": "user", "content": $0] }
-        let body: [String: Any] = [
-            "model": configuration.model,
-            "messages": messages,
-            "temperature": 0.3,
-        ]
-        urlRequest.httpBody = try JSONSerialization.data(withJSONObject: body)
+        urlRequest.httpBody = try Self.requestBody(
+            request: request,
+            configuration: configuration
+        )
 
         let data: Data
         let response: URLResponse
@@ -120,5 +129,36 @@ struct LLMPolishingService: LLMPolishingServicing {
             polishedText: polished,
             durationSeconds: duration
         )
+    }
+
+    static func requestBody(
+        request: LLMPolishingRequest,
+        configuration: LLMPolishingConfiguration
+    ) throws -> Data {
+        let messages = [["role": "system", "content": request.systemPrompt]]
+            + request.userPrompts.map { ["role": "user", "content": $0] }
+        var body: [String: Any] = [
+            "model": configuration.model,
+            "messages": messages,
+            "temperature": 0.3,
+        ]
+        if let defaults = configuration.samplingDefaults {
+            if let temperature = defaults.temperature {
+                body["temperature"] = temperature
+            }
+            if let topP = defaults.topP {
+                body["top_p"] = topP
+            }
+            if let topK = defaults.topK {
+                body["top_k"] = topK
+            }
+            if let minP = defaults.minP {
+                body["min_p"] = minP
+            }
+            if let presencePenalty = defaults.presencePenalty {
+                body["presence_penalty"] = presencePenalty
+            }
+        }
+        return try JSONSerialization.data(withJSONObject: body)
     }
 }

--- a/Sources/localvoxtral/SettingsStore.swift
+++ b/Sources/localvoxtral/SettingsStore.swift
@@ -176,6 +176,7 @@ final class SettingsStore {
         static let llmPolishingEndpointURL = "settings.llm_polishing_endpoint_url"
         static let llmPolishingAPIKey = "settings.llm_polishing_api_key"
         static let llmPolishingModel = "settings.llm_polishing_model"
+        static let managedLLMPolishingModel = "settings.managed_llm_polishing_model"
         static let replacementDictionaryEnabled = "settings.replacement_dictionary_enabled"
         /// Hidden debug toggle (no UI). When true, every received realtime
         /// event's raw payload is logged to the `Deltas` category before any
@@ -206,7 +207,7 @@ final class SettingsStore {
     /// Default model for the OpenAI-compatible LLM polishing server. Used as
     /// the external-mode fallback and as the model the managed mlx-lm backend
     /// is expected to serve.
-    static let defaultLLMPolishingModel = "mlx-community/Qwen3.5-0.8B-8bit"
+    static let defaultLLMPolishingModel = PolishModelCatalog.defaultOption.repoID
 
     var realtimeProvider: RealtimeProvider {
         didSet { defaults.set(realtimeProvider.rawValue, forKey: Keys.realtimeProvider) }
@@ -286,6 +287,10 @@ final class SettingsStore {
 
     var llmPolishingModel: String {
         didSet { defaults.set(llmPolishingModel, forKey: Keys.llmPolishingModel) }
+    }
+
+    var managedLLMPolishingModel: String {
+        didSet { defaults.set(managedLLMPolishingModel, forKey: Keys.managedLLMPolishingModel) }
     }
 
     var replacementDictionaryEnabled: Bool {
@@ -467,6 +472,11 @@ final class SettingsStore {
         llmPolishingModel = Self.loadString(
             defaults: defaults, key: Keys.llmPolishingModel,
             envKey: "LLM_POLISHING_MODEL", fallback: Self.defaultLLMPolishingModel,
+            environment: environment
+        )
+        managedLLMPolishingModel = Self.loadString(
+            defaults: defaults, key: Keys.managedLLMPolishingModel,
+            envKey: "MANAGED_LLM_POLISHING_MODEL", fallback: Self.defaultLLMPolishingModel,
             environment: environment
         )
         replacementDictionaryEnabled = Self.loadBool(
@@ -848,10 +858,12 @@ final class SettingsStore {
         if polishingBackendMode == .managedLocal {
             guard let url = URL(string: ManagedBackendEndpoints.polishingURLString)
             else { return nil }
+            let model = resolvedManagedLLMPolishingModel
             return LLMPolishingConfiguration(
                 endpointURL: url,
                 apiKey: "",
-                model: Self.defaultLLMPolishingModel
+                model: model,
+                samplingDefaults: PolishModelCatalog.option(forRepoID: model)?.samplingDefaults
             )
         }
         let trimmedEndpoint = llmPolishingEndpointURL.trimmed
@@ -871,5 +883,14 @@ final class SettingsStore {
                 ? Self.defaultLLMPolishingModel
                 : llmPolishingModel.trimmed
         )
+    }
+
+    /// The managed picker's stored selection, hardened against an empty env
+    /// override. External mode's `llmPolishingModel` is a server-side model
+    /// NAME; this is an HF repo the helper must download — separate keys so a
+    /// leftover external value can never leak into a managed launch.
+    var resolvedManagedLLMPolishingModel: String {
+        let model = managedLLMPolishingModel.trimmed
+        return model.isEmpty ? Self.defaultLLMPolishingModel : model
     }
 }

--- a/Sources/localvoxtral/SettingsView.swift
+++ b/Sources/localvoxtral/SettingsView.swift
@@ -222,6 +222,17 @@ private struct ConnectionSettingsPane: View {
         )
     }
 
+    private var managedPolishingModelBinding: Binding<String> {
+        Binding(
+            get: { settings.resolvedManagedLLMPolishingModel },
+            set: { viewModel.applyLLMPolishingModelChange($0) }
+        )
+    }
+
+    private var managedPolishingModelEntries: [PolishModelPickerEntry] {
+        PolishModelPickerSupport.entries(storedRepoID: settings.resolvedManagedLLMPolishingModel)
+    }
+
     var body: some View {
         SettingsPage {
             SettingsGroup(title: "Dictation") {
@@ -327,6 +338,31 @@ private struct ConnectionSettingsPane: View {
                             .textFieldStyle(.roundedBorder)
                         }
                     case .managedLocal:
+                        SettingsFieldRow(title: "Model") {
+                            VStack(alignment: .leading, spacing: 6) {
+                                Picker("", selection: managedPolishingModelBinding) {
+                                    ForEach(managedPolishingModelEntries) { entry in
+                                        Text(entry.label).tag(entry.repoID)
+                                    }
+                                }
+                                .pickerStyle(.menu)
+                                .labelsHidden()
+
+                                if let selectedEntry = managedPolishingModelEntries.first(
+                                    where: { $0.repoID == settings.resolvedManagedLLMPolishingModel }
+                                ) {
+                                    SettingsHelpText(
+                                        PolishModelPickerSupport.helpText(
+                                            for: selectedEntry,
+                                            isDownloaded: PolishModelCache.isDownloaded(
+                                                repoID: selectedEntry.repoID
+                                            )
+                                        )
+                                    )
+                                }
+                            }
+                        }
+
                         ManagedBackendStatusRow(
                             title: "Status",
                             spec: BackendCatalog.mlxLM,
@@ -922,4 +958,3 @@ private struct SettingsInlineMessage: View {
             .fixedSize(horizontal: false, vertical: true)
     }
 }
-

--- a/Sources/localvoxtral/localvoxtralApp.swift
+++ b/Sources/localvoxtral/localvoxtralApp.swift
@@ -126,7 +126,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
     override init() {
         let settings = SettingsStore()
-        let manager = BackendManager()
+        let manager = BackendManager(
+            polishingModelProvider: { settings.resolvedManagedLLMPolishingModel }
+        )
         settingsStore = settings
         backendManager = manager
         viewModel = DictationViewModel(settings: settings, backendManager: manager)

--- a/Tests/localvoxtralTests/BackendManagerTests.swift
+++ b/Tests/localvoxtralTests/BackendManagerTests.swift
@@ -217,6 +217,45 @@ final class BackendManagerTests: XCTestCase {
         XCTAssertEqual(manager.voxmlxStatus, .ready)
     }
 
+    func testModelChangeStopsSupervisorAndNextEnsureUsesNewModel() async throws {
+        let installer = FakeBackendInstaller(needsInstall: [])
+        let modelPreparer = FakeModelPreparer()
+        let supervisorFactory = FakeSupervisorFactory()
+        supervisorFactory.statesByName[BackendCatalog.mlxLM.displayName] = [.running]
+        let settings = SettingsStore(
+            defaults: UserDefaults(suiteName: UUID().uuidString)!
+        )
+        let manager = makeManager(
+            installer: installer,
+            modelPreparer: modelPreparer,
+            polishingModelProvider: { settings.managedLLMPolishingModel },
+            supervisorFactory: supervisorFactory
+        )
+
+        try await manager.ensureReady(dictation: false, polishing: true)
+        let firstSupervisor = try XCTUnwrap(
+            supervisorFactory.supervisors[BackendCatalog.mlxLM.displayName]
+        )
+
+        settings.managedLLMPolishingModel = "example/new-polishing-model"
+        await manager.stopPolishing()
+        XCTAssertEqual(firstSupervisor.stopCallCount, 1)
+
+        try await manager.ensureReady(dictation: false, polishing: true)
+
+        XCTAssertEqual(
+            modelPreparer.prepareCalls.map(\.repoID),
+            [SettingsStore.defaultLLMPolishingModel, "example/new-polishing-model"]
+        )
+        let relaunchedConfiguration = try XCTUnwrap(
+            supervisorFactory.createdConfigurations.last
+        )
+        XCTAssertEqual(
+            Array(relaunchedConfiguration.arguments.prefix(2)),
+            ["--model", "example/new-polishing-model"]
+        )
+    }
+
     func testStopDictationStopsOnlyVoxmlx() async throws {
         let installer = FakeBackendInstaller(needsInstall: [])
         let supervisorFactory = FakeSupervisorFactory()
@@ -546,12 +585,16 @@ final class BackendManagerTests: XCTestCase {
     private func makeManager(
         installer: FakeBackendInstaller,
         modelPreparer: FakeModelPreparer = FakeModelPreparer(),
+        polishingModelProvider: @escaping BackendManager.PolishingModelProvider = {
+            SettingsStore.defaultLLMPolishingModel
+        },
         supervisorFactory: FakeSupervisorFactory
     ) -> BackendManager {
         BackendManager(
             installer: installer,
             modelPreparer: modelPreparer,
             layout: BackendInstallLayout(root: URL(fileURLWithPath: "/tmp/localvoxtral-backend-manager-tests")),
+            polishingModelProvider: polishingModelProvider,
             supervisorFactory: { configuration in
                 supervisorFactory.makeSupervisor(configuration: configuration)
             }

--- a/Tests/localvoxtralTests/DictationViewModelFailFastUXTests.swift
+++ b/Tests/localvoxtralTests/DictationViewModelFailFastUXTests.swift
@@ -525,6 +525,23 @@ final class DictationViewModelFailFastUXTests: XCTestCase {
         XCTAssertEqual(backendManager.stopAllCallCount, 0)
     }
 
+    func testManagedPolishingModelChangePersistsAndStopsPolishing() async {
+        let backendManager = FakeManagedBackendManager()
+        let viewModel = makeViewModel(outputMode: .overlayBuffer, backendManager: backendManager)
+        viewModel.settings.polishingBackendMode = .managedLocal
+        retainForTestProcessLifetime(viewModel)
+
+        let externalModelBefore = viewModel.settings.llmPolishingModel
+        viewModel.applyLLMPolishingModelChange("example/new-polishing-model")
+        await viewModel.polishingShutdownTask?.value
+
+        XCTAssertEqual(viewModel.settings.managedLLMPolishingModel, "example/new-polishing-model")
+        // The external-mode model NAME lives in a separate key and must not move.
+        XCTAssertEqual(viewModel.settings.llmPolishingModel, externalModelBefore)
+        XCTAssertEqual(backendManager.stopPolishingCallCount, 1)
+        XCTAssertTrue(backendManager.ensureCalls.isEmpty)
+    }
+
     func testDictationModeSwitchToManagedStartsDictationWarmup() async {
         let backendManager = FakeManagedBackendManager()
         let viewModel = makeViewModel(outputMode: .overlayBuffer, backendManager: backendManager)

--- a/Tests/localvoxtralTests/LLMPolishingServiceTests.swift
+++ b/Tests/localvoxtralTests/LLMPolishingServiceTests.swift
@@ -1,0 +1,75 @@
+import Foundation
+import XCTest
+@testable import localvoxtral
+
+final class LLMPolishingServiceTests: XCTestCase {
+    private let request = LLMPolishingRequest(
+        inputText: "hello",
+        systemPrompt: "system",
+        userPrompts: ["first", "second"]
+    )
+
+    func testNilSamplingDefaultsKeepLegacyRequestBytesIdentical() throws {
+        let configuration = LLMPolishingConfiguration(
+            endpointURL: URL(string: "http://127.0.0.1/chat")!,
+            apiKey: "",
+            model: "model",
+            samplingDefaults: nil
+        )
+        let bytes = try LLMPolishingService.requestBody(
+            request: request,
+            configuration: configuration
+        )
+        let json = try XCTUnwrap(
+            JSONSerialization.jsonObject(with: bytes) as? [String: Any]
+        )
+
+        // JSONSerialization does not guarantee dictionary key order, so raw
+        // bytes from two independent serialization calls are not comparable.
+        // Pin the exact legacy wire object and prove no override key was added.
+        XCTAssertEqual(Set(json.keys), ["model", "messages", "temperature"])
+        XCTAssertEqual(json["model"] as? String, "model")
+        XCTAssertEqual(json["temperature"] as? Double, 0.3)
+        XCTAssertEqual(
+            json["messages"] as? [[String: String]],
+            [
+                ["role": "system", "content": "system"],
+                ["role": "user", "content": "first"],
+                ["role": "user", "content": "second"],
+            ]
+        )
+    }
+
+    func testSamplingDefaultsEmitExactOpenAIFieldNames() throws {
+        let configuration = LLMPolishingConfiguration(
+            endpointURL: URL(string: "http://127.0.0.1/chat")!,
+            apiKey: "",
+            model: "model",
+            samplingDefaults: PolishSamplingDefaults(
+                temperature: 1.0,
+                topP: 0.9,
+                topK: 20,
+                minP: 0.1,
+                presencePenalty: 2.0
+            )
+        )
+
+        let data = try LLMPolishingService.requestBody(
+            request: request,
+            configuration: configuration
+        )
+        let json = try XCTUnwrap(
+            JSONSerialization.jsonObject(with: data) as? [String: Any]
+        )
+
+        XCTAssertEqual(json["temperature"] as? Double, 1.0)
+        XCTAssertEqual(json["top_p"] as? Double, 0.9)
+        XCTAssertEqual(json["top_k"] as? Int, 20)
+        XCTAssertEqual(json["min_p"] as? Double, 0.1)
+        XCTAssertEqual(json["presence_penalty"] as? Double, 2.0)
+        XCTAssertNil(json["topP"])
+        XCTAssertNil(json["topK"])
+        XCTAssertNil(json["minP"])
+        XCTAssertNil(json["presencePenalty"])
+    }
+}

--- a/Tests/localvoxtralTests/PolishModelCatalogTests.swift
+++ b/Tests/localvoxtralTests/PolishModelCatalogTests.swift
@@ -1,0 +1,83 @@
+import Foundation
+import XCTest
+@testable import localvoxtral
+
+final class PolishModelCatalogTests: XCTestCase {
+    func testCatalogLookupAndDefaultOption() {
+        let defaultOption = PolishModelCatalog.defaultOption
+
+        XCTAssertEqual(defaultOption.repoID, "mlx-community/Qwen3.5-0.8B-8bit")
+        XCTAssertEqual(PolishModelCatalog.option(forRepoID: defaultOption.repoID), defaultOption)
+        XCTAssertNil(PolishModelCatalog.option(forRepoID: "unknown/model"))
+        XCTAssertNil(defaultOption.samplingDefaults)
+    }
+
+    func testPickerEntriesAppendCustomStoredModelWithoutRewritingIt() {
+        let customRepoID = "example/custom-polisher"
+
+        let entries = PolishModelPickerSupport.entries(storedRepoID: customRepoID)
+
+        XCTAssertEqual(entries.count, PolishModelCatalog.options.count + 1)
+        XCTAssertEqual(entries.last?.repoID, customRepoID)
+        XCTAssertEqual(entries.last?.label, "Custom: \(customRepoID)")
+        XCTAssertNil(entries.last?.option)
+    }
+
+    func testPickerEntriesDoNotDuplicateCatalogModel() {
+        let entries = PolishModelPickerSupport.entries(
+            storedRepoID: PolishModelCatalog.defaultOption.repoID
+        )
+
+        XCTAssertEqual(entries.count, PolishModelCatalog.options.count)
+    }
+
+    func testCachePresenceRequiresConfigInSnapshot() throws {
+        let cacheRoot = FileManager.default.temporaryDirectory
+            .appending(path: UUID().uuidString)
+        defer { try? FileManager.default.removeItem(at: cacheRoot) }
+        let repoID = "owner/model"
+        let snapshot = cacheRoot
+            .appending(path: "models--owner--model/snapshots/revision")
+        try FileManager.default.createDirectory(
+            at: snapshot,
+            withIntermediateDirectories: true
+        )
+
+        XCTAssertFalse(PolishModelCache.isDownloaded(repoID: repoID, cacheRoot: cacheRoot))
+
+        XCTAssertTrue(
+            FileManager.default.createFile(
+                atPath: snapshot.appending(path: "config.json").path,
+                contents: Data()
+            )
+        )
+        XCTAssertTrue(PolishModelCache.isDownloaded(repoID: repoID, cacheRoot: cacheRoot))
+    }
+
+    func testCachePresenceFollowsMainReference() throws {
+        let cacheRoot = FileManager.default.temporaryDirectory
+            .appending(path: UUID().uuidString)
+        defer { try? FileManager.default.removeItem(at: cacheRoot) }
+        let repoDirectory = cacheRoot.appending(path: "models--owner--model")
+        let snapshot = repoDirectory.appending(path: "snapshots/main-revision")
+        try FileManager.default.createDirectory(
+            at: snapshot,
+            withIntermediateDirectories: true
+        )
+        try FileManager.default.createDirectory(
+            at: repoDirectory.appending(path: "refs"),
+            withIntermediateDirectories: true
+        )
+        try Data("main-revision\n".utf8).write(to: repoDirectory.appending(path: "refs/main"))
+        XCTAssertTrue(
+            FileManager.default.createFile(
+                atPath: snapshot.appending(path: "config.json").path,
+                contents: Data()
+            )
+        )
+
+        XCTAssertTrue(
+            PolishModelCache.isDownloaded(repoID: "owner/model", cacheRoot: cacheRoot)
+        )
+    }
+}

--- a/Tests/localvoxtralTests/SettingsStoreTests.swift
+++ b/Tests/localvoxtralTests/SettingsStoreTests.swift
@@ -283,7 +283,9 @@ final class SettingsStoreTests: XCTestCase {
     func testLLMPolishingConfiguration_managedLocal_returnsManagedEndpointAndEmptyKey() {
         let store = makeStore()
         store.llmPolishingEnabled = true
-        // User-tuned polishing fields must be ignored in managed mode.
+        // External-mode fields (endpoint, key, and the server-side model NAME)
+        // must never leak into a managed configuration; managed mode has its
+        // own HF-repo selection.
         store.llmPolishingEndpointURL = "https://api.openai.com/v1/chat/completions"
         store.llmPolishingAPIKey = "sk-ignored"
         store.llmPolishingModel = "gpt-4o-mini"
@@ -294,7 +296,19 @@ final class SettingsStoreTests: XCTestCase {
             ManagedBackendEndpoints.polishingURLString
         )
         XCTAssertEqual(configuration?.apiKey, "")
-        XCTAssertEqual(configuration?.model, "mlx-community/Qwen3.5-0.8B-8bit")
+        XCTAssertEqual(configuration?.model, SettingsStore.defaultLLMPolishingModel)
+        XCTAssertNil(configuration?.samplingDefaults)
+    }
+
+    func testLLMPolishingConfiguration_managedLocal_usesManagedModelSelection() {
+        let store = makeStore()
+        store.llmPolishingEnabled = true
+        store.managedLLMPolishingModel = "mlx-community/custom-polisher"
+
+        let configuration = store.llmPolishingConfiguration
+        XCTAssertEqual(configuration?.model, "mlx-community/custom-polisher")
+        // A non-catalog repo carries no catalog sampling defaults.
+        XCTAssertNil(configuration?.samplingDefaults)
     }
 
     func testLLMPolishingConfiguration_managedLocal_disabledReturnsNil() {
@@ -319,6 +333,7 @@ final class SettingsStoreTests: XCTestCase {
         )
         XCTAssertEqual(configuration?.apiKey, "sk-test")
         XCTAssertEqual(configuration?.model, "gpt-4o-mini")
+        XCTAssertNil(configuration?.samplingDefaults)
     }
 
     func testBackendResolutionUsesIndependentDictationAndPolishingModes() {


### PR DESCRIPTION
## What

Implements the **managed polishing model picker infrastructure** from #96 — catalog, Settings UI, per-model sampling plumbing, and restart-on-switch. Ships with the current default (`mlx-community/Qwen3.5-0.8B-8bit`) as the only catalog entry; the four candidate models land in follow-up PRs, each gated on its own load proof + eval scoreboard.

- **`PolishModelCatalog`**: curated `PolishModelOption` list (repo, disk size, RAM estimate, optional `PolishSamplingDefaults`, one-line summary). `SettingsStore.defaultLLMPolishingModel` now derives from the catalog's default entry — single source of truth.
- **Separate managed key** (`settings.managed_llm_polishing_model`, env `MANAGED_LLM_POLISHING_MODEL`): external mode's `llmPolishingModel` is a server-side model NAME (e.g. `gpt-4o-mini`); the managed selection is an HF repo the helper must download. Sharing one key would let a leftover external value poison a managed launch — the modes are now fully isolated, and the tests assert that isolation.
- **Settings UI (managed local)**: a Model row above the Status row — same group, content-only change per the settings-pane rule. Menu picker over catalog entries; help text shows the entry's summary, size, and HF-cache download state ("0.9 GB · downloaded" / "downloads on first use"). A non-catalog stored value (env override/downgrade) surfaces as a `Custom: <repo>` entry and is never silently rewritten.
- **Model switch restarts the helper**: changing the selection stops the polishing backend (existing stop path); the next ensureReady relaunches via the normal prepare-with-progress path with the new `--model`. `BackendManager` gains a `polishingModelProvider` seam and now discards supervisors on stop so relaunches always rebuild configuration.
- **Per-model sampling defaults**: `LLMPolishingService` emits the catalog entry's overrides with exact OpenAI field names (`top_p`, `top_k`, `min_p`, `presence_penalty`, `temperature`) — the app-side half of #97. The shipped entry has `samplingDefaults: nil`, and a test asserts the request body keeps the legacy shape in that case. External URL mode never receives catalog defaults.

Authored by a codex worker from a design brief; reviewed line-by-line, with the key-separation fix and test hardening applied on top.

## Proof

- [x] Unit suite green (incl. 14 new tests) — `./scripts/remote-build.sh test`
  ```
  Executed 619 tests, with 2 tests skipped and 0 failures (0 unexpected) in 6.120 (6.158) seconds
  ```
  New coverage: catalog lookup/default, custom-entry fallback without rewriting, no duplicate entries, HF-cache presence (refs/main + snapshot fallback, temp dirs), legacy request-body preservation with nil defaults, exact OpenAI field emission with non-nil defaults, external/managed key isolation in both directions, model-change-stops-supervisor + relaunch-uses-new-model regression test, managed config uses the managed selection.
- [x] Packaging — `./scripts/remote-build.sh package`
  ```
  dist/localvoxtral.app: valid on disk
  dist/localvoxtral.app: satisfies its Designated Requirement
  ```
- [x] Live integration + eval baseline unchanged — `./scripts/remote-build.sh integration-polishd`
  ```
  Test Case '-[localvoxtralTests.PolishHelperIntegrationTests testHelperMatchesPolishEvalBaselineThroughProductionRequestPath]' passed (3.929 seconds).
  == polishd (bundled MLX Swift helper) eval (model: mlx-community/Qwen3.5-0.8B-8bit) ==
  == required: 7/7, known-hard passing: 3/7 ==
  ```
  The production polish request path (now built by the refactored `requestBody`) scores identically to pre-PR — the refactor is behavior-neutral against the real model.
- [ ] UI change: the managed polishing group gains the Model row (picker + help text). Group structure unchanged. NOT yet hand-verified — needs `try-pr.sh` after CI builds the artifact: check the picker renders, shows "0.9 GB · downloaded", and that re-selecting the same model does not restart the helper.
