### PR TITLE
Polish client: 40 s request timeout; failure diagnostics name the endpoint actually used

### DIFF
--- a/Sources/localvoxtral/DictationViewModel+Session.swift
+++ b/Sources/localvoxtral/DictationViewModel+Session.swift
@@ -674,7 +674,16 @@ extension DictationViewModel {
                             if case .networkError(let details) = error as? LLMPolishingError {
                                 llmConnectionFailure = (
                                     "Unable to connect to the configured LLM polishing endpoint.",
-                                    self.llmPolishingConnectionTechnicalDetails(details)
+                                    // Name the endpoint the request was ACTUALLY
+                                    // sent to — in managed mode the external-URL
+                                    // setting (its untouched placeholder default,
+                                    // typically :8080) was never used, and naming
+                                    // it sent field debugging to the wrong
+                                    // process (2026-07-11).
+                                    self.llmPolishingConnectionTechnicalDetails(
+                                        details,
+                                        endpointURL: config.endpointURL
+                                    )
                                 )
                             }
                             Log.polishing.error(
@@ -1253,7 +1262,15 @@ extension DictationViewModel {
         sanitizedRealtimeEndpointForLogging()
     }
 
+    /// The endpoint the ACTIVE polishing configuration resolves to — in
+    /// managed mode that is the managed polishd URL, never the external-URL
+    /// setting (whose untouched placeholder default used to be reported here
+    /// and misdirected field debugging, 2026-07-11). Falls back to the raw
+    /// setting text only when no configuration resolves at all.
     private func sanitizedLLMPolishingEndpointForLogging() -> String {
+        if let configured = settings.llmPolishingConfiguration?.endpointURL {
+            return sanitizedURLForLogging(configured)
+        }
         let endpointText = settings.llmPolishingEndpointURL.trimmed
         guard !endpointText.isEmpty,
               let endpoint = URL(string: endpointText)
@@ -1269,8 +1286,14 @@ extension DictationViewModel {
         return trimmed.isEmpty ? nil : trimmed
     }
 
-    private func llmPolishingConnectionTechnicalDetails(_ details: String) -> String {
-        let endpoint = sanitizedLLMPolishingEndpointForLogging()
+    /// Failure details for the alert/`lastError`, naming `endpointURL` — the
+    /// endpoint the failing request was actually sent to, captured from the
+    /// request's own configuration (Settings may have changed since).
+    func llmPolishingConnectionTechnicalDetails(
+        _ details: String,
+        endpointURL: URL
+    ) -> String {
+        let endpoint = sanitizedURLForLogging(endpointURL)
         let normalizedDetails = details.trimmed
         if normalizedDetails.isEmpty {
             return "Unable to connect to endpoint \(endpoint)."

--- a/Sources/localvoxtral/LLMPolishingService.swift
+++ b/Sources/localvoxtral/LLMPolishingService.swift
@@ -65,7 +65,12 @@ enum LLMPolishingError: Error, LocalizedError, Sendable {
 }
 
 struct LLMPolishingService: LLMPolishingServicing {
-    private static let timeoutInterval: TimeInterval = 15
+    /// Polish request timeout. Sized for the managed worst case, not the warm
+    /// path: a 4B model whose polishd prefix-cache checkpoint was invalidated
+    /// re-prefills ~2.3k tokens before generating — a real request took 23.6 s
+    /// and the previous 15 s timeout abandoned it (field, 2026-07-11). Polish
+    /// is async behind the overlay: a slow polish beats a discarded one.
+    static let requestTimeoutInterval: TimeInterval = 40
 
     func polish(
         request: LLMPolishingRequest,
@@ -78,15 +83,7 @@ struct LLMPolishingService: LLMPolishingServicing {
 
         let startTime = CFAbsoluteTimeGetCurrent()
 
-        var urlRequest = URLRequest(url: configuration.endpointURL)
-        urlRequest.httpMethod = "POST"
-        urlRequest.setValue("application/json", forHTTPHeaderField: "Content-Type")
-        if !configuration.apiKey.isEmpty {
-            urlRequest.setValue("Bearer \(configuration.apiKey)", forHTTPHeaderField: "Authorization")
-        }
-        urlRequest.timeoutInterval = Self.timeoutInterval
-
-        urlRequest.httpBody = try Self.requestBody(
+        let urlRequest = try Self.makeURLRequest(
             request: request,
             configuration: configuration
         )
@@ -132,6 +129,26 @@ struct LLMPolishingService: LLMPolishingServicing {
             polishedText: polished,
             durationSeconds: duration
         )
+    }
+
+    /// The full URLRequest for one polish call — the single construction path
+    /// (and the test seam pinning the timeout without networking).
+    static func makeURLRequest(
+        request: LLMPolishingRequest,
+        configuration: LLMPolishingConfiguration
+    ) throws -> URLRequest {
+        var urlRequest = URLRequest(url: configuration.endpointURL)
+        urlRequest.httpMethod = "POST"
+        urlRequest.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        if !configuration.apiKey.isEmpty {
+            urlRequest.setValue("Bearer \(configuration.apiKey)", forHTTPHeaderField: "Authorization")
+        }
+        urlRequest.timeoutInterval = Self.requestTimeoutInterval
+        urlRequest.httpBody = try requestBody(
+            request: request,
+            configuration: configuration
+        )
+        return urlRequest
     }
 
     static func requestBody(

--- a/Tests/localvoxtralTests/DictationViewModelOverlayLifecycleTests.swift
+++ b/Tests/localvoxtralTests/DictationViewModelOverlayLifecycleTests.swift
@@ -607,6 +607,12 @@ final class DictationViewModelOverlayLifecycleTests: XCTestCase {
         settings.replacementDictionaryEnabled = true
         settings.llmPolishingEnabled = true
         settings.llmPolishingEndpointURL = "https://example.com/v1/chat/completions"
+        // Pin external mode so the configured endpoint above is the one the
+        // request is sent to (and therefore the one the failure names). Under
+        // managed mode this test used to pass only because the failure message
+        // wrongly named the unused external-URL setting — the exact field bug
+        // DictationViewModelPolishFailureDiagnosticsTests now covers.
+        settings.polishingBackendMode = .externalURL
 
         let overlayCoordinator = MockOverlayCoordinator()
         let polishingService = NetworkFailingMockLLMPolishingService()

--- a/Tests/localvoxtralTests/DictationViewModelPolishFailureDiagnosticsTests.swift
+++ b/Tests/localvoxtralTests/DictationViewModelPolishFailureDiagnosticsTests.swift
@@ -1,0 +1,169 @@
+import Foundation
+import XCTest
+@testable import localvoxtral
+
+/// Connection-failure diagnostics for LLM polishing must name the endpoint the
+/// failing request was ACTUALLY sent to. Field regression (2026-07-11): in
+/// managed mode (polishd on 127.0.0.1:8472) a timeout was reported against the
+/// external-URL setting's untouched placeholder default (127.0.0.1:8080),
+/// sending debugging to a process that was never involved.
+@MainActor
+final class DictationViewModelPolishFailureDiagnosticsTests: XCTestCase {
+    // DictationViewModel owns app-lifetime services; retain test instances for
+    // the process lifetime (mirrors the token-guard suite).
+    private static var retainedViewModels: [DictationViewModel] = []
+
+    /// Managed mode + a polish request that fails with a network error: the
+    /// surfaced failure details must name the managed polishd endpoint (the
+    /// one the request went to), never the external-URL setting.
+    func testManagedModeFailureNamesManagedEndpointNotExternalSetting() async throws {
+        let settings = makeSettings(outputMode: .overlayBuffer)
+        settings.llmPolishingEnabled = true
+        settings.polishingBackendMode = .managedLocal
+        // The external-URL setting keeps its placeholder default (:8080). In
+        // managed mode it plays no part in the request.
+        XCTAssertTrue(settings.llmPolishingEndpointURL.contains("8080"))
+
+        let viewModel = DictationViewModel(
+            settings: settings,
+            overlayBufferCoordinator: MockOverlayCoordinator(),
+            startRuntimeServices: false
+        )
+        viewModel.appConfigStore = MockAppConfigStore()
+        viewModel.llmPolishingService = TimeoutFailingPolishingService()
+        // The failure path presents a REAL modal NSAlert when NSApp exists —
+        // the exact suite-hang class AGENTS.md warns about. Pre-setting the
+        // alert flag makes presentConnectionFailureAlert a no-op (same
+        // pattern as the sibling network-failure tests); lastError is still
+        // set before the alert gate.
+        viewModel.isShowingConnectionFailureAlert = true
+        retainForTestProcessLifetime(viewModel)
+
+        viewModel.sessionOutputMode = .overlayBuffer
+        viewModel.isFinalizingStop = true
+        viewModel.currentDictationEventText = "polish this text"
+
+        viewModel.finishStoppedSession(promotePendingSegment: false)
+        await waitUntilStoppedSessionCompletes(viewModel)
+
+        let lastError = try XCTUnwrap(viewModel.lastError)
+        XCTAssertTrue(
+            lastError.contains("127.0.0.1:8472"),
+            "failure details must name the managed endpoint actually used: \(lastError)"
+        )
+        XCTAssertFalse(
+            lastError.contains("8080"),
+            "failure details must not name the unused external-URL setting: \(lastError)"
+        )
+    }
+
+    /// The details formatter itself: the given endpoint URL (sanitized) is
+    /// named both with and without underlying error details.
+    func testConnectionTechnicalDetailsNameTheGivenEndpoint() {
+        let settings = makeSettings(outputMode: .overlayBuffer)
+        let viewModel = DictationViewModel(
+            settings: settings,
+            overlayBufferCoordinator: MockOverlayCoordinator(),
+            startRuntimeServices: false
+        )
+        viewModel.appConfigStore = MockAppConfigStore()
+        retainForTestProcessLifetime(viewModel)
+        let endpoint = URL(string: "http://127.0.0.1:8472/v1/chat/completions")!
+
+        XCTAssertEqual(
+            viewModel.llmPolishingConnectionTechnicalDetails(
+                "request timed out", endpointURL: endpoint
+            ),
+            "request timed out [endpoint: http://127.0.0.1:8472/v1/chat/completions]"
+        )
+        XCTAssertEqual(
+            viewModel.llmPolishingConnectionTechnicalDetails(
+                "  ", endpointURL: endpoint
+            ),
+            "Unable to connect to endpoint http://127.0.0.1:8472/v1/chat/completions."
+        )
+    }
+
+    // MARK: - Harness (mirrors the token-guard suite)
+
+    private func waitUntilStoppedSessionCompletes(_ viewModel: DictationViewModel) async {
+        let deadline = ContinuousClock.now + .seconds(1)
+        while viewModel.isCompletingStoppedSession, ContinuousClock.now < deadline {
+            try? await Task.sleep(for: .milliseconds(10))
+        }
+    }
+
+    private func makeSettings(outputMode: DictationOutputMode) -> SettingsStore {
+        let suiteName =
+            "localvoxtral.DictationViewModelPolishFailureDiagnosticsTests.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defaults.removePersistentDomain(forName: suiteName)
+        addTeardownBlock {
+            defaults.removePersistentDomain(forName: suiteName)
+        }
+
+        let settings = SettingsStore(defaults: defaults, environment: [:])
+        settings.dictationOutputMode = outputMode
+        return settings
+    }
+
+    private func retainForTestProcessLifetime(_ viewModel: DictationViewModel) {
+        Self.retainedViewModels.append(viewModel)
+    }
+}
+
+/// Always fails like a client-side timeout, exercising the connection-failure
+/// diagnostics path without networking.
+private actor TimeoutFailingPolishingService: LLMPolishingServicing {
+    func polish(
+        request _: LLMPolishingRequest,
+        configuration _: LLMPolishingConfiguration
+    ) async throws -> LLMPolishingResult {
+        throw LLMPolishingError.networkError("The request timed out.")
+    }
+}
+
+private final class MockAppConfigStore: AppConfigServing {
+    func configDirectoryURL() -> URL {
+        FileManager.default.temporaryDirectory
+    }
+
+    func loadReplacementDictionary() -> ReplacementDictionary {
+        ReplacementDictionary(entries: [])
+    }
+
+    func loadLLMPromptTemplates() -> LLMPromptTemplates {
+        LLMPromptTemplates(systemContent: "system", userContent: "{{input_text}}")
+    }
+
+    func loadTerminalAppBundleIDs() -> [String] {
+        []
+    }
+}
+
+@MainActor
+private final class MockOverlayCoordinator: OverlayBufferSessionCoordinating {
+    var commitTargetAppPID: pid_t? = nil
+
+    func resolveAnchorNow() -> OverlayAnchor {
+        OverlayAnchor(
+            targetRect: CGRect(x: 0, y: 0, width: 100, height: 24),
+            source: .windowCenter
+        )
+    }
+
+    func startSession(preResolvedAnchor _: OverlayAnchor?) {}
+    func beginFinalizing(displayBufferText _: String, commitBufferText _: String) {}
+    func refresh(displayBufferText _: String, commitBufferText _: String) {}
+
+    func commitIfNeeded(
+        using _: OverlayTextCommitting,
+        autoCopyEnabled _: Bool
+    ) -> OverlayBufferCommitOutcome {
+        .succeeded
+    }
+
+    func dismissAfterHold(minimumVisibility _: TimeInterval) {}
+    func reset() {}
+    func captureLiveCommitTargetAppPID() {}
+}

--- a/Tests/localvoxtralTests/LLMPolishingServiceTests.swift
+++ b/Tests/localvoxtralTests/LLMPolishingServiceTests.swift
@@ -9,6 +9,27 @@ final class LLMPolishingServiceTests: XCTestCase {
         userPrompts: ["first", "second"]
     )
 
+    /// The polish request timeout must accommodate the managed worst case: a
+    /// 4B model with an invalidated polishd prefix cache re-prefills ~2.3k
+    /// tokens and took 23.6 s on a real request — the previous 15 s timeout
+    /// abandoned it and the user lost the polish (field, 2026-07-11). Polish
+    /// is async behind the overlay, so slow beats discarded. Pinned through
+    /// the request-construction seam — no networking, no wall-clock.
+    func testPolishRequestTimeoutAccommodatesManagedWorstCase() throws {
+        XCTAssertEqual(LLMPolishingService.requestTimeoutInterval, 40)
+
+        let configuration = LLMPolishingConfiguration(
+            endpointURL: URL(string: "http://127.0.0.1:8472/v1/chat/completions")!,
+            apiKey: "",
+            model: "model"
+        )
+        let urlRequest = try LLMPolishingService.makeURLRequest(
+            request: request,
+            configuration: configuration
+        )
+        XCTAssertEqual(urlRequest.timeoutInterval, 40)
+    }
+
     func testNilSamplingDefaultsKeepLegacyRequestBytesIdentical() throws {
         let configuration = LLMPolishingConfiguration(
             endpointURL: URL(string: "http://127.0.0.1/chat")!,


### PR DESCRIPTION
## What

2026-07-11 field-test fixes (managed polishd = Qwen3.5-4B-OptiQ on 8472), the two client-side ones that stand alone off main:

1. **Polish request timeout 15 s → 40 s.** The unified log showed `LLM polishing failed: request timed out` while polishd stderr showed the same request completing legitimately in 23.6 s (`prompt cache: checkpointed 2276 prefix tokens; prefilling 53` → invalidated checkpoint → full re-prefill on a 4B model). The client abandoned work the server finished. Polish is async behind the overlay — a slow polish beats a discarded one. The timeout is pinned through a new `LLMPolishingService.makeURLRequest` construction seam (assertable without networking; no wall-clock in tests). The prefix-cache invalidation itself is fixed separately in #105.

2. **Connection-failure diagnostics name the endpoint the request was ACTUALLY sent to.** The failure alert/`lastError`/log line labeled the endpoint with the external-URL *setting* (its untouched placeholder default `http://127.0.0.1:8080/...`, SettingsStore's fallback) while the app was in managed mode talking to `127.0.0.1:8472` — misdirected field debugging. `llmPolishingConnectionTechnicalDetails` now takes the endpoint captured from the failing request's own configuration; the log-line label resolves through the active polishing configuration (managed → managed URL).

`testFinishStoppedSessionLLMNetworkFailureSurfacesConnectionError` now pins `polishingBackendMode = .externalURL` explicitly: it configures an external URL and asserts it is named, but under the default managed mode it passed only *because* of the mislabeling bug (the request actually used the managed config). Same pattern the adjacent invalid-endpoint test already documents.

## Proof

- [x] Bug fix: regression tests added — failing before / passing after

Before (fix behaviorally reverted: timeout 15, settings-based endpoint label):

```
error: ... testPolishRequestTimeoutAccommodatesManagedWorstCase : XCTAssertEqual failed: ("15.0") is not equal to ("40.0")
error: ... testManagedModeFailureNamesManagedEndpointNotExternalSetting : XCTAssertTrue failed - failure details must name the managed endpoint actually used: The request timed out. [endpoint: http://127.0.0.1:8080/v1/chat/completions]
error: ... testConnectionTechnicalDetailsNameTheGivenEndpoint : XCTAssertEqual failed: ("request timed out [endpoint: http://127.0.0.1:8080/v1/chat/completions]") is not equal to ("request timed out [endpoint: http://127.0.0.1:8472/v1/chat/completions]")
Executed 6 tests, with 6 failures (0 unexpected) in 0.124 (0.125) seconds
```

After (fix in place):

```
Test Suite 'DictationViewModelPolishFailureDiagnosticsTests' passed
Test Suite 'LLMPolishingServiceTests' passed
Executed 6 tests, with 0 failures (0 unexpected) in 0.030 (0.030) seconds
```

- [x] Unit suite green — `./scripts/remote-build.sh`

```
Executed 690 tests, with 2 tests skipped and 0 failures (0 unexpected) in 8.748 (8.783) seconds
```

### Review follow-up (codex P2): failure-path test can no longer hang the suite

`DictationViewModelPolishFailureDiagnosticsTests` drives the real LLM connection-failure path, which presents a modal NSAlert when NSApp exists — the suite-hang class AGENTS.md warns about. The test now pre-sets `viewModel.isShowingConnectionFailureAlert = true` (making `presentConnectionFailureAlert` a no-op; `lastError` is set before that gate), same pattern as the sibling network-failure tests. Filtered suites re-run green: `Executed 6 tests, with 0 failures`; full unit suite re-verified on the amended branch.
