### PR TITLE
install.sh: never resolve dSYM zips as the app asset

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,6 +128,10 @@ jobs:
           key: swiftpm-${{ runner.os }}-${{ hashFiles('Package.resolved') }}
           restore-keys: swiftpm-${{ runner.os }}-
 
+      - name: Installer asset-resolution regression test (issue #131)
+        # Pure bash against a stubbed curl — no network, sub-second.
+        run: ./scripts/ci/test-install-resolve.sh
+
       - name: Format lint (advisory)
         # Advisory until the one-shot tree reformat lands: swift-format exits 0
         # on findings without --strict. After the reformat, add --strict here

--- a/scripts/ci/test-install-resolve.sh
+++ b/scripts/ci/test-install-resolve.sh
@@ -2,10 +2,13 @@
 # Regression test for install.sh release-asset resolution (issue #131).
 #
 # v0.7.4 started shipping dSYM archives next to the app zip, and the GitHub
-# API lists them first, so "take the first .zip asset" resolved the
-# debug-symbol archive and the install failed at extraction. This test runs
-# install.sh in dry-run mode against a stubbed curl serving a fixture that
-# mirrors the real v0.7.4 API asset ordering, and asserts the app zip wins.
+# API listed them first, so "take the first .zip asset" resolved the
+# debug-symbol archive and the install failed at extraction. The fix selects
+# the asset by its exact contractual name (localvoxtral-<tag>.zip, the name
+# release.yml has produced for every release), so no ordering and no future
+# extra zip asset can ever be picked by mistake. This test runs install.sh in
+# dry-run mode against a stubbed curl serving hostile fixtures and asserts
+# the app zip always wins — or that resolution fails loudly.
 #
 # Pure bash, no network, runs anywhere: ./scripts/ci/test-install-resolve.sh
 set -euo pipefail
@@ -39,18 +42,23 @@ STUB
 chmod +x "$TMP_DIR/bin/curl"
 
 run_resolve() {
-  local fixture="$1"
+  local fixture="$1" version="$2"
   PATH="$TMP_DIR/bin:$PATH" LV_TEST_FIXTURE="$fixture" \
-    LOCALVOXTRAL_INSTALL_DRYRUN=1 LOCALVOXTRAL_VERSION=v0.7.4 \
+    LOCALVOXTRAL_INSTALL_DRYRUN=1 LOCALVOXTRAL_VERSION="$version" \
     bash "$ROOT_DIR/scripts/install.sh"
 }
 
-# Case 1: real v0.7.4 asset ordering (dSYM zip listed before the app zip),
-# plus the polishd dSYM zip that release.yml attaches to newer releases.
+expected="https://github.com/T0mSIlver/localvoxtral/releases/download/v0.7.4/localvoxtral-v0.7.4.zip"
+
+# Case 1: hostile asset ordering. Mirrors the real v0.7.4 API response (dSYM
+# zip listed before the app zip, which triggered #131), plus the polishd dSYM
+# zip release.yml attaches to newer releases, plus a hypothetical future
+# non-dSYM zip listed first — the case a dSYM-only blocklist would get wrong.
 cat > "$TMP_DIR/release.json" <<'JSON'
 {
   "tag_name": "v0.7.4",
   "assets": [
+    {"browser_download_url": "https://github.com/T0mSIlver/localvoxtral/releases/download/v0.7.4/localvoxtral-v0.7.4-update.zip"},
     {"browser_download_url": "https://github.com/T0mSIlver/localvoxtral/releases/download/v0.7.4/localvoxtral-v0.7.4.dmg"},
     {"browser_download_url": "https://github.com/T0mSIlver/localvoxtral/releases/download/v0.7.4/localvoxtral-v0.7.4.dmg.sha256"},
     {"browser_download_url": "https://github.com/T0mSIlver/localvoxtral/releases/download/v0.7.4/localvoxtral-v0.7.4.dSYM.zip"},
@@ -61,15 +69,15 @@ cat > "$TMP_DIR/release.json" <<'JSON'
 }
 JSON
 
-output="$(run_resolve "$TMP_DIR/release.json")" || fail "install.sh dry run exited non-zero:
+output="$(run_resolve "$TMP_DIR/release.json" v0.7.4)" || fail "install.sh dry run exited non-zero:
 $output"
 resolved="$(printf '%s\n' "$output" | sed -n 's/^Resolved zip: //p')"
-expected="https://github.com/T0mSIlver/localvoxtral/releases/download/v0.7.4/localvoxtral-v0.7.4.zip"
 [ "$resolved" = "$expected" ] ||
   fail "resolved '$resolved', expected '$expected'"
-echo "PASS: app zip wins over dSYM zips"
+echo "PASS: exact app zip wins over dSYM zips and other zip assets"
 
-# Case 2: a release with only dSYM zips must die loudly, not install symbols.
+# Case 2: a release without the contractual app zip must die loudly, not
+# fall back to whatever zip is present (here: only a dSYM archive).
 cat > "$TMP_DIR/release-dsym-only.json" <<'JSON'
 {
   "tag_name": "v0.7.4",
@@ -79,13 +87,24 @@ cat > "$TMP_DIR/release-dsym-only.json" <<'JSON'
 }
 JSON
 
-if output="$(run_resolve "$TMP_DIR/release-dsym-only.json" 2>&1)"; then
-  fail "expected failure when only dSYM zips exist, got:
+if output="$(run_resolve "$TMP_DIR/release-dsym-only.json" v0.7.4 2>&1)"; then
+  fail "expected failure when the app zip asset is missing, got:
 $output"
 fi
-printf '%s\n' "$output" | grep -q 'No .zip asset found' ||
-  fail "expected 'No .zip asset found' error, got:
+case "$output" in
+  *"has no asset named localvoxtral-v0.7.4.zip"*) ;;
+  *) fail "expected 'has no asset named' error, got:
+$output" ;;
+esac
+echo "PASS: release without the app zip fails with a clear error"
+
+# Case 3: VERSION=latest — the expected asset name must come from the
+# metadata's tag_name, not from LOCALVOXTRAL_VERSION.
+output="$(run_resolve "$TMP_DIR/release.json" latest)" || fail "install.sh dry run (latest) exited non-zero:
 $output"
