### PR TITLE
Vendor Voxtral Swift ASR engine (SpeechHelper package) — part 1: engine + fixes + delta tests

### DIFF
--- a/SpeechHelper/LICENSE.mlx-audio-swift
+++ b/SpeechHelper/LICENSE.mlx-audio-swift
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Prince Canuma
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/SpeechHelper/Package.swift
+++ b/SpeechHelper/Package.swift
@@ -22,6 +22,9 @@ let package = Package(
         // swift-transformers 1.1.9 (>=1.2 fails to compile under Xcode 26).
         .package(url: "https://github.com/ml-explore/mlx-swift.git", exact: "0.31.3"),
         .package(url: "https://github.com/ml-explore/mlx-swift-lm.git", exact: "3.31.3"),
+        // Pinned but not directly imported: it's a transitive dep of mlx-audio-swift, and
+        // >=1.2 fails to compile under Xcode 26 (the xcodebuild packaging lane). Pinning it
+        // here freezes the whole graph to 1.1.9. (SPM warns it's "unused" — expected.)
         .package(url: "https://github.com/huggingface/swift-transformers.git", exact: "1.1.9"),
         .package(url: "https://github.com/huggingface/swift-huggingface.git", exact: "0.8.1"),
         .package(url: "https://github.com/Blaizzy/mlx-audio-swift.git", exact: "0.1.3"),

--- a/SpeechHelper/Package.swift
+++ b/SpeechHelper/Package.swift
@@ -54,7 +54,7 @@ let package = Package(
         ),
         .executableTarget(
             name: "localvoxtral-speechd",
-            dependencies: ["SpeechEngine"]
+            dependencies: ["SpeechEngine", "SpeechEngineText"]
         ),
     ]
 )

--- a/SpeechHelper/Package.swift
+++ b/SpeechHelper/Package.swift
@@ -1,0 +1,57 @@
+// swift-tools-version: 6.1
+import PackageDescription
+
+// Standalone package (like PolishHelper) so the main app's `swift build` / `swift test`
+// loop never compiles mlx-swift's C++/Metal core. The shippable helper is built with
+// xcodebuild by scripts/package_app.sh; a plain `swift build` of this package compiles
+// but produces a binary that cannot load Metal kernels at runtime — fine for the
+// Metal-free unit tests (SpeechEngineTextTests), which is what CI's tier-0 lane runs here.
+//
+// SpeechEngine vendors Blaizzy/mlx-audio-swift's VoxtralRealtime (MIT) with local fixes —
+// see VENDORED.md. It replaces the managed Python voxmlx backend.
+let package = Package(
+    name: "SpeechHelper",
+    platforms: [.macOS(.v15)],
+    products: [
+        .executable(name: "localvoxtral-speechd", targets: ["localvoxtral-speechd"]),
+        .library(name: "SpeechEngineText", targets: ["SpeechEngineText"]),
+    ],
+    dependencies: [
+        // Pinned to mlx-audio-swift's own resolved graph (its Package.resolved): mlx-swift
+        // 0.31.3 (the last version before the #428 evalLock deadlock in 0.31.4) and
+        // swift-transformers 1.1.9 (>=1.2 fails to compile under Xcode 26).
+        .package(url: "https://github.com/ml-explore/mlx-swift.git", exact: "0.31.3"),
+        .package(url: "https://github.com/ml-explore/mlx-swift-lm.git", exact: "3.31.3"),
+        .package(url: "https://github.com/huggingface/swift-transformers.git", exact: "1.1.9"),
+        .package(url: "https://github.com/huggingface/swift-huggingface.git", exact: "0.8.1"),
+        .package(url: "https://github.com/Blaizzy/mlx-audio-swift.git", exact: "0.1.3"),
+    ],
+    targets: [
+        // Pure-Swift, Metal-free: the append-only delta contract. Kept separate so its
+        // regression tests run in the tier-0 `swift test` lane without touching MLX.
+        .target(name: "SpeechEngineText"),
+        .testTarget(
+            name: "SpeechEngineTextTests",
+            dependencies: ["SpeechEngineText"]
+        ),
+        // The vendored Voxtral Realtime engine (MLX; needs Metal at runtime).
+        .target(
+            name: "SpeechEngine",
+            dependencies: [
+                "SpeechEngineText",
+                .product(name: "MLXAudioCore", package: "mlx-audio-swift"),
+                .product(name: "MLXAudioVAD", package: "mlx-audio-swift"),
+                .product(name: "MLX", package: "mlx-swift"),
+                .product(name: "MLXFast", package: "mlx-swift"),
+                .product(name: "MLXNN", package: "mlx-swift"),
+                .product(name: "MLXRandom", package: "mlx-swift"),
+                .product(name: "MLXLMCommon", package: "mlx-swift-lm"),
+                .product(name: "HuggingFace", package: "swift-huggingface"),
+            ]
+        ),
+        .executableTarget(
+            name: "localvoxtral-speechd",
+            dependencies: ["SpeechEngine"]
+        ),
+    ]
+)

--- a/SpeechHelper/Sources/SpeechEngine/Generation.swift
+++ b/SpeechHelper/Sources/SpeechEngine/Generation.swift
@@ -1,0 +1,68 @@
+import MLX
+
+public struct STTGenerateParameters: Sendable {
+    public let maxTokens: Int
+    public let temperature: Float
+    public let topP: Float
+    public let topK: Int
+    public let verbose: Bool
+    public let language: String?
+    public let chunkDuration: Float
+    public let minChunkDuration: Float
+    public let repetitionPenalty: Float
+    public let repetitionContextSize: Int
+
+    public init(
+        maxTokens: Int = 8192,
+        temperature: Float = 0.0,
+        topP: Float = 0.95,
+        topK: Int = 0,
+        verbose: Bool = false,
+        language: String? = nil,
+        chunkDuration: Float = 1200.0,
+        minChunkDuration: Float = 1.0,
+        repetitionPenalty: Float = 1.0,
+        repetitionContextSize: Int = 32
+    ) {
+        self.maxTokens = maxTokens
+        self.temperature = temperature
+        self.topP = topP
+        self.topK = topK
+        self.verbose = verbose
+        self.language = language
+        self.chunkDuration = chunkDuration
+        self.minChunkDuration = minChunkDuration
+        self.repetitionPenalty = repetitionPenalty
+        self.repetitionContextSize = repetitionContextSize
+    }
+}
+
+public protocol STTGenerationModel: AnyObject {
+    var defaultGenerationParameters: STTGenerateParameters { get }
+
+    func generate(
+        audio: MLXArray,
+        generationParameters: STTGenerateParameters
+    ) -> STTOutput
+
+    func generateStream(
+        audio: MLXArray,
+        generationParameters: STTGenerateParameters
+    ) -> AsyncThrowingStream<STTGeneration, Error>
+}
+
+public extension STTGenerationModel {
+    func generate(
+        audio: MLXArray,
+        generationParameters: STTGenerateParameters? = nil
+    ) -> STTOutput {
+        generate(audio: audio, generationParameters: generationParameters ?? defaultGenerationParameters)
+    }
+
+    func generateStream(
+        audio: MLXArray,
+        generationParameters: STTGenerateParameters? = nil
+    ) -> AsyncThrowingStream<STTGeneration, Error> {
+        generateStream(audio: audio, generationParameters: generationParameters ?? defaultGenerationParameters)
+    }
+}

--- a/SpeechHelper/Sources/SpeechEngine/RealtimeSpeechServer.swift
+++ b/SpeechHelper/Sources/SpeechEngine/RealtimeSpeechServer.swift
@@ -1,0 +1,245 @@
+import Foundation
+import MLX
+import Network
+import SpeechEngineText
+import Synchronization
+
+/// Loopback OpenAI-Realtime-compatible ASR server: a drop-in for the Python `voxmlx`
+/// process. Serves `GET /health` (the supervisor's readiness probe) and a WebSocket
+/// `/v1/realtime` on the same port, driving a `VoxtralRealtimeStreamSession` per connection.
+///
+/// All model/session access is confined to one serial queue — MLX inference is not
+/// concurrency-safe, and dictation uses one connection at a time anyway. The Network
+/// callbacks (also serialized per connection) only parse bytes and hand decoded messages to
+/// that queue in order.
+public final class RealtimeSpeechServer: @unchecked Sendable {
+    private let model: VoxtralRealtimeModel
+    private let transcriptionDelayMs: Int?
+    private let listener: NWListener
+    private let netQueue = DispatchQueue(label: "localvoxtral.speechd.net")
+    private let inferenceQueue = DispatchQueue(label: "localvoxtral.speechd.inference")
+
+    /// Called when the listener dies after serving began; the supervised helper passes
+    /// `{ exit(1) }` so a dead port gets the process restarted (mirrors PolishHelper).
+    public var onListenerFailure: (@Sendable (Error) -> Void)?
+
+    /// Load the Voxtral model and build a server ready to `start()`. Public entry point for the
+    /// executable target, which cannot see the (module-internal) model type. Sets the MLX GPU
+    /// cache limit and loads from an HF id or a local directory.
+    public static func load(
+        modelID: String?,
+        modelDirectory: String?,
+        port: UInt16,
+        transcriptionDelayMs: Int?,
+        cacheLimitMB: Int
+    ) async throws -> RealtimeSpeechServer {
+        MLX.GPU.set(cacheLimit: cacheLimitMB * 1024 * 1024)
+        let model: VoxtralRealtimeModel
+        if let dir = modelDirectory {
+            model = try VoxtralRealtimeModel.fromDirectory(URL(fileURLWithPath: dir))
+        } else if let id = modelID {
+            model = try await VoxtralRealtimeModel.fromPretrained(id)
+        } else {
+            throw ServerError.noModelSpecified
+        }
+        return try RealtimeSpeechServer(
+            model: model, port: port, transcriptionDelayMs: transcriptionDelayMs)
+    }
+
+    public enum ServerError: Error { case noModelSpecified }
+
+    init(model: VoxtralRealtimeModel, port: UInt16, transcriptionDelayMs: Int?) throws {
+        self.model = model
+        self.transcriptionDelayMs = transcriptionDelayMs
+        let parameters = NWParameters.tcp
+        parameters.allowLocalEndpointReuse = true
+        parameters.requiredLocalEndpoint = NWEndpoint.hostPort(
+            host: .ipv4(.loopback),
+            port: NWEndpoint.Port(rawValue: port) ?? .any
+        )
+        self.listener = try NWListener(using: parameters)
+    }
+
+    public var boundPort: UInt16 { listener.port?.rawValue ?? 0 }
+
+    public func start() async throws {
+        listener.newConnectionHandler = { [weak self] connection in
+            self?.accept(connection)
+        }
+        let resumeOnce = ResumeOnce()
+        try await withCheckedThrowingContinuation { (cont: CheckedContinuation<Void, Error>) in
+            listener.stateUpdateHandler = { [weak self] state in
+                switch state {
+                case .ready:
+                    resumeOnce.run { cont.resume() }
+                case .failed(let error), .waiting(let error):
+                    // Pre-ready fails start(); post-ready means the listener died under us —
+                    // cancel and escalate so the supervised helper exits and is restarted.
+                    let wasPreReady = resumeOnce.run { cont.resume(throwing: error) }
+                    self?.listener.cancel()
+                    if !wasPreReady { self?.onListenerFailure?(error) }
+                case .cancelled:
+                    resumeOnce.run { cont.resume(throwing: CancellationError()) }
+                default:
+                    break
+                }
+            }
+            listener.start(queue: netQueue)
+        }
+    }
+
+    /// A continuation resumes once, but the listener can emit several terminal transitions —
+    /// collapse them to the first. `run` returns whether THIS call was first (the body ran).
+    private final class ResumeOnce: Sendable {
+        private let resumed = Mutex(false)
+        @discardableResult
+        func run(_ body: () -> Void) -> Bool {
+            let first = resumed.withLock { v in let p = v; v = true; return !p }
+            if first { body() }
+            return first
+        }
+    }
+
+    public func stop() { listener.cancel() }
+
+    // MARK: - Per-connection state
+
+    /// Mutable state for one connection, touched only on the network queue (buffer/phase) and
+    /// the inference queue (session). @unchecked because it crosses those queue boundaries;
+    /// the two never touch the same field concurrently.
+    private final class Connection: @unchecked Sendable {
+        var phase: Phase = .http
+        var buffer = Data()
+        var session: VoxtralRealtimeStreamSession?
+        enum Phase { case http, webSocket }
+    }
+
+    private func accept(_ connection: NWConnection) {
+        connection.start(queue: netQueue)
+        receive(connection, Connection())
+    }
+
+    private func receive(_ connection: NWConnection, _ ctx: Connection) {
+        connection.receive(minimumIncompleteLength: 1, maximumLength: 1 << 16) {
+            [weak self] data, _, isComplete, error in
+            guard let self else { connection.cancel(); return }
+            if let data, !data.isEmpty {
+                ctx.buffer.append(data)
+                do {
+                    try self.drain(connection, ctx)
+                } catch {
+                    connection.cancel()
+                    return
+                }
+            }
+            if error != nil || isComplete { connection.cancel(); return }
+            self.receive(connection, ctx)
+        }
+    }
+
+    /// Consume as much of `ctx.buffer` as forms complete units (the HTTP head, then whole WS
+    /// frames).
+    private func drain(_ connection: NWConnection, _ ctx: Connection) throws {
+        if ctx.phase == .http {
+            guard let (head, headerBytes) = WebSocketHandshake.parseRequestHead(ctx.buffer) else {
+                return  // need more bytes
+            }
+            ctx.buffer.removeFirst(headerBytes)
+
+            guard head.isWebSocketUpgrade, let key = head.header("sec-websocket-key") else {
+                // Plain HTTP: the readiness probe. Anything else also gets a simple 200 so a
+                // stray GET can't wedge the supervisor.
+                let json = head.path == "/health" ? #"{"status":"ok"}"# : #"{"status":"ok"}"#
+                self.rawSend(connection, WebSocketHandshake.httpResponse(status: "200 OK", json: json),
+                             thenClose: true)
+                return
+            }
+
+            self.rawSend(connection, WebSocketHandshake.upgradeResponse(secWebSocketKey: key))
+            ctx.phase = .webSocket
+            // The client gates flushing its queued messages on session.created (with a 3s
+            // fallback), so send it as soon as the socket is up.
+            self.sendServer(connection, .sessionCreated)
+        }
+
+        // WebSocket phase: decode every complete frame currently buffered.
+        while ctx.phase == .webSocket {
+            let result = try WebSocketFrameCodec.decode(ctx.buffer)
+            guard case .frame(let frame, let consumed) = result else { break }
+            ctx.buffer.removeFirst(consumed)
+            try self.handle(frame, connection, ctx)
+        }
+    }
+
+    private func handle(_ frame: WebSocketFrame, _ connection: NWConnection, _ ctx: Connection) throws {
+        switch frame.opcode {
+        case .ping:
+            rawSend(connection, WebSocketFrameCodec.pong(frame.payload))
+        case .close:
+            rawSend(connection, WebSocketFrameCodec.close(), thenClose: true)
+        case .pong, .continuation:
+            break
+        case .text, .binary:
+            let message: RealtimeClientMessage
+            do {
+                message = try RealtimeClientMessage.parse(frame.payload)
+            } catch {
+                sendServer(connection, .error(message: "malformed message: \(error)"))
+                return
+            }
+            dispatch(message, connection, ctx)
+        }
+    }
+
+    // MARK: - Inference (serial queue)
+
+    private func dispatch(_ message: RealtimeClientMessage, _ connection: NWConnection, _ ctx: Connection) {
+        inferenceQueue.async { [weak self] in
+            guard let self else { return }
+            switch message {
+            case .sessionUpdate:
+                self.sendServer(connection, .sessionUpdated)
+            case .audioAppend(let base64):
+                guard let samples = PCM16.decode(base64: base64) else {
+                    self.sendServer(connection, .error(message: "Invalid PCM16 payload"))
+                    return
+                }
+                let session = self.ensureSession(ctx)
+                let delta = session.step(samples).text
+                if !delta.isEmpty { self.sendServer(connection, .transcriptDelta(delta)) }
+            case .commit(let final):
+                guard final else { return }  // non-final commit is a no-op, matching voxmlx
+                let session = self.ensureSession(ctx)
+                let tail = session.finish().text
+                if !tail.isEmpty { self.sendServer(connection, .transcriptDelta(tail)) }
+                self.sendServer(connection, .transcriptDone(text: session.text))
+                ctx.session = nil  // ready for the next utterance
+            case .clear:
+                ctx.session = nil
+            case .ignored:
+                break
+            }
+        }
+    }
+
+    /// Must be called on `inferenceQueue`.
+    private func ensureSession(_ ctx: Connection) -> VoxtralRealtimeStreamSession {
+        if let s = ctx.session { return s }
+        let s = model.makeStreamSession(temperature: 0.0, transcriptionDelayMs: transcriptionDelayMs)
+        ctx.session = s
+        return s
+    }
+
+    // MARK: - Send helpers
+
+    private func sendServer(_ connection: NWConnection, _ message: RealtimeServerMessage) {
+        rawSend(connection, WebSocketFrameCodec.text(message.json()))
+    }
+
+    private func rawSend(_ connection: NWConnection, _ data: Data, thenClose: Bool = false) {
+        connection.send(
+            content: data,
+            completion: .contentProcessed { _ in if thenClose { connection.cancel() } }
+        )
+    }
+}

--- a/SpeechHelper/Sources/SpeechEngine/STTOutput.swift
+++ b/SpeechHelper/Sources/SpeechEngine/STTOutput.swift
@@ -1,0 +1,152 @@
+//
+//  STTOutput.swift
+//  MLXAudioSTT
+//
+// Created by Prince Canuma on 04/01/2026.
+//
+
+import Foundation
+
+// MARK: - STT Generation Events
+
+/// Events emitted during speech-to-text streaming generation.
+public enum STTGeneration: Sendable {
+    /// A generated text token during transcription
+    case token(String)
+    /// Generation statistics
+    case info(STTGenerationInfo)
+    /// Final transcription result
+    case result(STTOutput)
+}
+
+/// Information about the STT generation process.
+public struct STTGenerationInfo: Sendable {
+    public let promptTokenCount: Int
+    public let generationTokenCount: Int
+    public let prefillTime: TimeInterval
+    public let generateTime: TimeInterval
+    public let tokensPerSecond: Double
+    public let peakMemoryUsage: Double
+
+    public init(
+        promptTokenCount: Int,
+        generationTokenCount: Int,
+        prefillTime: TimeInterval,
+        generateTime: TimeInterval,
+        tokensPerSecond: Double,
+        peakMemoryUsage: Double
+    ) {
+        self.promptTokenCount = promptTokenCount
+        self.generationTokenCount = generationTokenCount
+        self.prefillTime = prefillTime
+        self.generateTime = generateTime
+        self.tokensPerSecond = tokensPerSecond
+        self.peakMemoryUsage = peakMemoryUsage
+    }
+
+    public var summary: String {
+        """
+        Prompt:     \(promptTokenCount) tokens, \(String(format: "%.2f", Double(promptTokenCount) / max(prefillTime, 0.001))) tokens/s, \(String(format: "%.3f", prefillTime))s
+        Generation: \(generationTokenCount) tokens, \(String(format: "%.2f", tokensPerSecond)) tokens/s, \(String(format: "%.3f", generateTime))s
+        Peak Memory Usage: \(peakMemoryUsage) GB
+        """
+    }
+}
+
+/// Errors that can occur during STT generation.
+public enum STTError: Error, LocalizedError {
+    case modelNotInitialized(String)
+    case generationFailed(String)
+    case invalidInput(String)
+    case audioProcessingFailed(String)
+
+    public var errorDescription: String? {
+        switch self {
+        case .modelNotInitialized(let message):
+            return "Model not initialized: \(message)"
+        case .generationFailed(let message):
+            return "Generation failed: \(message)"
+        case .invalidInput(let message):
+            return "Invalid input: \(message)"
+        case .audioProcessingFailed(let message):
+            return "Audio processing failed: \(message)"
+        }
+    }
+}
+
+// MARK: - STT Output
+
+/// Output from speech-to-text transcription.
+public struct STTOutput: @unchecked Sendable {
+    /// The transcribed text.
+    public let text: String
+
+    /// Transcription segments with timing information (optional).
+    public let segments: [[String: Any]]?
+
+    /// Detected language (optional).
+    public let language: String?
+
+    /// Number of tokens in the prompt.
+    public let promptTokens: Int
+
+    /// Number of tokens generated.
+    public let generationTokens: Int
+
+    /// Total number of tokens processed.
+    public let totalTokens: Int
+
+    /// Prompt processing tokens per second.
+    public let promptTps: Double
+
+    /// Generation tokens per second.
+    public let generationTps: Double
+
+    /// Total processing time in seconds.
+    public let totalTime: Double
+
+    /// Peak memory usage in GB.
+    public let peakMemoryUsage: Double
+
+    public init(
+        text: String,
+        segments: [[String: Any]]? = nil,
+        language: String? = nil,
+        promptTokens: Int = 0,
+        generationTokens: Int = 0,
+        totalTokens: Int = 0,
+        promptTps: Double = 0.0,
+        generationTps: Double = 0.0,
+        totalTime: Double = 0.0,
+        peakMemoryUsage: Double = 0.0
+    ) {
+        self.text = text
+        self.segments = segments
+        self.language = language
+        self.promptTokens = promptTokens
+        self.generationTokens = generationTokens
+        self.totalTokens = totalTokens
+        self.promptTps = promptTps
+        self.generationTps = generationTps
+        self.totalTime = totalTime
+        self.peakMemoryUsage = peakMemoryUsage
+    }
+}
+
+extension STTOutput: CustomStringConvertible {
+    public var description: String {
+        var result = "STTOutput:\n"
+        result += "  text: \(text)\n"
+        if let language = language {
+            result += "  language: \(language)\n"
+        }
+        result += "  prompt_tokens: \(promptTokens)\n"
+        result += "  generation_tokens: \(generationTokens)\n"
+        result += "  total_tokens: \(totalTokens)\n"
+        result += "  prompt_tps: \(String(format: "%.2f", promptTps))\n"
+        result += "  generation_tps: \(String(format: "%.2f", generationTps))\n"
+        result += "  total_time: \(String(format: "%.2f", totalTime))s\n"
+        result += "  peak_memory_usage: \(String(format: "%.2f", peakMemoryUsage)) GB"
+        return result
+    }
+}

