### PR TITLE
Polishing model: Qwen3.5-4B-OptiQ (14/14 eval) + chat_template_kwargs support + per-model eval gate

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,7 +19,7 @@ is machine-local config, set once per clone (never committed):
 ./scripts/remote-build.sh integration     # realtime pipeline vs live voxmlx
 ./scripts/remote-build.sh eval-llm        # default polish prompt eval vs a live chat/completions server
 ./scripts/remote-build.sh package         # build the .app bundle (also builds the polishing helper)
-./scripts/remote-build.sh integration-polishd  # bundled polish helper vs real model + eval baseline (run package first)
+./scripts/remote-build.sh integration-polishd [hf-repo]  # bundled polish helper vs real model + eval baseline (run package first); optional repo = per-model gate for PolishModelCatalog additions (self-provisions weights)
 ./scripts/remote-build.sh build --package-path PolishHelper   # helper package alone
 ./scripts/remote-build.sh test  --package-path PolishHelper   # helper unit tests (Metal-free)
 ```

--- a/PolishHelper/Package.swift
+++ b/PolishHelper/Package.swift
@@ -32,7 +32,11 @@ let package = Package(
         ),
         .testTarget(
             name: "PolishHelperCoreTests",
-            dependencies: ["PolishHelperCore"]
+            dependencies: [
+                "PolishHelperCore",
+                .product(name: "Hub", package: "swift-transformers"),
+                .product(name: "Tokenizers", package: "swift-transformers"),
+            ]
         ),
     ]
 )

--- a/PolishHelper/Sources/PolishHelperCore/ChatCompletionAPI.swift
+++ b/PolishHelper/Sources/PolishHelperCore/ChatCompletionAPI.swift
@@ -6,6 +6,7 @@ import Foundation
 public struct ChatCompletionRequest: Codable, Sendable {
     public var model: String?
     public var messages: [ChatCompletionMessage]
+    public var chatTemplateArguments: [String: ChatTemplateArgumentValue]?
     public var temperature: Float?
     public var topP: Float?
     public var topK: Int?
@@ -17,6 +18,7 @@ public struct ChatCompletionRequest: Codable, Sendable {
     enum CodingKeys: String, CodingKey {
         case model
         case messages
+        case chatTemplateArguments = "chat_template_kwargs"
         case temperature
         case topP = "top_p"
         case topK = "top_k"
@@ -29,6 +31,7 @@ public struct ChatCompletionRequest: Codable, Sendable {
     public init(
         model: String? = nil,
         messages: [ChatCompletionMessage],
+        chatTemplateArguments: [String: ChatTemplateArgumentValue]? = nil,
         temperature: Float? = nil,
         topP: Float? = nil,
         topK: Int? = nil,
@@ -39,6 +42,7 @@ public struct ChatCompletionRequest: Codable, Sendable {
     ) {
         self.model = model
         self.messages = messages
+        self.chatTemplateArguments = chatTemplateArguments
         self.temperature = temperature
         self.topP = topP
         self.topK = topK
@@ -57,6 +61,61 @@ public struct ChatCompletionRequest: Codable, Sendable {
             presencePenalty: presencePenalty,
             maxTokens: maxTokens
         )
+    }
+}
+
+public enum ChatTemplateArgumentValue: Codable, Equatable, Hashable, Sendable {
+    case bool(Bool)
+    case string(String)
+    case int(Int)
+    case double(Double)
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        if let value = try? container.decode(Bool.self) {
+            self = .bool(value)
+        } else if let value = try? container.decode(String.self) {
+            self = .string(value)
+        } else if let value = try? container.decode(Int.self) {
+            self = .int(value)
+        } else if let value = try? container.decode(Double.self) {
+            self = .double(value)
+        } else {
+            throw DecodingError.typeMismatch(
+                ChatTemplateArgumentValue.self,
+                DecodingError.Context(
+                    codingPath: decoder.codingPath,
+                    debugDescription: "chat_template_kwargs values must be Bool, String, Int, or Double"
+                )
+            )
+        }
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        switch self {
+        case .bool(let value):
+            try container.encode(value)
+        case .string(let value):
+            try container.encode(value)
+        case .int(let value):
+            try container.encode(value)
+        case .double(let value):
+            try container.encode(value)
+        }
+    }
+
+    var templateContextValue: any Sendable {
+        switch self {
+        case .bool(let value):
+            value
+        case .string(let value):
+            value
+        case .int(let value):
+            value
+        case .double(let value):
+            value
+        }
     }
 }
 

--- a/PolishHelper/Sources/PolishHelperCore/PolishModelHost.swift
+++ b/PolishHelper/Sources/PolishHelperCore/PolishModelHost.swift
@@ -8,6 +8,7 @@ import MLXLMCommon
 public protocol ChatResponding: Sendable {
     func respond(
         to messages: [ChatCompletionMessage],
+        chatTemplateArguments: [String: ChatTemplateArgumentValue]?,
         sampling: ChatSamplingParameters
     ) async throws -> String
 }
@@ -42,6 +43,7 @@ public final class MLXPolishModel: ChatResponding, @unchecked Sendable {
     /// `container.perform`, which serializes all access.
     private struct PrefixSnapshot {
         let prefixTokens: [Int]
+        let chatTemplateArguments: [String: ChatTemplateArgumentValue]?
         let caches: [KVCache]
     }
     private var prefixSnapshot: PrefixSnapshot?
@@ -61,6 +63,7 @@ public final class MLXPolishModel: ChatResponding, @unchecked Sendable {
 
     public func respond(
         to messages: [ChatCompletionMessage],
+        chatTemplateArguments: [String: ChatTemplateArgumentValue]? = nil,
         sampling: ChatSamplingParameters
     ) async throws -> String {
         var parameters = GenerateParameters()
@@ -95,13 +98,21 @@ public final class MLXPolishModel: ChatResponding, @unchecked Sendable {
             return ["role": message.role, "content": message.content]
         }
         let prefixMessageCount = PromptPrefixPlan.cacheablePrefix(of: messages)?.count
+        let chatTemplateContext: [String: any Sendable]? = chatTemplateArguments?
+            .mapValues { $0.templateContextValue }
 
         return try await container.perform { context in
-            let fullTokens = try context.tokenizer.applyChatTemplate(messages: templateMessages)
+            let fullTokens = try context.tokenizer.applyChatTemplate(
+                messages: templateMessages,
+                tools: nil,
+                additionalContext: chatTemplateContext
+            )
             let (cache, promptTokens) = try self.promptState(
                 fullTokens: fullTokens,
                 templateMessages: templateMessages,
                 prefixMessageCount: prefixMessageCount,
+                chatTemplateArguments: chatTemplateArguments,
+                chatTemplateContext: chatTemplateContext,
                 context: context,
                 parameters: generateParameters
             )
@@ -126,6 +137,8 @@ public final class MLXPolishModel: ChatResponding, @unchecked Sendable {
         fullTokens: [Int],
         templateMessages: [[String: any Sendable]],
         prefixMessageCount: Int?,
+        chatTemplateArguments: [String: ChatTemplateArgumentValue]?,
+        chatTemplateContext: [String: any Sendable]?,
         context: ModelContext,
         parameters: GenerateParameters
     ) throws -> ([KVCache]?, [Int]) {
@@ -136,7 +149,9 @@ public final class MLXPolishModel: ChatResponding, @unchecked Sendable {
         }
 
         let prefixTokens = try prefixEncoder.encodeChatPrefix(
-            messages: Array(templateMessages.prefix(prefixMessageCount)))
+            messages: Array(templateMessages.prefix(prefixMessageCount)),
+            additionalContext: chatTemplateContext
+        )
 
         switch PromptPrefixPlan.plan(fullTokens: fullTokens, cachedPrefixTokens: prefixTokens) {
         case .fullPrefill:
@@ -149,7 +164,10 @@ public final class MLXPolishModel: ChatResponding, @unchecked Sendable {
             return (nil, fullTokens)
 
         case .reusePrefix(let suffixTokens):
-            if let snapshot = prefixSnapshot, snapshot.prefixTokens == prefixTokens {
+            if let snapshot = prefixSnapshot,
+                snapshot.prefixTokens == prefixTokens,
+                snapshot.chatTemplateArguments == chatTemplateArguments
+            {
                 PolishdLog.info(
                     "prompt cache: hit — reusing \(prefixTokens.count) prefix tokens, "
                         + "prefilling \(suffixTokens.count)")
@@ -157,7 +175,11 @@ public final class MLXPolishModel: ChatResponding, @unchecked Sendable {
             }
 
             let caches = try prefill(tokens: prefixTokens, context: context, parameters: parameters)
-            prefixSnapshot = PrefixSnapshot(prefixTokens: prefixTokens, caches: caches)
+            prefixSnapshot = PrefixSnapshot(
+                prefixTokens: prefixTokens,
+                chatTemplateArguments: chatTemplateArguments,
+                caches: caches
+            )
             PolishdLog.info(
                 "prompt cache: checkpointed \(prefixTokens.count) prefix tokens; "
                     + "prefilling \(suffixTokens.count)")

--- a/PolishHelper/Sources/PolishHelperCore/PolishdRouter.swift
+++ b/PolishHelper/Sources/PolishHelperCore/PolishdRouter.swift
@@ -42,6 +42,7 @@ public struct PolishdRouter: Sendable {
             let start = ContinuousClock.now
             let content = try await responder.respond(
                 to: completion.messages,
+                chatTemplateArguments: completion.chatTemplateArguments,
                 sampling: completion.sampling
             )
             let elapsed = start.duration(to: .now)

--- a/PolishHelper/Sources/PolishHelperCore/TransformersTokenizerLoader.swift
+++ b/PolishHelper/Sources/PolishHelperCore/TransformersTokenizerLoader.swift
@@ -21,10 +21,13 @@ public struct TransformersTokenizerLoader: TokenizerLoader {
 /// MLXLMCommon's `Tokenizer` protocol always adds the generation prompt, so
 /// this is a separate seam the prefix cache downcasts to.
 public protocol ChatPrefixEncoding {
-    func encodeChatPrefix(messages: [[String: any Sendable]]) throws -> [Int]
+    func encodeChatPrefix(
+        messages: [[String: any Sendable]],
+        additionalContext: [String: any Sendable]?
+    ) throws -> [Int]
 }
 
-private struct TokenizerBridge: MLXLMCommon.Tokenizer {
+struct TokenizerBridge: MLXLMCommon.Tokenizer {
     private let upstream: any Tokenizers.Tokenizer
 
     init(_ upstream: any Tokenizers.Tokenizer) {
@@ -67,7 +70,10 @@ private struct TokenizerBridge: MLXLMCommon.Tokenizer {
 }
 
 extension TokenizerBridge: ChatPrefixEncoding {
-    func encodeChatPrefix(messages: [[String: any Sendable]]) throws -> [Int] {
+    func encodeChatPrefix(
+        messages: [[String: any Sendable]],
+        additionalContext: [String: any Sendable]?
+    ) throws -> [Int] {
         do {
             // The full-control protocol requirement: the convenience
             // overloads with defaulted addGenerationPrompt live on concrete
@@ -78,7 +84,9 @@ extension TokenizerBridge: ChatPrefixEncoding {
                 addGenerationPrompt: false,
                 truncation: false,
                 maxLength: nil,
-                tools: nil)
+                tools: nil,
+                additionalContext: additionalContext
+            )
         } catch Tokenizers.TokenizerError.missingChatTemplate {
             throw MLXLMCommon.TokenizerError.missingChatTemplate
         }

--- a/PolishHelper/Tests/PolishHelperCoreTests/ChatTemplateKwargsTokenizerTests.swift
+++ b/PolishHelper/Tests/PolishHelperCoreTests/ChatTemplateKwargsTokenizerTests.swift
@@ -1,0 +1,96 @@
+import Hub
+import Tokenizers
+import XCTest
+
+@testable import PolishHelperCore
+
+final class ChatTemplateKwargsTokenizerTests: XCTestCase {
+    private let messages: [[String: any Sendable]] = [
+        ["role": "system", "content": "instructions"],
+        ["role": "user", "content": "raw"],
+    ]
+
+    func testInlineTemplateBranchesOnEnableThinkingKwarg() throws {
+        let tokenizer = try makeTokenizer()
+
+        let thinkingTokens = try tokenizer.applyChatTemplate(
+            messages: [messages[1]],
+            tools: nil,
+            additionalContext: ["enable_thinking": true]
+        )
+        let directTokens = try tokenizer.applyChatTemplate(
+            messages: [messages[1]],
+            tools: nil,
+            additionalContext: ["enable_thinking": false]
+        )
+
+        XCTAssertEqual(tokenizer.decode(tokenIds: thinkingTokens, skipSpecialTokens: false), "userrawthinkassistant")
+        XCTAssertEqual(tokenizer.decode(tokenIds: directTokens, skipSpecialTokens: false), "userrawdirectassistant")
+    }
+
+    func testPrefixAndFullPromptUseMatchingKwargsForStrictTokenPrefix() throws {
+        let tokenizer = try makeTokenizer()
+        let kwargs: [String: any Sendable] = ["enable_thinking": false]
+
+        let fullTokens = try tokenizer.applyChatTemplate(
+            messages: messages,
+            tools: nil,
+            additionalContext: kwargs
+        )
+        let prefixTokens = try tokenizer.encodeChatPrefix(
+            messages: [messages[0]],
+            additionalContext: kwargs
+        )
+
+        XCTAssertTrue(fullTokens.starts(with: prefixTokens))
+        XCTAssertEqual(
+            PromptPrefixPlan.plan(fullTokens: fullTokens, cachedPrefixTokens: prefixTokens),
+            .reusePrefix(suffixTokens: Array(fullTokens.dropFirst(prefixTokens.count)))
+        )
+        XCTAssertEqual(
+            tokenizer.decode(tokenIds: prefixTokens, skipSpecialTokens: false),
+            "systeminstructions"
+        )
+        XCTAssertEqual(
+            tokenizer.decode(tokenIds: fullTokens, skipSpecialTokens: false),
+            "systeminstructionsuserrawdirectassistant"
+        )
+    }
+
+    private func makeTokenizer() throws -> TokenizerBridge {
+        let template =
+            """
+            {% for message in messages %}{{ message['role'] }} {{ message['content'] }} {% endfor %}{% if add_generation_prompt %}{% if enable_thinking %}think {% else %}direct {% endif %}assistant{% endif %}
+            """
+        let vocabulary = [
+            "[UNK]": 0,
+            "system": 1,
+            "user": 2,
+            "assistant": 3,
+            "instructions": 4,
+            "raw": 5,
+            "think": 6,
+            "direct": 7,
+        ]
+        let tokenizerConfig = Config([
+            "tokenizer_class": Config("BertTokenizer"),
+            "chat_template": Config(template),
+            "do_lower_case": Config(false),
+        ])
+        let vocabConfig = vocabulary.reduce(into: [String: Config]()) { partialResult, entry in
+            partialResult[entry.key] = Config(entry.value)
+        }
+        let tokenizerData = Config([
+            "model": Config([
+                "vocab": Config(vocabConfig),
+            ]),
+            "added_tokens": Config([Config]()),
+        ])
+
+        let upstream = try PreTrainedTokenizer(
+            tokenizerConfig: tokenizerConfig,
+            tokenizerData: tokenizerData
+        )
+        return TokenizerBridge(upstream)
+    }
+}

--- a/PolishHelper/Tests/PolishHelperCoreTests/PolishdRouterTests.swift
+++ b/PolishHelper/Tests/PolishHelperCoreTests/PolishdRouterTests.swift
@@ -4,7 +4,12 @@ import XCTest
 
 private final class StubResponder: ChatResponding, @unchecked Sendable {
     let result: Result<String, Error>
-    private(set) var received: (messages: [ChatCompletionMessage], sampling: ChatSamplingParameters)?
+    private(set) var received:
+        (
+            messages: [ChatCompletionMessage],
+            chatTemplateArguments: [String: ChatTemplateArgumentValue]?,
+            sampling: ChatSamplingParameters
+        )?
 
     init(result: Result<String, Error> = .success("polished")) {
         self.result = result
@@ -12,9 +17,10 @@ private final class StubResponder: ChatResponding, @unchecked Sendable {
 
     func respond(
         to messages: [ChatCompletionMessage],
+        chatTemplateArguments: [String: ChatTemplateArgumentValue]?,
         sampling: ChatSamplingParameters
     ) async throws -> String {
-        received = (messages, sampling)
+        received = (messages, chatTemplateArguments, sampling)
         return try result.get()
     }
 }
@@ -51,8 +57,38 @@ final class PolishdRouterTests: XCTestCase {
         XCTAssertEqual(decoded.model, "x")
         XCTAssertEqual(responder.received?.messages.count, 3)
         XCTAssertEqual(responder.received?.messages[1].content, "raw one")
+        XCTAssertNil(responder.received?.chatTemplateArguments)
         XCTAssertEqual(responder.received?.sampling.temperature, 0.3)
         XCTAssertNil(responder.received?.sampling.maxTokens)
+    }
+
+    func testChatCompletionDecodesChatTemplateKwargs() async throws {
+        let responder = StubResponder()
+        let router = PolishdRouter(responder: responder, modelName: "test-model")
+        let response = await router.handle(
+            chatRequest(
+                """
+                {"chat_template_kwargs": {
+                    "enable_thinking": false,
+                    "mode": "polish",
+                    "budget": 4,
+                    "scale": 1.5
+                 },
+                 "messages": [{"role": "user", "content": "raw"}]}
+                """
+            )
+        )
+
+        XCTAssertEqual(response.status, 200)
+        XCTAssertEqual(
+            responder.received?.chatTemplateArguments,
+            [
+                "enable_thinking": .bool(false),
+                "mode": .string("polish"),
+                "budget": .int(4),
+                "scale": .double(1.5),
+            ]
+        )
     }
 
     func testChatCompletionRoundTripsSamplingOverrides() async throws {

--- a/Sources/localvoxtral/Backends/BackendManager.swift
+++ b/Sources/localvoxtral/Backends/BackendManager.swift
@@ -218,8 +218,8 @@ final class BackendManager: ManagedBackendManaging {
     }
 
     func stopAll() async {
-        let cancelledDictationEnsure = cancelEnsureTask(for: BackendCatalog.voxmlx)
-        let cancelledPolishingEnsure = cancelEnsureTask(for: BackendCatalog.mlxLM)
+        let cancelledDictationEnsure = await cancelEnsureTaskAndAwaitCompletion(for: BackendCatalog.voxmlx)
+        let cancelledPolishingEnsure = await cancelEnsureTaskAndAwaitCompletion(for: BackendCatalog.mlxLM)
         let hadPolishingSupervisor = mlxLMSupervisor != nil
         await voxmlxSupervisor?.stop()
         await mlxLMSupervisor?.stop()
@@ -237,7 +237,7 @@ final class BackendManager: ManagedBackendManaging {
     }
 
     func stopDictation() async {
-        let cancelledEnsure = cancelEnsureTask(for: BackendCatalog.voxmlx)
+        let cancelledEnsure = await cancelEnsureTaskAndAwaitCompletion(for: BackendCatalog.voxmlx)
         await voxmlxSupervisor?.stop()
         voxmlxStateMirrorTask?.cancel()
         voxmlxStateMirrorTask = nil
@@ -250,7 +250,7 @@ final class BackendManager: ManagedBackendManaging {
         // Stop only the polishing supervisor. voxmlx (dictation) keeps running
         // and its state mirror is left intact. Modeled on stopAll()'s mlx-lm
         // branch: cancel the mirror task and pin the status to .stopped.
-        let cancelledEnsure = cancelEnsureTask(for: BackendCatalog.mlxLM)
+        let cancelledEnsure = await cancelEnsureTaskAndAwaitCompletion(for: BackendCatalog.mlxLM)
         let hadSupervisor = mlxLMSupervisor != nil
         await mlxLMSupervisor?.stop()
         mlxLMSupervisor = nil
@@ -261,15 +261,22 @@ final class BackendManager: ManagedBackendManaging {
         }
     }
 
-    private func cancelEnsureTask(for spec: ManagedBackendSpec) -> Bool {
+    /// Cancels the in-flight ensure task AND waits for it to finish unwinding.
+    /// Returning before it completes let a new ensure start while the old
+    /// one's model-download process was still terminating — two downloaders
+    /// writing the same HF cache blob corrupt the partial file and force a
+    /// restart (field finding: inflated "6 GB / 3.3 GB" progress, PR #99).
+    private func cancelEnsureTaskAndAwaitCompletion(for spec: ManagedBackendSpec) async -> Bool {
         let task: Task<Void, Error>?
         if spec.id == BackendCatalog.voxmlx.id {
             task = dictationEnsureTask
         } else {
             task = polishingEnsureTask
         }
-        task?.cancel()
-        return task != nil
+        guard let task else { return false }
+        task.cancel()
+        _ = try? await task.value
+        return true
     }
 
     func status(for spec: ManagedBackendSpec) -> ManagedBackendStatus {

--- a/Sources/localvoxtral/Backends/HFModelDownloader.swift
+++ b/Sources/localvoxtral/Backends/HFModelDownloader.swift
@@ -170,11 +170,16 @@ def should_count_for_download(info):
 # snapshot_download runs one byte-unit tqdm bar per file, on worker threads.
 # Reporting a single bar's n/total made the UI fraction bounce between files
 # and let a per-file total stomp the aggregate from resolve_total, so the bar
-# jumped around. Instead every byte delta from every bar feeds one shared
-# counter, reported against the aggregate total only (total is omitted here;
-# the Swift side keeps the one from the "total" event).
+# jumped around. The aggregate is POSITION-based and keyed per FILE (the
+# bar's desc, which hf_hub sets to the filename): each bar reports its
+# current position (self.n, which includes tqdm's `initial=` for resumed
+# files), and the reported value is the sum of per-file positions. A pure
+# delta counter double-counted whenever hf_hub restarted a file (e.g. a
+# partial blob invalidated by an interrupted earlier run, or an in-run
+# retry), inflating the UI past the total ("6 GB / 3.3 GB" in the field);
+# with per-file keys a restarted file's new bar REPLACES its old position.
 _AGGREGATE_LOCK = threading.Lock()
-_AGGREGATE = {"downloaded": 0, "last_emit_at": 0.0}
+_AGGREGATE = {"positions": {}, "last_emit_at": 0.0}
 
 
 class JSONTqdm(tqdm):
@@ -183,6 +188,11 @@ class JSONTqdm(tqdm):
         self._localvoxtral_emit_interval = self._emit_interval()
         kwargs["file"] = _NullTqdmFile()
         super().__init__(*args, **kwargs)
+        if self._localvoxtral_reports_bytes:
+            # Record silently: a resumed bar starts at initial=resume_size and
+            # a restarted bar resets its file's position to 0 — both must be
+            # reflected in the sum, but only real byte updates emit events.
+            self._localvoxtral_record_position(emit_allowed=False, force_emit=False)
 
     def _emit_interval(self):
         value = os.environ.get("LOCALVOXTRAL_HF_EMIT_INTERVAL")
@@ -201,26 +211,32 @@ class JSONTqdm(tqdm):
 
     def update(self, n=1):
         result = super().update(n)
-        if not self._localvoxtral_reports_bytes or not n or n < 0:
+        if not self._localvoxtral_reports_bytes:
             return result
-        now = time.monotonic()
         total = self.total
         bar_finished = total is not None and self.n >= total
+        self._localvoxtral_record_position(emit_allowed=True, force_emit=bar_finished)
+        return result
+
+    def _localvoxtral_record_position(self, emit_allowed, force_emit):
+        now = time.monotonic()
+        key = getattr(self, "desc", None) or id(self)
         with _AGGREGATE_LOCK:
-            _AGGREGATE["downloaded"] += int(n)
+            _AGGREGATE["positions"][key] = int(self.n or 0)
+            if not emit_allowed:
+                return
             if (
-                self._localvoxtral_emit_interval == 0
+                force_emit
+                or self._localvoxtral_emit_interval == 0
                 or now - _AGGREGATE["last_emit_at"] >= self._localvoxtral_emit_interval
-                or bar_finished
             ):
                 _AGGREGATE["last_emit_at"] = now
                 emit({
                     "event": "progress",
                     "repo": ARGS.repo,
-                    "downloaded": _AGGREGATE["downloaded"],
+                    "downloaded": sum(_AGGREGATE["positions"].values()),
                     "total": None,
                 })
-        return result
 
 
 class _NullTqdmFile:

--- a/Sources/localvoxtral/Backends/PolishModelCatalog.swift
+++ b/Sources/localvoxtral/Backends/PolishModelCatalog.swift
@@ -28,6 +28,7 @@ struct PolishModelOption: Equatable, Sendable {
     let sizeOnDiskGB: Double
     let estimatedRAMGB: Double
     let samplingDefaults: PolishSamplingDefaults?
+    let chatTemplateArguments: [String: Bool]?
     let summary: String
 }
 
@@ -39,6 +40,7 @@ enum PolishModelCatalog {
             sizeOnDiskGB: 0.9,
             estimatedRAMGB: 1.0,
             samplingDefaults: nil,
+            chatTemplateArguments: nil,
             summary: "Cleans up transcripts with negligible overhead"
         ),
         PolishModelOption(
@@ -47,6 +49,7 @@ enum PolishModelCatalog {
             sizeOnDiskGB: 3.0,
             estimatedRAMGB: 3.5,
             samplingDefaults: nil,
+            chatTemplateArguments: ["enable_thinking": false],
             summary: "Stronger cleanup, slower first load"
         ),
     ]

--- a/Sources/localvoxtral/Backends/PolishModelCatalog.swift
+++ b/Sources/localvoxtral/Backends/PolishModelCatalog.swift
@@ -127,9 +127,9 @@ enum PolishModelCache {
         if let revision = try? String(contentsOf: mainReference, encoding: .utf8)
             .trimmingCharacters(in: .whitespacesAndNewlines),
             !revision.isEmpty,
-            fileManager.fileExists(
-                atPath: snapshotsDirectory.appending(path: revision)
-                    .appending(path: "config.json").path
+            snapshotIsComplete(
+                snapshotsDirectory.appending(path: revision),
+                fileManager: fileManager
             )
         {
             return true
@@ -141,7 +141,39 @@ enum PolishModelCache {
                 includingPropertiesForKeys: nil
             )) ?? []
         return snapshots.contains {
-            fileManager.fileExists(atPath: $0.appending(path: "config.json").path)
+            snapshotIsComplete($0, fileManager: fileManager)
+        }
+    }
+
+    /// True only when the WEIGHTS are complete, not just the metadata:
+    /// config.json lands first in a download, and hf's cache only links a
+    /// snapshot file once its blob finished — so "config.json exists" flips
+    /// to "downloaded" the moment a download STARTS (field finding, PR #99).
+    /// Sharded models are checked against their index's weight_map.
+    private static func snapshotIsComplete(_ snapshot: URL, fileManager: FileManager) -> Bool {
+        guard fileManager.fileExists(atPath: snapshot.appending(path: "config.json").path) else {
+            return false
+        }
+
+        let indexURL = snapshot.appending(path: "model.safetensors.index.json")
+        if let data = try? Data(contentsOf: indexURL),
+            let object = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+            let weightMap = object["weight_map"] as? [String: String]
+        {
+            let shardNames = Set(weightMap.values)
+            return !shardNames.isEmpty
+                && shardNames.allSatisfy {
+                    // fileExists resolves symlinks: a link to a still-partial
+                    // (unlinked) blob does not count.
+                    fileManager.fileExists(atPath: snapshot.appending(path: $0).path)
+                }
+        }
+
+        let entries =
+            (try? fileManager.contentsOfDirectory(atPath: snapshot.path)) ?? []
+        return entries.contains {
+            $0.hasSuffix(".safetensors")
+                && fileManager.fileExists(atPath: snapshot.appending(path: $0).path)
         }
     }
 }

--- a/Sources/localvoxtral/Backends/PolishModelCatalog.swift
+++ b/Sources/localvoxtral/Backends/PolishModelCatalog.swift
@@ -40,7 +40,15 @@ enum PolishModelCatalog {
             estimatedRAMGB: 1.0,
             samplingDefaults: nil,
             summary: "Cleans up transcripts with negligible overhead"
-        )
+        ),
+        PolishModelOption(
+            repoID: "mlx-community/Qwen3.5-4B-OptiQ-4bit",
+            displayName: "Qwen3.5 4B (better quality)",
+            sizeOnDiskGB: 3.0,
+            estimatedRAMGB: 3.5,
+            samplingDefaults: nil,
+            summary: "Stronger cleanup, slower first load"
+        ),
     ]
 
     static let defaultOption = options[0]

--- a/Sources/localvoxtral/DictationViewModel.swift
+++ b/Sources/localvoxtral/DictationViewModel.swift
@@ -955,12 +955,17 @@ final class DictationViewModel {
         settings.managedLLMPolishingModel = model
         guard settings.polishingBackendMode == .managedLocal else { return }
 
-        Log.backends.info("managed polishing model changed; stopping polishing engine")
+        Log.backends.info("managed polishing model changed; restarting polishing engine")
         polishingWarmupTask?.cancel()
         polishingShutdownTask?.cancel()
-        polishingShutdownTask = Task { @MainActor [backendManager] in
+        polishingShutdownTask = Task { @MainActor [weak self, backendManager] in
             guard !Task.isCancelled else { return }
             await backendManager.stopPolishing()
+            // Same eager UX as the enable/mode toggles: download + relaunch
+            // now, with progress in the status row — not on the next
+            // dictation (field finding, PR #99 hand-test).
+            guard !Task.isCancelled, let self, self.isManagedPolishingWarmupWanted else { return }
+            self.startPolishingWarmup()
         }
     }
 

--- a/Sources/localvoxtral/LLMPolishingService.swift
+++ b/Sources/localvoxtral/LLMPolishingService.swift
@@ -21,17 +21,20 @@ struct LLMPolishingConfiguration: Sendable {
     let apiKey: String
     let model: String
     let samplingDefaults: PolishSamplingDefaults?
+    let chatTemplateArguments: [String: Bool]?
 
     init(
         endpointURL: URL,
         apiKey: String,
         model: String,
-        samplingDefaults: PolishSamplingDefaults? = nil
+        samplingDefaults: PolishSamplingDefaults? = nil,
+        chatTemplateArguments: [String: Bool]? = nil
     ) {
         self.endpointURL = endpointURL
         self.apiKey = apiKey
         self.model = model
         self.samplingDefaults = samplingDefaults
+        self.chatTemplateArguments = chatTemplateArguments
     }
 }
 
@@ -158,6 +161,9 @@ struct LLMPolishingService: LLMPolishingServicing {
             if let presencePenalty = defaults.presencePenalty {
                 body["presence_penalty"] = presencePenalty
             }
+        }
+        if let chatTemplateArguments = configuration.chatTemplateArguments {
+            body["chat_template_kwargs"] = chatTemplateArguments
         }
         return try JSONSerialization.data(withJSONObject: body)
     }

--- a/Sources/localvoxtral/SettingsStore.swift
+++ b/Sources/localvoxtral/SettingsStore.swift
@@ -859,11 +859,13 @@ final class SettingsStore {
             guard let url = URL(string: ManagedBackendEndpoints.polishingURLString)
             else { return nil }
             let model = resolvedManagedLLMPolishingModel
+            let option = PolishModelCatalog.option(forRepoID: model)
             return LLMPolishingConfiguration(
                 endpointURL: url,
                 apiKey: "",
                 model: model,
-                samplingDefaults: PolishModelCatalog.option(forRepoID: model)?.samplingDefaults
+                samplingDefaults: option?.samplingDefaults,
+                chatTemplateArguments: option?.chatTemplateArguments
             )
         }
         let trimmedEndpoint = llmPolishingEndpointURL.trimmed

--- a/Sources/localvoxtral/SettingsView.swift
+++ b/Sources/localvoxtral/SettingsView.swift
@@ -406,6 +406,10 @@ private struct ManagedBackendStatusLabel: View {
                 .frame(width: 8, height: 8)
                 .accessibilityHidden(true)
 
+            // Determinate progress renders as a 54pt linear bar; the
+            // indeterminate case is a circular spinner, which must NOT get
+            // the bar's fixed width (it centers inside it, reading as a big
+            // blob of horizontal padding next to the caption text).
             if case .installing(let progress) = status {
                 if let fraction = installFraction(from: progress) {
                     ProgressView(value: fraction)
@@ -413,8 +417,7 @@ private struct ManagedBackendStatusLabel: View {
                         .frame(width: 54)
                 } else {
                     ProgressView()
-                        .controlSize(.small)
-                        .frame(width: 54)
+                        .controlSize(.mini)
                 }
             } else if case .preparingModel(let progress) = status {
                 if let fraction = progress.fraction {
@@ -423,8 +426,7 @@ private struct ManagedBackendStatusLabel: View {
                         .frame(width: 54)
                 } else {
                     ProgressView()
-                        .controlSize(.small)
-                        .frame(width: 54)
+                        .controlSize(.mini)
                 }
             }
 
@@ -493,7 +495,10 @@ private struct ManagedBackendStatusLabel: View {
             // the user ever sees, so don't claim a download is happening.
             return "Checking model..."
         }
-        return "Downloading model - \(Self.byteText(progress.downloadedBytes)) of \(Self.byteText(totalBytes))"
+        // Clamp: the downloader's aggregate can transiently disagree with the
+        // dry-run total (retries, resumed partials); never render > 100%.
+        let downloaded = min(progress.downloadedBytes, totalBytes)
+        return "Downloading model - \(Self.byteText(downloaded)) of \(Self.byteText(totalBytes))"
     }
 
     private static func byteText(_ bytes: Int64) -> String {

--- a/Tests/localvoxtralTests/BackendManagerTests.swift
+++ b/Tests/localvoxtralTests/BackendManagerTests.swift
@@ -256,6 +256,39 @@ final class BackendManagerTests: XCTestCase {
         )
     }
 
+    func testStopPolishingAwaitsCancelledEnsureSoASubsequentEnsureStartsFresh() async throws {
+        // Field regression (PR #99): stop cancelled the in-flight ensure but
+        // returned without awaiting it, so a model switch mid-download started
+        // a second downloader process while the first was still terminating —
+        // both writing the same HF cache blob. Stop must not return until the
+        // cancelled ensure (and its downloader) fully unwound.
+        let installer = FakeBackendInstaller(needsInstall: [])
+        let modelPreparer = FakeModelPreparer(suspendBackendIDs: [BackendCatalog.mlxLM.id])
+        let supervisorFactory = FakeSupervisorFactory()
+        supervisorFactory.statesByName[BackendCatalog.mlxLM.displayName] = [.running]
+        let manager = makeManager(
+            installer: installer,
+            modelPreparer: modelPreparer,
+            supervisorFactory: supervisorFactory
+        )
+
+        let firstEnsure = Task { @MainActor in
+            try await manager.ensureReady(dictation: false, polishing: true)
+        }
+        await modelPreparer.waitUntilPrepareStarted()
+
+        await manager.stopPolishing()
+
+        // The cancelled prepare observed its termination BEFORE stop returned…
+        XCTAssertEqual(modelPreparer.terminatedBackendIDs, [BackendCatalog.mlxLM.id])
+        // …so a new ensure starts fresh instead of joining the dead
+        // single-flight task (which would rethrow its CancellationError).
+        try await manager.ensureReady(dictation: false, polishing: true)
+        XCTAssertEqual(modelPreparer.prepareCalls.count, 2)
+        XCTAssertEqual(manager.mlxLMStatus, .ready)
+        _ = await firstEnsure.result
+    }
+
     func testStopDictationStopsOnlyVoxmlx() async throws {
         let installer = FakeBackendInstaller(needsInstall: [])
         let supervisorFactory = FakeSupervisorFactory()
@@ -610,6 +643,7 @@ private final class FakeModelPreparer: ModelPreparing, @unchecked Sendable {
     private struct State {
         var prepareCalls: [ModelPreparationRequest] = []
         var terminatedBackendIDs: [String] = []
+        var alreadySuspendedBackendIDs: Set<String> = []
         var prepareStartedContinuation: CheckedContinuation<Void, Never>?
         var prepareResumeContinuation: CheckedContinuation<Void, Error>?
     }
@@ -648,7 +682,11 @@ private final class FakeModelPreparer: ModelPreparing, @unchecked Sendable {
             await progress(event)
         }
 
-        if suspendBackendIDs.contains(request.backendID) {
+        // Suspend only the FIRST prepare per backend: retry-after-stop tests
+        // need the follow-up prepare to complete normally.
+        let shouldSuspend = suspendBackendIDs.contains(request.backendID)
+            && state.withLock { $0.alreadySuspendedBackendIDs.insert(request.backendID).inserted }
+        if shouldSuspend {
             try await withTaskCancellationHandler {
                 try await withCheckedThrowingContinuation { continuation in
                     state.withLock { $0.prepareResumeContinuation = continuation }

--- a/Tests/localvoxtralTests/DictationViewModelFailFastUXTests.swift
+++ b/Tests/localvoxtralTests/DictationViewModelFailFastUXTests.swift
@@ -525,10 +525,11 @@ final class DictationViewModelFailFastUXTests: XCTestCase {
         XCTAssertEqual(backendManager.stopAllCallCount, 0)
     }
 
-    func testManagedPolishingModelChangePersistsAndStopsPolishing() async {
+    func testManagedPolishingModelChangePersistsAndStopsPolishingWhenDisabled() async {
         let backendManager = FakeManagedBackendManager()
         let viewModel = makeViewModel(outputMode: .overlayBuffer, backendManager: backendManager)
         viewModel.settings.polishingBackendMode = .managedLocal
+        viewModel.settings.llmPolishingEnabled = false
         retainForTestProcessLifetime(viewModel)
 
         let externalModelBefore = viewModel.settings.llmPolishingModel
@@ -539,7 +540,26 @@ final class DictationViewModelFailFastUXTests: XCTestCase {
         // The external-mode model NAME lives in a separate key and must not move.
         XCTAssertEqual(viewModel.settings.llmPolishingModel, externalModelBefore)
         XCTAssertEqual(backendManager.stopPolishingCallCount, 1)
+        // Polishing disabled: stop only, no eager relaunch.
         XCTAssertTrue(backendManager.ensureCalls.isEmpty)
+    }
+
+    func testManagedPolishingModelChangeRestartsEngineEagerly() async {
+        let backendManager = FakeManagedBackendManager()
+        let viewModel = makeViewModel(outputMode: .overlayBuffer, backendManager: backendManager)
+        viewModel.settings.polishingBackendMode = .managedLocal
+        viewModel.settings.llmPolishingEnabled = true
+        viewModel.settings.onboardingCompleted = true
+        retainForTestProcessLifetime(viewModel)
+
+        viewModel.applyLLMPolishingModelChange("example/new-polishing-model")
+        await viewModel.polishingShutdownTask?.value
+        await viewModel.polishingWarmupTask?.value
+
+        // Field regression (PR #99 hand-test): picking a model must download
+        // and relaunch immediately, not wait for a disable/enable toggle.
+        XCTAssertEqual(backendManager.stopPolishingCallCount, 1)
+        XCTAssertEqual(backendManager.ensureCalls, [.init(dictation: false, polishing: true)])
     }
 
     func testDictationModeSwitchToManagedStartsDictationWarmup() async {

--- a/Tests/localvoxtralTests/HFModelDownloaderTests.swift
+++ b/Tests/localvoxtralTests/HFModelDownloaderTests.swift
@@ -77,6 +77,11 @@ final class HFModelDownloaderTests: XCTestCase {
                 .progress(repo: "org/model", downloadedBytes: 7, totalBytes: nil),
                 .progress(repo: "org/model", downloadedBytes: 20, totalBytes: nil),
                 .progress(repo: "org/model", downloadedBytes: 25, totalBytes: nil),
+                // Restarted file: the new bar REPLACES the old position…
+                .progress(repo: "org/model", downloadedBytes: 55, totalBytes: nil),
+                .progress(repo: "org/model", downloadedBytes: 35, totalBytes: nil),
+                // …and a resumed bar's initial= bytes count toward the sum.
+                .progress(repo: "org/model", downloadedBytes: 105, totalBytes: nil),
             ]
         )
         XCTAssertFalse(result.stderr.contains("Fetching"), "tqdm rendered to stderr: \(result.stderr)")
@@ -184,7 +189,23 @@ second_byte_bar = namespace["JSONTqdm"](total=50, unit="B")
 second_byte_bar.update(5)
 second_byte_bar.close()
 
-expected_downloaded = [7, 20, 25]
+# A restarted file (same desc, hf_hub names bars by filename) must REPLACE its
+# old position, not add to it — delta counting inflated the aggregate past the
+# total in the field ("6 GB / 3.3 GB") whenever a partial blob was invalidated.
+restart_first = namespace["JSONTqdm"](total=40, unit="B", desc="model.safetensors")
+restart_first.update(30)
+restart_first.close()
+restart_second = namespace["JSONTqdm"](total=40, unit="B", desc="model.safetensors")
+restart_second.update(10)
+restart_second.close()
+
+# A resumed file's bar starts at initial=resume_size; the already-on-disk bytes
+# count toward the aggregate as soon as the bar reports real progress.
+resumed = namespace["JSONTqdm"](total=100, unit="B", initial=60, desc="weights.safetensors")
+resumed.update(10)
+resumed.close()
+
+expected_downloaded = [7, 20, 25, 55, 35, 105]
 actual_downloaded = [event["downloaded"] for event in events]
 if actual_downloaded != expected_downloaded:
     raise AssertionError(f"downloaded counts {actual_downloaded} != {expected_downloaded}")

--- a/Tests/localvoxtralTests/LLMPolishingServiceTests.swift
+++ b/Tests/localvoxtralTests/LLMPolishingServiceTests.swift
@@ -38,6 +38,7 @@ final class LLMPolishingServiceTests: XCTestCase {
                 ["role": "user", "content": "second"],
             ]
         )
+        XCTAssertNil(json["chat_template_kwargs"])
     }
 
     func testSamplingDefaultsEmitExactOpenAIFieldNames() throws {
@@ -71,5 +72,26 @@ final class LLMPolishingServiceTests: XCTestCase {
         XCTAssertNil(json["topK"])
         XCTAssertNil(json["minP"])
         XCTAssertNil(json["presencePenalty"])
+    }
+
+    func testChatTemplateArgumentsEmitMlxLmFieldName() throws {
+        let configuration = LLMPolishingConfiguration(
+            endpointURL: URL(string: "http://127.0.0.1/chat")!,
+            apiKey: "",
+            model: "model",
+            chatTemplateArguments: ["enable_thinking": false]
+        )
+
+        let data = try LLMPolishingService.requestBody(
+            request: request,
+            configuration: configuration
+        )
+        let json = try XCTUnwrap(
+            JSONSerialization.jsonObject(with: data) as? [String: Any]
+        )
+        let kwargs = try XCTUnwrap(json["chat_template_kwargs"] as? [String: Bool])
+
+        XCTAssertEqual(kwargs, ["enable_thinking": false])
+        XCTAssertNil(json["chatTemplateArguments"])
     }
 }

--- a/Tests/localvoxtralTests/PolishHelperIntegrationTests.swift
+++ b/Tests/localvoxtralTests/PolishHelperIntegrationTests.swift
@@ -285,10 +285,15 @@ final class PolishHelperIntegrationTests: XCTestCase {
         let (_, healthResponse) = try await URLSession.shared.data(from: healthURL)
         XCTAssertEqual((healthResponse as? HTTPURLResponse)?.statusCode, 200)
 
+        // Mirror production: SettingsStore attaches the catalog entry's
+        // sampling defaults and chat-template kwargs for the managed model.
+        let option = PolishModelCatalog.option(forRepoID: model)
         let configuration = LLMPolishingConfiguration(
             endpointURL: URL(string: "http://127.0.0.1:\(port)/v1/chat/completions")!,
             apiKey: "",
-            model: model
+            model: model,
+            samplingDefaults: option?.samplingDefaults,
+            chatTemplateArguments: option?.chatTemplateArguments
         )
         let (templates, cleanup) = try LLMPolishEvalSupport.defaultPromptTemplates()
         addTeardownBlock { cleanup() }
@@ -345,10 +350,13 @@ final class PolishHelperIntegrationTests: XCTestCase {
         try await ensureModelCached(model)
         let (process, port, _) = try await launchHelper(binary: binary, model: model)
 
+        // Catalog chat-template kwargs still apply (the experiment varies
+        // sampling only, not templating).
         let configuration = LLMPolishingConfiguration(
             endpointURL: URL(string: "http://127.0.0.1:\(port)/v1/chat/completions")!,
             apiKey: "",
-            model: model
+            model: model,
+            chatTemplateArguments: PolishModelCatalog.option(forRepoID: model)?.chatTemplateArguments
         )
         let (templates, cleanup) = try LLMPolishEvalSupport.defaultPromptTemplates()
         addTeardownBlock { cleanup() }
@@ -417,7 +425,7 @@ private struct QwenRecommendedSamplingPolishingService: LLMPolishingServicing {
 
         let messages = [["role": "system", "content": request.systemPrompt]]
             + request.userPrompts.map { ["role": "user", "content": $0] }
-        let body: [String: Any] = [
+        var body: [String: Any] = [
             "model": configuration.model,
             "messages": messages,
             "temperature": 1.0,
@@ -426,6 +434,9 @@ private struct QwenRecommendedSamplingPolishingService: LLMPolishingServicing {
             "min_p": 0.0,
             "presence_penalty": 2.0,
         ]
+        if let chatTemplateArguments = configuration.chatTemplateArguments {
+            body["chat_template_kwargs"] = chatTemplateArguments
+        }
         urlRequest.httpBody = try JSONSerialization.data(withJSONObject: body)
 
         let (data, response) = try await URLSession.shared.data(for: urlRequest)

--- a/Tests/localvoxtralTests/PolishModelCatalogTests.swift
+++ b/Tests/localvoxtralTests/PolishModelCatalogTests.swift
@@ -10,6 +10,13 @@ final class PolishModelCatalogTests: XCTestCase {
         XCTAssertEqual(PolishModelCatalog.option(forRepoID: defaultOption.repoID), defaultOption)
         XCTAssertNil(PolishModelCatalog.option(forRepoID: "unknown/model"))
         XCTAssertNil(defaultOption.samplingDefaults)
+        XCTAssertNil(defaultOption.chatTemplateArguments)
+        XCTAssertEqual(
+            PolishModelCatalog.option(
+                forRepoID: "mlx-community/Qwen3.5-4B-OptiQ-4bit"
+            )?.chatTemplateArguments,
+            ["enable_thinking": false]
+        )
     }
 
     func testPickerEntriesAppendCustomStoredModelWithoutRewritingIt() {

--- a/Tests/localvoxtralTests/PolishModelCatalogTests.swift
+++ b/Tests/localvoxtralTests/PolishModelCatalogTests.swift
@@ -38,7 +38,7 @@ final class PolishModelCatalogTests: XCTestCase {
         XCTAssertEqual(entries.count, PolishModelCatalog.options.count)
     }
 
-    func testCachePresenceRequiresConfigInSnapshot() throws {
+    func testCachePresenceRequiresConfigANDCompleteWeights() throws {
         let cacheRoot = FileManager.default.temporaryDirectory
             .appending(path: UUID().uuidString)
         defer { try? FileManager.default.removeItem(at: cacheRoot) }
@@ -52,10 +52,66 @@ final class PolishModelCatalogTests: XCTestCase {
 
         XCTAssertFalse(PolishModelCache.isDownloaded(repoID: repoID, cacheRoot: cacheRoot))
 
+        // config.json lands FIRST in a real download — its presence alone is
+        // the mid-download state and must NOT read as downloaded (field
+        // finding: the picker said "downloaded" while 3 GB were in flight).
         XCTAssertTrue(
             FileManager.default.createFile(
                 atPath: snapshot.appending(path: "config.json").path,
                 contents: Data()
+            )
+        )
+        XCTAssertFalse(PolishModelCache.isDownloaded(repoID: repoID, cacheRoot: cacheRoot))
+
+        XCTAssertTrue(
+            FileManager.default.createFile(
+                atPath: snapshot.appending(path: "model.safetensors").path,
+                contents: Data("weights".utf8)
+            )
+        )
+        XCTAssertTrue(PolishModelCache.isDownloaded(repoID: repoID, cacheRoot: cacheRoot))
+    }
+
+    func testCachePresenceChecksAllShardsAgainstTheWeightIndex() throws {
+        let cacheRoot = FileManager.default.temporaryDirectory
+            .appending(path: UUID().uuidString)
+        defer { try? FileManager.default.removeItem(at: cacheRoot) }
+        let repoID = "owner/model"
+        let snapshot = cacheRoot
+            .appending(path: "models--owner--model/snapshots/revision")
+        try FileManager.default.createDirectory(
+            at: snapshot,
+            withIntermediateDirectories: true
+        )
+        XCTAssertTrue(
+            FileManager.default.createFile(
+                atPath: snapshot.appending(path: "config.json").path,
+                contents: Data()
+            )
+        )
+        let index: [String: Any] = [
+            "weight_map": [
+                "a.weight": "model-00001-of-00002.safetensors",
+                "b.weight": "model-00002-of-00002.safetensors",
+            ]
+        ]
+        try JSONSerialization.data(withJSONObject: index)
+            .write(to: snapshot.appending(path: "model.safetensors.index.json"))
+
+        // One of two shards present (the index itself downloads early): the
+        // snapshot is incomplete even though *a* safetensors file exists.
+        XCTAssertTrue(
+            FileManager.default.createFile(
+                atPath: snapshot.appending(path: "model-00001-of-00002.safetensors").path,
+                contents: Data("shard".utf8)
+            )
+        )
+        XCTAssertFalse(PolishModelCache.isDownloaded(repoID: repoID, cacheRoot: cacheRoot))
+
+        XCTAssertTrue(
+            FileManager.default.createFile(
+                atPath: snapshot.appending(path: "model-00002-of-00002.safetensors").path,
+                contents: Data("shard".utf8)
             )
         )
         XCTAssertTrue(PolishModelCache.isDownloaded(repoID: repoID, cacheRoot: cacheRoot))
@@ -82,9 +138,42 @@ final class PolishModelCatalogTests: XCTestCase {
                 contents: Data()
             )
         )
+        XCTAssertTrue(
+            FileManager.default.createFile(
+                atPath: snapshot.appending(path: "model.safetensors").path,
+                contents: Data("weights".utf8)
+            )
+        )
 
         XCTAssertTrue(
             PolishModelCache.isDownloaded(repoID: "owner/model", cacheRoot: cacheRoot)
         )
+    }
+
+    func testCachePresenceIgnoresDanglingWeightSymlink() throws {
+        // hf's cache links snapshot files to blobs only on completion, but a
+        // link to a blob deleted by cache GC must not read as downloaded.
+        let cacheRoot = FileManager.default.temporaryDirectory
+            .appending(path: UUID().uuidString)
+        defer { try? FileManager.default.removeItem(at: cacheRoot) }
+        let repoID = "owner/model"
+        let snapshot = cacheRoot
+            .appending(path: "models--owner--model/snapshots/revision")
+        try FileManager.default.createDirectory(
+            at: snapshot,
+            withIntermediateDirectories: true
+        )
+        XCTAssertTrue(
+            FileManager.default.createFile(
+                atPath: snapshot.appending(path: "config.json").path,
+                contents: Data()
+            )
+        )
+        try FileManager.default.createSymbolicLink(
+            at: snapshot.appending(path: "model.safetensors"),
+            withDestinationURL: cacheRoot.appending(path: "models--owner--model/blobs/missing")
+        )
+
+        XCTAssertFalse(PolishModelCache.isDownloaded(repoID: repoID, cacheRoot: cacheRoot))
     }
 }

--- a/Tests/localvoxtralTests/SettingsStoreTests.swift
+++ b/Tests/localvoxtralTests/SettingsStoreTests.swift
@@ -298,6 +298,7 @@ final class SettingsStoreTests: XCTestCase {
         XCTAssertEqual(configuration?.apiKey, "")
         XCTAssertEqual(configuration?.model, SettingsStore.defaultLLMPolishingModel)
         XCTAssertNil(configuration?.samplingDefaults)
+        XCTAssertNil(configuration?.chatTemplateArguments)
     }
 
     func testLLMPolishingConfiguration_managedLocal_usesManagedModelSelection() {
@@ -309,6 +310,16 @@ final class SettingsStoreTests: XCTestCase {
         XCTAssertEqual(configuration?.model, "mlx-community/custom-polisher")
         // A non-catalog repo carries no catalog sampling defaults.
         XCTAssertNil(configuration?.samplingDefaults)
+        XCTAssertNil(configuration?.chatTemplateArguments)
+    }
+
+    func testLLMPolishingConfiguration_managedLocal_usesCatalogChatTemplateArguments() {
+        let store = makeStore()
+        store.llmPolishingEnabled = true
+        store.managedLLMPolishingModel = "mlx-community/Qwen3.5-4B-OptiQ-4bit"
+
+        let configuration = store.llmPolishingConfiguration
+        XCTAssertEqual(configuration?.chatTemplateArguments, ["enable_thinking": false])
     }
 
     func testLLMPolishingConfiguration_managedLocal_disabledReturnsNil() {
@@ -334,6 +345,7 @@ final class SettingsStoreTests: XCTestCase {
         XCTAssertEqual(configuration?.apiKey, "sk-test")
         XCTAssertEqual(configuration?.model, "gpt-4o-mini")
         XCTAssertNil(configuration?.samplingDefaults)
+        XCTAssertNil(configuration?.chatTemplateArguments)
     }
 
     func testBackendResolutionUsesIndependentDictationAndPolishingModes() {

--- a/scripts/remote-build.sh
+++ b/scripts/remote-build.sh
@@ -152,15 +152,27 @@ case "$CMD" in
     # prefixes per-command). Requires a helper binary from a prior
     # `./scripts/remote-build.sh package` run — the remote PolishHelper/.build
     # tree survives rsync (excluded from --delete).
-    if [[ $# -ne 0 ]]; then
-      echo "integration-polishd does not accept extra arguments" >&2
+    # Optional arg: HF repo to hold to the eval baseline instead of the
+    # default polishing model (the suite self-provisions missing weights into
+    # the build user's HF cache) — the per-model gate for PolishModelCatalog
+    # additions.
+    if [[ $# -gt 1 ]]; then
+      echo "integration-polishd accepts at most one argument (HF model repo)" >&2
       exit 1
     fi
+    POLISHD_MODEL="${1:-}"
     POLISHD_MARKER="$ROOT_DIR/.polishd-integration-enable.json"
     trap 'rm -f "$POLISHD_MARKER"' EXIT
-    printf '{"helperPath": "%s"}\n' \
-      "PolishHelper/.build/xcode/Build/Products/Release/localvoxtral-polishd" \
-      >"$POLISHD_MARKER"
+    if [[ -n "$POLISHD_MODEL" ]]; then
+      printf '{"helperPath": "%s", "model": "%s"}\n' \
+        "PolishHelper/.build/xcode/Build/Products/Release/localvoxtral-polishd" \
+        "$POLISHD_MODEL" \
+        >"$POLISHD_MARKER"
+    else
+      printf '{"helperPath": "%s"}\n' \
+        "PolishHelper/.build/xcode/Build/Products/Release/localvoxtral-polishd" \
+        >"$POLISHD_MARKER"
+    fi
     REMOTE_CMD=(swift test --filter PolishHelperIntegrationTests)
     ;;
   eval-llm)


### PR DESCRIPTION
## What

**Adds `mlx-community/Qwen3.5-4B-OptiQ-4bit` to the polishing model catalog** (#96, first model PR) — and the two pieces it forced:

1. **Per-model eval gate**: `./scripts/remote-build.sh integration-polishd [hf-repo]` — the optional repo rides the existing marker file into `PolishHelperIntegrationTests`, which already self-provisions weights into the build user's HF cache. Every future catalog addition runs this gate and pastes its scoreboard.

2. **`chat_template_kwargs` support in `localvoxtral-polishd`** (mlx-lm wire parity). The first live 4B run failed the gate hard (3/7 required): the model's chat template **enables thinking by default**, so outputs began with the model's reasoning transcript and long generations blew the request timeout. The template's own off switch is `enable_thinking: false`, passed via `chat_template_kwargs`:
   - Helper: decoded as typed values (Bool/String/Int/Double), applied identically to BOTH templating calls (full prompt and the `addGenerationPrompt: false` prefix encoding from #93), and included in the KV prefix snapshot's identity so changed kwargs rebuild the checkpoint instead of reusing stale state. The strict-token-prefix guard + loud fallback are unchanged.
   - App: `PolishModelOption.chatTemplateArguments`; managed mode attaches the catalog entry's kwargs to the request. The 4B entry sets `enable_thinking: false`; **the 0.8B entry stays nil** — its request shape is untouched, proven by the unchanged baseline below.
   - Integration harness now mirrors production config construction (catalog sampling defaults + template kwargs attached), closing a gap where the gate tested a different request shape than the app sends.

**OptiQ compatibility**: the mixed 4/8-bit quant loads fine in our pinned mlx-swift-lm 3.31.4 — first empirical proof for the OptiQ family.

## Proof

- [x] Bug demonstrated before the fix — first gate run of the 4B (commit 3f729a0's message records it; failing output):
  ```
  FAIL fr-colon-missing-space: request failed: The request timed out. — output: <no output>
  FAIL en-question-extra-space: expected "Are you coming to the meeting tomorrow?" — output: Thinking Process:\n\n1.  **Analyze the Request:** ...
  == required: 3/7 ==   (Executed 3 tests, with 1 failure ... in 1079 seconds)
  ```
- [x] Passing after — `./scripts/remote-build.sh integration-polishd mlx-community/Qwen3.5-4B-OptiQ-4bit`:
  ```
  == polishd (bundled MLX Swift helper) eval (model: mlx-community/Qwen3.5-4B-OptiQ-4bit) ==
  == required: 7/7, known-hard passing: 7/7 ==
  Test Case 'testHelperMatchesPolishEvalBaselineThroughProductionRequestPath' passed (11.977 seconds).
  ```
  **14/14 — a perfect corpus score** (the 0.8B baseline is 10/14), incl. all prompt-cache assertions (checkpoint + hits, zero full-prefill fallbacks). Full 14-case eval incl. helper launch + model load: ~12 s (0.8B: ~4 s); warm per-request latency well inside the production timeout.
- [x] 0.8B baseline regression check — `./scripts/remote-build.sh integration-polishd` (no arg):
  ```
  == polishd (bundled MLX Swift helper) eval (model: mlx-community/Qwen3.5-0.8B-8bit) ==
  == required: 7/7, known-hard passing: 3/7 ==
  ```
  Identical to pre-PR — nil kwargs leave the legacy request byte-shape alone (also unit-asserted).
- [x] Sampling experiment on the 4B (informative, non-gating): Qwen recommended sampling scores 6/7 + 7/7 — still worse than deterministic temp-0.3 on required cases, so engine defaults stay.
- [x] Unit suites green — root: `Executed 621 tests, with 2 tests skipped and 0 failures`; helper: `Executed 39 tests, with 0 failures` (new: template-kwarg branch rendering, prefix/full-prompt kwarg consistency, request decode, app-side emission + catalog plumbing).
- [x] Packaging green (helper rebuilt via the xcodebuild lane).
- [x] UI hand-tested by the owner (first artifact): picker renders, 4B downloads, polishing works with the 4B, switch-back works. Two field findings, both fixed in the follow-up commit:
  - Model change only stopped the helper; download/relaunch waited for a polishing off/on toggle. Now the shutdown chains into the same eager warmup as the enable/mode toggles (`testManagedPolishingModelChangeRestartsEngineEagerly`; stop-only when polishing is disabled stays tested).
  - The toggle-restarted download double-counted progress ("6 GB / 3.x GB"). The repo maths says only the 4-bit quant is downloadable (`model.safetensors` 3.27 GB; no fp16 exists in the repo, and the 667 MB vision tower + MTP head are excluded by the include patterns) — the inflated readout was the restarted run's cumulative counter, which the eager-restart fix removes. If it reappears in the fixed flow it gets its own issue.
  - Re-verify on the updated artifact: pick a model → download + relaunch starts immediately with progress in the status row, no toggle needed.