-echo "PASS: dSYM-only release fails with a clear error"
+resolved="$(printf '%s\n' "$output" | sed -n 's/^Resolved zip: //p')"
+[ "$resolved" = "$expected" ] ||
+  fail "latest resolved '$resolved', expected '$expected'"
+echo "PASS: VERSION=latest resolves via the metadata tag_name"
 
 echo "OK: all install.sh resolution tests passed"

--- a/scripts/ci/test-install-resolve.sh
+++ b/scripts/ci/test-install-resolve.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+# Regression test for install.sh release-asset resolution (issue #131).
+#
+# v0.7.4 started shipping dSYM archives next to the app zip, and the GitHub
+# API lists them first, so "take the first .zip asset" resolved the
+# debug-symbol archive and the install failed at extraction. This test runs
+# install.sh in dry-run mode against a stubbed curl serving a fixture that
+# mirrors the real v0.7.4 API asset ordering, and asserts the app zip wins.
+#
+# Pure bash, no network, runs anywhere: ./scripts/ci/test-install-resolve.sh
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "$0")/../.." && pwd)"
+TMP_DIR="$(mktemp -d "${TMPDIR:-/tmp}/lv-install-test.XXXXXX")"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+fail() {
+  printf 'FAIL: %s\n' "$*" >&2
+  exit 1
+}
+
+# Stub curl: writes the fixture named by LV_TEST_FIXTURE to the -o target and
+# prints the HTTP code install.sh expects from -w '%{http_code}'.
+mkdir -p "$TMP_DIR/bin"
+cat > "$TMP_DIR/bin/curl" <<'STUB'
+#!/usr/bin/env bash
+out=""
+while [ $# -gt 0 ]; do
+  case "$1" in
+    -o) out="$2"; shift 2 ;;
+    -w) shift 2 ;;
+    *) shift ;;
+  esac
+done
+[ -n "$out" ] || exit 1
+cat "$LV_TEST_FIXTURE" > "$out"
+printf '200'
+STUB
+chmod +x "$TMP_DIR/bin/curl"
+
+run_resolve() {
+  local fixture="$1"
+  PATH="$TMP_DIR/bin:$PATH" LV_TEST_FIXTURE="$fixture" \
+    LOCALVOXTRAL_INSTALL_DRYRUN=1 LOCALVOXTRAL_VERSION=v0.7.4 \
+    bash "$ROOT_DIR/scripts/install.sh"
+}
+
+# Case 1: real v0.7.4 asset ordering (dSYM zip listed before the app zip),
+# plus the polishd dSYM zip that release.yml attaches to newer releases.
+cat > "$TMP_DIR/release.json" <<'JSON'
+{
+  "tag_name": "v0.7.4",
+  "assets": [
+    {"browser_download_url": "https://github.com/T0mSIlver/localvoxtral/releases/download/v0.7.4/localvoxtral-v0.7.4.dmg"},
+    {"browser_download_url": "https://github.com/T0mSIlver/localvoxtral/releases/download/v0.7.4/localvoxtral-v0.7.4.dmg.sha256"},
+    {"browser_download_url": "https://github.com/T0mSIlver/localvoxtral/releases/download/v0.7.4/localvoxtral-v0.7.4.dSYM.zip"},
+    {"browser_download_url": "https://github.com/T0mSIlver/localvoxtral/releases/download/v0.7.4/localvoxtral-polishd-v0.7.4.dSYM.zip"},
+    {"browser_download_url": "https://github.com/T0mSIlver/localvoxtral/releases/download/v0.7.4/localvoxtral-v0.7.4.zip"},
+    {"browser_download_url": "https://github.com/T0mSIlver/localvoxtral/releases/download/v0.7.4/localvoxtral-v0.7.4.zip.sha256"}
+  ]
+}
+JSON
+
+output="$(run_resolve "$TMP_DIR/release.json")" || fail "install.sh dry run exited non-zero:
+$output"
+resolved="$(printf '%s\n' "$output" | sed -n 's/^Resolved zip: //p')"
+expected="https://github.com/T0mSIlver/localvoxtral/releases/download/v0.7.4/localvoxtral-v0.7.4.zip"
+[ "$resolved" = "$expected" ] ||
+  fail "resolved '$resolved', expected '$expected'"
+echo "PASS: app zip wins over dSYM zips"
+
+# Case 2: a release with only dSYM zips must die loudly, not install symbols.
+cat > "$TMP_DIR/release-dsym-only.json" <<'JSON'
+{
+  "tag_name": "v0.7.4",
+  "assets": [
+    {"browser_download_url": "https://github.com/T0mSIlver/localvoxtral/releases/download/v0.7.4/localvoxtral-v0.7.4.dSYM.zip"}
+  ]
+}
+JSON
+
+if output="$(run_resolve "$TMP_DIR/release-dsym-only.json" 2>&1)"; then
+  fail "expected failure when only dSYM zips exist, got:
+$output"
+fi
+printf '%s\n' "$output" | grep -q 'No .zip asset found' ||
+  fail "expected 'No .zip asset found' error, got:
+$output"
+echo "PASS: dSYM-only release fails with a clear error"
+
+echo "OK: all install.sh resolution tests passed"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -36,7 +36,7 @@ resolve_release_api_url() {
 }
 
 resolve_zip_url() {
-  local api_url http_code release_json release_json_file zip_url zip_urls
+  local api_url http_code release_json release_json_file tag zip_url zip_urls
 
   api_url="$(resolve_release_api_url)"
   release_json_file="$(mktemp "${TMPDIR:-/tmp}/localvoxtral-release.XXXXXX")"
@@ -55,16 +55,25 @@ resolve_zip_url() {
     *) die "Could not fetch GitHub release metadata from $api_url (HTTP $http_code)" ;;
   esac
 
-  # Releases also attach debug-symbol archives (*.dSYM.zip), and the GitHub
-  # API can list those before the app zip — filter them out or the installer
-  # downloads symbols instead of the app (issue #131).
+  # Select the app asset by its exact, contractual name: release.yml has
+  # named it localvoxtral-<tag>.zip in every release ever published. Picking
+  # by position or by excluding known-bad names broke in v0.7.4, when the API
+  # listed the dSYM archive before the app zip and the installer downloaded
+  # debug symbols (issue #131); exact-name selection is immune to new assets
+  # appearing in any order. The tag comes from the metadata itself so
+  # VERSION=latest resolves correctly too.
+  tag="$(printf '%s\n' "$release_json" |
+    sed -n 's/.*"tag_name"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' |
+    sed -n '1p')"
+  [ -n "$tag" ] || die "Could not read tag_name from GitHub release metadata for '${VERSION}'"
+
   zip_urls="$(printf '%s\n' "$release_json" |
     grep '"browser_download_url"[[:space:]]*:' |
