### PR TITLE
CI: eliminate the remaining duplicate compilation per run

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,9 +63,6 @@ jobs:
           key: swiftpm-${{ runner.os }}-${{ hashFiles('Package.resolved') }}
           restore-keys: swiftpm-${{ runner.os }}-
 
-      - name: Build
-        run: swift build
-
       - name: Format lint (advisory)
         # Advisory until the one-shot tree reformat lands: swift-format exits 0
         # on findings without --strict. After the reformat, add --strict here
@@ -77,7 +74,10 @@ jobs:
 
       - name: Test (unit suite)
         # The integration suite needs a live inference backend and is exercised
-        # manually; see CLAUDE.md.
+        # manually; see CLAUDE.md. This is also the job's compile gate: the
+        # old standalone `swift build` step built plain-debug products that
+        # nothing downstream consumed (tests rebuild with coverage flags,
+        # packaging builds release), so it was pure duplicate compilation.
         run: |
           swift test \
             --skip RealtimeAPIVLLMIntegrationTests \
@@ -128,7 +128,11 @@ jobs:
         env:
           VLLM_REALTIME_TEST_ENABLE: "1"
           VLLM_REALTIME_TEST_MODEL: T0mSIlver/Voxtral-Mini-4B-Realtime-2602-MLX-4bit
-        run: swift test --filter RealtimeAPIVLLMIntegrationTests
+        # --enable-code-coverage matches the unit step's build flags exactly:
+        # without it SwiftPM treats the coverage-instrumented products as
+        # stale and recompiles the whole app+test module a second time
+        # (~12 s per run for zero information).
+        run: swift test --filter RealtimeAPIVLLMIntegrationTests --enable-code-coverage
 
       - name: Polishing helper unit tests (PolishHelper package)
         # Self-hosted only: hosted runners would pay a cold Cmlx C++ compile

--- a/PolishHelper/Sources/PolishHelperCore/ParentProcessWatchdog.swift
+++ b/PolishHelper/Sources/PolishHelperCore/ParentProcessWatchdog.swift
@@ -2,7 +2,7 @@ import Foundation
 import Synchronization
 
 /// Exits the helper when the supervising app dies, so a crashed or killed app
