### PR TITLE
speechd part 3: swap managed dictation to the bundled engine (pinned mlx-community checkpoint)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -311,10 +311,11 @@ Key subsystems:
 - Overlay: `OverlayBufferSessionCoordinator` (session + hold-before-dismiss
   timing), `OverlayBufferStateMachine`, `DictationOverlayController` (NSPanel)
 - Backends: `BackendManager` lazily bootstraps app-managed local serving on
-  first dictation start; catalog pinned to fork wheel releases; installer
-  downloads a pinned `uv` on first use, then shells out to it; supervisors
-  spawn/health-check/stop the managed processes; install root lives under
-  Application Support. User-facing backend copy (pinned models, fork
+  first dictation start; managed ASR is the bundled `localvoxtral-speechd`
+  helper on port 8471 with an exact HF model revision, while the legacy
+  managed voxmlx spec remains only for part-4 retirement/cleanup. The installer/downloader keeps
+  pinned `uv` machinery; supervisors spawn/health-check/stop the managed
+  processes. User-facing backend copy (pinned models, fork
   optimizations, vLLM example) lives in the README "Under the hood" section
   (`/docs` is gitignored local notes — nothing user-facing goes there); keep
   it in sync when pins change.

--- a/README.md
+++ b/README.md
@@ -107,10 +107,10 @@ The config folder at `~/Library/Application Support/localvoxtral/config` holds `
 
 In **Managed local** mode (the default), localvoxtral launches and supervises two inference engines for you — no terminal required:
 
-- **Dictation — [voxmlx](https://github.com/T0mSIlver/voxmlx)** streaming [Voxtral Mini 4B Realtime in 4-bit](https://huggingface.co/T0mSIlver/Voxtral-Mini-4B-Realtime-2602-MLX-4bit). localvoxtral ships a tuned build that adds a native OpenAI Realtime WebSocket server and memory-management optimizations for long dictation sessions.
+- **Dictation — a bundled native speech engine** built on [mlx-audio-swift](https://github.com/Blaizzy/mlx-audio-swift), streaming [Voxtral Mini 4B Realtime in 4-bit](https://huggingface.co/mlx-community/Voxtral-Mini-4B-Realtime-2602-4bit) through the app's OpenAI Realtime-compatible server.
 - **Polishing — a bundled native engine** built on Apple's [MLX Swift](https://github.com/ml-explore/mlx-swift-lm), running [Qwen3.5-4B-OptiQ in 4-bit](https://huggingface.co/mlx-community/Qwen3.5-4B-OptiQ-4bit) by default (a lighter 0.8B and a larger 9B are one click away in Settings). A warm prompt cache keeps polish latency low, and the engine runs as a supervised helper process, so turning polishing off frees its memory immediately.
 
-The dictation engine installs from pinned, checksum-verified releases into `~/Library/Application Support/localvoxtral`; the polishing engine ships inside the app bundle. Model weights download from Hugging Face at an exact pinned commit, so an upstream edit to a model repo can never change what your install runs. Neither engine ever outlives the app (a watchdog stops them even after a crash), and uninstalling means deleting the app and that one folder.
+Both engines ship inside the app bundle; the legacy voxmlx installation machinery remains under `~/Library/Application Support/localvoxtral` pending retirement. Model weights download from Hugging Face at exact pinned commits, so an upstream edit to a model repo can never change what your install runs. Neither engine ever outlives the app (a watchdog stops them even after a crash), and uninstalling means deleting the app and that one folder.
 
 Prefer your own hardware? Switch Dictation or Polishing to **External URL** in **Settings → Endpoints**: any OpenAI Realtime-compatible server works for dictation, any chat-completions server for polishing.
 

--- a/Sources/localvoxtral/Backends/BackendCatalog.swift
+++ b/Sources/localvoxtral/Backends/BackendCatalog.swift
@@ -34,6 +34,8 @@ struct UVDistribution: Equatable, Sendable {
 }
 
 enum BackendCatalog {
+    /// Retained for installed-backend cleanup and the part-4 retirement work.
+    /// It is no longer part of the managed bootstrap set.
     static let voxmlx = ManagedBackendSpec(
         id: "voxmlx",
         displayName: "voxmlx",
@@ -45,6 +47,19 @@ enum BackendCatalog {
             pythonVersion: "3.12"
         ),
         executableName: "voxmlx-serve",
+        port: 8471
+    )
+
+    /// The dictation engine: localvoxtral-speechd (MLX Swift, see
+    /// SpeechHelper/), bundled inside the .app. It serves the same loopback
+    /// OpenAI Realtime subset and port as voxmlx, so client endpoints stay
+    /// stable while managed bootstrap moves off the Python process.
+    static let speechd = ManagedBackendSpec(
+        id: "speechd",
+        displayName: "Dictation engine",
+        version: "bundled",
+        installKind: .bundledExecutable,
+        executableName: "localvoxtral-speechd",
         port: 8471
     )
 
@@ -62,5 +77,5 @@ enum BackendCatalog {
         port: 8472
     )
 
-    static let all: [ManagedBackendSpec] = [voxmlx, polishd]
+    static let all: [ManagedBackendSpec] = [speechd, polishd]
 }

--- a/Sources/localvoxtral/Backends/BackendManager.swift
+++ b/Sources/localvoxtral/Backends/BackendManager.swift
@@ -90,6 +90,9 @@ protocol ManagedBackendManaging: AnyObject {
 final class BackendManager: ManagedBackendManaging {
     typealias SupervisorFactory = @MainActor (BackendProcessConfiguration) -> any ManagedBackendSupervising
     typealias PolishingModelProvider = @MainActor () -> String
+    /// Megabytes for the speechd `--cache-limit-mb` flag, or nil to omit it and
+    /// let the helper apply its built-in default.
+    typealias SpeechdCacheLimitProvider = @MainActor () -> Int?
 
     private(set) var speechdStatus: ManagedBackendStatus
     private(set) var polishdStatus: ManagedBackendStatus
@@ -99,6 +102,7 @@ final class BackendManager: ManagedBackendManaging {
     @ObservationIgnored private let layout: BackendInstallLayout
     @ObservationIgnored private let supervisorFactory: SupervisorFactory
     @ObservationIgnored private let polishingModelProvider: PolishingModelProvider
+    @ObservationIgnored private let speechdCacheLimitProvider: SpeechdCacheLimitProvider
     @ObservationIgnored private var speechdSupervisor: (any ManagedBackendSupervising)?
     @ObservationIgnored private var polishdSupervisor: (any ManagedBackendSupervising)?
     // Per-backend single-flight slots. A global shared slot (the previous
@@ -122,6 +126,7 @@ final class BackendManager: ManagedBackendManaging {
         polishingModelProvider: @escaping PolishingModelProvider = {
             SettingsStore.defaultLLMPolishingModel
         },
+        speechdCacheLimitProvider: @escaping SpeechdCacheLimitProvider = { nil },
         supervisorFactory: @escaping SupervisorFactory = { configuration in
             BackendProcessSupervisor(configuration: configuration)
         }
@@ -130,6 +135,7 @@ final class BackendManager: ManagedBackendManaging {
         self.layout = layout
         self.modelPreparer = modelPreparer ?? HFModelDownloader(layout: layout)
         self.polishingModelProvider = polishingModelProvider
+        self.speechdCacheLimitProvider = speechdCacheLimitProvider
         self.supervisorFactory = supervisorFactory
         self.speechdStatus = installer.needsInstallOrUpdate(BackendCatalog.speechd)
             ? .notInstalled
@@ -471,7 +477,7 @@ final class BackendManager: ManagedBackendManaging {
         switch spec.id {
         case BackendCatalog.speechd.id:
             let option = SpeechModelCatalog.defaultOption
-            return [
+            var arguments = [
                 "--model",
                 option.repoID,
                 "--model-revision",
@@ -481,6 +487,11 @@ final class BackendManager: ManagedBackendManaging {
                 "--parent-pid",
                 parentPID,
             ]
+            // Auto (nil) omits the flag so the helper's built-in default applies.
+            if let cacheLimitMB = speechdCacheLimitProvider() {
+                arguments.append(contentsOf: ["--cache-limit-mb", "\(cacheLimitMB)"])
+            }
+            return arguments
         case BackendCatalog.polishd.id:
             let repoID = polishingModelProvider()
             var arguments = [

--- a/Sources/localvoxtral/Backends/BackendManager.swift
+++ b/Sources/localvoxtral/Backends/BackendManager.swift
@@ -67,16 +67,16 @@ extension BackendProcessSupervisor: ManagedBackendSupervising {}
 
 @MainActor
 protocol ManagedBackendManaging: AnyObject {
-    var voxmlxStatus: ManagedBackendStatus { get }
+    var speechdStatus: ManagedBackendStatus { get }
     var polishdStatus: ManagedBackendStatus { get }
     var statusUpdates: AsyncStream<ManagedBackendStatusUpdate> { get }
 
     func ensureReady(dictation: Bool, polishing: Bool) async throws
     func stopAll() async
-    /// Stop only the managed voxmlx (dictation) process, leaving polishd
-    /// (polishing) untouched. A no-op if voxmlx was never started.
+    /// Stop only the managed speechd (dictation) process, leaving polishd
+    /// (polishing) untouched. A no-op if speechd was never started.
     func stopDictation() async
-    /// Stop only the managed polishd (polishing) process, leaving voxmlx
+    /// Stop only the managed polishd (polishing) process, leaving speechd
     /// (dictation) untouched. A no-op if polishd was never started.
     func stopPolishing() async
     /// Recent supervisor output lines for the given backend, or empty if the
@@ -91,7 +91,7 @@ final class BackendManager: ManagedBackendManaging {
     typealias SupervisorFactory = @MainActor (BackendProcessConfiguration) -> any ManagedBackendSupervising
     typealias PolishingModelProvider = @MainActor () -> String
 
-    private(set) var voxmlxStatus: ManagedBackendStatus
+    private(set) var speechdStatus: ManagedBackendStatus
     private(set) var polishdStatus: ManagedBackendStatus
 
     @ObservationIgnored private let installer: any BackendInstalling
@@ -99,7 +99,7 @@ final class BackendManager: ManagedBackendManaging {
     @ObservationIgnored private let layout: BackendInstallLayout
     @ObservationIgnored private let supervisorFactory: SupervisorFactory
     @ObservationIgnored private let polishingModelProvider: PolishingModelProvider
-    @ObservationIgnored private var voxmlxSupervisor: (any ManagedBackendSupervising)?
+    @ObservationIgnored private var speechdSupervisor: (any ManagedBackendSupervising)?
     @ObservationIgnored private var polishdSupervisor: (any ManagedBackendSupervising)?
     // Per-backend single-flight slots. A global shared slot (the previous
     // design) let a lingering dictation run swallow a polishing request whose
@@ -108,7 +108,7 @@ final class BackendManager: ManagedBackendManaging {
     // share a slot.
     @ObservationIgnored private var dictationEnsureTask: Task<Void, Error>?
     @ObservationIgnored private var polishingEnsureTask: Task<Void, Error>?
-    @ObservationIgnored private var voxmlxStateMirrorTask: Task<Void, Never>?
+    @ObservationIgnored private var speechdStateMirrorTask: Task<Void, Never>?
     @ObservationIgnored private var polishdStateMirrorTask: Task<Void, Never>?
     @ObservationIgnored private var statusUpdateContinuations: [UUID: AsyncStream<ManagedBackendStatusUpdate>.Continuation] = [:]
     #if DEBUG
@@ -131,7 +131,7 @@ final class BackendManager: ManagedBackendManaging {
         self.modelPreparer = modelPreparer ?? HFModelDownloader(layout: layout)
         self.polishingModelProvider = polishingModelProvider
         self.supervisorFactory = supervisorFactory
-        self.voxmlxStatus = installer.needsInstallOrUpdate(BackendCatalog.voxmlx)
+        self.speechdStatus = installer.needsInstallOrUpdate(BackendCatalog.speechd)
             ? .notInstalled
             : .stopped
         self.polishdStatus = installer.needsInstallOrUpdate(BackendCatalog.polishd)
@@ -158,7 +158,7 @@ final class BackendManager: ManagedBackendManaging {
         )
         var tasks: [Task<Void, Error>] = []
         if dictation {
-            tasks.append(singleFlightEnsureTask(for: BackendCatalog.voxmlx))
+            tasks.append(singleFlightEnsureTask(for: BackendCatalog.speechd))
         }
         if polishing {
             tasks.append(singleFlightEnsureTask(for: BackendCatalog.polishd))
@@ -172,7 +172,7 @@ final class BackendManager: ManagedBackendManaging {
     /// backend has its own slot so concurrent callers join per-backend work
     /// and requests for different backends never block or swallow each other.
     private func singleFlightEnsureTask(for spec: ManagedBackendSpec) -> Task<Void, Error> {
-        if spec.id == BackendCatalog.voxmlx.id, let dictationEnsureTask {
+        if spec.id == BackendCatalog.speechd.id, let dictationEnsureTask {
             return dictationEnsureTask
         }
         if spec.id == BackendCatalog.polishd.id, let polishingEnsureTask {
@@ -193,7 +193,7 @@ final class BackendManager: ManagedBackendManaging {
                 throw error
             }
         }
-        if spec.id == BackendCatalog.voxmlx.id {
+        if spec.id == BackendCatalog.speechd.id {
             dictationEnsureTask = task
         } else {
             polishingEnsureTask = task
@@ -202,7 +202,7 @@ final class BackendManager: ManagedBackendManaging {
     }
 
     private func clearEnsureTask(for spec: ManagedBackendSpec) {
-        if spec.id == BackendCatalog.voxmlx.id {
+        if spec.id == BackendCatalog.speechd.id {
             dictationEnsureTask = nil
         } else {
             polishingEnsureTask = nil
@@ -218,18 +218,18 @@ final class BackendManager: ManagedBackendManaging {
     }
 
     func stopAll() async {
-        let cancelledDictationEnsure = await cancelEnsureTaskAndAwaitCompletion(for: BackendCatalog.voxmlx)
+        let cancelledDictationEnsure = await cancelEnsureTaskAndAwaitCompletion(for: BackendCatalog.speechd)
         let cancelledPolishingEnsure = await cancelEnsureTaskAndAwaitCompletion(for: BackendCatalog.polishd)
         let hadPolishingSupervisor = polishdSupervisor != nil
-        await voxmlxSupervisor?.stop()
+        await speechdSupervisor?.stop()
         await polishdSupervisor?.stop()
         polishdSupervisor = nil
-        voxmlxStateMirrorTask?.cancel()
-        voxmlxStateMirrorTask = nil
+        speechdStateMirrorTask?.cancel()
+        speechdStateMirrorTask = nil
         polishdStateMirrorTask?.cancel()
         polishdStateMirrorTask = nil
-        if cancelledDictationEnsure || voxmlxSupervisor != nil {
-            setStatus(.stopped, for: BackendCatalog.voxmlx)
+        if cancelledDictationEnsure || speechdSupervisor != nil {
+            setStatus(.stopped, for: BackendCatalog.speechd)
         }
         if cancelledPolishingEnsure || hadPolishingSupervisor {
             setStatus(.stopped, for: BackendCatalog.polishd)
@@ -237,17 +237,17 @@ final class BackendManager: ManagedBackendManaging {
     }
 
     func stopDictation() async {
-        let cancelledEnsure = await cancelEnsureTaskAndAwaitCompletion(for: BackendCatalog.voxmlx)
-        await voxmlxSupervisor?.stop()
-        voxmlxStateMirrorTask?.cancel()
-        voxmlxStateMirrorTask = nil
-        if cancelledEnsure || voxmlxSupervisor != nil {
-            setStatus(.stopped, for: BackendCatalog.voxmlx)
+        let cancelledEnsure = await cancelEnsureTaskAndAwaitCompletion(for: BackendCatalog.speechd)
+        await speechdSupervisor?.stop()
+        speechdStateMirrorTask?.cancel()
+        speechdStateMirrorTask = nil
+        if cancelledEnsure || speechdSupervisor != nil {
+            setStatus(.stopped, for: BackendCatalog.speechd)
         }
     }
 
     func stopPolishing() async {
-        // Stop only the polishing supervisor. voxmlx (dictation) keeps running
+        // Stop only the polishing supervisor. speechd (dictation) keeps running
         // and its state mirror is left intact. Modeled on stopAll()'s polishd
         // branch: cancel the mirror task and pin the status to .stopped.
         let cancelledEnsure = await cancelEnsureTaskAndAwaitCompletion(for: BackendCatalog.polishd)
@@ -268,7 +268,7 @@ final class BackendManager: ManagedBackendManaging {
     /// restart (field finding: inflated "6 GB / 3.3 GB" progress, PR #99).
     private func cancelEnsureTaskAndAwaitCompletion(for spec: ManagedBackendSpec) async -> Bool {
         let task: Task<Void, Error>?
-        if spec.id == BackendCatalog.voxmlx.id {
+        if spec.id == BackendCatalog.speechd.id {
             task = dictationEnsureTask
         } else {
             task = polishingEnsureTask
@@ -281,8 +281,8 @@ final class BackendManager: ManagedBackendManaging {
 
     func status(for spec: ManagedBackendSpec) -> ManagedBackendStatus {
         switch spec.id {
-        case BackendCatalog.voxmlx.id:
-            return voxmlxStatus
+        case BackendCatalog.speechd.id:
+            return speechdStatus
         case BackendCatalog.polishd.id:
             return polishdStatus
         default:
@@ -292,8 +292,8 @@ final class BackendManager: ManagedBackendManaging {
 
     func recentOutput(for spec: ManagedBackendSpec) -> [String] {
         switch spec.id {
-        case BackendCatalog.voxmlx.id:
-            return voxmlxSupervisor?.recentOutput ?? []
+        case BackendCatalog.speechd.id:
+            return speechdSupervisor?.recentOutput ?? []
         case BackendCatalog.polishd.id:
             return polishdSupervisor?.recentOutput ?? []
         default:
@@ -411,13 +411,13 @@ final class BackendManager: ManagedBackendManaging {
 
     private func supervisor(for spec: ManagedBackendSpec) -> any ManagedBackendSupervising {
         switch spec.id {
-        case BackendCatalog.voxmlx.id:
-            if let voxmlxSupervisor {
-                startStateMirrorIfNeeded(supervisor: voxmlxSupervisor, spec: spec)
-                return voxmlxSupervisor
+        case BackendCatalog.speechd.id:
+            if let speechdSupervisor {
+                startStateMirrorIfNeeded(supervisor: speechdSupervisor, spec: spec)
+                return speechdSupervisor
             }
             let supervisor = supervisorFactory(configuration(for: spec))
-            voxmlxSupervisor = supervisor
+            speechdSupervisor = supervisor
             startStateMirrorIfNeeded(supervisor: supervisor, spec: spec)
             return supervisor
         case BackendCatalog.polishd.id:
@@ -457,9 +457,9 @@ final class BackendManager: ManagedBackendManaging {
                 return auxiliary
             }
             // Dev runs outside a packaged bundle: sibling of the main binary.
-            // (`swift run` has no bundled helper — managed polishing fails at
+            // (`swift run` has no bundled helpers — managed startup fails at
             // spawn with a visible supervisor error there; use a packaged
-            // build for hand-testing polishing.)
+            // build for hand-testing managed engines.)
             return (Bundle.main.executableURL ?? URL(fileURLWithPath: CommandLine.arguments[0]))
                 .deletingLastPathComponent()
                 .appendingPathComponent(spec.executableName)
@@ -469,10 +469,13 @@ final class BackendManager: ManagedBackendManaging {
     private func arguments(for spec: ManagedBackendSpec) -> [String] {
         let parentPID = "\(Darwin.getpid())"
         switch spec.id {
-        case BackendCatalog.voxmlx.id:
+        case BackendCatalog.speechd.id:
+            let option = SpeechModelCatalog.defaultOption
             return [
                 "--model",
-                SettingsStore.RealtimeProvider.realtimeAPI.defaultModelName,
+                option.repoID,
+                "--model-revision",
+                option.revision,
                 "--port",
                 "\(spec.port)",
                 "--parent-pid",
@@ -502,25 +505,28 @@ final class BackendManager: ManagedBackendManaging {
 
     private func modelPreparationRequest(for spec: ManagedBackendSpec) -> ModelPreparationRequest {
         // Keep these include patterns in sync with:
-        // - /home/dev/work/voxmlx/voxmlx/weights.py download_model
+        // - mlx-audio-swift's VoxtralRealtimeModel.fromDirectory loader:
+        //   config.json, every model*.safetensors file, and tekken.json.
+        //   The index is included so sharded revisions remain complete.
         // - PolishHelper's loader (MLXLLM loadContainer + AutoTokenizer):
         //   config.json, generation_config.json, model*.safetensors,
         //   tokenizer.json/tokenizer_config.json, chat template *.jinja —
         //   the list below is a superset kept identical to the old mlx-lm
         //   one so existing HF snapshots stay valid.
         switch spec.id {
-        case BackendCatalog.voxmlx.id:
+        case BackendCatalog.speechd.id:
+            let option = SpeechModelCatalog.defaultOption
             return ModelPreparationRequest(
                 backendID: spec.id,
                 displayName: spec.displayName,
-                repoID: SettingsStore.RealtimeProvider.realtimeAPI.defaultModelName,
+                repoID: option.repoID,
+                revision: option.revision,
                 includePatterns: [
-                    "consolidated.safetensors",
-                    "model*.safetensors",
-                    "model.safetensors.index.json",
-                    "params.json",
                     "config.json",
                     "tekken.json",
+                    "tokenizer*.json",
+                    "model*.safetensors",
+                    "model.safetensors.index.json",
                 ]
             )
         case BackendCatalog.polishd.id:
@@ -564,10 +570,10 @@ final class BackendManager: ManagedBackendManaging {
 
     private func readinessTimeout(for spec: ManagedBackendSpec) -> Duration {
         switch spec.id {
-        case BackendCatalog.voxmlx.id:
-            // First run downloads the model inside the server before /health
-            // responds; 600 s is too tight on slow links.
-            return .seconds(1800)
+        case BackendCatalog.speechd.id:
+            // Model weights are downloaded by prepareModel before the helper
+            // spawns; /health waits only on strict model load + Metal setup.
+            return .seconds(300)
         case BackendCatalog.polishd.id:
             // Model weights are downloaded by prepareModel before the helper
             // spawns; /health waits only on model load + first Metal JIT
@@ -580,8 +586,8 @@ final class BackendManager: ManagedBackendManaging {
 
     private func isReady(_ spec: ManagedBackendSpec) -> Bool {
         switch spec.id {
-        case BackendCatalog.voxmlx.id:
-            return voxmlxSupervisor?.state == .running
+        case BackendCatalog.speechd.id:
+            return speechdSupervisor?.state == .running
         case BackendCatalog.polishd.id:
             return polishdSupervisor?.state == .running
         default:
@@ -594,9 +600,9 @@ final class BackendManager: ManagedBackendManaging {
         spec: ManagedBackendSpec
     ) {
         switch spec.id {
-        case BackendCatalog.voxmlx.id:
-            guard voxmlxStateMirrorTask == nil else { return }
-            voxmlxStateMirrorTask = makeStateMirrorTask(supervisor: supervisor, spec: spec)
+        case BackendCatalog.speechd.id:
+            guard speechdStateMirrorTask == nil else { return }
+            speechdStateMirrorTask = makeStateMirrorTask(supervisor: supervisor, spec: spec)
         case BackendCatalog.polishd.id:
             guard polishdStateMirrorTask == nil else { return }
             polishdStateMirrorTask = makeStateMirrorTask(supervisor: supervisor, spec: spec)
@@ -637,8 +643,8 @@ final class BackendManager: ManagedBackendManaging {
 
     private func setStatus(_ status: ManagedBackendStatus, for spec: ManagedBackendSpec) {
         switch spec.id {
-        case BackendCatalog.voxmlx.id:
-            voxmlxStatus = status
+        case BackendCatalog.speechd.id:
+            speechdStatus = status
         case BackendCatalog.polishd.id:
             polishdStatus = status
         default:

--- a/Sources/localvoxtral/Backends/LegacyMLXLMCleanup.swift
+++ b/Sources/localvoxtral/Backends/LegacyMLXLMCleanup.swift
@@ -5,10 +5,10 @@ import Foundation
 /// replaced it (2026-07). Idempotent: once everything is gone, running it
 /// again is a silent no-op, so it runs on every launch.
 ///
-/// Deliberately untouched: the voxmlx tool (still uv-installed), the managed
-/// uv binary and its caches (voxmlx installs/updates still need them), and
-/// the downloaded model weights (the bundled helper reads the same HF cache
-/// the old engine populated).
+/// Deliberately untouched: the legacy voxmlx tool and its installed marker
+/// (retirement belongs to part 4), the managed uv binary and caches (still
+/// used for HF model preparation), and downloaded model weights (the bundled
+/// helpers read the same shared HF cache).
 struct LegacyMLXLMCleanup {
     private let layout: BackendInstallLayout
     private let fileManager: FileManager

--- a/Sources/localvoxtral/Backends/ManagedBackendEndpoints.swift
+++ b/Sources/localvoxtral/Backends/ManagedBackendEndpoints.swift
@@ -3,8 +3,8 @@ import Foundation
 /// Fixed localhost endpoints for app-managed backends. Deliberately NOT
 /// 8000/8080 so a user-run server never collides with the managed ones.
 enum ManagedBackendEndpoints {
-    static let voxmlxPort = BackendCatalog.voxmlx.port
+    static let speechdPort = BackendCatalog.speechd.port
     static let polishdPort = BackendCatalog.polishd.port
-    static let realtimeURLString = "ws://127.0.0.1:\(voxmlxPort)/v1/realtime"
+    static let realtimeURLString = "ws://127.0.0.1:\(speechdPort)/v1/realtime"
     static let polishingURLString = "http://127.0.0.1:\(polishdPort)/v1/chat/completions"
 }

--- a/Sources/localvoxtral/Backends/SpeechModelCatalog.swift
+++ b/Sources/localvoxtral/Backends/SpeechModelCatalog.swift
@@ -1,0 +1,33 @@
+import Foundation
+
+struct SpeechModelOption: Equatable, Sendable {
+    let repoID: String
+    /// Exact commit downloaded by the app and loaded by speechd. The upstream
+    /// loader otherwise resolves `main`, which would let a model-repo edit
+    /// change strict weight keys beneath an installed app.
+    let revision: String
+    let displayName: String
+}
+
+enum SpeechModelCatalog {
+    static let options: [SpeechModelOption] = [
+        SpeechModelOption(
+            repoID: "mlx-community/Voxtral-Mini-4B-Realtime-2602-4bit",
+            revision: "fdebf7b2af834a1db4b8a3c99ab7480b333adf9e",
+            displayName: "Voxtral Mini 4B Realtime (4-bit)"
+        ),
+    ]
+
+    static let defaultOption: SpeechModelOption = {
+        guard let option = option(
+            forRepoID: "mlx-community/Voxtral-Mini-4B-Realtime-2602-4bit"
+        ) else {
+            preconditionFailure("Default speech model missing from the catalog.")
+        }
+        return option
+    }()
+
+    static func option(forRepoID repoID: String) -> SpeechModelOption? {
+        options.first { $0.repoID == repoID }
+    }
+}

--- a/Sources/localvoxtral/DiagnosticsExporter.swift
+++ b/Sources/localvoxtral/DiagnosticsExporter.swift
@@ -23,9 +23,9 @@ struct DiagnosticsSnapshot: Sendable, Equatable {
     var hasRealtimeAPIKey: Bool
     var polishingSummary: String
     var hasPolishingAPIKey: Bool
-    var voxmlxStatus: String
+    var speechdStatus: String
     var polishdStatus: String
-    var voxmlxRecentOutput: [String]
+    var speechdRecentOutput: [String]
     var polishdRecentOutput: [String]
 }
 
@@ -62,9 +62,9 @@ enum DiagnosticsExporter {
     @MainActor
     static func makeSnapshot(
         settings: SettingsStore,
-        voxmlxStatus: ManagedBackendStatus,
+        speechdStatus: ManagedBackendStatus,
         polishdStatus: ManagedBackendStatus,
-        voxmlxRecentOutput: [String],
+        speechdRecentOutput: [String],
         polishdRecentOutput: [String],
         bundle: Bundle = .main,
         processInfo: ProcessInfo = .processInfo
@@ -98,9 +98,9 @@ enum DiagnosticsExporter {
             hasRealtimeAPIKey: !settings.apiKey.trimmed.isEmpty,
             polishingSummary: polishingSummary,
             hasPolishingAPIKey: !settings.llmPolishingAPIKey.trimmed.isEmpty,
-            voxmlxStatus: describe(voxmlxStatus),
+            speechdStatus: describe(speechdStatus),
             polishdStatus: describe(polishdStatus),
-            voxmlxRecentOutput: voxmlxRecentOutput,
+            speechdRecentOutput: speechdRecentOutput,
             polishdRecentOutput: polishdRecentOutput
         )
     }
@@ -138,17 +138,17 @@ enum DiagnosticsExporter {
         lines.append("")
 
         lines.append("== Managed backend status ==")
-        lines.append("voxmlx: \(snapshot.voxmlxStatus)")
+        lines.append("dictation engine (localvoxtral-speechd): \(snapshot.speechdStatus)")
         lines.append("polishing engine (localvoxtral-polishd): \(snapshot.polishdStatus)")
         lines.append("")
 
         lines.append("== Managed backend recent output ==")
-        if snapshot.voxmlxRecentOutput.isEmpty && snapshot.polishdRecentOutput.isEmpty {
+        if snapshot.speechdRecentOutput.isEmpty && snapshot.polishdRecentOutput.isEmpty {
             lines.append("(no supervisor output captured)")
         } else {
-            if !snapshot.voxmlxRecentOutput.isEmpty {
-                lines.append("-- voxmlx --")
-                lines.append(contentsOf: snapshot.voxmlxRecentOutput)
+            if !snapshot.speechdRecentOutput.isEmpty {
+                lines.append("-- localvoxtral-speechd --")
+                lines.append(contentsOf: snapshot.speechdRecentOutput)
             }
             if !snapshot.polishdRecentOutput.isEmpty {
                 lines.append("-- localvoxtral-polishd --")

--- a/Sources/localvoxtral/DictationViewModel+Session.swift
+++ b/Sources/localvoxtral/DictationViewModel+Session.swift
@@ -159,14 +159,14 @@ extension DictationViewModel {
     }
 
     private func managedBackendStartupStatusText(dictation: Bool, polishing: Bool) -> String {
-        if dictation, case .preparingModel(let progress) = backendManager.voxmlxStatus {
+        if dictation, case .preparingModel(let progress) = backendManager.speechdStatus {
             return modelDownloadStartupText(kind: "dictation", progress: progress)
         }
         if polishing, case .preparingModel(let progress) = backendManager.polishdStatus {
             return modelDownloadStartupText(kind: "polishing", progress: progress)
         }
         if shouldShowManagedBackendInstallStatus(
-            voxmlxStatus: dictation ? backendManager.voxmlxStatus : nil,
+            speechdStatus: dictation ? backendManager.speechdStatus : nil,
             polishdStatus: polishing ? backendManager.polishdStatus : nil
         ) {
             if !dictation, polishing {
@@ -189,10 +189,10 @@ extension DictationViewModel {
     }
 
     private func shouldShowManagedBackendInstallStatus(
-        voxmlxStatus: ManagedBackendStatus?,
+        speechdStatus: ManagedBackendStatus?,
         polishdStatus: ManagedBackendStatus?
     ) -> Bool {
-        if voxmlxStatus?.requiresInstallProgressText == true {
+        if speechdStatus?.requiresInstallProgressText == true {
             return true
         }
         return polishdStatus?.requiresInstallProgressText == true

--- a/Sources/localvoxtral/DictationViewModel.swift
+++ b/Sources/localvoxtral/DictationViewModel.swift
@@ -535,7 +535,8 @@ final class DictationViewModel {
         self.backendManager =
             backendManager
             ?? BackendManager(
-                polishingModelProvider: { settings.resolvedManagedLLMPolishingModel }
+                polishingModelProvider: { settings.resolvedManagedLLMPolishingModel },
+                speechdCacheLimitProvider: { settings.speechdCacheLimit.megabytes }
             )
         self.managesRuntimeServices = startRuntimeServices
         if let overlayBufferCoordinator {

--- a/Sources/localvoxtral/DictationViewModel.swift
+++ b/Sources/localvoxtral/DictationViewModel.swift
@@ -211,7 +211,7 @@ final class DictationViewModel {
     var requiredManagedBackendsReady: Bool {
         guard settings.onboardingCompleted else { return true }
         if settings.dictationBackendMode == .managedLocal,
-           !isReady(backendManager.voxmlxStatus)
+           !isReady(backendManager.speechdStatus)
         {
             return false
         }
@@ -351,7 +351,7 @@ final class DictationViewModel {
     // watches inline progress in Settings instead of waiting for dictation.
     // One slot per backend (mirroring BackendManager's per-backend single-flight
     // rationale): a polishing toggle/mode flip must never cancel an in-flight
-    // voxmlx warmup, and vice versa. Kept awaitable for tests.
+    // speechd warmup, and vice versa. Kept awaitable for tests.
     @ObservationIgnored
     var dictationWarmupTask: Task<Void, Never>?
     @ObservationIgnored
@@ -1011,7 +1011,7 @@ final class DictationViewModel {
         }
 
         if previousMode == .managedLocal, mode == .externalURL {
-            Log.backends.info("dictation backend mode switched to external; stopping managed voxmlx")
+            Log.backends.info("dictation backend mode switched to external; stopping managed speechd")
             cancelManagedStartupTask()
             dictationWarmupTask?.cancel()
             if isConnectingRealtimeSession {
@@ -1191,9 +1191,9 @@ final class DictationViewModel {
     func exportDiagnostics() {
         let snapshot = DiagnosticsExporter.makeSnapshot(
             settings: settings,
-            voxmlxStatus: backendManager.voxmlxStatus,
+            speechdStatus: backendManager.speechdStatus,
             polishdStatus: backendManager.polishdStatus,
-            voxmlxRecentOutput: backendManager.recentOutput(for: BackendCatalog.voxmlx),
+            speechdRecentOutput: backendManager.recentOutput(for: BackendCatalog.speechd),
             polishdRecentOutput: backendManager.recentOutput(for: BackendCatalog.polishd)
         )
 

--- a/Sources/localvoxtral/Onboarding/LiveOnboardingBootstrapDriver.swift
+++ b/Sources/localvoxtral/Onboarding/LiveOnboardingBootstrapDriver.swift
@@ -2,7 +2,7 @@ import Foundation
 import Observation
 
 /// Production onboarding driver: kicks off `BackendManager.ensureReady` and
-/// mirrors the observable `voxmlxStatus` / `polishdStatus` into `itemStates`.
+/// mirrors the observable `speechdStatus` / `polishdStatus` into `itemStates`.
 ///
 /// It only ever CALLS existing backend API from main — it never mutates the
 /// backend beyond the single `ensureReady` request, and the status → item-state
@@ -62,7 +62,7 @@ final class LiveOnboardingBootstrapDriver: OnboardingBootstrapDriving {
     /// next main-actor hop keeps `itemStates` current for the whole run.
     private func observeStatuses() {
         withObservationTracking {
-            _ = backendManager.voxmlxStatus
+            _ = backendManager.speechdStatus
             _ = backendManager.polishdStatus
         } onChange: { [weak self] in
             Task { @MainActor in
@@ -76,7 +76,7 @@ final class LiveOnboardingBootstrapDriver: OnboardingBootstrapDriving {
     private func recomputeItemStates() {
         var states: [OnboardingItemID: OnboardingItemState] = [:]
         if dictationRequested {
-            states[.dictation] = OnboardingItemState(managedStatus: backendManager.voxmlxStatus)
+            states[.dictation] = OnboardingItemState(managedStatus: backendManager.speechdStatus)
         }
         if polishingRequested {
             states[.polishing] = OnboardingItemState(managedStatus: backendManager.polishdStatus)

--- a/Sources/localvoxtral/Onboarding/OnboardingBootstrapDriving.swift
+++ b/Sources/localvoxtral/Onboarding/OnboardingBootstrapDriving.swift
@@ -3,7 +3,7 @@ import Foundation
 /// The managed downloads the onboarding wizard can kick off. Each maps to one
 /// managed backend + its model weights.
 enum OnboardingItemID: String, CaseIterable, Identifiable, Sendable {
-    /// voxmlx + the Voxtral realtime dictation model.
+    /// Bundled speechd + the Voxtral realtime dictation model.
     case dictation
     /// The bundled polishing engine's LLM model.
     case polishing
@@ -23,7 +23,7 @@ enum OnboardingItemID: String, CaseIterable, Identifiable, Sendable {
     var detail: String {
         switch self {
         case .dictation:
-            return "voxmlx + the Voxtral realtime model"
+            return "the bundled dictation engine + Voxtral model"
         case .polishing:
             return "the polishing LLM (bundled engine)"
         }

--- a/Sources/localvoxtral/Onboarding/OnboardingWizardView.swift
+++ b/Sources/localvoxtral/Onboarding/OnboardingWizardView.swift
@@ -190,7 +190,7 @@ private struct DownloadsPage: View {
                 systemImage: "arrow.down.circle",
                 title: "Set up the local engine",
                 subtitle:
-                    "localvoxtral will install voxmlx and download the Voxtral dictation model. Nothing downloads until you start it below."
+                    "localvoxtral will prepare the bundled dictation engine and download its Voxtral model. Nothing downloads until you start it below."
             )
 
             Toggle(isOn: $model.polishingConsent) {

--- a/Sources/localvoxtral/SettingsStore.swift
+++ b/Sources/localvoxtral/SettingsStore.swift
@@ -83,7 +83,7 @@ enum BackendMode: String, CaseIterable, Identifiable {
     var dictationDescription: String {
         switch self {
         case .managedLocal:
-            return "Installs and runs voxmlx on this Mac."
+            return "Runs the bundled dictation engine on this Mac."
         case .externalURL:
             return "Use an OpenAI Realtime-compatible endpoint you run yourself."
         }
@@ -905,9 +905,11 @@ final class SettingsStore {
 
     func effectiveModelName(for provider: RealtimeProvider) -> String {
         if dictationBackendMode == .managedLocal {
-            // Managed mode always serves the managed default model; a
-            // user-typed override in external-mode fields is ignored.
-            return RealtimeProvider.realtimeAPI.defaultModelName
+            // The bundled Swift engine needs its dedicated HF-layout pin.
+            // Keep the external provider's placeholder/default independent:
+            // user-typed external values remain ignored in managed mode, but
+            // an existing external endpoint still sees its historical model.
+            return SpeechModelCatalog.defaultOption.repoID
         }
         let normalized = Self.normalizedModelName(from: modelName(for: provider))
         return normalized.isEmpty ? provider.defaultModelName : normalized

--- a/Sources/localvoxtral/SettingsStore.swift
+++ b/Sources/localvoxtral/SettingsStore.swift
@@ -99,6 +99,41 @@ enum BackendMode: String, CaseIterable, Identifiable {
     }
 }
 
+/// Metal buffer-pool cache limit for the managed dictation helper. `Auto`
+/// omits the `--cache-limit-mb` flag so the helper's built-in default applies;
+/// every other case pins an explicit ceiling.
+enum SpeechdCacheLimit: String, CaseIterable, Identifiable, Sendable {
+    case auto
+    case gb2 = "2gb"
+    case gb4 = "4gb"
+    case gb6 = "6gb"
+    case gb8 = "8gb"
+
+    var id: String { rawValue }
+
+    var displayName: String {
+        switch self {
+        case .auto: return "Auto"
+        case .gb2: return "2 GB"
+        case .gb4: return "4 GB"
+        case .gb6: return "6 GB"
+        case .gb8: return "8 GB"
+        }
+    }
+
+    /// Megabytes to pass via `--cache-limit-mb`, or nil for `Auto` (the flag is
+    /// omitted and the helper's built-in default applies).
+    var megabytes: Int? {
+        switch self {
+        case .auto: return nil
+        case .gb2: return 2048
+        case .gb4: return 4096
+        case .gb6: return 6144
+        case .gb8: return 8192
+        }
+    }
+}
+
 enum DictationShortcutValidation {
     static let allowedModifierFlagsMask = UInt32(cmdKey | optionKey | shiftKey | controlKey)
 
@@ -160,6 +195,7 @@ final class SettingsStore {
         static let apiKey = "settings.api_key"
         static let realtimeAPIModelName = "settings.realtime_api_model_name"
         static let dictationBackendMode = "settings.dictation_backend_mode"
+        static let speechdCacheLimit = "settings.speechd_cache_limit"
         static let polishingBackendMode = "settings.polishing_backend_mode"
         // Legacy global backend mode. Read only for one-time migration.
         static let backendMode = "settings.backend_mode"
@@ -224,6 +260,12 @@ final class SettingsStore {
 
     var polishingBackendMode: BackendMode {
         didSet { defaults.set(polishingBackendMode.rawValue, forKey: Keys.polishingBackendMode) }
+    }
+
+    /// Metal buffer-pool cache limit for the managed dictation helper. Applies
+    /// the next time the managed dictation backend (re)starts.
+    var speechdCacheLimit: SpeechdCacheLimit {
+        didSet { defaults.set(speechdCacheLimit.rawValue, forKey: Keys.speechdCacheLimit) }
     }
 
     /// True once the user has completed (or skipped) the first-launch onboarding
@@ -459,6 +501,14 @@ final class SettingsStore {
         polishingBackendMode = resolvedBackendModes.polishing
         defaults.set(resolvedBackendModes.dictation.rawValue, forKey: Keys.dictationBackendMode)
         defaults.set(resolvedBackendModes.polishing.rawValue, forKey: Keys.polishingBackendMode)
+
+        if let storedCacheLimit = defaults.string(forKey: Keys.speechdCacheLimit),
+            let parsedCacheLimit = SpeechdCacheLimit(rawValue: storedCacheLimit)
+        {
+            speechdCacheLimit = parsedCacheLimit
+        } else {
+            speechdCacheLimit = .auto
+        }
 
         let configuredProvider = Self.loadString(
             defaults: defaults, key: Keys.realtimeProvider,

--- a/Sources/localvoxtral/SettingsView.swift
+++ b/Sources/localvoxtral/SettingsView.swift
@@ -245,6 +245,16 @@ private struct ConnectionSettingsPane: View {
                             .textFieldStyle(.roundedBorder)
                     }
                 case .managedLocal:
+                    SettingsFieldRow(title: "Memory limit") {
+                        Picker("", selection: $settings.speechdCacheLimit) {
+                            ForEach(SpeechdCacheLimit.allCases) { limit in
+                                Text(limit.displayName).tag(limit)
+                            }
+                        }
+                        .pickerStyle(.menu)
+                        .labelsHidden()
+                    }
+
                     ManagedBackendStatusRow(
                         title: "Status",
                         status: backendManager.speechdStatus

--- a/Sources/localvoxtral/SettingsView.swift
+++ b/Sources/localvoxtral/SettingsView.swift
@@ -247,7 +247,7 @@ private struct ConnectionSettingsPane: View {
                 case .managedLocal:
                     ManagedBackendStatusRow(
                         title: "Status",
-                        status: backendManager.voxmlxStatus
+                        status: backendManager.speechdStatus
                     )
                 }
             }

--- a/Sources/localvoxtral/localvoxtralApp.swift
+++ b/Sources/localvoxtral/localvoxtralApp.swift
@@ -131,7 +131,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     override init() {
         let settings = SettingsStore()
         let manager = BackendManager(
-            polishingModelProvider: { settings.resolvedManagedLLMPolishingModel }
+            polishingModelProvider: { settings.resolvedManagedLLMPolishingModel },
+            speechdCacheLimitProvider: { settings.speechdCacheLimit.megabytes }
         )
         settingsStore = settings
         backendManager = manager

--- a/SpeechHelper/DEPENDENCY.md
+++ b/SpeechHelper/DEPENDENCY.md
@@ -16,15 +16,24 @@ checkout — we no longer keep a copy here.
 
 ```
 .package(
-    url: "https://github.com/Blaizzy/mlx-audio-swift.git",
-    revision: "3b0b114fc7d98dd000bb7f631588a172b5c61823"
+    url: "https://github.com/T0mSIlver/mlx-audio-swift.git",
+    revision: "03890317975a2371fe0a0a9b13ad6a790f929814"
 )
 ```
 
 Pinned to a full-SHA **revision**, not a tag, so the exact reviewed tree is reproducible and
-can't move under us. `3b0b114` is the merge of
-[Blaizzy/mlx-audio-swift#226](https://github.com/Blaizzy/mlx-audio-swift/pull/226)
-("Fix float32 leak in VoxtralRealtime streaming"), authored by us.
+can't move under us.
+
+**Temporary fork pin.** `0389031` is our fork's `localvoxtral-pin-e1-e2` branch: upstream
+`3b0b114` (the merge of
+[Blaizzy/mlx-audio-swift#226](https://github.com/Blaizzy/mlx-audio-swift/pull/226),
+"Fix float32 leak in VoxtralRealtime streaming", authored by us) plus two
+streaming-performance fixes staged for upstream as fork PRs
+([#2](https://github.com/T0mSIlver/mlx-audio-swift/pull/2): Metal-pool clear cadence,
+[#3](https://github.com/T0mSIlver/mlx-audio-swift/pull/3): incremental mel/conv front end —
+both with bench evidence in the PR threads). Switchback plan: once both merge upstream, point
+the URL back at `Blaizzy/mlx-audio-swift` at the containing revision and delete the fork
+branch; nothing else changes.
 
 ## What #226 upstreamed
 

--- a/SpeechHelper/DEPENDENCY.md
+++ b/SpeechHelper/DEPENDENCY.md
@@ -5,6 +5,10 @@ VoxtralRealtime engine as an **upstream SwiftPM dependency** (product `MLXAudioS
 It used to be vendored into `Sources/SpeechEngine/` with local patches; those patches were
 upstreamed (see below), so we depend instead of vendor.
 
+The app now consumes this package as its production managed ASR backend:
+`BackendCatalog.speechd` launches the bundled `localvoxtral-speechd`, and the
+app pre-downloads the catalog-pinned HF snapshot that the helper loads exactly.
+
 Attribution: the dependency ships its own `LICENSE` (MIT, © 2025 Prince Canuma) in its SwiftPM
 checkout — we no longer keep a copy here.
 

--- a/SpeechHelper/Package.resolved
+++ b/SpeechHelper/Package.resolved
@@ -21,9 +21,9 @@
     {
       "identity": "mlx-audio-swift",
       "kind": "remoteSourceControl",
-      "location": "https://github.com/Blaizzy/mlx-audio-swift.git",
+      "location": "https://github.com/T0mSIlver/mlx-audio-swift.git",
       "state": {
-        "revision": "3b0b114fc7d98dd000bb7f631588a172b5c61823"
+        "revision": "03890317975a2371fe0a0a9b13ad6a790f929814"
       }
     },
     {

--- a/SpeechHelper/Package.swift
+++ b/SpeechHelper/Package.swift
@@ -33,9 +33,15 @@ let package = Package(
         // The Voxtral Realtime engine, consumed as a dependency (was vendored+patched before
         // #226). Pinned to a full-SHA revision, not a tag, so the exact reviewed tree is
         // reproducible — see DEPENDENCY.md for the upgrade procedure.
+        //
+        // TEMPORARY FORK PIN: our fork's `localvoxtral-pin-e1-e2` = upstream 3b0b114 plus two
+        // streaming-performance fixes staged for upstream (fork PRs; see DEPENDENCY.md):
+        // cache-clear cadence (per-step -> per-256-tokens + finish) and the incremental
+        // mel/conv front end (O(N^2) -> O(N) per utterance). Switch the URL back to
+        // Blaizzy/mlx-audio-swift once both merge upstream.
         .package(
-            url: "https://github.com/Blaizzy/mlx-audio-swift.git",
-            revision: "3b0b114fc7d98dd000bb7f631588a172b5c61823"
+            url: "https://github.com/T0mSIlver/mlx-audio-swift.git",
+            revision: "03890317975a2371fe0a0a9b13ad6a790f929814"
         ),
     ],
     targets: [

--- a/SpeechHelper/Sources/SpeechEngine/RealtimeSpeechServer.swift
+++ b/SpeechHelper/Sources/SpeechEngine/RealtimeSpeechServer.swift
@@ -16,6 +16,7 @@ import Synchronization
 public final class RealtimeSpeechServer: @unchecked Sendable {
     private let model: VoxtralRealtimeModel
     private let transcriptionDelayMs: Int?
+    private let stepMilliseconds: Int
     private let listener: NWListener
     private let netQueue = DispatchQueue(label: "localvoxtral.speechd.net")
     private let inferenceQueue = DispatchQueue(label: "localvoxtral.speechd.inference")
@@ -33,33 +34,34 @@ public final class RealtimeSpeechServer: @unchecked Sendable {
         modelDirectory: String?,
         port: UInt16,
         transcriptionDelayMs: Int?,
-        cacheLimitMB: Int
+        cacheLimitMB: Int,
+        stepMilliseconds: Int = 480
     ) async throws -> RealtimeSpeechServer {
         Memory.cacheLimit = cacheLimitMB * 1024 * 1024
-        let model: VoxtralRealtimeModel
-        if let dir = modelDirectory {
-            model = try VoxtralRealtimeModel.fromDirectory(URL(fileURLWithPath: dir))
-        } else if let id = modelID, let revision = modelRevision {
-            let directory = try SpeechHFCacheModelLocator.locate(
-                repoID: id,
-                revision: revision,
-                cacheRoot: SpeechHFCacheModelLocator.defaultCacheRoot()
-            )
-            model = try VoxtralRealtimeModel.fromDirectory(directory)
-        } else if let id = modelID {
-            model = try await VoxtralRealtimeModel.fromPretrained(id)
-        } else {
-            throw ServerError.noModelSpecified
-        }
+        let model = try await SpeechModelLoader.load(
+            modelID: modelID,
+            modelRevision: modelRevision,
+            modelDirectory: modelDirectory
+        )
         return try RealtimeSpeechServer(
-            model: model, port: port, transcriptionDelayMs: transcriptionDelayMs)
+            model: model,
+            port: port,
+            transcriptionDelayMs: transcriptionDelayMs,
+            stepMilliseconds: stepMilliseconds
+        )
     }
 
     public enum ServerError: Error { case noModelSpecified }
 
-    init(model: VoxtralRealtimeModel, port: UInt16, transcriptionDelayMs: Int?) throws {
+    init(
+        model: VoxtralRealtimeModel,
+        port: UInt16,
+        transcriptionDelayMs: Int?,
+        stepMilliseconds: Int
+    ) throws {
         self.model = model
         self.transcriptionDelayMs = transcriptionDelayMs
+        self.stepMilliseconds = stepMilliseconds
         let parameters = NWParameters.tcp
         parameters.allowLocalEndpointReuse = true
         parameters.requiredLocalEndpoint = NWEndpoint.hostPort(
@@ -120,17 +122,22 @@ public final class RealtimeSpeechServer: @unchecked Sendable {
         var phase: Phase = .http
         var buffer = Data()
         var session: VoxtralRealtimeStreamSession?
+        var stepBatcher: StepBatcher
         // Append-only delta contract lives in OUR layer now (the engine is an upstream
         // dependency whose raw `Delta` re-emits the whole transcript on a non-prefix step).
         // Feed it the session's full-transcript snapshot after each step/finish; emit only
         // its append-only delta. Touched only on the inference queue, like `session`.
         var deltas = TranscriptDeltaEmitter()
         enum Phase { case http, webSocket }
+
+        init(stepMilliseconds: Int) {
+            self.stepBatcher = StepBatcher(cadenceMilliseconds: stepMilliseconds)
+        }
     }
 
     private func accept(_ connection: NWConnection) {
         connection.start(queue: netQueue)
-        receive(connection, Connection())
+        receive(connection, Connection(stepMilliseconds: stepMilliseconds))
     }
 
     private func receive(_ connection: NWConnection, _ ctx: Connection) {
@@ -218,16 +225,20 @@ public final class RealtimeSpeechServer: @unchecked Sendable {
                     self.sendServer(connection, .error(message: "Invalid PCM16 payload"))
                     return
                 }
-                let session = self.ensureSession(ctx)
-                session.step(samples)
-                // Emit the append-only delta from the full transcript snapshot, NOT the
-                // engine's raw `Delta` (which re-emits the whole transcript on a non-prefix
-                // step — our no-backspace insertion path would duplicate it).
-                let delta = ctx.deltas.emit(fullText: session.text)
-                if !delta.isEmpty { self.sendServer(connection, .transcriptDelta(delta)) }
+                for batch in ctx.stepBatcher.append(samples) {
+                    let session = self.ensureSession(ctx)
+                    session.step(batch)
+                    // Emit the append-only delta from the full transcript snapshot, NOT the
+                    // engine's raw `Delta` (which re-emits the whole transcript on a non-prefix
+                    // step — our no-backspace insertion path would duplicate it).
+                    let delta = ctx.deltas.emit(fullText: session.text)
+                    if !delta.isEmpty { self.sendServer(connection, .transcriptDelta(delta)) }
+                }
             case .commit(let final):
                 guard final else { return }  // non-final commit is a no-op, matching voxmlx
                 let session = self.ensureSession(ctx)
+                let remainder = ctx.stepBatcher.flushRemainder()
+                if !remainder.isEmpty { session.step(remainder) }
                 session.finish()
                 let tail = ctx.deltas.emit(fullText: session.text)
                 if !tail.isEmpty { self.sendServer(connection, .transcriptDelta(tail)) }
@@ -236,9 +247,11 @@ public final class RealtimeSpeechServer: @unchecked Sendable {
                 self.sendServer(connection, .transcriptDone(text: ctx.deltas.emittedText))
                 ctx.session = nil  // ready for the next utterance
                 ctx.deltas = TranscriptDeltaEmitter()
+                ctx.stepBatcher.clear()
             case .clear:
                 ctx.session = nil
                 ctx.deltas = TranscriptDeltaEmitter()
+                ctx.stepBatcher.clear()
             case .ignored:
                 break
             }
@@ -264,5 +277,29 @@ public final class RealtimeSpeechServer: @unchecked Sendable {
             content: data,
             completion: .contentProcessed { _ in if thenClose { connection.cancel() } }
         )
+    }
+}
+
+enum SpeechModelLoader {
+    static func load(
+        modelID: String?,
+        modelRevision: String?,
+        modelDirectory: String?
+    ) async throws -> VoxtralRealtimeModel {
+        if let dir = modelDirectory {
+            return try VoxtralRealtimeModel.fromDirectory(URL(fileURLWithPath: dir))
+        }
+        if let id = modelID, let revision = modelRevision {
+            let directory = try SpeechHFCacheModelLocator.locate(
+                repoID: id,
+                revision: revision,
+                cacheRoot: SpeechHFCacheModelLocator.defaultCacheRoot()
+            )
+            return try VoxtralRealtimeModel.fromDirectory(directory)
+        }
+        if let id = modelID {
+            return try await VoxtralRealtimeModel.fromPretrained(id)
+        }
+        throw RealtimeSpeechServer.ServerError.noModelSpecified
     }
 }

--- a/SpeechHelper/Sources/SpeechEngine/RealtimeSpeechServer.swift
+++ b/SpeechHelper/Sources/SpeechEngine/RealtimeSpeechServer.swift
@@ -29,15 +29,23 @@ public final class RealtimeSpeechServer: @unchecked Sendable {
     /// cache limit and loads from an HF id or a local directory.
     public static func load(
         modelID: String?,
+        modelRevision: String?,
         modelDirectory: String?,
         port: UInt16,
         transcriptionDelayMs: Int?,
         cacheLimitMB: Int
     ) async throws -> RealtimeSpeechServer {
-        MLX.GPU.set(cacheLimit: cacheLimitMB * 1024 * 1024)
+        Memory.cacheLimit = cacheLimitMB * 1024 * 1024
         let model: VoxtralRealtimeModel
         if let dir = modelDirectory {
             model = try VoxtralRealtimeModel.fromDirectory(URL(fileURLWithPath: dir))
+        } else if let id = modelID, let revision = modelRevision {
+            let directory = try SpeechHFCacheModelLocator.locate(
+                repoID: id,
+                revision: revision,
+                cacheRoot: SpeechHFCacheModelLocator.defaultCacheRoot()
+            )
+            model = try VoxtralRealtimeModel.fromDirectory(directory)
         } else if let id = modelID {
             model = try await VoxtralRealtimeModel.fromPretrained(id)
         } else {

--- a/SpeechHelper/Sources/SpeechEngine/StreamingSpeechBenchmark.swift
+++ b/SpeechHelper/Sources/SpeechEngine/StreamingSpeechBenchmark.swift
@@ -1,0 +1,242 @@
+import Foundation
+import MLX
+import MLXAudioSTT
+import SpeechEngineText
+
+/// Packaged-helper benchmark for the streaming front-end recomputation path.
+public enum StreamingSpeechBenchmark {
+    private static let sampleRate = 16_000
+    private static let appendSamples = 1_600
+
+    public static func run(_ options: SpeechdLaunchOptions) async throws {
+        guard let benchmark = options.benchmark else { return }
+
+        Memory.cacheLimit = options.cacheLimitMB * 1024 * 1024
+        let model = try await SpeechModelLoader.load(
+            modelID: options.modelID,
+            modelRevision: options.modelRevision,
+            modelDirectory: options.modelDirectory
+        )
+        let audio = try BenchmarkAudio.make(
+            seconds: benchmark.seconds,
+            wavPath: benchmark.wavPath
+        )
+        let session = model.makeStreamSession(
+            temperature: 0.0,
+            transcriptionDelayMs: options.transcriptionDelayMs
+        )
+        var batcher = StepBatcher(
+            cadenceMilliseconds: benchmark.cadenceMilliseconds,
+            sampleRate: sampleRate
+        )
+        var records: [StepRecord] = []
+        let marks = [5, 15, 30, 60].filter { $0 <= benchmark.seconds }
+        var nextMarkIndex = 0
+        var appendedSamples = 0
+        var steppedSamples = 0
+        var offset = 0
+
+        while offset < audio.count {
+            let end = min(offset + appendSamples, audio.count)
+            let chunk = Array(audio[offset..<end])
+            appendedSamples += chunk.count
+            for batch in batcher.append(chunk) {
+                steppedSamples += batch.count
+                records.append(measureStep(session: session, samples: batch, at: steppedSamples))
+            }
+            offset = end
+
+            while nextMarkIndex < marks.count,
+                  appendedSamples >= marks[nextMarkIndex] * sampleRate
+            {
+                printMark(
+                    marks[nextMarkIndex],
+                    cadenceMilliseconds: benchmark.cadenceMilliseconds,
+                    records: records
+                )
+                nextMarkIndex += 1
+            }
+        }
+
+        let remainder = batcher.flushRemainder()
+        if !remainder.isEmpty {
+            steppedSamples += remainder.count
+            records.append(measureStep(session: session, samples: remainder, at: steppedSamples))
+        }
+
+        // A nonstandard duration/cadence can put its final remainder exactly at a mark. Reprint
+        // only marks not already reported; normal 60 s runs reach every mark in the loop above.
+        while nextMarkIndex < marks.count {
+            printMark(
+                marks[nextMarkIndex],
+                cadenceMilliseconds: benchmark.cadenceMilliseconds,
+                records: records
+            )
+            nextMarkIndex += 1
+        }
+    }
+
+    private struct StepRecord {
+        let audioSamples: Int
+        let latencyMilliseconds: Double
+        let memory: Memory.Snapshot
+    }
+
+    private static func measureStep(
+        session: VoxtralRealtimeStreamSession,
+        samples: [Float],
+        at audioSamples: Int
+    ) -> StepRecord {
+        let duration = ContinuousClock().measure {
+            session.step(samples)
+        }
+        let components = duration.components
+        let milliseconds = Double(components.seconds) * 1_000
+            + Double(components.attoseconds) / 1_000_000_000_000_000
+        return StepRecord(
+            audioSamples: audioSamples,
+            latencyMilliseconds: milliseconds,
+            memory: Memory.snapshot()
+        )
+    }
+
+    private static func printMark(
+        _ markSeconds: Int,
+        cadenceMilliseconds: Int,
+        records: [StepRecord]
+    ) {
+        let markSamples = markSeconds * sampleRate
+        guard let current = records.last(where: { $0.audioSamples <= markSamples }) ?? records.last else {
+            return
+        }
+        let trailingStart = max(0, current.audioSamples - sampleRate)
+        let trailing = records.filter {
+            $0.audioSamples > trailingStart && $0.audioSamples <= current.audioSamples
+        }
+        let mean = trailing.map(\.latencyMilliseconds).reduce(0, +)
+            / Double(max(1, trailing.count))
+        let activeValues = trailing.map { $0.memory.activeMemory }
+        let swing = (activeValues.max() ?? current.memory.activeMemory)
+            - (activeValues.min() ?? current.memory.activeMemory)
+        let bytesPerMB = 1024.0 * 1024.0
+
+        print(
+            String(
+                format:
+                    "BENCH mark=%ds cadence_ms=%d steps=%d step_ms=%.3f mean_ms=%.3f "
+                    + "active_mb=%.1f cache_mb=%.1f peak_mb=%.1f swing_mb=%.1f",
+                markSeconds,
+                cadenceMilliseconds,
+                records.filter { $0.audioSamples <= markSamples }.count,
+                current.latencyMilliseconds,
+                mean,
+                Double(current.memory.activeMemory) / bytesPerMB,
+                Double(current.memory.cacheMemory) / bytesPerMB,
+                Double(current.memory.peakMemory) / bytesPerMB,
+                Double(swing) / bytesPerMB
+            )
+        )
+    }
+}
+
+private enum BenchmarkAudio {
+    enum Error: Swift.Error, CustomStringConvertible {
+        case invalidWAV(String)
+
+        var description: String {
+            switch self {
+            case .invalidWAV(let message): return "invalid benchmark WAV: \(message)"
+            }
+        }
+    }
+
+    static func make(seconds: Int, wavPath: String?) throws -> [Float] {
+        let targetCount = seconds * 16_000
+        let source = try wavPath.map(loadWAV) ?? synthesizeSpeechBandNoise(count: targetCount)
+        guard !source.isEmpty else { throw Error.invalidWAV("audio data is empty") }
+        if source.count == targetCount { return source }
+
+        var looped: [Float] = []
+        looped.reserveCapacity(targetCount)
+        while looped.count < targetCount {
+            looped.append(contentsOf: source.prefix(targetCount - looped.count))
+        }
+        return looped
+    }
+
+    private static func loadWAV(path: String) throws -> [Float] {
+        let data = try Data(contentsOf: URL(fileURLWithPath: path))
+        guard data.count >= 12,
+              String(data: data[0..<4], encoding: .ascii) == "RIFF",
+              String(data: data[8..<12], encoding: .ascii) == "WAVE"
+        else {
+            throw Error.invalidWAV("not a RIFF/WAVE file")
+        }
+
+        var format: (code: UInt16, channels: UInt16, rate: UInt32, bits: UInt16)?
+        var pcm: Data?
+        var index = 12
+        while index + 8 <= data.count {
+            let chunkID = String(data: data[index..<(index + 4)], encoding: .ascii) ?? ""
+            let size = Int(readUInt32(data, at: index + 4))
+            let start = index + 8
+            let end = start + size
+            guard end <= data.count else { throw Error.invalidWAV("truncated chunk") }
+            if chunkID == "fmt ", size >= 16 {
+                format = (
+                    readUInt16(data, at: start),
+                    readUInt16(data, at: start + 2),
+                    readUInt32(data, at: start + 4),
+                    readUInt16(data, at: start + 14)
+                )
+            } else if chunkID == "data" {
+                pcm = data.subdata(in: start..<end)
+            }
+            index = end + (size & 1)
+        }
+
+        guard let format, let pcm else {
+            throw Error.invalidWAV("missing fmt or data chunk")
+        }
+        guard format.channels == 1, format.rate == 16_000 else {
+            throw Error.invalidWAV("expected mono 16000 Hz audio")
+        }
+        guard format.code == 1, format.bits == 16 else {
+            throw Error.invalidWAV("expected 16-bit integer PCM")
+        }
+
+        var samples: [Float] = []
+        samples.reserveCapacity(pcm.count / 2)
+        var sampleIndex = 0
+        while sampleIndex + 1 < pcm.count {
+            let bits = UInt16(pcm[sampleIndex]) | (UInt16(pcm[sampleIndex + 1]) << 8)
+            samples.append(Float(Int16(bitPattern: bits)) / 32_768)
+            sampleIndex += 2
+        }
+        return samples
+    }
+
+    private static func synthesizeSpeechBandNoise(count: Int) -> [Float] {
+        var state: UInt32 = 0x5EED_1234
+        var lowPass: Float = 0
+        var slow: Float = 0
+        return (0..<count).map { _ in
+            state = state &* 1_664_525 &+ 1_013_904_223
+            let white = Float(state >> 8) / Float(1 << 24) * 2 - 1
+            lowPass += 0.35 * (white - lowPass)
+            slow += 0.01 * (lowPass - slow)
+            return (lowPass - slow) * 0.08
+        }
+    }
+
+    private static func readUInt16(_ data: Data, at offset: Int) -> UInt16 {
+        UInt16(data[offset]) | (UInt16(data[offset + 1]) << 8)
+    }
+
+    private static func readUInt32(_ data: Data, at offset: Int) -> UInt32 {
+        UInt32(data[offset])
+            | (UInt32(data[offset + 1]) << 8)
+            | (UInt32(data[offset + 2]) << 16)
+            | (UInt32(data[offset + 3]) << 24)
+    }
+}

--- a/SpeechHelper/Sources/SpeechEngineText/SpeechHFCacheModelLocator.swift
+++ b/SpeechHelper/Sources/SpeechEngineText/SpeechHFCacheModelLocator.swift
@@ -1,0 +1,54 @@
+import Foundation
+
+/// Resolves app-prepared Hugging Face snapshots from the shared hub cache.
+/// The managed helper never resolves a pinned model through `main`: the exact
+/// catalog revision must be present or startup fails with an actionable error.
+public enum SpeechHFCacheModelLocator {
+    public enum LocatorError: Error, CustomStringConvertible {
+        case modelNotCached(repoID: String, searched: URL)
+        case pinnedRevisionNotCached(repoID: String, revision: String, searched: URL)
+
+        public var description: String {
+            switch self {
+            case .modelNotCached(let repoID, let searched):
+                return "model \(repoID) not found in HF cache at \(searched.path); download it first"
+            case .pinnedRevisionNotCached(let repoID, let revision, let searched):
+                return "model \(repoID) has no snapshot for pinned revision \(revision) under \(searched.path); download it first"
+            }
+        }
+    }
+
+    /// Mirrors huggingface_hub: HF_HUB_CACHE, then HF_HOME/hub, then the
+    /// default ~/.cache/huggingface/hub directory.
+    public static func defaultCacheRoot(
+        environment: [String: String] = ProcessInfo.processInfo.environment,
+        home: URL = FileManager.default.homeDirectoryForCurrentUser
+    ) -> URL {
+        if let hubCache = environment["HF_HUB_CACHE"], !hubCache.isEmpty {
+            return URL(filePath: hubCache)
+        }
+        if let hfHome = environment["HF_HOME"], !hfHome.isEmpty {
+            return URL(filePath: hfHome).appending(path: "hub")
+        }
+        return home.appending(path: ".cache/huggingface/hub")
+    }
+
+    public static func locate(repoID: String, revision: String, cacheRoot: URL) throws -> URL {
+        let snapshots = cacheRoot
+            .appending(path: "models--" + repoID.replacingOccurrences(of: "/", with: "--"))
+            .appending(path: "snapshots")
+        guard FileManager.default.fileExists(atPath: snapshots.path) else {
+            throw LocatorError.modelNotCached(repoID: repoID, searched: cacheRoot)
+        }
+
+        let pinned = snapshots.appending(path: revision)
+        guard FileManager.default.fileExists(atPath: pinned.appending(path: "config.json").path) else {
+            throw LocatorError.pinnedRevisionNotCached(
+                repoID: repoID,
+                revision: revision,
+                searched: snapshots
+            )
+        }
+        return pinned
+    }
+}

--- a/SpeechHelper/Sources/SpeechEngineText/SpeechdLaunchOptions.swift
+++ b/SpeechHelper/Sources/SpeechEngineText/SpeechdLaunchOptions.swift
@@ -1,0 +1,82 @@
+import Darwin
+
+public struct SpeechdLaunchOptions: Equatable {
+    public var modelID: String?
+    /// Exact HF commit prepared by the app. Nil keeps `--model` useful for
+    /// development against a custom repo that intentionally follows main.
+    public var modelRevision: String?
+    public var modelDirectory: String?
+    public var port: UInt16 = 8471
+    public var parentPID: pid_t?
+    public var transcriptionDelayMs: Int?
+    public var cacheLimitMB = 4096
+
+    public init() {}
+}
+
+public enum SpeechdOptionError: Error, CustomStringConvertible, Equatable {
+    case missingValue(String)
+    case invalidValue(String)
+    case unknownFlag(String)
+    case missingModel
+
+    public var description: String {
+        switch self {
+        case .missingValue(let flag): return "missing value for \(flag)"
+        case .invalidValue(let flag): return "invalid value for \(flag)"
+        case .unknownFlag(let flag): return "unknown flag \(flag)"
+        case .missingModel: return "one of --model or --model-dir is required"
+        }
+    }
+}
+
+public enum SpeechdOptionParser {
+    public static func parse(_ arguments: [String]) throws -> SpeechdLaunchOptions {
+        var options = SpeechdLaunchOptions()
+        var iterator = arguments.makeIterator()
+        func value(_ flag: String) throws -> String {
+            guard let value = iterator.next() else {
+                throw SpeechdOptionError.missingValue(flag)
+            }
+            return value
+        }
+
+        while let flag = iterator.next() {
+            switch flag {
+            case "--model":
+                options.modelID = try value(flag)
+            case "--model-revision":
+                options.modelRevision = try value(flag)
+            case "--model-dir":
+                options.modelDirectory = try value(flag)
+            case "--port":
+                guard let port = UInt16(try value(flag)) else {
+                    throw SpeechdOptionError.invalidValue(flag)
+                }
+                options.port = port
+            case "--parent-pid":
+                guard let pid = pid_t(try value(flag)) else {
+                    throw SpeechdOptionError.invalidValue(flag)
+                }
+                options.parentPID = pid
+            case "--transcription-delay-ms":
+                guard let milliseconds = Int(try value(flag)), milliseconds > 0 else {
+                    throw SpeechdOptionError.invalidValue(flag)
+                }
+                options.transcriptionDelayMs = milliseconds
+            case "--cache-limit-mb":
+                guard let megabytes = Int(try value(flag)), megabytes >= 0 else {
+                    throw SpeechdOptionError.invalidValue(flag)
+                }
+                options.cacheLimitMB = megabytes
+            default:
+                throw SpeechdOptionError.unknownFlag(flag)
+            }
+        }
+
+        guard options.modelID != nil || options.modelDirectory != nil else {
+            throw SpeechdOptionError.missingModel
+        }
+        return options
+    }
+}

--- a/SpeechHelper/Sources/SpeechEngineText/SpeechdLaunchOptions.swift
+++ b/SpeechHelper/Sources/SpeechEngineText/SpeechdLaunchOptions.swift
@@ -10,8 +10,22 @@ public struct SpeechdLaunchOptions: Equatable {
     public var parentPID: pid_t?
     public var transcriptionDelayMs: Int?
     public var cacheLimitMB = 4096
+    public var stepMilliseconds = 480
+    public var benchmark: SpeechdBenchmarkOptions?
 
     public init() {}
+}
+
+public struct SpeechdBenchmarkOptions: Equatable, Sendable {
+    public let seconds: Int
+    public let cadenceMilliseconds: Int
+    public let wavPath: String?
+
+    public init(seconds: Int, cadenceMilliseconds: Int, wavPath: String?) {
+        self.seconds = seconds
+        self.cadenceMilliseconds = cadenceMilliseconds
+        self.wavPath = wavPath
+    }
 }
 
 public enum SpeechdOptionError: Error, CustomStringConvertible, Equatable {
@@ -33,6 +47,11 @@ public enum SpeechdOptionError: Error, CustomStringConvertible, Equatable {
 public enum SpeechdOptionParser {
     public static func parse(_ arguments: [String]) throws -> SpeechdLaunchOptions {
         var options = SpeechdLaunchOptions()
+        var benchmarkEnabled = false
+        var benchmarkSeconds: Int?
+        var benchmarkCadenceMilliseconds = 480
+        var benchmarkWAVPath: String?
+        var sawBenchmarkOnlyFlag: String?
         var iterator = arguments.makeIterator()
         func value(_ flag: String) throws -> String {
             guard let value = iterator.next() else {
@@ -69,9 +88,52 @@ public enum SpeechdOptionParser {
                     throw SpeechdOptionError.invalidValue(flag)
                 }
                 options.cacheLimitMB = megabytes
+            case "--step-ms":
+                guard let milliseconds = Int(try value(flag)), milliseconds > 0,
+                      !16_000.multipliedReportingOverflow(by: milliseconds).overflow
+                else {
+                    throw SpeechdOptionError.invalidValue(flag)
+                }
+                options.stepMilliseconds = milliseconds
+            case "--bench":
+                benchmarkEnabled = true
+            case "--seconds":
+                guard let seconds = Int(try value(flag)), seconds > 0,
+                      !16_000.multipliedReportingOverflow(by: seconds).overflow
+                else {
+                    throw SpeechdOptionError.invalidValue(flag)
+                }
+                benchmarkSeconds = seconds
+                sawBenchmarkOnlyFlag = flag
+            case "--cadence-ms":
+                guard let milliseconds = Int(try value(flag)), milliseconds > 0,
+                      !16_000.multipliedReportingOverflow(by: milliseconds).overflow
+                else {
+                    throw SpeechdOptionError.invalidValue(flag)
+                }
+                benchmarkCadenceMilliseconds = milliseconds
+                sawBenchmarkOnlyFlag = flag
+            case "--wav":
+                let path = try value(flag)
+                guard !path.isEmpty else { throw SpeechdOptionError.invalidValue(flag) }
+                benchmarkWAVPath = path
+                sawBenchmarkOnlyFlag = flag
             default:
                 throw SpeechdOptionError.unknownFlag(flag)
             }
+        }
+
+        if benchmarkEnabled {
+            guard let benchmarkSeconds else {
+                throw SpeechdOptionError.missingValue("--seconds")
+            }
+            options.benchmark = SpeechdBenchmarkOptions(
+                seconds: benchmarkSeconds,
+                cadenceMilliseconds: benchmarkCadenceMilliseconds,
+                wavPath: benchmarkWAVPath
+            )
+        } else if let sawBenchmarkOnlyFlag {
+            throw SpeechdOptionError.invalidValue(sawBenchmarkOnlyFlag)
         }
 
         guard options.modelID != nil || options.modelDirectory != nil else {

--- a/SpeechHelper/Sources/SpeechEngineText/StepBatcher.swift
+++ b/SpeechHelper/Sources/SpeechEngineText/StepBatcher.swift
@@ -1,0 +1,54 @@
+/// Accumulates 16 kHz audio and yields fixed-cadence batches for streaming inference.
+///
+/// The realtime client normally appends 100 ms chunks, while Voxtral's native streaming
+/// cadence is 480 ms. Batching here avoids rerunning the model front end for every network
+/// append without changing the audio presented to the stream session.
+public struct StepBatcher: Sendable {
+    public let samplesPerStep: Int
+    private var bufferedSamples: [Float] = []
+
+    public init(cadenceMilliseconds: Int, sampleRate: Int = 16_000) {
+        precondition(cadenceMilliseconds > 0, "cadenceMilliseconds must be positive")
+        precondition(sampleRate > 0, "sampleRate must be positive")
+        let (product, overflow) = sampleRate.multipliedReportingOverflow(
+            by: cadenceMilliseconds
+        )
+        precondition(!overflow, "cadence is too large")
+        self.samplesPerStep = max(1, product / 1_000)
+    }
+
+    public var bufferedSampleCount: Int { bufferedSamples.count }
+
+    /// Append samples and return every complete cadence-sized batch now due.
+    /// A large append can produce more than one batch; any short tail remains buffered.
+    public mutating func append(_ samples: [Float]) -> [[Float]] {
+        guard !samples.isEmpty else { return [] }
+        bufferedSamples.append(contentsOf: samples)
+
+        let batchCount = bufferedSamples.count / samplesPerStep
+        guard batchCount > 0 else { return [] }
+
+        var batches: [[Float]] = []
+        batches.reserveCapacity(batchCount)
+        var start = 0
+        for _ in 0..<batchCount {
+            let end = start + samplesPerStep
+            batches.append(Array(bufferedSamples[start..<end]))
+            start = end
+        }
+        bufferedSamples.removeFirst(start)
+        return batches
+    }
+
+    /// Return the sub-cadence tail, if any, and empty the batcher.
+    public mutating func flushRemainder() -> [Float] {
+        guard !bufferedSamples.isEmpty else { return [] }
+        let remainder = bufferedSamples
+        bufferedSamples.removeAll(keepingCapacity: true)
+        return remainder
+    }
+
+    public mutating func clear() {
+        bufferedSamples.removeAll(keepingCapacity: true)
+    }
+}

--- a/SpeechHelper/Sources/localvoxtral-speechd/SpeechdMain.swift
+++ b/SpeechHelper/Sources/localvoxtral-speechd/SpeechdMain.swift
@@ -19,6 +19,11 @@ struct SpeechdMain {
     }
 
     static func run(_ options: SpeechdLaunchOptions) async throws {
+        if options.benchmark != nil {
+            try await StreamingSpeechBenchmark.run(options)
+            return
+        }
+
         // Load BEFORE binding the listener so /health only answers once inference is ready.
         let server = try await RealtimeSpeechServer.load(
             modelID: options.modelID,
@@ -26,7 +31,8 @@ struct SpeechdMain {
             modelDirectory: options.modelDirectory,
             port: options.port,
             transcriptionDelayMs: options.transcriptionDelayMs,
-            cacheLimitMB: options.cacheLimitMB
+            cacheLimitMB: options.cacheLimitMB,
+            stepMilliseconds: options.stepMilliseconds
         )
 
         // Exit if the supervising app dies, so a killed app never orphans the model.

--- a/SpeechHelper/Sources/localvoxtral-speechd/SpeechdMain.swift
+++ b/SpeechHelper/Sources/localvoxtral-speechd/SpeechdMain.swift
@@ -9,73 +9,20 @@ import SpeechEngineText
 /// supervisor's readinessURL contract).
 @main
 struct SpeechdMain {
-    struct Options {
-        var modelID: String?
-        var modelDirectory: String?
-        var port: UInt16 = 8471  // matches BackendCatalog.voxmlx.port
-        var parentPID: pid_t?
-        var transcriptionDelayMs: Int?
-        var cacheLimitMB = 4096
-    }
-
-    enum OptionError: Error, CustomStringConvertible {
-        case missingValue(String), invalidValue(String), unknownFlag(String), missingModel
-        var description: String {
-            switch self {
-            case .missingValue(let f): return "missing value for \(f)"
-            case .invalidValue(let f): return "invalid value for \(f)"
-            case .unknownFlag(let f): return "unknown flag \(f)"
-            case .missingModel: return "one of --model or --model-dir is required"
-            }
-        }
-    }
-
     static func main() async {
         do {
-            try await run(parse(Array(CommandLine.arguments.dropFirst())))
+            try await run(SpeechdOptionParser.parse(Array(CommandLine.arguments.dropFirst())))
         } catch {
             FileHandle.standardError.write(Data("speechd: \(error)\n".utf8))
             exit(1)
         }
     }
 
-    static func parse(_ arguments: [String]) throws -> Options {
-        var options = Options()
-        var it = arguments.makeIterator()
-        func value(_ flag: String) throws -> String {
-            guard let v = it.next() else { throw OptionError.missingValue(flag) }
-            return v
-        }
-        while let flag = it.next() {
-            switch flag {
-            case "--model": options.modelID = try value(flag)
-            case "--model-dir": options.modelDirectory = try value(flag)
-            case "--port":
-                guard let p = UInt16(try value(flag)) else { throw OptionError.invalidValue(flag) }
-                options.port = p
-            case "--parent-pid":
-                guard let pid = pid_t(try value(flag)) else { throw OptionError.invalidValue(flag) }
-                options.parentPID = pid
-            case "--transcription-delay-ms":
-                guard let ms = Int(try value(flag)), ms > 0 else { throw OptionError.invalidValue(flag) }
-                options.transcriptionDelayMs = ms
-            case "--cache-limit-mb":
-                guard let mb = Int(try value(flag)), mb >= 0 else { throw OptionError.invalidValue(flag) }
-                options.cacheLimitMB = mb
-            default:
-                throw OptionError.unknownFlag(flag)
-            }
-        }
-        guard options.modelID != nil || options.modelDirectory != nil else {
-            throw OptionError.missingModel
-        }
-        return options
-    }
-
-    static func run(_ options: Options) async throws {
+    static func run(_ options: SpeechdLaunchOptions) async throws {
         // Load BEFORE binding the listener so /health only answers once inference is ready.
         let server = try await RealtimeSpeechServer.load(
             modelID: options.modelID,
+            modelRevision: options.modelRevision,
             modelDirectory: options.modelDirectory,
             port: options.port,
             transcriptionDelayMs: options.transcriptionDelayMs,

--- a/SpeechHelper/Tests/SpeechEngineTextTests/SpeechdLaunchOptionsTests.swift
+++ b/SpeechHelper/Tests/SpeechEngineTextTests/SpeechdLaunchOptionsTests.swift
@@ -1,0 +1,52 @@
+import Foundation
+import XCTest
+
+@testable import SpeechEngineText
+
+final class SpeechdLaunchOptionsTests: XCTestCase {
+    func testParsesPinnedModelRevisionAndSupervisorArguments() throws {
+        let options = try SpeechdOptionParser.parse([
+            "--model", "mlx-community/Voxtral-Mini-4B-Realtime-2602-4bit",
+            "--model-revision", "0123456789abcdef0123456789abcdef01234567",
+            "--port", "8471",
+            "--parent-pid", "4321",
+        ])
+
+        XCTAssertEqual(options.modelID, "mlx-community/Voxtral-Mini-4B-Realtime-2602-4bit")
+        XCTAssertEqual(options.modelRevision, "0123456789abcdef0123456789abcdef01234567")
+        XCTAssertEqual(options.port, 8471)
+        XCTAssertEqual(options.parentPID, 4321)
+    }
+
+    func testPinnedRevisionLocatorNeverFallsBackToMain() throws {
+        let cacheRoot = FileManager.default.temporaryDirectory
+            .appending(path: "speechd-hf-cache-\(UUID().uuidString)")
+        defer { try? FileManager.default.removeItem(at: cacheRoot) }
+        let repoID = "mlx-community/Voxtral-Mini-4B-Realtime-2602-4bit"
+        let snapshots = cacheRoot
+            .appending(path: "models--mlx-community--Voxtral-Mini-4B-Realtime-2602-4bit")
+            .appending(path: "snapshots")
+        let pinned = snapshots.appending(path: "pinned")
+        let main = snapshots.appending(path: "moved-main")
+        try FileManager.default.createDirectory(at: pinned, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: main, withIntermediateDirectories: true)
+        try Data("{}".utf8).write(to: pinned.appending(path: "config.json"))
+        try Data("{}".utf8).write(to: main.appending(path: "config.json"))
+
+        XCTAssertEqual(
+            try SpeechHFCacheModelLocator.locate(
+                repoID: repoID,
+                revision: "pinned",
+                cacheRoot: cacheRoot
+            ).standardizedFileURL,
+            pinned.standardizedFileURL
+        )
+        XCTAssertThrowsError(
+            try SpeechHFCacheModelLocator.locate(
+                repoID: repoID,
+                revision: "absent-pin",
+                cacheRoot: cacheRoot
+            )
+        )
+    }
+}

--- a/SpeechHelper/Tests/SpeechEngineTextTests/SpeechdLaunchOptionsTests.swift
+++ b/SpeechHelper/Tests/SpeechEngineTextTests/SpeechdLaunchOptionsTests.swift
@@ -10,12 +10,90 @@ final class SpeechdLaunchOptionsTests: XCTestCase {
             "--model-revision", "0123456789abcdef0123456789abcdef01234567",
             "--port", "8471",
             "--parent-pid", "4321",
+            "--step-ms", "240",
         ])
 
         XCTAssertEqual(options.modelID, "mlx-community/Voxtral-Mini-4B-Realtime-2602-4bit")
         XCTAssertEqual(options.modelRevision, "0123456789abcdef0123456789abcdef01234567")
         XCTAssertEqual(options.port, 8471)
         XCTAssertEqual(options.parentPID, 4321)
+        XCTAssertEqual(options.stepMilliseconds, 240)
+    }
+
+    func testStepCadenceDefaultsToModelNativeCadence() throws {
+        let options = try SpeechdOptionParser.parse(["--model", "example/model"])
+
+        XCTAssertEqual(options.stepMilliseconds, 480)
+    }
+
+    func testStepCadenceAllowsSmallPositiveValues() throws {
+        let options = try SpeechdOptionParser.parse([
+            "--model", "example/model", "--step-ms", "1",
+        ])
+
+        XCTAssertEqual(options.stepMilliseconds, 1)
+    }
+
+    func testStepCadenceRejectsNonPositiveAndNonNumericValues() {
+        for value in ["0", "-1", "nope"] {
+            XCTAssertThrowsError(
+                try SpeechdOptionParser.parse([
+                    "--model", "example/model", "--step-ms", value,
+                ])
+            ) { error in
+                XCTAssertEqual(error as? SpeechdOptionError, .invalidValue("--step-ms"))
+            }
+        }
+    }
+
+    func testParsesBenchmarkOptions() throws {
+        let options = try SpeechdOptionParser.parse([
+            "--model", "example/model",
+            "--bench", "--seconds", "60", "--cadence-ms", "100",
+            "--wav", "/tmp/example.wav",
+        ])
+
+        XCTAssertEqual(
+            options.benchmark,
+            SpeechdBenchmarkOptions(
+                seconds: 60,
+                cadenceMilliseconds: 100,
+                wavPath: "/tmp/example.wav"
+            )
+        )
+    }
+
+    func testBenchmarkCadenceDefaultsToNativeCadence() throws {
+        let options = try SpeechdOptionParser.parse([
+            "--model", "example/model", "--bench", "--seconds", "5",
+        ])
+
+        XCTAssertEqual(options.benchmark?.cadenceMilliseconds, 480)
+    }
+
+    func testBenchmarkRequiresPositiveSeconds() {
+        XCTAssertThrowsError(
+            try SpeechdOptionParser.parse(["--model", "example/model", "--bench"])
+        ) { error in
+            XCTAssertEqual(error as? SpeechdOptionError, .missingValue("--seconds"))
+        }
+        XCTAssertThrowsError(
+            try SpeechdOptionParser.parse([
+                "--model", "example/model", "--bench", "--seconds", "0",
+            ])
+        ) { error in
+            XCTAssertEqual(error as? SpeechdOptionError, .invalidValue("--seconds"))
+        }
+    }
+
+    func testBenchmarkOnlyFlagsRequireBenchMode() {
+        XCTAssertThrowsError(
+            try SpeechdOptionParser.parse([
+                "--model", "example/model", "--seconds", "60",
+            ])
+        ) { error in
+            XCTAssertEqual(error as? SpeechdOptionError, .invalidValue("--seconds"))
+        }
     }
 
     func testPinnedRevisionLocatorNeverFallsBackToMain() throws {

--- a/SpeechHelper/Tests/SpeechEngineTextTests/StepBatcherTests.swift
+++ b/SpeechHelper/Tests/SpeechEngineTextTests/StepBatcherTests.swift
@@ -1,0 +1,75 @@
+import XCTest
+
+@testable import SpeechEngineText
+
+final class StepBatcherTests: XCTestCase {
+    func testCadenceBoundaryExactlyAtThreshold() {
+        var batcher = StepBatcher(cadenceMilliseconds: 100)
+
+        let batches = batcher.append(samples(count: 1_600, startingAt: 0))
+
+        XCTAssertEqual(batches, [samples(count: 1_600, startingAt: 0)])
+        XCTAssertEqual(batcher.bufferedSampleCount, 0)
+    }
+
+    func testCadenceBoundaryJustBelowThreshold() {
+        var batcher = StepBatcher(cadenceMilliseconds: 100)
+
+        XCTAssertTrue(batcher.append(samples(count: 1_599, startingAt: 0)).isEmpty)
+        XCTAssertEqual(batcher.bufferedSampleCount, 1_599)
+    }
+
+    func testCadenceBoundaryJustAboveThresholdKeepsRemainder() {
+        var batcher = StepBatcher(cadenceMilliseconds: 100)
+
+        let batches = batcher.append(samples(count: 1_601, startingAt: 0))
+
+        XCTAssertEqual(batches, [samples(count: 1_600, startingAt: 0)])
+        XCTAssertEqual(batcher.bufferedSampleCount, 1)
+        XCTAssertEqual(batcher.flushRemainder(), [1_600])
+    }
+
+    func testLargeAppendYieldsMultipleBatchesInOrder() {
+        var batcher = StepBatcher(cadenceMilliseconds: 100)
+
+        let batches = batcher.append(samples(count: 3_500, startingAt: 0))
+
+        XCTAssertEqual(batches.count, 2)
+        XCTAssertEqual(batches[0], samples(count: 1_600, startingAt: 0))
+        XCTAssertEqual(batches[1], samples(count: 1_600, startingAt: 1_600))
+        XCTAssertEqual(batcher.flushRemainder(), samples(count: 300, startingAt: 3_200))
+    }
+
+    func testFlushReturnsAccumulatedRemainderAndResetsBatcher() {
+        var batcher = StepBatcher(cadenceMilliseconds: 100)
+        XCTAssertTrue(batcher.append([1, 2]).isEmpty)
+        XCTAssertTrue(batcher.append([3]).isEmpty)
+
+        XCTAssertEqual(batcher.flushRemainder(), [1, 2, 3])
+        XCTAssertEqual(batcher.bufferedSampleCount, 0)
+        XCTAssertTrue(batcher.flushRemainder().isEmpty)
+    }
+
+    func testZeroLengthAppendDoesNotChangeBufferedSamples() {
+        var batcher = StepBatcher(cadenceMilliseconds: 100)
+        XCTAssertTrue(batcher.append([1, 2, 3]).isEmpty)
+
+        XCTAssertTrue(batcher.append([]).isEmpty)
+        XCTAssertEqual(batcher.bufferedSampleCount, 3)
+        XCTAssertEqual(batcher.flushRemainder(), [1, 2, 3])
+    }
+
+    func testClearDropsBufferedSamples() {
+        var batcher = StepBatcher(cadenceMilliseconds: 100)
+        XCTAssertTrue(batcher.append([1, 2, 3]).isEmpty)
+
+        batcher.clear()
+
+        XCTAssertEqual(batcher.bufferedSampleCount, 0)
+        XCTAssertTrue(batcher.flushRemainder().isEmpty)
+    }
+
+    private func samples(count: Int, startingAt start: Int) -> [Float] {
+        (start..<(start + count)).map(Float.init)
+    }
+}

--- a/Tests/localvoxtralTests/BackendManagerTests.swift
+++ b/Tests/localvoxtralTests/BackendManagerTests.swift
@@ -5,36 +5,38 @@ import XCTest
 
 @MainActor
 final class BackendManagerTests: XCTestCase {
-    func testInstallThenStartHappyPathRecordsStatusSequence() async throws {
-        let installer = FakeBackendInstaller(needsInstall: [BackendCatalog.voxmlx.id])
+    func testBundledDictationBackendNeverEntersInstallPathAndRecordsStartSequence() async throws {
+        let installer = FakeBackendInstaller(needsInstall: [BackendCatalog.speechd.id])
         let supervisorFactory = FakeSupervisorFactory()
-        supervisorFactory.statesByName[BackendCatalog.voxmlx.displayName] = [
+        supervisorFactory.statesByName[BackendCatalog.speechd.displayName] = [
             .launching,
             .waitingForReady,
             .running,
         ]
         let manager = makeManager(installer: installer, supervisorFactory: supervisorFactory)
-        var voxmlxStatuses: [ManagedBackendStatus] = []
+        var speechdStatuses: [ManagedBackendStatus] = []
         manager.debugStatusChangeSink = { spec, status in
-            guard spec.id == BackendCatalog.voxmlx.id else { return }
-            voxmlxStatuses.append(status)
+            guard spec.id == BackendCatalog.speechd.id else { return }
+            speechdStatuses.append(status)
         }
 
         try await manager.ensureReady(dictation: true, polishing: false)
 
-        XCTAssertEqual(installer.installCalls.map(\.id), [BackendCatalog.voxmlx.id])
-        XCTAssertEqual(manager.voxmlxStatus, .ready)
-        XCTAssertTrue(voxmlxStatuses.contains(.installing(progress: .downloading(fraction: nil))))
-        XCTAssertTrue(voxmlxStatuses.contains(.installing(progress: .verifying)))
-        XCTAssertTrue(voxmlxStatuses.contains(.starting))
-        XCTAssertEqual(voxmlxStatuses.last, .ready)
+        XCTAssertTrue(installer.installCalls.isEmpty)
+        XCTAssertEqual(manager.speechdStatus, .ready)
+        XCTAssertTrue(speechdStatuses.contains {
+            if case .preparingModel = $0 { return true }
+            return false
+        })
+        XCTAssertTrue(speechdStatuses.contains(.starting))
+        XCTAssertEqual(speechdStatuses.last, .ready)
     }
 
-    func testAlreadyInstalledSkipsInstaller() async throws {
+    func testSpeechdConfigurationUsesBundlePathPinnedModelRevisionAndHFFileSet() async throws {
         let installer = FakeBackendInstaller(needsInstall: [])
         let modelPreparer = FakeModelPreparer()
         let supervisorFactory = FakeSupervisorFactory()
-        supervisorFactory.statesByName[BackendCatalog.voxmlx.displayName] = [.running]
+        supervisorFactory.statesByName[BackendCatalog.speechd.displayName] = [.running]
         let manager = makeManager(
             installer: installer,
             modelPreparer: modelPreparer,
@@ -44,34 +46,60 @@ final class BackendManagerTests: XCTestCase {
         try await manager.ensureReady(dictation: true, polishing: false)
 
         XCTAssertTrue(installer.installCalls.isEmpty)
-        XCTAssertEqual(modelPreparer.prepareCalls.map(\.backendID), [BackendCatalog.voxmlx.id])
-        XCTAssertEqual(supervisorFactory.createdConfigurations.map(\.name), [BackendCatalog.voxmlx.displayName])
-        XCTAssertEqual(manager.voxmlxStatus, .ready)
+        XCTAssertEqual(modelPreparer.prepareCalls.map(\.backendID), [BackendCatalog.speechd.id])
+        XCTAssertEqual(supervisorFactory.createdConfigurations.map(\.name), [BackendCatalog.speechd.displayName])
+        XCTAssertEqual(manager.speechdStatus, .ready)
+
+        let option = SpeechModelCatalog.defaultOption
+        XCTAssertEqual(modelPreparer.prepareCalls.count, 1)
+        let request = try XCTUnwrap(modelPreparer.prepareCalls.first)
+        XCTAssertEqual(request.repoID, option.repoID)
+        XCTAssertEqual(request.revision, option.revision)
+        XCTAssertEqual(
+            request.includePatterns,
+            [
+                "config.json",
+                "tekken.json",
+                "tokenizer*.json",
+                "model*.safetensors",
+                "model.safetensors.index.json",
+            ]
+        )
+
+        XCTAssertEqual(supervisorFactory.createdConfigurations.count, 1)
+        let configuration = try XCTUnwrap(supervisorFactory.createdConfigurations.first)
+        XCTAssertEqual(configuration.executableURL.lastPathComponent, "localvoxtral-speechd")
+        XCTAssertFalse(configuration.executableURL.path.contains("backends"))
+        XCTAssertEqual(configuration.readinessURL.absoluteString, "http://127.0.0.1:8471/health")
+        XCTAssertTrue(configuration.arguments.contains("--parent-pid"))
+        let modelIndex = try XCTUnwrap(configuration.arguments.firstIndex(of: "--model"))
+        XCTAssertEqual(configuration.arguments[modelIndex + 1], option.repoID)
+        let revisionIndex = try XCTUnwrap(
+            configuration.arguments.firstIndex(of: "--model-revision")
+        )
+        XCTAssertEqual(configuration.arguments[revisionIndex + 1], option.revision)
     }
 
-    func testInstallFailureMarksBackendFailed() async {
+    func testBundledDictationBackendIgnoresInstallerFailureClaim() async throws {
         let installer = FakeBackendInstaller(
-            needsInstall: [BackendCatalog.voxmlx.id],
-            installFailures: [BackendCatalog.voxmlx.id: FakeBackendError(message: "wheel unavailable")]
+            needsInstall: [BackendCatalog.speechd.id],
+            installFailures: [BackendCatalog.speechd.id: FakeBackendError(message: "wheel unavailable")]
         )
-        let manager = makeManager(installer: installer, supervisorFactory: FakeSupervisorFactory())
+        let supervisorFactory = FakeSupervisorFactory()
+        supervisorFactory.statesByName[BackendCatalog.speechd.displayName] = [.running]
+        let manager = makeManager(installer: installer, supervisorFactory: supervisorFactory)
 
-        do {
-            try await manager.ensureReady(dictation: true, polishing: false)
-            XCTFail("expected ensureReady to throw")
-        } catch {
-            XCTAssertTrue(error.localizedDescription.contains("voxmlx"))
-            XCTAssertTrue(error.localizedDescription.contains("wheel unavailable"))
-        }
+        try await manager.ensureReady(dictation: true, polishing: false)
 
-        XCTAssertEqual(manager.voxmlxStatus, .failed(summary: "wheel unavailable", detail: nil))
+        XCTAssertTrue(installer.installCalls.isEmpty)
+        XCTAssertEqual(manager.speechdStatus, .ready)
     }
 
     func testPolishingFlagControlsWhetherPolishdIsTouched() async throws {
         let installer = FakeBackendInstaller(needsInstall: [])
         let modelPreparer = FakeModelPreparer()
         let supervisorFactory = FakeSupervisorFactory()
-        supervisorFactory.statesByName[BackendCatalog.voxmlx.displayName] = [.running]
+        supervisorFactory.statesByName[BackendCatalog.speechd.displayName] = [.running]
         supervisorFactory.statesByName[BackendCatalog.polishd.displayName] = [.running]
         let manager = makeManager(
             installer: installer,
@@ -80,20 +108,20 @@ final class BackendManagerTests: XCTestCase {
         )
 
         try await manager.ensureReady(dictation: true, polishing: false)
-        XCTAssertEqual(supervisorFactory.createdConfigurations.map(\.name), [BackendCatalog.voxmlx.displayName])
-        XCTAssertEqual(modelPreparer.prepareCalls.map(\.backendID), [BackendCatalog.voxmlx.id])
+        XCTAssertEqual(supervisorFactory.createdConfigurations.map(\.name), [BackendCatalog.speechd.displayName])
+        XCTAssertEqual(modelPreparer.prepareCalls.map(\.backendID), [BackendCatalog.speechd.id])
 
         try await manager.ensureReady(dictation: true, polishing: true)
         // Set + count, not positional (concurrent ensure tasks): exactly one
-        // creation/prepare per backend, voxmlx not re-done by the second call.
+        // creation/prepare per backend, speechd not re-done by the second call.
         XCTAssertEqual(
             Set(supervisorFactory.createdConfigurations.map(\.name)),
-            [BackendCatalog.voxmlx.displayName, BackendCatalog.polishd.displayName]
+            [BackendCatalog.speechd.displayName, BackendCatalog.polishd.displayName]
         )
         XCTAssertEqual(supervisorFactory.createdConfigurations.count, 2)
         XCTAssertEqual(
             Set(modelPreparer.prepareCalls.map(\.backendID)),
-            [BackendCatalog.voxmlx.id, BackendCatalog.polishd.id]
+            [BackendCatalog.speechd.id, BackendCatalog.polishd.id]
         )
         XCTAssertEqual(modelPreparer.prepareCalls.count, 2)
         XCTAssertEqual(manager.polishdStatus, .ready)
@@ -169,7 +197,7 @@ final class BackendManagerTests: XCTestCase {
         XCTAssertEqual(manager.polishdStatus, .ready)
     }
 
-    func testPolishingOnlyEnsureReadyDoesNotTouchVoxmlx() async throws {
+    func testPolishingOnlyEnsureReadyDoesNotTouchSpeechd() async throws {
         let installer = FakeBackendInstaller(needsInstall: [])
         let modelPreparer = FakeModelPreparer()
         let supervisorFactory = FakeSupervisorFactory()
@@ -184,71 +212,77 @@ final class BackendManagerTests: XCTestCase {
 
         XCTAssertEqual(supervisorFactory.createdConfigurations.map(\.name), [BackendCatalog.polishd.displayName])
         XCTAssertEqual(modelPreparer.prepareCalls.map(\.backendID), [BackendCatalog.polishd.id])
-        XCTAssertEqual(manager.voxmlxStatus, .stopped)
+        XCTAssertEqual(manager.speechdStatus, .stopped)
         XCTAssertEqual(manager.polishdStatus, .ready)
     }
 
-    func testConcurrentEnsureReadyDoesNotDoubleInstall() async throws {
-        let installer = FakeBackendInstaller(
-            needsInstall: [BackendCatalog.voxmlx.id],
-            suspendInstalls: true
-        )
+    func testConcurrentEnsureReadyDoesNotDoublePrepareOrStartSpeechd() async throws {
+        let installer = FakeBackendInstaller(needsInstall: [])
+        let modelPreparer = FakeModelPreparer(suspendBackendIDs: [BackendCatalog.speechd.id])
         let supervisorFactory = FakeSupervisorFactory()
-        supervisorFactory.statesByName[BackendCatalog.voxmlx.displayName] = [.running]
-        let manager = makeManager(installer: installer, supervisorFactory: supervisorFactory)
+        supervisorFactory.statesByName[BackendCatalog.speechd.displayName] = [.running]
+        let manager = makeManager(
+            installer: installer,
+            modelPreparer: modelPreparer,
+            supervisorFactory: supervisorFactory
+        )
 
         let first = Task { @MainActor in
             try await manager.ensureReady(dictation: true, polishing: false)
         }
-        await installer.waitUntilInstallStarted()
+        await modelPreparer.waitUntilPrepareStarted()
 
         let second = Task { @MainActor in
             try await manager.ensureReady(dictation: true, polishing: false)
         }
         await Task.yield()
 
-        XCTAssertEqual(installer.installCalls.map(\.id), [BackendCatalog.voxmlx.id])
-        installer.resumeInstall()
+        XCTAssertTrue(installer.installCalls.isEmpty)
+        XCTAssertEqual(modelPreparer.prepareCalls.map(\.backendID), [BackendCatalog.speechd.id])
+        XCTAssertTrue(supervisorFactory.createdConfigurations.isEmpty)
 
+        modelPreparer.resumePrepare()
         try await first.value
         try await second.value
-        XCTAssertEqual(installer.installCalls.map(\.id), [BackendCatalog.voxmlx.id])
-        XCTAssertEqual(manager.voxmlxStatus, .ready)
+        XCTAssertEqual(
+            supervisorFactory.supervisors[BackendCatalog.speechd.displayName]?.startCallCount,
+            1
+        )
     }
 
     func testStopAllStopsBothSupervisors() async throws {
         let installer = FakeBackendInstaller(needsInstall: [])
         let supervisorFactory = FakeSupervisorFactory()
-        supervisorFactory.statesByName[BackendCatalog.voxmlx.displayName] = [.running]
+        supervisorFactory.statesByName[BackendCatalog.speechd.displayName] = [.running]
         supervisorFactory.statesByName[BackendCatalog.polishd.displayName] = [.running]
         let manager = makeManager(installer: installer, supervisorFactory: supervisorFactory)
 
         try await manager.ensureReady(dictation: true, polishing: true)
         await manager.stopAll()
 
-        XCTAssertEqual(supervisorFactory.supervisors[BackendCatalog.voxmlx.displayName]?.stopCallCount, 1)
+        XCTAssertEqual(supervisorFactory.supervisors[BackendCatalog.speechd.displayName]?.stopCallCount, 1)
         XCTAssertEqual(supervisorFactory.supervisors[BackendCatalog.polishd.displayName]?.stopCallCount, 1)
-        XCTAssertEqual(manager.voxmlxStatus, .stopped)
+        XCTAssertEqual(manager.speechdStatus, .stopped)
         XCTAssertEqual(manager.polishdStatus, .stopped)
     }
 
     func testStopPolishingStopsOnlyPolishd() async throws {
         let installer = FakeBackendInstaller(needsInstall: [])
         let supervisorFactory = FakeSupervisorFactory()
-        supervisorFactory.statesByName[BackendCatalog.voxmlx.displayName] = [.running]
+        supervisorFactory.statesByName[BackendCatalog.speechd.displayName] = [.running]
         supervisorFactory.statesByName[BackendCatalog.polishd.displayName] = [.running]
         let manager = makeManager(installer: installer, supervisorFactory: supervisorFactory)
 
         try await manager.ensureReady(dictation: true, polishing: true)
-        XCTAssertEqual(manager.voxmlxStatus, .ready)
+        XCTAssertEqual(manager.speechdStatus, .ready)
         XCTAssertEqual(manager.polishdStatus, .ready)
 
         await manager.stopPolishing()
 
         XCTAssertEqual(supervisorFactory.supervisors[BackendCatalog.polishd.displayName]?.stopCallCount, 1)
         XCTAssertEqual(manager.polishdStatus, .stopped)
-        XCTAssertEqual(supervisorFactory.supervisors[BackendCatalog.voxmlx.displayName]?.stopCallCount, 0)
-        XCTAssertEqual(manager.voxmlxStatus, .ready)
+        XCTAssertEqual(supervisorFactory.supervisors[BackendCatalog.speechd.displayName]?.stopCallCount, 0)
+        XCTAssertEqual(manager.speechdStatus, .ready)
     }
 
     func testModelChangeStopsSupervisorAndNextEnsureUsesNewModel() async throws {
@@ -328,21 +362,21 @@ final class BackendManagerTests: XCTestCase {
         _ = await firstEnsure.result
     }
 
-    func testStopDictationStopsOnlyVoxmlx() async throws {
+    func testStopDictationStopsOnlySpeechd() async throws {
         let installer = FakeBackendInstaller(needsInstall: [])
         let supervisorFactory = FakeSupervisorFactory()
-        supervisorFactory.statesByName[BackendCatalog.voxmlx.displayName] = [.running]
+        supervisorFactory.statesByName[BackendCatalog.speechd.displayName] = [.running]
         supervisorFactory.statesByName[BackendCatalog.polishd.displayName] = [.running]
         let manager = makeManager(installer: installer, supervisorFactory: supervisorFactory)
 
         try await manager.ensureReady(dictation: true, polishing: true)
-        XCTAssertEqual(manager.voxmlxStatus, .ready)
+        XCTAssertEqual(manager.speechdStatus, .ready)
         XCTAssertEqual(manager.polishdStatus, .ready)
 
         await manager.stopDictation()
 
-        XCTAssertEqual(supervisorFactory.supervisors[BackendCatalog.voxmlx.displayName]?.stopCallCount, 1)
-        XCTAssertEqual(manager.voxmlxStatus, .stopped)
+        XCTAssertEqual(supervisorFactory.supervisors[BackendCatalog.speechd.displayName]?.stopCallCount, 1)
+        XCTAssertEqual(manager.speechdStatus, .stopped)
         XCTAssertEqual(supervisorFactory.supervisors[BackendCatalog.polishd.displayName]?.stopCallCount, 0)
         XCTAssertEqual(manager.polishdStatus, .ready)
     }
@@ -350,12 +384,12 @@ final class BackendManagerTests: XCTestCase {
     func testSupervisorStateMirrorMarksLaterFailureAndNextEnsureDoesNotShortCircuit() async throws {
         let installer = FakeBackendInstaller(needsInstall: [])
         let supervisorFactory = FakeSupervisorFactory()
-        supervisorFactory.statesByName[BackendCatalog.voxmlx.displayName] = [.running]
+        supervisorFactory.statesByName[BackendCatalog.speechd.displayName] = [.running]
         let manager = makeManager(installer: installer, supervisorFactory: supervisorFactory)
 
         try await manager.ensureReady(dictation: true, polishing: false)
-        let supervisor = try XCTUnwrap(supervisorFactory.supervisors[BackendCatalog.voxmlx.displayName])
-        XCTAssertEqual(manager.voxmlxStatus, .ready)
+        let supervisor = try XCTUnwrap(supervisorFactory.supervisors[BackendCatalog.speechd.displayName])
+        XCTAssertEqual(manager.speechdStatus, .ready)
         XCTAssertEqual(supervisor.startCallCount, 1)
 
         // Deterministic happens-before edge for the mirror's async consumption
@@ -367,23 +401,23 @@ final class BackendManagerTests: XCTestCase {
         let statusUpdates = manager.statusUpdates
         supervisor.emit(.failed(summary: "process crashed after readiness", detail: nil))
         for await update in statusUpdates {
-            if update.spec.id == BackendCatalog.voxmlx.id, case .failed = update.status {
+            if update.spec.id == BackendCatalog.speechd.id, case .failed = update.status {
                 break
             }
         }
 
-        XCTAssertEqual(manager.voxmlxStatus, .failed(summary: "process crashed after readiness", detail: nil))
+        XCTAssertEqual(manager.speechdStatus, .failed(summary: "process crashed after readiness", detail: nil))
 
         try await manager.ensureReady(dictation: true, polishing: false)
 
         XCTAssertEqual(supervisor.startCallCount, 2)
-        XCTAssertEqual(manager.voxmlxStatus, .ready)
+        XCTAssertEqual(manager.speechdStatus, .ready)
     }
 
-    func testManagedBackendConfigurationsUseLongFirstRunReadinessTimeouts() async throws {
+    func testBundledBackendConfigurationsUseModelLoadReadinessTimeouts() async throws {
         let installer = FakeBackendInstaller(needsInstall: [])
         let supervisorFactory = FakeSupervisorFactory()
-        supervisorFactory.statesByName[BackendCatalog.voxmlx.displayName] = [.running]
+        supervisorFactory.statesByName[BackendCatalog.speechd.displayName] = [.running]
         supervisorFactory.statesByName[BackendCatalog.polishd.displayName] = [.running]
         let manager = makeManager(installer: installer, supervisorFactory: supervisorFactory)
 
@@ -397,10 +431,7 @@ final class BackendManagerTests: XCTestCase {
                     .map { ($0.name, $0.readinessTimeout) }
             ),
             [
-                // voxmlx still downloads its model inside the server on first
-                // run; the bundled polishing helper only loads pre-downloaded
-                // weights.
-                BackendCatalog.voxmlx.displayName: .seconds(1800),
+                BackendCatalog.speechd.displayName: .seconds(300),
                 BackendCatalog.polishd.displayName: .seconds(300),
             ]
         )
@@ -410,37 +441,37 @@ final class BackendManagerTests: XCTestCase {
         let installer = FakeBackendInstaller(needsInstall: [])
         let modelPreparer = FakeModelPreparer(
             scriptedProgress: [
-                BackendCatalog.voxmlx.id: [
+                BackendCatalog.speechd.id: [
                     ModelDownloadProgress(downloadedBytes: 0, totalBytes: 100),
                     ModelDownloadProgress(downloadedBytes: 40, totalBytes: 100),
                 ],
             ]
         )
         let supervisorFactory = FakeSupervisorFactory()
-        supervisorFactory.statesByName[BackendCatalog.voxmlx.displayName] = [.running]
+        supervisorFactory.statesByName[BackendCatalog.speechd.displayName] = [.running]
         let manager = makeManager(
             installer: installer,
             modelPreparer: modelPreparer,
             supervisorFactory: supervisorFactory
         )
-        var voxmlxStatuses: [ManagedBackendStatus] = []
+        var speechdStatuses: [ManagedBackendStatus] = []
         manager.debugStatusChangeSink = { spec, status in
-            guard spec.id == BackendCatalog.voxmlx.id else { return }
-            voxmlxStatuses.append(status)
+            guard spec.id == BackendCatalog.speechd.id else { return }
+            speechdStatuses.append(status)
         }
 
         try await manager.ensureReady(dictation: true, polishing: false)
 
         XCTAssertEqual(
             modelPreparer.prepareCalls.map(\.repoID),
-            [SettingsStore.RealtimeProvider.realtimeAPI.defaultModelName]
+            [SpeechModelCatalog.defaultOption.repoID]
         )
-        XCTAssertTrue(voxmlxStatuses.contains(.preparingModel(progress: ModelDownloadProgress(downloadedBytes: 40, totalBytes: 100))))
-        XCTAssertTrue(voxmlxStatuses.contains(.starting))
-        XCTAssertEqual(voxmlxStatuses.last, .ready)
+        XCTAssertTrue(speechdStatuses.contains(.preparingModel(progress: ModelDownloadProgress(downloadedBytes: 40, totalBytes: 100))))
+        XCTAssertTrue(speechdStatuses.contains(.starting))
+        XCTAssertEqual(speechdStatuses.last, .ready)
         XCTAssertLessThan(
-            try XCTUnwrap(voxmlxStatuses.firstIndex(of: .preparingModel(progress: ModelDownloadProgress(downloadedBytes: 40, totalBytes: 100)))),
-            try XCTUnwrap(voxmlxStatuses.firstIndex(of: .starting))
+            try XCTUnwrap(speechdStatuses.firstIndex(of: .preparingModel(progress: ModelDownloadProgress(downloadedBytes: 40, totalBytes: 100)))),
+            try XCTUnwrap(speechdStatuses.firstIndex(of: .starting))
         )
     }
 
@@ -448,7 +479,7 @@ final class BackendManagerTests: XCTestCase {
         let installer = FakeBackendInstaller(needsInstall: [])
         let modelPreparer = FakeModelPreparer()
         let supervisorFactory = FakeSupervisorFactory()
-        supervisorFactory.statesByName[BackendCatalog.voxmlx.displayName] = [.running]
+        supervisorFactory.statesByName[BackendCatalog.speechd.displayName] = [.running]
         supervisorFactory.statesByName[BackendCatalog.polishd.displayName] = [.running]
         let manager = makeManager(
             installer: installer,
@@ -466,17 +497,17 @@ final class BackendManagerTests: XCTestCase {
                     .map { ($0.backendID, $0.repoID) }
             ),
             [
-                BackendCatalog.voxmlx.id: SettingsStore.RealtimeProvider.realtimeAPI.defaultModelName,
+                BackendCatalog.speechd.id: SpeechModelCatalog.defaultOption.repoID,
                 BackendCatalog.polishd.id: SettingsStore.defaultLLMPolishingModel,
             ]
         )
     }
 
-    func testEnsureReadyWithoutPolishingPreparesOnlyVoxmlx() async throws {
+    func testEnsureReadyWithoutPolishingPreparesOnlySpeechd() async throws {
         let installer = FakeBackendInstaller(needsInstall: [])
         let modelPreparer = FakeModelPreparer()
         let supervisorFactory = FakeSupervisorFactory()
-        supervisorFactory.statesByName[BackendCatalog.voxmlx.displayName] = [.running]
+        supervisorFactory.statesByName[BackendCatalog.speechd.displayName] = [.running]
         supervisorFactory.statesByName[BackendCatalog.polishd.displayName] = [.running]
         let manager = makeManager(
             installer: installer,
@@ -486,15 +517,15 @@ final class BackendManagerTests: XCTestCase {
 
         try await manager.ensureReady(dictation: true, polishing: false)
 
-        XCTAssertEqual(modelPreparer.prepareCalls.map(\.backendID), [BackendCatalog.voxmlx.id])
-        XCTAssertEqual(supervisorFactory.createdConfigurations.map(\.name), [BackendCatalog.voxmlx.displayName])
+        XCTAssertEqual(modelPreparer.prepareCalls.map(\.backendID), [BackendCatalog.speechd.id])
+        XCTAssertEqual(supervisorFactory.createdConfigurations.map(\.name), [BackendCatalog.speechd.displayName])
     }
 
     func testCancellingEnsureReadyDuringModelPreparationTerminatesAndDoesNotMarkReady() async throws {
         let installer = FakeBackendInstaller(needsInstall: [])
-        let modelPreparer = FakeModelPreparer(suspendBackendIDs: [BackendCatalog.voxmlx.id])
+        let modelPreparer = FakeModelPreparer(suspendBackendIDs: [BackendCatalog.speechd.id])
         let supervisorFactory = FakeSupervisorFactory()
-        supervisorFactory.statesByName[BackendCatalog.voxmlx.displayName] = [.running]
+        supervisorFactory.statesByName[BackendCatalog.speechd.displayName] = [.running]
         let manager = makeManager(
             installer: installer,
             modelPreparer: modelPreparer,
@@ -516,9 +547,9 @@ final class BackendManagerTests: XCTestCase {
             XCTFail("expected CancellationError, got \(error)")
         }
 
-        XCTAssertEqual(modelPreparer.terminatedBackendIDs, [BackendCatalog.voxmlx.id])
+        XCTAssertEqual(modelPreparer.terminatedBackendIDs, [BackendCatalog.speechd.id])
         XCTAssertTrue(supervisorFactory.createdConfigurations.isEmpty)
-        XCTAssertEqual(manager.voxmlxStatus, .stopped)
+        XCTAssertEqual(manager.speechdStatus, .stopped)
     }
 
     func testStopPolishingCancelsInFlightEnsureBeforeSupervisorCanStart() async throws {
@@ -557,7 +588,7 @@ final class BackendManagerTests: XCTestCase {
         let installer = FakeBackendInstaller(needsInstall: [])
         let modelPreparer = FakeModelPreparer(
             failures: [
-                BackendCatalog.voxmlx.id: ModelDownloadError.downloaderReportedError(
+                BackendCatalog.speechd.id: ModelDownloadError.downloaderReportedError(
                     message: "Hugging Face rejected the request.",
                     stderrTail: "stderr \(marker)"
                 ),
@@ -573,14 +604,17 @@ final class BackendManagerTests: XCTestCase {
             try await manager.ensureReady(dictation: true, polishing: false)
             XCTFail("expected ensureReady to throw")
         } catch let error as ManagedBackendManagerError {
-            XCTAssertEqual(error.localizedDescription, "voxmlx failed: Hugging Face rejected the request.")
+            XCTAssertEqual(
+                error.localizedDescription,
+                "Dictation engine failed: Hugging Face rejected the request."
+            )
             XCTAssertEqual(error.technicalDetails, "stderr \(marker)")
         } catch {
             XCTFail("expected ManagedBackendManagerError, got \(error)")
         }
 
         XCTAssertEqual(
-            manager.voxmlxStatus,
+            manager.speechdStatus,
             .failed(summary: "Hugging Face rejected the request.", detail: "stderr \(marker)")
         )
     }
@@ -589,7 +623,7 @@ final class BackendManagerTests: XCTestCase {
         let marker = "FAKE_STDERR_TRACEBACK"
         let installer = FakeBackendInstaller(needsInstall: [])
         let supervisorFactory = FakeSupervisorFactory()
-        supervisorFactory.statesByName[BackendCatalog.voxmlx.displayName] = [.running]
+        supervisorFactory.statesByName[BackendCatalog.speechd.displayName] = [.running]
         supervisorFactory.statesByName[BackendCatalog.polishd.displayName] = [
             .failed(
                 summary: "polishd exited 5 consecutive times.",
@@ -624,13 +658,13 @@ final class BackendManagerTests: XCTestCase {
     func testPolishingEnsureIsNotBlockedByAStuckDictationEnsure() async throws {
         let installer = FakeBackendInstaller(needsInstall: [])
         let supervisorFactory = FakeSupervisorFactory()
-        // voxmlx never reaches .running: its ensure blocks awaiting readiness.
-        supervisorFactory.statesByName[BackendCatalog.voxmlx.displayName] = []
+        // speechd never reaches .running: its ensure blocks awaiting readiness.
+        supervisorFactory.statesByName[BackendCatalog.speechd.displayName] = []
         supervisorFactory.statesByName[BackendCatalog.polishd.displayName] = [.running]
         let manager = makeManager(installer: installer, supervisorFactory: supervisorFactory)
 
         let stuckDictation = Task { try await manager.ensureReady(dictation: true, polishing: false) }
-        while supervisorFactory.supervisors[BackendCatalog.voxmlx.displayName]?.startCallCount != 1 {
+        while supervisorFactory.supervisors[BackendCatalog.speechd.displayName]?.startCallCount != 1 {
             await Task.yield()
         }
 
@@ -650,13 +684,13 @@ final class BackendManagerTests: XCTestCase {
     func testSecondEnsureReadyAddsPolishingAfterDictationOnlyRun() async throws {
         let installer = FakeBackendInstaller(needsInstall: [])
         let supervisorFactory = FakeSupervisorFactory()
-        supervisorFactory.statesByName[BackendCatalog.voxmlx.displayName] = [.running]
+        supervisorFactory.statesByName[BackendCatalog.speechd.displayName] = [.running]
         supervisorFactory.statesByName[BackendCatalog.polishd.displayName] = [.running]
         let manager = makeManager(installer: installer, supervisorFactory: supervisorFactory)
 
         // First dictation: polishing disabled at the time.
         try await manager.ensureReady(dictation: true, polishing: false)
-        XCTAssertEqual(manager.voxmlxStatus, .ready)
+        XCTAssertEqual(manager.speechdStatus, .ready)
         XCTAssertEqual(manager.polishdStatus, .stopped)
 
         // User enables polishing, dictates again: polishd must come up now.
@@ -770,6 +804,15 @@ private final class FakeModelPreparer: ModelPreparing, @unchecked Sendable {
                 continuation.resume()
             }
         }
+    }
+
+    func resumePrepare() {
+        let continuation: CheckedContinuation<Void, Error>? = state.withLock {
+            let continuation = $0.prepareResumeContinuation
+            $0.prepareResumeContinuation = nil
+            return continuation
+        }
+        continuation?.resume()
     }
 }
 

--- a/Tests/localvoxtralTests/BackendManagerTests.swift
+++ b/Tests/localvoxtralTests/BackendManagerTests.swift
@@ -1,3 +1,4 @@
+import Darwin
 import Foundation
 import Synchronization
 import XCTest
@@ -78,6 +79,55 @@ final class BackendManagerTests: XCTestCase {
             configuration.arguments.firstIndex(of: "--model-revision")
         )
         XCTAssertEqual(configuration.arguments[revisionIndex + 1], option.revision)
+        // Default provider is Auto: the cache-limit flag is omitted so the
+        // helper's built-in default applies.
+        XCTAssertFalse(configuration.arguments.contains("--cache-limit-mb"))
+    }
+
+    func testSpeechdCacheLimitAutoOmitsFlagAndPresetsAppendMegabytes() async throws {
+        let option = SpeechModelCatalog.defaultOption
+        let baseArguments = [
+            "--model", option.repoID,
+            "--model-revision", option.revision,
+            "--port", "8471",
+            "--parent-pid", "\(Darwin.getpid())",
+        ]
+
+        // Auto: identical to the base argument list, no cache-limit flag.
+        let autoConfiguration = try await speechdConfiguration(cacheLimitMB: nil)
+        XCTAssertEqual(autoConfiguration.arguments, baseArguments)
+
+        // Each preset appends exactly `--cache-limit-mb <value>` and leaves the
+        // model / revision / port / parent-pid arguments untouched.
+        for megabytes in [2048, 4096, 6144, 8192] {
+            let configuration = try await speechdConfiguration(cacheLimitMB: megabytes)
+            XCTAssertEqual(
+                configuration.arguments,
+                baseArguments + ["--cache-limit-mb", "\(megabytes)"]
+            )
+        }
+    }
+
+    /// Starts speechd with the given cache-limit provider and returns the
+    /// supervisor configuration it was launched with.
+    private func speechdConfiguration(
+        cacheLimitMB: Int?
+    ) async throws -> BackendProcessConfiguration {
+        let installer = FakeBackendInstaller(needsInstall: [])
+        let supervisorFactory = FakeSupervisorFactory()
+        supervisorFactory.statesByName[BackendCatalog.speechd.displayName] = [.running]
+        let manager = makeManager(
+            installer: installer,
+            speechdCacheLimitProvider: { cacheLimitMB },
+            supervisorFactory: supervisorFactory
+        )
+
+        try await manager.ensureReady(dictation: true, polishing: false)
+
+        return try XCTUnwrap(
+            supervisorFactory.createdConfigurations
+                .first { $0.name == BackendCatalog.speechd.displayName }
+        )
     }
 
     func testBundledDictationBackendIgnoresInstallerFailureClaim() async throws {
@@ -705,6 +755,7 @@ final class BackendManagerTests: XCTestCase {
         polishingModelProvider: @escaping BackendManager.PolishingModelProvider = {
             SettingsStore.defaultLLMPolishingModel
         },
+        speechdCacheLimitProvider: @escaping BackendManager.SpeechdCacheLimitProvider = { nil },
         supervisorFactory: FakeSupervisorFactory
     ) -> BackendManager {
         BackendManager(
@@ -712,6 +763,7 @@ final class BackendManagerTests: XCTestCase {
             modelPreparer: modelPreparer,
             layout: BackendInstallLayout(root: URL(fileURLWithPath: "/tmp/localvoxtral-backend-manager-tests")),
             polishingModelProvider: polishingModelProvider,
+            speechdCacheLimitProvider: speechdCacheLimitProvider,
             supervisorFactory: { configuration in
                 supervisorFactory.makeSupervisor(configuration: configuration)
             }

--- a/Tests/localvoxtralTests/DiagnosticsExporterTests.swift
+++ b/Tests/localvoxtralTests/DiagnosticsExporterTests.swift
@@ -46,16 +46,16 @@ final class DiagnosticsExporterTests: XCTestCase {
 
     private func makeSnapshot(
         settings: SettingsStore,
-        voxmlxStatus: ManagedBackendStatus = .notInstalled,
+        speechdStatus: ManagedBackendStatus = .notInstalled,
         polishdStatus: ManagedBackendStatus = .notInstalled,
-        voxmlxRecentOutput: [String] = [],
+        speechdRecentOutput: [String] = [],
         polishdRecentOutput: [String] = []
     ) -> DiagnosticsSnapshot {
         DiagnosticsExporter.makeSnapshot(
             settings: settings,
-            voxmlxStatus: voxmlxStatus,
+            speechdStatus: speechdStatus,
             polishdStatus: polishdStatus,
-            voxmlxRecentOutput: voxmlxRecentOutput,
+            speechdRecentOutput: speechdRecentOutput,
             polishdRecentOutput: polishdRecentOutput
         )
     }
@@ -78,7 +78,7 @@ final class DiagnosticsExporterTests: XCTestCase {
         XCTAssertTrue(report.contains("realtime endpoint: ws://127.0.0.1:8000/v1/realtime"))
         XCTAssertTrue(report.contains("realtime API key: not set"))
         XCTAssertTrue(report.contains("LLM polishing: <disabled>"))
-        XCTAssertTrue(report.contains("voxmlx: not installed"))
+        XCTAssertTrue(report.contains("dictation engine (localvoxtral-speechd): not installed"))
         XCTAssertTrue(report.contains("polishing engine (localvoxtral-polishd): not installed"))
     }
 
@@ -86,14 +86,17 @@ final class DiagnosticsExporterTests: XCTestCase {
         let store = makeExternalStore()
         let snapshot = makeSnapshot(
             settings: store,
-            voxmlxRecentOutput: ["[voxmlx stdout] INFO started", "[voxmlx stderr] listening"],
+            speechdRecentOutput: [
+                "[localvoxtral-speechd stdout] INFO started",
+                "[localvoxtral-speechd stderr] listening",
+            ],
             polishdRecentOutput: ["[localvoxtral-polishd stdout] ready"]
         )
         let report = DiagnosticsExporter.makeReport(snapshot: snapshot, now: Date())
 
-        XCTAssertTrue(report.contains("-- voxmlx --"))
-        XCTAssertTrue(report.contains("[voxmlx stdout] INFO started"))
-        XCTAssertTrue(report.contains("[voxmlx stderr] listening"))
+        XCTAssertTrue(report.contains("-- localvoxtral-speechd --"))
+        XCTAssertTrue(report.contains("[localvoxtral-speechd stdout] INFO started"))
+        XCTAssertTrue(report.contains("[localvoxtral-speechd stderr] listening"))
         XCTAssertTrue(report.contains("-- localvoxtral-polishd --"))
         XCTAssertTrue(report.contains("[localvoxtral-polishd stdout] ready"))
     }
@@ -213,7 +216,7 @@ final class DiagnosticsExporterTests: XCTestCase {
         let store = makeExternalStore()
         let snapshot = makeSnapshot(
             settings: store,
-            voxmlxRecentOutput: ["[voxmlx stdout] up"]
+            speechdRecentOutput: ["[localvoxtral-speechd stdout] up"]
         )
         let now = Date(timeIntervalSince1970: 1_750_000_000)
 

--- a/Tests/localvoxtralTests/DictationViewModelFailFastUXTests.swift
+++ b/Tests/localvoxtralTests/DictationViewModelFailFastUXTests.swift
@@ -278,7 +278,9 @@ final class DictationViewModelFailFastUXTests: XCTestCase {
 
     func testStartDictationInManagedModeAwaitsBackendManagerAndSurfacesFailure() async {
         let backendManager = FakeManagedBackendManager()
-        backendManager.ensureError = FakeManagedBackendFailure(message: "voxmlx failed: missing wheel")
+        backendManager.ensureError = FakeManagedBackendFailure(
+            message: "Dictation engine failed: model unavailable"
+        )
         backendManager.suspendEnsure = true
         let viewModel = makeViewModel(outputMode: .overlayBuffer, backendManager: backendManager)
         viewModel.settings.dictationBackendMode = .managedLocal
@@ -355,7 +357,7 @@ final class DictationViewModelFailFastUXTests: XCTestCase {
 
         await emitStatusAndAwaitMirror(
             backendManager, viewModel: viewModel,
-            spec: BackendCatalog.voxmlx,
+            spec: BackendCatalog.speechd,
             status: .preparingModel(progress: ModelDownloadProgress(downloadedBytes: 36, totalBytes: 100))
         )
 
@@ -591,7 +593,7 @@ final class DictationViewModelFailFastUXTests: XCTestCase {
         viewModel.applyDictationBackendModeChange(.managedLocal)
         await backendManager.waitUntilEnsureStarted()
 
-        // Turning polishing off must stop polishd only — the voxmlx warmup keeps
+        // Turning polishing off must stop polishd only — the speechd warmup keeps
         // its own task slot and must survive (regression: a shared slot let this
         // cancel the in-flight dictation warmup).
         viewModel.llmPolishingEnabledDidChange(false)
@@ -619,7 +621,7 @@ final class DictationViewModelFailFastUXTests: XCTestCase {
         await backendManager.waitForStopDictationCallCount(1)
 
         // Flip back while the stop is still executing: the warmup must wait for
-        // the stop to finish, or the stale stop kills the fresh voxmlx process
+        // the stop to finish, or the stale stop kills the fresh speechd process
         // (review finding on rapid managed→external→managed flips).
         viewModel.applyDictationBackendModeChange(.managedLocal)
         await Task.yield()
@@ -1027,7 +1029,7 @@ final class DictationViewModelFailFastUXTests: XCTestCase {
 
     func testMenuBarIndicatorShowsFailureWhenManagedDictationBackendIsNotReady() {
         let backendManager = FakeManagedBackendManager()
-        backendManager.voxmlxStatus = .starting
+        backendManager.speechdStatus = .starting
         let viewModel = makeViewModel(outputMode: .overlayBuffer, backendManager: backendManager)
         viewModel.settings.dictationBackendMode = .managedLocal
         viewModel.settings.polishingBackendMode = .externalURL
@@ -1040,7 +1042,7 @@ final class DictationViewModelFailFastUXTests: XCTestCase {
 
     func testMenuBarIndicatorShowsIdleWhenRequiredManagedBackendsAreReady() {
         let backendManager = FakeManagedBackendManager()
-        backendManager.voxmlxStatus = .ready
+        backendManager.speechdStatus = .ready
         backendManager.polishdStatus = .ready
         let viewModel = makeViewModel(outputMode: .overlayBuffer, backendManager: backendManager)
         viewModel.settings.dictationBackendMode = .managedLocal
@@ -1055,7 +1057,7 @@ final class DictationViewModelFailFastUXTests: XCTestCase {
 
     func testMenuBarIndicatorShowsIdleForExternalModesEvenWhenManagedBackendsAreStopped() {
         let backendManager = FakeManagedBackendManager()
-        backendManager.voxmlxStatus = .stopped
+        backendManager.speechdStatus = .stopped
         backendManager.polishdStatus = .failed(summary: "mlx-lm failed to start.", detail: "trace")
         let viewModel = makeViewModel(outputMode: .overlayBuffer, backendManager: backendManager)
         viewModel.settings.dictationBackendMode = .externalURL
@@ -1070,7 +1072,7 @@ final class DictationViewModelFailFastUXTests: XCTestCase {
 
     func testMenuBarIndicatorShowsFailureWhenRequiredManagedPolishingBackendFailed() {
         let backendManager = FakeManagedBackendManager()
-        backendManager.voxmlxStatus = .ready
+        backendManager.speechdStatus = .ready
         backendManager.polishdStatus = .failed(summary: "mlx-lm failed to start.", detail: "trace")
         let viewModel = makeViewModel(outputMode: .overlayBuffer, backendManager: backendManager)
         viewModel.settings.dictationBackendMode = .externalURL
@@ -1085,7 +1087,7 @@ final class DictationViewModelFailFastUXTests: XCTestCase {
 
     func testMenuBarIndicatorIgnoresManagedBackendReadinessUntilOnboardingCompletes() {
         let backendManager = FakeManagedBackendManager()
-        backendManager.voxmlxStatus = .notInstalled
+        backendManager.speechdStatus = .notInstalled
         backendManager.polishdStatus = .notInstalled
         let viewModel = makeViewModel(outputMode: .overlayBuffer, backendManager: backendManager)
         viewModel.settings.dictationBackendMode = .managedLocal
@@ -1100,7 +1102,7 @@ final class DictationViewModelFailFastUXTests: XCTestCase {
 
     func testMenuBarIndicatorSessionConnectedWinsOverUnreadyManagedBackend() {
         let backendManager = FakeManagedBackendManager()
-        backendManager.voxmlxStatus = .starting
+        backendManager.speechdStatus = .starting
         let viewModel = makeViewModel(outputMode: .overlayBuffer, backendManager: backendManager)
         viewModel.settings.dictationBackendMode = .managedLocal
         viewModel.settings.onboardingCompleted = true
@@ -1113,7 +1115,7 @@ final class DictationViewModelFailFastUXTests: XCTestCase {
 
     func testMenuBarIndicatorRecentFailureWinsOverReadyManagedBackends() {
         let backendManager = FakeManagedBackendManager()
-        backendManager.voxmlxStatus = .ready
+        backendManager.speechdStatus = .ready
         let viewModel = makeViewModel(outputMode: .overlayBuffer, backendManager: backendManager)
         viewModel.settings.dictationBackendMode = .managedLocal
         viewModel.settings.onboardingCompleted = true
@@ -1389,7 +1391,7 @@ private final class FakeManagedBackendManager: ManagedBackendManaging {
         var polishing: Bool
     }
 
-    var voxmlxStatus: ManagedBackendStatus = .notInstalled
+    var speechdStatus: ManagedBackendStatus = .notInstalled
     var polishdStatus: ManagedBackendStatus = .notInstalled
     private var statusUpdateContinuations: [UUID: AsyncStream<ManagedBackendStatusUpdate>.Continuation] = [:]
     var statusUpdates: AsyncStream<ManagedBackendStatusUpdate> {
@@ -1432,7 +1434,7 @@ private final class FakeManagedBackendManager: ManagedBackendManaging {
         }
 
         if dictation {
-            emitStatus(spec: BackendCatalog.voxmlx, status: .ready)
+            emitStatus(spec: BackendCatalog.speechd, status: .ready)
         }
         if polishing {
             emitStatus(spec: BackendCatalog.polishd, status: .ready)
@@ -1467,8 +1469,8 @@ private final class FakeManagedBackendManager: ManagedBackendManaging {
 
     func emitStatus(spec: ManagedBackendSpec, status: ManagedBackendStatus) {
         switch spec.id {
-        case BackendCatalog.voxmlx.id:
-            voxmlxStatus = status
+        case BackendCatalog.speechd.id:
+            speechdStatus = status
         case BackendCatalog.polishd.id:
             polishdStatus = status
         default:

--- a/Tests/localvoxtralTests/LegacyMLXLMCleanupTests.swift
+++ b/Tests/localvoxtralTests/LegacyMLXLMCleanupTests.swift
@@ -50,7 +50,7 @@ final class LegacyMLXLMCleanupTests: XCTestCase {
             .appendingPathComponent("mlx_lm-0.31.3.post4-py3-none-any.whl")
         try Data("wheel".utf8).write(to: legacyWheel)
 
-        // Still-managed voxmlx install — must survive untouched.
+        // Legacy voxmlx install is deliberately preserved for part-4 cleanup.
         let voxmlxVenv = layout.tools.appendingPathComponent("voxmlx", isDirectory: true)
         try fileManager.createDirectory(at: voxmlxVenv, withIntermediateDirectories: true)
         let voxmlxBin = layout.toolBin.appendingPathComponent("voxmlx-serve")

--- a/Tests/localvoxtralTests/OnboardingBootstrapDriverTests.swift
+++ b/Tests/localvoxtralTests/OnboardingBootstrapDriverTests.swift
@@ -103,7 +103,7 @@ final class OnboardingItemStateMappingTests: XCTestCase {
 final class LiveOnboardingBootstrapDriverTests: XCTestCase {
     func testStart_seedsItemStatesFromCurrentBackendStatus() {
         let manager = OnboardingTestBackendManager()
-        manager.voxmlxStatus = .installing(progress: .downloading(fraction: 0.5))
+        manager.speechdStatus = .installing(progress: .downloading(fraction: 0.5))
         manager.polishdStatus = .notInstalled
         let driver = LiveOnboardingBootstrapDriver(backendManager: manager)
 
@@ -140,7 +140,7 @@ final class LiveOnboardingBootstrapDriverTests: XCTestCase {
 
     func testObservation_reflectsBackendStatusChanges() async {
         let manager = OnboardingTestBackendManager()
-        manager.voxmlxStatus = .starting
+        manager.speechdStatus = .starting
         let driver = LiveOnboardingBootstrapDriver(backendManager: manager)
 
         driver.start(dictation: true, polishing: false)
@@ -150,7 +150,7 @@ final class LiveOnboardingBootstrapDriverTests: XCTestCase {
         )
 
         let states = await awaitReadyStateChange(from: driver) {
-            manager.voxmlxStatus = .ready
+            manager.speechdStatus = .ready
         }
 
         XCTAssertEqual(states[.dictation], .ready)
@@ -243,7 +243,7 @@ final class OnboardingTestBackendManager: ManagedBackendManaging {
         var polishing: Bool
     }
 
-    var voxmlxStatus: ManagedBackendStatus = .notInstalled
+    var speechdStatus: ManagedBackendStatus = .notInstalled
     var polishdStatus: ManagedBackendStatus = .notInstalled
     @ObservationIgnored private var statusUpdateContinuations: [UUID: AsyncStream<ManagedBackendStatusUpdate>.Continuation] = [:]
     var statusUpdates: AsyncStream<ManagedBackendStatusUpdate> {

--- a/Tests/localvoxtralTests/PolishPromptWarmupTests.swift
+++ b/Tests/localvoxtralTests/PolishPromptWarmupTests.swift
@@ -7,6 +7,25 @@ import XCTest
 final class PolishPromptWarmupTests: XCTestCase {
     // MARK: - Fakes
 
+    private final class LockedBool: @unchecked Sendable {
+        private let lock = NSLock()
+        private var storage: Bool
+
+        init(_ value: Bool) { storage = value }
+
+        var value: Bool {
+            lock.lock()
+            defer { lock.unlock() }
+            return storage
+        }
+
+        func set(_ value: Bool) {
+            lock.lock()
+            storage = value
+            lock.unlock()
+        }
+    }
+
     /// Records polish calls and answers from a configurable result. Locked,
     /// not actor-based, matching the repo's locked-fake convention.
     private final class RecordingPolishService: LLMPolishingServicing, @unchecked Sendable {
@@ -164,21 +183,21 @@ final class PolishPromptWarmupTests: XCTestCase {
         XCTAssertEqual(service.requests.count, 3)
     }
 
-    func testWarmupIgnoresVoxmlxUpdates() async {
+    func testWarmupIgnoresSpeechdUpdates() async {
         let service = RecordingPolishService()
         let coordinator = PolishPromptWarmupCoordinator(
             serviceProvider: { service },
             planProvider: { [plan = makePlan()] in plan }
         )
 
-        coordinator.handleStatusUpdate(update(BackendCatalog.voxmlx, .ready))
+        coordinator.handleStatusUpdate(update(BackendCatalog.speechd, .ready))
         await awaitWarmup(coordinator)
         XCTAssertTrue(service.requests.isEmpty)
 
-        // A voxmlx non-ready update must not reset polishd's edge state.
+        // A speechd non-ready update must not reset polishd's edge state.
         coordinator.handleStatusUpdate(update(BackendCatalog.polishd, .ready))
         await awaitWarmup(coordinator)
-        coordinator.handleStatusUpdate(update(BackendCatalog.voxmlx, .stopped))
+        coordinator.handleStatusUpdate(update(BackendCatalog.speechd, .stopped))
         coordinator.handleStatusUpdate(update(BackendCatalog.polishd, .ready))
         await awaitWarmup(coordinator)
         XCTAssertEqual(service.requests.count, 1)
@@ -190,10 +209,10 @@ final class PolishPromptWarmupTests: XCTestCase {
         // coordinator must not fire a request in that case, and must warm
         // normally once a later launch has a plan.
         let service = RecordingPolishService()
-        var planAvailable = false
+        let planAvailable = LockedBool(false)
         let coordinator = PolishPromptWarmupCoordinator(
             serviceProvider: { service },
-            planProvider: { [plan = makePlan()] in planAvailable ? plan : nil }
+            planProvider: { [plan = makePlan()] in planAvailable.value ? plan : nil }
         )
 
         coordinator.handleStatusUpdate(update(BackendCatalog.polishd, .ready))
@@ -201,7 +220,7 @@ final class PolishPromptWarmupTests: XCTestCase {
         XCTAssertNil(coordinator.warmupTask)
         XCTAssertTrue(service.requests.isEmpty)
 
-        planAvailable = true
+        planAvailable.set(true)
         coordinator.handleStatusUpdate(update(BackendCatalog.polishd, .stopped))
         coordinator.handleStatusUpdate(update(BackendCatalog.polishd, .ready))
         await awaitWarmup(coordinator)

--- a/Tests/localvoxtralTests/RealtimeAPIVLLMIntegrationTests.swift
+++ b/Tests/localvoxtralTests/RealtimeAPIVLLMIntegrationTests.swift
@@ -289,6 +289,10 @@ final class RealtimeAPIVLLMIntegrationTests: XCTestCase {
             expected: longPhrase,
             actual: combinedFinalTranscript
         )
+        print(
+            "voxmlx integration: word accuracy \(String(format: "%.3f", wordAccuracy)); "
+                + "transcript: \(combinedFinalTranscript)"
+        )
         XCTAssertGreaterThanOrEqual(
             wordAccuracy,
             0.55,

--- a/Tests/localvoxtralTests/SettingsStoreTests.swift
+++ b/Tests/localvoxtralTests/SettingsStoreTests.swift
@@ -55,6 +55,32 @@ final class SettingsStoreTests: XCTestCase {
         XCTAssertTrue(store.isOverlayBufferSessionReachable)
     }
 
+    // MARK: - speechd Metal cache limit
+
+    func testSpeechdCacheLimit_defaultsToAuto() {
+        XCTAssertEqual(makeStore().speechdCacheLimit, .auto)
+        // Auto omits the flag: the helper's built-in default applies.
+        XCTAssertNil(SpeechdCacheLimit.auto.megabytes)
+    }
+
+    func testSpeechdCacheLimit_persistsAcrossStores() {
+        let store = makeStore()
+        store.speechdCacheLimit = .gb6
+        XCTAssertEqual(makeStore().speechdCacheLimit, .gb6)
+    }
+
+    func testSpeechdCacheLimit_unknownStoredValueFallsBackToAuto() {
+        defaults.set("garbage", forKey: "settings.speechd_cache_limit")
+        XCTAssertEqual(makeStore().speechdCacheLimit, .auto)
+    }
+
+    func testSpeechdCacheLimit_megabytesForEachPreset() {
+        XCTAssertEqual(SpeechdCacheLimit.gb2.megabytes, 2048)
+        XCTAssertEqual(SpeechdCacheLimit.gb4.megabytes, 4096)
+        XCTAssertEqual(SpeechdCacheLimit.gb6.megabytes, 6144)
+        XCTAssertEqual(SpeechdCacheLimit.gb8.megabytes, 8192)
+    }
+
     // MARK: - Overlay Buffer font size
 
     func testOverlayBufferFontSize_defaultsTo14() {

--- a/Tests/localvoxtralTests/SettingsStoreTests.swift
+++ b/Tests/localvoxtralTests/SettingsStoreTests.swift
@@ -275,13 +275,18 @@ final class SettingsStoreTests: XCTestCase {
         )
     }
 
-    func testEffectiveModelName_managedLocal_returnsManagedDefaultIgnoringOverride() {
+    func testEffectiveModelName_managedLocal_returnsSpeechdModelIgnoringExternalOverride() {
         let store = makeStore()
         store.realtimeAPIModelName = "user-typed-override"
 
         XCTAssertEqual(
             store.effectiveModelName,
-            SettingsStore.RealtimeProvider.realtimeAPI.defaultModelName
+            SpeechModelCatalog.defaultOption.repoID
+        )
+        XCTAssertEqual(
+            store.modelPlaceholder,
+            "T0mSIlver/Voxtral-Mini-4B-Realtime-2602-MLX-4bit",
+            "external endpoint placeholder remains independent from managed speechd"
         )
     }
 
@@ -403,7 +408,7 @@ final class SettingsStoreTests: XCTestCase {
             XCTAssertEqual(
                 store.effectiveModelName,
                 dictationMode == .managedLocal
-                    ? SettingsStore.RealtimeProvider.realtimeAPI.defaultModelName
+                    ? SpeechModelCatalog.defaultOption.repoID
                     : "external-realtime-model"
             )
             XCTAssertEqual(

--- a/Tests/localvoxtralTests/SpeechHelperIntegrationTests.swift
+++ b/Tests/localvoxtralTests/SpeechHelperIntegrationTests.swift
@@ -22,11 +22,8 @@ final class SpeechHelperIntegrationTests: XCTestCase {
     private static let markerFileName = ".speechd-integration-enable.json"
     private static let defaultHelperPath =
         "dist/localvoxtral.app/Contents/MacOS/localvoxtral-speechd"
-    /// The upstream engine's documented 4-bit conversion. The app's current
-    /// realtime default remains the Python-backend model until the part-3
-    /// backend/catalog swap.
-    private static let defaultModel =
-        "mlx-community/Voxtral-Mini-4B-Realtime-2602-4bit"
+    /// The same pinned managed model the app downloads and launches.
+    private static let defaultModel = SpeechModelCatalog.defaultOption.repoID
 
     /// Dedicated integration-only port, intentionally outside the app's
     /// production speechd/polishd ports (8471/8472).
@@ -91,6 +88,115 @@ final class SpeechHelperIntegrationTests: XCTestCase {
         return (binary, model?.isEmpty == false ? model! : Self.defaultModel)
     }
 
+    private struct ModelProvisioningError: Error, CustomStringConvertible {
+        let description: String
+    }
+
+    /// The helper deliberately never downloads weights. Provision the exact
+    /// managed revision in the shared Hugging Face cache before launching it,
+    /// using the same file set as BackendManager's progress-reporting download.
+    /// Failures are failures rather than skips because this suite is explicitly
+    /// enabled and a green skip would conceal broken first-run infrastructure.
+    private func ensureModelCached(_ repoID: String) async throws {
+        let cacheRoot = FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent(".cache/huggingface/hub")
+        let repoDir = cacheRoot.appendingPathComponent(
+            "models--" + repoID.replacingOccurrences(of: "/", with: "--")
+        )
+        let snapshotsDir = repoDir.appendingPathComponent("snapshots")
+        let pinnedRevision = SpeechModelCatalog.option(forRepoID: repoID)?.revision
+
+        if let pinnedRevision {
+            if Self.snapshotIsProvisioned(snapshotsDir.appendingPathComponent(pinnedRevision)) {
+                return
+            }
+        } else if let revision = try? String(
+            contentsOf: repoDir.appendingPathComponent("refs/main"),
+            encoding: .utf8
+        )
+        .trimmingCharacters(in: .whitespacesAndNewlines),
+            !revision.isEmpty,
+            Self.snapshotIsProvisioned(snapshotsDir.appendingPathComponent(revision))
+        {
+            return
+        }
+
+        print("speechd integration: downloading \(repoID) into \(cacheRoot.path)")
+        struct RepoInfo: Decodable {
+            struct Sibling: Decodable { let rfilename: String }
+            let sha: String
+            let siblings: [Sibling]
+        }
+        let apiURL = URL(
+            string:
+                "https://huggingface.co/api/models/\(repoID)/revision/\(pinnedRevision ?? "main")"
+        )!
+        let (infoData, infoResponse) = try await URLSession.shared.data(from: apiURL)
+        guard (infoResponse as? HTTPURLResponse)?.statusCode == 200 else {
+            throw ModelProvisioningError(
+                description: "HF API unreachable for \(repoID): \(infoResponse)"
+            )
+        }
+        let info = try JSONDecoder().decode(RepoInfo.self, from: infoData)
+        if let pinnedRevision, info.sha != pinnedRevision {
+            throw ModelProvisioningError(
+                description:
+                    "HF resolved \(repoID)@\(pinnedRevision) to sha \(info.sha) — pin is not a commit"
+            )
+        }
+
+        let patterns = [
+            "config.json", "tekken.json", "tokenizer*.json",
+            "model*.safetensors", "model.safetensors.index.json",
+        ]
+        let wanted = info.siblings.map(\.rfilename).filter { name in
+            patterns.contains { fnmatch($0, name, 0) == 0 }
+        }
+        guard !wanted.isEmpty else {
+            throw ModelProvisioningError(description: "HF listing for \(repoID) matched no files")
+        }
+
+        let snapshotDir = snapshotsDir.appendingPathComponent(info.sha)
+        try FileManager.default.createDirectory(
+            at: snapshotDir, withIntermediateDirectories: true
+        )
+        for name in wanted {
+            let destination = snapshotDir.appendingPathComponent(name)
+            if FileManager.default.fileExists(atPath: destination.path) { continue }
+            try FileManager.default.createDirectory(
+                at: destination.deletingLastPathComponent(), withIntermediateDirectories: true
+            )
+            let source = URL(
+                string: "https://huggingface.co/\(repoID)/resolve/\(info.sha)/\(name)"
+            )!
+            let (temporary, response) = try await URLSession.shared.download(from: source)
+            guard (response as? HTTPURLResponse)?.statusCode == 200 else {
+                throw ModelProvisioningError(description: "download failed for \(name): \(response)")
+            }
+            try FileManager.default.moveItem(at: temporary, to: destination)
+        }
+
+        if pinnedRevision == nil {
+            let refsDir = repoDir.appendingPathComponent("refs")
+            try FileManager.default.createDirectory(at: refsDir, withIntermediateDirectories: true)
+            try Data("\(info.sha)\n".utf8).write(to: repoDir.appendingPathComponent("refs/main"))
+        }
+        try Data().write(to: snapshotDir.appendingPathComponent(Self.provisionedSentinel))
+        print("speechd integration: model provisioned (\(wanted.count) files)")
+    }
+
+    static let provisionedSentinel = ".localvoxtral-provisioned"
+
+    static func snapshotIsProvisioned(_ snapshot: URL) -> Bool {
+        let fileManager = FileManager.default
+        return fileManager.fileExists(
+            atPath: snapshot.appendingPathComponent(provisionedSentinel).path
+        )
+            && fileManager.fileExists(atPath: snapshot.appendingPathComponent("config.json").path)
+            && fileManager.fileExists(atPath: snapshot.appendingPathComponent("tekken.json").path)
+            && fileManager.fileExists(atPath: snapshot.appendingPathComponent("model.safetensors").path)
+    }
+
     private func launchHelper(
         binary: URL,
         model: String,
@@ -98,10 +204,14 @@ final class SpeechHelperIntegrationTests: XCTestCase {
     ) async throws -> (process: Process, stderrLog: LineLog) {
         let process = Process()
         process.executableURL = binary
-        process.arguments = [
+        var arguments = [
             "--model", model,
             "--port", "\(Self.testPort)",
-        ] + extraArguments
+        ]
+        if let revision = SpeechModelCatalog.option(forRepoID: model)?.revision {
+            arguments.append(contentsOf: ["--model-revision", revision])
+        }
+        process.arguments = arguments + extraArguments
 
         let stderr = Pipe()
         process.standardError = stderr
@@ -158,6 +268,7 @@ final class SpeechHelperIntegrationTests: XCTestCase {
 
     func testRealAudioMeetsAccuracyAndAppendOnlyDeltaContract() async throws {
         let (binary, model) = try helperConfiguration()
+        try await ensureModelCached(model)
         let (process, _) = try await launchHelper(binary: binary, model: model)
 
         let healthURL = URL(string: "http://127.0.0.1:\(Self.testPort)/health")!
@@ -268,6 +379,7 @@ final class SpeechHelperIntegrationTests: XCTestCase {
 
     func testHelperExitsWhenParentPIDDies() async throws {
         let (binary, model) = try helperConfiguration()
+        try await ensureModelCached(model)
 
         let decoyParent = Process()
         decoyParent.executableURL = URL(fileURLWithPath: "/bin/cat")

--- a/Tests/localvoxtralTests/SpeechModelCatalogTests.swift
+++ b/Tests/localvoxtralTests/SpeechModelCatalogTests.swift
@@ -1,0 +1,21 @@
+import XCTest
+
+@testable import localvoxtral
+
+final class SpeechModelCatalogTests: XCTestCase {
+    func testManagedCatalogUsesBundledSpeechdAndRetainsVoxmlxOnlyForRetirement() {
+        XCTAssertEqual(BackendCatalog.speechd.displayName, "Dictation engine")
+        XCTAssertEqual(BackendCatalog.speechd.installKind, .bundledExecutable)
+        XCTAssertEqual(BackendCatalog.speechd.executableName, "localvoxtral-speechd")
+        XCTAssertEqual(BackendCatalog.speechd.port, 8471)
+        XCTAssertEqual(BackendCatalog.all.map(\.id), ["speechd", "polishd"])
+        XCTAssertFalse(BackendCatalog.all.contains { $0.id == BackendCatalog.voxmlx.id })
+    }
+
+    func testSpeechModelCatalogPinsFullCommitSHA() {
+        let option = SpeechModelCatalog.defaultOption
+        XCTAssertEqual(option.repoID, "mlx-community/Voxtral-Mini-4B-Realtime-2602-4bit")
+        XCTAssertEqual(option.revision.count, 40)
+        XCTAssertTrue(option.revision.allSatisfy(\.isHexDigit))
+    }
+}

--- a/Tests/localvoxtralTests/SpeechdStreamingBenchTests.swift
+++ b/Tests/localvoxtralTests/SpeechdStreamingBenchTests.swift
@@ -1,0 +1,123 @@
+import Foundation
+import XCTest
+
+@testable import localvoxtral
+
+/// Marker-gated launcher for the packaged speech helper's Metal benchmark.
+/// The SSH build gate permits `swift test` but not arbitrary executables, so
+/// `scripts/remote-build.sh speechd-bench` enables this test and relays BENCH lines.
+final class SpeechdStreamingBenchTests: XCTestCase {
+    private static let markerFileName = ".speechd-bench-enable.json"
+    private static let defaultHelperPath =
+        "dist/localvoxtral.app/Contents/MacOS/localvoxtral-speechd"
+
+    private struct MarkerConfig: Decodable {
+        let helperPath: String?
+        let seconds: Int
+        let cadenceMilliseconds: Int
+        let wavPath: String?
+    }
+
+    private var repoRoot: URL {
+        URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+    }
+
+    func testPackagedStreamingBenchmark() throws {
+        let markerURL = repoRoot.appendingPathComponent(Self.markerFileName)
+        guard FileManager.default.fileExists(atPath: markerURL.path) else {
+            throw XCTSkip(
+                "Speechd benchmark disabled; run ./scripts/remote-build.sh speechd-bench"
+            )
+        }
+        let config = try JSONDecoder().decode(
+            MarkerConfig.self,
+            from: Data(contentsOf: markerURL)
+        )
+        let helperPath = config.helperPath?.isEmpty == false
+            ? config.helperPath!
+            : Self.defaultHelperPath
+        let binary = helperPath.hasPrefix("/")
+            ? URL(fileURLWithPath: helperPath)
+            : repoRoot.appendingPathComponent(helperPath)
+        guard FileManager.default.isExecutableFile(atPath: binary.path) else {
+            XCTFail("Packaged speech helper missing at \(binary.path); run package first")
+            return
+        }
+
+        let model = SpeechModelCatalog.defaultOption
+        var arguments = [
+            "--model", model.repoID,
+            "--model-revision", model.revision,
+            "--bench",
+            "--seconds", "\(config.seconds)",
+            "--cadence-ms", "\(config.cadenceMilliseconds)",
+        ]
+        if let wavPath = config.wavPath, !wavPath.isEmpty {
+            arguments.append(contentsOf: ["--wav", wavPath])
+        }
+
+        let process = Process()
+        process.executableURL = binary
+        process.arguments = arguments
+        let stdout = Pipe()
+        let stderr = Pipe()
+        process.standardOutput = stdout
+        process.standardError = stderr
+        let stdoutLog = BenchLineLog()
+        let stderrLog = BenchLineLog()
+        let stdoutReader = PipeLineReader(
+            fileHandle: stdout.fileHandleForReading,
+            onLine: stdoutLog.append
+        )
+        let stderrReader = PipeLineReader(
+            fileHandle: stderr.fileHandleForReading,
+            onLine: stderrLog.append
+        )
+
+        try process.run()
+        stdoutReader.start()
+        stderrReader.start()
+        process.waitUntilExit()
+        stdoutReader.waitUntilFinished()
+        stderrReader.waitUntilFinished()
+
+        let lines = stdoutLog.snapshot()
+        for line in lines { print(line) }
+        for line in stderrLog.snapshot() { print("speechd bench stderr: \(line)") }
+
+        XCTAssertEqual(
+            process.terminationStatus,
+            0,
+            "speechd bench failed with status \(process.terminationStatus)"
+        )
+        let benchLines = lines.filter { $0.hasPrefix("BENCH ") }
+        let expectedMarks = [5, 15, 30, 60].filter { $0 <= config.seconds }
+        XCTAssertEqual(benchLines.count, expectedMarks.count, lines.joined(separator: "\n"))
+        for mark in expectedMarks {
+            XCTAssertTrue(
+                benchLines.contains { $0.contains("mark=\(mark)s ") },
+                "missing BENCH mark=\(mark)s"
+            )
+        }
+    }
+}
+
+private final class BenchLineLog: @unchecked Sendable {
+    private let lock = NSLock()
+    private var lines: [String] = []
+
+    func append(_ line: String) {
+        lock.lock()
+        lines.append(line)
+        lock.unlock()
+    }
+
+    func snapshot() -> [String] {
+        lock.lock()
+        defer { lock.unlock() }
+        return lines
+    }
+}

--- a/scripts/ci/speechd-lane-filter.sh
+++ b/scripts/ci/speechd-lane-filter.sh
@@ -21,11 +21,15 @@ set -euo pipefail
 MARKER='[run-speechd-integration]'
 
 # Changes here can alter the helper binary, its pinned mlx-audio-swift graph,
-# the packaged resource layout, or the live-model contract asserted by the
-# integration suite. SpeechHelper/* includes Package.swift + Package.resolved,
-# which are the mlx-audio-swift pin surface.
+# the managed launch/model-download contract, the packaged resource layout,
+# or the live-model contract asserted by the integration suite.
+# SpeechHelper/* includes Package.swift + Package.resolved, which are the
+# mlx-audio-swift pin surface.
 PATTERNS=(
   'SpeechHelper/*'
+  'Sources/localvoxtral/Backends/BackendCatalog.swift'
+  'Sources/localvoxtral/Backends/BackendManager.swift'
+  'Sources/localvoxtral/Backends/SpeechModelCatalog.swift'
   'scripts/package_app.sh'
   'scripts/ci/speechd-lane-filter.sh'
   'Tests/localvoxtralTests/SpeechHelperIntegrationTests.swift'

--- a/scripts/remote-build.sh
+++ b/scripts/remote-build.sh
@@ -6,7 +6,7 @@ set -euo pipefail
 # tree (no commit needed) and runs the toolchain remotely over SSH.
 #
 # Usage:
-#   ./scripts/remote-build.sh [build|test|integration|integration-polishd|integration-speechd|eval-llm|eval-e2e|package|exec|diag|applog|voxlog|svc-status] [extra args...]
+#   ./scripts/remote-build.sh [build|test|integration|integration-polishd|integration-speechd|speechd-bench|eval-llm|eval-e2e|package|exec|diag|applog|voxlog|svc-status] [extra args...]
 #     build        swift build
 #     test         swift build + unit tests (default; skips live-backend suites)
 #     integration  realtime pipeline tests against the live voxmlx service
@@ -18,6 +18,9 @@ set -euo pipefail
 #                  spawn the packaged speech helper (built by `package`),
 #                  transcribe real audio through the production websocket
 #                  client, and assert accuracy + delta + parent-pid contracts
+#     speechd-bench run the packaged speech helper's streaming benchmark;
+#                  optional args = seconds (default 60) and cadence ms
+#                  (default 480); requires a prior `package`
 #     eval-llm     default-polish-prompt eval against a live mlx-lm server;
 #                  optional args = chat/completions endpoint and external
 #                  model alias (default endpoint
@@ -167,7 +170,7 @@ esac
 
 UNIT_TEST_SKIPS=(--skip RealtimeAPIVLLMIntegrationTests --skip LLMPolishPromptEvalTests
   --skip PolishHelperIntegrationTests --skip SpeechHelperIntegrationTests
-  --skip AgentDictationE2EEvalTests)
+  --skip SpeechdStreamingBenchTests --skip AgentDictationE2EEvalTests)
 
 # On-demand test server to warm before the suite runs (empty = none). The
 # build host's voxmlx/mlxlm launchd services are launch-on-demand to keep their
@@ -234,6 +237,32 @@ case "$CMD" in
         >"$SPEECHD_MARKER"
     fi
     REMOTE_CMD=(swift test --filter SpeechHelperIntegrationTests)
+    ;;
+  speechd-bench)
+    # The SSH gate does not allow arbitrary packaged-binary execution. A marker-gated
+    # root XCTest launches the xcodebuild-produced helper and relays its BENCH output.
+    if [[ $# -gt 2 ]]; then
+      echo "speechd-bench accepts optional seconds and cadence-ms arguments" >&2
+      exit 1
+    fi
+    SPEECHD_BENCH_SECONDS="${1:-60}"
+    SPEECHD_BENCH_CADENCE="${2:-480}"
+    if [[ ! "$SPEECHD_BENCH_SECONDS" =~ ^[1-9][0-9]*$ ]]; then
+      echo "speechd-bench seconds must be a positive integer" >&2
+      exit 1
+    fi
+    if [[ ! "$SPEECHD_BENCH_CADENCE" =~ ^[1-9][0-9]*$ ]]; then
+      echo "speechd-bench cadence-ms must be a positive integer" >&2
+      exit 1
+    fi
+    SPEECHD_BENCH_MARKER="$ROOT_DIR/.speechd-bench-enable.json"
+    trap 'cleanup_transient_marker "$SPEECHD_BENCH_MARKER"' EXIT
+    printf '{"helperPath":"%s","seconds":%s,"cadenceMilliseconds":%s}\n' \
+      "dist/localvoxtral.app/Contents/MacOS/localvoxtral-speechd" \
+      "$SPEECHD_BENCH_SECONDS" \
+      "$SPEECHD_BENCH_CADENCE" \
+      >"$SPEECHD_BENCH_MARKER"
+    REMOTE_CMD=(swift test --filter SpeechdStreamingBenchTests)
     ;;
   eval-e2e)
     # Agent-dictation end-to-end eval (nightly + manual, never tier 0):
@@ -320,7 +349,7 @@ case "$CMD" in
     REMOTE_CMD=("$@")
     ;;
   *)
-    echo "Usage: $0 [build|test|integration|integration-polishd|eval-llm|eval-e2e|package|exec|diag|applog|voxlog|svc-status] [extra args...]" >&2
+    echo "Usage: $0 [build|test|integration|integration-polishd|integration-speechd|speechd-bench|eval-llm|eval-e2e|package|exec|diag|applog|voxlog|svc-status] [extra args...]" >&2
     exit 1
     ;;
 esac


### PR DESCRIPTION
## What

Part 3 of the SpeechHelper series (stacked on #145): managed dictation swaps from the uv-installed Python voxmlx to the bundled `localvoxtral-speechd` on the same port 8471. voxmlx code/machinery stays compilable but leaves the managed set — retirement is part 4.

- **Catalog/supervision**: new `speechd` spec (`.bundledExecutable`, port 8471) in the managed set alongside polishd; spawned/health-checked/watchdogged like polishd; `ManagedBackendEndpoints` port now derives from the speechd spec; loud `Log.backends` on the new paths. Fresh installs no longer trigger uv/wheel installation.
- **Model pin (the checkpoint changes)**: the upstream Swift engine strict-loads HF-layout checkpoints (`verify: .all`) and cannot read the Mistral-layout `T0mSIlver/Voxtral-Mini-4B-Realtime-2602-MLX-4bit` the Python backend served. Managed mode now uses a dedicated `SpeechModelCatalog` pin: `mlx-community/Voxtral-Mini-4B-Realtime-2602-4bit` at revision `fdebf7b2af83…` (exact-commit download + `--model-revision` launch arg + fail-closed snapshot locator in the helper — no silent `main` resolution).
- **`defaultModelName` decision**: `RealtimeProvider.realtimeAPI.defaultModelName` stays `T0mSIlver/…` for EXTERNAL endpoints and the placeholder; `effectiveModelName` returns the SpeechModelCatalog pin only in managed mode, so `session.update` always matches what speechd serves while existing external setups see no change.
- **Helper hardening**: `SpeechdLaunchOptions` (testable parser, `--model-revision`/`--model-dir`), `SpeechHFCacheModelLocator` (resolves only the exact prepared snapshot), `RealtimeSpeechServer` loads via the pinned snapshot directory.
- **UI/status**: onboarding rows, `requiredManagedBackendsReady`, Settings managed status row, popover/status strings, DiagnosticsExporter labels now track the "Dictation engine". Settings group count unchanged (12 before/after); popover strings stay one sentence.
- **Tests/CI**: new unit coverage (managed set membership, pinned launch args, HF preparation patterns, bundle path, fail-closed locator, catalog shape); existing suites adapted for the swap with no assertion weakened; `speechd-lane-filter.sh` gains the model/catalog/manager paths so this class of change always runs the live lane (it fires on this PR).
- **Docs**: AGENTS.md backends paragraph, README factual pin line only, DEPENDENCY.md consumption note.

## Proof

- [x] Unit suite green — `./scripts/remote-build.sh test`
```
Executed 990 tests, with 2 tests skipped and 0 failures (0 unexpected)
```
- [x] SpeechHelper unit suite green — `./scripts/remote-build.sh test --package-path SpeechHelper`
```
Executed 32 tests, with 0 failures (0 unexpected)
```
- [x] Packaging green — `./scripts/remote-build.sh package` (signature validated; `localvoxtral`, `localvoxtral-polishd`, `localvoxtral-speechd` present)
- [x] Live packaged speechd integration green post-swap — `./scripts/remote-build.sh integration-speechd`
```
Executed 2 tests, with 0 failures (0 unexpected)
speechd integration: word accuracy 0.789
```
- [x] **Accuracy A/B on the same fixture/scorer** (the served checkpoint changes with this PR):
```
voxmlx  (T0mSIlver Mistral-layout, Python backend): word accuracy 0.821
speechd (mlx-community HF-layout, bundled engine):  word accuracy 0.789
delta: −0.032 (inside the pre-declared 0.05 decision boundary)
```
- [x] LLM lanes: not required — ASR/backend-supervision path; no prompts/polish-path/pins-for-polish changes. eval-e2e: not run here — the nightly harness drives the standalone voxmlx service (port 8000), which this PR does not touch; the app-managed swap is covered by the live speechd lane above.
- [x] No weakened tests: adaptations verified (e.g. `testConcurrentEnsureReadyDoesNotDoubleInstall` → single-flight now proven on the prepare path since bundled backends have no install path; `PolishPromptWarmupTests` gained a locked flag for Swift 6.2 sendability — assertions unchanged).

Two independent pre-push reviews (static, this diff only): both PASS, no merge-blocking findings.

## UI change — owner hand-verification needed (try-pr.sh)

- First-run: Downloads page shows "Dictation engine", model preparation runs with progress (bytes/percent) in onboarding/Settings/popover, reaches Ready.
- Settings → Endpoints: same group layout; Managed local shows the bundled-engine description + speechd status.
- Popover/menu-bar stays compact through download → load → ready → forced helper restart; no raw errors.
- Managed → External stops speechd; back to Managed reconnects and dictates through 8471.
- Export Diagnostics labels the process `localvoxtral-speechd`.

## Notes

- Build-host incident during verification: the Mac ran out of disk during the first package/model-download attempt; only disposable task-owned remote build dirs were removed, after which all lanes passed. Worth a disk-space glance before the next heavy run.
- Part-4 follow-ups collected from review: retire voxmlx + uv machinery and existing-install cleanup; consider killing stale `voxmlx-serve` on 8471 at launch; snapshot sentinel tolerance for sharded checkpoints; parser mutual-exclusion for `--model`/`--model-dir`.
