### PR TITLE
Overlay 'Polished' badge + popover raw-transcript copy after polished commits

### DIFF
--- a/Sources/localvoxtral/DictationOverlayController.swift
+++ b/Sources/localvoxtral/DictationOverlayController.swift
@@ -94,7 +94,8 @@ final class DictationOverlayController {
             text: "",
             errorMessage: nil,
             secureInputActive: false,
-            metrics: OverlayLayoutMetrics(bodyFontSize: fontSizeProvider())
+            metrics: OverlayLayoutMetrics(bodyFontSize: fontSizeProvider()),
+            polished: false
         )
         hostingView = TransparentHostingView(rootView: initialView)
         // Without this, NSHostingView probes the SwiftUI content at ∞×∞ and
@@ -141,7 +142,8 @@ final class DictationOverlayController {
             text: snapshot.bufferText,
             errorMessage: snapshot.errorMessage,
             secureInputActive: snapshot.secureInputActive,
-            metrics: metrics
+            metrics: metrics,
+            polished: snapshot.polished
         )
 
         let contentHeight = metrics.contentHeight(

--- a/Sources/localvoxtral/DictationOverlayView.swift
+++ b/Sources/localvoxtral/DictationOverlayView.swift
@@ -84,6 +84,7 @@ struct DictationOverlayView: View {
     /// Sizing shared with `DictationOverlayController`'s panel measurement —
     /// see `OverlayLayoutMetrics` for why the two must stay in lockstep.
     let metrics: OverlayLayoutMetrics
+    var polished: Bool = false
     private let cornerRadius: CGFloat = 12
 
     /// Warning text needs explicit light/dark variants: system `.red` over
@@ -135,6 +136,26 @@ struct DictationOverlayView: View {
         metrics.unclampedBodyTextHeight(for: displayText)
     }
 
+    /// Subtle, trailing "Polished" pill shown while the LLM-polished text is
+    /// held before dismissal. Intentionally quiet — it annotates the panel
+    /// rather than competing with the transcript below it.
+    private var polishedBadge: some View {
+        Label("Polished", systemImage: "wand.and.stars")
+            .labelStyle(.titleAndIcon)
+            .font(.system(size: 10, weight: .semibold))
+            .foregroundStyle(.secondary)
+            .padding(.horizontal, 6)
+            .padding(.vertical, 1)
+            .background(
+                Capsule(style: .continuous).fill(Color.primary.opacity(0.08))
+            )
+            .overlay(
+                Capsule(style: .continuous)
+                    .strokeBorder(Color.primary.opacity(0.15), lineWidth: 0.5)
+            )
+            .accessibilityLabel("Polished by the language model")
+    }
+
     var body: some View {
         VStack(alignment: .leading, spacing: OverlayLayoutMetrics.stackSpacing) {
             HStack(alignment: .center, spacing: 6) {
@@ -146,6 +167,9 @@ struct DictationOverlayView: View {
                         .controlSize(.small)
                 }
                 Spacer(minLength: 0)
+                if polished {
+                    polishedBadge
+                }
             }
             .frame(height: metrics.headerHeight)
 

--- a/Sources/localvoxtral/DictationViewModel+Session.swift
+++ b/Sources/localvoxtral/DictationViewModel+Session.swift
@@ -230,6 +230,9 @@ extension DictationViewModel {
 
     func beginDictationSession(outputMode: DictationOutputMode? = nil) {
         lastSocketErrorMessage = nil
+        // A new session starts: retire any prior "Copy raw transcript"
+        // affordance so it never references a stale, unrelated transcript.
+        lastPolishChangedRawTranscript = nil
         polishAndCommitTask?.cancel()
         polishAndCommitTask = nil
         stopFinalizationTask?.cancel()
@@ -896,6 +899,23 @@ extension DictationViewModel {
                             self.currentDictationEventText = self.clipboardPayloadSubstituted(
                                 committedText, payload: clipboardPayload
                             )
+                            // Polish-changed iff the guarded/verified committed
+                            // text differs from the pre-polish working text: a
+                            // `.clean` outcome that left the text identical, a
+                            // `.fallback` to raw, or a placeholder-count revert
+                            // all leave committedText == workingText → not
+                            // changed. Drives the overlay badge (during hold)
+                            // and the "Copy raw transcript" popover affordance.
+                            let polishChanged = committedText != workingText
+                            self.overlayBufferCoordinator.markPolished(polishChanged)
+                            // Retain the RAW (pre-everything) transcript for the
+                            // one-line popover copy affordance — but only when the
+                            // commit visibly changed it, so a no-op polish leaves
+                            // no stale affordance. Persisted `rawText` uses the
+                            // same `originalText`.
+                            self.lastPolishChangedRawTranscript =
+                                (polishChanged && originalText != committedText)
+                                ? originalText : nil
                             self.refreshOverlayBufferSession()
                             Log.polishing.info(
                                 "LLM polishing succeeded in \(String(format: "%.2f", result.durationSeconds))s"

--- a/Sources/localvoxtral/DictationViewModel.swift
+++ b/Sources/localvoxtral/DictationViewModel.swift
@@ -167,6 +167,20 @@ final class DictationViewModel {
     #endif
     var lastFinalSegment = ""
 
+    /// Raw (pre-polish) transcript of the most recent stop-commit whose LLM
+    /// polishing visibly changed the text. Drives the "Copy raw transcript"
+    /// popover affordance (F6): terminals can't un-type, so the raw text a
+    /// polish replaced is offered for one-tap copy instead. `nil` when the last
+    /// commit wasn't polish-changed; cleared on every new session start.
+    /// Observable (not `@ObservationIgnored`) so the popover re-renders when it
+    /// appears/disappears.
+    var lastPolishChangedRawTranscript: String?
+
+    /// Whether the "Copy raw transcript" popover row should be offered.
+    var canCopyRawTranscript: Bool {
+        lastPolishChangedRawTranscript?.trimmed.isEmpty == false
+    }
+
     /// Whether the app focused at the most recent session start behaves like
     /// a terminal emulator (bundle allowlist, AX-writability heuristic
     /// fallback). Refreshed at each session start; live replacement strategy
@@ -466,6 +480,13 @@ final class DictationViewModel {
     /// guessing with `Task.yield()`.
     @ObservationIgnored
     var debugManagedStatusMirrorEventSink: (() -> Void)?
+    /// Test seam: replaces the `NSPasteboard.general` write used by the copy
+    /// actions (`copyLatestSegment`, `copyRawTranscript`) so tests assert what
+    /// gets copied without a pasteboard server or clobbering the host clipboard.
+    #if DEBUG
+    @ObservationIgnored
+    var debugPasteboardWriteOverride: ((String) -> Void)?
+    #endif
     @ObservationIgnored
     var debugMicrophoneAuthorizationStatusOverride: MicrophoneAuthorizationStatus?
     /// Test seam: replaces `microphone.requestAccess` in the session-start
@@ -1560,13 +1581,34 @@ final class DictationViewModel {
         let segment = lastFinalSegment.trimmed
         guard !segment.isEmpty else { return }
 
-        let pasteboard = NSPasteboard.general
-        pasteboard.clearContents()
-        pasteboard.setString(segment, forType: .string)
+        writeToPasteboard(segment)
 
         if updateStatus {
             statusText = "Latest segment copied."
         }
+    }
+
+    /// Copies the RAW (pre-polish) transcript of the last polish-changed commit
+    /// to the clipboard (F6). No-op when there is nothing to offer.
+    func copyRawTranscript() {
+        guard let raw = lastPolishChangedRawTranscript?.trimmed, !raw.isEmpty else { return }
+        writeToPasteboard(raw)
+        statusText = "Raw transcript copied."
+    }
+
+    /// Single pasteboard-write seam. In DEBUG a test can substitute the write to
+    /// avoid touching (and clobbering) `NSPasteboard.general` — headless CI has
+    /// no pasteboard server, and clobbering the host clipboard is antisocial.
+    private func writeToPasteboard(_ text: String) {
+        #if DEBUG
+        if let override = debugPasteboardWriteOverride {
+            override(text)
+            return
+        }
+        #endif
+        let pasteboard = NSPasteboard.general
+        pasteboard.clearContents()
+        pasteboard.setString(text, forType: .string)
     }
 
     func requestAccessibilityPermission() {

--- a/Sources/localvoxtral/OverlayBufferSessionCoordinator.swift
+++ b/Sources/localvoxtral/OverlayBufferSessionCoordinator.swift
@@ -57,10 +57,15 @@ protocol OverlayBufferSessionCoordinating: AnyObject {
     /// Surfaces the Secure Keyboard Entry warning inside the overlay panel
     /// while buffering. Defaulted so test doubles stay unchanged.
     func showSecureInputWarning()
+    /// Flags that LLM polishing changed the committed text vs the raw
+    /// transcript, so the overlay shows the "Polished" badge while the polished
+    /// text is held before dismissal. Defaulted so test doubles stay unchanged.
+    func markPolished(_ polished: Bool)
 }
 
 extension OverlayBufferSessionCoordinating {
     func showSecureInputWarning() {}
+    func markPolished(_ polished: Bool) {}
 }
 
 @MainActor
@@ -255,6 +260,11 @@ final class OverlayBufferSessionCoordinator: OverlayBufferSessionCoordinating {
 
     func showSecureInputWarning() {
         stateMachine.setSecureInputWarning()
+        renderCurrentSnapshot()
+    }
+
+    func markPolished(_ polished: Bool) {
+        stateMachine.setPolished(polished)
         renderCurrentSnapshot()
     }
 

--- a/Sources/localvoxtral/OverlayBufferStateMachine.swift
+++ b/Sources/localvoxtral/OverlayBufferStateMachine.swift
@@ -104,6 +104,11 @@ struct OverlayBufferStateMachine {
         let bufferText: String
         let errorMessage: String?
         let secureInputActive: Bool
+        /// True once LLM polishing has changed the displayed text vs the raw
+        /// transcript for this session. Drives the subtle "Polished" badge shown
+        /// while the polished text is held before dismissal. Set only by the
+        /// stop-commit polish path; cleared on every new session.
+        let polished: Bool
         let anchor: OverlayAnchor
     }
 
@@ -111,6 +116,7 @@ struct OverlayBufferStateMachine {
     private(set) var bufferText = ""
     private(set) var errorMessage: String?
     private(set) var secureInputActive = false
+    private(set) var polished = false
     private(set) var anchor: OverlayAnchor?
 
     var snapshot: Snapshot? {
@@ -120,6 +126,7 @@ struct OverlayBufferStateMachine {
             bufferText: bufferText,
             errorMessage: errorMessage,
             secureInputActive: secureInputActive,
+            polished: polished,
             anchor: anchor
         )
     }
@@ -134,7 +141,17 @@ struct OverlayBufferStateMachine {
         bufferText = ""
         errorMessage = nil
         secureInputActive = false
+        polished = false
         self.anchor = anchor
+    }
+
+    /// Marks that LLM polishing changed the displayed text vs the raw
+    /// transcript. Set from the stop-commit polish path once the polished text
+    /// is on screen; the badge then rides the finalizing/hold snapshot. Ignored
+    /// when idle (no session to annotate); a new session clears it.
+    mutating func setPolished(_ value: Bool) {
+        guard phase != .idle else { return }
+        polished = value
     }
 
     /// Marks the buffering session as running under Secure Keyboard Entry.
@@ -178,6 +195,7 @@ struct OverlayBufferStateMachine {
         bufferText = ""
         errorMessage = nil
         secureInputActive = false
+        polished = false
         anchor = nil
     }
 }

--- a/Sources/localvoxtral/StatusPopoverView.swift
+++ b/Sources/localvoxtral/StatusPopoverView.swift
@@ -103,6 +103,16 @@ struct StatusPopoverView: View {
             }
             .disabled(!hasLatestSegment)
 
+            // Polished commits can't be un-typed into the target app; offer the
+            // pre-polish raw transcript for one-tap copy instead (F6). Appears
+            // only after a polish-changed commit; a one-line action, never the
+            // transcript itself (owner rule: no long text in the popover).
+            if viewModel.canCopyRawTranscript {
+                Button("Copy Raw Transcript") {
+                    viewModel.copyRawTranscript()
+                }
+            }
+
             Divider()
 
             Button("Settings…") {

--- a/Tests/localvoxtralTests/DictationViewModelOverlayLifecycleTests.swift
+++ b/Tests/localvoxtralTests/DictationViewModelOverlayLifecycleTests.swift
@@ -462,6 +462,112 @@ final class DictationViewModelOverlayLifecycleTests: XCTestCase {
         XCTAssertEqual(overlayCoordinator.commitCallCount, 1)
     }
 
+    // MARK: - F6: polished badge flag + raw-transcript copy affordance
+
+    /// Shared completion wait for the F6 tests (poll-with-deadline, matching
+    /// the file's existing pattern). Known debt: the whole file's completion
+    /// waiting is wall-clock polling rather than an injected clock — new tests
+    /// at least share one helper instead of inlining more copies.
+    private func waitUntilStoppedSessionCompletes(_ viewModel: DictationViewModel) async {
+        let deadline = ContinuousClock.now + .seconds(1)
+        while viewModel.isCompletingStoppedSession, ContinuousClock.now < deadline {
+            try? await Task.sleep(for: .milliseconds(10))
+        }
+    }
+
+    func testPolishChangedCommitFlagsBadgeAndRetainsRawTranscript() async {
+        let settings = makeSettings(outputMode: .overlayBuffer)
+        settings.llmPolishingEnabled = true
+        settings.llmPolishingEndpointURL = "https://example.com/v1/chat/completions"
+
+        let overlayCoordinator = MockOverlayCoordinator()
+        let polishingService = CapturingMockLLMPolishingService(resultText: "Hello world.")
+        let viewModel = DictationViewModel(
+            settings: settings,
+            overlayBufferCoordinator: overlayCoordinator,
+            startRuntimeServices: false
+        )
+        viewModel.appConfigStore = MockAppConfigStore()
+        viewModel.llmPolishingService = polishingService
+        retainForTestProcessLifetime(viewModel)
+
+        viewModel.sessionOutputMode = .overlayBuffer
+        viewModel.isFinalizingStop = true
+        viewModel.currentDictationEventText = "hello world"
+
+        viewModel.finishStoppedSession(promotePendingSegment: false)
+
+        await waitUntilStoppedSessionCompletes(viewModel)
+
+        XCTAssertEqual(viewModel.currentDictationEventText, "Hello world.")
+        XCTAssertEqual(
+            overlayCoordinator.markPolishedCalls.last, true,
+            "the overlay must be told the polish changed the text so it shows the badge"
+        )
+        XCTAssertEqual(
+            viewModel.lastPolishChangedRawTranscript, "hello world",
+            "the RAW pre-polish transcript is retained for the popover copy affordance"
+        )
+        XCTAssertTrue(viewModel.canCopyRawTranscript)
+    }
+
+    func testUnchangedPolishOffersNoBadgeOrRawCopy() async {
+        let settings = makeSettings(outputMode: .overlayBuffer)
+        settings.llmPolishingEnabled = true
+        settings.llmPolishingEndpointURL = "https://example.com/v1/chat/completions"
+
+        let overlayCoordinator = MockOverlayCoordinator()
+        // The model returns the input verbatim — no visible change to annotate.
+        let polishingService = CapturingMockLLMPolishingService(resultText: "hello world")
+        let viewModel = DictationViewModel(
+            settings: settings,
+            overlayBufferCoordinator: overlayCoordinator,
+            startRuntimeServices: false
+        )
+        viewModel.appConfigStore = MockAppConfigStore()
+        viewModel.llmPolishingService = polishingService
+        // Seed a stale affordance to prove the unchanged commit clears it.
+        viewModel.lastPolishChangedRawTranscript = "stale raw"
+        retainForTestProcessLifetime(viewModel)
+
+        viewModel.sessionOutputMode = .overlayBuffer
+        viewModel.isFinalizingStop = true
+        viewModel.currentDictationEventText = "hello world"
+
+        viewModel.finishStoppedSession(promotePendingSegment: false)
+
+        await waitUntilStoppedSessionCompletes(viewModel)
+
+        XCTAssertEqual(overlayCoordinator.markPolishedCalls.last, false)
+        XCTAssertNil(viewModel.lastPolishChangedRawTranscript)
+        XCTAssertFalse(viewModel.canCopyRawTranscript)
+    }
+
+    func testCopyRawTranscriptWritesRawTextThroughPasteboardSeam() {
+        let settings = makeSettings(outputMode: .overlayBuffer)
+        let viewModel = DictationViewModel(
+            settings: settings,
+            overlayBufferCoordinator: MockOverlayCoordinator(),
+            startRuntimeServices: false
+        )
+        retainForTestProcessLifetime(viewModel)
+
+        var written: [String] = []
+        viewModel.debugPasteboardWriteOverride = { written.append($0) }
+
+        // Nothing retained: the action is a no-op and writes nothing.
+        XCTAssertFalse(viewModel.canCopyRawTranscript)
+        viewModel.copyRawTranscript()
+        XCTAssertTrue(written.isEmpty)
+
+        viewModel.lastPolishChangedRawTranscript = "the raw words"
+        XCTAssertTrue(viewModel.canCopyRawTranscript)
+        viewModel.copyRawTranscript()
+
+        XCTAssertEqual(written, ["the raw words"], "the RAW transcript is what lands on the clipboard")
+        XCTAssertEqual(viewModel.statusText, "Raw transcript copied.")
+    }
+
     func testFinishStoppedSessionSendsReplacementDictionaryInLLMRequest() async {
         let settings = makeSettings(outputMode: .overlayBuffer)
         settings.replacementDictionaryEnabled = true
@@ -1127,6 +1233,7 @@ private final class MockOverlayCoordinator: OverlayBufferSessionCoordinating {
     var resetCallCount = 0
     var captureLiveCommitTargetAppPIDCallCount = 0
     var commitTargetAppPID: pid_t? = nil
+    var markPolishedCalls: [Bool] = []
 
     func resolveAnchorNow() -> OverlayAnchor {
         OverlayAnchor(
@@ -1170,5 +1277,9 @@ private final class MockOverlayCoordinator: OverlayBufferSessionCoordinating {
 
     func captureLiveCommitTargetAppPID() {
         captureLiveCommitTargetAppPIDCallCount += 1
+    }
+
+    func markPolished(_ polished: Bool) {
+        markPolishedCalls.append(polished)
     }
 }

--- a/Tests/localvoxtralTests/OverlayBufferSessionCoordinatorTests.swift
+++ b/Tests/localvoxtralTests/OverlayBufferSessionCoordinatorTests.swift
@@ -165,6 +165,40 @@ final class OverlayBufferSessionCoordinatorTests: XCTestCase {
         )
     }
 
+    func testMarkPolishedRendersBadgeIntoSnapshotAndResetClearsIt() {
+        let renderer = MockOverlayRenderer()
+        let coordinator = OverlayBufferSessionCoordinator(
+            stateMachine: OverlayBufferStateMachine(),
+            renderer: renderer,
+            anchorResolver: MockOverlayAnchorResolver()
+        )
+
+        coordinator.startSession()
+        coordinator.beginFinalizing(displayBufferText: "Hello world.", commitBufferText: "Hello world.")
+        coordinator.markPolished(true)
+
+        let rendered = renderer.snapshots.compactMap { $0 }.last
+        XCTAssertEqual(rendered?.phase, .finalizing)
+        XCTAssertEqual(
+            rendered?.polished, true,
+            "the badge must reach the rendered snapshot, not just the state machine"
+        )
+
+        // Clearing the flag re-renders without the badge (no lingering annotation).
+        coordinator.markPolished(false)
+        XCTAssertEqual(renderer.snapshots.compactMap { $0 }.last?.polished, false)
+
+        // A fresh session (reset precedes startSession in the real flow) is clean.
+        coordinator.markPolished(true)
+        coordinator.reset()
+        coordinator.startSession()
+        coordinator.beginFinalizing(displayBufferText: "next", commitBufferText: "next")
+        XCTAssertEqual(
+            renderer.snapshots.compactMap { $0 }.last?.polished, false,
+            "a new session must not carry a stale badge"
+        )
+    }
+
     func testCommitUsesPIDCapturedAtStopTime() {
         let renderer = MockOverlayRenderer()
         let anchorResolver = MockOverlayAnchorResolver()

--- a/Tests/localvoxtralTests/OverlayBufferStateMachineTests.swift
+++ b/Tests/localvoxtralTests/OverlayBufferStateMachineTests.swift
@@ -89,6 +89,38 @@ final class OverlayBufferStateMachineTests: XCTestCase {
         XCTAssertNil(machine.anchor)
     }
 
+    func testPolishedFlagSetsInFinalizingAndResetsOnNewSession() {
+        var machine = OverlayBufferStateMachine()
+        let anchor = OverlayAnchor(
+            targetRect: CGRect(x: 0, y: 0, width: 80, height: 24),
+            source: .windowCenter
+        )
+
+        machine.setPolished(true)
+        XCTAssertNil(machine.snapshot, "no session, no flag")
+
+        machine.startSession(anchor: anchor)
+        XCTAssertEqual(machine.snapshot?.polished, false, "a fresh session is unpolished")
+
+        machine.beginFinalizing(anchor: nil)
+        machine.setPolished(true)
+        XCTAssertEqual(
+            machine.snapshot?.polished, true,
+            "the badge rides the finalizing snapshot while the polished text is held"
+        )
+
+        machine.setPolished(false)
+        XCTAssertEqual(machine.snapshot?.polished, false, "a no-op polish clears the flag")
+
+        machine.setPolished(true)
+        machine.reset()
+        machine.startSession(anchor: anchor)
+        XCTAssertEqual(
+            machine.snapshot?.polished, false,
+            "reset + a new session must not carry a stale badge"
+        )
+    }
+
     func testOverlayAssembler_partialAndFinalMergeWithoutDuplication() {
         let merged = OverlayBufferTextAssembler.displayText(
             committedText: "hello world",


### PR DESCRIPTION
# Overlay "Polished" badge + popover raw-transcript copy (polish revert affordance)

Feature 6 (last) of the polish-for-agents series (stacked on #112 ← #106 ← #105 ← #103 ← #101).

The overlay auto-commits at stop, the panel takes no keystrokes, and terminals
can't un-type — a true in-place revert is impossible. v1 is **visibility plus a
copy affordance**:

- **"Polished" badge**: `OverlayBufferStateMachine` carries a `polished` flag
  (reset on `startSession`/`reset`, ignored when idle); the coordinator exposes
  `markPolished(_:)` (protocol default no-op keeps all existing test doubles
  untouched); the overlay header shows a quiet trailing "Polished" pill
  (`wand.and.stars`, secondary style) while the polished text is held before
  dismissal. It lives inside the fixed 16 pt header row, so panel height is
  unaffected.
- **"Copy Raw Transcript" popover action**: after a commit where polishing
  visibly changed the text, the status popover offers a one-line action that
  copies the raw (pre-polish) transcript — it never renders the transcript
  itself (owner popover rule). Cleared on every new session start and on any
  non-changed commit. The raw text is the already-captured `originalText`
  (same value persisted as `rawText`) — no parallel store, no new record field.
- **Polish-changed** means `committedText != workingText`, computed in
  placeholder space on both sides: a `.clean`-identical result, a `.fallback`
  to raw, and a placeholder-count revert all show no badge, and payload
  substitution (applied to the display copy afterwards) can neither fake nor
  mask a change. `originalText` is captured before the payload macro fires, so
  the copy affordance can never leak clipboard payload content.
- Pasteboard writes go through a single seam with a DEBUG override so tests
  assert copied content without a pasteboard server or clobbering the host
  clipboard. No new setting (visibility affordance, always on); settings
  groups untouched.

## Review (Fable deep review, whole diff including the #112 hardening commit)

- **P2 (fixed in #112's tip commit)**: wedged vocabulary pipelines accumulate
  blocked cooperative-pool threads until the deadline mechanism itself starves
  → `RepoVocabularyFlightGate` single-flights the pipeline; a wedge costs at
  most one thread and subsequent commits fast-skip. Regression test
  `testWedgedPipelineSingleFlightSkipsNextCommit` (deterministic: gate decides
  synchronously; count assertion waits on a start signal, no wall-clock).
- **P3 (fixed in #112's tip commit)**: the deadline race dropped the old
  `await .value` priority escalation → deadline task now `.userInitiated`
  (documented tradeoff; the pipeline deliberately stays `.utility`).
- **P3 (fixed here)**: the two new lifecycle tests inlined the file's
  wall-clock polling pattern → deduped into one shared helper with the debt
  documented (converting the file's 6 pre-existing copies to an injected clock
  is out of scope).
- Verified clean with no findings: continuation-race soundness (resume-once,
  no double/never-resume, abandoned pipeline retains nothing `@MainActor`),
  `polishChanged` semantics across every polish branch, `markPolished`
  lifecycle (`reset()` provably precedes every `startSession()` — no
  stale-badge path), popover one-line rule + `@Observable` row visibility,
  overlay height stability, pure-addition test diffs.

## Proof

`./scripts/remote-build.sh` (build + full unit suite) final tail:

```
	 Executed 761 tests, with 2 tests skipped and 0 failures (0 unexpected) in 7.954 (7.994) seconds
```

754 (base) → 761: +5 F6 tests, +1 deadline-race test and +1 single-flight test
(both in #112's hardening commit). 0 failures, 0 warnings.

Behavior-demonstrating tests:

- `OverlayBufferStateMachineTests.testPolishedFlagSetsInFinalizingAndResetsOnNewSession`
- `OverlayBufferSessionCoordinatorTests.testMarkPolishedRendersBadgeIntoSnapshotAndResetClearsIt`
- `DictationViewModelOverlayLifecycleTests.testPolishChangedCommitFlagsBadgeAndRetainsRawTranscript`
  (polish changes text → `markPolished(true)` + raw retained + `canCopyRawTranscript`)
- `DictationViewModelOverlayLifecycleTests.testUnchangedPolishOffersNoBadgeOrRawCopy`
  (verbatim polish → `markPolished(false)` + seeded stale affordance cleared)
- `DictationViewModelOverlayLifecycleTests.testCopyRawTranscriptWritesRawTextThroughPasteboardSeam`

No wall-clock added beyond the file's existing poll-wait pattern (now shared
via one helper); no test reaches `beginDictationSession` (connect-timeout
SIGTRAP rule not triggered); all four modified test files are pure additions.

## Hand verification needed (UI-visual; will do via try-pr.sh)

1. Badge appears during the hold window after a polish-changed commit; quiet
   secondary styling in light + dark; absent when polish returns verbatim or is
   disabled; does not linger into the next session.
2. Popover shows the one-line "Copy Raw Transcript" row under "Copy Latest
   Segment" only after a polish-changed commit; clicking copies the raw
   transcript and sets status "Raw transcript copied."; row absent after
   non-changed commits and at next session start; popover width stable.
