### PR TITLE
Agent-dictation eval Phase 2: end-to-end harness (TTS → voxmlx → stop-commit polish), eval-e2e lane + nightly workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,6 +48,11 @@ jobs:
             mv .build.smoke-hidden .build
           fi
           rm -rf dist format-lint.txt default.profraw
+          # Transient eval enable markers (gitignored, marker-through-the-tree
+          # pattern): clean: false preserves them across runs, and a stray one
+          # would flip a marker-gated live suite ON in the plain unit step.
+          rm -f .agent-eval-e2e-enable.json .llm-polish-eval-enable.json \
+            .polishd-integration-enable.json
 
       - name: Decide LLM eval lane (path filter + [run-llm-eval] marker)
         # CI must not pay ~8 min of 4B weight-loading + live inference on
@@ -144,8 +149,14 @@ jobs:
         # nothing downstream consumed (tests rebuild with coverage flags,
         # packaging builds release), so it was pure duplicate compilation.
         run: |
+          # AgentDictationE2EEvalTests is skipped explicitly (belt) on top of
+          # the marker cleanup above (suspenders): it is the nightly
+          # eval-e2e.yml lane, never tier 0, and a leftover enable marker in
+          # this persistent workspace must not turn the unit step into a
+          # many-minute live-inference run.
           swift test \
             --skip RealtimeAPIVLLMIntegrationTests \
+            --skip AgentDictationE2EEvalTests \
             --enable-code-coverage
 
       - name: Coverage summary

--- a/.github/workflows/eval-e2e.yml
+++ b/.github/workflows/eval-e2e.yml
@@ -1,0 +1,118 @@
+name: Agent Dictation E2E Eval
+
+# The wide agent-dictation eval (owner decision 2026-07-11): nightly + manual
+# only, NEVER per-PR — it runs live TTS -> voxmlx ASR -> polishd inference
+# over the ~160-case EvalCorpus/agent-dictation corpus and takes many minutes.
+# Required cases (the 7 migrated punctuation cases) assert individually;
+# everything else is XFAIL-tracked on the scoreboard. Local equivalent:
+# ./scripts/remote-build.sh eval-e2e (after `package`).
+on:
+  workflow_dispatch:
+  schedule:
+    # Nightly, offset from ui-smoke's 04:00 so the two self-hosted GUI/eval
+    # lanes never contend for the runner at the same minute.
+    - cron: "45 4 * * *"
+
+concurrency:
+  group: eval-e2e
+  cancel-in-progress: false
+
+jobs:
+  eval-e2e:
+    # Self-hosted only, and there is no pull_request trigger above — fork code
+    # must never reach this runner (same invariant as ci.yml/ui-smoke.yml).
+    runs-on: [self-hosted, macOS, ARM64]
+    timeout-minutes: 120
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          # Keep gitignored build state between runs on the persistent
+          # self-hosted runner (same rationale as ci.yml: default git clean
+          # would force a cold MLX C++ + Metal helper rebuild every night).
+          clean: false
+
+      - name: Clean stale outputs (keep build caches)
+        run: |
+          if [[ -d .build.smoke-hidden ]]; then
+            rm -rf .build
+            mv .build.smoke-hidden .build
+          fi
+          rm -rf dist logs
+
+      - name: Ensure Metal toolchain
+        # Same probe as ci.yml: `xcrun --find metal` succeeding does NOT mean
+        # the component is installed; only invoking metal proves it.
+        run: |
+          if ! xcrun metal --version >/dev/null 2>&1; then
+            echo "Metal toolchain not active for $(whoami); installing component..."
+            for attempt in 1 2 3; do
+              xcodebuild -downloadComponent MetalToolchain && break
+              echo "catalog fetch failed (attempt $attempt); retrying in 10s..."
+              sleep 10
+            done
+            xcrun metal --version
+          fi
+
+      - name: Package app bundle (builds the polishing helper)
+        env:
+          LOCALVOXTRAL_CODESIGN_IDENTITY: localvoxtral-dev
+        run: ./scripts/package_app.sh release
+
+      - name: Warm on-demand voxmlx server
+        # Launch-on-demand infra (scripts/mac/lv-test-servers.sh): touch the
+        # trigger and block until port 8000 is healthy. Best-effort during
+        # rollout — the eval itself fails loudly if voxmlx is really down.
+        run: |
+          if [ -d /Users/Shared/localvoxtral/run ]; then
+            ./scripts/mac/lv-test-servers.sh ensure voxmlx
+          else
+            echo "on-demand infra not installed (run dir absent) — relying on the" \
+                 "always-on voxmlx; see scripts/mac/README.md to enable on-demand."
+          fi
+
+      - name: Run agent-dictation E2E eval
+        env:
+          LV_AGENT_EVAL_E2E_ENABLE: "1"
+          LV_AGENT_EVAL_E2E_HELPER_PATH: PolishHelper/.build/xcode/Build/Products/Release/localvoxtral-polishd
+          LV_AGENT_EVAL_E2E_ASR_MODEL: T0mSIlver/Voxtral-Mini-4B-Realtime-2602-MLX-4bit
+        run: |
+          mkdir -p logs
+          set -o pipefail
+          swift test --filter AgentDictationE2EEvalTests 2>&1 | tee logs/eval-e2e.log
+
+      - name: Scoreboard to step summary
+        # Extract the section between the scoreboard markers (kept in sync
+        # with AgentDictationE2EEvalSupport.scoreboardBeginMarker/EndMarker).
+        if: always()
+        run: |
+          if [[ -f logs/eval-e2e.log ]]; then
+            {
+              echo '```'
+              awk '/^== agent-dictation E2E eval scoreboard ==/{flag=1} flag{print} /^== end agent-dictation E2E eval scoreboard ==/{flag=0}' logs/eval-e2e.log
+              echo '```'
+            } >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "no eval log produced" >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+      - name: Upload eval log (scoreboard artifact)
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: eval-e2e-scoreboard
+          path: logs/eval-e2e.log
+          retention-days: 30
+
+      - name: Process leak check (informational)
+        if: always()
+        run: |
+          survivors="$(ps -axo pid,etime,ucomm \
+            | grep -iE 'localvoxtral|polishd|xctest|swiftpm-testing|XCBBuildService' \
+            | grep -v grep || true)"
+          if [[ -n "$survivors" ]]; then
+            echo "candidate processes still alive at job end:"
+            echo "$survivors"
+          else
+            echo "no candidate processes alive at job end"
+          fi

--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ DerivedData/
 .opencode/
 
 # Transient enable markers written by remote-build.sh eval-llm /
-# integration-polishd
+# integration-polishd / eval-e2e
 /.llm-polish-eval-enable.json
 /.polishd-integration-enable.json
+/.agent-eval-e2e-enable.json

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,6 +20,7 @@ is machine-local config, set once per clone (never committed):
 ./scripts/remote-build.sh eval-llm        # default polish prompt eval vs a live chat/completions server
 ./scripts/remote-build.sh package         # build the .app bundle (also builds the polishing helper)
 ./scripts/remote-build.sh integration-polishd [hf-repo]  # bundled polish helper vs real model + eval baseline (run package first); optional repo = per-model gate for PolishModelCatalog additions (self-provisions weights)
+./scripts/remote-build.sh eval-e2e        # agent-dictation E2E eval: TTS -> live voxmlx ASR -> polishd stop-commit path (run package first; many minutes)
 ./scripts/remote-build.sh build --package-path PolishHelper   # helper package alone
 ./scripts/remote-build.sh test  --package-path PolishHelper   # helper unit tests (Metal-free)
 ```
@@ -134,6 +135,7 @@ This is a real app with daily users. Nothing ships on "it compiles".
 | 1 | `RealtimeAPIVLLMIntegrationTests` vs live local voxmlx: real inference through the production websocket client, word-accuracy asserted | every PR/push on the self-hosted runner; locally via `remote-build.sh integration` | ~20 s |
 | 1 | `PolishHelperIntegrationTests`: the packaged polishing helper vs the real pinned model — production request path, shared eval baseline, parent-pid tether | conditional in CI (self-hosted, after packaging): only when the diff touches LLM-relevant paths or the PR opts in with `[run-llm-eval]` — see "When must the LLM lanes run?"; locally via `remote-build.sh integration-polishd` | minutes (4B weights + live inference) |
 | 2 | `ui-smoke.yml` AX smoke drill (status item, settings tabs, lazy managed-backend launch invariant); dictation-with-audio remains future work | nightly + manual on the self-hosted GUI runner | — |
+| 2 | `AgentDictationE2EEvalTests` (`eval-e2e.yml`): wide agent-dictation eval — TTS(`say`) → live voxmlx ASR → bundled polishd through the production stop-commit path, scored against `EvalCorpus/agent-dictation/` (7 migrated required cases asserted; the rest XFAIL; WER informational; guard-off diagnostic column) | nightly + manual, NEVER per-PR (owner decision 2026-07-11); locally via `remote-build.sh eval-e2e` (run `package` first) | many minutes (live TTS/ASR/4B polish over ~160 cases; WAVs cached on the host) |
 
 Tier 1 details: the suite is env-gated (`VLLM_REALTIME_TEST_ENABLE=1`) and
 expects voxmlx at `ws://127.0.0.1:8000/v1/realtime` — on the build host it runs
@@ -146,7 +148,7 @@ On-demand test servers: the voxmlx (8000) and mlxlm (8080) launchd services are
 launch-on-demand (a trigger file + idle reaper — `scripts/mac/lv-test-servers.sh`,
 owner runbook `scripts/mac/README.md`), so their weights are not resident 24/7.
 This is hands-free: CI warms voxmlx in a step before the integration suite, and
-`remote-build.sh integration|eval-llm` warm the right server through the gate's
+`remote-build.sh integration|eval-llm|eval-e2e` warm the right server through the gate's
 `ensure` verb first, blocking until the port is healthy. A burst of runs reuses
 one warm process (each `ensure` resets a ~20 min idle window); the reaper frees
 the RAM once the machine goes quiet.
@@ -197,9 +199,18 @@ Either way, the PR's Proof section states one of the two: the lane's
 scoreboard, or a one-line justification for skipping. If the path filter
 misses a change that belongs above, add `[run-llm-eval]` AND extend the
 filter list in the same PR. `./scripts/remote-build.sh integration-polishd`
-remains the local equivalent. There is no nightly eval — a lane skipped by
-the filter runs again only when a matching change (or the marker) triggers
-it.
+remains the local equivalent. The nightly `eval-e2e.yml` lane is the only
+scheduled eval; the per-PR polishd lane skipped by the filter runs again only
+when a matching change (or the marker) triggers it.
+
+Agent-dictation E2E eval (`AgentDictationE2EEvalTests`, nightly `eval-e2e.yml`
++ `remote-build.sh eval-e2e`): model/prompt/feature-pipeline changes — anything
+the rule above marks LLM-relevant, plus the TTS→ASR→polish harness itself —
+MUST paste the eval-e2e scoreboard in the PR's Proof section, or explicitly
+justify skipping it in one line. Only the 7 migrated punctuation cases are
+`required` today; Phase 3 calibration will promote cases that prove stable
+across server states (restarts / prompt-cache configurations) to `required` —
+promotion PRs must carry that cross-state evidence.
 
 ## CI / shipping
 

--- a/Tests/localvoxtralTests/AgentDictationE2EEvalSupport.swift
+++ b/Tests/localvoxtralTests/AgentDictationE2EEvalSupport.swift
@@ -541,4 +541,113 @@ enum AgentDictationE2EEvalSupport {
             failedRequired ? "FAIL \(row.caseID) [required]" : "XFAIL \(row.caseID) (known-hard)"
         return "\(label): \(failureParts.joined(separator: " ")) — output: \(flatOutput)\(suffix)"
     }
+
+    // MARK: - Per-case inspection report
+
+    /// Sentinels bracketing the JSONL inspection report in the suite's
+    /// stdout. The SSH build gate has no file fetch-back channel, so the
+    /// remote log (`.build/last-remote.log`) is the transport: between the
+    /// sentinels, line 1 is the `ReportHeader` and every further line is one
+    /// `CaseReportRecord`.
+    static let reportBeginSentinel = "=== AGENT-E2E-INSPECTION-REPORT-BEGIN ==="
+    static let reportEndSentinel = "=== AGENT-E2E-INSPECTION-REPORT-END ==="
+
+    /// Line 1 of the report: run metadata plus the deduplicated system-prompt
+    /// table — two profiles means two entries, so per-case records reference
+    /// an index instead of repeating kilobytes 150+ times.
+    struct ReportHeader: Codable, Equatable {
+        let polishModel: String
+        let asrModel: String
+        let systemPrompts: [String]
+    }
+
+    /// Intermediate pipeline artifacts the live suite observes for one case,
+    /// beyond what `CaseResult` scores: the ASR transcript, the exact polish
+    /// request, and the model output before the token guard.
+    struct CaseCapture {
+        /// ASR output (nil when the pipeline skipped speech recognition).
+        var transcript: String?
+        /// The system prompt exactly as the production request carried it.
+        var polishSystemPrompt: String?
+        var polishUserPrompts: [String]?
+        var polishInputText: String?
+        /// Pre-guard model output (macro cases: still placeholder-form).
+        var rawModelOutput: String?
+        /// Guard-off diagnostic text as scored (macro payload substituted).
+        var guardOffOutput: String?
+    }
+
+    /// Everything the harness saw for one case, for offline inspection:
+    /// corpus inputs, pipeline artifacts, and the scored verdicts.
+    struct CaseReportRecord: Codable {
+        let caseID: String
+        let stratum: String
+        let pipeline: AgentDictationEvalCorpus.Pipeline
+        let lang: AgentDictationEvalCorpus.Language
+        let statusByMetric: [String: AgentDictationEvalCorpus.Status]
+        let spokenForm: String
+        let intendedText: String
+        let requiredTokens: [String]
+        let features: AgentDictationEvalCorpus.Features?
+        let transcript: String?
+        /// Index into `ReportHeader.systemPrompts`; nil when no polish ran.
+        let systemPromptIndex: Int?
+        let userPrompts: [String]?
+        let polishInputText: String?
+        let rawModelOutput: String?
+        let guardOffOutput: String?
+        let output: String
+        let skipReason: String?
+        let infraFailure: String?
+        let tokensFailures: [String]
+        let exactTextFailures: [String]?
+        let guardOffTokensFailures: [String]?
+        let wordAccuracyVsIntended: Double?
+    }
+
+    static func makeReportRecord(
+        evalCase: AgentDictationEvalCorpus.Case,
+        result: CaseResult,
+        capture: CaseCapture,
+        systemPromptIndex: Int?
+    ) -> CaseReportRecord {
+        CaseReportRecord(
+            caseID: result.caseID,
+            stratum: result.stratum,
+            pipeline: result.pipeline,
+            lang: result.lang,
+            statusByMetric: result.statusByMetric,
+            spokenForm: evalCase.spokenForm,
+            intendedText: evalCase.intendedText,
+            requiredTokens: evalCase.requiredTokens,
+            features: evalCase.features,
+            transcript: capture.transcript,
+            systemPromptIndex: systemPromptIndex,
+            userPrompts: capture.polishUserPrompts,
+            polishInputText: capture.polishInputText,
+            rawModelOutput: capture.rawModelOutput,
+            guardOffOutput: capture.guardOffOutput,
+            output: result.output,
+            skipReason: result.skipReason,
+            infraFailure: result.infraFailure,
+            tokensFailures: result.tokensFailures,
+            exactTextFailures: result.exactTextFailures,
+            guardOffTokensFailures: result.guardOffTokensFailures,
+            wordAccuracyVsIntended: result.wordAccuracyVsIntended
+        )
+    }
+
+    static func renderReport(
+        header: ReportHeader, records: [CaseReportRecord]
+    ) throws -> String {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys, .withoutEscapingSlashes]
+        var lines: [String] = [reportBeginSentinel]
+        lines.append(String(decoding: try encoder.encode(header), as: UTF8.self))
+        for record in records {
+            lines.append(String(decoding: try encoder.encode(record), as: UTF8.self))
+        }
+        lines.append(reportEndSentinel)
+        return lines.joined(separator: "\n")
+    }
 }

