### PR TITLE
Spoken clipboard-paste macro: “paste clipboard” embeds the clipboard at commit

### DIFF
--- a/Sources/localvoxtral/ClipboardPayloadMacro.swift
+++ b/Sources/localvoxtral/ClipboardPayloadMacro.swift
@@ -1,0 +1,171 @@
+import Foundation
+
+/// The "spoken clipboard-paste macro": on an Overlay Buffer commit, a spoken
+/// marker phrase ("paste clipboard", "colle le presse-papiers", …) is replaced
+/// by the actual contents of the user's clipboard, formatted as inline code or
+/// a fenced code block. Stack traces and error logs are the one thing you can't
+/// dictate but always need in a coding-agent prompt.
+///
+/// Pure functions on `String`, mirroring `PolishTokenGuard` /
+/// `TextMergingAlgorithms`. The two halves are deliberately separated across
+/// the polish boundary:
+///   1. `replaceMarkersWithPlaceholder` swaps each marker for the env-var-shaped
+///      `placeholder`. That placeholder is what flows through the LLM polish
+///      request and the persisted session record — never the payload.
+///      `PolishTokenGuard.protectedTokens` already recognizes `$LV_..._..` shapes
+///      (`\$[A-Z_][A-Z0-9_]+`), so F1's verify/repair/fallback machinery
+///      guarantees the placeholder survives the model byte-exact.
+///   2. `substitutePayload` runs only at the very end, after polish + token
+///      guard, replacing the placeholder with the formatted clipboard payload
+///      just before commit.
+enum ClipboardPayloadMacro {
+    /// Env-var-shaped so `PolishTokenGuard` protects it through polishing with
+    /// zero guard changes (see the type doc). All markers collapse to this one
+    /// placeholder string.
+    static let placeholder = "$LV_CLIPBOARD_PAYLOAD"
+
+    /// A single-line payload no longer than this (after trimming) is inlined as
+    /// `` `payload` `` rather than fenced.
+    static let inlineCharacterThreshold = 60
+
+    /// Head cap on the payload inside a fenced block. A pasted 200 MB log must
+    /// not blow up the overlay or the committed text; the head is what matters
+    /// for an error/stack trace.
+    static let payloadCharacterCap = 8000
+
+    /// Appended as the final line inside the fence when the payload was capped.
+    static let truncationMarker = "… [clipboard truncated]"
+
+    // MARK: - Marker detection
+
+    // Case-insensitive, `\b`-guarded so a marker is matched standalone and the
+    // surrounding punctuation/commas the STT sprinkles in ("… — paste clipboard
+    // — …", "paste the clipboard, I think") are left untouched. English bases
+    // take an optional " here"/" contents"/" content" suffix, greedily, so
+    // "paste the clipboard here" consumes the " here" (longest match). French
+    // tolerates the STT dropping the hyphen ("presse papiers"). A static literal:
+    // a bad pattern is a coding error we want to crash on immediately.
+    private static let markerRegex = try! NSRegularExpression(
+        pattern:
+            "(?i)\\b(?:(?:paste|insert)(?: the)? clipboard(?: here| contents?)?"
+            + "|(?:colle|insère) le presse[- ]papiers?)\\b"
+    )
+
+    /// Ranges of every marker phrase in `text`, left to right, non-overlapping.
+    static func detectMarkers(in text: String) -> [Range<String.Index>] {
+        let ns = text as NSString
+        return markerRegex
+            .matches(in: text, range: NSRange(location: 0, length: ns.length))
+            .compactMap { Range($0.range, in: text) }
+    }
+
+    /// Replaces every marker phrase with `placeholder`, returning the rewritten
+    /// text and the number of markers replaced.
+    static func replaceMarkersWithPlaceholder(in text: String) -> (text: String, count: Int) {
+        let ns = text as NSString
+        let matches = markerRegex.matches(
+            in: text, range: NSRange(location: 0, length: ns.length)
+        )
+        guard !matches.isEmpty else { return (text, 0) }
+
+        var result = ""
+        var cursor = 0
+        for match in matches {
+            let range = match.range
+            result += ns.substring(with: NSRange(location: cursor, length: range.location - cursor))
+            result += placeholder
+            cursor = range.location + range.length
+        }
+        result += ns.substring(from: cursor)
+        return (result, matches.count)
+    }
+
+    // MARK: - Placeholder integrity
+
+    /// Standalone occurrences of `placeholder` in `text` — same body-char
+    /// boundary rule as `PolishTokenGuard` (an occurrence with a letter/digit/
+    /// `_`/`-` glued to either side is corruption, not an occurrence). The
+    /// commit path compares this count before and after polishing: the guard
+    /// only verifies the placeholder SURVIVED (dedup + at-least-once), so a
+    /// model output that duplicated the placeholder (payload pasted twice) or
+    /// dropped one of two would otherwise sail through.
+    static func standalonePlaceholderCount(in text: String) -> Int {
+        var count = 0
+        var searchRange = text.startIndex..<text.endIndex
+        while let found = text.range(of: placeholder, range: searchRange) {
+            let standaloneBefore = found.lowerBound == text.startIndex
+                || !PolishTokenGuard.isBodyCharacter(text[text.index(before: found.lowerBound)])
+            let standaloneAfter = found.upperBound == text.endIndex
+                || !PolishTokenGuard.isBodyCharacter(text[found.upperBound])
+            if standaloneBefore && standaloneAfter { count += 1 }
+            searchRange = found.upperBound..<text.endIndex
+        }
+        return count
+    }
+
+    // MARK: - Payload substitution
+
+    /// Replaces every `placeholder` occurrence in `text` with the formatted
+    /// `payload`. A single-line, backtick-free payload ≤
+    /// `inlineCharacterThreshold` chars is inlined as `` `payload` ``; anything
+    /// else becomes a fenced code block, capped at `payloadCharacterCap` (head)
+    /// with a truncation marker inside the fence when it bit. Per CommonMark,
+    /// the fence is one backtick longer than the longest backtick run inside
+    /// the payload (minimum 3), so a payload containing ``` can never close the
+    /// fence early; a payload containing any backtick is never inlined (a
+    /// single-backtick wrap would break). Fences get a leading/trailing newline
+    /// only when the placeholder wasn't already at a line boundary, so the
+    /// block always stands on its own lines without doubling blank lines.
+    static func substitutePayload(in text: String, payload: String) -> String {
+        guard text.contains(placeholder) else { return text }
+
+        let clean = payload.trimmingCharacters(in: .whitespacesAndNewlines)
+
+        if !clean.contains("\n"), !clean.contains("`"),
+           clean.count <= inlineCharacterThreshold
+        {
+            return text.replacingOccurrences(of: placeholder, with: "`\(clean)`")
+        }
+
+        let body: String
+        if clean.count > payloadCharacterCap {
+            body = String(clean.prefix(payloadCharacterCap)) + "\n" + truncationMarker
+        } else {
+            body = clean
+        }
+        let fenceMarker = String(
+            repeating: "`",
+            count: max(3, longestBacktickRun(in: body) + 1)
+        )
+        let fence = "\(fenceMarker)\n\(body)\n\(fenceMarker)"
+
+        var result = ""
+        var searchStart = text.startIndex
+        while let range = text.range(of: placeholder, range: searchStart..<text.endIndex) {
+            result += text[searchStart..<range.lowerBound]
+            let atLineStart = range.lowerBound == text.startIndex
+                || text[text.index(before: range.lowerBound)] == "\n"
+            let atLineEnd = range.upperBound == text.endIndex
+                || text[range.upperBound] == "\n"
+            result += (atLineStart ? "" : "\n") + fence + (atLineEnd ? "" : "\n")
+            searchStart = range.upperBound
+        }
+        result += text[searchStart..<text.endIndex]
+        return result
+    }
+
+    /// Length of the longest run of consecutive backticks in `s` (0 when none).
+    private static func longestBacktickRun(in s: String) -> Int {
+        var longest = 0
+        var current = 0
+        for character in s {
+            if character == "`" {
+                current += 1
+                longest = max(longest, current)
+            } else {
+                current = 0
+            }
+        }
+        return longest
+    }
+}

