### PR TITLE
Polishd integration teardown: reap the helper, don't just signal it

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,9 +56,13 @@ jobs:
         # print those records so the culprit is named. Process names only, no
         # command lines: this log is public.
         if: runner.environment == 'self-hosted'
+        # The Worker log embeds each job's full message JSON, and any PR body
+        # or commit message containing "orphan" floods a bare grep (this PR's
+        # own does). Termination records are plain trace lines with no quote
+        # characters; JSON payload lines always have them — filter on that.
         run: |
           grep -h -i "orphan" "$HOME"/actions-runner/_diag/Worker_*.log 2>/dev/null \
-            | grep -v "Cleaning up orphan processes" | tail -n 60 \
+            | grep -v '"' | tail -n 60 \
             || echo "no orphan-termination records found in Worker logs"
 
       - name: Setup Swift

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,24 +49,6 @@ jobs:
           fi
           rm -rf dist format-lint.txt default.profraw
 
-      - name: TEMP diagnostic — name past orphan-process kills (remove before merge)
-        # 4 of the last 25 runs spent ~105 s in the post-job "Cleaning up
-        # orphan processes" phase. The runner's own Worker logs record which
-        # processes it reaped ("Terminate orphan process: pid (N) (name)") —
-        # print those records so the culprit is named. Process names only, no
-        # command lines: this log is public.
-        if: runner.environment == 'self-hosted'
-        # v3: v2 proved the Worker logs contain NO 'Terminate orphan process'
-        # records — the ~105 s is spent inside the cleanup phase itself, not
-        # killing a named process. Print the timestamped trace context around
-        # the phase so the slow operation is visible. Quote-filter drops job
-        # message JSON (PR bodies mentioning 'orphan' flooded v1).
-        run: |
-          grep -h -A 20 "Cleaning up orphan processes" \
-            "$HOME"/actions-runner/_diag/Worker_*.log 2>/dev/null \
-            | grep -v '"' | tail -n 120 \
-            || echo "phase marker not found in Worker logs"
-
       - name: Setup Swift
         if: runner.environment == 'github-hosted'
         uses: swift-actions/setup-swift@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,18 @@ jobs:
           fi
           rm -rf dist format-lint.txt default.profraw
 
+      - name: TEMP diagnostic — name past orphan-process kills (remove before merge)
+        # 4 of the last 25 runs spent ~105 s in the post-job "Cleaning up
+        # orphan processes" phase. The runner's own Worker logs record which
+        # processes it reaped ("Terminate orphan process: pid (N) (name)") —
+        # print those records so the culprit is named. Process names only, no
+        # command lines: this log is public.
+        if: runner.environment == 'self-hosted'
+        run: |
+          grep -h -i "orphan" "$HOME"/actions-runner/_diag/Worker_*.log 2>/dev/null \
+            | grep -v "Cleaning up orphan processes" | tail -n 60 \
+            || echo "no orphan-termination records found in Worker logs"
+
       - name: Setup Swift
         if: runner.environment == 'github-hosted'
         uses: swift-actions/setup-swift@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -270,3 +270,22 @@ jobs:
             process.kill()
             process.wait(timeout=5)
           PY
+
+      - name: Process leak check (informational)
+        # ~15% of runs spend ~105 s in the runner's post-job "Cleaning up
+        # orphan processes" phase, and the Worker logs don't name what it
+        # reaps. Snapshot candidate survivors at job end so any future
+        # occurrence identifies itself. Short process names only (ucomm, no
+        # paths or arguments): this log is public. Informational — never
+        # fails the job.
+        if: ${{ always() && runner.environment == 'self-hosted' }}
+        run: |
+          survivors="$(ps -axo pid,etime,ucomm \
+            | grep -iE 'localvoxtral|polishd|xctest|swiftpm-testing|XCBBuildService' \
+            | grep -v grep || true)"
+          if [[ -n "$survivors" ]]; then
+            echo "candidate processes still alive at job end:"
+            echo "$survivors"
+          else
+            echo "no candidate processes alive at job end"
+          fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,14 +56,16 @@ jobs:
         # print those records so the culprit is named. Process names only, no
         # command lines: this log is public.
         if: runner.environment == 'self-hosted'
