### PR TITLE
PolishHelper: pin mlx-swift-lm past the safetensors-index loader bug

### DIFF
--- a/PolishHelper/Package.resolved
+++ b/PolishHelper/Package.resolved
@@ -23,8 +23,7 @@
       "kind": "remoteSourceControl",
       "location": "https://github.com/ml-explore/mlx-swift-lm.git",
       "state": {
-        "revision": "bd4b7434e6bdb588c7ef55706ff8904cb7fd4c57",
-        "version": "3.31.4"
+        "revision": "f5f18ed9d3373b21874bd43da34922377c6da0fb"
       }
     },
     {

--- a/PolishHelper/Package.swift
+++ b/PolishHelper/Package.swift
@@ -14,7 +14,19 @@ let package = Package(
         .executable(name: "localvoxtral-polishd", targets: ["localvoxtral-polishd"])
     ],
     dependencies: [
-        .package(url: "https://github.com/ml-explore/mlx-swift-lm.git", exact: "3.31.4"),
+        // Revision, not a tag: the newest release (3.31.4) loads EVERY
+        // .safetensors file under the model directory, ignoring
+        // model.safetensors.index.json. Our default polishing model
+        // (mlx-community/Qwen3.5-4B-OptiQ-4bit) ships optiq/mtp.safetensors +
+        // optiq/optiq_vision.safetensors next to the indexed weights, so those
+        // auxiliary tensors get merged into the model's weight dictionary and
+        // generation comes out incoherent. Fixed upstream by ml-explore/
+        // mlx-swift-lm#408 (this commit, main head); move back to a tag once a
+        // release carries it.
+        .package(
+            url: "https://github.com/ml-explore/mlx-swift-lm.git",
+            revision: "f5f18ed9d3373b21874bd43da34922377c6da0fb"
+        ),
         .package(url: "https://github.com/huggingface/swift-transformers.git", from: "1.3.0"),
     ],
     targets: [


### PR DESCRIPTION
## What

`mlx-swift-lm` 3.31.4 — our `exact:` pin, and still the newest release — loads **every** `.safetensors` file under the model directory, ignoring `model.safetensors.index.json`. The auxiliary tensors get merged into the model's weight dictionary, pass through `sanitize`, and generation comes out incoherent.

This is our bug, not a hypothetical: our default polishing model ships exactly those extra files.

| Catalog repo | Extra safetensors next to the indexed weights |
|---|---|
| `Qwen3.5-4B-OptiQ-4bit` (default) | `optiq/mtp.safetensors`, `optiq/optiq_vision.safetensors` |
| `Qwen3.5-9B-OptiQ-4bit` | same two |
| `Qwen3.5-0.8B-8bit` | none — unaffected |

**Why nobody has seen garbled polish output yet:** we are shielded by accident. `BackendManager.modelPreparationRequest` downloads with `allow_patterns` of `model*.safetensors`, which does not match `optiq/…`, and `PolishHelperIntegrationTests` provisions with the same patterns — so the aux files never land in the snapshot the helper loads. The eval baseline is therefore honest, not silently corrupted.

The shield is thin, though. The helper resolves models out of the **shared** `~/.cache/huggingface/hub`, so any user who has pulled that repo with `hf download` or Python `mlx-lm` has the extras sitting in the same snapshot directory — and on 3.31.4 their polish output turns to garbage with no error surfaced.

Fixed upstream in [ml-explore/mlx-swift-lm#408](https://github.com/ml-explore/mlx-swift-lm/pull/408) (merged 2026-07-13, after 3.31.4 shipped, not yet in any release — the PR names our 4B OptiQ repo as its repro). Hence a **revision pin at main head** (`f5f18ed9`) rather than a tag, with a comment in the manifest to return to a tag once a release carries the fix. The rest of the graph is unchanged — `mlx-swift` stays at 0.31.4, which still satisfies upstream's `.upToNextMinor`.

## Proof

- [x] Unit suite green — `./scripts/remote-build.sh test`

```
Executed 900 tests, with 2 tests skipped and 0 failures (0 unexpected) in 11.202 seconds
```

- [x] PolishHelper unit suite green — `./scripts/remote-build.sh test --package-path PolishHelper`

```
Executed 45 tests, with 0 failures (0 unexpected) in 0.125 seconds
```

- [x] LLM lane green (required: this diff is in the PolishHelper path filter) — `./scripts/remote-build.sh integration-polishd`, the packaged helper against the real pinned 4B:

```
== required: 7/7, known-hard passing: 10/10 ==
== technical: 2/17 ==
== polishd prompt-prefix slots: alternating standard/agent profiles (model: mlx-community/Qwen3.5-4B-OptiQ-4bit) ==
2 slots (default): 2.445s, 0.815s, 0.449s, 0.413s, 0.408s, 0.418s
1 slot  (legacy):  2.382s, 0.875s, 2.727s, 1.006s, 2.856s, 0.888s

Executed 6 tests, with 0 failures (0 unexpected) in 91.359 seconds
```

Baseline held — no regression from the bump. `technical: 2/17` is the exploratory section whose cases are asserted XFAIL (known-hard, pre-existing), not new breakage. The warm-checkpoint timings (0.4s vs 2.7s re-prefill) show the `KVCache.copy()` prefix-cache path survived the revision change.

- [x] Packaging green — `./scripts/remote-build.sh package`. This is the contract test for the hand-edited `Package.resolved`: `package_app.sh` runs xcodebuild with `-disableAutomaticPackageResolution`, so a resolved file inconsistent with the manifest fails loudly instead of silently re-resolving. It built and signed the bundle with both binaries present (`localvoxtral`, `localvoxtral-polishd`).

### What this does NOT prove

These lanes prove the bump is **safe**, not that it **fixes** observable behavior here — the include patterns mean the build host was never in the corrupting state. The uncovered case is the shared-HF-cache one described above. A regression test that provisions a snapshot **with** an `optiq/`-style extra safetensors present and asserts the helper still polishes coherently would fail on 3.31.4 and pass on this pin; happy to add it in this PR or a follow-up — say which.