### PR TITLE
Unit tests never sample live host state (fixes overnight CI failures under locked screen)

### DIFF
--- a/Sources/localvoxtral/TerminalTargetDetector.swift
+++ b/Sources/localvoxtral/TerminalTargetDetector.swift
@@ -140,6 +140,7 @@ enum TerminalTargetDetector {
         if let override = debugSecureEventInputOverride {
             return override()
         }
+        if isRunningUnderXCTest { return false }
         #endif
         return IsSecureEventInputEnabled()
     }
@@ -149,6 +150,7 @@ enum TerminalTargetDetector {
         if let override = debugFrontmostBundleIDOverride {
             return override()
         }
+        if isRunningUnderXCTest { return nil }
         #endif
         return NSWorkspace.shared.frontmostApplication?.bundleIdentifier
     }
@@ -161,6 +163,7 @@ enum TerminalTargetDetector {
         if let override = debugFocusedElementProbeOverride {
             return override()
         }
+        if isRunningUnderXCTest { return .probeUnavailable }
         #endif
         // Without Accessibility trust every AX read fails; that says nothing
         // about the target.
@@ -206,5 +209,17 @@ enum TerminalTargetDetector {
     static var debugFrontmostBundleIDOverride: (() -> String?)?
     static var debugFocusedElementProbeOverride: (() -> FocusedElementProbe)?
     static var debugSecureEventInputOverride: (() -> Bool)?
+
+    // When XCTest is in the process and a test did not pin an override, the
+    // live reads above return whatever the HOST happens to be doing — and
+    // loginwindow holds Secure Keyboard Entry the entire time the screen is
+    // locked, so every unpinned test on a commit/session-start path failed
+    // whenever CI ran unattended (runs 29160724070, 29159948228/455/578).
+    // The frontmost-app and AX-focus reads flake the same way (a terminal
+    // frontmost while the suite runs flips the session verdict), so all
+    // three seams resolve to fixed defaults under XCTest: secure input off,
+    // no frontmost bundle, probe unavailable. Tests that exercise the live
+    // behaviors pin the overrides explicitly.
+    static let isRunningUnderXCTest = NSClassFromString("XCTestCase") != nil
     #endif
 }

--- a/Tests/localvoxtralTests/TerminalTargetDetectorTests.swift
+++ b/Tests/localvoxtralTests/TerminalTargetDetectorTests.swift
@@ -1,3 +1,4 @@
+import Carbon
 import Foundation
 import XCTest
 @testable import localvoxtral
@@ -13,6 +14,54 @@ final class TerminalTargetDetectorTests: XCTestCase {
         TerminalTargetDetector.debugFocusedElementProbeOverride = nil
         TerminalTargetDetector.debugSecureEventInputOverride = nil
         try await super.tearDown()
+    }
+
+    // MARK: - Live host state must never leak into unpinned tests
+
+    // Regression for the overnight CI failures (runs 29160724070,
+    // 29159948228/455/578): loginwindow holds Secure Keyboard Entry while the
+    // screen is locked, and every test that reached a commit/session-start
+    // path without pinning debugSecureEventInputOverride sampled it. Here the
+    // test process itself turns secure input on (Carbon refcounts it
+    // per-process, and the flag reads back system-wide), which reproduces the
+    // locked-screen host deterministically.
+    func testUnpinnedSecureInputReadIsFalseUnderXCTestEvenWhileLiveStateIsOn() {
+        TerminalTargetDetector.debugSecureEventInputOverride = nil
+        // In a GUI session (the CI runner) this genuinely flips the
+        // system-wide flag, reproducing the locked-screen host; in a non-GUI
+        // SSH session (remote-build.sh) the call no-ops with noErr and the
+        // live flag stays off, so the assertion below is trivially true
+        // there instead of exercising the flip.
+        let enableStatus = EnableSecureEventInput()
+        defer {
+            if enableStatus == noErr { DisableSecureEventInput() }
+        }
+        if !IsSecureEventInputEnabled() {
+            print("note: live secure-input flip unavailable in this session; asserting the pinned default only")
+        }
+        XCTAssertFalse(
+            TerminalTargetDetector.isSecureKeyboardEntryEnabled(),
+            "unpinned tests must never sample the host's live Secure Keyboard Entry state"
+        )
+    }
+
+    func testPinnedSecureInputOverrideStillWinsUnderXCTest() {
+        TerminalTargetDetector.debugSecureEventInputOverride = { true }
+        XCTAssertTrue(TerminalTargetDetector.isSecureKeyboardEntryEnabled())
+    }
+
+    // The frontmost-app and AX-focus reads leak the same way (a terminal
+    // frontmost on the host while the suite runs would flip the verdict), so
+    // unpinned they must resolve to the fixed unknown-target default.
+    func testUnpinnedCurrentTargetDetectionIsDeterministicUnderXCTest() {
+        TerminalTargetDetector.debugFrontmostBundleIDOverride = nil
+        TerminalTargetDetector.debugFocusedElementProbeOverride = nil
+        let verdict = TerminalTargetDetector.detectCurrentTarget()
+        XCTAssertEqual(
+            verdict,
+            TerminalTargetDetector.Decision(isTerminalLike: false, reason: .axProbeUnavailable),
+            "unpinned tests must never sample the host's frontmost app or AX focus"
+        )
     }
 
     // MARK: - Bundle allowlist (pure)


### PR DESCRIPTION
## What

Four PR CI runs failed overnight with identical unit-suite failures (29160724070, 29159948228/455/578): tests expecting normal commit/session-start behavior instead saw "Blocked: Secure Keyboard Entry is on." / "Secure input blocked auto-paste". Root cause: **loginwindow holds Secure Keyboard Entry while the screen is locked**, and every test that reaches `TerminalTargetDetector.isSecureKeyboardEntryEnabled()` without pinning `debugSecureEventInputOverride` samples the host's live state — so any CI run executing while the Mac sits locked fails, regardless of the diff (#121's run failed in main-suite tests its PolishHelper-only diff cannot touch).

The frontmost-app and AX-focus reads leak the same way (a terminal frontmost while the suite runs flips the session verdict — increasingly load-bearing once the agent-profile stack lands). Fix: under XCTest, all three live seams resolve to fixed defaults — secure input **off**, frontmost bundle **nil**, probe **.probeUnavailable** — and explicit debug overrides still win. Release builds are untouched (DEBUG-only, and XCTest is never loaded in the app).

## Proof

Tests-first commit pushed alone so the runner itself demonstrates the failure (the regression test turns secure input on via `EnableSecureEventInput` — Carbon refcounts it per-process and the flag reads back system-wide, reproducing the locked-screen host in a GUI session):

- [ ] Before (tests-only, expected RED on the self-hosted runner): run link to be filled in
- [ ] After (fix pushed, expected green): run link to be filled in

Full unit suite at the fixed tip via `./scripts/remote-build.sh`:
```
Executed 707 tests, with 2 tests skipped and 0 failures (0 unexpected) in 9.298 (9.339) seconds
```
(Over SSH the secure-input flip no-ops — non-GUI session — so the regression test degrades to asserting the pinned default there; the real flip is exercised on the runner.)

Note: this PR's CI should also demonstrate #120's optimization — no LLM-relevant paths touched, so the polishd live-model lane must report SKIPPED.