--- a/Tests/localvoxtralTests/AgentDictationE2EEvalSupport.swift
+++ b/Tests/localvoxtralTests/AgentDictationE2EEvalSupport.swift
@@ -1,0 +1,525 @@
+import CryptoKit
+import Foundation
+
+@testable import localvoxtral
+
+/// Pure helpers for the agent-dictation end-to-end eval harness
+/// (`AgentDictationE2EEvalTests`): enablement/marker resolution, WAV-cache key
+/// derivation, per-pipeline stage routing, per-stratum polish-profile routing,
+/// corpus-contract scoring, `say -v ?` voice picking, and scoreboard
+/// rendering. Everything here is deterministic and unit-tested in the plain
+/// tier-0 suite (`AgentDictationE2EEvalSupportTests`) — the live suite only
+/// adds TTS/ASR/polish I/O around these functions.
+enum AgentDictationE2EEvalSupport {
+    // MARK: - Enablement
+
+    /// The gitignored marker file `remote-build.sh eval-e2e` writes at the
+    /// repo root (the SSH build gate pins env prefixes per-command, so
+    /// enablement travels inside the rsynced tree — same pattern as
+    /// `.polishd-integration-enable.json`).
+    static let markerFileName = ".agent-eval-e2e-enable.json"
+    static let enableEnvKey = "LV_AGENT_EVAL_E2E_ENABLE"
+    static let helperPathEnvKey = "LV_AGENT_EVAL_E2E_HELPER_PATH"
+    static let voxmlxEndpointEnvKey = "LV_AGENT_EVAL_E2E_VOXMLX_ENDPOINT"
+    static let asrModelEnvKey = "LV_AGENT_EVAL_E2E_ASR_MODEL"
+    static let polishModelEnvKey = "LV_AGENT_EVAL_E2E_POLISH_MODEL"
+
+    static let defaultHelperPath =
+        "PolishHelper/.build/xcode/Build/Products/Release/localvoxtral-polishd"
+    static let defaultVoxmlxEndpoint = "ws://127.0.0.1:8000/v1/realtime"
+    /// The realtime model the build host's voxmlx service serves (same pin as
+    /// the tier-1 integration lane in `remote-build.sh integration`).
+    static let defaultASRModel = "T0mSIlver/Voxtral-Mini-4B-Realtime-2602-MLX-4bit"
+
+    struct MarkerConfig: Decodable, Equatable {
+        let helperPath: String?
+        let voxmlxEndpoint: String?
+        let asrModel: String?
+        let polishModel: String?
+
+        init(
+            helperPath: String? = nil,
+            voxmlxEndpoint: String? = nil,
+            asrModel: String? = nil,
+            polishModel: String? = nil
+        ) {
+            self.helperPath = helperPath
+            self.voxmlxEndpoint = voxmlxEndpoint
+            self.asrModel = asrModel
+            self.polishModel = polishModel
+        }
+    }
+
+    struct Enablement: Equatable {
+        let helperPath: String
+        let voxmlxEndpoint: URL
+        let asrModel: String
+        let polishModel: String
+    }
+
+    static func parseMarker(_ data: Data) throws -> MarkerConfig {
+        try JSONDecoder().decode(MarkerConfig.self, from: data)
+    }
+
+    /// Resolves the effective configuration from env (when the enable env var
+    /// is "1") or a parsed marker (when present); nil = the suite self-skips.
+    /// Defaults are applied field-by-field so a marker only carrying
+    /// `helperPath` still gets the pinned ASR endpoint/model.
+    static func resolveEnablement(
+        environment: [String: String],
+        marker: MarkerConfig?
+    ) -> Enablement? {
+        let envEnabled = environment[enableEnvKey] == "1"
+        guard envEnabled || marker != nil else { return nil }
+
+        func pick(_ envKey: String, _ markerValue: String?, default defaultValue: String) -> String {
+            if envEnabled, let value = environment[envKey], !value.isEmpty {
+                return value
+            }
+            if let markerValue, !markerValue.isEmpty {
+                return markerValue
+            }
+            return defaultValue
+        }
+
+        let endpointString = pick(
+            voxmlxEndpointEnvKey, marker?.voxmlxEndpoint, default: defaultVoxmlxEndpoint
+        )
+        guard let endpoint = URL(string: endpointString) else { return nil }
+        return Enablement(
+            helperPath: pick(helperPathEnvKey, marker?.helperPath, default: defaultHelperPath),
+            voxmlxEndpoint: endpoint,
+            asrModel: pick(asrModelEnvKey, marker?.asrModel, default: defaultASRModel),
+            // Same pin as production's default (SettingsStore
+            // .defaultLLMPolishingModel resolves to this catalog entry; the
+            // settings store itself is MainActor-isolated, the catalog is not).
+            polishModel: pick(
+                polishModelEnvKey, marker?.polishModel,
+                default: PolishModelCatalog.defaultOption.repoID
+            )
+        )
+    }
+
+    // MARK: - WAV cache
+
+    static let ttsDataFormat = "LEI16@16000"
+
+    /// Cache key for a synthesized utterance: SHA-256 over the exact
+    /// text + voice + data format, so any change to what `say` would produce
+    /// changes the key and a rerun over an unchanged corpus is a pure cache
+    /// hit (TTS is the slow step across ~150 cases x reruns). `voice == nil`
+    /// (the system default voice) keys as "default". Each field is
+    /// length-prefixed before hashing — a plain separator join is ambiguous
+    /// (text "a|B" + voice nil collides with text "a" + voice "B|default";
+    /// caught by the tier-0 collision test).
+    static func wavCacheKey(
+        text: String,
+        voice: String?,
+        dataFormat: String = ttsDataFormat
+    ) -> String {
+        var hasher = SHA256()
+        for field in [text, voice ?? "default", dataFormat] {
+            let bytes = Data(field.utf8)
+            withUnsafeBytes(of: UInt64(bytes.count).littleEndian) {
+                hasher.update(bufferPointer: $0)
+            }
+            hasher.update(data: bytes)
+        }
+        return hasher.finalize()
+            .map { String(format: "%02x", $0) }
+            .joined()
+    }
+
+    // MARK: - Pipeline routing
+
+    struct StagePlan: Equatable {
+        /// TTS(spokenForm) -> websocket ASR.
+        let runsSpeechRecognition: Bool
+        /// The polish stop-commit path.
+        let runsPolish: Bool
+    }
+
+    static func stagePlan(for pipeline: AgentDictationEvalCorpus.Pipeline) -> StagePlan {
+        switch pipeline {
+        case .full:
+            return StagePlan(runsSpeechRecognition: true, runsPolish: true)
+        case .asrOnly:
+            return StagePlan(runsSpeechRecognition: true, runsPolish: false)
+        case .polishOnly:
+            return StagePlan(runsSpeechRecognition: false, runsPolish: true)
+        }
+    }
+
+    // MARK: - Polish-profile routing
+
+    /// A terminal-like bundle ID on the built-in allowlist — the production
+    /// profile selector maps it to the AGENT prompt profile.
+    static let terminalTargetBundleID = "com.apple.Terminal"
+    /// A bundle ID no allowlist knows — the selector keeps the STANDARD
+    /// profile.
+    static let textFieldTargetBundleID = "com.localvoxtral.eval.textfield"
+
+    /// The commit-target bundle ID injected per stratum, which drives the
+    /// production `selectedPolishProfile` switch. The agent-dictation corpus
+    /// runs the AGENT profile — except `punctuation-spacing-migration`, whose
+    /// cases (including all 7 day-one required cases) are byte-for-byte
+    /// migrations of the `LLMPolishEvalSupport` corpus whose required-case
+    /// stability was established under the STANDARD profile; asserting them
+    /// under a different prompt would be a new, uncalibrated claim (the
+    /// promotion rule demands cross-server-state evidence per prompt).
+    static func polishTargetBundleID(forStratum stratum: String) -> String {
+        stratum == "punctuation-spacing-migration"
+            ? textFieldTargetBundleID
+            : terminalTargetBundleID
+    }
+
+    // MARK: - Voice picking
+
+    /// Picks a TTS voice from `say -v ?` output: the first `preferred` name
+    /// present wins, else the first voice whose locale starts with
+    /// `languagePrefix` ("en"/"fr"), else nil. Voice names may contain spaces
+    /// ("Bad News"), so lines parse as name + 2+ spaces + locale.
+    static func pickVoice(
+        fromSayVoicesOutput output: String,
+        languagePrefix: String,
+        preferred: [String]
+    ) -> String? {
+        var candidates: [String] = []
+        for line in output.split(separator: "\n") {
+            guard let (name, locale) = parseVoiceLine(String(line)) else { continue }
+            let normalizedLocale = locale.replacingOccurrences(of: "-", with: "_").lowercased()
+            guard normalizedLocale.hasPrefix(languagePrefix.lowercased()) else { continue }
+            candidates.append(name)
+        }
+        for name in preferred where candidates.contains(name) {
+            return name
+        }
+        return candidates.first
+    }
+
+    private static func parseVoiceLine(_ line: String) -> (name: String, locale: String)? {
+        // "Thomas              fr_FR    # Bonjour! ..." — name up to the first
+        // run of 2+ spaces, locale is the next token.
+        guard let separator = line.range(of: "  ") else { return nil }
+        let name = String(line[..<separator.lowerBound]).trimmingCharacters(in: .whitespaces)
+        guard !name.isEmpty else { return nil }
+        let rest = line[separator.upperBound...].trimmingCharacters(in: .whitespaces)
+        guard let locale = rest.split(whereSeparator: \.isWhitespace).first else { return nil }
+        // Locale tokens look like en_US / fr-FR / fr_CA.
+        guard locale.contains("_") || locale.contains("-") else { return nil }
+        return (name, String(locale))
+    }
+
+    // MARK: - Scoring (corpus contract)
+
+    /// `tokens` metric: every `requiredTokens` entry present (byte-exact after
+    /// spacing normalization; case-sensitive unless the case sets
+    /// `caseInsensitive`) AND no `forbiddenSubstrings` entry present (always
+    /// case-insensitive). Returns human-readable failure descriptions; empty
+    /// means pass.
+    static func tokensFailures(
+        output: String,
+        evalCase: AgentDictationEvalCorpus.Case
+    ) -> [String] {
+        let normalized = LLMPolishEvalSupport.normalizedSpacing(output)
+        let requiredHaystack = evalCase.isCaseInsensitive ? normalized.lowercased() : normalized
+        var failures: [String] = []
+        for token in evalCase.requiredTokens {
+            var needle = LLMPolishEvalSupport.normalizedSpacing(token)
+            if evalCase.isCaseInsensitive { needle = needle.lowercased() }
+            if !requiredHaystack.contains(needle) {
+                failures.append("missing \"\(token)\"")
+            }
+        }
+        let forbiddenHaystack = normalized.lowercased()
+        for needle in evalCase.forbidden {
+            let normalizedNeedle = LLMPolishEvalSupport.normalizedSpacing(needle).lowercased()
+            if forbiddenHaystack.contains(normalizedNeedle) {
+                failures.append("contains forbidden \"\(needle)\"")
+            }
+        }
+        return failures
+    }
+
+    /// `exactText` metric: normalized whole-output equality with
+    /// `intendedText` (spacing normalization; lowercased when the case is
+    /// `caseInsensitive` — the migrated punctuation cases keep the old
+    /// scorer's semantics). nil = pass.
+    static func exactTextFailure(
+        output: String,
+        evalCase: AgentDictationEvalCorpus.Case
+    ) -> String? {
+        var actual = LLMPolishEvalSupport.normalizedSpacing(output)
+        var expected = LLMPolishEvalSupport.normalizedSpacing(evalCase.intendedText)
+        if evalCase.isCaseInsensitive {
+            actual = actual.lowercased()
+            expected = expected.lowercased()
+        }
+        guard actual != expected else { return nil }
+        let expectedForLog = evalCase.intendedText.replacingOccurrences(of: "\n", with: "\\n")
+        return "expected \"\(expectedForLog)\""
+    }
+
+    /// Anti-rewrite guard (scorer behavior per the corpus README, not corpus
+    /// data): letters/digits word accuracy between the polish INPUT and the
+    /// final output must clear `LLMPolishEvalSupport.requiredWordAccuracy`,
+    /// or the polisher rewrote instead of cleaning. Positive macro cases are
+    /// exempt — embedding the clipboard payload legitimately explodes the
+    /// token count. nil = pass.
+    static func antiRewriteFailure(
+        polishInput: String,
+        output: String,
+        evalCase: AgentDictationEvalCorpus.Case
+    ) -> String? {
+        guard evalCase.features?.macro != true else { return nil }
+        let accuracy = IntegrationTestSupport.wordAccuracy(expected: polishInput, actual: output)
+        guard accuracy < LLMPolishEvalSupport.requiredWordAccuracy else { return nil }
+        return "word accuracy vs input \(String(format: "%.2f", accuracy)) "
+            + "< \(LLMPolishEvalSupport.requiredWordAccuracy) (rewrote the text)"
+    }
+
+    // MARK: - Case results + scoreboard
+
+    /// The outcome of one corpus case, one row of the scoreboard. Columns:
+    /// `tokensFailures`/`exactTextFailures` score the BASELINE run (the
+    /// production path, token guard on); `guardOffTokensFailures` is the
+    /// diagnostic guard-off column — the same run's RAW model output scored on
+    /// the tokens metric, measuring what the token guard saved (how often #101
+    /// earns its keep) at zero extra inference cost. More ablation columns
+    /// (feature-off runs) slot in as additional optional fields + a line
+    /// suffix in `renderLine` (Phase 3).
+    struct CaseResult {
+        let caseID: String
+        let stratum: String
+        let pipeline: AgentDictationEvalCorpus.Pipeline
+        let lang: AgentDictationEvalCorpus.Language
+        let statusByMetric: [String: AgentDictationEvalCorpus.Status]
+        /// Environmental skip (e.g. no French TTS voice installed): printed
+        /// and counted, never a failure.
+        var skipReason: String?
+        /// Pipeline infrastructure error (say failed, ASR connect/timeout,
+        /// polish request failed): fails the suite — infra rot must redden
+        /// the nightly lane, not silently degrade it.
+        var infraFailure: String?
+        var tokensFailures: [String]
+        /// nil when the case carries no exactText status.
+        var exactTextFailures: [String]?
+        /// nil when no polish ran (asr-only) or no raw output was captured.
+        var guardOffTokensFailures: [String]?
+        /// Informational: word accuracy of the final output vs intendedText.
+        var wordAccuracyVsIntended: Double?
+        var output: String
+
+        init(
+            caseID: String,
+            stratum: String,
+            pipeline: AgentDictationEvalCorpus.Pipeline,
+            lang: AgentDictationEvalCorpus.Language,
+            statusByMetric: [String: AgentDictationEvalCorpus.Status],
+            skipReason: String? = nil,
+            infraFailure: String? = nil,
+            tokensFailures: [String] = [],
+            exactTextFailures: [String]? = nil,
+            guardOffTokensFailures: [String]? = nil,
+            wordAccuracyVsIntended: Double? = nil,
+            output: String = ""
+        ) {
+            self.caseID = caseID
+            self.stratum = stratum
+            self.pipeline = pipeline
+            self.lang = lang
+            self.statusByMetric = statusByMetric
+            self.skipReason = skipReason
+            self.infraFailure = infraFailure
+            self.tokensFailures = tokensFailures
+            self.exactTextFailures = exactTextFailures
+            self.guardOffTokensFailures = guardOffTokensFailures
+            self.wordAccuracyVsIntended = wordAccuracyVsIntended
+            self.output = output
+        }
+
+        /// Metrics whose status is `required` and whose baseline column
+        /// failed — each one is asserted individually by the suite.
+        var failedRequiredMetrics: [(metric: String, failures: [String])] {
+            var failed: [(String, [String])] = []
+            if statusByMetric["tokens"] == .required, !tokensFailures.isEmpty {
+                failed.append(("tokens", tokensFailures))
+            }
+            if statusByMetric["exactText"] == .required,
+                let exactTextFailures, !exactTextFailures.isEmpty
+            {
+                failed.append(("exactText", exactTextFailures))
+            }
+            return failed
+        }
+
+        var scoredMetricsAllPass: Bool {
+            tokensFailures.isEmpty && (exactTextFailures?.isEmpty ?? true)
+        }
+
+        var carriesRequiredMetric: Bool {
+            statusByMetric.values.contains(.required)
+        }
+    }
+
+    struct RenderedScoreboard {
+        let text: String
+        /// One entry per failed REQUIRED metric, ready for XCTFail — names the
+        /// case, the metric, the failures, and the output.
+        let requiredFailures: [String]
+        /// One entry per infrastructure error, ready for XCTFail.
+        let infraFailures: [String]
+    }
+
+    // Scoreboard delimiters — eval-e2e.yml extracts the section between them
+    // into the run's step summary; keep in sync with the workflow.
+    static let scoreboardBeginMarker = "== agent-dictation E2E eval scoreboard =="
+    static let scoreboardEndMarker = "== end agent-dictation E2E eval scoreboard =="
+
+    static func renderScoreboard(
+        results: [CaseResult],
+        header: String
+    ) -> RenderedScoreboard {
+        var lines: [String] = [scoreboardBeginMarker, header]
+        var requiredFailures: [String] = []
+        var infraFailures: [String] = []
+
+        // Preserve corpus order; group rows by stratum in first-seen order.
+        var strataOrder: [String] = []
+        var byStratum: [String: [CaseResult]] = [:]
+        for result in results {
+            if byStratum[result.stratum] == nil {
+                strataOrder.append(result.stratum)
+            }
+            byStratum[result.stratum, default: []].append(result)
+        }
+
+        var totalRequired = 0
+        var totalRequiredPassed = 0
+        var totalKnownHardScored = 0
+        var totalKnownHardPassed = 0
+        var totalGuardSaves = 0
+        var totalSkipped = 0
+        var totalErrors = 0
+
+        for stratum in strataOrder {
+            let rows = byStratum[stratum] ?? []
+            let pipeline = rows.first?.pipeline.rawValue ?? "full"
+            lines.append("-- \(stratum) (pipeline \(pipeline), \(rows.count) cases) --")
+
+            var tokensPassed = 0
+            var tokensScored = 0
+            var exactPassed = 0
+            var exactScored = 0
+            var accuracies: [Double] = []
+            var skipped = 0
+            var errors = 0
+
+            for row in rows {
+                if let reason = row.skipReason {
+                    lines.append("SKIP \(row.caseID) — \(reason)")
+                    skipped += 1
+                    continue
+                }
+                if let infra = row.infraFailure {
+                    lines.append("ERROR \(row.caseID) — \(infra)")
+                    infraFailures.append("infra error on \(row.caseID): \(infra)")
+                    errors += 1
+                    continue
+                }
+
+                tokensScored += 1
+                if row.tokensFailures.isEmpty { tokensPassed += 1 }
+                if let exactTextFailures = row.exactTextFailures {
+                    exactScored += 1
+                    if exactTextFailures.isEmpty { exactPassed += 1 }
+                }
+                if let accuracy = row.wordAccuracyVsIntended {
+                    accuracies.append(accuracy)
+                }
+
+                let failedRequired = row.failedRequiredMetrics
+                totalRequired += row.statusByMetric.values.count { $0 == .required }
+                totalRequiredPassed +=
+                    row.statusByMetric.values.count { $0 == .required } - failedRequired.count
+                if !row.carriesRequiredMetric {
+                    totalKnownHardScored += 1
+                    if row.scoredMetricsAllPass { totalKnownHardPassed += 1 }
+                }
+
+                lines.append(renderLine(row: row))
+
+                for (metric, failures) in failedRequired {
+                    requiredFailures.append(
+                        "required case \(row.caseID) failed [\(metric)]: "
+                            + "\(failures.joined(separator: "; ")) — output: \(row.output)"
+                    )
+                }
+                if let guardOff = row.guardOffTokensFailures,
+                    row.tokensFailures.isEmpty, !guardOff.isEmpty
+                {
+                    totalGuardSaves += 1
+                }
+            }
+
+            let meanAccuracy =
+                accuracies.isEmpty
+                ? "n/a"
+                : String(format: "%.2f", accuracies.reduce(0, +) / Double(accuracies.count))
+            lines.append(
+                "-- \(stratum) summary: tokens \(tokensPassed)/\(tokensScored), "
+                    + "exactText \(exactPassed)/\(exactScored), "
+                    + "mean word-accuracy vs intended \(meanAccuracy)"
+                    + (skipped > 0 ? ", skipped \(skipped)" : "")
+                    + (errors > 0 ? ", errors \(errors)" : "") + " --"
+            )
+            totalSkipped += skipped
+            totalErrors += errors
+        }
+
+        lines.append(
+            "== required: \(totalRequiredPassed)/\(totalRequired) metric checks passed, "
+                + "known-hard cases fully passing: \(totalKnownHardPassed)/\(totalKnownHardScored), "
+                + "skipped \(totalSkipped), errors \(totalErrors) =="
+        )
+        lines.append(
+            "== guard-off diagnostic: token guard flipped \(totalGuardSaves) case(s) "
+                + "from fail (raw model output) to pass (guarded commit) =="
+        )
+        lines.append(scoreboardEndMarker)
+
+        return RenderedScoreboard(
+            text: lines.joined(separator: "\n"),
+            requiredFailures: requiredFailures,
+            infraFailures: infraFailures
+        )
+    }
+
+    private static func renderLine(row: CaseResult) -> String {
+        var failureParts: [String] = []
+        if !row.tokensFailures.isEmpty {
+            failureParts.append("[tokens] \(row.tokensFailures.joined(separator: "; "))")
+        }
+        if let exactTextFailures = row.exactTextFailures, !exactTextFailures.isEmpty {
+            failureParts.append("[exactText] \(exactTextFailures.joined(separator: "; "))")
+        }
+
+        var suffix = ""
+        if let guardOff = row.guardOffTokensFailures {
+            suffix = " | guard-off tokens: \(guardOff.isEmpty ? "PASS" : "FAIL")"
+        }
+
+        let flatOutput = row.output.replacingOccurrences(of: "\n", with: "\\n")
+        if failureParts.isEmpty {
+            let annotation =
+                row.carriesRequiredMetric
+                ? ""
+                : " (known-hard — promote only with cross-server-state evidence)"
+            return "PASS \(row.caseID)\(annotation)\(suffix)"
+        }
+        let failedRequired = !row.failedRequiredMetrics.isEmpty
+        let label =
+            failedRequired ? "FAIL \(row.caseID) [required]" : "XFAIL \(row.caseID) (known-hard)"
+        return "\(label): \(failureParts.joined(separator: " ")) — output: \(flatOutput)\(suffix)"
+    }
+}

