### PR TITLE
Polish token guard: protect code-like tokens through LLM polishing byte-exact

### DIFF
--- a/Sources/localvoxtral/DictationViewModel+Session.swift
+++ b/Sources/localvoxtral/DictationViewModel+Session.swift
@@ -628,13 +628,42 @@ extension DictationViewModel {
                                 request: polishingRequest,
                                 configuration: config
                             )
-                            processedTextForPersistence =
-                                result.polishedText != originalText ? result.polishedText : nil
                             polishingDuration = result.durationSeconds
+
+                            // Token protection: a small polish model can mangle
+                            // code-like tokens (CLI flags, paths, URLs, backtick
+                            // spans). Repair byte-exact where possible; if a
+                            // protected token is neither present nor repairable,
+                            // discard the polish and keep the pre-polish text.
+                            let guardResult = PolishTokenGuard.verifyAndRepair(
+                                polished: result.polishedText,
+                                original: workingText
+                            )
+                            let committedText: String
+                            switch guardResult.outcome {
+                            case .clean:
+                                committedText = guardResult.text
+                            case .repaired(let count):
+                                committedText = guardResult.text
+                                Log.polishing.info(
+                                    "Token guard repaired \(count) protected token(s) after polishing"
+                                )
+                            case .fallback(let missing):
+                                committedText = workingText
+                                // Count is public; the token list is dictated
+                                // content (URLs, paths, env vars) and keeps the
+                                // default private redaction in unified logs.
+                                Log.polishing.warning(
+                                    "Token guard discarded polish; \(missing.count, privacy: .public) protected token(s) not preserved: \(missing.joined(separator: ", "))"
+                                )
+                            }
+
+                            processedTextForPersistence =
+                                committedText != originalText ? committedText : nil
 
                             guard !Task.isCancelled else { return }
 
