### PR TITLE
Polishing default: Qwen3.5-4B-OptiQ for all users (0.8B stays selectable)

### DIFF
--- a/.github/workflows/mac-crashlog.yml
+++ b/.github/workflows/mac-crashlog.yml
@@ -62,7 +62,7 @@ jobs:
             UV_TOOL_DIR="$UV_TOOL_DIR" UV_TOOL_BIN_DIR="$UV_TOOL_BIN_DIR" \
             "$UV" run --python 3.12 \
             --with 'huggingface_hub<2' --with 'tqdm<5' \
-            python -u "$SCRIPT" mlx-community/Qwen3.5-0.8B-8bit \
+            python -u "$SCRIPT" mlx-community/Qwen3.5-4B-OptiQ-4bit \
             --include '*.json' --include 'model*.safetensors' --include '*.py' \
             --include 'tokenizer.model' --include '*.tiktoken' --include 'tiktoken.model' \
             --include '*.txt' --include '*.jsonl' --include '*.jinja' \

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ The shared config directory lives at `~/Library/Application Support/localvoxtral
 In **Managed local** mode (the default), localvoxtral launches and supervises two inference engines for you — no terminal required:
 
 - **Dictation — [voxmlx](https://github.com/T0mSIlver/voxmlx)** streaming [Voxtral Mini 4B Realtime in 4-bit](https://huggingface.co/T0mSIlver/Voxtral-Mini-4B-Realtime-2602-MLX-4bit). localvoxtral ships a tuned build that adds a native OpenAI Realtime WebSocket server and memory-management optimizations for long dictation sessions.
-- **Polishing — a bundled native engine** built on Apple's [MLX Swift](https://github.com/ml-explore/mlx-swift-lm), running [Qwen3.5-0.8B in 8-bit](https://huggingface.co/mlx-community/Qwen3.5-0.8B-8bit), a lightweight model that cleans up transcripts with negligible overhead. It ships inside the app — nothing to install — and runs as a supervised helper process, so turning polishing off frees its memory immediately.
+- **Polishing — a bundled native engine** built on Apple's [MLX Swift](https://github.com/ml-explore/mlx-swift-lm), running [Qwen3.5-4B-OptiQ in 4-bit](https://huggingface.co/mlx-community/Qwen3.5-4B-OptiQ-4bit) by default (a lighter 0.8B and a larger 9B are one click away in Settings). It cleans up transcripts on-device, ships inside the app — nothing to install — and runs as a supervised helper process, so turning polishing off frees its memory immediately.
 
 The dictation engine installs from pinned, checksum-verified releases into `~/Library/Application Support/localvoxtral`; the polishing engine ships inside the app bundle. Neither ever outlives the app (a watchdog stops them even after a crash); uninstalling means deleting the app and that one folder.
 

--- a/Sources/localvoxtral/Backends/PolishModelCatalog.swift
+++ b/Sources/localvoxtral/Backends/PolishModelCatalog.swift
@@ -41,21 +41,21 @@ enum PolishModelCatalog {
         // them (field finding: picker said 6.6, bar said 7.1).
         PolishModelOption(
             repoID: "mlx-community/Qwen3.5-0.8B-8bit",
-            displayName: "Qwen3.5 0.8B (fastest, default)",
+            displayName: "Qwen3.5 0.8B (fastest)",
             sizeOnDiskGB: 1.0,
             estimatedRAMGB: 1.2,
             samplingDefaults: nil,
             chatTemplateArguments: nil,
-            summary: "For any Apple Silicon Mac"
+            summary: "Lightest option, for constrained Macs"
         ),
         PolishModelOption(
             repoID: "mlx-community/Qwen3.5-4B-OptiQ-4bit",
-            displayName: "Qwen3.5 4B (better quality)",
+            displayName: "Qwen3.5 4B (better quality, default)",
             sizeOnDiskGB: 3.3,
             estimatedRAMGB: 3.8,
             samplingDefaults: nil,
             chatTemplateArguments: ["enable_thinking": false],
-            summary: "For 16 GB+ Macs"
+            summary: "For any Apple Silicon Mac"
         ),
         PolishModelOption(
             repoID: "mlx-community/Qwen3.5-9B-OptiQ-4bit",
@@ -68,7 +68,15 @@ enum PolishModelCatalog {
         ),
     ]
 
-    static let defaultOption = options[0]
+    /// Owner decision 2026-07-11: the 4B is the default for ALL users (14/14
+    /// on the punctuation eval vs the 0.8B's 10/14) — no RAM-based fallback;
+    /// the 0.8B stays selectable in the picker for constrained Macs.
+    static let defaultOption: PolishModelOption = {
+        guard let option = option(forRepoID: "mlx-community/Qwen3.5-4B-OptiQ-4bit") else {
+            preconditionFailure("Default polishing model missing from the catalog.")
+        }
+        return option
+    }()
 
     static func option(forRepoID repoID: String) -> PolishModelOption? {
         options.first { $0.repoID == repoID }

--- a/Sources/localvoxtral/SettingsView.swift
+++ b/Sources/localvoxtral/SettingsView.swift
@@ -332,7 +332,7 @@ private struct ConnectionSettingsPane: View {
 
                         SettingsFieldRow(title: "Model") {
                             TextField(
-                                "mlx-community/Qwen3.5-0.8B-8bit",
+                                "mlx-community/Qwen3.5-4B-OptiQ-4bit",
                                 text: $settings.llmPolishingModel
                             )
                             .textFieldStyle(.roundedBorder)

--- a/Tests/localvoxtralTests/LLMPolishEvalSupport.swift
+++ b/Tests/localvoxtralTests/LLMPolishEvalSupport.swift
@@ -103,7 +103,9 @@ enum LLMPolishEvalSupport {
         ),
     ]
 
-    /// Cases the pinned 0.8B model cannot do reliably. Two flavors:
+    /// Cases the original 0.8B default could not do reliably (the 4B default
+    /// since 2026-07-11 passes many of them — promotion still requires
+    /// stability across TWO server states, see below). Two flavors:
     /// never-pass cases (a probe battery showed the model cannot even
     /// perceive the error — it answers "the spacing is correct" when asked
     /// yes/no with the rule stated in the question) and state-dependent
@@ -182,8 +184,9 @@ enum LLMPolishEvalSupport {
     ]
 
     /// Print-only technical-dictation cases for model differentiation.
-    /// These intentionally do NOT gate CI while the default 0.8B model is
-    /// expected to miss many identifier, command, and markdown transforms.
+    /// These intentionally do NOT gate CI while the pinned small default
+    /// models are expected to miss identifier, command, and markdown
+    /// transforms; the same two-server-state rule gates any promotion.
     static let technicalCases: [LLMPolishEvalCase] = [
         // Filename + SwiftUI lifecycle identifier spoken as natural words.
         LLMPolishEvalCase(

--- a/Tests/localvoxtralTests/LLMPolishEvalSupport.swift
+++ b/Tests/localvoxtralTests/LLMPolishEvalSupport.swift
@@ -309,6 +309,28 @@ enum LLMPolishEvalSupport {
         ),
     ]
 
+    /// Eval-lane configuration builder: mirrors how production builds the
+    /// managed configuration for a model (`SettingsStore
+    /// .llmPolishingConfiguration`) — a catalog model carries its catalog
+    /// sampling defaults AND chat-template kwargs. Without this the 4B
+    /// default would be evaluated with its template's thinking mode ON while
+    /// the shipped request disables it (`enable_thinking: false`), so the
+    /// eval would score a request shape production never sends.
+    static func configuration(
+        endpointURL: URL,
+        apiKey: String,
+        model: String
+    ) -> LLMPolishingConfiguration {
+        let option = PolishModelCatalog.option(forRepoID: model)
+        return LLMPolishingConfiguration(
+            endpointURL: endpointURL,
+            apiKey: apiKey,
+            model: model,
+            samplingDefaults: option?.samplingDefaults,
+            chatTemplateArguments: option?.chatTemplateArguments
+        )
+    }
+
     /// The bundled default templates, loaded through the production config
     /// path (a fresh override directory gets seeded with the bundled files).
     /// The caller owns cleanup of the returned directory.