--- a/SpeechHelper/Sources/SpeechEngine/VoxtralRealtime.swift
+++ b/SpeechHelper/Sources/SpeechEngine/VoxtralRealtime.swift
@@ -1,0 +1,654 @@
+import Foundation
+import MLX
+import MLXNN
+import MLXAudioCore
+import MLXAudioVAD
+import MLXLMCommon
+import HuggingFace
+
+private enum VoxtralRealtimeConstants {
+    static let sampleRate = 16000
+    static let frameRate: Float = 12.5
+    static let rawAudioLengthPerToken = Int(Float(sampleRate) / frameRate) // 1280
+    static let hopLength = 160
+    static let audioLengthPerToken = rawAudioLengthPerToken / hopLength // 8
+}
+
+private struct VoxtralPrefillContext {
+    let adapterOut: MLXArray
+    let nAudioTotal: Int
+    let promptLength: Int
+    var logits: MLXArray
+    var cache: [VoxtralRealtimeDecoderKVCache?]
+    let startTime: Date
+}
+
+public final class VoxtralRealtimeModel: Module, STTGenerationModel {
+    public let config: VoxtralRealtimeConfig
+
+    @ModuleInfo(key: "encoder") var encoder: VoxtralRealtimeAudioEncoder
+    @ModuleInfo(key: "decoder") var decoder: VoxtralRealtimeDecoder
+
+    private var tokenizer: VoxtralRealtimeTokenizer?
+    private var adaScaleDelay: Int = -1
+
+    public var defaultGenerationParameters: STTGenerateParameters {
+        STTGenerateParameters(
+            maxTokens: 4096,
+            temperature: 0.0,
+            topP: 1.0,
+            topK: 0,
+            verbose: false,
+            language: "en",
+            chunkDuration: 1200.0,
+            minChunkDuration: 1.0
+        )
+    }
+
+    public init(_ config: VoxtralRealtimeConfig) {
+        self.config = config
+        self._encoder.wrappedValue = VoxtralRealtimeAudioEncoder(
+            config.encoderArgs,
+            decoderDim: config.decoder.dim
+        )
+        self._decoder.wrappedValue = VoxtralRealtimeDecoder(config.decoder)
+    }
+
+    public func generate(
+        audio: MLXArray,
+        generationParameters: STTGenerateParameters
+    ) -> STTOutput {
+        let audio1D = audio.ndim > 1 ? audio.mean(axis: -1) : audio
+        var context = encodeAndPrefill(
+            audio: audio1D,
+            verbose: generationParameters.verbose,
+            transcriptionDelayMs: nil
+        )
+
+        var generated: [Int] = []
+        let decodeStart = Date()
+
+        for pos in context.promptLength..<context.nAudioTotal {
+            let token = sample(logits: context.logits, temperature: generationParameters.temperature)
+            generated.append(token)
+
+            if token == config.eosTokenId || generated.count > generationParameters.maxTokens {
+                break
+            }
+
+            let tokenEmbed = decoder.embedToken(tokenId: token)
+            let inputEmbed: MLXArray
+            if pos < context.adapterOut.shape[0] {
+                inputEmbed = context.adapterOut[pos] + tokenEmbed
+            } else {
+                inputEmbed = tokenEmbed
+            }
+
+            let next = decoder(
+                inputEmbed.expandedDimensions(axis: 0),
+                startPos: pos,
+                cache: context.cache
+            )
+            context.cache = next.1
+            context.logits = decoder.logits(next.0[0])
+
+            eval(context.logits)
+            if generated.count % 256 == 0 {
+                Memory.clearCache()
+            }
+        }
+
+        if generated.last == config.eosTokenId {
+            _ = generated.popLast()
+        }
+
+        let text = tokenizer?.decode(tokenIds: generated).trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+
+        let end = Date()
+        let totalTime = end.timeIntervalSince(context.startTime)
+        let decodeTime = end.timeIntervalSince(decodeStart)
+
+        Memory.clearCache()
+
+        return STTOutput(
+            text: text,
+            language: generationParameters.language,
+            promptTokens: context.promptLength,
+            generationTokens: generated.count,
+            totalTokens: context.promptLength + generated.count,
+            promptTps: totalTime > 0 ? Double(context.promptLength) / totalTime : 0,
+            generationTps: decodeTime > 0 ? Double(generated.count) / decodeTime : 0,
+            totalTime: totalTime,
+            peakMemoryUsage: Double(Memory.peakMemory) / 1e9
+        )
+    }
+
+    public func generate(
+        audio: MLXArray,
+        generationParameters: STTGenerateParameters,
+        vad: (model: SileroVAD, config: SpeechSegmentConfig)?
+    ) -> STTOutput {
+        guard let vad else {
+            return generate(audio: audio, generationParameters: generationParameters)
+        }
+        let audio1D = audio.ndim > 1 ? audio.mean(axis: -1) : audio
+        let chunks: [(MLXArray, Float)]
+        do {
+            chunks = try segmentSpeech(
+                audio: audio1D,
+                sampleRate: VoxtralRealtimeConstants.sampleRate,
+                vadModel: vad.model,
+                config: vad.config
+            )
+        } catch {
+            if generationParameters.verbose {
+                print("VAD pre-processing failed (\(error)); falling back to single-pass generate")
+            }
+            return generate(audio: audio1D, generationParameters: generationParameters)
+        }
+        if chunks.count <= 1 {
+            // One speech region: transcribe the trimmed chunk, not the original buffer
+            // (keeps the VAD's leading/trailing-silence removal). `chunks` is never empty,
+            // but fall back to `audio1D` defensively.
+            return generate(audio: chunks.first?.0 ?? audio1D, generationParameters: generationParameters)
+        }
+
+        var outputs: [STTOutput] = []
+        outputs.reserveCapacity(chunks.count)
+        var remainingTokens = generationParameters.maxTokens
+        for (chunkAudio, offsetSeconds) in chunks {
+            if remainingTokens <= 0 { break }
+            if generationParameters.verbose {
+                print("Voxtral VAD chunk at \(String(format: "%.1f", offsetSeconds))s")
+            }
+            let chunkParameters = STTGenerateParameters(
+                maxTokens: remainingTokens,
+                temperature: generationParameters.temperature,
+                topP: generationParameters.topP,
+                topK: generationParameters.topK,
+                verbose: generationParameters.verbose,
+                language: generationParameters.language,
+                chunkDuration: generationParameters.chunkDuration,
+                minChunkDuration: generationParameters.minChunkDuration
+            )
+            let out = generate(audio: chunkAudio, generationParameters: chunkParameters)
+            outputs.append(out)
+            remainingTokens = max(0, remainingTokens - out.generationTokens)
+        }
+
+        let combinedText = outputs
+            .map(\.text)
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { !$0.isEmpty }
+            .joined(separator: "\n")
+        let promptTokens = outputs.reduce(0) { $0 + $1.promptTokens }
+        let generationTokens = outputs.reduce(0) { $0 + $1.generationTokens }
+        let totalTokens = outputs.reduce(0) { $0 + $1.totalTokens }
+        let totalTime = outputs.reduce(0.0) { $0 + $1.totalTime }
+        let peakMemoryUsage = outputs.map(\.peakMemoryUsage).max() ?? 0
+
+        return STTOutput(
+            text: combinedText,
+            language: generationParameters.language,
+            promptTokens: promptTokens,
+            generationTokens: generationTokens,
+            totalTokens: totalTokens,
+            promptTps: totalTime > 0 ? Double(promptTokens) / totalTime : 0,
+            generationTps: totalTime > 0 ? Double(generationTokens) / totalTime : 0,
+            totalTime: totalTime,
+            peakMemoryUsage: peakMemoryUsage
+        )
+    }
+
+    public func generateStream(
+        audio: MLXArray,
+        generationParameters: STTGenerateParameters
+    ) -> AsyncThrowingStream<STTGeneration, Error> {
+        AsyncThrowingStream { continuation in
+            let audio1D = audio.ndim > 1 ? audio.mean(axis: -1) : audio
+            var context = encodeAndPrefill(
+                audio: audio1D,
+                verbose: generationParameters.verbose,
+                transcriptionDelayMs: nil
+            )
+
+            var generated: [Int] = []
+            var previousText = ""
+            let decodeStart = Date()
+
+            for pos in context.promptLength..<context.nAudioTotal {
+                let token = sample(logits: context.logits, temperature: generationParameters.temperature)
+                generated.append(token)
+
+                let filtered = generated.filter { $0 != config.eosTokenId }
+                let textSoFar = tokenizer?.decode(tokenIds: filtered) ?? ""
+                if textSoFar != previousText {
+                    let delta: String
+                    if textSoFar.hasPrefix(previousText) {
+                        delta = String(textSoFar.dropFirst(previousText.count))
+                    } else {
+                        delta = textSoFar
+                    }
+                    if !delta.isEmpty {
+                        continuation.yield(.token(delta))
+                    }
+                    previousText = textSoFar
+                }
+
+                if token == config.eosTokenId || generated.count > generationParameters.maxTokens {
+                    break
+                }
+
+                let tokenEmbed = decoder.embedToken(tokenId: token)
+                let inputEmbed: MLXArray
+                if pos < context.adapterOut.shape[0] {
+                    inputEmbed = context.adapterOut[pos] + tokenEmbed
+                } else {
+                    inputEmbed = tokenEmbed
+                }
+
+                let next = decoder(
+                    inputEmbed.expandedDimensions(axis: 0),
+                    startPos: pos,
+                    cache: context.cache
+                )
+                context.cache = next.1
+                context.logits = decoder.logits(next.0[0])
+
+                eval(context.logits)
+                if generated.count % 256 == 0 {
+                    Memory.clearCache()
+                }
+            }
+
+            if generated.last == self.config.eosTokenId {
+                _ = generated.popLast()
+            }
+
+            let finalText = tokenizer?.decode(tokenIds: generated).trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+            let end = Date()
+            let totalTime = end.timeIntervalSince(context.startTime)
+            let decodeTime = end.timeIntervalSince(decodeStart)
+
+            let output = STTOutput(
+                text: finalText,
+                language: generationParameters.language,
+                promptTokens: context.promptLength,
+                generationTokens: generated.count,
+                totalTokens: context.promptLength + generated.count,
+                promptTps: totalTime > 0 ? Double(context.promptLength) / totalTime : 0,
+                generationTps: decodeTime > 0 ? Double(generated.count) / decodeTime : 0,
+                totalTime: totalTime,
+                peakMemoryUsage: Double(Memory.peakMemory) / 1e9
+            )
+
+            continuation.yield(.result(output))
+            continuation.finish()
+        }
+    }
+}
+
+extension VoxtralRealtimeModel {
+    func numAudioTokens(_ audioLength: Int) -> Int {
+        let hop = VoxtralRealtimeConstants.hopLength
+        let perTok = VoxtralRealtimeConstants.audioLengthPerToken
+
+        let frames: Int
+        if audioLength % hop != 0 {
+            frames = Int(ceil(Double(audioLength) / Double(hop) - 1.0))
+        } else {
+            frames = audioLength / hop
+        }
+        return Int(ceil(Double(frames) / Double(perTok)))
+    }
+
+    func numDelayTokens(_ delayMs: Int) -> Int {
+        let delayLen = Int(Double(delayMs) / 1000.0 * Double(VoxtralRealtimeConstants.sampleRate))
+        return numAudioTokens(delayLen)
+    }
+
+    func padAudioStreaming(_ audio: MLXArray, leftTokens: Int, rightTokens: Int) -> MLXArray {
+        let mult = VoxtralRealtimeConstants.rawAudioLengthPerToken
+        let nSamples = audio.shape[0]
+
+        let alignPad = (mult - (nSamples % mult)) % mult
+        let rightPad = alignPad + rightTokens * mult
+        let leftPad = leftTokens * mult
+
+        return MLX.padded(audio, widths: [IntOrPair((leftPad, rightPad))])
+    }
+
+    func ensureMelFilters() -> MLXArray {
+        let a = config.audioEncodingArgs
+        return VoxtralRealtimeAudio.computeMelFilters(
+            numMelBins: a.numMelBins,
+            windowSize: a.windowSize,
+            sampleRate: a.samplingRate
+        ).asType(.float32)
+    }
+
+    func ensureAdaScales(transcriptionDelayMs: Int?) {
+        let delayMs = transcriptionDelayMs ?? config.transcriptionDelayMs
+        let delayTokens = numDelayTokens(delayMs)
+
+        if delayTokens != adaScaleDelay {
+            let tCond = voxtralComputeTimeEmbedding(
+                tValue: Float(delayTokens),
+                dim: config.decoder.dim
+            )
+            decoder.precomputeAdaScales(tCond)
+            if let adaScales = decoder.adaScales {
+                for scale in adaScales {
+                    if let scale {
+                        eval(scale)
+                    }
+                }
+            }
+            adaScaleDelay = delayTokens
+        }
+    }
+
+    func prepareMel(_ audio: MLXArray, transcriptionDelayMs: Int?) -> (MLXArray, Int) {
+        let delayMs = transcriptionDelayMs ?? config.transcriptionDelayMs
+        let nDelay = numDelayTokens(delayMs)
+        let nLeft = config.nLeftPadTokens
+        let nRight = (nDelay + 1) + 10
+
+        let padded = padAudioStreaming(audio, leftTokens: nLeft, rightTokens: nRight)
+        let a = config.audioEncodingArgs
+        let mel = VoxtralRealtimeAudio.computeMelSpectrogram(
+            audio: padded,
+            melFilters: ensureMelFilters(),
+            windowSize: a.windowSize,
+            hopLength: a.hopLength,
+            globalLogMelMax: a.globalLogMelMax
+        )
+
+        if mel.shape[1] % 2 != 0 {
+            return (mel[0..., 1...], nDelay)
+        }
+        return (mel, nDelay)
+    }
+
+    /// Encode audio → audio-conditioning rows (`adapterOut`), the per-token span
+    /// (`nAudioTotal`), and the decoder prompt length. Shared by the offline
+    /// (`encodeAndPrefill`) and streaming (`VoxtralRealtimeStreamSession`) paths.
+    /// Causal conv + causal/sliding-window attention make `adapterOut[0..<k]`
+    /// identical whether encoded from a prefix or the full buffer.
+    /// Conv-stem seam: audio → conv-stem frames (`convOut`, the transformer input),
+    /// the per-token span, and the prompt length. Shared by the offline encode and
+    /// the streaming session (which feeds `convOut` incrementally).
+    func convStemForAudio(
+        audio: MLXArray,
+        transcriptionDelayMs: Int?
+    ) -> (convOut: MLXArray, nAudioTotal: Int, promptLength: Int) {
+        ensureAdaScales(transcriptionDelayMs: transcriptionDelayMs)
+        let (mel, nDelay) = prepareMel(audio, transcriptionDelayMs: transcriptionDelayMs)
+
+        let convOut = encoder.convStem(mel)
+        let ds = config.encoderArgs.downsampleFactor
+        let nAudioTotal = convOut.shape[0] / ds
+        let promptLength = 1 + config.nLeftPadTokens + nDelay
+        return (convOut, nAudioTotal, promptLength)
+    }
+
+    func encodeAudio(
+        audio: MLXArray,
+        transcriptionDelayMs: Int?
+    ) -> (adapterOut: MLXArray, nAudioTotal: Int, promptLength: Int) {
+        let (convOut, nAudioTotal, promptLength) = convStemForAudio(
+            audio: audio,
+            transcriptionDelayMs: transcriptionDelayMs
+        )
+        let adapterOut: MLXArray
+        if convOut.shape[0] <= config.encoderArgs.slidingWindow {
+            adapterOut = encoder.encodeFull(convOut)
+        } else {
+            adapterOut = encoder.encodeChunked(convOut)
+        }
+        return (adapterOut, nAudioTotal, promptLength)
+    }
+
+    fileprivate func encodeAndPrefill(
+        audio: MLXArray,
+        verbose: Bool,
+        transcriptionDelayMs: Int?
+    ) -> VoxtralPrefillContext {
+        let start = Date()
+
+        let (adapterOut, nAudioTotal, promptLength) = encodeAudio(
+            audio: audio,
+            transcriptionDelayMs: transcriptionDelayMs
+        )
+        let nDelay = promptLength - 1 - config.nLeftPadTokens
+
+        let promptIds = [config.bosTokenId] + Array(
+            repeating: config.streamingPadTokenId,
+            count: config.nLeftPadTokens + nDelay
+        )
+        let promptIdsMX = MLXArray(promptIds.map(Int32.init))
+        let promptTextEmbeds = decoder.embedTokens(promptIdsMX)
+
+        let prefixEmbeds = adapterOut[0..<promptLength, 0...] + promptTextEmbeds
+
+        let prefill = decoder(prefixEmbeds, startPos: 0, cache: nil)
+        let h = prefill.0
+        let cache = prefill.1
+
+        let logits = decoder.logits(h[h.shape[0] - 1])
+
+        var cacheArrays: [MLXArray] = [logits]
+        for layerCache in cache {
+            if let layerCache {
+                cacheArrays.append(layerCache.keys)
+                cacheArrays.append(layerCache.values)
+            }
+        }
+        eval(cacheArrays)
+
+        if verbose {
+            let seconds = Double(audio.shape[0]) / Double(VoxtralRealtimeConstants.sampleRate)
+            print("Audio: \(audio.shape[0]) samples (\(String(format: "%.1f", seconds))s)")
+            print("Prompt: \(promptLength) tokens, Audio span: \(nAudioTotal) tokens")
+        }
+
+        return VoxtralPrefillContext(
+            adapterOut: adapterOut,
+            nAudioTotal: nAudioTotal,
+            promptLength: promptLength,
+            logits: logits,
+            cache: cache,
+            startTime: start
+        )
+    }
+
+    /// Token-id → text seam for the streaming session (which lives in another file
+    /// and cannot reach the private `tokenizer`).
+    func decodeStreaming(_ tokenIds: [Int]) -> String {
+        tokenizer?.decode(tokenIds: tokenIds) ?? ""
+    }
+
+    func sample(logits: MLXArray, temperature: Float) -> Int {
+        let logits1D: MLXArray
+        if logits.ndim > 1 {
+            logits1D = logits.squeezed()
+        } else {
+            logits1D = logits
+        }
+
+        if temperature == 0 {
+            return logits1D.argMax(axis: -1).item(Int.self)
+        }
+
+        let scaled = (logits1D / temperature).expandedDimensions(axis: 0)
+        let sampled = categorical(scaled)
+        return sampled.item(Int.self)
+    }
+}
+
+public extension VoxtralRealtimeModel {
+    static func fromDirectory(_ modelDir: URL) throws -> VoxtralRealtimeModel {
+        let configURL = modelDir.appendingPathComponent("config.json")
+        let configData = try Data(contentsOf: configURL)
+        let config = try JSONDecoder().decode(VoxtralRealtimeConfig.self, from: configData)
+
+        let quantConfig = try JSONDecoder().decode(VoxtralQuantizationConfig.self, from: configData)
+
+        let model = VoxtralRealtimeModel(config)
+        model.tokenizer = try VoxtralRealtimeTokenizer.fromModelDirectory(modelDir)
+        guard model.tokenizer != nil else {
+            throw NSError(
+                domain: "VoxtralRealtimeModel",
+                code: 2,
+                userInfo: [
+                    NSLocalizedDescriptionKey: "Failed to load tokenizer from \(modelDir.path)"
+                ]
+            )
+        }
+        _ = model.ensureMelFilters()
+
+        let files = try FileManager.default.contentsOfDirectory(at: modelDir, includingPropertiesForKeys: nil)
+        let safetensors = files.filter { $0.pathExtension == "safetensors" }
+
+        var weights: [String: MLXArray] = [:]
+        for file in safetensors {
+            let shard = try MLX.loadArrays(url: file)
+            weights.merge(shard) { _, new in new }
+        }
+
+        let sanitized = sanitize(weights: weights)
+
+        if let perLayerQuantization = quantConfig.perLayerQuantization {
+            quantize(model: model) { path, _ in
+                guard model.shouldQuantize(path: path) else {
+                    return nil
+                }
+                if sanitized["\(path).scales"] != nil {
+                    return perLayerQuantization.quantization(layer: path)?.asTuple
+                }
+                return nil
+            }
+        }
+
+        try model.update(parameters: ModuleParameters.unflattened(sanitized), verify: .all)
+        model.ensureAdaScales(transcriptionDelayMs: config.transcriptionDelayMs)
+        eval(model)
+
+        return model
+    }
+
+    static func fromPretrained(_ modelPath: String) async throws -> VoxtralRealtimeModel {
+        let hfToken: String? = ProcessInfo.processInfo.environment["HF_TOKEN"]
+            ?? Bundle.main.object(forInfoDictionaryKey: "HF_TOKEN") as? String
+
+        guard let repoID = Repo.ID(rawValue: modelPath) else {
+            throw NSError(
+                domain: "VoxtralRealtimeModel",
+                code: 1,
+                userInfo: [NSLocalizedDescriptionKey: "Invalid repository ID: \(modelPath)"]
+            )
+        }
+
+        let modelDir = try await ModelUtils.resolveOrDownloadModel(
+            repoID: repoID,
+            requiredExtension: "safetensors",
+            hfToken: hfToken
+        )
+
+        return try fromDirectory(modelDir)
+    }
+
+    static func sanitize(weights: [String: MLXArray]) -> [String: MLXArray] {
+        var newWeights: [String: MLXArray] = [:]
+        newWeights.reserveCapacity(weights.count)
+
+        let encPrefix = "mm_streams_embeddings.embedding_module.whisper_encoder"
+        let adapterPrefix = "mm_streams_embeddings.embedding_module"
+        let tokEmbKey = "mm_streams_embeddings.embedding_module.tok_embeddings.weight"
+
+        for (key, value) in weights {
+            var v = value
+            var mapped: String?
+
+            if key == tokEmbKey {
+                mapped = "decoder.tok_embeddings.weight"
+            } else if key == "norm.weight" {
+                mapped = "decoder.norm.weight"
+            } else if key.hasPrefix("\(encPrefix).conv_layers.") {
+                let rest = String(key.dropFirst("\(encPrefix).conv_layers.".count))
+                let parts = rest.split(separator: ".", maxSplits: 2, omittingEmptySubsequences: false)
+                if parts.count == 3 {
+                    let layerIdx = String(parts[0])
+                    let param = String(parts[2])
+                    mapped = "encoder.conv_layers_\(layerIdx)_conv.conv.\(param)"
+                    if param == "weight" && v.ndim == 3 {
+                        v = v.transposed(0, 2, 1)
+                    }
+                }
+            } else if key.hasPrefix("\(encPrefix).transformer.layers.") {
+                let rest = String(key.dropFirst("\(encPrefix).transformer.layers.".count))
+                let parts = rest.split(separator: ".", maxSplits: 1, omittingEmptySubsequences: false)
+                if parts.count == 2 {
+                    let layerIdx = String(parts[0])
+                    var paramPath = String(parts[1])
+                    paramPath = paramPath.replacingOccurrences(of: "feed_forward.w1.", with: "feed_forward_w1.")
+                    paramPath = paramPath.replacingOccurrences(of: "feed_forward.w2.", with: "feed_forward_w2.")
+                    paramPath = paramPath.replacingOccurrences(of: "feed_forward.w3.", with: "feed_forward_w3.")
+                    mapped = "encoder.transformer_layers.\(layerIdx).\(paramPath)"
+                }
+            } else if key.hasPrefix("\(encPrefix).transformer.norm.") {
+                let rest = String(key.dropFirst("\(encPrefix).transformer.norm.".count))
+                mapped = "encoder.transformer_norm.\(rest)"
+            } else if key.hasPrefix("\(adapterPrefix).audio_language_projection.") {
+                let rest = String(key.dropFirst("\(adapterPrefix).audio_language_projection.".count))
+                let parts = rest.split(separator: ".", maxSplits: 1, omittingEmptySubsequences: false)
+                if parts.count == 2 {
+                    let idx = String(parts[0])
+                    let param = String(parts[1])
+                    mapped = "encoder.audio_language_projection_\(idx).\(param)"
+                }
+            } else if key.hasPrefix("layers.") {
+                let rest = String(key.dropFirst("layers.".count))
+                let parts = rest.split(separator: ".", maxSplits: 1, omittingEmptySubsequences: false)
+                if parts.count == 2 {
+                    let layerIdx = String(parts[0])
+                    var paramPath = String(parts[1])
+                    paramPath = paramPath.replacingOccurrences(of: "feed_forward.w1.", with: "feed_forward_w1.")
+                    paramPath = paramPath.replacingOccurrences(of: "feed_forward.w2.", with: "feed_forward_w2.")
+                    paramPath = paramPath.replacingOccurrences(of: "feed_forward.w3.", with: "feed_forward_w3.")
+                    paramPath = paramPath.replacingOccurrences(of: "ada_rms_norm_t_cond.0.", with: "ada_rms_norm_t_cond.ada_down.")
+                    paramPath = paramPath.replacingOccurrences(of: "ada_rms_norm_t_cond.2.", with: "ada_rms_norm_t_cond.ada_up.")
+                    mapped = "decoder.layers.\(layerIdx).\(paramPath)"
+                }
+            }
+
+            if let mapped {
+                newWeights[mapped] = v
+            } else {
+                newWeights[key] = v
+            }
+        }
+
+        return newWeights
+    }
+
+    func shouldQuantize(path: String) -> Bool {
+        let skipPatterns = [
+            "norm",
+            "ada_rms_norm",
+            "tok_embeddings",
+            "conv_layers",
+            "audio_language_projection",
+        ]
+        return !skipPatterns.contains(where: { path.contains($0) })
+    }
+}
+
+private struct VoxtralQuantizationConfig: Decodable {
+    let perLayerQuantization: BaseConfiguration.PerLayerQuantization?
+
+    init(from decoder: Decoder) throws {
+        let base = try? BaseConfiguration(from: decoder)
+        self.perLayerQuantization = base?.perLayerQuantization
+    }
+}