-    sed -n 's/.*"browser_download_url"[[:space:]]*:[[:space:]]*"\([^"]*\.zip\)".*/\1/p' |
-    grep -v '\.dSYM\.zip$' || true)"
-  zip_url="$(printf '%s\n' "$zip_urls" | sed -n '1p')"
+    sed -n 's/.*"browser_download_url"[[:space:]]*:[[:space:]]*"\([^"]*\.zip\)".*/\1/p' || true)"
+  zip_url="$(printf '%s\n' "$zip_urls" |
+    awk -v want="localvoxtral-${tag}.zip" -F/ '$NF == want { print; exit }')"
 
-  [ -n "$zip_url" ] || die "No .zip asset found for release '${VERSION}'. Check https://github.com/${REPO}/releases"
+  [ -n "$zip_url" ] || die "Release '${tag}' has no asset named localvoxtral-${tag}.zip. Check https://github.com/${REPO}/releases"
   printf '%s\n' "$zip_url"
 }
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -55,9 +55,13 @@ resolve_zip_url() {
     *) die "Could not fetch GitHub release metadata from $api_url (HTTP $http_code)" ;;
   esac
 
+  # Releases also attach debug-symbol archives (*.dSYM.zip), and the GitHub
+  # API can list those before the app zip — filter them out or the installer
+  # downloads symbols instead of the app (issue #131).
   zip_urls="$(printf '%s\n' "$release_json" |
     grep '"browser_download_url"[[:space:]]*:' |
