### PR TITLE
CI: keep build caches between runs on the self-hosted runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,31 @@ jobs:
           # Full history + tags so package_app.sh can git-describe the
           # artifact version (shallow clones can't, and fall back to 0.0.0-dev).
           fetch-depth: 0
+          # Keep gitignored build state between runs on the persistent
+          # self-hosted runner. The default `git clean -ffdx` wiped .build/ and
+          # PolishHelper/.build/ (including the helper's xcodebuild
+          # DerivedData) at the start of EVERY run, forcing a cold MLX C++ +
+          # Metal rebuild twice per run — ~4.5 min of a ~7.5 min job. Releases
+          # keep the pristine-tree guarantee (release.yml checks out with the
+          # default clean), and hosted fork-PR runners are ephemeral, so this
+          # only affects same-repo CI. If the runner's incremental state ever
+          # corrupts (e.g. a stale SwiftPM lock from a killed run), one-time
+          # fix: `git clean -ffdx` in the runner's _work/localvoxtral tree.
+          clean: false
+
+      - name: Clean stale outputs (keep build caches)
+        # clean: false above skips git clean entirely, so outputs a previous
+        # run generated must be removed by hand — but NOT the build caches.
+        # Also repair the smoke test's .build rename if a cancelled run died
+        # mid-smoke (its EXIT trap doesn't run on SIGKILL): a leftover
+        # .build.smoke-hidden would make the next run's `mv` nest one dir
+        # inside the other and silently corrupt the cache.
+        run: |
+          if [[ -d .build.smoke-hidden ]]; then
+            rm -rf .build
+            mv .build.smoke-hidden .build
+          fi
+          rm -rf dist format-lint.txt default.profraw
 
       - name: Setup Swift
         if: runner.environment == 'github-hosted'


### PR DESCRIPTION
## What

CI's biggest time sinks were two cold rebuilds of the MLX Swift dependency graph **per run**: `swift test --package-path PolishHelper` (~110 s) and the packaging step's helper xcodebuild (~165 s). The cause is `actions/checkout`'s default `clean: true` — its `git clean -ffdx` wiped `.build/` and `PolishHelper/.build/` (including the helper's xcodebuild DerivedData) at the start of every run, defeating the persistent-workspace rationale for the self-hosted runner (log excerpt from run 29041039190):

```
##[group]Cleaning the repository
[command]/usr/bin/git clean -ffdx
Removing .build/
Removing PolishHelper/.build/
```

This PR sets `clean: false` and replaces the blanket wipe with a surgical cleanup of run outputs only (`dist/`, `format-lint.txt`, `default.profraw`), plus a repair for a half-finished smoke-test `.build` rename if a killed run skipped its EXIT trap.

Safety valves kept:
- `release.yml` checks out with the default clean → release artifacts still build from a pristine tree.
- Hosted fork-PR runners are ephemeral → unaffected.
- The packaged-launch smoke test still runs the app copied outside the workspace with `.build` hidden.
- If the runner's incremental state ever corrupts, the one-time fix is `git clean -ffdx` in the runner's work tree (documented in the workflow comment).

## Proof

Step timings, baseline (runs 29041039190 / 29040992741 / 29039282620 / 29039312293) vs this PR's two runs. Run 1 (29043073428) inherited a half-built workspace from a cancelled run; run 2 (29044139757, empty commit) shows the steady-state warm floor:

| Step | Baseline | Run 1 | Run 2 (steady state) |
|---|---|---|---|
| Build | 14–19 s | 2 s | 6 s |
| Test (unit suite) | 22–24 s | 17 s | 16 s |
| Integration tests (live voxmlx) | 28–41 s | 29 s | 28 s |
| Polishing helper unit tests | 103–127 s | 38 s | **11 s** |
| Package app bundle | 164–211 s | 178 s* | **32 s** |
| Polishing helper integration | 14–31 s | 14 s | 11 s |
| **Total job** | **6.5–9.5 min** | 5m02s | **2m07s** |

\* Run 1's packaging was still cold: the workspace it inherited came from a run cancelled after its `git clean` but before its helper build, so the xcodebuild DerivedData didn't exist yet.

Both runs green end-to-end on the self-hosted lane: unit suite, live voxmlx integration, PolishHelper unit suite, packaging + codesign identity check, polishd live-model eval baseline, packaged-launch smoke test.

- [x] Warm-run step timings pasted (two consecutive runs)
- [x] Unit + integration suites green on this PR's CI (runs 29043073428, 29044139757)