--- a/SpeechHelper/Sources/SpeechEngine/VoxtralRealtimeAudio.swift
+++ b/SpeechHelper/Sources/SpeechEngine/VoxtralRealtimeAudio.swift
@@ -1,0 +1,104 @@
+import Foundation
+import MLX
+import MLXAudioCore
+
+enum VoxtralRealtimeAudio {
+    static func computeMelFilters(
+        numMelBins: Int = 128,
+        windowSize: Int = 400,
+        sampleRate: Int = 16000
+    ) -> MLXArray {
+        melFilters(
+            sampleRate: sampleRate,
+            nFft: windowSize,
+            nMels: numMelBins,
+            fMin: 0,
+            fMax: 8000,
+            norm: "slaney",
+            melScale: .slaney
+        )
+    }
+
+    static func computeMelSpectrogram(
+        audio: MLXArray,
+        melFilters: MLXArray,
+        windowSize: Int = 400,
+        hopLength: Int = 160,
+        globalLogMelMax: Float = 1.5
+    ) -> MLXArray {
+        // Periodic Hann window uses N denominator, not N-1.
+        let n = MLXArray(0..<windowSize).asType(.float32)
+        let window = 0.5 * (1.0 - cos((2.0 * Float.pi * n) / Float(windowSize)))
+
+        let audio1D: MLXArray
+        if audio.ndim > 1 {
+            audio1D = audio.reshaped([-1])
+        } else {
+            audio1D = audio
+        }
+
+        let paddedAudio = reflectPadCenter(audio1D, pad: windowSize / 2)
+        let nSamples = paddedAudio.shape[0]
+        let nFrames = 1 + max(0, (nSamples - windowSize) / hopLength)
+
+        if nFrames <= 0 {
+            return MLXArray.zeros([melFilters.shape[1], 0], type: Float.self)
+        }
+
+        let frameIdx = asStrided(
+            paddedAudio,
+            [nFrames, windowSize],
+            strides: [hopLength, 1],
+            offset: 0
+        )
+
+        let frames = frameIdx * window.expandedDimensions(axis: 0)
+        let spectrum = MLXFFT.rfft(frames, axis: -1)
+        var magnitudes = MLX.abs(spectrum).square()
+
+        // Match reference: drop last frame, then transpose to [freq, frames].
+        if magnitudes.shape[0] > 0 {
+            magnitudes = magnitudes[0..<(magnitudes.shape[0] - 1), 0...]
+        }
+        magnitudes = magnitudes.transposed(1, 0)
+
+        var melSpec = MLX.matmul(melFilters.transposed(1, 0), magnitudes)
+        melSpec = MLX.maximum(melSpec, MLXArray(Float(1e-10)))
+        var logSpec = MLX.log10(melSpec)
+
+        let minVal = globalLogMelMax - 8.0
+        logSpec = MLX.maximum(logSpec, MLXArray(minVal))
+        logSpec = (logSpec + MLXArray(Float(4.0))) / MLXArray(Float(4.0))
+        return logSpec
+    }
+
+    private static func reflectPadCenter(_ audio: MLXArray, pad: Int) -> MLXArray {
+        guard pad > 0 else { return audio.asType(.float32) }
+
+        let samples = audio.asType(.float32).asArray(Float.self)
+        guard !samples.isEmpty else {
+            return MLXArray.zeros([2 * pad], type: Float.self)
+        }
+
+        func reflectIndex(_ idx: Int, count: Int) -> Int {
+            if count <= 1 { return 0 }
+            var i = idx
+            while i < 0 || i >= count {
+                if i < 0 {
+                    i = -i
+                } else {
+                    i = 2 * count - i - 2
+                }
+            }
+            return i
+        }
+
+        var out = [Float](repeating: 0, count: samples.count + 2 * pad)
+        for i in 0..<out.count {
+            let src = i - pad
+            out[i] = samples[reflectIndex(src, count: samples.count)]
+        }
+
+        return MLXArray(out)
+    }
+}

--- a/SpeechHelper/Sources/SpeechEngine/VoxtralRealtimeConfig.swift
+++ b/SpeechHelper/Sources/SpeechEngine/VoxtralRealtimeConfig.swift
@@ -1,0 +1,284 @@
+import Foundation
+
+public struct VoxtralRealtimeAudioEncodingConfig: Codable, Sendable {
+    public var samplingRate: Int
+    public var frameRate: Float
+    public var numMelBins: Int
+    public var hopLength: Int
+    public var windowSize: Int
+    public var globalLogMelMax: Float
+
+    enum CodingKeys: String, CodingKey {
+        case samplingRate = "sampling_rate"
+        case frameRate = "frame_rate"
+        case numMelBins = "num_mel_bins"
+        case hopLength = "hop_length"
+        case windowSize = "window_size"
+        case globalLogMelMax = "global_log_mel_max"
+    }
+
+    public init(
+        samplingRate: Int = 16000,
+        frameRate: Float = 12.5,
+        numMelBins: Int = 128,
+        hopLength: Int = 160,
+        windowSize: Int = 400,
+        globalLogMelMax: Float = 1.5
+    ) {
+        self.samplingRate = samplingRate
+        self.frameRate = frameRate
+        self.numMelBins = numMelBins
+        self.hopLength = hopLength
+        self.windowSize = windowSize
+        self.globalLogMelMax = globalLogMelMax
+    }
+
+    public init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        samplingRate = try c.decodeIfPresent(Int.self, forKey: .samplingRate) ?? 16000
+        frameRate = try c.decodeIfPresent(Float.self, forKey: .frameRate) ?? 12.5
+        numMelBins = try c.decodeIfPresent(Int.self, forKey: .numMelBins) ?? 128
+        hopLength = try c.decodeIfPresent(Int.self, forKey: .hopLength) ?? 160
+        windowSize = try c.decodeIfPresent(Int.self, forKey: .windowSize) ?? 400
+        globalLogMelMax = try c.decodeIfPresent(Float.self, forKey: .globalLogMelMax) ?? 1.5
+    }
+}
+
+public struct VoxtralRealtimeEncoderConfig: Codable, Sendable {
+    public var dim: Int
+    public var nLayers: Int
+    public var nHeads: Int
+    public var headDim: Int
+    public var hiddenDim: Int
+    public var nKvHeads: Int
+    public var normEps: Float
+    public var ropeTheta: Float
+    public var slidingWindow: Int
+    public var causal: Bool
+    public var useBiases: Bool
+    public var downsampleFactor: Int
+
+    enum CodingKeys: String, CodingKey {
+        case dim
+        case nLayers = "n_layers"
+        case nHeads = "n_heads"
+        case headDim = "head_dim"
+        case hiddenDim = "hidden_dim"
+        case nKvHeads = "n_kv_heads"
+        case normEps = "norm_eps"
+        case ropeTheta = "rope_theta"
+        case slidingWindow = "sliding_window"
+        case causal
+        case useBiases = "use_biases"
+        case downsampleFactor = "downsample_factor"
+    }
+
+    public init(
+        dim: Int = 1280,
+        nLayers: Int = 32,
+        nHeads: Int = 32,
+        headDim: Int = 64,
+        hiddenDim: Int = 5120,
+        nKvHeads: Int = 32,
+        normEps: Float = 1e-5,
+        ropeTheta: Float = 1_000_000,
+        slidingWindow: Int = 750,
+        causal: Bool = true,
+        useBiases: Bool = true,
+        downsampleFactor: Int = 4
+    ) {
+        self.dim = dim
+        self.nLayers = nLayers
+        self.nHeads = nHeads
+        self.headDim = headDim
+        self.hiddenDim = hiddenDim
+        self.nKvHeads = nKvHeads
+        self.normEps = normEps
+        self.ropeTheta = ropeTheta
+        self.slidingWindow = slidingWindow
+        self.causal = causal
+        self.useBiases = useBiases
+        self.downsampleFactor = downsampleFactor
+    }
+
+    public init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        dim = try c.decodeIfPresent(Int.self, forKey: .dim) ?? 1280
+        nLayers = try c.decodeIfPresent(Int.self, forKey: .nLayers) ?? 32
+        nHeads = try c.decodeIfPresent(Int.self, forKey: .nHeads) ?? 32
+        headDim = try c.decodeIfPresent(Int.self, forKey: .headDim) ?? 64
+        hiddenDim = try c.decodeIfPresent(Int.self, forKey: .hiddenDim) ?? 5120
+        nKvHeads = try c.decodeIfPresent(Int.self, forKey: .nKvHeads) ?? 32
+        normEps = try c.decodeIfPresent(Float.self, forKey: .normEps) ?? 1e-5
+        ropeTheta = try c.decodeIfPresent(Float.self, forKey: .ropeTheta) ?? 1_000_000
+        slidingWindow = try c.decodeIfPresent(Int.self, forKey: .slidingWindow) ?? 750
+        causal = try c.decodeIfPresent(Bool.self, forKey: .causal) ?? true
+        useBiases = try c.decodeIfPresent(Bool.self, forKey: .useBiases) ?? true
+        downsampleFactor = try c.decodeIfPresent(Int.self, forKey: .downsampleFactor) ?? 4
+    }
+}
+
+public struct VoxtralRealtimeDecoderConfig: Codable, Sendable {
+    public var dim: Int
+    public var nLayers: Int
+    public var nHeads: Int
+    public var nKvHeads: Int
+    public var headDim: Int
+    public var hiddenDim: Int
+    public var vocabSize: Int
+    public var normEps: Float
+    public var ropeTheta: Float
+    public var slidingWindow: Int
+    public var tiedEmbeddings: Bool
+    public var adaRmsNormTCond: Bool
+    public var adaRmsNormTCondDim: Int
+
+    enum CodingKeys: String, CodingKey {
+        case dim
+        case nLayers = "n_layers"
+        case nHeads = "n_heads"
+        case nKvHeads = "n_kv_heads"
+        case headDim = "head_dim"
+        case hiddenDim = "hidden_dim"
+        case vocabSize = "vocab_size"
+        case normEps = "norm_eps"
+        case ropeTheta = "rope_theta"
+        case slidingWindow = "sliding_window"
+        case tiedEmbeddings = "tied_embeddings"
+        case adaRmsNormTCond = "ada_rms_norm_t_cond"
+        case adaRmsNormTCondDim = "ada_rms_norm_t_cond_dim"
+    }
+
+    public init(
+        dim: Int = 3072,
+        nLayers: Int = 26,
+        nHeads: Int = 32,
+        nKvHeads: Int = 8,
+        headDim: Int = 128,
+        hiddenDim: Int = 9216,
+        vocabSize: Int = 131072,
+        normEps: Float = 1e-5,
+        ropeTheta: Float = 1_000_000,
+        slidingWindow: Int = 8192,
+        tiedEmbeddings: Bool = true,
+        adaRmsNormTCond: Bool = true,
+        adaRmsNormTCondDim: Int = 32
+    ) {
+        self.dim = dim
+        self.nLayers = nLayers
+        self.nHeads = nHeads
+        self.nKvHeads = nKvHeads
+        self.headDim = headDim
+        self.hiddenDim = hiddenDim
+        self.vocabSize = vocabSize
+        self.normEps = normEps
+        self.ropeTheta = ropeTheta
+        self.slidingWindow = slidingWindow
+        self.tiedEmbeddings = tiedEmbeddings
+        self.adaRmsNormTCond = adaRmsNormTCond
+        self.adaRmsNormTCondDim = adaRmsNormTCondDim
+    }
+
+    public init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        dim = try c.decodeIfPresent(Int.self, forKey: .dim) ?? 3072
+        nLayers = try c.decodeIfPresent(Int.self, forKey: .nLayers) ?? 26
+        nHeads = try c.decodeIfPresent(Int.self, forKey: .nHeads) ?? 32
+        nKvHeads = try c.decodeIfPresent(Int.self, forKey: .nKvHeads) ?? 8
+        headDim = try c.decodeIfPresent(Int.self, forKey: .headDim) ?? 128
+        hiddenDim = try c.decodeIfPresent(Int.self, forKey: .hiddenDim) ?? 9216
+        vocabSize = try c.decodeIfPresent(Int.self, forKey: .vocabSize) ?? 131072
+        normEps = try c.decodeIfPresent(Float.self, forKey: .normEps) ?? 1e-5
+        ropeTheta = try c.decodeIfPresent(Float.self, forKey: .ropeTheta) ?? 1_000_000
+        slidingWindow = try c.decodeIfPresent(Int.self, forKey: .slidingWindow) ?? 8192
+        tiedEmbeddings = try c.decodeIfPresent(Bool.self, forKey: .tiedEmbeddings) ?? true
+        adaRmsNormTCond = try c.decodeIfPresent(Bool.self, forKey: .adaRmsNormTCond) ?? true
+        adaRmsNormTCondDim = try c.decodeIfPresent(Int.self, forKey: .adaRmsNormTCondDim) ?? 32
+    }
+}
+
+public struct VoxtralRealtimeConfig: Codable, Sendable {
+    public var modelType: String
+    public var encoderArgs: VoxtralRealtimeEncoderConfig
+    public var decoder: VoxtralRealtimeDecoderConfig
+    public var audioEncodingArgs: VoxtralRealtimeAudioEncodingConfig
+    public var transcriptionDelayMs: Int
+
+    public var vocabSize: Int
+    public var hiddenSize: Int
+
+    public var bosTokenId: Int
+    public var eosTokenId: Int
+    public var streamingPadTokenId: Int
+    public var nLeftPadTokens: Int
+
+    enum CodingKeys: String, CodingKey {
+        case modelType = "model_type"
+        case encoderArgs = "encoder_args"
+        case decoder
+        case audioEncodingArgs = "audio_encoding_args"
+        case transcriptionDelayMs = "transcription_delay_ms"
+        case vocabSize = "vocab_size"
+        case hiddenSize = "hidden_size"
+        case bosTokenId = "bos_token_id"
+        case eosTokenId = "eos_token_id"
+        case streamingPadTokenId = "streaming_pad_token_id"
+        case nLeftPadTokens = "n_left_pad_tokens"
+    }
+
+    private enum NestedEncoderCodingKeys: String, CodingKey {
+        case audioEncodingArgs = "audio_encoding_args"
+    }
+
+    public init(
+        modelType: String = "voxtral_realtime",
+        encoderArgs: VoxtralRealtimeEncoderConfig = VoxtralRealtimeEncoderConfig(),
+        decoder: VoxtralRealtimeDecoderConfig = VoxtralRealtimeDecoderConfig(),
+        audioEncodingArgs: VoxtralRealtimeAudioEncodingConfig = VoxtralRealtimeAudioEncodingConfig(),
+        transcriptionDelayMs: Int = 480,
+        vocabSize: Int = 131072,
+        hiddenSize: Int = 3072,
+        bosTokenId: Int = 1,
+        eosTokenId: Int = 2,
+        streamingPadTokenId: Int = 32,
+        nLeftPadTokens: Int = 32
+    ) {
+        self.modelType = modelType
+        self.encoderArgs = encoderArgs
+        self.decoder = decoder
+        self.audioEncodingArgs = audioEncodingArgs
+        self.transcriptionDelayMs = transcriptionDelayMs
+        self.vocabSize = vocabSize
+        self.hiddenSize = hiddenSize
+        self.bosTokenId = bosTokenId
+        self.eosTokenId = eosTokenId
+        self.streamingPadTokenId = streamingPadTokenId
+        self.nLeftPadTokens = nLeftPadTokens
+    }
+
+    public init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+
+        modelType = try c.decodeIfPresent(String.self, forKey: .modelType) ?? "voxtral_realtime"
+        encoderArgs = try c.decodeIfPresent(VoxtralRealtimeEncoderConfig.self, forKey: .encoderArgs) ?? VoxtralRealtimeEncoderConfig()
+        self.decoder = try c.decodeIfPresent(VoxtralRealtimeDecoderConfig.self, forKey: .decoder) ?? VoxtralRealtimeDecoderConfig()
+
+        if let directAudio = try c.decodeIfPresent(VoxtralRealtimeAudioEncodingConfig.self, forKey: .audioEncodingArgs) {
+            audioEncodingArgs = directAudio
+        } else if let nestedEncoder = try? c.nestedContainer(keyedBy: NestedEncoderCodingKeys.self, forKey: .encoderArgs),
+                  let nestedAudio = try nestedEncoder.decodeIfPresent(VoxtralRealtimeAudioEncodingConfig.self, forKey: .audioEncodingArgs) {
+            audioEncodingArgs = nestedAudio
+        } else {
+            audioEncodingArgs = VoxtralRealtimeAudioEncodingConfig()
+        }
+
+        transcriptionDelayMs = try c.decodeIfPresent(Int.self, forKey: .transcriptionDelayMs) ?? 480
+        bosTokenId = try c.decodeIfPresent(Int.self, forKey: .bosTokenId) ?? 1
+        eosTokenId = try c.decodeIfPresent(Int.self, forKey: .eosTokenId) ?? 2
+        streamingPadTokenId = try c.decodeIfPresent(Int.self, forKey: .streamingPadTokenId) ?? 32
+        nLeftPadTokens = try c.decodeIfPresent(Int.self, forKey: .nLeftPadTokens) ?? 32
+
+        vocabSize = try c.decodeIfPresent(Int.self, forKey: .vocabSize) ?? self.decoder.vocabSize
+        hiddenSize = try c.decodeIfPresent(Int.self, forKey: .hiddenSize) ?? self.decoder.dim
+    }
+}