-    sed -n 's/.*"browser_download_url"[[:space:]]*:[[:space:]]*"\([^"]*\.zip\)".*/\1/p' || true)"
+    sed -n 's/.*"browser_download_url"[[:space:]]*:[[:space:]]*"\([^"]*\.zip\)".*/\1/p' |
+    grep -v '\.dSYM\.zip$' || true)"
   zip_url="$(printf '%s\n' "$zip_urls" | sed -n '1p')"
 
   [ -n "$zip_url" ] || die "No .zip asset found for release '${VERSION}'. Check https://github.com/${REPO}/releases"


### PR DESCRIPTION
## What

Fixes #131. Since v0.7.4, releases attach `localvoxtral-vX.Y.Z.dSYM.zip` next to the app zip, and the GitHub API lists the dSYM asset first — so `resolve_zip_url()`'s "take the first `.zip` asset" downloaded debug symbols and the one-command install died at extraction ("Extracted zip did not contain localvoxtral.app").

- `scripts/install.sh`: select the app asset by its exact contractual name `localvoxtral-<tag>.zip` (the name `release.yml` has produced for all 19 releases ever published; verified against the live API). The tag comes from the metadata's `tag_name`, so `LOCALVOXTRAL_VERSION=latest` resolves too. A release missing that asset dies loudly instead of falling back to whatever zip happens to be first. An exact-name allowlist (rather than a dSYM blocklist) is immune to any future extra zip asset in any order.
- `scripts/ci/test-install-resolve.sh`: new regression test — runs install.sh in dry-run mode against a stubbed `curl` serving hostile fixtures: the real v0.7.4 asset ordering (dSYM zips before the app zip) plus a hypothetical future non-dSYM zip listed first, an app-zip-missing release (must fail loudly), and a `VERSION=latest` run (tag must come from metadata). Pure bash, no network.
- `ci.yml`: run the test as a cheap per-push step (sub-second, runs on all lanes including fork PRs).