--- a/Tests/localvoxtralTests/LLMPolishEvalSupportTests.swift
+++ b/Tests/localvoxtralTests/LLMPolishEvalSupportTests.swift
@@ -1,0 +1,50 @@
+import Foundation
+import XCTest
+
+@testable import localvoxtral
+
+@MainActor
+final class LLMPolishEvalSupportTests: XCTestCase {
+    /// The eval lanes must score the request shape production actually
+    /// sends: a catalog model's eval configuration carries the catalog's
+    /// sampling defaults and chat-template kwargs (for the 4B default that
+    /// is `enable_thinking: false` — evaluating it with thinking ON would
+    /// score a request production never sends and emit reasoning transcripts
+    /// that blow the request timeout, #99).
+    func testEvalConfigurationCarriesCatalogRequestShape() throws {
+        let endpointURL = try XCTUnwrap(URL(string: "http://127.0.0.1:8080/v1/chat/completions"))
+        let defaultModel = SettingsStore.defaultLLMPolishingModel
+        let catalogOption = try XCTUnwrap(PolishModelCatalog.option(forRepoID: defaultModel))
+
+        let configuration = LLMPolishEvalSupport.configuration(
+            endpointURL: endpointURL,
+            apiKey: "key",
+            model: defaultModel
+        )
+
+        XCTAssertEqual(configuration.endpointURL, endpointURL)
+        XCTAssertEqual(configuration.apiKey, "key")
+        XCTAssertEqual(configuration.model, defaultModel)
+        XCTAssertEqual(configuration.samplingDefaults, catalogOption.samplingDefaults)
+        XCTAssertEqual(configuration.chatTemplateArguments, catalogOption.chatTemplateArguments)
+        // The default is the 4B, whose shipped request shape disables
+        // thinking — the eval lane must send exactly that.
+        XCTAssertEqual(configuration.chatTemplateArguments, ["enable_thinking": false])
+    }
+
+    /// A non-catalog (custom) model keeps the legacy request shape: no
+    /// sampling overrides, no template kwargs — same as production's managed
+    /// path for a custom repo.
+    func testEvalConfigurationLeavesNonCatalogModelsUntouched() throws {
+        let endpointURL = try XCTUnwrap(URL(string: "http://127.0.0.1:8080/v1/chat/completions"))
+
+        let configuration = LLMPolishEvalSupport.configuration(
+            endpointURL: endpointURL,
+            apiKey: "",
+            model: "example/custom-polisher"
+        )
+
+        XCTAssertNil(configuration.samplingDefaults)
+        XCTAssertNil(configuration.chatTemplateArguments)
+    }
+}

