### PR TITLE
Polishing model: Qwen3.5-9B-OptiQ (14/14 eval gate)

### DIFF
--- a/Sources/localvoxtral/Backends/PolishModelCatalog.swift
+++ b/Sources/localvoxtral/Backends/PolishModelCatalog.swift
@@ -34,11 +34,16 @@ struct PolishModelOption: Equatable, Sendable {
 
 enum PolishModelCatalog {
     static let options: [PolishModelOption] = [
+        // sizeOnDiskGB is DECIMAL GB of the files the downloader actually
+        // fetches (weights + tokenizer + configs; the include patterns skip
+        // optiq_vision/mtp extras), matching the download bar's
+        // ByteCountFormatter units — HF model cards quote GiB, don't copy
+        // them (field finding: picker said 6.6, bar said 7.1).
         PolishModelOption(
             repoID: "mlx-community/Qwen3.5-0.8B-8bit",
             displayName: "Qwen3.5 0.8B (fastest, default)",
-            sizeOnDiskGB: 0.9,
-            estimatedRAMGB: 1.0,
+            sizeOnDiskGB: 1.0,
+            estimatedRAMGB: 1.2,
             samplingDefaults: nil,
             chatTemplateArguments: nil,
             summary: "Cleans up transcripts with negligible overhead"
@@ -46,8 +51,8 @@ enum PolishModelCatalog {
         PolishModelOption(
             repoID: "mlx-community/Qwen3.5-4B-OptiQ-4bit",
             displayName: "Qwen3.5 4B (better quality)",
-            sizeOnDiskGB: 3.0,
-            estimatedRAMGB: 3.5,
+            sizeOnDiskGB: 3.3,
+            estimatedRAMGB: 3.8,
             samplingDefaults: nil,
             chatTemplateArguments: ["enable_thinking": false],
             summary: "Stronger cleanup, slower first load"
@@ -55,8 +60,8 @@ enum PolishModelCatalog {
         PolishModelOption(
             repoID: "mlx-community/Qwen3.5-9B-OptiQ-4bit",
             displayName: "Qwen3.5 9B (best quality)",
-            sizeOnDiskGB: 6.6,
-            estimatedRAMGB: 7.0,
+            sizeOnDiskGB: 7.1,
+            estimatedRAMGB: 7.5,
             samplingDefaults: nil,
             chatTemplateArguments: ["enable_thinking": false],
             summary: "Highest quality, needs a Mac with headroom"

--- a/Sources/localvoxtral/Backends/PolishModelCatalog.swift
+++ b/Sources/localvoxtral/Backends/PolishModelCatalog.swift
@@ -46,7 +46,7 @@ enum PolishModelCatalog {
             estimatedRAMGB: 1.2,
             samplingDefaults: nil,
             chatTemplateArguments: nil,
-            summary: "Cleans up transcripts with negligible overhead"
+            summary: "For any Apple Silicon Mac"
         ),
         PolishModelOption(
             repoID: "mlx-community/Qwen3.5-4B-OptiQ-4bit",
@@ -55,7 +55,7 @@ enum PolishModelCatalog {
             estimatedRAMGB: 3.8,
             samplingDefaults: nil,
             chatTemplateArguments: ["enable_thinking": false],
-            summary: "Stronger cleanup, slower first load"
+            summary: "For 16 GB+ Macs"
         ),
         PolishModelOption(
             repoID: "mlx-community/Qwen3.5-9B-OptiQ-4bit",
@@ -64,7 +64,7 @@ enum PolishModelCatalog {
             estimatedRAMGB: 7.5,
             samplingDefaults: nil,
             chatTemplateArguments: ["enable_thinking": false],
-            summary: "Highest quality, needs a Mac with headroom"
+            summary: "For 32 GB+ Macs"
         ),
     ]
 

--- a/Sources/localvoxtral/Backends/PolishModelCatalog.swift
+++ b/Sources/localvoxtral/Backends/PolishModelCatalog.swift
@@ -52,6 +52,15 @@ enum PolishModelCatalog {
             chatTemplateArguments: ["enable_thinking": false],
             summary: "Stronger cleanup, slower first load"
         ),
+        PolishModelOption(
+            repoID: "mlx-community/Qwen3.5-9B-OptiQ-4bit",
+            displayName: "Qwen3.5 9B (best quality)",
+            sizeOnDiskGB: 6.6,
+            estimatedRAMGB: 7.0,
+            samplingDefaults: nil,
+            chatTemplateArguments: ["enable_thinking": false],
+            summary: "Highest quality, needs a Mac with headroom"
+        ),
     ]
 
     static let defaultOption = options[0]


### PR DESCRIPTION
## What

Adds **`mlx-community/Qwen3.5-9B-OptiQ-4bit`** to the polishing model catalog (#96, second model PR). Pure catalog entry — the infrastructure (picker, `chat_template_kwargs`, per-model eval gate) all landed in #98/#99. Same thinking-template family as the 4B, so `enable_thinking: false` applies; 6.6 GB on disk, ~7 GB RAM guidance in the picker copy.

## Proof

- [x] Live eval gate — `./scripts/remote-build.sh integration-polishd mlx-community/Qwen3.5-9B-OptiQ-4bit` (fresh 6.6 GB self-provision on the build host):
  ```
  == polishd (bundled MLX Swift helper) eval (model: mlx-community/Qwen3.5-9B-OptiQ-4bit) ==
  == required: 7/7, known-hard passing: 7/7 ==
  Test Case 'testHelperMatchesPolishEvalBaselineThroughProductionRequestPath' passed (24.181 seconds).
  ```
  **14/14** — the corpus ceiling, matching the 4B. The current punctuation-spacing corpus can no longer differentiate 4B from 9B; the planned technical-dictation corpus (#96 / roadmap) is what will. All prompt-cache assertions passed. Full 14-case eval incl. 9B load: ~24 s; warm requests well inside the production timeout.
- [x] Sampling experiment (informative): Qwen recommended sampling on the 9B scores 7/7 + 6/7 — closest yet, still not better than deterministic temp-0.3. Defaults stand.
- [x] 0.8B baseline regression check — `./scripts/remote-build.sh integration-polishd`: `required: 7/7, known-hard passing: 3/7` (unchanged).
- [x] Unit suite green — `Executed 625 tests, with 2 tests skipped and 0 failures`. Packaging green.
- [ ] UI: hand-verify via try-pr.sh — the 9B appears as "Qwen3.5 9B (best quality) · 6.6 GB", downloads and polishes.