-/// can never leave an orphaned model holding memory. This reproduces the
+/// can never leave an orphaned model holding memory. Reproduces the
 /// `--parent-pid` watchdog the mlx-lm fork implemented on the Python side.
 public final class ParentProcessWatchdog: @unchecked Sendable {
     private let source: DispatchSourceProcess

--- a/scripts/package_app.sh
+++ b/scripts/package_app.sh
@@ -183,22 +183,29 @@ while IFS= read -r bundle_path; do
   fi
 done < <(find "$BUILD_PRODUCTS_DIR" -maxdepth 1 -type d -name "*.bundle" -print)
 
-ICONSET_DIR="$ROOT_DIR/.build/AppIcon.iconset"
-rm -rf "$ICONSET_DIR"
-mkdir -p "$ICONSET_DIR"
+# The icns is a pure function of the source PNG — cache it keyed on the
+# source hash (hash in the filename, so a changed icon can never reuse a
+# stale cache entry).
+ICNS_CACHE="$ROOT_DIR/.build/AppIcon-$(shasum -a 256 "$APP_ICON_SOURCE" | cut -c1-16).icns"
+if [[ ! -f "$ICNS_CACHE" ]]; then
+  ICONSET_DIR="$ROOT_DIR/.build/AppIcon.iconset"
+  rm -rf "$ICONSET_DIR"
+  mkdir -p "$ICONSET_DIR"
 
-sips -z 16 16 "$APP_ICON_SOURCE" --out "$ICONSET_DIR/icon_16x16.png" >/dev/null
-sips -z 32 32 "$APP_ICON_SOURCE" --out "$ICONSET_DIR/icon_16x16@2x.png" >/dev/null
-sips -z 32 32 "$APP_ICON_SOURCE" --out "$ICONSET_DIR/icon_32x32.png" >/dev/null
-sips -z 64 64 "$APP_ICON_SOURCE" --out "$ICONSET_DIR/icon_32x32@2x.png" >/dev/null
-sips -z 128 128 "$APP_ICON_SOURCE" --out "$ICONSET_DIR/icon_128x128.png" >/dev/null
-sips -z 256 256 "$APP_ICON_SOURCE" --out "$ICONSET_DIR/icon_128x128@2x.png" >/dev/null
-sips -z 256 256 "$APP_ICON_SOURCE" --out "$ICONSET_DIR/icon_256x256.png" >/dev/null
-sips -z 512 512 "$APP_ICON_SOURCE" --out "$ICONSET_DIR/icon_256x256@2x.png" >/dev/null
-sips -z 512 512 "$APP_ICON_SOURCE" --out "$ICONSET_DIR/icon_512x512.png" >/dev/null
-sips -z 1024 1024 "$APP_ICON_SOURCE" --out "$ICONSET_DIR/icon_512x512@2x.png" >/dev/null
+  sips -z 16 16 "$APP_ICON_SOURCE" --out "$ICONSET_DIR/icon_16x16.png" >/dev/null
+  sips -z 32 32 "$APP_ICON_SOURCE" --out "$ICONSET_DIR/icon_16x16@2x.png" >/dev/null
+  sips -z 32 32 "$APP_ICON_SOURCE" --out "$ICONSET_DIR/icon_32x32.png" >/dev/null
+  sips -z 64 64 "$APP_ICON_SOURCE" --out "$ICONSET_DIR/icon_32x32@2x.png" >/dev/null
+  sips -z 128 128 "$APP_ICON_SOURCE" --out "$ICONSET_DIR/icon_128x128.png" >/dev/null
+  sips -z 256 256 "$APP_ICON_SOURCE" --out "$ICONSET_DIR/icon_128x128@2x.png" >/dev/null
+  sips -z 256 256 "$APP_ICON_SOURCE" --out "$ICONSET_DIR/icon_256x256.png" >/dev/null
+  sips -z 512 512 "$APP_ICON_SOURCE" --out "$ICONSET_DIR/icon_256x256@2x.png" >/dev/null
+  sips -z 512 512 "$APP_ICON_SOURCE" --out "$ICONSET_DIR/icon_512x512.png" >/dev/null
+  sips -z 1024 1024 "$APP_ICON_SOURCE" --out "$ICONSET_DIR/icon_512x512@2x.png" >/dev/null
 
-iconutil -c icns "$ICONSET_DIR" -o "$APP_DIR/Contents/Resources/AppIcon.icns"
+  iconutil -c icns "$ICONSET_DIR" -o "$ICNS_CACHE"
+fi
+cp "$ICNS_CACHE" "$APP_DIR/Contents/Resources/AppIcon.icns"
 
 cp "$MENUBAR_ICON_SOURCE" "$APP_DIR/Contents/Resources/MicIconTemplate.png"
 cp "$MENUBAR_ICON_2X_SOURCE" "$APP_DIR/Contents/Resources/MicIconTemplate@2x.png"
@@ -260,6 +267,41 @@ if [[ "${LOCALVOXTRAL_SKIP_POLISHD:-0}" == "1" ]]; then
   rm -rf "$ROOT_DIR/dist/localvoxtral-polishd.dSYM"
 else
 
+HELPER_DERIVED_DATA="$ROOT_DIR/PolishHelper/.build/xcode"
+HELPER_BUILD_LOG="$ROOT_DIR/PolishHelper/.build/xcodebuild.log"
+HELPER_PRODUCTS_DIR="$HELPER_DERIVED_DATA/Build/Products/Release"
+HELPER_BINARY="$HELPER_PRODUCTS_DIR/localvoxtral-polishd"
+HELPER_DSYM_SOURCE="$HELPER_PRODUCTS_DIR/localvoxtral-polishd.dSYM"
+HELPER_FINGERPRINT_FILE="$HELPER_DERIVED_DATA/.localvoxtral-helper-fingerprint"
+mkdir -p "$ROOT_DIR/PolishHelper/.build"
+
+# Even a no-op helper xcodebuild costs ~11 s of planning overhead per run, so
+# skip it entirely when nothing that feeds the product changed. Content hash,
+# not git metadata: remote-build rsync trees have no .git. Covers the helper
+# sources, both manifests (Package.resolved pins the MLX deps), and the Xcode
+# version (a toolchain update must rebuild the Metal kernels).
+HELPER_FINGERPRINT="$(
+  {
+    xcodebuild -version
+    find "$ROOT_DIR/PolishHelper/Sources" \
+      "$ROOT_DIR/PolishHelper/Package.swift" \
+      "$ROOT_DIR/PolishHelper/Package.resolved" \
+      -type f -print0 | sort -z | xargs -0 shasum -a 256
+  } | shasum -a 256 | awk '{print $1}'
+)"
+
+if [[ -f "$HELPER_FINGERPRINT_FILE" \
+  && "$(cat "$HELPER_FINGERPRINT_FILE")" == "$HELPER_FINGERPRINT" \
+  && -f "$HELPER_BINARY" \
+  && -d "$HELPER_PRODUCTS_DIR/mlx-swift_Cmlx.bundle" \
+  && -d "$HELPER_DSYM_SOURCE" ]]; then
+  echo "Polishing helper unchanged (fingerprint match) — reusing products in $HELPER_PRODUCTS_DIR"
+else
+
+# Cleared before building so an interrupted build can never leave a stale
+# fingerprint that matches next run's tree.
+rm -f "$HELPER_FINGERPRINT_FILE"
+
 # A real invocation, not `xcrun --find`: on Xcode 26+ the metal shim exists
 # even when the toolchain component is missing, and only fails when executed.
 # One-time host provision (owner runbook: scripts/mac/README.md):
@@ -272,9 +314,6 @@ if ! xcrun metal --version >/dev/null 2>&1; then
   exit 1
 fi
 