-        # The Worker log embeds each job's full message JSON, and any PR body
-        # or commit message containing "orphan" floods a bare grep (this PR's
-        # own does). Termination records are plain trace lines with no quote
-        # characters; JSON payload lines always have them — filter on that.
+        # v3: v2 proved the Worker logs contain NO 'Terminate orphan process'
+        # records — the ~105 s is spent inside the cleanup phase itself, not
+        # killing a named process. Print the timestamped trace context around
+        # the phase so the slow operation is visible. Quote-filter drops job
+        # message JSON (PR bodies mentioning 'orphan' flooded v1).
         run: |
-          grep -h -i "orphan" "$HOME"/actions-runner/_diag/Worker_*.log 2>/dev/null \
-            | grep -v '"' | tail -n 60 \
-            || echo "no orphan-termination records found in Worker logs"
+          grep -h -A 20 "Cleaning up orphan processes" \
+            "$HOME"/actions-runner/_diag/Worker_*.log 2>/dev/null \
+            | grep -v '"' | tail -n 120 \
+            || echo "phase marker not found in Worker logs"
 
       - name: Setup Swift
         if: runner.environment == 'github-hosted'

--- a/Tests/localvoxtralTests/PolishHelperIntegrationTests.swift
+++ b/Tests/localvoxtralTests/PolishHelperIntegrationTests.swift
@@ -209,8 +209,23 @@ final class PolishHelperIntegrationTests: XCTestCase {
         try process.run()
         reader.start()
         addTeardownBlock {
+            // Reap, don't just signal: SIGTERM is asynchronous, so a teardown
+            // that only calls terminate() lets the test process exit while the
+            // helper is still dying — the CI runner then spends ~105 s per run
+            // reaping the orphan ("Cleaning up orphan processes"). Wait for the
+            // exit (bounded), and escalate to SIGKILL if it never comes.
             if process.isRunning {
                 process.terminate()
+            }
+            let reaped = XCTestExpectation(description: "helper exited after SIGTERM")
+            DispatchQueue.global().async {
+                process.waitUntilExit()  // returns immediately if already exited
+                reaped.fulfill()
+            }
+            _ = await XCTWaiter.fulfillment(of: [reaped], timeout: 10)
+            if process.isRunning {
+                kill(process.processIdentifier, SIGKILL)
+                process.waitUntilExit()
             }
         }
 


### PR DESCRIPTION
## What

4 of the last 25 CI runs spent ~105 s in the runner's post-job "Cleaning up orphan processes" phase (e.g. runs 29041039190, 29037979725, 29034554098 — always ~105–107 s), and the latest runs still pay ~25 s there. Two changes:

1. **`PolishHelperIntegrationTests` teardown now reaps the helper instead of fire-and-forget signaling it**: SIGTERM → bounded 10 s wait on `waitUntilExit` → SIGKILL escalation. The old teardown returned immediately after `terminate()`, so the test process could exit while the helper was still dying, leaving it for the runner's reaper.
2. **Permanent informational "Process leak check" step at job end** (self-hosted, `if: always()`, never fails the job): snapshots surviving candidate processes (short names only — the log is public) so any future lingerer names itself in the run where it appears, instead of needing log archaeology.

## Investigation trail (what the ~105 s actually is)

- polishd installs **no signal handlers** (verified: no `signal`/`SIGTERM` handling anywhere in `PolishHelper/Sources`), so a hung graceful shutdown is ruled out; the only helper-side orphan path was the teardown race fixed here.
- A TEMP diagnostic (since dropped) proved the runner's `_diag/Worker_*.log` files contain **no per-process reap records** — the historical culprit could not be recovered from logs.
- The new leak check immediately caught a live one on its first run (29054255586):

```
candidate processes still alive at job end:
61519    07:39:12 xctest
```

A **wedged `xctest` process alive for 7h39m** (started ~14:46 today, surviving every orphan-cleanup phase since) — consistent with the reaper repeatedly fighting an unkillable/slow-dying test runner. That PID needs a one-time manual `kill` on the runner Mac; the teardown fix prevents the polishd-side variant, and the leak check will name any recurrence in the run that creates it.

## Proof

- `PolishHelperIntegrationTests` (live pinned model, production request path, eval baseline, parent-pid tether) green with the reaping teardown: runs 29044353355, 29053854733, 29054255586.
- Leak-check output above is from run 29054255586 (real capture, first run of the step).
- Post-merge monitoring: "Complete job" durations should return to ~0–1 s once the wedged xctest is killed; any new lingerer will be named by the leak check in the offending run.