--- a/SpeechHelper/Sources/SpeechEngine/VoxtralRealtimeDecoder.swift
+++ b/SpeechHelper/Sources/SpeechEngine/VoxtralRealtimeDecoder.swift
@@ -133,7 +133,11 @@ final class VoxtralRealtimeDecoderAttention: Module {
             let causal = kPos .<= qPos
             let window = kPos .>= (qPos - MLXArray(Int32(slidingWindow - 1)))
             let allowed = logicalAnd(causal, window)
-            let mask = MLX.where(allowed, MLXArray(0.0), MLXArray(-1e9))
+            // LOCAL FIX (see VENDORED.md): build the additive mask in the activation dtype.
+            // Once the hidden state is fp16 (the dtype fixes above), a float32 mask makes
+            // scaled_dot_product_attention abort ("Mask type must promote to output type
+            // float16"). Required companion to the float32-leak fix, not optional polish.
+            let mask = MLX.where(allowed, MLXArray(0.0), MLXArray(-1e9)).asType(q.dtype)
             maskMode = .array(mask)
         }
 

--- a/SpeechHelper/Sources/SpeechEngine/VoxtralRealtimeDecoder.swift
+++ b/SpeechHelper/Sources/SpeechEngine/VoxtralRealtimeDecoder.swift
@@ -1,0 +1,280 @@
+import Foundation
+import MLX
+import MLXNN
+
+struct VoxtralRealtimeDecoderKVCache {
+    var keys: MLXArray   // [kv_len, n_kv_heads * head_dim]
+    var values: MLXArray // [kv_len, n_kv_heads * head_dim]
+    var positionOffset: Int
+}
+
+func voxtralComputeTimeEmbedding(
+    tValue: Float,
+    dim: Int,
+    theta: Float = 10000.0
+) -> MLXArray {
+    let halfDim = dim / 2
+    let invFreq = MLX.exp(
+        -log(theta) * MLXArray(0..<halfDim).asType(.float32) / Float(halfDim)
+    )
+    let emb = tValue * invFreq
+    return MLX.concatenated([MLX.cos(emb), MLX.sin(emb)], axis: 0)
+}
+
+final class VoxtralRealtimeAdaRMSNorm: Module {
+    @ModuleInfo(key: "ada_down") var adaDown: Linear
+    @ModuleInfo(key: "ada_up") var adaUp: Linear
+
+    init(dim: Int, bottleneckDim: Int) {
+        self._adaDown.wrappedValue = Linear(dim, bottleneckDim, bias: false)
+        self._adaUp.wrappedValue = Linear(bottleneckDim, dim, bias: false)
+    }
+
+    func computeScale(tCond: MLXArray) -> MLXArray {
+        let hidden = gelu(adaDown(tCond))
+        return adaUp(hidden)
+    }
+
+    func callAsFunction(_ x: MLXArray, adaScale: MLXArray) -> MLXArray {
+        // LOCAL FIX (see VENDORED.md): the time-conditioning scale is built in float32, so
+        // this multiply promoted the fp16 hidden state to float32 in every one of the 32
+        // decoder layers — which forced the tied fp16 embedding to be upcast on every token
+        // (LM head 73→5 ms/token). Cast to the activation dtype, as voxmlx does.
+        x * (1.0 + adaScale.asType(x.dtype))
+    }
+}
+
+final class VoxtralRealtimeDecoderAttention: Module {
+    let nHeads: Int
+    let nKvHeads: Int
+    let headDim: Int
+    let slidingWindow: Int
+    let ropeTheta: Float
+    let scale: Float
+
+    @ModuleInfo(key: "wq") var wq: Linear
+    @ModuleInfo(key: "wk") var wk: Linear
+    @ModuleInfo(key: "wv") var wv: Linear
+    @ModuleInfo(key: "wo") var wo: Linear
+
+    init(_ config: VoxtralRealtimeDecoderConfig) {
+        nHeads = config.nHeads
+        nKvHeads = config.nKvHeads
+        headDim = config.headDim
+        slidingWindow = config.slidingWindow
+        ropeTheta = config.ropeTheta
+        scale = pow(Float(config.headDim), -0.5)
+
+        let qDim = config.nHeads * config.headDim
+        let kvDim = config.nKvHeads * config.headDim
+
+        self._wq.wrappedValue = Linear(config.dim, qDim, bias: false)
+        self._wk.wrappedValue = Linear(config.dim, kvDim, bias: false)
+        self._wv.wrappedValue = Linear(config.dim, kvDim, bias: false)
+        self._wo.wrappedValue = Linear(qDim, config.dim, bias: false)
+
+    }
+
+    private func ropeFrequencies(positions: MLXArray) -> (MLXArray, MLXArray) {
+        let idx = MLXArray(stride(from: 0, to: headDim, by: 2)).asType(.float32)
+        let ropeInvFreq = 1.0 / MLX.pow(MLXArray(ropeTheta), idx / Float(headDim))
+        let angles = positions.asType(.float32).expandedDimensions(axis: 1) * ropeInvFreq.expandedDimensions(axis: 0)
+        return (MLX.cos(angles), MLX.sin(angles))
+    }
+
+    func callAsFunction(
+        _ x: MLXArray,
+        positions: MLXArray,
+        cache: VoxtralRealtimeDecoderKVCache?
+    ) -> (MLXArray, VoxtralRealtimeDecoderKVCache) {
+        let seqLen = x.shape[0]
+
+        var q = wq(x)
+        var k = wk(x)
+        var v = wv(x)
+
+        let (cos, sin) = ropeFrequencies(positions: positions)
+        q = voxtralApplyInterleavedRoPE(q, cos: cos, sin: sin, nHeads: nHeads, headDim: headDim)
+        k = voxtralApplyInterleavedRoPE(k, cos: cos, sin: sin, nHeads: nKvHeads, headDim: headDim)
+
+        var positionOffset = cache?.positionOffset ?? 0
+        if let cache {
+            k = MLX.concatenated([cache.keys, k], axis: 0)
+            v = MLX.concatenated([cache.values, v], axis: 0)
+        }
+
+        var kvLen = k.shape[0]
+        if kvLen > slidingWindow {
+            let trim = kvLen - slidingWindow
+            k = k[trim...]
+            v = v[trim...]
+            kvLen = slidingWindow
+            positionOffset += trim
+        }
+
+        let newCache = VoxtralRealtimeDecoderKVCache(
+            keys: k,
+            values: v,
+            positionOffset: positionOffset
+        )
+
+        let q4 = q.reshaped(1, seqLen, nHeads, headDim).transposed(0, 2, 1, 3)
+        let k4 = k.reshaped(1, kvLen, nKvHeads, headDim).transposed(0, 2, 1, 3)
+        let v4 = v.reshaped(1, kvLen, nKvHeads, headDim).transposed(0, 2, 1, 3)
+
+        let maskMode: MLXFast.ScaledDotProductAttentionMaskMode
+        if seqLen == 1 {
+            maskMode = .none
+        } else if seqLen <= slidingWindow && cache == nil {
+            maskMode = .causal
+        } else {
+            let qPos = positions.expandedDimensions(axis: 1)
+            let kPos = MLXArray(positionOffset..<(positionOffset + kvLen)).asType(.int32).expandedDimensions(axis: 0)
+            let causal = kPos .<= qPos
+            let window = kPos .>= (qPos - MLXArray(Int32(slidingWindow - 1)))
+            let allowed = logicalAnd(causal, window)
+            let mask = MLX.where(allowed, MLXArray(0.0), MLXArray(-1e9))
+            maskMode = .array(mask)
+        }
+
+        let attn = MLXFast.scaledDotProductAttention(
+            queries: q4,
+            keys: k4,
+            values: v4,
+            scale: scale,
+            mask: maskMode
+        )
+
+        let out = attn.transposed(0, 2, 1, 3).reshaped(seqLen, nHeads * headDim)
+        return (wo(out), newCache)
+    }
+}
+
+final class VoxtralRealtimeDecoderLayer: Module {
+    @ModuleInfo(key: "attention_norm") var attentionNorm: RMSNorm
+    @ModuleInfo(key: "attention") var attention: VoxtralRealtimeDecoderAttention
+    @ModuleInfo(key: "ffn_norm") var ffnNorm: RMSNorm
+
+    @ModuleInfo(key: "ada_rms_norm_t_cond") var adaRmsNormTCond: VoxtralRealtimeAdaRMSNorm?
+
+    @ModuleInfo(key: "feed_forward_w1") var feedForwardW1: Linear
+    @ModuleInfo(key: "feed_forward_w3") var feedForwardW3: Linear
+    @ModuleInfo(key: "feed_forward_w2") var feedForwardW2: Linear
+
+    init(_ config: VoxtralRealtimeDecoderConfig) {
+        self._attentionNorm.wrappedValue = RMSNorm(dimensions: config.dim, eps: config.normEps)
+        self._attention.wrappedValue = VoxtralRealtimeDecoderAttention(config)
+        self._ffnNorm.wrappedValue = RMSNorm(dimensions: config.dim, eps: config.normEps)
+
+        if config.adaRmsNormTCond {
+            self._adaRmsNormTCond.wrappedValue = VoxtralRealtimeAdaRMSNorm(
+                dim: config.dim,
+                bottleneckDim: config.adaRmsNormTCondDim
+            )
+        } else {
+            self._adaRmsNormTCond.wrappedValue = nil
+        }
+
+        self._feedForwardW1.wrappedValue = Linear(config.dim, config.hiddenDim, bias: false)
+        self._feedForwardW3.wrappedValue = Linear(config.dim, config.hiddenDim, bias: false)
+        self._feedForwardW2.wrappedValue = Linear(config.hiddenDim, config.dim, bias: false)
+    }
+
+    func callAsFunction(
+        _ x: MLXArray,
+        positions: MLXArray,
+        adaScale: MLXArray?,
+        cache: VoxtralRealtimeDecoderKVCache?
+    ) -> (MLXArray, VoxtralRealtimeDecoderKVCache) {
+        var out = x
+
+        var h = attentionNorm(out)
+        let attn = attention(h, positions: positions, cache: cache)
+        h = attn.0
+        out = out + h
+
+        h = ffnNorm(out)
+        if let adaScale, let ada = adaRmsNormTCond {
+            h = ada(h, adaScale: adaScale)
+        }
+
+        let gate = silu(feedForwardW1(h))
+        let up = feedForwardW3(h)
+        out = out + feedForwardW2(gate * up)
+
+        return (out, attn.1)
+    }
+}
+
+final class VoxtralRealtimeDecoder: Module {
+    let config: VoxtralRealtimeDecoderConfig
+
+    @ModuleInfo(key: "tok_embeddings") var tokEmbeddings: Embedding
+    @ModuleInfo(key: "layers") var layers: [VoxtralRealtimeDecoderLayer]
+    @ModuleInfo(key: "norm") var norm: RMSNorm
+
+    var adaScales: [MLXArray?]?
+
+    init(_ config: VoxtralRealtimeDecoderConfig) {
+        self.config = config
+        self._tokEmbeddings.wrappedValue = Embedding(
+            embeddingCount: config.vocabSize,
+            dimensions: config.dim
+        )
+        self._layers.wrappedValue = (0..<config.nLayers).map { _ in
+            VoxtralRealtimeDecoderLayer(config)
+        }
+        self._norm.wrappedValue = RMSNorm(dimensions: config.dim, eps: config.normEps)
+    }
+
+    func precomputeAdaScales(_ tCond: MLXArray) {
+        var scales: [MLXArray?] = []
+        scales.reserveCapacity(layers.count)
+
+        for layer in layers {
+            if let ada = layer.adaRmsNormTCond {
+                scales.append(ada.computeScale(tCond: tCond))
+            } else {
+                scales.append(nil)
+            }
+        }
+
+        adaScales = scales
+    }
+
+    func embedToken(tokenId: Int) -> MLXArray {
+        tokEmbeddings.weight[tokenId]
+    }
+
+    func embedTokens(_ tokenIds: MLXArray) -> MLXArray {
+        tokEmbeddings(tokenIds)
+    }
+
+    func callAsFunction(
+        _ embeds: MLXArray,
+        startPos: Int,
+        cache: [VoxtralRealtimeDecoderKVCache?]? = nil
+    ) -> (MLXArray, [VoxtralRealtimeDecoderKVCache?]) {
+        var h = embeds
+        let seqLen = h.shape[0]
+        let positions = MLXArray(startPos..<(startPos + seqLen)).asType(.int32)
+
+        var newCache: [VoxtralRealtimeDecoderKVCache?] = []
+        newCache.reserveCapacity(layers.count)
+
+        for i in layers.indices {
+            let layerCache = cache?[i]
+            let adaScale = adaScales?[i]
+            let next = layers[i](h, positions: positions, adaScale: adaScale, cache: layerCache)
+            h = next.0
+            newCache.append(next.1)
+        }
+
+        h = norm(h)
+        return (h, newCache)
+    }
+
+    func logits(_ h: MLXArray) -> MLXArray {
+        MLX.matmul(h, tokEmbeddings.weight.transposed(1, 0))
+    }
+}

--- a/SpeechHelper/Sources/SpeechEngine/VoxtralRealtimeDecoder.swift
+++ b/SpeechHelper/Sources/SpeechEngine/VoxtralRealtimeDecoder.swift
@@ -137,6 +137,12 @@ final class VoxtralRealtimeDecoderAttention: Module {
             // Once the hidden state is fp16 (the dtype fixes above), a float32 mask makes
             // scaled_dot_product_attention abort ("Mask type must promote to output type
             // float16"). Required companion to the float32-leak fix, not optional polish.
+            // See the encoder's note on -1e9→-inf. NOTE: this decoder `.array` branch is not
+            // reached under the current config — single-token decode uses `.none` and prefill
+            // (promptLength ≈ 39 ≪ slidingWindow 8192) uses `.causal`. It's defensive. If a
+            // future config ever made promptLength > slidingWindow, prefill would enter here AND
+            // trim, fully-masking early query rows (qPos < trim) → NaN under the fp16 -inf mask.
+            // Revisit the sentinel value (e.g. a finite fp16 floor) before enabling that.
             let mask = MLX.where(allowed, MLXArray(0.0), MLXArray(-1e9)).asType(q.dtype)
             maskMode = .array(mask)
         }

