### PR TITLE
Ground technical terms before polishing

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -328,11 +328,17 @@ Key subsystems:
 - **LLM polishing trusts the model's text in both profiles.** Human dictation
   evaluation found that `PolishTokenGuard` could reduce fidelity by undoing
   useful formatting and reconstructed identifiers, so it is not in the commit
-  path. Clipboard context is only a prompt/vocabulary hint; no content-based
-  leak detector scans or rejects the model output. Only explicit clipboard-paste
-  payload-placeholder count integrity remains active for both profiles. The
-  token guard type remains as a recognizer used by clipboard vocabulary and by
-  focused unit coverage; do not infer that it runs at commit.
+  path. Repo/clipboard vocabulary is an INPUT-side exception: matcher-approved
+  `(heard span, exact local term)` pairs are boundary-checked and pre-applied
+  before the single polish call. When the existing exact/edit-distance-one
+  matcher finds nothing, a bounded aligned fallback may emit at most one pair;
+  it score/margin-gates, abstains on ambiguity/glued prose, and will not add an
+  unspoken filename extension without a nearby file cue. This is grounding,
+  not an output guard. No content-based leak detector scans or rejects model
+  output. Only explicit clipboard-paste payload-placeholder count integrity
+  remains active for both profiles. The token guard type remains as a recognizer
+  used by clipboard vocabulary and by focused unit coverage; do not infer that
+  it runs at commit.
 
 ## Conventions
 

--- a/EvalCorpus/agent-dictation/README.md
+++ b/EvalCorpus/agent-dictation/README.md
@@ -152,6 +152,12 @@ approved, then uses the aligned fallback only when no mapping was emitted. It
 deliberately does not repair the model output afterward; a model that changes an
 approved literal remains visible as a failure.
 
+Production grounding lives in `RepoVocabularyMatcher.groundedCandidateEntries`
+and `preapplying`: it ports the same one-fallback/pre-apply shape, but adds a
+production-scale character n-gram index, a per-span candidate-work cap, and an
+unspoken-file-extension cue gate. The Python arm remains a fixture-level
+reference rather than a byte-for-byte implementation of the Swift matcher.
+
 Every response is appended immediately to
 `.build/agent-eval-ablation.jsonl`, so interruption does not lose completed
 inference. Rerunning the same command resumes by endpoint, model, variant, and

