### PR TITLE
Mechanical rename: mlxLM* → polishd* (deferred from #84)

### DIFF
--- a/Sources/localvoxtral/Backends/BackendCatalog.swift
+++ b/Sources/localvoxtral/Backends/BackendCatalog.swift
@@ -52,9 +52,8 @@ enum BackendCatalog {
     /// bundled inside the .app. It replaced the uv-installed mlx-lm fork wheel:
     /// upstream mlx-lm went unmaintained and the fork existed to carry fixes
     /// (transformers pins, prompt-cache correctness, parent-pid watchdog) that
-    /// the Swift helper now owns directly. Swift symbols keep the historical
-    /// `mlxLM` name to keep that mechanical rename out of the functional diff.
-    static let mlxLM = ManagedBackendSpec(
+    /// the Swift helper now owns directly.
+    static let polishd = ManagedBackendSpec(
         id: "polishd",
         displayName: "Polishing engine",
         version: "bundled",
@@ -63,5 +62,5 @@ enum BackendCatalog {
         port: 8472
     )
 
-    static let all: [ManagedBackendSpec] = [voxmlx, mlxLM]
+    static let all: [ManagedBackendSpec] = [voxmlx, polishd]
 }

--- a/Sources/localvoxtral/Backends/BackendManager.swift
+++ b/Sources/localvoxtral/Backends/BackendManager.swift
@@ -68,16 +68,16 @@ extension BackendProcessSupervisor: ManagedBackendSupervising {}
 @MainActor
 protocol ManagedBackendManaging: AnyObject {
     var voxmlxStatus: ManagedBackendStatus { get }
-    var mlxLMStatus: ManagedBackendStatus { get }
+    var polishdStatus: ManagedBackendStatus { get }
     var statusUpdates: AsyncStream<ManagedBackendStatusUpdate> { get }
 
     func ensureReady(dictation: Bool, polishing: Bool) async throws
     func stopAll() async
-    /// Stop only the managed voxmlx (dictation) process, leaving mlx-lm
+    /// Stop only the managed voxmlx (dictation) process, leaving polishd
     /// (polishing) untouched. A no-op if voxmlx was never started.
     func stopDictation() async
-    /// Stop only the managed mlx-lm (polishing) process, leaving voxmlx
-    /// (dictation) untouched. A no-op if mlx-lm was never started.
+    /// Stop only the managed polishd (polishing) process, leaving voxmlx
+    /// (dictation) untouched. A no-op if polishd was never started.
     func stopPolishing() async
     /// Recent supervisor output lines for the given backend, or empty if the
     /// supervisor has not been created yet (backend never started). For local
@@ -92,7 +92,7 @@ final class BackendManager: ManagedBackendManaging {
     typealias PolishingModelProvider = @MainActor () -> String
 
     private(set) var voxmlxStatus: ManagedBackendStatus
-    private(set) var mlxLMStatus: ManagedBackendStatus
+    private(set) var polishdStatus: ManagedBackendStatus
 
     @ObservationIgnored private let installer: any BackendInstalling
     @ObservationIgnored private let modelPreparer: any ModelPreparing
@@ -100,7 +100,7 @@ final class BackendManager: ManagedBackendManaging {
     @ObservationIgnored private let supervisorFactory: SupervisorFactory
     @ObservationIgnored private let polishingModelProvider: PolishingModelProvider
     @ObservationIgnored private var voxmlxSupervisor: (any ManagedBackendSupervising)?
-    @ObservationIgnored private var mlxLMSupervisor: (any ManagedBackendSupervising)?
+    @ObservationIgnored private var polishdSupervisor: (any ManagedBackendSupervising)?
     // Per-backend single-flight slots. A global shared slot (the previous
     // design) let a lingering dictation run swallow a polishing request whose
     // flags it never covered — field-hit 2026-07-04: enabling polishing did
@@ -109,7 +109,7 @@ final class BackendManager: ManagedBackendManaging {
     @ObservationIgnored private var dictationEnsureTask: Task<Void, Error>?
     @ObservationIgnored private var polishingEnsureTask: Task<Void, Error>?
     @ObservationIgnored private var voxmlxStateMirrorTask: Task<Void, Never>?
-    @ObservationIgnored private var mlxLMStateMirrorTask: Task<Void, Never>?
+    @ObservationIgnored private var polishdStateMirrorTask: Task<Void, Never>?
     @ObservationIgnored private var statusUpdateContinuations: [UUID: AsyncStream<ManagedBackendStatusUpdate>.Continuation] = [:]
     #if DEBUG
     @ObservationIgnored var debugStatusChangeSink: ((ManagedBackendSpec, ManagedBackendStatus) -> Void)?
@@ -134,7 +134,7 @@ final class BackendManager: ManagedBackendManaging {
         self.voxmlxStatus = installer.needsInstallOrUpdate(BackendCatalog.voxmlx)
             ? .notInstalled
             : .stopped
-        self.mlxLMStatus = installer.needsInstallOrUpdate(BackendCatalog.mlxLM)
+        self.polishdStatus = installer.needsInstallOrUpdate(BackendCatalog.polishd)
             ? .notInstalled
             : .stopped
     }
@@ -161,7 +161,7 @@ final class BackendManager: ManagedBackendManaging {
             tasks.append(singleFlightEnsureTask(for: BackendCatalog.voxmlx))
         }
         if polishing {
-            tasks.append(singleFlightEnsureTask(for: BackendCatalog.mlxLM))
+            tasks.append(singleFlightEnsureTask(for: BackendCatalog.polishd))
         }
         for task in tasks {
             try await awaitEnsureReadyTask(task)
@@ -175,7 +175,7 @@ final class BackendManager: ManagedBackendManaging {
         if spec.id == BackendCatalog.voxmlx.id, let dictationEnsureTask {
             return dictationEnsureTask
         }
-        if spec.id == BackendCatalog.mlxLM.id, let polishingEnsureTask {
+        if spec.id == BackendCatalog.polishd.id, let polishingEnsureTask {
             return polishingEnsureTask
         }
         let task = Task { @MainActor in
@@ -219,20 +219,20 @@ final class BackendManager: ManagedBackendManaging {
 
     func stopAll() async {
         let cancelledDictationEnsure = await cancelEnsureTaskAndAwaitCompletion(for: BackendCatalog.voxmlx)
-        let cancelledPolishingEnsure = await cancelEnsureTaskAndAwaitCompletion(for: BackendCatalog.mlxLM)
-        let hadPolishingSupervisor = mlxLMSupervisor != nil
+        let cancelledPolishingEnsure = await cancelEnsureTaskAndAwaitCompletion(for: BackendCatalog.polishd)
+        let hadPolishingSupervisor = polishdSupervisor != nil
         await voxmlxSupervisor?.stop()
-        await mlxLMSupervisor?.stop()
-        mlxLMSupervisor = nil
+        await polishdSupervisor?.stop()
+        polishdSupervisor = nil
         voxmlxStateMirrorTask?.cancel()
         voxmlxStateMirrorTask = nil
-        mlxLMStateMirrorTask?.cancel()
-        mlxLMStateMirrorTask = nil
+        polishdStateMirrorTask?.cancel()
+        polishdStateMirrorTask = nil
         if cancelledDictationEnsure || voxmlxSupervisor != nil {
             setStatus(.stopped, for: BackendCatalog.voxmlx)
         }
         if cancelledPolishingEnsure || hadPolishingSupervisor {
-            setStatus(.stopped, for: BackendCatalog.mlxLM)
+            setStatus(.stopped, for: BackendCatalog.polishd)
         }
     }
 
@@ -248,16 +248,16 @@ final class BackendManager: ManagedBackendManaging {
 
     func stopPolishing() async {
         // Stop only the polishing supervisor. voxmlx (dictation) keeps running
-        // and its state mirror is left intact. Modeled on stopAll()'s mlx-lm
+        // and its state mirror is left intact. Modeled on stopAll()'s polishd
         // branch: cancel the mirror task and pin the status to .stopped.
-        let cancelledEnsure = await cancelEnsureTaskAndAwaitCompletion(for: BackendCatalog.mlxLM)
-        let hadSupervisor = mlxLMSupervisor != nil
-        await mlxLMSupervisor?.stop()
-        mlxLMSupervisor = nil
-        mlxLMStateMirrorTask?.cancel()
-        mlxLMStateMirrorTask = nil
+        let cancelledEnsure = await cancelEnsureTaskAndAwaitCompletion(for: BackendCatalog.polishd)
+        let hadSupervisor = polishdSupervisor != nil
+        await polishdSupervisor?.stop()
+        polishdSupervisor = nil
+        polishdStateMirrorTask?.cancel()
+        polishdStateMirrorTask = nil
         if cancelledEnsure || hadSupervisor {
-            setStatus(.stopped, for: BackendCatalog.mlxLM)
+            setStatus(.stopped, for: BackendCatalog.polishd)
         }
     }
 
@@ -283,8 +283,8 @@ final class BackendManager: ManagedBackendManaging {
         switch spec.id {
         case BackendCatalog.voxmlx.id:
             return voxmlxStatus
-        case BackendCatalog.mlxLM.id:
-            return mlxLMStatus
+        case BackendCatalog.polishd.id:
+            return polishdStatus
         default:
             return .failed(summary: "Unknown managed backend '\(spec.id)'.", detail: nil)
         }
@@ -294,8 +294,8 @@ final class BackendManager: ManagedBackendManaging {
         switch spec.id {
         case BackendCatalog.voxmlx.id:
             return voxmlxSupervisor?.recentOutput ?? []
-        case BackendCatalog.mlxLM.id:
-            return mlxLMSupervisor?.recentOutput ?? []
+        case BackendCatalog.polishd.id:
+            return polishdSupervisor?.recentOutput ?? []
         default:
             return []
         }
@@ -420,13 +420,13 @@ final class BackendManager: ManagedBackendManaging {
             voxmlxSupervisor = supervisor
             startStateMirrorIfNeeded(supervisor: supervisor, spec: spec)
             return supervisor
-        case BackendCatalog.mlxLM.id:
-            if let mlxLMSupervisor {
-                startStateMirrorIfNeeded(supervisor: mlxLMSupervisor, spec: spec)
-                return mlxLMSupervisor
+        case BackendCatalog.polishd.id:
+            if let polishdSupervisor {
+                startStateMirrorIfNeeded(supervisor: polishdSupervisor, spec: spec)
+                return polishdSupervisor
             }
             let supervisor = supervisorFactory(configuration(for: spec))
-            mlxLMSupervisor = supervisor
+            polishdSupervisor = supervisor
             startStateMirrorIfNeeded(supervisor: supervisor, spec: spec)
             return supervisor
         default:
@@ -478,7 +478,7 @@ final class BackendManager: ManagedBackendManaging {
                 "--parent-pid",
                 parentPID,
             ]
-        case BackendCatalog.mlxLM.id:
+        case BackendCatalog.polishd.id:
             return [
                 "--model",
                 polishingModelProvider(),
@@ -515,7 +515,7 @@ final class BackendManager: ManagedBackendManaging {
                     "tekken.json",
                 ]
             )
-        case BackendCatalog.mlxLM.id:
+        case BackendCatalog.polishd.id:
             return ModelPreparationRequest(
                 backendID: spec.id,
                 displayName: spec.displayName,
@@ -558,7 +558,7 @@ final class BackendManager: ManagedBackendManaging {
             // First run downloads the model inside the server before /health
             // responds; 600 s is too tight on slow links.
             return .seconds(1800)
-        case BackendCatalog.mlxLM.id:
+        case BackendCatalog.polishd.id:
             // Model weights are downloaded by prepareModel before the helper
             // spawns; /health waits only on model load + first Metal JIT
             // compile (seconds, not minutes).
@@ -572,8 +572,8 @@ final class BackendManager: ManagedBackendManaging {
         switch spec.id {
         case BackendCatalog.voxmlx.id:
             return voxmlxSupervisor?.state == .running
-        case BackendCatalog.mlxLM.id:
-            return mlxLMSupervisor?.state == .running
+        case BackendCatalog.polishd.id:
+            return polishdSupervisor?.state == .running
         default:
             return false
         }
@@ -587,9 +587,9 @@ final class BackendManager: ManagedBackendManaging {
         case BackendCatalog.voxmlx.id:
             guard voxmlxStateMirrorTask == nil else { return }
             voxmlxStateMirrorTask = makeStateMirrorTask(supervisor: supervisor, spec: spec)
-        case BackendCatalog.mlxLM.id:
-            guard mlxLMStateMirrorTask == nil else { return }
-            mlxLMStateMirrorTask = makeStateMirrorTask(supervisor: supervisor, spec: spec)
+        case BackendCatalog.polishd.id:
+            guard polishdStateMirrorTask == nil else { return }
+            polishdStateMirrorTask = makeStateMirrorTask(supervisor: supervisor, spec: spec)
         default:
             break
         }
@@ -629,8 +629,8 @@ final class BackendManager: ManagedBackendManaging {
         switch spec.id {
         case BackendCatalog.voxmlx.id:
             voxmlxStatus = status
-        case BackendCatalog.mlxLM.id:
-            mlxLMStatus = status
+        case BackendCatalog.polishd.id:
+            polishdStatus = status
         default:
             break
         }

--- a/Sources/localvoxtral/Backends/ManagedBackendEndpoints.swift
+++ b/Sources/localvoxtral/Backends/ManagedBackendEndpoints.swift
@@ -4,7 +4,7 @@ import Foundation
 /// 8000/8080 so a user-run server never collides with the managed ones.
 enum ManagedBackendEndpoints {
     static let voxmlxPort = BackendCatalog.voxmlx.port
-    static let mlxLMPort = BackendCatalog.mlxLM.port
+    static let polishdPort = BackendCatalog.polishd.port
     static let realtimeURLString = "ws://127.0.0.1:\(voxmlxPort)/v1/realtime"
-    static let polishingURLString = "http://127.0.0.1:\(mlxLMPort)/v1/chat/completions"
+    static let polishingURLString = "http://127.0.0.1:\(polishdPort)/v1/chat/completions"
 }

--- a/Sources/localvoxtral/DiagnosticsExporter.swift
+++ b/Sources/localvoxtral/DiagnosticsExporter.swift
@@ -24,9 +24,9 @@ struct DiagnosticsSnapshot: Sendable, Equatable {
     var polishingSummary: String
     var hasPolishingAPIKey: Bool
     var voxmlxStatus: String
-    var mlxLMStatus: String
+    var polishdStatus: String
     var voxmlxRecentOutput: [String]
-    var mlxLMRecentOutput: [String]
+    var polishdRecentOutput: [String]
 }
 
 enum DiagnosticsExporter {
@@ -63,9 +63,9 @@ enum DiagnosticsExporter {
     static func makeSnapshot(
         settings: SettingsStore,
         voxmlxStatus: ManagedBackendStatus,
-        mlxLMStatus: ManagedBackendStatus,
+        polishdStatus: ManagedBackendStatus,
         voxmlxRecentOutput: [String],
-        mlxLMRecentOutput: [String],
+        polishdRecentOutput: [String],
         bundle: Bundle = .main,
         processInfo: ProcessInfo = .processInfo
     ) -> DiagnosticsSnapshot {
@@ -99,9 +99,9 @@ enum DiagnosticsExporter {
             polishingSummary: polishingSummary,
             hasPolishingAPIKey: !settings.llmPolishingAPIKey.trimmed.isEmpty,
             voxmlxStatus: describe(voxmlxStatus),
-            mlxLMStatus: describe(mlxLMStatus),
+            polishdStatus: describe(polishdStatus),
             voxmlxRecentOutput: voxmlxRecentOutput,
-            mlxLMRecentOutput: mlxLMRecentOutput
+            polishdRecentOutput: polishdRecentOutput
         )
     }
 
@@ -139,20 +139,20 @@ enum DiagnosticsExporter {
 
         lines.append("== Managed backend status ==")
         lines.append("voxmlx: \(snapshot.voxmlxStatus)")
-        lines.append("polishing engine (localvoxtral-polishd): \(snapshot.mlxLMStatus)")
+        lines.append("polishing engine (localvoxtral-polishd): \(snapshot.polishdStatus)")
         lines.append("")
 
         lines.append("== Managed backend recent output ==")
-        if snapshot.voxmlxRecentOutput.isEmpty && snapshot.mlxLMRecentOutput.isEmpty {
+        if snapshot.voxmlxRecentOutput.isEmpty && snapshot.polishdRecentOutput.isEmpty {
             lines.append("(no supervisor output captured)")
         } else {
             if !snapshot.voxmlxRecentOutput.isEmpty {
                 lines.append("-- voxmlx --")
                 lines.append(contentsOf: snapshot.voxmlxRecentOutput)
             }
-            if !snapshot.mlxLMRecentOutput.isEmpty {
+            if !snapshot.polishdRecentOutput.isEmpty {
                 lines.append("-- localvoxtral-polishd --")
-                lines.append(contentsOf: snapshot.mlxLMRecentOutput)
+                lines.append(contentsOf: snapshot.polishdRecentOutput)
             }
         }
 

--- a/Sources/localvoxtral/DictationViewModel+Session.swift
+++ b/Sources/localvoxtral/DictationViewModel+Session.swift
@@ -161,12 +161,12 @@ extension DictationViewModel {
         if dictation, case .preparingModel(let progress) = backendManager.voxmlxStatus {
             return modelDownloadStartupText(kind: "dictation", progress: progress)
         }
-        if polishing, case .preparingModel(let progress) = backendManager.mlxLMStatus {
+        if polishing, case .preparingModel(let progress) = backendManager.polishdStatus {
             return modelDownloadStartupText(kind: "polishing", progress: progress)
         }
         if shouldShowManagedBackendInstallStatus(
             voxmlxStatus: dictation ? backendManager.voxmlxStatus : nil,
-            mlxLMStatus: polishing ? backendManager.mlxLMStatus : nil
+            polishdStatus: polishing ? backendManager.polishdStatus : nil
         ) {
             if !dictation, polishing {
                 return "Installing polishing backend..."
@@ -189,12 +189,12 @@ extension DictationViewModel {
 
     private func shouldShowManagedBackendInstallStatus(
         voxmlxStatus: ManagedBackendStatus?,
-        mlxLMStatus: ManagedBackendStatus?
+        polishdStatus: ManagedBackendStatus?
     ) -> Bool {
         if voxmlxStatus?.requiresInstallProgressText == true {
             return true
         }
-        return mlxLMStatus?.requiresInstallProgressText == true
+        return polishdStatus?.requiresInstallProgressText == true
     }
 
     private func handleManagedBackendStartupFailure(_ error: Error) {

--- a/Sources/localvoxtral/DictationViewModel.swift
+++ b/Sources/localvoxtral/DictationViewModel.swift
@@ -202,7 +202,7 @@ final class DictationViewModel {
             return false
         }
         if isManagedPolishingWarmupWanted,
-           !isReady(backendManager.mlxLMStatus)
+           !isReady(backendManager.polishdStatus)
         {
             return false
         }
@@ -317,7 +317,7 @@ final class DictationViewModel {
     var managedStartupTask: Task<Void, Never>?
     @ObservationIgnored
     var managedStartupTaskID: UUID?
-    // Stops the managed mlx-lm (polishing) process when LLM polishing is turned
+    // Stops the managed polishd (polishing) process when LLM polishing is turned
     // off in Managed local mode. Kept awaitable so tests can await the shutdown.
     // Shutdown tasks are tracked (never fire-and-forget) so a warmup requested
     // right after a stop can cancel a still-queued stop and serialize behind a
@@ -939,7 +939,7 @@ final class DictationViewModel {
         }
 
         if previousMode == .managedLocal, mode == .externalURL {
-            Log.backends.info("polishing backend mode switched to external; stopping managed mlx-lm")
+            Log.backends.info("polishing backend mode switched to external; stopping managed polishd")
             cancelManagedStartupTask()
             polishingWarmupTask?.cancel()
             polishingShutdownTask?.cancel()
@@ -971,13 +971,13 @@ final class DictationViewModel {
 
     func applyDictationOutputModeChange(_ mode: DictationOutputMode) {
         // The menu-bar output mode is not a reachability input (see
-        // `isOverlayBufferSessionReachable`), so managed mlx-lm is unaffected.
+        // `isOverlayBufferSessionReachable`), so managed polishd is unaffected.
         settings.dictationOutputMode = mode
     }
 
     /// The trigger picker in Settings > Dictation. Switching between the
     /// single-modifier gesture and per-mode shortcuts changes whether an
-    /// Overlay Buffer session is reachable, so managed mlx-lm follows.
+    /// Overlay Buffer session is reachable, so managed polishd follows.
     func applyDictationTriggerModeChange(modifierOnlyEnabled: Bool) {
         guard settings.modifierOnlyHotKeyEnabled != modifierOnlyEnabled else { return }
         let wasReachable = settings.isOverlayBufferSessionReachable
@@ -986,7 +986,7 @@ final class DictationViewModel {
         handleOverlayReachabilityTransition(wasReachable: wasReachable)
     }
 
-    /// Managed mlx-lm follows Overlay Buffer reachability: polishing runs only
+    /// Managed polishd follows Overlay Buffer reachability: polishing runs only
     /// on Overlay Buffer commits, so when no trigger can start one the process
     /// is stopped instead of idling in memory.
     func handleOverlayReachabilityTransition(wasReachable: Bool) {
@@ -999,7 +999,7 @@ final class DictationViewModel {
         if isReachable {
             startPolishingWarmup()
         } else {
-            Log.backends.info("no Overlay Buffer trigger configured; stopping managed mlx-lm")
+            Log.backends.info("no Overlay Buffer trigger configured; stopping managed polishd")
             polishingWarmupTask?.cancel()
             polishingShutdownTask?.cancel()
             polishingShutdownTask = Task { @MainActor [backendManager] in
@@ -1010,7 +1010,7 @@ final class DictationViewModel {
     }
 
     /// React to the LLM polishing enable toggle. Disabling polishing in Managed
-    /// local polishing mode stops the managed mlx-lm process so it stops holding memory.
+    /// local polishing mode stops the managed polishd process so it stops holding memory.
     /// Enabling in Managed local mode eagerly starts the polishing warmup so
     /// install/model progress is visible in Settings. External URL mode owns
     /// no local process.
@@ -1022,7 +1022,7 @@ final class DictationViewModel {
         if enabled, settings.isOverlayBufferSessionReachable {
             startPolishingWarmup()
         } else {
-            Log.backends.info("polishing disabled; stopping managed mlx-lm")
+            Log.backends.info("polishing disabled; stopping managed polishd")
             polishingWarmupTask?.cancel()
             polishingShutdownTask = Task { @MainActor [backendManager] in
                 guard !Task.isCancelled else { return }
@@ -1093,9 +1093,9 @@ final class DictationViewModel {
         let snapshot = DiagnosticsExporter.makeSnapshot(
             settings: settings,
             voxmlxStatus: backendManager.voxmlxStatus,
-            mlxLMStatus: backendManager.mlxLMStatus,
+            polishdStatus: backendManager.polishdStatus,
             voxmlxRecentOutput: backendManager.recentOutput(for: BackendCatalog.voxmlx),
-            mlxLMRecentOutput: backendManager.recentOutput(for: BackendCatalog.mlxLM)
+            polishdRecentOutput: backendManager.recentOutput(for: BackendCatalog.polishd)
         )
 
         guard let desktop = FileManager.default.urls(
@@ -1678,10 +1678,10 @@ final class DictationViewModel {
 
     /// Warmup-time variant of `isManagedPolishingRequired`: instead of a
     /// session's output mode, gates on whether a keyboard trigger can start
-    /// an Overlay Buffer session at all. When false, managed mlx-lm stays
+    /// an Overlay Buffer session at all. When false, managed polishd stays
     /// stopped — an overlay session started from the menu-bar button still
     /// polishes via the dictation-time `ensureReady` backstop, paying the
-    /// mlx-lm cold start (deliberate: see
+    /// polishd cold start (deliberate: see
     /// `SettingsStore.isOverlayBufferSessionReachable`).
     var isManagedPolishingWarmupWanted: Bool {
         settings.llmPolishingEnabled

--- a/Sources/localvoxtral/Onboarding/LiveOnboardingBootstrapDriver.swift
+++ b/Sources/localvoxtral/Onboarding/LiveOnboardingBootstrapDriver.swift
@@ -2,7 +2,7 @@ import Foundation
 import Observation
 
 /// Production onboarding driver: kicks off `BackendManager.ensureReady` and
-/// mirrors the observable `voxmlxStatus` / `mlxLMStatus` into `itemStates`.
+/// mirrors the observable `voxmlxStatus` / `polishdStatus` into `itemStates`.
 ///
 /// It only ever CALLS existing backend API from main — it never mutates the
 /// backend beyond the single `ensureReady` request, and the status → item-state
@@ -63,7 +63,7 @@ final class LiveOnboardingBootstrapDriver: OnboardingBootstrapDriving {
     private func observeStatuses() {
         withObservationTracking {
             _ = backendManager.voxmlxStatus
-            _ = backendManager.mlxLMStatus
+            _ = backendManager.polishdStatus
         } onChange: { [weak self] in
             Task { @MainActor in
                 guard let self else { return }
@@ -79,7 +79,7 @@ final class LiveOnboardingBootstrapDriver: OnboardingBootstrapDriving {
             states[.dictation] = OnboardingItemState(managedStatus: backendManager.voxmlxStatus)
         }
         if polishingRequested {
-            states[.polishing] = OnboardingItemState(managedStatus: backendManager.mlxLMStatus)
+            states[.polishing] = OnboardingItemState(managedStatus: backendManager.polishdStatus)
         }
         if itemStates != states {
             itemStates = states

--- a/Sources/localvoxtral/Onboarding/OnboardingViewModel.swift
+++ b/Sources/localvoxtral/Onboarding/OnboardingViewModel.swift
@@ -20,7 +20,7 @@ final class OnboardingViewModel {
 
     private(set) var page: Page = .welcome
 
-    /// Consent to download mlx-lm + the polishing LLM during setup. Default ON;
+    /// Consent to download the polishing LLM during setup. Default ON;
     /// declining skips the polishing download now (it downloads later, the first
     /// time polishing is enabled in Settings).
     var polishingConsent = true

--- a/Sources/localvoxtral/SettingsStore.swift
+++ b/Sources/localvoxtral/SettingsStore.swift
@@ -205,7 +205,7 @@ final class SettingsStore {
     )
 
     /// Default model for the OpenAI-compatible LLM polishing server. Used as
-    /// the external-mode fallback and as the model the managed mlx-lm backend
+    /// the external-mode fallback and as the model the managed polishd backend
     /// is expected to serve.
     static let defaultLLMPolishingModel = PolishModelCatalog.defaultOption.repoID
 
@@ -733,11 +733,11 @@ final class SettingsStore {
     /// True when a keyboard trigger can start an Overlay Buffer session: the
     /// single-modifier tap gesture, or a dedicated Overlay Buffer shortcut.
     /// LLM polishing runs only on Overlay Buffer commits, so when this is
-    /// false Settings shows polishing as unavailable and managed mlx-lm is
+    /// false Settings shows polishing as unavailable and managed polishd is
     /// kept stopped. The menu-bar Start Dictation button deliberately does
     /// not count (owner call, 2026-07-06): an overlay session started from
     /// the popover still polishes via the session-time ensureReady backstop,
-    /// paying the mlx-lm cold start.
+    /// paying the polishd cold start.
     var isOverlayBufferSessionReachable: Bool {
         modifierOnlyHotKeyEnabled || overlayBufferShortcut != nil
     }

--- a/Sources/localvoxtral/SettingsView.swift
+++ b/Sources/localvoxtral/SettingsView.swift
@@ -214,9 +214,9 @@ private struct ConnectionSettingsPane: View {
                 if newValue, !wasEnabled {
                     viewModel.prepareLLMPolishingPromptAccessIfNeeded()
                 }
-                // Turning polishing off stops the managed mlx-lm process
+                // Turning polishing off stops the managed polishd process
                 // (Managed local mode only). External URL mode owns no local
-                // process, and re-enabling starts managed mlx-lm eagerly.
+                // process, and re-enabling starts managed polishd eagerly.
                 viewModel.llmPolishingEnabledDidChange(newValue)
             }
         )
@@ -365,9 +365,9 @@ private struct ConnectionSettingsPane: View {
 
                         ManagedBackendStatusRow(
                             title: "Status",
-                            spec: BackendCatalog.mlxLM,
+                            spec: BackendCatalog.polishd,
                             endpoint: ManagedBackendEndpoints.polishingURLString,
-                            status: backendManager.mlxLMStatus
+                            status: backendManager.polishdStatus
                         )
                     }
                 }

--- a/Tests/localvoxtralTests/BackendInstallerTests.swift
+++ b/Tests/localvoxtralTests/BackendInstallerTests.swift
@@ -362,9 +362,9 @@ final class BackendInstallerTests: XCTestCase {
         let installer = BackendInstaller(
             layout: BackendInstallLayout(root: makeTemporaryDirectory())
         )
-        XCTAssertEqual(BackendCatalog.mlxLM.installKind, .bundledExecutable)
-        XCTAssertFalse(installer.needsInstallOrUpdate(BackendCatalog.mlxLM))
-        XCTAssertNil(installer.installedVersion(of: BackendCatalog.mlxLM))
+        XCTAssertEqual(BackendCatalog.polishd.installKind, .bundledExecutable)
+        XCTAssertFalse(installer.needsInstallOrUpdate(BackendCatalog.polishd))
+        XCTAssertNil(installer.installedVersion(of: BackendCatalog.polishd))
     }
 
     private func makeTemporaryDirectory() -> URL {

--- a/Tests/localvoxtralTests/BackendManagerTests.swift
+++ b/Tests/localvoxtralTests/BackendManagerTests.swift
@@ -67,12 +67,12 @@ final class BackendManagerTests: XCTestCase {
         XCTAssertEqual(manager.voxmlxStatus, .failed(summary: "wheel unavailable", detail: nil))
     }
 
-    func testPolishingFlagControlsWhetherMLXLMIsTouched() async throws {
+    func testPolishingFlagControlsWhetherPolishdIsTouched() async throws {
         let installer = FakeBackendInstaller(needsInstall: [])
         let modelPreparer = FakeModelPreparer()
         let supervisorFactory = FakeSupervisorFactory()
         supervisorFactory.statesByName[BackendCatalog.voxmlx.displayName] = [.running]
-        supervisorFactory.statesByName[BackendCatalog.mlxLM.displayName] = [.running]
+        supervisorFactory.statesByName[BackendCatalog.polishd.displayName] = [.running]
         let manager = makeManager(
             installer: installer,
             modelPreparer: modelPreparer,
@@ -88,35 +88,35 @@ final class BackendManagerTests: XCTestCase {
         // creation/prepare per backend, voxmlx not re-done by the second call.
         XCTAssertEqual(
             Set(supervisorFactory.createdConfigurations.map(\.name)),
-            [BackendCatalog.voxmlx.displayName, BackendCatalog.mlxLM.displayName]
+            [BackendCatalog.voxmlx.displayName, BackendCatalog.polishd.displayName]
         )
         XCTAssertEqual(supervisorFactory.createdConfigurations.count, 2)
         XCTAssertEqual(
             Set(modelPreparer.prepareCalls.map(\.backendID)),
-            [BackendCatalog.voxmlx.id, BackendCatalog.mlxLM.id]
+            [BackendCatalog.voxmlx.id, BackendCatalog.polishd.id]
         )
         XCTAssertEqual(modelPreparer.prepareCalls.count, 2)
-        XCTAssertEqual(manager.mlxLMStatus, .ready)
+        XCTAssertEqual(manager.polishdStatus, .ready)
 
-        let mlxLMConfiguration = try XCTUnwrap(
+        let polishdConfiguration = try XCTUnwrap(
             supervisorFactory.createdConfigurations
-                .first { $0.name == BackendCatalog.mlxLM.displayName }
+                .first { $0.name == BackendCatalog.polishd.displayName }
         )
         // The bundled helper owns prompt handling internally; the supervisor
         // contract is model id + port + parent-pid tethering.
-        XCTAssertTrue(mlxLMConfiguration.arguments.contains("--parent-pid"))
+        XCTAssertTrue(polishdConfiguration.arguments.contains("--parent-pid"))
         XCTAssertEqual(
-            mlxLMConfiguration.arguments.prefix(2),
+            polishdConfiguration.arguments.prefix(2),
             ["--model", SettingsStore.defaultLLMPolishingModel]
         )
-        XCTAssertFalse(mlxLMConfiguration.arguments.contains("--prompt-cache-size"))
+        XCTAssertFalse(polishdConfiguration.arguments.contains("--prompt-cache-size"))
         // The bundled executable resolves next to the app binary, never from
         // the uv tools tree.
         XCTAssertEqual(
-            mlxLMConfiguration.executableURL.lastPathComponent,
-            BackendCatalog.mlxLM.executableName
+            polishdConfiguration.executableURL.lastPathComponent,
+            BackendCatalog.polishd.executableName
         )
-        XCTAssertFalse(mlxLMConfiguration.executableURL.path.contains("backends"))
+        XCTAssertFalse(polishdConfiguration.executableURL.path.contains("backends"))
     }
 
     func testBundledPolishingBackendNeverEntersInstallPathEvenIfInstallerClaimsNeed() async throws {
@@ -124,22 +124,22 @@ final class BackendManagerTests: XCTestCase {
         // (mis)configured installer that claims the bundled backend needs an
         // install must never be invoked for it — the real installer traps on
         // bundled installs.
-        let installer = FakeBackendInstaller(needsInstall: [BackendCatalog.mlxLM.id])
+        let installer = FakeBackendInstaller(needsInstall: [BackendCatalog.polishd.id])
         let supervisorFactory = FakeSupervisorFactory()
-        supervisorFactory.statesByName[BackendCatalog.mlxLM.displayName] = [.running]
+        supervisorFactory.statesByName[BackendCatalog.polishd.displayName] = [.running]
         let manager = makeManager(installer: installer, supervisorFactory: supervisorFactory)
 
         try await manager.ensureReady(dictation: false, polishing: true)
 
         XCTAssertTrue(installer.installCalls.isEmpty)
-        XCTAssertEqual(manager.mlxLMStatus, .ready)
+        XCTAssertEqual(manager.polishdStatus, .ready)
     }
 
     func testPolishingOnlyEnsureReadyDoesNotTouchVoxmlx() async throws {
         let installer = FakeBackendInstaller(needsInstall: [])
         let modelPreparer = FakeModelPreparer()
         let supervisorFactory = FakeSupervisorFactory()
-        supervisorFactory.statesByName[BackendCatalog.mlxLM.displayName] = [.running]
+        supervisorFactory.statesByName[BackendCatalog.polishd.displayName] = [.running]
         let manager = makeManager(
             installer: installer,
             modelPreparer: modelPreparer,
@@ -148,10 +148,10 @@ final class BackendManagerTests: XCTestCase {
 
         try await manager.ensureReady(dictation: false, polishing: true)
 
-        XCTAssertEqual(supervisorFactory.createdConfigurations.map(\.name), [BackendCatalog.mlxLM.displayName])
-        XCTAssertEqual(modelPreparer.prepareCalls.map(\.backendID), [BackendCatalog.mlxLM.id])
+        XCTAssertEqual(supervisorFactory.createdConfigurations.map(\.name), [BackendCatalog.polishd.displayName])
+        XCTAssertEqual(modelPreparer.prepareCalls.map(\.backendID), [BackendCatalog.polishd.id])
         XCTAssertEqual(manager.voxmlxStatus, .stopped)
-        XCTAssertEqual(manager.mlxLMStatus, .ready)
+        XCTAssertEqual(manager.polishdStatus, .ready)
     }
 
     func testConcurrentEnsureReadyDoesNotDoubleInstall() async throws {
@@ -186,33 +186,33 @@ final class BackendManagerTests: XCTestCase {
         let installer = FakeBackendInstaller(needsInstall: [])
         let supervisorFactory = FakeSupervisorFactory()
         supervisorFactory.statesByName[BackendCatalog.voxmlx.displayName] = [.running]
-        supervisorFactory.statesByName[BackendCatalog.mlxLM.displayName] = [.running]
+        supervisorFactory.statesByName[BackendCatalog.polishd.displayName] = [.running]
         let manager = makeManager(installer: installer, supervisorFactory: supervisorFactory)
 
         try await manager.ensureReady(dictation: true, polishing: true)
         await manager.stopAll()
 
         XCTAssertEqual(supervisorFactory.supervisors[BackendCatalog.voxmlx.displayName]?.stopCallCount, 1)
-        XCTAssertEqual(supervisorFactory.supervisors[BackendCatalog.mlxLM.displayName]?.stopCallCount, 1)
+        XCTAssertEqual(supervisorFactory.supervisors[BackendCatalog.polishd.displayName]?.stopCallCount, 1)
         XCTAssertEqual(manager.voxmlxStatus, .stopped)
-        XCTAssertEqual(manager.mlxLMStatus, .stopped)
+        XCTAssertEqual(manager.polishdStatus, .stopped)
     }
 
-    func testStopPolishingStopsOnlyMLXLM() async throws {
+    func testStopPolishingStopsOnlyPolishd() async throws {
         let installer = FakeBackendInstaller(needsInstall: [])
         let supervisorFactory = FakeSupervisorFactory()
         supervisorFactory.statesByName[BackendCatalog.voxmlx.displayName] = [.running]
-        supervisorFactory.statesByName[BackendCatalog.mlxLM.displayName] = [.running]
+        supervisorFactory.statesByName[BackendCatalog.polishd.displayName] = [.running]
         let manager = makeManager(installer: installer, supervisorFactory: supervisorFactory)
 
         try await manager.ensureReady(dictation: true, polishing: true)
         XCTAssertEqual(manager.voxmlxStatus, .ready)
-        XCTAssertEqual(manager.mlxLMStatus, .ready)
+        XCTAssertEqual(manager.polishdStatus, .ready)
 
         await manager.stopPolishing()
 
-        XCTAssertEqual(supervisorFactory.supervisors[BackendCatalog.mlxLM.displayName]?.stopCallCount, 1)
-        XCTAssertEqual(manager.mlxLMStatus, .stopped)
+        XCTAssertEqual(supervisorFactory.supervisors[BackendCatalog.polishd.displayName]?.stopCallCount, 1)
+        XCTAssertEqual(manager.polishdStatus, .stopped)
         XCTAssertEqual(supervisorFactory.supervisors[BackendCatalog.voxmlx.displayName]?.stopCallCount, 0)
         XCTAssertEqual(manager.voxmlxStatus, .ready)
     }
@@ -221,7 +221,7 @@ final class BackendManagerTests: XCTestCase {
         let installer = FakeBackendInstaller(needsInstall: [])
         let modelPreparer = FakeModelPreparer()
         let supervisorFactory = FakeSupervisorFactory()
-        supervisorFactory.statesByName[BackendCatalog.mlxLM.displayName] = [.running]
+        supervisorFactory.statesByName[BackendCatalog.polishd.displayName] = [.running]
         let settings = SettingsStore(
             defaults: UserDefaults(suiteName: UUID().uuidString)!
         )
@@ -234,7 +234,7 @@ final class BackendManagerTests: XCTestCase {
 
         try await manager.ensureReady(dictation: false, polishing: true)
         let firstSupervisor = try XCTUnwrap(
-            supervisorFactory.supervisors[BackendCatalog.mlxLM.displayName]
+            supervisorFactory.supervisors[BackendCatalog.polishd.displayName]
         )
 
         settings.managedLLMPolishingModel = "example/new-polishing-model"
@@ -263,9 +263,9 @@ final class BackendManagerTests: XCTestCase {
         // both writing the same HF cache blob. Stop must not return until the
         // cancelled ensure (and its downloader) fully unwound.
         let installer = FakeBackendInstaller(needsInstall: [])
-        let modelPreparer = FakeModelPreparer(suspendBackendIDs: [BackendCatalog.mlxLM.id])
+        let modelPreparer = FakeModelPreparer(suspendBackendIDs: [BackendCatalog.polishd.id])
         let supervisorFactory = FakeSupervisorFactory()
-        supervisorFactory.statesByName[BackendCatalog.mlxLM.displayName] = [.running]
+        supervisorFactory.statesByName[BackendCatalog.polishd.displayName] = [.running]
         let manager = makeManager(
             installer: installer,
             modelPreparer: modelPreparer,
@@ -280,12 +280,12 @@ final class BackendManagerTests: XCTestCase {
         await manager.stopPolishing()
 
         // The cancelled prepare observed its termination BEFORE stop returned…
-        XCTAssertEqual(modelPreparer.terminatedBackendIDs, [BackendCatalog.mlxLM.id])
+        XCTAssertEqual(modelPreparer.terminatedBackendIDs, [BackendCatalog.polishd.id])
         // …so a new ensure starts fresh instead of joining the dead
         // single-flight task (which would rethrow its CancellationError).
         try await manager.ensureReady(dictation: false, polishing: true)
         XCTAssertEqual(modelPreparer.prepareCalls.count, 2)
-        XCTAssertEqual(manager.mlxLMStatus, .ready)
+        XCTAssertEqual(manager.polishdStatus, .ready)
         _ = await firstEnsure.result
     }
 
@@ -293,19 +293,19 @@ final class BackendManagerTests: XCTestCase {
         let installer = FakeBackendInstaller(needsInstall: [])
         let supervisorFactory = FakeSupervisorFactory()
         supervisorFactory.statesByName[BackendCatalog.voxmlx.displayName] = [.running]
-        supervisorFactory.statesByName[BackendCatalog.mlxLM.displayName] = [.running]
+        supervisorFactory.statesByName[BackendCatalog.polishd.displayName] = [.running]
         let manager = makeManager(installer: installer, supervisorFactory: supervisorFactory)
 
         try await manager.ensureReady(dictation: true, polishing: true)
         XCTAssertEqual(manager.voxmlxStatus, .ready)
-        XCTAssertEqual(manager.mlxLMStatus, .ready)
+        XCTAssertEqual(manager.polishdStatus, .ready)
 
         await manager.stopDictation()
 
         XCTAssertEqual(supervisorFactory.supervisors[BackendCatalog.voxmlx.displayName]?.stopCallCount, 1)
         XCTAssertEqual(manager.voxmlxStatus, .stopped)
-        XCTAssertEqual(supervisorFactory.supervisors[BackendCatalog.mlxLM.displayName]?.stopCallCount, 0)
-        XCTAssertEqual(manager.mlxLMStatus, .ready)
+        XCTAssertEqual(supervisorFactory.supervisors[BackendCatalog.polishd.displayName]?.stopCallCount, 0)
+        XCTAssertEqual(manager.polishdStatus, .ready)
     }
 
     func testSupervisorStateMirrorMarksLaterFailureAndNextEnsureDoesNotShortCircuit() async throws {
@@ -334,7 +334,7 @@ final class BackendManagerTests: XCTestCase {
         let installer = FakeBackendInstaller(needsInstall: [])
         let supervisorFactory = FakeSupervisorFactory()
         supervisorFactory.statesByName[BackendCatalog.voxmlx.displayName] = [.running]
-        supervisorFactory.statesByName[BackendCatalog.mlxLM.displayName] = [.running]
+        supervisorFactory.statesByName[BackendCatalog.polishd.displayName] = [.running]
         let manager = makeManager(installer: installer, supervisorFactory: supervisorFactory)
 
         try await manager.ensureReady(dictation: true, polishing: true)
@@ -351,7 +351,7 @@ final class BackendManagerTests: XCTestCase {
                 // run; the bundled polishing helper only loads pre-downloaded
                 // weights.
                 BackendCatalog.voxmlx.displayName: .seconds(1800),
-                BackendCatalog.mlxLM.displayName: .seconds(300),
+                BackendCatalog.polishd.displayName: .seconds(300),
             ]
         )
     }
@@ -399,7 +399,7 @@ final class BackendManagerTests: XCTestCase {
         let modelPreparer = FakeModelPreparer()
         let supervisorFactory = FakeSupervisorFactory()
         supervisorFactory.statesByName[BackendCatalog.voxmlx.displayName] = [.running]
-        supervisorFactory.statesByName[BackendCatalog.mlxLM.displayName] = [.running]
+        supervisorFactory.statesByName[BackendCatalog.polishd.displayName] = [.running]
         let manager = makeManager(
             installer: installer,
             modelPreparer: modelPreparer,
@@ -417,7 +417,7 @@ final class BackendManagerTests: XCTestCase {
             ),
             [
                 BackendCatalog.voxmlx.id: SettingsStore.RealtimeProvider.realtimeAPI.defaultModelName,
-                BackendCatalog.mlxLM.id: SettingsStore.defaultLLMPolishingModel,
+                BackendCatalog.polishd.id: SettingsStore.defaultLLMPolishingModel,
             ]
         )
     }
@@ -427,7 +427,7 @@ final class BackendManagerTests: XCTestCase {
         let modelPreparer = FakeModelPreparer()
         let supervisorFactory = FakeSupervisorFactory()
         supervisorFactory.statesByName[BackendCatalog.voxmlx.displayName] = [.running]
-        supervisorFactory.statesByName[BackendCatalog.mlxLM.displayName] = [.running]
+        supervisorFactory.statesByName[BackendCatalog.polishd.displayName] = [.running]
         let manager = makeManager(
             installer: installer,
             modelPreparer: modelPreparer,
@@ -473,9 +473,9 @@ final class BackendManagerTests: XCTestCase {
 
     func testStopPolishingCancelsInFlightEnsureBeforeSupervisorCanStart() async throws {
         let installer = FakeBackendInstaller(needsInstall: [])
-        let modelPreparer = FakeModelPreparer(suspendBackendIDs: [BackendCatalog.mlxLM.id])
+        let modelPreparer = FakeModelPreparer(suspendBackendIDs: [BackendCatalog.polishd.id])
         let supervisorFactory = FakeSupervisorFactory()
-        supervisorFactory.statesByName[BackendCatalog.mlxLM.displayName] = [.running]
+        supervisorFactory.statesByName[BackendCatalog.polishd.displayName] = [.running]
         let manager = makeManager(
             installer: installer,
             modelPreparer: modelPreparer,
@@ -497,9 +497,9 @@ final class BackendManagerTests: XCTestCase {
             XCTFail("expected CancellationError, got \(error)")
         }
 
-        XCTAssertEqual(modelPreparer.terminatedBackendIDs, [BackendCatalog.mlxLM.id])
+        XCTAssertEqual(modelPreparer.terminatedBackendIDs, [BackendCatalog.polishd.id])
         XCTAssertTrue(supervisorFactory.createdConfigurations.isEmpty)
-        XCTAssertEqual(manager.mlxLMStatus, .stopped)
+        XCTAssertEqual(manager.polishdStatus, .stopped)
     }
 
     func testModelPreparationFailureMarksBackendFailedWithDetails() async {
@@ -540,7 +540,7 @@ final class BackendManagerTests: XCTestCase {
         let installer = FakeBackendInstaller(needsInstall: [])
         let supervisorFactory = FakeSupervisorFactory()
         supervisorFactory.statesByName[BackendCatalog.voxmlx.displayName] = [.running]
-        supervisorFactory.statesByName[BackendCatalog.mlxLM.displayName] = [
+        supervisorFactory.statesByName[BackendCatalog.polishd.displayName] = [
             .failed(
                 summary: "polishd exited 5 consecutive times.",
                 detail: "stderr: traceback \(marker)"
@@ -563,7 +563,7 @@ final class BackendManagerTests: XCTestCase {
         }
 
         XCTAssertEqual(
-            manager.mlxLMStatus,
+            manager.polishdStatus,
             .failed(
                 summary: "polishd exited 5 consecutive times.",
                 detail: "stderr: traceback \(marker)"
@@ -576,7 +576,7 @@ final class BackendManagerTests: XCTestCase {
         let supervisorFactory = FakeSupervisorFactory()
         // voxmlx never reaches .running: its ensure blocks awaiting readiness.
         supervisorFactory.statesByName[BackendCatalog.voxmlx.displayName] = []
-        supervisorFactory.statesByName[BackendCatalog.mlxLM.displayName] = [.running]
+        supervisorFactory.statesByName[BackendCatalog.polishd.displayName] = [.running]
         let manager = makeManager(installer: installer, supervisorFactory: supervisorFactory)
 
         let stuckDictation = Task { try await manager.ensureReady(dictation: true, polishing: false) }
@@ -586,11 +586,11 @@ final class BackendManagerTests: XCTestCase {
 
         // Field regression (2026-07-04): with one shared single-flight slot,
         // this joined the stuck dictation run — whose flags never covered
-        // polishing — and silently never started mlx-lm.
+        // polishing — and silently never started polishd.
         try await manager.ensureReady(dictation: false, polishing: true)
-        XCTAssertEqual(manager.mlxLMStatus, .ready)
+        XCTAssertEqual(manager.polishdStatus, .ready)
         XCTAssertEqual(
-            supervisorFactory.supervisors[BackendCatalog.mlxLM.displayName]?.startCallCount, 1
+            supervisorFactory.supervisors[BackendCatalog.polishd.displayName]?.startCallCount, 1
         )
 
         stuckDictation.cancel()
@@ -601,18 +601,18 @@ final class BackendManagerTests: XCTestCase {
         let installer = FakeBackendInstaller(needsInstall: [])
         let supervisorFactory = FakeSupervisorFactory()
         supervisorFactory.statesByName[BackendCatalog.voxmlx.displayName] = [.running]
-        supervisorFactory.statesByName[BackendCatalog.mlxLM.displayName] = [.running]
+        supervisorFactory.statesByName[BackendCatalog.polishd.displayName] = [.running]
         let manager = makeManager(installer: installer, supervisorFactory: supervisorFactory)
 
         // First dictation: polishing disabled at the time.
         try await manager.ensureReady(dictation: true, polishing: false)
         XCTAssertEqual(manager.voxmlxStatus, .ready)
-        XCTAssertEqual(manager.mlxLMStatus, .stopped)
+        XCTAssertEqual(manager.polishdStatus, .stopped)
 
-        // User enables polishing, dictates again: mlx-lm must come up now.
+        // User enables polishing, dictates again: polishd must come up now.
         try await manager.ensureReady(dictation: true, polishing: true)
-        XCTAssertEqual(manager.mlxLMStatus, .ready)
-        XCTAssertEqual(supervisorFactory.supervisors[BackendCatalog.mlxLM.displayName]?.startCallCount, 1)
+        XCTAssertEqual(manager.polishdStatus, .ready)
+        XCTAssertEqual(supervisorFactory.supervisors[BackendCatalog.polishd.displayName]?.startCallCount, 1)
     }
 
     private func makeManager(

--- a/Tests/localvoxtralTests/DiagnosticsExporterTests.swift
+++ b/Tests/localvoxtralTests/DiagnosticsExporterTests.swift
@@ -47,16 +47,16 @@ final class DiagnosticsExporterTests: XCTestCase {
     private func makeSnapshot(
         settings: SettingsStore,
         voxmlxStatus: ManagedBackendStatus = .notInstalled,
-        mlxLMStatus: ManagedBackendStatus = .notInstalled,
+        polishdStatus: ManagedBackendStatus = .notInstalled,
         voxmlxRecentOutput: [String] = [],
-        mlxLMRecentOutput: [String] = []
+        polishdRecentOutput: [String] = []
     ) -> DiagnosticsSnapshot {
         DiagnosticsExporter.makeSnapshot(
             settings: settings,
             voxmlxStatus: voxmlxStatus,
-            mlxLMStatus: mlxLMStatus,
+            polishdStatus: polishdStatus,
             voxmlxRecentOutput: voxmlxRecentOutput,
-            mlxLMRecentOutput: mlxLMRecentOutput
+            polishdRecentOutput: polishdRecentOutput
         )
     }
 
@@ -87,7 +87,7 @@ final class DiagnosticsExporterTests: XCTestCase {
         let snapshot = makeSnapshot(
             settings: store,
             voxmlxRecentOutput: ["[voxmlx stdout] INFO started", "[voxmlx stderr] listening"],
-            mlxLMRecentOutput: ["[mlx-lm stdout] ready"]
+            polishdRecentOutput: ["[localvoxtral-polishd stdout] ready"]
         )
         let report = DiagnosticsExporter.makeReport(snapshot: snapshot, now: Date())
 
@@ -95,7 +95,7 @@ final class DiagnosticsExporterTests: XCTestCase {
         XCTAssertTrue(report.contains("[voxmlx stdout] INFO started"))
         XCTAssertTrue(report.contains("[voxmlx stderr] listening"))
         XCTAssertTrue(report.contains("-- localvoxtral-polishd --"))
-        XCTAssertTrue(report.contains("[mlx-lm stdout] ready"))
+        XCTAssertTrue(report.contains("[localvoxtral-polishd stdout] ready"))
     }
 
     // MARK: - API key redaction (the core privacy property)

--- a/Tests/localvoxtralTests/DictationViewModelFailFastUXTests.swift
+++ b/Tests/localvoxtralTests/DictationViewModelFailFastUXTests.swift
@@ -382,7 +382,7 @@ final class DictationViewModelFailFastUXTests: XCTestCase {
 
         await emitStatusAndAwaitMirror(
             backendManager, viewModel: viewModel,
-            spec: BackendCatalog.mlxLM,
+            spec: BackendCatalog.polishd,
             status: .preparingModel(progress: ModelDownloadProgress(downloadedBytes: 1, totalBytes: 4))
         )
 
@@ -591,7 +591,7 @@ final class DictationViewModelFailFastUXTests: XCTestCase {
         viewModel.applyDictationBackendModeChange(.managedLocal)
         await backendManager.waitUntilEnsureStarted()
 
-        // Turning polishing off must stop mlx-lm only — the voxmlx warmup keeps
+        // Turning polishing off must stop polishd only — the voxmlx warmup keeps
         // its own task slot and must survive (regression: a shared slot let this
         // cancel the in-flight dictation warmup).
         viewModel.llmPolishingEnabledDidChange(false)
@@ -636,7 +636,7 @@ final class DictationViewModelFailFastUXTests: XCTestCase {
 
     /// Shortcuts mode with no Overlay Buffer shortcut and the menu-bar output
     /// mode on Live Auto-Paste: no trigger can start an Overlay Buffer session,
-    /// so enabling polishing must not start managed mlx-lm.
+    /// so enabling polishing must not start managed polishd.
     func testPolishingEnableSkipsWarmupWhenOverlayBufferUnreachable() async {
         let backendManager = FakeManagedBackendManager()
         let viewModel = makeViewModel(outputMode: .liveAutoPaste, backendManager: backendManager)
@@ -673,7 +673,7 @@ final class DictationViewModelFailFastUXTests: XCTestCase {
 
     /// With the single-modifier gesture active, tap always starts an Overlay
     /// Buffer session, so switching the menu-bar output mode to Live Auto-Paste
-    /// must keep managed mlx-lm running (regression: the old check stopped it).
+    /// must keep managed polishd running (regression: the old check stopped it).
     func testOutputModeSwitchToLiveKeepsPolishingWhenGestureConfigured() async {
         let backendManager = FakeManagedBackendManager()
         let viewModel = makeViewModel(outputMode: .overlayBuffer, backendManager: backendManager)
@@ -691,7 +691,7 @@ final class DictationViewModelFailFastUXTests: XCTestCase {
 
     /// Exact field repro (2026-07-06): shortcuts mode, menu-bar output mode
     /// still on Overlay Buffer, user clears the Overlay Buffer shortcut —
-    /// polishing must become unavailable and managed mlx-lm must stop. The
+    /// polishing must become unavailable and managed polishd must stop. The
     /// menu-bar output mode does not count as a trigger.
     func testClearingOverlayShortcutStopsManagedPolishing() async {
         let backendManager = FakeManagedBackendManager()
@@ -740,7 +740,7 @@ final class DictationViewModelFailFastUXTests: XCTestCase {
         retainForTestProcessLifetime(viewModel)
 
         // Off then immediately on: the queued stop must never run, or it lands
-        // after the warmup and stops the mlx-lm the settings now require.
+        // after the warmup and stops the polishd the settings now require.
         viewModel.llmPolishingEnabledDidChange(false)
         viewModel.llmPolishingEnabledDidChange(true)
         await viewModel.polishingWarmupTask?.value
@@ -780,7 +780,7 @@ final class DictationViewModelFailFastUXTests: XCTestCase {
         XCTAssertNil(viewModel.polishingWarmupTask)
     }
 
-    // MARK: - LLM polishing enable toggle stops managed mlx-lm
+    // MARK: - LLM polishing enable toggle stops managed polishd
 
     func testLLMPolishingDisabledInManagedModeStopsPolishing() async {
         let backendManager = FakeManagedBackendManager()
@@ -864,7 +864,7 @@ final class DictationViewModelFailFastUXTests: XCTestCase {
     }
 
     /// The menu-bar output mode is not a reachability input: switching it in
-    /// either direction must never start or stop managed mlx-lm.
+    /// either direction must never start or stop managed polishd.
     func testDictationOutputModeSwitchesNeverTouchManagedPolishing() async {
         let backendManager = FakeManagedBackendManager()
         let viewModel = makeViewModel(outputMode: .overlayBuffer, backendManager: backendManager)
@@ -1039,7 +1039,7 @@ final class DictationViewModelFailFastUXTests: XCTestCase {
     func testMenuBarIndicatorShowsIdleWhenRequiredManagedBackendsAreReady() {
         let backendManager = FakeManagedBackendManager()
         backendManager.voxmlxStatus = .ready
-        backendManager.mlxLMStatus = .ready
+        backendManager.polishdStatus = .ready
         let viewModel = makeViewModel(outputMode: .overlayBuffer, backendManager: backendManager)
         viewModel.settings.dictationBackendMode = .managedLocal
         viewModel.settings.polishingBackendMode = .managedLocal
@@ -1054,7 +1054,7 @@ final class DictationViewModelFailFastUXTests: XCTestCase {
     func testMenuBarIndicatorShowsIdleForExternalModesEvenWhenManagedBackendsAreStopped() {
         let backendManager = FakeManagedBackendManager()
         backendManager.voxmlxStatus = .stopped
-        backendManager.mlxLMStatus = .failed(summary: "mlx-lm failed to start.", detail: "trace")
+        backendManager.polishdStatus = .failed(summary: "mlx-lm failed to start.", detail: "trace")
         let viewModel = makeViewModel(outputMode: .overlayBuffer, backendManager: backendManager)
         viewModel.settings.dictationBackendMode = .externalURL
         viewModel.settings.polishingBackendMode = .externalURL
@@ -1069,7 +1069,7 @@ final class DictationViewModelFailFastUXTests: XCTestCase {
     func testMenuBarIndicatorShowsFailureWhenRequiredManagedPolishingBackendFailed() {
         let backendManager = FakeManagedBackendManager()
         backendManager.voxmlxStatus = .ready
-        backendManager.mlxLMStatus = .failed(summary: "mlx-lm failed to start.", detail: "trace")
+        backendManager.polishdStatus = .failed(summary: "mlx-lm failed to start.", detail: "trace")
         let viewModel = makeViewModel(outputMode: .overlayBuffer, backendManager: backendManager)
         viewModel.settings.dictationBackendMode = .externalURL
         viewModel.settings.polishingBackendMode = .managedLocal
@@ -1084,7 +1084,7 @@ final class DictationViewModelFailFastUXTests: XCTestCase {
     func testMenuBarIndicatorIgnoresManagedBackendReadinessUntilOnboardingCompletes() {
         let backendManager = FakeManagedBackendManager()
         backendManager.voxmlxStatus = .notInstalled
-        backendManager.mlxLMStatus = .notInstalled
+        backendManager.polishdStatus = .notInstalled
         let viewModel = makeViewModel(outputMode: .overlayBuffer, backendManager: backendManager)
         viewModel.settings.dictationBackendMode = .managedLocal
         viewModel.settings.polishingBackendMode = .managedLocal
@@ -1388,7 +1388,7 @@ private final class FakeManagedBackendManager: ManagedBackendManaging {
     }
 
     var voxmlxStatus: ManagedBackendStatus = .notInstalled
-    var mlxLMStatus: ManagedBackendStatus = .notInstalled
+    var polishdStatus: ManagedBackendStatus = .notInstalled
     private var statusUpdateContinuations: [UUID: AsyncStream<ManagedBackendStatusUpdate>.Continuation] = [:]
     var statusUpdates: AsyncStream<ManagedBackendStatusUpdate> {
         let id = UUID()
@@ -1433,7 +1433,7 @@ private final class FakeManagedBackendManager: ManagedBackendManaging {
             emitStatus(spec: BackendCatalog.voxmlx, status: .ready)
         }
         if polishing {
-            emitStatus(spec: BackendCatalog.mlxLM, status: .ready)
+            emitStatus(spec: BackendCatalog.polishd, status: .ready)
         }
     }
 
@@ -1467,8 +1467,8 @@ private final class FakeManagedBackendManager: ManagedBackendManaging {
         switch spec.id {
         case BackendCatalog.voxmlx.id:
             voxmlxStatus = status
-        case BackendCatalog.mlxLM.id:
-            mlxLMStatus = status
+        case BackendCatalog.polishd.id:
+            polishdStatus = status
         default:
             break
         }

--- a/Tests/localvoxtralTests/OnboardingBootstrapDriverTests.swift
+++ b/Tests/localvoxtralTests/OnboardingBootstrapDriverTests.swift
@@ -104,7 +104,7 @@ final class LiveOnboardingBootstrapDriverTests: XCTestCase {
     func testStart_seedsItemStatesFromCurrentBackendStatus() {
         let manager = OnboardingTestBackendManager()
         manager.voxmlxStatus = .installing(progress: .downloading(fraction: 0.5))
-        manager.mlxLMStatus = .notInstalled
+        manager.polishdStatus = .notInstalled
         let driver = LiveOnboardingBootstrapDriver(backendManager: manager)
 
         driver.start(dictation: true, polishing: true)
@@ -244,7 +244,7 @@ final class OnboardingTestBackendManager: ManagedBackendManaging {
     }
 
     var voxmlxStatus: ManagedBackendStatus = .notInstalled
-    var mlxLMStatus: ManagedBackendStatus = .notInstalled
+    var polishdStatus: ManagedBackendStatus = .notInstalled
     @ObservationIgnored private var statusUpdateContinuations: [UUID: AsyncStream<ManagedBackendStatusUpdate>.Continuation] = [:]
     var statusUpdates: AsyncStream<ManagedBackendStatusUpdate> {
         let id = UUID()


### PR DESCRIPTION
## What

The mechanical `mlxLM*` → `polishd*` symbol rename deferred from #84 ("kept to keep that diff reviewable"). Zero behavior change.

- `BackendCatalog.mlxLM` → `.polishd`; `mlxLMStatus/Supervisor/StateMirrorTask/Port/RecentOutput` → `polishd*`; matching test fakes/helpers; stale "managed mlx-lm" comments and log phrases that meant the current engine now say polishd. The obsolete "Swift symbols keep the historical name" catalog comment is gone.
- Deliberately KEPT: `LegacyMLXLMCleanup` (the historical uv-installed Python engine it removes), eval-service/fork-wheel references (`LLMPolishEvalSupport`, prompt-eval tests, probe tests), the external-endpoint 8080 default test name, and on-disk keys/spec ids (already `polishd`).

## Proof

- [x] Unit suite green — `./scripts/remote-build.sh test`
  ```
  Executed 625 tests, with 2 tests skipped and 0 failures (0 unexpected) in 6.761 (6.801) seconds
  ```
- [x] No residual `mlxLM` symbols outside the deliberate keep-list (`git grep`), no UI string changes (log/diagnostics labels only, with their tests updated in the same diff).
- Rename-only diff: 15 files, +172/−173.