--- a/SpeechHelper/Sources/SpeechEngine/VoxtralRealtimeEncoder.swift
+++ b/SpeechHelper/Sources/SpeechEngine/VoxtralRealtimeEncoder.swift
@@ -1,0 +1,366 @@
+import Foundation
+import MLX
+import MLXNN
+
+struct VoxtralRealtimeEncoderKVCache {
+    var keys: MLXArray   // [kv_len, n_heads * head_dim]
+    var values: MLXArray // [kv_len, n_heads * head_dim]
+    var positionOffset: Int
+}
+
+func voxtralComputeRopeFrequencies(
+    positions: MLXArray,
+    headDim: Int,
+    theta: Float
+) -> (cos: MLXArray, sin: MLXArray) {
+    let idx = MLXArray(stride(from: 0, to: headDim, by: 2)).asType(.float32)
+    let invFreq = MLX.exp((-log(theta)) * (idx / Float(headDim)))
+    let angles = positions.asType(.float32).expandedDimensions(axis: 1) * invFreq.expandedDimensions(axis: 0)
+    return (MLX.cos(angles), MLX.sin(angles))
+}
+
+func voxtralApplyInterleavedRoPE(
+    _ x: MLXArray,
+    cos: MLXArray,
+    sin: MLXArray,
+    nHeads: Int,
+    headDim: Int
+) -> MLXArray {
+    let seqLen = x.shape[0]
+    let halfDim = headDim / 2
+
+    let reshaped = x.reshaped(seqLen, nHeads, halfDim, 2)
+    let x1 = reshaped[0..., 0..., 0..., 0]
+    let x2 = reshaped[0..., 0..., 0..., 1]
+
+    let cosE = cos.expandedDimensions(axis: 1)
+    let sinE = sin.expandedDimensions(axis: 1)
+
+    let o1 = x1 * cosE - x2 * sinE
+    let o2 = x2 * cosE + x1 * sinE
+
+    let out = MLX.concatenated(
+        [o1.expandedDimensions(axis: -1), o2.expandedDimensions(axis: -1)],
+        axis: -1
+    )
+    return out.reshaped(seqLen, nHeads * headDim)
+}
+
+final class VoxtralRealtimeCausalConv1d: Module {
+    let kernelSize: Int
+    let stride: Int
+    let padding: Int
+
+    @ModuleInfo(key: "conv") var conv: Conv1d
+
+    init(inChannels: Int, outChannels: Int, kernelSize: Int, stride: Int = 1) {
+        self.kernelSize = kernelSize
+        self.stride = stride
+        self.padding = kernelSize - stride
+        self._conv.wrappedValue = Conv1d(
+            inputChannels: inChannels,
+            outputChannels: outChannels,
+            kernelSize: kernelSize,
+            stride: stride,
+            padding: 0,
+            bias: true
+        )
+    }
+
+    func callAsFunction(_ x: MLXArray) -> MLXArray {
+        var out = x
+        if padding > 0 {
+            out = MLX.padded(
+                out,
+                widths: [
+                    IntOrPair(0),
+                    IntOrPair((padding, 0)),
+                    IntOrPair(0),
+                ]
+            )
+        }
+        return conv(out)
+    }
+}
+
+final class VoxtralRealtimeEncoderAttention: Module {
+    let nHeads: Int
+    let headDim: Int
+    let slidingWindow: Int
+    let ropeTheta: Float
+    let scale: Float
+
+    @ModuleInfo(key: "wq") var wq: Linear
+    @ModuleInfo(key: "wk") var wk: Linear
+    @ModuleInfo(key: "wv") var wv: Linear
+    @ModuleInfo(key: "wo") var wo: Linear
+
+    init(_ config: VoxtralRealtimeEncoderConfig) {
+        nHeads = config.nHeads
+        headDim = config.headDim
+        slidingWindow = config.slidingWindow
+        ropeTheta = config.ropeTheta
+        scale = pow(Float(config.headDim), -0.5)
+
+        let attnDim = config.nHeads * config.headDim
+        self._wq.wrappedValue = Linear(config.dim, attnDim, bias: true)
+        self._wk.wrappedValue = Linear(config.dim, attnDim, bias: false)
+        self._wv.wrappedValue = Linear(config.dim, attnDim, bias: true)
+        self._wo.wrappedValue = Linear(attnDim, config.dim, bias: true)
+    }
+
+    func callAsFunction(
+        _ x: MLXArray,
+        positions: MLXArray,
+        cache: VoxtralRealtimeEncoderKVCache?
+    ) -> (MLXArray, VoxtralRealtimeEncoderKVCache) {
+        let seqLen = x.shape[0]
+
+        var q = wq(x)
+        var k = wk(x)
+        var v = wv(x)
+
+        let (cos, sin) = voxtralComputeRopeFrequencies(
+            positions: positions,
+            headDim: headDim,
+            theta: ropeTheta
+        )
+
+        q = voxtralApplyInterleavedRoPE(q, cos: cos, sin: sin, nHeads: nHeads, headDim: headDim)
+        k = voxtralApplyInterleavedRoPE(k, cos: cos, sin: sin, nHeads: nHeads, headDim: headDim)
+
+        var positionOffset = cache?.positionOffset ?? 0
+        if let cache {
+            k = MLX.concatenated([cache.keys, k], axis: 0)
+            v = MLX.concatenated([cache.values, v], axis: 0)
+        }
+
+        var kvLen = k.shape[0]
+        if kvLen > slidingWindow {
+            let trim = kvLen - slidingWindow
+            k = k[trim...]
+            v = v[trim...]
+            kvLen = slidingWindow
+            positionOffset += trim
+        }
+
+        let newCache = VoxtralRealtimeEncoderKVCache(
+            keys: k,
+            values: v,
+            positionOffset: positionOffset
+        )
+
+        let q4 = q.reshaped(1, seqLen, nHeads, headDim).transposed(0, 2, 1, 3)
+        let k4 = k.reshaped(1, kvLen, nHeads, headDim).transposed(0, 2, 1, 3)
+        let v4 = v.reshaped(1, kvLen, nHeads, headDim).transposed(0, 2, 1, 3)
+
+        let maskMode: MLXFast.ScaledDotProductAttentionMaskMode
+        if seqLen == 1 {
+            maskMode = .none
+        } else if cache == nil && seqLen <= slidingWindow {
+            maskMode = .causal
+        } else {
+            let qPos = positions.expandedDimensions(axis: 1)
+            let kPos = MLXArray(positionOffset..<(positionOffset + kvLen)).asType(.int32).expandedDimensions(axis: 0)
+            let causal = kPos .<= qPos
+            let window = kPos .>= (qPos - MLXArray(Int32(slidingWindow - 1)))
+            let allowed = logicalAnd(causal, window)
+            let mask = MLX.where(allowed, MLXArray(0.0), MLXArray(-1e9))
+            maskMode = .array(mask)
+        }
+
+        let attn = MLXFast.scaledDotProductAttention(
+            queries: q4,
+            keys: k4,
+            values: v4,
+            scale: scale,
+            mask: maskMode
+        )
+
+        let out = attn.transposed(0, 2, 1, 3).reshaped(seqLen, nHeads * headDim)
+        return (wo(out), newCache)
+    }
+}
+
+final class VoxtralRealtimeEncoderLayer: Module {
+    @ModuleInfo(key: "attention_norm") var attentionNorm: RMSNorm
+    @ModuleInfo(key: "attention") var attention: VoxtralRealtimeEncoderAttention
+    @ModuleInfo(key: "ffn_norm") var ffnNorm: RMSNorm
+
+    @ModuleInfo(key: "feed_forward_w1") var feedForwardW1: Linear
+    @ModuleInfo(key: "feed_forward_w3") var feedForwardW3: Linear
+    @ModuleInfo(key: "feed_forward_w2") var feedForwardW2: Linear
+
+    init(_ config: VoxtralRealtimeEncoderConfig) {
+        self._attentionNorm.wrappedValue = RMSNorm(dimensions: config.dim, eps: config.normEps)
+        self._attention.wrappedValue = VoxtralRealtimeEncoderAttention(config)
+        self._ffnNorm.wrappedValue = RMSNorm(dimensions: config.dim, eps: config.normEps)
+
+        self._feedForwardW1.wrappedValue = Linear(config.dim, config.hiddenDim, bias: false)
+        self._feedForwardW3.wrappedValue = Linear(config.dim, config.hiddenDim, bias: false)
+        self._feedForwardW2.wrappedValue = Linear(config.hiddenDim, config.dim, bias: true)
+    }
+
+    func callAsFunction(
+        _ x: MLXArray,
+        positions: MLXArray,
+        cache: VoxtralRealtimeEncoderKVCache?
+    ) -> (MLXArray, VoxtralRealtimeEncoderKVCache) {
+        var out = x
+
+        var h = attentionNorm(out)
+        let attnOut = attention(h, positions: positions, cache: cache)
+        h = attnOut.0
+        out = out + h
+
+        h = ffnNorm(out)
+        let gate = silu(feedForwardW1(h))
+        let up = feedForwardW3(h)
+        out = out + feedForwardW2(gate * up)
+
+        return (out, attnOut.1)
+    }
+}
+
+final class VoxtralRealtimeAudioEncoder: Module {
+    let config: VoxtralRealtimeEncoderConfig
+    let decoderDim: Int
+
+    @ModuleInfo(key: "conv_layers_0_conv") var convLayers0Conv: VoxtralRealtimeCausalConv1d
+    @ModuleInfo(key: "conv_layers_1_conv") var convLayers1Conv: VoxtralRealtimeCausalConv1d
+
+    @ModuleInfo(key: "transformer_layers") var transformerLayers: [VoxtralRealtimeEncoderLayer]
+    @ModuleInfo(key: "transformer_norm") var transformerNorm: RMSNorm
+
+    @ModuleInfo(key: "audio_language_projection_0") var audioLanguageProjection0: Linear
+    @ModuleInfo(key: "audio_language_projection_2") var audioLanguageProjection2: Linear
+
+    init(_ config: VoxtralRealtimeEncoderConfig, decoderDim: Int = 3072) {
+        self.config = config
+        self.decoderDim = decoderDim
+
+        self._convLayers0Conv.wrappedValue = VoxtralRealtimeCausalConv1d(
+            inChannels: 128,
+            outChannels: config.dim,
+            kernelSize: 3,
+            stride: 1
+        )
+        self._convLayers1Conv.wrappedValue = VoxtralRealtimeCausalConv1d(
+            inChannels: config.dim,
+            outChannels: config.dim,
+            kernelSize: 3,
+            stride: 2
+        )
+
+        self._transformerLayers.wrappedValue = (0..<config.nLayers).map { _ in
+            VoxtralRealtimeEncoderLayer(config)
+        }
+        self._transformerNorm.wrappedValue = RMSNorm(dimensions: config.dim, eps: config.normEps)
+
+        let adapterInputDim = config.dim * config.downsampleFactor
+        self._audioLanguageProjection0.wrappedValue = Linear(adapterInputDim, decoderDim, bias: false)
+        self._audioLanguageProjection2.wrappedValue = Linear(decoderDim, decoderDim, bias: false)
+    }
+
+    func convStem(_ mel: MLXArray) -> MLXArray {
+        // LOCAL FIX (see VENDORED.md): the mel is float32 (DFT/filters), so feeding it into
+        // fp16 conv weights promoted the whole hidden state to float32. Cast at the seam.
+        var x = mel.asType(convLayers0Conv.conv.weight.dtype).transposed(1, 0).expandedDimensions(axis: 0)
+        x = gelu(convLayers0Conv(x))
+        x = gelu(convLayers1Conv(x))
+        x = x.squeezed(axis: 0)
+
+        let trunc = x.shape[0] % config.downsampleFactor
+        if trunc > 0 {
+            x = x[trunc...]
+        }
+
+        return x
+    }
+
+    func encodeFull(_ convOut: MLXArray) -> MLXArray {
+        let seqLen = convOut.shape[0]
+        let positions = MLXArray(0..<seqLen).asType(.int32)
+
+        var x = convOut
+        for layer in transformerLayers {
+            x = layer(x, positions: positions, cache: nil).0
+        }
+
+        x = transformerNorm(x)
+        return downsampleAndProject(x)
+    }
+
+    func encodeChunked(_ convOut: MLXArray) -> MLXArray {
+        let seqLen = convOut.shape[0]
+        let sw = config.slidingWindow
+
+        if seqLen <= sw {
+            return encodeFull(convOut)
+        }
+
+        var caches: [VoxtralRealtimeEncoderKVCache?] = Array(repeating: nil, count: transformerLayers.count)
+        var outputs: [MLXArray] = []
+
+        var chunkStart = 0
+        while chunkStart < seqLen {
+            let chunkEnd = min(chunkStart + sw, seqLen)
+            var x = convOut[chunkStart..<chunkEnd, 0...]
+            let positions = MLXArray(chunkStart..<chunkEnd).asType(.int32)
+
+            for i in transformerLayers.indices {
+                let next = transformerLayers[i](x, positions: positions, cache: caches[i])
+                x = next.0
+                caches[i] = next.1
+            }
+
+            outputs.append(transformerNorm(x))
+            chunkStart = chunkEnd
+        }
+
+        let encoded = outputs.count == 1 ? outputs[0] : MLX.concatenated(outputs, axis: 0)
+        return downsampleAndProject(encoded)
+    }
+
+    /// Feed a block of new conv-stem frames at absolute positions `[startPos, startPos+n)`
+    /// through the transformer with persistent per-layer KV-caches, returning the
+    /// transformer-normed frames (pre-downsample). While the total fed length stays
+    /// `<= slidingWindow` the caches never trim, so the result is bit-identical to
+    /// `encodeFull` over the same prefix — see `VoxtralRealtimeStreamSession`.
+    func encodeIncremental(
+        _ convBlock: MLXArray,
+        startPos: Int,
+        caches: inout [VoxtralRealtimeEncoderKVCache?]
+    ) -> MLXArray {
+        var x = convBlock
+        let positions = MLXArray(startPos..<(startPos + convBlock.shape[0])).asType(.int32)
+        for i in transformerLayers.indices {
+            let next = transformerLayers[i](x, positions: positions, cache: caches[i])
+            x = next.0
+            caches[i] = next.1
+        }
+        return transformerNorm(x)
+    }
+
+    func downsampleAndProject(_ encoded: MLXArray) -> MLXArray {
+        let seqLen = encoded.shape[0]
+        let ds = config.downsampleFactor
+        let dsLen = seqLen / ds
+
+        if dsLen == 0 {
+            return encoded[0..<0, 0...]
+        }
+
+        var x = encoded[0..<(dsLen * ds), 0...].reshaped(dsLen, config.dim * ds)
+        x = gelu(audioLanguageProjection0(x))
+        return audioLanguageProjection2(x)
+    }
+
+    func callAsFunction(_ mel: MLXArray) -> MLXArray {
+        let convOut = convStem(mel)
+        if convOut.shape[0] <= config.slidingWindow {
+            return encodeFull(convOut)
+        }
+        return encodeChunked(convOut)
+    }
+}

--- a/SpeechHelper/Sources/SpeechEngine/VoxtralRealtimeEncoder.swift
+++ b/SpeechHelper/Sources/SpeechEngine/VoxtralRealtimeEncoder.swift
@@ -173,6 +173,12 @@ final class VoxtralRealtimeEncoderAttention: Module {
             // Once the hidden state is fp16 (the dtype fixes above), a float32 mask makes
             // scaled_dot_product_attention abort ("Mask type must promote to output type
             // float16"). Required companion to the float32-leak fix, not optional polish.
+            // -1e9 overflows fp16 to -inf, which is the correct additive-mask value for a
+            // PARTIALLY masked row. It would only NaN a FULLY masked row (softmax over all
+            // -inf). That can't happen here: within a sliding-window block the total length is
+            // <= sw so caches never trim and every query keeps its own (diagonal) key; the
+            // offline chunked path likewise always retains the query's own position. So every
+            // row has >= 1 unmasked key. (Live path: reached by feedIncremental blocks 2+.)
             let mask = MLX.where(allowed, MLXArray(0.0), MLXArray(-1e9)).asType(q.dtype)
             maskMode = .array(mask)
         }

