### PR TITLE
record-demo: terminal-first scene dictating into Claude Code, audible-takeover warning, warmup + capture-abort hardening

### DIFF
--- a/.github/workflows/record-demo.yml
+++ b/.github/workflows/record-demo.yml
@@ -66,6 +66,9 @@ jobs:
           DEMO_TERMINAL_AGENT: ${{ inputs.terminal_agent || 'auto' }}
         run: |
           bash scripts/record-demo.sh dist/localvoxtral.app
+          # The runner's /bin/bash 3.2 has returned exit 0 on a PARSE ERROR
+          # before — never trust the exit code alone, require the artifact.
+          test -s dist/demo/demo.mp4 || { echo "demo.mp4 was not produced"; exit 1; }
           echo "ran=true" >> "$GITHUB_OUTPUT"
 
       - name: Upload demo video

--- a/.github/workflows/record-demo.yml
+++ b/.github/workflows/record-demo.yml
@@ -1,17 +1,32 @@
 name: Record README Demo
 
 # Hands-free demo recording on the self-hosted runner (the owner's Mac, GUI
-# session): scripts/record-demo.sh drives the app and speaks the demo lines
+# session): scripts/record-demo.sh stages a terminal-centric scene (a small
+# git repo in Terminal.app, with a real Claude Code session when the runner
+# has a logged-in `claude` CLI), drives the app, and speaks the demo lines
 # via TTS into the BlackHole loopback device. The encoded mp4 lands in the
 # run's artifacts; publishing it is manual by design — GitHub only renders
 # inline README video from user-attachments URLs, which have no upload API,
 # so the owner drag-drops the mp4 into a PR comment and pastes the URL.
+#
+# The script announces itself audibly and waits 3 s before taking over the
+# GUI session (owner rule), and needs an UNLOCKED session — it fails fast
+# when Secure Keyboard Entry is held (locked screen).
 #
 # One-time runner-machine setup (beyond the capture-assets grants):
 #   brew install blackhole-2ch ffmpeg
 
 on:
   workflow_dispatch:
+    inputs:
+      terminal_agent:
+        description: "Terminal scene: auto = real Claude Code session when usable else plain zsh; claude = require it; shell = plain zsh"
+        type: choice
+        default: auto
+        options:
+          - auto
+          - claude
+          - shell
 
 concurrency:
   group: record-demo-${{ github.ref }}
@@ -48,6 +63,7 @@ jobs:
         env:
           DEMO_HANDS_FREE: "1"
           DEMO_WARMUP_SECONDS: "25"
+          DEMO_TERMINAL_AGENT: ${{ inputs.terminal_agent || 'auto' }}
         run: |
           bash scripts/record-demo.sh dist/localvoxtral.app
           echo "ran=true" >> "$GITHUB_OUTPUT"

--- a/scripts/record-demo.sh
+++ b/scripts/record-demo.sh
@@ -398,6 +398,9 @@ defaults write "$BUNDLE_ID" "settings.modifier_only_hotkey_modifier" -string "ri
 defaults write "$BUNDLE_ID" "settings.llm_polishing_enabled" -bool true
 defaults write "$BUNDLE_ID" "settings.agent_polish_profile_enabled" -bool true
 defaults write "$BUNDLE_ID" "settings.managed_llm_polishing_model" -string "mlx-community/Qwen3.5-4B-OptiQ-4bit"
+# Overlay body font scaled up to match the 21 pt terminal font so the overlay
+# beat reads at README width (clamped to OverlayLayoutMetrics.maximum, 24).
+defaults write "$BUNDLE_ID" "settings.overlay_buffer_font_size" -float 22
 if [[ -n "$DEMO_SAY_INPUT_UID" ]]; then
   defaults write "$BUNDLE_ID" "settings.selected_input_device_uid" -string "$DEMO_SAY_INPUT_UID"
 fi
@@ -527,10 +530,16 @@ on run argv
         delay 1
         set windowID to id of front window
         set ttyName to tty of demoTab
-        -- Dark Pro profile + big font so terminal text is legible at README
-        -- width. Per-tab only: nothing is persisted to Terminal preferences.
+        -- Explicit OPAQUE colors + big font so terminal text is legible at
+        -- README width. Never the "Pro" profile: it is translucent and the
+        -- recording shows the desktop (and whatever is on it) through the
+        -- window — take 2 leaked real Finder windows that way. Per-tab
+        -- only: nothing is persisted to Terminal preferences.
         try
-            set current settings of demoTab to settings set "Pro"
+            set background color of demoTab to {0, 0, 0}
+            set normal text color of demoTab to {59000, 59000, 59000}
+            set bold text color of demoTab to {65535, 65535, 65535}
+            set cursor color of demoTab to {45000, 45000, 45000}
         end try
         try
             set font name of demoTab to "Menlo"
@@ -589,15 +598,6 @@ OSA
   sleep 3
 fi
 
