### PR TITLE
CI: LLM inference lanes are opt-in (path filter + [run-llm-eval] marker)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,71 @@ jobs:
           fi
           rm -rf dist format-lint.txt default.profraw
 
+      - name: Decide LLM eval lane (path filter + [run-llm-eval] marker)
+        # CI must not pay ~8 min of 4B weight-loading + live inference on
+        # every push: the polishd live-model integration step below runs only
+        # when the diff touches LLM-relevant paths, or when the PR body /
+        # head commit message contains the literal marker [run-llm-eval].
+        # The path list and the matching logic live in
+        # scripts/ci/llm-lane-filter.sh (kept out of the workflow so it is
+        # testable locally); the human-judgment rule is AGENTS.md
+        # "When must the LLM lanes run?". The PolishHelper UNIT suite and the
+        # tier-1 voxmlx realtime integration stay per-push.
+        id: llm_lane
+        if: runner.environment == 'self-hosted'
+        env:
+          # env indirection, not inline ${{ }} in the script body: PR bodies
+          # and commit messages are attacker-shaped strings.
+          PR_BODY: ${{ github.event.pull_request.body }}
+          PUSH_HEAD_MESSAGE: ${{ github.event.head_commit.message }}
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          PUSH_BEFORE_SHA: ${{ github.event.before }}
+          BASE_REF: ${{ github.base_ref }}
+        run: |
+          set -euo pipefail
+          FILES="$RUNNER_TEMP/llm-lane-changed-files.txt"
+          MARKER_TEXT="$RUNNER_TEMP/llm-lane-marker-text.txt"
+
+          # Changed files against the merge base. fetch-depth: 0 above means
+          # full history is present; clean: false does not affect refs.
+          BASE=""
+          if [[ "$GITHUB_EVENT_NAME" == "pull_request" ]]; then
+            BASE="$(git merge-base "origin/$BASE_REF" HEAD || true)"
+          else
+            # push to main: the previous tip, unless history was rewritten
+            # or this is the first push (all-zero sha / unknown object).
+            if git cat-file -e "$PUSH_BEFORE_SHA^{commit}" 2>/dev/null; then
+              BASE="$PUSH_BEFORE_SHA"
+            fi
+          fi
+          if [[ -z "$BASE" ]]; then
+            # Fail open: an uncomputable diff must never skip a gate.
+            echo "run=true" >> "$GITHUB_OUTPUT"
+            echo "LLM eval lane: RUNNING (diff unavailable — failing open)" \
+              | tee -a "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+          git diff --name-only "$BASE" HEAD > "$FILES"
+
+          # Marker sources: PR body + PR head commit message, or (on push)
+          # the head commit message. On PRs HEAD is the synthetic merge
+          # commit, so read the message from the real head sha.
+          printf '%s\n' "$PR_BODY" > "$MARKER_TEXT"
+          if [[ "$GITHUB_EVENT_NAME" == "pull_request" ]]; then
+            git log -1 --format=%B "$PR_HEAD_SHA" >> "$MARKER_TEXT" || true
+          else
+            printf '%s\n' "$PUSH_HEAD_MESSAGE" >> "$MARKER_TEXT"
+          fi
+
+          DECISION="$(./scripts/ci/llm-lane-filter.sh "$FILES" "$MARKER_TEXT")"
+          echo "$DECISION" >> "$GITHUB_OUTPUT"
+          REASON="$(sed -n 's/^reason=//p' <<<"$DECISION")"
+          if [[ "$(sed -n 's/^run=//p' <<<"$DECISION")" == "true" ]]; then
+            echo "LLM eval lane: RUNNING ($REASON)" | tee -a "$GITHUB_STEP_SUMMARY"
+          else
+            echo "LLM eval lane: SKIPPED ($REASON)" | tee -a "$GITHUB_STEP_SUMMARY"
+          fi
+
       - name: Setup Swift
         if: runner.environment == 'github-hosted'
         uses: swift-actions/setup-swift@v2
@@ -184,8 +249,12 @@ jobs:
       - name: Polishing helper integration (live model + eval baseline)
         # Spawns the helper built by the packaging step with the real pinned
         # model, drives the production polish request path, and asserts the
