### PR TITLE
Repo vocabulary: index the focused terminal's repo, hint the polisher (opt-in, loopback-only)

### DIFF
--- a/Sources/localvoxtral/AppConfigStore.swift
+++ b/Sources/localvoxtral/AppConfigStore.swift
@@ -220,6 +220,14 @@ struct LLMPromptTemplates: Equatable, Sendable {
     private static let userPromptPlaceholderPattern = #"\{\{[a-zA-Z0-9_]+\}\}"#
     private static let splitPlaceholders = ["{{replacement_dictionary}}", "{{input_text}}"]
 
+    /// True when the user template carries the OPTIONAL dictionary placeholder.
+    /// The placeholder is documented as removable; features that ride in that
+    /// slot (repo vocabulary) must check this BEFORE doing any work, because
+    /// `renderTemplate` silently drops the section when the slot is absent.
+    var supportsReplacementDictionary: Bool {
+        userContent.contains("{{replacement_dictionary}}")
+    }
+
     func renderedUserPrompt(
         inputText: String,
         replacementDictionary: String

--- a/Sources/localvoxtral/DictationViewModel+Session.swift
+++ b/Sources/localvoxtral/DictationViewModel+Session.swift
@@ -626,59 +626,113 @@ extension DictationViewModel {
                 let capturedPolishProfile = polishProfile.rawValue
                 let promptTemplates = appConfigStore.loadLLMPromptTemplates(profile: polishProfile)
 
-                var userPrompts = promptTemplates.renderedUserPrompts(
-                    inputText: workingText,
-                    replacementDictionary: replacementDictionaryPrompt
-                )
-                // Opt-in clipboard grounding: prepend ONE reference-context
-                // block to the FINAL user message that lets the polish model
-                // fix near-miss spelling of technical terms against whatever
-                // the user just copied. When the setting is off OR the
-                // polishing endpoint is not loopback, the pasteboard is never
-                // read (privacy).
-                let capturedPolishContextSummary: String?
-                // The excerpt is retained for the post-polish leak guard: the
-                // model output must never smuggle clipboard content into the
-                // committed text.
-                let capturedClipboardExcerpt: String?
-                if let endpointURL = polishingConfig?.endpointURL,
-                   let clipboardContext = polishClipboardContextIfEnabled(endpointURL: endpointURL)
-                {
-                    // Prompt-cache safety: polishd checkpoints ALL-BUT-LAST
-                    // messages as its single-slot prefix cache, so per-request
-                    // context must ride INSIDE the last message — a separate
-                    // context message between prefix and suffix invalidated
-                    // the checkpoint on every request and a cold 4B re-prefill
-                    // blew the polish client timeout (field, 2026-07-11).
-                    // Prepended, never appended: the working text stays LAST
-                    // in the message (this model family echoes instructions
-                    // placed after the input text).
-                    let lastIndex = userPrompts.count - 1
-                    userPrompts[lastIndex] =
-                        PolishContextClipboardReader.contextMessage(
-                            excerpt: clipboardContext.excerpt
-                        ) + "\n\n" + userPrompts[lastIndex]
-                    capturedPolishContextSummary = clipboardContext.provenanceSummary
-                    capturedClipboardExcerpt = clipboardContext.excerpt
-                    Log.polishing.info(
-                        "Polish clipboard context attached: \(clipboardContext.provenanceSummary, privacy: .public)"
-                    )
-                } else {
-                    capturedPolishContextSummary = nil
-                    capturedClipboardExcerpt = nil
-                }
-
-                let polishingRequest = LLMPolishingRequest(
-                    inputText: workingText,
-                    systemPrompt: promptTemplates.systemContent,
-                    userPrompts: userPrompts
-                )
-
                 statusText = StatusStrings.polishing
                 debugLog("LLM polishing started for \(workingText.count) chars")
 
+                // Opt-in clipboard grounding is read HERE, pre-Task, right next
+                // to the payload-macro clipboard read above, so both features
+                // observe the SAME pasteboard state — the repo-vocabulary await
+                // inside the Task can take up to ~2 s, and a copy landing during
+                // that window must not make the context ground against different
+                // text than the payload macro substitutes. When the setting is
+                // off OR the polishing endpoint is not loopback, the pasteboard
+                // is never read (privacy).
+                let capturedClipboardContext: PolishClipboardContext?
+                if let endpointURL = polishingConfig?.endpointURL {
+                    capturedClipboardContext = polishClipboardContextIfEnabled(
+                        endpointURL: endpointURL
+                    )
+                } else {
+                    capturedClipboardContext = nil
+                }
+
+                // Repo vocabulary rides in the `{{replacement_dictionary}}`
+                // slot; a user template without that placeholder (removing it is
+                // explicitly supported) silently drops the section in
+                // renderTemplate, so the whole vocabulary path — AX read, git
+                // subprocess, provenance — is skipped up front when the ACTIVE
+                // template can't carry it.
+                let templateCarriesDictionarySlot =
+                    promptTemplates.supportsReplacementDictionary
+
                 polishAndCommitTask = Task { @MainActor [weak self] in
                     guard let self else { return }
+
+                    // The polish request is assembled HERE, inside the Task, so
+                    // the opt-in repo-vocabulary indexing — whose git subprocess
+                    // runs OFF the main actor with a 2 s timeout — can complete
+                    // before the request is built without stalling the commit. On
+                    // timeout / no repo / feature off it is a fast no-op and the
+                    // request is byte-identical to the no-vocabulary path.
+                    var replacementDictionarySection = replacementDictionaryPrompt
+                    var repoVocabularyCount = 0
+                    // The vocabulary corrections we ASK the model to make must
+                    // also be sanctioned through the token guard, or its
+                    // near-miss repair would deterministically revert them
+                    // (the STT's wrong filename-shaped token is what the guard
+                    // protects). (from: spoken alias, to: exact term) pairs.
+                    var sanctionedVocabularyRewrites: [(from: String, to: String)] = []
+                    if templateCarriesDictionarySlot,
+                       let endpointURL = polishingConfig?.endpointURL,
+                       let vocabularyEntries = await self.repoVocabularyEntriesIfEnabled(
+                           endpointURL: endpointURL,
+                           transcript: workingText
+                       )
+                    {
+                        // Append to the replacement-dictionary section string so
+                        // the entries land in the `{{replacement_dictionary}}`
+                        // slot both profiles already carry — dynamic-suffix side
+                        // of the prompt-cache split, never the cached prefix.
+                        replacementDictionarySection = RepoVocabularyMatcher.appendedPromptSection(
+                            base: replacementDictionarySection,
+                            entries: vocabularyEntries
+                        )
+                        repoVocabularyCount = vocabularyEntries.count
+                        sanctionedVocabularyRewrites = vocabularyEntries.flatMap { entry in
+                            entry.matches.map { (from: $0, to: entry.replaceWith) }
+                        }
+                        Log.polishing.info(
+                            "Repo vocabulary attached: \(vocabularyEntries.count, privacy: .public) entries"
+                        )
+                    }
+
+                    guard !Task.isCancelled else { return }
+
+                    var userPrompts = promptTemplates.renderedUserPrompts(
+                        inputText: workingText,
+                        replacementDictionary: replacementDictionarySection
+                    )
+                    // Prepend the pre-captured clipboard reference-context block
+                    // to the FINAL user message (letting the polish model fix
+                    // near-miss spelling of technical terms against what the
+                    // user copied).
+                    var capturedPolishContextSummary: String? = nil
+                    if let clipboardContext = capturedClipboardContext {
+                        // Prompt-cache safety: polishd checkpoints ALL-BUT-LAST
+                        // messages as its single-slot prefix cache, so per-request
+                        // context must ride INSIDE the last message — a separate
+                        // context message between prefix and suffix invalidated
+                        // the checkpoint on every request and a cold 4B re-prefill
+                        // blew the polish client timeout (field, 2026-07-11).
+                        // Prepended, never appended: the working text stays LAST
+                        // in the message (this model family echoes instructions
+                        // placed after the input text).
+                        let lastIndex = userPrompts.count - 1
+                        userPrompts[lastIndex] =
+                            PolishContextClipboardReader.contextMessage(
+                                excerpt: clipboardContext.excerpt
+                            ) + "\n\n" + userPrompts[lastIndex]
+                        capturedPolishContextSummary = clipboardContext.provenanceSummary
+                        Log.polishing.info(
+                            "Polish clipboard context attached: \(clipboardContext.provenanceSummary, privacy: .public)"
+                        )
+                    }
+
+                    let polishingRequest = LLMPolishingRequest(
+                        inputText: workingText,
+                        systemPrompt: promptTemplates.systemContent,
+                        userPrompts: userPrompts
+                    )
 
                     var processedTextForPersistence: String? =
                         workingText != originalText ? workingText : nil
@@ -701,8 +755,14 @@ extension DictationViewModel {
                             // discard the polish and keep the pre-polish text.
                             let guardResult = PolishTokenGuard.verifyAndRepair(
                                 polished: result.polishedText,
-                                original: workingText
+                                original: workingText,
+                                sanctionedReplacements: sanctionedVocabularyRewrites
                             )
+                            if guardResult.sanctionedCount > 0 {
+                                Log.polishing.info(
+                                    "Token guard accepted \(guardResult.sanctionedCount, privacy: .public) sanctioned repo-vocabulary rewrite(s)"
+                                )
+                            }
                             var committedText: String
                             switch guardResult.outcome {
                             case .clean:
@@ -734,12 +794,19 @@ extension DictationViewModel {
                             // (same fallback shape as the token guard).
                             // Counts-only logging — the matched run is
                             // clipboard content.
-                            if let excerpt = capturedClipboardExcerpt,
+                            // Sanctioned rewrites are the one kind of
+                            // clipboard-derived output we ASKED for: their
+                            // `to` values are exempt (masked out before the
+                            // scan), so an intentional exact-entity insertion
+                            // can never trip the leak guard however long the
+                            // entity.
+                            if let excerpt = capturedClipboardContext?.excerpt,
                                committedText != workingText,
                                let leakedLength = PolishContextClipboardReader.detectClipboardLeak(
                                    polished: committedText,
                                    original: workingText,
-                                   excerpt: excerpt
+                                   excerpt: excerpt,
+                                   exemptions: sanctionedVocabularyRewrites.map(\.to)
                                )
                             {
                                 committedText = workingText
@@ -848,7 +915,8 @@ extension DictationViewModel {
                         polishProfile: capturedPolishProfile,
                         polishContextSummary: self.mergedPolishProvenanceSummary(
                             context: capturedPolishContextSummary,
-                            payload: payloadProvenanceSummary
+                            payload: payloadProvenanceSummary,
+                            vocabulary: repoVocabularyCount > 0 ? "vocab:\(repoVocabularyCount)" : nil
                         )
                     )
 
@@ -1114,16 +1182,65 @@ extension DictationViewModel {
         return ClipboardPayloadMacro.substitutePayload(in: text, payload: payload)
     }
 
-    /// Combines the clipboard polish-context and payload-macro provenance notes
-    /// into the single `polishContextSummary` record field (counts only):
-    /// `clipboard:24ch+payload:1532ch`, or either alone, or nil.
-    func mergedPolishProvenanceSummary(context: String?, payload: String?) -> String? {
-        switch (context, payload) {
-        case (nil, nil): return nil
-        case let (context?, nil): return context
-        case let (nil, payload?): return payload
-        case let (context?, payload?): return "\(context)+\(payload)"
+    /// Combines the clipboard polish-context, payload-macro, and repo-vocabulary
+    /// provenance notes into the single `polishContextSummary` record field
+    /// (counts only): `clipboard:24ch+payload:1532ch+vocab:3`, any subset, or nil.
+    func mergedPolishProvenanceSummary(
+        context: String?,
+        payload: String?,
+        vocabulary: String? = nil
+    ) -> String? {
+        let parts = [context, payload, vocabulary].compactMap { $0 }
+        return parts.isEmpty ? nil : parts.joined(separator: "+")
+    }
+
+    /// Opt-in repo-vocabulary grounding: harvests file names / path components /
+    /// the branch from the git repo in the focused terminal and returns the
+    /// transcript-relevant ones as replacement entries — but ONLY when the
+    /// setting is on AND the polishing endpoint is loopback (repo file names must
+    /// never ride to a remote endpoint, same privacy stance as clipboard
+    /// context). Both gates short-circuit before any AX read or subprocess.
+    /// Only the AX title read happens on the main actor (with a 0.5 s AX
+    /// messaging timeout); everything blocking-ish — FS stats on the title's
+    /// path candidates (possibly a stale network mount), the git subprocess
+    /// (2 s timeout), and the n-gram match over a possibly-20k-term vocabulary
+    /// — runs in one detached hop so the commit path can never beachball.
+    /// Returns nil (silent skip) when off, remote, no terminal window, no
+    /// repo, or no transcript-relevant match.
+    func repoVocabularyEntriesIfEnabled(
+        endpointURL: URL,
+        transcript: String
+    ) async -> [ReplacementEntry]? {
+        guard settings.repoVocabularyEnabled else { return nil }
+        guard PolishContextClipboardReader.isLoopbackEndpoint(endpointURL) else {
+            Log.polishing.info("Repo vocabulary skipped: polishing endpoint is not local")
+            return nil
         }
+        #if DEBUG
+        if let override = debugRepoVocabularyEntriesOverride {
+            return override(transcript)
+        }
+        #endif
+        guard let title = resolveCommitTargetWindowTitle() else {
+            Log.polishing.debug("Repo vocabulary: no terminal window title available")
+            return nil
+        }
+        let cache = repoVocabularyCache
+        return await Task.detached(priority: .utility) {
+            await RepoVocabularyService.entries(
+                forWindowTitle: title,
+                transcript: transcript,
+                cache: cache
+            )
+        }.value
+    }
+
+    /// The focused/main window title of the app owning the overlay commit PID
+    /// (the same source `resolveTargetAppBundleID` uses). Main-actor AX read;
+    /// nil on any failure.
+    private func resolveCommitTargetWindowTitle() -> String? {
+        guard let pid = overlayBufferCoordinator.commitTargetAppPID else { return nil }
+        return TerminalWorkingDirectoryResolver.windowTitle(forApplicationPID: pid)
     }
 
     private func resolveClipboardPayloadPasteboardReader() -> any PasteboardReading {

--- a/Sources/localvoxtral/DictationViewModel+Session.swift
+++ b/Sources/localvoxtral/DictationViewModel+Session.swift
@@ -1,5 +1,6 @@
 import AppKit
 import Foundation
+import Synchronization
 import os
 
 extension DictationViewModel {
@@ -688,6 +689,14 @@ extension DictationViewModel {
                             entries: vocabularyEntries
                         )
                         repoVocabularyCount = vocabularyEntries.count
+                        // Known hole (safe direction; follow-up: substring-
+                        // canonical sanctioning): when a sanctioned alias is a
+                        // multi-word gram whose TAIL is itself a protected
+                        // token ("use auth.ts" containing protected `auth.ts`),
+                        // the guard token canonically equals no alias, so the
+                        // rewrite still falls back — the pre-polish text
+                        // commits and the vocabulary correction is lost, but
+                        // nothing is corrupted.
                         sanctionedVocabularyRewrites = vocabularyEntries.flatMap { entry in
                             entry.matches.map { (from: $0, to: entry.replaceWith) }
                         }
@@ -1194,6 +1203,13 @@ extension DictationViewModel {
         return parts.isEmpty ? nil : parts.joined(separator: "+")
     }
 
+    /// Overall deadline on the detached vocabulary pipeline. The git wait is
+    /// internally bounded, but a `fileExists` stat on a stale network mount in
+    /// the cwd resolution can block indefinitely — and the polish Task awaits
+    /// this, so without a deadline that session's commit would wedge at
+    /// "Polishing…". Vocabulary is best-effort; the commit is not.
+    static let repoVocabularyPipelineDeadline: Duration = .seconds(3)
+
     /// Opt-in repo-vocabulary grounding: harvests file names / path components /
     /// the branch from the git repo in the focused terminal and returns the
     /// transcript-relevant ones as replacement entries — but ONLY when the
@@ -1204,9 +1220,14 @@ extension DictationViewModel {
     /// messaging timeout); everything blocking-ish — FS stats on the title's
     /// path candidates (possibly a stale network mount), the git subprocess
     /// (2 s timeout), and the n-gram match over a possibly-20k-term vocabulary
-    /// — runs in one detached hop so the commit path can never beachball.
+    /// — runs in one detached hop RACED against
+    /// `repoVocabularyPipelineDeadline`, so no blocked syscall can ever wedge
+    /// the commit. A single-flight gate caps the cost of abandonment at one
+    /// blocked pool thread: while an abandoned pipeline is still wedged,
+    /// subsequent commits fast-skip vocabulary instead of stacking more
+    /// blocked threads until the pool (and the deadline itself) starves.
     /// Returns nil (silent skip) when off, remote, no terminal window, no
-    /// repo, or no transcript-relevant match.
+    /// repo, no transcript-relevant match, deadline expiry, or in-flight skip.
     func repoVocabularyEntriesIfEnabled(
         endpointURL: URL,
         transcript: String
@@ -1221,18 +1242,106 @@ extension DictationViewModel {
             return override(transcript)
         }
         #endif
+        guard repoVocabularyPipelineInFlight.acquire() else {
+            Log.polishing.info("Repo vocabulary skipped: a previous pipeline is still in flight")
+            return nil
+        }
+        guard let pipelineTask = makeRepoVocabularyPipelineTask(transcript: transcript) else {
+            repoVocabularyPipelineInFlight.release()
+            return nil
+        }
+
+        let deadlineSleep = resolveRepoVocabularyDeadlineSleep()
+        // Race via a resume-once continuation, NOT a task group: a group
+        // awaits ALL its children before returning, and the pipeline child —
+        // awaiting a possibly-forever-blocked task's value, which is not
+        // cancellation-responsive — would wedge the group (and the commit)
+        // in exactly the case the deadline exists for. The losing side is
+        // abandoned; its late resumeOnce call is a guarded no-op.
+        let raceOutcome = await withCheckedContinuation {
+            (continuation: CheckedContinuation<RepoVocabularyRaceOutcome, Never>) in
+            let resumed = Mutex(false)
+            let resumeOnce: @Sendable (RepoVocabularyRaceOutcome) -> Void = { outcome in
+                let shouldResume = resumed.withLock { alreadyResumed in
+                    if alreadyResumed { return false }
+                    alreadyResumed = true
+                    return true
+                }
+                if shouldResume { continuation.resume(returning: outcome) }
+            }
+            // The continuation propagates no priority to the race children
+            // (unlike the previous direct `await .value`, which escalated the
+            // pipeline to the awaiting task's priority). Deliberate for the
+            // pipeline — vocabulary is best-effort background work — but the
+            // deadline's whole job is timeliness, so it runs `.userInitiated`
+            // to keep its resumption from being starved under CPU pressure.
+            Task.detached(priority: .utility) { [gate = repoVocabularyPipelineInFlight] in
+                let entries = await pipelineTask.value
+                // Release the single-flight gate only when the pipeline truly
+                // finished — on the abandonment path this runs arbitrarily
+                // late, and until then new commits fast-skip vocabulary.
+                gate.release()
+                resumeOnce(.pipeline(entries))
+            }
+            Task.detached(priority: .userInitiated) {
+                await deadlineSleep()
+                resumeOnce(.deadlineExpired)
+            }
+        }
+
+        switch raceOutcome {
+        case .pipeline(let entries):
+            return entries
+        case .deadlineExpired:
+            // Abandonment is safe by construction: the detached pipeline only
+            // ever RETURNS a value — it never mutates view-model state — so
+            // when it eventually completes its result is simply discarded.
+            // (Its only shared side effects are inserting into the
+            // Mutex-guarded RepoVocabularyCache, which only makes a later
+            // session faster, and releasing the single-flight gate.) Until it
+            // completes it holds the gate, so a genuinely wedged pipeline
+            // costs at most ONE blocked pool thread across any number of
+            // subsequent commits.
+            Log.polishing.info("Repo vocabulary skipped: pipeline exceeded deadline")
+            return nil
+        }
+    }
+
+    /// The detached title -> cwd -> index -> match pipeline as a task, or nil
+    /// when there is no window title to start from. Split out so the deadline
+    /// race above stays readable and the DEBUG pipeline seam replaces exactly
+    /// the detached section (keeping the race in play for deadline tests).
+    private func makeRepoVocabularyPipelineTask(
+        transcript: String
+    ) -> Task<[ReplacementEntry]?, Never>? {
+        #if DEBUG
+        if let override = debugRepoVocabularyPipelineOverride {
+            return Task.detached(priority: .utility) { await override(transcript) }
+        }
+        #endif
         guard let title = resolveCommitTargetWindowTitle() else {
             Log.polishing.debug("Repo vocabulary: no terminal window title available")
             return nil
         }
         let cache = repoVocabularyCache
-        return await Task.detached(priority: .utility) {
+        return Task.detached(priority: .utility) {
             await RepoVocabularyService.entries(
                 forWindowTitle: title,
                 transcript: transcript,
                 cache: cache
             )
-        }.value
+        }
+    }
+
+    private func resolveRepoVocabularyDeadlineSleep() -> @Sendable () async -> Void {
+        #if DEBUG
+        if let override = debugRepoVocabularyDeadlineSleepOverride {
+            return override
+        }
+        #endif
+        return {
+            try? await Task.sleep(for: Self.repoVocabularyPipelineDeadline)
+        }
     }
 
     /// The focused/main window title of the app owning the overlay commit PID
@@ -1728,4 +1837,12 @@ extension DictationViewModel {
             commitBufferText: currentOverlayCommitText()
         )
     }
+}
+
+/// Winner of the repo-vocabulary race in `repoVocabularyEntriesIfEnabled`:
+/// either the detached pipeline finished (with or without entries) or the
+/// deadline expired first and the pipeline was abandoned.
+private enum RepoVocabularyRaceOutcome: Sendable {
+    case pipeline([ReplacementEntry]?)
+    case deadlineExpired
 }

--- a/Sources/localvoxtral/DictationViewModel+Session.swift
+++ b/Sources/localvoxtral/DictationViewModel+Session.swift
@@ -689,20 +689,54 @@ extension DictationViewModel {
                             entries: vocabularyEntries
                         )
                         repoVocabularyCount = vocabularyEntries.count
-                        // Known hole (safe direction; follow-up: substring-
-                        // canonical sanctioning): when a sanctioned alias is a
-                        // multi-word gram whose TAIL is itself a protected
-                        // token ("use auth.ts" containing protected `auth.ts`),
-                        // the guard token canonically equals no alias, so the
-                        // rewrite still falls back — the pre-polish text
-                        // commits and the vocabulary correction is lost, but
-                        // nothing is corrupted.
+                        // A multi-word alias whose tail is itself a protected
+                        // token ("user session manager.swift" containing
+                        // `manager.swift`) is covered by the guard's
+                        // substring-canonical sanctioning.
                         sanctionedVocabularyRewrites = vocabularyEntries.flatMap { entry in
                             entry.matches.map { (from: $0, to: entry.replaceWith) }
                         }
                         Log.polishing.info(
                             "Repo vocabulary attached: \(vocabularyEntries.count, privacy: .public) entries"
                         )
+                    }
+
+                    // Clipboard vocabulary: the SAME sanctioned-rewrite pipeline,
+                    // grounded in the already privacy-gated clipboard excerpt
+                    // (feature toggle ON + loopback endpoint + never concealed/
+                    // transient — all enforced when the excerpt was captured;
+                    // nil context means none of it runs). Without this, the
+                    // context excerpt lets the model produce the exact copied
+                    // spelling and the token guard then DISCARDS that very
+                    // correction whenever the misheard form was filename-shaped
+                    // (field, 2026-07-11: `manager.swift` glued into
+                    // `UserSessionManager.swift`). Hint entries need the
+                    // dictionary slot; sanctioning must apply even without it —
+                    // the model corrects from the context excerpt alone.
+                    var clipboardVocabularyCount = 0
+                    if let clipboardContext = capturedClipboardContext {
+                        let clipboardEntries = ClipboardVocabulary.candidateEntries(
+                            transcript: workingText,
+                            excerpt: clipboardContext.excerpt
+                        )
+                        if !clipboardEntries.isEmpty {
+                            if templateCarriesDictionarySlot {
+                                replacementDictionarySection =
+                                    RepoVocabularyMatcher.appendedPromptSection(
+                                        base: replacementDictionarySection,
+                                        entries: clipboardEntries,
+                                        header: RepoVocabularyMatcher.clipboardVocabularyHeader
+                                    )
+                            }
+                            sanctionedVocabularyRewrites += clipboardEntries.flatMap { entry in
+                                entry.matches.map { (from: $0, to: entry.replaceWith) }
+                            }
+                            clipboardVocabularyCount = clipboardEntries.count
+                            // Counts only — entity content is clipboard content.
+                            Log.polishing.info(
+                                "Clipboard vocabulary attached: clipboard-vocab:\(clipboardEntries.count, privacy: .public)"
+                            )
+                        }
                     }
 
                     guard !Task.isCancelled else { return }
@@ -925,7 +959,15 @@ extension DictationViewModel {
                         polishContextSummary: self.mergedPolishProvenanceSummary(
                             context: capturedPolishContextSummary,
                             payload: payloadProvenanceSummary,
-                            vocabulary: repoVocabularyCount > 0 ? "vocab:\(repoVocabularyCount)" : nil
+                            vocabulary: {
+                                let parts = [
+                                    repoVocabularyCount > 0
+                                        ? "vocab:\(repoVocabularyCount)" : nil,
+                                    clipboardVocabularyCount > 0
+                                        ? "clipboard-vocab:\(clipboardVocabularyCount)" : nil,
+                                ].compactMap { $0 }
+                                return parts.isEmpty ? nil : parts.joined(separator: "+")
+                            }()
                         )
                     )
 
@@ -1320,7 +1362,7 @@ extension DictationViewModel {
         }
         #endif
         guard let title = resolveCommitTargetWindowTitle() else {
-            Log.polishing.debug("Repo vocabulary: no terminal window title available")
+            Log.polishing.info("Repo vocabulary: no terminal window title available")
             return nil
         }
         let cache = repoVocabularyCache

--- a/Sources/localvoxtral/DictationViewModel.swift
+++ b/Sources/localvoxtral/DictationViewModel.swift
@@ -430,6 +430,18 @@ final class DictationViewModel {
     /// marker was spoken.
     @ObservationIgnored
     var debugClipboardPayloadPasteboardReaderOverride: (() -> any PasteboardReading)?
+    /// Test seam: replaces the whole AX-title -> git-index -> match pipeline of
+    /// `repoVocabularyEntriesIfEnabled` with a closure returning the entries for
+    /// a given transcript, so VM tests exercise the setting + loopback gates
+    /// without touching live AX or a git subprocess. Consulted only AFTER those
+    /// two gates pass, so "off"/"remote" tests still prove the no-op paths.
+    /// `@MainActor` so ordering tests can read main-actor stub state inside it.
+    @ObservationIgnored
+    var debugRepoVocabularyEntriesOverride: (@MainActor (String) -> [ReplacementEntry]?)?
+    /// TTL cache for harvested repo vocabularies, keyed by git root. Held for the
+    /// view model's lifetime so a burst of commits reuses one index.
+    @ObservationIgnored
+    let repoVocabularyCache = RepoVocabularyCache()
     /// Test seam: invoked after the managed-startup status mirror finishes
     /// handling each status update (including updates its guard skips), so
     /// tests can await mirror processing deterministically instead of

--- a/Sources/localvoxtral/DictationViewModel.swift
+++ b/Sources/localvoxtral/DictationViewModel.swift
@@ -435,13 +435,31 @@ final class DictationViewModel {
     /// a given transcript, so VM tests exercise the setting + loopback gates
     /// without touching live AX or a git subprocess. Consulted only AFTER those
     /// two gates pass, so "off"/"remote" tests still prove the no-op paths.
-    /// `@MainActor` so ordering tests can read main-actor stub state inside it.
+    /// Bypasses the deadline race entirely — to exercise that, use the
+    /// pipeline/deadline-sleep seams below instead. `@MainActor` so ordering
+    /// tests can read main-actor stub state inside it.
     @ObservationIgnored
     var debugRepoVocabularyEntriesOverride: (@MainActor (String) -> [ReplacementEntry]?)?
+    /// Test seam: replaces only the DETACHED vocabulary pipeline (AX title +
+    /// cwd resolve + git index + match) while keeping the deadline race in
+    /// play, so tests can inject a never-completing pipeline and prove the
+    /// commit still proceeds (without vocabulary) when the deadline expires.
+    @ObservationIgnored
+    var debugRepoVocabularyPipelineOverride: (@Sendable (String) async -> [ReplacementEntry]?)?
+    /// Test seam: replaces the deadline sleep of the vocabulary race (repo
+    /// reference pattern: injected clock/sleep seams, no wall-clock in tests).
+    /// An immediately-returning closure makes the deadline expire instantly.
+    @ObservationIgnored
+    var debugRepoVocabularyDeadlineSleepOverride: (@Sendable () async -> Void)?
     /// TTL cache for harvested repo vocabularies, keyed by git root. Held for the
     /// view model's lifetime so a burst of commits reuses one index.
     @ObservationIgnored
     let repoVocabularyCache = RepoVocabularyCache()
+    /// Single-flight gate for the detached vocabulary pipeline (see
+    /// `RepoVocabularyFlightGate`): while a prior pipeline is still in flight,
+    /// commits fast-skip vocabulary instead of stacking more blocked threads.
+    @ObservationIgnored
+    let repoVocabularyPipelineInFlight = RepoVocabularyFlightGate()
     /// Test seam: invoked after the managed-startup status mirror finishes
     /// handling each status update (including updates its guard skips), so
     /// tests can await mirror processing deterministically instead of

--- a/Sources/localvoxtral/PolishTokenGuard.swift
+++ b/Sources/localvoxtral/PolishTokenGuard.swift
@@ -253,9 +253,19 @@ enum PolishTokenGuard {
     }
 
     /// True when `token` matches a sanctioned pair's `from` (canonical-form
-    /// equality: case-insensitive, dash/space-normalized) and that pair's `to`
-    /// occurs standalone in `text` — i.e. the model applied a rewrite the
+    /// CONTAINMENT: case-insensitive, dash/space-normalized) and that pair's
+    /// `to` occurs standalone in `text` — i.e. the model applied a rewrite the
     /// caller explicitly asked for, so the token counts as preserved.
+    ///
+    /// Containment, not equality (field regression, 2026-07-11): a sanctioned
+    /// alias is often a multi-word transcript gram whose TAIL is itself the
+    /// protected token — "user session manager.swift" containing protected
+    /// `manager.swift`, corrected to `UserSessionManager.swift`. Under
+    /// equality the guard token canonically equals no alias, so the very
+    /// correction the caller requested was reverted (or the whole polish
+    /// discarded). When the alias gram subsumes the protected token's
+    /// occurrence and the model produced the requested `to`, the token's
+    /// disappearance is explained and sanctioned.
     ///
     /// Deletion-masking limitation (accepted): there is no occurrence counting
     /// here — a sanctioned `to` present ANYWHERE in the polished text lets an
@@ -268,8 +278,9 @@ enum PolishTokenGuard {
     ) -> Bool {
         guard !sanctionedReplacements.isEmpty else { return false }
         let canonicalToken = canonical(token)
+        guard !canonicalToken.isEmpty else { return false }
         for (from, to) in sanctionedReplacements {
-            guard canonical(from) == canonicalToken else { continue }
+            guard canonical(from).contains(canonicalToken) else { continue }
             if standaloneOccurrenceCount(of: to, in: text) > 0 { return true }
         }
         return false

--- a/Sources/localvoxtral/PolishTokenGuard.swift
+++ b/Sources/localvoxtral/PolishTokenGuard.swift
@@ -256,6 +256,11 @@ enum PolishTokenGuard {
     /// equality: case-insensitive, dash/space-normalized) and that pair's `to`
     /// occurs standalone in `text` — i.e. the model applied a rewrite the
     /// caller explicitly asked for, so the token counts as preserved.
+    ///
+    /// Deletion-masking limitation (accepted): there is no occurrence counting
+    /// here — a sanctioned `to` present ANYWHERE in the polished text lets an
+    /// outright deletion of the `from` occurrence pass without fallback (e.g.
+    /// the token was spoken twice and the model kept the corrected form once).
     private static func isSanctionedRewrite(
         of token: String,
         in text: String,

--- a/Sources/localvoxtral/PolishTokenGuard.swift
+++ b/Sources/localvoxtral/PolishTokenGuard.swift
@@ -19,6 +19,18 @@ enum PolishTokenGuard {
         /// what to keep by switching on `outcome`.
         let text: String
         let outcome: Outcome
+        /// How many protected tokens were accepted as SANCTIONED rewrites (see
+        /// `verifyAndRepair(polished:original:sanctionedReplacements:)`) rather
+        /// than found verbatim. Callers log this so field logs show when the
+        /// repo-vocabulary path changed a protected token on purpose. Defaulted
+        /// so every pre-existing construction/comparison stays byte-identical.
+        let sanctionedCount: Int
+
+        init(text: String, outcome: Outcome, sanctionedCount: Int = 0) {
+            self.text = text
+            self.outcome = outcome
+            self.sanctionedCount = sanctionedCount
+        }
 
         enum Outcome: Equatable {
             case clean
@@ -160,12 +172,31 @@ enum PolishTokenGuard {
     /// (`run --force first, then – force again`). If any occurrence is neither
     /// present nor repairable, returns `.fallback` and the caller keeps its
     /// pre-polish text.
-    static func verifyAndRepair(polished: String, original: String) -> Repair {
+    ///
+    /// `sanctionedReplacements` teaches the guard about rewrites the CALLER
+    /// requested from the model (repo vocabulary: the prompt asks it to fix a
+    /// misheard `useauth.ts` to the repo's exact `useAuth.ts`). Without this,
+    /// the guard protects the STT's WRONG filename-shaped token and its
+    /// near-miss repair deterministically REVERTS the very correction the
+    /// vocabulary injected (or, for a fuzzy fix the canonical form can't
+    /// bridge, discards the whole polish). A protected token missing from
+    /// `polished` is treated as preserved — no repair, no fallback — when it
+    /// canonically equals a pair's `from` AND that pair's `to` occurs
+    /// standalone in `polished`. Comparison is the guard's own `canonical`
+    /// form (case-insensitive, dash/space-normalized) so the guard stays
+    /// self-contained. The default `[]` keeps all pre-existing behavior
+    /// byte-identical.
+    static func verifyAndRepair(
+        polished: String,
+        original: String,
+        sanctionedReplacements: [(from: String, to: String)] = []
+    ) -> Repair {
         let tokens = protectedTokens(in: original)
         guard !tokens.isEmpty else { return Repair(text: polished, outcome: .clean) }
 
         var working = polished
         var repairedCount = 0
+        var sanctionedCount = 0
         var missing: [String] = []
 
         for token in tokens {
@@ -173,6 +204,19 @@ enum PolishTokenGuard {
             // at least once in its own source text.
             let required = max(1, standaloneOccurrenceCount(of: token, in: original))
             var surviving = standaloneOccurrenceCount(of: token, in: working)
+            // Sanctioned rewrites are consulted BEFORE near-miss repair: the
+            // repair path is exactly what would revert a case-only vocabulary
+            // correction back to the misheard spelling. A sanctioned token is
+            // treated as preserved for ALL its occurrences (the caller asked
+            // the model to rewrite it wherever it appears).
+            if surviving < required,
+                isSanctionedRewrite(
+                    of: token, in: working, sanctionedReplacements: sanctionedReplacements
+                )
+            {
+                sanctionedCount += 1
+                continue
+            }
             while surviving < required {
                 guard let repaired = repairFirstNearMiss(of: token, in: working) else {
                     missing.append(token)
@@ -192,12 +236,38 @@ enum PolishTokenGuard {
         }
 
         if !missing.isEmpty {
-            return Repair(text: original, outcome: .fallback(missing: missing))
+            return Repair(
+                text: original,
+                outcome: .fallback(missing: missing),
+                sanctionedCount: sanctionedCount
+            )
         }
         if repairedCount > 0 {
-            return Repair(text: working, outcome: .repaired(count: repairedCount))
+            return Repair(
+                text: working,
+                outcome: .repaired(count: repairedCount),
+                sanctionedCount: sanctionedCount
+            )
         }
-        return Repair(text: working, outcome: .clean)
+        return Repair(text: working, outcome: .clean, sanctionedCount: sanctionedCount)
+    }
+
+    /// True when `token` matches a sanctioned pair's `from` (canonical-form
+    /// equality: case-insensitive, dash/space-normalized) and that pair's `to`
+    /// occurs standalone in `text` — i.e. the model applied a rewrite the
+    /// caller explicitly asked for, so the token counts as preserved.
+    private static func isSanctionedRewrite(
+        of token: String,
+        in text: String,
+        sanctionedReplacements: [(from: String, to: String)]
+    ) -> Bool {
+        guard !sanctionedReplacements.isEmpty else { return false }
+        let canonicalToken = canonical(token)
+        for (from, to) in sanctionedReplacements {
+            guard canonical(from) == canonicalToken else { continue }
+            if standaloneOccurrenceCount(of: to, in: text) > 0 { return true }
+        }
+        return false
     }
 
     /// Canonical form for near-miss comparison: lowercase, dash variants unified

--- a/Sources/localvoxtral/RepoVocabulary.swift
+++ b/Sources/localvoxtral/RepoVocabulary.swift
@@ -1,0 +1,814 @@
+import ApplicationServices
+import Darwin
+import Foundation
+import Synchronization
+
+// Repo vocabulary: when the dictation target is a terminal sitting in a git
+// repo, harvest file names / path components / the branch name from that repo
+// and inject the transcript-relevant ones into the polish prompt's replacement-
+// dictionary section, so the polish model spells `useAuth.ts` /
+// `UserSessionManager.swift` exactly instead of hallucinating. Opt-in, loopback
+// endpoints only (repo file names must not ride to a remote endpoint), and
+// prompt-context only (no deterministic auto-replacement). Three separable,
+// independently testable pieces + a TTL cache do the amortizing:
+//   1. `TerminalWorkingDirectoryResolver` — terminal window title -> cwd
+//   2. `RepoIndexing` / `RepoGitRunner` / `RepoVocabularyService` — cwd -> vocab
+//   3. `RepoVocabularyMatcher` — transcript + vocab -> replacement entries
+
+// MARK: - 1. Terminal cwd resolution
+
+/// Extracts a working directory from a terminal emulator's window title, then
+/// (via the AX seam) reads that title for the app owning the dictation-commit
+/// PID. The title parser is a PURE function so it is table-testable without AX;
+/// only `windowTitle(forApplicationPID:)` touches live AX and is `@MainActor`.
+enum TerminalWorkingDirectoryResolver {
+    /// Path-like segments extracted from a terminal window title, in order of
+    /// appearance, tilde-expanded. Only `/`- or `~`-prefixed segments count: a
+    /// bare last-path-component (Terminal.app's "proj — zsh — 80×24") is NOT
+    /// resolvable, so bare names are ignored. Trailing decorations (" — zsh",
+    /// " - vim", box-dimension suffixes, sentence punctuation) are trimmed.
+    /// `homeDirectory` is injected (default `NSHomeDirectory()`) for testability.
+    static func workingDirectoryCandidates(
+        fromWindowTitle title: String,
+        homeDirectory: String = NSHomeDirectory()
+    ) -> [String] {
+        // A run starting at `~` or `/` and continuing over non-whitespace. Box
+        // dimensions ("80×24"), shell/editor decorations (" — zsh") and bare
+        // window names never start with `~`/`/`, so they never match.
+        let matches = pathRunRegex.matches(
+            in: title,
+            range: NSRange(title.startIndex..., in: title)
+        )
+        var result: [String] = []
+        var seen = Set<String>()
+        for match in matches {
+            guard let range = Range(match.range, in: title) else { continue }
+            let trimmed = trimDecorations(String(title[range]))
+            guard trimmed.first == "~" || trimmed.first == "/" else { continue }
+            // A lone "~" resolves to home; a lone "/" is just the root separator
+            // (never a meaningful cwd), so require length >= 2 otherwise.
+            guard trimmed == "~" || trimmed.count >= 2 else { continue }
+            let expanded = expandTilde(trimmed, homeDirectory: homeDirectory)
+            if seen.insert(expanded).inserted {
+                result.append(expanded)
+            }
+        }
+        return result
+    }
+
+    /// The first candidate that verifies as an existing directory. The FS check
+    /// is injectable so parser tests never hit the disk.
+    static func resolveWorkingDirectory(
+        fromWindowTitle title: String,
+        homeDirectory: String = NSHomeDirectory(),
+        isDirectory: (String) -> Bool = { path in
+            var isDir: ObjCBool = false
+            return FileManager.default.fileExists(atPath: path, isDirectory: &isDir) && isDir.boolValue
+        }
+    ) -> String? {
+        for candidate in workingDirectoryCandidates(fromWindowTitle: title, homeDirectory: homeDirectory) {
+            if isDirectory(candidate) { return candidate }
+        }
+        return nil
+    }
+
+    /// Reads the AX title of the focused (then main) window of the app owning
+    /// `pid`. Returns nil on any AX failure (no trust, no window, no title) —
+    /// silent skip is fine. This is the only piece that touches live AX.
+    @MainActor
+    static func windowTitle(forApplicationPID pid: pid_t) -> String? {
+        guard AXIsProcessTrusted() else { return nil }
+        let appElement = AXUIElementCreateApplication(pid)
+        // A wedged/unresponsive target app must not stall the commit: cap AX
+        // messaging at 0.5 s instead of the global default. The timeout is
+        // per-element, so the window element below gets its own cap.
+        _ = AXUIElementSetMessagingTimeout(appElement, 0.5)
+        for attribute in [kAXFocusedWindowAttribute, kAXMainWindowAttribute] {
+            var windowObject: AnyObject?
+            let status = AXUIElementCopyAttributeValue(
+                appElement, attribute as CFString, &windowObject
+            )
+            guard status == .success,
+                  let windowObject,
+                  CFGetTypeID(windowObject) == AXUIElementGetTypeID()
+            else { continue }
+            let window = unsafeDowncast(windowObject, to: AXUIElement.self)
+            _ = AXUIElementSetMessagingTimeout(window, 0.5)
+            var titleObject: AnyObject?
+            let titleStatus = AXUIElementCopyAttributeValue(
+                window, kAXTitleAttribute as CFString, &titleObject
+            )
+            if titleStatus == .success,
+               let title = titleObject as? String,
+               !title.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+            {
+                return title
+            }
+        }
+        return nil
+    }
+
+    // Static literal: a bad pattern is a coding error to crash on immediately
+    // (same rationale as TextMergingAlgorithms / PolishTokenGuard).
+    private static let pathRunRegex = try! NSRegularExpression(pattern: "[~/][^\\s]*")
+
+    /// Trailing sentence/decoration punctuation trimmed off an extracted run.
+    private static let trailingDecorations: Set<Character> =
+        [",", ";", ":", ")", "]", ".", "'", "\"", "»", "”"]
+
+    private static func trimDecorations(_ segment: String) -> String {
+        var value = segment
+        while let last = value.last, trailingDecorations.contains(last) {
+            value.removeLast()
+        }
+        return value
+    }
+
+    private static func expandTilde(_ path: String, homeDirectory: String) -> String {
+        if path == "~" { return homeDirectory }
+        if path.hasPrefix("~/") {
+            return homeDirectory + String(path.dropFirst(1))
+        }
+        return path
+    }
+}
+
+// MARK: - 2. Repo indexing
+
+/// The vocabulary harvested from a repo: exact spellings the matcher may emit
+/// (file basenames, directory path components, the branch name), deduped.
+///
+/// The matcher indexes are built ONCE here, at vocabulary construction — off
+/// the main actor and amortized by the TTL cache — so matching a transcript
+/// against a 20k-term monorepo vocabulary is O(n-grams) dictionary lookups for
+/// the exact tier plus a length-bucketed sweep for the fuzzy tier, never an
+/// O(grams × terms) Levenshtein product.
+struct RepoVocabulary: Sendable {
+    let terms: [String]
+    let branch: String?
+    /// Normalized form -> exact term (first appearance wins): the exact tier.
+    let exactIndex: [String: String]
+    /// Fuzzy-tier candidates (normalized length >= the fuzzy threshold) keyed
+    /// by normalized length, so an n-gram only edit-distance-checks terms
+    /// within ±1 of its own length, with character arrays precomputed.
+    let fuzzyBuckets: [Int: [FuzzyCandidate]]
+
+    struct FuzzyCandidate: Sendable {
+        let term: String
+        let normalizedCharacters: [Character]
+    }
+
+    init(terms: [String], branch: String?) {
+        self.terms = terms
+        self.branch = branch
+        var exact: [String: String] = [:]
+        var buckets: [Int: [FuzzyCandidate]] = [:]
+        for term in terms {
+            let normalized = RepoVocabularyMatcher.normalize(term)
+            guard normalized.count >= RepoVocabularyMatcher.minNormalizedLength else { continue }
+            if exact[normalized] == nil { exact[normalized] = term }
+            if normalized.count >= RepoVocabularyMatcher.fuzzyMinNormalizedLength {
+                buckets[normalized.count, default: []].append(
+                    FuzzyCandidate(term: term, normalizedCharacters: Array(normalized))
+                )
+            }
+        }
+        self.exactIndex = exact
+        self.fuzzyBuckets = buckets
+    }
+}
+
+extension RepoVocabulary: Equatable {
+    /// The indexes are a pure function of `terms`, so identity is terms+branch.
+    static func == (lhs: RepoVocabulary, rhs: RepoVocabulary) -> Bool {
+        lhs.terms == rhs.terms && lhs.branch == rhs.branch
+    }
+}
+
+/// Pure-ish git-tree indexing over an injectable `FileManager`: git-root walk,
+/// `.git/HEAD` branch parse (worktree gitdir-file aware), null-delimited
+/// `ls-files` parsing with caps, and vocabulary assembly. No subprocess here —
+/// the `ls-files` run lives in `RepoGitRunner`; this parses its bytes.
+enum RepoIndexing {
+    /// Walks up from `path` looking for a `.git` entry (dir OR file — worktrees
+    /// use a gitdir file), capped at `maxDepth` levels. Returns the directory
+    /// that contains `.git`.
+    static func findGitRoot(
+        startingAt path: String,
+        fileManager: FileManager = .default,
+        maxDepth: Int = 20
+    ) -> String? {
+        var current = URL(fileURLWithPath: path).standardizedFileURL
+        var depth = 0
+        while depth <= maxDepth {
+            let gitEntry = current.appendingPathComponent(".git")
+            if fileManager.fileExists(atPath: gitEntry.path) {
+                return current.path
+            }
+            let parent = current.deletingLastPathComponent()
+            if parent.path == current.path { break }  // reached filesystem root
+            current = parent
+            depth += 1
+        }
+        return nil
+    }
+
+    /// The actual git directory for a root: `<root>/.git` when it is a real
+    /// directory, else (worktree `.git` file) the `gitdir:` pointer target.
+    static func resolveGitDirectory(root: String, fileManager: FileManager = .default) -> String? {
+        let dotGit = URL(fileURLWithPath: root).appendingPathComponent(".git")
+        var isDir: ObjCBool = false
+        guard fileManager.fileExists(atPath: dotGit.path, isDirectory: &isDir) else { return nil }
+        if isDir.boolValue { return dotGit.path }
+        guard let content = try? String(contentsOf: dotGit, encoding: .utf8) else { return nil }
+        for line in content.split(whereSeparator: \.isNewline) {
+            let trimmed = line.trimmingCharacters(in: .whitespaces)
+            guard trimmed.hasPrefix("gitdir:") else { continue }
+            let raw = trimmed.dropFirst("gitdir:".count).trimmingCharacters(in: .whitespaces)
+            guard !raw.isEmpty else { return nil }
+            if raw.hasPrefix("/") { return raw }
+            return URL(fileURLWithPath: root)
+                .appendingPathComponent(raw)
+                .standardizedFileURL.path
+        }
+        return nil
+    }
+
+    /// The HEAD file inside the resolved git directory.
+    static func headFileURL(root: String, fileManager: FileManager = .default) -> URL? {
+        guard let gitDir = resolveGitDirectory(root: root, fileManager: fileManager) else {
+            return nil
+        }
+        return URL(fileURLWithPath: gitDir).appendingPathComponent("HEAD")
+    }
+
+    /// The current branch from `.git/HEAD` (`ref: refs/heads/<branch>`), or nil
+    /// when detached (HEAD holds a raw SHA) or unreadable. No subprocess.
+    static func branch(root: String, fileManager: FileManager = .default) -> String? {
+        guard let headURL = headFileURL(root: root, fileManager: fileManager),
+              let content = try? String(contentsOf: headURL, encoding: .utf8)
+        else { return nil }
+        let trimmed = content.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard trimmed.hasPrefix("ref:") else { return nil }  // detached HEAD
+        let ref = trimmed.dropFirst("ref:".count).trimmingCharacters(in: .whitespaces)
+        guard let markerRange = ref.range(of: "refs/heads/") else { return nil }
+        let branch = String(ref[markerRange.upperBound...])
+        return branch.isEmpty ? nil : branch
+    }
+
+    /// The `.git/HEAD` modification date, used to invalidate the cache on a
+    /// checkout/commit without re-running git.
+    static func headModificationDate(root: String, fileManager: FileManager = .default) -> Date? {
+        guard let headURL = headFileURL(root: root, fileManager: fileManager) else { return nil }
+        return (try? fileManager.attributesOfItem(atPath: headURL.path))?[.modificationDate] as? Date
+    }
+
+    /// Parses `git ls-files -z` output: paths separated by NUL. A trailing entry
+    /// not terminated by NUL (a subprocess killed mid-write on timeout/cap) is
+    /// dropped as incomplete — "use what was read, cleanly parseable up to the
+    /// cap". Empty entries are skipped and the list is capped at `maxEntries`.
+    static func parseNullDelimitedPaths(_ data: Data, maxEntries: Int = 20_000) -> [String] {
+        guard !data.isEmpty else { return [] }
+        let endsCleanly = data.last == 0x00
+        let text = String(decoding: data, as: UTF8.self)
+        var parts = text.components(separatedBy: "\0")
+        if !endsCleanly, !parts.isEmpty {
+            parts.removeLast()  // truncated final entry
+        }
+        var result: [String] = []
+        for part in parts where !part.isEmpty {
+            result.append(part)
+            if result.count >= maxEntries { break }
+        }
+        return result
+    }
+
+    /// Builds the vocabulary from relative paths + the branch: each path's
+    /// basename (with extension), plus its directory components as auxiliary
+    /// words, plus the branch name — each admitted only when it carries a
+    /// technical signal (`isTechnicalTerm`). Deduped, first-appearance order.
+    static func buildVocabulary(paths: [String], branch: String?) -> RepoVocabulary {
+        var terms: [String] = []
+        var seen = Set<String>()
+        func add(_ value: String) {
+            guard !value.isEmpty, isTechnicalTerm(value), seen.insert(value).inserted else {
+                return
+            }
+            terms.append(value)
+        }
+        for path in paths {
+            let components = path.split(separator: "/").map(String.init)
+            guard let basename = components.last else { continue }
+            add(basename)
+            for component in components.dropLast() { add(component) }
+        }
+        if let branch { add(branch) }
+        return RepoVocabulary(terms: terms, branch: branch)
+    }
+
+    /// Technical-signal gate: common-word path components (`Tests`,
+    /// `Resources`, `docs`) must not become prompt hints — they would
+    /// capitalize ordinary prose ("run the tests" -> "run the Tests"). A term
+    /// qualifies only with a dot, a separator (`/`, `_`, `-`), or an internal
+    /// capital in a MIXED-case word (camelCase/PascalCase: an uppercase letter
+    /// past position 0 plus at least one lowercase letter — so `LICENSE`-style
+    /// all-caps does not qualify). Accepted losses, deliberately: bare names
+    /// like `Makefile`, `LICENSE`, `Dockerfile` carry no machine-checkable
+    /// signal and are excluded.
+    static func isTechnicalTerm(_ term: String) -> Bool {
+        if term.contains(where: { $0 == "." || $0 == "/" || $0 == "_" || $0 == "-" }) {
+            return true
+        }
+        let hasInternalUppercase = term.dropFirst().contains(where: \.isUppercase)
+        let hasLowercase = term.contains(where: \.isLowercase)
+        return hasInternalUppercase && hasLowercase
+    }
+}
+
+// MARK: - git ls-files subprocess
+
+/// Runs `git ls-files -z` off the main actor with hard timeout / output caps.
+/// Piping uses `POSIXPipeRead` (never `FileHandle.availableData`, which raises
+/// an uncatchable ObjC exception on descriptor errors — AGENTS.md, PR #60).
+enum RepoGitRunner {
+    struct Output: Sendable {
+        let data: Data
+        let exitCode: Int32
+        let timedOut: Bool
+        let capped: Bool
+    }
+
+    /// Async wrapper: hops to a background queue so the blocking Process run
+    /// never touches the main actor (the caller is the @MainActor polish Task).
+    static func lsFiles(
+        root: String,
+        timeoutSeconds: TimeInterval = 2.0,
+        maxBytes: Int = 2_000_000
+    ) async -> Output? {
+        await withCheckedContinuation { (continuation: CheckedContinuation<Output?, Never>) in
+            DispatchQueue.global(qos: .utility).async {
+                continuation.resume(
+                    returning: runBlocking(root: root, timeoutSeconds: timeoutSeconds, maxBytes: maxBytes)
+                )
+            }
+        }
+    }
+
+    private static func runBlocking(root: String, timeoutSeconds: TimeInterval, maxBytes: Int) -> Output? {
+        let gitURL = URL(fileURLWithPath: "/usr/bin/git")
+        guard FileManager.default.isExecutableFile(atPath: gitURL.path) else {
+            Log.polishing.debug("Repo vocabulary: /usr/bin/git not executable")
+            return nil
+        }
+
+        let process = Process()
+        process.executableURL = gitURL
+        process.arguments = ["-C", root, "ls-files", "-z"]
+        // Determinism against user git config: no global/system config (ls-files
+        // runs no hooks/aliases, this pins it) and never a credential prompt.
+        var environment = ProcessInfo.processInfo.environment
+        environment["GIT_CONFIG_GLOBAL"] = "/dev/null"
+        environment["GIT_CONFIG_SYSTEM"] = "/dev/null"
+        environment["GIT_TERMINAL_PROMPT"] = "0"
+        process.environment = environment
+        let outPipe = Pipe()
+        process.standardOutput = outPipe
+        process.standardError = FileHandle.nullDevice
+        // Exit is observed via terminationHandler + semaphore so the final
+        // wait can be BOUNDED (see below). Set before run() so the signal can
+        // never be missed, even for a process that exits instantly.
+        let exited = DispatchSemaphore(value: 0)
+        process.terminationHandler = { _ in exited.signal() }
+        do {
+            try process.run()
+        } catch {
+            Log.polishing.debug("Repo vocabulary: git ls-files failed to launch")
+            return nil
+        }
+
+        // The reader thread owns the pipe fd and only mutates the mutex-guarded
+        // collector; the process handle is touched only from THIS thread, so no
+        // non-Sendable state crosses threads.
+        let readFD = outPipe.fileHandleForReading.fileDescriptor
+        let collector = Mutex<(data: Data, capped: Bool)>((Data(), false))
+        let finished = DispatchSemaphore(value: 0)
+
+        let readerThread = Thread {
+            while true {
+                let chunk = POSIXPipeRead.nextChunk(fromDescriptor: readFD)
+                if chunk.isEmpty { break }
+                let reachedCap = collector.withLock { state -> Bool in
+                    state.data.append(chunk)
+                    if state.data.count >= maxBytes {
+                        state.capped = true
+                        return true
+                    }
+                    return false
+                }
+                if reachedCap { break }
+            }
+            finished.signal()
+        }
+        readerThread.stackSize = 1 << 20
+        readerThread.start()
+
+        let timedOut = finished.wait(timeout: .now() + timeoutSeconds) == .timedOut
+        let capped = collector.withLock { $0.capped }
+        if timedOut || capped, process.isRunning {
+            // Cap: the reader stopped consuming, so a still-writing process
+            // would block forever on a full pipe — a polite SIGTERM suffices
+            // (never a raw kill on a possibly-already-exited pid). Timeout:
+            // the process ignored 2 s of expectations; escalate to SIGKILL so
+            // the reader's read(2) sees EOF promptly.
+            process.terminate()
+            if timedOut {
+                kill(process.processIdentifier, SIGKILL)
+            }
+        }
+        if timedOut {
+            // Only the timeout path still has a live reader thread (blocked in
+            // read(2)); the kill closes the pipe's write end so it hits EOF —
+            // wait briefly for it to finish before reading the collector. The
+            // cap path's reader already exited (its signal was consumed by the
+            // first wait above), so waiting again there would burn the whole
+            // grace period on a semaphore that can never be signaled.
+            _ = finished.wait(timeout: .now() + 0.5)
+        }
+        // BOUNDED replacement for waitUntilExit(): a child stuck in
+        // uninterruptible disk-wait can survive even SIGKILL indefinitely, and
+        // an unbounded wait here would wedge the polish task and lose the
+        // commit. On expiry, abandon: Foundation's process monitor (and, on
+        // the timeout path, the reader thread) is deliberately leaked until
+        // the kernel eventually reaps the child — vocabulary is best-effort,
+        // the commit is not.
+        guard exited.wait(timeout: .now() + 2.0) != .timedOut else {
+            Log.polishing.debug(
+                "Repo vocabulary: git ls-files did not exit after kill; abandoning"
+            )
+            return nil
+        }
+
+        let data = collector.withLock { $0.data }
+        return Output(
+            data: data,
+            exitCode: process.terminationStatus,
+            timedOut: timedOut,
+            capped: capped
+        )
+    }
+}
+
+// MARK: - TTL cache
+
+/// Root-keyed cache of harvested vocabularies. TTL-bounded and invalidated when
+/// `.git/HEAD` mtime changes. `Mutex`-guarded per repo conventions (no actors).
+/// The clock is injected at every call so tests never touch wall-clock.
+final class RepoVocabularyCache: Sendable {
+    private struct Cached {
+        let vocabulary: RepoVocabulary
+        let headModificationDate: Date?
+        let cachedAt: Date
+    }
+
+    private let ttl: TimeInterval
+    private let storage = Mutex<[String: Cached]>([:])
+
+    init(ttl: TimeInterval = 300) {
+        self.ttl = ttl
+    }
+
+    /// The cached vocabulary for `root` when still within TTL AND the HEAD mtime
+    /// is unchanged, else nil (a fresh index is required).
+    func lookup(root: String, now: Date, currentHeadModificationDate: Date?) -> RepoVocabulary? {
+        storage.withLock { store in
+            guard let cached = store[root] else { return nil }
+            if now.timeIntervalSince(cached.cachedAt) > ttl { return nil }
+            if cached.headModificationDate != currentHeadModificationDate { return nil }
+            return cached.vocabulary
+        }
+    }
+
+    func insert(root: String, vocabulary: RepoVocabulary, headModificationDate: Date?, now: Date) {
+        storage.withLock { store in
+            store[root] = Cached(
+                vocabulary: vocabulary,
+                headModificationDate: headModificationDate,
+                cachedAt: now
+            )
+        }
+    }
+}
+
+// MARK: - Orchestration
+
+/// Ties indexing + cache + subprocess together: cwd -> git root -> (cache hit or
+/// fresh index) -> vocabulary. The `now` clock and `runLsFiles` subprocess are
+/// injected so the whole flow is testable against fixture repos / stubs.
+enum RepoVocabularyService {
+    static func vocabulary(
+        forWorkingDirectory cwd: String,
+        cache: RepoVocabularyCache,
+        fileManager: FileManager = .default,
+        now: @Sendable () -> Date = { Date() },
+        runLsFiles: @Sendable (_ root: String) async -> RepoGitRunner.Output? = { root in
+            await RepoGitRunner.lsFiles(root: root)
+        }
+    ) async -> RepoVocabulary? {
+        guard let root = RepoIndexing.findGitRoot(startingAt: cwd, fileManager: fileManager) else {
+            return nil
+        }
+        let headModificationDate = RepoIndexing.headModificationDate(root: root, fileManager: fileManager)
+        if let cached = cache.lookup(
+            root: root, now: now(), currentHeadModificationDate: headModificationDate
+        ) {
+            return cached
+        }
+
+        let branch = RepoIndexing.branch(root: root, fileManager: fileManager)
+        guard let output = await runLsFiles(root) else {
+            Log.polishing.debug("Repo vocabulary: git ls-files unavailable")
+            return nil
+        }
+        // A clean non-zero exit (not a repo, git error) with no cap/timeout is a
+        // real failure: skip. On timeout/cap we keep whatever was cleanly read.
+        if !output.timedOut, !output.capped, output.exitCode != 0 {
+            Log.polishing.debug("Repo vocabulary: git ls-files exited non-zero")
+            return nil
+        }
+
+        let paths = RepoIndexing.parseNullDelimitedPaths(output.data)
+        let vocabulary = RepoIndexing.buildVocabulary(paths: paths, branch: branch)
+        guard !vocabulary.terms.isEmpty else { return nil }
+        cache.insert(
+            root: root,
+            vocabulary: vocabulary,
+            headModificationDate: headModificationDate,
+            now: now()
+        )
+        return vocabulary
+    }
+
+    /// The full title -> cwd -> vocabulary -> matched-entries pipeline for one
+    /// commit. Everything here may block (FS stats on the title's path
+    /// candidates — possibly a stale network mount —, the git subprocess, the
+    /// n-gram match over a large vocabulary), so the view model runs this
+    /// inside a detached task; only the AX title read stays on the main actor.
+    static func entries(
+        forWindowTitle title: String,
+        transcript: String,
+        cache: RepoVocabularyCache
+    ) async -> [ReplacementEntry]? {
+        guard let workingDirectory = TerminalWorkingDirectoryResolver
+            .resolveWorkingDirectory(fromWindowTitle: title)
+        else {
+            Log.polishing.debug("Repo vocabulary: no working directory resolved from window title")
+            return nil
+        }
+        guard let vocabulary = await vocabulary(
+            forWorkingDirectory: workingDirectory, cache: cache
+        ) else {
+            return nil
+        }
+        let entries = RepoVocabularyMatcher.candidateEntries(
+            transcript: transcript, vocabulary: vocabulary
+        )
+        return entries.isEmpty ? nil : entries
+    }
+}
+
+// MARK: - 3. Transcript matching
+
+/// Matches spoken transcript n-grams against repo vocabulary and emits
+/// `ReplacementEntry`s (exact spelling -> the spoken form) for the polish
+/// prompt. Pure functions, mirroring `PolishTokenGuard` / `TextMergingAlgorithms`.
+enum RepoVocabularyMatcher {
+    /// Hard cap on emitted entries — grounding hints, not an index dump.
+    static let maxEntries = 12
+    /// Minimum normalized length on BOTH sides. Drops collision-prone short
+    /// forms (`app`, `src`) as standalone entries while still letting them count
+    /// inside longer n-grams (`app.tsx`).
+    static let minNormalizedLength = 4
+    /// Minimum normalized length (both sides) for the edit-distance-1 fuzzy
+    /// tier — short forms would collide constantly.
+    static let fuzzyMinNormalizedLength = 8
+
+    /// Spoken separator words map to the symbols the file side already strips,
+    /// so "use auth dot t s" normalizes identically to `useAuth.ts`.
+    private static let spokenSeparators: Set<String> =
+        ["dot", "point", "slash", "dash", "hyphen", "underscore"]
+
+    /// Small stopword set: an n-gram made up entirely of these (or spoken
+    /// separators) can never be a file/identifier and is skipped.
+    private static let stopwords: Set<String> = [
+        "the", "a", "an", "to", "in", "of", "and", "or", "for", "on", "at",
+        "is", "it", "file", "this", "that", "with", "my", "please",
+    ]
+
+    /// Normalizes for comparison: lowercase, drop spoken separator words, strip
+    /// `.`/`/`/`_`/`-` and whitespace. "use auth dot t s" -> "useauthts";
+    /// "useAuth.ts" -> "useauthts".
+    static func normalize(_ text: String) -> String {
+        let tokens = text.lowercased().split(whereSeparator: { $0 == " " || $0 == "\t" || $0 == "\n" })
+        var output = ""
+        for token in tokens {
+            let stripped = stripJoiners(String(token))
+            if spokenSeparators.contains(stripped) { continue }
+            output += stripped
+        }
+        return output
+    }
+
+    /// The candidate replacement entries for `transcript` grounded in
+    /// `vocabulary`, ranked (longer normalized match first, then earlier
+    /// transcript position) and capped. One entry per matched exact term.
+    ///
+    /// Complexity: the exact tier is one `exactIndex` lookup per n-gram; the
+    /// fuzzy tier (grams >= `fuzzyMinNormalizedLength`, skipped entirely when
+    /// the exact tier hit) sweeps only the ±1-length `fuzzyBuckets` with an
+    /// early-exit distance-1 check, and each distinct normalized gram is swept
+    /// at most once (its first transcript position is already its best rank).
+    static func candidateEntries(
+        transcript: String,
+        vocabulary: RepoVocabulary
+    ) -> [ReplacementEntry] {
+        let words = tokenize(transcript)
+        guard !words.isEmpty, !vocabulary.exactIndex.isEmpty else { return [] }
+
+        var bestByTerm: [String: Hit] = [:]
+        func record(_ hit: Hit) {
+            if let existing = bestByTerm[hit.term], !isBetter(hit, than: existing) { return }
+            bestByTerm[hit.term] = hit
+        }
+        var fuzzySweptGrams = Set<String>()
+
+        for start in 0..<words.count {
+            let maxWindow = min(6, words.count - start)
+            for length in 1...maxWindow {
+                let window = Array(words[start..<(start + length)])
+                if window.allSatisfy({ isCommon($0) }) { continue }
+                let spoken = window.joined(separator: " ")
+                let normalizedGram = normalize(spoken)
+                guard normalizedGram.count >= minNormalizedLength else { continue }
+
+                if let term = vocabulary.exactIndex[normalizedGram] {
+                    record(Hit(
+                        term: term,
+                        normalizedLength: normalizedGram.count,
+                        position: start,
+                        spoken: spoken,
+                        exact: true
+                    ))
+                    continue
+                }
+
+                guard normalizedGram.count >= fuzzyMinNormalizedLength,
+                      fuzzySweptGrams.insert(normalizedGram).inserted
+                else { continue }
+                let gramCharacters = Array(normalizedGram)
+                for bucketLength in (normalizedGram.count - 1)...(normalizedGram.count + 1) {
+                    for candidate in vocabulary.fuzzyBuckets[bucketLength] ?? [] {
+                        guard isEditDistanceAtMostOne(
+                            gramCharacters, candidate.normalizedCharacters
+                        ) else { continue }
+                        record(Hit(
+                            term: candidate.term,
+                            normalizedLength: candidate.normalizedCharacters.count,
+                            position: start,
+                            spoken: spoken,
+                            exact: false
+                        ))
+                    }
+                }
+            }
+        }
+
+        let ranked = bestByTerm.values.sorted { lhs, rhs in
+            if lhs.normalizedLength != rhs.normalizedLength {
+                return lhs.normalizedLength > rhs.normalizedLength
+            }
+            return lhs.position < rhs.position
+        }
+        return ranked.prefix(maxEntries).map {
+            ReplacementEntry(replaceWith: $0.term, matches: [$0.spoken])
+        }
+    }
+
+    // MARK: - Internals
+
+    /// One matched (term, transcript n-gram) pairing.
+    private struct Hit {
+        let term: String
+        let normalizedLength: Int
+        let position: Int
+        let spoken: String
+        let exact: Bool
+    }
+
+    private static let nonAlphanumericEdges = CharacterSet.alphanumerics.inverted
+
+    /// Splits on whitespace and trims each word of leading/trailing
+    /// non-alphanumerics (STT-sprinkled commas/periods) so the normalized form
+    /// and the "as spoken" match string are both clean.
+    private static func tokenize(_ transcript: String) -> [String] {
+        transcript
+            .split(whereSeparator: { $0 == " " || $0 == "\t" || $0 == "\n" })
+            .map { $0.trimmingCharacters(in: nonAlphanumericEdges) }
+            .filter { !$0.isEmpty }
+    }
+
+    private static func stripJoiners(_ token: String) -> String {
+        token.filter { $0 != "." && $0 != "/" && $0 != "_" && $0 != "-" }
+    }
+
+    private static func isCommon(_ word: String) -> Bool {
+        let normalized = stripJoiners(word.lowercased())
+        return stopwords.contains(normalized) || spokenSeparators.contains(normalized)
+    }
+
+    /// Within one term, prefer an exact match over a fuzzy one, then the earlier
+    /// transcript position, then the more specific (longer spoken) n-gram.
+    private static func isBetter(_ candidate: Hit, than existing: Hit) -> Bool {
+        if candidate.exact != existing.exact { return candidate.exact }
+        if candidate.position != existing.position { return candidate.position < existing.position }
+        return candidate.spoken.count > existing.spoken.count
+    }
+
+    /// Specialized distance-1 check (all the fuzzy tier needs): two-pointer
+    /// single pass with early exit — no O(n²) matrix, no per-pair count
+    /// recomputation (callers pass precomputed character arrays).
+    private static func isEditDistanceAtMostOne(_ a: [Character], _ b: [Character]) -> Bool {
+        let lengthDelta = a.count - b.count
+        if abs(lengthDelta) > 1 { return false }
+        var i = 0
+        var j = 0
+        var edits = 0
+        while i < a.count, j < b.count {
+            if a[i] == b[j] {
+                i += 1
+                j += 1
+                continue
+            }
+            edits += 1
+            if edits > 1 { return false }
+            if lengthDelta == 0 {
+                i += 1  // substitution
+                j += 1
+            } else if lengthDelta > 0 {
+                i += 1  // deletion from a
+            } else {
+                j += 1  // insertion into a
+            }
+        }
+        edits += (a.count - i) + (b.count - j)
+        return edits <= 1
+    }
+
+    // MARK: - Prompt rendering
+
+    /// Defense-in-depth for prompt rendering: `git ls-files -z` preserves
+    /// newlines/tabs and other control characters in file names, and a raw
+    /// interpolation could break a `- key: aliases` line into stray prompt
+    /// lines. Reuses the shared clipboard sanitizer (drops control chars) and
+    /// additionally removes the newline/tab it deliberately keeps — a rendered
+    /// dictionary line must stay single-line.
+    static func sanitizedTerm(_ term: String) -> String {
+        PolishContextClipboardReader.sanitizeControlCharacters(term)
+            .filter { $0 != "\n" && $0 != "\t" }
+            .trimmingCharacters(in: .whitespaces)
+    }
+
+    /// A sanitized term is renderable when something meaningful remains: not
+    /// empty, and not a bare dash run (`---` would read as a section divider).
+    private static func isRenderableTerm(_ term: String) -> Bool {
+        !term.isEmpty && !term.allSatisfy { $0 == "-" }
+    }
+
+    /// Renders matched entries as a prompt section mirroring
+    /// `ReplacementDictionary.renderedPromptSection`'s `- key: aliases` shape,
+    /// under a repo-specific header. Every key/alias is sanitized first; an
+    /// entry whose key or every alias becomes unrenderable is dropped. Empty
+    /// entries render nothing.
+    static func promptSection(entries: [ReplacementEntry]) -> String {
+        let lines: [String] = entries.compactMap { entry in
+            let key = sanitizedTerm(entry.replaceWith)
+            guard isRenderableTerm(key) else { return nil }
+            let aliases = entry.matches.map(sanitizedTerm).filter(isRenderableTerm)
+            guard !aliases.isEmpty else { return nil }
+            return "- \(key): \(aliases.joined(separator: ", "))"
+        }
+        guard !lines.isEmpty else { return "" }
+        return "Repository vocabulary (exact file names and identifiers from the project the "
+            + "speaker is working in; use them to correct near-miss spellings of the terms "
+            + "below, never to add new content):\n\(lines.joined(separator: "\n"))"
+    }
+
+    /// Appends the vocabulary section to an existing replacement-dictionary
+    /// prompt string. When the base is empty (dictionary disabled) the section
+    /// stands alone; when there are no entries the base is returned unchanged.
+    static func appendedPromptSection(base: String, entries: [ReplacementEntry]) -> String {
+        let section = promptSection(entries: entries)
+        guard !section.isEmpty else { return base }
+        guard !base.isEmpty else { return section }
+        return base + "\n\n" + section
+    }
+}

--- a/Sources/localvoxtral/RepoVocabulary.swift
+++ b/Sources/localvoxtral/RepoVocabulary.swift
@@ -56,8 +56,53 @@ enum TerminalWorkingDirectoryResolver {
         return result
     }
 
-    /// The first candidate that verifies as an existing directory. The FS check
-    /// is injectable so parser tests never hit the disk.
+    /// Home-anchored fallback candidates for ABBREVIATED titles, in order of
+    /// appearance. Ghostty elides leading path components in tab titles as
+    /// `..` ("../Desktop/projects/proj" for `$HOME/Desktop/projects/proj`),
+    /// which is never statable as-is — its only meaningful resolution is
+    /// re-anchoring at home (field, 2026-07-11: the whole vocabulary feature
+    /// silently no-oped in Ghostty). ONLY `../`-prefixed runs are re-anchored:
+    /// the title itself must signal elision. A genuinely absolute path that
+    /// happens not to exist locally (an SSH/container path like `/work/repo`,
+    /// an unmounted volume) must NEVER be re-anchored — that would index a
+    /// same-named repo under home and inject wrong-repo vocabulary.
+    /// These are FALLBACKS: `resolveWorkingDirectory` tries every exact
+    /// candidate first.
+    static func homeAnchoredFallbackCandidates(
+        fromWindowTitle title: String,
+        homeDirectory: String = NSHomeDirectory()
+    ) -> [String] {
+        var result: [String] = []
+        var seen = Set<String>()
+        let matches = abbreviatedRunRegex.matches(
+            in: title,
+            range: NSRange(title.startIndex..., in: title)
+        )
+        for match in matches {
+            guard let range = Range(match.range, in: title) else { continue }
+            let trimmed = trimDecorations(String(title[range]))
+            // "../X" (or an ellipsis-elided variant) -> "$HOME/X".
+            guard let prefix = elidedPrefixes.first(where: { trimmed.hasPrefix($0) }),
+                  trimmed.count > prefix.count
+            else { continue }
+            let anchored = homeDirectory + "/" + String(trimmed.dropFirst(prefix.count))
+            if seen.insert(anchored).inserted { result.append(anchored) }
+        }
+        return result
+    }
+
+    /// Elided-title prefixes accepted for home-anchoring: ASCII "../" plus
+    /// the Unicode ellipses terminals actually render — U+2026 HORIZONTAL
+    /// ELLIPSIS ("…/", Ghostty's real output; the T6 field title was
+    /// "…/Desktop/projects/supervoxtral", owner-confirmed 2026-07-11 — a
+    /// typed report loses the distinction from "../") and U+2025 TWO DOT
+    /// LEADER ("‥/").
+    private static let elidedPrefixes = ["../", "…/", "‥/"]
+
+    /// The first candidate that verifies as an existing directory — every
+    /// exact candidate first, then the home-anchored fallbacks for
+    /// abbreviated titles. The FS check is injectable so parser tests never
+    /// hit the disk.
     static func resolveWorkingDirectory(
         fromWindowTitle title: String,
         homeDirectory: String = NSHomeDirectory(),
@@ -68,6 +113,11 @@ enum TerminalWorkingDirectoryResolver {
     ) -> String? {
         for candidate in workingDirectoryCandidates(fromWindowTitle: title, homeDirectory: homeDirectory) {
             if isDirectory(candidate) { return candidate }
+        }
+        for fallback in homeAnchoredFallbackCandidates(
+            fromWindowTitle: title, homeDirectory: homeDirectory
+        ) {
+            if isDirectory(fallback) { return fallback }
         }
         return nil
     }
@@ -108,9 +158,40 @@ enum TerminalWorkingDirectoryResolver {
         return nil
     }
 
+    /// Redacted SHAPE of a window title for field diagnostics (the T6 failure
+    /// was undiagnosable because the log line carried no hint of what the
+    /// title looked like): letters map to "a", digits to "9", path separators
+    /// and elision marks (`/`, `.`, `~`, `…`, `‥`) and spaces survive,
+    /// anything else becomes "?", capped at 60 characters. Class-mapped shape
+    /// only — never raw content.
+    static func titleShape(_ title: String, cap: Int = 60) -> String {
+        var shape = ""
+        for character in title.prefix(cap) {
+            if character.isLetter {
+                shape.append("a")
+            } else if character.isNumber {
+                shape.append("9")
+            } else if character == "/" || character == "." || character == "~"
+                || character == "…" || character == "‥" || character == " "
+            {
+                shape.append(character)
+            } else {
+                shape.append("?")
+            }
+        }
+        return shape
+    }
+
     // Static literal: a bad pattern is a coding error to crash on immediately
     // (same rationale as TextMergingAlgorithms / PolishTokenGuard).
     private static let pathRunRegex = try! NSRegularExpression(pattern: "[~/][^\\s]*")
+
+    /// A Ghostty-elided run: "../", "…/" (U+2026) or "‥/" (U+2025), then
+    /// non-whitespace. Prose "..." or a bare ".."/"…" never matches (the
+    /// character after the elision mark must be `/`).
+    private static let abbreviatedRunRegex = try! NSRegularExpression(
+        pattern: "(?:\\.\\.|…|‥)/[^\\s]*"
+    )
 
     /// Trailing sentence/decoration punctuation trimmed off an extracted run.
     private static let trailingDecorations: Set<Character> =
@@ -591,7 +672,12 @@ enum RepoVocabularyService {
         guard let workingDirectory = TerminalWorkingDirectoryResolver
             .resolveWorkingDirectory(fromWindowTitle: title)
         else {
-            Log.polishing.info("Repo vocabulary: no working directory resolved from window title")
+            // Shape is class-mapped (letters->a, digits->9), never content —
+            // safe as .public, and makes the NEXT field failure of this kind
+            // self-diagnosing (T6 was invisible without it).
+            Log.polishing.info(
+                "Repo vocabulary: no working directory resolved from window title (shape: \(TerminalWorkingDirectoryResolver.titleShape(title), privacy: .public))"
+            )
             return nil
         }
         guard let vocabulary = await vocabulary(

--- a/Sources/localvoxtral/RepoVocabulary.swift
+++ b/Sources/localvoxtral/RepoVocabulary.swift
@@ -458,6 +458,33 @@ enum RepoGitRunner {
     }
 }
 
+// MARK: - Single-flight gate
+
+/// Single-flight gate for the detached vocabulary pipeline. An abandoned
+/// (deadline-expired) pipeline can stay parked in a blocking syscall, pinning
+/// one cooperative-pool thread; without this gate every subsequent commit
+/// against the same wedged mount would stack another blocked thread until the
+/// pool — and the deadline mechanism itself — starves. A class holding the
+/// `Mutex` (per repo conventions) so the detached pipeline wrapper can release
+/// it from off-main on eventual completion.
+final class RepoVocabularyFlightGate: Sendable {
+    private let inFlight = Mutex(false)
+
+    /// True when the caller acquired the gate; false when a prior pipeline is
+    /// still in flight and the caller must fast-skip.
+    func acquire() -> Bool {
+        inFlight.withLock { alreadyInFlight in
+            if alreadyInFlight { return false }
+            alreadyInFlight = true
+            return true
+        }
+    }
+
+    func release() {
+        inFlight.withLock { $0 = false }
+    }
+}
+
 // MARK: - TTL cache
 
 /// Root-keyed cache of harvested vocabularies. TTL-bounded and invalidated when

--- a/Sources/localvoxtral/RepoVocabulary.swift
+++ b/Sources/localvoxtral/RepoVocabulary.swift
@@ -357,7 +357,7 @@ enum RepoGitRunner {
     private static func runBlocking(root: String, timeoutSeconds: TimeInterval, maxBytes: Int) -> Output? {
         let gitURL = URL(fileURLWithPath: "/usr/bin/git")
         guard FileManager.default.isExecutableFile(atPath: gitURL.path) else {
-            Log.polishing.debug("Repo vocabulary: /usr/bin/git not executable")
+            Log.polishing.info("Repo vocabulary: /usr/bin/git not executable")
             return nil
         }
 
@@ -382,7 +382,7 @@ enum RepoGitRunner {
         do {
             try process.run()
         } catch {
-            Log.polishing.debug("Repo vocabulary: git ls-files failed to launch")
+            Log.polishing.info("Repo vocabulary: git ls-files failed to launch")
             return nil
         }
 
@@ -442,7 +442,7 @@ enum RepoGitRunner {
         // the kernel eventually reaps the child — vocabulary is best-effort,
         // the commit is not.
         guard exited.wait(timeout: .now() + 2.0) != .timedOut else {
-            Log.polishing.debug(
+            Log.polishing.info(
                 "Repo vocabulary: git ls-files did not exit after kill; abandoning"
             )
             return nil
@@ -553,19 +553,22 @@ enum RepoVocabularyService {
 
         let branch = RepoIndexing.branch(root: root, fileManager: fileManager)
         guard let output = await runLsFiles(root) else {
-            Log.polishing.debug("Repo vocabulary: git ls-files unavailable")
+            Log.polishing.info("Repo vocabulary: git ls-files unavailable")
             return nil
         }
         // A clean non-zero exit (not a repo, git error) with no cap/timeout is a
         // real failure: skip. On timeout/cap we keep whatever was cleanly read.
         if !output.timedOut, !output.capped, output.exitCode != 0 {
-            Log.polishing.debug("Repo vocabulary: git ls-files exited non-zero")
+            Log.polishing.info("Repo vocabulary: git ls-files exited non-zero")
             return nil
         }
 
         let paths = RepoIndexing.parseNullDelimitedPaths(output.data)
         let vocabulary = RepoIndexing.buildVocabulary(paths: paths, branch: branch)
-        guard !vocabulary.terms.isEmpty else { return nil }
+        guard !vocabulary.terms.isEmpty else {
+            Log.polishing.info("Repo vocabulary: repo yielded no technical terms")
+            return nil
+        }
         cache.insert(
             root: root,
             vocabulary: vocabulary,
@@ -588,7 +591,7 @@ enum RepoVocabularyService {
         guard let workingDirectory = TerminalWorkingDirectoryResolver
             .resolveWorkingDirectory(fromWindowTitle: title)
         else {
-            Log.polishing.debug("Repo vocabulary: no working directory resolved from window title")
+            Log.polishing.info("Repo vocabulary: no working directory resolved from window title")
             return nil
         }
         guard let vocabulary = await vocabulary(
@@ -599,7 +602,15 @@ enum RepoVocabularyService {
         let entries = RepoVocabularyMatcher.candidateEntries(
             transcript: transcript, vocabulary: vocabulary
         )
-        return entries.isEmpty ? nil : entries
+        if entries.isEmpty {
+            // Static string + no content: the LAST silent skip on this path.
+            // Every skip reason is .info — .debug is not persisted by the
+            // unified log store, which made a field no-attach undiagnosable
+            // (2026-07-11, Ghostty).
+            Log.polishing.info("Repo vocabulary: no transcript-relevant matches")
+            return nil
+        }
+        return entries
     }
 }
 
@@ -810,12 +821,28 @@ enum RepoVocabularyMatcher {
         !term.isEmpty && !term.allSatisfy { $0 == "-" }
     }
 
+    /// Header for entries harvested from the focused terminal's git repo.
+    static let repositoryVocabularyHeader =
+        "Repository vocabulary (exact file names and identifiers from the project the "
+        + "speaker is working in; use them to correct near-miss spellings of the terms "
+        + "below, never to add new content):"
+
+    /// Header for entries harvested from the user's clipboard excerpt (the
+    /// clipboard polish-context feature): same rendering, honest provenance.
+    static let clipboardVocabularyHeader =
+        "Clipboard vocabulary (exact file names and identifiers from text the user "
+        + "recently copied; use them to correct near-miss spellings of the terms "
+        + "below, never to add new content):"
+
     /// Renders matched entries as a prompt section mirroring
     /// `ReplacementDictionary.renderedPromptSection`'s `- key: aliases` shape,
-    /// under a repo-specific header. Every key/alias is sanitized first; an
-    /// entry whose key or every alias becomes unrenderable is dropped. Empty
-    /// entries render nothing.
-    static func promptSection(entries: [ReplacementEntry]) -> String {
+    /// under the given header. Every key/alias is sanitized first; an entry
+    /// whose key or every alias becomes unrenderable is dropped. Empty entries
+    /// render nothing.
+    static func promptSection(
+        entries: [ReplacementEntry],
+        header: String = repositoryVocabularyHeader
+    ) -> String {
         let lines: [String] = entries.compactMap { entry in
             let key = sanitizedTerm(entry.replaceWith)
             guard isRenderableTerm(key) else { return nil }
@@ -824,18 +851,74 @@ enum RepoVocabularyMatcher {
             return "- \(key): \(aliases.joined(separator: ", "))"
         }
         guard !lines.isEmpty else { return "" }
-        return "Repository vocabulary (exact file names and identifiers from the project the "
-            + "speaker is working in; use them to correct near-miss spellings of the terms "
-            + "below, never to add new content):\n\(lines.joined(separator: "\n"))"
+        return "\(header)\n\(lines.joined(separator: "\n"))"
     }
 
     /// Appends the vocabulary section to an existing replacement-dictionary
     /// prompt string. When the base is empty (dictionary disabled) the section
     /// stands alone; when there are no entries the base is returned unchanged.
-    static func appendedPromptSection(base: String, entries: [ReplacementEntry]) -> String {
-        let section = promptSection(entries: entries)
+    static func appendedPromptSection(
+        base: String,
+        entries: [ReplacementEntry],
+        header: String = repositoryVocabularyHeader
+    ) -> String {
+        let section = promptSection(entries: entries, header: header)
         guard !section.isEmpty else { return base }
         guard !base.isEmpty else { return section }
         return base + "\n\n" + section
+    }
+}
+
+// MARK: - Clipboard vocabulary
+
+/// Clipboard entities join the sanctioned-rewrite pipeline (field regression,
+/// 2026-07-11): the clipboard polish-context excerpt already tells the model
+/// the exact spelling of a copied identifier, but when the STT's misheard form
+/// was itself a protected token (`manager.swift` for a dictated
+/// "user session manager dot swift", clipboard holding
+/// `UserSessionManager.swift`), the token guard deterministically DISCARDED
+/// the model's correct rewrite. Extracting the excerpt's code-like entities
+/// (the guard's OWN recognizer — never a second grammar), matching transcript
+/// n-grams against them exactly like repo vocabulary, and registering the
+/// matches as sanctioned pairs makes that correction survive the guard.
+///
+/// Pure functions; all privacy gating (feature toggle, loopback endpoint,
+/// concealed/transient pasteboard) already happened when the excerpt was
+/// captured — this type never touches the pasteboard.
+enum ClipboardVocabulary {
+    /// Ordered, de-duplicated code-like entities in `excerpt`, recognized by
+    /// `PolishTokenGuard.protectedTokens` (backtick spans, dotted filenames,
+    /// paths, flags, env vars, URLs, hashes, versions). Backtick spans are
+    /// unwrapped to their inner text: the vocabulary term is the identifier,
+    /// not its markdown decoration.
+    static func entities(inExcerpt excerpt: String) -> [String] {
+        var seen = Set<String>()
+        var result: [String] = []
+        for token in PolishTokenGuard.protectedTokens(in: excerpt) {
+            var term = token
+            if term.hasPrefix("`"), term.hasSuffix("`"), term.count > 2 {
+                term = String(term.dropFirst().dropLast())
+            }
+            guard !term.isEmpty, seen.insert(term).inserted else { continue }
+            result.append(term)
+        }
+        return result
+    }
+
+    /// The transcript-relevant clipboard entities as replacement entries, via
+    /// the exact matcher repo vocabulary uses (same n-gram windows, same
+    /// normalization, same fuzzy tier, same cap). Empty when the excerpt holds
+    /// no code-like entities or none matches the transcript.
+    static func candidateEntries(
+        transcript: String,
+        excerpt: String
+    ) -> [ReplacementEntry] {
+        let terms = entities(inExcerpt: excerpt)
+        guard !terms.isEmpty else { return [] }
+        let vocabulary = RepoVocabulary(terms: terms, branch: nil)
+        return RepoVocabularyMatcher.candidateEntries(
+            transcript: transcript,
+            vocabulary: vocabulary
+        )
     }
 }

--- a/Sources/localvoxtral/SettingsStore.swift
+++ b/Sources/localvoxtral/SettingsStore.swift
@@ -181,6 +181,7 @@ final class SettingsStore {
         static let agentPolishProfileEnabled = "settings.agent_polish_profile_enabled"
         static let polishClipboardContextEnabled = "settings.polish_clipboard_context_enabled"
         static let clipboardPayloadMacroEnabled = "settings.clipboard_payload_macro_enabled"
+        static let repoVocabularyEnabled = "settings.repo_vocabulary_enabled"
         /// Hidden debug toggle (no UI). When true, every received realtime
         /// event's raw payload is logged to the `Deltas` category before any
         /// merge/preprocess/insertion processing — instrumentation for
@@ -337,6 +338,20 @@ final class SettingsStore {
     var clipboardPayloadMacroEnabled: Bool {
         didSet {
             defaults.set(clipboardPayloadMacroEnabled, forKey: Keys.clipboardPayloadMacroEnabled)
+        }
+    }
+
+    /// When true, and the polishing endpoint is loopback
+    /// (`PolishContextClipboardReader.isLoopbackEndpoint`), file names / path
+    /// components / the branch name from the git repo in the focused terminal
+    /// are harvested and the transcript-relevant ones injected into the polish
+    /// prompt's replacement-dictionary section, so the model spells technical
+    /// terms exactly. Opt-in (default false), prompt-context only (no
+    /// deterministic replacement), local endpoints only — repo file names must
+    /// never ride to a remote endpoint. See `RepoVocabulary`.
+    var repoVocabularyEnabled: Bool {
+        didSet {
+            defaults.set(repoVocabularyEnabled, forKey: Keys.repoVocabularyEnabled)
         }
     }
 
@@ -534,6 +549,8 @@ final class SettingsStore {
             defaults: defaults, key: Keys.polishClipboardContextEnabled, fallback: false)
         clipboardPayloadMacroEnabled = Self.loadBool(
             defaults: defaults, key: Keys.clipboardPayloadMacroEnabled, fallback: true)
+        repoVocabularyEnabled = Self.loadBool(
+            defaults: defaults, key: Keys.repoVocabularyEnabled, fallback: false)
         debugLogRealtimeDeltas = Self.loadBool(
             defaults: defaults, key: Keys.debugLogRealtimeDeltas, fallback: false)
         modifierOnlyHotKeyEnabled = Self.loadBool(

--- a/Sources/localvoxtral/SettingsView.swift
+++ b/Sources/localvoxtral/SettingsView.swift
@@ -346,6 +346,18 @@ private struct ConnectionSettingsPane: View {
                         }
                     }
 
+                    SettingsFieldRow(title: "Repo vocabulary from terminal") {
+                        VStack(alignment: .leading, spacing: 6) {
+                            Toggle("", isOn: $settings.repoVocabularyEnabled)
+                                .labelsHidden()
+                                .toggleStyle(.switch)
+
+                            SettingsHelpText(
+                                "Reads file names from the git repo in your terminal to fix technical spellings. Local polishing endpoints only."
+                            )
+                        }
+                    }
+
                     switch settings.polishingBackendMode {
                     case .externalURL:
                         SettingsFieldRow(title: "Endpoint") {

--- a/Tests/localvoxtralTests/PolishTokenGuardTests.swift
+++ b/Tests/localvoxtralTests/PolishTokenGuardTests.swift
@@ -1,4 +1,5 @@
 import Foundation
+import Synchronization
 import XCTest
 @testable import localvoxtral
 
@@ -1272,6 +1273,126 @@ final class DictationViewModelPolishTokenGuardTests: XCTestCase {
             viewModel.currentDictationEventText,
             "open useAuth.ts and fix the import"
         )
+    }
+
+    /// The deadline race: a vocabulary pipeline that NEVER completes (a stat
+    /// blocked on a stale network mount) must not wedge the commit. With an
+    /// instantly-expiring deadline (injected sleep seam — no wall-clock), the
+    /// polish request is built WITHOUT vocabulary, the commit completes, and
+    /// no vocab provenance is recorded. Abandonment is safe: the pipeline only
+    /// returns a value, never mutates view-model state.
+    func testVocabularyPipelineDeadlineProceedsWithoutVocabulary() async throws {
+        let settings = makeSettings(outputMode: .overlayBuffer)
+        settings.llmPolishingEnabled = true
+        settings.polishingBackendMode = .externalURL
+        settings.llmPolishingEndpointURL = "http://127.0.0.1:8472/v1/chat/completions"
+        settings.repoVocabularyEnabled = true
+
+        let template = LLMPromptTemplates(
+            systemContent: "system",
+            userContent: "Clean this up.\n{{replacement_dictionary}}\nWorking text:\n{{input_text}}"
+        )
+        let mockConfig = MockAppConfigStore(
+            promptTemplates: template,
+            agentPromptTemplates: template
+        )
+        let service = RecordingPolishingService()
+        let overlayCoordinator = MockOverlayCoordinator()
+        let viewModel = DictationViewModel(
+            settings: settings,
+            overlayBufferCoordinator: overlayCoordinator,
+            startRuntimeServices: false
+        )
+        viewModel.appConfigStore = mockConfig
+        viewModel.llmPolishingService = service
+        viewModel.debugResolveTargetAppBundleIDOverride = { "com.apple.Terminal" }
+        // Pipeline seam (NOT the entries seam, which bypasses the race):
+        // suspends forever, like an uncancelable syscall. Deliberately leaked
+        // for the test process lifetime, mirroring the production abandonment.
+        viewModel.debugRepoVocabularyPipelineOverride = { _ in
+            await withUnsafeContinuation { (_: UnsafeContinuation<Void, Never>) in }
+            return nil
+        }
+        // Deadline sleep seam: returns immediately — the deadline expires
+        // before the pipeline can ever win.
+        viewModel.debugRepoVocabularyDeadlineSleepOverride = {}
+        var savedRecord: DictationSessionRecord?
+        viewModel.debugSavedSessionRecordSink = { savedRecord = $0 }
+        retainForTestProcessLifetime(viewModel)
+
+        viewModel.sessionOutputMode = .overlayBuffer
+        viewModel.isFinalizingStop = true
+        viewModel.currentDictationEventText = "open use auth dot t s and fix the import"
+
+        viewModel.finishStoppedSession(promotePendingSegment: false)
+        await waitUntilStoppedSessionCompletes(viewModel)
+
+        // The commit completed despite the wedged pipeline...
+        XCTAssertEqual(overlayCoordinator.commitCallCount, 1)
+        // ...the request was built WITHOUT vocabulary...
+        let capturedRequest = await service.capturedRequest
+        let request = try XCTUnwrap(capturedRequest)
+        XCTAssertFalse(
+            request.userPrompts.contains { $0.contains("Repository vocabulary") }
+        )
+        // ...and no vocab provenance was recorded for work that never landed.
+        XCTAssertNil(savedRecord?.polishContextSummary)
+    }
+
+    /// Single-flight: an abandoned (deadline-expired) pipeline holds the
+    /// in-flight gate, so the NEXT commit fast-skips vocabulary instead of
+    /// stacking another blocked pool thread — the pipeline seam must run
+    /// exactly once across both calls. Deterministic: the second call's skip
+    /// is decided synchronously by the gate (acquired before the pipeline
+    /// spawns), and the count assertion waits on a start signal from the
+    /// wedged pipeline, never on wall-clock.
+    func testWedgedPipelineSingleFlightSkipsNextCommit() async {
+        let settings = makeSettings(outputMode: .overlayBuffer)
+        settings.llmPolishingEnabled = true
+        settings.polishingBackendMode = .externalURL
+        settings.llmPolishingEndpointURL = "http://127.0.0.1:8472/v1/chat/completions"
+        settings.repoVocabularyEnabled = true
+
+        let viewModel = DictationViewModel(
+            settings: settings,
+            overlayBufferCoordinator: MockOverlayCoordinator(),
+            startRuntimeServices: false
+        )
+        let pipelineCalls = SendableCallCounter()
+        let (pipelineStarted, startSignal) = AsyncStream.makeStream(of: Void.self)
+        // Wedged pipeline: signals that it started, then suspends forever
+        // (deliberately leaked for the test process lifetime, mirroring the
+        // production abandonment).
+        viewModel.debugRepoVocabularyPipelineOverride = { _ in
+            pipelineCalls.increment()
+            startSignal.yield()
+            await withUnsafeContinuation { (_: UnsafeContinuation<Void, Never>) in }
+            return nil
+        }
+        viewModel.debugRepoVocabularyDeadlineSleepOverride = {}
+
+        let endpoint = URL(string: "http://127.0.0.1:8472/v1/chat/completions")!
+        let first = await viewModel.repoVocabularyEntriesIfEnabled(
+            endpointURL: endpoint, transcript: "open use auth dot t s"
+        )
+        // Deadline expired; the wedged pipeline was abandoned holding the gate.
+        XCTAssertNil(first)
+        var startIterator = pipelineStarted.makeAsyncIterator()
+        _ = await startIterator.next()
+
+        let second = await viewModel.repoVocabularyEntriesIfEnabled(
+            endpointURL: endpoint, transcript: "open use auth dot t s"
+        )
+        XCTAssertNil(second)
+        XCTAssertEqual(pipelineCalls.value, 1)
+    }
+
+    /// Off-main-safe call counter for `@Sendable` seams (the nested main-actor
+    /// counter class can't cross into a detached pipeline).
+    private final class SendableCallCounter: Sendable {
+        private let storage = Mutex(0)
+        func increment() { storage.withLock { $0 += 1 } }
+        var value: Int { storage.withLock { $0 } }
     }
 
     /// Records override calls so the privacy/toggle gates can be asserted by call

--- a/Tests/localvoxtralTests/PolishTokenGuardTests.swift
+++ b/Tests/localvoxtralTests/PolishTokenGuardTests.swift
@@ -301,6 +301,70 @@ final class PolishTokenGuardTests: XCTestCase {
         XCTAssertEqual(second.outcome, .clean)
         XCTAssertEqual(second.text, first.text)
     }
+
+    // MARK: - Sanctioned rewrites (repo vocabulary)
+
+    /// The flagship repo-vocabulary case: the STT misheard `useAuth.ts` as
+    /// `useauth.ts` (a protected filename token), the prompt asked the model to
+    /// fix it, and the model did. The sanctioned pair must stop the near-miss
+    /// repair from case-reverting the correction.
+    func testSanctionedRewriteIsNotRevertedByCaseRepair() {
+        let result = PolishTokenGuard.verifyAndRepair(
+            polished: "Open useAuth.ts now.",
+            original: "open useauth.ts now",
+            sanctionedReplacements: [(from: "useauth.ts", to: "useAuth.ts")]
+        )
+        XCTAssertEqual(result.outcome, .clean)
+        XCTAssertEqual(result.text, "Open useAuth.ts now.")
+        XCTAssertEqual(result.sanctionedCount, 1)
+    }
+
+    /// The fuzzy (edit-distance-1) vocabulary fix: `usenauth.ts` -> `useAuth.ts`
+    /// is beyond the guard's canonical form, so without sanctioning the whole
+    /// polish would be discarded as `.fallback`.
+    func testSanctionedFuzzyRewriteDoesNotFallBack() {
+        let result = PolishTokenGuard.verifyAndRepair(
+            polished: "Open useAuth.ts now.",
+            original: "open usenauth.ts now",
+            sanctionedReplacements: [(from: "usenauth.ts", to: "useAuth.ts")]
+        )
+        XCTAssertEqual(result.outcome, .clean)
+        XCTAssertEqual(result.text, "Open useAuth.ts now.")
+        XCTAssertEqual(result.sanctionedCount, 1)
+    }
+
+    /// Without sanctioned pairs the pre-existing behavior holds byte-identically:
+    /// the case-only change is reverted as a repair, and the fuzzy change
+    /// triggers the fallback.
+    func testWithoutSanctionedPairsOldGuardBehaviorHolds() {
+        let reverted = PolishTokenGuard.verifyAndRepair(
+            polished: "Open useAuth.ts now.",
+            original: "open useauth.ts now"
+        )
+        XCTAssertEqual(reverted.outcome, .repaired(count: 1))
+        XCTAssertEqual(reverted.text, "Open useauth.ts now.")
+        XCTAssertEqual(reverted.sanctionedCount, 0)
+
+        let fallback = PolishTokenGuard.verifyAndRepair(
+            polished: "Open useAuth.ts now.",
+            original: "open usenauth.ts now"
+        )
+        XCTAssertEqual(fallback.outcome, .fallback(missing: ["usenauth.ts"]))
+        XCTAssertEqual(fallback.text, "open usenauth.ts now")
+    }
+
+    /// A sanctioned pair whose `to` is absent from the polished text is no
+    /// license at all: the token really is gone, and the normal fallback fires.
+    func testSanctionedToAbsentFallsBackNormally() {
+        let result = PolishTokenGuard.verifyAndRepair(
+            polished: "Open the file now.",
+            original: "open useauth.ts now",
+            sanctionedReplacements: [(from: "useauth.ts", to: "useAuth.ts")]
+        )
+        XCTAssertEqual(result.outcome, .fallback(missing: ["useauth.ts"]))
+        XCTAssertEqual(result.text, "open useauth.ts now")
+        XCTAssertEqual(result.sanctionedCount, 0)
+    }
 }
 
 // MARK: - View-model integration
@@ -1001,6 +1065,276 @@ final class DictationViewModelPolishTokenGuardTests: XCTestCase {
             request: request,
             committedText: viewModel.currentDictationEventText
         )
+    }
+
+    // MARK: - Repo vocabulary
+
+    /// Setting ON + loopback endpoint: the stubbed vocabulary entries are
+    /// appended to the request's replacement-dictionary section (the
+    /// `{{replacement_dictionary}}` slot), and the record's provenance carries
+    /// `vocab:<n>`.
+    func testRepoVocabularyInjectedIntoDictionarySection() async throws {
+        let counter = RepoVocabularyOverrideCounter()
+        let (record, request) = await runRepoVocabularySession(
+            repoVocabularyEnabled: true,
+            vocabularyEntries: [
+                ReplacementEntry(replaceWith: "useAuth.ts", matches: ["use auth dot t s"]),
+            ],
+            overrideCounter: counter
+        )
+
+        XCTAssertEqual(counter.count, 1)
+        let prompts = try XCTUnwrap(request?.userPrompts)
+        let joined = prompts.joined(separator: "\n")
+        XCTAssertTrue(joined.contains("Repository vocabulary"))
+        XCTAssertTrue(joined.contains("useAuth.ts"))
+        XCTAssertTrue(joined.contains("use auth dot t s"))
+        XCTAssertEqual(record?.polishContextSummary, "vocab:1")
+    }
+
+    /// Setting OFF: the override is never consulted, the request carries no
+    /// vocabulary, and the provenance summary is nil.
+    func testRepoVocabularyDisabledLeavesRequestUntouched() async throws {
+        let counter = RepoVocabularyOverrideCounter()
+        let (record, request) = await runRepoVocabularySession(
+            repoVocabularyEnabled: false,
+            vocabularyEntries: [
+                ReplacementEntry(replaceWith: "useAuth.ts", matches: ["use auth dot t s"]),
+            ],
+            overrideCounter: counter
+        )
+
+        XCTAssertEqual(counter.count, 0)
+        let prompts = try XCTUnwrap(request?.userPrompts)
+        XCTAssertFalse(prompts.contains { $0.contains("Repository vocabulary") })
+        XCTAssertFalse(prompts.contains { $0.contains("useAuth.ts") })
+        XCTAssertNil(record?.polishContextSummary)
+    }
+
+    /// The privacy gate: setting ON but a REMOTE polishing endpoint. The
+    /// loopback gate short-circuits before the resolver/indexer seam, so the
+    /// override is never consulted (repo file names never ride off-Mac) and the
+    /// request is untouched.
+    func testRepoVocabularyRemoteEndpointSkipsInjection() async throws {
+        let counter = RepoVocabularyOverrideCounter()
+        let (record, request) = await runRepoVocabularySession(
+            repoVocabularyEnabled: true,
+            endpointURL: "https://example.com/v1/chat/completions",
+            vocabularyEntries: [
+                ReplacementEntry(replaceWith: "useAuth.ts", matches: ["use auth dot t s"]),
+            ],
+            overrideCounter: counter
+        )
+
+        XCTAssertEqual(counter.count, 0)
+        let prompts = try XCTUnwrap(request?.userPrompts)
+        XCTAssertFalse(prompts.contains { $0.contains("Repository vocabulary") })
+        XCTAssertNil(record?.polishContextSummary)
+    }
+
+    /// The user removed `{{replacement_dictionary}}` from their template
+    /// (explicitly supported): the vocabulary path must be skipped ENTIRELY —
+    /// the seam is never consulted (so no AX read / git subprocess would run),
+    /// the request carries no vocabulary, and no `vocab:` provenance is
+    /// recorded for work that could not land in the prompt.
+    func testRepoVocabularySkippedWhenTemplateLacksDictionarySlot() async throws {
+        let counter = RepoVocabularyOverrideCounter()
+        let (record, request) = await runRepoVocabularySession(
+            repoVocabularyEnabled: true,
+            templateUserContent: "Clean this up.\nWorking text:\n{{input_text}}",
+            vocabularyEntries: [
+                ReplacementEntry(replaceWith: "useAuth.ts", matches: ["use auth dot t s"]),
+            ],
+            overrideCounter: counter
+        )
+
+        XCTAssertEqual(counter.count, 0)
+        let prompts = try XCTUnwrap(request?.userPrompts)
+        XCTAssertFalse(prompts.contains { $0.contains("Repository vocabulary") })
+        XCTAssertFalse(prompts.contains { $0.contains("useAuth.ts") })
+        XCTAssertNil(record?.polishContextSummary)
+    }
+
+    /// Pins clipboard-read ordering vs the vocabulary await: the payload-macro
+    /// and polish-context pasteboard reads BOTH happen pre-Task, so when the
+    /// vocabulary seam (which stands in for the up-to-2s git index inside the
+    /// Task) runs, each stub has already been read exactly once. A copy landing
+    /// during the index can therefore never split the two features across
+    /// different pasteboard states.
+    func testClipboardReadsHappenBeforeVocabularyIndexing() async throws {
+        let settings = makeSettings(outputMode: .overlayBuffer)
+        settings.llmPolishingEnabled = true
+        settings.polishingBackendMode = .externalURL
+        settings.llmPolishingEndpointURL = "http://127.0.0.1:8472/v1/chat/completions"
+        settings.polishClipboardContextEnabled = true
+        settings.clipboardPayloadMacroEnabled = true
+        settings.repoVocabularyEnabled = true
+
+        let template = LLMPromptTemplates(
+            systemContent: "system",
+            userContent: "Clean this up.\n{{replacement_dictionary}}\nWorking text:\n{{input_text}}"
+        )
+        let mockConfig = MockAppConfigStore(
+            promptTemplates: template,
+            agentPromptTemplates: template
+        )
+        let service = RecordingPolishingService()
+        let contextStub = PasteboardStub(string: "UserSessionManager.swift")
+        let payloadStub = PasteboardStub(string: "err.log payload")
+
+        let viewModel = DictationViewModel(
+            settings: settings,
+            overlayBufferCoordinator: MockOverlayCoordinator(),
+            startRuntimeServices: false
+        )
+        viewModel.appConfigStore = mockConfig
+        viewModel.llmPolishingService = service
+        viewModel.debugResolveTargetAppBundleIDOverride = { "com.acme.notes" }
+        viewModel.debugPolishContextPasteboardReaderOverride = { contextStub }
+        viewModel.debugClipboardPayloadPasteboardReaderOverride = { payloadStub }
+        var contextReadsWhenVocabRan = -1
+        var payloadReadsWhenVocabRan = -1
+        viewModel.debugRepoVocabularyEntriesOverride = { _ in
+            contextReadsWhenVocabRan = contextStub.stringCallCount
+            payloadReadsWhenVocabRan = payloadStub.stringCallCount
+            return nil
+        }
+        var savedRecord: DictationSessionRecord?
+        viewModel.debugSavedSessionRecordSink = { savedRecord = $0 }
+        retainForTestProcessLifetime(viewModel)
+
+        viewModel.sessionOutputMode = .overlayBuffer
+        viewModel.isFinalizingStop = true
+        viewModel.currentDictationEventText = "fix this paste clipboard thanks"
+
+        viewModel.finishStoppedSession(promotePendingSegment: false)
+        await waitUntilStoppedSessionCompletes(viewModel)
+
+        // The vocab seam ran, and by then BOTH clipboard reads had happened.
+        XCTAssertEqual(contextReadsWhenVocabRan, 1)
+        XCTAssertEqual(payloadReadsWhenVocabRan, 1)
+        // Both features still landed in the request/record as usual.
+        let capturedRequest = await service.capturedRequest
+        let request = try XCTUnwrap(capturedRequest)
+        XCTAssertTrue(request.inputText.contains(ClipboardPayloadMacro.placeholder))
+        XCTAssertTrue(
+            request.userPrompts.contains {
+                $0.contains(PolishContextClipboardReader.contextMessageInstruction)
+            }
+        )
+        XCTAssertNotNil(savedRecord?.polishContextSummary)
+    }
+
+    /// The full sanctioned-rewrite path end to end: the vocabulary entry asks
+    /// the model to fix the misheard `useauth.ts` to the repo's `useAuth.ts`,
+    /// the model complies, and the token guard must NOT case-revert the
+    /// correction (its pre-sanctioning behavior for protected filenames).
+    func testSanctionedVocabularyRewriteSurvivesTokenGuard() async {
+        let settings = makeSettings(outputMode: .overlayBuffer)
+        settings.llmPolishingEnabled = true
+        settings.polishingBackendMode = .externalURL
+        settings.llmPolishingEndpointURL = "http://127.0.0.1:8472/v1/chat/completions"
+        settings.repoVocabularyEnabled = true
+
+        let template = LLMPromptTemplates(
+            systemContent: "system",
+            userContent: "Clean this up.\n{{replacement_dictionary}}\nWorking text:\n{{input_text}}"
+        )
+        let mockConfig = MockAppConfigStore(
+            promptTemplates: template,
+            agentPromptTemplates: template
+        )
+        // The model applies exactly the injected vocabulary correction.
+        let service = RecordingPolishingService(transform: {
+            $0.replacingOccurrences(of: "useauth.ts", with: "useAuth.ts")
+        })
+        let viewModel = DictationViewModel(
+            settings: settings,
+            overlayBufferCoordinator: MockOverlayCoordinator(),
+            startRuntimeServices: false
+        )
+        viewModel.appConfigStore = mockConfig
+        viewModel.llmPolishingService = service
+        viewModel.debugResolveTargetAppBundleIDOverride = { "com.apple.Terminal" }
+        viewModel.debugRepoVocabularyEntriesOverride = { _ in
+            [ReplacementEntry(replaceWith: "useAuth.ts", matches: ["useauth.ts"])]
+        }
+        retainForTestProcessLifetime(viewModel)
+
+        viewModel.sessionOutputMode = .overlayBuffer
+        viewModel.isFinalizingStop = true
+        viewModel.currentDictationEventText = "open useauth.ts and fix the import"
+
+        viewModel.finishStoppedSession(promotePendingSegment: false)
+        await waitUntilStoppedSessionCompletes(viewModel)
+
+        XCTAssertEqual(
+            viewModel.currentDictationEventText,
+            "open useAuth.ts and fix the import"
+        )
+    }
+
+    /// Records override calls so the privacy/toggle gates can be asserted by call
+    /// count (0 = the resolver/indexer seam was never reached).
+    private final class RepoVocabularyOverrideCounter {
+        var count = 0
+    }
+
+    /// Drives an overlay stop-commit with polishing enabled and a template that
+    /// carries `{{replacement_dictionary}}` (overridable, to prove the
+    /// missing-slot skip), injecting the repo-vocabulary resolver/indexer seam
+    /// directly so no AX read or git subprocess runs. Endpoint defaults to
+    /// loopback so the local-endpoint gate passes.
+    private func runRepoVocabularySession(
+        repoVocabularyEnabled: Bool,
+        endpointURL: String = "http://127.0.0.1:8472/v1/chat/completions",
+        templateUserContent: String =
+            "Clean this up.\n{{replacement_dictionary}}\nWorking text:\n{{input_text}}",
+        vocabularyEntries: [ReplacementEntry]?,
+        overrideCounter: RepoVocabularyOverrideCounter
+    ) async -> (record: DictationSessionRecord?, request: LLMPolishingRequest?) {
+        let settings = makeSettings(outputMode: .overlayBuffer)
+        settings.llmPolishingEnabled = true
+        settings.polishingBackendMode = .externalURL
+        settings.llmPolishingEndpointURL = endpointURL
+        settings.repoVocabularyEnabled = repoVocabularyEnabled
+
+        // Both profiles use the same template so the injected section (or its
+        // absence) is observable regardless of the agent/standard switch.
+        let template = LLMPromptTemplates(
+            systemContent: "system",
+            userContent: templateUserContent
+        )
+        let mockConfig = MockAppConfigStore(
+            promptTemplates: template,
+            agentPromptTemplates: template
+        )
+        let service = RecordingPolishingService()
+
+        let viewModel = DictationViewModel(
+            settings: settings,
+            overlayBufferCoordinator: MockOverlayCoordinator(),
+            startRuntimeServices: false
+        )
+        viewModel.appConfigStore = mockConfig
+        viewModel.llmPolishingService = service
+        viewModel.debugResolveTargetAppBundleIDOverride = { "com.apple.Terminal" }
+        viewModel.debugRepoVocabularyEntriesOverride = { _ in
+            overrideCounter.count += 1
+            return vocabularyEntries
+        }
+        var savedRecord: DictationSessionRecord?
+        viewModel.debugSavedSessionRecordSink = { savedRecord = $0 }
+        retainForTestProcessLifetime(viewModel)
+
+        viewModel.sessionOutputMode = .overlayBuffer
+        viewModel.isFinalizingStop = true
+        viewModel.currentDictationEventText = "open use auth dot t s and fix the import"
+
+        viewModel.finishStoppedSession(promotePendingSegment: false)
+        await waitUntilStoppedSessionCompletes(viewModel)
+        let request = await service.capturedRequest
+        return (savedRecord, request)
     }
 
     // MARK: - Helpers

--- a/Tests/localvoxtralTests/PolishTokenGuardTests.swift
+++ b/Tests/localvoxtralTests/PolishTokenGuardTests.swift
@@ -366,6 +366,41 @@ final class PolishTokenGuardTests: XCTestCase {
         XCTAssertEqual(result.text, "open useauth.ts now")
         XCTAssertEqual(result.sanctionedCount, 0)
     }
+
+    /// Substring-canonical sanctioning (field regression, 2026-07-11): the
+    /// sanctioned alias is a multi-word gram whose TAIL is the protected token
+    /// — the STT glued "user session manager dot swift" into `manager.swift`,
+    /// the caller asked for `UserSessionManager.swift`, the model complied.
+    /// The protected `manager.swift` canonically equals no alias, but it IS
+    /// canonically contained in one whose `to` the model produced: sanctioned,
+    /// never a fallback.
+    func testSanctionedAliasContainingProtectedTokenDoesNotFallBack() {
+        let result = PolishTokenGuard.verifyAndRepair(
+            polished: "Look at UserSessionManager.swift.",
+            original: "look at user session manager.swift",
+            sanctionedReplacements: [
+                (from: "user session manager.swift", to: "UserSessionManager.swift")
+            ]
+        )
+        XCTAssertEqual(result.outcome, .clean)
+        XCTAssertEqual(result.text, "Look at UserSessionManager.swift.")
+        XCTAssertEqual(result.sanctionedCount, 1)
+    }
+
+    /// Containment is no blanket license: a protected token that is NOT part
+    /// of any sanctioned alias still falls back when the model deletes it,
+    /// even while an unrelated sanctioned rewrite happened in the same text.
+    func testUnrelatedProtectedTokenStillGuardedUnderContainment() {
+        let result = PolishTokenGuard.verifyAndRepair(
+            polished: "Look at UserSessionManager.swift now.",
+            original: "look at user session manager.swift and run --force",
+            sanctionedReplacements: [
+                (from: "user session manager.swift", to: "UserSessionManager.swift")
+            ]
+        )
+        XCTAssertEqual(result.outcome, .fallback(missing: ["--force"]))
+        XCTAssertEqual(result.text, "look at user session manager.swift and run --force")
+    }
 }
 
 // MARK: - View-model integration
@@ -1272,6 +1307,139 @@ final class DictationViewModelPolishTokenGuardTests: XCTestCase {
         XCTAssertEqual(
             viewModel.currentDictationEventText,
             "open useAuth.ts and fix the import"
+        )
+    }
+
+    /// THE T5 field regression (2026-07-11) end to end: clipboard context ON,
+    /// clipboard holding `UserSessionManager.swift`, the user dictated "look at
+    /// user session manager dot swift" and the STT glued the tail into the
+    /// guard-protected `manager.swift`. The model (stubbed) applies exactly the
+    /// correction the clipboard grounds. Clipboard entities must join the
+    /// sanctioned-rewrite pipeline so the guard does NOT discard the polish —
+    /// pre-fix it deterministically fell back to the misheard text.
+    func testClipboardEntityCorrectionSurvivesTokenGuard() async throws {
+        let settings = makeSettings(outputMode: .overlayBuffer)
+        settings.llmPolishingEnabled = true
+        settings.polishingBackendMode = .externalURL
+        settings.llmPolishingEndpointURL = "http://127.0.0.1:8472/v1/chat/completions"
+        settings.polishClipboardContextEnabled = true
+        settings.repoVocabularyEnabled = false
+
+        let template = LLMPromptTemplates(
+            systemContent: "system",
+            userContent: "Clean this up.\n{{replacement_dictionary}}\nWorking text:\n{{input_text}}"
+        )
+        let mockConfig = MockAppConfigStore(
+            promptTemplates: template,
+            agentPromptTemplates: template
+        )
+        // The model applies exactly the clipboard-grounded correction.
+        let service = RecordingPolishingService(transform: {
+            $0.replacingOccurrences(
+                of: "user session manager.swift",
+                with: "UserSessionManager.swift"
+            )
+        })
+        let viewModel = DictationViewModel(
+            settings: settings,
+            overlayBufferCoordinator: MockOverlayCoordinator(),
+            startRuntimeServices: false
+        )
+        viewModel.appConfigStore = mockConfig
+        viewModel.llmPolishingService = service
+        viewModel.debugResolveTargetAppBundleIDOverride = { "com.apple.Terminal" }
+        viewModel.debugPolishContextPasteboardReaderOverride = {
+            PasteboardStub(string: "UserSessionManager.swift")
+        }
+        var savedRecord: DictationSessionRecord?
+        viewModel.debugSavedSessionRecordSink = { savedRecord = $0 }
+        retainForTestProcessLifetime(viewModel)
+
+        viewModel.sessionOutputMode = .overlayBuffer
+        viewModel.isFinalizingStop = true
+        viewModel.currentDictationEventText = "look at user session manager.swift"
+
+        viewModel.finishStoppedSession(promotePendingSegment: false)
+        await waitUntilStoppedSessionCompletes(viewModel)
+
+        // The guard must sanction, not discard: the correction commits.
+        XCTAssertEqual(
+            viewModel.currentDictationEventText,
+            "look at UserSessionManager.swift"
+        )
+        // The matched entity also rode the dictionary slot as a hint entry.
+        let capturedRequest = await service.capturedRequest
+        let request = try XCTUnwrap(capturedRequest)
+        XCTAssertTrue(
+            request.userPrompts.contains {
+                $0.contains(RepoVocabularyMatcher.clipboardVocabularyHeader)
+                    && $0.contains("- UserSessionManager.swift: user session manager.swift")
+            }
+        )
+        // Counts-only provenance.
+        XCTAssertEqual(
+            savedRecord?.polishContextSummary,
+            "clipboard:24ch+clipboard-vocab:1"
+        )
+    }
+
+    /// Sanctioning must not depend on the dictionary slot: a user template
+    /// without `{{replacement_dictionary}}` gets no hint entries, but the
+    /// model still corrects from the context excerpt alone and the guard must
+    /// still sanction that correction instead of discarding it.
+    func testClipboardEntitySanctioningWorksWithoutDictionarySlot() async throws {
+        let settings = makeSettings(outputMode: .overlayBuffer)
+        settings.llmPolishingEnabled = true
+        settings.polishingBackendMode = .externalURL
+        settings.llmPolishingEndpointURL = "http://127.0.0.1:8472/v1/chat/completions"
+        settings.polishClipboardContextEnabled = true
+        settings.repoVocabularyEnabled = false
+
+        let template = LLMPromptTemplates(
+            systemContent: "system",
+            userContent: "Clean this up.\n{{input_text}}"
+        )
+        let mockConfig = MockAppConfigStore(
+            promptTemplates: template,
+            agentPromptTemplates: template
+        )
+        let service = RecordingPolishingService(transform: {
+            $0.replacingOccurrences(
+                of: "user session manager.swift",
+                with: "UserSessionManager.swift"
+            )
+        })
+        let viewModel = DictationViewModel(
+            settings: settings,
+            overlayBufferCoordinator: MockOverlayCoordinator(),
+            startRuntimeServices: false
+        )
+        viewModel.appConfigStore = mockConfig
+        viewModel.llmPolishingService = service
+        viewModel.debugResolveTargetAppBundleIDOverride = { "com.apple.Terminal" }
+        viewModel.debugPolishContextPasteboardReaderOverride = {
+            PasteboardStub(string: "UserSessionManager.swift")
+        }
+        retainForTestProcessLifetime(viewModel)
+
+        viewModel.sessionOutputMode = .overlayBuffer
+        viewModel.isFinalizingStop = true
+        viewModel.currentDictationEventText = "look at user session manager.swift"
+
+        viewModel.finishStoppedSession(promotePendingSegment: false)
+        await waitUntilStoppedSessionCompletes(viewModel)
+
+        XCTAssertEqual(
+            viewModel.currentDictationEventText,
+            "look at UserSessionManager.swift"
+        )
+        // No dictionary slot: the hint section must not appear anywhere.
+        let capturedRequest = await service.capturedRequest
+        let request = try XCTUnwrap(capturedRequest)
+        XCTAssertFalse(
+            request.userPrompts.contains {
+                $0.contains(RepoVocabularyMatcher.clipboardVocabularyHeader)
+            }
         )
     }
 

--- a/Tests/localvoxtralTests/RepoVocabularyTests.swift
+++ b/Tests/localvoxtralTests/RepoVocabularyTests.swift
@@ -74,6 +74,7 @@ final class TerminalWorkingDirectoryResolverTests: XCTestCase {
         )
         XCTAssertNil(resolved)
     }
+
 }
 
 // MARK: - Git-root walk + HEAD/branch parsing (fixture dirs, no git binary)
@@ -432,6 +433,61 @@ final class RepoVocabularyMatcherTests: XCTestCase {
 }
 
 // MARK: - Service orchestration (injected subprocess + fixture .git)
+
+final class ClipboardVocabularyTests: XCTestCase {
+    // MARK: - Entity extraction (reuses the guard's recognizer)
+
+    func testEntitiesRecognizeCodeLikeTokensAndDedupe() {
+        let excerpt = """
+        Fix UserSessionManager.swift and rerun with --force.
+        See src/auth/useAuth.ts and $HOME_DIR, then UserSessionManager.swift again.
+        """
+        XCTAssertEqual(
+            ClipboardVocabulary.entities(inExcerpt: excerpt),
+            ["UserSessionManager.swift", "--force", "src/auth/useAuth.ts", "$HOME_DIR"]
+        )
+    }
+
+    func testEntitiesUnwrapBacktickSpans() {
+        XCTAssertEqual(
+            ClipboardVocabulary.entities(inExcerpt: "call `resolveWorkingDirectory` here"),
+            ["resolveWorkingDirectory"]
+        )
+    }
+
+    func testProseExcerptYieldsNoEntities() {
+        XCTAssertTrue(
+            ClipboardVocabulary.entities(
+                inExcerpt: "just a plain sentence with no code tokens at all"
+            ).isEmpty
+        )
+    }
+
+    // MARK: - Transcript matching (same matcher as repo vocabulary)
+
+    /// The T5 field case (2026-07-11): clipboard holds the exact identifier,
+    /// the STT glued the dictated tail into `manager.swift`. The transcript
+    /// n-gram must match the clipboard entity and yield the hint entry whose
+    /// (spoken, exact) pair the session sanctions through the guard.
+    func testT5TranscriptGramMatchesClipboardEntity() {
+        let result = ClipboardVocabulary.candidateEntries(
+            transcript: "look at user session manager.swift",
+            excerpt: "UserSessionManager.swift"
+        )
+        XCTAssertEqual(result.count, 1)
+        XCTAssertEqual(result.first?.replaceWith, "UserSessionManager.swift")
+        XCTAssertEqual(result.first?.matches, ["user session manager.swift"])
+    }
+
+    func testUnrelatedTranscriptYieldsNoEntries() {
+        XCTAssertTrue(
+            ClipboardVocabulary.candidateEntries(
+                transcript: "completely unrelated dictation about lunch",
+                excerpt: "UserSessionManager.swift"
+            ).isEmpty
+        )
+    }
+}
 
 final class RepoVocabularyServiceTests: XCTestCase {
     private func makeFixtureRepo() -> URL {

--- a/Tests/localvoxtralTests/RepoVocabularyTests.swift
+++ b/Tests/localvoxtralTests/RepoVocabularyTests.swift
@@ -75,6 +75,159 @@ final class TerminalWorkingDirectoryResolverTests: XCTestCase {
         XCTAssertNil(resolved)
     }
 
+    // MARK: - Ghostty-abbreviated titles (leading components elided as `..`)
+
+    /// The T6 field case (2026-07-11): Ghostty's tab title is exactly
+    /// "../Desktop/projects/supervoxtral". The extracted absolute run
+    /// "/Desktop/projects/supervoxtral" does not exist; the home-anchored
+    /// expansion does and must resolve.
+    func testGhosttyAbbreviatedTitleResolvesHomeAnchored() {
+        let resolved = TerminalWorkingDirectoryResolver.resolveWorkingDirectory(
+            fromWindowTitle: "../Desktop/projects/supervoxtral",
+            homeDirectory: "/Users/x",
+            isDirectory: { $0 == "/Users/x/Desktop/projects/supervoxtral" }
+        )
+        XCTAssertEqual(resolved, "/Users/x/Desktop/projects/supervoxtral")
+    }
+
+    /// A genuinely absolute path that exists must never be shadowed by its
+    /// home-anchored twin, even when both exist.
+    func testExistingAbsolutePathWinsOverHomeAnchoredTwin() {
+        let resolved = TerminalWorkingDirectoryResolver.resolveWorkingDirectory(
+            fromWindowTitle: "/opt/work/repo",
+            homeDirectory: home,
+            isDirectory: { $0 == "/opt/work/repo" || $0 == "\(self.home)/opt/work/repo" }
+        )
+        XCTAssertEqual(resolved, "/opt/work/repo")
+    }
+
+    /// A genuinely absolute path that does not exist locally (an SSH or
+    /// container path, an unmounted volume) must resolve to NIL — never be
+    /// re-anchored under home, which would index a same-named local repo and
+    /// inject wrong-repo vocabulary. Only `../`-prefixed (explicitly elided)
+    /// titles get home-anchoring.
+    func testNonExistentAbsolutePathDoesNotFallBackToHome() {
+        let resolved = TerminalWorkingDirectoryResolver.resolveWorkingDirectory(
+            fromWindowTitle: "/work/repo — zsh",
+            homeDirectory: home,
+            isDirectory: { $0 == "\(self.home)/work/repo" }
+        )
+        XCTAssertNil(resolved)
+    }
+
+    /// THE T6 field failure, canonical case (owner-confirmed 2026-07-11):
+    /// Ghostty's tab title elides with a Unicode HORIZONTAL ELLIPSIS, not
+    /// ASCII dots — the real title was "…/Desktop/projects/supervoxtral"
+    /// (reported by typing, which loses the distinction from "../"). The
+    /// ellipsis-elided title must home-anchor exactly like the ASCII form.
+    func testT6GhosttyEllipsisElidedTitleResolvesHomeAnchored() {
+        let resolved = TerminalWorkingDirectoryResolver.resolveWorkingDirectory(
+            fromWindowTitle: "…/Desktop/projects/supervoxtral",
+            homeDirectory: "/Users/owner",
+            isDirectory: { $0 == "/Users/owner/Desktop/projects/supervoxtral" }
+        )
+        XCTAssertEqual(resolved, "/Users/owner/Desktop/projects/supervoxtral")
+    }
+
+    /// The same canonical T6 case through the PRODUCTION existence check (no
+    /// injected predicate — the default real-filesystem one), against a real
+    /// temp directory tree, so hermetic test defaults can never mask a broken
+    /// production wiring again.
+    func testT6GhosttyEllipsisElidedTitleResolvesWithRealFilesystemCheck() throws {
+        let tempHome = FileManager.default.temporaryDirectory
+            .appendingPathComponent("t6-home-\(UUID().uuidString)").path
+        let repo = tempHome + "/Desktop/projects/supervoxtral"
+        try FileManager.default.createDirectory(
+            atPath: repo, withIntermediateDirectories: true
+        )
+        addTeardownBlock { try? FileManager.default.removeItem(atPath: tempHome) }
+
+        XCTAssertEqual(
+            TerminalWorkingDirectoryResolver.resolveWorkingDirectory(
+                fromWindowTitle: "…/Desktop/projects/supervoxtral",
+                homeDirectory: tempHome
+            ),
+            repo
+        )
+    }
+
+    /// U+2025 TWO DOT LEADER is accepted as an elision mark too.
+    func testTwoDotLeaderElidedTitleResolvesHomeAnchored() {
+        let resolved = TerminalWorkingDirectoryResolver.resolveWorkingDirectory(
+            fromWindowTitle: "‥/dev/proj — zsh",
+            homeDirectory: home,
+            isDirectory: { $0 == "\(self.home)/dev/proj" }
+        )
+        XCTAssertEqual(resolved, "/Users/tester/dev/proj")
+    }
+
+    func testEllipsisFallbackCandidateShape() {
+        XCTAssertEqual(
+            TerminalWorkingDirectoryResolver.homeAnchoredFallbackCandidates(
+                fromWindowTitle: "…/Desktop/proj — zsh",
+                homeDirectory: home
+            ),
+            ["/Users/tester/Desktop/proj"]
+        )
+    }
+
+    // MARK: - Redacted title-shape diagnostic
+
+    /// Letters map to "a", digits to "9", separators/elision marks and spaces
+    /// survive, everything else is "?" — never raw content.
+    func testTitleShapeClassMapsContent() {
+        XCTAssertEqual(
+            TerminalWorkingDirectoryResolver.titleShape("…/Desktop/projects2 — zsh"),
+            "…/aaaaaaa/aaaaaaaa9 ? aaa"
+        )
+        XCTAssertEqual(
+            TerminalWorkingDirectoryResolver.titleShape("~/dev.proj"),
+            "~/aaa.aaaa"
+        )
+    }
+
+    func testTitleShapeCapsLength() {
+        let shape = TerminalWorkingDirectoryResolver.titleShape(
+            String(repeating: "secret", count: 30)
+        )
+        XCTAssertEqual(shape.count, 60)
+        XCTAssertEqual(shape, String(repeating: "a", count: 60))
+    }
+
+    func testAbbreviatedTitleWithNothingExistingResolvesNil() {
+        let resolved = TerminalWorkingDirectoryResolver.resolveWorkingDirectory(
+            fromWindowTitle: "../foo",
+            homeDirectory: home,
+            isDirectory: { _ in false }
+        )
+        XCTAssertNil(resolved)
+    }
+
+    func testHomeAnchoredFallbackCandidateShapes() {
+        XCTAssertEqual(
+            TerminalWorkingDirectoryResolver.homeAnchoredFallbackCandidates(
+                fromWindowTitle: "../Desktop/proj — zsh",
+                homeDirectory: home
+            ),
+            ["/Users/tester/Desktop/proj"]
+        )
+        // A tilde run is already home-anchored: no fallback is generated.
+        XCTAssertEqual(
+            TerminalWorkingDirectoryResolver.homeAnchoredFallbackCandidates(
+                fromWindowTitle: "~/dev/proj",
+                homeDirectory: home
+            ),
+            []
+        )
+        // An absolute run generates NO fallback: only `../` signals elision.
+        XCTAssertEqual(
+            TerminalWorkingDirectoryResolver.homeAnchoredFallbackCandidates(
+                fromWindowTitle: "/work/repo — zsh",
+                homeDirectory: home
+            ),
+            []
+        )
+    }
 }
 
 // MARK: - Git-root walk + HEAD/branch parsing (fixture dirs, no git binary)

--- a/Tests/localvoxtralTests/RepoVocabularyTests.swift
+++ b/Tests/localvoxtralTests/RepoVocabularyTests.swift
@@ -1,0 +1,628 @@
+import Foundation
+import XCTest
+@testable import localvoxtral
+
+// MARK: - Terminal window-title parser
+
+final class TerminalWorkingDirectoryResolverTests: XCTestCase {
+    private let home = "/Users/tester"
+
+    private func candidates(_ title: String) -> [String] {
+        TerminalWorkingDirectoryResolver.workingDirectoryCandidates(
+            fromWindowTitle: title, homeDirectory: home
+        )
+    }
+
+    func testAbsolutePathWithShellDecoration() {
+        XCTAssertEqual(candidates("/Users/x/dev/proj — zsh"), ["/Users/x/dev/proj"])
+    }
+
+    func testTildePathIsExpanded() {
+        XCTAssertEqual(candidates("~/dev/proj"), ["/Users/tester/dev/proj"])
+    }
+
+    func testBareTildeExpandsToHome() {
+        XCTAssertEqual(candidates("~"), ["/Users/tester"])
+    }
+
+    func testTerminalDotAppBareNameIsRejected() {
+        // "proj — zsh — 80×24": a bare last-path-component is not resolvable.
+        XCTAssertEqual(candidates("proj — zsh — 80×24"), [])
+    }
+
+    func testITerm2UserHostStyle() {
+        XCTAssertEqual(candidates("user@host: ~/dev/proj"), ["/Users/tester/dev/proj"])
+    }
+
+    func testEditorDecorationAndBoxDimensions() {
+        XCTAssertEqual(candidates("/a — vim (80×24)"), ["/a"])
+    }
+
+    func testTrailingCommaTrimmed() {
+        XCTAssertEqual(candidates("~/dev/proj,"), ["/Users/tester/dev/proj"])
+    }
+
+    func testBoxDimensionsOnlyYieldNoCandidate() {
+        XCTAssertEqual(candidates("80×24"), [])
+    }
+
+    func testMultipleCandidatesInOrderOfAppearance() {
+        XCTAssertEqual(
+            candidates("host: ~/a and /b/c done"),
+            ["/Users/tester/a", "/b/c"]
+        )
+    }
+
+    func testDeduplicatesRepeatedCandidates() {
+        XCTAssertEqual(candidates("/x/y and /x/y"), ["/x/y"])
+    }
+
+    func testResolveReturnsFirstExistingDirectory() {
+        let resolved = TerminalWorkingDirectoryResolver.resolveWorkingDirectory(
+            fromWindowTitle: "cd /nope then ~/yes",
+            homeDirectory: home,
+            isDirectory: { $0 == "/Users/tester/yes" }
+        )
+        XCTAssertEqual(resolved, "/Users/tester/yes")
+    }
+
+    func testResolveReturnsNilWhenNoneExist() {
+        let resolved = TerminalWorkingDirectoryResolver.resolveWorkingDirectory(
+            fromWindowTitle: "/a /b",
+            homeDirectory: home,
+            isDirectory: { _ in false }
+        )
+        XCTAssertNil(resolved)
+    }
+}
+
+// MARK: - Git-root walk + HEAD/branch parsing (fixture dirs, no git binary)
+
+final class RepoIndexingWalkTests: XCTestCase {
+    private func makeTempDir() -> URL {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("repovocab-walk-\(UUID().uuidString)")
+        try! FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+        addTeardownBlock { try? FileManager.default.removeItem(at: url) }
+        return url
+    }
+
+    private func write(_ content: String, to url: URL) {
+        try! FileManager.default.createDirectory(
+            at: url.deletingLastPathComponent(), withIntermediateDirectories: true
+        )
+        try! content.write(to: url, atomically: true, encoding: .utf8)
+    }
+
+    func testFindsGitRootWalkingUp() {
+        let repo = makeTempDir()
+        write("ref: refs/heads/main\n", to: repo.appendingPathComponent(".git/HEAD"))
+        let deep = repo.appendingPathComponent("sub/deep")
+        try! FileManager.default.createDirectory(at: deep, withIntermediateDirectories: true)
+
+        let root = RepoIndexing.findGitRoot(startingAt: deep.path)
+        XCTAssertEqual(root, repo.standardizedFileURL.path)
+    }
+
+    func testFindGitRootReturnsNilOutsideRepo() {
+        let dir = makeTempDir()
+        XCTAssertNil(RepoIndexing.findGitRoot(startingAt: dir.path))
+    }
+
+    func testBranchParsedFromHead() {
+        let repo = makeTempDir()
+        write("ref: refs/heads/feature/foo\n", to: repo.appendingPathComponent(".git/HEAD"))
+        XCTAssertEqual(RepoIndexing.branch(root: repo.path), "feature/foo")
+    }
+
+    func testDetachedHeadYieldsNilBranch() {
+        let repo = makeTempDir()
+        write(
+            "9fceb02d0ae598e95dc970b74767f19372d61af8\n",
+            to: repo.appendingPathComponent(".git/HEAD")
+        )
+        XCTAssertNil(RepoIndexing.branch(root: repo.path))
+    }
+
+    func testWorktreeGitdirPointerFollowedToHead() {
+        // A linked worktree: `.git` is a FILE pointing at the real gitdir, whose
+        // HEAD holds the worktree's branch.
+        let mainRepo = makeTempDir()
+        let worktreeGitDir = mainRepo.appendingPathComponent(".git/worktrees/wt")
+        write("ref: refs/heads/wt-branch\n", to: worktreeGitDir.appendingPathComponent("HEAD"))
+
+        let worktree = makeTempDir()
+        write("gitdir: \(worktreeGitDir.path)\n", to: worktree.appendingPathComponent(".git"))
+
+        XCTAssertEqual(
+            RepoIndexing.findGitRoot(startingAt: worktree.path),
+            worktree.standardizedFileURL.path
+        )
+        XCTAssertEqual(RepoIndexing.branch(root: worktree.path), "wt-branch")
+    }
+}
+
+// MARK: - ls-files parsing + vocabulary build (synthesized bytes)
+
+final class RepoIndexingParsingTests: XCTestCase {
+    func testParsesCleanNullDelimitedPaths() {
+        let data = "a/b.ts\u{0}c/d.swift\u{0}".data(using: .utf8)!
+        XCTAssertEqual(
+            RepoIndexing.parseNullDelimitedPaths(data),
+            ["a/b.ts", "c/d.swift"]
+        )
+    }
+
+    func testDropsTruncatedFinalEntry() {
+        // No trailing NUL: the final entry was cut mid-write (timeout/cap).
+        let data = "a/b.ts\u{0}c/d.sw".data(using: .utf8)!
+        XCTAssertEqual(RepoIndexing.parseNullDelimitedPaths(data), ["a/b.ts"])
+    }
+
+    func testCapsAtMaxEntries() {
+        let data = "x\u{0}y\u{0}z\u{0}".data(using: .utf8)!
+        XCTAssertEqual(
+            RepoIndexing.parseNullDelimitedPaths(data, maxEntries: 2),
+            ["x", "y"]
+        )
+    }
+
+    func testEmptyDataYieldsNoPaths() {
+        XCTAssertEqual(RepoIndexing.parseNullDelimitedPaths(Data()), [])
+    }
+
+    func testBuildVocabularyBasenamesComponentsAndBranch() {
+        let vocab = RepoIndexing.buildVocabulary(
+            paths: ["useAuth.ts", "Sources/App/UserSessionManager.swift"],
+            branch: "feat/repo-vocabulary"
+        )
+        XCTAssertTrue(vocab.terms.contains("useAuth.ts"))
+        XCTAssertTrue(vocab.terms.contains("UserSessionManager.swift"))
+        // Bare common-word components carry no technical signal — excluded
+        // (they would capitalize ordinary prose as false hints).
+        XCTAssertFalse(vocab.terms.contains("Sources"))
+        XCTAssertFalse(vocab.terms.contains("App"))
+        // A branch with separators is technical and included as a term.
+        XCTAssertTrue(vocab.terms.contains("feat/repo-vocabulary"))
+        XCTAssertEqual(vocab.branch, "feat/repo-vocabulary")
+    }
+
+    func testBuildVocabularyExcludesNonTechnicalTerms() {
+        let vocab = RepoIndexing.buildVocabulary(
+            paths: [
+                "Tests/FooTests.swift",
+                "Resources/image.png",
+                "docs/readme.txt",
+                "Makefile",
+            ],
+            branch: "main"
+        )
+        XCTAssertTrue(vocab.terms.contains("FooTests.swift"))
+        XCTAssertTrue(vocab.terms.contains("image.png"))
+        XCTAssertTrue(vocab.terms.contains("readme.txt"))
+        // Common-word components: excluded (would inject `- Tests: tests`
+        // style false hints that capitalize ordinary prose).
+        XCTAssertFalse(vocab.terms.contains("Tests"))
+        XCTAssertFalse(vocab.terms.contains("Resources"))
+        XCTAssertFalse(vocab.terms.contains("docs"))
+        // Accepted loss (documented in `isTechnicalTerm`): bare names without
+        // separators or internal capitals carry no machine-checkable signal.
+        XCTAssertFalse(vocab.terms.contains("Makefile"))
+        // A plain-word branch is excluded from TERMS but still reported.
+        XCTAssertFalse(vocab.terms.contains("main"))
+        XCTAssertEqual(vocab.branch, "main")
+    }
+
+    func testIsTechnicalTermRule() {
+        XCTAssertTrue(RepoIndexing.isTechnicalTerm("useAuth.ts"))          // dot
+        XCTAssertTrue(RepoIndexing.isTechnicalTerm("feat/polish-guard"))   // separators
+        XCTAssertTrue(RepoIndexing.isTechnicalTerm("snake_case"))          // underscore
+        XCTAssertTrue(RepoIndexing.isTechnicalTerm("UserSessionManager"))  // PascalCase
+        XCTAssertTrue(RepoIndexing.isTechnicalTerm("useAuth"))             // camelCase
+        XCTAssertFalse(RepoIndexing.isTechnicalTerm("Tests"))              // leading cap only
+        XCTAssertFalse(RepoIndexing.isTechnicalTerm("Resources"))
+        XCTAssertFalse(RepoIndexing.isTechnicalTerm("docs"))               // all lowercase
+        XCTAssertFalse(RepoIndexing.isTechnicalTerm("LICENSE"))            // all caps, no lower
+        XCTAssertFalse(RepoIndexing.isTechnicalTerm("Makefile"))           // accepted loss
+    }
+}
+
+// MARK: - TTL cache (injected clock + mtime)
+
+final class RepoVocabularyCacheTests: XCTestCase {
+    private let vocab = RepoVocabulary(terms: ["useAuth.ts"], branch: "main")
+
+    func testHitWithinTTLAndUnchangedHead() {
+        let cache = RepoVocabularyCache(ttl: 300)
+        let start = Date(timeIntervalSince1970: 1_000)
+        let head = Date(timeIntervalSince1970: 500)
+        cache.insert(root: "/r", vocabulary: vocab, headModificationDate: head, now: start)
+
+        let hit = cache.lookup(
+            root: "/r",
+            now: start.addingTimeInterval(299),
+            currentHeadModificationDate: head
+        )
+        XCTAssertEqual(hit, vocab)
+    }
+
+    func testMissAfterTTLExpiry() {
+        let cache = RepoVocabularyCache(ttl: 300)
+        let start = Date(timeIntervalSince1970: 1_000)
+        let head = Date(timeIntervalSince1970: 500)
+        cache.insert(root: "/r", vocabulary: vocab, headModificationDate: head, now: start)
+
+        let miss = cache.lookup(
+            root: "/r",
+            now: start.addingTimeInterval(301),
+            currentHeadModificationDate: head
+        )
+        XCTAssertNil(miss)
+    }
+
+    func testMissWhenHeadMTimeChanged() {
+        let cache = RepoVocabularyCache(ttl: 300)
+        let start = Date(timeIntervalSince1970: 1_000)
+        cache.insert(
+            root: "/r",
+            vocabulary: vocab,
+            headModificationDate: Date(timeIntervalSince1970: 500),
+            now: start
+        )
+
+        let miss = cache.lookup(
+            root: "/r",
+            now: start,
+            currentHeadModificationDate: Date(timeIntervalSince1970: 600)
+        )
+        XCTAssertNil(miss)
+    }
+}
+
+// MARK: - Matcher
+
+final class RepoVocabularyMatcherTests: XCTestCase {
+    private func entries(_ transcript: String, terms: [String]) -> [ReplacementEntry] {
+        RepoVocabularyMatcher.candidateEntries(
+            transcript: transcript,
+            vocabulary: RepoVocabulary(terms: terms, branch: nil)
+        )
+    }
+
+    func testCanonicalUseAuthExample() {
+        let result = entries("open use auth dot t s and fix the import", terms: ["useAuth.ts"])
+        XCTAssertEqual(result.count, 1)
+        XCTAssertEqual(result.first?.replaceWith, "useAuth.ts")
+        XCTAssertEqual(result.first?.matches, ["use auth dot t s"])
+    }
+
+    func testCanonicalUserSessionManagerExample() {
+        let result = entries(
+            "rename the user session manager dot swift file",
+            terms: ["UserSessionManager.swift"]
+        )
+        XCTAssertEqual(result.count, 1)
+        XCTAssertEqual(result.first?.replaceWith, "UserSessionManager.swift")
+        XCTAssertEqual(result.first?.matches, ["user session manager dot swift"])
+    }
+
+    func testEditDistanceOneNearMiss() {
+        // "use auth s" -> "useauths" (8), one deletion from "useauthts".
+        let result = entries("please use auth s now", terms: ["useAuth.ts"])
+        XCTAssertEqual(result.count, 1)
+        XCTAssertEqual(result.first?.replaceWith, "useAuth.ts")
+    }
+
+    func testShortFormTermsRejected() {
+        // Bare "app"/"src" normalize to < 4 chars: no standalone entries.
+        XCTAssertTrue(entries("open the app and src", terms: ["app", "src"]).isEmpty)
+    }
+
+    func testShortComponentCountsInsideLongerNGram() {
+        // "app" alone is too short, but "app dot t s x" -> "apptsx" matches app.tsx.
+        let result = entries("edit app dot t s x here", terms: ["app.tsx"])
+        XCTAssertEqual(result.first?.replaceWith, "app.tsx")
+    }
+
+    func testPureStopwordNGramsRejected() {
+        // "the file" is all stopwords: never a file match even if it normalizes
+        // to a real term.
+        XCTAssertTrue(entries("open the file now", terms: ["thefile"]).isEmpty)
+    }
+
+    func testEntryCapAtTwelve() {
+        let terms = (0..<15).map { "alphafile\(String(format: "%02d", $0))" }
+        let transcript = terms.joined(separator: " ")
+        XCTAssertEqual(entries(transcript, terms: terms).count, 12)
+    }
+
+    func testRankingLongerNormalizedFirst() {
+        let result = entries("config configuration", terms: ["config", "configuration"])
+        XCTAssertEqual(result.map(\.replaceWith), ["configuration", "config"])
+    }
+
+    func testPromptSectionRendersDictionaryShape() {
+        let section = RepoVocabularyMatcher.promptSection(entries: [
+            ReplacementEntry(replaceWith: "useAuth.ts", matches: ["use auth dot t s"]),
+        ])
+        XCTAssertTrue(section.contains("Repository vocabulary"))
+        XCTAssertTrue(section.contains("- useAuth.ts: use auth dot t s"))
+    }
+
+    func testAppendedSectionStandsAloneWhenBaseEmpty() {
+        let appended = RepoVocabularyMatcher.appendedPromptSection(
+            base: "",
+            entries: [ReplacementEntry(replaceWith: "useAuth.ts", matches: ["use auth"])]
+        )
+        XCTAssertTrue(appended.hasPrefix("Repository vocabulary"))
+    }
+
+    func testAppendedSectionUnchangedWithNoEntries() {
+        XCTAssertEqual(
+            RepoVocabularyMatcher.appendedPromptSection(base: "Replacement dictionary:\n- x: y", entries: []),
+            "Replacement dictionary:\n- x: y"
+        )
+    }
+
+    func testPromptSectionSanitizesEmbeddedNewlineIntoSingleLine() {
+        // `git ls-files -z` preserves newlines in file names; the rendered
+        // dictionary line must stay a single intact `- key: aliases` line.
+        let section = RepoVocabularyMatcher.promptSection(entries: [
+            ReplacementEntry(replaceWith: "use\nAuth.ts", matches: ["use auth dot t s"]),
+        ])
+        let entryLines = section.split(separator: "\n").filter { $0.hasPrefix("- ") }
+        XCTAssertEqual(entryLines.count, 1)
+        XCTAssertEqual(entryLines.first, "- useAuth.ts: use auth dot t s")
+    }
+
+    func testPromptSectionStripsControlCharactersFromAliases() {
+        let section = RepoVocabularyMatcher.promptSection(entries: [
+            ReplacementEntry(replaceWith: "ok.ts", matches: ["use\u{0007}\tok"]),
+        ])
+        XCTAssertTrue(section.contains("- ok.ts: useok"))
+    }
+
+    func testPromptSectionDropsUnrenderableEntries() {
+        // Key empty after sanitization, key reduced to a dash run, and an entry
+        // whose every alias sanitizes away: none may render (and with nothing
+        // renderable the whole section is empty).
+        let section = RepoVocabularyMatcher.promptSection(entries: [
+            ReplacementEntry(replaceWith: "\u{0007}\n", matches: ["spoken"]),
+            ReplacementEntry(replaceWith: "---", matches: ["spoken"]),
+            ReplacementEntry(replaceWith: "ok.ts", matches: ["\n", "\u{0000}"]),
+        ])
+        XCTAssertEqual(section, "")
+    }
+
+    func testCommonComponentWordsDoNotBecomeMatcherEntries() {
+        // A repo full of Tests/Resources directories must not turn ordinary
+        // prose into capitalization "corrections": the technical-signal gate
+        // keeps those components out of the vocabulary entirely.
+        let vocab = RepoIndexing.buildVocabulary(
+            paths: ["Tests/FooTests.swift", "Resources/image.png"],
+            branch: nil
+        )
+        let entries = RepoVocabularyMatcher.candidateEntries(
+            transcript: "run the tests and update the resources please",
+            vocabulary: vocab
+        )
+        XCTAssertTrue(entries.isEmpty, "entries: \(entries)")
+    }
+
+    func testMatcherHandlesLargeVocabulary() {
+        // 20k technical terms x a 300-word transcript. No wall-clock assertion
+        // (repo rule) — the guarantee is the complexity restructure (exact tier
+        // = one index lookup per gram; fuzzy tier = ±1-length buckets swept at
+        // most once per distinct gram); this pins CORRECTNESS at that scale and
+        // acts as a canary: a return to O(grams x terms) Levenshtein would make
+        // it obviously pathological.
+        var terms = (0..<20_000).map { "GeneratedFile\($0).swift" }
+        terms.append("useAuth.ts")
+        let vocab = RepoVocabulary(terms: terms, branch: nil)
+        let filler = Array(
+            repeating: "please improve overall code quality generally",
+            count: 50
+        ).joined(separator: " ")
+        let transcript = filler + " then open use auth dot t s directly"
+        let entries = RepoVocabularyMatcher.candidateEntries(
+            transcript: transcript, vocabulary: vocab
+        )
+        XCTAssertTrue(entries.contains { $0.replaceWith == "useAuth.ts" })
+    }
+}
+
+// MARK: - Service orchestration (injected subprocess + fixture .git)
+
+final class RepoVocabularyServiceTests: XCTestCase {
+    private func makeFixtureRepo() -> URL {
+        let repo = FileManager.default.temporaryDirectory
+            .appendingPathComponent("repovocab-svc-\(UUID().uuidString)")
+        let gitDir = repo.appendingPathComponent(".git")
+        try! FileManager.default.createDirectory(at: gitDir, withIntermediateDirectories: true)
+        try! "ref: refs/heads/main\n".write(
+            to: gitDir.appendingPathComponent("HEAD"), atomically: true, encoding: .utf8
+        )
+        addTeardownBlock { try? FileManager.default.removeItem(at: repo) }
+        return repo
+    }
+
+    func testTimedOutRunStillUsesCleanlyReadPartialData() async {
+        let repo = makeFixtureRepo()
+        // Simulate a killed subprocess: partial, non-clean exit, timedOut flag.
+        let output = RepoGitRunner.Output(
+            data: "a/b.ts\u{0}c/incomplete".data(using: .utf8)!,
+            exitCode: -9,
+            timedOut: true,
+            capped: false
+        )
+        let vocab = await RepoVocabularyService.vocabulary(
+            forWorkingDirectory: repo.path,
+            cache: RepoVocabularyCache(),
+            runLsFiles: { _ in output }
+        )
+        // "c/incomplete" is dropped (no trailing NUL); "a/b.ts" survives.
+        XCTAssertEqual(vocab?.terms.contains("b.ts"), true)
+        XCTAssertEqual(vocab?.branch, "main")
+    }
+
+    func testCleanNonZeroExitIsSkipped() async {
+        let repo = makeFixtureRepo()
+        let output = RepoGitRunner.Output(
+            data: Data(), exitCode: 128, timedOut: false, capped: false
+        )
+        let vocab = await RepoVocabularyService.vocabulary(
+            forWorkingDirectory: repo.path,
+            cache: RepoVocabularyCache(),
+            runLsFiles: { _ in output }
+        )
+        XCTAssertNil(vocab)
+    }
+
+    func testCacheHitAvoidsSecondSubprocess() async {
+        let repo = makeFixtureRepo()
+        let runCount = RunCounter()
+        let cache = RepoVocabularyCache()
+        let clock: @Sendable () -> Date = { Date(timeIntervalSince1970: 5_000) }
+        let run: @Sendable (String) async -> RepoGitRunner.Output? = { _ in
+            await runCount.increment()
+            return RepoGitRunner.Output(
+                data: "useAuth.ts\u{0}".data(using: .utf8)!,
+                exitCode: 0, timedOut: false, capped: false
+            )
+        }
+
+        _ = await RepoVocabularyService.vocabulary(
+            forWorkingDirectory: repo.path, cache: cache, now: clock, runLsFiles: run
+        )
+        _ = await RepoVocabularyService.vocabulary(
+            forWorkingDirectory: repo.path, cache: cache, now: clock, runLsFiles: run
+        )
+        let count = await runCount.value
+        XCTAssertEqual(count, 1)
+    }
+
+    private actor RunCounter {
+        private(set) var value = 0
+        func increment() { value += 1 }
+    }
+}
+
+// MARK: - Real-git indexer end to end
+
+final class RepoVocabularyIndexerEndToEndTests: XCTestCase {
+    @discardableResult
+    private func runGit(_ args: [String], in directory: URL) -> Int32 {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/git")
+        process.arguments = args
+        process.currentDirectoryURL = directory
+        process.standardOutput = FileHandle.nullDevice
+        process.standardError = FileHandle.nullDevice
+        var env = ProcessInfo.processInfo.environment
+        // Isolate from the developer's global gitconfig / signing / hooks.
+        env["GIT_CONFIG_GLOBAL"] = "/dev/null"
+        env["GIT_CONFIG_SYSTEM"] = "/dev/null"
+        env["GIT_TERMINAL_PROMPT"] = "0"
+        env["HOME"] = directory.path
+        process.environment = env
+        try? process.run()
+        process.waitUntilExit()
+        return process.terminationStatus
+    }
+
+    func testHarvestsVocabularyFromRealRepo() async throws {
+        // The Mac build host always has /usr/bin/git; use it plainly (no skip).
+        XCTAssertTrue(FileManager.default.isExecutableFile(atPath: "/usr/bin/git"))
+
+        let repo = FileManager.default.temporaryDirectory
+            .appendingPathComponent("repovocab-e2e-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: repo, withIntermediateDirectories: true)
+        addTeardownBlock { try? FileManager.default.removeItem(at: repo) }
+
+        XCTAssertEqual(runGit(["init", "-b", "main"], in: repo), 0)
+        runGit(["config", "user.email", "test@example.com"], in: repo)
+        runGit(["config", "user.name", "Test"], in: repo)
+        runGit(["config", "commit.gpgsign", "false"], in: repo)
+
+        try "export const useAuth = () => {}\n".write(
+            to: repo.appendingPathComponent("useAuth.ts"), atomically: true, encoding: .utf8
+        )
+        let nested = repo.appendingPathComponent("Sources/App")
+        try FileManager.default.createDirectory(at: nested, withIntermediateDirectories: true)
+        try "final class UserSessionManager {}\n".write(
+            to: nested.appendingPathComponent("UserSessionManager.swift"),
+            atomically: true, encoding: .utf8
+        )
+
+        XCTAssertEqual(runGit(["add", "-A"], in: repo), 0)
+        XCTAssertEqual(runGit(["commit", "-m", "init"], in: repo), 0)
+
+        let vocab = await RepoVocabularyService.vocabulary(
+            forWorkingDirectory: repo.path,
+            cache: RepoVocabularyCache()
+        )
+        let terms = try XCTUnwrap(vocab?.terms)
+        XCTAssertTrue(terms.contains("useAuth.ts"), "terms: \(terms)")
+        XCTAssertTrue(terms.contains("UserSessionManager.swift"), "terms: \(terms)")
+        XCTAssertTrue(["main", "master"].contains(vocab?.branch), "branch: \(String(describing: vocab?.branch))")
+
+        // Matching the harvested vocabulary end to end.
+        let entries = RepoVocabularyMatcher.candidateEntries(
+            transcript: "open use auth dot t s then user session manager dot swift",
+            vocabulary: vocab!
+        )
+        XCTAssertTrue(entries.contains { $0.replaceWith == "useAuth.ts" })
+        XCTAssertTrue(entries.contains { $0.replaceWith == "UserSessionManager.swift" })
+
+        // The full title -> cwd -> vocabulary -> entries pipeline (the exact
+        // off-main section the view model runs detached).
+        let titleEntries = await RepoVocabularyService.entries(
+            forWindowTitle: "user@mac: \(repo.path) — zsh",
+            transcript: "open use auth dot t s please",
+            cache: RepoVocabularyCache()
+        )
+        XCTAssertEqual(titleEntries?.first?.replaceWith, "useAuth.ts")
+    }
+
+    /// Byte-cap path of the real subprocess runner: a tiny `maxBytes` trips the
+    /// cap on the first read, the runner marks `capped` (not `timedOut`) and
+    /// still returns the bytes read so far. This exercises the restructured
+    /// wait logic where the cap path must NOT re-wait on the reader semaphore
+    /// (the reader already exited and its signal was consumed by the first
+    /// wait). The remaining branch — a genuine 2 s TIMEOUT with a live reader —
+    /// needs `ls-files` to stall mid-stream, which cannot be arranged
+    /// deterministically without wall-clock waits, so it stays covered by the
+    /// stubbed-Output service tests instead.
+    func testLsFilesByteCapMarksCappedAndKeepsData() async throws {
+        XCTAssertTrue(FileManager.default.isExecutableFile(atPath: "/usr/bin/git"))
+
+        let repo = FileManager.default.temporaryDirectory
+            .appendingPathComponent("repovocab-cap-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: repo, withIntermediateDirectories: true)
+        addTeardownBlock { try? FileManager.default.removeItem(at: repo) }
+
+        XCTAssertEqual(runGit(["init", "-b", "main"], in: repo), 0)
+        runGit(["config", "user.email", "test@example.com"], in: repo)
+        runGit(["config", "user.name", "Test"], in: repo)
+        runGit(["config", "commit.gpgsign", "false"], in: repo)
+        for index in 0..<5 {
+            try "x\n".write(
+                to: repo.appendingPathComponent("file-\(index).txt"),
+                atomically: true, encoding: .utf8
+            )
+        }
+        XCTAssertEqual(runGit(["add", "-A"], in: repo), 0)
+        XCTAssertEqual(runGit(["commit", "-m", "init"], in: repo), 0)
+
+        let rawOutput = await RepoGitRunner.lsFiles(
+            root: repo.path, timeoutSeconds: 2.0, maxBytes: 4
+        )
+        let output = try XCTUnwrap(rawOutput)
+        XCTAssertTrue(output.capped)
+        XCTAssertFalse(output.timedOut)
+        XCTAssertGreaterThanOrEqual(output.data.count, 4)
+        // Whatever was read parses without error (complete entries only; a
+        // truncated tail is dropped by design).
+        _ = RepoIndexing.parseNullDelimitedPaths(output.data)
+    }
+}

--- a/Tests/localvoxtralTests/SettingsStoreTests.swift
+++ b/Tests/localvoxtralTests/SettingsStoreTests.swift
@@ -523,6 +523,21 @@ final class SettingsStoreTests: XCTestCase {
         XCTAssertFalse(reloadedStore.clipboardPayloadMacroEnabled)
     }
 
+    // MARK: - repoVocabularyEnabled
+
+    func testRepoVocabularyEnabled_defaultsToFalse() {
+        let store = makeStore()
+        XCTAssertFalse(store.repoVocabularyEnabled)
+    }
+
+    func testRepoVocabularyEnabled_persistsAcrossReload() {
+        let store = makeStore()
+        store.repoVocabularyEnabled = true
+
+        let reloadedStore = makeStore()
+        XCTAssertTrue(reloadedStore.repoVocabularyEnabled)
+    }
+
     func testDictationOutputMode_defaultsToOverlayBuffer() {
         let store = makeStore()
         XCTAssertEqual(store.dictationOutputMode, .overlayBuffer)


### PR DESCRIPTION
# Repo vocabulary from the focused terminal (opt-in, loopback-only)

Feature 5 of the polish-for-agents series (stacked on #106 ← #105 ← #103 ← #101).

When dictating into a terminal, the polisher now knows the project's actual file
names and identifiers: the app resolves the frontmost terminal's working
directory from its AX window title, walks up to the git root, indexes
`git ls-files` output (bounded subprocess, 5-min TTL cache keyed on HEAD mtime),
fuzzy-matches transcript n-grams against the vocabulary off the main actor, and
injects the top matches as extra replacement-dictionary entries into the polish
prompt. Spoken "use auth dot t s" lands as `useAuth.ts`.

## Privacy / gating

- Setting `repoVocabularyEnabled`, **default OFF** (one row inside the existing
  Polishing group — group count/identity unchanged).
- Attaches **only to loopback polishing endpoints** (same gate as clipboard
  context, #105). Also skipped entirely when the active prompt template lacks
  the `{{replacement_dictionary}}` slot.
- Logs and session records carry **counts, never content**
  (`vocab:<n>` in the provenance summary; "Repo vocabulary attached: N entries").

## Design points

- **Sanctioned rewrites** (resolves the F1↔F5 conflict): the token guard (#101)
  used to protect the STT's *wrong* filename-shaped token and deterministically
  revert the very correction the vocabulary hint requested.
  `PolishTokenGuard.verifyAndRepair` gained an append-only
  `sanctionedReplacements: [(from, to)] = []` parameter: a missing protected
  token counts as preserved iff it canonically equals a pair's `from` AND that
  pair's `to` occurs standalone in the polished text — checked *before*
  near-miss repair (the revert path). Default `[]` keeps F1–F4 byte-identical;
  `PolishTokenGuardTests` diff has **zero deleted lines** (pure additions).
- **Technical-signal gate**: a vocabulary term needs a dot, separator, or
  internal capital (camelCase/PascalCase). `Tests`/`Resources`/`docs`/`main`
  never become hints that capitalize ordinary prose; accepted loss:
  `Makefile`/`LICENSE`-style bare names (documented).
- **No main-actor stalls**: exact-index + ±1-length fuzzy buckets built at
  construction (TTL-amortized); resolve-cwd → index → match runs in one
  `Task.detached` hop; only the AX title read stays on main, with
  `AXUIElementSetMessagingTimeout(0.5)` on both elements.
- **Bounded subprocess**: `/usr/bin/git ls-files -z` with 2 s timeout, 2 MB cap,
  `POSIXPipeRead` (never `FileHandle.availableData`), terminationHandler +
  2 s-bounded exit wait, `isRunning`-guarded signals, hardened env
  (`GIT_CONFIG_GLOBAL=/dev/null`, `GIT_CONFIG_SYSTEM=/dev/null`,
  `GIT_TERMINAL_PROMPT=0`).
- Slot-in with PR #99/#100 maintained: no `LLMPolishingRequest`/`Configuration`
  shape changes, no live-replacement machinery touched, `AppConfigStore`
  append-only.

## Reviews (three rounds)

1. Self-review + build round: 2 compile fixes, then green (739).
2. Independent opencode/GLM review — 4 P3s fixed: template-without-placeholder
   gate; clipboard-read atomicity (context read hoisted back pre-Task next to
   the payload read); filename sanitization at prompt render; byte-cap path no
   longer burns a 0.5 s grace wait. (745 green.)
3. Fable deep review — 2 P2s + 4 P3s fixed: sanctioned rewrites (P2, above);
   matcher complexity + main-actor beachball (P2, above); AX/FS main-actor
   hangs; unbounded `waitUntilExit`; raw kill on possibly-reaped pid;
   common-word false hints. (754 green.)

## Proof

`./scripts/remote-build.sh` (build + full unit suite) final tail:

```
Test Suite 'localvoxtralPackageTests.xctest' passed at 2026-07-10 00:18:06.856.
	 Executed 754 tests, with 2 tests skipped and 0 failures (0 unexpected) in 7.078 (7.118) seconds
```

754 tests (694 → 754 across the round: +45 pure indexer/matcher/cache/parser
cases, +5 VM-level, +2 settings, +4 sanctioning quartet, +tech-signal and
scale tests), 2 skipped (env-gated Tier-1), 0 failures, 0 warnings in changed
files under Swift 6.2 strict concurrency.

Behavior-demonstrating tests (named per proof culture):

- `RepoVocabularyIndexerEndToEndTests.testHarvestsVocabularyFromRealRepo` —
  live `git init/add/commit/ls-files` through the full
  `RepoVocabularyService.entries` title→entries pipeline; asserts
  `useAuth.ts`, `UserSessionManager.swift`, branch.
- `DictationViewModelPolishTokenGuardTests.testSanctionedVocabularyRewriteSurvivesTokenGuard`
  — VM end-to-end: vocabulary entries → sanctioned pairs → stub polish applies
  the case fix → committed text keeps `useAuth.ts` (pre-fix the guard reverted
  it; quartet `testSanctionedRewriteIsNotRevertedByCaseRepair` /
  `testSanctionedFuzzyRewriteDoesNotFallBack` /
  `testWithoutSanctionedPairsOldGuardBehaviorHolds` /
  `testSanctionedToAbsentFallsBackNormally` pins each side).
- `RepoVocabularyMatcherTests.testMatcherHandlesLargeVocabulary` — 20k terms ×
  300-word transcript, correctness at scale, 0.130 s (no wall-clock assertion
  per repo rule; the index restructure is the guarantee, this is the canary).
- OFF path byte-identical: all pre-existing polish/context/macro/profile VM
  tests pass unchanged; `ClipboardPayloadMacroTests` /
  `PolishContextClipboardReaderTests` / `TerminalTargetDetectorTests` have no
  diff at all.

No `integration-polishd` / `eval-llm` run needed: no prompt-template files,
eval corpus, or request/config shapes changed.

## Needs Mac-side hand verification (will note before merge)

- AX window-title read is seam-stubbed in unit tests. Real check: setting ON,
  loopback endpoint, dictate into Terminal/iTerm2 sitting in a git repo →
  `Log.polishing` shows "Repo vocabulary attached: N entries" and a spoken
  "use auth dot t s" commits as the exact filename. Requires the existing
  Accessibility grant; silent skip without it.
- Terminal.app shows a bare folder name by default (correctly ignored);
  iTerm2/Ghostty/WezTerm `~/path` titles resolve. Worth spot-checking across
  emulators.
- New settings row visual pass via `try-pr.sh` (same pass pending for
  #103/#105/#106).


---

## 2026-07-11 field-test fixes

Two new commits after restacking on the amended #105:

**1. Clipboard entities join the sanctioned-rewrite pipeline (+ substring-canonical sanctioning).** Field log (T5): `Token guard discarded polish; 1 protected token(s) not preserved` — clipboard context ON, clipboard holding `UserSessionManager.swift`, dictated "look at user session manager dot swift"; STT emitted the guard-protected `manager.swift`, the model correctly produced `UserSessionManager.swift`, and the guard discarded the whole polish. Now: code-like entities are extracted from the (already privacy-gated) clipboard excerpt with the guard's OWN recognizer (`ClipboardVocabulary`, no second grammar), matched against transcript n-grams with the exact repo-vocabulary matcher, injected as dictionary-slot hints, and registered as sanctioned pairs. The guard's sanction check is now substring-canonical (a protected token canonically contained in a sanctioned alias whose `to` the model produced counts as preserved) — closing the previously documented "known hole". Gates unchanged: toggle ON + loopback only + concealed/transient never read; counts-only logging (`clipboard-vocab:<n>`).

Also: repo-vocab **skip reasons elevated `.debug` → `.info`** (the unified log store does not persist `.debug`, which made the field no-attach undiagnosable) and the two remaining silent skips (empty vocabulary, no transcript-relevant matches) got `.info` lines. All static strings + counts; "Repo vocabulary attached: N entries" was already `.info`.

**2. Ghostty's `..`-abbreviated window titles resolve (T6 root cause).** Ghostty elides leading path components: the owner's tab title was exactly `../Desktop/projects/supervoxtral`, the parser extracted `/Desktop/projects/supervoxtral`, the existence check failed, and the feature silently no-oped. `TerminalWorkingDirectoryResolver` gains a home-anchored FALLBACK tier (consulted only after every exact candidate fails): `../X/Y` → `$HOME/X/Y`, and a non-existent absolute `/X/Y` not under home → `$HOME/X/Y`. Exact candidates keep priority; `workingDirectoryCandidates` is untouched (existing parser table byte-identical).

Proof — new tests shown failing with the fixes behaviorally reverted (guard containment → equality, clipboard-vocab wiring off, resolver fallback off), passing after:

```
before:
  testClipboardEntityCorrectionSurvivesTokenGuard                      failed  (T5 end-to-end: guard discards)
  testClipboardEntitySanctioningWorksWithoutDictionarySlot             failed
  testSanctionedAliasContainingProtectedTokenDoesNotFallBack           failed
  testUnrelatedProtectedTokenStillGuardedUnderContainment              failed
  testGhosttyAbbreviatedTitleResolvesHomeAnchored                      failed  (T6)
  testNonExistentAbsolutePathFallsBackToHomeAnchored                   failed
  Executed 78 tests, with 10 failures (0 unexpected)
after:
  Executed 78 tests, with 0 failures (0 unexpected)   (PolishTokenGuardTests + resolver + ClipboardVocabularyTests)
  Executed 30 tests, with 0 failures (0 unexpected)   (all RepoVocabulary* classes)
```

Full unit suite on the restacked stack tip (feat/polish-revert-affordance): `Executed 827 tests, with 2 tests skipped and 0 failures (0 unexpected)`.

### Review follow-up (codex P2): fallback constrained to `../`-prefixed titles

The first cut re-anchored ANY non-existent absolute path under home — an SSH/container path like `/work/repo` or an unmounted volume would have resolved to `$HOME/work/repo` and injected wrong-repo vocabulary. The fallback now applies ONLY to `../`-prefixed runs (the title itself must signal elision); non-existent absolute paths resolve to nil, full stop. The confirmed Ghostty case is `../`-prefixed, so coverage is unchanged. Also wired the #105 leak-guard exemptions: sanctioned rewrites' `to` values are exempt from the clipboard leak scan (the T5 end-to-end test exercises this — `UserSessionManager.swift` sits exactly at the 24-char leak threshold).

Proof — over-broad re-anchoring vs constrained:

```
before: testNonExistentAbsolutePathDoesNotFallBackToHome     failed (resolved $HOME/work/repo)
        testHomeAnchoredFallbackCandidateShapes              failed (absolute run generated a fallback)
        Executed 17 tests, with 2 failures (0 unexpected)
after:  Executed 17 tests, with 0 failures; all touched suites: Executed 124 tests, with 0 failures
```

Restacked full unit suite on the stack tip: `Executed 835 tests, with 2 tests skipped and 0 failures (0 unexpected)`.

### T6 round 2 (owner re-test): the elision mark is a Unicode ellipsis

The owner's re-test with the fallback build STILL failed — because Ghostty's real elision prefix is `…/` (U+2026 HORIZONTAL ELLIPSIS), not ASCII `../` (a typed report loses the distinction; owner-confirmed). Accepted elided prefixes are now `../`, `…/`, and `‥/` (U+2025). Production wiring was verified sound (`entries()` → `resolveWorkingDirectory` with the real-filesystem default predicate; the miss was purely the regex). The canonical field case is now a named regression test, additionally run through the REAL filesystem predicate against a temp directory tree so hermetic test defaults can never mask production behavior. The no-resolution log line now includes a redacted title SHAPE (letters→a, digits→9, separators/elision marks kept, capped 60) so the next such failure is self-diagnosing without leaking paths.

```
before: testT6GhosttyEllipsisElidedTitleResolvesHomeAnchored           failed
        testT6GhosttyEllipsisElidedTitleResolvesWithRealFilesystemCheck failed
        testTwoDotLeaderElidedTitleResolvesHomeAnchored                 failed
        testEllipsisFallbackCandidateShape                              failed
        Executed 23 tests, with 4 failures (0 unexpected)
after:  Executed 23 tests, with 0 failures; all repo-vocab suites: 53/53
```

Stack rebased onto main (now carrying #116/#117/#118); full unit suite on the stack tip: `Executed 864 tests, with 2 tests skipped and 0 failures (0 unexpected)`.
