### PR TITLE
Live Auto-Paste: hold back only text a rule can still match

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -211,7 +211,9 @@ Key subsystems:
   (vLLM/voxmlx) over `BaseRealtimeWebSocketClient`
 - Text merge: `TextMergingAlgorithms` (pure functions — overlap merge,
   word-boundary stabilization, punctuation spacing), `FirstChunkPreprocessor`
-- Insertion: `TextInsertionService` (AX replace → Unicode CGEvents → Cmd+V)
+- Insertion: `TextInsertionService` (AX replace → Unicode CGEvents → Cmd+V);
+  Live Auto-Paste replacements run through `LiveHoldBackReplacementStream`
+  before typing — see "Known tradeoffs" below for the latency it costs
 - Overlay: `OverlayBufferSessionCoordinator` (session + hold-before-dismiss
   timing), `OverlayBufferStateMachine`, `DictationOverlayController` (NSPanel)
 - Backends: `BackendManager` lazily bootstraps app-managed local serving on
@@ -230,6 +232,15 @@ Key subsystems:
   MLX Swift inference + a minimal loopback OpenAI server + parent-pid
   watchdog), supervised like any managed backend on port 8472. Replaced the
   uv-installed mlx-lm fork wheel (upstream mlx-lm unmaintained, 2026-07).
+
+## Known tradeoffs — deliberate, not bugs
+
+- **Live Auto-Paste holds back the tail of the transcript.** Replacements are
+  applied before typing (nothing is ever un-typed — there are no backspaces in
+  the insertion path, and terminals can't support them: field bug 2026-07-06),
+  so `LiveHoldBackReplacementStream` withholds the trailing partial word plus
+  any suffix that is still a live prefix of a dictionary rule. Nothing is lost
+  (`flushRemainder()` releases it at stop) but it costs latency of appearance.
 
 ## Conventions
 

--- a/Sources/localvoxtral/AppConfigStore.swift
+++ b/Sources/localvoxtral/AppConfigStore.swift
@@ -31,7 +31,7 @@ struct ReplacementDictionary: Equatable, Sendable {
                         regex: regex,
                         replaceWith: entry.replaceWith,
                         matchLength: normalized.count,
-                        wordCount: normalized.split(whereSeparator: \.isWhitespace).count,
+                        keyWords: normalized.split(whereSeparator: \.isWhitespace).map(String.init),
                         originalOrder: originalOrder
                     )
                 )
