### PR TITLE
polishd: warm the prompt-prefix cache at helper startup (first polish 3.97s -> 0.42s on the 4B)

### DIFF
--- a/Sources/localvoxtral/DictationViewModel.swift
+++ b/Sources/localvoxtral/DictationViewModel.swift
@@ -286,6 +286,12 @@ final class DictationViewModel {
     var llmPolishingService: any LLMPolishingServicing = LLMPolishingService()
     @ObservationIgnored
     var appConfigStore: any AppConfigServing = AppConfigStore()
+    /// Warms the managed polishing helper's prompt-prefix cache on every
+    /// helper launch (see `PolishPromptWarmupCoordinator`). Created only when
+    /// runtime services run — trigger logic is unit-tested on the coordinator
+    /// directly.
+    @ObservationIgnored
+    private(set) var polishPromptWarmupCoordinator: PolishPromptWarmupCoordinator?
     @ObservationIgnored
     let backendManager: any ManagedBackendManaging
     @ObservationIgnored
@@ -549,6 +555,22 @@ final class DictationViewModel {
             refreshMicrophoneInputs()
             registerLifecycleObservers()
             requestStartupPermissionsIfNeeded()
+            // Subscribe BEFORE the launch warmup below so the very first
+            // polishd ready edge is observed and prompt-prefix-warmed.
+            let promptWarmup = PolishPromptWarmupCoordinator(
+                serviceProvider: { [weak self] in
+                    self?.llmPolishingService ?? LLMPolishingService()
+                },
+                planProvider: { [weak self] in
+                    guard let self else { return nil }
+                    return PolishPromptWarmup.plan(
+                        settings: self.settings,
+                        appConfigStore: self.appConfigStore
+                    )
+                }
+            )
+            polishPromptWarmupCoordinator = promptWarmup
+            promptWarmup.observe(self.backendManager.statusUpdates)
             warmUpManagedBackendsAtLaunchIfNeeded()
         }
     }
