### PR TITLE
mlx-lm cleanup: remove the bare console script, not just the dotted entry points

### DIFF
--- a/Sources/localvoxtral/Backends/LegacyMLXLMCleanup.swift
+++ b/Sources/localvoxtral/Backends/LegacyMLXLMCleanup.swift
@@ -15,8 +15,14 @@ struct LegacyMLXLMCleanup {
 
     /// uv tool venv directory name (`tools/mlx-lm`) and `installed.json` key.
     private static let legacyToolID = "mlx-lm"
-    /// Entry points uv linked into `bin/` (`mlx_lm.server`, `mlx_lm.generate`, …).
-    private static let legacyBinPrefix = "mlx_lm."
+    /// Entry points uv linked into `bin/`. The wheel installs a BARE `mlx_lm`
+    /// console script alongside the dotted ones (`mlx_lm.server`,
+    /// `mlx_lm.generate`, …). An earlier `"mlx_lm."` prefix here removed the
+    /// dotted siblings and walked straight past the bare one, leaving it behind
+    /// as a dangling symlink — and making a later `uv tool install mlx-lm` fail
+    /// with "Executable already exists". Found by hand-testing the 0.7.4 → 0.8.0
+    /// upgrade; the undotted prefix covers both shapes.
+    private static let legacyBinPrefix = "mlx_lm"
     /// Wheels the installer parked in `downloads/`.
     private static let legacyWheelPrefix = "mlx_lm-"
 

--- a/Tests/localvoxtralTests/LegacyMLXLMCleanupTests.swift
+++ b/Tests/localvoxtralTests/LegacyMLXLMCleanupTests.swift
@@ -28,6 +28,16 @@ final class LegacyMLXLMCleanupTests: XCTestCase {
         try fileManager.createDirectory(at: layout.toolBin, withIntermediateDirectories: true)
         // uv links bin entries into the venv; after the venv is gone these
         // dangle, which fileExists-based checks would miss.
+        //
+        // The wheel installs a BARE `mlx_lm` console script alongside the dotted
+        // entry points. Fixturing only the dotted names is what let the bare one
+        // ship unremoved: the old `"mlx_lm."` prefix deleted its siblings and
+        // left it behind.
+        let consoleScriptLink = layout.toolBin.appendingPathComponent("mlx_lm")
+        try fileManager.createSymbolicLink(
+            at: consoleScriptLink,
+            withDestinationURL: legacyVenv.appendingPathComponent("bin/mlx_lm")
+        )
         let serverLink = layout.toolBin.appendingPathComponent("mlx_lm.server")
         try fileManager.createSymbolicLink(
             at: serverLink,
@@ -57,13 +67,15 @@ final class LegacyMLXLMCleanupTests: XCTestCase {
 
         let removedPaths = Set(removed.map(\.path))
         XCTAssertTrue(removedPaths.contains(legacyVenv.path))
+        XCTAssertTrue(removedPaths.contains(consoleScriptLink.path))
         XCTAssertTrue(removedPaths.contains(serverLink.path))
         XCTAssertTrue(removedPaths.contains(generateBin.path))
         XCTAssertTrue(removedPaths.contains(legacyWheel.path))
         XCTAssertTrue(removedPaths.contains(markerURL.path))
-        XCTAssertEqual(removedPaths.count, 5)
+        XCTAssertEqual(removedPaths.count, 6)
 
         XCTAssertFalse(fileManager.fileExists(atPath: legacyVenv.path))
+        XCTAssertNil(try? fileManager.destinationOfSymbolicLink(atPath: consoleScriptLink.path))
         XCTAssertNil(try? fileManager.destinationOfSymbolicLink(atPath: serverLink.path))
         XCTAssertFalse(fileManager.fileExists(atPath: generateBin.path))
         XCTAssertFalse(fileManager.fileExists(atPath: legacyWheel.path))
@@ -92,6 +104,34 @@ final class LegacyMLXLMCleanupTests: XCTestCase {
 
         XCTAssertEqual(removed.map(\.path), [danglingLink.path])
         XCTAssertNil(try? fileManager.destinationOfSymbolicLink(atPath: danglingLink.path))
+    }
+
+    /// The field state observed on a real 0.7.4 → 0.8.0 upgrade: a first cleanup
+    /// pass (dotted prefix) had already removed `mlx_lm.server` and friends, so
+    /// the bare `mlx_lm` shim was the only legacy entry left — dangling, and
+    /// enough to make a later `uv tool install mlx-lm` fail with "Executable
+    /// already exists". Re-running cleanup must finish the job.
+    func testBareConsoleScriptLeftByAnEarlierPassIsStillRemoved() throws {
+        let root = makeTemporaryDirectory()
+        let layout = BackendInstallLayout(root: root)
+        let fileManager = FileManager.default
+        try fileManager.createDirectory(at: layout.toolBin, withIntermediateDirectories: true)
+
+        let bareShim = layout.toolBin.appendingPathComponent("mlx_lm")
+        try fileManager.createSymbolicLink(
+            at: bareShim,
+            withDestinationURL: layout.tools.appendingPathComponent("mlx-lm/bin/mlx_lm")
+        )
+        // voxmlx sits in the same directory and must survive: the undotted
+        // prefix must not start matching its neighbours.
+        let voxmlxBin = layout.toolBin.appendingPathComponent("voxmlx-serve")
+        try Data("#!/bin/sh".utf8).write(to: voxmlxBin)
+
+        let removed = LegacyMLXLMCleanup(layout: layout).run()
+
+        XCTAssertEqual(removed.map(\.path), [bareShim.path])
+        XCTAssertNil(try? fileManager.destinationOfSymbolicLink(atPath: bareShim.path))
+        XCTAssertTrue(fileManager.fileExists(atPath: voxmlxBin.path))
     }
 
     func testSecondRunAndMissingRootAreSilentNoOps() throws {


### PR DESCRIPTION
## What

Found by hand-testing the 0.7.4 → 0.8.0 upgrade path (the one thing CI can't cover — this is exactly what it was for).

`uv tool install mlx-lm` aborted during 0.7.4's onboarding with:

```
error: Executable already exists mlx_lm (use --force)
```

The install's `backends/bin/` held a **dangling** `mlx_lm` symlink pointing into the long-deleted `tools/mlx-lm/bin/mlx_lm`:

```
lrwxr-xr-x  1 tom  staff  84 Jul  9 00:17 mlx_lm -> …/backends/tools/mlx-lm/bin/mlx_lm
lrwxr-xr-x  1 tom  staff  84 Jul  5 11:37 voxmlx -> …/backends/tools/voxmlx/bin/voxmlx
```

## Cause

The wheel installs a **bare `mlx_lm`** console script alongside the dotted ones (`mlx_lm.server`, `mlx_lm.generate`, …). `LegacyMLXLMCleanup.legacyBinPrefix` was `"mlx_lm."` — *with the dot* — so `"mlx_lm".hasPrefix("mlx_lm.")` is `false`. Cleanup removed the venv, the wheels, the marker entry and every dotted sibling, then walked straight past the one entry that remained.

Every install upgraded to 0.8.0 carries that orphan. Nothing reads it, so it is inert — but the cleanup claims to remove the install completely and doesn't, and it breaks any subsequent (re)install of mlx-lm.

**Why the tests missed it:** their fixtures only ever created `mlx_lm.server` / `mlx_lm.generate` — a `bin/` layout no real install has. The suite was green against an imaginary directory.

## Fix

Drop the dot. The undotted prefix covers both shapes. `voxmlx*` neighbours are unaffected, and there's now an assertion pinning that.

**Checked the rest of the tree:** `mlx_lm.server` also appears in `ui-smoke.sh`, `mac-diag.sh` and `scripts/mac/localvoxtral-build-gate.sh`. Those are **process-name** patterns, not filesystem prefixes, and that process is still live — the eval launchd service runs `mlx_lm.server` (`scripts/mac/README.md:109`). Correct as-is; changing them would break the eval-server diagnostics. The defect is confined to the one prefix.

## Proof

Both new/updated tests fail against the shipped code and pass with the fix.

Before (shipped `"mlx_lm."` prefix):

```
testBareConsoleScriptLeftByAnEarlierPassIsStillRemoved → failed
testRemovesOrphanedMLXLMPiecesAndKeepsEverythingElse   → failed
testDanglingBinSymlinkAloneIsStillRemoved              → passed
testMarkerWithoutLegacyEntryIsLeftByteIdentical        → passed
testSecondRunAndMissingRootAreSilentNoOps              → passed
```

After, full unit suite on the Mac build host:

```
Executed 900 tests, with 2 tests skipped and 0 failures (0 unexpected) in 11.974 seconds
```

Cleanup stays idempotent (`testSecondRunAndMissingRootAreSilentNoOps`), so an install already cleaned by 0.8.0 gets the leftover shim removed on its next launch — no user action needed.

LLM lanes: not required — no prompt, model pin, sampling, or polish-request change.

## Ships in

0.8.1.