### PR TITLE
Existing installs adopt updated bundled config defaults (fixes the #126 known limitation)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -295,6 +295,10 @@ Key subsystems:
   `StatusPopoverView.statusDetailView` line-limits as a backstop — keep it.
 - Hand-testing builds: see "Hand-testing & field debugging" above — use
   try-pr.sh and the stable signing identity, don't reinvent manual steps.
+- Bundled config TOMLs (`Sources/localvoxtral/Resources/Config`): any content
+  change must append the new file's SHA-256 to `BundledConfigDefaultHistory`
+  (keep the old hashes — they let existing installs auto-adopt the new
+  default). A tier-0 test fails with the exact hash to paste if you forget.
 - Backend/lifecycle code paths log their requests, completions, and failures
   (`Log.backends`) — a silent failure path is how the ensureReady
   single-flight bug cost an hour of remote probing. Keep new paths loud.

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ Open **Settings** from the menu bar popover:
 - **Text Processing** — exact-match replacements, plus the LLM Polishing switch and its agent-dictation features (agent prompt profile, repo vocabulary, clipboard context, spoken clipboard paste)
 - **About** — version, link to this repository, and Export Diagnostics (writes a redacted local report to the Desktop)
 
-The shared config folder at `~/Library/Application Support/localvoxtral/config` holds `replacement_dictionary.toml`, the LLM prompt TOMLs (including the agent variants), and `terminal_apps.toml`. When an update ships improved defaults, files you haven't edited are refreshed automatically; files you have edited are never touched without asking — the app offers to update them and keeps your versions as `.backup` files alongside.
+The config folder at `~/Library/Application Support/localvoxtral/config` holds `replacement_dictionary.toml`, the LLM prompt TOMLs (including the agent variants), and `terminal_apps.toml`. When an update ships improved defaults, files you haven't edited are refreshed automatically; files you have edited are never touched without asking — the app offers to update them and keeps your versions as `.backup` files alongside.
 
 ## Under the hood
 

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ Open **Settings** from the menu bar popover:
 - **Text Processing** — exact-match replacements, plus the LLM Polishing switch and its agent-dictation features (agent prompt profile, repo vocabulary, clipboard context, spoken clipboard paste)
 - **About** — version, link to this repository, and Export Diagnostics (writes a redacted local report to the Desktop)
 
-The shared config folder at `~/Library/Application Support/localvoxtral/config` holds `replacement_dictionary.toml`, the LLM prompt TOMLs (including the agent variants), and `terminal_apps.toml`.
+The shared config folder at `~/Library/Application Support/localvoxtral/config` holds `replacement_dictionary.toml`, the LLM prompt TOMLs (including the agent variants), and `terminal_apps.toml`. When an update ships improved defaults, files you haven't edited are refreshed automatically; files you have edited are never touched without asking — the app offers to update them and keeps your versions as `.backup` files alongside.
 
 ## Under the hood
 

--- a/Sources/localvoxtral/AppConfigStore.swift
+++ b/Sources/localvoxtral/AppConfigStore.swift
@@ -953,6 +953,11 @@ extension AppConfigStore {
         }
 
         for file in ConfigFile.allCases {
+            // The replacement dictionary is the user's own rule set, not a
+            // tunable default — its format has never changed since shipping,
+            // and "updating" it would only swap the user's rules for the
+            // bundled samples. Never refresh it, never prompt for it.
+            if file == .replacementDictionary { continue }
             guard let bundled = bundledConfigData(for: file) else { continue }
             if state.resolvedBundledHashes[file.fileName] == bundled.hash { continue }
             let userURL = directory.appendingPathComponent(file.fileName, isDirectory: false)

--- a/Sources/localvoxtral/AppConfigStore.swift
+++ b/Sources/localvoxtral/AppConfigStore.swift
@@ -1,3 +1,4 @@
+import CryptoKit
 import Foundation
 
 /// Which polishing prompt profile to load. `standard` is the general STT
@@ -401,15 +402,24 @@ struct AppConfigStore: AppConfigServing {
     private let fileManager: FileManager
     private let bundle: Bundle
     private let configDirectoryOverride: URL?
+    /// Seams for `reconcileBundledDefaults()`: tests inject a fixed clock for
+    /// deterministic backup names and a custom hash table to simulate old
+    /// shipped defaults without carrying their full content.
+    private let knownDefaultHashes: [String: Set<String>]
+    private let now: @Sendable () -> Date
 
     init(
         fileManager: FileManager = .default,
         bundle: Bundle = .localvoxtralResources,
-        configDirectoryOverride: URL? = nil
+        configDirectoryOverride: URL? = nil,
+        knownDefaultHashes: [String: Set<String>] = BundledConfigDefaultHistory.knownDefaultHashes,
+        now: @escaping @Sendable () -> Date = { Date() }
     ) {
         self.fileManager = fileManager
         self.bundle = bundle
         self.configDirectoryOverride = configDirectoryOverride
+        self.knownDefaultHashes = knownDefaultHashes
+        self.now = now
     }
 
     func configDirectoryURL() -> URL {
@@ -899,6 +909,190 @@ struct AppConfigStore: AppConfigServing {
         }
 
         return content
+    }
+}
+
+// MARK: - Bundled defaults reconciliation
+
+/// `ensureConfigFilesExist` seeds bundled config files only when absent, so an
+/// existing install never picks up improved bundled defaults on its own. This
+/// extension closes that gap at launch: a user file whose content matches ANY
+/// default ever shipped (`BundledConfigDefaultHistory`) is an unedited stale
+/// seed and is refreshed in place; anything else is a customization and is
+/// only ever replaced through `adoptBundledDefaults` after the user agrees.
+/// A hidden sidecar in the config directory remembers which bundled version a
+/// "keep mine" decision applied to, so the user is asked once per default
+/// change, not once per launch.
+extension AppConfigStore {
+    private static let defaultsStateFileName = ".bundled-defaults-state.json"
+
+    private struct BundledDefaultsState: Codable {
+        /// fileName → bundled-default hash the user has already resolved
+        /// (adopted or declined). A prompt is due only when the current
+        /// bundled hash differs from this entry.
+        var resolvedBundledHashes: [String: String] = [:]
+    }
+
+    func reconcileBundledDefaults() -> BundledDefaultsReconciliation {
+        let directory = resolvedConfigDirectoryURL()
+        ensureConfigFilesExist(at: directory)
+
+        var result = BundledDefaultsReconciliation()
+        var state = readBundledDefaultsState(in: directory)
+        var stateChanged = false
+
+        for file in ConfigFile.allCases {
+            guard let bundled = bundledConfigData(for: file) else { continue }
+            let userURL = directory.appendingPathComponent(file.fileName, isDirectory: false)
+            guard let userData = try? Data(contentsOf: userURL) else { continue }
+
+            let userHash = Self.sha256Hex(userData)
+            if userHash == bundled.hash {
+                // In sync — drop any stale decision so a future default
+                // change prompts again.
+                if state.resolvedBundledHashes.removeValue(forKey: file.fileName) != nil {
+                    stateChanged = true
+                }
+                continue
+            }
+
+            if knownDefaultHashes[file.fileName, default: []].contains(userHash) {
+                do {
+                    try bundled.data.write(to: userURL, options: .atomic)
+                    result.refreshedFileNames.append(file.fileName)
+                    if state.resolvedBundledHashes.removeValue(forKey: file.fileName) != nil {
+                        stateChanged = true
+                    }
+                    Log.config.notice(
+                        "Refreshed unedited default \(file.fileName, privacy: .public) to the current bundled version"
+                    )
+                } catch {
+                    Log.config.error(
+                        "Failed to refresh stale default \(file.fileName, privacy: .public): \(error.localizedDescription, privacy: .public)"
+                    )
+                }
+                continue
+            }
+
+            if state.resolvedBundledHashes[file.fileName] == bundled.hash { continue }
+            result.customizedOutdatedFileNames.append(file.fileName)
+        }
+
+        if stateChanged {
+            writeBundledDefaultsState(state, in: directory)
+        }
+        return result
+    }
+
+    /// Replaces the named user config files with the current bundled defaults,
+    /// saving each existing file alongside as `<name>.backup-<timestamp>`.
+    /// Returns the backup file names that were created.
+    func adoptBundledDefaults(fileNames: [String]) -> [String] {
+        let directory = resolvedConfigDirectoryURL()
+        var state = readBundledDefaultsState(in: directory)
+        var stateChanged = false
+        var backupNames: [String] = []
+        let suffix = backupSuffix()
+
+        for file in ConfigFile.allCases where fileNames.contains(file.fileName) {
+            guard let bundled = bundledConfigData(for: file) else { continue }
+            let userURL = directory.appendingPathComponent(file.fileName, isDirectory: false)
+
+            do {
+                if fileManager.fileExists(atPath: userURL.path) {
+                    let backupName = "\(file.fileName).backup-\(suffix)"
+                    let backupURL = directory.appendingPathComponent(backupName, isDirectory: false)
+                    try? fileManager.removeItem(at: backupURL)
+                    try fileManager.copyItem(at: userURL, to: backupURL)
+                    backupNames.append(backupName)
+                }
+                try bundled.data.write(to: userURL, options: .atomic)
+                if state.resolvedBundledHashes.removeValue(forKey: file.fileName) != nil {
+                    stateChanged = true
+                }
+                Log.config.notice(
+                    "Adopted new bundled default for \(file.fileName, privacy: .public)"
+                )
+            } catch {
+                Log.config.error(
+                    "Failed to adopt bundled default for \(file.fileName, privacy: .public): \(error.localizedDescription, privacy: .public)"
+                )
+            }
+        }
+
+        if stateChanged {
+            writeBundledDefaultsState(state, in: directory)
+        }
+        return backupNames
+    }
+
+    /// Records that the user chose to keep their customized versions of the
+    /// named files for the CURRENTLY bundled defaults — no further prompt
+    /// until the bundled defaults change again.
+    func recordKeptCustomizedDefaults(fileNames: [String]) {
+        let directory = resolvedConfigDirectoryURL()
+        var state = readBundledDefaultsState(in: directory)
+        var stateChanged = false
+
+        for file in ConfigFile.allCases where fileNames.contains(file.fileName) {
+            guard let bundled = bundledConfigData(for: file) else { continue }
+            if state.resolvedBundledHashes[file.fileName] != bundled.hash {
+                state.resolvedBundledHashes[file.fileName] = bundled.hash
+                stateChanged = true
+            }
+        }
+
+        if stateChanged {
+            writeBundledDefaultsState(state, in: directory)
+        }
+    }
+
+    private func bundledConfigData(for file: ConfigFile) -> (data: Data, hash: String)? {
+        guard let url = bundledResourceURL(for: file),
+              let data = try? Data(contentsOf: url)
+        else { return nil }
+        return (data, Self.sha256Hex(data))
+    }
+
+    private func readBundledDefaultsState(in directory: URL) -> BundledDefaultsState {
+        let url = directory.appendingPathComponent(Self.defaultsStateFileName, isDirectory: false)
+        guard let data = try? Data(contentsOf: url),
+              let state = try? JSONDecoder().decode(BundledDefaultsState.self, from: data)
+        else {
+            return BundledDefaultsState()
+        }
+        return state
+    }
+
+    private func writeBundledDefaultsState(_ state: BundledDefaultsState, in directory: URL) {
+        let url = directory.appendingPathComponent(Self.defaultsStateFileName, isDirectory: false)
+        do {
+            let encoder = JSONEncoder()
+            encoder.outputFormatting = [.sortedKeys]
+            try encoder.encode(state).write(to: url, options: .atomic)
+        } catch {
+            Log.config.error(
+                "Failed to persist bundled-defaults state: \(error.localizedDescription, privacy: .public)"
+            )
+        }
+    }
+
+    private func backupSuffix() -> String {
+        let components = Calendar(identifier: .gregorian)
+            .dateComponents(in: TimeZone.current, from: now())
+        return String(
+            format: "%04d%02d%02d-%02d%02d%02d",
+            components.year ?? 0,
+            components.month ?? 0,
+            components.day ?? 0,
+            components.hour ?? 0,
+            components.minute ?? 0,
+            components.second ?? 0
+        )
+    }
+
+    static func sha256Hex(_ data: Data) -> String {
+        SHA256.hash(data: data).map { String(format: "%02x", $0) }.joined()
     }
 }
 

--- a/Sources/localvoxtral/AppConfigStore.swift
+++ b/Sources/localvoxtral/AppConfigStore.swift
@@ -927,9 +927,13 @@ extension AppConfigStore {
     private static let defaultsStateFileName = ".bundled-defaults-state.json"
 
     private struct BundledDefaultsState: Codable {
-        /// fileName → bundled-default hash the user has already resolved
-        /// (adopted or declined). A prompt is due only when the current
-        /// bundled hash differs from this entry.
+        /// fileName → bundled-default hash that has already been handled for
+        /// that file (seen in sync, silently refreshed to, adopted, or
+        /// declined). A file is reconsidered only when the current bundled
+        /// hash differs from this entry — which is also what lets a user
+        /// deliberately restore an OLD shipped default: the restore happens
+        /// after the current default was recorded as handled, so it sticks
+        /// instead of being silently re-refreshed on every launch.
         var resolvedBundledHashes: [String: String] = [:]
     }
 
@@ -941,18 +945,22 @@ extension AppConfigStore {
         var state = readBundledDefaultsState(in: directory)
         var stateChanged = false
 
+        func markResolved(_ file: ConfigFile, hash: String) {
+            if state.resolvedBundledHashes[file.fileName] != hash {
+                state.resolvedBundledHashes[file.fileName] = hash
+                stateChanged = true
+            }
+        }
+
         for file in ConfigFile.allCases {
             guard let bundled = bundledConfigData(for: file) else { continue }
+            if state.resolvedBundledHashes[file.fileName] == bundled.hash { continue }
             let userURL = directory.appendingPathComponent(file.fileName, isDirectory: false)
             guard let userData = try? Data(contentsOf: userURL) else { continue }
 
             let userHash = Self.sha256Hex(userData)
             if userHash == bundled.hash {
-                // In sync — drop any stale decision so a future default
-                // change prompts again.
-                if state.resolvedBundledHashes.removeValue(forKey: file.fileName) != nil {
-                    stateChanged = true
-                }
+                markResolved(file, hash: bundled.hash)
                 continue
             }
 
@@ -960,9 +968,7 @@ extension AppConfigStore {
                 do {
                     try bundled.data.write(to: userURL, options: .atomic)
                     result.refreshedFileNames.append(file.fileName)
-                    if state.resolvedBundledHashes.removeValue(forKey: file.fileName) != nil {
-                        stateChanged = true
-                    }
+                    markResolved(file, hash: bundled.hash)
                     Log.config.notice(
                         "Refreshed unedited default \(file.fileName, privacy: .public) to the current bundled version"
                     )
@@ -974,7 +980,6 @@ extension AppConfigStore {
                 continue
             }
 
-            if state.resolvedBundledHashes[file.fileName] == bundled.hash { continue }
             result.customizedOutdatedFileNames.append(file.fileName)
         }
 
@@ -999,15 +1004,21 @@ extension AppConfigStore {
             let userURL = directory.appendingPathComponent(file.fileName, isDirectory: false)
 
             do {
+                var backupName: String?
                 if fileManager.fileExists(atPath: userURL.path) {
-                    let backupName = "\(file.fileName).backup-\(suffix)"
-                    let backupURL = directory.appendingPathComponent(backupName, isDirectory: false)
-                    try? fileManager.removeItem(at: backupURL)
-                    try fileManager.copyItem(at: userURL, to: backupURL)
-                    backupNames.append(backupName)
+                    let name = availableBackupName(for: file.fileName, suffix: suffix, in: directory)
+                    try fileManager.copyItem(
+                        at: userURL,
+                        to: directory.appendingPathComponent(name, isDirectory: false)
+                    )
+                    backupName = name
                 }
                 try bundled.data.write(to: userURL, options: .atomic)
-                if state.resolvedBundledHashes.removeValue(forKey: file.fileName) != nil {
+                if let backupName {
+                    backupNames.append(backupName)
+                }
+                if state.resolvedBundledHashes[file.fileName] != bundled.hash {
+                    state.resolvedBundledHashes[file.fileName] = bundled.hash
                     stateChanged = true
                 }
                 Log.config.notice(
@@ -1045,6 +1056,26 @@ extension AppConfigStore {
         if stateChanged {
             writeBundledDefaultsState(state, in: directory)
         }
+    }
+
+    /// First `<fileName>.backup-<suffix>` name (with a `.2`, `.3`, … tiebreak)
+    /// that doesn't already exist, so repeated adoptions never destroy an
+    /// earlier backup.
+    private func availableBackupName(
+        for fileName: String,
+        suffix: String,
+        in directory: URL
+    ) -> String {
+        let base = "\(fileName).backup-\(suffix)"
+        var candidate = base
+        var counter = 2
+        while fileManager.fileExists(
+            atPath: directory.appendingPathComponent(candidate, isDirectory: false).path
+        ) {
+            candidate = "\(base).\(counter)"
+            counter += 1
+        }
+        return candidate
     }
 
     private func bundledConfigData(for file: ConfigFile) -> (data: Data, hash: String)? {
@@ -1094,6 +1125,15 @@ extension AppConfigStore {
     static func sha256Hex(_ data: Data) -> String {
         SHA256.hash(data: data).map { String(format: "%02x", $0) }.joined()
     }
+
+    #if DEBUG
+    /// Test seam: the canonical config file list, so the
+    /// `BundledConfigDefaultHistory` guard-rail test can't drift from the
+    /// private `ConfigFile` enum when a new config file is added.
+    static var debugAllConfigFileNames: [String] {
+        ConfigFile.allCases.map(\.fileName)
+    }
+    #endif
 }
 
 private func uncommented(_ line: String) -> String {

--- a/Sources/localvoxtral/BundledConfigDefaultHistory.swift
+++ b/Sources/localvoxtral/BundledConfigDefaultHistory.swift
@@ -12,7 +12,7 @@ import Foundation
 /// When you change a TOML under `Sources/localvoxtral/Resources/Config`, ADD
 /// the new content's hash here and KEEP the old ones — the old entries are
 /// what lets existing installs adopt your change.
-/// `AppConfigStoreTests.testCurrentBundledDefaultsAreRegisteredInHistory`
+/// `AppConfigDefaultsReconcileTests.testCurrentBundledDefaultsAreRegisteredInHistory`
 /// fails with the exact hash to paste if you forget.
 enum BundledConfigDefaultHistory {
     static let knownDefaultHashes: [String: Set<String>] = [

--- a/Sources/localvoxtral/BundledConfigDefaultHistory.swift
+++ b/Sources/localvoxtral/BundledConfigDefaultHistory.swift
@@ -1,0 +1,66 @@
+import Foundation
+
+/// SHA-256 (hex) of every version of each bundled default config file ever
+/// shipped on main, keyed by file name.
+///
+/// `AppConfigStore.reconcileBundledDefaults()` uses this to tell an UNEDITED
+/// stale seed (its hash is listed here, so replacing it loses nothing) from a
+/// user-customized file (unknown hash — never overwritten without asking).
+/// A hash missing from this list degrades safely: the file is treated as
+/// customized and the user is prompted instead of silently refreshed.
+///
+/// When you change a TOML under `Sources/localvoxtral/Resources/Config`, ADD
+/// the new content's hash here and KEEP the old ones — the old entries are
+/// what lets existing installs adopt your change.
+/// `AppConfigStoreTests.testCurrentBundledDefaultsAreRegisteredInHistory`
+/// fails with the exact hash to paste if you forget.
+enum BundledConfigDefaultHistory {
+    static let knownDefaultHashes: [String: Set<String>] = [
+        "llm_system_prompt.toml": [
+            // 2026-07-12 prompt trim (#126)
+            "6255e385bcc265e7948b9b9be263fac5a193510dfcd7385d544ec9889547cef6",
+            // 2026-07-07 punctuation-spacing focus (#80)
+            "31dbd825f037d73aa54e8b49bc103fa3d023cfd0c458c82bafa65ce68b512675",
+            // 2026-03-14 v0.6.0 initial (#14)
+            "6736867bb539f20e241812c45399198dc86b4c87488ddc50458348c2558ace69",
+        ],
+        "llm_user_prompt.toml": [
+            // 2026-07-12 prompt trim (#126)
+            "06c1b26b7708748d07392f85ddce1a7a9a8da97c7a69a01c550c41648f9d5bd7",
+            // 2026-07-07 punctuation-spacing focus (#80)
+            "d53ce4d91c98249861cf3177c9f7431b83661e31d09603e2f5ef1331680e046f",
+            // 2026-03-14 v0.6.0 initial (#14)
+            "43ededf94739fe2a1d5ccfb7c99bcefc438afc30737c974cd9d284826bbbb771",
+        ],
+        "llm_system_prompt_agent.toml": [
+            // 2026-07-12 prompt trim (#126)
+            "e3c586e3cf1a7ba2d30fe693f2e0213b63f97e4e62dabb915ae1dc90298d0a8c",
+            // 2026-07-12 agent profile introduction (#113)
+            "8150e32ae3868e19554707e7b7b76fb979c1311306339d8dae1308cd7cf84cb5",
+        ],
+        "llm_user_prompt_agent.toml": [
+            // 2026-07-12 prompt trim (#126)
+            "0041927e3aed8fd87d0e0f8033b24faf22fc0a685b86740a9c2f8e063da04134",
+            // 2026-07-12 agent profile introduction (#113)
+            "283f547c020da4da1ea2fa62873752bd3561f10830b590023dadd26f854b04fa",
+        ],
+        "replacement_dictionary.toml": [
+            // 2026-03-14 v0.6.0 initial (#14)
+            "6a03d1fb6fc480aeac2d71a48ec4426cb6f4c07f1fd166e30b52f6b456288e38",
+        ],
+        "terminal_apps.toml": [
+            // 2026-07-08 terminal-safe live dictation (#82)
+            "f0fbb2b09c20274b88ec4a868d2e3faa2389ef678fd4504b84f089d09f936426",
+        ],
+    ]
+}
+
+/// Outcome of `AppConfigStore.reconcileBundledDefaults()`.
+struct BundledDefaultsReconciliation: Equatable, Sendable {
+    /// Files whose on-disk content was an unedited older default; they were
+    /// silently replaced with the current bundled default.
+    var refreshedFileNames: [String] = []
+    /// Files the user customized while this build ships a newer default, with
+    /// no decision recorded for that default yet. The caller should prompt.
+    var customizedOutdatedFileNames: [String] = []
+}

--- a/Sources/localvoxtral/localvoxtralApp.swift
+++ b/Sources/localvoxtral/localvoxtralApp.swift
@@ -123,6 +123,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     let settingsNavigator = SettingsNavigator()
 
     private var onboardingController: OnboardingWindowController?
+    private let appConfigStore = AppConfigStore()
+    /// Customized-but-outdated config files awaiting the user's
+    /// update-or-keep decision; held here while onboarding is on screen.
+    private var pendingConfigDefaultsPromptFileNames: [String]?
 
     override init() {
         let settings = SettingsStore()
@@ -151,24 +155,30 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
     /// Brings existing installs up to date with this build's bundled config
     /// defaults: unedited stale seeds are refreshed silently; customized files
-    /// are never touched without asking. Fresh installs are always in sync, so
-    /// the alert can never stack on top of first-launch onboarding.
+    /// are never touched without asking. When onboarding is still due (a
+    /// pre-onboarding install upgrading, or a wizard never finished), the
+    /// prompt is held until the wizard closes so the modal never stacks on
+    /// top of it.
     private func reconcileBundledConfigDefaults() {
-        let store = AppConfigStore()
-        let outcome = store.reconcileBundledDefaults()
+        let outcome = appConfigStore.reconcileBundledDefaults()
         guard !outcome.customizedOutdatedFileNames.isEmpty else { return }
+        pendingConfigDefaultsPromptFileNames = outcome.customizedOutdatedFileNames
+        guard settingsStore.onboardingCompleted else { return }
 
         // Defer past launch so the alert never blocks
         // applicationDidFinishLaunching.
         Task { @MainActor in
-            self.promptToUpdateCustomizedConfigFiles(
-                store: store,
-                fileNames: outcome.customizedOutdatedFileNames
-            )
+            self.presentPendingConfigDefaultsPromptIfNeeded()
         }
     }
 
-    private func promptToUpdateCustomizedConfigFiles(store: AppConfigStore, fileNames: [String]) {
+    private func presentPendingConfigDefaultsPromptIfNeeded() {
+        guard let fileNames = pendingConfigDefaultsPromptFileNames else { return }
+        pendingConfigDefaultsPromptFileNames = nil
+        promptToUpdateCustomizedConfigFiles(fileNames: fileNames)
+    }
+
+    private func promptToUpdateCustomizedConfigFiles(fileNames: [String]) {
         NSApp.activate(ignoringOtherApps: true)
         let alert = NSAlert()
         alert.alertStyle = .informational
@@ -190,12 +200,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
         switch alert.runModal() {
         case .alertFirstButtonReturn:
-            let backups = store.adoptBundledDefaults(fileNames: fileNames)
+            let backups = appConfigStore.adoptBundledDefaults(fileNames: fileNames)
             Log.config.notice(
                 "User adopted new bundled defaults for \(fileNames.joined(separator: ", "), privacy: .public); backups: \(backups.joined(separator: ", "), privacy: .public)"
             )
         case .alertSecondButtonReturn:
-            store.recordKeptCustomizedDefaults(fileNames: fileNames)
+            appConfigStore.recordKeptCustomizedDefaults(fileNames: fileNames)
             Log.config.notice(
                 "User kept customized config files \(fileNames.joined(separator: ", "), privacy: .public)"
             )
@@ -203,7 +213,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             // Show Files: reveal the config folder and leave the decision
             // open — the prompt returns on the next launch.
             NSWorkspace.shared.activateFileViewerSelecting(
-                fileNames.map { store.configDirectoryURL().appendingPathComponent($0) }
+                fileNames.map { appConfigStore.configDirectoryURL().appendingPathComponent($0) }
             )
         }
     }
@@ -225,6 +235,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             // once the wizard is done — finished or skipped — start whatever
             // required managed backends it didn't already start.
             self?.viewModel.warmUpManagedBackendsAtLaunchIfNeeded()
+            self?.presentPendingConfigDefaultsPromptIfNeeded()
         }
         onboardingController = controller
         controller.present()

--- a/Sources/localvoxtral/localvoxtralApp.swift
+++ b/Sources/localvoxtral/localvoxtralApp.swift
@@ -144,8 +144,68 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         Task.detached(priority: .utility) {
             LegacyMLXLMCleanup().run()
         }
+        reconcileBundledConfigDefaults()
         guard !settingsStore.onboardingCompleted else { return }
         presentOnboarding()
+    }
+
+    /// Brings existing installs up to date with this build's bundled config
+    /// defaults: unedited stale seeds are refreshed silently; customized files
+    /// are never touched without asking. Fresh installs are always in sync, so
+    /// the alert can never stack on top of first-launch onboarding.
+    private func reconcileBundledConfigDefaults() {
+        let store = AppConfigStore()
+        let outcome = store.reconcileBundledDefaults()
+        guard !outcome.customizedOutdatedFileNames.isEmpty else { return }
+
+        // Defer past launch so the alert never blocks
+        // applicationDidFinishLaunching.
+        Task { @MainActor in
+            self.promptToUpdateCustomizedConfigFiles(
+                store: store,
+                fileNames: outcome.customizedOutdatedFileNames
+            )
+        }
+    }
+
+    private func promptToUpdateCustomizedConfigFiles(store: AppConfigStore, fileNames: [String]) {
+        NSApp.activate(ignoringOtherApps: true)
+        let alert = NSAlert()
+        alert.alertStyle = .informational
+        alert.messageText = "Updated default config files"
+        let fileList = fileNames.map { "•  \($0)" }.joined(separator: "\n")
+        let single = fileNames.count == 1
+        alert.informativeText = """
+        This version of localvoxtral improves the default content of:
+
+        \(fileList)
+
+        You've edited \(single ? "this file" : "these files"), so \(single ? "it was" : "they were") left untouched.
+
+        Update replaces \(single ? "it" : "them") with the new defaults and saves your \(single ? "version" : "versions") alongside as .backup files. Keep Mine won't ask again until the defaults next change.
+        """
+        alert.addButton(withTitle: "Update (Keep Backups)")
+        alert.addButton(withTitle: "Keep Mine")
+        alert.addButton(withTitle: "Show Files…")
+
+        switch alert.runModal() {
+        case .alertFirstButtonReturn:
+            let backups = store.adoptBundledDefaults(fileNames: fileNames)
+            Log.config.notice(
+                "User adopted new bundled defaults for \(fileNames.joined(separator: ", "), privacy: .public); backups: \(backups.joined(separator: ", "), privacy: .public)"
+            )
+        case .alertSecondButtonReturn:
+            store.recordKeptCustomizedDefaults(fileNames: fileNames)
+            Log.config.notice(
+                "User kept customized config files \(fileNames.joined(separator: ", "), privacy: .public)"
+            )
+        default:
+            // Show Files: reveal the config folder and leave the decision
+            // open — the prompt returns on the next launch.
+            NSWorkspace.shared.activateFileViewerSelecting(
+                fileNames.map { store.configDirectoryURL().appendingPathComponent($0) }
+            )
+        }
     }
 
     private func presentOnboarding() {

--- a/Sources/localvoxtral/localvoxtralApp.swift
+++ b/Sources/localvoxtral/localvoxtralApp.swift
@@ -198,23 +198,29 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         alert.addButton(withTitle: "Keep Mine")
         alert.addButton(withTitle: "Show Files…")
 
-        switch alert.runModal() {
-        case .alertFirstButtonReturn:
-            let backups = appConfigStore.adoptBundledDefaults(fileNames: fileNames)
-            Log.config.notice(
-                "User adopted new bundled defaults for \(fileNames.joined(separator: ", "), privacy: .public); backups: \(backups.joined(separator: ", "), privacy: .public)"
-            )
-        case .alertSecondButtonReturn:
-            appConfigStore.recordKeptCustomizedDefaults(fileNames: fileNames)
-            Log.config.notice(
-                "User kept customized config files \(fileNames.joined(separator: ", "), privacy: .public)"
-            )
-        default:
-            // Show Files: reveal the config folder and leave the decision
-            // open — the prompt returns on the next launch.
-            NSWorkspace.shared.activateFileViewerSelecting(
-                fileNames.map { appConfigStore.configDirectoryURL().appendingPathComponent($0) }
-            )
+        decision: while true {
+            switch alert.runModal() {
+            case .alertFirstButtonReturn:
+                let backups = appConfigStore.adoptBundledDefaults(fileNames: fileNames)
+                Log.config.notice(
+                    "User adopted new bundled defaults for \(fileNames.joined(separator: ", "), privacy: .public); backups: \(backups.joined(separator: ", "), privacy: .public)"
+                )
+                break decision
+            case .alertSecondButtonReturn:
+                appConfigStore.recordKeptCustomizedDefaults(fileNames: fileNames)
+                Log.config.notice(
+                    "User kept customized config files \(fileNames.joined(separator: ", "), privacy: .public)"
+                )
+                break decision
+            default:
+                // Show Files: reveal the files in Finder and re-present the
+                // alert so Update/Keep Mine stay available — Finder is a
+                // separate app, so the user can inspect the files while the
+                // alert waits. Quitting instead still re-prompts next launch.
+                NSWorkspace.shared.activateFileViewerSelecting(
+                    fileNames.map { appConfigStore.configDirectoryURL().appendingPathComponent($0) }
+                )
+            }
         }
     }
 

--- a/Tests/localvoxtralTests/AppConfigDefaultsReconcileTests.swift
+++ b/Tests/localvoxtralTests/AppConfigDefaultsReconcileTests.swift
@@ -106,6 +106,38 @@ final class AppConfigDefaultsReconcileTests: XCTestCase {
         XCTAssertEqual(untouched, customized)
     }
 
+    /// The replacement dictionary is the user's own rule set, not a tunable
+    /// default: even a byte-identical old shipped seed must never be
+    /// refreshed, and an edited dictionary must never be reported for the
+    /// update prompt.
+    func testReconcileNeverTouchesOrReportsReplacementDictionary() throws {
+        let directory = makeTemporaryConfigDirectory()
+        let staleSeed = "an older shipped dictionary default"
+        try write(staleSeed, named: "replacement_dictionary.toml", in: directory)
+
+        var hashes = BundledConfigDefaultHistory.knownDefaultHashes
+        hashes["replacement_dictionary.toml", default: []]
+            .insert(AppConfigStore.sha256Hex(Data(staleSeed.utf8)))
+        let store = AppConfigStore(
+            configDirectoryOverride: directory,
+            knownDefaultHashes: hashes
+        )
+
+        XCTAssertEqual(store.reconcileBundledDefaults(), BundledDefaultsReconciliation())
+        XCTAssertEqual(
+            try String(
+                contentsOf: directory.appendingPathComponent("replacement_dictionary.toml"),
+                encoding: .utf8
+            ),
+            staleSeed
+        )
+
+        // An edited dictionary is a customization by definition — still
+        // neither refreshed nor reported.
+        try write("my = \"own rules\"", named: "replacement_dictionary.toml", in: directory)
+        XCTAssertEqual(store.reconcileBundledDefaults(), BundledDefaultsReconciliation())
+    }
+
     func testReconcileFreshSeedReportsNothing() throws {
         let store = AppConfigStore(configDirectoryOverride: makeTemporaryConfigDirectory())
         _ = store.configDirectoryURL()

--- a/Tests/localvoxtralTests/AppConfigDefaultsReconcileTests.swift
+++ b/Tests/localvoxtralTests/AppConfigDefaultsReconcileTests.swift
@@ -8,15 +8,6 @@ import XCTest
 /// edited, and only with the user's consent (`adoptBundledDefaults` /
 /// `recordKeptCustomizedDefaults`) when it was.
 final class AppConfigDefaultsReconcileTests: XCTestCase {
-    private static let allConfigFileNames = [
-        "replacement_dictionary.toml",
-        "llm_system_prompt.toml",
-        "llm_user_prompt.toml",
-        "llm_system_prompt_agent.toml",
-        "llm_user_prompt_agent.toml",
-        "terminal_apps.toml",
-    ]
-
     private var temporaryDirectories: [URL] = []
 
     override func tearDown() {
@@ -33,7 +24,7 @@ final class AppConfigDefaultsReconcileTests: XCTestCase {
     /// refreshing. If this fails, append the printed hash for that file to
     /// `BundledConfigDefaultHistory.knownDefaultHashes` (keep the old ones).
     func testCurrentBundledDefaultsAreRegisteredInHistory() throws {
-        for fileName in Self.allConfigFileNames {
+        for fileName in AppConfigStore.debugAllConfigFileNames {
             let data = try bundledData(for: fileName)
             let hash = AppConfigStore.sha256Hex(data)
             XCTAssertTrue(
@@ -64,6 +55,38 @@ final class AppConfigDefaultsReconcileTests: XCTestCase {
         let refreshed = try Data(
             contentsOf: directory.appendingPathComponent("llm_system_prompt.toml"))
         XCTAssertEqual(refreshed, try bundledData(for: "llm_system_prompt.toml"))
+    }
+
+    /// A silent refresh happens at most once per bundled version: a user who
+    /// deliberately restores an OLD shipped default afterwards must not be
+    /// re-refreshed on every launch (their restore sticks).
+    func testDeliberateRestoreOfOldDefaultSticksAfterOneRefresh() throws {
+        let directory = makeTemporaryConfigDirectory()
+        let oldDefault = "content = \"an older shipped default\""
+        try write(oldDefault, named: "llm_system_prompt.toml", in: directory)
+
+        var hashes = BundledConfigDefaultHistory.knownDefaultHashes
+        hashes["llm_system_prompt.toml", default: []]
+            .insert(AppConfigStore.sha256Hex(Data(oldDefault.utf8)))
+        let store = AppConfigStore(
+            configDirectoryOverride: directory,
+            knownDefaultHashes: hashes
+        )
+
+        XCTAssertEqual(
+            store.reconcileBundledDefaults().refreshedFileNames,
+            ["llm_system_prompt.toml"]
+        )
+
+        // The user restores the old default by hand.
+        try write(oldDefault, named: "llm_system_prompt.toml", in: directory)
+
+        XCTAssertEqual(store.reconcileBundledDefaults(), BundledDefaultsReconciliation())
+        let untouched = try String(
+            contentsOf: directory.appendingPathComponent("llm_system_prompt.toml"),
+            encoding: .utf8
+        )
+        XCTAssertEqual(untouched, oldDefault)
     }
 
     func testReconcileReportsCustomizedFileWithoutTouchingIt() throws {

--- a/Tests/localvoxtralTests/AppConfigDefaultsReconcileTests.swift
+++ b/Tests/localvoxtralTests/AppConfigDefaultsReconcileTests.swift
@@ -1,0 +1,217 @@
+import Foundation
+import XCTest
+
+@testable import localvoxtral
+
+/// `AppConfigStore.reconcileBundledDefaults()`: existing installs must pick up
+/// improved bundled config defaults — silently when the seeded file was never
+/// edited, and only with the user's consent (`adoptBundledDefaults` /
+/// `recordKeptCustomizedDefaults`) when it was.
+final class AppConfigDefaultsReconcileTests: XCTestCase {
+    private static let allConfigFileNames = [
+        "replacement_dictionary.toml",
+        "llm_system_prompt.toml",
+        "llm_user_prompt.toml",
+        "llm_system_prompt_agent.toml",
+        "llm_user_prompt_agent.toml",
+        "terminal_apps.toml",
+    ]
+
+    private var temporaryDirectories: [URL] = []
+
+    override func tearDown() {
+        for directory in temporaryDirectories {
+            try? FileManager.default.removeItem(at: directory)
+        }
+        temporaryDirectories.removeAll()
+        super.tearDown()
+    }
+
+    /// Guard rail for `BundledConfigDefaultHistory`: every bundled default in
+    /// this build must be registered, or existing installs would treat the
+    /// unedited previous seed as a customization and nag instead of silently
+    /// refreshing. If this fails, append the printed hash for that file to
+    /// `BundledConfigDefaultHistory.knownDefaultHashes` (keep the old ones).
+    func testCurrentBundledDefaultsAreRegisteredInHistory() throws {
+        for fileName in Self.allConfigFileNames {
+            let data = try bundledData(for: fileName)
+            let hash = AppConfigStore.sha256Hex(data)
+            XCTAssertTrue(
+                BundledConfigDefaultHistory.knownDefaultHashes[fileName, default: []]
+                    .contains(hash),
+                "You changed the bundled \(fileName) — add \"\(hash)\" to BundledConfigDefaultHistory.knownDefaultHashes so existing installs pick it up."
+            )
+        }
+    }
+
+    func testReconcileRefreshesUneditedStaleSeed() throws {
+        let directory = makeTemporaryConfigDirectory()
+        let staleSeed = "content = \"an older shipped default\""
+        try write(staleSeed, named: "llm_system_prompt.toml", in: directory)
+
+        var hashes = BundledConfigDefaultHistory.knownDefaultHashes
+        hashes["llm_system_prompt.toml", default: []]
+            .insert(AppConfigStore.sha256Hex(Data(staleSeed.utf8)))
+        let store = AppConfigStore(
+            configDirectoryOverride: directory,
+            knownDefaultHashes: hashes
+        )
+
+        let outcome = store.reconcileBundledDefaults()
+
+        XCTAssertEqual(outcome.refreshedFileNames, ["llm_system_prompt.toml"])
+        XCTAssertEqual(outcome.customizedOutdatedFileNames, [])
+        let refreshed = try Data(
+            contentsOf: directory.appendingPathComponent("llm_system_prompt.toml"))
+        XCTAssertEqual(refreshed, try bundledData(for: "llm_system_prompt.toml"))
+    }
+
+    func testReconcileReportsCustomizedFileWithoutTouchingIt() throws {
+        let directory = makeTemporaryConfigDirectory()
+        let customized = "content = \"my own carefully tuned prompt\""
+        try write(customized, named: "llm_system_prompt.toml", in: directory)
+        let store = AppConfigStore(configDirectoryOverride: directory)
+
+        let outcome = store.reconcileBundledDefaults()
+
+        XCTAssertEqual(outcome.refreshedFileNames, [])
+        XCTAssertEqual(outcome.customizedOutdatedFileNames, ["llm_system_prompt.toml"])
+        let untouched = try String(
+            contentsOf: directory.appendingPathComponent("llm_system_prompt.toml"),
+            encoding: .utf8
+        )
+        XCTAssertEqual(untouched, customized)
+    }
+
+    func testReconcileFreshSeedReportsNothing() throws {
+        let store = AppConfigStore(configDirectoryOverride: makeTemporaryConfigDirectory())
+        _ = store.configDirectoryURL()
+
+        let outcome = store.reconcileBundledDefaults()
+
+        XCTAssertEqual(outcome, BundledDefaultsReconciliation())
+    }
+
+    func testAdoptBundledDefaultsBacksUpAndReplaces() throws {
+        let directory = makeTemporaryConfigDirectory()
+        let customized = "content = \"my own carefully tuned prompt\""
+        try write(customized, named: "llm_system_prompt.toml", in: directory)
+        let store = AppConfigStore(
+            configDirectoryOverride: directory,
+            now: { Date(timeIntervalSince1970: 1_800_000_000) }
+        )
+
+        let backups = store.adoptBundledDefaults(fileNames: ["llm_system_prompt.toml"])
+
+        XCTAssertEqual(backups.count, 1)
+        let backupName = try XCTUnwrap(backups.first)
+        XCTAssertTrue(backupName.hasPrefix("llm_system_prompt.toml.backup-"))
+        let backupContent = try String(
+            contentsOf: directory.appendingPathComponent(backupName),
+            encoding: .utf8
+        )
+        XCTAssertEqual(backupContent, customized)
+        let adopted = try Data(
+            contentsOf: directory.appendingPathComponent("llm_system_prompt.toml"))
+        XCTAssertEqual(adopted, try bundledData(for: "llm_system_prompt.toml"))
+
+        // Now in sync — no further prompt.
+        XCTAssertEqual(store.reconcileBundledDefaults(), BundledDefaultsReconciliation())
+    }
+
+    func testAdoptOnlyTouchesRequestedFiles() throws {
+        let directory = makeTemporaryConfigDirectory()
+        let customizedSystem = "content = \"my system prompt\""
+        let customizedUser = "content = \"mine: {{input_text}}\""
+        try write(customizedSystem, named: "llm_system_prompt.toml", in: directory)
+        try write(customizedUser, named: "llm_user_prompt.toml", in: directory)
+        let store = AppConfigStore(configDirectoryOverride: directory)
+
+        _ = store.adoptBundledDefaults(fileNames: ["llm_system_prompt.toml"])
+
+        let untouched = try String(
+            contentsOf: directory.appendingPathComponent("llm_user_prompt.toml"),
+            encoding: .utf8
+        )
+        XCTAssertEqual(untouched, customizedUser)
+        XCTAssertEqual(
+            store.reconcileBundledDefaults().customizedOutdatedFileNames,
+            ["llm_user_prompt.toml"]
+        )
+    }
+
+    func testKeepMineSuppressesRepromptForSameDefault() throws {
+        let directory = makeTemporaryConfigDirectory()
+        let customized = "content = \"my own carefully tuned prompt\""
+        try write(customized, named: "llm_system_prompt.toml", in: directory)
+        let store = AppConfigStore(configDirectoryOverride: directory)
+
+        XCTAssertEqual(
+            store.reconcileBundledDefaults().customizedOutdatedFileNames,
+            ["llm_system_prompt.toml"]
+        )
+
+        store.recordKeptCustomizedDefaults(fileNames: ["llm_system_prompt.toml"])
+
+        let afterDecision = store.reconcileBundledDefaults()
+        XCTAssertEqual(afterDecision.customizedOutdatedFileNames, [])
+        XCTAssertEqual(afterDecision.refreshedFileNames, [])
+        let untouched = try String(
+            contentsOf: directory.appendingPathComponent("llm_system_prompt.toml"),
+            encoding: .utf8
+        )
+        XCTAssertEqual(untouched, customized)
+    }
+
+    /// A recorded "keep mine" is tied to the bundled hash it declined: when the
+    /// bundled default changes again, the prompt must come back.
+    func testKeepMineRepromptsWhenDefaultChangesAgain() throws {
+        let directory = makeTemporaryConfigDirectory()
+        let customized = "content = \"my own carefully tuned prompt\""
+        try write(customized, named: "llm_system_prompt.toml", in: directory)
+        let store = AppConfigStore(configDirectoryOverride: directory)
+        store.recordKeptCustomizedDefaults(fileNames: ["llm_system_prompt.toml"])
+
+        // Simulate the NEXT release shipping a different default by rewriting
+        // the recorded decision to point at a hash that no longer matches the
+        // bundled file.
+        let stateURL = directory.appendingPathComponent(".bundled-defaults-state.json")
+        let staleState = #"{"resolvedBundledHashes":{"llm_system_prompt.toml":"0000"}}"#
+        try staleState.write(to: stateURL, atomically: true, encoding: .utf8)
+
+        XCTAssertEqual(
+            store.reconcileBundledDefaults().customizedOutdatedFileNames,
+            ["llm_system_prompt.toml"]
+        )
+    }
+
+    private func bundledData(for fileName: String) throws -> Data {
+        let resourceName = fileName.replacingOccurrences(of: ".toml", with: "")
+        let url = try XCTUnwrap(
+            Bundle.localvoxtralResources.url(forResource: resourceName, withExtension: "toml"),
+            "Missing bundled resource \(fileName)"
+        )
+        return try Data(contentsOf: url)
+    }
+
+    private func makeTemporaryConfigDirectory() -> URL {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent(
+                "localvoxtral-defaults-reconcile-tests-\(UUID().uuidString)", isDirectory: true)
+        temporaryDirectories.append(directory)
+        return directory
+    }
+
+    private func write(_ content: String, named fileName: String, in directory: URL) throws {
+        try FileManager.default.createDirectory(
+            at: directory,
+            withIntermediateDirectories: true,
+            attributes: nil
+        )
+        try content.write(
+            to: directory.appendingPathComponent(fileName, isDirectory: false),
+            atomically: true,
+            encoding: .utf8
+        )
+    }
+}


### PR DESCRIPTION
## What

Fixes the known limitation surfaced in #126: `ensureConfigFilesExist` seeds bundled config files only when absent, so **existing installs never picked up improved bundled defaults** (the #126 prompt trim reached fresh installs only).

Mechanism — `AppConfigStore.reconcileBundledDefaults()`, run once at launch:

- **Unedited stale seeds refresh silently.** `BundledConfigDefaultHistory` registers the SHA-256 of every default config version ever shipped on main (all 12 historical versions, derived from git history and independently re-verified). A user file matching any of them is an unedited seed — replacing it loses nothing, so it's refreshed in place and logged.
- **Customized files are never touched without asking.** Unknown content gets one alert (after launch, and held until the onboarding wizard closes if one is due): **Update (Keep Backups)** replaces the files and saves the user's versions alongside as `<name>.toml.backup-<timestamp>` (collision-safe); **Keep Mine** records the decision in a hidden `.bundled-defaults-state.json` sidecar so the prompt never repeats for the same default version — it returns only when the defaults change again; **Show Files…** reveals the files in Finder and re-presents the alert, so Update/Keep Mine stay available while you inspect (quitting instead still re-prompts next launch).
- **The replacement dictionary is exempt.** It's the user's own rule set, not a tunable default — the format has never changed since shipping, so reconcile never refreshes it and never prompts for it (regression-tested).
- **Refreshes are once-per-version too**: a silent refresh records the bundled hash it handled, so a user who deliberately restores an old shipped default afterwards keeps it — no refresh loop.
- A hash missing from the history table degrades safely: the file is treated as customized and prompted, never clobbered. A new guard-rail test fails with the exact hash to paste whenever a bundled TOML changes without a matching history entry, and it enumerates files through a `#if DEBUG` seam on the private `ConfigFile` enum so it can't drift. AGENTS.md documents the rule; README documents the user-facing behavior.

Reviewed by a Fable subagent (adversarial pass over hash table, sidecar state machine, strict concurrency, AGENTS.md rules): all 12 historical hashes independently re-derived from git and confirmed; its three substantive findings (refresh loop on deliberate restores, alert stacking on the onboarding wizard for pre-onboarding installs, unguarded test file list) are fixed in the second commit, each with a regression test where testable.

## Proof

- **New suite `AppConfigDefaultsReconcileTests` (9 tests, all passing on the build host)**: current-bundle-registered guard rail; stale seed refreshed to bundled bytes; deliberate restore of an old default sticks after one refresh; customized file reported and untouched; fresh seed reports nothing; adopt backs up + replaces + stops prompting; adopt touches only requested files; Keep Mine suppresses re-prompt for the same version; Keep Mine re-prompts when the default changes again.
- **Tier 0 full suite**: 890 tests, 2 env-gated skips, 0 failures in the reconcile/config area. (`BackendProcessSupervisorTests.testStopHonorsTERMWithoutRestarting` flaked twice while the Record README Demo workflow was hammering the host — it races a real `/bin/sh` `trap TERM` install against supervisor shutdown, passes in isolation, and is untouched by this diff; clean full-suite rerun after the workflow finished: **890 tests, 2 env-gated skips, 0 failures** — supervisor test included.)
- **LLM lanes skipped — justification**: no prompt content, model pins, sampling, request shape, or eval corpus changes. This PR changes only *which file on disk* holds the (already-evaled, #126) bundled default content and when it's copied there; the polish request path is untouched.
- **Hand-testing (UI)**: the alert flow is new UI and has NOT been hand-tested — the reconcile/adopt/keep logic behind each button is fully unit-tested against the real bundle and real file IO, but the NSAlert itself needs one `try-pr.sh` pass on a real install (I didn't want to mutate the live config folder on the build host). Steps: edit `llm_system_prompt.toml` under `~/Library/Application Support/localvoxtral/config` (any byte), launch, and exercise each button — Update creates the `.backup-<timestamp>` file and swaps in the new default; Keep Mine writes `.bundled-defaults-state.json` and stays quiet on relaunch; Show Files reveals the files in Finder and the alert re-presents immediately with Update/Keep Mine still available. Bonus check for the silent path: an *unedited* pre-#126 install's prompt files should just get the trimmed defaults with a `Refreshed unedited default…` line in the config log.

