### PR TITLE
TRIAL: SpeechHelper pin bump to 70281a0 (attention-invariant hoisting, fork PR #4)

### DIFF
--- a/SpeechHelper/Package.resolved
+++ b/SpeechHelper/Package.resolved
@@ -23,7 +23,7 @@
       "kind": "remoteSourceControl",
       "location": "https://github.com/T0mSIlver/mlx-audio-swift.git",
       "state": {
-        "revision": "03890317975a2371fe0a0a9b13ad6a790f929814"
+        "revision": "70281a074571373397f468313446208517896029"
       }
     },
     {

--- a/SpeechHelper/Package.swift
+++ b/SpeechHelper/Package.swift
@@ -34,14 +34,15 @@ let package = Package(
         // #226). Pinned to a full-SHA revision, not a tag, so the exact reviewed tree is
         // reproducible — see DEPENDENCY.md for the upgrade procedure.
         //
-        // TEMPORARY FORK PIN: our fork's `localvoxtral-pin-e1-e2` = upstream 3b0b114 plus two
+        // TEMPORARY FORK PIN: our fork's `localvoxtral-pin-e1-e2` = upstream 3b0b114 plus three
         // streaming-performance fixes staged for upstream (fork PRs; see DEPENDENCY.md):
-        // cache-clear cadence (per-step -> per-256-tokens + finish) and the incremental
-        // mel/conv front end (O(N^2) -> O(N) per utterance). Switch the URL back to
-        // Blaizzy/mlx-audio-swift once both merge upstream.
+        // cache-clear cadence (per-step -> per-256-tokens + finish), the incremental
+        // mel/conv front end (O(N^2) -> O(N) per utterance), and hoisted per-layer-invariant
+        // attention inputs (~3%/step). Switch the URL back to Blaizzy/mlx-audio-swift once
+        // all merge upstream.
         .package(
             url: "https://github.com/T0mSIlver/mlx-audio-swift.git",
-            revision: "03890317975a2371fe0a0a9b13ad6a790f929814"
+            revision: "70281a074571373397f468313446208517896029"
         ),
     ],
     targets: [


### PR DESCRIPTION
## What

Field-trial build, stacked on #148. Bumps the SpeechHelper fork pin `0389031` → `70281a0` (= the reviewed E1+E2 pin plus the merge of [T0mSIlver/mlx-audio-swift#4](https://github.com/T0mSIlver/mlx-audio-swift/pull/4): per-layer-invariant RoPE tables + SDPA masks hoisted out of the Voxtral layer loops).

**Expectation setting**: the bench delta is ~2–4 ms/step (~3%) — likely imperceptible by hand. This build exists so the owner can (a) confirm no regression in feel and (b) decide whether the pin bump rides along now or waits for the upstream submissions. Not for merge as-is.

Known-stale: DEPENDENCY.md's pin section here predates #146's `86f38ac` docs commit (it arrives via the merge-train rebase); reconcile if this ever graduates from TRIAL.

## Proof

- Engine equivalence: fork PR #4 argues bit-identical outputs (same ops, same order, hoisted once) and is covered by the fork's `VoxtralRealtimeStreamingFrontEndTests` exact-equality suite; bench evidence in the PR body.
- This repo's CI (speechd lane fires on SpeechHelper/** changes) validates the packaged helper against the live accuracy baseline.

## Owner hand-test

`./scripts/try-pr.sh <this PR number>` → set Step interval to 100 ms → dictate; compare against the #148 build.