@@ -573,6 +595,7 @@ final class DictationViewModel {
         finalizationWatchdogTask?.cancel()
         startupPermissionTask?.cancel()
         polishAndCommitTask?.cancel()
+        polishPromptWarmupCoordinator?.cancelTasks()
         textInsertion.stopAllTasks()
         overlayBufferCoordinator.reset()
         healthMonitor.cancelTasks()

--- a/Sources/localvoxtral/LLMPolishingService.swift
+++ b/Sources/localvoxtral/LLMPolishingService.swift
@@ -14,6 +14,23 @@ struct LLMPolishingRequest: Sendable {
     let inputText: String
     let systemPrompt: String
     let userPrompts: [String]
+    /// Optional generation cap forwarded as `max_tokens`. Production polish
+    /// requests leave it nil (the helper applies its own default); the
+    /// prompt-prefix warmup sets 1 so the throwaway generation costs a
+    /// single token.
+    let maxTokens: Int?
+
+    init(
+        inputText: String,
+        systemPrompt: String,
+        userPrompts: [String],
+        maxTokens: Int? = nil
+    ) {
+        self.inputText = inputText
+        self.systemPrompt = systemPrompt
+        self.userPrompts = userPrompts
+        self.maxTokens = maxTokens
+    }
 }
 
 struct LLMPolishingConfiguration: Sendable {
@@ -161,6 +178,9 @@ struct LLMPolishingService: LLMPolishingServicing {
             if let presencePenalty = defaults.presencePenalty {
                 body["presence_penalty"] = presencePenalty
             }
+        }
+        if let maxTokens = request.maxTokens {
+            body["max_tokens"] = maxTokens
         }
         if let chatTemplateArguments = configuration.chatTemplateArguments {
             body["chat_template_kwargs"] = chatTemplateArguments

--- a/Sources/localvoxtral/PolishPromptWarmup.swift
+++ b/Sources/localvoxtral/PolishPromptWarmup.swift
@@ -1,0 +1,163 @@
+import Foundation
+
+/// Warms the managed polishing helper's prompt-prefix cache right after it
+/// becomes ready, so the FIRST real polish request of a helper launch does
+/// not pay the full static-prefix prefill (with the 4B default that prefill
+/// is the dominant share of first-polish latency).
+///
+/// Why app-side: `localvoxtral-polishd` keeps a single KV-state checkpoint of
+/// the templated stable prefix — every message except the last — keyed by the
+/// exact prefix tokens plus chat-template kwargs (`MLXPolishModel`). The app,
+/// not the helper, knows the prompt templates, and every production polish
+/// request shares the same `[system, static user prefix]` head (the rendered
+/// user prompt is split at its first placeholder — `LLMPromptTemplates
+/// .renderedUserPrompts`). One request through the production request path
+/// with that head and a throwaway tail therefore checkpoints exactly the
+/// state real requests reuse.
+enum PolishPromptWarmup {
+    /// Throwaway final-message content. Its text never matters for cache
+    /// reuse — only the preceding messages are checkpointed — it just has to
+    /// be non-empty (the service rejects empty input).
+    static let warmupInputText = "Ready."
+
+    /// The warmup request: identical prefix messages to a production polish
+    /// request (same system prompt, same static user prefix, dictionary slot
+    /// rides the dynamic tail), minimal tail, and a 1-token generation cap.
+    ///
+    /// TODO(profile-aware warmup): once the agent polish profile ships, warm
+    /// the profile the next commit will actually use instead of assuming the
+    /// standard one.
+    static func request(templates: LLMPromptTemplates) -> LLMPolishingRequest {
+        LLMPolishingRequest(
+            inputText: warmupInputText,
+            systemPrompt: templates.systemContent,
+            userPrompts: templates.renderedUserPrompts(
+                inputText: warmupInputText,
+                replacementDictionary: ""
+            ),
+            maxTokens: 1
+        )
+    }
+
+    /// The warmup to run for the current settings, or nil when warmup must
+    /// not run: polishing disabled, or the polishing backend is an external
+    /// URL (never warm someone else's server — and its cache keying is
+    /// unknown anyway).
+    @MainActor
+    static func plan(
+        settings: SettingsStore,
+        appConfigStore: any AppConfigServing
+    ) -> (request: LLMPolishingRequest, configuration: LLMPolishingConfiguration)? {
+        guard settings.polishingBackendMode == .managedLocal,
+            let configuration = settings.llmPolishingConfiguration
+        else {
+            return nil
+        }
+        return (request(templates: appConfigStore.loadLLMPromptTemplates()), configuration)
+    }
+}
+
+/// Fires one prompt-prefix warmup per managed-helper launch by edge-detecting
+/// the polishd status stream: a transition into `.ready` from any non-ready
+/// status is a (re)launch with a cold cache — initial start, crash
+/// auto-restart, model-switch restart, or polishing re-enable. The duplicate
+/// `.ready` that `BackendManager.ensureReady` re-emits on every dictation
+/// start is NOT an edge, so warmup never fires per dictation.
+///
+/// The warmup task is fire-and-forget: nothing in the session path ever
+/// awaits it, so it cannot delay a real polish request app-side. Helper-side
+/// the two requests serialize on the model container; with `max_tokens: 1`
+/// the warmup's tail work past the (wanted) prefix prefill is a few tail
+/// tokens plus one generated token. Failures are logged to `Log.backends`
+/// and swallowed — warmup is never user-visible.
+@MainActor
+final class PolishPromptWarmupCoordinator {
+    typealias PlanProvider =
+        @MainActor () -> (request: LLMPolishingRequest, configuration: LLMPolishingConfiguration)?
+    typealias ServiceProvider = @MainActor () -> any LLMPolishingServicing
+
+    private let serviceProvider: ServiceProvider
+    private let planProvider: PlanProvider
+    private var polishdWasReady = false
+    private var observationTask: Task<Void, Never>?
+    /// Kept awaitable for tests (same convention as the view model's
+    /// warmup/shutdown task slots).
+    private(set) var warmupTask: Task<Void, Never>?
+
+    init(
+        serviceProvider: @escaping ServiceProvider,
+        planProvider: @escaping PlanProvider
+    ) {
+        self.serviceProvider = serviceProvider
+        self.planProvider = planProvider
+    }
+
+    /// Consumes a `BackendManager.statusUpdates` subscription for the process
+    /// lifetime. Call at most once.
+    func observe(_ updates: AsyncStream<ManagedBackendStatusUpdate>) {
+        precondition(observationTask == nil, "PolishPromptWarmupCoordinator.observe called twice")
+        observationTask = Task { @MainActor [weak self] in
+            for await update in updates {
+                guard let self else { return }
+                self.handleStatusUpdate(update)
+            }
+        }
+    }
+
+    func cancelTasks() {
+        observationTask?.cancel()
+        warmupTask?.cancel()
+    }
+
+    func handleStatusUpdate(_ update: ManagedBackendStatusUpdate) {
+        guard update.spec.id == BackendCatalog.polishd.id else { return }
+        let isReady = update.status == .ready
+        defer { polishdWasReady = isReady }
+        if !isReady {
+            // The helper this warmup targeted is stopping/restarting; its
+            // cache dies with it. The next ready edge starts a fresh warmup.
+            warmupTask?.cancel()
+            return
+        }
+        guard !polishdWasReady else { return }
+        startWarmup()
+    }
+
+    private func startWarmup() {
+        guard let plan = planProvider() else {
+            Log.backends.info(
+                "polish prompt warmup skipped (polishing disabled or backend not managed)"
+            )
+            return
+        }
+        warmupTask?.cancel()
+        Log.backends.info(
+            "polish prompt warmup started for model \(plan.configuration.model, privacy: .public)"
+        )
+        let service = serviceProvider()
+        warmupTask = Task { @MainActor in
+            do {
+                let result = try await service.polish(
+                    request: plan.request,
+                    configuration: plan.configuration
+                )
+                Log.backends.info(
+                    "polish prompt warmup completed in \(String(format: "%.2f", result.durationSeconds), privacy: .public)s"
+                )
+            } catch is CancellationError {
+                Log.backends.info("polish prompt warmup cancelled")
+            } catch {
+                guard !Task.isCancelled else {
+                    Log.backends.info("polish prompt warmup cancelled")
+                    return
+                }
+                // Log-only by design: the helper may still have prefilled the
+                // prefix (e.g. a client-side timeout), and the next real
+                // request works either way — it just pays full prefill.
+                Log.backends.error(
+                    "polish prompt warmup failed (log-only): \(error.localizedDescription, privacy: .public)"
+                )
+            }
+        }
+    }
+}

--- a/Tests/localvoxtralTests/BackendManagerTests.swift
+++ b/Tests/localvoxtralTests/BackendManagerTests.swift
@@ -319,8 +319,19 @@ final class BackendManagerTests: XCTestCase {
         XCTAssertEqual(manager.voxmlxStatus, .ready)
         XCTAssertEqual(supervisor.startCallCount, 1)
 
+        // Deterministic happens-before edge for the mirror's async consumption
+        // task: subscribe BEFORE emitting, then drain the stream until the
+        // failure lands. The previous single `Task.yield()` is not a
+        // synchronization point — under scheduler load the mirror was still
+        // `.ready` when asserted (pre-existing flake on main, surfaced by CI
+        // load on 2026-07-11). Assertions unchanged.
+        let statusUpdates = manager.statusUpdates
         supervisor.emit(.failed(summary: "process crashed after readiness", detail: nil))
-        await Task.yield()
+        for await update in statusUpdates {
+            if update.spec.id == BackendCatalog.voxmlx.id, case .failed = update.status {
+                break
+            }
+        }
 
         XCTAssertEqual(manager.voxmlxStatus, .failed(summary: "process crashed after readiness", detail: nil))
 

--- a/Tests/localvoxtralTests/LLMPolishingServiceTests.swift
+++ b/Tests/localvoxtralTests/LLMPolishingServiceTests.swift
@@ -74,6 +74,43 @@ final class LLMPolishingServiceTests: XCTestCase {
         XCTAssertNil(json["presencePenalty"])
     }
 
+    func testMaxTokensEmitsOpenAIFieldNameOnlyWhenSet() throws {
+        let configuration = LLMPolishingConfiguration(
+            endpointURL: URL(string: "http://127.0.0.1/chat")!,
+            apiKey: "",
+            model: "model"
+        )
+        let warmupRequest = LLMPolishingRequest(
+            inputText: "hello",
+            systemPrompt: "system",
+            userPrompts: ["first", "second"],
+            maxTokens: 1
+        )
+
+        let warmupJSON = try XCTUnwrap(
+            JSONSerialization.jsonObject(
+                with: LLMPolishingService.requestBody(
+                    request: warmupRequest,
+                    configuration: configuration
+                )
+            ) as? [String: Any]
+        )
+        XCTAssertEqual(warmupJSON["max_tokens"] as? Int, 1)
+
+        // The production polish request (nil maxTokens) keeps its legacy wire
+        // shape: no max_tokens key at all, the helper applies its default.
+        let productionJSON = try XCTUnwrap(
+            JSONSerialization.jsonObject(
+                with: LLMPolishingService.requestBody(
+                    request: request,
+                    configuration: configuration
+                )
+            ) as? [String: Any]
+        )
+        XCTAssertNil(productionJSON["max_tokens"])
+        XCTAssertNil(productionJSON["maxTokens"])
+    }
+
     func testChatTemplateArgumentsEmitMlxLmFieldName() throws {
         let configuration = LLMPolishingConfiguration(
             endpointURL: URL(string: "http://127.0.0.1/chat")!,

--- a/Tests/localvoxtralTests/PolishHelperIntegrationTests.swift
+++ b/Tests/localvoxtralTests/PolishHelperIntegrationTests.swift
@@ -209,24 +209,7 @@ final class PolishHelperIntegrationTests: XCTestCase {
         try process.run()
         reader.start()
         addTeardownBlock {
-            // Reap, don't just signal: SIGTERM is asynchronous, so a teardown
-            // that only calls terminate() lets the test process exit while the
-            // helper is still dying — the CI runner then spends ~105 s per run
-            // reaping the orphan ("Cleaning up orphan processes"). Wait for the
-            // exit (bounded), and escalate to SIGKILL if it never comes.
-            if process.isRunning {
-                process.terminate()
-            }
-            let reaped = XCTestExpectation(description: "helper exited after SIGTERM")
-            DispatchQueue.global().async {
-                process.waitUntilExit()  // returns immediately if already exited
-                reaped.fulfill()
-            }
-            _ = await XCTWaiter.fulfillment(of: [reaped], timeout: 10)
-            if process.isRunning {
-                kill(process.processIdentifier, SIGKILL)
-                process.waitUntilExit()
-            }
+            await Self.reap(process)
         }
 
         await fulfillment(of: [readyOrExited], timeout: Self.readyTimeout)
@@ -243,6 +226,29 @@ final class PolishHelperIntegrationTests: XCTestCase {
             throw XCTSkip("helper did not become ready")
         }
         return (process, port, stderrLog)
+    }
+
+    /// Reap, don't just signal: SIGTERM is asynchronous, so `terminate()`
+    /// alone lets the caller move on while the helper is still dying — in
+    /// teardown that costs the CI runner ~105 s of orphan cleanup (#111),
+    /// and between back-to-back launches it would briefly keep TWO copies
+    /// of the model in memory on the shared runner. Wait for the exit
+    /// (bounded), and escalate to SIGKILL if it never comes. Idempotent for
+    /// an already-exited process.
+    private static func reap(_ process: Process) async {
+        if process.isRunning {
+            process.terminate()
+        }
+        let reaped = XCTestExpectation(description: "helper exited after SIGTERM")
+        DispatchQueue.global().async {
+            process.waitUntilExit()  // returns immediately if already exited
+            reaped.fulfill()
+        }
+        _ = await XCTWaiter.fulfillment(of: [reaped], timeout: 10)
+        if process.isRunning {
+            kill(process.processIdentifier, SIGKILL)
+            process.waitUntilExit()
+        }
     }
 
     private final class LineLog: @unchecked Sendable {
@@ -398,7 +404,11 @@ final class PolishHelperIntegrationTests: XCTestCase {
             request: realPolishRequest,
             configuration: configuration(port: cold.port)
         )
-        cold.process.terminate()
+        // Reap the cold helper BEFORE launching the second one: terminate()
+        // is only an asynchronous SIGTERM, and overlapping two helpers would
+        // briefly double the model's memory on the shared runner (~2x 4 GB
+        // with the 4B) — same reap-don't-signal rule as teardown (#111).
+        await Self.reap(cold.process)
 
         // Warmed: cold helper again, the app's warmup request lands first.
         let warmed = try await launchHelper(binary: binary, model: model)

--- a/Tests/localvoxtralTests/PolishHelperIntegrationTests.swift
+++ b/Tests/localvoxtralTests/PolishHelperIntegrationTests.swift
@@ -352,6 +352,110 @@ final class PolishHelperIntegrationTests: XCTestCase {
         process.terminate()
     }
 
+    /// Regression-style demonstration for the app-side prompt-prefix warmup:
+    /// two cold helper launches — one where the first real polish pays the
+    /// full static-prefix prefill, one where the app's exact warmup request
+    /// (`PolishPromptWarmup.request`, max_tokens=1) lands first. Asserts the
+    /// BEHAVIOR (the warmup checkpoints the prefix; the first real polish is
+    /// then a cache hit, zero full-prefill fallbacks, identical output) and
+    /// prints the measured latencies informationally — no timing assertions
+    /// (no-wall-clock rule).
+    func testAppWarmupRequestPrimesPromptCacheForFirstRealPolish() async throws {
+        let (binary, model) = try helperConfiguration()
+        try await ensureModelCached(model)
+        let option = PolishModelCatalog.option(forRepoID: model)
+        let (templates, cleanup) = try LLMPolishEvalSupport.defaultPromptTemplates()
+        addTeardownBlock { cleanup() }
+        let service = LLMPolishingService()
+
+        // A required eval case: its polished output is deterministic and
+        // stable, so the cold and warmed runs must agree on it.
+        let transcript = "Are you coming to the meeting tomorrow ?"
+        let expectedNormalized = LLMPolishEvalSupport.normalized(
+            "Are you coming to the meeting tomorrow?"
+        )
+        func configuration(port: UInt16) -> LLMPolishingConfiguration {
+            LLMPolishingConfiguration(
+                endpointURL: URL(string: "http://127.0.0.1:\(port)/v1/chat/completions")!,
+                apiKey: "",
+                model: model,
+                samplingDefaults: option?.samplingDefaults,
+                chatTemplateArguments: option?.chatTemplateArguments
+            )
+        }
+        let realPolishRequest = LLMPolishingRequest(
+            inputText: transcript,
+            systemPrompt: templates.systemContent,
+            userPrompts: templates.renderedUserPrompts(
+                inputText: transcript,
+                replacementDictionary: ""
+            )
+        )
+
+        // Baseline: cold helper, the first real polish pays the full prefill.
+        let cold = try await launchHelper(binary: binary, model: model)
+        let coldResult = try await service.polish(
+            request: realPolishRequest,
+            configuration: configuration(port: cold.port)
+        )
+        cold.process.terminate()
+
+        // Warmed: cold helper again, the app's warmup request lands first.
+        let warmed = try await launchHelper(binary: binary, model: model)
+        let warmupRequest = PolishPromptWarmup.request(templates: templates)
+        var warmupDuration = Double.nan
+        do {
+            warmupDuration = try await service.polish(
+                request: warmupRequest,
+                configuration: configuration(port: warmed.port)
+            ).durationSeconds
+        } catch LLMPolishingError.invalidResponse {
+            // A 1-token generation can trim to an empty response; the
+            // checkpoint exists server-side either way and the assertions
+            // below prove it (the production warmup is log-only too).
+        }
+        let warmResult = try await service.polish(
+            request: realPolishRequest,
+            configuration: configuration(port: warmed.port)
+        )
+        // Worst-case serialization cost for a real polish that lands behind
+        // an in-flight warmup: the warmup's post-checkpoint work, measured
+        // here as a second warmup request against the warm cache.
+        let queuedWarmupDuration = try? await service.polish(
+            request: warmupRequest,
+            configuration: configuration(port: warmed.port)
+        ).durationSeconds
+
+        // Warmup checkpointed the prefix once; the first real polish reused
+        // it instead of re-checkpointing, and nothing fell back to a full
+        // prefill in either launch.
+        XCTAssertEqual(
+            warmed.stderrLog.countOfLines(containing: "prompt cache: checkpointed"), 1,
+            "expected exactly one checkpoint (the warmup's) across the warmed launch"
+        )
+        XCTAssertGreaterThan(
+            warmed.stderrLog.countOfLines(containing: "prompt cache: hit"), 0,
+            "the first real polish after warmup did not reuse the warmed prefix"
+        )
+        XCTAssertEqual(warmed.stderrLog.countOfLines(containing: "full prefill"), 0)
+        XCTAssertEqual(cold.stderrLog.countOfLines(containing: "full prefill"), 0)
+
+        // Cache reuse must not change polish output.
+        XCTAssertEqual(LLMPolishEvalSupport.normalized(coldResult.polishedText), expectedNormalized)
+        XCTAssertEqual(LLMPolishEvalSupport.normalized(warmResult.polishedText), expectedNormalized)
+
+        print(
+            """
+            == polishd prompt-prefix warmup: first-polish latency (model: \(model)) ==
+            without warmup (cold cache):            \(String(format: "%.3f", coldResult.durationSeconds))s
+            warmup request itself (cold cache):     \(String(format: "%.3f", warmupDuration))s
+            first real polish after warmup:         \(String(format: "%.3f", warmResult.durationSeconds))s
+            worst-case queue-behind-warmup (proxy): \(String(format: "%.3f", queuedWarmupDuration ?? .nan))s
+            """
+        )
+        warmed.process.terminate()
+    }
+
     /// EXPERIMENT (2026-07-09, print-only — no score assertions): run the
     /// same corpus with the Qwen3.5 model card's recommended non-thinking
     /// text sampling (temperature 1.0, top_p 1.0, top_k 20, min_p 0,

--- a/Tests/localvoxtralTests/PolishPromptWarmupTests.swift
+++ b/Tests/localvoxtralTests/PolishPromptWarmupTests.swift
@@ -1,0 +1,376 @@
+import Foundation
+import XCTest
+
+@testable import localvoxtral
+
+@MainActor
+final class PolishPromptWarmupTests: XCTestCase {
+    // MARK: - Fakes
+
+    /// Records polish calls and answers from a configurable result. Locked,
+    /// not actor-based, matching the repo's locked-fake convention.
+    private final class RecordingPolishService: LLMPolishingServicing, @unchecked Sendable {
+        private let lock = NSLock()
+        private var recordedRequests: [LLMPolishingRequest] = []
+        private var failure: Error?
+
+        func setFailure(_ error: Error?) {
+            lock.lock()
+            failure = error
+            lock.unlock()
+        }
+
+        var requests: [LLMPolishingRequest] {
+            lock.lock()
+            defer { lock.unlock() }
+            return recordedRequests
+        }
+
+        func polish(
+            request: LLMPolishingRequest,
+            configuration: LLMPolishingConfiguration
+        ) async throws -> LLMPolishingResult {
+            let pendingFailure: Error? = lock.withLock {
+                recordedRequests.append(request)
+                return failure
+            }
+            if let pendingFailure {
+                throw pendingFailure
+            }
+            return LLMPolishingResult(
+                rawText: request.inputText,
+                polishedText: request.inputText,
+                durationSeconds: 0
+            )
+        }
+    }
+
+    /// Suspends inside polish() until the surrounding task is cancelled —
+    /// event-driven (continuation resumed by the cancellation handler), no
+    /// wall-clock waiting.
+    private final class SuspendingPolishService: LLMPolishingServicing, @unchecked Sendable {
+        private let lock = NSLock()
+        private var continuation: CheckedContinuation<Void, Error>?
+        private var cancellationObserved = false
+        let started = XCTestExpectation(description: "polish request reached the service")
+
+        var observedCancellation: Bool {
+            lock.lock()
+            defer { lock.unlock() }
+            return cancellationObserved
+        }
+
+        func polish(
+            request: LLMPolishingRequest,
+            configuration: LLMPolishingConfiguration
+        ) async throws -> LLMPolishingResult {
+            started.fulfill()
+            try await withTaskCancellationHandler {
+                try await withCheckedThrowingContinuation { continuation in
+                    lock.lock()
+                    self.continuation = continuation
+                    lock.unlock()
+                }
+            } onCancel: {
+                lock.lock()
+                cancellationObserved = true
+                let continuation = self.continuation
+                self.continuation = nil
+                lock.unlock()
+                continuation?.resume(throwing: CancellationError())
+            }
+            return LLMPolishingResult(rawText: "", polishedText: "", durationSeconds: 0)
+        }
+    }
+
+    // MARK: - Helpers
+
+    private func makePlan() -> (
+        request: LLMPolishingRequest, configuration: LLMPolishingConfiguration
+    ) {
+        (
+            request: LLMPolishingRequest(
+                inputText: "warm",
+                systemPrompt: "system",
+                userPrompts: ["static prefix", "tail"],
+                maxTokens: 1
+            ),
+            configuration: LLMPolishingConfiguration(
+                endpointURL: URL(string: "http://127.0.0.1:9/v1/chat/completions")!,
+                apiKey: "",
+                model: "test-model"
+            )
+        )
+    }
+
+    private func update(
+        _ spec: ManagedBackendSpec,
+        _ status: ManagedBackendStatus
+    ) -> ManagedBackendStatusUpdate {
+        ManagedBackendStatusUpdate(spec: spec, status: status)
+    }
+
+    private func awaitWarmup(_ coordinator: PolishPromptWarmupCoordinator) async {
+        await coordinator.warmupTask?.value
+    }
+
+    // MARK: - Trigger logic
+
+    func testWarmupFiresOnReadyEdgeButNotOnDuplicateReady() async {
+        let service = RecordingPolishService()
+        let coordinator = PolishPromptWarmupCoordinator(
+            serviceProvider: { service },
+            planProvider: { [plan = makePlan()] in plan }
+        )
+
+        coordinator.handleStatusUpdate(update(BackendCatalog.polishd, .starting))
+        XCTAssertNil(coordinator.warmupTask, "warmup must not fire before ready")
+
+        coordinator.handleStatusUpdate(update(BackendCatalog.polishd, .ready))
+        await awaitWarmup(coordinator)
+        XCTAssertEqual(service.requests.count, 1)
+        XCTAssertEqual(service.requests.first?.maxTokens, 1)
+
+        // ensureReady re-emits .ready on every dictation start — NOT a new
+        // helper launch, must not re-warm.
+        coordinator.handleStatusUpdate(update(BackendCatalog.polishd, .ready))
+        coordinator.handleStatusUpdate(update(BackendCatalog.polishd, .ready))
+        await awaitWarmup(coordinator)
+        XCTAssertEqual(service.requests.count, 1, "duplicate ready must not re-fire warmup")
+    }
+
+    func testWarmupFiresAgainAfterHelperRestart() async {
+        let service = RecordingPolishService()
+        let coordinator = PolishPromptWarmupCoordinator(
+            serviceProvider: { service },
+            planProvider: { [plan = makePlan()] in plan }
+        )
+
+        coordinator.handleStatusUpdate(update(BackendCatalog.polishd, .ready))
+        await awaitWarmup(coordinator)
+        XCTAssertEqual(service.requests.count, 1)
+
+        // Model switch / polishing toggle: stopped then relaunched.
+        coordinator.handleStatusUpdate(update(BackendCatalog.polishd, .stopped))
+        coordinator.handleStatusUpdate(update(BackendCatalog.polishd, .ready))
+        await awaitWarmup(coordinator)
+        XCTAssertEqual(service.requests.count, 2)
+
+        // Crash auto-restart: the supervisor mirrors .restarting as .starting
+        // before the fresh .ready.
+        coordinator.handleStatusUpdate(update(BackendCatalog.polishd, .starting))
+        coordinator.handleStatusUpdate(update(BackendCatalog.polishd, .ready))
+        await awaitWarmup(coordinator)
+        XCTAssertEqual(service.requests.count, 3)
+    }
+
+    func testWarmupIgnoresVoxmlxUpdates() async {
+        let service = RecordingPolishService()
+        let coordinator = PolishPromptWarmupCoordinator(
+            serviceProvider: { service },
+            planProvider: { [plan = makePlan()] in plan }
+        )
+
+        coordinator.handleStatusUpdate(update(BackendCatalog.voxmlx, .ready))
+        await awaitWarmup(coordinator)
+        XCTAssertTrue(service.requests.isEmpty)
+
+        // A voxmlx non-ready update must not reset polishd's edge state.
+        coordinator.handleStatusUpdate(update(BackendCatalog.polishd, .ready))
+        await awaitWarmup(coordinator)
+        coordinator.handleStatusUpdate(update(BackendCatalog.voxmlx, .stopped))
+        coordinator.handleStatusUpdate(update(BackendCatalog.polishd, .ready))
+        await awaitWarmup(coordinator)
+        XCTAssertEqual(service.requests.count, 1)
+    }
+
+    func testWarmupSkippedWhenPlanProviderDeclines() async {
+        // The plan provider returns nil for "polishing disabled" and
+        // "external endpoint" (see PolishPromptWarmupPlanTests) — the
+        // coordinator must not fire a request in that case, and must warm
+        // normally once a later launch has a plan.
+        let service = RecordingPolishService()
+        var planAvailable = false
+        let coordinator = PolishPromptWarmupCoordinator(
+            serviceProvider: { service },
+            planProvider: { [plan = makePlan()] in planAvailable ? plan : nil }
+        )
+
+        coordinator.handleStatusUpdate(update(BackendCatalog.polishd, .ready))
+        await awaitWarmup(coordinator)
+        XCTAssertNil(coordinator.warmupTask)
+        XCTAssertTrue(service.requests.isEmpty)
+
+        planAvailable = true
+        coordinator.handleStatusUpdate(update(BackendCatalog.polishd, .stopped))
+        coordinator.handleStatusUpdate(update(BackendCatalog.polishd, .ready))
+        await awaitWarmup(coordinator)
+        XCTAssertEqual(service.requests.count, 1)
+    }
+
+    func testWarmupFailureIsSwallowedAndNextLaunchWarmsAgain() async {
+        let service = RecordingPolishService()
+        service.setFailure(LLMPolishingError.networkError("connection refused"))
+        let coordinator = PolishPromptWarmupCoordinator(
+            serviceProvider: { service },
+            planProvider: { [plan = makePlan()] in plan }
+        )
+
+        coordinator.handleStatusUpdate(update(BackendCatalog.polishd, .ready))
+        await awaitWarmup(coordinator)
+        XCTAssertEqual(service.requests.count, 1)
+
+        // The failure is log-only; the next helper launch warms again.
+        service.setFailure(nil)
+        coordinator.handleStatusUpdate(update(BackendCatalog.polishd, .stopped))
+        coordinator.handleStatusUpdate(update(BackendCatalog.polishd, .ready))
+        await awaitWarmup(coordinator)
+        XCTAssertEqual(service.requests.count, 2)
+    }
+
+    func testHelperStopCancelsInFlightWarmup() async {
+        let service = SuspendingPolishService()
+        let coordinator = PolishPromptWarmupCoordinator(
+            serviceProvider: { service },
+            planProvider: { [plan = makePlan()] in plan }
+        )
+
+        coordinator.handleStatusUpdate(update(BackendCatalog.polishd, .ready))
+        await fulfillment(of: [service.started], timeout: 5)
+
+        // The helper this warmup targeted is going away — the request must
+        // be cancelled, not left to land on (or race) the next launch.
+        coordinator.handleStatusUpdate(update(BackendCatalog.polishd, .stopped))
+        await awaitWarmup(coordinator)
+        XCTAssertTrue(service.observedCancellation)
+    }
+
+    // MARK: - Warmup request shape (the cache-hit invariant)
+
+    /// The invariant that makes app-side warmup work: the helper checkpoints
+    /// every message EXCEPT the last, so the warmup request's non-final
+    /// messages must be byte-identical to a production polish request's,
+    /// whatever the transcript or dictionary content.
+    func testWarmupRequestSharesAllNonFinalMessagesWithProductionRequests() throws {
+        let (templates, cleanup) = try LLMPolishEvalSupport.defaultPromptTemplates()
+        defer { cleanup() }
+
+        let warmup = PolishPromptWarmup.request(templates: templates)
+        let production = LLMPolishingRequest(
+            inputText: "fix the bug in src/auth/useAuth.ts , then run the tests .",
+            systemPrompt: templates.systemContent,
+            userPrompts: templates.renderedUserPrompts(
+                inputText: "fix the bug in src/auth/useAuth.ts , then run the tests .",
+                replacementDictionary: "- \"local vox\" -> \"localvoxtral\""
+            )
+        )
+
+        XCTAssertEqual(warmup.systemPrompt, production.systemPrompt)
+        XCTAssertEqual(warmup.userPrompts.count, production.userPrompts.count)
+        XCTAssertEqual(
+            Array(warmup.userPrompts.dropLast()),
+            Array(production.userPrompts.dropLast()),
+            "warmup must prime the exact prefix messages production requests reuse"
+        )
+        XCTAssertEqual(warmup.maxTokens, 1)
+        XCTAssertFalse(
+            warmup.inputText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
+            "the service rejects empty input"
+        )
+    }
+
+    /// A custom user template with no static text before its first
+    /// placeholder renders as a single user message; the shared prefix is
+    /// then just the system message, and warmup must mirror that shape.
+    func testWarmupRequestMatchesSingleMessageTemplates() {
+        let templates = LLMPromptTemplates(
+            systemContent: "You fix punctuation.",
+            userContent: "{{input_text}}"
+        )
+
+        let warmup = PolishPromptWarmup.request(templates: templates)
+        let production = templates.renderedUserPrompts(
+            inputText: "any transcript",
+            replacementDictionary: ""
+        )
+
+        XCTAssertEqual(warmup.systemPrompt, "You fix punctuation.")
+        XCTAssertEqual(warmup.userPrompts.count, production.count)
+        XCTAssertEqual(warmup.userPrompts, [PolishPromptWarmup.warmupInputText])
+    }
+}
+
+@MainActor
+final class PolishPromptWarmupPlanTests: XCTestCase {
+    private var defaults: UserDefaults!
+    private var defaultsSuiteName = ""
+
+    override func setUp() async throws {
+        try await super.setUp()
+        defaultsSuiteName = "localvoxtral.PolishPromptWarmupPlanTests.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: defaultsSuiteName)!
+        defaults.removePersistentDomain(forName: defaultsSuiteName)
+        self.defaults = defaults
+    }
+
+    override func tearDown() async throws {
+        defaults?.removePersistentDomain(forName: defaultsSuiteName)
+        defaults = nil
+        defaultsSuiteName = ""
+        try await super.tearDown()
+    }
+
+    private func makeStore() -> SettingsStore {
+        SettingsStore(defaults: defaults, environment: [:])
+    }
+
+    private var configStore: some AppConfigServing {
+        struct Fixed: AppConfigServing {
+            func configDirectoryURL() -> URL { URL(fileURLWithPath: "/dev/null") }
+            func loadReplacementDictionary() -> ReplacementDictionary {
+                ReplacementDictionary(entries: [])
+            }
+            func loadLLMPromptTemplates() -> LLMPromptTemplates {
+                LLMPromptTemplates(systemContent: "system", userContent: "prefix {{input_text}}")
+            }
+            func loadTerminalAppBundleIDs() -> [String] { [] }
+        }
+        return Fixed()
+    }
+
+    func testPlanWarmsManagedEndpointWhenPolishingEnabled() throws {
+        let store = makeStore()
+        store.llmPolishingEnabled = true
+
+        let plan = try XCTUnwrap(
+            PolishPromptWarmup.plan(settings: store, appConfigStore: configStore)
+        )
+
+        XCTAssertEqual(
+            plan.configuration.endpointURL.absoluteString,
+            ManagedBackendEndpoints.polishingURLString
+        )
+        XCTAssertEqual(plan.request.maxTokens, 1)
+    }
+
+    func testPlanIsNilWhenPolishingDisabled() {
+        let store = makeStore()
+        store.llmPolishingEnabled = false
+
+        XCTAssertNil(PolishPromptWarmup.plan(settings: store, appConfigStore: configStore))
+    }
+
+    func testPlanIsNilInExternalURLMode() {
+        // Never warm someone else's server: an external chat/completions
+        // endpoint gets no throwaway traffic even though polishing is
+        // enabled and its configuration is valid.
+        let store = makeStore()
+        store.llmPolishingEnabled = true
+        store.polishingBackendMode = .externalURL
+        store.llmPolishingEndpointURL = "https://api.example.com/v1/chat/completions"
+        store.llmPolishingAPIKey = "sk-test"
+
+        XCTAssertNotNil(store.llmPolishingConfiguration, "precondition: external config is valid")
+        XCTAssertNil(PolishPromptWarmup.plan(settings: store, appConfigStore: configStore))
+    }
+}


### PR DESCRIPTION
## What

**polishd's prompt-prefix cache is now warmed at helper startup**, so the first real polish of a helper launch no longer pays the full static-prefix prefill — the worst first-use experience, and one that gets ~3x worse with the 4B default (#116).

**What the helper's caching actually is** (investigated first, design matches it): `MLXPolishModel` keeps a SINGLE-SLOT KV-state checkpoint of the templated stable prefix — every message except the last — keyed by the exact prefix tokens plus chat-template kwargs; requests serialize on the `ModelContainer`. Every production polish request shares the same `[system, static user prefix]` head (the rendered user prompt splits at its first placeholder, `LLMPromptTemplates.renderedUserPrompts`; the dictionary slot rides the dynamic tail). So ONE app-side request through the production request path with that exact head, a throwaway tail, and `max_tokens: 1` checkpoints precisely the state every real request reuses — no helper change needed beyond what #93/#99 already built.

- **`PolishPromptWarmupCoordinator`**: edge-detects the polishd status stream — a transition into `.ready` from any non-ready status is a (re)launch with a cold cache (initial start, crash auto-restart, model-switch restart, polishing re-enable). The duplicate `.ready` that `BackendManager.ensureReady` re-emits on every dictation start is NOT an edge, so warmup fires once per helper launch, never per dictation. A non-ready update cancels an in-flight warmup (its target cache died with the helper).
- **Never someone else's server**: `PolishPromptWarmup.plan` returns nil when polishing is disabled or the backend mode is External URL — asserted.
- **Never blocks a real polish**: the warmup task is fire-and-forget, nothing in the session path awaits it. Helper-side the two requests serialize on the model container; a stop-commit landing behind the in-flight warmup waits only for the warmup's post-checkpoint work (the prefix prefill it would have paid itself) — measured at **~0.25 s worst case on the 4B** (~0.16 s on the 0.8B), vs the ~3.5 s it saves.
- **Failures are log-only** (`Log.backends`, loud start/complete/fail lines), never user-visible.
- `LLMPolishingRequest` gains optional `maxTokens` → `max_tokens` (the helper already decodes it). Nil keeps the legacy wire shape, byte-asserted by the existing pinned-keys test plus a new one.
- TODO left in code: profile-aware warmup once the agent polish profile stack merges — the standard profile is warmed for now (that stack is not on main).

No new wall-clock timers: the coordinator is purely event-driven (status edges), test synchronization is continuation/expectation-based, and the latency numbers are print-only.

## Proof

- [x] Unit suite green — `./scripts/remote-build.sh` (12 new tests: trigger edge/dedupe/restart, voxmlx isolation, plan gating incl. external-endpoint refusal, failure swallowing, in-flight cancellation, warmup/production prefix-message identity, max_tokens wire shape):
  ```
  Executed 699 tests, with 2 tests skipped and 0 failures (0 unexpected) in 9.226 (9.263) seconds
  ```
- [x] PolishHelper unit suite green — `./scripts/remote-build.sh test --package-path PolishHelper` (helper source untouched):
  ```
  Executed 39 tests, with 0 failures (0 unexpected) in 0.111 (0.114) seconds
  ```
- [x] Regression-style demonstration on the real packaged helper — `testAppWarmupRequestPrimesPromptCacheForFirstRealPolish` (two cold launches per run; asserts the app's exact warmup request checkpoints the prefix, the first real polish is a cache hit with zero full-prefill fallbacks, and cache reuse does not change the polished output; latencies informational):

  `./scripts/remote-build.sh integration-polishd mlx-community/Qwen3.5-4B-OptiQ-4bit` (the incoming #116 default):
  ```
  == polishd prompt-prefix warmup: first-polish latency (model: mlx-community/Qwen3.5-4B-OptiQ-4bit) ==
  without warmup (cold cache):            3.965s
  warmup request itself (cold cache):     3.661s
  first real polish after warmup:         0.416s
  worst-case queue-behind-warmup (proxy): 0.246s
  ```
  `./scripts/remote-build.sh integration-polishd` (this branch's 0.8B default):
  ```
  == polishd prompt-prefix warmup: first-polish latency (model: mlx-community/Qwen3.5-0.8B-8bit) ==
  without warmup (cold cache):            1.244s
  warmup request itself (cold cache):     1.446s
  first real polish after warmup:         0.294s
  worst-case queue-behind-warmup (proxy): 0.157s
  ```
  **First-polish latency drops 3.97 s → 0.42 s on the 4B** (1.24 s → 0.29 s on the 0.8B).
- [x] Full polishd integration suite green in both runs, including the unchanged eval baseline gate (4B: required 7/7, known-hard 10/10; 0.8B: required 7/7, known-hard 6/10 — the usual between-state wobble that keeps known-hard XFAIL) and the parent-PID tether.
- [x] Packaging green (`./scripts/remote-build.sh package`).
- [ ] Field check (not verifiable from this Linux box): on next `try-pr.sh`, `log stream` should show `polish prompt warmup started/completed` once after launch (and again after a model switch), and the first overlay commit with polishing on should feel instant.

## Notes

- Based on `main`; independent of #116 (works with any managed model). The 4B measurement above uses the per-model lane arg.
- If a client-side timeout ever hits the warmup (e.g. first-request Metal JIT), the helper still finishes the prefill server-side — the warmup is log-only and the next real request benefits or, at worst, pays full prefill exactly as today.


## Review fix (Codex P2) — ae29ca2

**Finding**: the measurement test called `terminate()` (an asynchronous SIGTERM) on the baseline helper and immediately launched the warmed one — two helper processes could briefly coexist, doubling the model's memory (~2x 4 GB with the 4B) on the shared runner.

**Fix**: the teardown's reap logic (#111) is now a shared static helper (`reap(_:)` — bounded wait for exit, SIGKILL escalation, idempotent), and the test reaps the cold helper to full exit BEFORE launching the second one. Teardown blocks use the same helper.

**Proof** — `./scripts/remote-build.sh integration-polishd mlx-community/Qwen3.5-4B-OptiQ-4bit` on a quiet host:
```
Test Case 'testAppWarmupRequestPrimesPromptCacheForFirstRealPolish' passed (10.572 seconds).
Test Case 'testEvalScoreboardWithQwenRecommendedSampling' passed (24.615 seconds).
Test Case 'testHelperExitsWhenParentPIDDies' passed (1.157 seconds).
Test Case 'testHelperMatchesPolishEvalBaselineThroughProductionRequestPath' passed (24.175 seconds).
Executed 4 tests, with 0 failures (0 unexpected) in 60.519 (60.520) seconds

== polishd prompt-prefix warmup: first-polish latency (model: mlx-community/Qwen3.5-4B-OptiQ-4bit) ==
without warmup (cold cache):            3.809s
warmup request itself (cold cache):     3.569s
first real polish after warmup:         0.411s
worst-case queue-behind-warmup (proxy): 0.262s
```
Gate unchanged: required 7/7, known-hard 10/10. (Two intermediate lane runs failed on 15 s client timeouts while the owner was live-dictating on the build host and the CI queue was draining a stack of pushes — machine contention, not this change; the quiet-host rerun above is clean. The queued "Polish client: 40 s request timeout" PR addresses that flake class.)

> **Red check on ae29ca2 is a runner-environment outage, not this PR**: since ~10:44Z every branch's CI (this one, `feat/polish-revert-affordance`, `fix/polish-timeout-endpoint-diagnostics`, `feat/repo-vocabulary`, `feat/clipboard-payload-macro`) fails the same ~20 secure-input-sensitive unit tests ("Blocked: Secure Keyboard Entry is on") — something in the owner's GUI session (where the runner lives) is holding Secure Keyboard Entry. The identical suites pass over SSH as `builder` right now (`OverlayBufferSessionCoordinatorTests: Executed 18 tests, with 0 failures`), and this PR's identical code was CI-green at 9ae8360. Owner: release secure input (close the password prompt / untick Terminal → Secure Keyboard Entry), then re-run the check.

## Test-only deflake — 1168719

`BackendManagerTests.testSupervisorStateMirrorMarksLaterFailureAndNextEnsureDoesNotShortCircuit` — a pre-existing latent flake on main that this PR's extra test load exposed in CI (green on #112/#115/#118 minutes earlier and in every remote lane): the test emitted the supervisor failure and asserted the mirrored status after a single `Task.yield()`, which is not a happens-before edge for the mirror's async consumption task — under scheduler load the mirror was still `.ready` when asserted (`XCTAssertEqual failed: ("ready") is not equal to ("failed(...)")`).

Synchronization-only fix: subscribe to `manager.statusUpdates` BEFORE emitting, then drain the stream until the voxmlx `.failed` update arrives (event-driven, no wall-clock, assertions byte-identical). The file's only other `emit(` site is this one; its remaining `Task.yield()` uses are a converging poll loop and a didn't-happen guard, not this pattern.

Proof: full unit suite `Executed 699 tests, with 2 tests skipped and 0 failures`; `swift test --filter BackendManagerTests` repeated on the build host, every completed run `Executed 23 tests, with 0 failures`.