-HELPER_DERIVED_DATA="$ROOT_DIR/PolishHelper/.build/xcode"
-HELPER_BUILD_LOG="$ROOT_DIR/PolishHelper/.build/xcodebuild.log"
-mkdir -p "$ROOT_DIR/PolishHelper/.build"
 echo "Building polishing helper (xcodebuild; full log: $HELPER_BUILD_LOG)"
 (
   cd "$ROOT_DIR/PolishHelper"
@@ -296,14 +335,20 @@ echo "Building polishing helper (xcodebuild; full log: $HELPER_BUILD_LOG)"
   exit 1
 }
 
-HELPER_PRODUCTS_DIR="$HELPER_DERIVED_DATA/Build/Products/Release"
-HELPER_BINARY="$HELPER_PRODUCTS_DIR/localvoxtral-polishd"
 if [[ ! -f "$HELPER_BINARY" ]]; then
   echo "Polishing helper build reported success but produced no binary at:"
   echo "  $HELPER_BINARY"
   tail -n 40 "$HELPER_BUILD_LOG"
   exit 1
 fi
+
+# Written only after the build succeeded and the binary exists; the product
+# checks below (Cmlx bundle, dSYM) still hard-fail this run if the build
+# produced an incomplete set, and the skip condition re-verifies all three
+# products next run before trusting the fingerprint.
+printf '%s\n' "$HELPER_FINGERPRINT" > "$HELPER_FINGERPRINT_FILE"
+
+fi # helper fingerprint match
 
 cp "$HELPER_BINARY" "$APP_DIR/Contents/MacOS/localvoxtral-polishd"
 chmod +x "$APP_DIR/Contents/MacOS/localvoxtral-polishd"
@@ -325,7 +370,6 @@ fi
 # dSYM is a hard error: helper crashes (MLX C++/Metal) are the likeliest
 # field crashes now, and a silent skip would degrade symbolication without
 # any signal.
-HELPER_DSYM_SOURCE="$HELPER_PRODUCTS_DIR/localvoxtral-polishd.dSYM"
 if [[ ! -d "$HELPER_DSYM_SOURCE" ]]; then
   echo "Polishing helper dSYM missing at $HELPER_DSYM_SOURCE — the Release"
   echo "config should always emit one (DWARF with dSYM)."


### PR DESCRIPTION
## What

Follow-up to #110. On a warm run (29054255586, ~160 s) three redundancies remained:

1. **Integration step recompiled the whole app+test module (~12 s)** — it ran `swift test` without `--enable-code-coverage` while the unit step ran with it; the flag mismatch made SwiftPM invalidate everything the unit step had just built. The flag is now aligned (coverage instrumentation is inert for the suite's word-accuracy assertions).
2. **Standalone `swift build` step (~6 s) built products nothing consumed** — tests rebuild with coverage flags, packaging builds release. Dropped; compile failures surface in the unit step.
3. **Packaging paid ~11 s of no-op helper xcodebuild + ~2 s of icon regeneration every run.** `package_app.sh` now fingerprints the helper inputs (content hash of `PolishHelper/Sources` + `Package.swift` + `Package.resolved` + `xcodebuild -version`; content-based so remote-build rsync trees without .git work) and reuses DerivedData products on a match. Safety: fingerprint is cleared before building and written only after success; the skip path re-verifies binary + Cmlx bundle + dSYM existence before trusting it. The icns is cached keyed on the source PNG's hash.

Release lane unaffected in behavior: `release.yml` cold-checkouts, so the fingerprint file never exists there and the helper always builds.

## Proof

Three runs on this PR, exercising all fingerprint paths:

| Step | pre-#114 warm (29054255586) | Run A — first build (29055287225) | Run B — empty commit (29055877018) | Run C — helper source touched (29056209472) |
|---|---|---|---|---|
| Build (removed) | 6 s | — | — | — |
| Test (unit suite) | 16 s | 19 s | 21 s | 14 s |
| Integration tests (live voxmlx) | 28 s | **22 s** | 24 s | 22 s |
| Package app bundle | 33 s | 32 s | **14 s** | 21 s |
| Polishing helper integration | 11 s | 21 s | 39 s* | 28 s |
| **Total job** | ~160 s | 132 s | 137 s | 125 s |

\* polishd live-model load variance (on-demand idle reaper), not caused by this PR — run B's helper binary is byte-identical to run A's by construction.

Fingerprint behavior, from the run logs:
- Run A (fingerprint file absent): `Building polishing helper (xcodebuild; ...)` — builds, writes fingerprint.
- Run B (nothing changed): `Polishing helper unchanged (fingerprint match) — reusing products in .../PolishHelper/.build/xcode/Build/Products/Release` — packaging drops 32→14 s.
- Run C (comment-only edit to `ParentProcessWatchdog.swift`): skip line absent, `Building polishing helper` present — **invalidation proven**; incremental rebuild, packaging 21 s.

All three runs green end-to-end on the self-hosted lane (unit suite, live voxmlx integration, helper unit suite, packaging + codesign identity check, polishd live-model eval baseline, packaged-launch smoke).

- [x] Run A/B/C timings + skip/rebuild log lines pasted
- [x] Full suite green on all three runs