--- a/SpeechHelper/Sources/SpeechEngine/VoxtralRealtimeEncoder.swift
+++ b/SpeechHelper/Sources/SpeechEngine/VoxtralRealtimeEncoder.swift
@@ -33,8 +33,12 @@ func voxtralApplyInterleavedRoPE(
     let x1 = reshaped[0..., 0..., 0..., 0]
     let x2 = reshaped[0..., 0..., 0..., 1]
 
-    let cosE = cos.expandedDimensions(axis: 1)
-    let sinE = sin.expandedDimensions(axis: 1)
+    // LOCAL FIX (see VENDORED.md): cast the float32-computed cos/sin down to the activation
+    // dtype BEFORE the rotation. Angles are computed in float32 for precision, but
+    // multiplying fp16 activations by float32 factors promotes the whole hidden state to
+    // float32 (half of the leak; the other half is AdaptiveNorm's adaScale).
+    let cosE = cos.expandedDimensions(axis: 1).asType(x.dtype)
+    let sinE = sin.expandedDimensions(axis: 1).asType(x.dtype)
 
     let o1 = x1 * cosE - x2 * sinE
     let o2 = x2 * cosE + x1 * sinE

--- a/SpeechHelper/Sources/SpeechEngine/VoxtralRealtimeEncoder.swift
+++ b/SpeechHelper/Sources/SpeechEngine/VoxtralRealtimeEncoder.swift
@@ -169,7 +169,11 @@ final class VoxtralRealtimeEncoderAttention: Module {
             let causal = kPos .<= qPos
             let window = kPos .>= (qPos - MLXArray(Int32(slidingWindow - 1)))
             let allowed = logicalAnd(causal, window)
-            let mask = MLX.where(allowed, MLXArray(0.0), MLXArray(-1e9))
+            // LOCAL FIX (see VENDORED.md): build the additive mask in the activation dtype.
+            // Once the hidden state is fp16 (the dtype fixes above), a float32 mask makes
+            // scaled_dot_product_attention abort ("Mask type must promote to output type
+            // float16"). Required companion to the float32-leak fix, not optional polish.
+            let mask = MLX.where(allowed, MLXArray(0.0), MLXArray(-1e9)).asType(q.dtype)
             maskMode = .array(mask)
         }
 

--- a/SpeechHelper/Sources/SpeechEngine/VoxtralRealtimeStreamSession.swift
+++ b/SpeechHelper/Sources/SpeechEngine/VoxtralRealtimeStreamSession.swift
@@ -1,0 +1,303 @@
+import Foundation
+import MLX
+import MLXAudioCore
+import SpeechEngineText
+
+// True incremental (online) streaming for Voxtral Realtime.
+//
+// The offline `generate(...)` path encodes the entire audio buffer up front and only
+// then walks the decoder. This session ingests audio *as it arrives* (e.g. 80 ms mic
+// chunks), feeds only newly-frozen conv frames through the transformer encoder with a
+// persistent per-layer KV-cache, maintains the decoder KV-cache, and emits tokens with
+// the model's native transcription delay — O(1) work per chunk.
+//
+// Correctness (WER 0 vs offline):
+//   * conv stem is causal and `prepareMel` right-pads with zeros, so `convOut[0..<k]`
+//     re-derived from a prefix is bit-identical to the offline full encode for every
+//     frozen row k. The only unfrozen row is the trailing partial token (chunk ended
+//     mid-1280-sample-token) — guarded by `frozenGuardTokens`.
+//   * RoPE attention is relative-position invariant, so feeding conv frames in
+//     sliding-window-aligned blocks with the cache RESET at each boundary reproduces
+//     `encodeChunked` (>sw) exactly; a single un-reset block reproduces `encodeFull`
+//     (<=sw). See `feedIncremental`.
+//   * `finish()` reproduces the offline tail zero-pad ⇒ final transcript == generate().
+
+/// Persistent incremental-encoder state carried across `step` calls.
+struct VoxtralRealtimeStreamEncoderState {
+    var caches: [VoxtralRealtimeEncoderKVCache?]
+    var blockBase = 0   // absolute conv-frame index where the current sw-block began
+    var consumed = 0    // conv frames already fed to the transformer
+
+    init(layers: Int) {
+        caches = Array(repeating: nil, count: layers)
+    }
+}
+
+extension VoxtralRealtimeAudioEncoder {
+    /// Feed conv frames `[state.consumed, upTo)` through the transformer incrementally,
+    /// resetting the per-layer caches at each `slidingWindow` boundary so the result is
+    /// bit-identical to offline `encodeFull` (<=sw) / `encodeChunked` (>sw). Returns the
+    /// new transformer-normed frames (pre-downsample).
+    func feedIncremental(
+        _ convOut: MLXArray,
+        upTo: Int,
+        state: inout VoxtralRealtimeStreamEncoderState
+    ) -> MLXArray {
+        let sw = config.slidingWindow
+        var pieces: [MLXArray] = []
+        while state.consumed < upTo {
+            let blockEnd = state.blockBase + sw
+            let end = min(upTo, blockEnd)
+            let block = convOut[state.consumed..<end, 0...]
+            // Block-relative positions: RoPE is relative, so this matches the absolute
+            // positions offline uses within each independent sw-block.
+            let relStart = state.consumed - state.blockBase
+            pieces.append(encodeIncremental(block, startPos: relStart, caches: &state.caches))
+            state.consumed = end
+            if state.consumed == blockEnd {
+                state.caches = Array(repeating: nil, count: transformerLayers.count)
+                state.blockBase = blockEnd
+            }
+        }
+        if pieces.isEmpty { return convOut[0..<0, 0...] }
+        return pieces.count == 1 ? pieces[0] : MLX.concatenated(pieces, axis: 0)
+    }
+}
+
+public final class VoxtralRealtimeStreamSession {
+    /// Text + token ids decoded by a single `step` / `finish` call.
+    public struct Delta {
+        public let text: String
+        public let tokenIds: [Int]
+    }
+
+    private let model: VoxtralRealtimeModel
+    private let temperature: Float
+    private let maxTokens: Int
+    private let transcriptionDelayMs: Int?
+
+    // Only the trailing partial token (chunk ended mid-1280-sample-token) is unfrozen.
+    private let frozenGuardTokens = 1
+
+    private var realAudio: [Float] = []
+    private var encState: VoxtralRealtimeStreamEncoderState
+    private var adapterBuf: MLXArray?
+    private var decCache: [VoxtralRealtimeDecoderKVCache?]?
+    private var lastLogits: MLXArray?
+    private var decPos = 0
+    private var promptLength = 0
+    private var prefilled = false
+    private var done = false
+
+    private var generated: [Int] = []
+    private var emittedText = ""
+
+    public init(
+        model: VoxtralRealtimeModel,
+        temperature: Float = 0.0,
+        maxTokens: Int = 4096,
+        transcriptionDelayMs: Int? = nil
+    ) {
+        self.model = model
+        self.temperature = temperature
+        self.maxTokens = maxTokens
+        self.transcriptionDelayMs = transcriptionDelayMs
+        self.encState = VoxtralRealtimeStreamEncoderState(
+            layers: model.encoder.transformerLayers.count
+        )
+    }
+
+    /// Full transcript decoded so far.
+    public var text: String { emittedText }
+    /// Token ids decoded so far (EOS stripped).
+    public var tokens: [Int] { generated }
+    /// Whether the stream has emitted EOS / hit maxTokens.
+    public var isFinished: Bool { done }
+
+    /// Ingest a chunk of 16 kHz mono samples; returns the text decoded by this call.
+    @discardableResult
+    public func step(_ samples: [Float]) -> Delta {
+        realAudio.append(contentsOf: samples)
+        return advance(final: false)
+    }
+
+    @discardableResult
+    public func step(_ samples: MLXArray) -> Delta {
+        let flat = samples.ndim > 1 ? samples.mean(axis: -1) : samples
+        return step(flat.asType(.float32).asArray(Float.self))
+    }
+
+    /// Flush the tail: reproduces the offline zero-pad so the final transcript equals
+    /// `generate(...)`. Call once after the last `step`.
+    @discardableResult
+    public func finish() -> Delta {
+        advance(final: true)
+    }
+
+    private func advance(final: Bool) -> Delta {
+        guard !done else { return Delta(text: "", tokenIds: []) }
+        guard !realAudio.isEmpty else { return Delta(text: "", tokenIds: []) }
+
+        let ds = model.config.encoderArgs.downsampleFactor
+        let audio = MLXArray(realAudio)
+        let (convOut, nAudioTotal, pLen) = model.convStemForAudio(
+            audio: audio,
+            transcriptionDelayMs: transcriptionDelayMs
+        )
+        promptLength = pLen
+
+        let realRegion = model.config.nLeftPadTokens + model.numAudioTokens(realAudio.count)
+        let emitLimit = final ? nAudioTotal : max(0, min(nAudioTotal, realRegion - frozenGuardTokens))
+        let convFreeze = min(convOut.shape[0], emitLimit * ds)
+
+        if convFreeze > encState.consumed {
+            let newEnc = model.encoder.feedIncremental(convOut, upTo: convFreeze, state: &encState)
+            let rows = model.encoder.downsampleAndProject(newEnc)   // multiple-of-ds ⇒ whole rows
+            adapterBuf = adapterBuf == nil ? rows : MLX.concatenated([adapterBuf!, rows], axis: 0)
+            freezeEncoderState()
+        }
+
+        guard let adapter = adapterBuf else {
+            Memory.clearCache()
+            return Delta(text: "", tokenIds: [])
+        }
+        prefillIfNeeded(adapter: adapter)
+        let delta = decode(adapter: adapter, upTo: min(emitLimit, adapter.shape[0]))
+
+        Memory.clearCache()
+        return delta
+    }
+
+    /// Materialise the adapter buffer + encoder caches so the lazy graph stays bounded
+    /// across chunks (each chunk would otherwise extend one unbroken graph).
+    private func freezeEncoderState() {
+        var arrays: [MLXArray] = []
+        if let adapterBuf { arrays.append(adapterBuf) }
+        for cache in encState.caches {
+            if let cache { arrays.append(cache.keys); arrays.append(cache.values) }
+        }
+        if !arrays.isEmpty { MLX.eval(arrays) }
+    }
+
+    private func prefillIfNeeded(adapter: MLXArray) {
+        guard !prefilled, adapter.shape[0] >= promptLength else { return }
+
+        let nLeft = model.config.nLeftPadTokens
+        let nDelay = promptLength - 1 - nLeft
+        let promptIds = [model.config.bosTokenId]
+            + Array(repeating: model.config.streamingPadTokenId, count: nLeft + nDelay)
+        let promptIdsMX = MLXArray(promptIds.map(Int32.init))
+        let promptTextEmbeds = model.decoder.embedTokens(promptIdsMX)
+
+        let prefixEmbeds = adapter[0..<promptLength, 0...] + promptTextEmbeds
+        let prefill = model.decoder(prefixEmbeds, startPos: 0, cache: nil)
+        lastLogits = model.decoder.logits(prefill.0[prefill.0.shape[0] - 1])
+        decCache = prefill.1
+        decPos = promptLength
+        prefilled = true
+        MLX.eval(lastLogits!)
+    }
+
+    private func decode(adapter: MLXArray, upTo emitLimit: Int) -> Delta {
+        guard prefilled else { return Delta(text: "", tokenIds: []) }
+
+        var newIds: [Int] = []
+        // Mirrors the offline `generate` loop exactly (append → check → pop trailing
+        // EOS) so the streamed token stream is identical at temperature 0.
+        while decPos < emitLimit {
+            guard let logits = lastLogits else { break }
+            let token = model.sample(logits: logits, temperature: temperature)
+            generated.append(token)
+
+            if token == model.config.eosTokenId || generated.count > maxTokens {
+                done = true
+                if generated.last == model.config.eosTokenId { generated.removeLast() }
+                break
+            }
+            newIds.append(token)
+
+            let tokenEmbed = model.decoder.embedToken(tokenId: token)
+            let inputEmbed = decPos < adapter.shape[0]
+                ? adapter[decPos] + tokenEmbed
+                : tokenEmbed
+            let next = model.decoder(
+                inputEmbed.expandedDimensions(axis: 0),
+                startPos: decPos,
+                cache: decCache
+            )
+            decCache = next.1
+            lastLogits = model.decoder.logits(next.0[0])
+            decPos += 1
+            MLX.eval(lastLogits!)
+        }
+
+        // LOCAL FIX (see VENDORED.md): route the delta through StreamingDelta so emitted
+        // text is always append-only (a trailing U+FFFD from a split multi-byte character is
+        // held back until it resolves). Upstream re-emitted the whole transcript on any
+        // non-prefix step, which our no-backspace insertion path would duplicate on screen.
+        let textSoFar = model.decodeStreaming(generated)
+        let step = StreamingDelta.next(previouslyEmitted: emittedText, fullText: textSoFar)
+        emittedText = step.emitted
+        return Delta(text: step.delta, tokenIds: newIds)
+    }
+}
+
+public extension VoxtralRealtimeModel {
+    /// Create an online streaming session. Feed audio with `step(_:)`, then `finish()`.
+    func makeStreamSession(
+        temperature: Float = 0.0,
+        maxTokens: Int = 4096,
+        transcriptionDelayMs: Int? = nil
+    ) -> VoxtralRealtimeStreamSession {
+        VoxtralRealtimeStreamSession(
+            model: self,
+            temperature: temperature,
+            maxTokens: maxTokens,
+            transcriptionDelayMs: transcriptionDelayMs
+        )
+    }
+
+    /// Transcribe a whole audio buffer through the online streaming session, feeding
+    /// fixed `chunkMs`-sized chunks as a live caller would — instead of the whole-buffer
+    /// `generateStream`. `onDelta` receives each newly decoded fragment as it is produced
+    /// (use it to render live output); the returned `STTOutput` is the full transcript.
+    func transcribeStreaming(
+        audio: MLXArray,
+        generationParameters: STTGenerateParameters = STTGenerateParameters(),
+        chunkMs: Int = 480,
+        onDelta: ((String) -> Void)? = nil
+    ) -> STTOutput {
+        let mono = audio.ndim > 1 ? audio.mean(axis: -1) : audio
+        let samples = mono.asType(.float32).asArray(Float.self)
+        let chunk = max(1, 16000 * chunkMs / 1000)
+
+        let session = makeStreamSession(
+            temperature: generationParameters.temperature,
+            maxTokens: generationParameters.maxTokens
+        )
+        let start = CFAbsoluteTimeGetCurrent()
+
+        func emit(_ delta: VoxtralRealtimeStreamSession.Delta) {
+            guard !delta.text.isEmpty else { return }
+            onDelta?(delta.text)
+        }
+        var idx = 0
+        while idx < samples.count {
+            let end = min(idx + chunk, samples.count)
+            emit(session.step(Array(samples[idx..<end])))
+            idx = end
+        }
+        emit(session.finish())
+
+        let totalTime = CFAbsoluteTimeGetCurrent() - start
+        let tokenCount = session.tokens.count
+        return STTOutput(
+            text: session.text.trimmingCharacters(in: .whitespacesAndNewlines),
+            language: generationParameters.language,
+            generationTokens: tokenCount,
+            totalTokens: tokenCount,
+            generationTps: totalTime > 0 ? Double(tokenCount) / totalTime : 0,
+            totalTime: totalTime
+        )
+    }
+}

--- a/SpeechHelper/Sources/SpeechEngine/VoxtralRealtimeTokenizer.swift
+++ b/SpeechHelper/Sources/SpeechEngine/VoxtralRealtimeTokenizer.swift
@@ -1,0 +1,99 @@
+import Foundation
+
+struct VoxtralRealtimeTekkenFile: Decodable {
+    struct Config: Decodable {
+        let defaultNumSpecialTokens: Int?
+
+        enum CodingKeys: String, CodingKey {
+            case defaultNumSpecialTokens = "default_num_special_tokens"
+        }
+    }
+
+    struct SpecialToken: Decodable {
+        let rank: Int?
+    }
+
+    struct VocabEntry: Decodable {
+        let tokenBytes: String
+
+        enum CodingKeys: String, CodingKey {
+            case tokenBytes = "token_bytes"
+        }
+    }
+
+    let vocab: [VocabEntry]
+    let config: Config?
+    let specialTokens: [SpecialToken]?
+
+    enum CodingKeys: String, CodingKey {
+        case vocab
+        case config
+        case specialTokens = "special_tokens"
+    }
+}
+
+final class VoxtralRealtimeTokenizer {
+    let vocab: [VoxtralRealtimeTekkenFile.VocabEntry]
+    let nSpecial: Int
+    let specialIds: Set<Int>
+
+    private var bytesCache: [Int: [UInt8]] = [:]
+
+    init(tekkenURL: URL) throws {
+        let data = try Data(contentsOf: tekkenURL)
+        let parsed = try JSONDecoder().decode(VoxtralRealtimeTekkenFile.self, from: data)
+        vocab = parsed.vocab
+        nSpecial = parsed.config?.defaultNumSpecialTokens ?? 1000
+        specialIds = Set((parsed.specialTokens ?? []).compactMap { $0.rank })
+    }
+
+    static func fromModelDirectory(_ modelDir: URL) throws -> VoxtralRealtimeTokenizer {
+        let tekkenURL = modelDir.appendingPathComponent("tekken.json")
+        guard FileManager.default.fileExists(atPath: tekkenURL.path) else {
+            throw NSError(
+                domain: "VoxtralRealtimeTokenizer",
+                code: 1,
+                userInfo: [NSLocalizedDescriptionKey: "tekken.json not found at \(modelDir.path)"]
+            )
+        }
+        return try VoxtralRealtimeTokenizer(tekkenURL: tekkenURL)
+    }
+
+    func decode(tokenIds: [Int]) -> String {
+        var out: [UInt8] = []
+        out.reserveCapacity(tokenIds.count * 2)
+
+        for tokenId in tokenIds {
+            guard tokenId >= 0 else { continue }
+            if tokenId < nSpecial || specialIds.contains(tokenId) {
+                continue
+            }
+            out.append(contentsOf: tokenBytes(for: tokenId))
+        }
+
+        return String(decoding: out, as: UTF8.self)
+    }
+
+    private func tokenBytes(for tokenId: Int) -> [UInt8] {
+        if let cached = bytesCache[tokenId] {
+            return cached
+        }
+
+        guard tokenId >= nSpecial, !specialIds.contains(tokenId) else {
+            bytesCache[tokenId] = []
+            return []
+        }
+
+        let vocabId = tokenId - nSpecial
+        guard vocabId >= 0, vocabId < vocab.count else {
+            bytesCache[tokenId] = []
+            return []
+        }
+
+        let entry = vocab[vocabId]
+        let decoded = Data(base64Encoded: entry.tokenBytes) ?? Data()
+        let bytes = [UInt8](decoded)
+        bytesCache[tokenId] = bytes
+        return bytes
+    }
+}

--- a/SpeechHelper/Sources/SpeechEngineText/ParentProcessWatchdog.swift
+++ b/SpeechHelper/Sources/SpeechEngineText/ParentProcessWatchdog.swift
@@ -1,0 +1,41 @@
+import Foundation
+import Synchronization
+
+/// Exits the helper when the supervising app dies, so a crashed or killed app can never leave
+/// an orphaned model holding memory. Mirrors PolishHelper's watchdog and the `--parent-pid`
+/// contract the Python voxmlx backend honored.
+public final class ParentProcessWatchdog: @unchecked Sendable {
+    private let source: DispatchSourceProcess
+    private let fired = Mutex(false)
+    private let onParentExit: @Sendable () -> Void
+
+    public init(parentPID: pid_t, onParentExit: @escaping @Sendable () -> Void) {
+        self.onParentExit = onParentExit
+        self.source = DispatchSource.makeProcessSource(
+            identifier: parentPID,
+            eventMask: .exit,
+            queue: DispatchQueue(label: "localvoxtral.speechd.watchdog")
+        )
+        source.setEventHandler { [weak self] in self?.fireOnce() }
+        source.activate()
+
+        // Registered-then-probed so there is no gap: if the parent died between spawn and
+        // here, the kqueue registration won't fire, so catch it with a direct probe.
+        if kill(parentPID, 0) != 0 && errno == ESRCH {
+            fireOnce()
+        }
+    }
+
+    private func fireOnce() {
+        let first = fired.withLock { value in
+            let previous = value
+            value = true
+            return !previous
+        }
+        if first { onParentExit() }
+    }
+
+    deinit {
+        source.cancel()
+    }
+}

--- a/SpeechHelper/Sources/SpeechEngineText/RealtimeProtocol.swift
+++ b/SpeechHelper/Sources/SpeechEngineText/RealtimeProtocol.swift
@@ -1,0 +1,104 @@
+import Foundation
+
+/// The OpenAI-Realtime-compatible message subset the app exchanges with the ASR backend.
+/// Matches what `RealtimeAPIWebSocketClient` sends and expects (verified against the client),
+/// so this Swift server is a drop-in for the Python `voxmlx` process. Pure and Metal-free.
+public enum RealtimeClientMessage: Equatable, Sendable {
+    case sessionUpdate
+    /// 16 kHz mono PCM16LE, base64-encoded.
+    case audioAppend(base64PCM16: String)
+    /// `final == true` finalizes the utterance; a non-final commit is a no-op (matches voxmlx).
+    case commit(final: Bool)
+    case clear
+    /// A well-formed frame we don't act on (forward-compat: ignore, don't error).
+    case ignored(type: String)
+
+    public enum ParseError: Error, Equatable, Sendable {
+        case notJSONObject
+        case missingType
+        case invalidAudioPayload
+    }
+
+    public static func parse(_ data: Data) throws -> RealtimeClientMessage {
+        guard let obj = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            throw ParseError.notJSONObject
+        }
+        guard let type = obj["type"] as? String else { throw ParseError.missingType }
+
+        switch type {
+        case "session.update":
+            return .sessionUpdate
+        case "input_audio_buffer.append":
+            guard let audio = obj["audio"] as? String, !audio.isEmpty else {
+                throw ParseError.invalidAudioPayload
+            }
+            return .audioAppend(base64PCM16: audio)
+        case "input_audio_buffer.commit":
+            // `final` may arrive as a Bool or a numeric 0/1 depending on the encoder.
+            let final = (obj["final"] as? Bool) ?? ((obj["final"] as? NSNumber)?.boolValue ?? false)
+            return .commit(final: final)
+        case "input_audio_buffer.clear":
+            return .clear
+        default:
+            return .ignored(type: type)
+        }
+    }
+}
+
+/// Server→client messages. Serialized to compact JSON text frames.
+public enum RealtimeServerMessage: Equatable, Sendable {
+    case sessionCreated
+    case sessionUpdated
+    case transcriptDelta(String)
+    case transcriptDone(text: String)
+    case error(message: String)
+
+    public func json() -> String {
+        switch self {
+        case .sessionCreated:
+            return #"{"type":"session.created"}"#
+        case .sessionUpdated:
+            return #"{"type":"session.updated"}"#
+        case .transcriptDelta(let delta):
+            return Self.object(["type": "response.audio_transcript.delta", "delta": delta])
+        case .transcriptDone(let text):
+            return Self.object(["type": "response.audio_transcript.done", "text": text])
+        case .error(let message):
+            return Self.object(["type": "error", "message": message])
+        }
+    }
+
+    /// JSONSerialization with sorted keys so a value like a string with quotes/newlines is
+    /// escaped correctly (never hand-format JSON around model-produced text).
+    private static func object(_ dict: [String: String]) -> String {
+        guard
+            let data = try? JSONSerialization.data(
+                withJSONObject: dict, options: [.sortedKeys, .withoutEscapingSlashes]),
+            let string = String(data: data, encoding: .utf8)
+        else {
+            return #"{"type":"error","message":"serialization failed"}"#
+        }
+        return string
+    }
+}
+
+public enum PCM16 {
+    /// Decode base64 PCM16LE mono to normalized Float samples in [-1, 1), the input the
+    /// streaming session's `step([Float])` expects. Returns nil on undecodable base64 or an
+    /// odd byte count (a truncated sample).
+    public static func decode(base64: String) -> [Float]? {
+        guard let data = Data(base64Encoded: base64) else { return nil }
+        guard data.count % 2 == 0 else { return nil }
+        let count = data.count / 2
+        var out = [Float](repeating: 0, count: count)
+        data.withUnsafeBytes { (raw: UnsafeRawBufferPointer) in
+            for i in 0..<count {
+                let lo = UInt16(raw[i * 2])
+                let hi = UInt16(raw[i * 2 + 1])
+                let sample = Int16(bitPattern: (hi << 8) | lo)
+                out[i] = Float(sample) / 32768.0
+            }
+        }
+        return out
+    }
+}

--- a/SpeechHelper/Sources/SpeechEngineText/StreamingDelta.swift
+++ b/SpeechHelper/Sources/SpeechEngineText/StreamingDelta.swift
@@ -50,26 +50,13 @@ public enum StreamingDelta {
             )
         }
 
-        // Divergence beyond a provisional trailing char. Never emit contradicting text:
-        // extend only along the longest common prefix, and flag the rewrite.
-        let common = commonPrefixCount(previouslyEmitted, stable)
-        let emitted = String(stable.prefix(common))
-        return Result(
-            delta: String(emitted.dropFirst(min(previouslyEmitted.count, emitted.count))),
-            emitted: emitted,
-            wasRewrite: true
-        )
-    }
-
-    private static func commonPrefixCount(_ a: String, _ b: String) -> Int {
-        var count = 0
-        var ai = a.startIndex
-        var bi = b.startIndex
-        while ai < a.endIndex, bi < b.endIndex, a[ai] == b[bi] {
-            count += 1
-            ai = a.index(after: ai)
-            bi = b.index(after: bi)
-        }
-        return count
+        // Divergence beyond a provisional trailing char (should not happen at temperature 0).
+        // The consumer has ALREADY typed `previouslyEmitted` and cannot un-type it, so we must
+        // never move `emitted` backwards: doing so would let a later forward extension append a
+        // suffix onto text the screen no longer matches, garbling it (e.g. "hello wXY" then
+        // "hello world" → "hello wXYorld"). Instead hold: emit nothing and keep `emitted`
+        // pinned to what was actually typed. Worst case is a stuck/slightly-wrong tail — strictly
+        // safer than duplication for a no-backspace sink. `wasRewrite` surfaces it for logging.
+        return Result(delta: "", emitted: previouslyEmitted, wasRewrite: true)
     }
 }

--- a/SpeechHelper/Sources/SpeechEngineText/StreamingDelta.swift
+++ b/SpeechHelper/Sources/SpeechEngineText/StreamingDelta.swift
@@ -1,0 +1,75 @@
+import Foundation
+
+/// Computes the incremental text to emit from a streaming transcript, guaranteeing that
+/// the running emitted text only ever GROWS — a consumer can append each delta and never
+/// has to un-type. Pure and Metal-free so it is unit-testable in the tier-0 lane.
+///
+/// Why this exists: the upstream `VoxtralRealtimeStreamSession` emitted the delta as
+/// `fullText.dropFirst(emitted.count)` when `fullText` extended `emitted`, but re-emitted
+/// the ENTIRE transcript otherwise. The "otherwise" fires routinely: when a multi-byte
+/// UTF-8 character's bytes are split across two tokens, the first token decodes to a
+/// trailing replacement char (U+FFFD), which the next token replaces with the real
+/// character — so `fullText` is not a prefix-extension of the previous text, and the whole
+/// transcript gets re-emitted. Our insertion path has no backspaces (terminals can't
+/// support them), so that duplicates text on screen. Accented input (French) is the common
+/// trigger.
+///
+/// The fix mirrors the app's hold-back philosophy: treat a trailing replacement char as
+/// provisional and withhold it until it resolves. The stable prefix is then always a
+/// forward extension of what was emitted before.
+public enum StreamingDelta {
+    public struct Result: Equatable, Sendable {
+        /// Newly emitted text to append (never contradicts prior output).
+        public let delta: String
+        /// The full running emitted text after this step — pass back as `previouslyEmitted`.
+        public let emitted: String
+        /// True when `fullText` diverged from prior output beyond a provisional trailing
+        /// char (should not happen at temperature 0; surfaced for observability rather than
+        /// silently re-emitting).
+        public let wasRewrite: Bool
+    }
+
+    /// A trailing run of U+FFFD is a multi-byte character still being assembled; hold it back.
+    public static func stablePrefix(of text: String) -> Substring {
+        var end = text.endIndex
+        while end > text.startIndex {
+            let prev = text.index(before: end)
+            if text[prev] == "\u{FFFD}" { end = prev } else { break }
+        }
+        return text[text.startIndex..<end]
+    }
+
+    public static func next(previouslyEmitted: String, fullText: String) -> Result {
+        let stable = String(stablePrefix(of: fullText))
+
+        if stable.hasPrefix(previouslyEmitted) {
+            return Result(
+                delta: String(stable.dropFirst(previouslyEmitted.count)),
+                emitted: stable,
+                wasRewrite: false
+            )
+        }
+
+        // Divergence beyond a provisional trailing char. Never emit contradicting text:
+        // extend only along the longest common prefix, and flag the rewrite.
+        let common = commonPrefixCount(previouslyEmitted, stable)
+        let emitted = String(stable.prefix(common))
+        return Result(
+            delta: String(emitted.dropFirst(min(previouslyEmitted.count, emitted.count))),
+            emitted: emitted,
+            wasRewrite: true
+        )
+    }
+
+    private static func commonPrefixCount(_ a: String, _ b: String) -> Int {
+        var count = 0
+        var ai = a.startIndex
+        var bi = b.startIndex
+        while ai < a.endIndex, bi < b.endIndex, a[ai] == b[bi] {
+            count += 1
+            ai = a.index(after: ai)
+            bi = b.index(after: bi)
+        }
+        return count
+    }
+}