-# --- record ----------------------------------------------------------------------
-mkdir -p "$OUT_DIR"
-rm -f "$RAW_MOV" "$OUT_MP4"
-CAPTURE_FLAGS=(-v -x)
-[[ "$DEMO_CAPTURE_AUDIO" == 1 ]] && CAPTURE_FLAGS+=(-g)
-screencapture "${CAPTURE_FLAGS[@]}" -R "${REGION_X},${REGION_Y},${DEMO_WIDTH},${DEMO_HEIGHT}" "$RAW_MOV" &
-RECORDER_PID=$!
-sleep 2
-
 cue() { # <beat-label> <sentence>
   echo
   echo "==================================================================="
@@ -615,6 +615,46 @@ speak_or_wait() { # <sentence>
     sleep "$DEMO_SPEAK_SECONDS"
   fi
 }
+
+# --- warm the AGENT-profile polish prompt cache off-camera ------------------------
+# The app's own launch warmup (PolishPromptWarmup) primes the STANDARD
+# profile's prefix slot; dictating into a terminal selects the AGENT profile,
+# whose first polish would pay the full static-prefix prefill ON CAMERA
+# (~2.6 s cold vs ~0.4 s warm). One throwaway overlay dictation with the
+# staged terminal focused runs the real agent-profile request end to end and
+# checkpoints the exact prefix the on-camera beat reuses; its residue is then
+# cleared off-camera.
+echo "Warming the agent-profile polish prompt cache off-camera..."
+osascript -e 'tell application "Terminal" to activate' >/dev/null
+sleep 1
+cue "WARMUP (off-camera, not recorded). Speak after the beep." "Ready to record the demo."
+tap_hotkey
+sleep 1
+speak_or_wait "Ready to record the demo."
+tap_hotkey
+sleep $(( DEMO_COMMIT_SECONDS + 4 )) # cold polish — wait it out fully before clearing
+if [[ "$TERMINAL_AGENT" == "claude" ]]; then
+  # Ctrl+C clears the composer text the warmup committed.
+  osascript -e 'tell application "System Events" to keystroke "c" using control down' >/dev/null
+else
+  # Kill the committed line, then run a literal `clear` — the ONLY Return
+  # this script ever sends to a shell, and only for that exact staged text.
+  osascript -e 'tell application "System Events" to keystroke "u" using control down' >/dev/null
+  sleep 0.5
+  osascript -e 'tell application "System Events" to keystroke "clear"' >/dev/null
+  sleep 0.5
+  osascript -e 'tell application "System Events" to key code 36' >/dev/null
+fi
+sleep 1.5
+
+# --- record ----------------------------------------------------------------------
+mkdir -p "$OUT_DIR"
+rm -f "$RAW_MOV" "$OUT_MP4"
+CAPTURE_FLAGS=(-v -x)
+[[ "$DEMO_CAPTURE_AUDIO" == 1 ]] && CAPTURE_FLAGS+=(-g)
+screencapture "${CAPTURE_FLAGS[@]}" -R "${REGION_X},${REGION_Y},${DEMO_WIDTH},${DEMO_HEIGHT}" "$RAW_MOV" &
+RECORDER_PID=$!
+sleep 2
 
 osascript -e 'tell application "Terminal" to activate' >/dev/null
 sleep 1

--- a/scripts/record-demo.sh
+++ b/scripts/record-demo.sh
@@ -17,8 +17,12 @@ set -euo pipefail
 #           terminal prompt while speaking (the differentiator; no stray
 #           newline ever submits the prompt)
 #   Beat 2  tap Right Command  -> overlay buffer -> speak a line with spoken
-#           symbol forms -> tap -> the agent-profile LLM polish writes
-#           `--flags` / `file.ts` and the commit lands in the terminal
+#           symbol forms + a real repo filename -> tap -> the agent-profile
+#           LLM polish (grounded by the repo vocabulary of the staged repo)
+#           writes `--flags` / `useAuth.ts` and the commit lands in the
+#           terminal; in claude mode the polished prompt is then genuinely
+#           SUBMITTED and the real response is recorded (one small request
+#           against the owner's Claude usage — DEMO_SUBMIT_PROMPT=0 disables)
 #
 # The voice is either YOU (default) or macOS text-to-speech through a loopback
 # audio device (hands-free mode — how the CI runner records it, see
@@ -54,6 +58,9 @@ set -euo pipefail
 #   DEMO_CAPTURE_AUDIO            1 = record default-input audio into the video
 #                                 (default: 1 for a human take, 0 hands-free)
 #   DEMO_LINE_LIVE / _OVERLAY     the lines shown in the prompts / spoken by TTS
+#   DEMO_SUBMIT_PROMPT            1 (default) = in claude mode, submit the
+#                                 polished beat-2 prompt and record the response
+#   DEMO_RESPONSE_SECONDS         how long to record the response (default 14)
 #   DEMO_TERMINAL_AGENT           auto (default) | claude | shell — what runs in
 #                                 the staged Terminal window. auto uses a real
 #                                 Claude Code session when `claude` is on the
@@ -90,8 +97,16 @@ DEMO_TERMINAL_AGENT="${DEMO_TERMINAL_AGENT:-auto}"
 # to a coding agent; streamed raw, so no spoken symbol forms here.
 DEMO_LINE_LIVE="${DEMO_LINE_LIVE:-Refactor the retry logic in the websocket client, and add a unit test for the reconnect path.}"
 # Beat 2 (tap -> overlay + agent-profile polish): spoken symbol forms the
-# polish profile turns into written forms (index.ts, --no-verify).
-DEMO_LINE_OVERLAY="${DEMO_LINE_OVERLAY:-Open index dot t s and run the tests again, then commit with dash dash no verify.}"
+# polish profile turns into written forms (useAuth.ts — grounded by the repo
+# vocabulary indexed from the staged repo — and --filter). Phrased as a
+# read-only question so submitting it to a real Claude Code session yields a
+# fast text answer instead of a tool-permission prompt.
+DEMO_LINE_OVERLAY="${DEMO_LINE_OVERLAY:-Look at use auth dot t s and tell me which tests dash dash filter auth would run.}"
+# In claude mode the polished beat-2 prompt is genuinely SUBMITTED (one small
+# request against the owner's Claude usage) and the response is recorded for
+# DEMO_RESPONSE_SECONDS. DEMO_SUBMIT_PROMPT=0 turns the ending off.
+DEMO_SUBMIT_PROMPT="${DEMO_SUBMIT_PROMPT:-1}"
+DEMO_RESPONSE_SECONDS="${DEMO_RESPONSE_SECONDS:-14}"
 DEMO_HANDS_FREE="${DEMO_HANDS_FREE:-0}"
 DEMO_SAY_DEVICE="${DEMO_SAY_DEVICE:-}"
 DEMO_SAY_INPUT_UID="${DEMO_SAY_INPUT_UID:-}"
@@ -404,6 +419,11 @@ defaults write "$BUNDLE_ID" "settings.managed_llm_polishing_model" -string "mlx-
 # Overlay body font scaled up to match the 21 pt terminal font so the overlay
 # beat reads at README width (clamped to OverlayLayoutMetrics.maximum, 24).
 defaults write "$BUNDLE_ID" "settings.overlay_buffer_font_size" -float 22
+# Repo vocabulary grounds beat 2's spoken filename ("use auth dot t s" ->
+# useAuth.ts, exactly as spelled in the staged repo). Resolution reads the
+# terminal window title, which must contain a /-prefixed path — the staging
+# AppleScript pins the tab's custom title to the staged repo path for that.
+defaults write "$BUNDLE_ID" "settings.repo_vocabulary_enabled" -bool true
 if [[ -n "$DEMO_SAY_INPUT_UID" ]]; then
   defaults write "$BUNDLE_ID" "settings.selected_input_device_uid" -string "$DEMO_SAY_INPUT_UID"
 fi
@@ -469,10 +489,14 @@ REGION_Y=$(( MAIN_Y + (MAIN_H - DEMO_HEIGHT) / 2 ))
 (( REGION_Y < MAIN_Y + 30 )) && REGION_Y=$(( MAIN_Y + 30 )) # keep clear of the menu bar
 
 # --- stage the demo repo + Terminal window inside the capture region --------------
-DEMO_STAGE="$(mktemp -d -t lv-demo-stage)"
+# Fixed short path (not mktemp): the tab's custom title is set to this path so
+# RepoVocabulary can resolve the repo from the window title, and a short path
+# keeps that title readable on camera. Wiped before use and on cleanup.
+DEMO_STAGE="/tmp/lv-demo"
+rm -rf "$DEMO_STAGE"
 REPO_DIR="$DEMO_STAGE/webapp"
 ZDOT_DIR="$DEMO_STAGE/zdot"
-mkdir -p "$REPO_DIR/src" "$ZDOT_DIR"
+mkdir -p "$REPO_DIR/src/auth" "$REPO_DIR/tests/auth" "$ZDOT_DIR"
 
 cat > "$REPO_DIR/package.json" <<'JSON'
 {
@@ -483,14 +507,6 @@ cat > "$REPO_DIR/package.json" <<'JSON'
   }
 }
 JSON