## Proof

- [x] Bug fix: regression test added — failing run before the fix and passing run after

Regression test vs the pre-fix `install.sh` (first-zip-wins):

```
$ ./scripts/ci/test-install-resolve.sh
FAIL: resolved '.../v0.7.4/localvoxtral-v0.7.4.dSYM.zip', expected '.../v0.7.4/localvoxtral-v0.7.4.zip'
(exit 1)
```

Same test vs an intermediate dSYM-blocklist fix (why the allowlist): with a hypothetical future `localvoxtral-v0.7.4-update.zip` listed first, the blocklist still resolves the wrong asset —

```
$ ./scripts/ci/test-install-resolve.sh   # blocklist version of install.sh
FAIL: resolved '.../v0.7.4/localvoxtral-v0.7.4-update.zip', expected '.../v0.7.4/localvoxtral-v0.7.4.zip'
(exit 1)
```

After the exact-name fix:

```
$ ./scripts/ci/test-install-resolve.sh
PASS: exact app zip wins over dSYM zips and other zip assets
PASS: release without the app zip fails with a clear error
PASS: VERSION=latest resolves via the metadata tag_name
OK: all install.sh resolution tests passed
(exit 0)
```

Live dry-runs against the real GitHub API (pinned tag, latest, and an old pre-dSYM release):

```
$ LOCALVOXTRAL_INSTALL_DRYRUN=1 LOCALVOXTRAL_VERSION=v0.7.4 bash scripts/install.sh
Resolved zip: https://github.com/T0mSIlver/localvoxtral/releases/download/v0.7.4/localvoxtral-v0.7.4.zip
$ LOCALVOXTRAL_INSTALL_DRYRUN=1 bash scripts/install.sh
Resolved zip: https://github.com/T0mSIlver/localvoxtral/releases/download/v0.7.4/localvoxtral-v0.7.4.zip
$ LOCALVOXTRAL_INSTALL_DRYRUN=1 LOCALVOXTRAL_VERSION=v0.5.0 bash scripts/install.sh
Resolved zip: https://github.com/T0mSIlver/localvoxtral/releases/download/v0.5.0/localvoxtral-v0.5.0.zip
```

Asset-name contract check: all 19 published releases (v0.1.0–v0.7.4) name the app asset exactly `localvoxtral-<tag>.zip` (verified via `gh release view` over every tag).

An 8-angle review pass ran over the diff; the blocklist-fragility finding (3 angles converged on it) drove the allowlist rework, and a pipefail/SIGPIPE-prone `grep -q` test assertion was replaced with a bash substring match.

- LLM eval lane: skipped — installer script + CI wiring only, no LLM-relevant paths touched (confirmed against `scripts/ci/llm-lane-filter.sh`).
- Unit/integration suites: unaffected by this change (shell-only); CI runs them per-push regardless.
