### PR TITLE
Spike: Swift Voxtral engine reaches parity with Python voxmlx (do not merge)

### DIFF
--- a/.github/workflows/voxtral-spike.yml
+++ b/.github/workflows/voxtral-spike.yml
@@ -1,0 +1,57 @@
+name: Voxtral Spike
+
+# THROWAWAY SPIKE lane. Answers one question before we commit to replacing the
+# managed Python voxmlx backend with a bundled Swift engine: does mlx-audio-swift's
+# VoxtralRealtime streaming session transcribe accurately, keep up with realtime,
+# and emit clean deltas (no re-emits — our insertion path has no backspaces)?
+#
+# Runs on the self-hosted Mac because it needs xcodebuild (SwiftPM's CLI cannot
+# compile mlx-swift's Metal kernels) and a real 4B model on the GPU.
+# Delete this workflow, spikes/, once the go/no-go is recorded.
+
+on:
+  push:
+    branches: ['spike/**']
+  workflow_dispatch:
+    inputs:
+      model_repo:
+        description: 'HF repo for the Voxtral realtime weights'
+        default: 'mlx-community/Voxtral-Mini-4B-Realtime-6bit'
+        required: false
+
+jobs:
+  spike:
+    runs-on: [self-hosted, macOS, ARM64]
+    timeout-minutes: 45
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Run Voxtral streaming spike
+        env:
+          MODEL_REPO: ${{ github.event.inputs.model_repo || 'mlx-community/Voxtral-Mini-4B-Realtime-6bit' }}
+        run: ./spikes/run-spike.sh
+
+      - name: Summarize
+        if: always()
+        run: |
+          {
+            echo '## Voxtral Swift spike'
+            for f in spikes/out/en.json spikes/out/fr.json; do
+              [[ -f "$f" ]] || continue
+              echo "### $f"
+              echo '```json'
+              cat "$f"
+              echo '```'
+            done
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: voxtral-spike-results
+          path: |
+            spikes/out/*.json
+            spikes/VoxtralSpike/.build/xcodebuild.log
+          if-no-files-found: warn

--- a/.github/workflows/voxtral-spike.yml
+++ b/.github/workflows/voxtral-spike.yml
@@ -22,15 +22,22 @@ on:
 jobs:
   spike:
     runs-on: [self-hosted, macOS, ARM64]
-    timeout-minutes: 45
+    # A cold xcodebuild of this package compiles mlx-swift's C++/Metal core from
+    # scratch (PolishHelper's DerivedData is warm on this runner; the spike's is not),
+    # which alone blew the original 45 min budget.
+    timeout-minutes: 120
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
+      # Split from the run step so a timeout tells us WHICH phase was slow.
+      - name: Build spike (xcodebuild)
+        run: ./spikes/run-spike.sh build
+
       - name: Run Voxtral streaming spike
         env:
           MODEL_REPO: ${{ github.event.inputs.model_repo || 'mlx-community/Voxtral-Mini-4B-Realtime-2602-4bit' }}
-        run: ./spikes/run-spike.sh
+        run: ./spikes/run-spike.sh run
 
       - name: Summarize
         if: always()

--- a/.github/workflows/voxtral-spike.yml
+++ b/.github/workflows/voxtral-spike.yml
@@ -44,7 +44,7 @@ jobs:
         run: |
           {
             echo '## Voxtral Swift spike'
-            for f in spikes/out/en.json spikes/out/fr.json; do
+            for f in spikes/out/*.json; do
               [[ -f "$f" ]] || continue
               echo "### $f"
               echo '```json'

--- a/.github/workflows/voxtral-spike.yml
+++ b/.github/workflows/voxtral-spike.yml
@@ -16,7 +16,7 @@ on:
     inputs:
       model_repo:
         description: 'HF repo for the Voxtral realtime weights'
-        default: 'mlx-community/Voxtral-Mini-4B-Realtime-6bit'
+        default: 'mlx-community/Voxtral-Mini-4B-Realtime-2602-4bit'
         required: false
 
 jobs:
@@ -29,7 +29,7 @@ jobs:
 
       - name: Run Voxtral streaming spike
         env:
-          MODEL_REPO: ${{ github.event.inputs.model_repo || 'mlx-community/Voxtral-Mini-4B-Realtime-6bit' }}
+          MODEL_REPO: ${{ github.event.inputs.model_repo || 'mlx-community/Voxtral-Mini-4B-Realtime-2602-4bit' }}
         run: ./spikes/run-spike.sh
 
       - name: Summarize

--- a/spikes/VoxtralSpike/Package.resolved
+++ b/spikes/VoxtralSpike/Package.resolved
@@ -1,0 +1,285 @@
+{
+  "originHash" : "0de47e2efcfdbd2abb306b485c46d6fc9b94854ac10c7413ede360d5ad7e2260",
+  "pins" : [
+    {
+      "identity" : "async-http-client",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/swift-server/async-http-client",
+      "state" : {
+        "revision" : "2fc4652fb4689eb24af10e55cabaa61d8ba774fd",
+        "version" : "1.32.0"
+      }
+    },
+    {
+      "identity" : "eventsource",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/mattt/EventSource.git",
+      "state" : {
+        "revision" : "a2965424a4babeb0c8e4b5ec9708c3939bc52449",
+        "version" : "1.2.0"
+      }
+    },
+    {
+      "identity" : "mlx-swift",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/ml-explore/mlx-swift.git",
+      "state" : {
+        "revision" : "61b9e011e09a62b489f6bd647958f1555bdf2896",
+        "version" : "0.31.3"
+      }
+    },
+    {
+      "identity" : "mlx-swift-lm",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/ml-explore/mlx-swift-lm.git",
+      "state" : {
+        "revision" : "1c05248bb0899e2a7a4962b84d319cf12f4e12aa",
+        "version" : "3.31.3"
+      }
+    },
+    {
+      "identity" : "swift-algorithms",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-algorithms.git",
+      "state" : {
+        "revision" : "87e50f483c54e6efd60e885f7f5aa946cee68023",
+        "version" : "1.2.1"
+      }
+    },
+    {
+      "identity" : "swift-asn1",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-asn1.git",
+      "state" : {
+        "revision" : "810496cf121e525d660cd0ea89a758740476b85f",
+        "version" : "1.5.1"
+      }
+    },
+    {
+      "identity" : "swift-async-algorithms",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-async-algorithms.git",
+      "state" : {
+        "revision" : "2971dd5d9f6e0515664b01044826bcea16e59fac",
+        "version" : "1.1.2"
+      }
+    },
+    {
+      "identity" : "swift-atomics",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-atomics.git",
+      "state" : {
+        "revision" : "b601256eab081c0f92f059e12818ac1d4f178ff7",
+        "version" : "1.3.0"
+      }
+    },
+    {
+      "identity" : "swift-certificates",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-certificates.git",
+      "state" : {
+        "revision" : "24ccdeeeed4dfaae7955fcac9dbf5489ed4f1a25",
+        "version" : "1.18.0"
+      }
+    },
+    {
+      "identity" : "swift-collections",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-collections.git",
+      "state" : {
+        "revision" : "7b847a3b7008b2dc2f47ca3110d8c782fb2e5c7e",
+        "version" : "1.3.0"
+      }
+    },
+    {
+      "identity" : "swift-configuration",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-configuration.git",
+      "state" : {
+        "revision" : "1bb939fe7bbb00b8f8bab664cc90020c035c08d9",
+        "version" : "1.1.0"
+      }
+    },
+    {
+      "identity" : "swift-crypto",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-crypto.git",
+      "state" : {
+        "revision" : "6f70fa9eab24c1fd982af18c281c4525d05e3095",
+        "version" : "4.2.0"
+      }
+    },
+    {
+      "identity" : "swift-distributed-tracing",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-distributed-tracing.git",
+      "state" : {
+        "revision" : "e109d8b5308d0e05201d9a1dd1c475446a946a11",
+        "version" : "1.4.0"
+      }
+    },
+    {
+      "identity" : "swift-http-structured-headers",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-http-structured-headers.git",
+      "state" : {
+        "revision" : "76d7627bd88b47bf5a0f8497dd244885960dde0b",
+        "version" : "1.6.0"
+      }
+    },
+    {
+      "identity" : "swift-http-types",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-http-types.git",
+      "state" : {
+        "revision" : "45eb0224913ea070ec4fba17291b9e7ecf4749ca",
+        "version" : "1.5.1"
+      }
+    },
+    {
+      "identity" : "swift-huggingface",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/huggingface/swift-huggingface.git",
+      "state" : {
+        "revision" : "de01c0ab8fd537bbd8216cea7f774275178501a2",
+        "version" : "0.8.1"
+      }
+    },
+    {
+      "identity" : "swift-jinja",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/huggingface/swift-jinja.git",
+      "state" : {
+        "revision" : "f731f03bf746481d4fda07f817c3774390c4d5b9",
+        "version" : "2.3.2"
+      }
+    },
+    {
+      "identity" : "swift-log",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-log.git",
+      "state" : {
+        "revision" : "bbd81b6725ae874c69e9b8c8804d462356b55523",
+        "version" : "1.10.1"
+      }
+    },
+    {
+      "identity" : "swift-nio",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-nio.git",
+      "state" : {
+        "revision" : "e932d3c4d8f77433c8f7093b5ebcbf91463948a0",
+        "version" : "2.95.0"
+      }
+    },
+    {
+      "identity" : "swift-nio-extras",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-nio-extras.git",
+      "state" : {
+        "revision" : "3df009d563dc9f21a5c85b33d8c2e34d2e4f8c3b",
+        "version" : "1.32.1"
+      }
+    },
+    {
+      "identity" : "swift-nio-http2",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-nio-http2.git",
+      "state" : {
+        "revision" : "b6571f3db40799df5a7fc0e92c399aa71c883edd",
+        "version" : "1.40.0"
+      }
+    },
+    {
+      "identity" : "swift-nio-ssl",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-nio-ssl.git",
+      "state" : {
+        "revision" : "173cc69a058623525a58ae6710e2f5727c663793",
+        "version" : "2.36.0"
+      }
+    },
+    {
+      "identity" : "swift-nio-transport-services",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-nio-transport-services.git",
+      "state" : {
+        "revision" : "60c3e187154421171721c1a38e800b390680fb5d",
+        "version" : "1.26.0"
+      }
+    },
+    {
+      "identity" : "swift-numerics",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-numerics",
+      "state" : {
+        "revision" : "0c0290ff6b24942dadb83a929ffaaa1481df04a2",
+        "version" : "1.1.1"
+      }
+    },
+    {
+      "identity" : "swift-service-context",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-service-context.git",
+      "state" : {
+        "revision" : "d0997351b0c7779017f88e7a93bc30a1878d7f29",
+        "version" : "1.3.0"
+      }
+    },
+    {
+      "identity" : "swift-service-lifecycle",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/swift-server/swift-service-lifecycle",
+      "state" : {
+        "revision" : "89888196dd79c61c50bca9a103d8114f32e1e598",
+        "version" : "2.10.1"
+      }
+    },
+    {
+      "identity" : "swift-syntax",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/swiftlang/swift-syntax.git",
+      "state" : {
+        "revision" : "0687f71944021d616d34d922343dcef086855920",
+        "version" : "600.0.1"
+      }
+    },
+    {
+      "identity" : "swift-system",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-system.git",
+      "state" : {
+        "revision" : "7c6ad0fc39d0763e0b699210e4124afd5041c5df",
+        "version" : "1.6.4"
+      }
+    },
+    {
+      "identity" : "swift-transformers",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/huggingface/swift-transformers.git",
+      "state" : {
+        "revision" : "150169bfba0889c229a2ce7494cf8949f18e6906",
+        "version" : "1.1.9"
+      }
+    },
+    {
+      "identity" : "swift-xet",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/mattt/swift-xet.git",
+      "state" : {
+        "revision" : "341bfd4172f6a57119bfd49bafa11cf5d21fab75",
+        "version" : "0.2.3"
+      }
+    },
+    {
+      "identity" : "yyjson",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/ibireme/yyjson.git",
+      "state" : {
+        "revision" : "8b4a38dc994a110abaec8a400615567bd996105f",
+        "version" : "0.12.0"
+      }
+    }
+  ],
+  "version" : 3
+}

--- a/spikes/VoxtralSpike/Package.swift
+++ b/spikes/VoxtralSpike/Package.swift
@@ -1,0 +1,32 @@
+// swift-tools-version: 6.1
+import PackageDescription
+
+// THROWAWAY SPIKE — not part of the shipped build.
+//
+// Answers one question: can mlx-audio-swift's VoxtralRealtime replace the
+// managed Python voxmlx backend with acceptable accuracy and realtime headroom?
+//
+// Like PolishHelper, this MUST be built with xcodebuild (aggregate scheme
+// "VoxtralSpike"), never `swift build`: SwiftPM's CLI cannot compile mlx-swift's
+// Metal kernels, and the resulting binary dies at runtime with
+// "Failed to load the default metallib".
+let package = Package(
+    name: "VoxtralSpike",
+    platforms: [.macOS(.v15)],
+    products: [
+        .executable(name: "voxtral-spike", targets: ["voxtral-spike"])
+    ],
+    dependencies: [
+        .package(url: "https://github.com/Blaizzy/mlx-audio-swift.git", exact: "0.1.3"),
+        .package(url: "https://github.com/ml-explore/mlx-swift.git", from: "0.30.6"),
+    ],
+    targets: [
+        .executableTarget(
+            name: "voxtral-spike",
+            dependencies: [
+                .product(name: "MLXAudioSTT", package: "mlx-audio-swift"),
+                .product(name: "MLX", package: "mlx-swift"),
+            ]
+        )
+    ]
+)

--- a/spikes/VoxtralSpike/Package.swift
+++ b/spikes/VoxtralSpike/Package.swift
@@ -18,7 +18,13 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/Blaizzy/mlx-audio-swift.git", exact: "0.1.3"),
-        .package(url: "https://github.com/ml-explore/mlx-swift.git", from: "0.30.6"),
+        // Pinned to mlx-audio-swift's own resolved graph. Left to float, SwiftPM picks
+        // swift-transformers >= 1.2, which does not compile under Xcode 26's toolchain
+        // (Hub/Config.swift: ObjectKey vs String dictionary-key type errors).
+        // mlx-swift 0.31.3 is also deliberate: 0.31.4 introduced the evalLock deadlock
+        // (ml-explore/mlx-swift#428) that our polishd helper is currently pinned to.
+        .package(url: "https://github.com/ml-explore/mlx-swift.git", exact: "0.31.3"),
+        .package(url: "https://github.com/huggingface/swift-transformers.git", exact: "1.1.9"),
     ],
     targets: [
         .executableTarget(

--- a/spikes/VoxtralSpike/Package.swift
+++ b/spikes/VoxtralSpike/Package.swift
@@ -25,14 +25,34 @@ let package = Package(
         // (ml-explore/mlx-swift#428) that our polishd helper is currently pinned to.
         .package(url: "https://github.com/ml-explore/mlx-swift.git", exact: "0.31.3"),
         .package(url: "https://github.com/huggingface/swift-transformers.git", exact: "1.1.9"),
+        .package(url: "https://github.com/huggingface/swift-huggingface.git", exact: "0.8.1"),
+        .package(url: "https://github.com/ml-explore/mlx-swift-lm.git", exact: "3.31.3"),
     ],
     targets: [
+        // The upstream VoxtralRealtime sources (MIT), vendored verbatim EXCEPT for the
+        // optimizations under test: fused dtype-preserving RoPE, an async-eval decode
+        // pipeline, and dtype-correct attention masks. Kept as its own module so the
+        // stock engine (MLXAudioSTT) stays importable side-by-side for A/B runs.
+        .target(
+            name: "VoxtralFast",
+            dependencies: [
+                .product(name: "MLXAudioCore", package: "mlx-audio-swift"),
+                .product(name: "MLXAudioVAD", package: "mlx-audio-swift"),
+                .product(name: "MLX", package: "mlx-swift"),
+                .product(name: "MLXFast", package: "mlx-swift"),
+                .product(name: "MLXNN", package: "mlx-swift"),
+                .product(name: "MLXRandom", package: "mlx-swift"),
+                .product(name: "MLXLMCommon", package: "mlx-swift-lm"),
+                .product(name: "HuggingFace", package: "swift-huggingface"),
+            ]
+        ),
         .executableTarget(
             name: "voxtral-spike",
             dependencies: [
+                "VoxtralFast",
                 .product(name: "MLXAudioSTT", package: "mlx-audio-swift"),
                 .product(name: "MLX", package: "mlx-swift"),
             ]
-        )
+        ),
     ]
 )

--- a/spikes/VoxtralSpike/Sources/VoxtralFast/FastEngineFacade.swift
+++ b/spikes/VoxtralSpike/Sources/VoxtralFast/FastEngineFacade.swift
@@ -10,6 +10,16 @@ public final class FastEngine {
 
     public init(repo: String) async throws {
         model = try await VoxtralRealtimeModel.fromPretrained(repo)
+        if FastFlags.fp16 {
+            model.castFloat32ParamsToFloat16()
+        }
+    }
+
+    /// What dtype is the model ACTUALLY running in? The profile said the LM head reads
+    /// ~800 MB at ~9 GB/s effective, which only makes sense if the weights are being
+    /// upcast per token — i.e. the activations are float32.
+    public func dtypes() -> [String: String] {
+        model.dtypeReport()
     }
 
     public func makeSession(temperature: Float = 0.0, transcriptionDelayMs: Int?) -> FastSession {

--- a/spikes/VoxtralSpike/Sources/VoxtralFast/FastEngineFacade.swift
+++ b/spikes/VoxtralSpike/Sources/VoxtralFast/FastEngineFacade.swift
@@ -1,0 +1,38 @@
+import Foundation
+
+/// Public facade over the vendored (and optimized) Voxtral engine.
+///
+/// The vendored sources keep their upstream access levels, which are module-internal;
+/// this exposes just what the spike harness drives, so the harness can measure the stock
+/// engine (MLXAudioSTT) and this one through identical code.
+public final class FastEngine {
+    private let model: VoxtralRealtimeModel
+
+    public init(repo: String) async throws {
+        model = try await VoxtralRealtimeModel.fromPretrained(repo)
+    }
+
+    public func makeSession(temperature: Float = 0.0, transcriptionDelayMs: Int?) -> FastSession {
+        FastSession(
+            model.makeStreamSession(
+                temperature: temperature,
+                transcriptionDelayMs: transcriptionDelayMs
+            )
+        )
+    }
+}
+
+public final class FastSession {
+    private let session: VoxtralRealtimeStreamSession
+
+    init(_ session: VoxtralRealtimeStreamSession) {
+        self.session = session
+    }
+
+    /// Text decoded by this chunk.
+    public func step(_ samples: [Float]) -> String { session.step(samples).text }
+    /// Flush the tail; returns the final fragment.
+    public func finish() -> String { session.finish().text }
+    /// Full transcript so far.
+    public var text: String { session.text }
+}

--- a/spikes/VoxtralSpike/Sources/VoxtralFast/FastFlags.swift
+++ b/spikes/VoxtralSpike/Sources/VoxtralFast/FastFlags.swift
@@ -16,9 +16,11 @@ public enum FastFlags {
     /// Keep activations in the weights' dtype: cast the mel at the conv-stem seam AND
     /// force any float32 parameter to float16 at load.
     static let fp16 = ProcessInfo.processInfo.environment["VOXFAST_FP16"] != "0"
+    /// Don't dump the Metal buffer pool on every chunk.
+    static let keepCache = ProcessInfo.processInfo.environment["VOXFAST_KEEPCACHE"] != "0"
 
     public static var description: String {
-        "rope=\(fusedRoPE ? 1 : 0) async=\(asyncDecode ? 1 : 0) mask=\(maskDtype ? 1 : 0) head=\(fusedHead ? 1 : 0) fp16=\(fp16 ? 1 : 0)"
+        "rope=\(fusedRoPE ? 1 : 0) async=\(asyncDecode ? 1 : 0) mask=\(maskDtype ? 1 : 0) head=\(fusedHead ? 1 : 0) fp16=\(fp16 ? 1 : 0) keepcache=\(keepCache ? 1 : 0)"
     }
 }
 

--- a/spikes/VoxtralSpike/Sources/VoxtralFast/FastFlags.swift
+++ b/spikes/VoxtralSpike/Sources/VoxtralFast/FastFlags.swift
@@ -12,9 +12,12 @@ public enum FastFlags {
     static let maskDtype = ProcessInfo.processInfo.environment["VOXFAST_MASK"] != "0"
     /// Tied-embedding LM head via `asLinear` instead of a transposed-view matmul.
     static let fusedHead = ProcessInfo.processInfo.environment["VOXFAST_HEAD"] != "0"
+    /// Keep activations in the weights' dtype: cast the mel at the conv-stem seam AND
+    /// force any float32 parameter to float16 at load.
+    static let fp16 = ProcessInfo.processInfo.environment["VOXFAST_FP16"] != "0"
 
     public static var description: String {
-        "rope=\(fusedRoPE ? 1 : 0) async=\(asyncDecode ? 1 : 0) mask=\(maskDtype ? 1 : 0) head=\(fusedHead ? 1 : 0)"
+        "rope=\(fusedRoPE ? 1 : 0) async=\(asyncDecode ? 1 : 0) mask=\(maskDtype ? 1 : 0) head=\(fusedHead ? 1 : 0) fp16=\(fp16 ? 1 : 0)"
     }
 }
 

--- a/spikes/VoxtralSpike/Sources/VoxtralFast/FastFlags.swift
+++ b/spikes/VoxtralSpike/Sources/VoxtralFast/FastFlags.swift
@@ -1,0 +1,44 @@
+import Foundation
+import MLX
+
+/// Each optimization is individually switchable so a single run can bisect which one
+/// breaks correctness (the first A/B produced word-accuracy 0.000 with all three on,
+/// while the stock engine scored 0.804 on the same audio in the same run).
+///
+/// Default ON; set the env var to "0" to fall back to the upstream behavior.
+public enum FastFlags {
+    static let fusedRoPE = ProcessInfo.processInfo.environment["VOXFAST_ROPE"] != "0"
+    static let asyncDecode = ProcessInfo.processInfo.environment["VOXFAST_ASYNC"] != "0"
+    static let maskDtype = ProcessInfo.processInfo.environment["VOXFAST_MASK"] != "0"
+
+    public static var description: String {
+        "rope=\(fusedRoPE ? 1 : 0) async=\(asyncDecode ? 1 : 0) mask=\(maskDtype ? 1 : 0)"
+    }
+}
+
+/// Numeric equivalence check: the fused RoPE must reproduce the manual one it replaces.
+/// Returns the max absolute deviation across a few (seqLen, offset) shapes — anything
+/// above ~1e-2 in fp16 means the layout or the rotation convention is wrong.
+public func voxtralRoPESelfTest() -> [String: Float] {
+    var results: [String: Float] = [:]
+    let nHeads = 4
+    let headDim = 128
+    let theta: Float = 10000.0
+
+    for (seqLen, offset) in [(1, 0), (1, 37), (8, 0), (8, 129)] {
+        let x = MLXRandom.normal([seqLen, nHeads * headDim]).asType(.float16)
+        let positions = MLXArray(offset..<(offset + seqLen)).asType(.int32)
+
+        let (cos, sin) = voxtralComputeRopeFrequencies(
+            positions: positions, headDim: headDim, theta: theta)
+        let manual = voxtralApplyInterleavedRoPE(
+            x, cos: cos, sin: sin, nHeads: nHeads, headDim: headDim)
+        let fused = voxtralFusedRoPE(
+            x, nHeads: nHeads, headDim: headDim, theta: theta, offset: offset)
+
+        let diff = MLX.abs(manual.asType(.float32) - fused.asType(.float32)).max()
+        MLX.eval(diff)
+        results["L\(seqLen)_off\(offset)"] = diff.item(Float.self)
+    }
+    return results
+}

--- a/spikes/VoxtralSpike/Sources/VoxtralFast/FastFlags.swift
+++ b/spikes/VoxtralSpike/Sources/VoxtralFast/FastFlags.swift
@@ -54,7 +54,7 @@ public func voxtralRoPESelfTest() -> [String: Float] {
 /// (this perturbs the total slightly; it is a diagnostic, not a benchmark).
 public enum FastProfile {
     public enum Phase: String, CaseIterable, Sendable {
-        case convStem, encoder, decodeTokens, logits
+        case convStem, encoder, decodeTokens, decoderForward, logits
     }
 
     public static let enabled = ProcessInfo.processInfo.environment["VOXFAST_PROFILE"] == "1"
@@ -80,4 +80,39 @@ public enum FastProfile {
         out["steps"] = Double(steps)
         return out
     }
+}
+
+/// Micro-benchmark of the tied-embedding LM head in isolation.
+///
+/// Needed because MLX is LAZY: timing `logits(...)` and calling `eval` on its output
+/// charges the ENTIRE decoder graph (32 layers) to the head. This times the head alone,
+/// with a materialised input, both ways.
+public func voxtralHeadBenchmark(dim: Int = 3072, vocab: Int = 131072, iters: Int = 50)
+    -> [String: Double]
+{
+    let w = MLXRandom.normal([vocab, dim]).asType(.float16)
+    let h = MLXRandom.normal([dim]).asType(.float16)
+    MLX.eval(w, h)
+
+    let emb = Embedding(embeddingCount: vocab, dimensions: dim)
+    emb.update(parameters: ModuleParameters.unflattened(["weight": .value(w)]))
+    MLX.eval(emb)
+
+    // transposed-view matmul (what upstream does)
+    var t0 = CFAbsoluteTimeGetCurrent()
+    for _ in 0..<iters {
+        let l = MLX.matmul(h, w.transposed(1, 0))
+        MLX.eval(l)
+    }
+    let matmulMs = (CFAbsoluteTimeGetCurrent() - t0) * 1000 / Double(iters)
+
+    // asLinear (what voxmlx's as_linear does)
+    t0 = CFAbsoluteTimeGetCurrent()
+    for _ in 0..<iters {
+        let l = emb.asLinear(h)
+        MLX.eval(l)
+    }
+    let asLinearMs = (CFAbsoluteTimeGetCurrent() - t0) * 1000 / Double(iters)
+
+    return ["matmul_transposed_ms": matmulMs, "as_linear_ms": asLinearMs]
 }

--- a/spikes/VoxtralSpike/Sources/VoxtralFast/FastFlags.swift
+++ b/spikes/VoxtralSpike/Sources/VoxtralFast/FastFlags.swift
@@ -42,3 +42,37 @@ public func voxtralRoPESelfTest() -> [String: Float] {
     }
     return results
 }
+
+/// Phase profiler. The three "obvious" optimizations bought only ~4%, which means the
+/// ~130 ms/step is somewhere else entirely — so measure it instead of theorising.
+/// MLX is lazy, so each phase `eval`s its own output to attribute GPU time honestly
+/// (this perturbs the total slightly; it is a diagnostic, not a benchmark).
+public enum FastProfile {
+    public enum Phase: String, CaseIterable, Sendable {
+        case convStem, encoder, decodeTokens, logits
+    }
+
+    public static let enabled = ProcessInfo.processInfo.environment["VOXFAST_PROFILE"] == "1"
+
+    nonisolated(unsafe) private static var totals: [String: Double] = [:]
+    nonisolated(unsafe) public private(set) static var tokens = 0
+    nonisolated(unsafe) public private(set) static var steps = 0
+
+    static func time<T>(_ phase: Phase, _ body: () -> T) -> T {
+        guard enabled else { return body() }
+        let t0 = CFAbsoluteTimeGetCurrent()
+        let r = body()
+        totals[phase.rawValue, default: 0] += (CFAbsoluteTimeGetCurrent() - t0) * 1000
+        return r
+    }
+
+    static func countToken() { if enabled { tokens += 1 } }
+    static func countStep() { if enabled { steps += 1 } }
+
+    public static func snapshot() -> [String: Double] {
+        var out = totals
+        out["tokens"] = Double(tokens)
+        out["steps"] = Double(steps)
+        return out
+    }
+}

--- a/spikes/VoxtralSpike/Sources/VoxtralFast/FastFlags.swift
+++ b/spikes/VoxtralSpike/Sources/VoxtralFast/FastFlags.swift
@@ -96,7 +96,7 @@ public func voxtralHeadBenchmark(dim: Int = 3072, vocab: Int = 131072, iters: In
     MLX.eval(w, h)
 
     let emb = Embedding(embeddingCount: vocab, dimensions: dim)
-    emb.update(parameters: ModuleParameters.unflattened(["weight": .value(w)]))
+    emb.update(parameters: ModuleParameters.unflattened([("weight", w)]))
     MLX.eval(emb)
 
     // transposed-view matmul (what upstream does)

--- a/spikes/VoxtralSpike/Sources/VoxtralFast/FastFlags.swift
+++ b/spikes/VoxtralSpike/Sources/VoxtralFast/FastFlags.swift
@@ -10,9 +10,11 @@ public enum FastFlags {
     static let fusedRoPE = ProcessInfo.processInfo.environment["VOXFAST_ROPE"] != "0"
     static let asyncDecode = ProcessInfo.processInfo.environment["VOXFAST_ASYNC"] != "0"
     static let maskDtype = ProcessInfo.processInfo.environment["VOXFAST_MASK"] != "0"
+    /// Tied-embedding LM head via `asLinear` instead of a transposed-view matmul.
+    static let fusedHead = ProcessInfo.processInfo.environment["VOXFAST_HEAD"] != "0"
 
     public static var description: String {
-        "rope=\(fusedRoPE ? 1 : 0) async=\(asyncDecode ? 1 : 0) mask=\(maskDtype ? 1 : 0)"
+        "rope=\(fusedRoPE ? 1 : 0) async=\(asyncDecode ? 1 : 0) mask=\(maskDtype ? 1 : 0) head=\(fusedHead ? 1 : 0)"
     }
 }
 

--- a/spikes/VoxtralSpike/Sources/VoxtralFast/FastFlags.swift
+++ b/spikes/VoxtralSpike/Sources/VoxtralFast/FastFlags.swift
@@ -18,9 +18,12 @@ public enum FastFlags {
     static let fp16 = ProcessInfo.processInfo.environment["VOXFAST_FP16"] != "0"
     /// Don't dump the Metal buffer pool on every chunk.
     static let keepCache = ProcessInfo.processInfo.environment["VOXFAST_KEEPCACHE"] != "0"
+    /// Manual RoPE, but dtype-preserving (cast cos/sin to the activation dtype). The
+    /// minimal, upstream-shaped alternative to swapping in the fused MLXFast.RoPE kernel.
+    static let ropeCast = ProcessInfo.processInfo.environment["VOXFAST_ROPECAST"] != "0"
 
     public static var description: String {
-        "rope=\(fusedRoPE ? 1 : 0) async=\(asyncDecode ? 1 : 0) mask=\(maskDtype ? 1 : 0) head=\(fusedHead ? 1 : 0) fp16=\(fp16 ? 1 : 0) keepcache=\(keepCache ? 1 : 0)"
+        "rope=\(fusedRoPE ? 1 : 0) async=\(asyncDecode ? 1 : 0) mask=\(maskDtype ? 1 : 0) head=\(fusedHead ? 1 : 0) fp16=\(fp16 ? 1 : 0) keepcache=\(keepCache ? 1 : 0) ropecast=\(ropeCast ? 1 : 0)"
     }
 }
 

--- a/spikes/VoxtralSpike/Sources/VoxtralFast/FastFlags.swift
+++ b/spikes/VoxtralSpike/Sources/VoxtralFast/FastFlags.swift
@@ -57,7 +57,7 @@ public func voxtralRoPESelfTest() -> [String: Float] {
 /// (this perturbs the total slightly; it is a diagnostic, not a benchmark).
 public enum FastProfile {
     public enum Phase: String, CaseIterable, Sendable {
-        case convStem, encoder, decodeTokens, decoderForward, logits
+        case convStem, encoder, decodeTokens, decoderForward, logits, headProbe
     }
 
     public static let enabled = ProcessInfo.processInfo.environment["VOXFAST_PROFILE"] == "1"
@@ -75,12 +75,15 @@ public enum FastProfile {
     }
 
     static func countToken() { if enabled { tokens += 1 } }
+    nonisolated(unsafe) public private(set) static var probes = 0
+    static func countProbe() { if enabled { probes += 1 } }
     static func countStep() { if enabled { steps += 1 } }
 
     public static func snapshot() -> [String: Double] {
         var out = totals
         out["tokens"] = Double(tokens)
         out["steps"] = Double(steps)
+        out["probes"] = Double(probes)
         return out
     }
 }

--- a/spikes/VoxtralSpike/Sources/VoxtralFast/FastFlags.swift
+++ b/spikes/VoxtralSpike/Sources/VoxtralFast/FastFlags.swift
@@ -1,5 +1,6 @@
 import Foundation
 import MLX
+import MLXNN
 
 /// Each optimization is individually switchable so a single run can bisect which one
 /// breaks correctness (the first A/B produced word-accuracy 0.000 with all three on,

--- a/spikes/VoxtralSpike/Sources/VoxtralFast/Generation.swift
+++ b/spikes/VoxtralSpike/Sources/VoxtralFast/Generation.swift
@@ -1,0 +1,68 @@
+import MLX
+
+public struct STTGenerateParameters: Sendable {
+    public let maxTokens: Int
+    public let temperature: Float
+    public let topP: Float
+    public let topK: Int
+    public let verbose: Bool
+    public let language: String?
+    public let chunkDuration: Float
+    public let minChunkDuration: Float
+    public let repetitionPenalty: Float
+    public let repetitionContextSize: Int
+
+    public init(
+        maxTokens: Int = 8192,
+        temperature: Float = 0.0,
+        topP: Float = 0.95,
+        topK: Int = 0,
+        verbose: Bool = false,
+        language: String? = nil,
+        chunkDuration: Float = 1200.0,
+        minChunkDuration: Float = 1.0,
+        repetitionPenalty: Float = 1.0,
+        repetitionContextSize: Int = 32
+    ) {
+        self.maxTokens = maxTokens
+        self.temperature = temperature
+        self.topP = topP
+        self.topK = topK
+        self.verbose = verbose
+        self.language = language
+        self.chunkDuration = chunkDuration
+        self.minChunkDuration = minChunkDuration
+        self.repetitionPenalty = repetitionPenalty
+        self.repetitionContextSize = repetitionContextSize
+    }
+}
+
+public protocol STTGenerationModel: AnyObject {
+    var defaultGenerationParameters: STTGenerateParameters { get }
+
+    func generate(
+        audio: MLXArray,
+        generationParameters: STTGenerateParameters
+    ) -> STTOutput
+
+    func generateStream(
+        audio: MLXArray,
+        generationParameters: STTGenerateParameters
+    ) -> AsyncThrowingStream<STTGeneration, Error>
+}
+
+public extension STTGenerationModel {
+    func generate(
+        audio: MLXArray,
+        generationParameters: STTGenerateParameters? = nil
+    ) -> STTOutput {
+        generate(audio: audio, generationParameters: generationParameters ?? defaultGenerationParameters)
+    }
+
+    func generateStream(
+        audio: MLXArray,
+        generationParameters: STTGenerateParameters? = nil
+    ) -> AsyncThrowingStream<STTGeneration, Error> {
+        generateStream(audio: audio, generationParameters: generationParameters ?? defaultGenerationParameters)
+    }
+}

--- a/spikes/VoxtralSpike/Sources/VoxtralFast/STTOutput.swift
+++ b/spikes/VoxtralSpike/Sources/VoxtralFast/STTOutput.swift
@@ -1,0 +1,152 @@
+//
+//  STTOutput.swift
+//  MLXAudioSTT
+//
+// Created by Prince Canuma on 04/01/2026.
+//
+
+import Foundation
+
+// MARK: - STT Generation Events
+
+/// Events emitted during speech-to-text streaming generation.
+public enum STTGeneration: Sendable {
+    /// A generated text token during transcription
+    case token(String)
+    /// Generation statistics
+    case info(STTGenerationInfo)
+    /// Final transcription result
+    case result(STTOutput)
+}
+
+/// Information about the STT generation process.
+public struct STTGenerationInfo: Sendable {
+    public let promptTokenCount: Int
+    public let generationTokenCount: Int
+    public let prefillTime: TimeInterval
+    public let generateTime: TimeInterval
+    public let tokensPerSecond: Double
+    public let peakMemoryUsage: Double
+
+    public init(
+        promptTokenCount: Int,
+        generationTokenCount: Int,
+        prefillTime: TimeInterval,
+        generateTime: TimeInterval,
+        tokensPerSecond: Double,
+        peakMemoryUsage: Double
+    ) {
+        self.promptTokenCount = promptTokenCount
+        self.generationTokenCount = generationTokenCount
+        self.prefillTime = prefillTime
+        self.generateTime = generateTime
+        self.tokensPerSecond = tokensPerSecond
+        self.peakMemoryUsage = peakMemoryUsage
+    }
+
+    public var summary: String {
+        """
+        Prompt:     \(promptTokenCount) tokens, \(String(format: "%.2f", Double(promptTokenCount) / max(prefillTime, 0.001))) tokens/s, \(String(format: "%.3f", prefillTime))s
+        Generation: \(generationTokenCount) tokens, \(String(format: "%.2f", tokensPerSecond)) tokens/s, \(String(format: "%.3f", generateTime))s
+        Peak Memory Usage: \(peakMemoryUsage) GB
+        """
+    }
+}
+
+/// Errors that can occur during STT generation.
+public enum STTError: Error, LocalizedError {
+    case modelNotInitialized(String)
+    case generationFailed(String)
+    case invalidInput(String)
+    case audioProcessingFailed(String)
+
+    public var errorDescription: String? {
+        switch self {
+        case .modelNotInitialized(let message):
+            return "Model not initialized: \(message)"
+        case .generationFailed(let message):
+            return "Generation failed: \(message)"
+        case .invalidInput(let message):
+            return "Invalid input: \(message)"
+        case .audioProcessingFailed(let message):
+            return "Audio processing failed: \(message)"
+        }
+    }
+}
+
+// MARK: - STT Output
+
+/// Output from speech-to-text transcription.
+public struct STTOutput: @unchecked Sendable {
+    /// The transcribed text.
+    public let text: String
+
+    /// Transcription segments with timing information (optional).
+    public let segments: [[String: Any]]?
+
+    /// Detected language (optional).
+    public let language: String?
+
+    /// Number of tokens in the prompt.
+    public let promptTokens: Int
+
+    /// Number of tokens generated.
+    public let generationTokens: Int
+
+    /// Total number of tokens processed.
+    public let totalTokens: Int
+
+    /// Prompt processing tokens per second.
+    public let promptTps: Double
+
+    /// Generation tokens per second.
+    public let generationTps: Double
+
+    /// Total processing time in seconds.
+    public let totalTime: Double
+
+    /// Peak memory usage in GB.
+    public let peakMemoryUsage: Double
+
+    public init(
+        text: String,
+        segments: [[String: Any]]? = nil,
+        language: String? = nil,
+        promptTokens: Int = 0,
+        generationTokens: Int = 0,
+        totalTokens: Int = 0,
+        promptTps: Double = 0.0,
+        generationTps: Double = 0.0,
+        totalTime: Double = 0.0,
+        peakMemoryUsage: Double = 0.0
+    ) {
+        self.text = text
+        self.segments = segments
+        self.language = language
+        self.promptTokens = promptTokens
+        self.generationTokens = generationTokens
+        self.totalTokens = totalTokens
+        self.promptTps = promptTps
+        self.generationTps = generationTps
+        self.totalTime = totalTime
+        self.peakMemoryUsage = peakMemoryUsage
+    }
+}
+
+extension STTOutput: CustomStringConvertible {
+    public var description: String {
+        var result = "STTOutput:\n"
+        result += "  text: \(text)\n"
+        if let language = language {
+            result += "  language: \(language)\n"
+        }
+        result += "  prompt_tokens: \(promptTokens)\n"
+        result += "  generation_tokens: \(generationTokens)\n"
+        result += "  total_tokens: \(totalTokens)\n"
+        result += "  prompt_tps: \(String(format: "%.2f", promptTps))\n"
+        result += "  generation_tps: \(String(format: "%.2f", generationTps))\n"
+        result += "  total_time: \(String(format: "%.2f", totalTime))s\n"
+        result += "  peak_memory_usage: \(String(format: "%.2f", peakMemoryUsage)) GB"
+        return result
+    }
+}

--- a/spikes/VoxtralSpike/Sources/VoxtralFast/VoxtralRealtime.swift
+++ b/spikes/VoxtralSpike/Sources/VoxtralFast/VoxtralRealtime.swift
@@ -645,6 +645,30 @@ public extension VoxtralRealtimeModel {
         return newWeights
     }
 
+    func dtypeReport() -> [String: String] {
+        [
+            "conv1.weight": "\(encoder.convLayers0Conv.conv.weight.dtype)",
+            "tok_embeddings.weight": "\(decoder.tokEmbeddings.weight.dtype)",
+            "adapter.w_in.weight": "\(adapter.wIn.weight.dtype)",
+        ]
+    }
+
+    /// Cast every float32 parameter to float16.
+    ///
+    /// The mel front-end is built in float32 (DFT/filters), and `convStem` fed it straight
+    /// into the conv weights — so the hidden state was promoted to float32 at layer 1 and
+    /// stayed there. float32 activations against float16 scales push `quantizedMM` onto a
+    /// silent upcast path (ml-explore/mlx-swift#420), and force the tied fp16 embedding to
+    /// be upcast on EVERY token — which is why the LM head profiled at 92 ms/token.
+    /// voxmlx avoids this by casting the mel to `conv1.weight.dtype` at the seam.
+    func castFloat32ParamsToFloat16() {
+        func cast(_ p: NestedDictionary<String, MLXArray>) -> NestedDictionary<String, MLXArray> {
+            p.mapValues { $0.dtype == .float32 ? $0.asType(.float16) : $0 }
+        }
+        update(parameters: cast(parameters()))
+        eval(self)
+    }
+
     func shouldQuantize(path: String) -> Bool {
         let skipPatterns = [
             "norm",

--- a/spikes/VoxtralSpike/Sources/VoxtralFast/VoxtralRealtime.swift
+++ b/spikes/VoxtralSpike/Sources/VoxtralFast/VoxtralRealtime.swift
@@ -649,7 +649,6 @@ public extension VoxtralRealtimeModel {
         [
             "conv1.weight": "\(encoder.convLayers0Conv.conv.weight.dtype)",
             "tok_embeddings.weight": "\(decoder.tokEmbeddings.weight.dtype)",
-            "adapter.w_in.weight": "\(adapter.wIn.weight.dtype)",
         ]
     }
 

--- a/spikes/VoxtralSpike/Sources/VoxtralFast/VoxtralRealtime.swift
+++ b/spikes/VoxtralSpike/Sources/VoxtralFast/VoxtralRealtime.swift
@@ -1,0 +1,667 @@
+import Foundation
+import MLX
+import MLXNN
+import MLXAudioCore
+import MLXAudioVAD
+import MLXLMCommon
+import HuggingFace
+
+private enum VoxtralRealtimeConstants {
+    static let sampleRate = 16000
+    static let frameRate: Float = 12.5
+    static let rawAudioLengthPerToken = Int(Float(sampleRate) / frameRate) // 1280
+    static let hopLength = 160
+    static let audioLengthPerToken = rawAudioLengthPerToken / hopLength // 8
+}
+
+private struct VoxtralPrefillContext {
+    let adapterOut: MLXArray
+    let nAudioTotal: Int
+    let promptLength: Int
+    var logits: MLXArray
+    var cache: [VoxtralRealtimeDecoderKVCache?]
+    let startTime: Date
+}
+
+public final class VoxtralRealtimeModel: Module, STTGenerationModel {
+    public let config: VoxtralRealtimeConfig
+
+    @ModuleInfo(key: "encoder") var encoder: VoxtralRealtimeAudioEncoder
+    @ModuleInfo(key: "decoder") var decoder: VoxtralRealtimeDecoder
+
+    private var tokenizer: VoxtralRealtimeTokenizer?
+    private var adaScaleDelay: Int = -1
+
+    public var defaultGenerationParameters: STTGenerateParameters {
+        STTGenerateParameters(
+            maxTokens: 4096,
+            temperature: 0.0,
+            topP: 1.0,
+            topK: 0,
+            verbose: false,
+            language: "en",
+            chunkDuration: 1200.0,
+            minChunkDuration: 1.0
+        )
+    }
+
+    public init(_ config: VoxtralRealtimeConfig) {
+        self.config = config
+        self._encoder.wrappedValue = VoxtralRealtimeAudioEncoder(
+            config.encoderArgs,
+            decoderDim: config.decoder.dim
+        )
+        self._decoder.wrappedValue = VoxtralRealtimeDecoder(config.decoder)
+    }
+
+    public func generate(
+        audio: MLXArray,
+        generationParameters: STTGenerateParameters
+    ) -> STTOutput {
+        let audio1D = audio.ndim > 1 ? audio.mean(axis: -1) : audio
+        var context = encodeAndPrefill(
+            audio: audio1D,
+            verbose: generationParameters.verbose,
+            transcriptionDelayMs: nil
+        )
+
+        var generated: [Int] = []
+        let decodeStart = Date()
+
+        for pos in context.promptLength..<context.nAudioTotal {
+            let token = sample(logits: context.logits, temperature: generationParameters.temperature)
+            generated.append(token)
+
+            if token == config.eosTokenId || generated.count > generationParameters.maxTokens {
+                break
+            }
+
+            let tokenEmbed = decoder.embedToken(tokenId: token)
+            let inputEmbed: MLXArray
+            if pos < context.adapterOut.shape[0] {
+                inputEmbed = context.adapterOut[pos] + tokenEmbed
+            } else {
+                inputEmbed = tokenEmbed
+            }
+
+            let next = decoder(
+                inputEmbed.expandedDimensions(axis: 0),
+                startPos: pos,
+                cache: context.cache
+            )
+            context.cache = next.1
+            context.logits = decoder.logits(next.0[0])
+
+            eval(context.logits)
+            if generated.count % 256 == 0 {
+                Memory.clearCache()
+            }
+        }
+
+        if generated.last == config.eosTokenId {
+            _ = generated.popLast()
+        }
+
+        let text = tokenizer?.decode(tokenIds: generated).trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+
+        let end = Date()
+        let totalTime = end.timeIntervalSince(context.startTime)
+        let decodeTime = end.timeIntervalSince(decodeStart)
+
+        Memory.clearCache()
+
+        return STTOutput(
+            text: text,
+            language: generationParameters.language,
+            promptTokens: context.promptLength,
+            generationTokens: generated.count,
+            totalTokens: context.promptLength + generated.count,
+            promptTps: totalTime > 0 ? Double(context.promptLength) / totalTime : 0,
+            generationTps: decodeTime > 0 ? Double(generated.count) / decodeTime : 0,
+            totalTime: totalTime,
+            peakMemoryUsage: Double(Memory.peakMemory) / 1e9
+        )
+    }
+
+    public func generate(
+        audio: MLXArray,
+        generationParameters: STTGenerateParameters,
+        vad: (model: SileroVAD, config: SpeechSegmentConfig)?
+    ) -> STTOutput {
+        guard let vad else {
+            return generate(audio: audio, generationParameters: generationParameters)
+        }
+        let audio1D = audio.ndim > 1 ? audio.mean(axis: -1) : audio
+        let chunks: [(MLXArray, Float)]
+        do {
+            chunks = try segmentSpeech(
+                audio: audio1D,
+                sampleRate: VoxtralRealtimeConstants.sampleRate,
+                vadModel: vad.model,
+                config: vad.config
+            )
+        } catch {
+            if generationParameters.verbose {
+                print("VAD pre-processing failed (\(error)); falling back to single-pass generate")
+            }
+            return generate(audio: audio1D, generationParameters: generationParameters)
+        }
+        if chunks.count <= 1 {
+            // One speech region: transcribe the trimmed chunk, not the original buffer
+            // (keeps the VAD's leading/trailing-silence removal). `chunks` is never empty,
+            // but fall back to `audio1D` defensively.
+            return generate(audio: chunks.first?.0 ?? audio1D, generationParameters: generationParameters)
+        }
+
+        var outputs: [STTOutput] = []
+        outputs.reserveCapacity(chunks.count)
+        var remainingTokens = generationParameters.maxTokens
+        for (chunkAudio, offsetSeconds) in chunks {
+            if remainingTokens <= 0 { break }
+            if generationParameters.verbose {
+                print("Voxtral VAD chunk at \(String(format: "%.1f", offsetSeconds))s")
+            }
+            let chunkParameters = STTGenerateParameters(
+                maxTokens: remainingTokens,
+                temperature: generationParameters.temperature,
+                topP: generationParameters.topP,
+                topK: generationParameters.topK,
+                verbose: generationParameters.verbose,
+                language: generationParameters.language,
+                chunkDuration: generationParameters.chunkDuration,
+                minChunkDuration: generationParameters.minChunkDuration
+            )
+            let out = generate(audio: chunkAudio, generationParameters: chunkParameters)
+            outputs.append(out)
+            remainingTokens = max(0, remainingTokens - out.generationTokens)
+        }
+
+        let combinedText = outputs
+            .map(\.text)
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { !$0.isEmpty }
+            .joined(separator: "\n")
+        let promptTokens = outputs.reduce(0) { $0 + $1.promptTokens }
+        let generationTokens = outputs.reduce(0) { $0 + $1.generationTokens }
+        let totalTokens = outputs.reduce(0) { $0 + $1.totalTokens }
+        let totalTime = outputs.reduce(0.0) { $0 + $1.totalTime }
+        let peakMemoryUsage = outputs.map(\.peakMemoryUsage).max() ?? 0
+
+        return STTOutput(
+            text: combinedText,
+            language: generationParameters.language,
+            promptTokens: promptTokens,
+            generationTokens: generationTokens,
+            totalTokens: totalTokens,
+            promptTps: totalTime > 0 ? Double(promptTokens) / totalTime : 0,
+            generationTps: totalTime > 0 ? Double(generationTokens) / totalTime : 0,
+            totalTime: totalTime,
+            peakMemoryUsage: peakMemoryUsage
+        )
+    }
+
+    public func generateStream(
+        audio: MLXArray,
+        generationParameters: STTGenerateParameters
+    ) -> AsyncThrowingStream<STTGeneration, Error> {
+        AsyncThrowingStream { continuation in
+            let audio1D = audio.ndim > 1 ? audio.mean(axis: -1) : audio
+            var context = encodeAndPrefill(
+                audio: audio1D,
+                verbose: generationParameters.verbose,
+                transcriptionDelayMs: nil
+            )
+
+            var generated: [Int] = []
+            var previousText = ""
+            let decodeStart = Date()
+
+            for pos in context.promptLength..<context.nAudioTotal {
+                let token = sample(logits: context.logits, temperature: generationParameters.temperature)
+                generated.append(token)
+
+                let filtered = generated.filter { $0 != config.eosTokenId }
+                let textSoFar = tokenizer?.decode(tokenIds: filtered) ?? ""
+                if textSoFar != previousText {
+                    let delta: String
+                    if textSoFar.hasPrefix(previousText) {
+                        delta = String(textSoFar.dropFirst(previousText.count))
+                    } else {
+                        delta = textSoFar
+                    }
+                    if !delta.isEmpty {
+                        continuation.yield(.token(delta))
+                    }
+                    previousText = textSoFar
+                }
+
+                if token == config.eosTokenId || generated.count > generationParameters.maxTokens {
+                    break
+                }
+
+                let tokenEmbed = decoder.embedToken(tokenId: token)
+                let inputEmbed: MLXArray
+                if pos < context.adapterOut.shape[0] {
+                    inputEmbed = context.adapterOut[pos] + tokenEmbed
+                } else {
+                    inputEmbed = tokenEmbed
+                }
+
+                let next = decoder(
+                    inputEmbed.expandedDimensions(axis: 0),
+                    startPos: pos,
+                    cache: context.cache
+                )
+                context.cache = next.1
+                context.logits = decoder.logits(next.0[0])
+
+                eval(context.logits)
+                if generated.count % 256 == 0 {
+                    Memory.clearCache()
+                }
+            }
+
+            if generated.last == self.config.eosTokenId {
+                _ = generated.popLast()
+            }
+
+            let finalText = tokenizer?.decode(tokenIds: generated).trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+            let end = Date()
+            let totalTime = end.timeIntervalSince(context.startTime)
+            let decodeTime = end.timeIntervalSince(decodeStart)
+
+            let output = STTOutput(
+                text: finalText,
+                language: generationParameters.language,
+                promptTokens: context.promptLength,
+                generationTokens: generated.count,
+                totalTokens: context.promptLength + generated.count,
+                promptTps: totalTime > 0 ? Double(context.promptLength) / totalTime : 0,
+                generationTps: decodeTime > 0 ? Double(generated.count) / decodeTime : 0,
+                totalTime: totalTime,
+                peakMemoryUsage: Double(Memory.peakMemory) / 1e9
+            )
+
+            continuation.yield(.result(output))
+            continuation.finish()
+        }
+    }
+}
+
+extension VoxtralRealtimeModel {
+    func numAudioTokens(_ audioLength: Int) -> Int {
+        let hop = VoxtralRealtimeConstants.hopLength
+        let perTok = VoxtralRealtimeConstants.audioLengthPerToken
+
+        let frames: Int
+        if audioLength % hop != 0 {
+            frames = Int(ceil(Double(audioLength) / Double(hop) - 1.0))
+        } else {
+            frames = audioLength / hop
+        }
+        return Int(ceil(Double(frames) / Double(perTok)))
+    }
+
+    func numDelayTokens(_ delayMs: Int) -> Int {
+        let delayLen = Int(Double(delayMs) / 1000.0 * Double(VoxtralRealtimeConstants.sampleRate))
+        return numAudioTokens(delayLen)
+    }
+
+    func padAudioStreaming(_ audio: MLXArray, leftTokens: Int, rightTokens: Int) -> MLXArray {
+        let mult = VoxtralRealtimeConstants.rawAudioLengthPerToken
+        let nSamples = audio.shape[0]
+
+        let alignPad = (mult - (nSamples % mult)) % mult
+        let rightPad = alignPad + rightTokens * mult
+        let leftPad = leftTokens * mult
+
+        return MLX.padded(audio, widths: [IntOrPair((leftPad, rightPad))])
+    }
+
+    func ensureMelFilters() -> MLXArray {
+        let a = config.audioEncodingArgs
+        return VoxtralRealtimeAudio.computeMelFilters(
+            numMelBins: a.numMelBins,
+            windowSize: a.windowSize,
+            sampleRate: a.samplingRate
+        ).asType(.float32)
+    }
+
+    func ensureAdaScales(transcriptionDelayMs: Int?) {
+        let delayMs = transcriptionDelayMs ?? config.transcriptionDelayMs
+        let delayTokens = numDelayTokens(delayMs)
+
+        if delayTokens != adaScaleDelay {
+            let tCond = voxtralComputeTimeEmbedding(
+                tValue: Float(delayTokens),
+                dim: config.decoder.dim
+            )
+            decoder.precomputeAdaScales(tCond)
+            if let adaScales = decoder.adaScales {
+                for scale in adaScales {
+                    if let scale {
+                        eval(scale)
+                    }
+                }
+            }
+            adaScaleDelay = delayTokens
+        }
+    }
+
+    func prepareMel(_ audio: MLXArray, transcriptionDelayMs: Int?) -> (MLXArray, Int) {
+        let delayMs = transcriptionDelayMs ?? config.transcriptionDelayMs
+        let nDelay = numDelayTokens(delayMs)
+        let nLeft = config.nLeftPadTokens
+        let nRight = (nDelay + 1) + 10
+
+        let padded = padAudioStreaming(audio, leftTokens: nLeft, rightTokens: nRight)
+        let a = config.audioEncodingArgs
+        let mel = VoxtralRealtimeAudio.computeMelSpectrogram(
+            audio: padded,
+            melFilters: ensureMelFilters(),
+            windowSize: a.windowSize,
+            hopLength: a.hopLength,
+            globalLogMelMax: a.globalLogMelMax
+        )
+
+        if mel.shape[1] % 2 != 0 {
+            return (mel[0..., 1...], nDelay)
+        }
+        return (mel, nDelay)
+    }
+
+    /// Encode audio → audio-conditioning rows (`adapterOut`), the per-token span
+    /// (`nAudioTotal`), and the decoder prompt length. Shared by the offline
+    /// (`encodeAndPrefill`) and streaming (`VoxtralRealtimeStreamSession`) paths.
+    /// Causal conv + causal/sliding-window attention make `adapterOut[0..<k]`
+    /// identical whether encoded from a prefix or the full buffer.
+    /// Conv-stem seam: audio → conv-stem frames (`convOut`, the transformer input),
+    /// the per-token span, and the prompt length. Shared by the offline encode and
+    /// the streaming session (which feeds `convOut` incrementally).
+    func convStemForAudio(
+        audio: MLXArray,
+        transcriptionDelayMs: Int?
+    ) -> (convOut: MLXArray, nAudioTotal: Int, promptLength: Int) {
+        ensureAdaScales(transcriptionDelayMs: transcriptionDelayMs)
+        let (mel, nDelay) = prepareMel(audio, transcriptionDelayMs: transcriptionDelayMs)
+
+        let convOut = encoder.convStem(mel)
+        let ds = config.encoderArgs.downsampleFactor
+        let nAudioTotal = convOut.shape[0] / ds
+        let promptLength = 1 + config.nLeftPadTokens + nDelay
+        return (convOut, nAudioTotal, promptLength)
+    }
+
+    func encodeAudio(
+        audio: MLXArray,
+        transcriptionDelayMs: Int?
+    ) -> (adapterOut: MLXArray, nAudioTotal: Int, promptLength: Int) {
+        let (convOut, nAudioTotal, promptLength) = convStemForAudio(
+            audio: audio,
+            transcriptionDelayMs: transcriptionDelayMs
+        )
+        let adapterOut: MLXArray
+        if convOut.shape[0] <= config.encoderArgs.slidingWindow {
+            adapterOut = encoder.encodeFull(convOut)
+        } else {
+            adapterOut = encoder.encodeChunked(convOut)
+        }
+        return (adapterOut, nAudioTotal, promptLength)
+    }
+
+    fileprivate func encodeAndPrefill(
+        audio: MLXArray,
+        verbose: Bool,
+        transcriptionDelayMs: Int?
+    ) -> VoxtralPrefillContext {
+        let start = Date()
+
+        let (adapterOut, nAudioTotal, promptLength) = encodeAudio(
+            audio: audio,
+            transcriptionDelayMs: transcriptionDelayMs
+        )
+        let nDelay = promptLength - 1 - config.nLeftPadTokens
+
+        let promptIds = [config.bosTokenId] + Array(
+            repeating: config.streamingPadTokenId,
+            count: config.nLeftPadTokens + nDelay
+        )
+        let promptIdsMX = MLXArray(promptIds.map(Int32.init))
+        let promptTextEmbeds = decoder.embedTokens(promptIdsMX)
+
+        let prefixEmbeds = adapterOut[0..<promptLength, 0...] + promptTextEmbeds
+
+        let prefill = decoder(prefixEmbeds, startPos: 0, cache: nil)
+        let h = prefill.0
+        let cache = prefill.1
+
+        let logits = decoder.logits(h[h.shape[0] - 1])
+
+        var cacheArrays: [MLXArray] = [logits]
+        for layerCache in cache {
+            if let layerCache {
+                cacheArrays.append(layerCache.keys)
+                cacheArrays.append(layerCache.values)
+            }
+        }
+        eval(cacheArrays)
+
+        if verbose {
+            let seconds = Double(audio.shape[0]) / Double(VoxtralRealtimeConstants.sampleRate)
+            print("Audio: \(audio.shape[0]) samples (\(String(format: "%.1f", seconds))s)")
+            print("Prompt: \(promptLength) tokens, Audio span: \(nAudioTotal) tokens")
+        }
+
+        return VoxtralPrefillContext(
+            adapterOut: adapterOut,
+            nAudioTotal: nAudioTotal,
+            promptLength: promptLength,
+            logits: logits,
+            cache: cache,
+            startTime: start
+        )
+    }
+
+    /// Token-id → text seam for the streaming session (which lives in another file
+    /// and cannot reach the private `tokenizer`).
+    func decodeStreaming(_ tokenIds: [Int]) -> String {
+        tokenizer?.decode(tokenIds: tokenIds) ?? ""
+    }
+
+    /// Sample WITHOUT synchronising: returns the token as a 1-element GPU array.
+    /// `sample(logits:temperature:)` ends in `.item()`, which blocks the CPU on the GPU
+    /// once per decoded token; the streaming session instead `asyncEval`s this and reads
+    /// the value one step later.
+    func sampleArray(logits: MLXArray, temperature: Float) -> MLXArray {
+        let logits1D = logits.ndim > 1 ? logits.squeezed() : logits
+        if temperature == 0 {
+            return logits1D.argMax(axis: -1).reshaped(1)
+        }
+        let scaled = (logits1D / temperature).expandedDimensions(axis: 0)
+        return categorical(scaled).reshaped(1)
+    }
+
+    func sample(logits: MLXArray, temperature: Float) -> Int {
+        let logits1D: MLXArray
+        if logits.ndim > 1 {
+            logits1D = logits.squeezed()
+        } else {
+            logits1D = logits
+        }
+
+        if temperature == 0 {
+            return logits1D.argMax(axis: -1).item(Int.self)
+        }
+
+        let scaled = (logits1D / temperature).expandedDimensions(axis: 0)
+        let sampled = categorical(scaled)
+        return sampled.item(Int.self)
+    }
+}
+
+public extension VoxtralRealtimeModel {
+    static func fromDirectory(_ modelDir: URL) throws -> VoxtralRealtimeModel {
+        let configURL = modelDir.appendingPathComponent("config.json")
+        let configData = try Data(contentsOf: configURL)
+        let config = try JSONDecoder().decode(VoxtralRealtimeConfig.self, from: configData)
+
+        let quantConfig = try JSONDecoder().decode(VoxtralQuantizationConfig.self, from: configData)
+
+        let model = VoxtralRealtimeModel(config)
+        model.tokenizer = try VoxtralRealtimeTokenizer.fromModelDirectory(modelDir)
+        guard model.tokenizer != nil else {
+            throw NSError(
+                domain: "VoxtralRealtimeModel",
+                code: 2,
+                userInfo: [
+                    NSLocalizedDescriptionKey: "Failed to load tokenizer from \(modelDir.path)"
+                ]
+            )
+        }
+        _ = model.ensureMelFilters()
+
+        let files = try FileManager.default.contentsOfDirectory(at: modelDir, includingPropertiesForKeys: nil)
+        let safetensors = files.filter { $0.pathExtension == "safetensors" }
+
+        var weights: [String: MLXArray] = [:]
+        for file in safetensors {
+            let shard = try MLX.loadArrays(url: file)
+            weights.merge(shard) { _, new in new }
+        }
+
+        let sanitized = sanitize(weights: weights)
+
+        if let perLayerQuantization = quantConfig.perLayerQuantization {
+            quantize(model: model) { path, _ in
+                guard model.shouldQuantize(path: path) else {
+                    return nil
+                }
+                if sanitized["\(path).scales"] != nil {
+                    return perLayerQuantization.quantization(layer: path)?.asTuple
+                }
+                return nil
+            }
+        }
+
+        try model.update(parameters: ModuleParameters.unflattened(sanitized), verify: .all)
+        model.ensureAdaScales(transcriptionDelayMs: config.transcriptionDelayMs)
+        eval(model)
+
+        return model
+    }
+
+    static func fromPretrained(_ modelPath: String) async throws -> VoxtralRealtimeModel {
+        let hfToken: String? = ProcessInfo.processInfo.environment["HF_TOKEN"]
+            ?? Bundle.main.object(forInfoDictionaryKey: "HF_TOKEN") as? String
+
+        guard let repoID = Repo.ID(rawValue: modelPath) else {
+            throw NSError(
+                domain: "VoxtralRealtimeModel",
+                code: 1,
+                userInfo: [NSLocalizedDescriptionKey: "Invalid repository ID: \(modelPath)"]
+            )
+        }
+
+        let modelDir = try await ModelUtils.resolveOrDownloadModel(
+            repoID: repoID,
+            requiredExtension: "safetensors",
+            hfToken: hfToken
+        )
+
+        return try fromDirectory(modelDir)
+    }
+
+    static func sanitize(weights: [String: MLXArray]) -> [String: MLXArray] {
+        var newWeights: [String: MLXArray] = [:]
+        newWeights.reserveCapacity(weights.count)
+
+        let encPrefix = "mm_streams_embeddings.embedding_module.whisper_encoder"
+        let adapterPrefix = "mm_streams_embeddings.embedding_module"
+        let tokEmbKey = "mm_streams_embeddings.embedding_module.tok_embeddings.weight"
+
+        for (key, value) in weights {
+            var v = value
+            var mapped: String?
+
+            if key == tokEmbKey {
+                mapped = "decoder.tok_embeddings.weight"
+            } else if key == "norm.weight" {
+                mapped = "decoder.norm.weight"
+            } else if key.hasPrefix("\(encPrefix).conv_layers.") {
+                let rest = String(key.dropFirst("\(encPrefix).conv_layers.".count))
+                let parts = rest.split(separator: ".", maxSplits: 2, omittingEmptySubsequences: false)
+                if parts.count == 3 {
+                    let layerIdx = String(parts[0])
+                    let param = String(parts[2])
+                    mapped = "encoder.conv_layers_\(layerIdx)_conv.conv.\(param)"
+                    if param == "weight" && v.ndim == 3 {
+                        v = v.transposed(0, 2, 1)
+                    }
+                }
+            } else if key.hasPrefix("\(encPrefix).transformer.layers.") {
+                let rest = String(key.dropFirst("\(encPrefix).transformer.layers.".count))
+                let parts = rest.split(separator: ".", maxSplits: 1, omittingEmptySubsequences: false)
+                if parts.count == 2 {
+                    let layerIdx = String(parts[0])
+                    var paramPath = String(parts[1])
+                    paramPath = paramPath.replacingOccurrences(of: "feed_forward.w1.", with: "feed_forward_w1.")
+                    paramPath = paramPath.replacingOccurrences(of: "feed_forward.w2.", with: "feed_forward_w2.")
+                    paramPath = paramPath.replacingOccurrences(of: "feed_forward.w3.", with: "feed_forward_w3.")
+                    mapped = "encoder.transformer_layers.\(layerIdx).\(paramPath)"
+                }
+            } else if key.hasPrefix("\(encPrefix).transformer.norm.") {
+                let rest = String(key.dropFirst("\(encPrefix).transformer.norm.".count))
+                mapped = "encoder.transformer_norm.\(rest)"
+            } else if key.hasPrefix("\(adapterPrefix).audio_language_projection.") {
+                let rest = String(key.dropFirst("\(adapterPrefix).audio_language_projection.".count))
+                let parts = rest.split(separator: ".", maxSplits: 1, omittingEmptySubsequences: false)
+                if parts.count == 2 {
+                    let idx = String(parts[0])
+                    let param = String(parts[1])
+                    mapped = "encoder.audio_language_projection_\(idx).\(param)"
+                }
+            } else if key.hasPrefix("layers.") {
+                let rest = String(key.dropFirst("layers.".count))
+                let parts = rest.split(separator: ".", maxSplits: 1, omittingEmptySubsequences: false)
+                if parts.count == 2 {
+                    let layerIdx = String(parts[0])
+                    var paramPath = String(parts[1])
+                    paramPath = paramPath.replacingOccurrences(of: "feed_forward.w1.", with: "feed_forward_w1.")
+                    paramPath = paramPath.replacingOccurrences(of: "feed_forward.w2.", with: "feed_forward_w2.")
+                    paramPath = paramPath.replacingOccurrences(of: "feed_forward.w3.", with: "feed_forward_w3.")
+                    paramPath = paramPath.replacingOccurrences(of: "ada_rms_norm_t_cond.0.", with: "ada_rms_norm_t_cond.ada_down.")
+                    paramPath = paramPath.replacingOccurrences(of: "ada_rms_norm_t_cond.2.", with: "ada_rms_norm_t_cond.ada_up.")
+                    mapped = "decoder.layers.\(layerIdx).\(paramPath)"
+                }
+            }
+
+            if let mapped {
+                newWeights[mapped] = v
+            } else {
+                newWeights[key] = v
+            }
+        }
+
+        return newWeights
+    }
+
+    func shouldQuantize(path: String) -> Bool {
+        let skipPatterns = [
+            "norm",
+            "ada_rms_norm",
+            "tok_embeddings",
+            "conv_layers",
+            "audio_language_projection",
+        ]
+        return !skipPatterns.contains(where: { path.contains($0) })
+    }
+}
+
+private struct VoxtralQuantizationConfig: Decodable {
+    let perLayerQuantization: BaseConfiguration.PerLayerQuantization?
+
+    init(from decoder: Decoder) throws {
+        let base = try? BaseConfiguration(from: decoder)
+        self.perLayerQuantization = base?.perLayerQuantization
+    }
+}

--- a/spikes/VoxtralSpike/Sources/VoxtralFast/VoxtralRealtimeAudio.swift
+++ b/spikes/VoxtralSpike/Sources/VoxtralFast/VoxtralRealtimeAudio.swift
@@ -1,0 +1,104 @@
+import Foundation
+import MLX
+import MLXAudioCore
+
+enum VoxtralRealtimeAudio {
+    static func computeMelFilters(
+        numMelBins: Int = 128,
+        windowSize: Int = 400,
+        sampleRate: Int = 16000
+    ) -> MLXArray {
+        melFilters(
+            sampleRate: sampleRate,
+            nFft: windowSize,
+            nMels: numMelBins,
+            fMin: 0,
+            fMax: 8000,
+            norm: "slaney",
+            melScale: .slaney
+        )
+    }
+
+    static func computeMelSpectrogram(
+        audio: MLXArray,
+        melFilters: MLXArray,
+        windowSize: Int = 400,
+        hopLength: Int = 160,
+        globalLogMelMax: Float = 1.5
+    ) -> MLXArray {
+        // Periodic Hann window uses N denominator, not N-1.
+        let n = MLXArray(0..<windowSize).asType(.float32)
+        let window = 0.5 * (1.0 - cos((2.0 * Float.pi * n) / Float(windowSize)))
+
+        let audio1D: MLXArray
+        if audio.ndim > 1 {
+            audio1D = audio.reshaped([-1])
+        } else {
+            audio1D = audio
+        }
+
+        let paddedAudio = reflectPadCenter(audio1D, pad: windowSize / 2)
+        let nSamples = paddedAudio.shape[0]
+        let nFrames = 1 + max(0, (nSamples - windowSize) / hopLength)
+
+        if nFrames <= 0 {
+            return MLXArray.zeros([melFilters.shape[1], 0], type: Float.self)
+        }
+
+        let frameIdx = asStrided(
+            paddedAudio,
+            [nFrames, windowSize],
+            strides: [hopLength, 1],
+            offset: 0
+        )
+
+        let frames = frameIdx * window.expandedDimensions(axis: 0)
+        let spectrum = MLXFFT.rfft(frames, axis: -1)
+        var magnitudes = MLX.abs(spectrum).square()
+
+        // Match reference: drop last frame, then transpose to [freq, frames].
+        if magnitudes.shape[0] > 0 {
+            magnitudes = magnitudes[0..<(magnitudes.shape[0] - 1), 0...]
+        }
+        magnitudes = magnitudes.transposed(1, 0)
+
+        var melSpec = MLX.matmul(melFilters.transposed(1, 0), magnitudes)
+        melSpec = MLX.maximum(melSpec, MLXArray(Float(1e-10)))
+        var logSpec = MLX.log10(melSpec)
+
+        let minVal = globalLogMelMax - 8.0
+        logSpec = MLX.maximum(logSpec, MLXArray(minVal))
+        logSpec = (logSpec + MLXArray(Float(4.0))) / MLXArray(Float(4.0))
+        return logSpec
+    }
+
+    private static func reflectPadCenter(_ audio: MLXArray, pad: Int) -> MLXArray {
+        guard pad > 0 else { return audio.asType(.float32) }
+
+        let samples = audio.asType(.float32).asArray(Float.self)
+        guard !samples.isEmpty else {
+            return MLXArray.zeros([2 * pad], type: Float.self)
+        }
+
+        func reflectIndex(_ idx: Int, count: Int) -> Int {
+            if count <= 1 { return 0 }
+            var i = idx
+            while i < 0 || i >= count {
+                if i < 0 {
+                    i = -i
+                } else {
+                    i = 2 * count - i - 2
+                }
+            }
+            return i
+        }
+
+        var out = [Float](repeating: 0, count: samples.count + 2 * pad)
+        for i in 0..<out.count {
+            let src = i - pad
+            out[i] = samples[reflectIndex(src, count: samples.count)]
+        }
+
+        return MLXArray(out)
+    }
+}

--- a/spikes/VoxtralSpike/Sources/VoxtralFast/VoxtralRealtimeConfig.swift
+++ b/spikes/VoxtralSpike/Sources/VoxtralFast/VoxtralRealtimeConfig.swift
@@ -1,0 +1,284 @@
+import Foundation
+
+public struct VoxtralRealtimeAudioEncodingConfig: Codable, Sendable {
+    public var samplingRate: Int
+    public var frameRate: Float
+    public var numMelBins: Int
+    public var hopLength: Int
+    public var windowSize: Int
+    public var globalLogMelMax: Float
+
+    enum CodingKeys: String, CodingKey {
+        case samplingRate = "sampling_rate"
+        case frameRate = "frame_rate"
+        case numMelBins = "num_mel_bins"
+        case hopLength = "hop_length"
+        case windowSize = "window_size"
+        case globalLogMelMax = "global_log_mel_max"
+    }
+
+    public init(
+        samplingRate: Int = 16000,
+        frameRate: Float = 12.5,
+        numMelBins: Int = 128,
+        hopLength: Int = 160,
+        windowSize: Int = 400,
+        globalLogMelMax: Float = 1.5
+    ) {
+        self.samplingRate = samplingRate
+        self.frameRate = frameRate
+        self.numMelBins = numMelBins
+        self.hopLength = hopLength
+        self.windowSize = windowSize
+        self.globalLogMelMax = globalLogMelMax
+    }
+
+    public init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        samplingRate = try c.decodeIfPresent(Int.self, forKey: .samplingRate) ?? 16000
+        frameRate = try c.decodeIfPresent(Float.self, forKey: .frameRate) ?? 12.5
+        numMelBins = try c.decodeIfPresent(Int.self, forKey: .numMelBins) ?? 128
+        hopLength = try c.decodeIfPresent(Int.self, forKey: .hopLength) ?? 160
+        windowSize = try c.decodeIfPresent(Int.self, forKey: .windowSize) ?? 400
+        globalLogMelMax = try c.decodeIfPresent(Float.self, forKey: .globalLogMelMax) ?? 1.5
+    }
+}
+
+public struct VoxtralRealtimeEncoderConfig: Codable, Sendable {
+    public var dim: Int
+    public var nLayers: Int
+    public var nHeads: Int
+    public var headDim: Int
+    public var hiddenDim: Int
+    public var nKvHeads: Int
+    public var normEps: Float
+    public var ropeTheta: Float
+    public var slidingWindow: Int
+    public var causal: Bool
+    public var useBiases: Bool
+    public var downsampleFactor: Int
+
+    enum CodingKeys: String, CodingKey {
+        case dim
+        case nLayers = "n_layers"
+        case nHeads = "n_heads"
+        case headDim = "head_dim"
+        case hiddenDim = "hidden_dim"
+        case nKvHeads = "n_kv_heads"
+        case normEps = "norm_eps"
+        case ropeTheta = "rope_theta"
+        case slidingWindow = "sliding_window"
+        case causal
+        case useBiases = "use_biases"
+        case downsampleFactor = "downsample_factor"
+    }
+
+    public init(
+        dim: Int = 1280,
+        nLayers: Int = 32,
+        nHeads: Int = 32,
+        headDim: Int = 64,
+        hiddenDim: Int = 5120,
+        nKvHeads: Int = 32,
+        normEps: Float = 1e-5,
+        ropeTheta: Float = 1_000_000,
+        slidingWindow: Int = 750,
+        causal: Bool = true,
+        useBiases: Bool = true,
+        downsampleFactor: Int = 4
+    ) {
+        self.dim = dim
+        self.nLayers = nLayers
+        self.nHeads = nHeads
+        self.headDim = headDim
+        self.hiddenDim = hiddenDim
+        self.nKvHeads = nKvHeads
+        self.normEps = normEps
+        self.ropeTheta = ropeTheta
+        self.slidingWindow = slidingWindow
+        self.causal = causal
+        self.useBiases = useBiases
+        self.downsampleFactor = downsampleFactor
+    }
+
+    public init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        dim = try c.decodeIfPresent(Int.self, forKey: .dim) ?? 1280
+        nLayers = try c.decodeIfPresent(Int.self, forKey: .nLayers) ?? 32
+        nHeads = try c.decodeIfPresent(Int.self, forKey: .nHeads) ?? 32
+        headDim = try c.decodeIfPresent(Int.self, forKey: .headDim) ?? 64
+        hiddenDim = try c.decodeIfPresent(Int.self, forKey: .hiddenDim) ?? 5120
+        nKvHeads = try c.decodeIfPresent(Int.self, forKey: .nKvHeads) ?? 32
+        normEps = try c.decodeIfPresent(Float.self, forKey: .normEps) ?? 1e-5
+        ropeTheta = try c.decodeIfPresent(Float.self, forKey: .ropeTheta) ?? 1_000_000
+        slidingWindow = try c.decodeIfPresent(Int.self, forKey: .slidingWindow) ?? 750
+        causal = try c.decodeIfPresent(Bool.self, forKey: .causal) ?? true
+        useBiases = try c.decodeIfPresent(Bool.self, forKey: .useBiases) ?? true
+        downsampleFactor = try c.decodeIfPresent(Int.self, forKey: .downsampleFactor) ?? 4
+    }
+}
+
+public struct VoxtralRealtimeDecoderConfig: Codable, Sendable {
+    public var dim: Int
+    public var nLayers: Int
+    public var nHeads: Int
+    public var nKvHeads: Int
+    public var headDim: Int
+    public var hiddenDim: Int
+    public var vocabSize: Int
+    public var normEps: Float
+    public var ropeTheta: Float
+    public var slidingWindow: Int
+    public var tiedEmbeddings: Bool
+    public var adaRmsNormTCond: Bool
+    public var adaRmsNormTCondDim: Int
+
+    enum CodingKeys: String, CodingKey {
+        case dim
+        case nLayers = "n_layers"
+        case nHeads = "n_heads"
+        case nKvHeads = "n_kv_heads"
+        case headDim = "head_dim"
+        case hiddenDim = "hidden_dim"
+        case vocabSize = "vocab_size"
+        case normEps = "norm_eps"
+        case ropeTheta = "rope_theta"
+        case slidingWindow = "sliding_window"
+        case tiedEmbeddings = "tied_embeddings"
+        case adaRmsNormTCond = "ada_rms_norm_t_cond"
+        case adaRmsNormTCondDim = "ada_rms_norm_t_cond_dim"
+    }
+
+    public init(
+        dim: Int = 3072,
+        nLayers: Int = 26,
+        nHeads: Int = 32,
+        nKvHeads: Int = 8,
+        headDim: Int = 128,
+        hiddenDim: Int = 9216,
+        vocabSize: Int = 131072,
+        normEps: Float = 1e-5,
+        ropeTheta: Float = 1_000_000,
+        slidingWindow: Int = 8192,
+        tiedEmbeddings: Bool = true,
+        adaRmsNormTCond: Bool = true,
+        adaRmsNormTCondDim: Int = 32
+    ) {
+        self.dim = dim
+        self.nLayers = nLayers
+        self.nHeads = nHeads
+        self.nKvHeads = nKvHeads
+        self.headDim = headDim
+        self.hiddenDim = hiddenDim
+        self.vocabSize = vocabSize
+        self.normEps = normEps
+        self.ropeTheta = ropeTheta
+        self.slidingWindow = slidingWindow
+        self.tiedEmbeddings = tiedEmbeddings
+        self.adaRmsNormTCond = adaRmsNormTCond
+        self.adaRmsNormTCondDim = adaRmsNormTCondDim
+    }
+
+    public init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        dim = try c.decodeIfPresent(Int.self, forKey: .dim) ?? 3072
+        nLayers = try c.decodeIfPresent(Int.self, forKey: .nLayers) ?? 26
+        nHeads = try c.decodeIfPresent(Int.self, forKey: .nHeads) ?? 32
+        nKvHeads = try c.decodeIfPresent(Int.self, forKey: .nKvHeads) ?? 8
+        headDim = try c.decodeIfPresent(Int.self, forKey: .headDim) ?? 128
+        hiddenDim = try c.decodeIfPresent(Int.self, forKey: .hiddenDim) ?? 9216
+        vocabSize = try c.decodeIfPresent(Int.self, forKey: .vocabSize) ?? 131072
+        normEps = try c.decodeIfPresent(Float.self, forKey: .normEps) ?? 1e-5
+        ropeTheta = try c.decodeIfPresent(Float.self, forKey: .ropeTheta) ?? 1_000_000
+        slidingWindow = try c.decodeIfPresent(Int.self, forKey: .slidingWindow) ?? 8192
+        tiedEmbeddings = try c.decodeIfPresent(Bool.self, forKey: .tiedEmbeddings) ?? true
+        adaRmsNormTCond = try c.decodeIfPresent(Bool.self, forKey: .adaRmsNormTCond) ?? true
+        adaRmsNormTCondDim = try c.decodeIfPresent(Int.self, forKey: .adaRmsNormTCondDim) ?? 32
+    }
+}
+
+public struct VoxtralRealtimeConfig: Codable, Sendable {
+    public var modelType: String
+    public var encoderArgs: VoxtralRealtimeEncoderConfig
+    public var decoder: VoxtralRealtimeDecoderConfig
+    public var audioEncodingArgs: VoxtralRealtimeAudioEncodingConfig
+    public var transcriptionDelayMs: Int
+
+    public var vocabSize: Int
+    public var hiddenSize: Int
+
+    public var bosTokenId: Int
+    public var eosTokenId: Int
+    public var streamingPadTokenId: Int
+    public var nLeftPadTokens: Int
+
+    enum CodingKeys: String, CodingKey {
+        case modelType = "model_type"
+        case encoderArgs = "encoder_args"
+        case decoder
+        case audioEncodingArgs = "audio_encoding_args"
+        case transcriptionDelayMs = "transcription_delay_ms"
+        case vocabSize = "vocab_size"
+        case hiddenSize = "hidden_size"
+        case bosTokenId = "bos_token_id"
+        case eosTokenId = "eos_token_id"
+        case streamingPadTokenId = "streaming_pad_token_id"
+        case nLeftPadTokens = "n_left_pad_tokens"
+    }
+
+    private enum NestedEncoderCodingKeys: String, CodingKey {
+        case audioEncodingArgs = "audio_encoding_args"
+    }
+
+    public init(
+        modelType: String = "voxtral_realtime",
+        encoderArgs: VoxtralRealtimeEncoderConfig = VoxtralRealtimeEncoderConfig(),
+        decoder: VoxtralRealtimeDecoderConfig = VoxtralRealtimeDecoderConfig(),
+        audioEncodingArgs: VoxtralRealtimeAudioEncodingConfig = VoxtralRealtimeAudioEncodingConfig(),
+        transcriptionDelayMs: Int = 480,
+        vocabSize: Int = 131072,
+        hiddenSize: Int = 3072,
+        bosTokenId: Int = 1,
+        eosTokenId: Int = 2,
+        streamingPadTokenId: Int = 32,
+        nLeftPadTokens: Int = 32
+    ) {
+        self.modelType = modelType
+        self.encoderArgs = encoderArgs
+        self.decoder = decoder
+        self.audioEncodingArgs = audioEncodingArgs
+        self.transcriptionDelayMs = transcriptionDelayMs
+        self.vocabSize = vocabSize
+        self.hiddenSize = hiddenSize
+        self.bosTokenId = bosTokenId
+        self.eosTokenId = eosTokenId
+        self.streamingPadTokenId = streamingPadTokenId
+        self.nLeftPadTokens = nLeftPadTokens
+    }
+
+    public init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+
+        modelType = try c.decodeIfPresent(String.self, forKey: .modelType) ?? "voxtral_realtime"
+        encoderArgs = try c.decodeIfPresent(VoxtralRealtimeEncoderConfig.self, forKey: .encoderArgs) ?? VoxtralRealtimeEncoderConfig()
+        self.decoder = try c.decodeIfPresent(VoxtralRealtimeDecoderConfig.self, forKey: .decoder) ?? VoxtralRealtimeDecoderConfig()
+
+        if let directAudio = try c.decodeIfPresent(VoxtralRealtimeAudioEncodingConfig.self, forKey: .audioEncodingArgs) {
+            audioEncodingArgs = directAudio
+        } else if let nestedEncoder = try? c.nestedContainer(keyedBy: NestedEncoderCodingKeys.self, forKey: .encoderArgs),
+                  let nestedAudio = try nestedEncoder.decodeIfPresent(VoxtralRealtimeAudioEncodingConfig.self, forKey: .audioEncodingArgs) {
+            audioEncodingArgs = nestedAudio
+        } else {
+            audioEncodingArgs = VoxtralRealtimeAudioEncodingConfig()
+        }
+
+        transcriptionDelayMs = try c.decodeIfPresent(Int.self, forKey: .transcriptionDelayMs) ?? 480
+        bosTokenId = try c.decodeIfPresent(Int.self, forKey: .bosTokenId) ?? 1
+        eosTokenId = try c.decodeIfPresent(Int.self, forKey: .eosTokenId) ?? 2
+        streamingPadTokenId = try c.decodeIfPresent(Int.self, forKey: .streamingPadTokenId) ?? 32
+        nLeftPadTokens = try c.decodeIfPresent(Int.self, forKey: .nLeftPadTokens) ?? 32
+
+        vocabSize = try c.decodeIfPresent(Int.self, forKey: .vocabSize) ?? self.decoder.vocabSize
+        hiddenSize = try c.decodeIfPresent(Int.self, forKey: .hiddenSize) ?? self.decoder.dim
+    }
+}

--- a/spikes/VoxtralSpike/Sources/VoxtralFast/VoxtralRealtimeDecoder.swift
+++ b/spikes/VoxtralSpike/Sources/VoxtralFast/VoxtralRealtimeDecoder.swift
@@ -90,8 +90,14 @@ final class VoxtralRealtimeDecoderAttention: Module {
         var k = wk(x)
         var v = wv(x)
 
-        q = voxtralFusedRoPE(q, nHeads: nHeads, headDim: headDim, theta: ropeTheta, offset: queryStart)
-        k = voxtralFusedRoPE(k, nHeads: nKvHeads, headDim: headDim, theta: ropeTheta, offset: queryStart)
+        if FastFlags.fusedRoPE {
+            q = voxtralFusedRoPE(q, nHeads: nHeads, headDim: headDim, theta: ropeTheta, offset: queryStart)
+            k = voxtralFusedRoPE(k, nHeads: nKvHeads, headDim: headDim, theta: ropeTheta, offset: queryStart)
+        } else {
+            let (cos, sin) = ropeFrequencies(positions: positions)
+            q = voxtralApplyInterleavedRoPE(q, cos: cos, sin: sin, nHeads: nHeads, headDim: headDim)
+            k = voxtralApplyInterleavedRoPE(k, cos: cos, sin: sin, nHeads: nKvHeads, headDim: headDim)
+        }
 
         var positionOffset = cache?.positionOffset ?? 0
         if let cache {
@@ -129,7 +135,8 @@ final class VoxtralRealtimeDecoderAttention: Module {
             let causal = kPos .<= qPos
             let window = kPos .>= (qPos - MLXArray(Int32(slidingWindow - 1)))
             let allowed = logicalAnd(causal, window)
-            let mask = MLX.where(allowed, MLXArray(0.0), MLXArray(-1e9)).asType(q.dtype)
+            var mask = MLX.where(allowed, MLXArray(0.0), MLXArray(-1e9))
+            if FastFlags.maskDtype { mask = mask.asType(q.dtype) }
             maskMode = .array(mask)
         }
 

--- a/spikes/VoxtralSpike/Sources/VoxtralFast/VoxtralRealtimeDecoder.swift
+++ b/spikes/VoxtralSpike/Sources/VoxtralFast/VoxtralRealtimeDecoder.swift
@@ -279,6 +279,15 @@ final class VoxtralRealtimeDecoder: Module {
     }
 
     func logits(_ h: MLXArray) -> MLXArray {
-        MLX.matmul(h, tokEmbeddings.weight.transposed(1, 0))
+        // 68% of ALL compute used to live on this line (92 ms/token, profiled).
+        // `matmul(h, weight.transposed(1, 0))` is a matvec against a TRANSPOSED VIEW of a
+        // 131072x3072 fp16 matrix — off MLX's fast path, and re-laying out ~800 MB per
+        // token. `asLinear` is the tied-embedding projection MLX provides for exactly this
+        // (voxmlx calls its Python twin, `embed_tokens.as_linear(x)`); it consumes the
+        // weight in its natural layout.
+        if FastFlags.fusedHead {
+            return tokEmbeddings.asLinear(h)
+        }
+        return MLX.matmul(h, tokEmbeddings.weight.transposed(1, 0))
     }
 }

--- a/spikes/VoxtralSpike/Sources/VoxtralFast/VoxtralRealtimeDecoder.swift
+++ b/spikes/VoxtralSpike/Sources/VoxtralFast/VoxtralRealtimeDecoder.swift
@@ -36,7 +36,16 @@ final class VoxtralRealtimeAdaRMSNorm: Module {
     }
 
     func callAsFunction(_ x: MLXArray, adaScale: MLXArray) -> MLXArray {
-        x * (1.0 + adaScale)
+        // THE float32 leak. The time-conditioning scale is built in float32
+        // (`voxtralComputeTimeEmbedding`), so this multiply promoted the hidden state to
+        // float32 — in every one of the 32 layers, from the very first token. Downstream,
+        // the tied fp16 embedding had to be upcast on EVERY token, which is why the LM head
+        // measured 73 ms/token in-loop but 13 ms on an fp16 vector (and ~5 ms isolated).
+        // voxmlx casts it: `t_cond.astype(x.dtype)`.
+        if FastFlags.fp16 {
+            return x * (1.0 + adaScale.asType(x.dtype))
+        }
+        return x * (1.0 + adaScale)
     }
 }
 

--- a/spikes/VoxtralSpike/Sources/VoxtralFast/VoxtralRealtimeDecoder.swift
+++ b/spikes/VoxtralSpike/Sources/VoxtralFast/VoxtralRealtimeDecoder.swift
@@ -1,0 +1,277 @@
+import Foundation
+import MLX
+import MLXNN
+
+struct VoxtralRealtimeDecoderKVCache {
+    var keys: MLXArray   // [kv_len, n_kv_heads * head_dim]
+    var values: MLXArray // [kv_len, n_kv_heads * head_dim]
+    var positionOffset: Int
+}
+
+func voxtralComputeTimeEmbedding(
+    tValue: Float,
+    dim: Int,
+    theta: Float = 10000.0
+) -> MLXArray {
+    let halfDim = dim / 2
+    let invFreq = MLX.exp(
+        -log(theta) * MLXArray(0..<halfDim).asType(.float32) / Float(halfDim)
+    )
+    let emb = tValue * invFreq
+    return MLX.concatenated([MLX.cos(emb), MLX.sin(emb)], axis: 0)
+}
+
+final class VoxtralRealtimeAdaRMSNorm: Module {
+    @ModuleInfo(key: "ada_down") var adaDown: Linear
+    @ModuleInfo(key: "ada_up") var adaUp: Linear
+
+    init(dim: Int, bottleneckDim: Int) {
+        self._adaDown.wrappedValue = Linear(dim, bottleneckDim, bias: false)
+        self._adaUp.wrappedValue = Linear(bottleneckDim, dim, bias: false)
+    }
+
+    func computeScale(tCond: MLXArray) -> MLXArray {
+        let hidden = gelu(adaDown(tCond))
+        return adaUp(hidden)
+    }
+
+    func callAsFunction(_ x: MLXArray, adaScale: MLXArray) -> MLXArray {
+        x * (1.0 + adaScale)
+    }
+}
+
+final class VoxtralRealtimeDecoderAttention: Module {
+    let nHeads: Int
+    let nKvHeads: Int
+    let headDim: Int
+    let slidingWindow: Int
+    let ropeTheta: Float
+    let scale: Float
+
+    @ModuleInfo(key: "wq") var wq: Linear
+    @ModuleInfo(key: "wk") var wk: Linear
+    @ModuleInfo(key: "wv") var wv: Linear
+    @ModuleInfo(key: "wo") var wo: Linear
+
+    init(_ config: VoxtralRealtimeDecoderConfig) {
+        nHeads = config.nHeads
+        nKvHeads = config.nKvHeads
+        headDim = config.headDim
+        slidingWindow = config.slidingWindow
+        ropeTheta = config.ropeTheta
+        scale = pow(Float(config.headDim), -0.5)
+
+        let qDim = config.nHeads * config.headDim
+        let kvDim = config.nKvHeads * config.headDim
+
+        self._wq.wrappedValue = Linear(config.dim, qDim, bias: false)
+        self._wk.wrappedValue = Linear(config.dim, kvDim, bias: false)
+        self._wv.wrappedValue = Linear(config.dim, kvDim, bias: false)
+        self._wo.wrappedValue = Linear(qDim, config.dim, bias: false)
+
+    }
+
+    private func ropeFrequencies(positions: MLXArray) -> (MLXArray, MLXArray) {
+        let idx = MLXArray(stride(from: 0, to: headDim, by: 2)).asType(.float32)
+        let ropeInvFreq = 1.0 / MLX.pow(MLXArray(ropeTheta), idx / Float(headDim))
+        let angles = positions.asType(.float32).expandedDimensions(axis: 1) * ropeInvFreq.expandedDimensions(axis: 0)
+        return (MLX.cos(angles), MLX.sin(angles))
+    }
+
+    func callAsFunction(
+        _ x: MLXArray,
+        positions: MLXArray,
+        queryStart: Int,
+        cache: VoxtralRealtimeDecoderKVCache?
+    ) -> (MLXArray, VoxtralRealtimeDecoderKVCache) {
+        let seqLen = x.shape[0]
+
+        var q = wq(x)
+        var k = wk(x)
+        var v = wv(x)
+
+        q = voxtralFusedRoPE(q, nHeads: nHeads, headDim: headDim, theta: ropeTheta, offset: queryStart)
+        k = voxtralFusedRoPE(k, nHeads: nKvHeads, headDim: headDim, theta: ropeTheta, offset: queryStart)
+
+        var positionOffset = cache?.positionOffset ?? 0
+        if let cache {
+            k = MLX.concatenated([cache.keys, k], axis: 0)
+            v = MLX.concatenated([cache.values, v], axis: 0)
+        }
+
+        var kvLen = k.shape[0]
+        if kvLen > slidingWindow {
+            let trim = kvLen - slidingWindow
+            k = k[trim...]
+            v = v[trim...]
+            kvLen = slidingWindow
+            positionOffset += trim
+        }
+
+        let newCache = VoxtralRealtimeDecoderKVCache(
+            keys: k,
+            values: v,
+            positionOffset: positionOffset
+        )
+
+        let q4 = q.reshaped(1, seqLen, nHeads, headDim).transposed(0, 2, 1, 3)
+        let k4 = k.reshaped(1, kvLen, nKvHeads, headDim).transposed(0, 2, 1, 3)
+        let v4 = v.reshaped(1, kvLen, nKvHeads, headDim).transposed(0, 2, 1, 3)
+
+        let maskMode: MLXFast.ScaledDotProductAttentionMaskMode
+        if seqLen == 1 {
+            maskMode = .none
+        } else if seqLen <= slidingWindow && cache == nil {
+            maskMode = .causal
+        } else {
+            let qPos = positions.expandedDimensions(axis: 1)
+            let kPos = MLXArray(positionOffset..<(positionOffset + kvLen)).asType(.int32).expandedDimensions(axis: 0)
+            let causal = kPos .<= qPos
+            let window = kPos .>= (qPos - MLXArray(Int32(slidingWindow - 1)))
+            let allowed = logicalAnd(causal, window)
+            let mask = MLX.where(allowed, MLXArray(0.0), MLXArray(-1e9)).asType(q.dtype)
+            maskMode = .array(mask)
+        }
+
+        let attn = MLXFast.scaledDotProductAttention(
+            queries: q4,
+            keys: k4,
+            values: v4,
+            scale: scale,
+            mask: maskMode
+        )
+
+        let out = attn.transposed(0, 2, 1, 3).reshaped(seqLen, nHeads * headDim)
+        return (wo(out), newCache)
+    }
+}
+
+final class VoxtralRealtimeDecoderLayer: Module {
+    @ModuleInfo(key: "attention_norm") var attentionNorm: RMSNorm
+    @ModuleInfo(key: "attention") var attention: VoxtralRealtimeDecoderAttention
+    @ModuleInfo(key: "ffn_norm") var ffnNorm: RMSNorm
+
+    @ModuleInfo(key: "ada_rms_norm_t_cond") var adaRmsNormTCond: VoxtralRealtimeAdaRMSNorm?
+
+    @ModuleInfo(key: "feed_forward_w1") var feedForwardW1: Linear
+    @ModuleInfo(key: "feed_forward_w3") var feedForwardW3: Linear
+    @ModuleInfo(key: "feed_forward_w2") var feedForwardW2: Linear
+
+    init(_ config: VoxtralRealtimeDecoderConfig) {
+        self._attentionNorm.wrappedValue = RMSNorm(dimensions: config.dim, eps: config.normEps)
+        self._attention.wrappedValue = VoxtralRealtimeDecoderAttention(config)
+        self._ffnNorm.wrappedValue = RMSNorm(dimensions: config.dim, eps: config.normEps)
+
+        if config.adaRmsNormTCond {
+            self._adaRmsNormTCond.wrappedValue = VoxtralRealtimeAdaRMSNorm(
+                dim: config.dim,
+                bottleneckDim: config.adaRmsNormTCondDim
+            )
+        } else {
+            self._adaRmsNormTCond.wrappedValue = nil
+        }
+
+        self._feedForwardW1.wrappedValue = Linear(config.dim, config.hiddenDim, bias: false)
+        self._feedForwardW3.wrappedValue = Linear(config.dim, config.hiddenDim, bias: false)
+        self._feedForwardW2.wrappedValue = Linear(config.hiddenDim, config.dim, bias: false)
+    }
+
+    func callAsFunction(
+        _ x: MLXArray,
+        positions: MLXArray,
+        queryStart: Int,
+        adaScale: MLXArray?,
+        cache: VoxtralRealtimeDecoderKVCache?
+    ) -> (MLXArray, VoxtralRealtimeDecoderKVCache) {
+        var out = x
+
+        var h = attentionNorm(out)
+        let attn = attention(h, positions: positions, queryStart: queryStart, cache: cache)
+        h = attn.0
+        out = out + h
+
+        h = ffnNorm(out)
+        if let adaScale, let ada = adaRmsNormTCond {
+            h = ada(h, adaScale: adaScale)
+        }
+
+        let gate = silu(feedForwardW1(h))
+        let up = feedForwardW3(h)
+        out = out + feedForwardW2(gate * up)
+
+        return (out, attn.1)
+    }
+}
+
+final class VoxtralRealtimeDecoder: Module {
+    let config: VoxtralRealtimeDecoderConfig
+
+    @ModuleInfo(key: "tok_embeddings") var tokEmbeddings: Embedding
+    @ModuleInfo(key: "layers") var layers: [VoxtralRealtimeDecoderLayer]
+    @ModuleInfo(key: "norm") var norm: RMSNorm
+
+    var adaScales: [MLXArray?]?
+
+    init(_ config: VoxtralRealtimeDecoderConfig) {
+        self.config = config
+        self._tokEmbeddings.wrappedValue = Embedding(
+            embeddingCount: config.vocabSize,
+            dimensions: config.dim
+        )
+        self._layers.wrappedValue = (0..<config.nLayers).map { _ in
+            VoxtralRealtimeDecoderLayer(config)
+        }
+        self._norm.wrappedValue = RMSNorm(dimensions: config.dim, eps: config.normEps)
+    }
+
+    func precomputeAdaScales(_ tCond: MLXArray) {
+        var scales: [MLXArray?] = []
+        scales.reserveCapacity(layers.count)
+
+        for layer in layers {
+            if let ada = layer.adaRmsNormTCond {
+                scales.append(ada.computeScale(tCond: tCond))
+            } else {
+                scales.append(nil)
+            }
+        }
+
+        adaScales = scales
+    }
+
+    func embedToken(tokenId: Int) -> MLXArray {
+        tokEmbeddings.weight[tokenId]
+    }
+
+    func embedTokens(_ tokenIds: MLXArray) -> MLXArray {
+        tokEmbeddings(tokenIds)
+    }
+
+    func callAsFunction(
+        _ embeds: MLXArray,
+        startPos: Int,
+        cache: [VoxtralRealtimeDecoderKVCache?]? = nil
+    ) -> (MLXArray, [VoxtralRealtimeDecoderKVCache?]) {
+        var h = embeds
+        let seqLen = h.shape[0]
+        let positions = MLXArray(startPos..<(startPos + seqLen)).asType(.int32)
+
+        var newCache: [VoxtralRealtimeDecoderKVCache?] = []
+        newCache.reserveCapacity(layers.count)
+
+        for i in layers.indices {
+            let layerCache = cache?[i]
+            let adaScale = adaScales?[i]
+            let next = layers[i](h, positions: positions, queryStart: startPos, adaScale: adaScale, cache: layerCache)
+            h = next.0
+            newCache.append(next.1)
+        }
+
+        h = norm(h)
+        return (h, newCache)
+    }
+
+    func logits(_ h: MLXArray) -> MLXArray {
+        MLX.matmul(h, tokEmbeddings.weight.transposed(1, 0))
+    }
+}

--- a/spikes/VoxtralSpike/Sources/VoxtralFast/VoxtralRealtimeEncoder.swift
+++ b/spikes/VoxtralSpike/Sources/VoxtralFast/VoxtralRealtimeEncoder.swift
@@ -1,0 +1,396 @@
+import Foundation
+import MLX
+import MLXNN
+
+struct VoxtralRealtimeEncoderKVCache {
+    var keys: MLXArray   // [kv_len, n_heads * head_dim]
+    var values: MLXArray // [kv_len, n_heads * head_dim]
+    var positionOffset: Int
+}
+
+func voxtralComputeRopeFrequencies(
+    positions: MLXArray,
+    headDim: Int,
+    theta: Float
+) -> (cos: MLXArray, sin: MLXArray) {
+    let idx = MLXArray(stride(from: 0, to: headDim, by: 2)).asType(.float32)
+    let invFreq = MLX.exp((-log(theta)) * (idx / Float(headDim)))
+    let angles = positions.asType(.float32).expandedDimensions(axis: 1) * invFreq.expandedDimensions(axis: 0)
+    return (MLX.cos(angles), MLX.sin(angles))
+}
+
+/// Fused, dtype-preserving interleaved RoPE — the OPTIMIZED replacement for
+/// `voxtralComputeRopeFrequencies` + `voxtralApplyInterleavedRoPE`.
+///
+/// The manual path cost us twice over:
+///   1. ~8 kernel launches per layer per step (arange/pow/cos/sin/slice/mul/add/concat),
+///      32 layers deep, on both the encoder and the decoder.
+///   2. It built its angles in .float32, so `x1 * cosE` PROMOTED the whole hidden state
+///      to float32 from the first layer onward. Every downstream QuantizedLinear then
+///      saw float32 activations against float16 scales, which silently pushes
+///      `quantizedMM` off its fast path (ml-explore/mlx-swift#420) — quantized weights
+///      ending up SLOWER than fp16.
+///
+/// `MLXFast.RoPE` is a single fused kernel and preserves the input dtype. `traditional:
+/// true` = interleaved (2i, 2i+1) pairs, matching both the manual code it replaces and
+/// voxmlx's `mx.fast.rope(..., traditional=True)`.
+/// Positions are always a contiguous range, so the integer `offset` is all the kernel needs.
+func voxtralFusedRoPE(
+    _ x: MLXArray,
+    nHeads: Int,
+    headDim: Int,
+    theta: Float,
+    offset: Int
+) -> MLXArray {
+    let seqLen = x.shape[0]
+    let heads = x.reshaped(seqLen, nHeads, headDim).transposed(1, 0, 2)  // [H, L, D]
+    let roped = MLXFast.RoPE(
+        heads,
+        dimensions: headDim,
+        traditional: true,
+        base: theta,
+        scale: 1.0,
+        offset: offset
+    )
+    return roped.transposed(1, 0, 2).reshaped(seqLen, nHeads * headDim)
+}
+
+func voxtralApplyInterleavedRoPE(
+    _ x: MLXArray,
+    cos: MLXArray,
+    sin: MLXArray,
+    nHeads: Int,
+    headDim: Int
+) -> MLXArray {
+    let seqLen = x.shape[0]
+    let halfDim = headDim / 2
+
+    let reshaped = x.reshaped(seqLen, nHeads, halfDim, 2)
+    let x1 = reshaped[0..., 0..., 0..., 0]
+    let x2 = reshaped[0..., 0..., 0..., 1]
+
+    let cosE = cos.expandedDimensions(axis: 1)
+    let sinE = sin.expandedDimensions(axis: 1)
+
+    let o1 = x1 * cosE - x2 * sinE
+    let o2 = x2 * cosE + x1 * sinE
+
+    let out = MLX.concatenated(
+        [o1.expandedDimensions(axis: -1), o2.expandedDimensions(axis: -1)],
+        axis: -1
+    )
+    return out.reshaped(seqLen, nHeads * headDim)
+}
+
+final class VoxtralRealtimeCausalConv1d: Module {
+    let kernelSize: Int
+    let stride: Int
+    let padding: Int
+
+    @ModuleInfo(key: "conv") var conv: Conv1d
+
+    init(inChannels: Int, outChannels: Int, kernelSize: Int, stride: Int = 1) {
+        self.kernelSize = kernelSize
+        self.stride = stride
+        self.padding = kernelSize - stride
+        self._conv.wrappedValue = Conv1d(
+            inputChannels: inChannels,
+            outputChannels: outChannels,
+            kernelSize: kernelSize,
+            stride: stride,
+            padding: 0,
+            bias: true
+        )
+    }
+
+    func callAsFunction(_ x: MLXArray) -> MLXArray {
+        var out = x
+        if padding > 0 {
+            out = MLX.padded(
+                out,
+                widths: [
+                    IntOrPair(0),
+                    IntOrPair((padding, 0)),
+                    IntOrPair(0),
+                ]
+            )
+        }
+        return conv(out)
+    }
+}
+
+final class VoxtralRealtimeEncoderAttention: Module {
+    let nHeads: Int
+    let headDim: Int
+    let slidingWindow: Int
+    let ropeTheta: Float
+    let scale: Float
+
+    @ModuleInfo(key: "wq") var wq: Linear
+    @ModuleInfo(key: "wk") var wk: Linear
+    @ModuleInfo(key: "wv") var wv: Linear
+    @ModuleInfo(key: "wo") var wo: Linear
+
+    init(_ config: VoxtralRealtimeEncoderConfig) {
+        nHeads = config.nHeads
+        headDim = config.headDim
+        slidingWindow = config.slidingWindow
+        ropeTheta = config.ropeTheta
+        scale = pow(Float(config.headDim), -0.5)
+
+        let attnDim = config.nHeads * config.headDim
+        self._wq.wrappedValue = Linear(config.dim, attnDim, bias: true)
+        self._wk.wrappedValue = Linear(config.dim, attnDim, bias: false)
+        self._wv.wrappedValue = Linear(config.dim, attnDim, bias: true)
+        self._wo.wrappedValue = Linear(attnDim, config.dim, bias: true)
+    }
+
+    func callAsFunction(
+        _ x: MLXArray,
+        positions: MLXArray,
+        queryStart: Int,
+        cache: VoxtralRealtimeEncoderKVCache?
+    ) -> (MLXArray, VoxtralRealtimeEncoderKVCache) {
+        let seqLen = x.shape[0]
+
+        var q = wq(x)
+        var k = wk(x)
+        var v = wv(x)
+
+        q = voxtralFusedRoPE(q, nHeads: nHeads, headDim: headDim, theta: ropeTheta, offset: queryStart)
+        k = voxtralFusedRoPE(k, nHeads: nHeads, headDim: headDim, theta: ropeTheta, offset: queryStart)
+
+        var positionOffset = cache?.positionOffset ?? 0
+        if let cache {
+            k = MLX.concatenated([cache.keys, k], axis: 0)
+            v = MLX.concatenated([cache.values, v], axis: 0)
+        }
+
+        var kvLen = k.shape[0]
+        if kvLen > slidingWindow {
+            let trim = kvLen - slidingWindow
+            k = k[trim...]
+            v = v[trim...]
+            kvLen = slidingWindow
+            positionOffset += trim
+        }
+
+        let newCache = VoxtralRealtimeEncoderKVCache(
+            keys: k,
+            values: v,
+            positionOffset: positionOffset
+        )
+
+        let q4 = q.reshaped(1, seqLen, nHeads, headDim).transposed(0, 2, 1, 3)
+        let k4 = k.reshaped(1, kvLen, nHeads, headDim).transposed(0, 2, 1, 3)
+        let v4 = v.reshaped(1, kvLen, nHeads, headDim).transposed(0, 2, 1, 3)
+
+        let maskMode: MLXFast.ScaledDotProductAttentionMaskMode
+        if seqLen == 1 {
+            maskMode = .none
+        } else if cache == nil && seqLen <= slidingWindow {
+            maskMode = .causal
+        } else {
+            let qPos = positions.expandedDimensions(axis: 1)
+            let kPos = MLXArray(positionOffset..<(positionOffset + kvLen)).asType(.int32).expandedDimensions(axis: 0)
+            let causal = kPos .<= qPos
+            let window = kPos .>= (qPos - MLXArray(Int32(slidingWindow - 1)))
+            let allowed = logicalAnd(causal, window)
+            let mask = MLX.where(allowed, MLXArray(0.0), MLXArray(-1e9)).asType(q.dtype)
+            maskMode = .array(mask)
+        }
+
+        let attn = MLXFast.scaledDotProductAttention(
+            queries: q4,
+            keys: k4,
+            values: v4,
+            scale: scale,
+            mask: maskMode
+        )
+
+        let out = attn.transposed(0, 2, 1, 3).reshaped(seqLen, nHeads * headDim)
+        return (wo(out), newCache)
+    }
+}
+
+final class VoxtralRealtimeEncoderLayer: Module {
+    @ModuleInfo(key: "attention_norm") var attentionNorm: RMSNorm
+    @ModuleInfo(key: "attention") var attention: VoxtralRealtimeEncoderAttention
+    @ModuleInfo(key: "ffn_norm") var ffnNorm: RMSNorm
+
+    @ModuleInfo(key: "feed_forward_w1") var feedForwardW1: Linear
+    @ModuleInfo(key: "feed_forward_w3") var feedForwardW3: Linear
+    @ModuleInfo(key: "feed_forward_w2") var feedForwardW2: Linear
+
+    init(_ config: VoxtralRealtimeEncoderConfig) {
+        self._attentionNorm.wrappedValue = RMSNorm(dimensions: config.dim, eps: config.normEps)
+        self._attention.wrappedValue = VoxtralRealtimeEncoderAttention(config)
+        self._ffnNorm.wrappedValue = RMSNorm(dimensions: config.dim, eps: config.normEps)
+
+        self._feedForwardW1.wrappedValue = Linear(config.dim, config.hiddenDim, bias: false)
+        self._feedForwardW3.wrappedValue = Linear(config.dim, config.hiddenDim, bias: false)
+        self._feedForwardW2.wrappedValue = Linear(config.hiddenDim, config.dim, bias: true)
+    }
+
+    func callAsFunction(
+        _ x: MLXArray,
+        positions: MLXArray,
+        queryStart: Int,
+        cache: VoxtralRealtimeEncoderKVCache?
+    ) -> (MLXArray, VoxtralRealtimeEncoderKVCache) {
+        var out = x
+
+        var h = attentionNorm(out)
+        let attnOut = attention(h, positions: positions, queryStart: queryStart, cache: cache)
+        h = attnOut.0
+        out = out + h
+
+        h = ffnNorm(out)
+        let gate = silu(feedForwardW1(h))
+        let up = feedForwardW3(h)
+        out = out + feedForwardW2(gate * up)
+
+        return (out, attnOut.1)
+    }
+}
+
+final class VoxtralRealtimeAudioEncoder: Module {
+    let config: VoxtralRealtimeEncoderConfig
+    let decoderDim: Int
+
+    @ModuleInfo(key: "conv_layers_0_conv") var convLayers0Conv: VoxtralRealtimeCausalConv1d
+    @ModuleInfo(key: "conv_layers_1_conv") var convLayers1Conv: VoxtralRealtimeCausalConv1d
+
+    @ModuleInfo(key: "transformer_layers") var transformerLayers: [VoxtralRealtimeEncoderLayer]
+    @ModuleInfo(key: "transformer_norm") var transformerNorm: RMSNorm
+
+    @ModuleInfo(key: "audio_language_projection_0") var audioLanguageProjection0: Linear
+    @ModuleInfo(key: "audio_language_projection_2") var audioLanguageProjection2: Linear
+
+    init(_ config: VoxtralRealtimeEncoderConfig, decoderDim: Int = 3072) {
+        self.config = config
+        self.decoderDim = decoderDim
+
+        self._convLayers0Conv.wrappedValue = VoxtralRealtimeCausalConv1d(
+            inChannels: 128,
+            outChannels: config.dim,
+            kernelSize: 3,
+            stride: 1
+        )
+        self._convLayers1Conv.wrappedValue = VoxtralRealtimeCausalConv1d(
+            inChannels: config.dim,
+            outChannels: config.dim,
+            kernelSize: 3,
+            stride: 2
+        )
+
+        self._transformerLayers.wrappedValue = (0..<config.nLayers).map { _ in
+            VoxtralRealtimeEncoderLayer(config)
+        }
+        self._transformerNorm.wrappedValue = RMSNorm(dimensions: config.dim, eps: config.normEps)
+
+        let adapterInputDim = config.dim * config.downsampleFactor
+        self._audioLanguageProjection0.wrappedValue = Linear(adapterInputDim, decoderDim, bias: false)
+        self._audioLanguageProjection2.wrappedValue = Linear(decoderDim, decoderDim, bias: false)
+    }
+
+    func convStem(_ mel: MLXArray) -> MLXArray {
+        var x = mel.transposed(1, 0).expandedDimensions(axis: 0)
+        x = gelu(convLayers0Conv(x))
+        x = gelu(convLayers1Conv(x))
+        x = x.squeezed(axis: 0)
+
+        let trunc = x.shape[0] % config.downsampleFactor
+        if trunc > 0 {
+            x = x[trunc...]
+        }
+
+        return x
+    }
+
+    func encodeFull(_ convOut: MLXArray) -> MLXArray {
+        let seqLen = convOut.shape[0]
+        let positions = MLXArray(0..<seqLen).asType(.int32)
+
+        var x = convOut
+        for layer in transformerLayers {
+            x = layer(x, positions: positions, queryStart: 0, cache: nil).0
+        }
+
+        x = transformerNorm(x)
+        return downsampleAndProject(x)
+    }
+
+    func encodeChunked(_ convOut: MLXArray) -> MLXArray {
+        let seqLen = convOut.shape[0]
+        let sw = config.slidingWindow
+
+        if seqLen <= sw {
+            return encodeFull(convOut)
+        }
+
+        var caches: [VoxtralRealtimeEncoderKVCache?] = Array(repeating: nil, count: transformerLayers.count)
+        var outputs: [MLXArray] = []
+
+        var chunkStart = 0
+        while chunkStart < seqLen {
+            let chunkEnd = min(chunkStart + sw, seqLen)
+            var x = convOut[chunkStart..<chunkEnd, 0...]
+            let positions = MLXArray(chunkStart..<chunkEnd).asType(.int32)
+
+            for i in transformerLayers.indices {
+                let next = transformerLayers[i](x, positions: positions, queryStart: chunkStart, cache: caches[i])
+                x = next.0
+                caches[i] = next.1
+            }
+
+            outputs.append(transformerNorm(x))
+            chunkStart = chunkEnd
+        }
+
+        let encoded = outputs.count == 1 ? outputs[0] : MLX.concatenated(outputs, axis: 0)
+        return downsampleAndProject(encoded)
+    }
+
+    /// Feed a block of new conv-stem frames at absolute positions `[startPos, startPos+n)`
+    /// through the transformer with persistent per-layer KV-caches, returning the
+    /// transformer-normed frames (pre-downsample). While the total fed length stays
+    /// `<= slidingWindow` the caches never trim, so the result is bit-identical to
+    /// `encodeFull` over the same prefix — see `VoxtralRealtimeStreamSession`.
+    func encodeIncremental(
+        _ convBlock: MLXArray,
+        startPos: Int,
+        caches: inout [VoxtralRealtimeEncoderKVCache?]
+    ) -> MLXArray {
+        var x = convBlock
+        let positions = MLXArray(startPos..<(startPos + convBlock.shape[0])).asType(.int32)
+        for i in transformerLayers.indices {
+            let next = transformerLayers[i](x, positions: positions, queryStart: startPos, cache: caches[i])
+            x = next.0
+            caches[i] = next.1
+        }
+        return transformerNorm(x)
+    }
+
+    func downsampleAndProject(_ encoded: MLXArray) -> MLXArray {
+        let seqLen = encoded.shape[0]
+        let ds = config.downsampleFactor
+        let dsLen = seqLen / ds
+
+        if dsLen == 0 {
+            return encoded[0..<0, 0...]
+        }
+
+        var x = encoded[0..<(dsLen * ds), 0...].reshaped(dsLen, config.dim * ds)
+        x = gelu(audioLanguageProjection0(x))
+        return audioLanguageProjection2(x)
+    }
+
+    func callAsFunction(_ mel: MLXArray) -> MLXArray {
+        let convOut = convStem(mel)
+        if convOut.shape[0] <= config.slidingWindow {
+            return encodeFull(convOut)
+        }
+        return encodeChunked(convOut)
+    }
+}

--- a/spikes/VoxtralSpike/Sources/VoxtralFast/VoxtralRealtimeEncoder.swift
+++ b/spikes/VoxtralSpike/Sources/VoxtralFast/VoxtralRealtimeEncoder.swift
@@ -77,8 +77,15 @@ func voxtralApplyInterleavedRoPE(
     let x1 = reshaped[0..., 0..., 0..., 0]
     let x2 = reshaped[0..., 0..., 0..., 1]
 
-    let cosE = cos.expandedDimensions(axis: 1)
-    let sinE = sin.expandedDimensions(axis: 1)
+    // Cast the float32-computed cos/sin down to the activation dtype BEFORE the rotation.
+    // Angles are computed in float32 (precision), but multiplying fp16 activations by
+    // float32 factors would promote the whole hidden state to float32 (the leak).
+    var cosE = cos.expandedDimensions(axis: 1)
+    var sinE = sin.expandedDimensions(axis: 1)
+    if FastFlags.ropeCast {
+        cosE = cosE.asType(x.dtype)
+        sinE = sinE.asType(x.dtype)
+    }
 
     let o1 = x1 * cosE - x2 * sinE
     let o2 = x2 * cosE + x1 * sinE

--- a/spikes/VoxtralSpike/Sources/VoxtralFast/VoxtralRealtimeEncoder.swift
+++ b/spikes/VoxtralSpike/Sources/VoxtralFast/VoxtralRealtimeEncoder.swift
@@ -157,8 +157,15 @@ final class VoxtralRealtimeEncoderAttention: Module {
         var k = wk(x)
         var v = wv(x)
 
-        q = voxtralFusedRoPE(q, nHeads: nHeads, headDim: headDim, theta: ropeTheta, offset: queryStart)
-        k = voxtralFusedRoPE(k, nHeads: nHeads, headDim: headDim, theta: ropeTheta, offset: queryStart)
+        if FastFlags.fusedRoPE {
+            q = voxtralFusedRoPE(q, nHeads: nHeads, headDim: headDim, theta: ropeTheta, offset: queryStart)
+            k = voxtralFusedRoPE(k, nHeads: nHeads, headDim: headDim, theta: ropeTheta, offset: queryStart)
+        } else {
+            let (cos, sin) = voxtralComputeRopeFrequencies(
+                positions: positions, headDim: headDim, theta: ropeTheta)
+            q = voxtralApplyInterleavedRoPE(q, cos: cos, sin: sin, nHeads: nHeads, headDim: headDim)
+            k = voxtralApplyInterleavedRoPE(k, cos: cos, sin: sin, nHeads: nHeads, headDim: headDim)
+        }
 
         var positionOffset = cache?.positionOffset ?? 0
         if let cache {
@@ -196,7 +203,8 @@ final class VoxtralRealtimeEncoderAttention: Module {
             let causal = kPos .<= qPos
             let window = kPos .>= (qPos - MLXArray(Int32(slidingWindow - 1)))
             let allowed = logicalAnd(causal, window)
-            let mask = MLX.where(allowed, MLXArray(0.0), MLXArray(-1e9)).asType(q.dtype)
+            var mask = MLX.where(allowed, MLXArray(0.0), MLXArray(-1e9))
+            if FastFlags.maskDtype { mask = mask.asType(q.dtype) }
             maskMode = .array(mask)
         }
 

--- a/spikes/VoxtralSpike/Sources/VoxtralFast/VoxtralRealtimeEncoder.swift
+++ b/spikes/VoxtralSpike/Sources/VoxtralFast/VoxtralRealtimeEncoder.swift
@@ -312,6 +312,13 @@ final class VoxtralRealtimeAudioEncoder: Module {
 
     func convStem(_ mel: MLXArray) -> MLXArray {
         var x = mel.transposed(1, 0).expandedDimensions(axis: 0)
+        // The mel is float32 (DFT + filters are built in float32). Feeding it straight into
+        // fp16 conv weights promotes the ENTIRE hidden state to float32 — through the
+        // encoder, the adapter, and the whole decoder. voxmlx casts here
+        // (`x_mel.astype(conv1.weight.dtype)`); mlx-audio-swift did not.
+        if FastFlags.fp16 {
+            x = x.asType(convLayers0Conv.conv.weight.dtype)
+        }
         x = gelu(convLayers0Conv(x))
         x = gelu(convLayers1Conv(x))
         x = x.squeezed(axis: 0)

--- a/spikes/VoxtralSpike/Sources/VoxtralFast/VoxtralRealtimeEncoder.swift
+++ b/spikes/VoxtralSpike/Sources/VoxtralFast/VoxtralRealtimeEncoder.swift
@@ -43,7 +43,15 @@ func voxtralFusedRoPE(
     offset: Int
 ) -> MLXArray {
     let seqLen = x.shape[0]
-    let heads = x.reshaped(seqLen, nHeads, headDim).transposed(1, 0, 2)  // [H, L, D]
+    // MUST be 4-D [B=1, H, L, D], not 3-D [H, L, D]. The 3-D form puts the heads in the
+    // BATCH position, and mlx-swift's Metal RoPE returns garbage for single-token decode
+    // when batch > 1 (ml-explore/mlx-swift#441) — which is every decode step, so the
+    // transcript came out empty. Verified by `voxtralRoPESelfTest`: the 3-D form matched
+    // the manual RoPE at L=8 but was off by ~3.2 at L=1. [1, H, L, D] is the layout
+    // mlx-swift-lm uses in production.
+    let heads = x.reshaped(seqLen, nHeads, headDim)
+        .transposed(1, 0, 2)
+        .expandedDimensions(axis: 0)  // [1, H, L, D]
     let roped = MLXFast.RoPE(
         heads,
         dimensions: headDim,
@@ -52,7 +60,7 @@ func voxtralFusedRoPE(
         scale: 1.0,
         offset: offset
     )
-    return roped.transposed(1, 0, 2).reshaped(seqLen, nHeads * headDim)
+    return roped.squeezed(axis: 0).transposed(1, 0, 2).reshaped(seqLen, nHeads * headDim)
 }
 
 func voxtralApplyInterleavedRoPE(

--- a/spikes/VoxtralSpike/Sources/VoxtralFast/VoxtralRealtimeStreamSession.swift
+++ b/spikes/VoxtralSpike/Sources/VoxtralFast/VoxtralRealtimeStreamSession.swift
@@ -197,8 +197,12 @@ public final class VoxtralRealtimeStreamSession {
         decCache = prefill.1
         decPos = promptLength
         prefilled = true
-        pendingToken = model.sampleArray(logits: lastLogits!, temperature: temperature)
-        MLX.asyncEval(pendingToken!)
+        if FastFlags.asyncDecode {
+            pendingToken = model.sampleArray(logits: lastLogits!, temperature: temperature)
+            MLX.asyncEval(pendingToken!)
+        } else {
+            MLX.eval(lastLogits!)
+        }
     }
 
     private func decode(adapter: MLXArray, upTo emitLimit: Int) -> Delta {
@@ -211,6 +215,29 @@ public final class VoxtralRealtimeStreamSession {
         // work is already done. The original blocked on `MLX.eval(lastLogits)` every
         // single token, serialising CPU and GPU once per decoded token.
         while decPos < emitLimit {
+            guard FastFlags.asyncDecode else {
+                // Upstream loop: blocking eval + `.item()` sample at the top of every step.
+                guard let logits = lastLogits else { break }
+                let token = model.sample(logits: logits, temperature: temperature)
+                generated.append(token)
+                if token == model.config.eosTokenId || generated.count > maxTokens {
+                    done = true
+                    if generated.last == model.config.eosTokenId { generated.removeLast() }
+                    break
+                }
+                newIds.append(token)
+                let tokenEmbed = model.decoder.embedToken(tokenId: token)
+                let inputEmbed = decPos < adapter.shape[0]
+                    ? adapter[decPos] + tokenEmbed
+                    : tokenEmbed
+                let next = model.decoder(
+                    inputEmbed.expandedDimensions(axis: 0), startPos: decPos, cache: decCache)
+                decCache = next.1
+                lastLogits = model.decoder.logits(next.0[0])
+                decPos += 1
+                MLX.eval(lastLogits!)
+                continue
+            }
             guard let y = pendingToken else { break }
             let token = y.item(Int.self)
             generated.append(token)

--- a/spikes/VoxtralSpike/Sources/VoxtralFast/VoxtralRealtimeStreamSession.swift
+++ b/spikes/VoxtralSpike/Sources/VoxtralFast/VoxtralRealtimeStreamSession.swift
@@ -271,6 +271,13 @@ public final class VoxtralRealtimeStreamSession {
             )
             decCache = next.1
             FastProfile.countToken()
+            // Attribute honestly: MLX is lazy, so `next` has computed NOTHING yet. Eval the
+            // decoder output FIRST (that's the 32-layer forward), and only then time the
+            // head. The earlier profile evaluated the whole graph inside the head's timer
+            // and blamed the head for 68% of compute.
+            FastProfile.time(.decoderForward) {
+                if FastProfile.enabled { MLX.eval(next.0) }
+            }
             let logits = FastProfile.time(.logits) {
                 let l = model.decoder.logits(next.0[0])
                 if FastProfile.enabled { MLX.eval(l) }

--- a/spikes/VoxtralSpike/Sources/VoxtralFast/VoxtralRealtimeStreamSession.swift
+++ b/spikes/VoxtralSpike/Sources/VoxtralFast/VoxtralRealtimeStreamSession.swift
@@ -295,7 +295,7 @@ public final class VoxtralRealtimeStreamSession {
             // is starved in this GPU state.
             if FastProfile.enabled {
                 FastProfile.time(.headProbe) {
-                    let h = MLXRandom.normal([model.config.dim]).asType(.float16)
+                    let h = MLXRandom.normal([model.config.decoder.dim]).asType(.float16)
                     MLX.eval(h)
                     let l = model.decoder.logits(h)
                     MLX.eval(l)

--- a/spikes/VoxtralSpike/Sources/VoxtralFast/VoxtralRealtimeStreamSession.swift
+++ b/spikes/VoxtralSpike/Sources/VoxtralFast/VoxtralRealtimeStreamSession.swift
@@ -1,0 +1,314 @@
+import Foundation
+import MLX
+import MLXAudioCore
+
+// True incremental (online) streaming for Voxtral Realtime.
+//
+// The offline `generate(...)` path encodes the entire audio buffer up front and only
+// then walks the decoder. This session ingests audio *as it arrives* (e.g. 80 ms mic
+// chunks), feeds only newly-frozen conv frames through the transformer encoder with a
+// persistent per-layer KV-cache, maintains the decoder KV-cache, and emits tokens with
+// the model's native transcription delay — O(1) work per chunk.
+//
+// Correctness (WER 0 vs offline):
+//   * conv stem is causal and `prepareMel` right-pads with zeros, so `convOut[0..<k]`
+//     re-derived from a prefix is bit-identical to the offline full encode for every
+//     frozen row k. The only unfrozen row is the trailing partial token (chunk ended
+//     mid-1280-sample-token) — guarded by `frozenGuardTokens`.
+//   * RoPE attention is relative-position invariant, so feeding conv frames in
+//     sliding-window-aligned blocks with the cache RESET at each boundary reproduces
+//     `encodeChunked` (>sw) exactly; a single un-reset block reproduces `encodeFull`
+//     (<=sw). See `feedIncremental`.
+//   * `finish()` reproduces the offline tail zero-pad ⇒ final transcript == generate().
+
+/// Persistent incremental-encoder state carried across `step` calls.
+struct VoxtralRealtimeStreamEncoderState {
+    var caches: [VoxtralRealtimeEncoderKVCache?]
+    var blockBase = 0   // absolute conv-frame index where the current sw-block began
+    var consumed = 0    // conv frames already fed to the transformer
+
+    init(layers: Int) {
+        caches = Array(repeating: nil, count: layers)
+    }
+}
+
+extension VoxtralRealtimeAudioEncoder {
+    /// Feed conv frames `[state.consumed, upTo)` through the transformer incrementally,
+    /// resetting the per-layer caches at each `slidingWindow` boundary so the result is
+    /// bit-identical to offline `encodeFull` (<=sw) / `encodeChunked` (>sw). Returns the
+    /// new transformer-normed frames (pre-downsample).
+    func feedIncremental(
+        _ convOut: MLXArray,
+        upTo: Int,
+        state: inout VoxtralRealtimeStreamEncoderState
+    ) -> MLXArray {
+        let sw = config.slidingWindow
+        var pieces: [MLXArray] = []
+        while state.consumed < upTo {
+            let blockEnd = state.blockBase + sw
+            let end = min(upTo, blockEnd)
+            let block = convOut[state.consumed..<end, 0...]
+            // Block-relative positions: RoPE is relative, so this matches the absolute
+            // positions offline uses within each independent sw-block.
+            let relStart = state.consumed - state.blockBase
+            pieces.append(encodeIncremental(block, startPos: relStart, caches: &state.caches))
+            state.consumed = end
+            if state.consumed == blockEnd {
+                state.caches = Array(repeating: nil, count: transformerLayers.count)
+                state.blockBase = blockEnd
+            }
+        }
+        if pieces.isEmpty { return convOut[0..<0, 0...] }
+        return pieces.count == 1 ? pieces[0] : MLX.concatenated(pieces, axis: 0)
+    }
+}
+
+public final class VoxtralRealtimeStreamSession {
+    /// Text + token ids decoded by a single `step` / `finish` call.
+    public struct Delta {
+        public let text: String
+        public let tokenIds: [Int]
+    }
+
+    private let model: VoxtralRealtimeModel
+    private let temperature: Float
+    private let maxTokens: Int
+    private let transcriptionDelayMs: Int?
+
+    // Only the trailing partial token (chunk ended mid-1280-sample-token) is unfrozen.
+    private let frozenGuardTokens = 1
+
+    private var realAudio: [Float] = []
+    private var encState: VoxtralRealtimeStreamEncoderState
+    private var adapterBuf: MLXArray?
+    private var decCache: [VoxtralRealtimeDecoderKVCache?]?
+    private var lastLogits: MLXArray?
+    /// The next token, still on the GPU. Materialised one step LATE (see `decode`), so the
+    /// sync waits on work that has already been dispatched instead of stalling the pipeline.
+    private var pendingToken: MLXArray?
+    private var decPos = 0
+    private var promptLength = 0
+    private var prefilled = false
+    private var done = false
+
+    private var generated: [Int] = []
+    private var emittedText = ""
+
+    public init(
+        model: VoxtralRealtimeModel,
+        temperature: Float = 0.0,
+        maxTokens: Int = 4096,
+        transcriptionDelayMs: Int? = nil
+    ) {
+        self.model = model
+        self.temperature = temperature
+        self.maxTokens = maxTokens
+        self.transcriptionDelayMs = transcriptionDelayMs
+        self.encState = VoxtralRealtimeStreamEncoderState(
+            layers: model.encoder.transformerLayers.count
+        )
+    }
+
+    /// Full transcript decoded so far.
+    public var text: String { emittedText }
+    /// Token ids decoded so far (EOS stripped).
+    public var tokens: [Int] { generated }
+    /// Whether the stream has emitted EOS / hit maxTokens.
+    public var isFinished: Bool { done }
+
+    /// Ingest a chunk of 16 kHz mono samples; returns the text decoded by this call.
+    @discardableResult
+    public func step(_ samples: [Float]) -> Delta {
+        realAudio.append(contentsOf: samples)
+        return advance(final: false)
+    }
+
+    @discardableResult
+    public func step(_ samples: MLXArray) -> Delta {
+        let flat = samples.ndim > 1 ? samples.mean(axis: -1) : samples
+        return step(flat.asType(.float32).asArray(Float.self))
+    }
+
+    /// Flush the tail: reproduces the offline zero-pad so the final transcript equals
+    /// `generate(...)`. Call once after the last `step`.
+    @discardableResult
+    public func finish() -> Delta {
+        advance(final: true)
+    }
+
+    private func advance(final: Bool) -> Delta {
+        guard !done else { return Delta(text: "", tokenIds: []) }
+        guard !realAudio.isEmpty else { return Delta(text: "", tokenIds: []) }
+
+        let ds = model.config.encoderArgs.downsampleFactor
+        let audio = MLXArray(realAudio)
+        let (convOut, nAudioTotal, pLen) = model.convStemForAudio(
+            audio: audio,
+            transcriptionDelayMs: transcriptionDelayMs
+        )
+        promptLength = pLen
+
+        let realRegion = model.config.nLeftPadTokens + model.numAudioTokens(realAudio.count)
+        let emitLimit = final ? nAudioTotal : max(0, min(nAudioTotal, realRegion - frozenGuardTokens))
+        let convFreeze = min(convOut.shape[0], emitLimit * ds)
+
+        if convFreeze > encState.consumed {
+            let newEnc = model.encoder.feedIncremental(convOut, upTo: convFreeze, state: &encState)
+            let rows = model.encoder.downsampleAndProject(newEnc)   // multiple-of-ds ⇒ whole rows
+            adapterBuf = adapterBuf == nil ? rows : MLX.concatenated([adapterBuf!, rows], axis: 0)
+            freezeEncoderState()
+        }
+
+        guard let adapter = adapterBuf else {
+            Memory.clearCache()
+            return Delta(text: "", tokenIds: [])
+        }
+        prefillIfNeeded(adapter: adapter)
+        let delta = decode(adapter: adapter, upTo: min(emitLimit, adapter.shape[0]))
+
+        Memory.clearCache()
+        return delta
+    }
+
+    /// Materialise the adapter buffer + encoder caches so the lazy graph stays bounded
+    /// across chunks (each chunk would otherwise extend one unbroken graph).
+    private func freezeEncoderState() {
+        var arrays: [MLXArray] = []
+        if let adapterBuf { arrays.append(adapterBuf) }
+        for cache in encState.caches {
+            if let cache { arrays.append(cache.keys); arrays.append(cache.values) }
+        }
+        if !arrays.isEmpty { MLX.eval(arrays) }
+    }
+
+    private func prefillIfNeeded(adapter: MLXArray) {
+        guard !prefilled, adapter.shape[0] >= promptLength else { return }
+
+        let nLeft = model.config.nLeftPadTokens
+        let nDelay = promptLength - 1 - nLeft
+        let promptIds = [model.config.bosTokenId]
+            + Array(repeating: model.config.streamingPadTokenId, count: nLeft + nDelay)
+        let promptIdsMX = MLXArray(promptIds.map(Int32.init))
+        let promptTextEmbeds = model.decoder.embedTokens(promptIdsMX)
+
+        let prefixEmbeds = adapter[0..<promptLength, 0...] + promptTextEmbeds
+        let prefill = model.decoder(prefixEmbeds, startPos: 0, cache: nil)
+        lastLogits = model.decoder.logits(prefill.0[prefill.0.shape[0] - 1])
+        decCache = prefill.1
+        decPos = promptLength
+        prefilled = true
+        pendingToken = model.sampleArray(logits: lastLogits!, temperature: temperature)
+        MLX.asyncEval(pendingToken!)
+    }
+
+    private func decode(adapter: MLXArray, upTo emitLimit: Int) -> Delta {
+        guard prefilled else { return Delta(text: "", tokenIds: []) }
+
+        var newIds: [Int] = []
+        // Same token stream as the original (append → check → pop trailing EOS), but
+        // pipelined like voxmlx: the next token is sampled on the GPU and `asyncEval`d,
+        // and only materialised (`.item`) on the FOLLOWING iteration — by which time its
+        // work is already done. The original blocked on `MLX.eval(lastLogits)` every
+        // single token, serialising CPU and GPU once per decoded token.
+        while decPos < emitLimit {
+            guard let y = pendingToken else { break }
+            let token = y.item(Int.self)
+            generated.append(token)
+
+            if token == model.config.eosTokenId || generated.count > maxTokens {
+                done = true
+                if generated.last == model.config.eosTokenId { generated.removeLast() }
+                break
+            }
+            newIds.append(token)
+
+            // Gather the embedding straight from the GPU token array — indexing by a Swift
+            // Int would force another sync.
+            let tokenEmbed = model.decoder.embedTokens(y)
+            let inputEmbed = decPos < adapter.shape[0]
+                ? adapter[decPos].expandedDimensions(axis: 0) + tokenEmbed
+                : tokenEmbed
+            let next = model.decoder(
+                inputEmbed,
+                startPos: decPos,
+                cache: decCache
+            )
+            decCache = next.1
+            let logits = model.decoder.logits(next.0[0])
+            lastLogits = logits
+            pendingToken = model.sampleArray(logits: logits, temperature: temperature)
+            MLX.asyncEval(pendingToken!)
+            decPos += 1
+        }
+
+        let textSoFar = model.decodeStreaming(generated)
+        let delta: String
+        if textSoFar.hasPrefix(emittedText) {
+            delta = String(textSoFar.dropFirst(emittedText.count))
+        } else {
+            delta = textSoFar
+        }
+        emittedText = textSoFar
+        return Delta(text: delta, tokenIds: newIds)
+    }
+}
+
+public extension VoxtralRealtimeModel {
+    /// Create an online streaming session. Feed audio with `step(_:)`, then `finish()`.
+    func makeStreamSession(
+        temperature: Float = 0.0,
+        maxTokens: Int = 4096,
+        transcriptionDelayMs: Int? = nil
+    ) -> VoxtralRealtimeStreamSession {
+        VoxtralRealtimeStreamSession(
+            model: self,
+            temperature: temperature,
+            maxTokens: maxTokens,
+            transcriptionDelayMs: transcriptionDelayMs
+        )
+    }
+
+    /// Transcribe a whole audio buffer through the online streaming session, feeding
+    /// fixed `chunkMs`-sized chunks as a live caller would — instead of the whole-buffer
+    /// `generateStream`. `onDelta` receives each newly decoded fragment as it is produced
+    /// (use it to render live output); the returned `STTOutput` is the full transcript.
+    func transcribeStreaming(
+        audio: MLXArray,
+        generationParameters: STTGenerateParameters = STTGenerateParameters(),
+        chunkMs: Int = 480,
+        onDelta: ((String) -> Void)? = nil
+    ) -> STTOutput {
+        let mono = audio.ndim > 1 ? audio.mean(axis: -1) : audio
+        let samples = mono.asType(.float32).asArray(Float.self)
+        let chunk = max(1, 16000 * chunkMs / 1000)
+
+        let session = makeStreamSession(
+            temperature: generationParameters.temperature,
+            maxTokens: generationParameters.maxTokens
+        )
+        let start = CFAbsoluteTimeGetCurrent()
+
+        func emit(_ delta: VoxtralRealtimeStreamSession.Delta) {
+            guard !delta.text.isEmpty else { return }
+            onDelta?(delta.text)
+        }
+        var idx = 0
+        while idx < samples.count {
+            let end = min(idx + chunk, samples.count)
+            emit(session.step(Array(samples[idx..<end])))
+            idx = end
+        }
+        emit(session.finish())
+
+        let totalTime = CFAbsoluteTimeGetCurrent() - start
+        let tokenCount = session.tokens.count
+        return STTOutput(
+            text: session.text.trimmingCharacters(in: .whitespacesAndNewlines),
+            language: generationParameters.language,
+            generationTokens: tokenCount,
+            totalTokens: tokenCount,
+            generationTps: totalTime > 0 ? Double(tokenCount) / totalTime : 0,
+            totalTime: totalTime
+        )
+    }
+}

--- a/spikes/VoxtralSpike/Sources/VoxtralFast/VoxtralRealtimeStreamSession.swift
+++ b/spikes/VoxtralSpike/Sources/VoxtralFast/VoxtralRealtimeStreamSession.swift
@@ -1,5 +1,7 @@
 import Foundation
 import MLX
+import MLXNN
+import MLXRandom
 import MLXAudioCore
 
 // True incremental (online) streaming for Voxtral Realtime.
@@ -285,6 +287,20 @@ public final class VoxtralRealtimeStreamSession {
                 let l = model.decoder.logits(next.0[0])
                 if FastProfile.enabled { MLX.eval(l) }
                 return l
+            }
+            // Discriminator: the SAME head op on a fresh random vector, timed right here in
+            // the loop. Isolated at startup it takes ~5 ms. If this probe is also ~5 ms while
+            // the real head above reads ~73 ms, then the head is innocent and the `logits`
+            // timer is absorbing queued GPU work. If the probe is ALSO slow, the head really
+            // is starved in this GPU state.
+            if FastProfile.enabled {
+                FastProfile.time(.headProbe) {
+                    let h = MLXRandom.normal([model.config.dim]).asType(.float16)
+                    MLX.eval(h)
+                    let l = model.decoder.logits(h)
+                    MLX.eval(l)
+                }
+                FastProfile.countProbe()
             }
             lastLogits = logits
             pendingToken = model.sampleArray(logits: logits, temperature: temperature)

--- a/spikes/VoxtralSpike/Sources/VoxtralFast/VoxtralRealtimeStreamSession.swift
+++ b/spikes/VoxtralSpike/Sources/VoxtralFast/VoxtralRealtimeStreamSession.swift
@@ -167,7 +167,7 @@ public final class VoxtralRealtimeStreamSession {
         }
 
         guard let adapter = adapterBuf else {
-            Memory.clearCache()
+            if !FastFlags.keepCache { Memory.clearCache() }
             return Delta(text: "", tokenIds: [])
         }
         prefillIfNeeded(adapter: adapter)
@@ -175,7 +175,10 @@ public final class VoxtralRealtimeStreamSession {
             decode(adapter: adapter, upTo: min(emitLimit, adapter.shape[0]))
         }
 
-        Memory.clearCache()
+        // Dumping MLX's buffer pool on EVERY chunk (331 times for a 26 s utterance) forces
+        // every subsequent allocation back through the driver. The LM head profiled at
+        // 79 ms/token in-loop but 5 ms in isolation — the op isn't slow, it's starved.
+        if !FastFlags.keepCache { Memory.clearCache() }
         return delta
     }
 

--- a/spikes/VoxtralSpike/Sources/VoxtralFast/VoxtralRealtimeStreamSession.swift
+++ b/spikes/VoxtralSpike/Sources/VoxtralFast/VoxtralRealtimeStreamSession.swift
@@ -140,12 +140,17 @@ public final class VoxtralRealtimeStreamSession {
         guard !done else { return Delta(text: "", tokenIds: []) }
         guard !realAudio.isEmpty else { return Delta(text: "", tokenIds: []) }
 
+        FastProfile.countStep()
         let ds = model.config.encoderArgs.downsampleFactor
-        let audio = MLXArray(realAudio)
-        let (convOut, nAudioTotal, pLen) = model.convStemForAudio(
-            audio: audio,
-            transcriptionDelayMs: transcriptionDelayMs
-        )
+        let (convOut, nAudioTotal, pLen) = FastProfile.time(.convStem) {
+            let audio = MLXArray(realAudio)
+            let r = model.convStemForAudio(
+                audio: audio,
+                transcriptionDelayMs: transcriptionDelayMs
+            )
+            if FastProfile.enabled { MLX.eval(r.0) }
+            return r
+        }
         promptLength = pLen
 
         let realRegion = model.config.nLeftPadTokens + model.numAudioTokens(realAudio.count)
@@ -153,10 +158,12 @@ public final class VoxtralRealtimeStreamSession {
         let convFreeze = min(convOut.shape[0], emitLimit * ds)
 
         if convFreeze > encState.consumed {
-            let newEnc = model.encoder.feedIncremental(convOut, upTo: convFreeze, state: &encState)
-            let rows = model.encoder.downsampleAndProject(newEnc)   // multiple-of-ds ⇒ whole rows
-            adapterBuf = adapterBuf == nil ? rows : MLX.concatenated([adapterBuf!, rows], axis: 0)
-            freezeEncoderState()
+            FastProfile.time(.encoder) {
+                let newEnc = model.encoder.feedIncremental(convOut, upTo: convFreeze, state: &encState)
+                let rows = model.encoder.downsampleAndProject(newEnc)  // multiple-of-ds ⇒ whole rows
+                adapterBuf = adapterBuf == nil ? rows : MLX.concatenated([adapterBuf!, rows], axis: 0)
+                freezeEncoderState()
+            }
         }
 
         guard let adapter = adapterBuf else {
@@ -164,7 +171,9 @@ public final class VoxtralRealtimeStreamSession {
             return Delta(text: "", tokenIds: [])
         }
         prefillIfNeeded(adapter: adapter)
-        let delta = decode(adapter: adapter, upTo: min(emitLimit, adapter.shape[0]))
+        let delta = FastProfile.time(.decodeTokens) {
+            decode(adapter: adapter, upTo: min(emitLimit, adapter.shape[0]))
+        }
 
         Memory.clearCache()
         return delta
@@ -261,7 +270,12 @@ public final class VoxtralRealtimeStreamSession {
                 cache: decCache
             )
             decCache = next.1
-            let logits = model.decoder.logits(next.0[0])
+            FastProfile.countToken()
+            let logits = FastProfile.time(.logits) {
+                let l = model.decoder.logits(next.0[0])
+                if FastProfile.enabled { MLX.eval(l) }
+                return l
+            }
             lastLogits = logits
             pendingToken = model.sampleArray(logits: logits, temperature: temperature)
             MLX.asyncEval(pendingToken!)

--- a/spikes/VoxtralSpike/Sources/VoxtralFast/VoxtralRealtimeTokenizer.swift
+++ b/spikes/VoxtralSpike/Sources/VoxtralFast/VoxtralRealtimeTokenizer.swift
@@ -1,0 +1,99 @@
+import Foundation
+
+struct VoxtralRealtimeTekkenFile: Decodable {
+    struct Config: Decodable {
+        let defaultNumSpecialTokens: Int?
+
+        enum CodingKeys: String, CodingKey {
+            case defaultNumSpecialTokens = "default_num_special_tokens"
+        }
+    }
+
+    struct SpecialToken: Decodable {
+        let rank: Int?
+    }
+
+    struct VocabEntry: Decodable {
+        let tokenBytes: String
+
+        enum CodingKeys: String, CodingKey {
+            case tokenBytes = "token_bytes"
+        }
+    }
+
+    let vocab: [VocabEntry]
+    let config: Config?
+    let specialTokens: [SpecialToken]?
+
+    enum CodingKeys: String, CodingKey {
+        case vocab
+        case config
+        case specialTokens = "special_tokens"
+    }
+}
+
+final class VoxtralRealtimeTokenizer {
+    let vocab: [VoxtralRealtimeTekkenFile.VocabEntry]
+    let nSpecial: Int
+    let specialIds: Set<Int>
+
+    private var bytesCache: [Int: [UInt8]] = [:]
+
+    init(tekkenURL: URL) throws {
+        let data = try Data(contentsOf: tekkenURL)
+        let parsed = try JSONDecoder().decode(VoxtralRealtimeTekkenFile.self, from: data)
+        vocab = parsed.vocab
+        nSpecial = parsed.config?.defaultNumSpecialTokens ?? 1000
+        specialIds = Set((parsed.specialTokens ?? []).compactMap { $0.rank })
+    }
+
+    static func fromModelDirectory(_ modelDir: URL) throws -> VoxtralRealtimeTokenizer {
+        let tekkenURL = modelDir.appendingPathComponent("tekken.json")
+        guard FileManager.default.fileExists(atPath: tekkenURL.path) else {
+            throw NSError(
+                domain: "VoxtralRealtimeTokenizer",
+                code: 1,
+                userInfo: [NSLocalizedDescriptionKey: "tekken.json not found at \(modelDir.path)"]
+            )
+        }
+        return try VoxtralRealtimeTokenizer(tekkenURL: tekkenURL)
+    }
+
+    func decode(tokenIds: [Int]) -> String {
+        var out: [UInt8] = []
+        out.reserveCapacity(tokenIds.count * 2)
+
+        for tokenId in tokenIds {
+            guard tokenId >= 0 else { continue }
+            if tokenId < nSpecial || specialIds.contains(tokenId) {
+                continue
+            }
+            out.append(contentsOf: tokenBytes(for: tokenId))
+        }
+
+        return String(decoding: out, as: UTF8.self)
+    }
+
+    private func tokenBytes(for tokenId: Int) -> [UInt8] {
+        if let cached = bytesCache[tokenId] {
+            return cached
+        }
+
+        guard tokenId >= nSpecial, !specialIds.contains(tokenId) else {
+            bytesCache[tokenId] = []
+            return []
+        }
+
+        let vocabId = tokenId - nSpecial
+        guard vocabId >= 0, vocabId < vocab.count else {
+            bytesCache[tokenId] = []
+            return []
+        }
+
+        let entry = vocab[vocabId]
+        let decoded = Data(base64Encoded: entry.tokenBytes) ?? Data()
+        let bytes = [UInt8](decoded)
+        bytesCache[tokenId] = bytes
+        return bytes
+    }
+}

--- a/spikes/VoxtralSpike/Sources/voxtral-spike/main.swift
+++ b/spikes/VoxtralSpike/Sources/voxtral-spike/main.swift
@@ -1,0 +1,190 @@
+import AVFoundation
+import Foundation
+import MLX
+import MLXAudioSTT
+
+// THROWAWAY SPIKE. Feeds a WAV through mlx-audio-swift's VoxtralRealtime online
+// streaming session exactly the way the app feeds the mic (fixed-size 16 kHz
+// mono chunks, in order, no lookahead) and reports:
+//
+//   * realtime headroom  — GPU compute per chunk vs the chunk's wall-clock budget
+//   * accuracy           — word-level Levenshtein vs the expected phrase
+//   * emission latency   — how much audio must be fed before the first text appears
+//   * delta integrity    — counts steps where the transcript is NOT a prefix-extension
+//                          of the previous one (the re-emit bug: our insertion path has
+//                          no backspaces, so a re-emit would duplicate text on screen)
+//
+// It also sweeps `transcriptionDelayMs`, which the Python backend hardcodes at 480 ms.
+
+// MARK: - Args
+
+func arg(_ name: String, default def: String? = nil) -> String? {
+    let args = CommandLine.arguments
+    guard let i = args.firstIndex(of: "--\(name)"), i + 1 < args.count else { return def }
+    return args[i + 1]
+}
+
+let repoID = arg("repo", default: "mlx-community/Voxtral-Mini-4B-Realtime-6bit")!
+let wavPath = arg("wav")!
+let expectedPath = arg("expected")
+let chunkMs = Int(arg("chunk-ms", default: "80")!)!
+// "default" = don't pass the parameter at all (whatever the model's config says).
+let delaySpecs = (arg("delays", default: "default")!).split(separator: ",").map(String.init)
+let label = arg("label", default: "run")!
+
+// MARK: - Audio
+
+/// Decode a WAV to 16 kHz mono Float — the same format the mic capture service produces.
+func loadPCM16kMono(_ path: String) throws -> [Float] {
+    let file = try AVAudioFile(forReading: URL(fileURLWithPath: path))
+    guard
+        let outFormat = AVAudioFormat(
+            commonFormat: .pcmFormatFloat32, sampleRate: 16000, channels: 1, interleaved: false),
+        let converter = AVAudioConverter(from: file.processingFormat, to: outFormat),
+        let inBuf = AVAudioPCMBuffer(
+            pcmFormat: file.processingFormat, frameCapacity: AVAudioFrameCount(file.length))
+    else { throw NSError(domain: "spike", code: 1) }
+
+    try file.read(into: inBuf)
+    let ratio = 16000.0 / file.processingFormat.sampleRate
+    let capacity = AVAudioFrameCount(Double(inBuf.frameLength) * ratio) + 1024
+    guard let outBuf = AVAudioPCMBuffer(pcmFormat: outFormat, frameCapacity: capacity) else {
+        throw NSError(domain: "spike", code: 2)
+    }
+
+    var supplied = false
+    var err: NSError?
+    converter.convert(to: outBuf, error: &err) { _, status in
+        if supplied {
+            status.pointee = .endOfStream
+            return nil
+        }
+        supplied = true
+        status.pointee = .haveData
+        return inBuf
+    }
+    if let err { throw err }
+    guard let ch = outBuf.floatChannelData else { throw NSError(domain: "spike", code: 3) }
+    return Array(UnsafeBufferPointer(start: ch[0], count: Int(outBuf.frameLength)))
+}
+
+// MARK: - Scoring (mirrors IntegrationTestSupport.wordAccuracy: word-level Levenshtein)
+
+func words(_ s: String) -> [String] {
+    s.lowercased()
+        .components(separatedBy: CharacterSet.alphanumerics.union(.init(charactersIn: "'éèêàçùûôîïüö")).inverted)
+        .filter { !$0.isEmpty }
+}
+
+func wordAccuracy(expected: String, actual: String) -> Double {
+    let e = words(expected), a = words(actual)
+    if e.isEmpty { return a.isEmpty ? 1.0 : 0.0 }
+    var prev = Array(0...a.count)
+    var cur = [Int](repeating: 0, count: a.count + 1)
+    for i in 1...e.count {
+        cur[0] = i
+        for j in 1...max(a.count, 1) where a.count > 0 {
+            cur[j] = min(
+                prev[j] + 1, cur[j - 1] + 1, prev[j - 1] + (e[i - 1] == a[j - 1] ? 0 : 1))
+        }
+        swap(&prev, &cur)
+    }
+    let distance = a.isEmpty ? e.count : prev[a.count]
+    let denom = max(e.count, a.count)
+    return max(0.0, 1.0 - Double(distance) / Double(denom))
+}
+
+func pct(_ xs: [Double], _ p: Double) -> Double {
+    guard !xs.isEmpty else { return 0 }
+    let s = xs.sorted()
+    return s[min(s.count - 1, max(0, Int((p / 100.0) * Double(s.count - 1)).advanced(by: 0)))]
+}
+
+// MARK: - Run
+
+GPU.set(cacheLimit: 4 * 1024 * 1024 * 1024)  // mirrors voxmlx's mx.metal.set_cache_limit
+
+let samples = try loadPCM16kMono(wavPath)
+let audioSeconds = Double(samples.count) / 16000.0
+let expected = expectedPath.flatMap { try? String(contentsOfFile: $0, encoding: .utf8) } ?? ""
+
+FileHandle.standardError.write(
+    "loading \(repoID) …\n".data(using: .utf8)!)
+let loadStart = CFAbsoluteTimeGetCurrent()
+let model = try await VoxtralRealtimeModel.fromPretrained(repoID)
+let loadSeconds = CFAbsoluteTimeGetCurrent() - loadStart
+
+// Warm the Metal pipelines so the first measured chunk isn't paying kernel-compile
+// cost. The real app warms on its first dictation the same way.
+let warm = model.makeStreamSession(temperature: 0.0)
+_ = warm.step(Array(samples.prefix(16000)))
+_ = warm.finish()
+
+let chunkSamples = max(1, 16000 * chunkMs / 1000)
+var report: [[String: Any]] = []
+
+for spec in delaySpecs {
+    let delayMs: Int? = spec == "default" ? nil : Int(spec)
+    let session = model.makeStreamSession(temperature: 0.0, transcriptionDelayMs: delayMs)
+
+    var stepMs: [Double] = []
+    var reemits = 0
+    var reemitExamples: [String] = []
+    var firstDeltaAfterAudioSec: Double?
+    var prevText = ""
+    var idx = 0
+
+    let runStart = CFAbsoluteTimeGetCurrent()
+    while idx < samples.count {
+        let end = min(idx + chunkSamples, samples.count)
+        let t0 = CFAbsoluteTimeGetCurrent()
+        let delta = session.step(Array(samples[idx..<end]))
+        stepMs.append((CFAbsoluteTimeGetCurrent() - t0) * 1000)
+
+        let newText = session.text
+        if !prevText.isEmpty && !newText.hasPrefix(prevText) {
+            reemits += 1
+            if reemitExamples.count < 3 {
+                reemitExamples.append("was:'\(prevText.suffix(24))' now:'\(newText.suffix(24))'")
+            }
+        }
+        if firstDeltaAfterAudioSec == nil && !delta.text.isEmpty {
+            firstDeltaAfterAudioSec = Double(end) / 16000.0
+        }
+        prevText = newText
+        idx = end
+    }
+    let t0 = CFAbsoluteTimeGetCurrent()
+    _ = session.finish()
+    let finishMs = (CFAbsoluteTimeGetCurrent() - t0) * 1000
+    let computeSeconds = CFAbsoluteTimeGetCurrent() - runStart
+
+    let text = session.text.trimmingCharacters(in: .whitespacesAndNewlines)
+    let acc = expected.isEmpty ? -1 : wordAccuracy(expected: expected, actual: text)
+
+    report.append([
+        "label": label,
+        "delay_ms": delayMs.map(String.init) ?? "default",
+        "chunk_ms": chunkMs,
+        "audio_sec": audioSeconds,
+        "compute_sec": computeSeconds,
+        "rtf": computeSeconds / audioSeconds,
+        "step_mean_ms": stepMs.reduce(0, +) / Double(stepMs.count),
+        "step_p50_ms": pct(stepMs, 50),
+        "step_p95_ms": pct(stepMs, 95),
+        "step_max_ms": stepMs.max() ?? 0,
+        "chunk_budget_ms": Double(chunkMs),
+        "finish_ms": finishMs,
+        "first_delta_after_audio_sec": firstDeltaAfterAudioSec ?? -1,
+        "reemits": reemits,
+        "reemit_examples": reemitExamples,
+        "word_accuracy": acc,
+        "transcript": text,
+        "peak_gpu_gb": Double(GPU.snapshot().peakMemory) / 1_073_741_824.0,
+        "load_sec": loadSeconds,
+    ])
+    FileHandle.standardError.write("  delay=\(spec) done\n".data(using: .utf8)!)
+}
+
+let json = try JSONSerialization.data(withJSONObject: report, options: [.prettyPrinted, .sortedKeys])
+print(String(data: json, encoding: .utf8)!)

--- a/spikes/VoxtralSpike/Sources/voxtral-spike/main.swift
+++ b/spikes/VoxtralSpike/Sources/voxtral-spike/main.swift
@@ -235,6 +235,19 @@ if let ws = arg("ws") {
     }
 }
 
+// Numeric equivalence check for the fused RoPE against the manual one it replaces.
+// Runs before any model work so a layout/convention error is caught on its own terms
+// instead of showing up as a mysteriously empty transcript.
+if arg("selftest") != nil {
+    let diffs = voxtralRoPESelfTest()
+    let worst = diffs.values.max() ?? 0
+    print(
+        "rope-selftest \(diffs.sorted { $0.key < $1.key }.map { "\($0.key)=\($0.value)" }.joined(separator: " "))"
+    )
+    print("rope-selftest worst=\(worst) verdict=\(worst < 1e-2 ? "MATCH" : "MISMATCH")")
+    exit(worst < 1e-2 ? 0 : 3)
+}
+
 // One engine per process: the stock upstream engine, or the vendored+optimized one.
 // Never both — two 4B models resident would distort the measurement (and may get the
 // process jetsam'd while the owner's app holds two more).
@@ -339,6 +352,7 @@ for (chunkMs, spec) in chunkSpecs.flatMap({ c in delaySpecs.map { (c, $0) } }) {
             (Double(round(stepMs[$0] * 10)) / 10)
         },
         "engine": "swift-\(engineName)",
+        "fast_flags": FastFlags.description,
     ])
     FileHandle.standardError.write("  delay=\(spec) done\n".data(using: .utf8)!)
 }

--- a/spikes/VoxtralSpike/Sources/voxtral-spike/main.swift
+++ b/spikes/VoxtralSpike/Sources/voxtral-spike/main.swift
@@ -27,7 +27,12 @@ func arg(_ name: String, default def: String? = nil) -> String? {
 let repoID = arg("repo", default: "mlx-community/Voxtral-Mini-4B-Realtime-2602-4bit")!
 let wavPath = arg("wav")!
 let expectedPath = arg("expected")
-let chunkMs = Int(arg("chunk-ms", default: "80")!)!
+// Every fixed per-step cost (encoder pass, kernel launches, the O(n) conv-stem
+// recompute, the GPU sync) is paid ONCE PER CHUNK — so chunk size is a first-class
+// performance knob, not just a plumbing detail. Upstream's own CLI feeds 480 ms.
+let chunkSpecs = (arg("chunks", default: arg("chunk-ms", default: "80")!)!)
+    .split(separator: ",").compactMap { Int($0) }
+let chunkMs = chunkSpecs.first!
 // "default" = don't pass the parameter at all (whatever the model's config says).
 let delaySpecs = (arg("delays", default: "default")!).split(separator: ",").map(String.init)
 let label = arg("label", default: "run")!
@@ -241,10 +246,10 @@ let warm = model.makeStreamSession(temperature: 0.0)
 _ = warm.step(Array(samples.prefix(16000)))
 _ = warm.finish()
 
-let chunkSamples = max(1, 16000 * chunkMs / 1000)
 var report: [[String: Any]] = []
 
-for spec in delaySpecs {
+for (chunkMs, spec) in chunkSpecs.flatMap({ c in delaySpecs.map { (c, $0) } }) {
+    let chunkSamples = max(1, 16000 * chunkMs / 1000)
     let delayMs: Int? = spec == "default" ? nil : Int(spec)
     let session = model.makeStreamSession(temperature: 0.0, transcriptionDelayMs: delayMs)
 

--- a/spikes/VoxtralSpike/Sources/voxtral-spike/main.swift
+++ b/spikes/VoxtralSpike/Sources/voxtral-spike/main.swift
@@ -353,6 +353,7 @@ for (chunkMs, spec) in chunkSpecs.flatMap({ c in delaySpecs.map { (c, $0) } }) {
         },
         "engine": "swift-\(engineName)",
         "fast_flags": FastFlags.description,
+        "profile_ms": FastProfile.snapshot(),
     ])
     FileHandle.standardError.write("  delay=\(spec) done\n".data(using: .utf8)!)
 }

--- a/spikes/VoxtralSpike/Sources/voxtral-spike/main.swift
+++ b/spikes/VoxtralSpike/Sources/voxtral-spike/main.swift
@@ -24,7 +24,7 @@ func arg(_ name: String, default def: String? = nil) -> String? {
     return args[i + 1]
 }
 
-let repoID = arg("repo", default: "mlx-community/Voxtral-Mini-4B-Realtime-6bit")!
+let repoID = arg("repo", default: "mlx-community/Voxtral-Mini-4B-Realtime-2602-4bit")!
 let wavPath = arg("wav")!
 let expectedPath = arg("expected")
 let chunkMs = Int(arg("chunk-ms", default: "80")!)!

--- a/spikes/VoxtralSpike/Sources/voxtral-spike/main.swift
+++ b/spikes/VoxtralSpike/Sources/voxtral-spike/main.swift
@@ -262,10 +262,13 @@ FileHandle.standardError.write(
     "loading \(repoID) [engine=\(engineName)] …\n".data(using: .utf8)!)
 let loadStart = CFAbsoluteTimeGetCurrent()
 
+var dtypeReport: [String: String] = [:]
 let engine: Engine
 switch engineName {
 case "fast":
     let fast = try await FastEngine(repo: repoID)
+    FileHandle.standardError.write("dtypes: \(fast.dtypes())\n".data(using: .utf8)!)
+    dtypeReport = fast.dtypes()
     engine = Engine(makeSession: { delay in
         let s = fast.makeSession(transcriptionDelayMs: delay)
         return (step: { s.step($0) }, finish: { s.finish() }, text: { s.text })
@@ -354,6 +357,7 @@ for (chunkMs, spec) in chunkSpecs.flatMap({ c in delaySpecs.map { (c, $0) } }) {
         "engine": "swift-\(engineName)",
         "fast_flags": FastFlags.description,
         "profile_ms": FastProfile.snapshot(),
+        "dtypes": dtypeReport,
     ])
     FileHandle.standardError.write("  delay=\(spec) done\n".data(using: .utf8)!)
 }

--- a/spikes/VoxtralSpike/Sources/voxtral-spike/main.swift
+++ b/spikes/VoxtralSpike/Sources/voxtral-spike/main.swift
@@ -2,6 +2,7 @@ import AVFoundation
 import Foundation
 import MLX
 import MLXAudioSTT
+import VoxtralFast
 
 // THROWAWAY SPIKE. Feeds a WAV through mlx-audio-swift's VoxtralRealtime online
 // streaming session exactly the way the app feeds the mic (fixed-size 16 kHz
@@ -234,15 +235,39 @@ if let ws = arg("ws") {
     }
 }
 
+// One engine per process: the stock upstream engine, or the vendored+optimized one.
+// Never both — two 4B models resident would distort the measurement (and may get the
+// process jetsam'd while the owner's app holds two more).
+let engineName = arg("engine", default: "stock")!
+
+/// Uniform handle so both engines are measured by identical code.
+struct Engine {
+    let makeSession: (Int?) -> (step: ([Float]) -> String, finish: () -> String, text: () -> String)
+}
+
 FileHandle.standardError.write(
-    "loading \(repoID) …\n".data(using: .utf8)!)
+    "loading \(repoID) [engine=\(engineName)] …\n".data(using: .utf8)!)
 let loadStart = CFAbsoluteTimeGetCurrent()
-let model = try await VoxtralRealtimeModel.fromPretrained(repoID)
+
+let engine: Engine
+switch engineName {
+case "fast":
+    let fast = try await FastEngine(repo: repoID)
+    engine = Engine(makeSession: { delay in
+        let s = fast.makeSession(transcriptionDelayMs: delay)
+        return (step: { s.step($0) }, finish: { s.finish() }, text: { s.text })
+    })
+default:
+    let stock = try await MLXAudioSTT.VoxtralRealtimeModel.fromPretrained(repoID)
+    engine = Engine(makeSession: { delay in
+        let s = stock.makeStreamSession(temperature: 0.0, transcriptionDelayMs: delay)
+        return (step: { s.step($0).text }, finish: { s.finish().text }, text: { s.text })
+    })
+}
 let loadSeconds = CFAbsoluteTimeGetCurrent() - loadStart
 
-// Warm the Metal pipelines so the first measured chunk isn't paying kernel-compile
-// cost. The real app warms on its first dictation the same way.
-let warm = model.makeStreamSession(temperature: 0.0)
+// Warm the Metal pipelines so the first measured chunk isn't paying kernel-compile cost.
+let warm = engine.makeSession(nil)
 _ = warm.step(Array(samples.prefix(16000)))
 _ = warm.finish()
 
@@ -251,7 +276,7 @@ var report: [[String: Any]] = []
 for (chunkMs, spec) in chunkSpecs.flatMap({ c in delaySpecs.map { (c, $0) } }) {
     let chunkSamples = max(1, 16000 * chunkMs / 1000)
     let delayMs: Int? = spec == "default" ? nil : Int(spec)
-    let session = model.makeStreamSession(temperature: 0.0, transcriptionDelayMs: delayMs)
+    let session = engine.makeSession(delayMs)
 
     var stepMs: [Double] = []
     var reemits = 0
@@ -267,14 +292,14 @@ for (chunkMs, spec) in chunkSpecs.flatMap({ c in delaySpecs.map { (c, $0) } }) {
         let delta = session.step(Array(samples[idx..<end]))
         stepMs.append((CFAbsoluteTimeGetCurrent() - t0) * 1000)
 
-        let newText = session.text
+        let newText = session.text()
         if !prevText.isEmpty && !newText.hasPrefix(prevText) {
             reemits += 1
             if reemitExamples.count < 3 {
                 reemitExamples.append("was:'\(prevText.suffix(24))' now:'\(newText.suffix(24))'")
             }
         }
-        if firstDeltaAfterAudioSec == nil && !delta.text.isEmpty {
+        if firstDeltaAfterAudioSec == nil && !delta.isEmpty {
             firstDeltaAfterAudioSec = Double(end) / 16000.0
         }
         prevText = newText
@@ -285,7 +310,7 @@ for (chunkMs, spec) in chunkSpecs.flatMap({ c in delaySpecs.map { (c, $0) } }) {
     let finishMs = (CFAbsoluteTimeGetCurrent() - t0) * 1000
     let computeSeconds = CFAbsoluteTimeGetCurrent() - runStart
 
-    let text = session.text.trimmingCharacters(in: .whitespacesAndNewlines)
+    let text = session.text().trimmingCharacters(in: .whitespacesAndNewlines)
     let acc = expected.isEmpty ? -1 : wordAccuracy(expected: expected, actual: text)
 
     report.append([
@@ -313,7 +338,7 @@ for (chunkMs, spec) in chunkSpecs.flatMap({ c in delaySpecs.map { (c, $0) } }) {
         "step_ms_every_20": stride(from: 0, to: stepMs.count, by: 20).map {
             (Double(round(stepMs[$0] * 10)) / 10)
         },
-        "engine": "swift-mlx-audio",
+        "engine": "swift-\(engineName)",
     ])
     FileHandle.standardError.write("  delay=\(spec) done\n".data(using: .utf8)!)
 }

--- a/spikes/VoxtralSpike/Sources/voxtral-spike/main.swift
+++ b/spikes/VoxtralSpike/Sources/voxtral-spike/main.swift
@@ -100,6 +100,106 @@ func pct(_ xs: [Double], _ p: Double) -> Double {
     return s[min(s.count - 1, max(0, Int((p / 100.0) * Double(s.count - 1)).advanced(by: 0)))]
 }
 
+// MARK: - Python voxmlx baseline (same audio, same chunking, same clock)
+
+/// Streams the WAV to the running Python voxmlx server over its realtime websocket and
+/// measures the same way the in-process path is measured. Both engines therefore see
+/// identical GPU contention — the only fair way to compare on a machine that is also
+/// running the owner's app.
+func runWebSocketBaseline(url: String, samples: [Float], chunkSamples: Int, expected: String)
+    async throws -> [String: Any]
+{
+    let task = URLSession.shared.webSocketTask(with: URL(string: url)!)
+    task.resume()
+
+    let collected = Mutex2<(deltas: [String], final: String?, firstDeltaAt: Double?)>(([], nil, nil))
+    let start = CFAbsoluteTimeGetCurrent()
+
+    // Receive loop.
+    let receiver = Task {
+        while !Task.isCancelled {
+            let msg = try await task.receive()
+            guard case .string(let s) = msg,
+                let obj = try? JSONSerialization.jsonObject(with: Data(s.utf8)) as? [String: Any],
+                let type = obj["type"] as? String
+            else { continue }
+            if type.hasSuffix("transcript.delta"), let d = obj["delta"] as? String {
+                collected.withLock {
+                    if $0.firstDeltaAt == nil { $0.firstDeltaAt = CFAbsoluteTimeGetCurrent() }
+                    $0.deltas.append(d)
+                }
+            } else if type.hasSuffix("transcript.done") {
+                collected.withLock { $0.final = (obj["text"] as? String) ?? $0.final }
+                return
+            }
+        }
+    }
+
+    func send(_ o: [String: Any]) async throws {
+        let d = try JSONSerialization.data(withJSONObject: o)
+        try await task.send(.string(String(data: d, encoding: .utf8)!))
+    }
+
+    try await send(["type": "session.update", "model": "voxtral-realtime"])
+
+    let sendStart = CFAbsoluteTimeGetCurrent()
+    var idx = 0
+    while idx < samples.count {
+        let end = min(idx + chunkSamples, samples.count)
+        // PCM16 LE, exactly what MicrophoneCaptureService produces.
+        var pcm = Data(capacity: (end - idx) * 2)
+        for s in samples[idx..<end] {
+            let v = Int16(max(-32768, min(32767, s * 32768))).littleEndian
+            withUnsafeBytes(of: v) { pcm.append(contentsOf: $0) }
+        }
+        try await send([
+            "type": "input_audio_buffer.append", "audio": pcm.base64EncodedString(),
+        ])
+        idx = end
+    }
+    try await send(["type": "input_audio_buffer.commit", "final": true])
+
+    _ = try await withThrowingTaskGroup(of: Bool.self) { group -> Bool in
+        group.addTask { _ = await receiver.result; return true }
+        group.addTask {
+            try await Task.sleep(for: .seconds(120))
+            receiver.cancel()
+            return false
+        }
+        let first = try await group.next()!
+        group.cancelAll()
+        return first
+    }
+    let totalSeconds = CFAbsoluteTimeGetCurrent() - sendStart
+    task.cancel(with: .goingAway, reason: nil)
+
+    let snap = collected.withLock { $0 }
+    let text = (snap.final ?? snap.deltas.joined()).trimmingCharacters(in: .whitespacesAndNewlines)
+    let audioSeconds = Double(samples.count) / 16000.0
+    return [
+        "engine": "python-voxmlx(ws)",
+        "audio_sec": audioSeconds,
+        "compute_sec": totalSeconds,
+        "rtf": totalSeconds / audioSeconds,
+        "first_delta_sec": snap.firstDeltaAt.map { $0 - sendStart } ?? -1,
+        "word_accuracy": expected.isEmpty ? -1 : wordAccuracy(expected: expected, actual: text),
+        "transcript": text,
+        "connect_overhead_sec": sendStart - start,
+    ]
+}
+
+/// Minimal lock (the spike can't import the app's Mutex helpers).
+final class Mutex2<T>: @unchecked Sendable {
+    private var value: T
+    private let lock = NSLock()
+    init(_ v: T) { value = v }
+    func withLock<R>(_ body: (inout T) -> R) -> R {
+        lock.lock()
+        defer { lock.unlock() }
+        return body(&value)
+    }
+}
+
 // MARK: - Run
 
 // voxmlx caps its Metal cache at 4 GB; the spike takes 1 GB because it may run while
@@ -114,6 +214,20 @@ FileHandle.standardError.write(
 let samples = try loadPCM16kMono(wavPath)
 let audioSeconds = Double(samples.count) / 16000.0
 let expected = expectedPath.flatMap { try? String(contentsOfFile: $0, encoding: .utf8) } ?? ""
+
+let chunkSamplesForBaseline = max(1, 16000 * chunkMs / 1000)
+var baseline: [String: Any]?
+// Run the Python baseline BEFORE loading the Swift model, so the Swift 4B isn't
+// resident on the GPU during its measurement (production runs one engine, not two).
+if let ws = arg("ws") {
+    FileHandle.standardError.write("baseline: streaming to \(ws) …\n".data(using: .utf8)!)
+    do {
+        baseline = try await runWebSocketBaseline(
+            url: ws, samples: samples, chunkSamples: chunkSamplesForBaseline, expected: expected)
+    } catch {
+        baseline = ["engine": "python-voxmlx(ws)", "error": "\(error)"]
+    }
+}
 
 FileHandle.standardError.write(
     "loading \(repoID) …\n".data(using: .utf8)!)
@@ -189,9 +303,17 @@ for spec in delaySpecs {
         "transcript": text,
         "peak_gpu_gb": Double(GPU.snapshot().peakMemory) / 1_073_741_824.0,
         "load_sec": loadSeconds,
+        // Every 20th step: if the session re-encodes history instead of working
+        // incrementally, this series climbs with position instead of staying flat.
+        "step_ms_every_20": stride(from: 0, to: stepMs.count, by: 20).map {
+            (Double(round(stepMs[$0] * 10)) / 10)
+        },
+        "engine": "swift-mlx-audio",
     ])
     FileHandle.standardError.write("  delay=\(spec) done\n".data(using: .utf8)!)
 }
+
+if let baseline { report.append(baseline) }
 
 let json = try JSONSerialization.data(withJSONObject: report, options: [.prettyPrinted, .sortedKeys])
 print(String(data: json, encoding: .utf8)!)

--- a/spikes/VoxtralSpike/Sources/voxtral-spike/main.swift
+++ b/spikes/VoxtralSpike/Sources/voxtral-spike/main.swift
@@ -102,7 +102,14 @@ func pct(_ xs: [Double], _ p: Double) -> Double {
 
 // MARK: - Run
 
-GPU.set(cacheLimit: 4 * 1024 * 1024 * 1024)  // mirrors voxmlx's mx.metal.set_cache_limit
+// voxmlx caps its Metal cache at 4 GB; the spike takes 1 GB because it may run while
+// the owner's app already holds a 4B ASR model (8471) and a 4B polish model (8472)
+// resident on the same GPU.
+GPU.set(cacheLimit: 1024 * 1024 * 1024)
+
+FileHandle.standardError.write(
+    "physical RAM: \(ProcessInfo.processInfo.physicalMemory / 1_073_741_824) GB\n"
+        .data(using: .utf8)!)
 
 let samples = try loadPCM16kMono(wavPath)
 let audioSeconds = Double(samples.count) / 16000.0

--- a/spikes/VoxtralSpike/Sources/voxtral-spike/main.swift
+++ b/spikes/VoxtralSpike/Sources/voxtral-spike/main.swift
@@ -238,6 +238,12 @@ if let ws = arg("ws") {
 // Numeric equivalence check for the fused RoPE against the manual one it replaces.
 // Runs before any model work so a layout/convention error is caught on its own terms
 // instead of showing up as a mysteriously empty transcript.
+if arg("bench-head") != nil {
+    let b = voxtralHeadBenchmark()
+    print("head-bench \(b.sorted { $0.key < $1.key }.map { "\($0.key)=\(String(format: "%.2f", $0.value))ms" }.joined(separator: " "))")
+    exit(0)
+}
+
 if arg("selftest") != nil {
     let diffs = voxtralRoPESelfTest()
     let worst = diffs.values.max() ?? 0

--- a/spikes/run-spike.sh
+++ b/spikes/run-spike.sh
@@ -72,14 +72,25 @@ do_run() {
 
   [[ -x "$BIN" ]] || { echo "spike binary missing — run the build phase first"; exit 1; }
 
+  # Warm the on-demand Python voxmlx (port 8000) so the SAME binary can measure it as a
+  # baseline: same audio, same chunking, same clock, same GPU contention. Without this
+  # the Swift RTF is unjudgeable — the owner's app may be holding two 4B models resident.
+  WS_ARGS=()
+  if [[ -d /Users/Shared/localvoxtral/run ]] && ./scripts/mac/lv-test-servers.sh ensure voxmlx; then
+    WS_ARGS=(--ws "ws://127.0.0.1:8000/v1/realtime")
+    echo "==> Python voxmlx baseline enabled (port 8000)"
+  else
+    echo "==> WARNING: no on-demand voxmlx — Swift RTF will have no baseline to compare against"
+  fi
+
   echo "==> EN: delay sweep (chunk 80 ms), model $MODEL_REPO"
   "$BIN" --repo "$MODEL_REPO" --wav "$OUT_DIR/en.wav" --expected "$OUT_DIR/en.txt" \
-    --chunk-ms 80 --delays "default,480,240,160,80" --label en \
+    --chunk-ms 80 --delays "default,480,240,160,80" --label en "${WS_ARGS[@]}" \
     | tee "$OUT_DIR/en.json"
 
   echo "==> FR: accented text (delta-integrity smoke)"
   "$BIN" --repo "$MODEL_REPO" --wav "$OUT_DIR/fr.wav" --expected "$OUT_DIR/fr.txt" \
-    --chunk-ms 80 --delays "default" --label fr \
+    --chunk-ms 80 --delays "default" --label fr "${WS_ARGS[@]}" \
     | tee "$OUT_DIR/fr.json"
 
   echo "==> done"

--- a/spikes/run-spike.sh
+++ b/spikes/run-spike.sh
@@ -96,11 +96,11 @@ do_run() {
   # so this isolates which one breaks correctness — and what each is worth on its own.
   #   fast-none = vendored with everything OFF; MUST match stock, proving the vendoring itself
   #               is faithful and the fault is in one of the three changes.
-  run_cfg() {  # name rope async mask head fp16 keepcache [extra args...]
-    local name="$1" rope="$2" async="$3" mask="$4" head="$5" fp16="$6" keep="$7"; shift 7
-    echo "==> [$name] EN (rope=$rope async=$async mask=$mask head=$head fp16=$fp16 keepcache=$keep)"
+  run_cfg() {  # name rope async mask head fp16 keepcache ropecast [extra args...]
+    local name="$1" rope="$2" async="$3" mask="$4" head="$5" fp16="$6" keep="$7" rc="$8"; shift 8
+    echo "==> [$name] EN (rope=$rope async=$async mask=$mask head=$head fp16=$fp16 keep=$keep ropecast=$rc)"
     VOXFAST_ROPE="$rope" VOXFAST_ASYNC="$async" VOXFAST_MASK="$mask" VOXFAST_HEAD="$head" \
-    VOXFAST_FP16="$fp16" VOXFAST_KEEPCACHE="$keep" \
+    VOXFAST_FP16="$fp16" VOXFAST_KEEPCACHE="$keep" VOXFAST_ROPECAST="$rc" \
       "$BIN" --engine fast --repo "$MODEL_REPO" --wav "$OUT_DIR/en.wav" \
         --expected "$OUT_DIR/en.txt" --chunks "80" --delays "default" --label "$name" \
         "${WS_ARGS[@]}" "$@" \
@@ -119,9 +119,12 @@ do_run() {
   # Final attribution. fp16 (mel cast + adaScale cast + fp16 params) is the load-bearing
   # one: it stops the float32 hidden state from upcasting the 805MB tied embedding on
   # every token.
-  run_cfg fast-none  0 0 0 0 0 0
-  run_cfg fast-fp16  0 0 0 0 1 0
-  run_cfg fast-all   1 1 1 1 1 1
+  # fast-min = the MINIMAL upstream-shaped fix, isolated: manual RoPE made dtype-preserving
+  # (ropecast) + adaScale/conv-seam casts (fp16), and NOTHING else. If this alone reaches
+  # parity, that is the patch worth sending upstream.
+  run_cfg fast-none  0 0 0 0 0 0 0
+  run_cfg fast-min   0 0 0 0 1 0 1
+  run_cfg fast-all   1 1 1 1 1 1 1
 
   # Where does the ~130 ms/step actually go? Phase-attributed, all optimizations on.
   echo "==> [profile] EN (phase breakdown)"

--- a/spikes/run-spike.sh
+++ b/spikes/run-spike.sh
@@ -116,8 +116,11 @@ do_run() {
   # the fp16 conv weights — promoting the whole model's activations to float32.
   # The LM head profiled at 79ms/token in-loop but 5ms in isolation — it is starved, not
   # slow. advance() dumps MLX's buffer pool (Memory.clearCache) on EVERY chunk.
+  # Final attribution. fp16 (mel cast + adaScale cast + fp16 params) is the load-bearing
+  # one: it stops the float32 hidden state from upcasting the 805MB tied embedding on
+  # every token.
   run_cfg fast-none  0 0 0 0 0 0
-  run_cfg fast-keep  0 0 0 0 0 1
+  run_cfg fast-fp16  0 0 0 0 1 0
   run_cfg fast-all   1 1 1 1 1 1
 
   # Where does the ~130 ms/step actually go? Phase-attributed, all optimizations on.
@@ -125,6 +128,18 @@ do_run() {
   VOXFAST_PROFILE=1 VOXFAST_KEEPCACHE=1 "$BIN" --engine fast --repo "$MODEL_REPO" --wav "$OUT_DIR/en.wav" \
     --expected "$OUT_DIR/en.txt" --chunks "80" --delays "default" --label profile \
     | tee "$OUT_DIR/profile.json"
+
+  echo "==> [fast-all] FR: accented text (delta integrity on the optimized engine)"
+  VOXFAST_ROPE=1 VOXFAST_ASYNC=1 VOXFAST_MASK=1 VOXFAST_HEAD=1 VOXFAST_FP16=1 VOXFAST_KEEPCACHE=1 \
+    "$BIN" --engine fast --repo "$MODEL_REPO" --wav "$OUT_DIR/fr.wav" --expected "$OUT_DIR/fr.txt" \
+      --chunks "80" --delays "default" --label fr-fast \
+    | tee "$OUT_DIR/fr-fast.json"
+
+  echo "==> [fast-all] EN: transcription delay sweep (the knob the Python backend hardcodes at 480ms)"
+  VOXFAST_ROPE=1 VOXFAST_ASYNC=1 VOXFAST_MASK=1 VOXFAST_HEAD=1 VOXFAST_FP16=1 VOXFAST_KEEPCACHE=1 \
+    "$BIN" --engine fast --repo "$MODEL_REPO" --wav "$OUT_DIR/en.wav" --expected "$OUT_DIR/en.txt" \
+      --chunks "80" --delays "default,240,160,80" --label delays-fast \
+    | tee "$OUT_DIR/delays-fast.json"
 
   echo "==> done"
 }

--- a/spikes/run-spike.sh
+++ b/spikes/run-spike.sh
@@ -83,24 +83,27 @@ do_run() {
     echo "==> WARNING: no on-demand voxmlx — Swift RTF will have no baseline to compare against"
   fi
 
-  # Chunk sweep FIRST: the engine pays its fixed per-step cost once per chunk (and
-  # recomputes the conv stem over all audio each step), so RTF should fall as chunks
-  # grow. If a realistic chunk size already lands under RTF 1.0, no engine surgery
-  # is needed. The Python baseline rides along at the first chunk size.
-  echo "==> EN: chunk sweep, model $MODEL_REPO"
-  "$BIN" --repo "$MODEL_REPO" --wav "$OUT_DIR/en.wav" --expected "$OUT_DIR/en.txt" \
-    --chunks "80,160,240,480,960" --delays "default" --label en-chunks "${WS_ARGS[@]}" \
-    | tee "$OUT_DIR/en-chunks.json"
+  # A/B, one engine per process (never two 4B models resident at once):
+  #   stock = upstream mlx-audio-swift            fast = vendored + optimized
+  # The Python baseline rides along in BOTH runs — it is the normalizer for whatever
+  # GPU contention the owner's app is causing at that moment (it swung 0.61→0.76 between
+  # runs), so stock-vs-fast is only meaningful relative to it.
+  for eng in stock fast; do
+    echo "==> [$eng] EN: chunk sweep, model $MODEL_REPO"
+    "$BIN" --engine "$eng" --repo "$MODEL_REPO" --wav "$OUT_DIR/en.wav" --expected "$OUT_DIR/en.txt" \
+      --chunks "80,240,480" --delays "default" --label "en-chunks-$eng" "${WS_ARGS[@]}" \
+      | tee "$OUT_DIR/en-chunks-$eng.json"
 
-  echo "==> EN: delay sweep at 80 ms chunks"
-  "$BIN" --repo "$MODEL_REPO" --wav "$OUT_DIR/en.wav" --expected "$OUT_DIR/en.txt" \
-    --chunks "80" --delays "default,480,240,160,80" --label en-delays \
-    | tee "$OUT_DIR/en-delays.json"
+    echo "==> [$eng] FR: accented text (delta-integrity smoke)"
+    "$BIN" --engine "$eng" --repo "$MODEL_REPO" --wav "$OUT_DIR/fr.wav" --expected "$OUT_DIR/fr.txt" \
+      --chunks "80" --delays "default" --label "fr-$eng" \
+      | tee "$OUT_DIR/fr-$eng.json"
+  done
 
-  echo "==> FR: accented text (delta-integrity smoke)"
-  "$BIN" --repo "$MODEL_REPO" --wav "$OUT_DIR/fr.wav" --expected "$OUT_DIR/fr.txt" \
-    --chunks "80,480" --delays "default" --label fr \
-    | tee "$OUT_DIR/fr.json"
+  echo "==> [fast] EN: delay sweep at 80 ms chunks"
+  "$BIN" --engine fast --repo "$MODEL_REPO" --wav "$OUT_DIR/en.wav" --expected "$OUT_DIR/en.txt" \
+    --chunks "80" --delays "default,240,160,80" --label en-delays-fast \
+    | tee "$OUT_DIR/en-delays-fast.json"
 
   echo "==> done"
 }

--- a/spikes/run-spike.sh
+++ b/spikes/run-spike.sh
@@ -85,6 +85,9 @@ do_run() {
 
   # Fused RoPE must reproduce the manual RoPE it replaces — check that numerically
   # BEFORE trusting any transcript from the optimized engine.
+  echo "==> LM head micro-benchmark (isolated; MLX laziness made the in-loop timing lie)"
+  "$BIN" --bench-head 1 --wav "$OUT_DIR/en.wav" || true
+
   echo "==> RoPE self-test"
   "$BIN" --selftest 1 --wav "$OUT_DIR/en.wav" || { echo "!! RoPE MISMATCH — fused path is wrong"; exit 1; }
 

--- a/spikes/run-spike.sh
+++ b/spikes/run-spike.sh
@@ -86,7 +86,7 @@ do_run() {
   # Fused RoPE must reproduce the manual RoPE it replaces — check that numerically
   # BEFORE trusting any transcript from the optimized engine.
   echo "==> RoPE self-test"
-  "$BIN" --selftest 1 --wav "$OUT_DIR/en.wav" || echo "!! RoPE MISMATCH — fused path is wrong"
+  "$BIN" --selftest 1 --wav "$OUT_DIR/en.wav" || { echo "!! RoPE MISMATCH — fused path is wrong"; exit 1; }
 
   # Bisect: the all-on optimized engine scored word-accuracy 0.000 while stock scored
   # 0.804 on the same audio in the same run. Each optimization is individually switchable,
@@ -98,7 +98,8 @@ do_run() {
     echo "==> [$name] EN (rope=$rope async=$async mask=$mask)"
     VOXFAST_ROPE="$rope" VOXFAST_ASYNC="$async" VOXFAST_MASK="$mask" \
       "$BIN" --engine fast --repo "$MODEL_REPO" --wav "$OUT_DIR/en.wav" \
-        --expected "$OUT_DIR/en.txt" --chunks "80" --delays "default" --label "$name" "$@" \
+        --expected "$OUT_DIR/en.txt" --chunks "80" --delays "default" --label "$name" \
+        "${WS_ARGS[@]}" "$@" \
       | tee "$OUT_DIR/$name.json"
   }
 
@@ -110,7 +111,7 @@ do_run() {
   run_cfg fast-none  0 0 0
   run_cfg fast-rope  1 0 0
   run_cfg fast-async 0 1 0
-  run_cfg fast-all   1 1 1 "${WS_ARGS[@]}"
+  run_cfg fast-all   1 1 1
 
   echo "==> done"
 }

--- a/spikes/run-spike.sh
+++ b/spikes/run-spike.sh
@@ -93,10 +93,11 @@ do_run() {
   # so this isolates which one breaks correctness — and what each is worth on its own.
   #   fast-none = vendored with everything OFF; MUST match stock, proving the vendoring itself
   #               is faithful and the fault is in one of the three changes.
-  run_cfg() {  # name rope async mask head [extra args...]
-    local name="$1" rope="$2" async="$3" mask="$4" head="$5"; shift 5
-    echo "==> [$name] EN (rope=$rope async=$async mask=$mask head=$head)"
+  run_cfg() {  # name rope async mask head fp16 [extra args...]
+    local name="$1" rope="$2" async="$3" mask="$4" head="$5" fp16="$6"; shift 6
+    echo "==> [$name] EN (rope=$rope async=$async mask=$mask head=$head fp16=$fp16)"
     VOXFAST_ROPE="$rope" VOXFAST_ASYNC="$async" VOXFAST_MASK="$mask" VOXFAST_HEAD="$head" \
+    VOXFAST_FP16="$fp16" \
       "$BIN" --engine fast --repo "$MODEL_REPO" --wav "$OUT_DIR/en.wav" \
         --expected "$OUT_DIR/en.txt" --chunks "80" --delays "default" --label "$name" \
         "${WS_ARGS[@]}" "$@" \
@@ -108,13 +109,15 @@ do_run() {
     --chunks "80" --delays "default" --label stock "${WS_ARGS[@]}" \
     | tee "$OUT_DIR/stock.json"
 
-  run_cfg fast-none  0 0 0 0
-  run_cfg fast-head  0 0 0 1
-  run_cfg fast-all   1 1 1 1
+  # VOXFAST_FP16 is the new suspect: the mel is float32, and convStem fed it straight into
+  # the fp16 conv weights — promoting the whole model's activations to float32.
+  run_cfg fast-none  0 0 0 0 0
+  run_cfg fast-fp16  0 0 0 0 1
+  run_cfg fast-all   1 1 1 1 1
 
   # Where does the ~130 ms/step actually go? Phase-attributed, all optimizations on.
   echo "==> [profile] EN (phase breakdown)"
-  VOXFAST_PROFILE=1 VOXFAST_HEAD=1 "$BIN" --engine fast --repo "$MODEL_REPO" --wav "$OUT_DIR/en.wav" \
+  VOXFAST_PROFILE=1 "$BIN" --engine fast --repo "$MODEL_REPO" --wav "$OUT_DIR/en.wav" \
     --expected "$OUT_DIR/en.txt" --chunks "80" --delays "default" --label profile \
     | tee "$OUT_DIR/profile.json"
 

--- a/spikes/run-spike.sh
+++ b/spikes/run-spike.sh
@@ -113,6 +113,12 @@ do_run() {
   run_cfg fast-async 0 1 0
   run_cfg fast-all   1 1 1
 
+  # Where does the ~130 ms/step actually go? Phase-attributed, all optimizations on.
+  echo "==> [profile] EN (phase breakdown)"
+  VOXFAST_PROFILE=1 "$BIN" --engine fast --repo "$MODEL_REPO" --wav "$OUT_DIR/en.wav" \
+    --expected "$OUT_DIR/en.txt" --chunks "80" --delays "default" --label profile \
+    | tee "$OUT_DIR/profile.json"
+
   echo "==> done"
 }
 

--- a/spikes/run-spike.sh
+++ b/spikes/run-spike.sh
@@ -93,10 +93,10 @@ do_run() {
   # so this isolates which one breaks correctness — and what each is worth on its own.
   #   fast-none = vendored with everything OFF; MUST match stock, proving the vendoring itself
   #               is faithful and the fault is in one of the three changes.
-  run_cfg() {  # name rope async mask [extra args...]
-    local name="$1" rope="$2" async="$3" mask="$4"; shift 4
-    echo "==> [$name] EN (rope=$rope async=$async mask=$mask)"
-    VOXFAST_ROPE="$rope" VOXFAST_ASYNC="$async" VOXFAST_MASK="$mask" \
+  run_cfg() {  # name rope async mask head [extra args...]
+    local name="$1" rope="$2" async="$3" mask="$4" head="$5"; shift 5
+    echo "==> [$name] EN (rope=$rope async=$async mask=$mask head=$head)"
+    VOXFAST_ROPE="$rope" VOXFAST_ASYNC="$async" VOXFAST_MASK="$mask" VOXFAST_HEAD="$head" \
       "$BIN" --engine fast --repo "$MODEL_REPO" --wav "$OUT_DIR/en.wav" \
         --expected "$OUT_DIR/en.txt" --chunks "80" --delays "default" --label "$name" \
         "${WS_ARGS[@]}" "$@" \
@@ -108,14 +108,13 @@ do_run() {
     --chunks "80" --delays "default" --label stock "${WS_ARGS[@]}" \
     | tee "$OUT_DIR/stock.json"
 
-  run_cfg fast-none  0 0 0
-  run_cfg fast-rope  1 0 0
-  run_cfg fast-async 0 1 0
-  run_cfg fast-all   1 1 1
+  run_cfg fast-none  0 0 0 0
+  run_cfg fast-head  0 0 0 1
+  run_cfg fast-all   1 1 1 1
 
   # Where does the ~130 ms/step actually go? Phase-attributed, all optimizations on.
   echo "==> [profile] EN (phase breakdown)"
-  VOXFAST_PROFILE=1 "$BIN" --engine fast --repo "$MODEL_REPO" --wav "$OUT_DIR/en.wav" \
+  VOXFAST_PROFILE=1 VOXFAST_HEAD=1 "$BIN" --engine fast --repo "$MODEL_REPO" --wav "$OUT_DIR/en.wav" \
     --expected "$OUT_DIR/en.txt" --chunks "80" --delays "default" --label profile \
     | tee "$OUT_DIR/profile.json"
 

--- a/spikes/run-spike.sh
+++ b/spikes/run-spike.sh
@@ -1,11 +1,14 @@
 #!/usr/bin/env bash
-# THROWAWAY SPIKE runner — executes ON the Mac build host (via remote-build.sh exec).
+# THROWAWAY SPIKE runner — executes ON the Mac build host (self-hosted CI).
 #
 # Builds the Voxtral streaming spike with xcodebuild (SwiftPM CLI cannot compile
 # mlx-swift's Metal kernels — see AGENTS.md) and runs it against `say`-synthesized
 # audio, reusing the exact phrase and scoring approach of the tier-1 integration test.
+#
+# Usage: run-spike.sh [build|run|all]   (default: all)
 set -euo pipefail
 
+PHASE="${1:-all}"
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 SPIKE_DIR="$ROOT_DIR/spikes/VoxtralSpike"
 OUT_DIR="$ROOT_DIR/spikes/out"
@@ -20,43 +23,71 @@ EN="hello from localvoxtral realtime test. this is a longer synthetic audio pass
 # Accented French: the trigger for the suspected multi-byte-UTF-8 re-emit bug.
 FR="le café était très élégant et la crème brûlée façonnée à Noël. nous répétons: éàçùôî, garçon, français."
 
-printf '%s' "$EN" > "$OUT_DIR/en.txt"
-printf '%s' "$FR" > "$OUT_DIR/fr.txt"
+do_build() {
+  if ! xcrun metal --version >/dev/null 2>&1; then
+    echo "Metal toolchain missing: xcodebuild -downloadComponent MetalToolchain" >&2
+    exit 1
+  fi
 
-# Arg shape copied verbatim from the tier-1 test (makeSpokenPCM16Data): the phrase
-# is a positional arg — `--file` makes `say` fail with "Opening output file failed".
-echo "==> Synthesizing audio with /usr/bin/say"
-say -o "$OUT_DIR/en.wav" --file-format=WAVE --data-format=LEI16@16000 "$EN"
-say -v Thomas -o "$OUT_DIR/fr.wav" --file-format=WAVE --data-format=LEI16@16000 "$FR" \
-  || say -o "$OUT_DIR/fr.wav" --file-format=WAVE --data-format=LEI16@16000 "$FR"
+  mkdir -p "$SPIKE_DIR/.build"
+  local log="$SPIKE_DIR/.build/xcodebuild.log"
+  echo "==> xcodebuild (cold builds compile mlx-swift's C++/Metal core; log: $log)"
 
-if ! xcrun metal --version >/dev/null 2>&1; then
-  echo "Metal toolchain missing: xcodebuild -downloadComponent MetalToolchain" >&2
-  exit 1
-fi
+  # Heartbeat: xcodebuild is quiet for a long time on a cold MLX build, and a silent
+  # step that later times out leaves NO log to diagnose (runs 3 and 4).
+  ( while true; do sleep 60; echo "    … still building ($(date +%H:%M:%S))"; done ) &
+  local hb=$!
+  trap 'kill '"$hb"' 2>/dev/null || true' EXIT
 
-echo "==> Building spike (xcodebuild; log: $SPIKE_DIR/.build/xcodebuild.log)"
-mkdir -p "$SPIKE_DIR/.build"
-(
-  cd "$SPIKE_DIR"
-  xcodebuild \
-    -scheme VoxtralSpike \
-    -destination 'platform=macOS,arch=arm64' \
-    -configuration Release \
-    -derivedDataPath "$DERIVED" \
-    build > "$SPIKE_DIR/.build/xcodebuild.log" 2>&1
-) || { echo "xcodebuild FAILED; last 40 lines:"; tail -40 "$SPIKE_DIR/.build/xcodebuild.log"; exit 1; }
+  local rc=0
+  ( cd "$SPIKE_DIR"
+    xcodebuild \
+      -scheme VoxtralSpike \
+      -destination 'platform=macOS,arch=arm64' \
+      -configuration Release \
+      -derivedDataPath "$DERIVED" \
+      build > "$log" 2>&1
+  ) || rc=$?
+  kill "$hb" 2>/dev/null || true
 
-[[ -x "$BIN" ]] || { echo "no binary at $BIN"; tail -40 "$SPIKE_DIR/.build/xcodebuild.log"; exit 1; }
+  if (( rc != 0 )); then
+    echo "xcodebuild FAILED (rc=$rc); last 40 lines:"
+    tail -40 "$log"
+    exit "$rc"
+  fi
+  [[ -x "$BIN" ]] || { echo "no binary at $BIN"; tail -40 "$log"; exit 1; }
+  echo "==> build ok: $BIN"
+}
 
-echo "==> EN: delay sweep (chunk 80 ms)"
-"$BIN" --repo "$MODEL_REPO" --wav "$OUT_DIR/en.wav" --expected "$OUT_DIR/en.txt" \
-  --chunk-ms 80 --delays "default,480,240,160,80" --label en \
-  | tee "$OUT_DIR/en.json"
+do_run() {
+  printf '%s' "$EN" > "$OUT_DIR/en.txt"
+  printf '%s' "$FR" > "$OUT_DIR/fr.txt"
 
-echo "==> FR: accented text (delta-integrity smoke)"
-"$BIN" --repo "$MODEL_REPO" --wav "$OUT_DIR/fr.wav" --expected "$OUT_DIR/fr.txt" \
-  --chunk-ms 80 --delays "default" --label fr \
-  | tee "$OUT_DIR/fr.json"
+  # Arg shape copied verbatim from the tier-1 test (makeSpokenPCM16Data): the phrase
+  # is a positional arg — `--file` makes `say` fail with "Opening output file failed".
+  echo "==> Synthesizing audio with /usr/bin/say"
+  say -o "$OUT_DIR/en.wav" --file-format=WAVE --data-format=LEI16@16000 "$EN"
+  say -v Thomas -o "$OUT_DIR/fr.wav" --file-format=WAVE --data-format=LEI16@16000 "$FR" \
+    || say -o "$OUT_DIR/fr.wav" --file-format=WAVE --data-format=LEI16@16000 "$FR"
 
-echo "==> done"
+  [[ -x "$BIN" ]] || { echo "spike binary missing — run the build phase first"; exit 1; }
+
+  echo "==> EN: delay sweep (chunk 80 ms), model $MODEL_REPO"
+  "$BIN" --repo "$MODEL_REPO" --wav "$OUT_DIR/en.wav" --expected "$OUT_DIR/en.txt" \
+    --chunk-ms 80 --delays "default,480,240,160,80" --label en \
+    | tee "$OUT_DIR/en.json"
+
+  echo "==> FR: accented text (delta-integrity smoke)"
+  "$BIN" --repo "$MODEL_REPO" --wav "$OUT_DIR/fr.wav" --expected "$OUT_DIR/fr.txt" \
+    --chunk-ms 80 --delays "default" --label fr \
+    | tee "$OUT_DIR/fr.json"
+
+  echo "==> done"
+}
+
+case "$PHASE" in
+  build) do_build ;;
+  run)   do_run ;;
+  all)   do_build; do_run ;;
+  *) echo "usage: $0 [build|run|all]" >&2; exit 2 ;;
+esac

--- a/spikes/run-spike.sh
+++ b/spikes/run-spike.sh
@@ -11,7 +11,7 @@ SPIKE_DIR="$ROOT_DIR/spikes/VoxtralSpike"
 OUT_DIR="$ROOT_DIR/spikes/out"
 DERIVED="$SPIKE_DIR/.build/xcode"
 BIN="$DERIVED/Build/Products/Release/voxtral-spike"
-MODEL_REPO="${MODEL_REPO:-mlx-community/Voxtral-Mini-4B-Realtime-6bit}"
+MODEL_REPO="${MODEL_REPO:-mlx-community/Voxtral-Mini-4B-Realtime-2602-4bit}"
 
 mkdir -p "$OUT_DIR"
 

--- a/spikes/run-spike.sh
+++ b/spikes/run-spike.sh
@@ -83,14 +83,23 @@ do_run() {
     echo "==> WARNING: no on-demand voxmlx — Swift RTF will have no baseline to compare against"
   fi
 
-  echo "==> EN: delay sweep (chunk 80 ms), model $MODEL_REPO"
+  # Chunk sweep FIRST: the engine pays its fixed per-step cost once per chunk (and
+  # recomputes the conv stem over all audio each step), so RTF should fall as chunks
+  # grow. If a realistic chunk size already lands under RTF 1.0, no engine surgery
+  # is needed. The Python baseline rides along at the first chunk size.
+  echo "==> EN: chunk sweep, model $MODEL_REPO"
   "$BIN" --repo "$MODEL_REPO" --wav "$OUT_DIR/en.wav" --expected "$OUT_DIR/en.txt" \
-    --chunk-ms 80 --delays "default,480,240,160,80" --label en "${WS_ARGS[@]}" \
-    | tee "$OUT_DIR/en.json"
+    --chunks "80,160,240,480,960" --delays "default" --label en-chunks "${WS_ARGS[@]}" \
+    | tee "$OUT_DIR/en-chunks.json"
+
+  echo "==> EN: delay sweep at 80 ms chunks"
+  "$BIN" --repo "$MODEL_REPO" --wav "$OUT_DIR/en.wav" --expected "$OUT_DIR/en.txt" \
+    --chunks "80" --delays "default,480,240,160,80" --label en-delays \
+    | tee "$OUT_DIR/en-delays.json"
 
   echo "==> FR: accented text (delta-integrity smoke)"
   "$BIN" --repo "$MODEL_REPO" --wav "$OUT_DIR/fr.wav" --expected "$OUT_DIR/fr.txt" \
-    --chunk-ms 80 --delays "default" --label fr "${WS_ARGS[@]}" \
+    --chunks "80,480" --delays "default" --label fr \
     | tee "$OUT_DIR/fr.json"
 
   echo "==> done"

--- a/spikes/run-spike.sh
+++ b/spikes/run-spike.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# THROWAWAY SPIKE runner — executes ON the Mac build host (via remote-build.sh exec).
+#
+# Builds the Voxtral streaming spike with xcodebuild (SwiftPM CLI cannot compile
+# mlx-swift's Metal kernels — see AGENTS.md) and runs it against `say`-synthesized
+# audio, reusing the exact phrase and scoring approach of the tier-1 integration test.
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SPIKE_DIR="$ROOT_DIR/spikes/VoxtralSpike"
+OUT_DIR="$ROOT_DIR/spikes/out"
+DERIVED="$SPIKE_DIR/.build/xcode"
+BIN="$DERIVED/Build/Products/Release/voxtral-spike"
+MODEL_REPO="${MODEL_REPO:-mlx-community/Voxtral-Mini-4B-Realtime-6bit}"
+
+mkdir -p "$OUT_DIR"
+
+# The tier-1 phrase, verbatim (Tests/.../RealtimeAPIVLLMIntegrationTests.swift:226).
+EN="hello from localvoxtral realtime test. this is a longer synthetic audio passage for integration testing. we are verifying that the vllm realtime server performs generation and returns transcript text. the websocket client sends pcm sixteen audio at sixteen kilohertz in sequential chunks. if this transcript is non empty, end to end processing is confirmed."
+# Accented French: the trigger for the suspected multi-byte-UTF-8 re-emit bug.
+FR="le café était très élégant et la crème brûlée façonnée à Noël. nous répétons: éàçùôî, garçon, français."
+
+printf '%s' "$EN" > "$OUT_DIR/en.txt"
+printf '%s' "$FR" > "$OUT_DIR/fr.txt"
+
+echo "==> Synthesizing audio with /usr/bin/say"
+say -o "$OUT_DIR/en.wav" --file-format=WAVE --data-format=LEI16@16000 --file "$OUT_DIR/en.txt"
+say -v Thomas -o "$OUT_DIR/fr.wav" --file-format=WAVE --data-format=LEI16@16000 --file "$OUT_DIR/fr.txt" \
+  || say -o "$OUT_DIR/fr.wav" --file-format=WAVE --data-format=LEI16@16000 --file "$OUT_DIR/fr.txt"
+
+if ! xcrun metal --version >/dev/null 2>&1; then
+  echo "Metal toolchain missing: xcodebuild -downloadComponent MetalToolchain" >&2
+  exit 1
+fi
+
+echo "==> Building spike (xcodebuild; log: $SPIKE_DIR/.build/xcodebuild.log)"
+mkdir -p "$SPIKE_DIR/.build"
+(
+  cd "$SPIKE_DIR"
+  xcodebuild \
+    -scheme VoxtralSpike \
+    -destination 'platform=macOS,arch=arm64' \
+    -configuration Release \
+    -derivedDataPath "$DERIVED" \
+    build > "$SPIKE_DIR/.build/xcodebuild.log" 2>&1
+) || { echo "xcodebuild FAILED; last 40 lines:"; tail -40 "$SPIKE_DIR/.build/xcodebuild.log"; exit 1; }
+
+[[ -x "$BIN" ]] || { echo "no binary at $BIN"; tail -40 "$SPIKE_DIR/.build/xcodebuild.log"; exit 1; }
+
+echo "==> EN: delay sweep (chunk 80 ms)"
+"$BIN" --repo "$MODEL_REPO" --wav "$OUT_DIR/en.wav" --expected "$OUT_DIR/en.txt" \
+  --chunk-ms 80 --delays "default,480,240,160,80" --label en \
+  | tee "$OUT_DIR/en.json"
+
+echo "==> FR: accented text (delta-integrity smoke)"
+"$BIN" --repo "$MODEL_REPO" --wav "$OUT_DIR/fr.wav" --expected "$OUT_DIR/fr.txt" \
+  --chunk-ms 80 --delays "default" --label fr \
+  | tee "$OUT_DIR/fr.json"
+
+echo "==> done"

--- a/spikes/run-spike.sh
+++ b/spikes/run-spike.sh
@@ -23,10 +23,12 @@ FR="le café était très élégant et la crème brûlée façonnée à Noël. n
 printf '%s' "$EN" > "$OUT_DIR/en.txt"
 printf '%s' "$FR" > "$OUT_DIR/fr.txt"
 
+# Arg shape copied verbatim from the tier-1 test (makeSpokenPCM16Data): the phrase
+# is a positional arg — `--file` makes `say` fail with "Opening output file failed".
 echo "==> Synthesizing audio with /usr/bin/say"
-say -o "$OUT_DIR/en.wav" --file-format=WAVE --data-format=LEI16@16000 --file "$OUT_DIR/en.txt"
-say -v Thomas -o "$OUT_DIR/fr.wav" --file-format=WAVE --data-format=LEI16@16000 --file "$OUT_DIR/fr.txt" \
-  || say -o "$OUT_DIR/fr.wav" --file-format=WAVE --data-format=LEI16@16000 --file "$OUT_DIR/fr.txt"
+say -o "$OUT_DIR/en.wav" --file-format=WAVE --data-format=LEI16@16000 "$EN"
+say -v Thomas -o "$OUT_DIR/fr.wav" --file-format=WAVE --data-format=LEI16@16000 "$FR" \
+  || say -o "$OUT_DIR/fr.wav" --file-format=WAVE --data-format=LEI16@16000 "$FR"
 
 if ! xcrun metal --version >/dev/null 2>&1; then
   echo "Metal toolchain missing: xcodebuild -downloadComponent MetalToolchain" >&2

--- a/spikes/run-spike.sh
+++ b/spikes/run-spike.sh
@@ -83,27 +83,34 @@ do_run() {
     echo "==> WARNING: no on-demand voxmlx — Swift RTF will have no baseline to compare against"
   fi
 
-  # A/B, one engine per process (never two 4B models resident at once):
-  #   stock = upstream mlx-audio-swift            fast = vendored + optimized
-  # The Python baseline rides along in BOTH runs — it is the normalizer for whatever
-  # GPU contention the owner's app is causing at that moment (it swung 0.61→0.76 between
-  # runs), so stock-vs-fast is only meaningful relative to it.
-  for eng in stock fast; do
-    echo "==> [$eng] EN: chunk sweep, model $MODEL_REPO"
-    "$BIN" --engine "$eng" --repo "$MODEL_REPO" --wav "$OUT_DIR/en.wav" --expected "$OUT_DIR/en.txt" \
-      --chunks "80,240,480" --delays "default" --label "en-chunks-$eng" "${WS_ARGS[@]}" \
-      | tee "$OUT_DIR/en-chunks-$eng.json"
+  # Fused RoPE must reproduce the manual RoPE it replaces — check that numerically
+  # BEFORE trusting any transcript from the optimized engine.
+  echo "==> RoPE self-test"
+  "$BIN" --selftest 1 --wav "$OUT_DIR/en.wav" || echo "!! RoPE MISMATCH — fused path is wrong"
 
-    echo "==> [$eng] FR: accented text (delta-integrity smoke)"
-    "$BIN" --engine "$eng" --repo "$MODEL_REPO" --wav "$OUT_DIR/fr.wav" --expected "$OUT_DIR/fr.txt" \
-      --chunks "80" --delays "default" --label "fr-$eng" \
-      | tee "$OUT_DIR/fr-$eng.json"
-  done
+  # Bisect: the all-on optimized engine scored word-accuracy 0.000 while stock scored
+  # 0.804 on the same audio in the same run. Each optimization is individually switchable,
+  # so this isolates which one breaks correctness — and what each is worth on its own.
+  #   fast-none = vendored with everything OFF; MUST match stock, proving the vendoring itself
+  #               is faithful and the fault is in one of the three changes.
+  run_cfg() {  # name rope async mask [extra args...]
+    local name="$1" rope="$2" async="$3" mask="$4"; shift 4
+    echo "==> [$name] EN (rope=$rope async=$async mask=$mask)"
+    VOXFAST_ROPE="$rope" VOXFAST_ASYNC="$async" VOXFAST_MASK="$mask" \
+      "$BIN" --engine fast --repo "$MODEL_REPO" --wav "$OUT_DIR/en.wav" \
+        --expected "$OUT_DIR/en.txt" --chunks "80" --delays "default" --label "$name" "$@" \
+      | tee "$OUT_DIR/$name.json"
+  }
 
-  echo "==> [fast] EN: delay sweep at 80 ms chunks"
-  "$BIN" --engine fast --repo "$MODEL_REPO" --wav "$OUT_DIR/en.wav" --expected "$OUT_DIR/en.txt" \
-    --chunks "80" --delays "default,240,160,80" --label en-delays-fast \
-    | tee "$OUT_DIR/en-delays-fast.json"
+  echo "==> [stock] EN"
+  "$BIN" --engine stock --repo "$MODEL_REPO" --wav "$OUT_DIR/en.wav" --expected "$OUT_DIR/en.txt" \
+    --chunks "80" --delays "default" --label stock "${WS_ARGS[@]}" \
+    | tee "$OUT_DIR/stock.json"
+
+  run_cfg fast-none  0 0 0
+  run_cfg fast-rope  1 0 0
+  run_cfg fast-async 0 1 0
+  run_cfg fast-all   1 1 1 "${WS_ARGS[@]}"
 
   echo "==> done"
 }

--- a/spikes/run-spike.sh
+++ b/spikes/run-spike.sh
@@ -123,7 +123,7 @@ do_run() {
   # (ropecast) + adaScale/conv-seam casts (fp16), and NOTHING else. If this alone reaches
   # parity, that is the patch worth sending upstream.
   run_cfg fast-none  0 0 0 0 0 0 0
-  run_cfg fast-min   0 0 0 0 1 0 1
+  run_cfg fast-min   0 0 1 0 1 0 1
   run_cfg fast-all   1 1 1 1 1 1 1
 
   # Where does the ~130 ms/step actually go? Phase-attributed, all optimizations on.

--- a/spikes/run-spike.sh
+++ b/spikes/run-spike.sh
@@ -96,11 +96,11 @@ do_run() {
   # so this isolates which one breaks correctness — and what each is worth on its own.
   #   fast-none = vendored with everything OFF; MUST match stock, proving the vendoring itself
   #               is faithful and the fault is in one of the three changes.
-  run_cfg() {  # name rope async mask head fp16 [extra args...]
-    local name="$1" rope="$2" async="$3" mask="$4" head="$5" fp16="$6"; shift 6
-    echo "==> [$name] EN (rope=$rope async=$async mask=$mask head=$head fp16=$fp16)"
+  run_cfg() {  # name rope async mask head fp16 keepcache [extra args...]
+    local name="$1" rope="$2" async="$3" mask="$4" head="$5" fp16="$6" keep="$7"; shift 7
+    echo "==> [$name] EN (rope=$rope async=$async mask=$mask head=$head fp16=$fp16 keepcache=$keep)"
     VOXFAST_ROPE="$rope" VOXFAST_ASYNC="$async" VOXFAST_MASK="$mask" VOXFAST_HEAD="$head" \
-    VOXFAST_FP16="$fp16" \
+    VOXFAST_FP16="$fp16" VOXFAST_KEEPCACHE="$keep" \
       "$BIN" --engine fast --repo "$MODEL_REPO" --wav "$OUT_DIR/en.wav" \
         --expected "$OUT_DIR/en.txt" --chunks "80" --delays "default" --label "$name" \
         "${WS_ARGS[@]}" "$@" \
@@ -114,13 +114,15 @@ do_run() {
 
   # VOXFAST_FP16 is the new suspect: the mel is float32, and convStem fed it straight into
   # the fp16 conv weights — promoting the whole model's activations to float32.
-  run_cfg fast-none  0 0 0 0 0
-  run_cfg fast-fp16  0 0 0 0 1
-  run_cfg fast-all   1 1 1 1 1
+  # The LM head profiled at 79ms/token in-loop but 5ms in isolation — it is starved, not
+  # slow. advance() dumps MLX's buffer pool (Memory.clearCache) on EVERY chunk.
+  run_cfg fast-none  0 0 0 0 0 0
+  run_cfg fast-keep  0 0 0 0 0 1
+  run_cfg fast-all   1 1 1 1 1 1
 
   # Where does the ~130 ms/step actually go? Phase-attributed, all optimizations on.
   echo "==> [profile] EN (phase breakdown)"
-  VOXFAST_PROFILE=1 "$BIN" --engine fast --repo "$MODEL_REPO" --wav "$OUT_DIR/en.wav" \
+  VOXFAST_PROFILE=1 VOXFAST_KEEPCACHE=1 "$BIN" --engine fast --repo "$MODEL_REPO" --wav "$OUT_DIR/en.wav" \
     --expected "$OUT_DIR/en.txt" --chunks "80" --delays "default" --label profile \
     | tee "$OUT_DIR/profile.json"
 


### PR DESCRIPTION
## What

**Spike — do not merge.** Recorded for the decision trail. Answers a single question: can a bundled Swift engine replace the managed Python `voxmlx` backend, at acceptable accuracy and realtime headroom?

**Answer: yes.** A vendored + optimized [`Blaizzy/mlx-audio-swift`](https://github.com/Blaizzy/mlx-audio-swift) `VoxtralRealtime` reaches **parity with the Python backend** — same audio, same 80 ms chunking, same harness, same GPU, back-to-back with the Python server as the contention normalizer:

| engine | RTF | vs Python (same process) | word accuracy | peak GPU |
|---|---|---|---|---|
| stock mlx-audio-swift | 1.84 | 3.35× slower | 0.804 | 5.1 GB |
| **optimized** | **0.62** | **~1.0×** | **0.804** (0.842 FR) | **3.3 GB** |

The stock upstream engine is **~3.2× slower than Python and cannot keep up with live dictation** (RTF ~1.85). The optimized engine keeps up with ~1.6× headroom, at bit-identical accuracy and 1.8 GB less memory. It also unlocks `transcriptionDelayMs` (the value the Python backend hardcodes at 480 ms), swept here from 480→80 ms.

### The bug behind the whole gap

A **float32 leak** with two sources that both had to be plugged:

1. `AdaptiveNorm` — `x * (1.0 + adaScale)` with a float32 `adaScale`, promoting the decoder hidden state to float32 in all 32 layers.
2. The manual RoPE — builds cos/sin in float32 and re-promotes even after (1) is fixed.

Consequence: the tied fp16 embedding (131072×3072, ~805 MB) was **upcast on every token**, and quantized matmuls fell off their fast path ([mlx-swift#420](https://github.com/ml-explore/mlx-swift/issues/420)). `voxmlx` casts (`t_cond.astype(x.dtype)`); this port didn't. Fixing both: logits **73.5 → 4.8 ms/token**, decoder forward 19.6 → 13.1, RTF **1.84 → 0.62**.

Fixing either one alone gives ~0% — which is why a naïve one-change-at-a-time bisect hid the cause.

### Other changes (small individually)

Fused `MLXFast.RoPE` (also fixes a `[H,L,D]` layout that hit [mlx-swift#441](https://github.com/ml-explore/mlx-swift/issues/441): Metal RoPE garbage for single-token decode with batch>1 → empty transcripts), async-eval one-step-lag decode, dtype-correct attention masks, `asLinear` LM head, and not dumping the Metal buffer pool every chunk.

### Layout

- `spikes/VoxtralSpike/` — throwaway harness; drives the online streaming session exactly as the app feeds the mic, scores with the tier-1 word-accuracy method, sweeps chunk size / delay / engine flags, and streams the same audio to the live Python `voxmlx` as a same-process baseline.
- `spikes/VoxtralSpike/Sources/VoxtralFast/` — the vendored engine (MIT) with the optimizations behind `VOXFAST_*` flags for bisecting.
- `.github/workflows/voxtral-spike.yml` — self-hosted lane (needs xcodebuild + a real 4B model; the SSH gate allowlist can't run it).

## Proof

Not a shippable behavior change — a spike. Evidence is the CI run matrix, all on the self-hosted Mac against `say`-synthesized tier-1 audio:

- Final confirmation: [run 29351575457](https://github.com/T0mSIlver/localvoxtral/actions/runs/29351575457) — optimized RTF 0.62 @ 0.804 EN / 0.842 FR, 0 delta re-emits, delay sweep 480→80 ms.
- Bisect that isolated the leak: [run 29350934524](https://github.com/T0mSIlver/localvoxtral/actions/runs/29341979759) (all-off = stock 0.804; all-on = 0.62 @ 0.804).
- RoPE numeric self-test: MATCH (max abs dev 0.001 vs the manual RoPE it replaces).

Follow-ups (next PRs): vendor the engine into the app properly with the fixes always-on + MIT provenance + unit tests (RoPE equivalence, delta-emission regression), then a bundled `speechd` helper speaking the Realtime websocket protocol to replace the `voxmlx` process. Upstream fix for the float32 leak is being prepared separately.

- [ ] N/A — spike, not for merge