-cat > "$REPO_DIR/src/index.ts" <<'TS'
-import { createClient } from "./client";
-
-export function main(): void {
-  const client = createClient();
-  client.connect();
-}
-TS
 cat > "$REPO_DIR/src/client.ts" <<'TS'
 export function createClient() {
   return {
@@ -500,10 +516,20 @@ export function createClient() {
   };
 }
 TS
-cat > "$REPO_DIR/src/client.test.ts" <<'TS'
-import { test } from "vitest";
+cat > "$REPO_DIR/src/auth/useAuth.ts" <<'TS'
+import { useState } from "react";
 
-test.todo("reconnects after a dropped connection");
+export function useAuth() {
+  const [token, setToken] = useState<string | null>(null);
+  return { token, isAuthenticated: token !== null, setToken };
+}
+TS
+cat > "$REPO_DIR/tests/auth/useAuth.test.ts" <<'TS'
+import { test, expect } from "vitest";
+import { useAuth } from "../../src/auth/useAuth";
+
+test.todo("starts unauthenticated");
+test.todo("exposes the token after setToken");
 TS
 git -C "$REPO_DIR" init -q -b main
 git -C "$REPO_DIR" add -A
@@ -533,6 +559,13 @@ on run argv
         delay 1
         set windowID to id of front window
         set ttyName to tty of demoTab
+        -- Pin the tab title to the absolute repo path: RepoVocabulary only
+        -- resolves a cwd from a /-prefixed path run in the window title
+        -- (Terminal's bare "webapp" basename is explicitly not resolvable).
+        try
+            set custom title of demoTab to (item 2 of argv)
+            set title displays custom title of demoTab to true
+        end try
         -- Explicit OPAQUE colors + big font so terminal text is legible at
         -- README width. Never the "Pro" profile: it is translucent and the
         -- recording shows the desktop (and whatever is on it) through the
@@ -552,7 +585,7 @@ on run argv
     end tell
 end run
 OSA
-TERMINAL_INFO="$(osascript "$STAGE_OSA" "$SHELL_CMD")"
+TERMINAL_INFO="$(osascript "$STAGE_OSA" "$SHELL_CMD" "$REPO_DIR")"
 TERMINAL_WINDOW_ID="${TERMINAL_INFO%% *}"
 TERMINAL_TTY="${TERMINAL_INFO##* }"
 if [[ -z "$TERMINAL_WINDOW_ID" || -z "$TERMINAL_TTY" || "$TERMINAL_TTY" != /dev/* ]]; then
@@ -692,6 +725,16 @@ tap_hotkey
 echo "Committing (agent-profile polish + insert)..."
 sleep "$DEMO_COMMIT_SECONDS"
 sleep 3 # let the committed text sit on screen
+
+# Ending (claude mode) — genuinely submit the polished prompt and record the
+# real response. This is the ONE deliberate Return on dictated text, owner-
+# approved: one small read-only request against the owner's Claude usage.
+if [[ "$TERMINAL_AGENT" == "claude" && "$DEMO_SUBMIT_PROMPT" == 1 ]]; then
+  echo "Submitting the polished prompt to claude (recording the response for ${DEMO_RESPONSE_SECONDS}s)..."
+  osascript -e 'tell application "Terminal" to activate' >/dev/null
+  osascript -e 'tell application "System Events" to key code 36' >/dev/null
+  sleep "$DEMO_RESPONSE_SECONDS"
+fi
 
 kill -INT "$RECORDER_PID"
 wait "$RECORDER_PID" 2>/dev/null || true

--- a/scripts/record-demo.sh
+++ b/scripts/record-demo.sh
@@ -514,7 +514,12 @@ ZSHRC
 
 pgrep -xq Terminal || LAUNCHED_TERMINAL_APP=1
 SHELL_CMD="cd $(printf %q "$REPO_DIR") && exec /usr/bin/env ZDOTDIR=$(printf %q "$ZDOT_DIR") /bin/zsh -i"
-TERMINAL_INFO="$(osascript - "$SHELL_CMD" <<'OSA'
+# AppleScript lives in a temp FILE, never in a heredoc inside $(...): the
+# runner executes this with /bin/bash 3.2, whose command-substitution parser
+# naively scans heredoc bodies and chokes on their quotes/parens — the first
+# hands-free take died exactly there, with a bogus exit 0 on top.
+STAGE_OSA="$DEMO_STAGE/stage-terminal.applescript"
+cat > "$STAGE_OSA" <<'OSA'
 on run argv
     tell application "Terminal"
         activate
@@ -522,9 +527,8 @@ on run argv
         delay 1
         set windowID to id of front window
         set ttyName to tty of demoTab
-        -- Dark "Pro" profile + big font so terminal text is legible at
-        -- README width. Per-tab only: nothing is persisted to the user's
-        -- Terminal preferences. Best-effort — the take review catches it.
+        -- Dark Pro profile + big font so terminal text is legible at README
+        -- width. Per-tab only: nothing is persisted to Terminal preferences.
         try
             set current settings of demoTab to settings set "Pro"
         end try
@@ -536,7 +540,7 @@ on run argv
     end tell
 end run
 OSA
-)"
+TERMINAL_INFO="$(osascript "$STAGE_OSA" "$SHELL_CMD")"
 TERMINAL_WINDOW_ID="${TERMINAL_INFO%% *}"
 TERMINAL_TTY="${TERMINAL_INFO##* }"
 if [[ -z "$TERMINAL_WINDOW_ID" || -z "$TERMINAL_TTY" || "$TERMINAL_TTY" != /dev/* ]]; then
@@ -570,13 +574,15 @@ sleep 1
 # ever submits it.
 if [[ "$TERMINAL_AGENT" == "claude" ]]; then
   echo "Launching claude ($CLAUDE_BIN) in the demo window..."
-  osascript - "$CLAUDE_BIN" "$TERMINAL_WINDOW_ID" >/dev/null <<'OSA'
+  LAUNCH_OSA="$DEMO_STAGE/launch-claude.applescript"
+  cat > "$LAUNCH_OSA" <<'OSA'
 on run argv
     tell application "Terminal"
         do script (item 1 of argv) in selected tab of window id ((item 2 of argv) as integer)
     end tell
 end run
 OSA
+  osascript "$LAUNCH_OSA" "$CLAUDE_BIN" "$TERMINAL_WINDOW_ID" >/dev/null
   sleep 10
   osascript -e 'tell application "Terminal" to activate' >/dev/null
   osascript -e 'tell application "System Events" to key code 36' >/dev/null 2>&1 || true

--- a/scripts/record-demo.sh
+++ b/scripts/record-demo.sh
@@ -692,6 +692,20 @@ screencapture "${CAPTURE_FLAGS[@]}" -R "${REGION_X},${REGION_Y},${DEMO_WIDTH},${
 RECORDER_PID=$!
 sleep 2
 
+# The capture can be stopped from OUTSIDE at any time via the menu-bar
+# recording indicator — exactly what happens when the owner is actively using
+# the Mac (take 5 died that way and its 2-frame capture showed the owner's
+# browser). A dead recorder means a partial capture of whoever is really at
+# the machine: throw it away and fail loudly instead of uploading it.
+recorder_alive_or_abort() {
+  kill -0 "$RECORDER_PID" 2>/dev/null && return 0
+  RECORDER_PID=""
+  rm -f "$RAW_MOV" "$OUT_MP4"
+  echo "The screen recorder stopped before the scene finished — the GUI session is likely IN USE by its human (the capture can be stopped from the menu-bar recording indicator). Re-run when the Mac is free." >&2
+  exit 1
+}
+recorder_alive_or_abort
+
 osascript -e 'tell application "Terminal" to activate' >/dev/null
 sleep 1
 
@@ -736,6 +750,7 @@ if [[ "$TERMINAL_AGENT" == "claude" && "$DEMO_SUBMIT_PROMPT" == 1 ]]; then
   sleep "$DEMO_RESPONSE_SECONDS"
 fi
 
+recorder_alive_or_abort
 kill -INT "$RECORDER_PID"
 wait "$RECORDER_PID" 2>/dev/null || true
 RECORDER_PID=""

--- a/scripts/record-demo.sh
+++ b/scripts/record-demo.sh
@@ -7,37 +7,58 @@ set -euo pipefail
 #                            user-attachments uploads, so that step is manual)
 #   dist/demo/demo-raw.mov  (raw capture, kept so the encode can be redone)
 #
-# The script stages the whole scene and drives the app; the voice is either
-# YOU (default) or macOS text-to-speech through a loopback audio device
-# (hands-free mode — how the CI runner records it, see record-demo.yml).
-# It pins dark mode, opens an empty TextEdit document at a fixed size, stages
-# the Right Command tap/hold gesture, warms up the backend off-camera, then
-# records two scenes, prompting in the terminal what to say and when:
+# The scene is TERMINAL-CENTRIC — localvoxtral is the dictation app to talk to
+# your coding agents. The script stages a small git repo, opens Terminal.app in
+# it (Terminal is always installed; when a logged-in `claude` CLI is available
+# it launches a real Claude Code session in that window instead of a bare
+# shell — never a faked one), and records two beats:
 #
-#   Scene 1  tap Right Command  -> overlay dictation -> speak -> tap -> commit
-#   Scene 2  hold Right Command -> live auto-paste while speaking -> release
+#   Beat 1  hold Right Command -> live dictation streams word-by-word into the
+#           terminal prompt while speaking (the differentiator; no stray
+#           newline ever submits the prompt)
+#   Beat 2  tap Right Command  -> overlay buffer -> speak a line with spoken
+#           symbol forms -> tap -> the agent-profile LLM polish writes
+#           `--flags` / `file.ts` and the commit lands in the terminal
+#
+# The voice is either YOU (default) or macOS text-to-speech through a loopback
+# audio device (hands-free mode — how the CI runner records it, see
+# record-demo.yml).
+#
+# OWNER RULE (this runs on a daily-driver Mac): before any focus-stealing
+# automation the script announces itself audibly on the DEFAULT output and
+# waits 3 seconds, and it announces completion/failure at the end — in
+# hands-free mode too.
 #
 # Run ON A MAC from the repo root, in a GUI session:
 #   ./scripts/record-demo.sh [path/to/localvoxtral.app]
 # Default app: dist/localvoxtral.app (build it with ./scripts/package_app.sh).
 #
 # One-time TCC grants for the terminal running this script:
-#   - Accessibility     (posts the Right Command gesture, drives TextEdit)
+#   - Accessibility     (posts the Right Command gesture, drives Terminal)
 #   - Screen Recording  (screencapture -v)
 #   - Microphone        (only when DEMO_CAPTURE_AUDIO=1, the default)
 # The app itself must already have its mic + Accessibility grants and a
 # working dictation backend (managed local installed, or your endpoints up).
-# ffmpeg (brew install ffmpeg) is needed for the final encode; without it the
-# raw .mov is still produced (GitHub accepts .mov drag-drops too).
+# The overlay beat needs the managed polishing helper: the script enables LLM
+# polishing with the default 4B model and waits for polishd health on port
+# 8472 before recording (a first-ever run may include a ~3.3 GB model
+# download). ffmpeg (brew install ffmpeg) is needed for the final encode;
+# without it the raw .mov is still produced (GitHub accepts .mov drag-drops).
 #
 # Tunables (env):
 #   DEMO_WIDTH / DEMO_HEIGHT      capture region in points (default 1280x800)
-#   DEMO_SPEAK_SECONDS            speaking window per scene (default 9)
+#   DEMO_SPEAK_SECONDS            speaking window per beat (default 9)
 #   DEMO_WARMUP_SECONDS           off-camera backend warmup (default 12)
-#   DEMO_COMMIT_SECONDS           wait for polish+commit after scene 1 (default 6)
+#   DEMO_COMMIT_SECONDS           wait for polish+commit after beat 2 (default 12)
+#   DEMO_POLISH_READY_SECONDS     max wait for polishd health (default 300)
 #   DEMO_CAPTURE_AUDIO            1 = record default-input audio into the video
 #                                 (default: 1 for a human take, 0 hands-free)
-#   DEMO_SENTENCE_1 / _2          suggested lines shown in the prompts
+#   DEMO_LINE_LIVE / _OVERLAY     the lines shown in the prompts / spoken by TTS
+#   DEMO_TERMINAL_AGENT           auto (default) | claude | shell — what runs in
+#                                 the staged Terminal window. auto uses a real
+#                                 Claude Code session when `claude` is on the
+#                                 login-shell PATH and logged in, else a plain
+#                                 zsh prompt in the staged repo.
 #   DEMO_HANDS_FREE               1 = no human: render the lines with `say`
 #                                 into the "BlackHole 2ch" loopback device and
 #                                 pin the app's mic to it. One-time machine
@@ -57,15 +78,20 @@ fi
 APP_PATH="${1:-dist/localvoxtral.app}"
 APP_PROCESS="localvoxtral"
 BUNDLE_ID="com.localvoxtral.app"
-TEXTEDIT_ID="com.apple.TextEdit"
 
 DEMO_WIDTH="${DEMO_WIDTH:-1280}"
 DEMO_HEIGHT="${DEMO_HEIGHT:-800}"
 DEMO_SPEAK_SECONDS="${DEMO_SPEAK_SECONDS:-9}"
 DEMO_WARMUP_SECONDS="${DEMO_WARMUP_SECONDS:-12}"
-DEMO_COMMIT_SECONDS="${DEMO_COMMIT_SECONDS:-6}"
-DEMO_SENTENCE_1="${DEMO_SENTENCE_1:-This is realtime dictation, running fully offline on my Mac. The overlay streams every word as I say it, and a local language model polishes the text before it lands in the document.}"
-DEMO_SENTENCE_2="${DEMO_SENTENCE_2:-And if I hold the key instead, my words are typed straight into the document, live, while I am still talking.}"
+DEMO_COMMIT_SECONDS="${DEMO_COMMIT_SECONDS:-12}"
+DEMO_POLISH_READY_SECONDS="${DEMO_POLISH_READY_SECONDS:-300}"
+DEMO_TERMINAL_AGENT="${DEMO_TERMINAL_AGENT:-auto}"
+# Beat 1 (hold -> live streaming): a technical sentence a developer would say
+# to a coding agent; streamed raw, so no spoken symbol forms here.
+DEMO_LINE_LIVE="${DEMO_LINE_LIVE:-Refactor the retry logic in the websocket client, and add a unit test for the reconnect path.}"
+# Beat 2 (tap -> overlay + agent-profile polish): spoken symbol forms the
+# polish profile turns into written forms (index.ts, --no-verify).
+DEMO_LINE_OVERLAY="${DEMO_LINE_OVERLAY:-Open index dot t s and run the tests again, then commit with dash dash no verify.}"
 DEMO_HANDS_FREE="${DEMO_HANDS_FREE:-0}"
 DEMO_SAY_DEVICE="${DEMO_SAY_DEVICE:-}"
 DEMO_SAY_INPUT_UID="${DEMO_SAY_INPUT_UID:-}"
@@ -79,23 +105,19 @@ if [[ -z "${DEMO_CAPTURE_AUDIO:-}" ]]; then
   if [[ -n "$DEMO_SAY_DEVICE" ]]; then DEMO_CAPTURE_AUDIO=0; else DEMO_CAPTURE_AUDIO=1; fi
 fi
 
+case "$DEMO_TERMINAL_AGENT" in
+  auto|claude|shell) ;;
+  *) echo "DEMO_TERMINAL_AGENT must be auto, claude, or shell (got: $DEMO_TERMINAL_AGENT)" >&2; exit 1;;
+esac
+
 OUT_DIR="dist/demo"
 RAW_MOV="$OUT_DIR/demo-raw.mov"
 OUT_MP4="$OUT_DIR/demo.mp4"
 
 DEFAULTS_BACKUP="${HOME}/.localvoxtral-record-demo.pre.plist"
 DEFAULTS_BACKUP_HAD_DOMAIN="${DEFAULTS_BACKUP}.had-domain"
-TEXTEDIT_BACKUP="${HOME}/.localvoxtral-record-demo.textedit.pre.plist"
-TEXTEDIT_BACKUP_HAD_DOMAIN="${TEXTEDIT_BACKUP}.had-domain"
 
 [[ -d "$APP_PATH" ]] || { echo "App bundle not found: $APP_PATH (build with ./scripts/package_app.sh)" >&2; exit 1; }
-
-# TextEdit gets its defaults mutated (plain text, big font) and its front
-# document discarded on cleanup — refuse to run over the user's open documents.
-if pgrep -xq TextEdit; then
-  echo "TextEdit is running. Quit it first (unsaved documents would be at risk)." >&2
-  exit 1
-fi
 
 # --- defaults snapshot/restore (same pattern as capture-readme-assets.sh) ----
 write_empty_plist() {
@@ -129,10 +151,11 @@ restore_domain() { # <domain> <backup> <had-domain-marker>
   rm -f "$2" "$3"
 }
 
-# --- permission preflight -----------------------------------------------------
+# --- permission + secure-input preflight ------------------------------------------
 PREFLIGHT="$(mktemp -t lv-demo-preflight).swift"
 cat > "$PREFLIGHT" <<'SWIFT'
 import ApplicationServices
+import Carbon
 import CoreGraphics
 
 var ok = true
@@ -143,6 +166,10 @@ if !AXIsProcessTrusted() {
 if !CGPreflightScreenCaptureAccess() {
     _ = CGRequestScreenCaptureAccess()
     print("MISSING Screen Recording: System Settings > Privacy & Security > Screen Recording — enable the app that launched this script, then rerun.")
+    ok = false
+}
+if IsSecureEventInputEnabled() {
+    print("BLOCKED Secure Keyboard Entry is held by some process — usually a LOCKED SCREEN, a password prompt, or Terminal's own Secure Keyboard Entry setting. The live-dictation beat would be refused. Unlock the GUI session / disable it, then rerun.")
     ok = false
 }
 exit(ok ? 0 : 1)
@@ -247,8 +274,13 @@ SWIFT
 # --- cleanup -------------------------------------------------------------------
 RECORDER_PID=""
 LAUNCHED_APP=0
-LAUNCHED_TEXTEDIT=0
+LAUNCHED_TERMINAL_APP=0
+TERMINAL_WINDOW_ID=""
+TERMINAL_TTY=""
+DEMO_STAGE=""
 ORIGINAL_DARK_MODE=""
+ANNOUNCED_TAKEOVER=0
+DEMO_COMPLETED=0
 cleanup() {
   if [[ -f "$GESTURE" ]]; then
     swift "$GESTURE" up >/dev/null 2>&1 || true # never leave Right Command stuck down
@@ -264,18 +296,36 @@ cleanup() {
     sleep 1
     pkill -x "$APP_PROCESS" >/dev/null 2>&1 || true
   fi
-  if [[ "$LAUNCHED_TEXTEDIT" == 1 ]]; then
-    osascript -e 'tell application "TextEdit" to close every document saving no' >/dev/null 2>&1 || true
-    osascript -e 'tell application "TextEdit" to quit' >/dev/null 2>&1 || true
+  # Terminal teardown is surgical: kill only the processes on OUR window's
+  # tty (never `pkill claude` — the owner may have his own sessions running),
+  # close only OUR window, and quit Terminal only if WE launched it.
+  if [[ -n "$TERMINAL_TTY" ]]; then
+    pkill -t "${TERMINAL_TTY#/dev/}" >/dev/null 2>&1 || true
+    sleep 1
+  fi
+  if [[ -n "$TERMINAL_WINDOW_ID" ]]; then
+    osascript -e "tell application \"Terminal\" to close window id $TERMINAL_WINDOW_ID" >/dev/null 2>&1 || true
+  fi
+  if [[ "$LAUNCHED_TERMINAL_APP" == 1 ]]; then
+    osascript -e 'tell application "Terminal" to quit' >/dev/null 2>&1 || true
+  fi
+  if [[ -n "$DEMO_STAGE" ]]; then
+    rm -rf "$DEMO_STAGE"
   fi
   if ! restore_domain "$BUNDLE_ID" "$DEFAULTS_BACKUP" "$DEFAULTS_BACKUP_HAD_DOMAIN"; then
     echo "WARNING: failed to restore $BUNDLE_ID defaults; backup left at $DEFAULTS_BACKUP" >&2
   fi
-  if ! restore_domain "$TEXTEDIT_ID" "$TEXTEDIT_BACKUP" "$TEXTEDIT_BACKUP_HAD_DOMAIN"; then
-    echo "WARNING: failed to restore $TEXTEDIT_ID defaults; backup left at $TEXTEDIT_BACKUP" >&2
-  fi
   if [[ -n "$ORIGINAL_DARK_MODE" ]]; then
     osascript -e "tell application \"System Events\" to tell appearance preferences to set dark mode to ${ORIGINAL_DARK_MODE}" >/dev/null 2>&1 || true
+  fi
+  # Owner rule: announce completion audibly (default output, never the
+  # loopback) whenever the script took over the GUI session.
+  if [[ "$ANNOUNCED_TAKEOVER" == 1 ]]; then
+    if [[ "$DEMO_COMPLETED" == 1 ]]; then
+      say "record demo done" >/dev/null 2>&1 || true
+    else
+      say "record demo failed" >/dev/null 2>&1 || true
+    fi
   fi
 }
 trap cleanup EXIT INT TERM HUP
@@ -298,6 +348,31 @@ fi
 command -v ffmpeg >/dev/null || \
   echo "NOTE: ffmpeg not found — the raw .mov will be produced but not encoded (brew install ffmpeg)." >&2
 
+# --- resolve what runs in the terminal window ------------------------------------
+# A real Claude Code session is the ideal scene; fall back to a plain zsh
+# prompt in the staged repo when the CLI is absent or not logged in. Never
+# fake a running agent — a bare shell is honest, a painted TUI is not.
+TERMINAL_AGENT="shell"
+CLAUDE_BIN=""
+if [[ "$DEMO_TERMINAL_AGENT" != "shell" ]]; then
+  # Resolve the absolute binary via the login shell: the staged demo zsh has a
+  # bare ZDOTDIR, so the user's own PATH additions won't exist inside it.
+  CLAUDE_BIN="$(zsh -lc 'command -v claude' 2>/dev/null || true)"
+  if [[ -n "$CLAUDE_BIN" ]] && grep -q '"oauthAccount"' "$HOME/.claude.json" 2>/dev/null; then
+    TERMINAL_AGENT="claude"
+  elif [[ "$DEMO_TERMINAL_AGENT" == "claude" ]]; then
+    echo "DEMO_TERMINAL_AGENT=claude, but no usable claude CLI (binary missing from the login-shell PATH, or not logged in)." >&2
+    exit 1
+  fi
+fi
+echo "Terminal scene agent: $TERMINAL_AGENT"
+
+# --- OWNER RULE: audible takeover warning BEFORE any focus-stealing action -------
+# On the DEFAULT audio output (never the loopback — that device is inaudible).
+say "record demo taking control in 3" >/dev/null 2>&1 || true
+ANNOUNCED_TAKEOVER=1
+sleep 3
+
 # --- stage settings -------------------------------------------------------------
 if pgrep -xq "$APP_PROCESS"; then
   echo "Quitting running $APP_PROCESS instance..."
@@ -310,29 +385,29 @@ pgrep -xq "$APP_PROCESS" && { echo "$APP_PROCESS refuses to quit; aborting." >&2
 
 snapshot_domain "$BUNDLE_ID" "$DEFAULTS_BACKUP" "$DEFAULTS_BACKUP_HAD_DOMAIN" \
   || { echo "Could not snapshot $BUNDLE_ID defaults; refusing to mutate them." >&2; exit 1; }
-snapshot_domain "$TEXTEDIT_ID" "$TEXTEDIT_BACKUP" "$TEXTEDIT_BACKUP_HAD_DOMAIN" \
-  || { echo "Could not snapshot TextEdit defaults; refusing to mutate them." >&2; exit 1; }
 
-# The demo always shows the Right Command tap/hold gesture; backend settings
-# are left as configured on this Mac (the demo should use the real setup).
+# The demo always shows the Right Command tap/hold gesture. Backend MODES are
+# left as configured on this Mac (the demo should use the real setup), but the
+# overlay beat depends on agent-profile polishing with the default 4B model —
+# the 0.8B does not normalize spoken flags reliably (see the demoted
+# agent-flag-spoken eval case) — so those are pinned (snapshotted above,
+# restored on exit).
 defaults write "$BUNDLE_ID" "settings.onboarding_completed" -bool true
 defaults write "$BUNDLE_ID" "settings.modifier_only_hotkey_enabled" -bool true
 defaults write "$BUNDLE_ID" "settings.modifier_only_hotkey_modifier" -string "right_command"
+defaults write "$BUNDLE_ID" "settings.llm_polishing_enabled" -bool true
+defaults write "$BUNDLE_ID" "settings.agent_polish_profile_enabled" -bool true
+defaults write "$BUNDLE_ID" "settings.managed_llm_polishing_model" -string "mlx-community/Qwen3.5-4B-OptiQ-4bit"
 if [[ -n "$DEMO_SAY_INPUT_UID" ]]; then
   defaults write "$BUNDLE_ID" "settings.selected_input_device_uid" -string "$DEMO_SAY_INPUT_UID"
 fi
-# TextEdit: plain-text mode with a large monospaced font so dictated text is
-# legible at README size.
-defaults write "$TEXTEDIT_ID" RichText -int 0
-defaults write "$TEXTEDIT_ID" NSFixedPitchFontSize -int 22
-defaults write "$TEXTEDIT_ID" CheckSpellingWhileTyping -bool false
 
 # Dark mode pinned, like the README screenshots.
 ORIGINAL_DARK_MODE="$(osascript -e 'tell application "System Events" to tell appearance preferences to get dark mode')"
 osascript -e 'tell application "System Events" to tell appearance preferences to set dark mode to true'
 sleep 1
 
-# --- launch + warm up the backend off-camera ------------------------------------
+# --- launch + warm up the backends off-camera ------------------------------------
 LAUNCHED_APP=1
 open "$APP_PATH"
 for _ in $(seq 1 20); do pgrep -xq "$APP_PROCESS" && break; sleep 0.5; done
@@ -347,13 +422,35 @@ sleep 3
 osascript -e 'tell application "System Events" to key code 53' >/dev/null 2>&1 || true # dismiss overlay
 sleep 1
 
-# --- stage TextEdit inside the capture region ------------------------------------
-# Region and window placement are computed from the MAIN display only. The
-# desktop-union bounding box is wrong on multi-monitor setups: its center can
-# be a void between displays, which records as black while macOS clamps the
-# window elsewhere (first hands-free runner take failed exactly like that).
-# CGDisplayBounds uses the same global top-left coordinates as screencapture
-# -R and System Events window positions.
+# The overlay beat's polish must be REAL — never record before the managed
+# polishing helper answers its health endpoint. (An external-URL polishing
+# setup is the owner's own working config and is not polled.)
+POLISH_MODE="$(defaults read "$BUNDLE_ID" settings.polishing_backend_mode 2>/dev/null || echo managed_local)"
+if [[ "$POLISH_MODE" != "external_url" ]]; then
+  HF_HUB_DIR="${HF_HUB_CACHE:-}"
+  [[ -z "$HF_HUB_DIR" && -n "${HF_HOME:-}" ]] && HF_HUB_DIR="$HF_HOME/hub"
+  [[ -z "$HF_HUB_DIR" ]] && HF_HUB_DIR="$HOME/.cache/huggingface/hub"
+  if [[ ! -d "$HF_HUB_DIR/models--mlx-community--Qwen3.5-4B-OptiQ-4bit" ]]; then
+    echo "NOTE: the 4B polish model is not in the HF cache yet — readiness may include a ~3.3 GB download." >&2
+  fi
+  echo "Waiting for the polishing helper (http://127.0.0.1:8472/health, up to ${DEMO_POLISH_READY_SECONDS}s)..."
+  POLISH_DEADLINE=$(( SECONDS + DEMO_POLISH_READY_SECONDS ))
+  until curl -sf -m 2 http://127.0.0.1:8472/health >/dev/null 2>&1; do
+    if (( SECONDS >= POLISH_DEADLINE )); then
+      echo "polishd never became healthy within ${DEMO_POLISH_READY_SECONDS}s — aborting (the overlay beat would show unpolished text)." >&2
+      exit 1
+    fi
+    sleep 2
+  done
+  echo "polishd healthy."
+fi
+
+# --- capture region (MAIN display only) -------------------------------------------
+# The desktop-union bounding box is wrong on multi-monitor setups: its center
+# can be a void between displays, which records as black while macOS clamps
+# the window elsewhere (first hands-free runner take failed exactly like
+# that). CGDisplayBounds uses the same global top-left coordinates as
+# screencapture -R and System Events window positions.
 read -r MAIN_X MAIN_Y MAIN_W MAIN_H < <(swift - <<'SWIFT'
 import CoreGraphics
 let b = CGDisplayBounds(CGMainDisplayID())
@@ -365,20 +462,126 @@ REGION_Y=$(( MAIN_Y + (MAIN_H - DEMO_HEIGHT) / 2 ))
 (( MAIN_W < DEMO_WIDTH || MAIN_H < DEMO_HEIGHT )) && { echo "Main display (${MAIN_W}x${MAIN_H}) is smaller than the ${DEMO_WIDTH}x${DEMO_HEIGHT} capture region." >&2; exit 1; }
 (( REGION_Y < MAIN_Y + 30 )) && REGION_Y=$(( MAIN_Y + 30 )) # keep clear of the menu bar
 
-LAUNCHED_TEXTEDIT=1
+# --- stage the demo repo + Terminal window inside the capture region --------------
+DEMO_STAGE="$(mktemp -d -t lv-demo-stage)"
+REPO_DIR="$DEMO_STAGE/webapp"
+ZDOT_DIR="$DEMO_STAGE/zdot"
+mkdir -p "$REPO_DIR/src" "$ZDOT_DIR"
+
+cat > "$REPO_DIR/package.json" <<'JSON'
+{
+  "name": "webapp",
+  "private": true,
+  "scripts": {
+    "test": "vitest run"
+  }
+}
+JSON
+cat > "$REPO_DIR/src/index.ts" <<'TS'
+import { createClient } from "./client";
+
+export function main(): void {
+  const client = createClient();
+  client.connect();
+}
+TS
+cat > "$REPO_DIR/src/client.ts" <<'TS'
+export function createClient() {
+  return {
+    connect(): void {
+      // TODO: retry logic
+    },
+  };
+}
+TS
+cat > "$REPO_DIR/src/client.test.ts" <<'TS'
+import { test } from "vitest";
+
+test.todo("reconnects after a dropped connection");
+TS
+git -C "$REPO_DIR" init -q -b main
+git -C "$REPO_DIR" add -A
+git -C "$REPO_DIR" -c user.name="demo" -c user.email="demo@example.com" \
+  commit -q -m "initial commit"
+
+# Minimal zsh prompt (repo name + branch), no rprompt, cleared screen — the
+# recording opens on a clean, legible prompt with no real username/hostname.
+cat > "$ZDOT_DIR/.zshrc" <<'ZSHRC'
+PROMPT='%F{green}➜%f %F{cyan}%1~%f %F{blue}git:(%F{red}main%F{blue})%f '
+unset RPROMPT
+clear
+ZSHRC
+
+pgrep -xq Terminal || LAUNCHED_TERMINAL_APP=1
+SHELL_CMD="cd $(printf %q "$REPO_DIR") && exec /usr/bin/env ZDOTDIR=$(printf %q "$ZDOT_DIR") /bin/zsh -i"
+TERMINAL_INFO="$(osascript - "$SHELL_CMD" <<'OSA'
+on run argv
+    tell application "Terminal"
+        activate
+        set demoTab to do script (item 1 of argv)
+        delay 1
+        set windowID to id of front window
+        set ttyName to tty of demoTab
+        -- Dark "Pro" profile + big font so terminal text is legible at
+        -- README width. Per-tab only: nothing is persisted to the user's
+        -- Terminal preferences. Best-effort — the take review catches it.
+        try
+            set current settings of demoTab to settings set "Pro"
+        end try
+        try
+            set font name of demoTab to "Menlo"
+            set font size of demoTab to 21
+        end try
+        return (windowID as text) & " " & ttyName
+    end tell
+end run
+OSA
+)"
+TERMINAL_WINDOW_ID="${TERMINAL_INFO%% *}"
+TERMINAL_TTY="${TERMINAL_INFO##* }"
+if [[ -z "$TERMINAL_WINDOW_ID" || -z "$TERMINAL_TTY" || "$TERMINAL_TTY" != /dev/* ]]; then
+  echo "Failed to stage the Terminal window (osascript returned: '$TERMINAL_INFO')." >&2
+  exit 1
+fi
+echo "Terminal demo window id $TERMINAL_WINDOW_ID on $TERMINAL_TTY"
+
+# If we launched Terminal ourselves it may have opened a default startup
+# window too — close everything that is not the demo window so nothing else
+# shows through the capture region.
+if [[ "$LAUNCHED_TERMINAL_APP" == 1 ]]; then
+  osascript -e "tell application \"Terminal\" to close (every window whose id is not $TERMINAL_WINDOW_ID)" >/dev/null 2>&1 || true
+fi
+
 # The window fills the region exactly so the recording never shows whatever
 # else is on the desktop.
 osascript >/dev/null <<OSA
-tell application "TextEdit"
-  activate
-  make new document
-end tell
-tell application "System Events" to tell process "TextEdit"
+tell application "Terminal" to activate
+tell application "System Events" to tell process "Terminal"
   set position of front window to {$REGION_X, $REGION_Y}
   set size of front window to {$DEMO_WIDTH, $DEMO_HEIGHT}
 end tell
 OSA
 sleep 1
+
+# A real Claude Code session, launched visibly in the staged window. The only
+# Return ever pressed is the folder-trust-dialog acceptance BEFORE any
+# dictated text exists (on an already-trusted folder that Return hits the
+# empty composer and is a no-op); once dictated text is on screen nothing
+# ever submits it.
+if [[ "$TERMINAL_AGENT" == "claude" ]]; then
+  echo "Launching claude ($CLAUDE_BIN) in the demo window..."
+  osascript - "$CLAUDE_BIN" "$TERMINAL_WINDOW_ID" >/dev/null <<'OSA'
+on run argv
+    tell application "Terminal"
+        do script (item 1 of argv) in selected tab of window id ((item 2 of argv) as integer)
+    end tell
+end run
+OSA
+  sleep 10
+  osascript -e 'tell application "Terminal" to activate' >/dev/null
+  osascript -e 'tell application "System Events" to key code 36' >/dev/null 2>&1 || true
+  sleep 3
+fi
 
 # --- record ----------------------------------------------------------------------
 mkdir -p "$OUT_DIR"
@@ -389,7 +592,7 @@ screencapture "${CAPTURE_FLAGS[@]}" -R "${REGION_X},${REGION_Y},${DEMO_WIDTH},${
 RECORDER_PID=$!
 sleep 2
 
-cue() { # <scene-label> <sentence>
+cue() { # <beat-label> <sentence>
   echo
   echo "==================================================================="
   echo "  $1"
@@ -407,32 +610,39 @@ speak_or_wait() { # <sentence>
   fi
 }
 
-# Scene 1 — tap: overlay dictation, then commit.
-osascript -e 'tell application "TextEdit" to activate' >/dev/null
-sleep 1
-cue "SCENE 1 — overlay (tap). Speak after the beep." "$DEMO_SENTENCE_1"
-tap_hotkey
-speak_or_wait "$DEMO_SENTENCE_1"
-tap_hotkey
-echo "Committing (polish + insert)..."
-sleep "$DEMO_COMMIT_SECONDS"
-
-# New line so scene 2's live text doesn't run into scene 1's commit.
-osascript -e 'tell application "System Events" to key code 36' >/dev/null
+osascript -e 'tell application "Terminal" to activate' >/dev/null
 sleep 1
 
-# Scene 2 — hold: live auto-paste while the key is down.
-cue "SCENE 2 — live typing (hold). Speak after the beep, keep talking." "$DEMO_SENTENCE_2"
+# Beat 1 — hold: live dictation streams word-by-word into the terminal prompt.
+# No Return is ever pressed: the streamed text sits at the prompt, unsubmitted.
+cue "BEAT 1 — live streaming into the terminal (hold). Speak after the beep, keep talking." "$DEMO_LINE_LIVE"
 if [[ -n "$DEMO_SAY_DEVICE" ]]; then
   press_hotkey
-  sleep 1 # get past the hold threshold so live dictation runs before the TTS starts
-  say -a "$DEMO_SAY_DEVICE" -r 180 "$DEMO_SENTENCE_2"
-  sleep 1
+  sleep 1.2 # get past the hold threshold so live dictation runs before the TTS starts
+  say -a "$DEMO_SAY_DEVICE" -r 180 "$DEMO_LINE_LIVE"
+  sleep 1.5
   release_hotkey
 else
   hold_hotkey "$DEMO_SPEAK_SECONDS"
 fi
-sleep 4 # let the last words land
+sleep 3 # stop finalization + held-back tail flush
+
+# Transition — clear the prompt line WITHOUT Return (Return would submit!).
+# A single Ctrl+C gives a fresh prompt line in zsh and clears Claude Code's
+# composer (a second one would exit claude — never send two).
+osascript -e 'tell application "System Events" to keystroke "c" using control down' >/dev/null
+sleep 1.5
+
+# Beat 2 — tap: overlay buffer, spoken symbol forms, agent-profile polish,
+# and the committed text lands in the terminal.
+cue "BEAT 2 — overlay + agent polish (tap). Speak after the beep." "$DEMO_LINE_OVERLAY"
+tap_hotkey
+sleep 1
+speak_or_wait "$DEMO_LINE_OVERLAY"
+tap_hotkey
+echo "Committing (agent-profile polish + insert)..."
+sleep "$DEMO_COMMIT_SECONDS"
+sleep 3 # let the committed text sit on screen
 
 kill -INT "$RECORDER_PID"
 wait "$RECORDER_PID" 2>/dev/null || true
@@ -456,3 +666,5 @@ if command -v ffmpeg >/dev/null; then
 else
   echo "ffmpeg missing — upload $RAW_MOV as-is or install ffmpeg and re-run the encode."
 fi
+
+DEMO_COMPLETED=1

--- a/scripts/record-demo.sh
+++ b/scripts/record-demo.sh
@@ -282,6 +282,7 @@ ORIGINAL_DARK_MODE=""
 ANNOUNCED_TAKEOVER=0
 DEMO_COMPLETED=0
 cleanup() {
+  set +e # cleanup is best-effort: one failing teardown step must not abort the rest
   if [[ -f "$GESTURE" ]]; then
     swift "$GESTURE" up >/dev/null 2>&1 || true # never leave Right Command stuck down
   fi
@@ -310,7 +311,9 @@ cleanup() {
     osascript -e 'tell application "Terminal" to quit' >/dev/null 2>&1 || true
   fi
   if [[ -n "$DEMO_STAGE" ]]; then
-    rm -rf "$DEMO_STAGE"
+    # The staged zsh writes .zsh_sessions into ZDOTDIR while exiting (we just
+    # killed its tty) — one rm can race that write (take 3 died here); retry.
+    rm -rf "$DEMO_STAGE" 2>/dev/null || { sleep 1; rm -rf "$DEMO_STAGE" 2>/dev/null || true; }
   fi
   if ! restore_domain "$BUNDLE_ID" "$DEFAULTS_BACKUP" "$DEFAULTS_BACKUP_HAD_DOMAIN"; then
     echo "WARNING: failed to restore $BUNDLE_ID defaults; backup left at $DEFAULTS_BACKUP" >&2

--- a/scripts/record-demo.sh
+++ b/scripts/record-demo.sh
@@ -97,16 +97,18 @@ DEMO_TERMINAL_AGENT="${DEMO_TERMINAL_AGENT:-auto}"
 # to a coding agent; streamed raw, so no spoken symbol forms here.
 DEMO_LINE_LIVE="${DEMO_LINE_LIVE:-Refactor the retry logic in the websocket client, and add a unit test for the reconnect path.}"
 # Beat 2 (tap -> overlay + agent-profile polish): spoken symbol forms the
-# polish profile turns into written forms (useAuth.ts — grounded by the repo
-# vocabulary indexed from the staged repo — and --filter). Phrased as a
-# read-only question so submitting it to a real Claude Code session yields a
-# fast text answer instead of a tool-permission prompt.
-DEMO_LINE_OVERLAY="${DEMO_LINE_OVERLAY:-Look at use auth dot t s and tell me which tests dash dash filter auth would run.}"
+# polish profile turns into written forms (`index.ts`, `--coverage`). Words
+# chosen for TTS->ASR robustness — take 6 proved "use auth" / "filter auth"
+# get misheard ("the use of that TS", "filter off") and the repo-vocabulary
+# rescue no-ops in claude mode because claude overwrites the Terminal title
+# the resolver reads. Phrased as a read-only ask so submitting it to a real
+# Claude Code session yields a fast text answer, not a tool-permission stall.
+DEMO_LINE_OVERLAY="${DEMO_LINE_OVERLAY:-Explain what index dot t s does, then give me the test command with dash dash coverage.}"
 # In claude mode the polished beat-2 prompt is genuinely SUBMITTED (one small
 # request against the owner's Claude usage) and the response is recorded for
 # DEMO_RESPONSE_SECONDS. DEMO_SUBMIT_PROMPT=0 turns the ending off.
 DEMO_SUBMIT_PROMPT="${DEMO_SUBMIT_PROMPT:-1}"
-DEMO_RESPONSE_SECONDS="${DEMO_RESPONSE_SECONDS:-14}"
+DEMO_RESPONSE_SECONDS="${DEMO_RESPONSE_SECONDS:-12}"
 DEMO_HANDS_FREE="${DEMO_HANDS_FREE:-0}"
 DEMO_SAY_DEVICE="${DEMO_SAY_DEVICE:-}"
 DEMO_SAY_INPUT_UID="${DEMO_SAY_INPUT_UID:-}"
@@ -507,6 +509,14 @@ cat > "$REPO_DIR/package.json" <<'JSON'
   }
 }
 JSON
+cat > "$REPO_DIR/src/index.ts" <<'TS'
+import { createClient } from "./client";
+
+export function main(): void {
+  const client = createClient();
+  client.connect();
+}
+TS
 cat > "$REPO_DIR/src/client.ts" <<'TS'
 export function createClient() {
   return {


### PR DESCRIPTION
## What

Restages the README demo around the app's headline use case: dictating into a real Claude Code session. `scripts/record-demo.sh` + `record-demo.yml` only — the recorded video itself is uploaded manually by the owner (user-attachments URL, README line 20).

- **Scene**: staged repo `/tmp/lv-demo/webapp` in Terminal.app (Menlo 21 pt, opaque tab), `claude` running visibly. Beat 1: hold → live word-by-word streaming into the Claude Code composer. Beat 2: tap → overlay, spoken symbols polished by the agent profile (`index.ts` backticked, "dash dash coverage" → `--coverage`), committed and genuinely submitted; Claude visibly works the repo.
- **Owner rule enforced (was missing)**: `say` warning + 3 s before any focus-stealing automation, completion/failure announcement on exit — hands-free mode included.
- **Warmup**: staging performs one off-camera throwaway overlay dictation so the AGENT-profile prompt-prefix slot is warm (launch warmup only primes standard); verified by commit-latency timing (~11 s unwarmed → ~5–7 s warmed).
- **Staging hardening**: overlay font staged to 22 pt (clamp max 24) and restored after; polish pinned on + 4B model; polishd /health poll; Secure-Keyboard-Entry fail-fast; recorder-death → capture aborted AND deleted (prevents leaking partial captures of whatever is on screen); surgical Terminal teardown (never `pkill claude`).
- Workflow inputs: `terminal_agent=claude|shell`, `DEMO_SUBMIT_PROMPT`, `DEMO_RESPONSE_SECONDS`/`DEMO_COMMIT_SECONDS`.

## Proof

- 7 hands-free dispatches on the self-hosted runner; recommended take: run 29210179189 (artifact `readme-demo`, 58.3 s). Frames reviewed for legibility and content.
- Beat-2 frame shows the exact polished commit: ``Explain what `index.ts` does, then give me the test command with `--coverage`.``
- Script change only; no app code touched. Tier 0 not applicable (bash + workflow), `bash -n` clean via CI dispatch runs.

## Known limitation surfaced (follow-up candidate)

Repo vocabulary cannot ground filenames while `claude` runs: the cwd resolver reads the terminal WINDOW TITLE, which Claude Code overwrites. A non-title cwd fallback (e.g. tty foreground-process cwd) would restore the feature in agent sessions — arguably the most important context for it.