--- a/Tests/localvoxtralTests/AgentDictationE2EEvalSupport.swift
+++ b/Tests/localvoxtralTests/AgentDictationE2EEvalSupport.swift
@@ -283,11 +283,13 @@ enum AgentDictationE2EEvalSupport {
     /// The outcome of one corpus case, one row of the scoreboard. Columns:
     /// `tokensFailures`/`exactTextFailures` score the BASELINE run (the
     /// production path, token guard on); `guardOffTokensFailures` is the
-    /// diagnostic guard-off column — the same run's RAW model output scored on
-    /// the tokens metric, measuring what the token guard saved (how often #101
-    /// earns its keep) at zero extra inference cost. More ablation columns
-    /// (feature-off runs) slot in as additional optional fields + a line
-    /// suffix in `renderLine` (Phase 3).
+    /// diagnostic guard-off column — the same run's PRE-GUARD model output
+    /// (for macro cases: after the commit-time payload substitution the
+    /// no-guard commit would still perform — the guard itself saw the
+    /// placeholder form) scored on the tokens metric, measuring what the
+    /// token guard saved (how often #101 earns its keep) at zero extra
+    /// inference cost. More ablation columns (feature-off runs) slot in as
+    /// additional optional fields + a line suffix in `renderLine` (Phase 3).
     struct CaseResult {
         let caseID: String
         let stratum: String
@@ -295,7 +297,10 @@ enum AgentDictationE2EEvalSupport {
         let lang: AgentDictationEvalCorpus.Language
         let statusByMetric: [String: AgentDictationEvalCorpus.Status]
         /// Environmental skip (e.g. no French TTS voice installed): printed
-        /// and counted, never a failure.
+        /// and counted; non-fatal for known-hard rows, but a skip on a row
+        /// carrying a REQUIRED metric is counted as a required failure by
+        /// `renderScoreboard` — a required case must be measured, not
+        /// silently passed over.
         var skipReason: String?
         /// Pipeline infrastructure error (say failed, ASR connect/timeout,
         /// polish request failed): fails the suite — infra rot must redden
@@ -417,7 +422,21 @@ enum AgentDictationE2EEvalSupport {
 
             for row in rows {
                 if let reason = row.skipReason {
-                    lines.append("SKIP \(row.caseID) — \(reason)")
+                    // A required case that never RAN must not pass silently:
+                    // environmental skips are tolerable for known-hard rows,
+                    // but a required metric demands a measurement. (No
+                    // required case is TTS-dependent today — all 7 are
+                    // polish-only — but Phase-3 promotion may change that.)
+                    if row.carriesRequiredMetric {
+                        lines.append(
+                            "SKIP \(row.caseID) — \(reason) [required case — skip counts as failure]"
+                        )
+                        requiredFailures.append(
+                            "required case \(row.caseID) was skipped without running: \(reason)"
+                        )
+                    } else {
+                        lines.append("SKIP \(row.caseID) — \(reason)")
+                    }
                     skipped += 1
                     continue
                 }

--- a/Tests/localvoxtralTests/AgentDictationE2EEvalSupportTests.swift
+++ b/Tests/localvoxtralTests/AgentDictationE2EEvalSupportTests.swift
@@ -516,4 +516,60 @@ final class AgentDictationE2EEvalSupportTests: XCTestCase {
             )
         )
     }
+
+    // MARK: - Inspection report
+
+    func testInspectionReportRendersSentinelDelimitedJSONL() throws {
+        let evalCase = try makeCase(
+            id: "r-en-report",
+            spokenForm: "open use auth dot t s",
+            intendedText: "Open `useAuth.ts`.",
+            requiredTokens: ["useAuth.ts"]
+        )
+        var result = makeResult(caseID: "r-en-report")
+        result.output = "Open `useAuth.ts`."
+        result.wordAccuracyVsIntended = 1.0
+        var capture = Support.CaseCapture()
+        capture.transcript = "open use auth dot t s"
+        capture.polishSystemPrompt = "SYSTEM PROMPT"
+        capture.polishUserPrompts = ["user prompt with\nnewline"]
+        capture.polishInputText = "open use auth dot t s"
+        capture.rawModelOutput = "Open `useAuth.ts`."
+
+        let record = Support.makeReportRecord(
+            evalCase: evalCase, result: result, capture: capture, systemPromptIndex: 0
+        )
+        let report = try Support.renderReport(
+            header: Support.ReportHeader(
+                polishModel: "polish-model", asrModel: "asr-model",
+                systemPrompts: ["SYSTEM PROMPT"]
+            ),
+            records: [record]
+        )
+
+        let lines = report.components(separatedBy: "\n")
+        XCTAssertEqual(lines.first, Support.reportBeginSentinel)
+        XCTAssertEqual(lines.last, Support.reportEndSentinel)
+        // Sentinels + header + one record, each JSON value on ONE line (the
+        // remote log is line-oriented; embedded newlines must stay escaped).
+        XCTAssertEqual(lines.count, 4)
+
+        let header = try JSONDecoder().decode(
+            Support.ReportHeader.self, from: Data(lines[1].utf8)
+        )
+        XCTAssertEqual(header.systemPrompts, ["SYSTEM PROMPT"])
+
+        let decoded = try JSONDecoder().decode(
+            Support.CaseReportRecord.self, from: Data(lines[2].utf8)
+        )
+        XCTAssertEqual(decoded.caseID, "r-en-report")
+        XCTAssertEqual(decoded.spokenForm, "open use auth dot t s")
+        XCTAssertEqual(decoded.intendedText, "Open `useAuth.ts`.")
+        XCTAssertEqual(decoded.transcript, "open use auth dot t s")
+        XCTAssertEqual(decoded.systemPromptIndex, 0)
+        XCTAssertEqual(decoded.userPrompts, ["user prompt with\nnewline"])
+        XCTAssertEqual(decoded.rawModelOutput, "Open `useAuth.ts`.")
+        XCTAssertEqual(decoded.output, "Open `useAuth.ts`.")
+        XCTAssertEqual(decoded.wordAccuracyVsIntended, 1.0)
+    }
 }

--- a/Tests/localvoxtralTests/AgentDictationE2EEvalSupportTests.swift
+++ b/Tests/localvoxtralTests/AgentDictationE2EEvalSupportTests.swift
@@ -1,0 +1,486 @@
+import Foundation
+import XCTest
+
+@testable import localvoxtral
+
+/// Tier-0 unit coverage for the deterministic pieces of the agent-dictation
+/// E2E eval harness (no gating, no network, no TTS): enablement resolution,
+/// WAV-cache key derivation, pipeline/profile routing, corpus-contract
+/// scoring, voice picking, and scoreboard rendering. @MainActor because two
+/// assertions consult MainActor-isolated production types (SettingsStore's
+/// default model pin, TerminalTargetDetector's allowlist).
+@MainActor
+final class AgentDictationE2EEvalSupportTests: XCTestCase {
+    private typealias Support = AgentDictationE2EEvalSupport
+
+    // MARK: - Marker parsing + enablement resolution
+
+    func testParseMarkerReadsAllFields() throws {
+        let data = Data(
+            """
+            {"helperPath": "/tmp/polishd", "voxmlxEndpoint": "ws://127.0.0.1:9000/v1/realtime",
+             "asrModel": "acme/asr", "polishModel": "acme/polish"}
+            """.utf8
+        )
+        let marker = try Support.parseMarker(data)
+        XCTAssertEqual(marker.helperPath, "/tmp/polishd")
+        XCTAssertEqual(marker.voxmlxEndpoint, "ws://127.0.0.1:9000/v1/realtime")
+        XCTAssertEqual(marker.asrModel, "acme/asr")
+        XCTAssertEqual(marker.polishModel, "acme/polish")
+    }
+
+    func testParseMarkerToleratesMissingFields() throws {
+        let marker = try Support.parseMarker(Data("{\"helperPath\": \"x\"}".utf8))
+        XCTAssertEqual(marker.helperPath, "x")
+        XCTAssertNil(marker.voxmlxEndpoint)
+        XCTAssertNil(marker.asrModel)
+        XCTAssertNil(marker.polishModel)
+    }
+
+    func testEnablementNilWithoutEnvOrMarker() {
+        XCTAssertNil(Support.resolveEnablement(environment: [:], marker: nil))
+        // A "0" env value is not enablement either.
+        XCTAssertNil(
+            Support.resolveEnablement(
+                environment: [Support.enableEnvKey: "0"], marker: nil
+            )
+        )
+    }
+
+    func testEnablementFromMarkerAppliesDefaultsFieldByField() throws {
+        let enablement = try XCTUnwrap(
+            Support.resolveEnablement(
+                environment: [:],
+                marker: Support.MarkerConfig(helperPath: "custom/polishd")
+            )
+        )
+        XCTAssertEqual(enablement.helperPath, "custom/polishd")
+        XCTAssertEqual(enablement.voxmlxEndpoint.absoluteString, Support.defaultVoxmlxEndpoint)
+        XCTAssertEqual(enablement.asrModel, Support.defaultASRModel)
+        XCTAssertEqual(enablement.polishModel, SettingsStore.defaultLLMPolishingModel)
+    }
+
+    func testEnablementFromEnvOverridesMarker() throws {
+        let enablement = try XCTUnwrap(
+            Support.resolveEnablement(
+                environment: [
+                    Support.enableEnvKey: "1",
+                    Support.helperPathEnvKey: "/env/polishd",
+                ],
+                marker: Support.MarkerConfig(helperPath: "marker/polishd", asrModel: "marker/asr")
+            )
+        )
+        XCTAssertEqual(enablement.helperPath, "/env/polishd")
+        // Fields the env does not carry still fall through to the marker.
+        XCTAssertEqual(enablement.asrModel, "marker/asr")
+    }
+
+    // MARK: - WAV cache key
+
+    func testWavCacheKeyIsDeterministicHex() {
+        let first = Support.wavCacheKey(text: "open the dot env file", voice: "Samantha")
+        let second = Support.wavCacheKey(text: "open the dot env file", voice: "Samantha")
+        XCTAssertEqual(first, second)
+        XCTAssertEqual(first.count, 64)
+        XCTAssertTrue(first.allSatisfy { $0.isHexDigit && !$0.isUppercase })
+    }
+
+    func testWavCacheKeyChangesWithEachInput() {
+        let base = Support.wavCacheKey(text: "hello", voice: "Samantha")
+        XCTAssertNotEqual(base, Support.wavCacheKey(text: "hello there", voice: "Samantha"))
+        XCTAssertNotEqual(base, Support.wavCacheKey(text: "hello", voice: "Thomas"))
+        XCTAssertNotEqual(base, Support.wavCacheKey(text: "hello", voice: nil))
+        XCTAssertNotEqual(
+            base, Support.wavCacheKey(text: "hello", voice: "Samantha", dataFormat: "LEI16@22050")
+        )
+    }
+
+    /// Field boundaries must be unambiguous: text containing a would-be
+    /// separator must not collide with a shifted voice value. (This test
+    /// caught the original "|"-join derivation doing exactly that; fields are
+    /// length-prefixed now.)
+    func testWavCacheKeyFieldBoundariesDoNotCollide() {
+        XCTAssertNotEqual(
+            Support.wavCacheKey(text: "a|Samantha", voice: nil),
+            Support.wavCacheKey(text: "a", voice: "Samantha|default")
+        )
+    }
+
+    // MARK: - Pipeline routing
+
+    func testStagePlanPerPipeline() {
+        XCTAssertEqual(
+            Support.stagePlan(for: .full),
+            Support.StagePlan(runsSpeechRecognition: true, runsPolish: true)
+        )
+        XCTAssertEqual(
+            Support.stagePlan(for: .asrOnly),
+            Support.StagePlan(runsSpeechRecognition: true, runsPolish: false)
+        )
+        XCTAssertEqual(
+            Support.stagePlan(for: .polishOnly),
+            Support.StagePlan(runsSpeechRecognition: false, runsPolish: true)
+        )
+    }
+
+    /// Every corpus stratum routes: the migration stratum keeps the STANDARD
+    /// profile (its required-case baseline was established under the standard
+    /// prompt), everything else is agent dictation and gets the terminal
+    /// target -> agent profile.
+    func testPolishProfileRoutingPerStratum() throws {
+        XCTAssertEqual(
+            Support.polishTargetBundleID(forStratum: "punctuation-spacing-migration"),
+            Support.textFieldTargetBundleID
+        )
+        XCTAssertFalse(
+            TerminalTargetDetector.isTerminalLikeBundleID(Support.textFieldTargetBundleID)
+        )
+        for stratum in AgentDictationEvalCorpus.expectedStrata
+        where stratum != "punctuation-spacing-migration" {
+            XCTAssertEqual(
+                Support.polishTargetBundleID(forStratum: stratum),
+                Support.terminalTargetBundleID
+            )
+        }
+        XCTAssertTrue(
+            TerminalTargetDetector.isTerminalLikeBundleID(Support.terminalTargetBundleID)
+        )
+    }
+
+    // MARK: - Voice picking
+
+    private let sampleVoices = """
+        Alex                en_US    # Most people recognize me by my voice.
+        Amélie              fr_CA    # Bonjour! Je m'appelle Amélie.
+        Bad News            en_US    # The light you see at the end of the tunnel...
+        Samantha            en_US    # Hello! My name is Samantha.
+        Thomas              fr_FR    # Bonjour! Je m'appelle Thomas.
+        """
+
+    func testPickVoicePrefersNamedVoice() {
+        XCTAssertEqual(
+            Support.pickVoice(
+                fromSayVoicesOutput: sampleVoices, languagePrefix: "fr",
+                preferred: ["Thomas", "Amélie"]
+            ),
+            "Thomas"
+        )
+        XCTAssertEqual(
+            Support.pickVoice(
+                fromSayVoicesOutput: sampleVoices, languagePrefix: "en",
+                preferred: ["Samantha"]
+            ),
+            "Samantha"
+        )
+    }
+
+    func testPickVoiceFallsBackToFirstLanguageMatch() {
+        XCTAssertEqual(
+            Support.pickVoice(
+                fromSayVoicesOutput: sampleVoices, languagePrefix: "fr",
+                preferred: ["Nonexistent"]
+            ),
+            "Amélie"
+        )
+    }
+
+    func testPickVoiceReturnsNilWhenLanguageAbsent() {
+        XCTAssertNil(
+            Support.pickVoice(
+                fromSayVoicesOutput: sampleVoices, languagePrefix: "de", preferred: ["Anna"]
+            )
+        )
+    }
+
+    /// Multi-word names ("Bad News") parse whole, and hyphenated locales
+    /// (fr-FR, seen on newer macOS) still match the language prefix.
+    func testPickVoiceParsesMultiWordNamesAndHyphenLocales() {
+        let output = """
+            Bad News            en_US    # ...
+            Jacques             fr-FR    # ...
+            """
+        XCTAssertEqual(
+            Support.pickVoice(
+                fromSayVoicesOutput: output, languagePrefix: "en", preferred: ["Bad News"]
+            ),
+            "Bad News"
+        )
+        XCTAssertEqual(
+            Support.pickVoice(
+                fromSayVoicesOutput: output, languagePrefix: "fr", preferred: []
+            ),
+            "Jacques"
+        )
+    }
+
+    // MARK: - Scoring
+
+    /// Cases are built through the loader's decoder (the custom init(from:)
+    /// suppresses the memberwise init), which also keeps these tests honest
+    /// about the schema.
+    private func makeCase(
+        id: String = "t-en-sample",
+        lang: String = "en",
+        spokenForm: String = "spoken",
+        intendedText: String = "Intended text.",
+        requiredTokens: [String] = ["Intended"],
+        forbiddenSubstrings: [String]? = nil,
+        caseInsensitive: Bool? = nil,
+        featuresJSON: String? = nil,
+        status: [String: String] = ["tokens": "known-hard"]
+    ) throws -> AgentDictationEvalCorpus.Case {
+        var fields: [String] = [
+            "\"id\": \(jsonString(id))",
+            "\"lang\": \(jsonString(lang))",
+            "\"spokenForm\": \(jsonString(spokenForm))",
+            "\"intendedText\": \(jsonString(intendedText))",
+            "\"requiredTokens\": [\(requiredTokens.map(jsonString).joined(separator: ", "))]",
+            "\"status\": {\(status.map { "\(jsonString($0.key)): \(jsonString($0.value))" }.joined(separator: ", "))}",
+            "\"notes\": \"unit-test case\"",
+        ]
+        if let forbiddenSubstrings {
+            fields.append(
+                "\"forbiddenSubstrings\": [\(forbiddenSubstrings.map(jsonString).joined(separator: ", "))]"
+            )
+        }
+        if let caseInsensitive {
+            fields.append("\"caseInsensitive\": \(caseInsensitive)")
+        }
+        if let featuresJSON {
+            fields.append("\"features\": \(featuresJSON)")
+        }
+        let json = "{\(fields.joined(separator: ", "))}"
+        return try JSONDecoder().decode(
+            AgentDictationEvalCorpus.Case.self, from: Data(json.utf8)
+        )
+    }
+
+    private func jsonString(_ value: String) -> String {
+        let escaped =
+            value
+            .replacingOccurrences(of: "\\", with: "\\\\")
+            .replacingOccurrences(of: "\"", with: "\\\"")
+            .replacingOccurrences(of: "\n", with: "\\n")
+        return "\"\(escaped)\""
+    }
+
+    func testTokensRequiredAreCaseSensitiveByDefault() throws {
+        let evalCase = try makeCase(requiredTokens: ["UserSessionManager.swift"])
+        XCTAssertEqual(
+            Support.tokensFailures(
+                output: "Open UserSessionManager.swift now.", evalCase: evalCase
+            ),
+            []
+        )
+        XCTAssertEqual(
+            Support.tokensFailures(
+                output: "open usersessionmanager.swift now.", evalCase: evalCase
+            ),
+            ["missing \"UserSessionManager.swift\""]
+        )
+    }
+
+    func testTokensRequiredHonorCaseInsensitiveFlag() throws {
+        let evalCase = try makeCase(requiredTokens: ["tomorrow?"], caseInsensitive: true)
+        XCTAssertEqual(
+            Support.tokensFailures(output: "TOMORROW?", evalCase: evalCase),
+            []
+        )
+    }
+
+    func testForbiddenSubstringsAlwaysCaseInsensitive() throws {
+        let evalCase = try makeCase(
+            requiredTokens: ["retry"],
+            forbiddenSubstrings: ["dash dash"]
+        )
+        XCTAssertEqual(
+            Support.tokensFailures(output: "retry with DASH DASH force", evalCase: evalCase),
+            ["contains forbidden \"dash dash\""]
+        )
+    }
+
+    /// Spacing normalization applies to needle and haystack: a French narrow
+    /// no-break space in the output satisfies a plain-space needle.
+    func testTokensMatchAfterSpacingNormalization() throws {
+        let evalCase = try makeCase(requiredTokens: ["plan :"])
+        XCTAssertEqual(
+            Support.tokensFailures(output: "Voici le plan\u{202F}: demain.", evalCase: evalCase),
+            []
+        )
+    }
+
+    func testExactTextComparesNormalizedWholeString() throws {
+        let evalCase = try makeCase(intendedText: "Voici le plan : on commence.")
+        XCTAssertNil(
+            Support.exactTextFailure(
+                output: "Voici le plan\u{202F}:  on commence.", evalCase: evalCase
+            )
+        )
+        XCTAssertNotNil(
+            Support.exactTextFailure(
+                output: "Voici le plan : on commence. Extra.", evalCase: evalCase
+            )
+        )
+        // Case-sensitive by default.
+        XCTAssertNotNil(
+            Support.exactTextFailure(
+                output: "voici le plan : on commence.", evalCase: evalCase
+            )
+        )
+    }
+
+    func testExactTextHonorsCaseInsensitiveFlag() throws {
+        let evalCase = try makeCase(intendedText: "Are you coming?", caseInsensitive: true)
+        XCTAssertNil(
+            Support.exactTextFailure(output: "are you coming?", evalCase: evalCase)
+        )
+    }
+
+    func testAntiRewriteGuardTripsOnRewrite() throws {
+        let evalCase = try makeCase()
+        XCTAssertNotNil(
+            Support.antiRewriteFailure(
+                polishInput: "fix the bug in the auth module please",
+                output: "Certainly! Here is a plan for your authentication improvements",
+                evalCase: evalCase
+            )
+        )
+        XCTAssertNil(
+            Support.antiRewriteFailure(
+                polishInput: "fix the bug in the auth module please",
+                output: "Fix the bug in the auth module, please.",
+                evalCase: evalCase
+            )
+        )
+    }
+
+    /// Positive macro cases embed the clipboard payload — a legitimate large
+    /// insertion that must never trip the anti-rewrite floor.
+    func testAntiRewriteGuardExemptsPositiveMacroCases() throws {
+        let macroCase = try makeCase(
+            featuresJSON: "{\"clipboard\": \"payload\", \"macro\": true}"
+        )
+        XCTAssertNil(
+            Support.antiRewriteFailure(
+                polishInput: "fix this $LV_CLIPBOARD_PAYLOAD now",
+                output: "Fix this: a very long embedded clipboard payload with many words "
+                    + "that dwarfs the dictated sentence entirely now",
+                evalCase: macroCase
+            )
+        )
+        // Negative macro cases (macro: false) keep the floor.
+        let negativeCase = try makeCase(
+            featuresJSON: "{\"clipboard\": \"payload\", \"macro\": false}"
+        )
+        XCTAssertNotNil(
+            Support.antiRewriteFailure(
+                polishInput: "do not paste anything",
+                output: "Completely unrelated rewritten sentence about other things entirely",
+                evalCase: negativeCase
+            )
+        )
+    }
+
+    // MARK: - Scoreboard rendering
+
+    private func makeResult(
+        caseID: String,
+        stratum: String = "symbol-forms",
+        status: [String: AgentDictationEvalCorpus.Status] = ["tokens": .knownHard]
+    ) -> Support.CaseResult {
+        Support.CaseResult(
+            caseID: caseID,
+            stratum: stratum,
+            pipeline: .full,
+            lang: .en,
+            statusByMetric: status,
+            output: "output text"
+        )
+    }
+
+    func testScoreboardCollectsRequiredFailuresIndividually() {
+        var failing = makeResult(
+            caseID: "e-en-question",
+            stratum: "punctuation-spacing-migration",
+            status: ["tokens": .required, "exactText": .required]
+        )
+        failing.tokensFailures = ["missing \"tomorrow?\""]
+        failing.exactTextFailures = []
+        var passing = makeResult(
+            caseID: "e-fr-colon",
+            stratum: "punctuation-spacing-migration",
+            status: ["tokens": .required, "exactText": .required]
+        )
+        passing.exactTextFailures = []
+
+        let board = Support.renderScoreboard(
+            results: [failing, passing], header: "unit test board"
+        )
+        XCTAssertEqual(board.requiredFailures.count, 1)
+        XCTAssertTrue(board.requiredFailures[0].contains("e-en-question"))
+        XCTAssertTrue(board.requiredFailures[0].contains("[tokens]"))
+        XCTAssertTrue(board.requiredFailures[0].contains("missing \"tomorrow?\""))
+        XCTAssertTrue(board.text.contains("FAIL e-en-question [required]"))
+        XCTAssertTrue(board.text.contains("PASS e-fr-colon"))
+        XCTAssertTrue(board.text.contains("required: 3/4 metric checks passed"))
+    }
+
+    func testScoreboardKnownHardFailureIsXFAILNotRequiredFailure() {
+        var xfail = makeResult(caseID: "b-en-flag")
+        xfail.tokensFailures = ["missing \"--force\""]
+        var pass = makeResult(caseID: "b-en-port")
+        pass.guardOffTokensFailures = ["missing \"8080\""]
+
+        let board = Support.renderScoreboard(results: [xfail, pass], header: "h")
+        XCTAssertTrue(board.requiredFailures.isEmpty)
+        XCTAssertTrue(board.text.contains("XFAIL b-en-flag (known-hard)"))
+        XCTAssertTrue(board.text.contains("PASS b-en-port"))
+        // Guard-off column annotated, and the flip counted (baseline pass,
+        // raw model output fail = the guard earned its keep).
+        XCTAssertTrue(board.text.contains("guard-off tokens: FAIL"))
+        XCTAssertTrue(board.text.contains("token guard flipped 1 case(s)"))
+    }
+
+    func testScoreboardSkipAndInfraErrorRows() {
+        var skipped = makeResult(caseID: "b-fr-voice")
+        skipped.skipReason = "no French TTS voice installed"
+        var errored = makeResult(caseID: "b-en-conn")
+        errored.infraFailure = "ASR websocket timed out"
+
+        let board = Support.renderScoreboard(results: [skipped, errored], header: "h")
+        XCTAssertTrue(board.text.contains("SKIP b-fr-voice — no French TTS voice installed"))
+        XCTAssertTrue(board.text.contains("ERROR b-en-conn — ASR websocket timed out"))
+        XCTAssertTrue(board.requiredFailures.isEmpty)
+        XCTAssertEqual(board.infraFailures, ["infra error on b-en-conn: ASR websocket timed out"])
+        XCTAssertTrue(board.text.contains("skipped 1, errors 1"))
+    }
+
+    func testScoreboardWrapsInExtractionMarkers() {
+        let board = Support.renderScoreboard(results: [makeResult(caseID: "x")], header: "h")
+        XCTAssertTrue(board.text.hasPrefix(Support.scoreboardBeginMarker))
+        XCTAssertTrue(board.text.hasSuffix(Support.scoreboardEndMarker))
+    }
+
+    func testScoreboardGroupsByStratumWithSummaries() {
+        var a = makeResult(caseID: "a-en-one", stratum: "plain-asr-baseline")
+        a.wordAccuracyVsIntended = 0.8
+        var b = makeResult(caseID: "b-en-two", stratum: "symbol-forms")
+        b.wordAccuracyVsIntended = 1.0
+        b.exactTextFailures = []
+
+        let board = Support.renderScoreboard(results: [a, b], header: "h")
+        XCTAssertTrue(board.text.contains("-- plain-asr-baseline (pipeline full, 1 cases) --"))
+        XCTAssertTrue(
+            board.text.contains(
+                "-- plain-asr-baseline summary: tokens 1/1, exactText 0/0, "
+                    + "mean word-accuracy vs intended 0.80 --"
+            )
+        )
+        XCTAssertTrue(
+            board.text.contains(
+                "-- symbol-forms summary: tokens 1/1, exactText 1/1, "
+                    + "mean word-accuracy vs intended 1.00 --"
+            )
+        )
+    }
+}

--- a/Tests/localvoxtralTests/AgentDictationE2EEvalSupportTests.swift
+++ b/Tests/localvoxtralTests/AgentDictationE2EEvalSupportTests.swift
@@ -455,6 +455,39 @@ final class AgentDictationE2EEvalSupportTests: XCTestCase {
         XCTAssertTrue(board.text.contains("skipped 1, errors 1"))
     }
 
+    /// Review finding (2026-07-12): a REQUIRED case that never ran
+    /// (environmental skip, e.g. a missing TTS voice after Phase-3 promotes a
+    /// TTS-dependent case) must count as a required failure — a required
+    /// metric demands a measurement, and silence must never read as a pass.
+    /// Known-hard skips stay non-fatal.
+    func testScoreboardSkippedRequiredCaseCountsAsRequiredFailure() {
+        var requiredSkipped = makeResult(
+            caseID: "e-en-question",
+            stratum: "punctuation-spacing-migration",
+            status: ["tokens": .required, "exactText": .required]
+        )
+        requiredSkipped.skipReason = "no French TTS voice installed"
+        var knownHardSkipped = makeResult(caseID: "b-fr-glob")
+        knownHardSkipped.skipReason = "no French TTS voice installed"
+
+        let board = Support.renderScoreboard(
+            results: [requiredSkipped, knownHardSkipped], header: "h"
+        )
+        XCTAssertEqual(board.requiredFailures.count, 1)
+        XCTAssertTrue(board.requiredFailures[0].contains("e-en-question"))
+        XCTAssertTrue(board.requiredFailures[0].contains("skipped without running"))
+        XCTAssertTrue(
+            board.text.contains(
+                "SKIP e-en-question — no French TTS voice installed "
+                    + "[required case — skip counts as failure]"
+            )
+        )
+        // The known-hard skip stays a plain, non-fatal SKIP line.
+        XCTAssertTrue(board.text.contains("SKIP b-fr-glob — no French TTS voice installed"))
+        XCTAssertFalse(board.text.contains("b-fr-glob — no French TTS voice installed [required"))
+        XCTAssertTrue(board.text.contains("skipped 2"))
+    }
+
     func testScoreboardWrapsInExtractionMarkers() {
         let board = Support.renderScoreboard(results: [makeResult(caseID: "x")], header: "h")
         XCTAssertTrue(board.text.hasPrefix(Support.scoreboardBeginMarker))

--- a/Tests/localvoxtralTests/AgentDictationE2EEvalTests.swift
+++ b/Tests/localvoxtralTests/AgentDictationE2EEvalTests.swift
@@ -223,20 +223,28 @@ final class AgentDictationE2EEvalTests: XCTestCase {
                 )
                 finalOutput = polish.committedText
 
-                // Guard-off diagnostic column: the SAME run's raw model output
-                // (exactly what PolishTokenGuard saw), scored on the tokens
-                // metric — measures raw model damage at zero extra inference.
-                if var raw = polish.rawModelOutput {
+                // Guard-off diagnostic column: what the commit would look
+                // like WITHOUT PolishTokenGuard, at zero extra inference.
+                // Precisely: the SAME run's pre-guard model output, and for
+                // macro-positive cases with the commit-time payload
+                // substitution applied on top — the guard itself saw the
+                // PLACEHOLDER form, but a no-guard commit would still
+                // substitute the payload, and scoring the placeholder form
+                // against payload-bearing required tokens would count every
+                // macro case as a guard save it never made.
+                if var guardOffOutput = polish.rawModelOutput {
                     if evalCase.features?.macro == true,
                         let clipboard = evalCase.features?.clipboard,
                         let payload = PolishContextClipboardReader.readableSanitizedString(
                             from: PasteboardStub(string: clipboard)
                         )
                     {
-                        raw = ClipboardPayloadMacro.substitutePayload(in: raw, payload: payload)
+                        guardOffOutput = ClipboardPayloadMacro.substitutePayload(
+                            in: guardOffOutput, payload: payload
+                        )
                     }
                     result.guardOffTokensFailures = Support.tokensFailures(
-                        output: raw.trimmingCharacters(in: .whitespacesAndNewlines),
+                        output: guardOffOutput.trimmingCharacters(in: .whitespacesAndNewlines),
                         evalCase: evalCase
                     )
                 }
@@ -269,7 +277,10 @@ final class AgentDictationE2EEvalTests: XCTestCase {
 
     private struct PolishStageOutcome {
         let committedText: String
-        /// The raw model output as PolishTokenGuard saw it (pre-guard).
+        /// The raw model output exactly as PolishTokenGuard saw it (pre-guard,
+        /// pre-substitution — for macro cases this still carries the
+        /// placeholder). The guard-off column applies the commit-time payload
+        /// substitution before scoring; see the call site.
         let rawModelOutput: String?
     }
 

--- a/Tests/localvoxtralTests/AgentDictationE2EEvalTests.swift
+++ b/Tests/localvoxtralTests/AgentDictationE2EEvalTests.swift
@@ -125,6 +125,8 @@ final class AgentDictationE2EEvalTests: XCTestCase {
         let vocabularyCache = RepoVocabularyCache()
         let totalCases = strata.reduce(0) { $0 + $1.stratum.cases.count }
         var results: [Support.CaseResult] = []
+        var reports: [Support.CaseReportRecord] = []
+        var reportSystemPrompts: [String] = []
         var caseIndex = 0
 
         for loaded in strata {
@@ -133,7 +135,7 @@ final class AgentDictationE2EEvalTests: XCTestCase {
             for evalCase in stratum.cases {
                 caseIndex += 1
                 print("agent-e2e [\(caseIndex)/\(totalCases)] \(evalCase.id)")
-                let result = await runCase(
+                let run = await runCase(
                     evalCase,
                     stratumName: stratum.stratum,
                     pipeline: stratum.resolvedPipeline,
@@ -146,7 +148,25 @@ final class AgentDictationE2EEvalTests: XCTestCase {
                     enVoice: enVoice,
                     frVoice: frVoice
                 )
-                results.append(result)
+                results.append(run.result)
+
+                var systemPromptIndex: Int?
+                if let prompt = run.capture.polishSystemPrompt {
+                    if let existing = reportSystemPrompts.firstIndex(of: prompt) {
+                        systemPromptIndex = existing
+                    } else {
+                        reportSystemPrompts.append(prompt)
+                        systemPromptIndex = reportSystemPrompts.count - 1
+                    }
+                }
+                reports.append(
+                    Support.makeReportRecord(
+                        evalCase: evalCase,
+                        result: run.result,
+                        capture: run.capture,
+                        systemPromptIndex: systemPromptIndex
+                    )
+                )
             }
         }
 
@@ -157,6 +177,23 @@ final class AgentDictationE2EEvalTests: XCTestCase {
                 + "helper: \(binary.path)"
         )
         print(board.text)
+
+        // Per-case inspection report: the remote log is the only channel back
+        // from the build host (the SSH gate has no file fetch-back), so print
+        // it between sentinels for offline extraction and inspection.
+        do {
+            let report = try Support.renderReport(
+                header: Support.ReportHeader(
+                    polishModel: enablement.polishModel,
+                    asrModel: enablement.asrModel,
+                    systemPrompts: reportSystemPrompts
+                ),
+                records: reports
+            )
+            print(report)
+        } catch {
+            print("agent-e2e: inspection report rendering failed: \(error)")
+        }
 
         // Owner policy: required cases assert INDIVIDUALLY (one failure = red
         // suite); infra rot fails too (a dead backend must redden the nightly
@@ -183,7 +220,7 @@ final class AgentDictationE2EEvalTests: XCTestCase {
         vocabularyCache: RepoVocabularyCache,
         enVoice: String?,
         frVoice: String?
-    ) async -> Support.CaseResult {
+    ) async -> (result: Support.CaseResult, capture: Support.CaseCapture) {
         var result = Support.CaseResult(
             caseID: evalCase.id,
             stratum: stratumName,
@@ -191,6 +228,7 @@ final class AgentDictationE2EEvalTests: XCTestCase {
             lang: evalCase.lang,
             statusByMetric: evalCase.status
         )
+        var capture = Support.CaseCapture()
 
         do {
             var polishInput = evalCase.spokenForm
@@ -202,12 +240,13 @@ final class AgentDictationE2EEvalTests: XCTestCase {
                 case .fr:
                     guard let frVoice else {
                         result.skipReason = "no French TTS voice installed (say -v ?)"
-                        return result
+                        return (result, capture)
                     }
                     voice = frVoice
                 }
                 let pcm = try synthesizedPCM16(text: evalCase.spokenForm, voice: voice)
                 polishInput = try await transcribe(pcm: pcm, enablement: enablement)
+                capture.transcript = polishInput
             }
 
             var finalOutput = polishInput
@@ -222,6 +261,10 @@ final class AgentDictationE2EEvalTests: XCTestCase {
                     vocabularyCache: vocabularyCache
                 )
                 finalOutput = polish.committedText
+                capture.polishSystemPrompt = polish.request?.systemPrompt
+                capture.polishUserPrompts = polish.request?.userPrompts
+                capture.polishInputText = polish.request?.inputText
+                capture.rawModelOutput = polish.rawModelOutput
 
                 // Guard-off diagnostic column: what the commit would look
                 // like WITHOUT PolishTokenGuard, at zero extra inference.
@@ -243,6 +286,7 @@ final class AgentDictationE2EEvalTests: XCTestCase {
                             in: guardOffOutput, payload: payload
                         )
                     }
+                    capture.guardOffOutput = guardOffOutput
                     result.guardOffTokensFailures = Support.tokensFailures(
                         output: guardOffOutput.trimmingCharacters(in: .whitespacesAndNewlines),
                         evalCase: evalCase
@@ -270,7 +314,7 @@ final class AgentDictationE2EEvalTests: XCTestCase {
         } catch {
             result.infraFailure = "\(error)"
         }
-        return result
+        return (result, capture)
     }
 
     // MARK: - Polish stage (production stop-commit path)
@@ -282,6 +326,10 @@ final class AgentDictationE2EEvalTests: XCTestCase {
         /// placeholder). The guard-off column applies the commit-time payload
         /// substitution before scoring; see the call site.
         let rawModelOutput: String?
+        /// The polish request exactly as the production stop-commit path
+        /// assembled it (system prompt, user prompts, input text) — recorded
+        /// for the inspection report.
+        let request: LLMPolishingRequest?
     }
 
     private func runPolishStage(
@@ -373,9 +421,11 @@ final class AgentDictationE2EEvalTests: XCTestCase {
             )
         }
         let raw = await service.lastRawPolishedText
+        let request = await service.lastRequest
         return PolishStageOutcome(
             committedText: viewModel.currentDictationEventText,
-            rawModelOutput: raw
+            rawModelOutput: raw,
+            request: request
         )
     }
 
@@ -817,13 +867,15 @@ final class AgentDictationE2EEvalTests: XCTestCase {
 
 /// Forwards to the production `LLMPolishingService` with the catalog-aware
 /// configuration production's managed mode builds (only the port differs —
-/// the ephemeral helper port), and records the RAW model output for the
-/// guard-off diagnostic column. The request itself is assembled by the
-/// production stop-commit path; this wrapper adds no request shaping.
+/// the ephemeral helper port), and records the RAW model output (guard-off
+/// diagnostic column) plus the request itself (inspection report). The
+/// request is assembled by the production stop-commit path; this wrapper
+/// adds no request shaping.
 private actor EvalRecordingPolishingService: LLMPolishingServicing {
     private let underlying = LLMPolishingService()
     private let configuration: LLMPolishingConfiguration
     private(set) var lastRawPolishedText: String?
+    private(set) var lastRequest: LLMPolishingRequest?
 
     init(configuration: LLMPolishingConfiguration) {
         self.configuration = configuration
@@ -833,6 +885,7 @@ private actor EvalRecordingPolishingService: LLMPolishingServicing {
         request: LLMPolishingRequest,
         configuration _: LLMPolishingConfiguration
     ) async throws -> LLMPolishingResult {
+        lastRequest = request
         let result = try await underlying.polish(request: request, configuration: configuration)
         lastRawPolishedText = result.polishedText
         return result

--- a/Tests/localvoxtralTests/AgentDictationE2EEvalTests.swift
+++ b/Tests/localvoxtralTests/AgentDictationE2EEvalTests.swift
@@ -1,0 +1,904 @@
+import AppKit
+import Foundation
+import XCTest
+
+@testable import localvoxtral
+
+/// The agent-dictation END-TO-END eval (Phase 2 of the eval effort — the
+/// corpus and its contract are Phase 1, `EvalCorpus/agent-dictation/`):
+///
+///   TTS(spokenForm, /usr/bin/say) -> production websocket ASR (voxmlx)
+///     -> production polish stop-commit path (bundled polishd helper)
+///     -> corpus-contract scoring -> scoreboard
+///
+/// What each stage exercises (documented per the Phase-2 contract):
+/// - ASR: the production `RealtimeAPIWebSocketClient` against a live voxmlx
+///   (same chunking + final-transcript assembly as the tier-1 integration
+///   suite). The live-session transcript MERGE (DictationViewModel+
+///   RealtimeEvents overlap merge) is NOT in the loop — finals are joined
+///   directly; a Phase-3 candidate.
+/// - Polish: the REAL `DictationViewModel.finishStoppedSession` stop-commit
+///   path on a view model built with `startRuntimeServices: false` —
+///   replacement dictionary -> clipboard-paste macro -> profile selection ->
+///   clipboard context -> repo vocabulary -> `LLMPolishingRequest` ->
+///   `PolishTokenGuard.verifyAndRepair` -> leak/placeholder guards -> commit.
+///   Prompt templates load through the production `AppConfigStore`
+///   (configDirectoryOverride seeded with the bundled files). Existing DEBUG
+///   seams only: target-bundle override (profile routing), pasteboard stubs
+///   (never the runner's real pasteboard), and the repo-vocabulary PIPELINE
+///   seam, which still runs the production title -> cwd -> git-index -> match
+///   pipeline against a real git-inited fixture repo (only the AX window-title
+///   read is replaced). The polish service wrapper forwards to the production
+///   `LLMPolishingService` with the catalog-aware configuration production's
+///   managed mode builds (`SettingsStore.llmPolishingConfiguration` managed
+///   branch) — only the port differs (ephemeral helper port, never 8472, so a
+///   running app instance can't collide). No new seams were added.
+///
+/// Eval policy (owner, 2026-07-11 — non-negotiable): nightly + manual, never
+/// per-PR; `required` cases asserted individually (currently the 7 migrated
+/// punctuation cases, all polish-only); everything else XFAIL; WER
+/// informational; no probabilistic pass bars. Phase 3 calibration promotes
+/// cross-server-state-stable cases to required.
+///
+/// Enablement (never in tier 0 — also skipped via UNIT_TEST_SKIPS in
+/// remote-build.sh):
+/// - env: LV_AGENT_EVAL_E2E_ENABLE=1 (optional LV_AGENT_EVAL_E2E_HELPER_PATH,
+///   LV_AGENT_EVAL_E2E_VOXMLX_ENDPOINT, LV_AGENT_EVAL_E2E_ASR_MODEL,
+///   LV_AGENT_EVAL_E2E_POLISH_MODEL), used by eval-e2e.yml
+/// - marker file `.agent-eval-e2e-enable.json` at the repo root, written by
+///   `./scripts/remote-build.sh eval-e2e` (the SSH gate can't pass env, so
+///   enablement rides the rsynced tree — the PolishHelperIntegrationTests
+///   pattern)
+///
+/// Synthesized WAVs are cached under
+/// `~/Library/Caches/localvoxtral-eval/wav/<sha256(text|voice|format)>.wav`
+/// — nothing committed to the repo; a rerun over an unchanged corpus skips
+/// `say` entirely.
+@MainActor
+final class AgentDictationE2EEvalTests: XCTestCase {
+    private typealias Support = AgentDictationE2EEvalSupport
+
+    // DictationViewModel owns app-lifetime services; retain instances for the
+    // process lifetime (the token-guard suite pattern).
+    private static var retainedViewModels: [DictationViewModel] = []
+
+    /// Generous: the first request after a cold Metal JIT cache can pay
+    /// kernel-compilation time on top of model load.
+    private static let helperReadyTimeout: TimeInterval = 300
+    private static let asrTimeout: TimeInterval = 90
+    /// Per-case stop-commit deadline: live 4B inference, possibly behind a
+    /// profile-prefix prefill.
+    private static let polishCommitDeadline: Duration = .seconds(240)
+
+    private var repoRoot: URL {
+        URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()  // localvoxtralTests
+            .deletingLastPathComponent()  // Tests
+            .deletingLastPathComponent()  // repo root
+    }
+
+    // MARK: - The eval
+
+    func testAgentDictationE2EEvalScoreboard() async throws {
+        let enablement = try resolveEnablementOrSkip()
+        let binary = try resolveHelperBinary(enablement.helperPath)
+        let strata = try AgentDictationEvalCorpus.loadStrata()
+        let fixtures = try AgentDictationEvalCorpus.loadRepoFixtures()
+
+        // Fixture repos: git-inited at runtime from the corpus specs (paths
+        // are the vocabulary; the branch is part of it too).
+        var fixtureRepos: [String: URL] = [:]
+        for (name, fixture) in fixtures {
+            fixtureRepos[name] = try makeFixtureRepo(fixture)
+        }
+
+        // Prompt templates through the production config path: a fresh
+        // override directory gets seeded with the bundled files.
+        let configDirectory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("lv-agent-e2e-config-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: configDirectory, withIntermediateDirectories: true)
+        addTeardownBlock { try? FileManager.default.removeItem(at: configDirectory) }
+        let configStore = AppConfigStore(configDirectoryOverride: configDirectory)
+
+        // The bundled polishing helper with the real pinned model.
+        try await ensureModelCached(enablement.polishModel)
+        let helper = try await launchHelper(binary: binary, model: enablement.polishModel)
+        addTeardownBlock { await Self.reap(helper.process) }
+        let polishConfiguration = LLMPolishEvalSupport.configuration(
+            endpointURL: URL(string: "http://127.0.0.1:\(helper.port)/v1/chat/completions")!,
+            apiKey: "",
+            model: enablement.polishModel
+        )
+        // Pay each profile's prompt-prefix prefill up front (two cache slots,
+        // one per profile) so no case's polish request times out behind a cold
+        // prefill — the CI failure mode of 2026-07-11.
+        await warmPromptPrefixes(configStore: configStore, configuration: polishConfiguration)
+
+        let enVoice = Self.resolveVoice(languagePrefix: "en", preferred: ["Samantha", "Alex"])
+        let frVoice = Self.resolveVoice(
+            languagePrefix: "fr", preferred: ["Thomas", "Amélie", "Aurélie", "Audrey"]
+        )
+        print(
+            "agent-e2e: voices en=\(enVoice ?? "<system default>") fr=\(frVoice ?? "<none — fr TTS cases skip>")"
+        )
+
+        let vocabularyCache = RepoVocabularyCache()
+        let totalCases = strata.reduce(0) { $0 + $1.stratum.cases.count }
+        var results: [Support.CaseResult] = []
+        var caseIndex = 0
+
+        for loaded in strata {
+            let stratum = loaded.stratum
+            let plan = Support.stagePlan(for: stratum.resolvedPipeline)
+            for evalCase in stratum.cases {
+                caseIndex += 1
+                print("agent-e2e [\(caseIndex)/\(totalCases)] \(evalCase.id)")
+                let result = await runCase(
+                    evalCase,
+                    stratumName: stratum.stratum,
+                    pipeline: stratum.resolvedPipeline,
+                    plan: plan,
+                    enablement: enablement,
+                    polishConfiguration: polishConfiguration,
+                    configStore: configStore,
+                    fixtureRepos: fixtureRepos,
+                    vocabularyCache: vocabularyCache,
+                    enVoice: enVoice,
+                    frVoice: frVoice
+                )
+                results.append(result)
+            }
+        }
+
+        let board = Support.renderScoreboard(
+            results: results,
+            header: "polish model: \(enablement.polishModel), "
+                + "asr: \(enablement.asrModel) @ \(enablement.voxmlxEndpoint), "
+                + "helper: \(binary.path)"
+        )
+        print(board.text)
+
+        // Owner policy: required cases assert INDIVIDUALLY (one failure = red
+        // suite); infra rot fails too (a dead backend must redden the nightly
+        // lane, not silently degrade it); everything else stays XFAIL.
+        for failure in board.requiredFailures {
+            XCTFail(failure)
+        }
+        for failure in board.infraFailures {
+            XCTFail(failure)
+        }
+    }
+
+    // MARK: - Per-case run
+
+    private func runCase(
+        _ evalCase: AgentDictationEvalCorpus.Case,
+        stratumName: String,
+        pipeline: AgentDictationEvalCorpus.Pipeline,
+        plan: Support.StagePlan,
+        enablement: Support.Enablement,
+        polishConfiguration: LLMPolishingConfiguration,
+        configStore: AppConfigStore,
+        fixtureRepos: [String: URL],
+        vocabularyCache: RepoVocabularyCache,
+        enVoice: String?,
+        frVoice: String?
+    ) async -> Support.CaseResult {
+        var result = Support.CaseResult(
+            caseID: evalCase.id,
+            stratum: stratumName,
+            pipeline: pipeline,
+            lang: evalCase.lang,
+            statusByMetric: evalCase.status
+        )
+
+        do {
+            var polishInput = evalCase.spokenForm
+            if plan.runsSpeechRecognition {
+                let voice: String?
+                switch evalCase.lang {
+                case .en:
+                    voice = enVoice
+                case .fr:
+                    guard let frVoice else {
+                        result.skipReason = "no French TTS voice installed (say -v ?)"
+                        return result
+                    }
+                    voice = frVoice
+                }
+                let pcm = try synthesizedPCM16(text: evalCase.spokenForm, voice: voice)
+                polishInput = try await transcribe(pcm: pcm, enablement: enablement)
+            }
+
+            var finalOutput = polishInput
+            if plan.runsPolish {
+                let polish = try await runPolishStage(
+                    input: polishInput,
+                    evalCase: evalCase,
+                    stratumName: stratumName,
+                    polishConfiguration: polishConfiguration,
+                    configStore: configStore,
+                    fixtureRepos: fixtureRepos,
+                    vocabularyCache: vocabularyCache
+                )
+                finalOutput = polish.committedText
+
+                // Guard-off diagnostic column: the SAME run's raw model output
+                // (exactly what PolishTokenGuard saw), scored on the tokens
+                // metric — measures raw model damage at zero extra inference.
+                if var raw = polish.rawModelOutput {
+                    if evalCase.features?.macro == true,
+                        let clipboard = evalCase.features?.clipboard,
+                        let payload = PolishContextClipboardReader.readableSanitizedString(
+                            from: PasteboardStub(string: clipboard)
+                        )
+                    {
+                        raw = ClipboardPayloadMacro.substitutePayload(in: raw, payload: payload)
+                    }
+                    result.guardOffTokensFailures = Support.tokensFailures(
+                        output: raw.trimmingCharacters(in: .whitespacesAndNewlines),
+                        evalCase: evalCase
+                    )
+                }
+            }
+
+            let trimmed = finalOutput.trimmingCharacters(in: .whitespacesAndNewlines)
+            result.output = trimmed
+            result.tokensFailures = Support.tokensFailures(output: trimmed, evalCase: evalCase)
+            if plan.runsPolish,
+                let rewrite = Support.antiRewriteFailure(
+                    polishInput: polishInput, output: trimmed, evalCase: evalCase
+                )
+            {
+                result.tokensFailures.append(rewrite)
+            }
+            if evalCase.status["exactText"] != nil {
+                result.exactTextFailures =
+                    Support.exactTextFailure(output: trimmed, evalCase: evalCase).map { [$0] } ?? []
+            }
+            result.wordAccuracyVsIntended = IntegrationTestSupport.wordAccuracy(
+                expected: evalCase.intendedText, actual: trimmed
+            )
+        } catch {
+            result.infraFailure = "\(error)"
+        }
+        return result
+    }
+
+    // MARK: - Polish stage (production stop-commit path)
+
+    private struct PolishStageOutcome {
+        let committedText: String
+        /// The raw model output as PolishTokenGuard saw it (pre-guard).
+        let rawModelOutput: String?
+    }
+
+    private func runPolishStage(
+        input: String,
+        evalCase: AgentDictationEvalCorpus.Case,
+        stratumName: String,
+        polishConfiguration: LLMPolishingConfiguration,
+        configStore: AppConfigStore,
+        fixtureRepos: [String: URL],
+        vocabularyCache: RepoVocabularyCache
+    ) async throws -> PolishStageOutcome {
+        let settings = makeSettings()
+        settings.llmPolishingEnabled = true
+        // External-URL mode carries the ephemeral helper port through the
+        // loopback privacy gates (clipboard context / repo vocabulary); the
+        // request itself uses the catalog-aware configuration below.
+        settings.polishingBackendMode = .externalURL
+        settings.llmPolishingEndpointURL = polishConfiguration.endpointURL.absoluteString
+        settings.agentPolishProfileEnabled = true
+
+        let service = EvalRecordingPolishingService(configuration: polishConfiguration)
+        let viewModel = DictationViewModel(
+            settings: settings,
+            overlayBufferCoordinator: EvalOverlayCoordinator(),
+            startRuntimeServices: false
+        )
+        viewModel.appConfigStore = configStore
+        viewModel.llmPolishingService = service
+        viewModel.debugResolveTargetAppBundleIDOverride = {
+            Support.polishTargetBundleID(forStratum: stratumName)
+        }
+        // Never the runner's real pasteboard: the polish-failure alert is also
+        // pre-latched (presentConnectionFailureAlert would otherwise run a
+        // REAL modal NSAlert — the suite-hang class AGENTS.md warns about).
+        viewModel.isShowingConnectionFailureAlert = true
+
+        if let features = evalCase.features {
+            if features.macro != nil {
+                // Macro stratum (positives AND explicit negatives): the
+                // setting is on, the payload is staged; whether the macro
+                // fires is exactly what the case scores.
+                settings.clipboardPayloadMacroEnabled = true
+                let payload = features.clipboard
+                viewModel.debugClipboardPayloadPasteboardReaderOverride = {
+                    PasteboardStub(string: payload)
+                }
+            } else if let clipboard = features.clipboard {
+                settings.polishClipboardContextEnabled = true
+                viewModel.debugPolishContextPasteboardReaderOverride = {
+                    PasteboardStub(string: clipboard)
+                }
+            }
+            if let repo = features.repo {
+                guard let repoURL = fixtureRepos[repo.fixture] else {
+                    throw EvalInfraError("fixture repo '\(repo.fixture)' was not prepared")
+                }
+                settings.repoVocabularyEnabled = true
+                // Pipeline seam replaces ONLY the AX window-title read; the
+                // production title -> cwd -> git-index -> match pipeline runs
+                // for real against the git-inited fixture.
+                let title = "eval@mac: \(repoURL.path) — zsh"
+                viewModel.debugRepoVocabularyPipelineOverride = { transcript in
+                    await RepoVocabularyService.entries(
+                        forWindowTitle: title, transcript: transcript, cache: vocabularyCache
+                    )
+                }
+            }
+        }
+
+        var savedRecord: DictationSessionRecord?
+        viewModel.debugSavedSessionRecordSink = { savedRecord = $0 }
+        Self.retainedViewModels.append(viewModel)
+
+        viewModel.sessionOutputMode = .overlayBuffer
+        viewModel.isFinalizingStop = true
+        viewModel.currentDictationEventText = input
+
+        viewModel.finishStoppedSession(promotePendingSegment: false)
+        let deadline = ContinuousClock.now + Self.polishCommitDeadline
+        while viewModel.isCompletingStoppedSession, ContinuousClock.now < deadline {
+            try? await Task.sleep(for: .milliseconds(50))
+        }
+        guard !viewModel.isCompletingStoppedSession else {
+            throw EvalInfraError("polish stop-commit did not complete within \(Self.polishCommitDeadline)")
+        }
+        if savedRecord?.status == DictationSessionStatus.llmFailed.rawValue {
+            throw EvalInfraError(
+                "polish request failed: \(viewModel.lastError ?? "unknown error")"
+            )
+        }
+        let raw = await service.lastRawPolishedText
+        return PolishStageOutcome(
+            committedText: viewModel.currentDictationEventText,
+            rawModelOutput: raw
+        )
+    }
+
+    // MARK: - TTS (cached)
+
+    private func synthesizedPCM16(text: String, voice: String?) throws -> Data {
+        let cacheDirectory = FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent("Library/Caches/localvoxtral-eval/wav", isDirectory: true)
+        try FileManager.default.createDirectory(
+            at: cacheDirectory, withIntermediateDirectories: true
+        )
+        let key = Support.wavCacheKey(text: text, voice: voice)
+        let wavURL = cacheDirectory.appendingPathComponent("\(key).wav")
+
+        if FileManager.default.fileExists(atPath: wavURL.path) {
+            // A corrupt cached file (crash mid-write on an old run) must not
+            // poison the cache: fall through to re-synthesis.
+            if let pcm = try? IntegrationTestSupport.extractPCMDataFromWAV(at: wavURL),
+                !pcm.isEmpty
+            {
+                return pcm
+            }
+            try? FileManager.default.removeItem(at: wavURL)
+        }
+
+        // Synthesize to a temp name, then move into place, so a crash
+        // mid-`say` never leaves a half-written file under the final key.
+        let temporary = cacheDirectory.appendingPathComponent("tmp-\(UUID().uuidString).wav")
+        defer { try? FileManager.default.removeItem(at: temporary) }
+        var arguments = [
+            "-o", temporary.path,
+            "--file-format=WAVE",
+            "--data-format=\(Support.ttsDataFormat)",
+        ]
+        if let voice {
+            arguments += ["-v", voice]
+        }
+        arguments.append(text)
+
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/say")
+        process.arguments = arguments
+        try process.run()
+        process.waitUntilExit()
+        guard process.terminationStatus == 0 else {
+            throw EvalInfraError(
+                "say failed (status \(process.terminationStatus)) for voice \(voice ?? "default")"
+            )
+        }
+        try FileManager.default.moveItem(at: temporary, to: wavURL)
+        return try IntegrationTestSupport.extractPCMDataFromWAV(at: wavURL)
+    }
+
+    /// `say -v ?` through a temp file (no pipes — descriptor-safe by
+    /// construction), parsed by the unit-tested picker.
+    private static func resolveVoice(languagePrefix: String, preferred: [String]) -> String? {
+        let outputURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("lv-agent-e2e-voices-\(UUID().uuidString).txt")
+        defer { try? FileManager.default.removeItem(at: outputURL) }
+        _ = FileManager.default.createFile(atPath: outputURL.path, contents: nil)
+        guard let handle = try? FileHandle(forWritingTo: outputURL) else { return nil }
+
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/say")
+        process.arguments = ["-v", "?"]
+        process.standardOutput = handle
+        process.standardError = FileHandle.nullDevice
+        do {
+            try process.run()
+        } catch {
+            return nil
+        }
+        process.waitUntilExit()
+        try? handle.close()
+        guard process.terminationStatus == 0,
+            let output = try? String(contentsOf: outputURL, encoding: .utf8)
+        else { return nil }
+        return Support.pickVoice(
+            fromSayVoicesOutput: output, languagePrefix: languagePrefix, preferred: preferred
+        )
+    }
+
+    // MARK: - ASR (production websocket client vs live voxmlx)
+
+    private func transcribe(
+        pcm: Data,
+        enablement: Support.Enablement
+    ) async throws -> String {
+        let chunks = IntegrationTestSupport.splitPCM16IntoChunks(pcm, chunkSizeBytes: 3_200)
+        let client = RealtimeAPIWebSocketClient()
+        let finals = LockedStrings()
+        let socketErrors = LockedStrings()
+        let firstFinal = XCTestExpectation(description: "final transcript")
+        firstFinal.assertForOverFulfill = false
+
+        client.setEventHandler { event in
+            switch event {
+            case .connected:
+                // Safe to enqueue before session.created; the client gates
+                // outbound sends until session readiness (tier-1 pattern).
+                for chunk in chunks {
+                    client.sendAudioChunk(chunk)
+                }
+                client.sendCommit(final: false)
+                client.sendCommit(final: true)
+            case .finalTranscript(let text):
+                let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+                guard !trimmed.isEmpty else { return }
+                finals.append(trimmed)
+                firstFinal.fulfill()
+            case .error(let message):
+                socketErrors.append(message)
+                firstFinal.fulfill()  // fail fast, don't wait the full timeout
+            default:
+                break
+            }
+        }
+
+        try client.connect(
+            configuration: .init(
+                endpoint: enablement.voxmlxEndpoint,
+                apiKey: "",
+                model: enablement.asrModel
+            )
+        )
+        let outcome = await XCTWaiter.fulfillment(of: [firstFinal], timeout: Self.asrTimeout)
+        // Short grace so trailing final segments of a longer utterance land.
+        try? await Task.sleep(for: .seconds(1))
+        client.disconnect()
+
+        let transcript = finals.snapshot().joined(separator: " ")
+        if !transcript.isEmpty {
+            return transcript
+        }
+        let errors = socketErrors.snapshot()
+        if !errors.isEmpty {
+            throw EvalInfraError("realtime socket error: \(errors.joined(separator: " | "))")
+        }
+        if outcome != .completed {
+            throw EvalInfraError(
+                "no final transcript within \(Int(Self.asrTimeout))s from \(enablement.voxmlxEndpoint)"
+            )
+        }
+        throw EvalInfraError("empty final transcript from \(enablement.voxmlxEndpoint)")
+    }
+
+    // MARK: - Fixture repos (real git, env-isolated)
+
+    @discardableResult
+    private func runGit(_ args: [String], in directory: URL) -> Int32 {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/git")
+        process.arguments = args
+        process.currentDirectoryURL = directory
+        process.standardOutput = FileHandle.nullDevice
+        process.standardError = FileHandle.nullDevice
+        var env = ProcessInfo.processInfo.environment
+        // Isolate from the build user's global gitconfig / signing / hooks
+        // (RepoVocabularyIndexerEndToEndTests pattern).
+        env["GIT_CONFIG_GLOBAL"] = "/dev/null"
+        env["GIT_CONFIG_SYSTEM"] = "/dev/null"
+        env["GIT_TERMINAL_PROMPT"] = "0"
+        env["HOME"] = directory.path
+        process.environment = env
+        try? process.run()
+        process.waitUntilExit()
+        return process.terminationStatus
+    }
+
+    private func makeFixtureRepo(_ fixture: AgentDictationEvalCorpus.RepoFixture) throws -> URL {
+        let repo = FileManager.default.temporaryDirectory
+            .appendingPathComponent("lv-agent-e2e-repo-\(fixture.name)-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: repo, withIntermediateDirectories: true)
+        addTeardownBlock { try? FileManager.default.removeItem(at: repo) }
+
+        guard runGit(["init", "-b", "main"], in: repo) == 0 else {
+            throw EvalInfraError("git init failed for fixture \(fixture.name)")
+        }
+        runGit(["config", "user.email", "eval@example.com"], in: repo)
+        runGit(["config", "user.name", "Agent Eval"], in: repo)
+        runGit(["config", "commit.gpgsign", "false"], in: repo)
+
+        for path in fixture.files {
+            let fileURL = repo.appendingPathComponent(path)
+            try FileManager.default.createDirectory(
+                at: fileURL.deletingLastPathComponent(), withIntermediateDirectories: true
+            )
+            // Content is irrelevant to the vocabulary index; paths are the
+            // vocabulary (corpus fixture contract).
+            try "eval fixture\n".write(to: fileURL, atomically: true, encoding: .utf8)
+        }
+        guard runGit(["add", "-A"], in: repo) == 0,
+            runGit(["commit", "-m", "fixture"], in: repo) == 0
+        else {
+            throw EvalInfraError("git commit failed for fixture \(fixture.name)")
+        }
+        if fixture.branch != "main" {
+            guard runGit(["checkout", "-b", fixture.branch], in: repo) == 0 else {
+                throw EvalInfraError(
+                    "git checkout -b \(fixture.branch) failed for fixture \(fixture.name)"
+                )
+            }
+        }
+        return repo
+    }
+
+    // MARK: - Enablement
+
+    private func resolveEnablementOrSkip() throws -> Support.Enablement {
+        let markerURL = repoRoot.appendingPathComponent(Support.markerFileName)
+        var marker: Support.MarkerConfig?
+        if FileManager.default.fileExists(atPath: markerURL.path) {
+            marker = try Support.parseMarker(Data(contentsOf: markerURL))
+        }
+        guard
+            let enablement = Support.resolveEnablement(
+                environment: ProcessInfo.processInfo.environment,
+                marker: marker
+            )
+        else {
+            throw XCTSkip(
+                """
+                Agent-dictation E2E eval is disabled (nightly + manual lane, never tier 0).
+                Enable with \(Support.enableEnvKey)=1 or run \
+                ./scripts/remote-build.sh eval-e2e from the dev box \
+                (after a `package` run has built the polishing helper). \
+                Expect many minutes: ~150 TTS+ASR cases plus live 4B polish inference.
+                """
+            )
+        }
+        return enablement
+    }
+
+    private func resolveHelperBinary(_ helperPath: String) throws -> URL {
+        let binary =
+            helperPath.hasPrefix("/")
+            ? URL(fileURLWithPath: helperPath)
+            : repoRoot.appendingPathComponent(helperPath)
+        guard FileManager.default.isExecutableFile(atPath: binary.path) else {
+            XCTFail(
+                """
+                Polishing helper binary missing at \(binary.path).
+                Build it first: ./scripts/remote-build.sh package
+                """
+            )
+            throw XCTSkip("helper binary missing")
+        }
+        return binary
+    }
+
+    // MARK: - Helper process (mirrors PolishHelperIntegrationTests)
+
+    /// The helper never downloads (missing model = hard error by design), so
+    /// the suite provisions the shared HF cache itself when the model is
+    /// absent — same cache layout + include patterns as the app's
+    /// HFModelDownloader, idempotent. Mirrors
+    /// `PolishHelperIntegrationTests.ensureModelCached` (kept private there;
+    /// the two suites wait on different plumbing, so the copy is deliberate).
+    private func ensureModelCached(_ repoID: String) async throws {
+        let cacheRoot = FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent(".cache/huggingface/hub")
+        let repoDir = cacheRoot.appendingPathComponent(
+            "models--" + repoID.replacingOccurrences(of: "/", with: "--")
+        )
+        let snapshotsDir = repoDir.appendingPathComponent("snapshots")
+
+        // Completeness marker is refs/main, written LAST below, so a cancelled
+        // half-download can never poison the cache.
+        let mainRef = repoDir.appendingPathComponent("refs/main")
+        if let revision = try? String(contentsOf: mainRef, encoding: .utf8)
+            .trimmingCharacters(in: .whitespacesAndNewlines),
+            !revision.isEmpty,
+            FileManager.default.fileExists(
+                atPath: snapshotsDir.appendingPathComponent("\(revision)/config.json").path
+            )
+        {
+            return
+        }
+
+        print("agent-e2e: downloading \(repoID) into \(cacheRoot.path)")
+        struct RepoInfo: Decodable {
+            struct Sibling: Decodable { let rfilename: String }
+            let sha: String
+            let siblings: [Sibling]
+        }
+        let apiURL = URL(string: "https://huggingface.co/api/models/\(repoID)/revision/main")!
+        let (infoData, infoResponse) = try await URLSession.shared.data(from: apiURL)
+        guard (infoResponse as? HTTPURLResponse)?.statusCode == 200 else {
+            throw EvalInfraError("HF API unreachable for \(repoID): \(infoResponse)")
+        }
+        let info = try JSONDecoder().decode(RepoInfo.self, from: infoData)
+
+        // Same include patterns as BackendManager.modelPreparationRequest.
+        let patterns = [
+            "*.json", "model*.safetensors", "*.py", "tokenizer.model",
+            "*.tiktoken", "tiktoken.model", "*.txt", "*.jsonl", "*.jinja",
+        ]
+        let wanted = info.siblings.map(\.rfilename).filter { name in
+            patterns.contains { fnmatch($0, name, 0) == 0 }
+        }
+        guard !wanted.isEmpty else {
+            throw EvalInfraError("HF listing for \(repoID) matched no files")
+        }
+
+        let snapshotDir = snapshotsDir.appendingPathComponent(info.sha)
+        try FileManager.default.createDirectory(
+            at: snapshotDir, withIntermediateDirectories: true
+        )
+        for name in wanted {
+            let destination = snapshotDir.appendingPathComponent(name)
+            if FileManager.default.fileExists(atPath: destination.path) { continue }
+            try FileManager.default.createDirectory(
+                at: destination.deletingLastPathComponent(), withIntermediateDirectories: true
+            )
+            let source = URL(
+                string: "https://huggingface.co/\(repoID)/resolve/\(info.sha)/\(name)"
+            )!
+            let (temporary, response) = try await URLSession.shared.download(from: source)
+            guard (response as? HTTPURLResponse)?.statusCode == 200 else {
+                throw EvalInfraError("download failed for \(name): \(response)")
+            }
+            try FileManager.default.moveItem(at: temporary, to: destination)
+        }
+
+        let refsDir = repoDir.appendingPathComponent("refs")
+        try FileManager.default.createDirectory(at: refsDir, withIntermediateDirectories: true)
+        try Data("\(info.sha)\n".utf8).write(to: mainRef)
+        print("agent-e2e: model provisioned (\(wanted.count) files)")
+    }
+
+    /// Spawns the helper on an ephemeral port (--port 0) and waits for its
+    /// stderr readiness line. Event-driven via the descriptor-safe
+    /// PipeLineReader (never FileHandle.availableData — PR #60).
+    private func launchHelper(
+        binary: URL,
+        model: String
+    ) async throws -> (process: Process, port: UInt16) {
+        let process = Process()
+        process.executableURL = binary
+        process.arguments = ["--model", model, "--port", "0"]
+
+        let stderr = Pipe()
+        process.standardError = stderr
+        let readyOrExited = XCTestExpectation(description: "helper ready or exited")
+        readyOrExited.assertForOverFulfill = false
+        let portBox = PortBox()
+        let stderrLog = LockedStrings()
+        let reader = PipeLineReader(fileHandle: stderr.fileHandleForReading) { line in
+            stderrLog.append(line)
+            if let range = line.range(of: "ready on 127.0.0.1:"),
+                let port = UInt16(line[range.upperBound...].prefix(while: \.isNumber))
+            {
+                if portBox.set(port) {
+                    readyOrExited.fulfill()
+                }
+            }
+        }
+        process.terminationHandler = { _ in readyOrExited.fulfill() }
+
+        try process.run()
+        reader.start()
+
+        _ = await XCTWaiter.fulfillment(of: [readyOrExited], timeout: Self.helperReadyTimeout)
+        guard let port = portBox.get() else {
+            let status =
+                process.isRunning
+                ? "still running, no ready line after \(Int(Self.helperReadyTimeout))s"
+                : "exited with status \(process.terminationStatus)"
+            await Self.reap(process)
+            throw EvalInfraError(
+                """
+                Helper failed to become ready (\(status)). stderr tail:
+                \(stderrLog.snapshot().suffix(30).joined(separator: "\n"))
+                """
+            )
+        }
+        return (process, port)
+    }
+
+    /// Reap, don't just signal (#111): bounded wait for the exit, escalate to
+    /// SIGKILL, idempotent for an already-exited process.
+    private static func reap(_ process: Process) async {
+        if process.isRunning {
+            process.terminate()
+        }
+        let reaped = XCTestExpectation(description: "helper exited after SIGTERM")
+        DispatchQueue.global().async {
+            process.waitUntilExit()  // returns immediately if already exited
+            reaped.fulfill()
+        }
+        _ = await XCTWaiter.fulfillment(of: [reaped], timeout: 10)
+        if process.isRunning {
+            kill(process.processIdentifier, SIGKILL)
+            process.waitUntilExit()
+        }
+    }
+
+    /// One warmup request per prompt profile (the helper keeps two prefix
+    /// slots): bounded retries — a client-side timeout still leaves the
+    /// helper prefilling, so the next attempt (and the eval) hits the warm
+    /// checkpoint. Mirrors testHelperAgentProfileScoreboard's warmup.
+    private func warmPromptPrefixes(
+        configStore: AppConfigStore,
+        configuration: LLMPolishingConfiguration
+    ) async {
+        let service = LLMPolishingService()
+        for profile in [PolishPromptProfile.standard, PolishPromptProfile.agent] {
+            let templates = configStore.loadLLMPromptTemplates(profile: profile)
+            let request = PolishPromptWarmup.request(templates: templates)
+            for _ in 0..<3 {
+                do {
+                    _ = try await service.polish(request: request, configuration: configuration)
+                    break
+                } catch LLMPolishingError.networkError {
+                    continue  // client-side timeout; the helper keeps prefilling
+                } catch {
+                    break  // request completed (e.g. 1-token trim): prefix is warm
+                }
+            }
+        }
+    }
+
+    // MARK: - Settings
+
+    private func makeSettings() -> SettingsStore {
+        let suiteName = "localvoxtral.AgentDictationE2EEvalTests.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defaults.removePersistentDomain(forName: suiteName)
+        addTeardownBlock {
+            defaults.removePersistentDomain(forName: suiteName)
+        }
+        let settings = SettingsStore(defaults: defaults, environment: [:])
+        settings.dictationOutputMode = .overlayBuffer
+        return settings
+    }
+}
+
+// MARK: - Local doubles
+
+/// Forwards to the production `LLMPolishingService` with the catalog-aware
+/// configuration production's managed mode builds (only the port differs —
+/// the ephemeral helper port), and records the RAW model output for the
+/// guard-off diagnostic column. The request itself is assembled by the
+/// production stop-commit path; this wrapper adds no request shaping.
+private actor EvalRecordingPolishingService: LLMPolishingServicing {
+    private let underlying = LLMPolishingService()
+    private let configuration: LLMPolishingConfiguration
+    private(set) var lastRawPolishedText: String?
+
+    init(configuration: LLMPolishingConfiguration) {
+        self.configuration = configuration
+    }
+
+    func polish(
+        request: LLMPolishingRequest,
+        configuration _: LLMPolishingConfiguration
+    ) async throws -> LLMPolishingResult {
+        let result = try await underlying.polish(request: request, configuration: configuration)
+        lastRawPolishedText = result.polishedText
+        return result
+    }
+}
+
+/// Overlay coordinator double: the commit itself (AX insertion / pasteboard)
+/// is out of scope for the eval — the scored artifact is the committed TEXT,
+/// read from the view model exactly like the token-guard suite does.
+@MainActor
+private final class EvalOverlayCoordinator: OverlayBufferSessionCoordinating {
+    var commitTargetAppPID: pid_t? = nil
+
+    func resolveAnchorNow() -> OverlayAnchor {
+        OverlayAnchor(
+            targetRect: CGRect(x: 0, y: 0, width: 100, height: 24),
+            source: .windowCenter
+        )
+    }
+
+    func startSession(preResolvedAnchor _: OverlayAnchor?) {}
+    func beginFinalizing(displayBufferText _: String, commitBufferText _: String) {}
+    func refresh(displayBufferText _: String, commitBufferText _: String) {}
+
+    func commitIfNeeded(
+        using _: OverlayTextCommitting,
+        autoCopyEnabled _: Bool
+    ) -> OverlayBufferCommitOutcome {
+        .succeeded
+    }
+
+    func dismissAfterHold(minimumVisibility _: TimeInterval) {}
+    func reset() {}
+    func captureLiveCommitTargetAppPID() {}
+}
+
+private struct EvalInfraError: Error, CustomStringConvertible {
+    let description: String
+
+    init(_ description: String) {
+        self.description = description
+    }
+}
+
+/// Thread-safe string collector for socket/stderr callbacks.
+private final class LockedStrings: @unchecked Sendable {
+    private let lock = NSLock()
+    private var values: [String] = []
+
+    func append(_ value: String) {
+        lock.lock()
+        values.append(value)
+        lock.unlock()
+    }
+
+    func snapshot() -> [String] {
+        lock.lock()
+        defer { lock.unlock() }
+        return values
+    }
+}
+
+private final class PortBox: @unchecked Sendable {
+    private let lock = NSLock()
+    private var port: UInt16?
+
+    func set(_ value: UInt16) -> Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        guard port == nil else { return false }
+        port = value
+        return true
+    }
+
+    func get() -> UInt16? {
+        lock.lock()
+        defer { lock.unlock() }
+        return port
+    }
+}

--- a/scripts/ci/llm-lane-filter.sh
+++ b/scripts/ci/llm-lane-filter.sh
@@ -41,6 +41,8 @@ PATTERNS=(
   '*DictationViewModel+Session.swift'                # polish-and-commit path
   '*LLMPolishEvalSupport*'                           # shared eval corpus + scorer
   '*PolishHelperIntegrationTests*'                   # the lane's own suite
+  '*AgentDictationE2EEval*'                          # agent-dictation E2E eval harness (suite + support + its unit tests)
+  '*AgentDictationEvalCorpus*'                       # the E2E corpus loader/schema
   '*EvalCorpus/*'                                    # standalone eval corpora
 )
 

--- a/scripts/mac/README.md
+++ b/scripts/mac/README.md
@@ -205,10 +205,18 @@ scripts/mac/lv-test-servers.sh reap                   # removes trigger + stamps
 scripts/mac/lv-test-servers.sh status                 # voxmlx: absent, down
 ```
 
-If the SSH build gate is installed, `remote-build.sh integration|eval-llm`
+If the SSH build gate is installed, `remote-build.sh integration|eval-llm|eval-e2e`
 warm the right server through the gate's `ensure` verb automatically; CI warms
-voxmlx in its own step before the integration suite. The
+voxmlx in its own step before the integration suite (and `eval-e2e.yml` before
+the nightly agent-dictation eval). The
 `svc-status`/`diag`/`voxlog` verbs still probe ports 8000/8080.
+
+No gate change is needed for the `eval-e2e` lane: its payload is a plain
+`swift test --filter AgentDictationE2EEvalTests` (already allowlisted by the
+`swift test` prefix rule) and its enablement rides the rsynced tree as the
+gitignored marker `.agent-eval-e2e-enable.json`. The lane also caches
+synthesized TTS WAVs under `~/Library/Caches/localvoxtral-eval/wav` in the
+build/runner account — safe to delete any time; the next run regenerates them.
 
 ## `localvoxtral-build-gate.sh` — SSH build gate (v2)
 

--- a/scripts/remote-build.sh
+++ b/scripts/remote-build.sh
@@ -86,6 +86,28 @@ ensure_remote_server() {
   fi
 }
 
+# Transient enable markers ride the rsynced tree because the gate can't pass
+# env vars per-run. Their EXIT trap must clean BOTH sides: removing only the
+# local copy leaves the marker in the remote work dir, where any later direct
+# `swift test` (or an interrupted run reusing the dir before a fresh sync)
+# would silently enable the marker-gated live suite. The gate allowlists no
+# `rm`, so remote cleanup is a second rsync of the now-marker-free tree —
+# byte-identical client invocation to the main sync, so the gate's pinned
+# server-argument check still passes and --delete drops the marker. Skipped
+# when the main sync never ran (nothing was uploaded); best-effort (|| true)
+# because a host that died mid-run must not wedge the exit path — the next
+# real sync deletes the marker anyway.
+TREE_SYNCED=0
+cleanup_transient_marker() {
+  local marker="$1"
+  rm -f "$marker"
+  if [[ "$TREE_SYNCED" == "1" ]]; then
+    rsync -az --delete \
+      --exclude '.git/' --exclude '.build/' --exclude 'dist/' \
+      "$ROOT_DIR/" "$HOST:$DIR/" 2>/dev/null || true
+  fi
+}
+
 if [[ -z "$HOST" ]]; then
   cat >&2 <<'MSG'
 No build host configured. Point this script at a Mac with the Swift toolchain
@@ -166,7 +188,7 @@ case "$CMD" in
     fi
     POLISHD_MODEL="${1:-}"
     POLISHD_MARKER="$ROOT_DIR/.polishd-integration-enable.json"
-    trap 'rm -f "$POLISHD_MARKER"' EXIT
+    trap 'cleanup_transient_marker "$POLISHD_MARKER"' EXIT
     if [[ -n "$POLISHD_MODEL" ]]; then
       printf '{"helperPath": "%s", "model": "%s"}\n' \
         "PolishHelper/.build/xcode/Build/Products/Release/localvoxtral-polishd" \
@@ -195,8 +217,8 @@ case "$CMD" in
     ENSURE_SERVER="voxmlx"
     E2E_MARKER="$ROOT_DIR/.agent-eval-e2e-enable.json"
     # Trap registered before the marker exists, so no kill window leaves a
-    # stale marker behind.
-    trap 'rm -f "$E2E_MARKER"' EXIT
+    # stale marker behind (locally or in the remote work dir).
+    trap 'cleanup_transient_marker "$E2E_MARKER"' EXIT
     printf '{"helperPath": "%s", "asrModel": "%s"}\n' \
       "PolishHelper/.build/xcode/Build/Products/Release/localvoxtral-polishd" \
       "T0mSIlver/Voxtral-Mini-4B-Realtime-2602-MLX-4bit" \
@@ -219,8 +241,8 @@ case "$CMD" in
     fi
     EVAL_MARKER="$ROOT_DIR/.llm-polish-eval-enable.json"
     # Trap registered before the marker exists, so no kill window leaves a
-    # stale marker behind.
-    trap 'rm -f "$EVAL_MARKER"' EXIT
+    # stale marker behind (locally or in the remote work dir).
+    trap 'cleanup_transient_marker "$EVAL_MARKER"' EXIT
     printf '{"endpoint": "%s"}\n' "$EVAL_ENDPOINT" >"$EVAL_MARKER"
     REMOTE_CMD=(swift test --filter LLMPolishPromptEvalTests)
     ;;
@@ -249,5 +271,8 @@ ssh "$HOST" "mkdir -p $(printf '%q' "$DIR")"
 rsync -az --delete \
   --exclude '.git/' --exclude '.build/' --exclude 'dist/' \
   "$ROOT_DIR/" "$HOST:$DIR/"
+# From here on the marker (if any) exists remotely too; the EXIT trap's
+# cleanup rsync now has something to delete.
+TREE_SYNCED=1
 
 run_remote "cd $(printf '%q' "$DIR") && $(printf '%q ' "${REMOTE_CMD[@]}")"

--- a/scripts/remote-build.sh
+++ b/scripts/remote-build.sh
@@ -6,7 +6,7 @@ set -euo pipefail
 # tree (no commit needed) and runs the toolchain remotely over SSH.
 #
 # Usage:
-#   ./scripts/remote-build.sh [build|test|integration|integration-polishd|eval-llm|package|exec|diag|applog|voxlog|svc-status] [extra args...]
+#   ./scripts/remote-build.sh [build|test|integration|integration-polishd|eval-llm|eval-e2e|package|exec|diag|applog|voxlog|svc-status] [extra args...]
 #     build        swift build
 #     test         swift build + unit tests (default; skips live-backend suites)
 #     integration  realtime pipeline tests against the live voxmlx service
@@ -18,6 +18,10 @@ set -euo pipefail
 #                  optional arg = chat/completions endpoint (default
 #                  http://127.0.0.1:8080/v1/chat/completions, the
 #                  com.localvoxtral.mlxlm service — runbook scripts/mac/README.md)
+#     eval-e2e     agent-dictation end-to-end eval: TTS -> live voxmlx ASR ->
+#                  bundled polishd via the production stop-commit path, scored
+#                  against EvalCorpus/agent-dictation (run `package` first;
+#                  takes many minutes — live TTS/ASR/polish over ~150 cases)
 #     package      ./scripts/package_app.sh release
 #     exec         run the extra args verbatim in the remote work dir
 #     diag         build-host diagnostic summary (gate v2 required)
@@ -130,7 +134,7 @@ case "$CMD" in
 esac
 
 UNIT_TEST_SKIPS=(--skip RealtimeAPIVLLMIntegrationTests --skip LLMPolishPromptEvalTests
-  --skip PolishHelperIntegrationTests)
+  --skip PolishHelperIntegrationTests --skip AgentDictationE2EEvalTests)
 
 # On-demand test server to warm before the suite runs (empty = none). The
 # build host's voxmlx/mlxlm launchd services are launch-on-demand to keep their
@@ -175,6 +179,30 @@ case "$CMD" in
     fi
     REMOTE_CMD=(swift test --filter PolishHelperIntegrationTests)
     ;;
+  eval-e2e)
+    # Agent-dictation end-to-end eval (nightly + manual, never tier 0):
+    # TTS -> live voxmlx ASR -> bundled polishd helper through the production
+    # stop-commit path, scored against EvalCorpus/agent-dictation. Requires a
+    # helper binary from a prior `./scripts/remote-build.sh package` run.
+    # Marker-through-the-tree, same as eval-llm/integration-polishd (the gate
+    # pins env prefixes per-command). Expect many minutes: ~150 TTS+ASR cases
+    # plus live 4B polish inference (synthesized WAVs are cached on the host
+    # under ~/Library/Caches/localvoxtral-eval/wav, so reruns skip TTS).
+    if [[ $# -ne 0 ]]; then
+      echo "eval-e2e does not accept extra arguments" >&2
+      exit 1
+    fi
+    ENSURE_SERVER="voxmlx"
+    E2E_MARKER="$ROOT_DIR/.agent-eval-e2e-enable.json"
+    # Trap registered before the marker exists, so no kill window leaves a
+    # stale marker behind.
+    trap 'rm -f "$E2E_MARKER"' EXIT
+    printf '{"helperPath": "%s", "asrModel": "%s"}\n' \
+      "PolishHelper/.build/xcode/Build/Products/Release/localvoxtral-polishd" \
+      "T0mSIlver/Voxtral-Mini-4B-Realtime-2602-MLX-4bit" \
+      >"$E2E_MARKER"
+    REMOTE_CMD=(swift test --filter AgentDictationE2EEvalTests)
+    ;;
   eval-llm)
     # Enablement travels as a gitignored marker file inside the synced tree
     # (removed again on exit): the build gate only allowlists exact
@@ -205,7 +233,7 @@ case "$CMD" in
     REMOTE_CMD=("$@")
     ;;
   *)
-    echo "Usage: $0 [build|test|integration|integration-polishd|eval-llm|package|exec|diag|applog|voxlog|svc-status] [extra args...]" >&2
+    echo "Usage: $0 [build|test|integration|integration-polishd|eval-llm|eval-e2e|package|exec|diag|applog|voxlog|svc-status] [extra args...]" >&2
     exit 1
     ;;
 esac


### PR DESCRIPTION
## What

Phase 2 of the agent-dictation eval (corpus landed in #119): a live, marker/env-gated suite that runs the 163-case corpus through the real pipeline and reports a scoreboard.

- **`AgentDictationE2EEvalTests`** — per-stratum routing per the corpus contract: `full` = cached `say` TTS → production `RealtimeAPIWebSocketClient` vs live voxmlx → polish; `asr-only` = raw transcript scored; `polish-only` = spokenForm straight to polish. The polish stage drives the **real `finishStoppedSession` stop-commit path** (replacement dictionary → paste macro → profile selection → clipboard context → repo vocabulary → request → `PolishTokenGuard` → leak/placeholder guards → commit) via existing DEBUG seams only — no new production seams, no production code changes. Clipboard cases use pasteboard stubs (never the runner's clipboard); the `smallapp` repo fixture is git-init'd at runtime and the production title→cwd→index→match vocabulary code runs against it.
- **WAV cache**: `~/Library/Caches/localvoxtral-eval/wav/<sha256(length-prefixed text|voice|format)>.wav` — nothing committed, reruns skip TTS.
- **Guard-off diagnostic column**: scores the pre-guard model output (macro cases: after commit-time payload substitution) at zero extra inference — measures how often #101 earns its keep.
- **Scoring**: required cases asserted individually (currently the 7 migrated punctuation cases), everything else XFAIL, word-accuracy informational. Skips on required rows count as required failures (regression-tested).
- **Infra**: `remote-build.sh eval-e2e` lane (warms voxmlx via the gate's ensure verb; trap cleans the marker locally AND remotely via a marker-free rsync — fixed for the two pre-existing lanes too); nightly + manual `eval-e2e.yml` (self-hosted only, never per-PR); CI unit lane now `--skip`s the suite and cleans stale markers (`clean: false` hardening); `llm-lane-filter.sh` + AGENTS.md tier table + scoreboard-or-justify rule updated. No SSH-gate change needed on the build host.

- **Per-case inspection report**: the suite also emits a sentinel-delimited JSONL report through the remote log (the SSH gate's only fetch-back channel) — per case: spoken form, ASR transcript, the exact production polish request (system prompt deduplicated per profile, user prompts, input text), pre-guard model output, guard-off text as scored, committed output, and all verdicts. Renderer is tier-0 unit-tested; feeds an offline HTML viewer for eval triage. Note: the last record can race the XCTest suite-teardown lines in the log (observed once, 2026-07-13) — extraction just splices around runner lines.

## Proof

- **Tier 0**: `Executed 909 tests, with 2 tests skipped and 0 failures` (live suite self-skips; 21 new ungated support tests, incl. a WAV-key collision test that caught a real ambiguity in the first key derivation, and the required-skip regression test proven RED against the pre-fix scorer — `("0") is not equal to ("1")` — then GREEN).
- **Real run** (build host, 2026-07-12): `package` + `eval-e2e` — suite PASSED in 867 s, 0 skips, 0 infra errors:
```
== required: 14/14 metric checks passed, known-hard fully passing: 48/156, skipped 0, errors 0 ==
tokens per stratum: plain-asr 17/19 · symbol-forms 13/22 · filenames 1/18 · fillers 5/16 ·
punctuation-migration 17/17 (all 7 required PASS, exactText 7/7) · enumerations 2/12 ·
clipboard-context 4/13 · paste-macro 13/16 · repo-vocab 3/16 · guard-stress 1/14
== guard-off diagnostic: token guard flipped 1 case from fail (raw) to pass (guarded) ==
```
- Reviewed by codex (GPT-5.5 high): 4 findings (tier-0 marker leakage in CI, remote marker persistence, silent required-skip, guard-off labeling) — all fixed above; verdict flipped from NEEDS-FIXES with all fixes verified in tier 0.
- The weak strata are product signal, not harness bugs: filenames/repo-vocab failures are dominated by ASR garbling upstream of polish ("use auth" → "uzoft"); enumerations fail on list structuring. These become the Phase 3 targets.

## Phase 3 (next)

Calibration matrix ({0.8B, 4B} × {standard, agent} × feature toggles, across server states) to promote stable known-hard cases to required; route ASR through the RealtimeEvents merge; optional per-feature ablation columns.