--- a/Sources/localvoxtral/DictationViewModel+Session.swift
+++ b/Sources/localvoxtral/DictationViewModel+Session.swift
@@ -577,10 +577,22 @@ extension DictationViewModel {
             }
             let replacementDictionaryPrompt = replacementDictionary.renderedPromptSection()
             let originalText = currentDictationEventText
-            let workingText =
+            let replacementAppliedText =
                 settings.replacementDictionaryEnabled
                 ? replacementDictionary.apply(to: originalText)
                 : originalText
+            // Spoken clipboard-paste macro (Overlay Buffer only): after the
+            // replacement dictionary and BEFORE the polish request is built,
+            // swap each spoken marker for the env-var-shaped placeholder and
+            // read the clipboard once. The placeholder — not the payload —
+            // flows through polish (PolishTokenGuard already protects its
+            // shape) and persistence; the real payload is substituted back only
+            // at the very end, just before commit. No marker or setting off:
+            // a no-op that never touches the pasteboard.
+            let clipboardMacro = applyClipboardPayloadMacroIfEnabled(to: replacementAppliedText)
+            let workingText = clipboardMacro.placeholderText
+            let clipboardPayload = clipboardMacro.payload
+            let payloadProvenanceSummary = clipboardMacro.summary
             let llmConfigurationFailure: (message: String, technicalDetails: String?)? =
                 settings.llmPolishingEnabled && polishingConfig == nil
                 ? (
@@ -589,8 +601,13 @@ extension DictationViewModel {
                 )
                 : nil
 
-            if currentDictationEventText != workingText {
-                currentDictationEventText = workingText
+            // Display the payload-substituted text (placeholder never shown to
+            // the user); with no macro this is exactly `workingText`.
+            let displayWorkingText = clipboardPayloadSubstituted(
+                workingText, payload: clipboardPayload
+            )
+            if currentDictationEventText != displayWorkingText {
+                currentDictationEventText = displayWorkingText
             }
             refreshOverlayBufferSession()
 
@@ -731,12 +748,44 @@ extension DictationViewModel {
                                 )
                             }
 
+                            // Placeholder-count integrity: the guard dedupes
+                            // tokens and only verifies "at least one standalone
+                            // occurrence", so a model output that DUPLICATED
+                            // the placeholder (payload pasted twice) or dropped
+                            // one of two (a requested paste lost) sails
+                            // through it. Compare standalone counts against
+                            // the pre-polish working text; on mismatch,
+                            // discard the polish and keep the placeholder-
+                            // bearing working text.
+                            if clipboardPayload != nil {
+                                let expectedPlaceholders =
+                                    ClipboardPayloadMacro.standalonePlaceholderCount(
+                                        in: workingText
+                                    )
+                                let actualPlaceholders =
+                                    ClipboardPayloadMacro.standalonePlaceholderCount(
+                                        in: committedText
+                                    )
+                                if actualPlaceholders != expectedPlaceholders {
+                                    committedText = workingText
+                                    Log.polishing.warning(
+                                        "Clipboard payload macro: polish changed placeholder count (\(expectedPlaceholders, privacy: .public) -> \(actualPlaceholders, privacy: .public)); polish discarded"
+                                    )
+                                }
+                            }
+
+                            // Persist the PLACEHOLDER-bearing committed text —
+                            // the clipboard payload must never enter the session
+                            // record. Substitution happens only for the display/
+                            // commit copy below.
                             processedTextForPersistence =
                                 committedText != originalText ? committedText : nil
 
                             guard !Task.isCancelled else { return }
 
-                            self.currentDictationEventText = committedText
+                            self.currentDictationEventText = self.clipboardPayloadSubstituted(
+                                committedText, payload: clipboardPayload
+                            )
                             self.refreshOverlayBufferSession()
                             Log.polishing.info(
                                 "LLM polishing succeeded in \(String(format: "%.2f", result.durationSeconds))s"
@@ -797,7 +846,10 @@ extension DictationViewModel {
                         status: sessionStatus,
                         commitSucceeded: commitSucceeded,
                         polishProfile: capturedPolishProfile,
-                        polishContextSummary: capturedPolishContextSummary
+                        polishContextSummary: self.mergedPolishProvenanceSummary(
+                            context: capturedPolishContextSummary,
+                            payload: payloadProvenanceSummary
+                        )
                     )
 
                     if let llmConnectionFailure {
@@ -832,6 +884,8 @@ extension DictationViewModel {
             saveSessionRecord(
                 startedAt: capturedSessionStartedAt,
                 rawText: originalText,
+                // Persist the PLACEHOLDER-bearing working text, never the
+                // payload; the payload lives only in the substituted commit copy.
                 polishedText: workingText != originalText ? workingText : nil,
                 polishingDuration: nil,
                 provider: capturedProvider,
@@ -839,7 +893,8 @@ extension DictationViewModel {
                 outputMode: capturedOutputMode,
                 targetAppBundleID: capturedTargetBundleID,
                 status: llmConfigurationFailure == nil ? .sttCompleted : .llmFailed,
-                commitSucceeded: commitSucceeded
+                commitSucceeded: commitSucceeded,
+                polishContextSummary: payloadProvenanceSummary
             )
 
             if let llmConfigurationFailure {
@@ -1002,6 +1057,78 @@ extension DictationViewModel {
     private func resolvePolishContextPasteboardReader() -> any PasteboardReading {
         #if DEBUG
         if let override = debugPolishContextPasteboardReaderOverride {
+            return override()
+        }
+        #endif
+        return SystemPasteboardReader()
+    }
+
+    /// Result of the spoken clipboard-paste macro over the (replacement-applied)
+    /// working text: `placeholderText` carries the placeholder in place of each
+    /// marker when the macro fired (else it is the input unchanged), `payload`
+    /// is the sanitized clipboard string to substitute back at commit (nil when
+    /// the macro did not fire), and `summary` is the count-only provenance note
+    /// for the session record (nil when the macro did not fire).
+    struct ClipboardPayloadMacroOutcome {
+        let placeholderText: String
+        let payload: String?
+        let summary: String?
+    }
+
+    /// Applies the spoken clipboard-paste macro to `text` when the setting is on
+    /// AND a marker phrase is present. Reads the clipboard exactly ONCE (through
+    /// the shared `PolishContextClipboardReader` readability rules — concealed/
+    /// transient/empty are skipped). An unreadable clipboard leaves the
+    /// transcript unchanged and logs one content-free line. When the setting is
+    /// off or no marker was spoken, the pasteboard is never touched.
+    func applyClipboardPayloadMacroIfEnabled(to text: String) -> ClipboardPayloadMacroOutcome {
+        guard settings.clipboardPayloadMacroEnabled else {
+            return ClipboardPayloadMacroOutcome(placeholderText: text, payload: nil, summary: nil)
+        }
+        guard !ClipboardPayloadMacro.detectMarkers(in: text).isEmpty else {
+            return ClipboardPayloadMacroOutcome(placeholderText: text, payload: nil, summary: nil)
+        }
+        guard let payload = PolishContextClipboardReader.readableSanitizedString(
+            from: resolveClipboardPayloadPasteboardReader()
+        ) else {
+            Log.polishing.info(
+                "Clipboard payload macro: marker spoken but clipboard unreadable; transcript left unchanged"
+            )
+            return ClipboardPayloadMacroOutcome(placeholderText: text, payload: nil, summary: nil)
+        }
+        let replaced = ClipboardPayloadMacro.replaceMarkersWithPlaceholder(in: text)
+        Log.polishing.info(
+            "Clipboard payload macro fired: \(replaced.count, privacy: .public) marker(s), payload:\(payload.count, privacy: .public)ch"
+        )
+        return ClipboardPayloadMacroOutcome(
+            placeholderText: replaced.text,
+            payload: payload,
+            summary: "payload:\(payload.count)ch"
+        )
+    }
+
+    /// Substitutes the clipboard payload back into `text` (replacing the macro
+    /// placeholder). A no-op when the macro did not fire (`payload == nil`).
+    func clipboardPayloadSubstituted(_ text: String, payload: String?) -> String {
+        guard let payload else { return text }
+        return ClipboardPayloadMacro.substitutePayload(in: text, payload: payload)
+    }
+
+    /// Combines the clipboard polish-context and payload-macro provenance notes
+    /// into the single `polishContextSummary` record field (counts only):
+    /// `clipboard:24ch+payload:1532ch`, or either alone, or nil.
+    func mergedPolishProvenanceSummary(context: String?, payload: String?) -> String? {
+        switch (context, payload) {
+        case (nil, nil): return nil
+        case let (context?, nil): return context
+        case let (nil, payload?): return payload
+        case let (context?, payload?): return "\(context)+\(payload)"
+        }
+    }
+
+    private func resolveClipboardPayloadPasteboardReader() -> any PasteboardReading {
+        #if DEBUG
+        if let override = debugClipboardPayloadPasteboardReaderOverride {
             return override()
         }
         #endif

--- a/Sources/localvoxtral/DictationViewModel.swift
+++ b/Sources/localvoxtral/DictationViewModel.swift
@@ -423,6 +423,13 @@ final class DictationViewModel {
     /// both the disabled toggle and a remote endpoint.
     @ObservationIgnored
     var debugPolishContextPasteboardReaderOverride: (() -> any PasteboardReading)?
+    /// Test seam: injects the pasteboard the spoken clipboard-paste macro reads,
+    /// replacing `SystemPasteboardReader`. Only resolved when the macro setting
+    /// is on AND a marker phrase is present, so a stub whose read methods were
+    /// never called proves the no-read guarantee when the setting is off or no
+    /// marker was spoken.
+    @ObservationIgnored
+    var debugClipboardPayloadPasteboardReaderOverride: (() -> any PasteboardReading)?
     /// Test seam: invoked after the managed-startup status mirror finishes
     /// handling each status update (including updates its guard skips), so
     /// tests can await mirror processing deterministically instead of

--- a/Sources/localvoxtral/PolishContextClipboardReader.swift
+++ b/Sources/localvoxtral/PolishContextClipboardReader.swift
@@ -98,12 +98,16 @@ enum PolishContextClipboardReader {
         return host == "127.0.0.1" || host == "localhost" || host == "::1"
     }
 
-    /// Returns a sanitized, capped excerpt of the pasteboard's string, or nil
-    /// when there is nothing usable or the source marked it sensitive.
+    /// The pasteboard's plain string with the sensitive-type and empty-content
+    /// rules applied and NUL/control scalars stripped (newline/tab kept), or nil
+    /// when the source marked the payload concealed/transient or there is
+    /// nothing usable. Shared "is this clipboard readable" decision for both the
+    /// polish-context excerpt (below) and the spoken clipboard-paste macro
+    /// (`ClipboardPayloadMacro`), so the two features honor identical rules.
     @MainActor
-    static func readClipboardContext(
+    static func readableSanitizedString(
         from pasteboard: any PasteboardReading
-    ) -> PolishClipboardContext? {
+    ) -> String? {
         // Never surface password-manager or transient payloads: a concealed or
         // transient type is the source explicitly asking clipboard tools not to
         // read/retain the contents (nspasteboard.org conventions).
@@ -119,6 +123,16 @@ enum PolishContextClipboardReader {
         guard !sanitized.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
             return nil
         }
+        return sanitized
+    }
+
+    /// Returns a sanitized, capped excerpt of the pasteboard's string, or nil
+    /// when there is nothing usable or the source marked it sensitive.
+    @MainActor
+    static func readClipboardContext(
+        from pasteboard: any PasteboardReading
+    ) -> PolishClipboardContext? {
+        guard let sanitized = readableSanitizedString(from: pasteboard) else { return nil }
 
         let originalCharacterCount = sanitized.count
         let excerpt = originalCharacterCount > excerptCharacterCap
@@ -233,8 +247,9 @@ enum PolishContextClipboardReader {
 
     /// Drops NUL and other control scalars (which can corrupt the request or the
     /// LLM's parsing) while preserving newlines and tabs so multi-line snippets
-    /// and indentation survive as spelling context.
-    private static func sanitizeControlCharacters(_ raw: String) -> String {
+    /// and indentation survive as spelling context. Shared with the clipboard-
+    /// paste macro through `readableSanitizedString`.
+    static func sanitizeControlCharacters(_ raw: String) -> String {
         var scalars = String.UnicodeScalarView()
         for scalar in raw.unicodeScalars {
             if scalar == "\n" || scalar == "\t" {

--- a/Sources/localvoxtral/PolishTokenGuard.swift
+++ b/Sources/localvoxtral/PolishTokenGuard.swift
@@ -242,7 +242,10 @@ enum PolishTokenGuard {
         return count
     }
 
-    private static func isBodyCharacter(_ c: Character) -> Bool {
+    /// Internal (not private): `ClipboardPayloadMacro` reuses this exact
+    /// boundary rule for its standalone placeholder count, so the guard and the
+    /// macro can never disagree on what "standalone" means.
+    static func isBodyCharacter(_ c: Character) -> Bool {
         c.isLetter || c.isNumber || c == "_" || c == "-"
     }
 

--- a/Sources/localvoxtral/SettingsStore.swift
+++ b/Sources/localvoxtral/SettingsStore.swift
@@ -180,6 +180,7 @@ final class SettingsStore {
         static let replacementDictionaryEnabled = "settings.replacement_dictionary_enabled"
         static let agentPolishProfileEnabled = "settings.agent_polish_profile_enabled"
         static let polishClipboardContextEnabled = "settings.polish_clipboard_context_enabled"
+        static let clipboardPayloadMacroEnabled = "settings.clipboard_payload_macro_enabled"
         /// Hidden debug toggle (no UI). When true, every received realtime
         /// event's raw payload is logged to the `Deltas` category before any
         /// merge/preprocess/insertion processing — instrumentation for
@@ -324,6 +325,18 @@ final class SettingsStore {
     var polishClipboardContextEnabled: Bool {
         didSet {
             defaults.set(polishClipboardContextEnabled, forKey: Keys.polishClipboardContextEnabled)
+        }
+    }
+
+    /// When true (default), an Overlay Buffer dictation that carries a spoken
+    /// marker phrase ("paste clipboard", "colle le presse-papiers", …) has that
+    /// marker replaced at commit with the actual clipboard contents, formatted
+    /// as inline code or a fenced code block. Default on: it only ever fires on
+    /// an explicit spoken marker, and the clipboard is read only then (once).
+    /// See `ClipboardPayloadMacro`.
+    var clipboardPayloadMacroEnabled: Bool {
+        didSet {
+            defaults.set(clipboardPayloadMacroEnabled, forKey: Keys.clipboardPayloadMacroEnabled)
         }
     }
 
@@ -519,6 +532,8 @@ final class SettingsStore {
             defaults: defaults, key: Keys.agentPolishProfileEnabled, fallback: true)
         polishClipboardContextEnabled = Self.loadBool(
             defaults: defaults, key: Keys.polishClipboardContextEnabled, fallback: false)
+        clipboardPayloadMacroEnabled = Self.loadBool(
+            defaults: defaults, key: Keys.clipboardPayloadMacroEnabled, fallback: true)
         debugLogRealtimeDeltas = Self.loadBool(
             defaults: defaults, key: Keys.debugLogRealtimeDeltas, fallback: false)
         modifierOnlyHotKeyEnabled = Self.loadBool(

--- a/Sources/localvoxtral/SettingsView.swift
+++ b/Sources/localvoxtral/SettingsView.swift
@@ -334,6 +334,18 @@ private struct ConnectionSettingsPane: View {
                         }
                     }
 
+                    SettingsFieldRow(title: "Spoken clipboard paste") {
+                        VStack(alignment: .leading, spacing: 6) {
+                            Toggle("", isOn: $settings.clipboardPayloadMacroEnabled)
+                                .labelsHidden()
+                                .toggleStyle(.switch)
+
+                            SettingsHelpText(
+                                "Say “paste clipboard” to insert your clipboard as a code block on commit."
+                            )
+                        }
+                    }
+
                     switch settings.polishingBackendMode {
                     case .externalURL:
                         SettingsFieldRow(title: "Endpoint") {

--- a/Tests/localvoxtralTests/ClipboardPayloadMacroTests.swift
+++ b/Tests/localvoxtralTests/ClipboardPayloadMacroTests.swift
@@ -1,0 +1,252 @@
+import Foundation
+import XCTest
+@testable import localvoxtral
+
+final class ClipboardPayloadMacroTests: XCTestCase {
+    private let placeholder = ClipboardPayloadMacro.placeholder
+
+    // MARK: - Marker detection
+
+    func testDetectsEveryPhraseVariant() {
+        let phrases = [
+            // English bases.
+            "paste the clipboard",
+            "paste clipboard",
+            "insert the clipboard",
+            "insert clipboard",
+            // English suffixes.
+            "paste the clipboard here",
+            "paste clipboard here",
+            "insert the clipboard contents",
+            "insert clipboard content",
+            "paste the clipboard contents",
+            // Case-insensitive.
+            "Paste The Clipboard",
+            "PASTE CLIPBOARD",
+            "Insert The Clipboard Here",
+            // French, hyphenated.
+            "colle le presse-papiers",
+            "colle le presse-papier",
+            "insère le presse-papiers",
+            "insère le presse-papier",
+            // French, STT dropped the hyphen.
+            "colle le presse papiers",
+            "insère le presse papier",
+        ]
+
+        for phrase in phrases {
+            let result = ClipboardPayloadMacro.replaceMarkersWithPlaceholder(
+                in: "before \(phrase) after"
+            )
+            XCTAssertEqual(result.count, 1, "phrase should match once: \(phrase)")
+            XCTAssertEqual(
+                result.text,
+                "before \(placeholder) after",
+                "phrase should be fully consumed: \(phrase)"
+            )
+        }
+    }
+
+    func testMarkerToleratesSurroundingPunctuation() {
+        let result = ClipboardPayloadMacro.replaceMarkersWithPlaceholder(
+            in: "here's the error — paste clipboard — I think it's the retry logic"
+        )
+        XCTAssertEqual(result.count, 1)
+        XCTAssertEqual(
+            result.text,
+            "here's the error — \(placeholder) — I think it's the retry logic"
+        )
+    }
+
+    func testLongestMatchConsumesSuffix() {
+        // "here" is consumed by the marker, not left dangling as prose.
+        let result = ClipboardPayloadMacro.replaceMarkersWithPlaceholder(
+            in: "read this paste the clipboard here please"
+        )
+        XCTAssertEqual(result.count, 1)
+        XCTAssertEqual(result.text, "read this \(placeholder) please")
+    }
+
+    func testMultipleMarkersEachBecomeAPlaceholder() {
+        let result = ClipboardPayloadMacro.replaceMarkersWithPlaceholder(
+            in: "paste clipboard and also insert clipboard"
+        )
+        XCTAssertEqual(result.count, 2)
+        XCTAssertEqual(result.text, "\(placeholder) and also \(placeholder)")
+    }
+
+    func testNegativeCasesDoNotMatch() {
+        let negatives = [
+            "clipboard history is broken",   // no paste/insert verb
+            "copy-paste the code please",    // paste, but of "the code", no clipboard
+            "let me paste the code here",    // paste, no clipboard
+            "the clipboard is full today",   // clipboard, no verb
+            "insertion sort in clipboard.js", // "insert" embedded in a word
+        ]
+        for input in negatives {
+            XCTAssertTrue(
+                ClipboardPayloadMacro.detectMarkers(in: input).isEmpty,
+                "should not match: \(input)"
+            )
+        }
+    }
+
+    func testAcceptedOvermatchOfContentSuffix() {
+        // Documented, acceptable over-match: "content" is a suffix, so this
+        // consumes "paste the clipboard content" and leaves " of the file".
+        let result = ClipboardPayloadMacro.replaceMarkersWithPlaceholder(
+            in: "paste the clipboard content of the file"
+        )
+        XCTAssertEqual(result.count, 1)
+        XCTAssertEqual(result.text, "\(placeholder) of the file")
+    }
+
+    // MARK: - Payload formatting
+
+    func testInlineForShortSingleLinePayload() {
+        let out = ClipboardPayloadMacro.substitutePayload(
+            in: "run \(placeholder) now", payload: "config.yaml"
+        )
+        XCTAssertEqual(out, "run `config.yaml` now")
+    }
+
+    func testInlineStripsSurroundingWhitespace() {
+        let out = ClipboardPayloadMacro.substitutePayload(
+            in: "x \(placeholder) y", payload: "  abc  "
+        )
+        XCTAssertEqual(out, "x `abc` y")
+    }
+
+    func testInlineThresholdBoundary() {
+        let sixty = String(repeating: "a", count: 60)
+        let sixtyOne = String(repeating: "a", count: 61)
+
+        let inline = ClipboardPayloadMacro.substitutePayload(
+            in: placeholder, payload: sixty
+        )
+        XCTAssertEqual(inline, "`\(sixty)`")
+
+        let fenced = ClipboardPayloadMacro.substitutePayload(
+            in: placeholder, payload: sixtyOne
+        )
+        XCTAssertEqual(fenced, "```\n\(sixtyOne)\n```")
+    }
+
+    func testMultiLinePayloadIsFencedWithSurroundingNewlines() {
+        // Placeholder mid-line: fence gains a leading and trailing newline.
+        let out = ClipboardPayloadMacro.substitutePayload(
+            in: "a \(placeholder) b", payload: "line1\nline2"
+        )
+        XCTAssertEqual(out, "a \n```\nline1\nline2\n```\n b")
+    }
+
+    func testFenceHonorsExistingLineBoundaries() {
+        // Placeholder already alone on its line: no doubled blank lines.
+        let out = ClipboardPayloadMacro.substitutePayload(
+            in: "a\n\(placeholder)\nb", payload: "line1\nline2"
+        )
+        XCTAssertEqual(out, "a\n```\nline1\nline2\n```\nb")
+    }
+
+    func testCapAppendsTruncationMarkerInsideFence() {
+        let big = String(repeating: "a", count: 8100)
+        let out = ClipboardPayloadMacro.substitutePayload(in: placeholder, payload: big)
+
+        XCTAssertTrue(out.hasPrefix("```\n"))
+        XCTAssertTrue(out.hasSuffix("\n```"))
+        XCTAssertTrue(out.contains(ClipboardPayloadMacro.truncationMarker))
+        // Exactly the head cap survives as a contiguous run; the rest is dropped.
+        let cap = ClipboardPayloadMacro.payloadCharacterCap
+        XCTAssertTrue(out.contains(String(repeating: "a", count: cap)))
+        XCTAssertFalse(out.contains(String(repeating: "a", count: cap + 1)))
+    }
+
+    // MARK: - Fence collision (CommonMark)
+
+    func testPayloadWithTripleBacktickBlockGetsLongerOuterFence() {
+        // The payload itself contains a fenced block: the outer fence must be
+        // longer (max run 3 → fence 4) so the inner ``` can't close it early,
+        // and the payload round-trips intact between the outer fences.
+        let payload = "error in:\n```\nlet x = 1\n```\ndone"
+        let out = ClipboardPayloadMacro.substitutePayload(in: placeholder, payload: payload)
+        XCTAssertEqual(out, "````\n\(payload)\n````")
+    }
+
+    func testShortPayloadWithBacktickIsFencedNotInline() {
+        // Short and single-line, but a backtick inside would break a single-
+        // backtick inline wrap: fenced instead.
+        let out = ClipboardPayloadMacro.substitutePayload(
+            in: "x \(placeholder) y", payload: "run `ls` now"
+        )
+        XCTAssertEqual(out, "x \n```\nrun `ls` now\n```\n y")
+    }
+
+    func testFenceIsOneLongerThanLongestBacktickRun() {
+        // A 5-backtick run inside the payload → 6-backtick outer fence.
+        let payload = "before\n`````\nafter"
+        let out = ClipboardPayloadMacro.substitutePayload(in: placeholder, payload: payload)
+        XCTAssertEqual(out, "``````\n\(payload)\n``````")
+    }
+
+    // MARK: - Standalone placeholder count
+
+    func testStandalonePlaceholderCount() {
+        XCTAssertEqual(ClipboardPayloadMacro.standalonePlaceholderCount(in: "no marker"), 0)
+        XCTAssertEqual(
+            ClipboardPayloadMacro.standalonePlaceholderCount(in: "a \(placeholder) b"), 1
+        )
+        XCTAssertEqual(
+            ClipboardPayloadMacro.standalonePlaceholderCount(
+                in: "\(placeholder) and \(placeholder)"
+            ),
+            2
+        )
+        // Sentence punctuation is not a body char: still standalone.
+        XCTAssertEqual(
+            ClipboardPayloadMacro.standalonePlaceholderCount(in: "see \(placeholder)."), 1
+        )
+        // A body char glued to either side is corruption, not an occurrence —
+        // same boundary rule as PolishTokenGuard.
+        XCTAssertEqual(
+            ClipboardPayloadMacro.standalonePlaceholderCount(in: "x\(placeholder) y"), 0
+        )
+        XCTAssertEqual(
+            ClipboardPayloadMacro.standalonePlaceholderCount(in: "\(placeholder)S y"), 0
+        )
+    }
+
+    func testNoPlaceholderLeavesTextUnchanged() {
+        let out = ClipboardPayloadMacro.substitutePayload(
+            in: "no marker here", payload: "abc"
+        )
+        XCTAssertEqual(out, "no marker here")
+    }
+
+    func testSubstitutesEveryPlaceholderOccurrence() {
+        let out = ClipboardPayloadMacro.substitutePayload(
+            in: "\(placeholder) and \(placeholder)", payload: "x.txt"
+        )
+        XCTAssertEqual(out, "`x.txt` and `x.txt`")
+    }
+
+    // MARK: - Token-guard interplay (the deliberate trick)
+
+    /// The placeholder is env-var-shaped, so `PolishTokenGuard` already treats
+    /// it as a protected token with ZERO guard changes. This pins that so a
+    /// future guard-recognizer change can't silently break the macro.
+    func testPlaceholderIsAProtectedToken() {
+        XCTAssertEqual(
+            PolishTokenGuard.protectedTokens(in: "x \(placeholder) y"),
+            [placeholder]
+        )
+    }
+
+    /// If the polish model deletes the placeholder, the guard falls back to the
+    /// placeholder-bearing working text — the macro survives the LLM.
+    func testGuardFallsBackWhenModelDropsPlaceholder() {
+        let original = "x \(placeholder) y"
+        let result = PolishTokenGuard.verifyAndRepair(polished: "x y", original: original)
+        XCTAssertEqual(result.outcome, .fallback(missing: [placeholder]))
+        XCTAssertEqual(result.text, original)
+    }
+}

--- a/Tests/localvoxtralTests/PolishTokenGuardTests.swift
+++ b/Tests/localvoxtralTests/PolishTokenGuardTests.swift
@@ -771,6 +771,238 @@ final class DictationViewModelPolishTokenGuardTests: XCTestCase {
         return (savedRecord, request)
     }
 
+    // MARK: - Clipboard payload macro
+
+    private struct ClipboardMacroSessionResult {
+        let record: DictationSessionRecord?
+        let request: LLMPolishingRequest?
+        let committedText: String
+    }
+
+    /// The polish path: a spoken marker fires the macro. The polish request
+    /// carries the PLACEHOLDER (never the payload), the committed/displayed text
+    /// carries the fenced payload, persistence keeps the placeholder, and the
+    /// record's summary carries the count.
+    func testClipboardPayloadMacroPolishPath() async throws {
+        let payload = "Traceback (most recent call last):\n  File \"app.py\", line 42\nValueError: boom"
+        let result = await runClipboardPayloadMacroSession(
+            transcript: "here is the error paste clipboard end",
+            payloadPasteboard: PasteboardStub(string: payload)
+        )
+
+        let request = try XCTUnwrap(result.request)
+        XCTAssertTrue(request.inputText.contains(ClipboardPayloadMacro.placeholder))
+        XCTAssertFalse(request.inputText.contains("Traceback"))
+        XCTAssertFalse(request.userPrompts.contains { $0.contains("Traceback") })
+
+        XCTAssertTrue(result.committedText.contains("```"))
+        XCTAssertTrue(result.committedText.contains("Traceback"))
+        XCTAssertFalse(result.committedText.contains(ClipboardPayloadMacro.placeholder))
+
+        let record = try XCTUnwrap(result.record)
+        XCTAssertEqual(record.rawText, "here is the error paste clipboard end")
+        XCTAssertEqual(
+            record.polishedText,
+            "here is the error \(ClipboardPayloadMacro.placeholder) end"
+        )
+        XCTAssertEqual(record.polishContextSummary, "payload:\(payload.count)ch")
+    }
+
+    /// The non-polish overlay path (polishing disabled): substitution still
+    /// happens at overlay commit, and persistence keeps the placeholder.
+    func testClipboardPayloadMacroNonPolishPath() async throws {
+        let payload = "def f():\n    return 1"
+        let result = await runClipboardPayloadMacroSession(
+            transcript: "insert clipboard please",
+            polishingEnabled: false,
+            payloadPasteboard: PasteboardStub(string: payload)
+        )
+
+        XCTAssertNil(result.request) // polishing off: the service is never called
+        XCTAssertTrue(result.committedText.contains("```"))
+        XCTAssertTrue(result.committedText.contains("return 1"))
+        XCTAssertFalse(result.committedText.contains(ClipboardPayloadMacro.placeholder))
+
+        let record = try XCTUnwrap(result.record)
+        XCTAssertEqual(
+            record.polishedText,
+            "\(ClipboardPayloadMacro.placeholder) please"
+        )
+        XCTAssertEqual(record.polishContextSummary, "payload:\(payload.count)ch")
+    }
+
+    /// A concealed clipboard yields no payload: the marker is left exactly as
+    /// dictated and nothing is substituted or persisted as provenance.
+    func testConcealedClipboardLeavesMarkerAsDictated() async throws {
+        let result = await runClipboardPayloadMacroSession(
+            transcript: "please paste clipboard now",
+            payloadPasteboard: PasteboardStub(
+                string: "secrettoken",
+                types: [.nsPasteboardConcealed, .string]
+            )
+        )
+
+        let request = try XCTUnwrap(result.request)
+        XCTAssertEqual(request.inputText, "please paste clipboard now")
+        XCTAssertEqual(result.committedText, "please paste clipboard now")
+        XCTAssertFalse(result.committedText.contains(ClipboardPayloadMacro.placeholder))
+        XCTAssertFalse(result.committedText.contains("secrettoken"))
+        XCTAssertNil(result.record?.polishContextSummary)
+    }
+
+    /// The setting off: the pasteboard is never touched (zero reads) and the
+    /// marker passes through as dictated.
+    func testClipboardPayloadMacroDisabledNeverReadsPasteboard() async throws {
+        let stub = PasteboardStub(string: "should not be read")
+        let result = await runClipboardPayloadMacroSession(
+            transcript: "please paste clipboard now",
+            macroEnabled: false,
+            payloadPasteboard: stub
+        )
+
+        XCTAssertEqual(stub.typesCallCount, 0)
+        XCTAssertEqual(stub.stringCallCount, 0)
+        let request = try XCTUnwrap(result.request)
+        XCTAssertEqual(request.inputText, "please paste clipboard now")
+        XCTAssertFalse(result.committedText.contains(ClipboardPayloadMacro.placeholder))
+        XCTAssertNil(result.record?.polishContextSummary)
+    }
+
+    /// F3 clipboard context + the macro in one session: both features fire, each
+    /// reads its clipboard exactly once (≤ 2 reads total), the polish request
+    /// carries the placeholder AND the reference-context message, the committed
+    /// text carries the payload, and the summary carries both counts.
+    func testClipboardContextAndMacroBothFireWithBoundedReads() async throws {
+        let clipboardText = "UserSessionManager.swift error at retry"
+        let payloadStub = PasteboardStub(string: clipboardText)
+        let contextStub = PasteboardStub(string: clipboardText)
+        let result = await runClipboardPayloadMacroSession(
+            transcript: "fix this paste clipboard thanks",
+            contextEnabled: true,
+            payloadPasteboard: payloadStub,
+            contextPasteboard: contextStub
+        )
+
+        let request = try XCTUnwrap(result.request)
+        XCTAssertTrue(request.inputText.contains(ClipboardPayloadMacro.placeholder))
+        XCTAssertTrue(
+            request.userPrompts.contains {
+                $0.contains(PolishContextClipboardReader.contextMessageInstruction)
+            }
+        )
+        XCTAssertTrue(result.committedText.contains(clipboardText))
+
+        XCTAssertEqual(payloadStub.stringCallCount, 1)
+        XCTAssertEqual(contextStub.stringCallCount, 1)
+
+        XCTAssertEqual(
+            result.record?.polishContextSummary,
+            "clipboard:\(clipboardText.count)ch+payload:\(clipboardText.count)ch"
+        )
+    }
+
+    /// The polish DUPLICATED the placeholder (payload would paste twice): the
+    /// token guard passes it (at least one standalone survival), but the
+    /// placeholder-count check discards the polish — the committed text is the
+    /// substituted pre-polish working text with the payload exactly once.
+    func testDuplicatedPlaceholderDiscardsPolishForCommit() async throws {
+        let result = await runClipboardPayloadMacroSession(
+            transcript: "here paste clipboard end",
+            payloadPasteboard: PasteboardStub(string: "err.log"),
+            polishTransform: { $0 + " " + ClipboardPayloadMacro.placeholder }
+        )
+
+        XCTAssertEqual(result.committedText, "here `err.log` end")
+        XCTAssertEqual(
+            result.committedText.components(separatedBy: "err.log").count - 1, 1
+        )
+        // Persistence keeps the placeholder-bearing working text.
+        XCTAssertEqual(
+            result.record?.polishedText,
+            "here \(ClipboardPayloadMacro.placeholder) end"
+        )
+    }
+
+    /// The polish DROPPED one of two placeholders (a requested paste lost): the
+    /// guard still passes (the surviving occurrence satisfies it), but the count
+    /// check falls back to the working text — both payloads are committed.
+    func testDroppedPlaceholderOfTwoDiscardsPolishForCommit() async throws {
+        let placeholder = ClipboardPayloadMacro.placeholder
+        let result = await runClipboardPayloadMacroSession(
+            transcript: "paste clipboard and insert clipboard",
+            payloadPasteboard: PasteboardStub(string: "err.log"),
+            polishTransform: { text in
+                // Drop the LAST placeholder only; the first survives, so the
+                // token guard sees a standalone occurrence and stays clean.
+                guard let range = text.range(of: placeholder, options: .backwards) else {
+                    return text
+                }
+                var mangled = text
+                mangled.removeSubrange(range)
+                return mangled
+            }
+        )
+
+        XCTAssertEqual(result.committedText, "`err.log` and `err.log`")
+        XCTAssertEqual(
+            result.record?.polishedText,
+            "\(placeholder) and \(placeholder)"
+        )
+    }
+
+    /// Drives an overlay stop-commit for the clipboard-paste macro. The payload
+    /// pasteboard is injected via the macro's debug seam; when `contextPasteboard`
+    /// is supplied it is injected via the polish-context seam so the two features
+    /// can be exercised together. Endpoint defaults to loopback (managed polishd)
+    /// so the context feature's local-endpoint gate passes.
+    private func runClipboardPayloadMacroSession(
+        transcript: String,
+        macroEnabled: Bool = true,
+        polishingEnabled: Bool = true,
+        contextEnabled: Bool = false,
+        payloadPasteboard: PasteboardStub,
+        contextPasteboard: PasteboardStub? = nil,
+        endpointURL: String = "http://127.0.0.1:8472/v1/chat/completions",
+        polishTransform: @escaping @Sendable (String) -> String = { $0 }
+    ) async -> ClipboardMacroSessionResult {
+        let settings = makeSettings(outputMode: .overlayBuffer)
+        settings.clipboardPayloadMacroEnabled = macroEnabled
+        settings.llmPolishingEnabled = polishingEnabled
+        settings.polishingBackendMode = .externalURL
+        settings.llmPolishingEndpointURL = endpointURL
+        settings.polishClipboardContextEnabled = contextEnabled
+
+        let service = RecordingPolishingService(transform: polishTransform)
+        let viewModel = DictationViewModel(
+            settings: settings,
+            overlayBufferCoordinator: MockOverlayCoordinator(),
+            startRuntimeServices: false
+        )
+        viewModel.appConfigStore = MockAppConfigStore()
+        viewModel.llmPolishingService = service
+        viewModel.debugResolveTargetAppBundleIDOverride = { "com.acme.notes" }
+        viewModel.debugClipboardPayloadPasteboardReaderOverride = { payloadPasteboard }
+        if let contextPasteboard {
+            viewModel.debugPolishContextPasteboardReaderOverride = { contextPasteboard }
+        }
+        var savedRecord: DictationSessionRecord?
+        viewModel.debugSavedSessionRecordSink = { savedRecord = $0 }
+        retainForTestProcessLifetime(viewModel)
+
+        viewModel.sessionOutputMode = .overlayBuffer
+        viewModel.isFinalizingStop = true
+        viewModel.currentDictationEventText = transcript
+
+        viewModel.finishStoppedSession(promotePendingSegment: false)
+        await waitUntilStoppedSessionCompletes(viewModel)
+        let request = await service.capturedRequest
+        return ClipboardMacroSessionResult(
+            record: savedRecord,
+            request: request,
+            committedText: viewModel.currentDictationEventText
+        )
+    }
+
     // MARK: - Helpers
 
     private func waitUntilStoppedSessionCompletes(_ viewModel: DictationViewModel) async {

--- a/Tests/localvoxtralTests/SettingsStoreTests.swift
+++ b/Tests/localvoxtralTests/SettingsStoreTests.swift
@@ -508,6 +508,21 @@ final class SettingsStoreTests: XCTestCase {
         XCTAssertFalse(reloadedStore.agentPolishProfileEnabled)
     }
 
+    // MARK: - clipboardPayloadMacroEnabled
+
+    func testClipboardPayloadMacroEnabled_defaultsToTrue() {
+        let store = makeStore()
+        XCTAssertTrue(store.clipboardPayloadMacroEnabled)
+    }
+
+    func testClipboardPayloadMacroEnabled_persistsAcrossReload() {
+        let store = makeStore()
+        store.clipboardPayloadMacroEnabled = false
+
+        let reloadedStore = makeStore()
+        XCTAssertFalse(reloadedStore.clipboardPayloadMacroEnabled)
+    }
+
     func testDictationOutputMode_defaultsToOverlayBuffer() {
         let store = makeStore()
         XCTAssertEqual(store.dictationOutputMode, .overlayBuffer)


### PR DESCRIPTION
## What

Feature 4 of the coding-agent dictation polish series (stacked on #105): the **spoken clipboard-paste macro**. Stack traces are the one thing you can't dictate and always need in an agent prompt — now you speak the frame and the clipboard supplies the payload:

> "here's the error I'm getting — *paste clipboard* — I think it's in the retry logic"

At overlay commit, the marker becomes the actual clipboard contents as a code block.

Mechanics (`ClipboardPayloadMacro`, pure enum + wiring in the stop-commit path):
- **Markers** (case-insensitive, word-boundary-guarded, longest-match): `paste/insert [the] clipboard [here|content(s)]`; French `colle/insère le presse-papier(s)` (hyphen optional).
- **Placeholder trick**: markers are replaced pre-polish by `$LV_CLIPBOARD_PAYLOAD` — env-var-shaped, so #101's token guard already protects it byte-exact through the LLM with zero guard changes (pinned by a test). Post-polish, placeholder counts are re-validated (guard dedupes, so a model-duplicated/dropped placeholder would otherwise paste twice or lose a paste — count mismatch discards the polish for commit; codex-review P2). The macro reuses the guard's own `isBodyCharacter` boundary rule so the two can never disagree.
- **Formatting**: inline `` `payload` `` for short single-line payloads without backticks; otherwise a CommonMark collision-safe fence (length = longest backtick run in payload + 1; codex-review P2). 8000-char cap with an explicit truncation marker; control chars stripped (shared F3 sanitizer).
- **Privacy by construction**: the payload never reaches the polishing endpoint (only the placeholder does — asserted on the recorded request), is never persisted (session records keep the placeholder-bearing text; provenance carries counts only, e.g. `payload:1532ch`), and concealed/transient (`org.nspasteboard`) clipboards leave the transcript exactly as dictated.
- Setting `clipboardPayloadMacroEnabled`, default ON (fires only on an explicit spoken marker), one row in the existing polishing settings group.
- Overlay Buffer mode only; Live Auto-Paste code paths untouched (PR #100 slot-in), `LLMPolishingRequest` untouched (PR #99 slot-in).

## Proof

- [x] Unit suite green — `./scripts/remote-build.sh`

```
Executed 694 tests, with 2 tests skipped and 0 failures (0 unexpected)
```

29 new tests: marker table (en/fr, case, longest-match, negatives like "clipboard history is broken"), formatting (inline/fence threshold, fence-collision cases, cap + truncation marker), placeholder-protection pin, standalone count, and VM-level end-to-end (request contains placeholder not payload; committed text carries the payload; persistence keeps the placeholder; duplicated/dropped-placeholder fallbacks; concealed skip; setting-off zero pasteboard reads; F3-context + macro in one session).

One pre-existing flake observed and ruled out: `BackendProcessSupervisorTests.testStopHonorsTERMWithoutRestarting` (real-process TERM timing, untouched by this diff) failed one intermediate run, passes 8/8 in isolation and in the final full run.

- [x] No prompt-template or eval-corpus changes → integration-polishd lane not required.

- [x] UI change: one toggle row inside the existing polishing group (group count/identity unchanged). Not hand-verified visually — needs the same `try-pr.sh` pass as #103/#105.