--- a/SpeechHelper/Sources/SpeechEngineText/WebSocketFrame.swift
+++ b/SpeechHelper/Sources/SpeechEngineText/WebSocketFrame.swift
@@ -1,0 +1,144 @@
+import Foundation
+
+/// Minimal RFC 6455 frame codec — just enough for the realtime ASR protocol on loopback.
+/// Pure and Metal-free so the framing logic is unit-testable without a socket or a model.
+///
+/// Scope: single-frame text/binary messages plus control frames (ping/pong/close). The app's
+/// `URLSessionWebSocketTask` client sends each realtime message as one (possibly large,
+/// masked) frame, so continuation frames are decoded defensively but the server only ever
+/// *emits* unfragmented frames.
+public enum WebSocketOpcode: UInt8, Sendable {
+    case continuation = 0x0
+    case text = 0x1
+    case binary = 0x2
+    case close = 0x8
+    case ping = 0x9
+    case pong = 0xA
+}
+
+public struct WebSocketFrame: Equatable, Sendable {
+    public let fin: Bool
+    public let opcode: WebSocketOpcode
+    public let payload: Data
+
+    public init(fin: Bool, opcode: WebSocketOpcode, payload: Data) {
+        self.fin = fin
+        self.opcode = opcode
+        self.payload = payload
+    }
+}
+
+public enum WebSocketDecodeResult: Equatable, Sendable {
+    /// A complete frame plus the number of bytes it consumed from the buffer.
+    case frame(WebSocketFrame, consumed: Int)
+    /// Not enough bytes yet — read more and retry.
+    case incomplete
+}
+
+public enum WebSocketFrameError: Error, Equatable, Sendable {
+    /// A client frame was not masked (RFC 6455 requires client→server frames to be masked).
+    case clientFrameNotMasked
+    case reservedOpcode(UInt8)
+    /// Payload length field exceeds what we will buffer (guards against a hostile length).
+    case payloadTooLarge(UInt64)
+}
+
+public enum WebSocketFrameCodec {
+    /// Hard cap on a single inbound frame we will assemble (audio-append base64 for a chunk
+    /// is a few KB; a whole utterance's worth is well under this). Prevents a bogus 64-bit
+    /// length from making us allocate gigabytes.
+    public static let maxPayloadBytes: UInt64 = 32 * 1024 * 1024
+
+    /// Try to decode one frame from the front of `buffer`. Returns `.incomplete` if more
+    /// bytes are needed. `requireMask` enforces the client-frame masking rule.
+    public static func decode(_ buffer: Data, requireMask: Bool = true) throws -> WebSocketDecodeResult {
+        // Index into `buffer` via its own indices (Data slices are not zero-based).
+        let bytes = [UInt8](buffer)
+        guard bytes.count >= 2 else { return .incomplete }
+
+        let b0 = bytes[0]
+        let b1 = bytes[1]
+        let fin = (b0 & 0x80) != 0
+        let rawOpcode = b0 & 0x0F
+        guard let opcode = WebSocketOpcode(rawValue: rawOpcode) else {
+            throw WebSocketFrameError.reservedOpcode(rawOpcode)
+        }
+        let masked = (b1 & 0x80) != 0
+        if requireMask && !masked {
+            throw WebSocketFrameError.clientFrameNotMasked
+        }
+
+        var offset = 2
+        var payloadLen = UInt64(b1 & 0x7F)
+        if payloadLen == 126 {
+            guard bytes.count >= offset + 2 else { return .incomplete }
+            payloadLen = (UInt64(bytes[offset]) << 8) | UInt64(bytes[offset + 1])
+            offset += 2
+        } else if payloadLen == 127 {
+            guard bytes.count >= offset + 8 else { return .incomplete }
+            payloadLen = 0
+            for i in 0..<8 { payloadLen = (payloadLen << 8) | UInt64(bytes[offset + i]) }
+            offset += 8
+        }
+        if payloadLen > maxPayloadBytes {
+            throw WebSocketFrameError.payloadTooLarge(payloadLen)
+        }
+
+        var maskKey: [UInt8] = []
+        if masked {
+            guard bytes.count >= offset + 4 else { return .incomplete }
+            maskKey = Array(bytes[offset..<offset + 4])
+            offset += 4
+        }
+
+        let len = Int(payloadLen)
+        guard bytes.count >= offset + len else { return .incomplete }
+
+        var payload = [UInt8](bytes[offset..<offset + len])
+        if masked {
+            for i in 0..<len { payload[i] ^= maskKey[i % 4] }
+        }
+        offset += len
+
+        return .frame(
+            WebSocketFrame(fin: fin, opcode: opcode, payload: Data(payload)),
+            consumed: offset
+        )
+    }
+
+    /// Encode a server→client frame. Server frames are never masked (RFC 6455).
+    public static func encode(_ frame: WebSocketFrame) -> Data {
+        var out = [UInt8]()
+        out.append((frame.fin ? 0x80 : 0x00) | frame.opcode.rawValue)
+
+        let len = frame.payload.count
+        if len < 126 {
+            out.append(UInt8(len))
+        } else if len <= 0xFFFF {
+            out.append(126)
+            out.append(UInt8((len >> 8) & 0xFF))
+            out.append(UInt8(len & 0xFF))
+        } else {
+            out.append(127)
+            let len64 = UInt64(len)
+            for shift in stride(from: 56, through: 0, by: -8) {
+                out.append(UInt8((len64 >> UInt64(shift)) & 0xFF))
+            }
+        }
+        out.append(contentsOf: frame.payload)
+        return Data(out)
+    }
+
+    public static func text(_ string: String) -> Data {
+        encode(WebSocketFrame(fin: true, opcode: .text, payload: Data(string.utf8)))
+    }
+
+    public static func pong(_ payload: Data) -> Data {
+        encode(WebSocketFrame(fin: true, opcode: .pong, payload: payload))
+    }
+
+    /// A close frame with the normal-closure status code (1000).
+    public static func close() -> Data {
+        encode(WebSocketFrame(fin: true, opcode: .close, payload: Data([0x03, 0xE8])))
+    }
+}

--- a/SpeechHelper/Sources/SpeechEngineText/WebSocketHandshake.swift
+++ b/SpeechHelper/Sources/SpeechEngineText/WebSocketHandshake.swift
@@ -1,0 +1,84 @@
+import CryptoKit
+import Foundation
+
+/// The WebSocket opening handshake (RFC 6455 §4.2) plus a tiny HTTP request parser — enough
+/// to tell a `GET /health` probe apart from a `/v1/realtime` upgrade on one loopback port.
+/// Pure and Metal-free.
+public struct HTTPRequestHead: Equatable, Sendable {
+    public let method: String
+    public let path: String
+    public let headers: [String: String]  // lowercased header names
+
+    public func header(_ name: String) -> String? { headers[name.lowercased()] }
+
+    /// A WebSocket upgrade request carries `Upgrade: websocket` + a `Sec-WebSocket-Key`.
+    public var isWebSocketUpgrade: Bool {
+        (header("upgrade")?.lowercased().contains("websocket") ?? false)
+            && header("sec-websocket-key") != nil
+    }
+}
+
+public enum WebSocketHandshake {
+    /// Fixed GUID from RFC 6455 §1.3.
+    static let magicGUID = "258EAFA5-E914-47DA-95CA-C5AB0DC85B11"
+
+    /// Parse an HTTP request head from the bytes before the `\r\n\r\n` terminator. Returns nil
+    /// if the header block isn't complete yet (caller should read more).
+    public static func parseRequestHead(_ buffer: Data) -> (head: HTTPRequestHead, headerBytes: Int)? {
+        guard let range = buffer.range(of: Data("\r\n\r\n".utf8)) else { return nil }
+        let headerBytes = range.upperBound - buffer.startIndex
+        guard let text = String(data: buffer[buffer.startIndex..<range.lowerBound], encoding: .utf8)
+        else { return nil }
+
+        let lines = text.components(separatedBy: "\r\n")
+        guard let requestLine = lines.first else { return nil }
+        let parts = requestLine.split(separator: " ")
+        guard parts.count >= 2 else { return nil }
+
+        var headers: [String: String] = [:]
+        for line in lines.dropFirst() {
+            guard let colon = line.firstIndex(of: ":") else { continue }
+            let name = line[line.startIndex..<colon].trimmingCharacters(in: .whitespaces).lowercased()
+            let value = line[line.index(after: colon)...].trimmingCharacters(in: .whitespaces)
+            headers[name] = value
+        }
+        return (
+            HTTPRequestHead(method: String(parts[0]), path: String(parts[1]), headers: headers),
+            headerBytes
+        )
+    }
+
+    /// `Sec-WebSocket-Accept` = base64(SHA1(key + magicGUID)).
+    public static func acceptKey(for secWebSocketKey: String) -> String {
+        let digest = Insecure.SHA1.hash(data: Data((secWebSocketKey + magicGUID).utf8))
+        return Data(digest).base64EncodedString()
+    }
+
+    /// The 101 Switching Protocols response bytes for a given client key.
+    public static func upgradeResponse(secWebSocketKey: String) -> Data {
+        let accept = acceptKey(for: secWebSocketKey)
+        let response = """
+            HTTP/1.1 101 Switching Protocols\r
+            Upgrade: websocket\r
+            Connection: Upgrade\r
+            Sec-WebSocket-Accept: \(accept)\r
+            \r
+
+            """
+        return Data(response.utf8)
+    }
+
+    /// A minimal HTTP/1.1 response with a JSON body and `Connection: close`.
+    public static func httpResponse(status: String, json: String) -> Data {
+        let body = Data(json.utf8)
+        let head = """
+            HTTP/1.1 \(status)\r
+            Content-Type: application/json\r
+            Content-Length: \(body.count)\r
+            Connection: close\r
+            \r
+
+            """
+        return Data(head.utf8) + body
+    }
+}

--- a/SpeechHelper/Sources/localvoxtral-speechd/main.swift
+++ b/SpeechHelper/Sources/localvoxtral-speechd/main.swift
@@ -1,10 +1,108 @@
 import Foundation
 import SpeechEngine
+import SpeechEngineText
 
-// Placeholder entry point. The bundled realtime ASR server (a loopback OpenAI-Realtime
-// websocket speaking the subset the app already uses with voxmlx, plus a parent-pid
-// watchdog) lands in the follow-up that wires this helper into BackendManager. For now the
-// deliverable is the vendored+fixed engine (SpeechEngine) and its Metal-free delta tests.
-FileHandle.standardError.write(
-    Data("localvoxtral-speechd: engine vendored; realtime server not yet wired.\n".utf8))
-exit(0)
+/// localvoxtral's bundled realtime ASR engine: loads the Voxtral MLX model and serves the
+/// OpenAI-Realtime websocket subset on loopback, a drop-in for the Python `voxmlx` process.
+/// Spawned and supervised by the app (BackendProcessSupervisor); the model is loaded BEFORE
+/// the listener binds, so `/health` becoming reachable is the readiness signal (matching the
+/// supervisor's readinessURL contract).
+@main
+struct SpeechdMain {
+    struct Options {
+        var modelID: String?
+        var modelDirectory: String?
+        var port: UInt16 = 8471  // matches BackendCatalog.voxmlx.port
+        var parentPID: pid_t?
+        var transcriptionDelayMs: Int?
+        var cacheLimitMB = 4096
+    }
+
+    enum OptionError: Error, CustomStringConvertible {
+        case missingValue(String), invalidValue(String), unknownFlag(String), missingModel
+        var description: String {
+            switch self {
+            case .missingValue(let f): return "missing value for \(f)"
+            case .invalidValue(let f): return "invalid value for \(f)"
+            case .unknownFlag(let f): return "unknown flag \(f)"
+            case .missingModel: return "one of --model or --model-dir is required"
+            }
+        }
+    }
+
+    static func main() async {
+        do {
+            try await run(parse(Array(CommandLine.arguments.dropFirst())))
+        } catch {
+            FileHandle.standardError.write(Data("speechd: \(error)\n".utf8))
+            exit(1)
+        }
+    }
+
+    static func parse(_ arguments: [String]) throws -> Options {
+        var options = Options()
+        var it = arguments.makeIterator()
+        func value(_ flag: String) throws -> String {
+            guard let v = it.next() else { throw OptionError.missingValue(flag) }
+            return v
+        }
+        while let flag = it.next() {
+            switch flag {
+            case "--model": options.modelID = try value(flag)
+            case "--model-dir": options.modelDirectory = try value(flag)
+            case "--port":
+                guard let p = UInt16(try value(flag)) else { throw OptionError.invalidValue(flag) }
+                options.port = p
+            case "--parent-pid":
+                guard let pid = pid_t(try value(flag)) else { throw OptionError.invalidValue(flag) }
+                options.parentPID = pid
+            case "--transcription-delay-ms":
+                guard let ms = Int(try value(flag)), ms > 0 else { throw OptionError.invalidValue(flag) }
+                options.transcriptionDelayMs = ms
+            case "--cache-limit-mb":
+                guard let mb = Int(try value(flag)), mb >= 0 else { throw OptionError.invalidValue(flag) }
+                options.cacheLimitMB = mb
+            default:
+                throw OptionError.unknownFlag(flag)
+            }
+        }
+        guard options.modelID != nil || options.modelDirectory != nil else {
+            throw OptionError.missingModel
+        }
+        return options
+    }
+
+    static func run(_ options: Options) async throws {
+        // Load BEFORE binding the listener so /health only answers once inference is ready.
+        let server = try await RealtimeSpeechServer.load(
+            modelID: options.modelID,
+            modelDirectory: options.modelDirectory,
+            port: options.port,
+            transcriptionDelayMs: options.transcriptionDelayMs,
+            cacheLimitMB: options.cacheLimitMB
+        )
+
+        // Exit if the supervising app dies, so a killed app never orphans the model.
+        var watchdog: ParentProcessWatchdog?
+        if let pid = options.parentPID {
+            watchdog = ParentProcessWatchdog(parentPID: pid) {
+                FileHandle.standardError.write(Data("speechd: parent \(pid) exited; stopping\n".utf8))
+                exit(0)
+            }
+        }
+        _ = watchdog  // retained for the process lifetime
+
+        // A listener that dies in a live process is invisible to the supervisor (it only
+        // watches process exit) — die loudly to get restarted.
+        server.onListenerFailure = { error in
+            FileHandle.standardError.write(Data("speechd: listener failed: \(error)\n".utf8))
+            exit(1)
+        }
+        try await server.start()
+        FileHandle.standardError.write(
+            Data("speechd: ready on 127.0.0.1:\(server.boundPort)\n".utf8))
+
+        // Park forever; the watchdog and listener-failure paths own process exit.
+        try await withUnsafeThrowingContinuation { (_: UnsafeContinuation<Void, Error>) in }
+    }
+}

--- a/SpeechHelper/Sources/localvoxtral-speechd/main.swift
+++ b/SpeechHelper/Sources/localvoxtral-speechd/main.swift
@@ -1,0 +1,10 @@
+import Foundation
+import SpeechEngine
+
+// Placeholder entry point. The bundled realtime ASR server (a loopback OpenAI-Realtime
+// websocket speaking the subset the app already uses with voxmlx, plus a parent-pid
+// watchdog) lands in the follow-up that wires this helper into BackendManager. For now the
+// deliverable is the vendored+fixed engine (SpeechEngine) and its Metal-free delta tests.
+FileHandle.standardError.write(
+    Data("localvoxtral-speechd: engine vendored; realtime server not yet wired.\n".utf8))
+exit(0)