--- a/Sources/localvoxtral/DictationViewModel+Session.swift
+++ b/Sources/localvoxtral/DictationViewModel+Session.swift
@@ -670,6 +670,7 @@ extension DictationViewModel {
                     // request is byte-identical to the no-vocabulary path.
                     var replacementDictionarySection = replacementDictionaryPrompt
                     var repoVocabularyCount = 0
+                    var repoVocabularyEntries: [ReplacementEntry] = []
                     if templateCarriesDictionarySlot,
                        let endpointURL = polishingConfig?.endpointURL,
                        let vocabularyEntries = await self.repoVocabularyEntriesIfEnabled(
@@ -685,6 +686,7 @@ extension DictationViewModel {
                             base: replacementDictionarySection,
                             entries: vocabularyEntries
                         )
+                        repoVocabularyEntries = vocabularyEntries
                         repoVocabularyCount = vocabularyEntries.count
                         Log.polishing.info(
                             "Repo vocabulary attached: \(vocabularyEntries.count, privacy: .public) entries"
@@ -699,12 +701,14 @@ extension DictationViewModel {
                     // context excerpt lets the model produce the exact copied
                     // spelling. Hint entries need the dictionary slot.
                     var clipboardVocabularyCount = 0
+                    var clipboardVocabularyEntries: [ReplacementEntry] = []
                     if let clipboardContext = capturedClipboardContext {
                         let clipboardEntries = ClipboardVocabulary.candidateEntries(
                             transcript: workingText,
                             excerpt: clipboardContext.excerpt
                         )
                         if !clipboardEntries.isEmpty {
+                            clipboardVocabularyEntries = clipboardEntries
                             if templateCarriesDictionarySlot {
                                 replacementDictionarySection =
                                     RepoVocabularyMatcher.appendedPromptSection(
@@ -723,8 +727,26 @@ extension DictationViewModel {
 
                     guard !Task.isCancelled else { return }
 
+                    // Exact repo/clipboard bytes and their ASR spans have
+                    // already been selected by the deterministic matcher. Put
+                    // those bytes into the working text before the single LLM
+                    // call instead of relying on a generative model to copy a
+                    // prompt hint exactly. The same mappings remain in the
+                    // prompt as provenance/context. Boundary checks make this
+                    // a no-op if a recorded span is no longer independently
+                    // replaceable.
+                    let groundedWorkingText = RepoVocabularyMatcher.preapplying(
+                        entries: repoVocabularyEntries + clipboardVocabularyEntries,
+                        to: workingText
+                    )
+                    if groundedWorkingText != workingText {
+                        Log.polishing.info(
+                            "Technical grounding pre-applied: repo=\(repoVocabularyEntries.count, privacy: .public), clipboard=\(clipboardVocabularyEntries.count, privacy: .public)"
+                        )
+                    }
+
                     var userPrompts = promptTemplates.renderedUserPrompts(
-                        inputText: workingText,
+                        inputText: groundedWorkingText,
                         replacementDictionary: replacementDictionarySection
                     )
                     // Prepend the pre-captured clipboard reference-context block
@@ -754,7 +776,7 @@ extension DictationViewModel {
                     }
 
                     let polishingRequest = LLMPolishingRequest(
-                        inputText: workingText,
+                        inputText: groundedWorkingText,
                         systemPrompt: promptTemplates.systemContent,
                         userPrompts: userPrompts
                     )
@@ -784,20 +806,20 @@ extension DictationViewModel {
                             // trusting model text: a duplicated placeholder
                             // would paste the payload twice, while dropping one
                             // of two would lose a requested paste. Compare
-                            // standalone counts against the pre-polish working
-                            // text; on mismatch, discard the polish and keep the
-                            // placeholder-bearing working text.
+                            // standalone counts against the grounded pre-polish
+                            // text; on mismatch, discard the polish and keep
+                            // that placeholder-bearing text.
                             if clipboardPayload != nil {
                                 let expectedPlaceholders =
                                     ClipboardPayloadMacro.standalonePlaceholderCount(
-                                        in: workingText
+                                        in: groundedWorkingText
                                     )
                                 let actualPlaceholders =
                                     ClipboardPayloadMacro.standalonePlaceholderCount(
                                         in: committedText
                                     )
                                 if actualPlaceholders != expectedPlaceholders {
-                                    committedText = workingText
+                                    committedText = groundedWorkingText
                                     Log.polishing.warning(
                                         "Clipboard payload macro: polish changed placeholder count (\(expectedPlaceholders, privacy: .public) -> \(actualPlaceholders, privacy: .public)); polish discarded"
                                     )
@@ -817,12 +839,12 @@ extension DictationViewModel {
                                 committedText, payload: clipboardPayload
                             )
                             // Polish-changed iff the guarded/verified committed
-                            // text differs from the pre-polish working text: a
-                            // `.clean` outcome that left the text identical, a
-                            // `.fallback` to raw, or a placeholder-count revert
-                            // all leave committedText == workingText → not
-                            // changed. Drives the overlay badge (during hold)
-                            // and the "Copy raw transcript" popover affordance.
+                            // text differs from the pre-grounding working text.
+                            // This intentionally counts an evidence-backed
+                            // deterministic spelling correction even when the
+                            // model otherwise returns its input unchanged.
+                            // Drives the overlay badge (during hold) and the
+                            // "Copy raw transcript" popover affordance.
                             let polishChanged = committedText != workingText
                             self.overlayBufferCoordinator.markPolished(polishChanged)
                             // Retain the RAW (pre-everything) transcript for the

--- a/Sources/localvoxtral/DictationViewModel+Session.swift
+++ b/Sources/localvoxtral/DictationViewModel+Session.swift
@@ -735,10 +735,29 @@ extension DictationViewModel {
                     // prompt as provenance/context. Boundary checks make this
                     // a no-op if a recorded span is no longer independently
                     // replaceable.
-                    let groundedWorkingText = RepoVocabularyMatcher.preapplying(
-                        entries: repoVocabularyEntries + clipboardVocabularyEntries,
-                        to: workingText
-                    )
+                    let groundingEntries = repoVocabularyEntries + clipboardVocabularyEntries
+                    let groundedWorkingText: String
+                    if clipboardPayload != nil {
+                        // The payload placeholder is a commit-control token,
+                        // not dictation. Ground every surrounding segment but
+                        // keep each placeholder byte-exact so its integrity
+                        // count and final substitution cannot be bypassed by a
+                        // vocabulary term with the same normalized body.
+                        groundedWorkingText = workingText
+                            .components(separatedBy: ClipboardPayloadMacro.placeholder)
+                            .map {
+                                RepoVocabularyMatcher.preapplying(
+                                    entries: groundingEntries,
+                                    to: $0
+                                )
+                            }
+                            .joined(separator: ClipboardPayloadMacro.placeholder)
+                    } else {
+                        groundedWorkingText = RepoVocabularyMatcher.preapplying(
+                            entries: groundingEntries,
+                            to: workingText
+                        )
+                    }
                     if groundedWorkingText != workingText {
                         Log.polishing.info(
                             "Technical grounding pre-applied: repo=\(repoVocabularyEntries.count, privacy: .public), clipboard=\(clipboardVocabularyEntries.count, privacy: .public)"

--- a/Sources/localvoxtral/RepoVocabulary.swift
+++ b/Sources/localvoxtral/RepoVocabulary.swift
@@ -9,7 +9,9 @@ import Synchronization
 // dictionary section, so the polish model spells `useAuth.ts` /
 // `UserSessionManager.swift` exactly instead of hallucinating. Opt-in, loopback
 // endpoints only (repo file names must not ride to a remote endpoint), and
-// prompt-context only (no deterministic auto-replacement). Three separable,
+// high-confidence mappings are also applied to the pre-polish working text so
+// exact local bytes do not depend on a generative model reproducing them.
+// Three separable,
 // independently testable pieces + a TTL cache do the amortizing:
 //   1. `TerminalWorkingDirectoryResolver` — terminal window title -> cwd
 //   2. `RepoIndexing` / `RepoGitRunner` / `RepoVocabularyService` — cwd -> vocab
@@ -233,9 +235,20 @@ struct RepoVocabulary: Sendable {
     /// by normalized length, so an n-gram only edit-distance-checks terms
     /// within ±1 of its own length, with character arrays precomputed.
     let fuzzyBuckets: [Int: [FuzzyCandidate]]
+    /// Candidate spellings and a character n-gram index for the conservative aligned
+    /// fallback. Built once with the vocabulary so a miss never degrades into
+    /// an O(transcript n-grams x every repo term) scan in a large monorepo.
+    let alignedCandidates: [AlignedCandidate]
+    let alignedNGramIndex: [String: [Int]]
 
     struct FuzzyCandidate: Sendable {
         let term: String
+        let normalizedCharacters: [Character]
+    }
+
+    struct AlignedCandidate: Sendable {
+        let term: String
+        let normalized: String
         let normalizedCharacters: [Character]
     }
 
@@ -244,6 +257,8 @@ struct RepoVocabulary: Sendable {
         self.branch = branch
         var exact: [String: String] = [:]
         var buckets: [Int: [FuzzyCandidate]] = [:]
+        var aligned: [AlignedCandidate] = []
+        var ngramIndex: [String: [Int]] = [:]
         for term in terms {
             let normalized = RepoVocabularyMatcher.normalize(term)
             guard normalized.count >= RepoVocabularyMatcher.minNormalizedLength else { continue }
@@ -253,9 +268,23 @@ struct RepoVocabulary: Sendable {
                     FuzzyCandidate(term: term, normalizedCharacters: Array(normalized))
                 )
             }
+            let alignedNormalized = RepoVocabularyMatcher.alignedNormalize(term)
+            if alignedNormalized.count >= RepoVocabularyMatcher.alignedMinNormalizedLength {
+                let candidateIndex = aligned.count
+                aligned.append(AlignedCandidate(
+                    term: term,
+                    normalized: alignedNormalized,
+                    normalizedCharacters: Array(alignedNormalized)
+                ))
+                for ngram in RepoVocabularyMatcher.characterNGrams(alignedNormalized) {
+                    ngramIndex[ngram, default: []].append(candidateIndex)
+                }
+            }
         }
         self.exactIndex = exact
         self.fuzzyBuckets = buckets
+        self.alignedCandidates = aligned
+        self.alignedNGramIndex = ngramIndex
     }
 }
 
@@ -685,7 +714,7 @@ enum RepoVocabularyService {
         ) else {
             return nil
         }
-        let entries = RepoVocabularyMatcher.candidateEntries(
+        let entries = RepoVocabularyMatcher.groundedCandidateEntries(
             transcript: transcript, vocabulary: vocabulary
         )
         if entries.isEmpty {
@@ -715,6 +744,16 @@ enum RepoVocabularyMatcher {
     /// Minimum normalized length (both sides) for the edit-distance-1 fuzzy
     /// tier — short forms would collide constantly.
     static let fuzzyMinNormalizedLength = 8
+    /// The aligned fallback is intentionally narrower than the exact matcher:
+    /// short strings collide too easily in normal prose.
+    static let alignedMinNormalizedLength = 8
+    static let alignedMinimumScore = 0.60
+    static let alignedMinimumMargin = 0.05
+    static let alignedMaxWords = 7
+    /// A span whose rarest shared n-gram still fans out beyond this cap is not
+    /// distinctive enough for deterministic grounding. This also bounds work
+    /// in large same-language monorepos.
+    static let alignedMaxCandidatesPerSpan = 512
 
     /// Spoken separator words map to the symbols the file side already strips,
     /// so "use auth dot t s" normalizes identically to `useAuth.ts`.
@@ -817,6 +856,169 @@ enum RepoVocabularyMatcher {
         }
     }
 
+    /// Production matcher: keep every entry approved by the existing exact /
+    /// edit-distance-one tiers. Only when those tiers find NOTHING, try one
+    /// broader aligned match and otherwise abstain.
+    static func groundedCandidateEntries(
+        transcript: String,
+        vocabulary: RepoVocabulary
+    ) -> [ReplacementEntry] {
+        let approved = candidateEntries(transcript: transcript, vocabulary: vocabulary)
+        guard approved.isEmpty else { return approved }
+        guard let fallback = alignedFallbackEntry(
+            transcript: transcript,
+            vocabulary: vocabulary
+        ) else { return [] }
+        return [fallback]
+    }
+
+    /// Places exact vocabulary bytes into only the literal ASR spans already
+    /// selected by the matcher. Longest aliases run first; technical-token
+    /// boundaries prevent a short alias from rewriting inside another path or
+    /// identifier. Punctuation remains outside the replaced range.
+    static func preapplying(
+        entries: [ReplacementEntry],
+        to text: String
+    ) -> String {
+        let mappings = entries.flatMap { entry in
+            entry.matches.map { (exact: entry.replaceWith, heard: $0) }
+        }.sorted { lhs, rhs in
+            if lhs.heard.count != rhs.heard.count {
+                return lhs.heard.count > rhs.heard.count
+            }
+            return lhs.exact.count > rhs.exact.count
+        }
+
+        var output = text
+        for mapping in mappings {
+            guard !mapping.exact.isEmpty, !mapping.heard.isEmpty,
+                  sanitizedTerm(mapping.exact) == mapping.exact,
+                  sanitizedTerm(mapping.heard) == mapping.heard,
+                  mapping.exact != mapping.heard
+            else { continue }
+
+            var searchStart = output.startIndex
+            while searchStart < output.endIndex,
+                  let range = output.range(
+                    of: mapping.heard,
+                    range: searchStart..<output.endIndex
+                  )
+            {
+                if hasTechnicalBoundaries(in: output, range: range) {
+                    output.replaceSubrange(range, with: mapping.exact)
+                    break
+                }
+                searchStart = range.upperBound
+            }
+        }
+        return output
+    }
+
+    /// Evaluation-proven fallback for phonetic damage beyond edit distance 1.
+    /// It searches only candidates sharing a character n-gram with the ASR
+    /// span, requires a strong best score and an unambiguous runner-up margin,
+    /// and emits at most one mapping.
+    static func alignedFallbackEntry(
+        transcript: String,
+        vocabulary: RepoVocabulary
+    ) -> ReplacementEntry? {
+        let tokens = fallbackTokens(in: transcript)
+        guard !tokens.isEmpty, !vocabulary.alignedCandidates.isEmpty else { return nil }
+
+        var bestByCandidate: [Int: AlignedHit] = [:]
+        for start in tokens.indices {
+            let maxLength = min(alignedMaxWords, tokens.count - start)
+            for length in 1...maxLength {
+                let rawRange = tokens[start].lowerBound..<tokens[start + length - 1].upperBound
+                let rawSpan = String(transcript[rawRange])
+                let heard = rawSpan.trimmingCharacters(in: fallbackEdgeCharacters)
+                let normalizedHeard = alignedNormalize(heard)
+                // The exact local term must be long; its damaged ASR span may
+                // be shorter (the field `uzoft.ts` -> `useAuth.ts` case is 7
+                // normalized characters). The score and ambiguity margin do
+                // the remaining safety work.
+                guard normalizedHeard.count >= minNormalizedLength else { continue }
+
+                let postingLists = characterNGrams(normalizedHeard).compactMap {
+                    vocabulary.alignedNGramIndex[$0]
+                }.sorted { $0.count < $1.count }
+                var candidateIndexes = Set<Int>()
+                for postings in postingLists {
+                    let additions = postings.filter { !candidateIndexes.contains($0) }
+                    guard candidateIndexes.count + additions.count
+                            <= alignedMaxCandidatesPerSpan
+                    else { continue }
+                    candidateIndexes.formUnion(additions)
+                }
+                guard !candidateIndexes.isEmpty else { continue }
+
+                let heardCharacters = Array(normalizedHeard)
+                for candidateIndex in candidateIndexes {
+                    let candidate = vocabulary.alignedCandidates[candidateIndex]
+                    guard normalizedHeard.count * 2 >= candidate.normalized.count,
+                          candidate.normalized.count * 2 >= normalizedHeard.count
+                    else { continue }
+                    var score = longestCommonSubsequenceRatio(
+                        heardCharacters,
+                        candidate.normalizedCharacters
+                    )
+                    if let fileExtension = shortFileExtension(in: candidate.term),
+                       heard.lowercased().contains(".\(fileExtension)")
+                    {
+                        score = min(1, score + 0.1)
+                    }
+                    let hit = AlignedHit(
+                        candidateIndex: candidateIndex,
+                        heard: heard,
+                        score: score,
+                        lengthDelta: abs(normalizedHeard.count - candidate.normalized.count),
+                        startWord: start,
+                        wordCount: length
+                    )
+                    if let previous = bestByCandidate[candidateIndex],
+                       !alignedHit(hit, isBetterThan: previous)
+                    {
+                        continue
+                    }
+                    bestByCandidate[candidateIndex] = hit
+                }
+            }
+        }
+
+        let ranked = bestByCandidate.values.sorted {
+            alignedHit($0, isBetterThan: $1)
+        }
+        guard let best = ranked.first, best.score >= alignedMinimumScore else { return nil }
+        let bestCandidate = vocabulary.alignedCandidates[best.candidateIndex]
+        let runnerUp = ranked.dropFirst().first
+        let margin = best.score - (runnerUp?.score ?? 0)
+        guard margin >= alignedMinimumMargin else { return nil }
+
+        // A filename extension that was not spoken is a semantic choice, not
+        // merely a spelling correction. Require a nearby file-oriented verb /
+        // noun before deterministic grounding; otherwise leave the exact term
+        // as clipboard context for the LLM to interpret. This prevents
+        // `fix the user session manager` from becoming a `.swift` filename,
+        // while `look at dictation view model` remains eligible.
+        if let fileExtension = shortFileExtension(in: bestCandidate.term),
+           !best.heard.lowercased().contains(".\(fileExtension)"),
+           !hasFileReferenceCue(tokens: tokens, hit: best, transcript: transcript)
+        {
+            return nil
+        }
+
+        let normalizedHeard = alignedNormalize(best.heard)
+        if !best.heard.contains(where: { $0.isWhitespace }),
+           Double(normalizedHeard.count) > Double(bestCandidate.normalized.count) * 1.2
+        {
+            return nil
+        }
+        return ReplacementEntry(
+            replaceWith: bestCandidate.term,
+            matches: [best.heard]
+        )
+    }
+
     // MARK: - Internals
 
     /// One matched (term, transcript n-gram) pairing.
@@ -828,7 +1030,24 @@ enum RepoVocabularyMatcher {
         let exact: Bool
     }
 
+    private struct FallbackToken {
+        let lowerBound: String.Index
+        let upperBound: String.Index
+    }
+
+    private struct AlignedHit {
+        let candidateIndex: Int
+        let heard: String
+        let score: Double
+        let lengthDelta: Int
+        let startWord: Int
+        let wordCount: Int
+    }
+
     private static let nonAlphanumericEdges = CharacterSet.alphanumerics.inverted
+    private static let fallbackEdgeCharacters = CharacterSet(
+        charactersIn: "`'\"“”‘’()[]{}<>.,;:!?"
+    )
 
     /// Splits on whitespace and trims each word of leading/trailing
     /// non-alphanumerics (STT-sprinkled commas/periods) so the normalized form
@@ -838,6 +1057,128 @@ enum RepoVocabularyMatcher {
             .split(whereSeparator: { $0 == " " || $0 == "\t" || $0 == "\n" })
             .map { $0.trimmingCharacters(in: nonAlphanumericEdges) }
             .filter { !$0.isEmpty }
+    }
+
+    private static func fallbackTokens(in transcript: String) -> [FallbackToken] {
+        let regex = try! NSRegularExpression(pattern: #"\S+"#)
+        return regex.matches(
+            in: transcript,
+            range: NSRange(transcript.startIndex..., in: transcript)
+        ).compactMap { match in
+            guard let range = Range(match.range, in: transcript) else { return nil }
+            return FallbackToken(lowerBound: range.lowerBound, upperBound: range.upperBound)
+        }
+    }
+
+    /// Comparison-only normalization used by the broader fallback. Diacritics
+    /// are folded so French ASR remains comparable; the emitted term and heard
+    /// span always retain their original bytes.
+    static func alignedNormalize(_ value: String) -> String {
+        value.folding(
+            options: [.caseInsensitive, .diacriticInsensitive],
+            locale: Locale(identifier: "en_US_POSIX")
+        ).unicodeScalars.filter {
+            CharacterSet.alphanumerics.contains($0)
+        }.map(String.init).joined()
+    }
+
+    static func characterNGrams(_ value: String, width: Int = 2) -> Set<String> {
+        let characters = Array(value)
+        guard characters.count >= width else { return [] }
+        return Set((0...(characters.count - width)).map {
+            String(characters[$0..<($0 + width)])
+        })
+    }
+
+    private static func longestCommonSubsequenceRatio(
+        _ lhs: [Character],
+        _ rhs: [Character]
+    ) -> Double {
+        guard !lhs.isEmpty, !rhs.isEmpty else { return 0 }
+        var previous = Array(repeating: 0, count: rhs.count + 1)
+        for left in lhs {
+            var current = Array(repeating: 0, count: rhs.count + 1)
+            for (offset, right) in rhs.enumerated() {
+                current[offset + 1] = left == right
+                    ? previous[offset] + 1
+                    : max(previous[offset + 1], current[offset])
+            }
+            previous = current
+        }
+        return Double(2 * previous[rhs.count]) / Double(lhs.count + rhs.count)
+    }
+
+    private static func alignedHit(
+        _ candidate: AlignedHit,
+        isBetterThan existing: AlignedHit
+    ) -> Bool {
+        if candidate.score != existing.score { return candidate.score > existing.score }
+        if candidate.lengthDelta != existing.lengthDelta {
+            return candidate.lengthDelta < existing.lengthDelta
+        }
+        if candidate.wordCount != existing.wordCount {
+            return candidate.wordCount < existing.wordCount
+        }
+        if candidate.startWord != existing.startWord {
+            return candidate.startWord < existing.startWord
+        }
+        return candidate.heard.count < existing.heard.count
+    }
+
+    private static func shortFileExtension(in term: String) -> String? {
+        let lastComponent = term.split(separator: "/").last.map(String.init) ?? term
+        guard let dot = lastComponent.lastIndex(of: ".") else { return nil }
+        let suffix = String(lastComponent[lastComponent.index(after: dot)...]).lowercased()
+        guard (1...8).contains(suffix.count),
+              suffix.unicodeScalars.allSatisfy(CharacterSet.alphanumerics.contains)
+        else { return nil }
+        return suffix
+    }
+
+    private static let fileReferenceCues: Set<String> = [
+        "open", "ouvre", "ouvrir", "edit", "edite", "édite", "update",
+        "look", "regard", "regarde", "corrige", "file", "filename", "fichier",
+    ]
+
+    private static func hasFileReferenceCue(
+        tokens: [FallbackToken],
+        hit: AlignedHit,
+        transcript: String
+    ) -> Bool {
+        let lower = max(0, hit.startWord - 3)
+        let upper = min(tokens.count, hit.startWord + hit.wordCount)
+        return tokens[lower..<upper].contains { token in
+            let value = String(transcript[token.lowerBound..<token.upperBound])
+                .trimmingCharacters(in: nonAlphanumericEdges)
+                .folding(
+                    options: [.caseInsensitive, .diacriticInsensitive],
+                    locale: Locale(identifier: "en_US_POSIX")
+                )
+            return fileReferenceCues.contains(value)
+        }
+    }
+
+    private static func hasTechnicalBoundaries(
+        in text: String,
+        range: Range<String.Index>
+    ) -> Bool {
+        if let first = text[range].first, first.isLetter || first.isNumber,
+           range.lowerBound > text.startIndex
+        {
+            let previous = text[text.index(before: range.lowerBound)]
+            if previous.isLetter || previous.isNumber || "._/-".contains(previous) {
+                return false
+            }
+        }
+        if let last = text[range].last, last.isLetter || last.isNumber,
+           range.upperBound < text.endIndex
+        {
+            let next = text[range.upperBound]
+            if next.isLetter || next.isNumber || "_/-".contains(next) {
+                return false
+            }
+        }
+        return true
     }
 
     private static func stripJoiners(_ token: String) -> String {
@@ -960,31 +1301,70 @@ enum RepoVocabularyMatcher {
 /// Clipboard entities join the vocabulary-hint pipeline: the clipboard polish-
 /// context excerpt tells the model the exact spelling of a copied identifier.
 /// Extracting its code-like entities with the existing `PolishTokenGuard`
-/// recognizer (never a second token grammar), matching transcript n-grams
-/// against them exactly like repo vocabulary, and registering the matches as
-/// leak-check exemptions lets grounded corrections commit safely.
+/// recognizer plus a narrow technical-identifier supplement, matching
+/// transcript n-grams against them exactly like repo vocabulary, then
+/// pre-applying only the selected spans gives the model exact bytes without
+/// scanning its output.
 ///
 /// Pure functions; all privacy gating (feature toggle, loopback endpoint,
 /// concealed/transient pasteboard) already happened when the excerpt was
 /// captured — this type never touches the pasteboard.
 enum ClipboardVocabulary {
     /// Ordered, de-duplicated code-like entities in `excerpt`, recognized by
-    /// `PolishTokenGuard.protectedTokens` (backtick spans, dotted filenames,
-    /// paths, flags, env vars, URLs, hashes, versions). Backtick spans are
-    /// unwrapped to their inner text: the vocabulary term is the identifier,
-    /// not its markdown decoration.
+    /// `PolishTokenGuard.protectedTokens` plus a narrow supplemental grammar
+    /// for long bare env vars, method signatures, and mixed-case identifiers.
+    /// Backtick spans are unwrapped to their inner text: the vocabulary term
+    /// is the identifier, not its markdown decoration.
     static func entities(inExcerpt excerpt: String) -> [String] {
         var seen = Set<String>()
         var result: [String] = []
+        func append(_ term: String) {
+            guard !term.isEmpty, seen.insert(term).inserted else { return }
+            result.append(term)
+        }
         for token in PolishTokenGuard.protectedTokens(in: excerpt) {
             var term = token
             if term.hasPrefix("`"), term.hasSuffix("`"), term.count > 2 {
                 term = String(term.dropFirst().dropLast())
             }
-            guard !term.isEmpty, seen.insert(term).inserted else { continue }
-            result.append(term)
+            append(term)
+        }
+        // The guard recognizer is intentionally conservative and does not
+        // cover every useful INPUT-side context spelling (notably a bare
+        // ALL_CAPS env var, a method signature, or a PascalCase package name).
+        // Admit only long tokens carrying machine-checkable technical signal;
+        // ordinary clipboard prose never becomes a fallback candidate.
+        for match in supplementalEntityRegex.matches(
+            in: excerpt,
+            range: NSRange(excerpt.startIndex..., in: excerpt)
+        ) {
+            guard let range = Range(match.range, in: excerpt) else { continue }
+            var term = String(excerpt[range])
+                .trimmingCharacters(in: supplementalEntityEdges)
+            if term.hasSuffix(")"), !term.contains("(") {
+                term.removeLast()
+            }
+            guard isSupplementalTechnicalEntity(term) else { continue }
+            append(term)
         }
         return result
+    }
+
+    private static let supplementalEntityRegex = try! NSRegularExpression(
+        pattern: #"[$#A-Za-z0-9][_$#A-Za-z0-9./:()'\-]{6,}"#
+    )
+    private static let supplementalEntityEdges = CharacterSet(
+        charactersIn: "`'\"“”‘’[]{}<>.,;!?"
+    )
+
+    private static func isSupplementalTechnicalEntity(_ value: String) -> Bool {
+        guard value.count >= 7 else { return false }
+        if value.contains(where: { "._/$#():-".contains($0) }) { return true }
+        let hasLowercase = value.contains { $0.isLowercase }
+        let hasInternalUppercase = value.dropFirst().contains { $0.isUppercase }
+        let hasLetter = value.contains { $0.isLetter }
+        let hasNumber = value.contains { $0.isNumber }
+        return (hasLowercase && hasInternalUppercase) || (hasLetter && hasNumber)
     }
 
     /// The transcript-relevant clipboard entities as replacement entries, via
@@ -998,7 +1378,7 @@ enum ClipboardVocabulary {
         let terms = entities(inExcerpt: excerpt)
         guard !terms.isEmpty else { return [] }
         let vocabulary = RepoVocabulary(terms: terms, branch: nil)
-        return RepoVocabularyMatcher.candidateEntries(
+        return RepoVocabularyMatcher.groundedCandidateEntries(
             transcript: transcript,
             vocabulary: vocabulary
         )

--- a/Sources/localvoxtral/RepoVocabulary.swift
+++ b/Sources/localvoxtral/RepoVocabulary.swift
@@ -856,15 +856,34 @@ enum RepoVocabularyMatcher {
         }
     }
 
-    /// Production matcher: keep every entry approved by the existing exact /
-    /// edit-distance-one tiers. Only when those tiers find NOTHING, try one
-    /// broader aligned match and otherwise abstain.
+    /// Production matcher: keep entries approved by the existing exact /
+    /// edit-distance-one tiers unless one heard span maps to multiple terms.
+    /// Exact-index hits are single-valued; multiple terms for the same span are
+    /// therefore tied distance-one fuzzy hits and must all abstain. Only when
+    /// those tiers leave NOTHING, try one broader aligned match (which applies
+    /// its own score margin) and otherwise abstain.
     static func groundedCandidateEntries(
         transcript: String,
         vocabulary: RepoVocabulary
     ) -> [ReplacementEntry] {
         let approved = candidateEntries(transcript: transcript, vocabulary: vocabulary)
-        guard approved.isEmpty else { return approved }
+        var termsByHeard: [String: Set<String>] = [:]
+        for entry in approved {
+            for heard in entry.matches {
+                termsByHeard[heard, default: []].insert(entry.replaceWith)
+            }
+        }
+        let ambiguousHeard = Set(
+            termsByHeard.compactMap { heard, terms in
+                terms.count > 1 ? heard : nil
+            }
+        )
+        let unambiguous = approved.compactMap { entry -> ReplacementEntry? in
+            let matches = entry.matches.filter { !ambiguousHeard.contains($0) }
+            guard !matches.isEmpty else { return nil }
+            return ReplacementEntry(replaceWith: entry.replaceWith, matches: matches)
+        }
+        guard unambiguous.isEmpty else { return unambiguous }
         guard let fallback = alignedFallbackEntry(
             transcript: transcript,
             vocabulary: vocabulary

--- a/Sources/localvoxtral/RepoVocabulary.swift
+++ b/Sources/localvoxtral/RepoVocabulary.swift
@@ -1378,7 +1378,19 @@ enum ClipboardVocabulary {
 
     private static func isSupplementalTechnicalEntity(_ value: String) -> Bool {
         guard value.count >= 7 else { return false }
-        if value.contains(where: { "._/$#():-".contains($0) }) { return true }
+        let envBody = value.drop(while: { $0 == "$" })
+        let isLongEnvironmentVariable = envBody.contains("_")
+            && envBody.contains(where: { $0.isLetter })
+            && envBody.allSatisfy { $0 == "_" || $0.isUppercase || $0.isNumber }
+        if isLongEnvironmentVariable { return true }
+
+        if let openParen = value.firstIndex(of: "("),
+           openParen != value.startIndex,
+           value.hasSuffix(")")
+        {
+            return true
+        }
+
         let hasLowercase = value.contains { $0.isLowercase }
         let hasInternalUppercase = value.dropFirst().contains { $0.isUppercase }
         let hasLetter = value.contains { $0.isLetter }

--- a/Tests/localvoxtralTests/PolishTokenGuardTests.swift
+++ b/Tests/localvoxtralTests/PolishTokenGuardTests.swift
@@ -644,7 +644,8 @@ final class DictationViewModelPolishTokenGuardTests: XCTestCase {
         // instructions placed after the input text (documented model-family
         // quirk), so the context block must always precede it.
         XCTAssertTrue(prompts[1].hasSuffix("fix the user session manager"))
-        // "UserSessionManager.swift" is 24 characters, untruncated.
+        // No explicit filename cue was spoken, so the fallback deliberately
+        // leaves the exact entity as context instead of forcing `.swift`.
         XCTAssertEqual(record?.polishContextSummary, "clipboard:24ch")
     }
 
@@ -1209,6 +1210,7 @@ final class DictationViewModelPolishTokenGuardTests: XCTestCase {
         XCTAssertEqual(counter.count, 1)
         let prompts = try XCTUnwrap(request?.userPrompts)
         let joined = prompts.joined(separator: "\n")
+        XCTAssertEqual(request?.inputText, "open useAuth.ts and fix the import")
         XCTAssertTrue(joined.contains("Repository vocabulary"))
         XCTAssertTrue(joined.contains("useAuth.ts"))
         XCTAssertTrue(joined.contains("use auth dot t s"))
@@ -1348,9 +1350,9 @@ final class DictationViewModelPolishTokenGuardTests: XCTestCase {
         XCTAssertNotNil(savedRecord?.polishContextSummary)
     }
 
-    /// The full vocabulary path end to end: the entry asks the model to fix the
-    /// misheard `useauth.ts` to the repo's `useAuth.ts`, and standard-profile
-    /// commit preserves the model's correction.
+    /// The full vocabulary path end to end: exact repo bytes are placed before
+    /// the model call, so even an identity model commits `useAuth.ts` rather
+    /// than depending on the model to reproduce the prompt hint.
     func testVocabularyRewriteCommitsInStandardProfile() async {
         let settings = makeSettings(outputMode: .overlayBuffer)
         settings.llmPolishingEnabled = true
@@ -1367,10 +1369,7 @@ final class DictationViewModelPolishTokenGuardTests: XCTestCase {
             promptTemplates: template,
             agentPromptTemplates: template
         )
-        // The model applies exactly the injected vocabulary correction.
-        let service = RecordingPolishingService(transform: {
-            $0.replacingOccurrences(of: "useauth.ts", with: "useAuth.ts")
-        })
+        let service = RecordingPolishingService()
         let viewModel = DictationViewModel(
             settings: settings,
             overlayBufferCoordinator: MockOverlayCoordinator(),
@@ -1391,6 +1390,8 @@ final class DictationViewModelPolishTokenGuardTests: XCTestCase {
         viewModel.finishStoppedSession(promotePendingSegment: false)
         await waitUntilStoppedSessionCompletes(viewModel)
 
+        let capturedRequest = await service.capturedRequest
+        XCTAssertEqual(capturedRequest?.inputText, "open useAuth.ts and fix the import")
         XCTAssertEqual(
             viewModel.currentDictationEventText,
             "open useAuth.ts and fix the import"
@@ -1419,13 +1420,7 @@ final class DictationViewModelPolishTokenGuardTests: XCTestCase {
             promptTemplates: template,
             agentPromptTemplates: template
         )
-        // The model applies exactly the clipboard-grounded correction.
-        let service = RecordingPolishingService(transform: {
-            $0.replacingOccurrences(
-                of: "user session manager.swift",
-                with: "UserSessionManager.swift"
-            )
-        })
+        let service = RecordingPolishingService()
         let viewModel = DictationViewModel(
             settings: settings,
             overlayBufferCoordinator: MockOverlayCoordinator(),
@@ -1455,6 +1450,7 @@ final class DictationViewModelPolishTokenGuardTests: XCTestCase {
         // The matched entity also rode the dictionary slot as a hint entry.
         let capturedRequest = await service.capturedRequest
         let request = try XCTUnwrap(capturedRequest)
+        XCTAssertEqual(request.inputText, "look at UserSessionManager.swift")
         XCTAssertTrue(
             request.userPrompts.contains {
                 $0.contains(RepoVocabularyMatcher.clipboardVocabularyHeader)
@@ -1487,12 +1483,7 @@ final class DictationViewModelPolishTokenGuardTests: XCTestCase {
             promptTemplates: template,
             agentPromptTemplates: template
         )
-        let service = RecordingPolishingService(transform: {
-            $0.replacingOccurrences(
-                of: "user session manager.swift",
-                with: "UserSessionManager.swift"
-            )
-        })
+        let service = RecordingPolishingService()
         let viewModel = DictationViewModel(
             settings: settings,
             overlayBufferCoordinator: MockOverlayCoordinator(),
@@ -1520,6 +1511,7 @@ final class DictationViewModelPolishTokenGuardTests: XCTestCase {
         // No dictionary slot: the hint section must not appear anywhere.
         let capturedRequest = await service.capturedRequest
         let request = try XCTUnwrap(capturedRequest)
+        XCTAssertEqual(request.inputText, "look at UserSessionManager.swift")
         XCTAssertFalse(
             request.userPrompts.contains {
                 $0.contains(RepoVocabularyMatcher.clipboardVocabularyHeader)

--- a/Tests/localvoxtralTests/PolishTokenGuardTests.swift
+++ b/Tests/localvoxtralTests/PolishTokenGuardTests.swift
@@ -1044,6 +1044,23 @@ final class DictationViewModelPolishTokenGuardTests: XCTestCase {
         )
     }
 
+    /// Clipboard vocabulary must never rewrite the payload macro placeholder,
+    /// even when the copied entity normalizes to the placeholder body. The
+    /// identity polisher then commits the real payload exactly once.
+    func testClipboardGroundingCannotRewritePayloadPlaceholder() async throws {
+        let clipboardText = "lvClipboardPayload"
+        let result = await runClipboardPayloadMacroSession(
+            transcript: "paste clipboard",
+            contextEnabled: true,
+            payloadPasteboard: PasteboardStub(string: clipboardText),
+            contextPasteboard: PasteboardStub(string: clipboardText)
+        )
+
+        XCTAssertEqual(result.request?.inputText, ClipboardPayloadMacro.placeholder)
+        XCTAssertEqual(result.committedText, "`\(clipboardText)`")
+        XCTAssertEqual(result.record?.polishedText, ClipboardPayloadMacro.placeholder)
+    }
+
     /// The polish DUPLICATED the placeholder (payload would paste twice): the
     /// placeholder-count check discards the polish, and the committed text is
     /// the substituted pre-polish working text with the payload exactly once.

--- a/Tests/localvoxtralTests/RepoVocabularyTests.swift
+++ b/Tests/localvoxtralTests/RepoVocabularyTests.swift
@@ -467,6 +467,23 @@ final class RepoVocabularyMatcherTests: XCTestCase {
         XCTAssertEqual(result.first?.replaceWith, "useAuth.ts")
     }
 
+    func testGroundedFuzzyTierAbstainsForTiedDistanceOneCandidates() {
+        let transcript = "Open ConfigC.swift."
+        let result = RepoVocabularyMatcher.groundedCandidateEntries(
+            transcript: transcript,
+            vocabulary: RepoVocabulary(
+                terms: ["ConfigA.swift", "ConfigB.swift"],
+                branch: nil
+            )
+        )
+
+        XCTAssertTrue(result.isEmpty, "entries: \(result)")
+        XCTAssertEqual(
+            RepoVocabularyMatcher.preapplying(entries: result, to: transcript),
+            transcript
+        )
+    }
+
     func testGroundedCandidatesUseAlignedFallbackAfterExistingMatcherMisses() {
         let result = RepoVocabularyMatcher.groundedCandidateEntries(
             transcript: "Open uzoft.ts and add a null check.",

--- a/Tests/localvoxtralTests/RepoVocabularyTests.swift
+++ b/Tests/localvoxtralTests/RepoVocabularyTests.swift
@@ -803,6 +803,27 @@ final class ClipboardVocabularyTests: XCTestCase {
         )
     }
 
+    func testSupplementalEntitiesRejectColonAndHyphenatedProse() {
+        let cases: [(excerpt: String, transcript: String)] = [
+            ("Description: details", "description"),
+            ("well-known", "well known"),
+        ]
+
+        for item in cases {
+            XCTAssertTrue(
+                ClipboardVocabulary.entities(inExcerpt: item.excerpt).isEmpty,
+                "excerpt: \(item.excerpt)"
+            )
+            XCTAssertTrue(
+                ClipboardVocabulary.candidateEntries(
+                    transcript: item.transcript,
+                    excerpt: item.excerpt
+                ).isEmpty,
+                "excerpt: \(item.excerpt)"
+            )
+        }
+    }
+
     func testProseExcerptYieldsNoEntities() {
         XCTAssertTrue(
             ClipboardVocabulary.entities(

--- a/Tests/localvoxtralTests/RepoVocabularyTests.swift
+++ b/Tests/localvoxtralTests/RepoVocabularyTests.swift
@@ -467,6 +467,154 @@ final class RepoVocabularyMatcherTests: XCTestCase {
         XCTAssertEqual(result.first?.replaceWith, "useAuth.ts")
     }
 
+    func testGroundedCandidatesUseAlignedFallbackAfterExistingMatcherMisses() {
+        let result = RepoVocabularyMatcher.groundedCandidateEntries(
+            transcript: "Open uzoft.ts and add a null check.",
+            vocabulary: RepoVocabulary(terms: ["useAuth.ts"], branch: nil)
+        )
+        XCTAssertEqual(
+            result,
+            [ReplacementEntry(replaceWith: "useAuth.ts", matches: ["uzoft.ts"])]
+        )
+    }
+
+    func testAlignedFallbackRecoversLongFrenchPhoneticDamage() {
+        let result = RepoVocabularyMatcher.groundedCandidateEntries(
+            transcript: "Regarde de dictation vie ou modèle.",
+            vocabulary: RepoVocabulary(terms: ["DictationViewModel.swift"], branch: nil)
+        )
+        XCTAssertEqual(result.first?.replaceWith, "DictationViewModel.swift")
+        XCTAssertEqual(result.first?.matches, ["dictation vie ou modèle"])
+    }
+
+    func testAlignedFallbackRecoversRecordedContextMisses() {
+        let cases: [(transcript: String, exact: String, heard: String)] = [
+            (
+                "Rebase my brand John to feed/Polish helper MLX Swift.",
+                "feat/polish-helper-mlx-swift",
+                "feed/Polish helper MLX Swift"
+            ),
+            (
+                "Why is local voxtral cotisin identity not picked up by the runner?",
+                "LOCALVOXTRAL_CODESIGN_IDENTITY",
+                "local voxtral cotisin identity"
+            ),
+            (
+                "The crash is in Pozik's pipe read next Chong.",
+                "POSIXPipeRead.nextChunk(fromDescriptor:)",
+                "Pozik's pipe read next Chong"
+            ),
+            (
+                "Pourquoi la variable locale Voxtral co-design identity est ignorée?",
+                "LOCALVOXTRAL_CODESIGN_IDENTITY",
+                "locale Voxtral co-design identity"
+            ),
+            (
+                "Move the token refresh into off service.ts.",
+                "AuthService.ts",
+                "service.ts"
+            ),
+        ]
+
+        for item in cases {
+            let result = RepoVocabularyMatcher.groundedCandidateEntries(
+                transcript: item.transcript,
+                vocabulary: RepoVocabulary(terms: [item.exact], branch: nil)
+            )
+            XCTAssertEqual(result.first?.replaceWith, item.exact, item.transcript)
+            XCTAssertEqual(result.first?.matches, [item.heard], item.transcript)
+        }
+    }
+
+    func testAlignedFallbackAbstainsWhenCandidatesAreAmbiguous() {
+        let result = RepoVocabularyMatcher.groundedCandidateEntries(
+            transcript: "Open auth sir vice here.",
+            vocabulary: RepoVocabulary(
+                terms: ["AuthService.ts", "AuthServices.ts"],
+                branch: nil
+            )
+        )
+        XCTAssertTrue(result.isEmpty, "entries: \(result)")
+    }
+
+    func testAlignedFallbackAbstainsOnUnrelatedProse() {
+        let result = RepoVocabularyMatcher.groundedCandidateEntries(
+            transcript: "Please improve the error message for users.",
+            vocabulary: RepoVocabulary(
+                terms: ["UserSessionManager.swift", "AuthService.ts"],
+                branch: nil
+            )
+        )
+        XCTAssertTrue(result.isEmpty, "entries: \(result)")
+    }
+
+    func testAlignedFallbackDoesNotForceUnspokenFileExtensionWithoutFileCue() {
+        let result = RepoVocabularyMatcher.groundedCandidateEntries(
+            transcript: "Fix the user session manager.",
+            vocabulary: RepoVocabulary(terms: ["UserSessionManager.swift"], branch: nil)
+        )
+        XCTAssertTrue(result.isEmpty, "entries: \(result)")
+    }
+
+    func testAlignedFallbackAbstainsOnGluedSingleTokenThatWouldDeleteProse() {
+        let result = RepoVocabularyMatcher.groundedCandidateEntries(
+            transcript: "Ouvreusot.ts maintenant.",
+            vocabulary: RepoVocabulary(terms: ["useAuth.ts"], branch: nil)
+        )
+        XCTAssertTrue(result.isEmpty, "entries: \(result)")
+    }
+
+    func testPreapplyApprovedMappingPreservesPunctuation() {
+        XCTAssertEqual(
+            RepoVocabularyMatcher.preapplying(
+                entries: [
+                    ReplacementEntry(
+                        replaceWith: "useAuth.ts",
+                        matches: ["use auth dot t s"]
+                    )
+                ],
+                to: "Open use auth dot t s, then add a null check."
+            ),
+            "Open useAuth.ts, then add a null check."
+        )
+    }
+
+    func testPreapplyApprovedMappingsUsesLongestAliasFirst() {
+        XCTAssertEqual(
+            RepoVocabularyMatcher.preapplying(
+                entries: [
+                    ReplacementEntry(replaceWith: "Auth", matches: ["auth"]),
+                    ReplacementEntry(
+                        replaceWith: "AuthService.ts",
+                        matches: ["auth service dot t s"]
+                    ),
+                ],
+                to: "Open auth service dot t s and inspect auth."
+            ),
+            "Open AuthService.ts and inspect Auth."
+        )
+    }
+
+    func testPreapplyApprovedMappingDoesNotRewriteInsideIdentifier() {
+        XCTAssertEqual(
+            RepoVocabularyMatcher.preapplying(
+                entries: [ReplacementEntry(replaceWith: "useAuth.ts", matches: ["auth"])],
+                to: "Keep preauth_handler unchanged."
+            ),
+            "Keep preauth_handler unchanged."
+        )
+    }
+
+    func testPreapplySkipsUnsafeControlCharacterTerm() {
+        XCTAssertEqual(
+            RepoVocabularyMatcher.preapplying(
+                entries: [ReplacementEntry(replaceWith: "bad\nname.ts", matches: ["bad name"])],
+                to: "Open bad name now."
+            ),
+            "Open bad name now."
+        )
+    }
+
     func testShortFormTermsRejected() {
         // Bare "app"/"src" normalize to < 4 chars: no standalone entries.
         XCTAssertTrue(entries("open the app and src", terms: ["app", "src"]).isEmpty)
@@ -583,6 +731,15 @@ final class RepoVocabularyMatcherTests: XCTestCase {
         )
         XCTAssertTrue(entries.contains { $0.replaceWith == "useAuth.ts" })
     }
+
+    func testAlignedFallbackAbstainsCleanlyWithLargeAmbiguousVocabulary() {
+        let terms = (0..<20_000).map { "GeneratedFile\($0).swift" }
+        let result = RepoVocabularyMatcher.groundedCandidateEntries(
+            transcript: "please improve overall error handling for generated files",
+            vocabulary: RepoVocabulary(terms: terms, branch: nil)
+        )
+        XCTAssertTrue(result.isEmpty, "entries: \(result)")
+    }
 }
 
 // MARK: - Service orchestration (injected subprocess + fixture .git)
@@ -608,6 +765,27 @@ final class ClipboardVocabularyTests: XCTestCase {
         )
     }
 
+    func testEntitiesRecognizeBareContextIdentifiersMissedByGuardGrammar() {
+        XCTAssertEqual(
+            ClipboardVocabulary.entities(
+                inExcerpt: "LOCALVOXTRAL_CODESIGN_IDENTITY ShortcutRecorder POSIXPipeRead.nextChunk(fromDescriptor:)"
+            ),
+            [
+                "LOCALVOXTRAL_CODESIGN_IDENTITY",
+                "ShortcutRecorder",
+                "POSIXPipeRead.nextChunk(fromDescriptor:)",
+            ]
+        )
+    }
+
+    func testSupplementalEntityExtractionRejectsOrdinaryClipboardProse() {
+        XCTAssertTrue(
+            ClipboardVocabulary.entities(
+                inExcerpt: "Please remember that authentication service behavior matters"
+            ).isEmpty
+        )
+    }
+
     func testProseExcerptYieldsNoEntities() {
         XCTAssertTrue(
             ClipboardVocabulary.entities(
@@ -620,8 +798,8 @@ final class ClipboardVocabularyTests: XCTestCase {
 
     /// The T5 field case (2026-07-11): clipboard holds the exact identifier,
     /// the STT glued the dictated tail into `manager.swift`. The transcript
-    /// n-gram must match the clipboard entity and yield the hint entry whose
-    /// (spoken, exact) pair the session sanctions through the guard.
+    /// n-gram must match the clipboard entity and yield the structured
+    /// (spoken, exact) pair the session can pre-apply before polishing.
     func testT5TranscriptGramMatchesClipboardEntity() {
         let result = ClipboardVocabulary.candidateEntries(
             transcript: "look at user session manager.swift",
@@ -630,6 +808,38 @@ final class ClipboardVocabularyTests: XCTestCase {
         XCTAssertEqual(result.count, 1)
         XCTAssertEqual(result.first?.replaceWith, "UserSessionManager.swift")
         XCTAssertEqual(result.first?.matches, ["user session manager.swift"])
+    }
+
+    func testSupplementalEntitiesGroundCommonTechnicalDictationDamage() {
+        let cases: [(transcript: String, excerpt: String, expected: String)] = [
+            (
+                "set local voxtral code sign identity before packaging",
+                "LOCALVOXTRAL_CODESIGN_IDENTITY",
+                "LOCALVOXTRAL_CODESIGN_IDENTITY"
+            ),
+            (
+                "the crash is in posix pipe read next chunk from descriptor",
+                "POSIXPipeRead.nextChunk(fromDescriptor:)",
+                "POSIXPipeRead.nextChunk(fromDescriptor:)"
+            ),
+            (
+                "check whether shortcut recorder is initialized",
+                "ShortcutRecorder",
+                "ShortcutRecorder"
+            ),
+        ]
+
+        for testCase in cases {
+            let result = ClipboardVocabulary.candidateEntries(
+                transcript: testCase.transcript,
+                excerpt: testCase.excerpt
+            )
+            XCTAssertEqual(
+                result.first?.replaceWith,
+                testCase.expected,
+                "transcript: \(testCase.transcript); entries: \(result)"
+            )
+        }
     }
 
     func testUnrelatedTranscriptYieldsNoEntries() {

--- a/Tests/localvoxtralTests/RepoVocabularyTests.swift
+++ b/Tests/localvoxtralTests/RepoVocabularyTests.swift
@@ -612,6 +612,45 @@ final class RepoVocabularyMatcherTests: XCTestCase {
         )
     }
 
+    func testPreapplyRepoClipboardConflictUsesLongerExactTermPrecedence() {
+        let repoEntry = ReplacementEntry(
+            replaceWith: "RepoAPI",
+            matches: ["heard api"]
+        )
+        let clipboardEntry = ReplacementEntry(
+            replaceWith: "ClipboardAPI",
+            matches: ["heard api"]
+        )
+
+        XCTAssertEqual(
+            RepoVocabularyMatcher.preapplying(
+                entries: [repoEntry, clipboardEntry],
+                to: "Open heard api."
+            ),
+            "Open ClipboardAPI."
+        )
+    }
+
+    func testFrenchComposedAndDecomposedAccentsFallbackAndPreapplyPreservePunctuation() {
+        let accentForms = ["modèle", "mode\u{0300}le"]
+        for accentForm in accentForms {
+            let transcript = "Regarde, dictation vie ou \(accentForm)."
+            let entries = RepoVocabularyMatcher.groundedCandidateEntries(
+                transcript: transcript,
+                vocabulary: RepoVocabulary(
+                    terms: ["DictationViewModel.swift"],
+                    branch: nil
+                )
+            )
+
+            XCTAssertEqual(entries.first?.matches, ["dictation vie ou \(accentForm)"])
+            XCTAssertEqual(
+                RepoVocabularyMatcher.preapplying(entries: entries, to: transcript),
+                "Regarde, DictationViewModel.swift."
+            )
+        }
+    }
+
     func testPreapplyApprovedMappingDoesNotRewriteInsideIdentifier() {
         XCTAssertEqual(
             RepoVocabularyMatcher.preapplying(


### PR DESCRIPTION
## What

Stacked on #139 (`codex/agent-eval-technical-terms`).

- Pre-apply matcher-approved repo and clipboard spellings to the working text before the single polishing request.
- Keep the same structured mappings in the prompt as provenance/context.
- Add one conservative aligned fallback when exact/edit-distance-one matching finds nothing: character n-gram indexed, bounded to 512 candidates per span, minimum score + runner-up margin, and at most one emitted correction.
- Abstain on ambiguous/glued matches and on unspoken filename extensions without a nearby file cue.
- Expand clipboard input evidence narrowly for long env vars, method signatures, and mixed-case identifiers; ordinary prose is rejected.
- Keep the production output path simple: no token guard, no leak scan, and no post-LLM repair. Clipboard payload placeholder-count integrity remains unchanged.

This is input grounding, not an output guard. Privacy gates are unchanged: repo and clipboard evidence still require their existing opt-ins and loopback endpoint checks.

[run-llm-eval]

## Proof

- [x] Unit suite green — `./scripts/remote-build.sh test`
  - `Executed 968 tests, with 2 tests skipped and 0 failures`
- [x] Focused matcher/clipboard regression coverage
  - `RepoVocabularyMatcherTests`: 28 tests, 0 failures
  - `ClipboardVocabularyTests`: 8 tests, 0 failures
  - `DictationViewModelPolishTokenGuardTests`: 36 tests, 0 failures
- [x] Packaged app — `./scripts/remote-build.sh package`
  - release app built, helper validated, codesign verification passed
- [x] Bundled 4B helper integration — `./scripts/remote-build.sh integration-polishd`
  - `Executed 6 tests, with 0 failures`
  - production standard baseline: required 7/7, known-hard 10/10
  - agent profile: required 1/1, known-hard 7/8
- [x] Agent-dictation E2E — `./scripts/remote-build.sh eval-e2e`
  - `Executed 1 test, with 0 failures` in 652.677s over 163 cases
  - punctuation migration: tokens 17/17, exactText 7/7
  - clipboard context: tokens 4/13, exactText 1/13, mean accuracy 0.88
  - repo vocabulary: tokens 4/16, exactText 0/16, mean accuracy 0.82

The E2E report confirms exact grounded input bytes for damaged ASR spans including `POSIXPipeRead.nextChunk(fromDescriptor:)`, `ShortcutRecorder`, `LOCALVOXTRAL_CODESIGN_IDENTITY`, `useAuth.ts`, `AuthService.ts`, and `DictationViewModel.swift`. Some technically correct outputs still fail the current aggregate anti-rewrite metric because reconstructing a split identifier changes its tokenization (for example, `Dictation View Model` → `DictationViewModel.swift`); thresholds were not weakened in this PR.

The private owner human WAV set is not present in the builder checkout, so this final production run used the harness's cached macOS `say` audio. The owner can run the strict human confirmation after stacking #139 locally.