### PR TITLE
speechd: idle at the weight floor — clear the buffer pool after session teardown

### DIFF
--- a/SpeechHelper/Sources/SpeechEngine/RealtimeSpeechServer.swift
+++ b/SpeechHelper/Sources/SpeechEngine/RealtimeSpeechServer.swift
@@ -198,6 +198,14 @@ public final class RealtimeSpeechServer: @unchecked Sendable {
             rawSend(connection, WebSocketFrameCodec.pong(frame.payload))
         case .close:
             rawSend(connection, WebSocketFrameCodec.close(), thenClose: true)
+            // A client that disconnects without a final commit (mid-utterance
+            // cancel) would otherwise release its session's buffers into the
+            // pool with no clear behind them. Serial queue: this lands after
+            // any already-queued steps for this connection.
+            inferenceQueue.async {
+                ctx.session = nil
+                Memory.clearCache()
+            }
         case .pong, .continuation:
             break
         case .text, .binary:
@@ -248,10 +256,20 @@ public final class RealtimeSpeechServer: @unchecked Sendable {
                 ctx.session = nil  // ready for the next utterance
                 ctx.deltas = TranscriptDeltaEmitter()
                 ctx.stepBatcher.clear()
+                // The engine's finish() clears the buffer pool, but at that point the
+                // session's KV caches and encoder state are still live — dropping the
+                // session afterwards releases them INTO the pool, which then sits at
+                // `Memory.cacheLimit` for as long as the helper idles (field-hit
+                // 2026-07-17: ~5 GB resident between dictations at a 2 GB cap). Clear
+                // AFTER the drop so idle footprint returns to the weight floor; the
+                // next utterance re-warms the pool while it streams.
+                Memory.clearCache()
             case .clear:
                 ctx.session = nil
                 ctx.deltas = TranscriptDeltaEmitter()
                 ctx.stepBatcher.clear()
+                // Same idle-footprint contract as the commit path above.
+                Memory.clearCache()
             case .ignored:
                 break
             }


### PR DESCRIPTION
## What

Owner field-testing (2026-07-17) found speechd idling at ~5 GB resident between dictations with a 2 GB cache limit (~7 GB at the 4 GB default) and never sagging after stop. Not a leak — an ordering bug: the engine's `finish()` clears the Metal buffer pool while the session's KV caches and carried front-end state are still **live**; the server then drops the session, releasing those buffers INTO the pool, which parks at `Memory.cacheLimit` until the process exits.

Fix: `RealtimeSpeechServer` clears the pool **after** the session drop on all three teardown paths — final commit, `input_audio_buffer.clear`, and client close without a commit (serial inference queue ordering keeps the close-path clear behind any queued steps). Expected idle footprint returns to the ~2.6 GB weight floor, matching the retired voxmlx backend; the pool re-warms during the next utterance.

The E1 fork PR's "memory returns to the weight floor" claim was corrected accordingly (code comment `5d6e6a3` on `perf/streaming-cache-cadence`, PR body bullet, and an evidence comment on T0mSIlver/mlx-audio-swift#2) so the upstream submission documents the caller-side contract this PR implements.

Stacked on #148 (whose supervisor-drop fix is what makes the cache-limit setting reach the helper at all).

## Proof

- The diff touches `SpeechHelper/**`, so CI's live speechd integration lane runs on this PR — that validates the production request path and the accuracy baseline through the changed server.
- Per-step behavior is untouched (no change to the 256-token cadence or step path); the clears added here run only at utterance teardown, so streaming latency is unaffected by construction.
- Steady-state memory is not assertable in a unit test (Metal-free suite) — hand-verification below is the behavioral proof, as with the cache-limit setting.

## Owner hand-verification (try-pr.sh, after CI)

Same three-readings protocol that found the bug: with Memory limit 2 GB — **(a)** idle after Ready ≈ weight floor (~2.6–3 GB); **(b)** during a ~30 s dictation climbs toward cap; **(c)** ~10 s after stop returns to (a), and stays there across repeated sessions.