--- a/SpeechHelper/Tests/SpeechEngineTextTests/RealtimeServerCodecTests.swift
+++ b/SpeechHelper/Tests/SpeechEngineTextTests/RealtimeServerCodecTests.swift
@@ -1,0 +1,157 @@
+import Foundation
+import XCTest
+
+@testable import SpeechEngineText
+
+/// Metal-free tests for the loopback realtime server's pure codecs: WebSocket framing, the
+/// upgrade handshake, the protocol messages, and PCM16 decode. These are the pieces that
+/// carry bytes on and off the wire, so they get exercised directly rather than through a
+/// socket.
+final class RealtimeServerCodecTests: XCTestCase {
+    // MARK: WebSocket frames
+
+    /// Round-trip a masked client frame through decode (server frames are unmasked, so we
+    /// build the masked bytes by hand the way a client would).
+    private func maskedClientFrame(opcode: WebSocketOpcode, payload: [UInt8], mask: [UInt8]) -> Data {
+        var out: [UInt8] = [0x80 | opcode.rawValue]
+        let len = payload.count
+        if len < 126 {
+            out.append(0x80 | UInt8(len))
+        } else if len <= 0xFFFF {
+            out.append(0x80 | 126)
+            out.append(UInt8((len >> 8) & 0xFF)); out.append(UInt8(len & 0xFF))
+        } else {
+            out.append(0x80 | 127)
+            let l = UInt64(len)
+            for shift in stride(from: 56, through: 0, by: -8) { out.append(UInt8((l >> UInt64(shift)) & 0xFF)) }
+        }
+        out.append(contentsOf: mask)
+        for (i, b) in payload.enumerated() { out.append(b ^ mask[i % 4]) }
+        return Data(out)
+    }
+
+    func testDecodeMaskedTextFrame() throws {
+        let text = "hello realtime"
+        let frame = maskedClientFrame(opcode: .text, payload: [UInt8](text.utf8), mask: [0x12, 0x34, 0x56, 0x78])
+        guard case .frame(let decoded, let consumed) = try WebSocketFrameCodec.decode(frame) else {
+            return XCTFail("expected a complete frame")
+        }
+        XCTAssertEqual(decoded.opcode, .text)
+        XCTAssertTrue(decoded.fin)
+        XCTAssertEqual(String(data: decoded.payload, encoding: .utf8), text)
+        XCTAssertEqual(consumed, frame.count)
+    }
+
+    func testDecodeIsIncompleteUntilFullFrameArrives() throws {
+        let full = maskedClientFrame(opcode: .text, payload: [UInt8]("abc".utf8), mask: [1, 2, 3, 4])
+        for prefixLen in 0..<full.count {
+            XCTAssertEqual(try WebSocketFrameCodec.decode(full.prefix(prefixLen)), .incomplete,
+                           "prefix of \(prefixLen) bytes should be incomplete")
+        }
+        guard case .frame = try WebSocketFrameCodec.decode(full) else { return XCTFail() }
+    }
+
+    func testDecodeExtendedLength126() throws {
+        let payload = [UInt8](repeating: 0x41, count: 300)  // > 125 → 16-bit length path
+        let frame = maskedClientFrame(opcode: .binary, payload: payload, mask: [9, 8, 7, 6])
+        guard case .frame(let decoded, _) = try WebSocketFrameCodec.decode(frame) else { return XCTFail() }
+        XCTAssertEqual([UInt8](decoded.payload), payload)
+    }
+
+    func testUnmaskedClientFrameRejected() {
+        let unmasked = Data([0x81, 0x03, 0x61, 0x62, 0x63])  // FIN+text, len 3, no mask
+        XCTAssertThrowsError(try WebSocketFrameCodec.decode(unmasked)) { error in
+            XCTAssertEqual(error as? WebSocketFrameError, .clientFrameNotMasked)
+        }
+    }
+
+    func testHostileLengthRejectedBeforeAllocating() {
+        // FIN+binary, 127 length marker, 64-bit length = 0xFFFFFFFF (masked bit set).
+        var bytes: [UInt8] = [0x82, 0xFF]
+        bytes.append(contentsOf: [0, 0, 0, 0, 0xFF, 0xFF, 0xFF, 0xFF])
+        XCTAssertThrowsError(try WebSocketFrameCodec.decode(Data(bytes))) { error in
+            guard case .payloadTooLarge = (error as? WebSocketFrameError) else {
+                return XCTFail("expected payloadTooLarge, got \(error)")
+            }
+        }
+    }
+
+    func testServerEncodeIsUnmaskedAndDecodesBack() throws {
+        let data = WebSocketFrameCodec.text("δelta")  // multibyte to check length in bytes
+        // A server frame must have the mask bit clear.
+        XCTAssertEqual(data[1] & 0x80, 0)
+        // Decode it back allowing unmasked (as a client would).
+        guard case .frame(let f, let consumed) = try WebSocketFrameCodec.decode(data, requireMask: false) else {
+            return XCTFail()
+        }
+        XCTAssertEqual(String(data: f.payload, encoding: .utf8), "δelta")
+        XCTAssertEqual(consumed, data.count)
+    }
+
+    // MARK: Handshake
+
+    func testAcceptKeyMatchesRFC6455Example() {
+        // The canonical example from RFC 6455 §1.3.
+        XCTAssertEqual(
+            WebSocketHandshake.acceptKey(for: "dGhlIHNhbXBsZSBub25jZQ=="),
+            "s3pPLMBiTxaQ9kYGzzhZRbK+xOo=")
+    }
+
+    func testParseRequestHeadDistinguishesHealthFromUpgrade() {
+        let health = Data("GET /health HTTP/1.1\r\nHost: x\r\n\r\n".utf8)
+        guard let (h, _) = WebSocketHandshake.parseRequestHead(health) else { return XCTFail() }
+        XCTAssertEqual(h.path, "/health")
+        XCTAssertFalse(h.isWebSocketUpgrade)
+
+        let upgrade = Data(
+            "GET /v1/realtime HTTP/1.1\r\nUpgrade: websocket\r\nSec-WebSocket-Key: abc==\r\n\r\n".utf8)
+        guard let (u, _) = WebSocketHandshake.parseRequestHead(upgrade) else { return XCTFail() }
+        XCTAssertTrue(u.isWebSocketUpgrade)
+        XCTAssertEqual(u.header("sec-websocket-key"), "abc==")
+    }
+
+    func testParseRequestHeadIncompleteUntilTerminator() {
+        XCTAssertNil(WebSocketHandshake.parseRequestHead(Data("GET /health HTTP/1.1\r\nHost: x".utf8)))
+    }
+
+    // MARK: Protocol
+
+    func testParseAudioAppend() throws {
+        let msg = try RealtimeClientMessage.parse(Data(#"{"type":"input_audio_buffer.append","audio":"AAECAw=="}"#.utf8))
+        XCTAssertEqual(msg, .audioAppend(base64PCM16: "AAECAw=="))
+    }
+
+    func testParseCommitFinalAndNonFinal() throws {
+        XCTAssertEqual(try RealtimeClientMessage.parse(Data(#"{"type":"input_audio_buffer.commit","final":true}"#.utf8)), .commit(final: true))
+        XCTAssertEqual(try RealtimeClientMessage.parse(Data(#"{"type":"input_audio_buffer.commit"}"#.utf8)), .commit(final: false))
+    }
+
+    func testUnknownTypeIsIgnoredNotAnError() throws {
+        XCTAssertEqual(try RealtimeClientMessage.parse(Data(#"{"type":"response.created"}"#.utf8)), .ignored(type: "response.created"))
+    }
+
+    func testServerMessageJSONEscapesText() {
+        // A transcript containing a quote and newline must be valid JSON, not hand-broken.
+        let json = RealtimeServerMessage.transcriptDone(text: "he said \"hi\"\nbye").json()
+        let parsed = try? JSONSerialization.jsonObject(with: Data(json.utf8)) as? [String: String]
+        XCTAssertEqual(parsed?["type"], "response.audio_transcript.done")
+        XCTAssertEqual(parsed?["text"], "he said \"hi\"\nbye")
+    }
+
+    // MARK: PCM16
+
+    func testPCM16DecodeNormalizes() {
+        // int16 samples 0, 32767, -32768 → 0, ~1, -1
+        let bytes: [UInt8] = [0x00, 0x00, 0xFF, 0x7F, 0x00, 0x80]
+        let b64 = Data(bytes).base64EncodedString()
+        let samples = PCM16.decode(base64: b64)
+        XCTAssertEqual(samples?.count, 3)
+        XCTAssertEqual(samples?[0], 0)
+        XCTAssertEqual(samples?[1] ?? 0, 0.99997, accuracy: 0.0001)
+        XCTAssertEqual(samples?[2], -1)
+    }
+
+    func testPCM16RejectsOddByteCount() {
+        XCTAssertNil(PCM16.decode(base64: Data([0x01, 0x02, 0x03]).base64EncodedString()))
+    }
+}

--- a/SpeechHelper/Tests/SpeechEngineTextTests/StreamingDeltaTests.swift
+++ b/SpeechHelper/Tests/SpeechEngineTextTests/StreamingDeltaTests.swift
@@ -1,0 +1,74 @@
+import XCTest
+
+@testable import SpeechEngineText
+
+/// Metal-free regression tests for the append-only delta contract. These guard the
+/// specific failure the vendored engine had upstream: re-emitting the whole transcript
+/// when a multi-byte UTF-8 character is split across tokens, which our no-backspace
+/// insertion path would duplicate on screen.
+final class StreamingDeltaTests: XCTestCase {
+    /// Drive a sequence of `fullText` snapshots through the running emitter the way the
+    /// decode loop does, returning the concatenation of every delta. In a correct emitter
+    /// that concatenation equals the final stable text — never more.
+    private func replay(_ snapshots: [String]) -> (concatenated: String, rewrites: Int) {
+        var emitted = ""
+        var out = ""
+        var rewrites = 0
+        for full in snapshots {
+            let step = StreamingDelta.next(previouslyEmitted: emitted, fullText: full)
+            out += step.delta
+            emitted = step.emitted
+            if step.wasRewrite { rewrites += 1 }
+        }
+        return (out, rewrites)
+    }
+
+    func testPlainForwardExtensionEmitsOnlyTheSuffix() {
+        let r = replay(["hel", "hello", "hello wo", "hello world"])
+        XCTAssertEqual(r.concatenated, "hello world")
+        XCTAssertEqual(r.rewrites, 0)
+    }
+
+    func testSplitMultibyteCharIsNotDuplicated() {
+        // "café": the é (2 UTF-8 bytes) is split across tokens, so the first snapshot ends
+        // in a replacement char that the next snapshot resolves. Upstream re-emitted the
+        // whole string here → "cafcafé". The concatenation must be exactly "café".
+        let r = replay(["caf", "caf\u{FFFD}", "café", "café "])
+        XCTAssertEqual(r.concatenated, "café ")
+        XCTAssertEqual(r.rewrites, 0, "resolving a provisional char is not a rewrite")
+    }
+
+    func testAccentedFrenchStreamNeverDuplicates() {
+        // A longer accented stream with several split points.
+        let snapshots = [
+            "le caf\u{FFFD}", "le café ", "le café \u{FFFD}", "le café était",
+            "le café était tr\u{FFFD}", "le café était très",
+        ]
+        let r = replay(snapshots)
+        XCTAssertEqual(r.concatenated, "le café était très")
+        XCTAssertEqual(r.rewrites, 0)
+    }
+
+    func testTrailingReplacementCharIsHeldBack() {
+        let step = StreamingDelta.next(previouslyEmitted: "abc", fullText: "abc\u{FFFD}")
+        XCTAssertEqual(step.delta, "", "a provisional trailing char must not be emitted")
+        XCTAssertEqual(step.emitted, "abc")
+        XCTAssertFalse(step.wasRewrite)
+    }
+
+    func testGenuineRewriteNeverEmitsContradictingText() {
+        // If the text truly diverges (not just a provisional char), we must not append text
+        // that contradicts what was already shown; we extend only along the common prefix.
+        let step = StreamingDelta.next(previouslyEmitted: "hello wXY", fullText: "hello world")
+        XCTAssertTrue("hello wXY".hasPrefix("hello w" + String(step.delta.prefix(0))))
+        XCTAssertFalse(step.emitted.hasPrefix("hello wXYZ"))
+        XCTAssertTrue(step.wasRewrite)
+        XCTAssertTrue("hello world".hasPrefix(step.emitted))
+    }
+
+    func testStablePrefixDropsOnlyTrailingReplacementChars() {
+        XCTAssertEqual(String(StreamingDelta.stablePrefix(of: "ab\u{FFFD}c")), "ab\u{FFFD}c")
+        XCTAssertEqual(String(StreamingDelta.stablePrefix(of: "abc\u{FFFD}\u{FFFD}")), "abc")
+        XCTAssertEqual(String(StreamingDelta.stablePrefix(of: "abc")), "abc")
+    }
+}

--- a/SpeechHelper/Tests/SpeechEngineTextTests/StreamingDeltaTests.swift
+++ b/SpeechHelper/Tests/SpeechEngineTextTests/StreamingDeltaTests.swift
@@ -56,14 +56,34 @@ final class StreamingDeltaTests: XCTestCase {
         XCTAssertFalse(step.wasRewrite)
     }
 
-    func testGenuineRewriteNeverEmitsContradictingText() {
-        // If the text truly diverges (not just a provisional char), we must not append text
-        // that contradicts what was already shown; we extend only along the common prefix.
+    func testGenuineRewriteHoldsInsteadOfMovingEmittedBackwards() {
+        // On a true divergence we must NOT shrink `emitted` (the consumer already typed it and
+        // can't un-type). Emit nothing, keep `emitted` == what was typed, flag the rewrite.
         let step = StreamingDelta.next(previouslyEmitted: "hello wXY", fullText: "hello world")
-        XCTAssertTrue("hello wXY".hasPrefix("hello w" + String(step.delta.prefix(0))))
-        XCTAssertFalse(step.emitted.hasPrefix("hello wXYZ"))
+        XCTAssertEqual(step.delta, "")
+        XCTAssertEqual(step.emitted, "hello wXY", "emitted must never move backwards")
         XCTAssertTrue(step.wasRewrite)
-        XCTAssertTrue("hello world".hasPrefix(step.emitted))
+    }
+
+    func testRewriteThenExtensionNeverGarblesAcrossSteps() {
+        // The regression the module exists to prevent: a rewrite followed by more text must not
+        // append a suffix onto stale on-screen text. Before the fix this produced "hello wXYorld".
+        let r = replay(["hello wXY", "hello world", "hello world"])
+        XCTAssertNotEqual(r.concatenated, "hello wXYorld")
+        // Append-only invariant: the running concatenation is always a prefix of itself over time
+        // and never contains contradicting interleaving. Here it holds at "hello wXY".
+        XCTAssertEqual(r.concatenated, "hello wXY")
+        XCTAssertEqual(r.rewrites, 2)
+    }
+
+    func testEmittedPlusDeltaAlwaysEqualsEmitted_invariant() {
+        // The core invariant, checked over a mixed sequence incl. a divergence.
+        var emitted = ""
+        for full in ["ab", "abc", "abX", "abcd", "abcde"] {
+            let step = StreamingDelta.next(previouslyEmitted: emitted, fullText: full)
+            XCTAssertEqual(emitted + step.delta, step.emitted, "invariant violated at fullText=\(full)")
+            emitted = step.emitted
+        }
     }
 
     func testStablePrefixDropsOnlyTrailingReplacementChars() {

--- a/SpeechHelper/Tests/SpeechEngineTextTests/StreamingDeltaTests.swift
+++ b/SpeechHelper/Tests/SpeechEngineTextTests/StreamingDeltaTests.swift
@@ -56,6 +56,28 @@ final class StreamingDeltaTests: XCTestCase {
         XCTAssertFalse(step.wasRewrite)
     }
 
+    func testStreamEndingInUnresolvedReplacementCharHoldsItBack() {
+        // The stream's FINAL snapshot still carries a trailing U+FFFD that never resolves
+        // (audio cut off mid multi-byte char). `stablePrefix` must hold it back: the running
+        // concatenation ends at the stable text, the provisional char is never emitted, and
+        // no rewrite is flagged (dropping a trailing provisional char is not a divergence).
+        let r = replay(["caf", "café", "café \u{FFFD}"])
+        XCTAssertEqual(r.concatenated, "café ")
+        XCTAssertFalse(r.concatenated.contains("\u{FFFD}"), "a provisional trailing char must never be emitted")
+        XCTAssertEqual(r.rewrites, 0)
+    }
+
+    func testShrinkToProperPrefixHoldsInsteadOfReEmitting() {
+        // `fullText` gets SHORTER — shrinking to a proper prefix of what was already emitted.
+        // The consumer has typed the longer text and can't un-type it, so this is the
+        // `wasRewrite` hold path (a shorter, not same-length, divergence): emit nothing, keep
+        // `emitted` pinned to what was typed, flag the rewrite. Re-emitting would garble.
+        let step = StreamingDelta.next(previouslyEmitted: "hello world", fullText: "hello")
+        XCTAssertEqual(step.delta, "", "a shrink must not re-emit")
+        XCTAssertEqual(step.emitted, "hello world", "emitted must never move backwards")
+        XCTAssertTrue(step.wasRewrite)
+    }
+
     func testGenuineRewriteHoldsInsteadOfMovingEmittedBackwards() {
         // On a true divergence we must NOT shrink `emitted` (the consumer already typed it and
         // can't un-type). Emit nothing, keep `emitted` == what was typed, flag the rewrite.

--- a/SpeechHelper/VENDORED.md
+++ b/SpeechHelper/VENDORED.md
@@ -6,9 +6,11 @@
 
 - Upstream commit: `d302a5c6080d2bb97bae38c7418f82abb76013b6` (tag `v0.1.3`, `main` at
   vendoring time — the `Models/VoxtralRealtime/` tree is identical between the two).
-- Files taken verbatim then modified: `Models/VoxtralRealtime/*.swift`, plus
-  `Generation.swift` and `Models/GLMASR/STTOutput.swift` (the `STT*` protocol types the
-  engine references).
+- Byte-identical verbatim copies: `VoxtralRealtime.swift`, `VoxtralRealtimeAudio.swift`,
+  `VoxtralRealtimeConfig.swift`, `VoxtralRealtimeTokenizer.swift`, `Generation.swift`, and
+  `STTOutput.swift` (the `STT*` protocol types the engine references). Only
+  `VoxtralRealtimeDecoder.swift`, `VoxtralRealtimeEncoder.swift`, and
+  `VoxtralRealtimeStreamSession.swift` carry `LOCAL FIX` changes.
 
 ## Why vendor instead of depend
 
@@ -24,7 +26,11 @@ it lands we can revisit depending on a release.
    float32 and promoted the fp16 hidden state. That forced the tied fp16 embedding
    (131072x3072) to be upcast on every token and pushed quantized matmuls off their fast
    path. Fixes: cast the adaScale to the activation dtype; make the manual RoPE
-   dtype-preserving; cast the float32 mel to the conv weight dtype at the conv-stem seam.
+   dtype-preserving; cast the float32 mel to the conv weight dtype at the conv-stem seam;
+   and, as a required correctness companion once q/k/v are fp16, cast the additive attention
+   mask to the query dtype in both the encoder (`VoxtralRealtimeEncoder.swift:172`) and the
+   decoder (`VoxtralRealtimeDecoder.swift:136`) — a float32 additive mask makes
+   `scaledDotProductAttention` abort with "Mask type must promote to output type float16".
    Measured downstream (see PR #141 / the `spike/voxtral-swift` branch): RTF 1.84 -> 0.62
    at identical word accuracy, reaching parity with the Python voxmlx backend.
 2. **append-only delta contract.** Delta computation is routed through

--- a/SpeechHelper/VENDORED.md
+++ b/SpeechHelper/VENDORED.md
@@ -1,0 +1,38 @@
+# Vendored: mlx-audio-swift VoxtralRealtime
+
+`Sources/SpeechEngine/` is vendored from
+[`Blaizzy/mlx-audio-swift`](https://github.com/Blaizzy/mlx-audio-swift), MIT-licensed
+(see `LICENSE.mlx-audio-swift`).
+
+- Upstream commit: `d302a5c6080d2bb97bae38c7418f82abb76013b6` (tag `v0.1.3`, `main` at
+  vendoring time — the `Models/VoxtralRealtime/` tree is identical between the two).
+- Files taken verbatim then modified: `Models/VoxtralRealtime/*.swift`, plus
+  `Generation.swift` and `Models/GLMASR/STTOutput.swift` (the `STT*` protocol types the
+  engine references).
+
+## Why vendor instead of depend
+
+The engine needed correctness/performance fixes that we want landing on our schedule, and
+we hold it to our own regression tests (notably the append-only delta contract, which our
+no-backspace insertion path depends on). We are proposing the performance fix upstream; if
+it lands we can revisit depending on a release.
+
+## Local modifications (all marked `LOCAL FIX` in the source)
+
+1. **float32 leak fix (performance, ~3x).** The decoder ran in float32 because the
+   time-conditioning scale (`AdaptiveNorm`) and the manual RoPE built their factors in
+   float32 and promoted the fp16 hidden state. That forced the tied fp16 embedding
+   (131072x3072) to be upcast on every token and pushed quantized matmuls off their fast
+   path. Fixes: cast the adaScale to the activation dtype; make the manual RoPE
+   dtype-preserving; cast the float32 mel to the conv weight dtype at the conv-stem seam.
+   Measured downstream (see PR #141 / the `spike/voxtral-swift` branch): RTF 1.84 -> 0.62
+   at identical word accuracy, reaching parity with the Python voxmlx backend.
+2. **append-only delta contract.** Delta computation is routed through
+   `SpeechEngineText.StreamingDelta`, which holds back a trailing U+FFFD from a split
+   multi-byte character instead of re-emitting the whole transcript. Guards duplication on
+   the no-backspace insertion path (regression tests in `SpeechEngineTextTests`).
+
+## Updating
+
+Re-copy the files from a newer upstream commit, then re-apply the `LOCAL FIX` blocks
+(diff against this note). Record the new commit hash above.


### PR DESCRIPTION
## What

**Part 1 of replacing the managed Python `voxmlx` backend with a bundled Swift ASR engine** (spike proof: #141). This PR vendors the engine, fixes it, and adds the Metal-free server plumbing; it does **not** wire anything into the app yet.

New `SpeechHelper/` package — a standalone SwiftPM package like `PolishHelper/`, so the root `swift build` never compiles the MLX C++/Metal core.

- `Sources/SpeechEngine/` — `Blaizzy/mlx-audio-swift`'s `VoxtralRealtime` (MIT), vendored from commit `d302a5c` (tag `v0.1.3`). Six `LOCAL FIX` divergences, all marked in-source and catalogued in `VENDORED.md` (independently audited against the upstream commit — no unmarked drift; 6 of 9 vendored files are byte-identical verbatim copies):
  - **float32-leak fix** (the ~3× win from the spike): cast `adaScale`, the manual RoPE cos/sin, and the conv-stem mel to the activation dtype so the decoder actually runs in fp16. Being proposed upstream separately.
  - **additive attention-mask dtype casts** (encoder + decoder) — required for correctness once q/k/v are fp16: a float32 additive mask makes `scaledDotProductAttention` abort ("Mask type must promote to output type float16").
  - **append-only delta contract**: delta computation routed through `SpeechEngineText.StreamingDelta`.
  - Plus `RealtimeSpeechServer` (original code, not vendored): a minimal loopback-only realtime websocket server speaking the exact OpenAI-Realtime subset the app already uses with voxmlx.
- `Sources/SpeechEngineText/` — pure, Metal-free target so its regression tests run in the tier-0 lane: `StreamingDelta` (holds back a trailing U+FFFD from a split multi-byte character; on true divergence it HOLDS rather than re-emitting — the app's no-backspace insertion path would duplicate any re-emit on screen), websocket frame codec + handshake, realtime protocol types, `ParentProcessWatchdog`.
- `Sources/localvoxtral-speechd/` — server entry point: loads the model, binds loopback-only, model-loaded-before-listen readiness, parent-pid watchdog. Not launched by anything yet.
- `VENDORED.md` / `LICENSE.mlx-audio-swift` — provenance + MIT license, with a re-apply procedure for upstream updates covering all six fix sites.

Dependency note: pins mlx-swift `0.31.3` (deliberately below the 0.31.4 `evalLock` deadlock, mlx-swift#428) and mlx-audio-swift's own `Package.resolved` graph (swift-transformers 1.1.9; ≥1.2 fails under Xcode 26).

## Proof

Metal-free unit lane (compiles the full package incl. the MLX-linking `SpeechEngine` + executable, then runs the delta/codec/protocol tests) — `./scripts/remote-build.sh test --package-path SpeechHelper`:

```
Executed 25 tests, with 0 failures (0 unexpected)
```

(RealtimeServerCodecTests 15 + StreamingDeltaTests 10, including new edge-case pins: trailing unresolved U+FFFD held back; `fullText` shrinking to a proper prefix holds instead of re-emitting.)

- [x] Independent vendored-fidelity audit vs upstream `d302a5c`: all divergences marked `LOCAL FIX` and catalogued; no unmarked semantic drift; root `Package.swift` untouched (root build stays MLX-free).
- [x] Unit suite green — `remote-build.sh test --package-path SpeechHelper` (25/25, output above); root tier-0 suite unaffected (CI green).
- [ ] Not wired into the app — no runtime behavior change; `SpeechHelper` is not built or bundled by `package_app.sh` in this PR.

The parity/accuracy proof for the engine itself (RTF 0.62 vs Python 0.62, word accuracy 0.804 EN / 0.842 FR) is in the spike PR #141. Known StreamingDelta tradeoff (documented + test-pinned): after a genuine mid-utterance divergence the tail is held for the rest of the utterance — safer than duplication on a no-backspace sink; only expected off temperature-0.

Next PRs — (2) packaging + integration lane (real model over the websocket, analogous to `PolishHelperIntegrationTests`), (3) `BackendManager` swap + tier-1 lane, (4) retire the Python `voxmlx` backend.