-        # shared eval baseline + parent-pid tether.
-        if: runner.environment == 'self-hosted'
+        # shared eval baseline + parent-pid tether. Conditional — this is the
+        # step that loads 4B weights and runs live inference; the decide step
+        # above (path filter + [run-llm-eval] marker) says whether this
+        # change can affect what the lane measures. Local equivalent:
+        # ./scripts/remote-build.sh integration-polishd
+        if: runner.environment == 'self-hosted' && steps.llm_lane.outputs.run == 'true'
         env:
           LOCALVOXTRAL_POLISHD_TEST_ENABLE: "1"
           LOCALVOXTRAL_POLISHD_TEST_PATH: PolishHelper/.build/xcode/Build/Products/Release/localvoxtral-polishd

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -173,7 +173,11 @@ CI does not run LLM inference on every push (owner decision, 2026-07-11):
 the polishd live-model integration step in `ci.yml` runs only when the diff
 touches LLM-relevant paths, or when the PR body / head commit message
 contains the literal marker `[run-llm-eval]` (the explicit opt-in for
-judgment calls). The exact path list lives in
+judgment calls). The marker must be present when the run is CREATED: editing
+the PR body after a skipped run does not retrigger CI, and rerunning a run
+reuses its original event payload — after adding the marker, push (an empty
+commit works, or put the marker in the commit message). The exact path list
+lives in
 `scripts/ci/llm-lane-filter.sh` — PolishHelper/**, the bundled
 `llm_*.toml` prompts, model catalog/pins, the polish client, token guard,
 prompt warmup, clipboard context/macro, repo vocabulary, the polish-commit

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -132,7 +132,7 @@ This is a real app with daily users. Nothing ships on "it compiles".
 |---|---|---|---|
 | 0 | Unit suite (500+ tests) + PolishHelper unit suite + packaging + launch smoke | every PR/push, CI (helper unit suite: self-hosted lanes only) | ~1 min |
 | 1 | `RealtimeAPIVLLMIntegrationTests` vs live local voxmlx: real inference through the production websocket client, word-accuracy asserted | every PR/push on the self-hosted runner; locally via `remote-build.sh integration` | ~20 s |
-| 1 | `PolishHelperIntegrationTests`: the packaged polishing helper vs the real pinned model — production request path, shared eval baseline, parent-pid tether | every PR/push on the self-hosted runner (after packaging); locally via `remote-build.sh integration-polishd` | ~15 s warm |
+| 1 | `PolishHelperIntegrationTests`: the packaged polishing helper vs the real pinned model — production request path, shared eval baseline, parent-pid tether | conditional in CI (self-hosted, after packaging): only when the diff touches LLM-relevant paths or the PR opts in with `[run-llm-eval]` — see "When must the LLM lanes run?"; locally via `remote-build.sh integration-polishd` | minutes (4B weights + live inference) |
 | 2 | `ui-smoke.yml` AX smoke drill (status item, settings tabs, lazy managed-backend launch invariant); dictation-with-audio remains future work | nightly + manual on the self-hosted GUI runner | — |
 
 Tier 1 details: the suite is env-gated (`VLLM_REALTIME_TEST_ENABLE=1`) and
@@ -167,12 +167,43 @@ scorer live in `LLMPolishEvalSupport`, shared with
 holds the bundled MLX Swift polishing helper to the same baseline — engine or
 model-pin changes MUST run that one too.
 
+### When must the LLM lanes run?
+
+CI does not run LLM inference on every push (owner decision, 2026-07-11):
+the polishd live-model integration step in `ci.yml` runs only when the diff
+touches LLM-relevant paths, or when the PR body / head commit message
+contains the literal marker `[run-llm-eval]` (the explicit opt-in for
+judgment calls). The exact path list lives in
+`scripts/ci/llm-lane-filter.sh` — PolishHelper/**, the bundled
+`llm_*.toml` prompts, model catalog/pins, the polish client, token guard,
+prompt warmup, clipboard context/macro, repo vocabulary, the polish-commit
+path (`DictationViewModel+Session.swift`), and the eval support/corpus. The
+decide step writes "LLM eval lane: RUNNING (…)" or "SKIPPED (…)" to the
+run's step summary so a skipped run is self-explanatory. The PolishHelper
+UNIT suite (Metal-free) and the tier-1 voxmlx realtime integration stay
+per-push.
+
+The rule behind the list — the LLM lanes are REQUIRED for changes to:
+prompts, model pins/catalog, sampling/template kwargs, the polish request
+shape or anything that alters what reaches the model (context attachment,
+dictionary/vocabulary hints, macro placeholders, token guard repair
+semantics), the helper engine, or the eval corpus/scorer. NOT required for
+UI, insertion, audio, backend-supervision, or test-only changes elsewhere.
+Either way, the PR's Proof section states one of the two: the lane's
+scoreboard, or a one-line justification for skipping. If the path filter
+misses a change that belongs above, add `[run-llm-eval]` AND extend the
+filter list in the same PR. `./scripts/remote-build.sh integration-polishd`
+remains the local equivalent. There is no nightly eval — a lane skipped by
+the filter runs again only when a matching change (or the marker) triggers
+it.
+
 ## CI / shipping
 
-- `ci.yml` runs tiers 0–1 on every PR and push to main. Same-repo branches run
-  on the self-hosted Mac runner (fast, warm cache); fork PRs run on
-  GitHub-hosted macOS. Never move fork-PR jobs to the self-hosted runner — it
-  is a personal machine.
+- `ci.yml` runs tiers 0–1 on every PR and push to main (the polishd
+  live-model lane conditionally — see "When must the LLM lanes run?").
+  Same-repo branches run on the self-hosted Mac runner (fast, warm cache);
+  fork PRs run on GitHub-hosted macOS. Never move fork-PR jobs to the
+  self-hosted runner — it is a personal machine.
 - Watch a PR's checks with `./scripts/watch-checks.sh <n>` (or `--run
   <run-id>` for a push/rerun). It polls like `gh pr checks --watch` but also
   probes the build host over SSH and fail-fasts in ~30 s with a wake-the-Mac

--- a/scripts/ci/llm-lane-filter.sh
+++ b/scripts/ci/llm-lane-filter.sh
@@ -79,4 +79,7 @@ while IFS= read -r file; do
 done <"$CHANGED_FILES_FILE"
 
 echo "run=false"
-echo "reason=no LLM-relevant changes; add $MARKER to the PR body or head commit to opt in"
+# "and push": the marker is only read from the event payload at run-creation
+# time — editing the PR body after a skipped run creates no new run, and
+# reruns reuse the original payload, so a late-added marker needs a push.
+echo "reason=no LLM-relevant changes; add $MARKER to the PR body or commit message and push to opt in"

--- a/scripts/ci/llm-lane-filter.sh
+++ b/scripts/ci/llm-lane-filter.sh
@@ -1,0 +1,82 @@
+#!/bin/bash
+# Decides whether CI's LLM-inference lanes (the polishd live-model integration
+# step) must run for a given change. Kept as a standalone script so the
+# decision logic is testable locally — workflows only register on main, which
+# makes pre-merge workflow testing awkward (see AGENTS.md).
+#
+# Usage:
+#   scripts/ci/llm-lane-filter.sh <changed-files-file> [marker-text-file]
+#
+#   <changed-files-file>  one changed path per line (git diff --name-only)
+#   [marker-text-file]    optional free text (PR body + head commit message);
+#                         if it contains the literal marker [run-llm-eval],
+#                         the lanes run regardless of the diff
+#
+# stdout is $GITHUB_OUTPUT-shaped:
+#   run=true|false
+#   reason=<one line, safe for a step summary>
+#
+# Exits 0 for both decisions; non-zero only on usage errors. The caller owns
+# fail-open behavior when it cannot produce a diff at all.
+set -euo pipefail
+
+MARKER='[run-llm-eval]'
+
+# LLM-relevant paths. A path belongs here when changing it can alter what
+# reaches the model, how the model is run, or how its output is scored —
+# the rule (and the matching human judgment call) lives in AGENTS.md under
+# "When must the LLM lanes run?". Some patterns are forward-looking for
+# in-flight branches (EvalCorpus, RepoVocabulary, clipboard context); an
+# unmatched pattern costs nothing.
+PATTERNS=(
+  'PolishHelper/*'                                   # helper engine, server, its own package
+  'Sources/localvoxtral/Resources/Config/llm_*.toml' # bundled polish prompts
+  '*PolishModelCatalog*'                             # model pins / catalog
+  '*LLMPolishing*'                                   # polish client: request shape, sampling, kwargs
+  '*PolishTokenGuard*'                               # token-protection repair semantics
+  '*PolishPromptWarmup*'                             # prompt-prefix warmup path
+  '*PolishContextClipboardReader*'                   # clipboard-as-context attachment
+  '*ClipboardPayloadMacro*'                          # spoken paste-clipboard macro placeholders
+  '*RepoVocabulary*'                                 # repo vocabulary hints fed to the polisher
+  '*DictationViewModel+Session.swift'                # polish-and-commit path
+  '*LLMPolishEvalSupport*'                           # shared eval corpus + scorer
+  '*PolishHelperIntegrationTests*'                   # the lane's own suite
+  '*EvalCorpus/*'                                    # standalone eval corpora
+)
+
+if [[ $# -lt 1 || $# -gt 2 ]]; then
+  echo "usage: $0 <changed-files-file> [marker-text-file]" >&2
+  exit 2
+fi
+
+CHANGED_FILES_FILE="$1"
+MARKER_TEXT_FILE="${2:-}"
+
+if [[ ! -f "$CHANGED_FILES_FILE" ]]; then
+  echo "changed-files file not found: $CHANGED_FILES_FILE" >&2
+  exit 2
+fi
+
+if [[ -n "$MARKER_TEXT_FILE" && -f "$MARKER_TEXT_FILE" ]] \
+    && grep -qF "$MARKER" "$MARKER_TEXT_FILE"; then
+  echo "run=true"
+  echo "reason=explicit $MARKER marker"
+  exit 0
+fi
+
+while IFS= read -r file; do
+  [[ -z "$file" ]] && continue
+  for pattern in "${PATTERNS[@]}"; do
+    # shellcheck disable=SC2254
+    case "$file" in
+      $pattern)
+        echo "run=true"
+        echo "reason=matched $file ($pattern)"
+        exit 0
+        ;;
+    esac
+  done
+done <"$CHANGED_FILES_FILE"
+
+echo "run=false"
+echo "reason=no LLM-relevant changes; add $MARKER to the PR body or head commit to opt in"


### PR DESCRIPTION
## What

CI no longer runs LLM inference on every push (owner decision, 2026-07-11). The polishd live-model integration step — the one that loads the 4B default's weights and runs live inference, ~8 min of what had become a ~10 min CI run since #116 — is now conditional. Everything else is per-push exactly as before: the unit suite, the PolishHelper UNIT suite (Metal-free, ~11 s), the tier-1 voxmlx realtime integration (~20 s, gates the core realtime pipeline), packaging (the launch smoke and artifact uploads consume it), and the smoke test.

## Mechanism

A "Decide LLM eval lane" step computes changed files against the merge base (`git merge-base origin/$BASE_REF HEAD` on PRs; `github.event.before` on pushes to main; full history is present via `fetch-depth: 0`, and `clean: false` doesn't affect refs) and feeds them to **`scripts/ci/llm-lane-filter.sh`**, which holds the documented path list. The lane runs iff either:

- the diff touches an LLM-relevant path, **or**
- the PR body or head commit message contains the literal marker **`[run-llm-eval]`** (explicit opt-in for judgment calls).

If the diff can't be computed (force push / unknown before-sha), the step **fails open** and the lane runs — an uncomputable diff must never skip a gate. The decision is written to the run's step summary ("LLM eval lane: RUNNING (matched …)" / "SKIPPED (no LLM-relevant changes; add [run-llm-eval] to opt in)") so a skipped run is self-explanatory in the UI. PR bodies / commit messages reach the shell via `env:` indirection, never inline `${{ }}`.

The logic lives in a standalone script (not workflow YAML) because workflows only register on main — pre-merge workflow testing is awkward, but the script is provable locally (below).

### Path list shipped (`scripts/ci/llm-lane-filter.sh`)

`PolishHelper/*` · `Sources/localvoxtral/Resources/Config/llm_*.toml` · `*PolishModelCatalog*` · `*LLMPolishing*` · `*PolishTokenGuard*` · `*PolishPromptWarmup*` · `*PolishContextClipboardReader*` · `*ClipboardPayloadMacro*` · `*RepoVocabulary*` · `*DictationViewModel+Session.swift` · `*LLMPolishEvalSupport*` · `*PolishHelperIntegrationTests*` · `*EvalCorpus/*`

(The clipboard-context / macro / repo-vocabulary / EvalCorpus patterns are forward-looking for the in-flight `lv/stack-tip` work — unmatched patterns cost nothing and they gate correctly the moment those files land on main.)

## Docs

AGENTS.md: the tier-1 `PolishHelperIntegrationTests` row is now "conditional in CI" with an honest cost ("minutes — 4B weights + live inference"), and a new **"When must the LLM lanes run?"** section states the rule: REQUIRED for prompts, model pins/catalog, sampling/template kwargs, the polish request shape or anything altering what reaches the model (context attachment, dictionary/vocabulary hints, macro placeholders, token guard repair semantics), the helper engine, or the eval corpus/scorer; NOT required for UI, insertion, audio, backend-supervision, or test-only changes elsewhere. Authors state in the PR's Proof section either the lane's scoreboard or a one-line justification for skipping. `./scripts/remote-build.sh integration-polishd` remains the local equivalent. No nightly eval exists — a lane skipped by the filter runs again only when a matching change (or the marker) triggers it.

**release.yml is untouched** — verified: its gates (build, unit tests, live voxmlx integration, packaging, launch smoke) are exactly as before this PR; it has never run the polishd integration lane, so nothing there weakens.

## Proof

Unit suite on the build host (`./scripts/remote-build.sh`), unchanged by a workflow+docs+new-script diff but run anyway:

```
Test Suite 'localvoxtralPackageTests.xctest' passed at 2026-07-11 18:20:58.556.
	 Executed 704 tests, with 2 tests skipped and 0 failures (0 unexpected) in 10.466 (10.513) seconds
```

Filter-script decisions, run locally (the three required cases):

```
$ printf '%s\n' "Sources/localvoxtral/SettingsView.swift" "PolishHelper/Sources/PolishServer/Router.swift" > diff-llm.txt
$ ./scripts/ci/llm-lane-filter.sh diff-llm.txt
run=true
reason=matched PolishHelper/Sources/PolishServer/Router.swift (PolishHelper/*)

$ printf '%s\n' "Sources/localvoxtral/SettingsView.swift" "Tests/localvoxtralTests/OverlayBufferStateMachineTests.swift" ".github/workflows/ci.yml" > diff-ui.txt
$ ./scripts/ci/llm-lane-filter.sh diff-ui.txt
run=false
reason=no LLM-relevant changes; add [run-llm-eval] to the PR body or commit message and push to opt in

$ printf '%s\n' "Refactor settings pane layout." "" "Sampling untouched but be safe: [run-llm-eval]" > body-marker.txt
$ ./scripts/ci/llm-lane-filter.sh diff-ui.txt body-marker.txt
run=true
reason=explicit [run-llm-eval] marker
```

Additionally, every pattern was checked against the real repo path it is meant to catch (one file per invocation → `run=true` for all 12, including `llm_system_prompt.toml`, `PolishModelCatalog.swift`, `DictationViewModel+Session.swift`, `LLMPolishEvalSupport.swift`, `PolishHelperIntegrationTests.swift`). `ci.yml` parses as valid YAML; the script passes `bash -n`.

## Review follow-up (Codex, P3) — 6d459c9

A marker added by EDITING the PR body after a skipped run silently does nothing: default `pull_request` activity types create no new run on body edits, and rerunning a run reuses its original event payload. Deliberately NOT fixed with an `edited` trigger (that would rerun full CI on every typo edit) — documentation-level only: the SKIPPED reason now reads "…add [run-llm-eval] to the PR body or commit message and push to opt in", and AGENTS.md states the marker must be present at run-creation time (push an empty commit, or put the marker in the commit message). Filter re-proven with the updated message (case 2 output above refreshed); `remote-build.sh build` green (0.85 s warm).

Note: this PR's own CI run is itself a live end-to-end proof — of the MARKER path, not the skip path: `pull_request` events execute the workflow from the PR branch, the diff touches no LLM-relevant path, but this very body quotes the literal `[run-llm-eval]` marker, so the decide step's summary will read "LLM eval lane: RUNNING (explicit [run-llm-eval] marker)" and the lane will run (and pass — nothing LLM-relevant changed). That is inherent to a literal-marker design: mentioning the marker invokes it. The SKIPPED summary line will first show on the next ordinary non-LLM PR.