--- a/Tests/localvoxtralTests/LLMPolishPromptEvalTests.swift
+++ b/Tests/localvoxtralTests/LLMPolishPromptEvalTests.swift
@@ -75,7 +75,11 @@ final class LLMPolishPromptEvalTests: XCTestCase {
             throw XCTSkip("Invalid eval endpoint: \(resolvedEndpoint)")
         }
 
-        return LLMPolishingConfiguration(
+        // Catalog-aware: the resolved model's catalog sampling defaults and
+        // chat-template kwargs ride along, exactly like the managed
+        // production configuration (pinned by
+        // `LLMPolishEvalSupportTests.testEvalConfigurationCarriesCatalogRequestShape`).
+        return LLMPolishEvalSupport.configuration(
             endpointURL: endpointURL,
             apiKey: apiKey ?? "",
             model: model?.isEmpty == false ? model! : SettingsStore.defaultLLMPolishingModel

--- a/Tests/localvoxtralTests/PolishHelperIntegrationTests.swift
+++ b/Tests/localvoxtralTests/PolishHelperIntegrationTests.swift
@@ -93,7 +93,8 @@ final class PolishHelperIntegrationTests: XCTestCase {
     /// The helper never downloads (missing model = hard error by design), so
     /// the suite provisions the shared HF cache itself when the model is
     /// absent — the same cache layout + include patterns as the app's
-    /// HFModelDownloader, idempotent, ~0.9 GB once per build host/user.
+    /// HFModelDownloader, idempotent, ~3.3 GB for the default 4B (once per
+    /// build host/user).
     /// Provisioning failures are test FAILURES, not skips: this suite only
     /// runs when explicitly enabled, and a green skip would hide broken infra.
     private func ensureModelCached(_ repoID: String) async throws {

--- a/Tests/localvoxtralTests/PolishModelCatalogTests.swift
+++ b/Tests/localvoxtralTests/PolishModelCatalogTests.swift
@@ -6,16 +6,19 @@ final class PolishModelCatalogTests: XCTestCase {
     func testCatalogLookupAndDefaultOption() {
         let defaultOption = PolishModelCatalog.defaultOption
 
-        XCTAssertEqual(defaultOption.repoID, "mlx-community/Qwen3.5-0.8B-8bit")
+        // Owner decision 2026-07-11: the 4B is the default for ALL users.
+        XCTAssertEqual(defaultOption.repoID, "mlx-community/Qwen3.5-4B-OptiQ-4bit")
         XCTAssertEqual(PolishModelCatalog.option(forRepoID: defaultOption.repoID), defaultOption)
         XCTAssertNil(PolishModelCatalog.option(forRepoID: "unknown/model"))
+        // nil sampling defaults = the engine's deterministic temp-0.3 default
+        // (proven better than Qwen's recommended sampling on the eval, #97).
         XCTAssertNil(defaultOption.samplingDefaults)
-        XCTAssertNil(defaultOption.chatTemplateArguments)
-        XCTAssertEqual(
+        XCTAssertEqual(defaultOption.chatTemplateArguments, ["enable_thinking": false])
+        // The 0.8B stays selectable with its legacy request shape (nil kwargs).
+        XCTAssertNil(
             PolishModelCatalog.option(
-                forRepoID: "mlx-community/Qwen3.5-4B-OptiQ-4bit"
-            )?.chatTemplateArguments,
-            ["enable_thinking": false]
+                forRepoID: "mlx-community/Qwen3.5-0.8B-8bit"
+            )?.chatTemplateArguments
         )
     }
 

--- a/Tests/localvoxtralTests/SettingsStoreTests.swift
+++ b/Tests/localvoxtralTests/SettingsStoreTests.swift
@@ -320,7 +320,9 @@ final class SettingsStoreTests: XCTestCase {
         XCTAssertEqual(configuration?.apiKey, "")
         XCTAssertEqual(configuration?.model, SettingsStore.defaultLLMPolishingModel)
         XCTAssertNil(configuration?.samplingDefaults)
-        XCTAssertNil(configuration?.chatTemplateArguments)
+        // The default 4B rides the catalog's enable_thinking=false kwargs
+        // (default flipped from the kwarg-less 0.8B on 2026-07-11).
+        XCTAssertEqual(configuration?.chatTemplateArguments, ["enable_thinking": false])
     }
 
     func testLLMPolishingConfiguration_managedLocal_usesManagedModelSelection() {


### PR DESCRIPTION
## What

**Qwen3.5-4B-OptiQ becomes the bundled default polishing model for ALL users** (owner decision 2026-07-11), replacing the 0.8B. No RAM-based fallback — the 0.8B stays selectable in the picker for constrained Macs, and an explicit stored selection is never rewritten (only never-touched installs resolve to the new default via `resolvedManagedLLMPolishingModel`'s empty-value fallback).

- `PolishModelCatalog.defaultOption` → the 4B entry, resolved by repo-ID lookup instead of `options[0]` so a future catalog reorder can't silently flip the default. Picker display names move the "default" marker to the 4B.
- The 4B's catalog data is unchanged from #99: nil `samplingDefaults` (= the engine's deterministic temp-0.3 default, proven better than Qwen's recommended sampling in #97/#99) and `enable_thinking: false` via `chat_template_kwargs`. Verified, not re-derived.
- README "Under the hood" polishing pin updated (AGENTS.md pin-sync rule); `mac-crashlog.yml`'s faithful pre-download probe follows the default (its include patterns are model-agnostic and already skip the OptiQ vision/MTP extras).
- External-mode model placeholder in Settings follows the default for consistency.
- Eval corpus untouched: known-hard cases stay XFAIL. All 10 now pass on the 4B in this run, but promotion to `requiredCases` requires stability across TWO server states (helper restart between runs) — left as a follow-up; candidates listed below.

## Proof

- [x] Unit suite green — `./scripts/remote-build.sh`:
  ```
  Executed 687 tests, with 2 tests skipped and 0 failures (0 unexpected) in 8.862 (8.894) seconds
  ```
  One pre-existing assertion updated to the new intended behavior (not weakened): `testLLMPolishingConfiguration_managedLocal_returnsManagedEndpointAndEmptyKey` now asserts the default managed configuration carries the 4B's `["enable_thinking": false]` kwargs (was `XCTAssertNil` for the kwarg-less 0.8B). Shown failing before the update on this branch's first run:
  ```
  SettingsStoreTests.swift:323: error: ... XCTAssertNil failed: "["enable_thinking": false]"
  Executed 687 tests, with 2 tests skipped and 1 failure
  ```
- [x] Packaging green — `./scripts/remote-build.sh package` (app + `localvoxtral-polishd` in Contents/MacOS).
- [x] Per-model gate with the 4B as the resolved default — `./scripts/remote-build.sh integration-polishd` (no arg, i.e. the lane now runs `SettingsStore.defaultLLMPolishingModel`):
  ```
  == polishd (bundled MLX Swift helper) eval (model: mlx-community/Qwen3.5-4B-OptiQ-4bit, endpoint: http://127.0.0.1:52584/v1/chat/completions) ==
  == required: 7/7, known-hard passing: 10/10 ==
  == technical: 2/17 ==
  Test Case 'testHelperMatchesPolishEvalBaselineThroughProductionRequestPath' passed (24.161 seconds).
  Test Suite 'PolishHelperIntegrationTests' passed.
  ```
  Baseline comparison: the 0.8B scored required 7/7, known-hard 3/10 (#99/#101). The parent-PID tether test also passed.
- [x] Non-gating sampling experiment (`testEvalScoreboardWithQwenRecommendedSampling`) on the 4B: required 6/7, known-hard 10/10 — recommended sampling still loses to deterministic temp-0.3 (its miss: the model wrapped the sentence in quotation marks), so engine defaults stay.
- [x] `eval-llm` not run: it scores the default *prompt* against the standalone mlxlm test server on port 8080 (its own model config). This PR changes neither the prompt nor anything that lane covers; the bundled-helper equivalent above is the relevant gate.
- [ ] UI: not hand-verifiable from this Linux box — on next `try-pr.sh`, confirm the picker shows "Qwen3.5 4B (better quality, default)", a fresh (or never-customized) install downloads the 4B (~3.3 GB) on first polish, and an existing explicit 0.8B selection is preserved.

### Known-hard promotion candidates (follow-up, needs two-server-state stability)

All 10 known-hard cases passed on the 4B in this single server state: `fr-question-missing-space`, `en-exclamation-extra-space`, `fr-exclamation-missing-space`, `fr-semicolon-missing-space`, `fr-multi-sentence`, `fr-proper-noun-question`, `en-colon-extra-space`, `en-flag-survives-cleanup`, `en-path-survives-cleanup`, `en-backtick-command-survives`.


## Review fix (Codex P2) — d012d60

**Finding**: the `eval-llm` lane resolved the new 4B default but built its `LLMPolishingConfiguration` without the catalog's `chat_template_kwargs` (and sampling defaults) — so the default eval would score the 4B with template thinking ON, a request shape managed production never sends (and one known to emit reasoning transcripts that blow the timeout, #99).

**Fix**: `LLMPolishEvalSupport.configuration(endpointURL:apiKey:model:)` builds the eval-lane configuration the way `SettingsStore`'s managed path does — catalog lookup attaches `samplingDefaults` + `chatTemplateArguments`; non-catalog (custom) models keep the legacy shape. `LLMPolishPromptEvalTests` now uses it.

**Proof**:
- Always-on unit tests pin the propagation (`LLMPolishEvalSupportTests`): the default model's eval config carries the catalog shape including `["enable_thinking": false]`; a non-catalog model stays nil/nil. Unit suite green:
  ```
  Executed 689 tests, with 2 tests skipped and 0 failures (0 unexpected) in 8.880 (8.911) seconds
  ```
- `eval-llm` itself could NOT be re-run from the dev box: the deployed SSH gate answers `denied command` to the `ensure` verb (the repo's gate script has it; the installed copy predates it), so the on-demand mlxlm service on 8080 cannot be woken remotely — every request fails with connection-refused before reaching a model. Owner action: redeploy the gate per `scripts/mac/README.md`, then `./scripts/remote-build.sh eval-llm` re-proves the lane live. The production request shape for the 4B is already live-proven by `integration-polishd` above (the integration harness has attached catalog kwargs since #99): required 7/7.