-                            self.currentDictationEventText = result.polishedText
+                            self.currentDictationEventText = committedText
                             self.refreshOverlayBufferSession()
                             Log.polishing.info(
                                 "LLM polishing succeeded in \(String(format: "%.2f", result.durationSeconds))s"

--- a/Sources/localvoxtral/PolishTokenGuard.swift
+++ b/Sources/localvoxtral/PolishTokenGuard.swift
@@ -1,0 +1,259 @@
+import Foundation
+
+/// Deterministic, app-side protection for code-like tokens through LLM
+/// polishing. Dictated coding-agent prompts carry CLI flags, paths, URLs,
+/// backtick spans, env vars, hashes and version literals; a small polish model
+/// can silently mangle exactly those (e.g. `--force` → `– force`, a path
+/// case-folded, backticks dropped). This enum recognizes such tokens in the
+/// pre-polish text and, after polishing, either confirms each survived
+/// byte-exact, repairs a near-miss the model introduced, or (when a token is
+/// gone and unrepairable) signals the caller to discard the polish entirely.
+///
+/// Pure functions on `String`, mirroring `TextMergingAlgorithms`. Recognition
+/// is deliberately conservative: prefer missing a token over a false positive
+/// that would block legitimate cleanup.
+enum PolishTokenGuard {
+    struct Repair: Equatable {
+        /// The text the caller should commit for `.clean`/`.repaired`. For
+        /// `.fallback` it is the untouched `original`, but the caller decides
+        /// what to keep by switching on `outcome`.
+        let text: String
+        let outcome: Outcome
+
+        enum Outcome: Equatable {
+            case clean
+            case repaired(count: Int)
+            case fallback(missing: [String])
+        }
+    }
+
+    // MARK: - Recognition
+
+    // Static literals: a bad pattern is a coding error we want to crash on
+    // immediately (same rationale as TextMergingAlgorithms).
+    private static let backtickSpan = try! NSRegularExpression(pattern: "`[^`\\n]+`")
+    private static let url = try! NSRegularExpression(pattern: "[A-Za-z][A-Za-z0-9+.-]*://[^\\s]+")
+    // A path is an optional leading `/` (absolute paths must protect it — a
+    // dropped slash silently turns `/tmp/app.log` relative) plus one or more
+    // "segment/" groups and a final segment. Segment chars include `.`, `~`,
+    // `-` so `./scripts/foo.sh` and `~/Library/x` match. Inside a URL the
+    // `/host/path` sub-span still matches but is dropped by containment.
+    private static let path = try! NSRegularExpression(pattern: "/?(?:[\\w.~-]+/)+[\\w.~-]+")
+    // Standalone dotted filename: stem must be 2+ chars holding a letter/
+    // underscore (rejects pure numbers like `3.14` and abbreviations `e.g`/
+    // `i.e`), ext is 1–8 all-lowercase alphanumerics (rejects `works.Then` —
+    // STT output missing the space after a sentence period; the polish
+    // legitimately fixes that, and a protected token here would make the
+    // guard revert the fix). Accepted losses per the conservative-recognition
+    // principle: uppercase-ext files (`Makefile.AM`) and single-letter stems
+    // (`a.txt`) go unprotected.
+    private static let filename = try! NSRegularExpression(
+        pattern: "\\b(?=[A-Za-z0-9_-]*[A-Za-z_])[A-Za-z0-9_-]{2,}\\.[a-z0-9]{1,8}\\b"
+    )
+    // Flags: whitespace/start-preceded; group 1 is the flag itself. Double dash
+    // takes an optional =value; single dash is exactly one alphanumeric (so
+    // hyphenated prose like "well-known" is never captured).
+    private static let flag = try! NSRegularExpression(
+        pattern: "(?:^|\\s)(--[A-Za-z][A-Za-z0-9-]*(?:=\\S+)?|-[A-Za-z0-9])(?![\\w-])"
+    )
+    private static let envVar = try! NSRegularExpression(pattern: "\\$[A-Z_][A-Z0-9_]+\\b")
+    // Standalone lowercase-hex run, 7–40 chars. Post-filtered to require at
+    // least one digit — a conservative refinement over a bare [0-9a-f]{7,40}
+    // that would flag all-letter English words like "acceded"/"defaced".
+    private static let hexHash = try! NSRegularExpression(pattern: "\\b[0-9a-f]{7,40}\\b")
+    // Version literal: `v` prefix needs 2+ components, bare needs 3+ (so prose
+    // "2.5" is not captured but "1.2.3" and "v2.5" are).
+    private static let version = try! NSRegularExpression(
+        pattern: "\\bv\\d+(?:\\.\\d+)+\\b|\\b\\d+\\.\\d+(?:\\.\\d+)+\\b"
+    )
+
+    /// Trailing sentence punctuation trimmed off URL/path/filename matches so a
+    /// dictated "…in src/foo.ts." protects `src/foo.ts`, not `src/foo.ts.`.
+    private static let trailingPunctuation: Set<Character> = [".", ",", ";", ":", "!", "?", ")"]
+
+    /// Ordered, de-duplicated protected tokens found in `text`. Ordering is by
+    /// first appearance; tokens whose span is fully contained in a longer
+    /// token's span (e.g. a filename inside a path) are dropped.
+    static func protectedTokens(in text: String) -> [String] {
+        let ns = text as NSString
+        let full = NSRange(location: 0, length: ns.length)
+
+        var spans: [(range: NSRange, token: String)] = []
+
+        func collect(_ regex: NSRegularExpression, captureGroup: Int = 0, trimTrailing: Bool = false,
+                     filter: (String) -> Bool = { _ in true }) {
+            for match in regex.matches(in: text, range: full) {
+                let range = match.range(at: captureGroup)
+                guard range.location != NSNotFound, range.length > 0 else { continue }
+                var token = ns.substring(with: range)
+                var effectiveRange = range
+                if trimTrailing {
+                    var trimmed = 0
+                    while let last = token.last, trailingPunctuation.contains(last) {
+                        token.removeLast()
+                        trimmed += 1
+                    }
+                    effectiveRange = NSRange(location: range.location, length: range.length - trimmed)
+                }
+                guard !token.isEmpty, filter(token) else { continue }
+                spans.append((effectiveRange, token))
+            }
+        }
+
+        collect(backtickSpan)
+        collect(url, trimTrailing: true)
+        collect(path, trimTrailing: true)
+        collect(filename, trimTrailing: true)
+        // trimTrailing only ever bites the `=value` tail (`--mode=fast.` at
+        // sentence end): the flag charset itself excludes punctuation.
+        collect(flag, captureGroup: 1, trimTrailing: true)
+        collect(envVar)
+        collect(hexHash, filter: { $0.contains(where: { $0.isNumber }) })
+        collect(version)
+
+        // Drop any span strictly contained in a longer span (path swallows its
+        // inner filename, URL swallows an inner path, etc.).
+        let kept = spans.enumerated().filter { _, span in
+            !spans.contains { other in
+                !NSEqualRanges(other.range, span.range)
+                    && other.range.location <= span.range.location
+                    && (span.range.location + span.range.length)
+                        <= (other.range.location + other.range.length)
+            }
+        }
+
+        var seen = Set<String>()
+        var result: [String] = []
+        for (_, span) in kept.sorted(by: { $0.element.range.location < $1.element.range.location }) {
+            if seen.insert(span.token).inserted {
+                result.append(span.token)
+            }
+        }
+        return result
+    }
+
+    // MARK: - Verify & repair
+
+    /// Confirms every protected token of `original` survived into `polished`,
+    /// repairing near-misses in place. If any token is neither present nor
+    /// repairable, returns `.fallback` and the caller keeps its pre-polish text.
+    static func verifyAndRepair(polished: String, original: String) -> Repair {
+        let tokens = protectedTokens(in: original)
+        guard !tokens.isEmpty else { return Repair(text: polished, outcome: .clean) }
+
+        var working = polished
+        var repairedCount = 0
+        var missing: [String] = []
+
+        for token in tokens {
+            if containsStandalone(token, in: working) { continue }
+            if let repaired = repairFirstNearMiss(of: token, in: working) {
+                working = repaired
+                repairedCount += 1
+            } else {
+                missing.append(token)
+            }
+        }
+
+        if !missing.isEmpty {
+            return Repair(text: original, outcome: .fallback(missing: missing))
+        }
+        if repairedCount > 0 {
+            return Repair(text: working, outcome: .repaired(count: repairedCount))
+        }
+        return Repair(text: working, outcome: .clean)
+    }
+
+    /// Canonical form for near-miss comparison: lowercase, dash variants unified
+    /// (en/em dash → `--`, Unicode hyphens → `-`), and inserted whitespace
+    /// removed. This is what makes a case-folded path, an en-dash-mangled
+    /// `--force`, or a `-- force` with an inserted space compare equal to the
+    /// exact token.
+    private static func canonical(_ s: String) -> String {
+        s.lowercased()
+            .replacingOccurrences(of: "\u{2014}", with: "--") // em dash
+            .replacingOccurrences(of: "\u{2013}", with: "--") // en dash
+            .replacingOccurrences(of: "\u{2012}", with: "-")  // figure dash
+            .replacingOccurrences(of: "\u{2010}", with: "-")  // hyphen
+            .replacingOccurrences(of: "\u{2011}", with: "-")  // non-breaking hyphen
+            .replacingOccurrences(of: " ", with: "")
+            .replacingOccurrences(of: "\t", with: "")
+            .replacingOccurrences(of: "\u{202F}", with: "")   // narrow no-break space
+            .replacingOccurrences(of: "\u{00A0}", with: "")   // no-break space
+    }
+
+    /// True when `token` occurs in `text` standalone: no letter/digit/`_`/`-`
+    /// glued to either side. An occurrence with a body char appended or
+    /// prepended is a corruption (`--force` inside `--forceful`,
+    /// `src/App.ts` inside `src/App.tsx`), not a survival. Sentence
+    /// punctuation is not a body char, so "src/App.ts." still counts.
+    private static func containsStandalone(_ token: String, in text: String) -> Bool {
+        var searchRange = text.startIndex..<text.endIndex
+        while let found = text.range(of: token, range: searchRange) {
+            let standaloneBefore = found.lowerBound == text.startIndex
+                || !isBodyCharacter(text[text.index(before: found.lowerBound)])
+            let standaloneAfter = found.upperBound == text.endIndex
+                || !isBodyCharacter(text[found.upperBound])
+            if standaloneBefore && standaloneAfter { return true }
+            guard found.lowerBound < text.endIndex else { break }
+            searchRange = text.index(after: found.lowerBound)..<text.endIndex
+        }
+        return false
+    }
+
+    private static func isBodyCharacter(_ c: Character) -> Bool {
+        c.isLetter || c.isNumber || c == "_" || c == "-"
+    }
+
+    /// Locates the leftmost, shortest substring of `text` whose canonical form
+    /// equals the token's and replaces it with the exact `token`. Window
+    /// endpoints must be non-space so a boundary space is never eaten (which
+    /// would merge the token into an adjacent word), and the window must be
+    /// standalone (no body char glued to either side) so a token embedded in a
+    /// longer word (`–forceful`) is never "repaired" into another corruption.
+    /// Returns nil if no near-miss exists.
+    private static func repairFirstNearMiss(of token: String, in text: String) -> String? {
+        let target = canonical(token)
+        guard !target.isEmpty else { return nil }
+
+        let chars = Array(text)
+        let n = chars.count
+        // Slack past the token length covers whitespace the model inserted.
+        let maxWindow = token.count + 8
+
+        for start in 0..<n where !isSkippableSpace(chars[start]) {
+            // A body char glued before the window means this start is the tail
+            // of a longer word — never a standalone repair site.
+            if start > 0, isBodyCharacter(chars[start - 1]) { continue }
+            let hi = min(n, start + maxWindow)
+            var end = start + 1
+            while end <= hi {
+                if isSkippableSpace(chars[end - 1]) {
+                    end += 1
+                    continue
+                }
+                let window = String(chars[start..<end])
+                let canon = canonical(window)
+                if canon == target {
+                    // A body char right after the window is appended-char
+                    // corruption; growing the window past it can only
+                    // overshoot the target, so give up on this start.
+                    if end < n, isBodyCharacter(chars[end]) { break }
+                    guard window != token else { return nil }
+                    var result = chars
+                    result.replaceSubrange(start..<end, with: Array(token))
+                    return String(result)
+                }
+                // canonical length is non-decreasing as the window grows, so
+                // once it overshoots the target there is no match past here.
+                if canon.count > target.count { break }
+                end += 1
+            }
+        }
+        return nil
+    }
+
+    private static func isSkippableSpace(_ c: Character) -> Bool {
+        c == " " || c == "\t" || c == "\u{202F}" || c == "\u{00A0}"
+    }
+}

--- a/Sources/localvoxtral/PolishTokenGuard.swift
+++ b/Sources/localvoxtral/PolishTokenGuard.swift
@@ -44,12 +44,28 @@ enum PolishTokenGuard {
     // `i.e`), ext is 1–8 all-lowercase alphanumerics (rejects `works.Then` —
     // STT output missing the space after a sentence period; the polish
     // legitimately fixes that, and a protected token here would make the
-    // guard revert the fix). Accepted losses per the conservative-recognition
-    // principle: uppercase-ext files (`Makefile.AM`) and single-letter stems
-    // (`a.txt`) go unprotected.
+    // guard revert the fix). The extension must additionally sit in
+    // `knownFileExtensions` — see that constant's comment. Accepted losses
+    // per the conservative-recognition principle: uppercase-ext files
+    // (`Makefile.AM`), single-letter stems (`a.txt`) and unlisted extensions
+    // go unprotected.
     private static let filename = try! NSRegularExpression(
         pattern: "\\b(?=[A-Za-z0-9_-]*[A-Za-z_])[A-Za-z0-9_-]{2,}\\.[a-z0-9]{1,8}\\b"
     )
+    // Conservative allowlist of real file extensions for the standalone
+    // dotted-filename recognizer. Lowercase STT glue like "works.then" /
+    // "dr.smith" / "st.louis" fits the stem.ext shape; without this gate the
+    // guard "protects" it and the repair path re-glues the polish's correct
+    // "works. Then" back into "works.then". Slash paths (`src/foo.xyz`) are
+    // recognized by `path` and are NOT gated on this list.
+    private static let knownFileExtensions: Set<String> = [
+        "swift", "ts", "tsx", "js", "jsx", "json", "md", "txt", "log", "sh",
+        "py", "rb", "go", "rs", "c", "h", "cpp", "hpp", "m", "mm",
+        "yml", "yaml", "toml", "xml", "html", "css", "plist", "entitlements",
+        "xcconfig", "lock", "csv", "sql", "env", "resolved", "cfg", "ini",
+        "conf", "png", "svg", "pdf", "proto", "java", "kt", "php", "gradle",
+        "zsh", "bash", "ipynb",
+    ]
     // Flags: whitespace/start-preceded; group 1 is the flag itself. Double dash
     // takes an optional =value; single dash is exactly one alphanumeric (so
     // hyphenated prose like "well-known" is never captured).
@@ -103,7 +119,10 @@ enum PolishTokenGuard {
         collect(backtickSpan)
         collect(url, trimTrailing: true)
         collect(path, trimTrailing: true)
-        collect(filename, trimTrailing: true)
+        collect(filename, trimTrailing: true, filter: { token in
+            guard let dotIndex = token.lastIndex(of: ".") else { return false }
+            return knownFileExtensions.contains(String(token[token.index(after: dotIndex)...]))
+        })
         // trimTrailing only ever bites the `=value` tail (`--mode=fast.` at
         // sentence end): the flag charset itself excludes punctuation.
         collect(flag, captureGroup: 1, trimTrailing: true)
@@ -135,8 +154,12 @@ enum PolishTokenGuard {
     // MARK: - Verify & repair
 
     /// Confirms every protected token of `original` survived into `polished`,
-    /// repairing near-misses in place. If any token is neither present nor
-    /// repairable, returns `.fallback` and the caller keeps its pre-polish text.
+    /// repairing near-misses in place. Verification is per-occurrence: a token
+    /// dictated twice must survive (or be repaired) twice — recognition dedup
+    /// must not let one intact occurrence vouch for a mangled duplicate
+    /// (`run --force first, then – force again`). If any occurrence is neither
+    /// present nor repairable, returns `.fallback` and the caller keeps its
+    /// pre-polish text.
     static func verifyAndRepair(polished: String, original: String) -> Repair {
         let tokens = protectedTokens(in: original)
         guard !tokens.isEmpty else { return Repair(text: polished, outcome: .clean) }
@@ -146,12 +169,25 @@ enum PolishTokenGuard {
         var missing: [String] = []
 
         for token in tokens {
-            if containsStandalone(token, in: working) { continue }
-            if let repaired = repairFirstNearMiss(of: token, in: working) {
+            // `max(1, …)` is belt-and-braces: a recognized token always counts
+            // at least once in its own source text.
+            let required = max(1, standaloneOccurrenceCount(of: token, in: original))
+            var surviving = standaloneOccurrenceCount(of: token, in: working)
+            while surviving < required {
+                guard let repaired = repairFirstNearMiss(of: token, in: working) else {
+                    missing.append(token)
+                    break
+                }
                 working = repaired
                 repairedCount += 1
-            } else {
-                missing.append(token)
+                let recounted = standaloneOccurrenceCount(of: token, in: working)
+                // Defensive: a repair that fails to add a standalone
+                // occurrence would loop forever — treat it as unrepairable.
+                guard recounted > surviving else {
+                    missing.append(token)
+                    break
+                }
+                surviving = recounted
             }
         }
 
@@ -182,23 +218,28 @@ enum PolishTokenGuard {
             .replacingOccurrences(of: "\u{00A0}", with: "")   // no-break space
     }
 
-    /// True when `token` occurs in `text` standalone: no letter/digit/`_`/`-`
-    /// glued to either side. An occurrence with a body char appended or
-    /// prepended is a corruption (`--force` inside `--forceful`,
-    /// `src/App.ts` inside `src/App.tsx`), not a survival. Sentence
-    /// punctuation is not a body char, so "src/App.ts." still counts.
-    private static func containsStandalone(_ token: String, in text: String) -> Bool {
+    /// Number of non-overlapping standalone occurrences of `token` in `text`:
+    /// no letter/digit/`_`/`-` glued to either side. An occurrence with a body
+    /// char appended or prepended is a corruption (`--force` inside
+    /// `--forceful`, `src/App.ts` inside `src/App.tsx`), not a survival.
+    /// Sentence punctuation is not a body char, so "src/App.ts." still counts.
+    private static func standaloneOccurrenceCount(of token: String, in text: String) -> Int {
+        var count = 0
         var searchRange = text.startIndex..<text.endIndex
         while let found = text.range(of: token, range: searchRange) {
             let standaloneBefore = found.lowerBound == text.startIndex
                 || !isBodyCharacter(text[text.index(before: found.lowerBound)])
             let standaloneAfter = found.upperBound == text.endIndex
                 || !isBodyCharacter(text[found.upperBound])
-            if standaloneBefore && standaloneAfter { return true }
-            guard found.lowerBound < text.endIndex else { break }
-            searchRange = text.index(after: found.lowerBound)..<text.endIndex
+            if standaloneBefore && standaloneAfter {
+                count += 1
+                searchRange = found.upperBound..<text.endIndex
+            } else {
+                guard found.lowerBound < text.endIndex else { break }
+                searchRange = text.index(after: found.lowerBound)..<text.endIndex
+            }
         }
-        return false
+        return count
     }
 
     private static func isBodyCharacter(_ c: Character) -> Bool {
@@ -239,7 +280,11 @@ enum PolishTokenGuard {
                     // corruption; growing the window past it can only
                     // overshoot the target, so give up on this start.
                     if end < n, isBodyCharacter(chars[end]) { break }
-                    guard window != token else { return nil }
+                    // An exact occurrence is not a near-miss: skip past it and
+                    // keep scanning — with per-occurrence verification an
+                    // intact first occurrence must not block the repair of a
+                    // mangled duplicate later in the text.
+                    if window == token { break }
                     var result = chars
                     result.replaceSubrange(start..<end, with: Array(token))
                     return String(result)

--- a/Tests/localvoxtralTests/LLMPolishEvalSupport.swift
+++ b/Tests/localvoxtralTests/LLMPolishEvalSupport.swift
@@ -151,6 +151,29 @@ enum LLMPolishEvalSupport {
             mustContain: ["plan:"],
             mustNotContain: ["plan :"]
         ),
+        // Token protection: a CLI flag must survive the punctuation cleanup
+        // byte-exact — the model must not fold "--force" into an en/single dash
+        // (needles are normalized/lowercased, matching the scorer).
+        LLMPolishEvalCase(
+            id: "en-flag-survives-cleanup",
+            input: "run the deploy script with --force , then check the logs .",
+            mustContain: ["--force"],
+            mustNotContain: ["– force", "- force"]
+        ),
+        // A filesystem path must keep its slashes and case-fold-sensitive
+        // segments (compared against the lowercased output, so the needle is
+        // the lowercased path).
+        LLMPolishEvalCase(
+            id: "en-path-survives-cleanup",
+            input: "open the file src/auth/useAuth.ts and fix the the import .",
+            mustContain: ["src/auth/useauth.ts"]
+        ),
+        // A backtick-delimited command must survive with its backticks intact.
+        LLMPolishEvalCase(
+            id: "en-backtick-command-survives",
+            input: "then run `git rebase -i` to squash the commits .",
+            mustContain: ["`git rebase -i`"]
+        ),
     ]
 
     /// The bundled default templates, loaded through the production config

--- a/Tests/localvoxtralTests/PolishTokenGuardTests.swift
+++ b/Tests/localvoxtralTests/PolishTokenGuardTests.swift
@@ -1,0 +1,458 @@
+import Foundation
+import XCTest
+@testable import localvoxtral
+
+final class PolishTokenGuardTests: XCTestCase {
+    // MARK: - Recognizer
+
+    func testProtectedTokensRecognizesEachClass() {
+        let cases: [(input: String, expected: [String])] = [
+            // Backtick span (backticks included, no nesting).
+            ("run `git status` please", ["`git status`"]),
+            // URL with trailing sentence punctuation trimmed.
+            ("see https://example.com/docs, ok", ["https://example.com/docs"]),
+            // Path with slashes; the inner filename span is suppressed.
+            ("edit src/auth/useAuth.ts now", ["src/auth/useAuth.ts"]),
+            ("run ./scripts/foo.sh here", ["./scripts/foo.sh"]),
+            ("cat ~/Library/Prefs done", ["~/Library/Prefs"]),
+            // Absolute path keeps its leading slash.
+            ("tail /tmp/app.log now", ["/tmp/app.log"]),
+            // The `/host/path` sub-span inside a URL is dropped by containment:
+            // the URL alone is the protected token.
+            ("read https://api.example.com/v1/users for details", ["https://api.example.com/v1/users"]),
+            // Standalone dotted filename.
+            ("open README.md now", ["README.md"]),
+            // CLI flags.
+            ("use --force here", ["--force"]),
+            ("pass --opt=value ok", ["--opt=value"]),
+            ("add -f flag", ["-f"]),
+            // Sentence punctuation after an =value tail is trimmed, not swallowed.
+            ("run with --mode=fast.", ["--mode=fast"]),
+            // Environment variable.
+            ("echo $HOME now", ["$HOME"]),
+            ("set $PATH_VAR too", ["$PATH_VAR"]),
+            // Hex hash (has a digit).
+            ("commit a1b2c3d done", ["a1b2c3d"]),
+            // Version literals.
+            ("bump 1.2.3 today", ["1.2.3"]),
+            ("tag v2.5 now", ["v2.5"]),
+            // Ordering follows first appearance; inner filename suppressed.
+            ("run --force on src/app.ts", ["--force", "src/app.ts"]),
+        ]
+
+        for testCase in cases {
+            XCTAssertEqual(
+                PolishTokenGuard.protectedTokens(in: testCase.input),
+                testCase.expected,
+                "input: \(testCase.input)"
+            )
+        }
+    }
+
+    func testProtectedTokensRejectsNonTokens() {
+        let negatives = [
+            "well-known issue and a follow-up",       // hyphenated prose, not a flag
+            "that is the end of file.",               // sentence-ending period, no ext
+            "pi is roughly 3.14 approx",              // pure decimal, not a version/filename
+            "we shipped 2.5 times faster",            // two-component prose number
+            "c'est l'idée qu'on a partagée",          // French apostrophes
+            "the decade faded fast",                  // all-letter word, not a hex hash
+            "use e.g. the second option",             // abbreviation, not a filename
+            "It works.Then we ship",                  // missing space the polish must be free to fix
+            "open README.MD now",                     // uppercase ext: accepted recognition loss
+        ]
+
+        for input in negatives {
+            XCTAssertEqual(
+                PolishTokenGuard.protectedTokens(in: input),
+                [],
+                "input should have no protected tokens: \(input)"
+            )
+        }
+    }
+
+    // MARK: - verifyAndRepair
+
+    func testVerifyAndRepairCleanPassThrough() {
+        let result = PolishTokenGuard.verifyAndRepair(
+            polished: "Use --force.",
+            original: "use --force"
+        )
+        XCTAssertEqual(result.outcome, .clean)
+        XCTAssertEqual(result.text, "Use --force.")
+    }
+
+    func testVerifyAndRepairWithNoTokensIsClean() {
+        let result = PolishTokenGuard.verifyAndRepair(
+            polished: "Hello world.",
+            original: "hello world"
+        )
+        XCTAssertEqual(result.outcome, .clean)
+        XCTAssertEqual(result.text, "Hello world.")
+    }
+
+    func testVerifyAndRepairRepairsCaseMangledPath() {
+        let result = PolishTokenGuard.verifyAndRepair(
+            polished: "Open src/auth/useauth.ts.",
+            original: "open src/Auth/useAuth.ts"
+        )
+        XCTAssertEqual(result.outcome, .repaired(count: 1))
+        XCTAssertEqual(result.text, "Open src/Auth/useAuth.ts.")
+    }
+
+    func testVerifyAndRepairRepairsEnDashMangledFlag() {
+        let result = PolishTokenGuard.verifyAndRepair(
+            polished: "run \u{2013} force",
+            original: "run --force"
+        )
+        XCTAssertEqual(result.outcome, .repaired(count: 1))
+        XCTAssertEqual(result.text, "run --force")
+    }
+
+    func testVerifyAndRepairFallsBackWhenTokenDeleted() {
+        let result = PolishTokenGuard.verifyAndRepair(
+            polished: "run now",
+            original: "run --force now"
+        )
+        XCTAssertEqual(result.outcome, .fallback(missing: ["--force"]))
+        XCTAssertEqual(result.text, "run --force now")
+    }
+
+    func testVerifyAndRepairRepairsMultipleTokens() {
+        let result = PolishTokenGuard.verifyAndRepair(
+            polished: "run \u{2013} force on src/app.ts",
+            original: "run --force on src/App.ts"
+        )
+        XCTAssertEqual(result.outcome, .repaired(count: 2))
+        XCTAssertEqual(result.text, "run --force on src/App.ts")
+    }
+
+    func testVerifyAndRepairDiscardsPartialRepairsWhenAnyTokenMissing() {
+        // The flag is repairable (en dash), but the path is gone entirely: the
+        // whole polish is discarded, partial repairs and all.
+        let result = PolishTokenGuard.verifyAndRepair(
+            polished: "run \u{2013} force on the file",
+            original: "run --force on src/App.ts"
+        )
+        XCTAssertEqual(result.outcome, .fallback(missing: ["src/App.ts"]))
+        XCTAssertEqual(result.text, "run --force on src/App.ts")
+    }
+
+    func testVerifyAndRepairFlagWithAppendedCharsIsNotPreserved() {
+        // "--forceful" contains "--force" but with a body char appended: that
+        // is corruption, not survival, and it is not a repairable near-miss
+        // either — the polish must be discarded.
+        let result = PolishTokenGuard.verifyAndRepair(
+            polished: "run --forceful now",
+            original: "run --force now"
+        )
+        XCTAssertEqual(result.outcome, .fallback(missing: ["--force"]))
+        XCTAssertEqual(result.text, "run --force now")
+    }
+
+    func testVerifyAndRepairPathWithAppendedExtensionCharIsNotPreserved() {
+        let result = PolishTokenGuard.verifyAndRepair(
+            polished: "open src/App.tsx",
+            original: "open src/App.ts"
+        )
+        XCTAssertEqual(result.outcome, .fallback(missing: ["src/App.ts"]))
+        XCTAssertEqual(result.text, "open src/App.ts")
+    }
+
+    func testVerifyAndRepairTokenFollowedBySentencePeriodStaysClean() {
+        // '.' is not a body char: a sentence period straight after the token
+        // is a standalone occurrence, not appended-char corruption.
+        let result = PolishTokenGuard.verifyAndRepair(
+            polished: "open src/App.ts. Done",
+            original: "open src/App.ts"
+        )
+        XCTAssertEqual(result.outcome, .clean)
+        XCTAssertEqual(result.text, "open src/App.ts. Done")
+    }
+
+    func testVerifyAndRepairAbsolutePathDroppedSlashFallsBack() {
+        // The model dropped the leading slash, silently turning an absolute
+        // path relative. Canonicalization never re-adds a slash, so this is
+        // unrepairable: the polish is discarded.
+        let result = PolishTokenGuard.verifyAndRepair(
+            polished: "Tail tmp/app.log now.",
+            original: "tail /tmp/app.log now"
+        )
+        XCTAssertEqual(result.outcome, .fallback(missing: ["/tmp/app.log"]))
+        XCTAssertEqual(result.text, "tail /tmp/app.log now")
+    }
+
+    func testVerifyAndRepairDoesNotRevertSentenceSpacingFix() {
+        // "works.Then" is STT output missing a space, not a filename: the
+        // polish inserts the space and the guard must leave that fix alone
+        // (a protected "works.Then" would make the space-stripping repair
+        // put the broken form back).
+        let result = PolishTokenGuard.verifyAndRepair(
+            polished: "It works. Then we ship.",
+            original: "It works.Then we ship"
+        )
+        XCTAssertEqual(result.outcome, .clean)
+        XCTAssertEqual(result.text, "It works. Then we ship.")
+    }
+
+    func testVerifyAndRepairIsIdempotentOnRepairedOutput() {
+        let original = "run --force on src/App.ts"
+        let first = PolishTokenGuard.verifyAndRepair(
+            polished: "run \u{2013} force on src/app.ts",
+            original: original
+        )
+        XCTAssertEqual(first.outcome, .repaired(count: 2))
+
+        // Running the guard again on its own repaired output is a no-op.
+        let second = PolishTokenGuard.verifyAndRepair(polished: first.text, original: original)
+        XCTAssertEqual(second.outcome, .clean)
+        XCTAssertEqual(second.text, first.text)
+    }
+}
+
+// MARK: - View-model integration
+
+@MainActor
+final class DictationViewModelPolishTokenGuardTests: XCTestCase {
+    // DictationViewModel owns app-lifetime services; retain test instances for
+    // the process duration so teardown does not race service shutdown.
+    private static var retainedViewModels: [DictationViewModel] = []
+
+    /// The guard repairs an en-dash-mangled flag: the committed and persisted
+    /// text keep `--force` byte-exact even though the model returned `– force`.
+    func testPolishTokenGuardRepairsMangledFlagInCommittedText() async {
+        let settings = makeSettings(outputMode: .overlayBuffer)
+        settings.llmPolishingEnabled = true
+        settings.llmPolishingEndpointURL = "https://example.com/v1/chat/completions"
+
+        let overlayCoordinator = MockOverlayCoordinator()
+        let polishingService = MangleFlagPolishingService(replacement: "\u{2013} force")
+        let viewModel = DictationViewModel(
+            settings: settings,
+            overlayBufferCoordinator: overlayCoordinator,
+            startRuntimeServices: false
+        )
+        viewModel.appConfigStore = MockAppConfigStore()
+        viewModel.llmPolishingService = polishingService
+        var savedRecord: DictationSessionRecord?
+        viewModel.debugSavedSessionRecordSink = { savedRecord = $0 }
+        retainForTestProcessLifetime(viewModel)
+
+        viewModel.sessionOutputMode = .overlayBuffer
+        viewModel.isFinalizingStop = true
+        viewModel.currentDictationEventText = "run --force now"
+
+        viewModel.finishStoppedSession(promotePendingSegment: false)
+        await waitUntilStoppedSessionCompletes(viewModel)
+
+        XCTAssertEqual(viewModel.currentDictationEventText, "run --force now")
+        XCTAssertEqual(overlayCoordinator.refreshCalls.last?.displayText, "run --force now")
+        XCTAssertFalse(viewModel.currentDictationEventText.contains("\u{2013} force"))
+        // Nothing changed vs the raw text, so no polished text is persisted.
+        XCTAssertEqual(savedRecord?.rawText, "run --force now")
+        XCTAssertNil(savedRecord?.polishedText)
+        XCTAssertEqual(overlayCoordinator.commitCallCount, 1)
+    }
+
+    /// The fallback path end to end: the model deletes the protected flag, so
+    /// the polish is discarded and the pre-polish working text (with the
+    /// replacement dictionary applied) is committed and persisted.
+    func testPolishTokenGuardFallbackKeepsPrePolishWorkingText() async {
+        let settings = makeSettings(outputMode: .overlayBuffer)
+        settings.replacementDictionaryEnabled = true
+        settings.llmPolishingEnabled = true
+        settings.llmPolishingEndpointURL = "https://example.com/v1/chat/completions"
+
+        let overlayCoordinator = MockOverlayCoordinator()
+        let polishingService = DeleteFlagPolishingService()
+        let viewModel = DictationViewModel(
+            settings: settings,
+            overlayBufferCoordinator: overlayCoordinator,
+            startRuntimeServices: false
+        )
+        viewModel.appConfigStore = MockAppConfigStore(
+            replacementDictionary: ReplacementDictionary(entries: [
+                ReplacementEntry(replaceWith: "immediately", matches: ["now"]),
+            ])
+        )
+        viewModel.llmPolishingService = polishingService
+        var savedRecord: DictationSessionRecord?
+        viewModel.debugSavedSessionRecordSink = { savedRecord = $0 }
+        retainForTestProcessLifetime(viewModel)
+
+        viewModel.sessionOutputMode = .overlayBuffer
+        viewModel.isFinalizingStop = true
+        viewModel.currentDictationEventText = "run --force now"
+
+        viewModel.finishStoppedSession(promotePendingSegment: false)
+        await waitUntilStoppedSessionCompletes(viewModel)
+
+        // The model dropped --force; the guard discards that polish and keeps
+        // the replacement-applied working text, which still carries --force.
+        XCTAssertEqual(viewModel.currentDictationEventText, "run --force immediately")
+        XCTAssertEqual(overlayCoordinator.refreshCalls.last?.displayText, "run --force immediately")
+        XCTAssertEqual(savedRecord?.rawText, "run --force now")
+        XCTAssertEqual(savedRecord?.polishedText, "run --force immediately")
+        XCTAssertEqual(overlayCoordinator.commitCallCount, 1)
+    }
+
+    // MARK: - Helpers
+
+    private func waitUntilStoppedSessionCompletes(_ viewModel: DictationViewModel) async {
+        let deadline = ContinuousClock.now + .seconds(1)
+        while viewModel.isCompletingStoppedSession, ContinuousClock.now < deadline {
+            try? await Task.sleep(for: .milliseconds(10))
+        }
+    }
+
+    private func makeSettings(outputMode: DictationOutputMode) -> SettingsStore {
+        let suiteName = "localvoxtral.DictationViewModelPolishTokenGuardTests.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defaults.removePersistentDomain(forName: suiteName)
+        addTeardownBlock {
+            defaults.removePersistentDomain(forName: suiteName)
+        }
+
+        let settings = SettingsStore(defaults: defaults, environment: [:])
+        settings.dictationOutputMode = outputMode
+        return settings
+    }
+
+    private func retainForTestProcessLifetime(_ viewModel: DictationViewModel) {
+        Self.retainedViewModels.append(viewModel)
+    }
+}
+
+/// Returns the input with `--force` rewritten to a mangled variant, as a small
+/// polish model that folds `--` into a dash might.
+private actor MangleFlagPolishingService: LLMPolishingServicing {
+    private let replacement: String
+
+    init(replacement: String) {
+        self.replacement = replacement
+    }
+
+    func polish(
+        request: LLMPolishingRequest,
+        configuration _: LLMPolishingConfiguration
+    ) async throws -> LLMPolishingResult {
+        let polished = request.inputText.replacingOccurrences(of: "--force", with: replacement)
+        return LLMPolishingResult(
+            rawText: request.inputText,
+            polishedText: polished,
+            durationSeconds: 0.01
+        )
+    }
+}
+
+/// Drops `--force` from the input entirely, exercising the unrepairable
+/// fallback path.
+private actor DeleteFlagPolishingService: LLMPolishingServicing {
+    func polish(
+        request: LLMPolishingRequest,
+        configuration _: LLMPolishingConfiguration
+    ) async throws -> LLMPolishingResult {
+        let polished = request.inputText.replacingOccurrences(of: "--force ", with: "")
+        return LLMPolishingResult(
+            rawText: request.inputText,
+            polishedText: polished,
+            durationSeconds: 0.01
+        )
+    }
+}
+
+private final class MockAppConfigStore: AppConfigServing {
+    private let replacementDictionary: ReplacementDictionary
+    private let promptTemplates: LLMPromptTemplates
+
+    init(
+        replacementDictionary: ReplacementDictionary = ReplacementDictionary(entries: []),
+        promptTemplates: LLMPromptTemplates = LLMPromptTemplates(
+            systemContent: "system",
+            userContent: "{{input_text}}"
+        )
+    ) {
+        self.replacementDictionary = replacementDictionary
+        self.promptTemplates = promptTemplates
+    }
+
+    func configDirectoryURL() -> URL {
+        FileManager.default.temporaryDirectory
+    }
+
+    func loadReplacementDictionary() -> ReplacementDictionary {
+        replacementDictionary
+    }
+
+    func loadLLMPromptTemplates() -> LLMPromptTemplates {
+        promptTemplates
+    }
+
+    func loadTerminalAppBundleIDs() -> [String] {
+        []
+    }
+}
+
+private struct BufferCall {
+    let displayText: String
+    let commitText: String
+}
+
+@MainActor
+private final class MockOverlayCoordinator: OverlayBufferSessionCoordinating {
+    var commitOutcome: OverlayBufferCommitOutcome = .succeeded
+
+    var startSessionAnchors: [OverlayAnchor?] = []
+    var beginFinalizingCalls: [BufferCall] = []
+    var refreshCalls: [BufferCall] = []
+    var commitCallCount = 0
+    var dismissAfterHoldCallCount = 0
+    var lastDismissAfterHoldMinimumVisibility: TimeInterval?
+    var resetCallCount = 0
+    var captureLiveCommitTargetAppPIDCallCount = 0
+    var commitTargetAppPID: pid_t? = nil
+
+    func resolveAnchorNow() -> OverlayAnchor {
+        OverlayAnchor(
+            targetRect: CGRect(x: 0, y: 0, width: 100, height: 24),
+            source: .windowCenter
+        )
+    }
+
+    func startSession(preResolvedAnchor: OverlayAnchor?) {
+        startSessionAnchors.append(preResolvedAnchor)
+    }
+
+    func beginFinalizing(displayBufferText: String, commitBufferText: String) {
+        beginFinalizingCalls.append(
+            BufferCall(displayText: displayBufferText, commitText: commitBufferText)
+        )
+    }
+
+    func refresh(displayBufferText: String, commitBufferText: String) {
+        refreshCalls.append(
+            BufferCall(displayText: displayBufferText, commitText: commitBufferText)
+        )
+    }
+
+    func commitIfNeeded(
+        using textCommitter: OverlayTextCommitting,
+        autoCopyEnabled: Bool
+    ) -> OverlayBufferCommitOutcome {
+        commitCallCount += 1
+        return commitOutcome
+    }
+
+    func dismissAfterHold(minimumVisibility: TimeInterval) {
+        dismissAfterHoldCallCount += 1
+        lastDismissAfterHoldMinimumVisibility = minimumVisibility
+    }
+
+    func reset() {
+        resetCallCount += 1
+    }
+
+    func captureLiveCommitTargetAppPID() {
+        captureLiveCommitTargetAppPIDCallCount += 1
+    }
+}

--- a/Tests/localvoxtralTests/PolishTokenGuardTests.swift
+++ b/Tests/localvoxtralTests/PolishTokenGuardTests.swift
@@ -195,6 +195,99 @@ final class PolishTokenGuardTests: XCTestCase {
         XCTAssertEqual(result.text, "It works. Then we ship.")
     }
 
+    // MARK: - Filename extension allowlist (PR #101 review, finding 1)
+
+    func testProtectedTokensRejectsLowercaseProseGlue() {
+        // Lowercase STT glue fits the stem.ext shape but is prose, not a
+        // filename; protecting it would let the repair path re-glue the
+        // polish's correct sentence split.
+        let negatives = [
+            "it works.then we ship",
+            "ask dr.smith for the plan",
+            "we drove through st.louis today",
+            "bring snacks etc.but no drinks",
+        ]
+
+        for input in negatives {
+            XCTAssertEqual(
+                PolishTokenGuard.protectedTokens(in: input),
+                [],
+                "input should have no protected tokens: \(input)"
+            )
+        }
+    }
+
+    func testVerifyAndRepairAcceptsSentenceSplitOfLowercaseGlue() {
+        // The polish correctly splits "works.then" into "works. Then"; with
+        // no protected token the polish must pass through untouched.
+        let result = PolishTokenGuard.verifyAndRepair(
+            polished: "It works. Then we ship.",
+            original: "it works.then we ship"
+        )
+        XCTAssertEqual(result.outcome, .clean)
+        XCTAssertEqual(result.text, "It works. Then we ship.")
+    }
+
+    func testProtectedTokensStillRecognizesKnownExtensionFilenames() {
+        let cases: [(input: String, expected: [String])] = [
+            ("open main.swift now", ["main.swift"]),
+            ("check package.json first", ["package.json"]),
+            ("edit src/Auth/useAuth.ts now", ["src/Auth/useAuth.ts"]),
+        ]
+
+        for testCase in cases {
+            XCTAssertEqual(
+                PolishTokenGuard.protectedTokens(in: testCase.input),
+                testCase.expected,
+                "input: \(testCase.input)"
+            )
+        }
+    }
+
+    // MARK: - Per-occurrence verification (PR #101 review, finding 2)
+
+    func testVerifyAndRepairRepairsMangledFirstDuplicateOccurrence() {
+        // Two occurrences dictated; the model mangled the first. The surviving
+        // second occurrence must not satisfy verification for both.
+        let result = PolishTokenGuard.verifyAndRepair(
+            polished: "run \u{2013} force first, then --force again",
+            original: "run --force first, then --force again"
+        )
+        XCTAssertEqual(result.outcome, .repaired(count: 1))
+        XCTAssertEqual(result.text, "run --force first, then --force again")
+    }
+
+    func testVerifyAndRepairRepairsMangledSecondDuplicateOccurrence() {
+        // The exact first occurrence must not stop the repair scan from
+        // reaching the mangled second occurrence.
+        let result = PolishTokenGuard.verifyAndRepair(
+            polished: "run --force first, then \u{2013} force again",
+            original: "run --force first, then --force again"
+        )
+        XCTAssertEqual(result.outcome, .repaired(count: 1))
+        XCTAssertEqual(result.text, "run --force first, then --force again")
+    }
+
+    func testVerifyAndRepairFallsBackWhenOneDuplicateOccurrenceDeleted() {
+        // One of two occurrences deleted outright: unrepairable, the whole
+        // polish is discarded — never accepted with a missing occurrence.
+        let result = PolishTokenGuard.verifyAndRepair(
+            polished: "run --force first, then again",
+            original: "run --force first, then --force again"
+        )
+        XCTAssertEqual(result.outcome, .fallback(missing: ["--force"]))
+        XCTAssertEqual(result.text, "run --force first, then --force again")
+    }
+
+    func testVerifyAndRepairAcceptsBothDuplicateOccurrencesSurviving() {
+        let result = PolishTokenGuard.verifyAndRepair(
+            polished: "Run --force first, then --force again.",
+            original: "run --force first, then --force again"
+        )
+        XCTAssertEqual(result.outcome, .clean)
+        XCTAssertEqual(result.text, "Run --force first, then --force again.")
+    }
+
     func testVerifyAndRepairIsIdempotentOnRepairedOutput() {
         let original = "run --force on src/App.ts"
         let first = PolishTokenGuard.verifyAndRepair(


### PR DESCRIPTION
## What

First slice of the coding-agent dictation polish series (features 1–6 from the 2026-07-09 competitor research): a deterministic, app-side guarantee that code-like tokens survive LLM polishing byte-exact.

Dictated agent prompts carry CLI flags, paths, URLs, backtick spans, env vars, hashes and version literals — exactly what a small polish model mangles (`--force` → `– force`, case-folded paths, dropped backticks; one eval run in this PR's logs shows the 0.8B hallucinating an entire code snippet from a path input). New `PolishTokenGuard`:

- **Recognition** (conservative by design — misses beat false positives): backtick spans, URLs, slash paths incl. absolute (`/tmp/app.log` keeps its leading slash), dotted filenames (stem ≥ 2 chars, lowercase ext — so sentence artifacts like `e.g` / `works.Then` are never protected and the polish stays free to fix missing spaces after periods), `-x`/`--long[=value]` flags (trailing punctuation trimmed), `$ENV_VARS`, hex hashes (digit required, so all-letter words like "defaced" don't match), version literals.
- **Verify & repair** after polish: each token must occur *standalone* (no letter/digit/`_`/`-` glued to either side — `--forceful` is a corruption of `--force`, not a survival). Near-misses are repaired in place via canonical comparison (case, Unicode-dash unification, model-inserted whitespace). Any unrepairable token ⇒ the whole polish is discarded and the pre-polish text committed.
- Integration in the overlay stop-commit polish task; persistence reflects the actually-committed text. Fallback logs count publicly, token list privately.
- 3 new known-hard eval corpus cases (flag / path / backticks through the real model) — informational per corpus policy, promotion requires cross-server-state stability.

Slot-in notes: no changes to `LLMPolishingRequest`/`Configuration` (PR #99 territory) nor the live-replacement machinery (PR #100 territory).

## Proof

- [x] Unit suite green — `./scripts/remote-build.sh`

```
Executed 636 tests, with 2 tests skipped and 0 failures (0 unexpected) in 6.480 (6.517) seconds
```

17 new tests (`PolishTokenGuardTests` + 2 `DictationViewModelPolishTokenGuardTests` VM regression tests through injected stub polishers).

- [x] Regression tests fail before the fix — with the guard integration replaced by direct `result.polishedText` commit:

```
Test Case '-[localvoxtralTests.DictationViewModelPolishTokenGuardTests testPolishTokenGuardRepairsMangledFlagInCommittedText]' failed
Test Case '-[localvoxtralTests.DictationViewModelPolishTokenGuardTests testPolishTokenGuardFallbackKeepsPrePolishWorkingText]' failed
  XCTAssertFalse failed                                     [committed text still contains "– force"]
  XCTAssertNil failed: "run – force now"                    [persisted polishedText leaked mangled text]
Executed 2 tests, with 7 failures (0 unexpected)
```

Passing after (see green run above).

- [x] Eval corpus additions scored against the bundled helper + real pinned model — `./scripts/remote-build.sh package && ./scripts/remote-build.sh integration-polishd` (production request path):

```
== polishd (bundled MLX Swift helper) eval (model: mlx-community/Qwen3.5-0.8B-8bit) ==
PASS en-flag-survives-cleanup (known-hard)
PASS en-path-survives-cleanup (known-hard)
PASS en-backtick-command-survives (known-hard)
== required: 7/7, known-hard passing: 6/10 ==
```

Baseline intact (7/7 required), all 3 new cases pass on 0.8B through the production path. `PolishHelperIntegrationTests`: Executed 3 tests, 0 failures.

- Infra note (pre-existing, hit while proving this): `remote-build.sh eval-llm`'s on-demand mlxlm warm-up doesn't come up from the Linux-side gate (connection refused on 8080) — the `integration-polishd` lane above is the authoritative eval for the bundled engine, but AGENTS.md still documents eval-llm as the prompt-eval path.
