### PR TITLE
Add a speechd step-cadence setting (--step-ms) to the managed dictation group

### DIFF
--- a/Sources/localvoxtral/Backends/BackendManager.swift
+++ b/Sources/localvoxtral/Backends/BackendManager.swift
@@ -215,15 +215,22 @@ final class BackendManager: ManagedBackendManaging {
     func stopAll() async {
         let cancelledDictationEnsure = await cancelEnsureTaskAndAwaitCompletion(for: BackendCatalog.speechd)
         let cancelledPolishingEnsure = await cancelEnsureTaskAndAwaitCompletion(for: BackendCatalog.polishd)
+        let hadDictationSupervisor = speechdSupervisor != nil
         let hadPolishingSupervisor = polishdSupervisor != nil
         await speechdSupervisor?.stop()
         await polishdSupervisor?.stop()
+        // Drop the supervisors, not just stop them: launch arguments are
+        // captured at supervisor creation, so a kept supervisor would relaunch
+        // with stale settings (cache limit / step cadence) — field-hit
+        // 2026-07-17: changing the memory limit and toggling Managed →
+        // External → Managed silently kept the old argv.
+        speechdSupervisor = nil
         polishdSupervisor = nil
         speechdStateMirrorTask?.cancel()
         speechdStateMirrorTask = nil
         polishdStateMirrorTask?.cancel()
         polishdStateMirrorTask = nil
-        if cancelledDictationEnsure || speechdSupervisor != nil {
+        if cancelledDictationEnsure || hadDictationSupervisor {
             setStatus(.stopped, for: BackendCatalog.speechd)
         }
         if cancelledPolishingEnsure || hadPolishingSupervisor {
@@ -233,10 +240,14 @@ final class BackendManager: ManagedBackendManaging {
 
     func stopDictation() async {
         let cancelledEnsure = await cancelEnsureTaskAndAwaitCompletion(for: BackendCatalog.speechd)
+        let hadSupervisor = speechdSupervisor != nil
         await speechdSupervisor?.stop()
+        // See stopAll(): drop the supervisor so the next ensure rebuilds the
+        // launch arguments from the current settings providers.
+        speechdSupervisor = nil
         speechdStateMirrorTask?.cancel()
         speechdStateMirrorTask = nil
-        if cancelledEnsure || speechdSupervisor != nil {
+        if cancelledEnsure || hadSupervisor {
             setStatus(.stopped, for: BackendCatalog.speechd)
         }
     }

--- a/Sources/localvoxtral/Backends/BackendManager.swift
+++ b/Sources/localvoxtral/Backends/BackendManager.swift
@@ -82,6 +82,9 @@ final class BackendManager: ManagedBackendManaging {
     /// Megabytes for the speechd `--cache-limit-mb` flag, or nil to omit it and
     /// let the helper apply its built-in default.
     typealias SpeechdCacheLimitProvider = @MainActor () -> Int?
+    /// Milliseconds for the speechd `--step-ms` flag, or nil to omit it and
+    /// let the helper apply its built-in default.
+    typealias SpeechdStepCadenceProvider = @MainActor () -> Int?
 
     private(set) var speechdStatus: ManagedBackendStatus
     private(set) var polishdStatus: ManagedBackendStatus
@@ -91,6 +94,7 @@ final class BackendManager: ManagedBackendManaging {
     @ObservationIgnored private let supervisorFactory: SupervisorFactory
     @ObservationIgnored private let polishingModelProvider: PolishingModelProvider
     @ObservationIgnored private let speechdCacheLimitProvider: SpeechdCacheLimitProvider
+    @ObservationIgnored private let speechdStepCadenceProvider: SpeechdStepCadenceProvider
     @ObservationIgnored private var speechdSupervisor: (any ManagedBackendSupervising)?
     @ObservationIgnored private var polishdSupervisor: (any ManagedBackendSupervising)?
     // Per-backend single-flight slots. A global shared slot (the previous
@@ -115,6 +119,7 @@ final class BackendManager: ManagedBackendManaging {
             SettingsStore.defaultLLMPolishingModel
         },
         speechdCacheLimitProvider: @escaping SpeechdCacheLimitProvider = { nil },
+        speechdStepCadenceProvider: @escaping SpeechdStepCadenceProvider = { nil },
         supervisorFactory: @escaping SupervisorFactory = { configuration in
             BackendProcessSupervisor(configuration: configuration)
         }
@@ -123,6 +128,7 @@ final class BackendManager: ManagedBackendManaging {
         self.legacyPortDefense = legacyPortDefense ?? LegacyVoxmlxPortDefense(layout: layout)
         self.polishingModelProvider = polishingModelProvider
         self.speechdCacheLimitProvider = speechdCacheLimitProvider
+        self.speechdStepCadenceProvider = speechdStepCadenceProvider
         self.supervisorFactory = supervisorFactory
         self.speechdStatus = .stopped
         self.polishdStatus = .stopped
@@ -455,6 +461,10 @@ final class BackendManager: ManagedBackendManaging {
             // Auto (nil) omits the flag so the helper's built-in default applies.
             if let cacheLimitMB = speechdCacheLimitProvider() {
                 arguments.append(contentsOf: ["--cache-limit-mb", "\(cacheLimitMB)"])
+            }
+            // Same Auto contract as the cache limit.
+            if let stepMilliseconds = speechdStepCadenceProvider() {
+                arguments.append(contentsOf: ["--step-ms", "\(stepMilliseconds)"])
             }
             return arguments
         case BackendCatalog.polishd.id:

--- a/Sources/localvoxtral/DictationViewModel.swift
+++ b/Sources/localvoxtral/DictationViewModel.swift
@@ -536,7 +536,8 @@ final class DictationViewModel {
             backendManager
             ?? BackendManager(
                 polishingModelProvider: { settings.resolvedManagedLLMPolishingModel },
-                speechdCacheLimitProvider: { settings.speechdCacheLimit.megabytes }
+                speechdCacheLimitProvider: { settings.speechdCacheLimit.megabytes },
+                speechdStepCadenceProvider: { settings.speechdStepCadence.milliseconds }
             )
         self.managesRuntimeServices = startRuntimeServices
         if let overlayBufferCoordinator {

--- a/Sources/localvoxtral/DictationViewModel.swift
+++ b/Sources/localvoxtral/DictationViewModel.swift
@@ -1051,6 +1051,39 @@ final class DictationViewModel {
         }
     }
 
+    /// Managed speechd's launch arguments carry this setting; a running engine
+    /// keeps its argv, so apply a change by restarting it (same eager UX as
+    /// `applyLLMPolishingModelChange`: stop, then warm back up with progress
+    /// in the status row). Outside Managed local mode only the stored value
+    /// changes — the next managed start reads current settings.
+    func applySpeechdCacheLimitChange(_ limit: SpeechdCacheLimit) {
+        guard settings.speechdCacheLimit != limit else { return }
+        settings.speechdCacheLimit = limit
+        restartManagedDictationEngineForSettingChange(reason: "memory limit changed")
+    }
+
+    /// See `applySpeechdCacheLimitChange` — same restart contract.
+    func applySpeechdStepCadenceChange(_ cadence: SpeechdStepCadence) {
+        guard settings.speechdStepCadence != cadence else { return }
+        settings.speechdStepCadence = cadence
+        restartManagedDictationEngineForSettingChange(reason: "step interval changed")
+    }
+
+    private func restartManagedDictationEngineForSettingChange(reason: String) {
+        guard settings.dictationBackendMode == .managedLocal else { return }
+        Log.backends.info(
+            "managed dictation setting changed (\(reason, privacy: .public)); restarting dictation engine"
+        )
+        dictationWarmupTask?.cancel()
+        dictationShutdownTask?.cancel()
+        dictationShutdownTask = Task { @MainActor [weak self, backendManager] in
+            guard !Task.isCancelled else { return }
+            await backendManager.stopDictation()
+            guard !Task.isCancelled, let self else { return }
+            self.startManagedBackendWarmup(dictation: true, polishing: false)
+        }
+    }
+
     func applyLLMPolishingModelChange(_ model: String) {
         guard settings.managedLLMPolishingModel != model else { return }
         settings.managedLLMPolishingModel = model

--- a/Sources/localvoxtral/SettingsStore.swift
+++ b/Sources/localvoxtral/SettingsStore.swift
@@ -296,14 +296,16 @@ final class SettingsStore {
         didSet { defaults.set(polishingBackendMode.rawValue, forKey: Keys.polishingBackendMode) }
     }
 
-    /// Metal buffer-pool cache limit for the managed dictation helper. Applies
-    /// the next time the managed dictation backend (re)starts.
+    /// Metal buffer-pool cache limit for the managed dictation helper. Changing
+    /// it from Settings restarts the engine so the new argv applies immediately
+    /// (`DictationViewModel.applySpeechdCacheLimitChange`); direct writes apply
+    /// on the next (re)start.
     var speechdCacheLimit: SpeechdCacheLimit {
         didSet { defaults.set(speechdCacheLimit.rawValue, forKey: Keys.speechdCacheLimit) }
     }
 
-    /// Streaming step cadence for the managed dictation helper. Applies the
-    /// next time the managed dictation backend (re)starts.
+    /// Streaming step cadence for the managed dictation helper. Same restart
+    /// contract as `speechdCacheLimit`.
     var speechdStepCadence: SpeechdStepCadence {
         didSet { defaults.set(speechdStepCadence.rawValue, forKey: Keys.speechdStepCadence) }
     }

--- a/Sources/localvoxtral/SettingsStore.swift
+++ b/Sources/localvoxtral/SettingsStore.swift
@@ -134,6 +134,39 @@ enum SpeechdCacheLimit: String, CaseIterable, Identifiable, Sendable {
     }
 }
 
+/// Streaming step cadence for the managed dictation helper: how much audio is
+/// batched before each incremental transcription step. Lower values show words
+/// sooner; higher values leave more compute headroom. `Auto` omits the
+/// `--step-ms` flag so the helper's built-in default applies.
+enum SpeechdStepCadence: String, CaseIterable, Identifiable, Sendable {
+    case auto
+    case ms100 = "100ms"
+    case ms240 = "240ms"
+    case ms480 = "480ms"
+
+    var id: String { rawValue }
+
+    var displayName: String {
+        switch self {
+        case .auto: return "Auto"
+        case .ms100: return "100 ms"
+        case .ms240: return "240 ms"
+        case .ms480: return "480 ms"
+        }
+    }
+
+    /// Milliseconds to pass via `--step-ms`, or nil for `Auto` (the flag is
+    /// omitted and the helper's built-in default applies).
+    var milliseconds: Int? {
+        switch self {
+        case .auto: return nil
+        case .ms100: return 100
+        case .ms240: return 240
+        case .ms480: return 480
+        }
+    }
+}
+
 enum DictationShortcutValidation {
     static let allowedModifierFlagsMask = UInt32(cmdKey | optionKey | shiftKey | controlKey)
 
@@ -196,6 +229,7 @@ final class SettingsStore {
         static let realtimeAPIModelName = "settings.realtime_api_model_name"
         static let dictationBackendMode = "settings.dictation_backend_mode"
         static let speechdCacheLimit = "settings.speechd_cache_limit"
+        static let speechdStepCadence = "settings.speechd_step_cadence"
         static let polishingBackendMode = "settings.polishing_backend_mode"
         // Legacy global backend mode. Read only for one-time migration.
         static let backendMode = "settings.backend_mode"
@@ -266,6 +300,12 @@ final class SettingsStore {
     /// the next time the managed dictation backend (re)starts.
     var speechdCacheLimit: SpeechdCacheLimit {
         didSet { defaults.set(speechdCacheLimit.rawValue, forKey: Keys.speechdCacheLimit) }
+    }
+
+    /// Streaming step cadence for the managed dictation helper. Applies the
+    /// next time the managed dictation backend (re)starts.
+    var speechdStepCadence: SpeechdStepCadence {
+        didSet { defaults.set(speechdStepCadence.rawValue, forKey: Keys.speechdStepCadence) }
     }
 
     /// True once the user has completed (or skipped) the first-launch onboarding
@@ -508,6 +548,14 @@ final class SettingsStore {
             speechdCacheLimit = parsedCacheLimit
         } else {
             speechdCacheLimit = .auto
+        }
+
+        if let storedStepCadence = defaults.string(forKey: Keys.speechdStepCadence),
+            let parsedStepCadence = SpeechdStepCadence(rawValue: storedStepCadence)
+        {
+            speechdStepCadence = parsedStepCadence
+        } else {
+            speechdStepCadence = .auto
         }
 
         let configuredProvider = Self.loadString(

--- a/Sources/localvoxtral/SettingsView.swift
+++ b/Sources/localvoxtral/SettingsView.swift
@@ -207,6 +207,20 @@ private struct ConnectionSettingsPane: View {
         )
     }
 
+    private var speechdCacheLimitBinding: Binding<SpeechdCacheLimit> {
+        Binding(
+            get: { settings.speechdCacheLimit },
+            set: { viewModel.applySpeechdCacheLimitChange($0) }
+        )
+    }
+
+    private var speechdStepCadenceBinding: Binding<SpeechdStepCadence> {
+        Binding(
+            get: { settings.speechdStepCadence },
+            set: { viewModel.applySpeechdStepCadenceChange($0) }
+        )
+    }
+
     private var managedPolishingModelEntries: [PolishModelPickerEntry] {
         PolishModelPickerSupport.entries(storedRepoID: settings.resolvedManagedLLMPolishingModel)
     }
@@ -246,7 +260,7 @@ private struct ConnectionSettingsPane: View {
                     }
                 case .managedLocal:
                     SettingsFieldRow(title: "Memory limit") {
-                        Picker("", selection: $settings.speechdCacheLimit) {
+                        Picker("", selection: speechdCacheLimitBinding) {
                             ForEach(SpeechdCacheLimit.allCases) { limit in
                                 Text(limit.displayName).tag(limit)
                             }
@@ -257,7 +271,7 @@ private struct ConnectionSettingsPane: View {
 
                     SettingsFieldRow(title: "Step interval") {
                         VStack(alignment: .leading, spacing: 6) {
-                            Picker("", selection: $settings.speechdStepCadence) {
+                            Picker("", selection: speechdStepCadenceBinding) {
                                 ForEach(SpeechdStepCadence.allCases) { cadence in
                                     Text(cadence.displayName).tag(cadence)
                                 }

--- a/Sources/localvoxtral/SettingsView.swift
+++ b/Sources/localvoxtral/SettingsView.swift
@@ -255,6 +255,22 @@ private struct ConnectionSettingsPane: View {
                         .labelsHidden()
                     }
 
+                    SettingsFieldRow(title: "Step interval") {
+                        VStack(alignment: .leading, spacing: 6) {
+                            Picker("", selection: $settings.speechdStepCadence) {
+                                ForEach(SpeechdStepCadence.allCases) { cadence in
+                                    Text(cadence.displayName).tag(cadence)
+                                }
+                            }
+                            .pickerStyle(.menu)
+                            .labelsHidden()
+
+                            SettingsHelpText(
+                                "Lower values show words sooner; higher values use less compute."
+                            )
+                        }
+                    }
+
                     ManagedBackendStatusRow(
                         title: "Status",
                         status: backendManager.speechdStatus

--- a/Sources/localvoxtral/localvoxtralApp.swift
+++ b/Sources/localvoxtral/localvoxtralApp.swift
@@ -132,7 +132,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         let settings = SettingsStore()
         let manager = BackendManager(
             polishingModelProvider: { settings.resolvedManagedLLMPolishingModel },
-            speechdCacheLimitProvider: { settings.speechdCacheLimit.megabytes }
+            speechdCacheLimitProvider: { settings.speechdCacheLimit.megabytes },
+            speechdStepCadenceProvider: { settings.speechdStepCadence.milliseconds }
         )
         settingsStore = settings
         backendManager = manager

--- a/SpeechHelper/Sources/SpeechEngine/RealtimeSpeechServer.swift
+++ b/SpeechHelper/Sources/SpeechEngine/RealtimeSpeechServer.swift
@@ -35,7 +35,7 @@ public final class RealtimeSpeechServer: @unchecked Sendable {
         port: UInt16,
         transcriptionDelayMs: Int?,
         cacheLimitMB: Int,
-        stepMilliseconds: Int = 480
+        stepMilliseconds: Int = 100
     ) async throws -> RealtimeSpeechServer {
         Memory.cacheLimit = cacheLimitMB * 1024 * 1024
         let model = try await SpeechModelLoader.load(

--- a/SpeechHelper/Sources/SpeechEngineText/SpeechdLaunchOptions.swift
+++ b/SpeechHelper/Sources/SpeechEngineText/SpeechdLaunchOptions.swift
@@ -10,7 +10,7 @@ public struct SpeechdLaunchOptions: Equatable {
     public var parentPID: pid_t?
     public var transcriptionDelayMs: Int?
     public var cacheLimitMB = 4096
-    public var stepMilliseconds = 480
+    public var stepMilliseconds = 100
     public var benchmark: SpeechdBenchmarkOptions?
 
     public init() {}
@@ -52,7 +52,7 @@ public enum SpeechdOptionParser {
         var options = SpeechdLaunchOptions()
         var benchmarkEnabled = false
         var benchmarkSeconds: Int?
-        var benchmarkCadenceMilliseconds = 480
+        var benchmarkCadenceMilliseconds = 100
         var benchmarkWAVPath: String?
         var sawBenchmarkOnlyFlag: String?
         var iterator = arguments.makeIterator()

--- a/SpeechHelper/Sources/SpeechEngineText/StepBatcher.swift
+++ b/SpeechHelper/Sources/SpeechEngineText/StepBatcher.swift
@@ -1,8 +1,11 @@
 /// Accumulates 16 kHz audio and yields fixed-cadence batches for streaming inference.
 ///
-/// The realtime client normally appends 100 ms chunks, while Voxtral's native streaming
-/// cadence is 480 ms. Batching here avoids rerunning the model front end for every network
-/// append without changing the audio presented to the stream session.
+/// The realtime client normally appends 100 ms chunks; batching to a fixed step cadence
+/// avoids rerunning the model front end for every network append without changing the
+/// audio presented to the stream session. The production default is 100 ms (owner decision
+/// 2026-07-17: snappiest appearance, bench-proven to fit at 74-80 ms/step); larger values
+/// such as 480 ms (the model's native transcription delay) trade appearance latency for
+/// per-step compute headroom.
 public struct StepBatcher: Sendable {
     public let samplesPerStep: Int
     private var bufferedSamples: [Float] = []

--- a/SpeechHelper/Tests/SpeechEngineTextTests/SpeechdLaunchOptionsTests.swift
+++ b/SpeechHelper/Tests/SpeechEngineTextTests/SpeechdLaunchOptionsTests.swift
@@ -23,7 +23,7 @@ final class SpeechdLaunchOptionsTests: XCTestCase {
     func testStepCadenceDefaultsToModelNativeCadence() throws {
         let options = try SpeechdOptionParser.parse(["--model", "example/model"])
 
-        XCTAssertEqual(options.stepMilliseconds, 480)
+        XCTAssertEqual(options.stepMilliseconds, 100)
     }
 
     func testStepCadenceAllowsSmallPositiveValues() throws {
@@ -68,7 +68,7 @@ final class SpeechdLaunchOptionsTests: XCTestCase {
             "--model", "example/model", "--bench", "--seconds", "5",
         ])
 
-        XCTAssertEqual(options.benchmark?.cadenceMilliseconds, 480)
+        XCTAssertEqual(options.benchmark?.cadenceMilliseconds, 100)
     }
 
     func testBenchmarkRequiresPositiveSeconds() {

--- a/Tests/localvoxtralTests/BackendManagerTests.swift
+++ b/Tests/localvoxtralTests/BackendManagerTests.swift
@@ -128,6 +128,65 @@ final class BackendManagerTests: XCTestCase {
         }
     }
 
+    /// Regression: launch arguments are captured at supervisor creation, so a
+    /// stop must DROP the supervisor — a kept one would relaunch with stale
+    /// settings (field-hit 2026-07-17: changing the memory limit and toggling
+    /// Managed → External → Managed silently kept the old argv).
+    func testStopDictationDropsSupervisorSoNextEnsureRebuildsArguments() async throws {
+        let supervisorFactory = FakeSupervisorFactory()
+        supervisorFactory.statesByName[BackendCatalog.speechd.displayName] = [.running]
+        let stepCadenceMs = ProvidedValueBox()
+        let manager = makeManager(
+            speechdStepCadenceProvider: { stepCadenceMs.value },
+            supervisorFactory: supervisorFactory
+        )
+
+        try await manager.ensureReady(dictation: true, polishing: false)
+        await manager.stopDictation()
+        stepCadenceMs.value = 100
+        try await manager.ensureReady(dictation: true, polishing: false)
+
+        let configurations = supervisorFactory.createdConfigurations
+            .filter { $0.name == BackendCatalog.speechd.displayName }
+        XCTAssertEqual(
+            configurations.count, 2,
+            "stopDictation must drop the supervisor so the next ensure rebuilds it"
+        )
+        XCTAssertFalse(try XCTUnwrap(configurations.first).arguments.contains("--step-ms"))
+        XCTAssertEqual(
+            Array(try XCTUnwrap(configurations.last).arguments.suffix(2)),
+            ["--step-ms", "100"]
+        )
+    }
+
+    /// Same contract for the full-stop path used when the app switches the
+    /// dictation backend mode away from Managed.
+    func testStopAllDropsSupervisorsSoNextEnsureRebuildsArguments() async throws {
+        let supervisorFactory = FakeSupervisorFactory()
+        supervisorFactory.statesByName[BackendCatalog.speechd.displayName] = [.running]
+        let cacheLimitMB = ProvidedValueBox()
+        let manager = makeManager(
+            speechdCacheLimitProvider: { cacheLimitMB.value },
+            supervisorFactory: supervisorFactory
+        )
+
+        try await manager.ensureReady(dictation: true, polishing: false)
+        await manager.stopAll()
+        cacheLimitMB.value = 2048
+        try await manager.ensureReady(dictation: true, polishing: false)
+
+        let configurations = supervisorFactory.createdConfigurations
+            .filter { $0.name == BackendCatalog.speechd.displayName }
+        XCTAssertEqual(
+            configurations.count, 2,
+            "stopAll must drop the supervisors so the next ensure rebuilds them"
+        )
+        XCTAssertEqual(
+            Array(try XCTUnwrap(configurations.last).arguments.suffix(2)),
+            ["--cache-limit-mb", "2048"]
+        )
+    }
+
     /// Starts speechd with the given cache-limit / step-cadence providers and
     /// returns the supervisor configuration it was launched with.
     private func speechdConfiguration(
@@ -749,6 +808,13 @@ final class BackendManagerTests: XCTestCase {
             }
         )
     }
+}
+
+/// Mutable value for settings-provider closures in tests. The providers are
+/// `@MainActor` and the tests mutate on the main actor too, but a captured
+/// `var` still trips the sendable-capture warning — box it instead.
+private final class ProvidedValueBox: @unchecked Sendable {
+    var value: Int?
 }
 
 private struct FixedLegacyPortDefense: LegacyVoxmlxPortDefending {

--- a/Tests/localvoxtralTests/BackendManagerTests.swift
+++ b/Tests/localvoxtralTests/BackendManagerTests.swift
@@ -74,9 +74,10 @@ final class BackendManagerTests: XCTestCase {
             configuration.arguments.firstIndex(of: "--model-revision")
         )
         XCTAssertEqual(configuration.arguments[revisionIndex + 1], option.revision)
-        // Default provider is Auto: the cache-limit flag is omitted so the
-        // helper's built-in default applies.
+        // Default providers are Auto: the cache-limit and step-cadence flags
+        // are omitted so the helper's built-in defaults apply.
         XCTAssertFalse(configuration.arguments.contains("--cache-limit-mb"))
+        XCTAssertFalse(configuration.arguments.contains("--step-ms"))
     }
 
     func testSpeechdCacheLimitAutoOmitsFlagAndPresetsAppendMegabytes() async throws {
@@ -103,15 +104,41 @@ final class BackendManagerTests: XCTestCase {
         }
     }
 
-    /// Starts speechd with the given cache-limit provider and returns the
-    /// supervisor configuration it was launched with.
+    func testSpeechdStepCadenceAutoOmitsFlagAndPresetsAppendMilliseconds() async throws {
+        let option = SpeechModelCatalog.defaultOption
+        let baseArguments = [
+            "--model", option.repoID,
+            "--model-revision", option.revision,
+            "--port", "8471",
+            "--parent-pid", "\(Darwin.getpid())",
+        ]
+
+        // Auto: identical to the base argument list, no step-cadence flag.
+        let autoConfiguration = try await speechdConfiguration(stepCadenceMs: nil)
+        XCTAssertEqual(autoConfiguration.arguments, baseArguments)
+
+        // Each preset appends exactly `--step-ms <value>` and leaves the
+        // model / revision / port / parent-pid arguments untouched.
+        for milliseconds in [100, 240, 480] {
+            let configuration = try await speechdConfiguration(stepCadenceMs: milliseconds)
+            XCTAssertEqual(
+                configuration.arguments,
+                baseArguments + ["--step-ms", "\(milliseconds)"]
+            )
+        }
+    }
+
+    /// Starts speechd with the given cache-limit / step-cadence providers and
+    /// returns the supervisor configuration it was launched with.
     private func speechdConfiguration(
-        cacheLimitMB: Int?
+        cacheLimitMB: Int? = nil,
+        stepCadenceMs: Int? = nil
     ) async throws -> BackendProcessConfiguration {
         let supervisorFactory = FakeSupervisorFactory()
         supervisorFactory.statesByName[BackendCatalog.speechd.displayName] = [.running]
         let manager = makeManager(
             speechdCacheLimitProvider: { cacheLimitMB },
+            speechdStepCadenceProvider: { stepCadenceMs },
             supervisorFactory: supervisorFactory
         )
 
@@ -707,6 +734,7 @@ final class BackendManagerTests: XCTestCase {
             SettingsStore.defaultLLMPolishingModel
         },
         speechdCacheLimitProvider: @escaping BackendManager.SpeechdCacheLimitProvider = { nil },
+        speechdStepCadenceProvider: @escaping BackendManager.SpeechdStepCadenceProvider = { nil },
         supervisorFactory: FakeSupervisorFactory
     ) -> BackendManager {
         BackendManager(
@@ -715,6 +743,7 @@ final class BackendManagerTests: XCTestCase {
             legacyPortDefense: legacyPortDefense,
             polishingModelProvider: polishingModelProvider,
             speechdCacheLimitProvider: speechdCacheLimitProvider,
+            speechdStepCadenceProvider: speechdStepCadenceProvider,
             supervisorFactory: { configuration in
                 supervisorFactory.makeSupervisor(configuration: configuration)
             }

--- a/Tests/localvoxtralTests/DictationViewModelFailFastUXTests.swift
+++ b/Tests/localvoxtralTests/DictationViewModelFailFastUXTests.swift
@@ -564,6 +564,72 @@ final class DictationViewModelFailFastUXTests: XCTestCase {
         XCTAssertEqual(backendManager.ensureCalls, [.init(dictation: false, polishing: true)])
     }
 
+    func testSpeechdCacheLimitChangeRestartsDictationEngineEagerly() async {
+        let backendManager = FakeManagedBackendManager()
+        let viewModel = makeViewModel(outputMode: .overlayBuffer, backendManager: backendManager)
+        viewModel.settings.dictationBackendMode = .managedLocal
+        viewModel.settings.onboardingCompleted = true
+        retainForTestProcessLifetime(viewModel)
+
+        viewModel.applySpeechdCacheLimitChange(.gb2)
+        await viewModel.dictationShutdownTask?.value
+        await viewModel.dictationWarmupTask?.value
+
+        // Owner rule (2026-07-17): changing the memory limit or step interval
+        // must not require a Managed -> External -> Managed round trip.
+        XCTAssertEqual(viewModel.settings.speechdCacheLimit, .gb2)
+        XCTAssertEqual(backendManager.stopDictationCallCount, 1)
+        XCTAssertEqual(backendManager.ensureCalls, [.init(dictation: true, polishing: false)])
+    }
+
+    func testSpeechdStepCadenceChangeRestartsDictationEngineEagerly() async {
+        let backendManager = FakeManagedBackendManager()
+        let viewModel = makeViewModel(outputMode: .overlayBuffer, backendManager: backendManager)
+        viewModel.settings.dictationBackendMode = .managedLocal
+        viewModel.settings.onboardingCompleted = true
+        retainForTestProcessLifetime(viewModel)
+
+        viewModel.applySpeechdStepCadenceChange(.ms100)
+        await viewModel.dictationShutdownTask?.value
+        await viewModel.dictationWarmupTask?.value
+
+        XCTAssertEqual(viewModel.settings.speechdStepCadence, .ms100)
+        XCTAssertEqual(backendManager.stopDictationCallCount, 1)
+        XCTAssertEqual(backendManager.ensureCalls, [.init(dictation: true, polishing: false)])
+    }
+
+    func testSpeechdSettingChangeOutsideManagedModePersistsWithoutRestart() async {
+        let backendManager = FakeManagedBackendManager()
+        let viewModel = makeViewModel(outputMode: .overlayBuffer, backendManager: backendManager)
+        viewModel.settings.dictationBackendMode = .externalURL
+        viewModel.settings.onboardingCompleted = true
+        retainForTestProcessLifetime(viewModel)
+
+        viewModel.applySpeechdCacheLimitChange(.gb2)
+        viewModel.applySpeechdStepCadenceChange(.ms100)
+
+        XCTAssertNil(viewModel.dictationShutdownTask)
+        XCTAssertEqual(viewModel.settings.speechdCacheLimit, .gb2)
+        XCTAssertEqual(viewModel.settings.speechdStepCadence, .ms100)
+        XCTAssertEqual(backendManager.stopDictationCallCount, 0)
+        XCTAssertTrue(backendManager.ensureCalls.isEmpty)
+    }
+
+    func testSpeechdSettingChangeToSameValueIsNoOp() async {
+        let backendManager = FakeManagedBackendManager()
+        let viewModel = makeViewModel(outputMode: .overlayBuffer, backendManager: backendManager)
+        viewModel.settings.dictationBackendMode = .managedLocal
+        viewModel.settings.onboardingCompleted = true
+        retainForTestProcessLifetime(viewModel)
+
+        viewModel.applySpeechdCacheLimitChange(viewModel.settings.speechdCacheLimit)
+        viewModel.applySpeechdStepCadenceChange(viewModel.settings.speechdStepCadence)
+
+        XCTAssertNil(viewModel.dictationShutdownTask)
+        XCTAssertEqual(backendManager.stopDictationCallCount, 0)
+        XCTAssertTrue(backendManager.ensureCalls.isEmpty)
+    }
+
     func testDictationModeSwitchToManagedStartsDictationWarmup() async {
         let backendManager = FakeManagedBackendManager()
         let viewModel = makeViewModel(outputMode: .overlayBuffer, backendManager: backendManager)

--- a/Tests/localvoxtralTests/SettingsStoreTests.swift
+++ b/Tests/localvoxtralTests/SettingsStoreTests.swift
@@ -74,6 +74,31 @@ final class SettingsStoreTests: XCTestCase {
         XCTAssertEqual(makeStore().speechdCacheLimit, .auto)
     }
 
+    // MARK: - speechd step cadence
+
+    func testSpeechdStepCadence_defaultsToAuto() {
+        XCTAssertEqual(makeStore().speechdStepCadence, .auto)
+        // Auto omits the flag: the helper's built-in default applies.
+        XCTAssertNil(SpeechdStepCadence.auto.milliseconds)
+    }
+
+    func testSpeechdStepCadence_persistsAcrossStores() {
+        let store = makeStore()
+        store.speechdStepCadence = .ms100
+        XCTAssertEqual(makeStore().speechdStepCadence, .ms100)
+    }
+
+    func testSpeechdStepCadence_unknownStoredValueFallsBackToAuto() {
+        defaults.set("garbage", forKey: "settings.speechd_step_cadence")
+        XCTAssertEqual(makeStore().speechdStepCadence, .auto)
+    }
+
+    func testSpeechdStepCadence_millisecondsForEachPreset() {
+        XCTAssertEqual(SpeechdStepCadence.ms100.milliseconds, 100)
+        XCTAssertEqual(SpeechdStepCadence.ms240.milliseconds, 240)
+        XCTAssertEqual(SpeechdStepCadence.ms480.milliseconds, 480)
+    }
+
     func testSpeechdCacheLimit_megabytesForEachPreset() {
         XCTAssertEqual(SpeechdCacheLimit.gb2.megabytes, 2048)
         XCTAssertEqual(SpeechdCacheLimit.gb4.megabytes, 4096)

--- a/scripts/remote-build.sh
+++ b/scripts/remote-build.sh
@@ -20,7 +20,7 @@ set -euo pipefail
 #                  client, and assert accuracy + delta + parent-pid contracts
 #     speechd-bench run the packaged speech helper's streaming benchmark;
 #                  optional args = seconds (default 60) and cadence ms
-#                  (default 480); requires a prior `package`
+#                  (default 100 = the production step cadence); requires a prior `package`
 #     eval-llm     default-polish-prompt eval against a live mlx-lm server;
 #                  optional args = chat/completions endpoint and external
 #                  model alias (default endpoint
@@ -289,7 +289,7 @@ case "$CMD" in
       exit 1
     fi
     SPEECHD_BENCH_SECONDS="${1:-60}"
-    SPEECHD_BENCH_CADENCE="${2:-480}"
+    SPEECHD_BENCH_CADENCE="${2:-100}"
     if [[ ! "$SPEECHD_BENCH_SECONDS" =~ ^[1-9][0-9]*$ ]]; then
       echo "speechd-bench seconds must be a positive integer" >&2
       exit 1


### PR DESCRIPTION
## What

Owner field-testing of the speechd swap (#146/#147) found the helper's baked-in 480ms step cadence adds ~0.5–0.7s of text-appearance lag versus voxmlx; a manual `--step-ms 100` A/B on the same build "feels much better", and the streaming bench already proved 100ms cadence fits (74–80ms/step, 0.76 RTF). This exposes the knob in Settings.

- `SpeechdStepCadence` (Auto / 100 ms / 240 ms / 480 ms) mirrors the `SpeechdCacheLimit` pattern end to end: persisted rawValue with fall-back-to-Auto on unknown stored values, `BackendManager.SpeechdStepCadenceProvider` (Auto = nil = flag omitted so the helper default applies), presets append exactly `--step-ms <value>` to the speechd launch args.
- Settings → Endpoints → Dictation (Managed local): new "Step interval" row under "Memory limit", menu picker + one-line help text. Row added inside the existing group — group count and identity unchanged (owner rule).
- Like the memory limit, the value applies the next time the managed helper (re)starts (toggling Managed → External → Managed applies it immediately).
- The model's transcription-delay look-ahead is untouched — this only changes serving-side batching, so accuracy is unaffected.

Stacked on #147 so the setting rides the same hand-test build; the default stays the helper's 480. Whether the shipped default should drop to 240/100 is a separate decision gated on bench-under-GUI-load evidence (headroom backlog).

## Proof

- [x] Unit suite green — `./scripts/remote-build.sh test`
```
Executed 984 tests, with 2 tests skipped and 0 failures (0 unexpected)
```
- [x] New coverage, all passing:
```
BackendManagerTests testSpeechdStepCadenceAutoOmitsFlagAndPresetsAppendMilliseconds
SettingsStoreTests  testSpeechdStepCadence_defaultsToAuto
SettingsStoreTests  testSpeechdStepCadence_persistsAcrossStores
SettingsStoreTests  testSpeechdStepCadence_unknownStoredValueFallsBackToAuto
SettingsStoreTests  testSpeechdStepCadence_millisecondsForEachPreset
```
The default-launch-args test now also asserts `--step-ms` is absent under Auto (no assertion weakened).
- [x] LLM lanes: not required — settings/backend-supervision path; no prompts, pins, or polish-path changes.

## UI change — owner hand-verification needed (try-pr.sh)

- Settings → Endpoints → Managed local shows the "Step interval" row; pick "100 ms", toggle Managed → External → Managed (or quit/relaunch), dictate: text appearance should match the manual `--step-ms 100` A/B.
- Export Diagnostics / `ps` shows `--step-ms 100` on the localvoxtral-speechd command line.

## Update (second commit): supervisors dropped on stop

Field-testing found the setting could not actually reach the helper: launch arguments are captured at supervisor creation and `stopDictation`/`stopAll` kept the speechd supervisor across stops, so Managed → External → Managed relaunched with the ORIGINAL argv (a 2 GB memory-limit change silently never applied; only a full app relaunch picked it up). `b9412ad` drops the supervisors on both stop paths — polishd already did this in `stopAll` — so the next ensure rebuilds the configuration from the current settings providers. Two regression tests change a provider value across a stop and assert the second launch's argv.

Proof refresh: full unit suite green with the fix — `Executed 986 tests, with 2 tests skipped and 0 failures` — including `testStopDictationDropsSupervisorSoNextEnsureRebuildsArguments` and `testStopAllDropsSupervisorsSoNextEnsureRebuildsArguments`. With this commit the hand-test instruction "toggle Managed → External → Managed to apply" is actually true.


## Update (third commit): settings apply by restarting the engine

Owner rule: no Managed → External → Managed round trip. `3928fbe` routes both pickers through `DictationViewModel` appliers that persist and — in Managed mode — stop speechd and eagerly warm it back up with progress in the status row (same task sequencing as `applyLLMPolishingModelChange`). External mode / same-value picks persist only. Four new tests mirror the polish-model-change coverage (eager restart for both settings, no restart outside Managed, same-value no-op). Suite: `Executed 990 tests, with 2 tests skipped and 0 failures`. A change made mid-dictation restarts the engine under the active session, which ends via the normal failure path — same precedent as the polish-model change.


## Update (fourth commit): 100 ms is now the default step cadence

Owner decision after field-testing: the shipped default moves 480 → 100 ms (helper default, so the picker's Auto resolves to 100; 240/480 remain selectable). Bench basis: 74–80 ms/step flat at 100 ms cadence, 0.76 RTF, plus a day of owner field use. `speechd-bench`'s default cadence follows the production value. The two default-value assertions in `SpeechdLaunchOptionsTests` move 480 → 100 with the product change — a deliberate default change, not a weakened test. SpeechHelper suite: `Executed 47 tests, with 0 failures`.
