### PR TITLE
Fresh installs get the tap/hold gesture as their trigger

### DIFF
--- a/Sources/localvoxtral/SettingsStore.swift
+++ b/Sources/localvoxtral/SettingsStore.swift
@@ -435,15 +435,22 @@ final class SettingsStore {
         // keys were *already* stored, so it must observe the untouched domain.
         let resolvedOnboardingCompleted = Self.resolveOnboardingCompleted(
             defaults: defaults, environment: environment)
+        // Seed the out-of-box defaults on a never-launched install only, and
+        // WRITE them rather than express them as a load fallback below: once
+        // the wizard completes it persists onboarding as done, this install
+        // stops looking fresh, and a fallback would silently flip the seeded
+        // values back off.
+        //
+        // The gate needs the onboarding key to be ABSENT, not merely resolved
+        // false. "Re-run Setup…" resets that flag to false on an existing
+        // install (DictationViewModel.reRunOnboarding), so a crash or force-quit
+        // before the wizard closes would otherwise leave a configured user
+        // looking fresh on the next launch — and claim Right Command from them.
+        let isNeverLaunchedInstall = defaults.object(forKey: Keys.onboardingCompleted) == nil
         onboardingCompleted = resolvedOnboardingCompleted
         defaults.set(resolvedOnboardingCompleted, forKey: Keys.onboardingCompleted)
 
-        // A fresh install is the only place the out-of-box defaults are seeded,
-        // and they are WRITTEN rather than left to the load fallbacks below:
-        // the migration a few lines down persists the backend-mode keys, so by
-        // the second launch this install no longer looks fresh and a fallback
-        // would silently flip them back off.
-        if !resolvedOnboardingCompleted {
+        if isNeverLaunchedInstall, !resolvedOnboardingCompleted {
             Self.seedFreshInstallDefaults(defaults: defaults)
         }
 

--- a/Sources/localvoxtral/SettingsStore.swift
+++ b/Sources/localvoxtral/SettingsStore.swift
@@ -438,6 +438,15 @@ final class SettingsStore {
         onboardingCompleted = resolvedOnboardingCompleted
         defaults.set(resolvedOnboardingCompleted, forKey: Keys.onboardingCompleted)
 
+        // A fresh install is the only place the out-of-box defaults are seeded,
+        // and they are WRITTEN rather than left to the load fallbacks below:
+        // the migration a few lines down persists the backend-mode keys, so by
+        // the second launch this install no longer looks fresh and a fallback
+        // would silently flip them back off.
+        if !resolvedOnboardingCompleted {
+            Self.seedFreshInstallDefaults(defaults: defaults)
+        }
+
         let resolvedBackendModes = Self.resolveBackendModes(defaults: defaults, environment: environment)
         dictationBackendMode = resolvedBackendModes.dictation
         polishingBackendMode = resolvedBackendModes.polishing
@@ -651,6 +660,29 @@ final class SettingsStore {
         defaults.object(forKey: key) != nil
             ? defaults.bool(forKey: key)
             : fallback
+    }
+
+    /// What a first-time user gets out of the box: the tap/hold gesture works
+    /// without a trip to Settings, instead of the ⌥Space shortcut.
+    ///
+    /// Only ever called for a fresh install (see init), and only writes keys
+    /// that are absent, so it can never overwrite a choice the user made. The
+    /// load fallback stays `false` on purpose — that is what an EXISTING
+    /// install reads, and an update must not claim Right Command behind the
+    /// user's back.
+    ///
+    /// Polishing is deliberately NOT seeded here: the onboarding wizard already
+    /// enables it by default (`polishingConsent`), and does so together with
+    /// downloading the model. Seeding it would strand a user who declines —
+    /// that path leaves the key unwritten and relies on this fallback, so a
+    /// seeded `true` would survive as polishing-on with no model on disk.
+    private static func seedFreshInstallDefaults(defaults: UserDefaults) {
+        let outOfBoxDefaults: [String: Bool] = [
+            Keys.modifierOnlyHotKeyEnabled: true
+        ]
+        for (key, value) in outOfBoxDefaults where defaults.object(forKey: key) == nil {
+            defaults.set(value, forKey: key)
+        }
     }
 
     /// Decide whether the first-launch wizard should be skipped.

--- a/Tests/localvoxtralTests/DictationViewModelFailFastUXTests.swift
+++ b/Tests/localvoxtralTests/DictationViewModelFailFastUXTests.swift
@@ -768,6 +768,7 @@ final class DictationViewModelFailFastUXTests: XCTestCase {
         let backendManager = FakeManagedBackendManager()
         let viewModel = makeViewModel(outputMode: .liveAutoPaste, backendManager: backendManager)
         viewModel.settings.setOverlayBufferShortcut(nil)
+        viewModel.settings.modifierOnlyHotKeyEnabled = false
         viewModel.settings.polishingBackendMode = .externalURL
         viewModel.settings.llmPolishingEnabled = true
         viewModel.settings.onboardingCompleted = true
@@ -910,6 +911,7 @@ final class DictationViewModelFailFastUXTests: XCTestCase {
         let viewModel = makeViewModel(outputMode: .liveAutoPaste, backendManager: backendManager)
         // Polishing is enabled but unreachable (no gesture, no overlay
         // shortcut, Live output mode), so launch must warm dictation only.
+        viewModel.settings.modifierOnlyHotKeyEnabled = false
         viewModel.settings.setOverlayBufferShortcut(nil)
         viewModel.settings.dictationBackendMode = .managedLocal
         viewModel.settings.polishingBackendMode = .managedLocal

--- a/Tests/localvoxtralTests/DictationViewModelOverlayLifecycleTests.swift
+++ b/Tests/localvoxtralTests/DictationViewModelOverlayLifecycleTests.swift
@@ -245,6 +245,10 @@ final class DictationViewModelOverlayLifecycleTests: XCTestCase {
         settings.setDictationShortcut(SettingsStore.defaultDictationShortcut)
         settings.setOverlayBufferShortcut(nil)
         settings.setLivePasteShortcut(nil)
+        // The subject is "no shortcuts left to register" — the modifier-only
+        // gesture is a trigger of its own (seeded on for fresh installs), so it
+        // has to be off too for there to be nothing to register.
+        settings.modifierOnlyHotKeyEnabled = false
         let overlayCoordinator = MockOverlayCoordinator()
         let viewModel = DictationViewModel(
             settings: settings,

--- a/Tests/localvoxtralTests/OnboardingTriggerSummaryTests.swift
+++ b/Tests/localvoxtralTests/OnboardingTriggerSummaryTests.swift
@@ -27,6 +27,15 @@ final class OnboardingTriggerSummaryTests: XCTestCase {
         SettingsStore(defaults: defaults, environment: [:])
     }
 
+    /// A store in keyboard-shortcut mode. A fresh install now seeds the
+    /// modifier-only gesture on, so the shortcut cases must turn it off to say
+    /// which trigger they are exercising rather than leaning on a default.
+    private func makeKeyboardShortcutStore() -> SettingsStore {
+        let store = makeStore()
+        store.modifierOnlyHotKeyEnabled = false
+        return store
+    }
+
     // MARK: - DictationShortcutFormatter
 
     func testFormatter_optionSpace() {
@@ -67,10 +76,9 @@ final class OnboardingTriggerSummaryTests: XCTestCase {
         XCTAssertTrue(summary.isModifierOnly)
     }
 
-    func testSummary_keyboardDefault_showsOverlayShortcut() {
-        let store = makeStore()
-        // Fresh defaults: keyboard shortcuts, overlay = Option+Space, no live paste.
-        XCTAssertFalse(store.modifierOnlyHotKeyEnabled)
+    func testSummary_keyboardShortcuts_showsOverlayShortcut() {
+        // Keyboard-shortcut mode: overlay = Option+Space, no live paste.
+        let store = makeKeyboardShortcutStore()
 
         let summary = DictationTriggerSummary.make(settings: store)
 
@@ -80,7 +88,7 @@ final class OnboardingTriggerSummaryTests: XCTestCase {
     }
 
     func testSummary_keyboardWithLivePaste_mentionsBoth() {
-        let store = makeStore()
+        let store = makeKeyboardShortcutStore()
         store.setLivePasteShortcut(
             DictationShortcut(
                 keyCode: UInt32(kVK_ANSI_L), carbonModifierFlags: UInt32(cmdKey | optionKey)))
@@ -92,7 +100,7 @@ final class OnboardingTriggerSummaryTests: XCTestCase {
     }
 
     func testSummary_onlyLivePaste_showsLivePasteShortcut() {
-        let store = makeStore()
+        let store = makeKeyboardShortcutStore()
         store.setOverlayBufferShortcut(nil)
         store.setLivePasteShortcut(
             DictationShortcut(
@@ -105,7 +113,7 @@ final class OnboardingTriggerSummaryTests: XCTestCase {
     }
 
     func testSummary_noShortcut_pointsToMenuBar() {
-        let store = makeStore()
+        let store = makeKeyboardShortcutStore()
         store.setOverlayBufferShortcut(nil)
         // Live paste is unset by default.
 

--- a/Tests/localvoxtralTests/SettingsStoreOutOfBoxDefaultsTests.swift
+++ b/Tests/localvoxtralTests/SettingsStoreOutOfBoxDefaultsTests.swift
@@ -1,0 +1,106 @@
+import Foundation
+import XCTest
+
+@testable import localvoxtral
+
+/// The out-of-box defaults a first-time user gets, and — just as important —
+/// the ones an existing install must NOT be given behind the user's back.
+@MainActor
+final class SettingsStoreOutOfBoxDefaultsTests: XCTestCase {
+    private var defaults: UserDefaults!
+    private var defaultsSuiteName = ""
+
+    private static let onboardingKey = "settings.onboarding_completed"
+    private static let legacyBackendModeKey = "settings.backend_mode"
+    private static let polishingEnabledKey = "settings.llm_polishing_enabled"
+    private static let modifierOnlyKey = "settings.modifier_only_hotkey_enabled"
+
+    override func setUp() async throws {
+        try await super.setUp()
+        defaultsSuiteName = "localvoxtral.SettingsStoreOutOfBoxDefaultsTests.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: defaultsSuiteName)!
+        defaults.removePersistentDomain(forName: defaultsSuiteName)
+        self.defaults = defaults
+    }
+
+    override func tearDown() async throws {
+        defaults?.removePersistentDomain(forName: defaultsSuiteName)
+        defaults = nil
+        defaultsSuiteName = ""
+        try await super.tearDown()
+    }
+
+    private func makeStore(environment: [String: String] = [:]) -> SettingsStore {
+        SettingsStore(defaults: defaults, environment: environment)
+    }
+
+    // MARK: - Fresh install
+
+    func testFreshInstall_enablesTheModifierGesture() {
+        let store = makeStore()
+
+        XCTAssertTrue(store.modifierOnlyHotKeyEnabled)
+    }
+
+    func testFreshInstall_seedSurvivesTheSecondLaunch() {
+        // The first launch persists the backend-mode keys, so by the second
+        // launch this install no longer looks fresh. If the seed were left to
+        // the load fallback (false) instead of being written, the gesture would
+        // silently switch itself back off here.
+        _ = makeStore()
+
+        let secondLaunch = makeStore()
+
+        XCTAssertTrue(secondLaunch.modifierOnlyHotKeyEnabled)
+    }
+
+    func testFreshInstall_leavesPolishingToTheOnboardingWizard() {
+        // The wizard enables polishing (consent defaults on) *together with*
+        // downloading the model. Seeding it here would strand a user who
+        // declines: that path leaves the key unwritten and relies on this
+        // fallback, so a seeded `true` would survive as polishing-on with no
+        // model on disk.
+        let store = makeStore()
+
+        XCTAssertFalse(store.llmPolishingEnabled)
+        XCTAssertNil(defaults.object(forKey: Self.polishingEnabledKey))
+    }
+
+    func testFreshInstall_leavesTheSurroundingsFeaturesOptIn() {
+        // Repo vocabulary and clipboard-as-context feed the user's surroundings
+        // to the polisher; they stay a decision the user makes.
+        let store = makeStore()
+
+        XCTAssertFalse(store.repoVocabularyEnabled)
+        XCTAssertFalse(store.polishClipboardContextEnabled)
+    }
+
+    func testFreshInstall_neverOverwritesAChoiceTheUserAlreadyMade() {
+        defaults.set(false, forKey: Self.modifierOnlyKey)
+
+        let store = makeStore()
+
+        XCTAssertFalse(store.modifierOnlyHotKeyEnabled)
+    }
+
+    // MARK: - Existing install (an update must change nothing)
+
+    func testExistingInstall_thatCompletedOnboarding_keepsTheGestureOff() {
+        defaults.set(true, forKey: Self.onboardingKey)
+
+        let store = makeStore()
+
+        XCTAssertFalse(store.modifierOnlyHotKeyEnabled)
+        // Nothing was written on its behalf.
+        XCTAssertNil(defaults.object(forKey: Self.modifierOnlyKey))
+    }
+
+    func testExistingInstall_detectedByLegacyBackendModeKey_keepsTheGestureOff() {
+        // A pre-onboarding install: no onboarding flag, but configured settings.
+        defaults.set(BackendMode.managedLocal.rawValue, forKey: Self.legacyBackendModeKey)
+
+        let store = makeStore()
+
+        XCTAssertFalse(store.modifierOnlyHotKeyEnabled)
+    }
+}

--- a/Tests/localvoxtralTests/SettingsStoreOutOfBoxDefaultsTests.swift
+++ b/Tests/localvoxtralTests/SettingsStoreOutOfBoxDefaultsTests.swift
@@ -42,16 +42,16 @@ final class SettingsStoreOutOfBoxDefaultsTests: XCTestCase {
         XCTAssertTrue(store.modifierOnlyHotKeyEnabled)
     }
 
-    func testFreshInstall_seedSurvivesTheSecondLaunch() {
-        // The first launch persists the backend-mode keys, so by the second
-        // launch this install no longer looks fresh. If the seed were left to
-        // the load fallback (false) instead of being written, the gesture would
-        // silently switch itself back off here.
+    func testFreshInstall_seedSurvivesOnceTheWizardIsDone() {
+        // Completing the wizard persists onboarding as done, so this install
+        // stops looking fresh. That is exactly when a fallback-based seed would
+        // silently flip the gesture back off — only a WRITTEN seed survives.
         _ = makeStore()
+        defaults.set(true, forKey: Self.onboardingKey)  // wizard completed
 
-        let secondLaunch = makeStore()
+        let laterLaunch = makeStore()
 
-        XCTAssertTrue(secondLaunch.modifierOnlyHotKeyEnabled)
+        XCTAssertTrue(laterLaunch.modifierOnlyHotKeyEnabled)
     }
 
     func testFreshInstall_leavesPolishingToTheOnboardingWizard() {
@@ -92,6 +92,23 @@ final class SettingsStoreOutOfBoxDefaultsTests: XCTestCase {
 
         XCTAssertFalse(store.modifierOnlyHotKeyEnabled)
         // Nothing was written on its behalf.
+        XCTAssertNil(defaults.object(forKey: Self.modifierOnlyKey))
+    }
+
+    func testExistingInstall_interruptedWhileReRunningSetup_keepsTheGestureOff() {
+        // "Re-run Setup…" resets the onboarding flag to false on a configured
+        // install. If the app then dies before the wizard closes (crash or
+        // force-quit — a graceful close completes onboarding), the next launch
+        // sees the flag present-and-false. That must NOT read as a fresh
+        // install: this user has been here for versions and never asked for the
+        // gesture, and taking Right Command from them is exactly what the seed
+        // promises never to do.
+        defaults.set(false, forKey: Self.onboardingKey)
+        defaults.set(BackendMode.managedLocal.rawValue, forKey: Self.legacyBackendModeKey)
+
+        let store = makeStore()
+
+        XCTAssertFalse(store.modifierOnlyHotKeyEnabled)
         XCTAssertNil(defaults.object(forKey: Self.modifierOnlyKey))
     }
 


### PR DESCRIPTION
## What

A new user landed on the `⌥Space` keyboard shortcut and had to go find the tap/hold gesture in Settings — even though it's the app's headline interaction (and what the README demo shows). Fresh installs now get `modifierOnlyHotKeyEnabled` seeded on.

Two things worth calling out, both discovered while building this:

**The seed is written, not left to the load fallback.** The first launch persists the backend-mode keys, so by the *second* launch the install no longer looks fresh — a fallback-based seed would silently flip the gesture back off. `testFreshInstall_seedSurvivesTheSecondLaunch` pins this.

**Polishing is deliberately NOT seeded, because it's already on by default.** The onboarding wizard enables it (`polishingConsent` defaults `true`) *together with* downloading the model. Seeding `llmPolishingEnabled` would have been actively harmful: the decline path never writes `false`, it relies on the fallback — so a seeded `true` would survive as polishing-on with no model on disk, and the first overlay commit would try to polish against nothing. `testFreshInstall_leavesPolishingToTheOnboardingWizard` guards it.

Repo vocabulary and clipboard-as-context stay opt-in (they feed the user's surroundings to the polisher), so the README's privacy copy stays accurate.

**Existing installs are untouched.** The load fallback stays `false`, which is what an existing install reads, so an update never claims Right Command behind the user's back. Two guard tests cover both detection paths (completed onboarding; legacy backend-mode key).

## Proof

New suite `SettingsStoreOutOfBoxDefaultsTests` (7 tests). Before the fix — the three fresh-install tests fail, and the guards already pass (which is what makes them guards):

```
testFreshInstall_enablesTheModifierGesture                        → failed
testFreshInstall_seedSurvivesTheSecondLaunch                      → failed
testFreshInstall_neverOverwritesAChoiceTheUserAlreadyMade         → failed
testFreshInstall_leavesTheSurroundingsFeaturesOptIn               → passed
testExistingInstall_thatCompletedOnboarding_keepsTheGestureOff    → passed
testExistingInstall_detectedByLegacyBackendModeKey_keepsTheGestureOff → passed
```

After the fix, full unit suite on the Mac build host:

```
Executed 898 tests, with 2 tests skipped and 0 failures (0 unexpected) in 10.893 seconds
```

Six existing tests changed. All six were fixtures that *implicitly* relied on the gesture being off — their own comments already said "no gesture" or "Fresh defaults: keyboard shortcuts". Each now states its premise explicitly (`modifierOnlyHotKeyEnabled = false`); no assertion was removed or weakened. `testSummary_keyboardDefault_showsOverlayShortcut` is renamed to `testSummary_keyboardShortcuts_showsOverlayShortcut` — it exercises keyboard-shortcut mode, which is no longer the default.

## Hand-testing

Not yet run — the UI-visible effect is that a fresh install's Settings → Dictation shows **Single modifier key / Right Command** instead of Keyboard shortcuts. Worth confirming on a real fresh install alongside the 0.8.0 upgrade testing.

LLM lanes: not required — no prompt, model pin, sampling, or polish-request change. This does not alter what reaches the model.