@@ -158,12 +158,21 @@ struct LiveReplacementRule: Comparable {
     let regex: NSRegularExpression
     let replaceWith: String
     let matchLength: Int
-    let wordCount: Int
+    /// The literal, whitespace-separated words of the match key, in order.
+    /// `makeRegex` escapes every key with `escapedPattern` and joins the words
+    /// with `\s+`, so a rule is a literal word list — no metacharacter ever
+    /// survives. `LiveHoldBackReplacementStream` prefix-matches against these
+    /// words directly to decide how little text it can hold back.
+    let keyWords: [String]
     let originalOrder: Int
+
+    var wordCount: Int {
+        keyWords.count
+    }
 
     static func == (lhs: LiveReplacementRule, rhs: LiveReplacementRule) -> Bool {
         lhs.matchLength == rhs.matchLength
-            && lhs.wordCount == rhs.wordCount
+            && lhs.keyWords == rhs.keyWords
             && lhs.originalOrder == rhs.originalOrder
             && lhs.replaceWith == rhs.replaceWith
             && lhs.regex.pattern == rhs.regex.pattern

--- a/Sources/localvoxtral/AppConfigStore.swift
+++ b/Sources/localvoxtral/AppConfigStore.swift
@@ -31,7 +31,9 @@ struct ReplacementDictionary: Equatable, Sendable {
                         regex: regex,
                         replaceWith: entry.replaceWith,
                         matchLength: normalized.count,
-                        keyWords: normalized.split(whereSeparator: \.isWhitespace).map(String.init),
+                        foldedKeyWords: normalized
+                            .split(whereSeparator: \.isWhitespace)
+                            .map { String($0).caseFoldedForMatching },
                         originalOrder: originalOrder
                     )
                 )
@@ -158,21 +160,25 @@ struct LiveReplacementRule: Comparable {
     let regex: NSRegularExpression
     let replaceWith: String
     let matchLength: Int
-    /// The literal, whitespace-separated words of the match key, in order.
+    /// The match key's whitespace-separated words, each fully case-folded.
+    ///
     /// `makeRegex` escapes every key with `escapedPattern` and joins the words
     /// with `\s+`, so a rule is a literal word list — no metacharacter ever
-    /// survives. `LiveHoldBackReplacementStream` prefix-matches against these
-    /// words directly to decide how little text it can hold back.
-    let keyWords: [String]
+    /// survives. `LiveHoldBackReplacementStream` prefix-matches these words to
+    /// decide how little text it can hold back. They are stored pre-folded
+    /// because the regex matches case-insensitively with FULL case folding,
+    /// which can change length (`ß` matches `ss`); comparing raw characters
+    /// would miss live prefixes and release text a correction still rewrites.
+    let foldedKeyWords: [String]
     let originalOrder: Int
 
     var wordCount: Int {
-        keyWords.count
+        foldedKeyWords.count
     }
 
     static func == (lhs: LiveReplacementRule, rhs: LiveReplacementRule) -> Bool {
         lhs.matchLength == rhs.matchLength
-            && lhs.keyWords == rhs.keyWords
+            && lhs.foldedKeyWords == rhs.foldedKeyWords
             && lhs.originalOrder == rhs.originalOrder
             && lhs.replaceWith == rhs.replaceWith
             && lhs.regex.pattern == rhs.regex.pattern

--- a/Sources/localvoxtral/LiveHoldBackReplacementStream.swift
+++ b/Sources/localvoxtral/LiveHoldBackReplacementStream.swift
@@ -23,6 +23,23 @@ import Foundation
 /// the same word segmentation, so a released prefix can never be reached by a
 /// correction the embedded corrector produces later.
 ///
+/// Rule chaining caveat: the viable-prefix judgment is made against the text
+/// as it stands, but applying a rule can rewrite held text INTO rule-key words
+/// (`x y -> bar` feeding `foo bar z -> FOO`), retroactively making released
+/// text part of a longer match. When the rule set has that potential
+/// (`LiveReplacementCorrector.hasChainingPotential`), the stream keeps the
+/// global `maxRuleWordCount - 1` word floor instead — correct by construction
+/// for rule sets whose replacements all keep at least one word, because no
+/// correction can then reach back further than that many complete words.
+///
+/// Deletion rule caveat: a rule that deletes its match outright
+/// (`LiveReplacementCorrector.hasDeletionRule`) breaks BOTH bounds — it
+/// bridges another key's words across the deleted gap (defeating the
+/// viable-prefix scan) and collapses held words out of the floor's post-
+/// deletion word count (defeating the floor). With any deletion rule in the
+/// set, nothing is released until `flushRemainder()`: with no releases before
+/// corrections, no correction can ever precede the release boundary.
+///
 /// Newline/tab policy (terminal targets): a typed newline can act as Enter
 /// and submit a prompt mid-dictation, and a typed Tab can trigger shell
 /// completion UI — both mutate terminal state. When `sanitizesNewlines` is
@@ -35,11 +52,33 @@ import Foundation
 /// dropped. Collapse runs at the very start of the session produce no
 /// leading space.
 struct LiveHoldBackReplacementStream {
+    /// How much text `safeReleaseLimit()` may release mid-session, chosen
+    /// once per rule set (see the type doc's caveats, most conservative
+    /// first): deletion rules hold everything until flush; chaining potential
+    /// holds the global word floor; otherwise the viable-prefix scan applies.
+    private enum HoldBackBound {
+        case untilFlush
+        case wordFloor
+        case viablePrefix
+    }
+
     private var corrector: LiveReplacementCorrector
     private let sanitizesNewlines: Bool
+    private let bound: HoldBackBound
     /// Character offset into `corrector.correctedText` already released for
     /// typing. Everything before this offset is immutable by construction.
     private var releasedCharacterCount = 0
+
+    #if DEBUG
+        /// Test seam: forces the viable-prefix bound even when a stricter
+        /// bound was selected, so tests can exercise the release-boundary
+        /// drop guard that backstops any detection gap.
+        var debugForceViablePrefixBound = false
+        /// Number of corrections dropped by the release-boundary guard. The
+        /// os_log error is invisible to tests; equivalence tests assert this
+        /// stays zero.
+        private(set) var debugDroppedCorrectionCount = 0
+    #endif
 
     // Newline/tab sanitization state, persisted across releases so whitespace
     // runs spanning chunk boundaries still collapse to a single space.
@@ -52,8 +91,25 @@ struct LiveHoldBackReplacementStream {
     private var pendingRunNeedsCollapse = false
 
     init(dictionary: ReplacementDictionary, sanitizesNewlines: Bool) {
-        corrector = LiveReplacementCorrector(dictionary: dictionary)
+        let corrector = LiveReplacementCorrector(dictionary: dictionary)
+        self.corrector = corrector
         self.sanitizesNewlines = sanitizesNewlines
+
+        let ruleCount = corrector.ruleCount
+        if corrector.hasDeletionRule {
+            bound = .untilFlush
+            Log.corrector.notice(
+                "holdback bound=until-flush reason=deletion-rule rules=\(ruleCount, privacy: .public)"
+            )
+        } else if corrector.hasChainingPotential {
+            bound = .wordFloor
+            let heldWords = corrector.maxRuleWordCount - 1
+            Log.corrector.notice(
+                "holdback bound=word-floor reason=rule-chaining-potential rules=\(ruleCount, privacy: .public) held_words=\(heldWords, privacy: .public)"
+            )
+        } else {
+            bound = .viablePrefix
+        }
     }
 
     var ruleCount: Int {
@@ -76,8 +132,7 @@ struct LiveHoldBackReplacementStream {
     mutating func flushRemainder() -> String {
         applyCompletedBoundaryCorrections()
         if let correction = corrector.finalUnboundedCorrection() {
-            assertCannotReachReleasedText(correction)
-            corrector.apply(correction)
+            applyIfInsideHoldBack(correction)
         }
         var output = release(upTo: corrector.correctedText.count)
         if sanitizesNewlines {
@@ -92,26 +147,34 @@ struct LiveHoldBackReplacementStream {
 
     private mutating func applyCompletedBoundaryCorrections() {
         while let correction = corrector.nextCompletedBoundaryCorrection() {
-            assertCannotReachReleasedText(correction)
-            corrector.apply(correction)
+            applyIfInsideHoldBack(correction)
         }
     }
 
-    /// The never-un-type invariant, checked on every correction in debug
+    /// The never-un-type invariant, enforced on every correction in ALL
     /// builds: a correction must never begin inside text already released for
     /// typing, because that text is in the user's app and cannot be recalled.
+    /// A violating correction is dropped with an error log — missing one
+    /// replacement is recoverable, rewriting the user's typed text is not —
+    /// and released text is never touched. This used to be a bare `assert`,
+    /// compiled out of release builds, which guarded production not at all.
     ///
     /// Comparing final output against a batch correction is a weaker oracle — a
     /// correction that rewrites released text can still reproduce it verbatim
     /// and slip through. This catches the violation where it happens.
-    private func assertCannotReachReleasedText(_ correction: LiveReplacementCorrection) {
-        assert(
-            correction.startOffset >= releasedCharacterCount,
-            """
-            hold-back violated: correction starts at \(correction.startOffset) \
-            but \(releasedCharacterCount) characters were already typed
-            """
-        )
+    private mutating func applyIfInsideHoldBack(_ correction: LiveReplacementCorrection) {
+        guard correction.startOffset >= releasedCharacterCount else {
+            let startOffset = correction.startOffset
+            let releasedCount = releasedCharacterCount
+            Log.corrector.error(
+                "holdback invariant violated: correction start=\(startOffset, privacy: .public) released_chars=\(releasedCount, privacy: .public) — correction dropped"
+            )
+            #if DEBUG
+                debugDroppedCorrectionCount += 1
+            #endif
+            return
+        }
+        corrector.apply(correction)
     }
 
     /// The largest character offset into the corrected text that no future
@@ -132,6 +195,12 @@ struct LiveHoldBackReplacementStream {
     /// then nothing is held beyond the trailing partial word — a single long
     /// entry in the dictionary no longer taxes every unrelated word.
     ///
+    /// Bound 2 judges viability against the CURRENT text, so it is only sound
+    /// when no correction can rewrite held text into rule-key words: with
+    /// chaining potential in the rule set, only bound 1 applies, and bound 1
+    /// itself only holds while every correction keeps at least one word —
+    /// deletion rules hold everything until flush instead (see the type doc).
+    ///
     /// The trailing partial word is always held: punctuation does not complete
     /// a word here, so "def" in "abc def." could still grow into "def.x".
     private func safeReleaseLimit() -> Int {
@@ -139,20 +208,35 @@ struct LiveHoldBackReplacementStream {
             return corrector.correctedText.count
         }
 
+        var effectiveBound = bound
+        #if DEBUG
+            if debugForceViablePrefixBound {
+                effectiveBound = .viablePrefix
+            }
+        #endif
+
+        if effectiveBound == .untilFlush {
+            // Release nothing mid-session; `flushRemainder()` releases the
+            // whole corrected text after the final corrections.
+            return releasedCharacterCount
+        }
+
         let characters = Array(corrector.correctedText)
         let partialWordStart = trailingPartialWordStart(in: characters)
         var offset = wordWindowStart(in: characters, before: partialWordStart)
 
-        // Advance to the earliest offset a rule match could still begin at.
-        // Candidate offsets are match starts, not word starts — see
-        // `isCandidateMatchStart`.
-        while offset < partialWordStart {
-            if LiveReplacementCorrector.isCandidateMatchStart(characters, offset),
-               corrector.isViableRulePrefix(String(characters[offset...]))
-            {
-                break
+        if effectiveBound == .viablePrefix {
+            // Advance to the earliest offset a rule match could still begin
+            // at. Candidate offsets are match starts, not word starts — see
+            // `isCandidateMatchStart`.
+            while offset < partialWordStart {
+                if LiveReplacementCorrector.isCandidateMatchStart(characters, offset),
+                   corrector.isViableRulePrefix(String(characters[offset...]))
+                {
+                    break
+                }
+                offset += 1
             }
-            offset += 1
         }
 
         return max(offset, releasedCharacterCount)

--- a/Sources/localvoxtral/LiveHoldBackReplacementStream.swift
+++ b/Sources/localvoxtral/LiveHoldBackReplacementStream.swift
@@ -76,6 +76,7 @@ struct LiveHoldBackReplacementStream {
     mutating func flushRemainder() -> String {
         applyCompletedBoundaryCorrections()
         if let correction = corrector.finalUnboundedCorrection() {
+            assertCannotReachReleasedText(correction)
             corrector.apply(correction)
         }
         var output = release(upTo: corrector.correctedText.count)
@@ -91,8 +92,26 @@ struct LiveHoldBackReplacementStream {
 
     private mutating func applyCompletedBoundaryCorrections() {
         while let correction = corrector.nextCompletedBoundaryCorrection() {
+            assertCannotReachReleasedText(correction)
             corrector.apply(correction)
         }
+    }
+
+    /// The never-un-type invariant, checked on every correction in debug
+    /// builds: a correction must never begin inside text already released for
+    /// typing, because that text is in the user's app and cannot be recalled.
+    ///
+    /// Comparing final output against a batch correction is a weaker oracle — a
+    /// correction that rewrites released text can still reproduce it verbatim
+    /// and slip through. This catches the violation where it happens.
+    private func assertCannotReachReleasedText(_ correction: LiveReplacementCorrection) {
+        assert(
+            correction.startOffset >= releasedCharacterCount,
+            """
+            hold-back violated: correction starts at \(correction.startOffset) \
+            but \(releasedCharacterCount) characters were already typed
+            """
+        )
     }
 
     /// The largest character offset into the corrected text that no future

--- a/Sources/localvoxtral/LiveHoldBackReplacementStream.swift
+++ b/Sources/localvoxtral/LiveHoldBackReplacementStream.swift
@@ -14,13 +14,14 @@ import Foundation
 /// are applied to the held text, and only corrected text is ever released
 /// for typing — no backspaces, ever.
 ///
-/// Hold-back policy: the trailing partial word (no whitespace after it yet)
-/// plus the last `maxRuleWordCount - 1` complete words stay held, because
-/// they could still be part of a rule match that only completes with future
-/// text. Single-word dictionaries therefore release with zero hold beyond
-/// the trailing partial word. The policy mirrors the corrector's own
-/// `lookbackStart(before:)` word segmentation, so a released prefix can
-/// never be reached by a correction the embedded corrector produces later.
+/// Hold-back policy: the trailing partial word (no whitespace after it yet) is
+/// always held, plus the shortest suffix before it that is still a live prefix
+/// of some rule — text a future match could still grow into. Text that is a
+/// prefix of no rule is released immediately, so an unrelated four-word entry
+/// in the dictionary no longer delays every dictated word by three. The bound
+/// is capped by the corrector's own `lookbackStart(before:)` window, and uses
+/// the same word segmentation, so a released prefix can never be reached by a
+/// correction the embedded corrector produces later.
 ///
 /// Newline/tab policy (terminal targets): a typed newline can act as Enter
 /// and submit a prompt mid-dictation, and a typed Tab can trigger shell
@@ -95,26 +96,62 @@ struct LiveHoldBackReplacementStream {
     }
 
     /// The largest character offset into the corrected text that no future
-    /// correction can modify. Corrections end at a future word boundary and
-    /// reach back at most `maxRuleWordCount` whitespace-separated words from
-    /// it, so the trailing partial word plus the `maxRuleWordCount - 1`
-    /// complete words before it must stay held.
+    /// correction can modify.
+    ///
+    /// Two independent lower bounds on where a future correction can start:
+    ///
+    /// 1. A correction reaches back at most `maxRuleWordCount` whitespace-
+    ///    separated words from a future word boundary, so it can never start
+    ///    before the `maxRuleWordCount - 1` complete words preceding the
+    ///    trailing partial word (`windowStart`).
+    /// 2. A correction starts at a rule match, so it can only start at an
+    ///    offset from which the remaining text is still a live prefix of some
+    ///    rule (`isViableRulePrefix`).
+    ///
+    /// Both bound the same quantity, so the safe limit is the larger. Bound 2
+    /// is usually far tighter: most text is a prefix of no rule at all, and
+    /// then nothing is held beyond the trailing partial word — a single long
+    /// entry in the dictionary no longer taxes every unrelated word.
+    ///
+    /// The trailing partial word is always held: punctuation does not complete
+    /// a word here, so "def" in "abc def." could still grow into "def.x".
     private func safeReleaseLimit() -> Int {
         guard corrector.hasRules else {
             return corrector.correctedText.count
         }
 
         let characters = Array(corrector.correctedText)
-        var offset = characters.count
+        let partialWordStart = trailingPartialWordStart(in: characters)
+        var offset = wordWindowStart(in: characters, before: partialWordStart)
 
-        // Hold the trailing partial word (punctuation does not complete a
-        // word here: "def" in "abc def." could still grow into "def.x").
+        // Advance to the earliest offset a rule match could still begin at.
+        // Candidate offsets are match starts, not word starts — see
+        // `isCandidateMatchStart`.
+        while offset < partialWordStart {
+            if LiveReplacementCorrector.isCandidateMatchStart(characters, offset),
+               corrector.isViableRulePrefix(String(characters[offset...]))
+            {
+                break
+            }
+            offset += 1
+        }
+
+        return max(offset, releasedCharacterCount)
+    }
+
+    /// The offset of the trailing run of non-whitespace characters.
+    private func trailingPartialWordStart(in characters: [Character]) -> Int {
+        var offset = characters.count
         while offset > 0, !LiveReplacementCorrector.isWhitespace(characters[offset - 1]) {
             offset -= 1
         }
+        return offset
+    }
 
-        // Hold the last (maxRuleWordCount - 1) complete words: they may be
-        // the leading words of a multi-word match that completes later.
+    /// The offset `maxRuleWordCount - 1` complete words before `end` — the
+    /// furthest back any correction can reach.
+    private func wordWindowStart(in characters: [Character], before end: Int) -> Int {
+        var offset = end
         var wordsToHold = corrector.maxRuleWordCount - 1
         while wordsToHold > 0, offset > 0 {
             while offset > 0, LiveReplacementCorrector.isWhitespace(characters[offset - 1]) {
@@ -125,8 +162,7 @@ struct LiveHoldBackReplacementStream {
             }
             wordsToHold -= 1
         }
-
-        return max(offset, releasedCharacterCount)
+        return offset
     }
 
     private mutating func release(upTo limit: Int) -> String {

--- a/Sources/localvoxtral/LiveReplacementCorrector.swift
+++ b/Sources/localvoxtral/LiveReplacementCorrector.swift
@@ -17,10 +17,66 @@ struct LiveReplacementCorrector {
     private var typedText = ""
     private var scanOffset = 0
 
+    /// True when applying one rule's replacement can rewrite held text into
+    /// words of a rule KEY, so that a later match reaches back across text the
+    /// viable-prefix bound already judged dead and released. Concrete repro:
+    /// rules `x y -> bar` and `foo bar z -> FOO` with chunks "foo x ", "y ",
+    /// "z " — "foo " is released (nothing viable starts there), the first
+    /// correction turns the held "x y " into "bar ", and "foo bar z" then
+    /// matches starting inside RELEASED text. `LiveHoldBackReplacementStream`
+    /// falls back to the global `maxRuleWordCount - 1` hold floor (correct by
+    /// construction for rule sets without deletion rules — see
+    /// `hasDeletionRule`) when this is true, and only uses the tighter
+    /// viable-prefix bound when it is false.
+    ///
+    /// Detection is deliberately conservative, word-level, and computed once
+    /// at construction: a rule's replacement value contains a word (same
+    /// whitespace segmentation and full case folding as the matcher) that
+    /// appears anywhere in ANOTHER rule's key word list, or in the INTERIOR
+    /// (neither first nor last word) of its OWN key. Own-rule edge words
+    /// cannot chain: a spanning re-match needs its first key word in already-
+    /// released text — text a replacement never produces, since corrections
+    /// start at or after the release boundary and the viable-prefix scan holds
+    /// any replacement suffix that begins a rule — and its last key word must
+    /// end at a word boundary the corrector's scan pointer has not passed,
+    /// which lies beyond the applied replacement. Excluding them keeps common
+    /// echo-style rules (`foo -> big foo`) on the fast bound.
+    ///
+    /// Known limitation: the comparison is WHOLE-TOKEN, but rule matches may
+    /// start mid-token after any non-letter/number character (the regex
+    /// lookbehind), so a replacement word can FUSE with adjacent released
+    /// characters into another rule's key token: with `x y -> bar` and
+    /// `foo-bar z -> T!`, correcting the tail of "foo-x y" produces
+    /// "foo-bar", whose "foo-" half was already released — invisible to
+    /// token-level comparison. Closing this would mean flagging every
+    /// replacement word that appears as a SUBSTRING of any key token, taxing
+    /// ordinary dictionaries with the floor for a contrived hazard; instead
+    /// the stream's runtime release-boundary guard backstops it by dropping
+    /// the violating correction with an error log.
+    let hasChainingPotential: Bool
+
+    /// True when some rule's replacement contains no words at all (empty or
+    /// whitespace-only replaceWith) — a DELETION rule. Deletion rules chain
+    /// without contributing any word `hasChainingPotential` could compare:
+    /// deleting the word between two key words of another rule BRIDGES its
+    /// neighbors (the key regex's `\s+` matches across the leftover
+    /// whitespace), so a later match can span the release boundary. They also
+    /// defeat the `maxRuleWordCount - 1` word floor: `lookbackStart(before:)`
+    /// counts words in POST-deletion text, so deleting held words drags a
+    /// later lookback window across text that was released while the deleted
+    /// words still existed. `LiveHoldBackReplacementStream` therefore
+    /// releases nothing until flush when this is true — with no releases
+    /// before corrections, no correction can precede the release boundary.
+    let hasDeletionRule: Bool
+
     init(dictionary: ReplacementDictionary) {
         let rules = dictionary.liveReplacementRules()
         self.rules = rules
         maxKeyWordCount = max(1, rules.map(\.wordCount).max() ?? 1)
+        hasChainingPotential = Self.detectChainingPotential(in: rules)
+        hasDeletionRule = rules.contains { rule in
+            rule.replaceWith.split(whereSeparator: { Self.isWhitespace($0) }).isEmpty
+        }
     }
 
     var hasRules: Bool {
@@ -252,6 +308,38 @@ struct LiveReplacementCorrector {
             guard !trailingWordIsComplete else { return true }
             return key[words.count - 1].hasPrefix(words[words.count - 1])
         }
+    }
+
+    /// See `hasChainingPotential`. Word-level and folded on both sides:
+    /// replacement values are segmented with the matcher's own whitespace
+    /// predicate and fully case-folded, exactly like `foldedKeyWords`.
+    private static func detectChainingPotential(in rules: [LiveReplacementRule]) -> Bool {
+        guard !rules.isEmpty else { return false }
+
+        for (index, rule) in rules.enumerated() {
+            let replacementWords = Set(
+                rule.replaceWith
+                    .split(whereSeparator: { isWhitespace($0) })
+                    .map { String($0).caseFoldedForMatching }
+            )
+            // Word-free replacements are deletion rules: no words to compare
+            // here, but they chain by bridging — `hasDeletionRule` escalates
+            // them to hold-until-flush regardless of this predicate.
+            guard !replacementWords.isEmpty else { continue }
+
+            for (targetIndex, target) in rules.enumerated() {
+                // Own key: only interior words can chain (see the property
+                // doc); another rule's key: any position, conservatively.
+                let reachableKeyWords = targetIndex == index
+                    ? target.foldedKeyWords.dropFirst().dropLast()
+                    : target.foldedKeyWords[...]
+                if reachableKeyWords.contains(where: replacementWords.contains) {
+                    return true
+                }
+            }
+        }
+
+        return false
     }
 
     private static func isCompletionBoundary(_ character: Character) -> Bool {

--- a/Sources/localvoxtral/LiveReplacementCorrector.swift
+++ b/Sources/localvoxtral/LiveReplacementCorrector.swift
@@ -3,7 +3,11 @@ import Foundation
 struct LiveReplacementCorrection: Sendable {
     let replacementText: String
 
-    fileprivate let startOffset: Int
+    /// Where in the corrected text this correction begins rewriting.
+    /// `LiveHoldBackReplacementStream` asserts it never precedes text it has
+    /// already released for typing.
+    let startOffset: Int
+
     fileprivate let endOffset: Int
 }
 
@@ -196,20 +200,29 @@ struct LiveReplacementCorrector {
     }
 
     /// True when `tail` can still grow into a match for some rule — that is,
-    /// when it is a live prefix of that rule's key words. `LiveHoldBackReplacementStream`
-    /// uses this to hold back only text that a future correction could still
-    /// reach, instead of a fixed `maxRuleWordCount` window.
+    /// when more text could complete a match starting at `tail`'s first
+    /// character. `LiveHoldBackReplacementStream` uses this to hold back only
+    /// text a future correction could still reach, instead of a fixed
+    /// `maxRuleWordCount` window.
     ///
-    /// This mirrors `ReplacementDictionary.makeRegex`: keys are literal words
-    /// joined by `\s+` and matched case-insensitively, so word equality plus a
-    /// prefix test on the trailing partial word is exactly the regex's
-    /// semantics. A complete word must match its key word outright; the
-    /// trailing partial word only has to be a prefix of its key word.
+    /// Rules are literal word lists (`makeRegex` escapes every key), so this
+    /// compares words directly. BOTH sides are fully case-folded first, because
+    /// the regex matches with full case folding, which can change length: the
+    /// rule `foo ßx` matches the text "foo ssx". Comparing raw characters would
+    /// judge the tail "foo s" dead (`"ßx"` does not start with `"s"`), release
+    /// it, and let the correction rewrite text already typed into the user's
+    /// app. Folding distributes over concatenation, so a folded prefix stays a
+    /// prefix.
     ///
-    /// Errs toward `true` (hold more): a full-length word run equal to the key
-    /// stays viable even though its correction has, in practice, already been
-    /// applied. Never erring toward `false` is what keeps released text
-    /// immutable.
+    /// Do NOT try to replace this with the regex's own `.hitEnd` matching flag.
+    /// It reports whether ICU read to the end of the input, not whether more
+    /// input could match: for the rule `the quick brown fox` it is set even for
+    /// the tail "world ", which can never begin that rule. It is safe but holds
+    /// nearly everything, which is the latency bug this bound exists to fix.
+    ///
+    /// Errs toward `true` (hold more): a completed match stays viable even
+    /// though its correction has, in practice, already been applied. Never
+    /// erring toward `false` is what keeps released text immutable.
     func isViableRulePrefix(_ tail: String) -> Bool {
         guard let firstCharacter = tail.first,
               let lastCharacter = tail.last,
@@ -218,7 +231,9 @@ struct LiveReplacementCorrector {
             return false
         }
 
-        let words = tail.split(whereSeparator: { Self.isWhitespace($0) }).map(String.init)
+        let words = tail
+            .split(whereSeparator: { Self.isWhitespace($0) })
+            .map { String($0).caseFoldedForMatching }
         guard !words.isEmpty else { return false }
 
         // A trailing whitespace character completes the final word; without it
@@ -227,30 +242,20 @@ struct LiveReplacementCorrector {
         let completeWordCount = trailingWordIsComplete ? words.count : words.count - 1
 
         return rules.contains { rule in
-            let key = rule.keyWords
+            let key = rule.foldedKeyWords
             guard words.count <= key.count else { return false }
 
-            for index in 0 ..< completeWordCount
-                where !Self.equalsIgnoringCase(words[index], key[index])
-            {
+            for index in 0 ..< completeWordCount where words[index] != key[index] {
                 return false
             }
 
             guard !trailingWordIsComplete else { return true }
-            return Self.hasPrefixIgnoringCase(key[words.count - 1], words[words.count - 1])
+            return key[words.count - 1].hasPrefix(words[words.count - 1])
         }
     }
 
     private static func isCompletionBoundary(_ character: Character) -> Bool {
         isWhitespace(character) || isPunctuation(character)
-    }
-
-    private static func equalsIgnoringCase(_ lhs: String, _ rhs: String) -> Bool {
-        lhs.compare(rhs, options: .caseInsensitive) == .orderedSame
-    }
-
-    private static func hasPrefixIgnoringCase(_ text: String, _ prefix: String) -> Bool {
-        text.range(of: prefix, options: [.caseInsensitive, .anchored]) != nil
     }
 
     // Internal (not private): `LiveHoldBackReplacementStream` computes its

--- a/Sources/localvoxtral/LiveReplacementCorrector.swift
+++ b/Sources/localvoxtral/LiveReplacementCorrector.swift
@@ -195,8 +195,62 @@ struct LiveReplacementCorrector {
         return 0
     }
 
+    /// True when `tail` can still grow into a match for some rule — that is,
+    /// when it is a live prefix of that rule's key words. `LiveHoldBackReplacementStream`
+    /// uses this to hold back only text that a future correction could still
+    /// reach, instead of a fixed `maxRuleWordCount` window.
+    ///
+    /// This mirrors `ReplacementDictionary.makeRegex`: keys are literal words
+    /// joined by `\s+` and matched case-insensitively, so word equality plus a
+    /// prefix test on the trailing partial word is exactly the regex's
+    /// semantics. A complete word must match its key word outright; the
+    /// trailing partial word only has to be a prefix of its key word.
+    ///
+    /// Errs toward `true` (hold more): a full-length word run equal to the key
+    /// stays viable even though its correction has, in practice, already been
+    /// applied. Never erring toward `false` is what keeps released text
+    /// immutable.
+    func isViableRulePrefix(_ tail: String) -> Bool {
+        guard let firstCharacter = tail.first,
+              let lastCharacter = tail.last,
+              !Self.isWhitespace(firstCharacter)
+        else {
+            return false
+        }
+
+        let words = tail.split(whereSeparator: { Self.isWhitespace($0) }).map(String.init)
+        guard !words.isEmpty else { return false }
+
+        // A trailing whitespace character completes the final word; without it
+        // the final word is still in flight and only needs to be a prefix.
+        let trailingWordIsComplete = Self.isWhitespace(lastCharacter)
+        let completeWordCount = trailingWordIsComplete ? words.count : words.count - 1
+
+        return rules.contains { rule in
+            let key = rule.keyWords
+            guard words.count <= key.count else { return false }
+
+            for index in 0 ..< completeWordCount
+                where !Self.equalsIgnoringCase(words[index], key[index])
+            {
+                return false
+            }
+
+            guard !trailingWordIsComplete else { return true }
+            return Self.hasPrefixIgnoringCase(key[words.count - 1], words[words.count - 1])
+        }
+    }
+
     private static func isCompletionBoundary(_ character: Character) -> Bool {
         isWhitespace(character) || isPunctuation(character)
+    }
+
+    private static func equalsIgnoringCase(_ lhs: String, _ rhs: String) -> Bool {
+        lhs.compare(rhs, options: .caseInsensitive) == .orderedSame
+    }
+
+    private static func hasPrefixIgnoringCase(_ text: String, _ prefix: String) -> Bool {
+        text.range(of: prefix, options: [.caseInsensitive, .anchored]) != nil
     }
 
     // Internal (not private): `LiveHoldBackReplacementStream` computes its
@@ -206,6 +260,40 @@ struct LiveReplacementCorrector {
     static func isWhitespace(_ character: Character) -> Bool {
         character.unicodeScalars.allSatisfy {
             CharacterSet.whitespacesAndNewlines.contains($0)
+        }
+    }
+
+    /// True when a rule match may begin at `offset`, mirroring the
+    /// `(?<![\p{L}\p{N}])` lookbehind in `ReplacementDictionary.makeRegex`.
+    ///
+    /// Match starts are NOT the same as whitespace-separated word starts: the
+    /// lookbehind only forbids a preceding letter or digit, so `voxtral`
+    /// matches inside `foo-voxtral`. The hold-back scan must treat every such
+    /// offset as a candidate, or it would release text a later correction
+    /// reaches back into.
+    static func isCandidateMatchStart(_ characters: [Character], _ offset: Int) -> Bool {
+        guard offset < characters.count, !isWhitespace(characters[offset]) else { return false }
+        guard offset > 0 else { return true }
+        return !isLetterOrNumber(characters[offset - 1])
+    }
+
+    /// `\p{L}` or `\p{N}` applied to the LAST unicode scalar of `character`.
+    ///
+    /// The regex lookbehind inspects the code point immediately before the
+    /// match, not the grapheme cluster. For a decomposed `e` + U+0301 the
+    /// preceding code point is a combining mark (category Mn), which the
+    /// lookbehind accepts — so the scan must accept it too. Testing the last
+    /// scalar reproduces that exactly, while a whole-grapheme test would
+    /// wrongly reject the offset and release text that can still be corrected.
+    private static func isLetterOrNumber(_ character: Character) -> Bool {
+        guard let scalar = character.unicodeScalars.last else { return false }
+        switch scalar.properties.generalCategory {
+        case .uppercaseLetter, .lowercaseLetter, .titlecaseLetter,
+             .modifierLetter, .otherLetter,
+             .decimalNumber, .letterNumber, .otherNumber:
+            return true
+        default:
+            return false
         }
     }
 

--- a/Sources/localvoxtral/StringExtensions.swift
+++ b/Sources/localvoxtral/StringExtensions.swift
@@ -9,4 +9,18 @@ extension String {
     var collapsingInternalWhitespace: String {
         split(whereSeparator: \.isWhitespace).joined(separator: " ")
     }
+
+    /// Full Unicode case folding, matching how `NSRegularExpression` compares
+    /// literals under `.caseInsensitive`: `ß` folds to `ss`, `ﬁ` to `fi`, and
+    /// U+212A KELVIN SIGN to `k`.
+    ///
+    /// Folding is defined per code point, so it distributes over concatenation
+    /// — the fold of a prefix is a prefix of the fold. That is what lets
+    /// `LiveHoldBackReplacementStream` decide whether partially-dictated text
+    /// can still grow into a replacement-rule match. `lowercased()` is not a
+    /// substitute: it leaves `ß` alone, and the rule `foo ßx` really does match
+    /// the text "foo ssx".
+    var caseFoldedForMatching: String {
+        folding(options: .caseInsensitive, locale: nil)
+    }
 }

--- a/Tests/localvoxtralTests/DictationViewModelLiveReplacementCorrectorTests.swift
+++ b/Tests/localvoxtralTests/DictationViewModelLiveReplacementCorrectorTests.swift
@@ -46,10 +46,13 @@ final class DictationViewModelLiveReplacementCorrectorTests: XCTestCase {
         )
 
         harness.viewModel.handle(event: .partialTranscript("local "))
+        // "local" could begin the two-word match, so it stays held.
+        XCTAssertEqual(harness.typed.value, [], "a possible first match word stays held")
+
         harness.viewModel.handle(event: .partialTranscript("voxtral "))
-        // A two-word rule holds the last complete word back — it could begin
-        // another match — so the corrected text is released on the stop flush.
-        XCTAssertEqual(harness.typed.value, [], "the last complete word stays held for a multi-word rule")
+        // Once the match applies, "localvoxtral" begins no rule, so it is
+        // released immediately rather than waiting for the stop flush.
+        XCTAssertEqual(harness.typed.value.joined(), "localvoxtral ")
 
         stop(harness.viewModel)
 

--- a/Tests/localvoxtralTests/LiveHoldBackReplacementStreamTests.swift
+++ b/Tests/localvoxtralTests/LiveHoldBackReplacementStreamTests.swift
@@ -40,9 +40,10 @@ final class LiveHoldBackReplacementStreamTests: XCTestCase {
             ReplacementEntry(replaceWith: "localvoxtral", matches: ["local voxtral"]),
         ])
         XCTAssertEqual(stream.ingest("local "), "")
-        XCTAssertEqual(stream.ingest("voxtral "), "")
-        XCTAssertEqual(stream.ingest("rocks "), "localvoxtral ")
-        XCTAssertEqual(stream.flushRemainder(), "rocks ")
+        // "localvoxtral" is a prefix of no rule, so it releases at once.
+        XCTAssertEqual(stream.ingest("voxtral "), "localvoxtral ")
+        XCTAssertEqual(stream.ingest("rocks "), "rocks ")
+        XCTAssertEqual(stream.flushRemainder(), "")
     }
 
     func testMultiWordRuleHoldsBackPossiblePrefixWords() {
@@ -52,10 +53,73 @@ final class LiveHoldBackReplacementStreamTests: XCTestCase {
         // "cloud" alone must not be released: it could be the first word of
         // the two-word match that only completes with the next chunk.
         XCTAssertEqual(stream.ingest("use cloud "), "use ")
-        // Once the match applies, everything but the trailing complete word
-        // (a possible prefix of the next two-word match) is released.
-        XCTAssertEqual(stream.ingest("code "), "Claude ")
-        XCTAssertEqual(stream.flushRemainder(), "Code ")
+        // Once the match applies, neither "Claude" nor "Code" can begin a
+        // rule, so both release immediately.
+        XCTAssertEqual(stream.ingest("code "), "Claude Code ")
+        XCTAssertEqual(stream.flushRemainder(), "")
+    }
+
+    // MARK: - Viable-prefix hold-back bound
+
+    func testLongRuleDoesNotDelayUnrelatedWords() {
+        var stream = makeStream(entries: [
+            ReplacementEntry(replaceWith: "Claude Code", matches: ["the quick brown fox"]),
+        ])
+        // A four-word rule used to hold three complete words of every
+        // dictation. Text that begins no rule is released with no extra hold.
+        XCTAssertEqual(stream.ingest("hello there wide world "), "hello there wide world ")
+        XCTAssertEqual(stream.flushRemainder(), "")
+    }
+
+    func testOnlyWordsThatCanBeginARuleAreHeld() {
+        var stream = makeStream(entries: [
+            ReplacementEntry(replaceWith: "Claude Code", matches: ["the quick brown fox"]),
+        ])
+        // "the quick" is a live prefix of the rule, so it is held; the words
+        // before it are not, so they go out immediately.
+        XCTAssertEqual(stream.ingest("hello world the quick "), "hello world ")
+        // The match fails at "slow" — nothing here begins the rule anymore.
+        XCTAssertEqual(stream.ingest("slow "), "the quick slow ")
+    }
+
+    func testMatchStartAfterPunctuationIsHeldBack() {
+        var stream = makeStream(entries: [
+            ReplacementEntry(replaceWith: "VOXTRAL ROCKS", matches: ["voxtral rocks"]),
+        ])
+        // The rule's lookbehind only forbids a preceding letter or digit, so a
+        // match can start inside a whitespace-delimited word: "voxtral" here
+        // begins after the hyphen. Releasing "foo-voxtral " would let the
+        // correction reach back into already-typed text.
+        XCTAssertEqual(stream.ingest("foo-voxtral "), "foo-")
+        XCTAssertEqual(stream.ingest("rocks "), "VOXTRAL ROCKS ")
+    }
+
+    func testMatchStartAfterCombiningMarkIsHeldBack() {
+        var stream = makeStream(entries: [
+            ReplacementEntry(replaceWith: "VOXTRAL ROCKS", matches: ["voxtral rocks"]),
+        ])
+        // Decomposed "é" is a letter grapheme, but the code point immediately
+        // before the match is a combining mark (category Mn), which the
+        // lookbehind accepts. The candidate scan must accept it too.
+        XCTAssertEqual(stream.ingest("e\u{0301}voxtral "), "e\u{0301}")
+        XCTAssertEqual(stream.ingest("rocks "), "VOXTRAL ROCKS ")
+    }
+
+    func testCaseInsensitivePrefixIsHeld() {
+        var stream = makeStream(entries: [
+            ReplacementEntry(replaceWith: "Claude Code", matches: ["cloud code"]),
+        ])
+        XCTAssertEqual(stream.ingest("use CLOUD "), "use ")
+        XCTAssertEqual(stream.ingest("Code "), "Claude Code ")
+    }
+
+    func testSingleWordRuleAmongMultiWordRulesStillReleasesPromptly() {
+        var stream = makeStream(entries: [
+            ReplacementEntry(replaceWith: "localvoxtral", matches: ["voxtral"]),
+            ReplacementEntry(replaceWith: "Claude Code", matches: ["cloud code"]),
+        ])
+        // maxRuleWordCount is 2, but "hello" begins neither rule.
+        XCTAssertEqual(stream.ingest("hello voxtral "), "hello localvoxtral ")
     }
 
     func testPunctuationBoundaryCompletesMatchButHoldsUntilWhitespace() {
@@ -180,13 +244,25 @@ final class LiveHoldBackReplacementStreamTests: XCTestCase {
 
     func testFlushedRemainderIsSanitized() {
         var stream = makeStream(
+            entries: [ReplacementEntry(replaceWith: "X", matches: ["run something"])],
+            sanitizesNewlines: true
+        )
+        // "run so" stays a live prefix of the rule, so everything is held back
+        // and the newline reaches the remainder flush; sanitization must still
+        // apply there.
+        XCTAssertEqual(stream.ingest("run\nso"), "")
+        XCTAssertEqual(stream.flushRemainder(), "run so")
+    }
+
+    func testCollapsedNewlineRunSpansAnEarlyRelease() {
+        var stream = makeStream(
             entries: [ReplacementEntry(replaceWith: "localvoxtral", matches: ["local voxtral"])],
             sanitizesNewlines: true
         )
-        // Two-word rule holds everything back so the newline reaches the
-        // remainder flush; sanitization must still apply there.
-        XCTAssertEqual(stream.ingest("run\nit"), "")
-        XCTAssertEqual(stream.flushRemainder(), "run it")
+        // "run" begins no rule, so it is released before the newline's fate is
+        // known. The collapsed space is emitted with the next release.
+        XCTAssertEqual(stream.ingest("run\nit"), "run")
+        XCTAssertEqual(stream.flushRemainder(), " it")
     }
 
     func testSanitizationOffPreservesNewlines() {
@@ -203,5 +279,123 @@ final class LiveHoldBackReplacementStreamTests: XCTestCase {
         var stream = makeStream(entries: [voxtralEntry], sanitizesNewlines: true)
         XCTAssertEqual(stream.ingest("voxtral\nrocks "), "localvoxtral rocks")
         XCTAssertEqual(stream.flushRemainder(), " ")
+    }
+
+    // MARK: - Never-un-type invariant
+
+    /// The dictionary the invariant tests run against.
+    ///
+    /// `cloud code` deliberately has no single-word `cloud` rule: a shorter
+    /// rule matching the multi-word rule's first word would fire at that word's
+    /// boundary and rewrite the text, so the multi-word rule could never reach
+    /// back across a release and the hazard would never be generated.
+    private var invariantDictionary: ReplacementDictionary {
+        ReplacementDictionary(entries: [
+            ReplacementEntry(replaceWith: "Claude Code", matches: ["cloud code"]),
+            ReplacementEntry(replaceWith: "FOX", matches: ["the quick brown fox"]),
+            ReplacementEntry(replaceWith: "localvoxtral", matches: ["voxtral"]),
+        ])
+    }
+
+    /// The stream only ever appends released text, so text released early can
+    /// never be taken back. Releasing too early therefore shows up as a final
+    /// output that disagrees with correcting the whole transcript in one pass.
+    /// This is the hold-back bound's core invariant: for ANY chunking, the
+    /// concatenated releases must equal the batch result.
+    private func assertReleasedTextMatchesBatch(
+        _ text: String,
+        chunkSizes: [Int] = [1, 2, 3, 5, 1024],
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) {
+        let dictionary = invariantDictionary
+        let batch = LiveReplacementCorrector.completedBoundaryCorrectedText(
+            text,
+            dictionary: dictionary,
+            includeFinalUnboundedWord: true
+        )
+
+        for size in chunkSizes {
+            var stream = LiveHoldBackReplacementStream(
+                dictionary: dictionary,
+                sanitizesNewlines: false
+            )
+            var released = ""
+            var remaining = Substring(text)
+            while !remaining.isEmpty {
+                let take = min(size, remaining.count)
+                released += stream.ingest(String(remaining.prefix(take)))
+                remaining = remaining.dropFirst(take)
+            }
+            released += stream.flushRemainder()
+
+            XCTAssertEqual(
+                released,
+                batch,
+                "chunk size \(size) diverged for input \(String(reflecting: text))",
+                file: file,
+                line: line
+            )
+        }
+    }
+
+    func testReleasedTextMatchesBatchCorrectionForAdversarialInputs() {
+        // Match starts that are not whitespace-delimited word starts, near
+        // misses, case folding, and a decomposed combining mark.
+        for text in [
+            "foo-cloud code ",
+            "e\u{0301}cloud code ",
+            "hello foo-cloud code world ",
+            "foo-cloud code",
+            "CLOUD Code ",
+            "cloud. code ",
+            "the quick brown fox ",
+            "hello the quick brown slow ",
+            "the quick brown fox",
+            "cloud cloud code ",
+            "voxtral foo-cloud code ",
+        ] {
+            assertReleasedTextMatchesBatch(text)
+        }
+    }
+
+    func testReleasedTextMatchesBatchCorrectionForRandomChunkings() {
+        let vocabulary = [
+            "cloud", "code", "the", "quick", "brown", "fox", "hello", "world",
+            "clouds", "codes", "foo-cloud", "e\u{0301}cloud", "CLOUD", "cloud.",
+            "voxtral", "local",
+        ]
+
+        var generator = SeededGenerator(seed: 0x5EED_1234)
+        for _ in 0 ..< 400 {
+            let wordCount = Int.random(in: 1 ... 9, using: &generator)
+            var text = ""
+            for _ in 0 ..< wordCount {
+                text += vocabulary.randomElement(using: &generator)! + " "
+            }
+            if Bool.random(using: &generator) {
+                text = String(text.dropLast())
+            }
+            let size = Int.random(in: 1 ... 4, using: &generator)
+            assertReleasedTextMatchesBatch(text, chunkSizes: [size])
+        }
+    }
+}
+
+/// Deterministic RNG: the suite forbids wall-clock and other nondeterminism,
+/// and a failing property case must be reproducible from the seed alone.
+private struct SeededGenerator: RandomNumberGenerator {
+    private var state: UInt64
+
+    init(seed: UInt64) {
+        state = seed
+    }
+
+    mutating func next() -> UInt64 {
+        state = state &* 6_364_136_223_846_793_005 &+ 1_442_695_040_888_963_407
+        var result = state
+        result = (result ^ (result >> 30)) &* 0xBF58_476D_1CE4_E5B9
+        result = (result ^ (result >> 27)) &* 0x94D0_49BB_1331_11EB
+        return result ^ (result >> 31)
     }
 }

--- a/Tests/localvoxtralTests/LiveHoldBackReplacementStreamTests.swift
+++ b/Tests/localvoxtralTests/LiveHoldBackReplacementStreamTests.swift
@@ -113,6 +113,36 @@ final class LiveHoldBackReplacementStreamTests: XCTestCase {
         XCTAssertEqual(stream.ingest("Code "), "Claude Code ")
     }
 
+    func testFullCaseFoldingExpansionIsHeld() {
+        // NSRegularExpression full-case-folds literals, so the rule `foo ßx`
+        // matches the text "foo ssx". A literal prefix check would judge the
+        // tail "foo s" dead ("ßx" does not start with "s") and release it, and
+        // the correction would then rewrite text already typed.
+        var stream = makeStream(entries: [
+            ReplacementEntry(replaceWith: "X", matches: ["foo ßx"]),
+        ])
+        XCTAssertEqual(stream.ingest("foo s"), "")
+        XCTAssertEqual(stream.ingest("sx "), "X ")
+    }
+
+    func testFullCaseFoldingLigatureIsHeld() {
+        // "ﬁ" folds to "fi", so the rule `fix it` matches the text "ﬁx it".
+        var stream = makeStream(entries: [
+            ReplacementEntry(replaceWith: "REPAIRED", matches: ["fix it"]),
+        ])
+        XCTAssertEqual(stream.ingest("ﬁx "), "")
+        XCTAssertEqual(stream.ingest("it "), "REPAIRED ")
+    }
+
+    func testKelvinSignFoldsToKAndIsHeld() {
+        // U+212A KELVIN SIGN folds to "k".
+        var stream = makeStream(entries: [
+            ReplacementEntry(replaceWith: "TEMP", matches: ["kelvin scale"]),
+        ])
+        XCTAssertEqual(stream.ingest("\u{212A}elvin "), "")
+        XCTAssertEqual(stream.ingest("scale "), "TEMP ")
+    }
+
     func testSingleWordRuleAmongMultiWordRulesStillReleasesPromptly() {
         var stream = makeStream(entries: [
             ReplacementEntry(replaceWith: "localvoxtral", matches: ["voxtral"]),
@@ -294,6 +324,12 @@ final class LiveHoldBackReplacementStreamTests: XCTestCase {
             ReplacementEntry(replaceWith: "Claude Code", matches: ["cloud code"]),
             ReplacementEntry(replaceWith: "FOX", matches: ["the quick brown fox"]),
             ReplacementEntry(replaceWith: "localvoxtral", matches: ["voxtral"]),
+            // Full-case-folding expansion: matches the text "gross ssx".
+            ReplacementEntry(replaceWith: "SS", matches: ["gross ßx"]),
+            // A replacement that reproduces its own key's first word. A
+            // correction rewriting released text could still reproduce it
+            // verbatim, so only the in-stream assertion catches that.
+            ReplacementEntry(replaceWith: "foo baz", matches: ["foo bar"]),
         ])
     }
 
@@ -354,6 +390,12 @@ final class LiveHoldBackReplacementStreamTests: XCTestCase {
             "the quick brown fox",
             "cloud cloud code ",
             "voxtral foo-cloud code ",
+            "gross ssx ",
+            "gross s",
+            "hello gross ssx world ",
+            "foo bar ",
+            "foo bar foo bar ",
+            "ﬁx it ",
         ] {
             assertReleasedTextMatchesBatch(text)
         }
@@ -363,7 +405,7 @@ final class LiveHoldBackReplacementStreamTests: XCTestCase {
         let vocabulary = [
             "cloud", "code", "the", "quick", "brown", "fox", "hello", "world",
             "clouds", "codes", "foo-cloud", "e\u{0301}cloud", "CLOUD", "cloud.",
-            "voxtral", "local",
+            "voxtral", "local", "gross", "ssx", "ßx", "foo", "bar", "baz",
         ]
 
         var generator = SeededGenerator(seed: 0x5EED_1234)

--- a/Tests/localvoxtralTests/LiveHoldBackReplacementStreamTests.swift
+++ b/Tests/localvoxtralTests/LiveHoldBackReplacementStreamTests.swift
@@ -143,6 +143,22 @@ final class LiveHoldBackReplacementStreamTests: XCTestCase {
         XCTAssertEqual(stream.ingest("scale "), "TEMP ")
     }
 
+    func testReplacementContainingItsOwnKeyTerminates() {
+        // `apply()` resumes scanning past the inserted replacement text, so a
+        // replacement that reproduces its own key cannot be re-matched forever.
+        // If that ever regresses, the app hangs mid-dictation rather than
+        // failing a test — pin it here.
+        var stream = makeStream(entries: [
+            ReplacementEntry(replaceWith: "big foo", matches: ["foo"]),
+        ])
+        XCTAssertEqual(stream.ingest("foo bar "), "big foo bar ")
+
+        var nested = makeStream(entries: [
+            ReplacementEntry(replaceWith: "xyz abc def", matches: ["abc def"]),
+        ])
+        XCTAssertEqual(nested.ingest("abc def tail "), "xyz abc def tail ")
+    }
+
     func testSingleWordRuleAmongMultiWordRulesStillReleasesPromptly() {
         var stream = makeStream(entries: [
             ReplacementEntry(replaceWith: "localvoxtral", matches: ["voxtral"]),

--- a/Tests/localvoxtralTests/LiveHoldBackReplacementStreamTests.swift
+++ b/Tests/localvoxtralTests/LiveHoldBackReplacementStreamTests.swift
@@ -327,6 +327,227 @@ final class LiveHoldBackReplacementStreamTests: XCTestCase {
         XCTAssertEqual(stream.flushRemainder(), " ")
     }
 
+    // MARK: - Rule chaining (a correction rewrites held text into rule-key words)
+
+    /// PR #100 review finding, exact repro: rules `"x y" -> "bar"` and
+    /// `"foo bar z" -> "FOO"`. The viable-prefix bound used to release "foo "
+    /// after chunk 1 (the scan saw only "x ", no live prefix at "foo x"),
+    /// chunk 2 then corrected the held "x y " into "bar ", and chunk 3
+    /// matched "foo bar z" starting inside RELEASED text — a correction that
+    /// would rewrite text already typed into the user's app. The rule set has
+    /// chaining potential, so the stream must hold to the word-count floor:
+    /// nothing is released until the chain resolves, and the final output is
+    /// the fully corrected text with no rewrite of released offsets.
+    func testChainedRuleMatchNeverReachesReleasedText() {
+        var stream = makeStream(entries: [
+            ReplacementEntry(replaceWith: "bar", matches: ["x y"]),
+            ReplacementEntry(replaceWith: "FOO", matches: ["foo bar z"]),
+        ])
+        XCTAssertEqual(stream.ingest("foo x "), "")
+        XCTAssertEqual(stream.ingest("y "), "")
+        XCTAssertEqual(stream.ingest("z "), "")
+        XCTAssertEqual(stream.flushRemainder(), "FOO ")
+        #if DEBUG
+            XCTAssertEqual(stream.debugDroppedCorrectionCount, 0)
+        #endif
+    }
+
+    /// A rule can chain with ITSELF when its replacement reproduces an
+    /// interior word of its own key: with `"a b c" -> "b"`, correcting
+    /// "a a b c " turns the held tail into "b " right after the released
+    /// "a ", and the next "c " completes a fresh "a b c" match starting at
+    /// offset 0 — inside released text. Batch semantics for the whole
+    /// transcript "a a b c c " are "b ".
+    func testSelfChainingRuleMatchNeverReachesReleasedText() {
+        var stream = makeStream(entries: [
+            ReplacementEntry(replaceWith: "b", matches: ["a b c"]),
+        ])
+        XCTAssertEqual(stream.ingest("a a "), "")
+        XCTAssertEqual(stream.ingest("b c "), "")
+        XCTAssertEqual(stream.ingest("c "), "")
+        XCTAssertEqual(stream.flushRemainder(), "b ")
+        #if DEBUG
+            XCTAssertEqual(stream.debugDroppedCorrectionCount, 0)
+        #endif
+    }
+
+    /// Second review round, finding 1: a DELETION rule (`um -> ""`) has no
+    /// replacement words for chaining detection to compare, but it chains by
+    /// BRIDGING — deleting the word between two key words lets the other
+    /// key's `\s+` separators match across the release boundary. "hello "
+    /// must not be released before the deletion resolves, and the output
+    /// must equal the batch result "HW ".
+    func testDeletionRuleBridgingNeverReachesReleasedText() {
+        var stream = makeStream(entries: [
+            ReplacementEntry(replaceWith: "", matches: ["um"]),
+            ReplacementEntry(replaceWith: "HW", matches: ["hello world"]),
+        ])
+        XCTAssertEqual(stream.ingest("hello um"), "")
+        XCTAssertEqual(stream.ingest(" world "), "")
+        XCTAssertEqual(stream.flushRemainder(), "HW ")
+        #if DEBUG
+            XCTAssertEqual(stream.debugDroppedCorrectionCount, 0)
+        #endif
+    }
+
+    /// Second review round, finding 2: the word floor is NOT correct under
+    /// deletion rules — `lookbackStart` counts words in POST-deletion text,
+    /// so deleting held words lets a later lookback cross the release
+    /// boundary even in floor mode. The unrelated `p q -> r2` / `r2 s -> S`
+    /// pair forces floor mode; the deletion rule must escalate the whole set
+    /// to hold-until-flush, and the output must equal the batch result "RK ".
+    func testDeletionRuleDefeatsWordFloorNeverReachesReleasedText() {
+        var stream = makeStream(entries: [
+            ReplacementEntry(replaceWith: "", matches: ["aa bb cc"]),
+            ReplacementEntry(replaceWith: "RK", matches: ["r k"]),
+            ReplacementEntry(replaceWith: "r2", matches: ["p q"]),
+            ReplacementEntry(replaceWith: "S", matches: ["r2 s"]),
+        ])
+        XCTAssertEqual(stream.ingest("r aa bb cc"), "")
+        XCTAssertEqual(stream.ingest(" k "), "")
+        XCTAssertEqual(stream.flushRemainder(), "RK ")
+        #if DEBUG
+            XCTAssertEqual(stream.debugDroppedCorrectionCount, 0)
+        #endif
+    }
+
+    func testDeletionRuleSetHoldsEverythingUntilFlush() {
+        // A deletion rule selects hold-until-flush: even text no rule could
+        // ever match stays held mid-session and is released only at flush.
+        var deleting = makeStream(entries: [
+            ReplacementEntry(replaceWith: "", matches: ["um"]),
+        ])
+        XCTAssertEqual(deleting.ingest("hello world "), "")
+        XCTAssertEqual(deleting.flushRemainder(), "hello world ")
+
+        // Same rule shape with a word-bearing replacement keeps the prior
+        // bounds — here the viable-prefix bound, releasing immediately.
+        var keeping = makeStream(entries: [
+            ReplacementEntry(replaceWith: "uh", matches: ["um"]),
+        ])
+        XCTAssertEqual(keeping.ingest("hello world "), "hello world ")
+        XCTAssertEqual(keeping.flushRemainder(), "")
+    }
+
+    func testDeletionRuleDetection() {
+        func hasDeletionRule(_ entries: [ReplacementEntry]) -> Bool {
+            LiveReplacementCorrector(dictionary: ReplacementDictionary(entries: entries))
+                .hasDeletionRule
+        }
+        XCTAssertTrue(hasDeletionRule([
+            ReplacementEntry(replaceWith: "", matches: ["um"]),
+        ]))
+        // Whitespace-only replacements delete their match's words just the same.
+        XCTAssertTrue(hasDeletionRule([
+            ReplacementEntry(replaceWith: "  ", matches: ["um"]),
+        ]))
+        XCTAssertFalse(hasDeletionRule([
+            ReplacementEntry(replaceWith: "uh", matches: ["um"]),
+        ]))
+    }
+
+    private var chainingEntries: [ReplacementEntry] {
+        [
+            ReplacementEntry(replaceWith: "bar", matches: ["x y"]),
+            ReplacementEntry(replaceWith: "FOO", matches: ["foo bar z"]),
+        ]
+    }
+
+    func testChainingRuleSetFallsBackToWordFloor() {
+        var stream = makeStream(entries: chainingEntries)
+        // maxRuleWordCount is 3, so the old global floor holds the last two
+        // complete words of even unrelated text.
+        XCTAssertEqual(stream.ingest("hello there world "), "hello ")
+        XCTAssertEqual(stream.flushRemainder(), "there world ")
+    }
+
+    func testNonChainingRuleSetKeepsViablePrefixBound() {
+        // Same key shapes as `chainingEntries`, but no replacement word feeds
+        // any rule key — unrelated text must keep releasing with no extra hold.
+        var stream = makeStream(entries: [
+            ReplacementEntry(replaceWith: "QQ", matches: ["x y"]),
+            ReplacementEntry(replaceWith: "FOO", matches: ["foo bar z"]),
+        ])
+        XCTAssertEqual(stream.ingest("hello there world "), "hello there world ")
+        XCTAssertEqual(stream.flushRemainder(), "")
+    }
+
+    // MARK: - Chaining detection
+
+    private func hasChainingPotential(_ entries: [ReplacementEntry]) -> Bool {
+        LiveReplacementCorrector(dictionary: ReplacementDictionary(entries: entries))
+            .hasChainingPotential
+    }
+
+    func testChainingDetectionFlagsReplacementWordInAnotherRulesKey() {
+        XCTAssertTrue(hasChainingPotential(chainingEntries))
+    }
+
+    func testChainingDetectionIgnoresDisjointRuleSets() {
+        XCTAssertFalse(hasChainingPotential([
+            ReplacementEntry(replaceWith: "QQ", matches: ["x y"]),
+            ReplacementEntry(replaceWith: "FOO", matches: ["foo bar z"]),
+        ]))
+        // The suite's shared invariant dictionary must stay on the fast bound,
+        // or the batch-equivalence tests would silently stop covering it.
+        XCTAssertFalse(
+            LiveReplacementCorrector(dictionary: invariantDictionary).hasChainingPotential
+        )
+    }
+
+    func testChainingDetectionComparesWithFullCaseFolding() {
+        // Simple case folding: replacement "BAR" feeds the key word "bar".
+        XCTAssertTrue(hasChainingPotential([
+            ReplacementEntry(replaceWith: "BAR", matches: ["x y"]),
+            ReplacementEntry(replaceWith: "FOO", matches: ["foo bar z"]),
+        ]))
+        // Full case folding: "ßx" and "ssx" are the same folded word, exactly
+        // as the matcher sees them.
+        XCTAssertTrue(hasChainingPotential([
+            ReplacementEntry(replaceWith: "ssx", matches: ["hello"]),
+            ReplacementEntry(replaceWith: "X", matches: ["a ßx b"]),
+        ]))
+    }
+
+    func testChainingDetectionIgnoresOwnKeyEdgeWords() {
+        // Echo-style replacements reproduce their own key's first/last words;
+        // those cannot chain (see `hasChainingPotential`) and must not push
+        // the rule set onto the slow floor.
+        XCTAssertFalse(hasChainingPotential([
+            ReplacementEntry(replaceWith: "big foo", matches: ["foo"]),
+        ]))
+        XCTAssertFalse(hasChainingPotential([
+            ReplacementEntry(replaceWith: "xyz abc def", matches: ["abc def"]),
+        ]))
+    }
+
+    func testChainingDetectionFlagsOwnKeyInteriorWord() {
+        XCTAssertTrue(hasChainingPotential([
+            ReplacementEntry(replaceWith: "b", matches: ["a b c"]),
+        ]))
+    }
+
+    #if DEBUG
+        /// Backstop for any gap in chaining detection: with the viable-prefix
+        /// bound forced back on, the chained "foo bar z" correction reaches
+        /// offset 0 after "foo " was already released. It must be dropped —
+        /// released text is in the user's app and can never be un-typed — so
+        /// the final output keeps the released words verbatim instead of
+        /// rewriting them. (In production this path also logs an error; the
+        /// old `assert` was compiled out of release builds entirely.)
+        func testCorrectionReachingReleasedTextIsDroppedNeverApplied() {
+            var stream = makeStream(entries: chainingEntries)
+            stream.debugForceViablePrefixBound = true
+            XCTAssertEqual(stream.ingest("foo x "), "foo ")
+            XCTAssertEqual(stream.ingest("y "), "")
+            // The chained correction is dropped; the held tail releases
+            // uncorrected — the best end state achievable without un-typing.
+            XCTAssertEqual(stream.ingest("z "), "bar z ")
+            XCTAssertEqual(stream.flushRemainder(), "")
+            XCTAssertEqual(stream.debugDroppedCorrectionCount, 1)
+        }
+    #endif
+
     // MARK: - Never-un-type invariant
 
     /// The dictionary the invariant tests run against.
@@ -388,6 +609,18 @@ final class LiveHoldBackReplacementStreamTests: XCTestCase {
                 file: file,
                 line: line
             )
+            #if DEBUG
+                // A dropped correction is the invariant guard firing — output
+                // equality alone could mask a violation whose rewrite happens
+                // to reproduce the released text.
+                XCTAssertEqual(
+                    stream.debugDroppedCorrectionCount,
+                    0,
+                    "chunk size \(size) dropped a correction for input \(String(reflecting: text))",
+                    file: file,
+                    line: line
+                )
+            #endif
         }
     }
 

--- a/Tests/localvoxtralTests/TextInsertionServiceLiveStrategyTests.swift
+++ b/Tests/localvoxtralTests/TextInsertionServiceLiveStrategyTests.swift
@@ -53,19 +53,20 @@ final class TextInsertionServiceLiveStrategyTests: XCTestCase {
         let service = makeService(capturing: typed)
         service.beginLiveReplacementSession(
             dictionary: ReplacementDictionary(entries: [
-                ReplacementEntry(replaceWith: "localvoxtral", matches: ["local voxtral"]),
+                ReplacementEntry(replaceWith: "X", matches: ["run something"]),
             ]),
             preferredAppPID: nil,
             isTerminalLikeTarget: true
         )
 
-        // The two-word rule holds everything back, so the newline is still
-        // held at session stop and must be sanitized on the remainder flush.
-        service.enqueueRealtimeInsertion("run\nit")
+        // "run so" stays a live prefix of the rule, so everything is held back
+        // and the newline is still held at session stop — it must be sanitized
+        // on the remainder flush.
+        service.enqueueRealtimeInsertion("run\nso")
         XCTAssertEqual(typed.value, [])
         service.flushFinalLiveReplacementCorrections()
 
-        XCTAssertEqual(typed.value.joined(), "run it")
+        XCTAssertEqual(typed.value.joined(), "run so")
     }
 
     func testTerminalLikeSessionWithoutDictionaryStillSanitizesNewlines() {


### PR DESCRIPTION
## What

Live Auto-Paste applies replacement-dictionary rules *before* typing, because released text can never be un-typed (there are no backspaces in the insertion path — terminals can't support them, field bug 2026-07-06). To guarantee that, `LiveHoldBackReplacementStream` held back the trailing partial word plus `maxRuleWordCount - 1` complete words.

`maxRuleWordCount` is the **global max across every rule**, so a single four-word entry anywhere in `replacements.toml` made *every* live-typed word lag three complete words behind speech — including text that could never match that rule. Live Auto-Paste is the mode where text appears as you speak, so this was directly felt.

This bounds the hold by **viable prefix** instead: hold from the earliest offset where the remaining text is still a live prefix of some rule. Text that begins no rule is released immediately.

It's cheap because `makeRegex` escapes every key with `escapedPattern` and joins the words with `\s+` — **rules are literal word lists**, not user regexes, so prefix-matching needs no regex machinery. `LiveReplacementRule` now carries its split `keyWords`.

The old N-word window is kept as a **floor**: both it and the prefix scan are lower bounds on a future correction's `startOffset`, so the safe limit is the larger of the two. Single-word dictionaries are bit-for-bit unchanged (the scan never runs).

### The subtle part

Candidate match starts are **not** whitespace-delimited word starts. The pattern's `(?<![\p{L}\p{N}])` lookbehind only forbids a preceding *letter or digit*:

- `voxtral` matches inside `foo-voxtral` (preceded by `-`)
- for a decomposed `e` + U+0301, the code point before the match is a combining mark (category `Mn`), which the lookbehind accepts

A scan keyed on word starts would release `foo-voxtral ` and then let a later `rocks ` fire a `voxtral rocks` correction reaching back into already-typed text — exactly the invariant the design exists to protect. So the scan tests every offset not preceded by a letter/digit, comparing the **last unicode scalar** of the preceding grapheme to mirror the regex rather than the grapheme as a whole.

### Behavior change in tests

Three existing tests asserted the old latency and now assert the earlier release. No assertion was weakened — each still checks the same final text, and two are strictly stronger (they now pin *when* text is released, not just that it eventually is):

- `testMultiWordRuleHoldsBackPossiblePrefixWords`: `ingest("code ")` now returns `"Claude Code "` instead of `"Claude "` + a stop-flush remainder.
- `testCorrectsMultiWordKeyWithLookbackWindow` (view model): `localvoxtral ` is typed live rather than at the stop flush.
- `testFlushedRemainderIsSanitized` / `testTerminalLikeSessionSanitizesNewlinesInFlushedRemainder`: these relied on a two-word rule holding *everything* so the newline reached the remainder flush. That setup no longer holds text the rule can't match, so they now use a rule the input stays a prefix of (`run something` / `run so`), preserving the original intent. Added `testCollapsedNewlineRunSpansAnEarlyRelease` to cover the new early-release-then-collapse interaction.

## Proof

- [x] Unit suite green — `./scripts/remote-build.sh`

```
Executed 618 tests, with 2 tests skipped and 0 failures (0 unexpected) in 8.121 (8.164) seconds
```

- [x] Realtime integration green — `./scripts/remote-build.sh integration`

```
Executed 7 tests, with 2 tests skipped and 0 failures (0 unexpected) in 18.537 (18.540) seconds
```

- [x] Regression tests fail before the fix, pass after

The hazard above is not hypothetical. Degrading **only** the candidate-start test to the naive word-start version (`return isWhitespace(characters[offset - 1])`) and re-running:

```
=== FAILING TESTS UNDER NAIVE WORD-START SCAN ===
LiveHoldBackReplacementStreamTests.testMatchStartAfterCombiningMarkIsHeldBack
LiveHoldBackReplacementStreamTests.testMatchStartAfterPunctuationIsHeldBack
LiveHoldBackReplacementStreamTests.testReleasedTextMatchesBatchCorrectionForAdversarialInputs
LiveHoldBackReplacementStreamTests.testReleasedTextMatchesBatchCorrectionForRandomChunkings

XCTAssertEqual failed: ("foo-cloud  Code ") is not equal to ("foo-Claude Code ")
XCTAssertEqual failed: ("évoxtral ") is not equal to ("é")
```

`foo-cloud  Code` is the corrupted-output signature of a correction rewriting text that had already been typed. With the fix, all four pass:

```
Executed 34 tests, with 0 failures (0 unexpected) in 1.837 (1.840) seconds
```

### On the property test

`testReleasedTextMatchesBatchCorrection*` asserts the invariant directly: for any chunking, the concatenated releases must equal correcting the whole transcript in one batch pass. Releasing too early can only show up as a final output that disagrees with the batch result.

Worth recording — **the first version of this property test passed under the naive scan**, i.e. it was worthless. Its corpus paired the multi-word rule `voxtral rocks` with a single-word `voxtral` rule; the shorter rule fires at the boundary after `foo-voxtral`, rewrites it to `foo-localvoxtral `, and the multi-word rule can then never reach back across a release. The hazard was unreachable by construction. The corpus now keeps `cloud code` free of any single-word rule on `cloud` (documented on `invariantDictionary`), and the adversarial inputs are enumerated explicitly rather than left to the RNG.

### Not verified by hand

No UI change. Behavior was verified by the suites above, not by dictating into a live terminal.

## Note

One unrelated flake seen once during a full-suite run: `BackendManagerTests.testSupervisorStateMirrorMarksLaterFailureAndNextEnsureDoesNotShortCircuit`. It passed 3/3 in isolation and on the next full-suite run, and touches no file in this diff. Flagging rather than ignoring — that suite was deflaked in c1b2baf and may still be racy.
