### PR TITLE
Contain and supervise persistent XCTest runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,6 +70,7 @@ jobs:
           ./scripts/ci/test-build-gate-process-cleanup.sh
           ./scripts/ci/test-build-gate-reap-command.sh
           ./scripts/ci/test-remote-build-reap.sh
+          ./scripts/ci/test-run-supervised-command.sh
 
       - name: Decide LLM eval lane (path filter + [run-llm-eval] marker)
         # CI must not pay ~8 min of 4B weight-loading + live inference on
@@ -215,17 +216,34 @@ jobs:
         # old standalone `swift build` step built plain-debug products that
         # nothing downstream consumed (tests rebuild with coverage flags,
         # packaging builds release), so it was pure duplicate compilation.
+        env:
+          RUNNER_ENVIRONMENT: ${{ runner.environment }}
         run: |
           # AgentDictationE2EEvalTests is skipped explicitly (belt) on top of
           # the marker cleanup above (suspenders): it is the nightly
           # eval-e2e.yml lane, never tier 0, and a leftover enable marker in
           # this persistent workspace must not turn the unit step into a
           # many-minute live-inference run.
-          swift test \
+          timeout_seconds=900
+          if [[ "$RUNNER_ENVIRONMENT" == "self-hosted" ]]; then
+            timeout_seconds=300
+          fi
+          ./scripts/ci/run-supervised-command.sh \
+            "$timeout_seconds" "$RUNNER_TEMP/localvoxtral-unit-tests.log" -- \
+            swift test \
             --skip RealtimeAPIVLLMIntegrationTests \
             --skip SpeechHelperIntegrationTests \
             --skip AgentDictationE2EEvalTests \
             --enable-code-coverage
+
+      - name: Upload complete unit-test log
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: unit-test-log-${{ runner.os }}
+          path: ${{ runner.temp }}/localvoxtral-unit-tests.log
+          if-no-files-found: error
+          retention-days: 7
 
       - name: Coverage summary
         # Visibility, not a gate: lets a PR's Proof section cite real coverage

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,6 +54,23 @@ jobs:
           rm -f .agent-eval-e2e-enable.json .llm-polish-eval-enable.json \
             .polishd-integration-enable.json .speechd-integration-enable.json
 
+      - name: Clean abandoned test processes in this workspace
+        # A cancelled self-hosted job can outlive the Actions process cookie
+        # and leave swift-package/xctest running in this persistent checkout.
+        # Scope by current user + lsof cwd/mapped text; never pkill globally
+        # because the owner and parallel worktrees may run legitimate tests.
+        if: runner.environment == 'self-hosted'
+        run: ./scripts/ci/cleanup-stale-test-processes.sh "$GITHUB_WORKSPACE"
+
+      - name: Process-cleanup regression tests
+        # Pure shell tests for the workspace selector and the SSH build gate's
+        # TERM -> KILL process-group teardown. Runs on hosted fork PRs too.
+        run: |
+          ./scripts/ci/test-cleanup-stale-test-processes.sh
+          ./scripts/ci/test-build-gate-process-cleanup.sh
+          ./scripts/ci/test-build-gate-reap-command.sh
+          ./scripts/ci/test-remote-build-reap.sh
+
       - name: Decide LLM eval lane (path filter + [run-llm-eval] marker)
         # CI must not pay ~8 min of 4B weight-loading + live inference on
         # every push: the polishd live-model integration step below runs only
@@ -414,12 +431,12 @@ jobs:
         # ~15% of runs spend ~105 s in the runner's post-job "Cleaning up
         # orphan processes" phase, and the Worker logs don't name what it
         # reaps. Snapshot candidate survivors at job end so any future
-        # occurrence identifies itself. Short process names only (ucomm, no
-        # paths or arguments): this log is public. Informational — never
-        # fails the job.
+        # occurrence identifies itself. UID/state distinguish another account
+        # and harmless zombies; names stay ucomm-only (no paths or arguments)
+        # because this log is public. Informational — never fails the job.
         if: ${{ always() && runner.environment == 'self-hosted' }}
         run: |
-          survivors="$(ps -axo pid,etime,ucomm \
+          survivors="$(ps -axo pid,uid,etime,state,ucomm \
             | grep -iE 'localvoxtral|polishd|speechd|xctest|swiftpm-testing|XCBBuildService' \
             | grep -v grep || true)"
           if [[ -n "$survivors" ]]; then

--- a/scripts/ci/cleanup-stale-test-processes.sh
+++ b/scripts/ci/cleanup-stale-test-processes.sh
@@ -1,0 +1,170 @@
+#!/usr/bin/env bash
+# Remove abandoned SwiftPM/XCTest processes from this checkout only.
+#
+# The self-hosted runner keeps one persistent checkout per repository. A job
+# cancelled while `swift test` is running can leave its driver or xctest host
+# behind; later suites then stall at arbitrary tests. Never use a global
+# `pkill`: the owner and parallel worktrees may be running legitimate tests.
+set -euo pipefail
+
+TERM_POLLS="${LOCALVOXTRAL_STALE_TEST_TERM_POLLS:-50}"
+TERM_POLL_SECONDS="${LOCALVOXTRAL_STALE_TEST_TERM_POLL_SECONDS:-0.1}"
+
+fail() {
+  printf 'stale-test cleanup: %s\n' "$*" >&2
+  exit 1
+}
+
+canonical_directory() {
+  local directory="$1"
+  (cd "$directory" 2>/dev/null && pwd -P)
+}
+
+is_test_process_name() {
+  local name="${1##*/}"
+  case "$name" in
+    xctest|swift-package|swift-test|swiftpm-testing*|XCBBuildService|localvoxtral*) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+# Input records are tab-separated: pid, uid, state, executable, start identity,
+# evidence path. Evidence is an lsof cwd or mapped-text path; XCTest itself
+# lives in Xcode, but its package test bundle remains mapped from `.build`.
+# Output records are pid, executable, identity. Keeping selection pure makes
+# every fail-closed boundary deterministic to regression-test.
+select_candidates() {
+  local workspace="$1" current_uid="$2" excluded_pids="$3"
+  local pid uid state executable identity evidence_path
+
+  while IFS=$'\t' read -r pid uid state executable identity evidence_path; do
+    [[ "$pid" =~ ^[0-9]+$ ]] || continue
+    case " $excluded_pids " in
+      *" $pid "*) continue ;;
+    esac
+    [[ "$uid" == "$current_uid" ]] || continue
+    [[ "$state" != Z* ]] || continue
+    is_test_process_name "$executable" || continue
+    [[ -n "$identity" && -n "$evidence_path" ]] || continue
+    case "$evidence_path" in
+      "$workspace"|"$workspace"/*)
+        printf '%s\t%s\t%s\n' "$pid" "${executable##*/}" "$identity"
+        ;;
+    esac
+  done
+}
+
+if [[ "${1:-}" == "--select" ]]; then
+  [[ $# -eq 4 ]] || fail "usage: $0 --select <workspace> <uid> <excluded-pids>"
+  workspace="$(canonical_directory "$2")" || fail "workspace is unreadable: $2"
+  select_candidates "$workspace" "$3" "$4"
+  exit 0
+fi
+
+[[ $# -eq 1 ]] || fail "usage: $0 <workspace-root>"
+[[ "$TERM_POLLS" =~ ^[0-9]+$ ]] || fail "invalid TERM poll count"
+command -v lsof >/dev/null 2>&1 || fail "lsof is required for cwd-scoped cleanup"
+
+workspace="$(canonical_directory "$1")" \
+  || fail "workspace is unreadable"
+current_uid="$(id -u)"
+tmp_dir="$(mktemp -d "${TMPDIR:-/tmp}/lv-stale-tests.XXXXXX")"
+snapshot="$tmp_dir/processes.tsv"
+metadata="$tmp_dir/metadata.tsv"
+lsof_records="$tmp_dir/lsof.txt"
+candidates="$tmp_dir/candidates.tsv"
+trap 'rm -rf "$tmp_dir"' EXIT
+
+excluded_pids="$$"
+ancestor="$PPID"
+while [[ "$ancestor" =~ ^[0-9]+$ && "$ancestor" -gt 1 ]]; do
+  case " $excluded_pids " in
+    *" $ancestor "*) break ;;
+  esac
+  excluded_pids="$excluded_pids $ancestor"
+  ancestor="$(ps -o ppid= -p "$ancestor" 2>/dev/null | tr -d '[:space:]' || true)"
+done
+
+# Do not inspect or print full command lines: agent/tool invocations sometimes
+# carry secrets there. One ps snapshot plus one lsof field-mode snapshot avoids
+# per-process forks; neither command requests argv. Join them by PID in awk.
+while read -r pid uid state executable identity; do
+  [[ "$pid" =~ ^[0-9]+$ ]] || continue
+  [[ "$uid" == "$current_uid" && "$state" != Z* ]] || continue
+  is_test_process_name "$executable" || continue
+  case " $excluded_pids " in
+    *" $pid "*) continue ;;
+  esac
+  [[ -n "$identity" ]] || continue
+  printf '%s\t%s\t%s\t%s\t%s\n' \
+    "$pid" "$uid" "$state" "$executable" "$identity"
+done < <(ps -axo pid=,uid=,state=,ucomm=,lstart=) >"$metadata"
+
+lsof -n -P -u "$current_uid" -a -d cwd,txt -F pn >"$lsof_records" 2>/dev/null || true
+awk -F '\t' '
+  FNR == NR { metadata[$1] = $0; next }
+  substr($0, 1, 1) == "p" { pid = substr($0, 2); next }
+  substr($0, 1, 1) == "n" && (pid in metadata) {
+    print metadata[pid] "\t" substr($0, 2)
+  }
+' "$metadata" "$lsof_records" >"$snapshot"
+
+select_candidates "$workspace" "$current_uid" "$excluded_pids" \
+  <"$snapshot" | sort -t $'\t' -k1,1n -u >"$candidates"
+
+if [[ ! -s "$candidates" ]]; then
+  printf 'stale-test cleanup: no abandoned processes in %s\n' "$workspace"
+  exit 0
+fi
+
+candidate_is_same_process() {
+  local pid="$1" expected_executable="$2" expected_identity="$3"
+  local uid state executable identity
+  uid="$(ps -o uid= -p "$pid" 2>/dev/null | tr -d '[:space:]' || true)"
+  state="$(ps -o state= -p "$pid" 2>/dev/null | tr -d '[:space:]' || true)"
+  executable="$(ps -o ucomm= -p "$pid" 2>/dev/null | sed 's/^[[:space:]]*//;s/[[:space:]]*$//' || true)"
+  identity="$(ps -o lstart= -p "$pid" 2>/dev/null | sed 's/^[[:space:]]*//;s/[[:space:]]*$//' || true)"
+  [[ "$uid" == "$current_uid" \
+    && -n "$state" && "$state" != Z* \
+    && "${executable##*/}" == "$expected_executable" \
+    && "$identity" == "$expected_identity" ]]
+}
+
+while IFS=$'\t' read -r pid executable identity; do
+  candidate_is_same_process "$pid" "$executable" "$identity" || continue
+  printf 'stale-test cleanup: TERM pid=%s executable=%s\n' "$pid" "$executable"
+  kill -TERM "$pid" 2>/dev/null || true
+done <"$candidates"
+
+poll=0
+while (( poll < TERM_POLLS )); do
+  any_live=0
+  while IFS=$'\t' read -r pid executable identity; do
+    if candidate_is_same_process "$pid" "$executable" "$identity"; then
+      any_live=1
+      break
+    fi
+  done <"$candidates"
+  (( any_live == 1 )) || break
+  sleep "$TERM_POLL_SECONDS"
+  poll=$((poll + 1))
+done
+
+while IFS=$'\t' read -r pid executable identity; do
+  if candidate_is_same_process "$pid" "$executable" "$identity"; then
+    printf 'stale-test cleanup: KILL pid=%s executable=%s\n' "$pid" "$executable"
+    kill -KILL "$pid" 2>/dev/null || true
+  fi
+done <"$candidates"
+
+remaining=0
+while IFS=$'\t' read -r pid executable identity; do
+  if candidate_is_same_process "$pid" "$executable" "$identity"; then
+    printf 'stale-test cleanup: pid=%s executable=%s survived cleanup\n' \
+      "$pid" "$executable" >&2
+    remaining=1
+  fi
+done <"$candidates"
+
+(( remaining == 0 )) || exit 1
+printf 'stale-test cleanup: complete\n'

--- a/scripts/ci/fixtures/build-gate-stubborn-tree.sh
+++ b/scripts/ci/fixtures/build-gate-stubborn-tree.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+# Fixture for test-build-gate-process-cleanup.sh. Both processes ignore TERM
+# so the gate's bounded KILL escalation is exercised deterministically.
+set -euo pipefail
+
+pid_fifo="$1"
+mode="${2:-wait}"
+trap '' TERM
+/bin/bash -c 'trap "" TERM; exec sleep 300' &
+stubborn_child=$!
+printf '%s %s\n' "$$" "$stubborn_child" >"$pid_fifo"
+if [[ "$mode" == "exit-leader" ]]; then
+  exit 0
+fi
+wait "$stubborn_child"

--- a/scripts/ci/run-supervised-command.sh
+++ b/scripts/ci/run-supervised-command.sh
@@ -1,0 +1,130 @@
+#!/usr/bin/env bash
+# Run one CI command with closed stdin, file-backed output, and an exact
+# process-group timeout. Compatible with the Bash 3.2 shipped by macOS.
+set -uo pipefail
+
+usage() {
+  echo "usage: $0 <timeout-seconds> <log-file> -- <command> [args...]" >&2
+  exit 64
+}
+
+[[ $# -ge 4 ]] || usage
+timeout_seconds="$1"
+log_file="$2"
+shift 2
+[[ "$1" == "--" ]] || usage
+shift
+[[ "$timeout_seconds" =~ ^[1-9][0-9]*$ ]] || usage
+
+term_polls="${LOCALVOXTRAL_SUPERVISOR_TERM_POLLS:-50}"
+poll_seconds="${LOCALVOXTRAL_SUPERVISOR_TERM_POLL_SECONDS:-0.1}"
+[[ "$term_polls" =~ ^[0-9]+$ ]] || usage
+
+mkdir -p "$(dirname "$log_file")"
+: >"$log_file"
+timeout_marker="${log_file}.timeout"
+rm -f "$timeout_marker"
+
+command_pid=""
+command_pgid=""
+watchdog_pid=""
+watchdog_pgid=""
+monitor_was_enabled=0
+
+group_is_alive() {
+  local pgid="$1"
+  [[ -n "$pgid" ]] && kill -0 -- "-$pgid" 2>/dev/null
+}
+
+terminate_group() {
+  local pgid="$1" poll=0
+  [[ -n "$pgid" ]] || return 0
+  if group_is_alive "$pgid"; then
+    kill -TERM -- "-$pgid" 2>/dev/null || true
+    while (( poll < term_polls )) && group_is_alive "$pgid"; do
+      sleep "$poll_seconds"
+      poll=$((poll + 1))
+    done
+    group_is_alive "$pgid" && kill -KILL -- "-$pgid" 2>/dev/null || true
+  fi
+}
+
+cleanup_owned_groups() {
+  terminate_group "$watchdog_pgid"
+  terminate_group "$command_pgid"
+  [[ -z "$watchdog_pid" ]] || wait "$watchdog_pid" 2>/dev/null || true
+  [[ -z "$command_pid" ]] || wait "$command_pid" 2>/dev/null || true
+  watchdog_pid=""
+  watchdog_pgid=""
+  command_pid=""
+  command_pgid=""
+}
+
+handle_signal() {
+  local status="$1"
+  trap - EXIT HUP INT TERM
+  cleanup_owned_groups
+  exit "$status"
+}
+
+trap 'handle_signal 129' HUP
+trap 'handle_signal 130' INT
+trap 'handle_signal 143' TERM
+trap 'cleanup_owned_groups' EXIT
+
+case "$-" in
+  *m*) monitor_was_enabled=1 ;;
+esac
+set -m
+"$@" </dev/null >"$log_file" 2>&1 &
+command_pid=$!
+command_pgid=$command_pid
+
+(
+  trap 'exit 0' HUP INT TERM
+  if [[ -n "${LOCALVOXTRAL_SUPERVISOR_TIMEOUT_FIFO:-}" ]]; then
+    read -r _ <"$LOCALVOXTRAL_SUPERVISOR_TIMEOUT_FIFO"
+  else
+    sleep "$timeout_seconds"
+  fi
+  : >"$timeout_marker"
+  terminate_group "$command_pgid"
+) &
+watchdog_pid=$!
+watchdog_pgid=$watchdog_pid
+(( monitor_was_enabled == 1 )) || set +m
+
+if wait "$command_pid"; then
+  command_status=0
+else
+  command_status=$?
+fi
+command_pid=""
+
+# Stop the timer first, then drain the whole command group. The leader may
+# exit while an xctest descendant remains alive.
+terminate_group "$watchdog_pgid"
+wait "$watchdog_pid" 2>/dev/null || true
+watchdog_pid=""
+watchdog_pgid=""
+terminate_group "$command_pgid"
+command_pgid=""
+
+if [[ -f "$timeout_marker" ]]; then
+  echo "Command exceeded ${timeout_seconds}s; final log output:" >&2
+  tail -n 200 "$log_file" >&2 || true
+  rm -f "$timeout_marker"
+  trap - EXIT
+  exit 124
+fi
+
+if (( command_status == 0 )); then
+  echo "Command completed; final log output:"
+  tail -n 40 "$log_file" || true
+else
+  echo "Command failed with status $command_status; final log output:" >&2
+  tail -n 200 "$log_file" >&2 || true
+fi
+
+trap - EXIT
+exit "$command_status"

--- a/scripts/ci/test-build-gate-process-cleanup.sh
+++ b/scripts/ci/test-build-gate-process-cleanup.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+# Regression test: an interrupted forced-command payload cannot orphan its
+# descendants, and ordinary command exit statuses still cross the wrapper.
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "$0")/../.." && pwd -P)"
+GATE="$ROOT_DIR/scripts/mac/localvoxtral-build-gate.sh"
+FIXTURE="$ROOT_DIR/scripts/ci/fixtures/build-gate-stubborn-tree.sh"
+TMP_DIR="$(mktemp -d "${TMPDIR:-/tmp}/lv-gate-process-test.XXXXXX")"
+wrapper_pid=""
+fixture_pid=""
+stubborn_pid=""
+
+cleanup() {
+  if [[ -n "$wrapper_pid" ]]; then
+    kill -TERM "$wrapper_pid" 2>/dev/null || true
+    wait "$wrapper_pid" 2>/dev/null || true
+  fi
+  [[ -z "$fixture_pid" ]] || kill -KILL "$fixture_pid" 2>/dev/null || true
+  [[ -z "$stubborn_pid" ]] || kill -KILL "$stubborn_pid" 2>/dev/null || true
+  rm -rf "$TMP_DIR"
+}
+trap cleanup EXIT
+
+fail() {
+  printf 'FAIL: %s\n' "$*" >&2
+  exit 1
+}
+
+LOCALVOXTRAL_BUILD_GATE_SOURCE_ONLY=1
+export LOCALVOXTRAL_BUILD_GATE_SOURCE_ONLY
+# shellcheck source=../mac/localvoxtral-build-gate.sh
+source "$GATE"
+
+if run_payload_with_cleanup 'exit 7'; then
+  fail "non-zero payload unexpectedly succeeded"
+else
+  status=$?
+fi
+[[ "$status" == "7" ]] || fail "payload exit status changed from 7 to $status"
+
+pid_fifo="$TMP_DIR/pids"
+mkfifo "$pid_fifo"
+printf -v payload '%q %q' "$FIXTURE" "$pid_fifo"
+
+# No wall-clock wait: reading the FIFO is the readiness handshake, and
+# waiting for the wrapper means its EXIT cleanup has completed.
+(
+  LOCALVOXTRAL_GATE_TERM_POLLS=0 run_payload_with_cleanup "$payload"
+) &
+wrapper_pid=$!
+read -r fixture_pid stubborn_pid <"$pid_fifo"
+
+kill -TERM "$wrapper_pid"
+if wait "$wrapper_pid"; then
+  fail "signal-interrupted payload unexpectedly succeeded"
+else
+  status=$?
+fi
+[[ "$status" == "143" ]] || fail "TERM exit status changed from 143 to $status"
+wrapper_pid=""
+
+is_live_non_zombie() {
+  local pid="$1" state
+  state="$(ps -o state= -p "$pid" 2>/dev/null | tr -d '[:space:]' || true)"
+  [[ -n "$state" && "$state" != Z* ]]
+}
+
+is_live_non_zombie "$fixture_pid" \
+  && fail "payload process $fixture_pid survived gate teardown"
+is_live_non_zombie "$stubborn_pid" \
+  && fail "payload descendant $stubborn_pid survived gate teardown"
+fixture_pid=""
+stubborn_pid=""
+
+pid_fifo="$TMP_DIR/normal-exit-pids"
+mkfifo "$pid_fifo"
+printf -v payload '%q %q %q' "$FIXTURE" "$pid_fifo" exit-leader
+(
+  LOCALVOXTRAL_GATE_TERM_POLLS=0 run_payload_with_cleanup "$payload"
+) &
+wrapper_pid=$!
+read -r fixture_pid stubborn_pid <"$pid_fifo"
+if ! wait "$wrapper_pid"; then
+  fail "leader-exit payload should preserve its zero exit status"
+fi
+wrapper_pid=""
+is_live_non_zombie "$stubborn_pid" \
+  && fail "descendant $stubborn_pid survived after its leader exited"
+fixture_pid=""
+stubborn_pid=""
+
+printf 'PASS: gate preserves status and drains signalled or leader-exited groups\n'

--- a/scripts/ci/test-build-gate-reap-command.sh
+++ b/scripts/ci/test-build-gate-reap-command.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# Security regression tests for the forced-command gate's scoped reap verb.
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "$0")/../.." && pwd -P)"
+GATE="$ROOT_DIR/scripts/mac/localvoxtral-build-gate.sh"
+TMP_DIR="$(mktemp -d "${TMPDIR:-/tmp}/lv-gate-reap-test.XXXXXX")"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+fail() {
+  printf 'FAIL: %s\n' "$*" >&2
+  exit 1
+}
+
+mkdir -p "$TMP_DIR/home/bin"
+reaper_log="$TMP_DIR/reaper.log"
+cat >"$TMP_DIR/home/bin/localvoxtral-cleanup-stale-test-processes.sh" <<'STUB'
+#!/usr/bin/env bash
+printf '%s\n' "$1" >"$LV_REAPER_LOG"
+STUB
+chmod +x "$TMP_DIR/home/bin/localvoxtral-cleanup-stale-test-processes.sh"
+
+HOME="$TMP_DIR/home" LV_REAPER_LOG="$reaper_log" \
+  SSH_ORIGINAL_COMMAND='reap work/localvoxtral-safe-123' bash "$GATE"
+expected="$TMP_DIR/home/work/localvoxtral-safe-123"
+actual="$(cat "$reaper_log")"
+[[ "$actual" == "$expected" ]] \
+  || fail "valid reap root was '$actual', expected '$expected'"
+
+assert_denied() {
+  local command="$1" status=0
+  if HOME="$TMP_DIR/home" LV_REAPER_LOG="$reaper_log" \
+    SSH_ORIGINAL_COMMAND="$command" bash "$GATE" >/dev/null 2>&1; then
+    fail "unsafe command was accepted: $command"
+  else
+    status=$?
+  fi
+  [[ "$status" == "126" ]] \
+    || fail "unsafe command '$command' exited $status instead of 126"
+}
+
+assert_denied 'reap'
+assert_denied 'reap ../../etc'
+assert_denied 'reap work/localvoxtral-safe-123 extra'
+assert_denied 'reap work/not-localvoxtral'
+assert_denied 'reap work/localvoxtral-safe-123;id'
+
+printf 'PASS: gate accepts one validated workdir and denies unsafe reap commands\n'

--- a/scripts/ci/test-cleanup-stale-test-processes.sh
+++ b/scripts/ci/test-cleanup-stale-test-processes.sh
@@ -63,10 +63,18 @@ if "$SCRIPT" >/dev/null 2>&1; then
 fi
 
 # Exercise the production ps+lsof+TERM path with a controlled executable whose
-# process name is exactly xctest. `sleep` only keeps the fixture alive; the test
-# synchronizes through the returned PID and never waits on elapsed time.
-cp "$(command -v sleep)" "$TMP_DIR/xctest"
-chmod +x "$TMP_DIR/xctest"
+# process name is exactly xctest. Do not copy a signed macOS system binary under
+# a new name: AMFI kills that with SIGKILL before the test can inspect it.
+# The fixture blocks in pause(); the test synchronizes through its PID and never
+# waits on elapsed time.
+cat >"$TMP_DIR/xctest.c" <<'C'
+#include <signal.h>
+#include <unistd.h>
+int main(void) {
+  for (;;) pause();
+}
+C
+cc "$TMP_DIR/xctest.c" -o "$TMP_DIR/xctest"
 (
   cd "$workspace"
   exec "$TMP_DIR/xctest" 300

--- a/scripts/ci/test-cleanup-stale-test-processes.sh
+++ b/scripts/ci/test-cleanup-stale-test-processes.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+# Deterministic scope regression tests for cleanup-stale-test-processes.sh.
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "$0")/../.." && pwd -P)"
+SCRIPT="$ROOT_DIR/scripts/ci/cleanup-stale-test-processes.sh"
+TMP_DIR="$(mktemp -d "${TMPDIR:-/tmp}/lv-stale-selector.XXXXXX")"
+TMP_DIR="$(cd "$TMP_DIR" && pwd -P)"
+fixture_pid=""
+sibling_pid=""
+
+cleanup() {
+  if [[ -n "$fixture_pid" ]]; then
+    kill -KILL "$fixture_pid" 2>/dev/null || true
+    wait "$fixture_pid" 2>/dev/null || true
+  fi
+  if [[ -n "$sibling_pid" ]]; then
+    kill -KILL "$sibling_pid" 2>/dev/null || true
+    wait "$sibling_pid" 2>/dev/null || true
+  fi
+  rm -rf "$TMP_DIR"
+}
+trap cleanup EXIT
+
+fail() {
+  printf 'FAIL: %s\n' "$*" >&2
+  exit 1
+}
+
+workspace="$TMP_DIR/actions/localvoxtral"
+mkdir -p "$workspace/subdir" "$TMP_DIR/actions/localvoxtral-other"
+
+fixture="$TMP_DIR/processes.tsv"
+printf '%s\t%s\t%s\t%s\t%s\t%s\n' \
+  101 501 S xctest start-101 "$workspace/.build/tests.xctest" \
+  102 501 S /usr/bin/swift-package start-102 "$workspace/subdir" \
+  103 502 S xctest start-103 "$workspace" \
+  104 501 S xctest start-104 "$TMP_DIR/actions/localvoxtral-other" \
+  105 501 S bash start-105 "$workspace" \
+  106 501 Z xctest start-106 "$workspace" \
+  998 501 S xctest start-998 "$workspace" \
+  999 501 S xctest start-999 "$workspace" \
+  not-a-pid 501 S xctest start-bad "$workspace" \
+  107 501 S swiftpm-testing-helper start-107 "$TMP_DIR/actions" \
+  >"$fixture"
+
+actual="$TMP_DIR/actual.tsv"
+"$SCRIPT" --select "$workspace" 501 "998 999" <"$fixture" >"$actual"
+
+expected="$TMP_DIR/expected.tsv"
+printf '101\txctest\tstart-101\n102\tswift-package\tstart-102\n' >"$expected"
+
+cmp -s "$expected" "$actual" || fail "selector crossed a user/path/state/name boundary:
+expected:
+$(cat "$expected")
+actual:
+$(cat "$actual")"
+
+printf 'PASS: cleanup selection is user, state, name, ancestor, and workspace scoped\n'
+
+if "$SCRIPT" >/dev/null 2>&1; then
+  fail "cleanup without an explicit workspace root unexpectedly succeeded"
+fi
+
+# Exercise the production ps+lsof+TERM path with a controlled executable whose
+# process name is exactly xctest. `sleep` only keeps the fixture alive; the test
+# synchronizes through the returned PID and never waits on elapsed time.
+cp "$(command -v sleep)" "$TMP_DIR/xctest"
+chmod +x "$TMP_DIR/xctest"
+(
+  cd "$workspace"
+  exec "$TMP_DIR/xctest" 300
+) &
+fixture_pid=$!
+(
+  cd "$TMP_DIR/actions/localvoxtral-other"
+  exec "$TMP_DIR/xctest" 300
+) &
+sibling_pid=$!
+fixture_name="$(ps -o ucomm= -p "$fixture_pid" | tr -d '[:space:]')"
+[[ "${fixture_name##*/}" == "xctest" ]] \
+  || fail "fixture process name is '$fixture_name', expected xctest"
+
+LOCALVOXTRAL_STALE_TEST_TERM_POLLS=0 "$SCRIPT" "$workspace"
+state="$(ps -o state= -p "$fixture_pid" 2>/dev/null | tr -d '[:space:]' || true)"
+[[ -z "$state" || "$state" == Z* ]] \
+  || fail "production cleanup left fixture pid $fixture_pid alive in state $state"
+sibling_state="$(ps -o state= -p "$sibling_pid" 2>/dev/null | tr -d '[:space:]' || true)"
+[[ -n "$sibling_state" && "$sibling_state" != Z* ]] \
+  || fail "production cleanup crossed into the sibling workspace"
+wait "$fixture_pid" 2>/dev/null || true
+fixture_pid=""
+kill -TERM "$sibling_pid" 2>/dev/null || true
+wait "$sibling_pid" 2>/dev/null || true
+sibling_pid=""
+
+printf 'PASS: production cleanup terminates its xctest and preserves a sibling workspace\n'

--- a/scripts/ci/test-remote-build-reap.sh
+++ b/scripts/ci/test-remote-build-reap.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+# Regression test: a failed/interrupted SSH payload requests one scoped reap,
+# while a successful payload does not. All transport commands are stubbed.
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "$0")/../.." && pwd -P)"
+REMOTE_BUILD="$ROOT_DIR/scripts/remote-build.sh"
+TMP_DIR="$(mktemp -d "${TMPDIR:-/tmp}/lv-remote-reap-test.XXXXXX")"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+fail() {
+  printf 'FAIL: %s\n' "$*" >&2
+  exit 1
+}
+
+mkdir -p "$TMP_DIR/bin"
+cat >"$TMP_DIR/bin/ssh" <<'STUB'
+#!/usr/bin/env bash
+while [[ $# -gt 1 ]]; do shift; done
+command="$1"
+case "$command" in
+  mkdir\ -p\ *) exit 0 ;;
+  reap\ *)
+    printf '%s\n' "$command" >>"$LV_TEST_REAP_LOG"
+    exit 0
+    ;;
+  cd\ *)
+    [[ "$LV_TEST_PAYLOAD_RESULT" == "success" ]] && exit 0
+    exit 42
+    ;;
+  *) exit 0 ;;
+esac
+STUB
+cat >"$TMP_DIR/bin/rsync" <<'STUB'
+#!/usr/bin/env bash
+exit 0
+STUB
+chmod +x "$TMP_DIR/bin/ssh" "$TMP_DIR/bin/rsync"
+
+reap_log="$TMP_DIR/reap.log"
+common_env=(
+  "PATH=$TMP_DIR/bin:$PATH"
+  "LV_BUILD_HOST=fake-host"
+  "LV_BUILD_DIR=work/localvoxtral-reap-regression"
+  "LV_TEST_REAP_LOG=$reap_log"
+  "LOCALVOXTRAL_REMOTE_LOG=$TMP_DIR/remote-build.log"
+)
+
+status=0
+if env "${common_env[@]}" LV_TEST_PAYLOAD_RESULT=failure \
+  "$REMOTE_BUILD" test --filter NoSuchTest >/dev/null 2>&1; then
+  fail "failed payload unexpectedly succeeded"
+else
+  status=$?
+fi
+[[ "$status" == "42" ]] || fail "payload exit status changed from 42 to $status"
+[[ "$(cat "$reap_log")" == 'reap work/localvoxtral-reap-regression' ]] \
+  || fail "failed payload did not request exactly its own workdir reap"
+
+: >"$reap_log"
+env "${common_env[@]}" LV_TEST_PAYLOAD_RESULT=success \
+  "$REMOTE_BUILD" test --filter NoSuchTest >/dev/null
+[[ ! -s "$reap_log" ]] || fail "successful payload unexpectedly requested a reap"
+
+printf 'PASS: remote-build reaps one failed payload and leaves successful runs alone\n'

--- a/scripts/ci/test-run-supervised-command.sh
+++ b/scripts/ci/test-run-supervised-command.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "$0")/../.." && pwd -P)"
+SUPERVISOR="$ROOT_DIR/scripts/ci/run-supervised-command.sh"
+FIXTURE="$ROOT_DIR/scripts/ci/fixtures/build-gate-stubborn-tree.sh"
+TMP_DIR="$(mktemp -d "${TMPDIR:-/tmp}/lv-supervisor-test.XXXXXX")"
+supervisor_pid=""
+fixture_pid=""
+stubborn_pid=""
+sibling_pid=""
+
+cleanup() {
+  [[ -z "$supervisor_pid" ]] || kill -TERM "$supervisor_pid" 2>/dev/null || true
+  [[ -z "$supervisor_pid" ]] || wait "$supervisor_pid" 2>/dev/null || true
+  [[ -z "$fixture_pid" ]] || kill -KILL "$fixture_pid" 2>/dev/null || true
+  [[ -z "$stubborn_pid" ]] || kill -KILL "$stubborn_pid" 2>/dev/null || true
+  [[ -z "$sibling_pid" ]] || kill -KILL "$sibling_pid" 2>/dev/null || true
+  rm -rf "$TMP_DIR"
+}
+trap cleanup EXIT
+
+fail() {
+  printf 'FAIL: %s\n' "$*" >&2
+  exit 1
+}
+
+is_live_non_zombie() {
+  local pid="$1" state
+  state="$(ps -o state= -p "$pid" 2>/dev/null | tr -d '[:space:]' || true)"
+  [[ -n "$state" && "$state" != Z* ]]
+}
+
+success_log="$TMP_DIR/success.log"
+"$SUPERVISOR" 30 "$success_log" -- /bin/bash -c 'echo supervised-output'
+[[ "$(cat "$success_log")" == "supervised-output" ]] || fail "success output was not captured"
+
+failure_log="$TMP_DIR/failure.log"
+if "$SUPERVISOR" 30 "$failure_log" -- /bin/bash -c 'echo failed-output; exit 7'; then
+  fail "non-zero command unexpectedly succeeded"
+else
+  status=$?
+fi
+[[ "$status" == "7" ]] || fail "exit status changed from 7 to $status"
+grep -q '^failed-output$' "$failure_log" || fail "failure output was not captured"
+
+# A FIFO triggers the timeout path deterministically; no wall-clock polling.
+pid_fifo="$TMP_DIR/timeout-pids"
+timeout_fifo="$TMP_DIR/timeout-trigger"
+mkfifo "$pid_fifo" "$timeout_fifo"
+LOCALVOXTRAL_SUPERVISOR_TIMEOUT_FIFO="$timeout_fifo" \
+LOCALVOXTRAL_SUPERVISOR_TERM_POLLS=0 \
+  "$SUPERVISOR" 999 "$TMP_DIR/timeout.log" -- "$FIXTURE" "$pid_fifo" &
+supervisor_pid=$!
+read -r fixture_pid stubborn_pid <"$pid_fifo"
+/bin/bash -c 'exec sleep 300' &
+sibling_pid=$!
+printf 'fire\n' >"$timeout_fifo"
+if wait "$supervisor_pid"; then
+  fail "timed-out command unexpectedly succeeded"
+else
+  status=$?
+fi
+supervisor_pid=""
+[[ "$status" == "124" ]] || fail "timeout status changed from 124 to $status"
+is_live_non_zombie "$fixture_pid" && fail "timed-out leader survived"
+is_live_non_zombie "$stubborn_pid" && fail "timed-out descendant survived"
+is_live_non_zombie "$sibling_pid" || fail "unrelated sibling was terminated"
+fixture_pid=""
+stubborn_pid=""
+
+# If the leader exits normally, the wrapper must still drain its descendant.
+pid_fifo="$TMP_DIR/leader-exit-pids"
+mkfifo "$pid_fifo"
+LOCALVOXTRAL_SUPERVISOR_TERM_POLLS=0 \
+  "$SUPERVISOR" 30 "$TMP_DIR/leader-exit.log" -- "$FIXTURE" "$pid_fifo" exit-leader &
+supervisor_pid=$!
+read -r fixture_pid stubborn_pid <"$pid_fifo"
+wait "$supervisor_pid" || fail "leader-exit command should preserve status zero"
+supervisor_pid=""
+is_live_non_zombie "$stubborn_pid" && fail "descendant survived its leader"
+fixture_pid=""
+stubborn_pid=""
+
+# Signal cancellation preserves the conventional status and drains the tree.
+pid_fifo="$TMP_DIR/signal-pids"
+mkfifo "$pid_fifo"
+LOCALVOXTRAL_SUPERVISOR_TERM_POLLS=0 \
+  "$SUPERVISOR" 300 "$TMP_DIR/signal.log" -- "$FIXTURE" "$pid_fifo" &
+supervisor_pid=$!
+read -r fixture_pid stubborn_pid <"$pid_fifo"
+kill -TERM "$supervisor_pid"
+if wait "$supervisor_pid"; then
+  fail "signal-cancelled supervisor unexpectedly succeeded"
+else
+  status=$?
+fi
+supervisor_pid=""
+[[ "$status" == "143" ]] || fail "TERM status changed from 143 to $status"
+is_live_non_zombie "$fixture_pid" && fail "signal-cancelled leader survived"
+is_live_non_zombie "$stubborn_pid" && fail "signal-cancelled descendant survived"
+fixture_pid=""
+stubborn_pid=""
+
+printf 'PASS: supervisor captures output, preserves status, and drains exact groups\n'

--- a/scripts/mac/README.md
+++ b/scripts/mac/README.md
@@ -225,7 +225,7 @@ When capture happens in a Mac checkout, `scripts/run-agent-eval-local.sh`
 runs the same env-gated suite directly and avoids copying the voice set through
 another source checkout.
 
-## `localvoxtral-build-gate.sh` — SSH build gate (v2)
+## `localvoxtral-build-gate.sh` — SSH build gate (v3)
 
 Forced command for the Linux dev box's build key on the Mac build host. It
 allowlists the `remote-build.sh` loop (rsync in, `swift build|test`,
@@ -233,8 +233,17 @@ allowlists the `remote-build.sh` loop (rsync in, `swift build|test`,
 `applog [minutes]`, `voxlog [lines]`, `svc-status`, and the on-demand
 test-server verb `ensure <voxmlx|mlxlm|all>` (touches a trigger file in the
 world-writable run dir and polls the port until warm — see the on-demand
-section above). Everything else is denied and logged to
-`~/Library/Logs/localvoxtral-build-gate.log`.
+section above). The `reap work/localvoxtral-<id>` recovery verb accepts one
+validated work directory and terminates only stale test processes proven by
+UID plus cwd/mapped-text evidence to belong to it. Everything else is denied
+and logged to `~/Library/Logs/localvoxtral-build-gate.log`.
+
+Allowed build payloads run in a dedicated process group. Whenever the payload
+leader exits — including a SIGPIPE after its SSH output channel closes — the
+gate sends TERM to any remaining group members, waits a bounded grace period,
+then sends KILL. `remote-build.sh` also requests an explicit scoped reap when
+the SSH payload fails. Both boundaries are one invocation/workdir: neither
+uses a global `pkill`, so parallel worktrees and unrelated tests survive.
 
 ### Installing / upgrading the gate
 
@@ -249,10 +258,16 @@ sudo install -d -m 0755 -o "$GATE_ACCOUNT" "/Users/$GATE_ACCOUNT/bin"
 sudo install -m 0755 -o "$GATE_ACCOUNT" \
   scripts/mac/localvoxtral-build-gate.sh \
   "/Users/$GATE_ACCOUNT/bin/localvoxtral-build-gate.sh"
+sudo install -m 0755 -o "$GATE_ACCOUNT" \
+  scripts/ci/cleanup-stale-test-processes.sh \
+  "/Users/$GATE_ACCOUNT/bin/localvoxtral-cleanup-stale-test-processes.sh"
 ```
 
 No `authorized_keys` change is needed — the entry already points at
 `$HOME/bin/localvoxtral-build-gate.sh`; this replaces the script in place.
+Upgrading the installed gate is required to gain interrupted-build teardown;
+merging the repository copy alone does not change the forced command already
+installed under the dedicated account.
 
 ### Machine-local config (`~/.localvoxtral-gate.conf` in the gate account)
 
@@ -293,6 +308,7 @@ fiddlier and breaks when the log file is rotated/recreated.)
 ./scripts/remote-build.sh voxlog 100  # voxmlx log tail
 ./scripts/remote-build.sh svc-status  # voxmlx service/process/port status
 ssh <gate-destination> 'ensure voxmlx' # warm the on-demand STT server
+ssh <gate-destination> 'reap work/localvoxtral-<id>' # scoped stale-test cleanup
 ssh <gate-destination> 'echo pwned'   # must print "denied command"
 ```
 

--- a/scripts/mac/localvoxtral-build-gate.sh
+++ b/scripts/mac/localvoxtral-build-gate.sh
@@ -1,11 +1,12 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# localvoxtral build gate v2.
+# localvoxtral build gate v3.
 #
 # This script is intended to be installed as the forced command for the Mac
 # build-host SSH key. It keeps the existing build/test/package allowlist and
-# adds read-only diagnostics without granting an interactive shell.
+# adds read-only diagnostics and scoped interrupted-test recovery without
+# granting an interactive shell.
 #
 # Gate v2 install notes: see scripts/mac/README.md. Install from a trusted
 # owner session, not through this gate. New diagnostic verbs allowed through
@@ -15,6 +16,7 @@ set -euo pipefail
 #   voxlog [lines]      # integer, clamped to 1..500, default 80
 #   svc-status
 #   ensure <voxmlx|mlxlm|all>   # warm an on-demand test server (touch + poll)
+#   reap work/localvoxtral-<id>  # terminate stale tests in one exact work dir
 
 LOG_FILE="$HOME/Library/Logs/localvoxtral-build-gate.log"
 VOXLOG_FILE="$HOME/Library/Logs/voxmlx.log"
@@ -32,6 +34,7 @@ VOXMLX_GUI_UID="$(id -u)"
 LV_RUN_DIR="/Users/Shared/localvoxtral/run"
 LV_ENSURE_READY_TIMEOUT=180
 LV_ENSURE_PROBE_TIMEOUT=2
+REAPER="$HOME/bin/localvoxtral-cleanup-stale-test-processes.sh"
 
 # Machine-local overrides (never committed): the gate account is separate
 # from the GUI owner account, so voxmlx's log path and GUI uid differ per
@@ -349,6 +352,88 @@ run_ensure_command() {
   esac
 }
 
+run_reap_command() {
+  local dir="$1"
+  validate_work_dir "$dir" || deny
+  if [[ ! -x "$REAPER" ]]; then
+    printf 'reap: installed helper missing: %s\n' "$REAPER" >&2
+    return 1
+  fi
+  "$REAPER" "$HOME/${dir%/}"
+}
+
+# The forced-command SSH session used to `exec bash -c` directly. When the
+# client disappeared (Ctrl-C, agent output ceiling, network loss), SwiftPM's
+# xctest descendants could outlive ssh for hours on the persistent Mac. Run
+# every allowed payload in its own process group so the gate can terminate
+# exactly that invocation without touching the owner's tests or another
+# agent's worktree.
+LV_GATE_PAYLOAD_PID=""
+LV_GATE_PAYLOAD_PGID=""
+
+payload_group_is_alive() {
+  [[ -n "$LV_GATE_PAYLOAD_PGID" ]] \
+    && kill -0 -- "-$LV_GATE_PAYLOAD_PGID" 2>/dev/null
+}
+
+terminate_payload_group() {
+  local polls="${LOCALVOXTRAL_GATE_TERM_POLLS:-50}"
+  local poll_seconds="${LOCALVOXTRAL_GATE_TERM_POLL_SECONDS:-0.1}"
+  local poll=0
+
+  if payload_group_is_alive; then
+    kill -TERM -- "-$LV_GATE_PAYLOAD_PGID" 2>/dev/null || true
+    while (( poll < polls )) && payload_group_is_alive; do
+      sleep "$poll_seconds"
+      poll=$((poll + 1))
+    done
+    if payload_group_is_alive; then
+      kill -KILL -- "-$LV_GATE_PAYLOAD_PGID" 2>/dev/null || true
+    fi
+  fi
+  if [[ -n "$LV_GATE_PAYLOAD_PID" ]]; then
+    wait "$LV_GATE_PAYLOAD_PID" 2>/dev/null || true
+  fi
+  LV_GATE_PAYLOAD_PID=""
+  LV_GATE_PAYLOAD_PGID=""
+}
+
+run_payload_with_cleanup() {
+  local payload="$1" status=0 monitor_was_enabled=0
+
+  [[ "${LOCALVOXTRAL_GATE_TERM_POLLS:-50}" =~ ^[0-9]+$ ]] || deny
+  case "$-" in
+    *m*) monitor_was_enabled=1 ;;
+  esac
+
+  # Monitor mode gives each background job a distinct process group even in
+  # this non-interactive Bash 3.2 shell. The PGID is the first child's PID.
+  set -m
+  /bin/bash -c "$payload" &
+  LV_GATE_PAYLOAD_PID=$!
+  LV_GATE_PAYLOAD_PGID=$LV_GATE_PAYLOAD_PID
+  (( monitor_was_enabled == 1 )) || set +m
+
+  # Signal handlers exit with conventional shell statuses; EXIT owns the one
+  # cleanup path. PIPE matters because stdout is `ssh | tee` on the client.
+  trap 'status=$?; trap - EXIT HUP INT TERM PIPE; terminate_payload_group; exit "$status"' EXIT
+  trap 'exit 129' HUP
+  trap 'exit 130' INT
+  trap 'exit 143' TERM
+  trap 'exit 141' PIPE
+
+  if wait "$LV_GATE_PAYLOAD_PID"; then
+    status=0
+  else
+    status=$?
+  fi
+  # The leader can exit on SIGPIPE while an xctest grandchild remains in the
+  # group. Always drain the group, even when the leader reported success.
+  terminate_payload_group
+  trap - EXIT HUP INT TERM PIPE
+  return "$status"
+}
+
 # Fail-closed metacharacter blocklist. Note the glob subtlety: a `]` inside
 # the bracket expression terminates the set early, so part of this pattern
 # matches as literal text — empirically ALL listed characters still block
@@ -407,7 +492,7 @@ run_cd_command() {
   allow_build_payload "$payload" || deny
 
   cd "$HOME/${dir%/}"
-  exec /bin/bash -c "$payload"
+  run_payload_with_cleanup "$payload"
 }
 
 run_bash_lc_command() {
@@ -462,6 +547,16 @@ run_rsync_command() {
   exec rsync "${argv[@]:1}"
 }
 
+# Shell regression tests source the reviewed implementation directly. This
+# variable cannot cross the forced-command SSH boundary, where the environment
+# is fixed by sshd; it only suppresses dispatch in a local test process.
+if [[ "${LOCALVOXTRAL_BUILD_GATE_SOURCE_ONLY:-0}" == "1" ]]; then
+  if [[ "${BASH_SOURCE[0]}" != "$0" ]]; then
+    return 0
+  fi
+  exit 0
+fi
+
 case "$original_command" in
   diag)
     run_diag
@@ -489,6 +584,11 @@ case "$original_command" in
     arg="${original_command#ensure }"
     [[ "$arg" != *" "* && -n "$arg" ]] || deny
     run_ensure_command "$arg"
+    ;;
+  reap\ work/localvoxtral-*)
+    arg="${original_command#reap }"
+    [[ "$arg" != *" "* && -n "$arg" ]] || deny
+    run_reap_command "$arg"
     ;;
   mkdir\ -p\ work/localvoxtral-*)
     run_mkdir_command "$original_command"

--- a/scripts/remote-build.sh
+++ b/scripts/remote-build.sh
@@ -60,7 +60,9 @@ TREE_SLUG="${TREE_SLUG%-}"
 TREE_HASH="$(printf '%s' "$ROOT_DIR" | md5sum | cut -c1-8)"
 DIR="${LV_BUILD_DIR:-work/localvoxtral-${TREE_SLUG}-${TREE_HASH}}"
 
-REMOTE_LOG="$ROOT_DIR/.build/last-remote.log"
+REMOTE_LOG="${LOCALVOXTRAL_REMOTE_LOG:-$ROOT_DIR/.build/last-remote.log}"
+REMOTE_PAYLOAD_ACTIVE=0
+REMOTE_REAP_ATTEMPTED=0
 
 run_remote() {
   local remote_command="$1"
@@ -71,6 +73,47 @@ run_remote() {
   echo "==> Full output: $REMOTE_LOG"
   return "$status"
 }
+
+reap_remote_workdir() {
+  [[ "$REMOTE_REAP_ATTEMPTED" == "0" ]] || return 0
+  REMOTE_REAP_ATTEMPTED=1
+  echo "==> Reaping interrupted test processes in $HOST:$DIR"
+  if ! ssh -o BatchMode=yes -o ConnectTimeout=10 \
+    "$HOST" "reap $(printf '%q' "$DIR")"; then
+    echo "==> WARN: remote process cleanup unavailable; install the current" \
+      "build gate + reaper from scripts/mac/README.md." >&2
+  fi
+}
+
+handle_remote_signal() {
+  local status="$1"
+  # A second Ctrl-C while the best-effort reap SSH is running must not skip
+  # existing EXIT traps that remove transient eval markers.
+  trap '' HUP INT TERM
+  if [[ "$REMOTE_PAYLOAD_ACTIVE" == "1" ]]; then
+    reap_remote_workdir
+  fi
+  exit "$status"
+}
+
+run_remote_payload() {
+  local remote_command="$1" status=0
+  REMOTE_PAYLOAD_ACTIVE=1
+  if run_remote "$remote_command"; then
+    status=0
+  else
+    status=$?
+  fi
+  REMOTE_PAYLOAD_ACTIVE=0
+  if (( status != 0 )); then
+    reap_remote_workdir
+  fi
+  return "$status"
+}
+
+trap 'handle_remote_signal 129' HUP
+trap 'handle_remote_signal 130' INT
+trap 'handle_remote_signal 143' TERM
 
 # Bring an on-demand test server up (and warm) before a suite that needs it.
 # The build host's voxmlx (8000) and mlxlm (8080) launchd services are
@@ -342,4 +385,4 @@ rsync -az --delete \
 # cleanup rsync now has something to delete.
 TREE_SYNCED=1
 
-run_remote "cd $(printf '%q' "$DIR") && $(printf '%q ' "${REMOTE_CMD[@]}")"
+run_remote_payload "cd $(printf '%q' "$DIR") && $(printf '%q ' "${REMOTE_CMD[@]}")"


### PR DESCRIPTION
## What

Contains persistent-runner XCTest orphans and prevents a verbose or genuinely stuck suite from occupying the personal Mac indefinitely, without any global process kill.

- Before self-hosted CI starts tests, reaps only current-UID, non-zombie test processes whose `cwd` or mapped executable is inside the exact Actions workspace. It excludes the cleanup process and ancestors, preserves sibling workspaces, and revalidates process identity before TERM/KILL.
- Runs allowed remote-build payloads in their own process groups, drains descendants when the leader exits, and adds a validated gate-v3 `reap work/localvoxtral-<id>` recovery verb.
- Runs the CI unit suite under a Bash-3.2-compatible supervisor with stdin closed, complete output written directly to an artifact, a 300s self-hosted / 900s hosted bound, and exact TERM→KILL process-group cleanup. Only the final summary/tail reaches the live Actions stream.
- Adds deterministic shell regressions for selector boundaries, real same-workspace `xctest`, sibling preservation, normal/nonzero status, timeout, signal cancellation, stubborn descendants, leader-first exit, gate validation, and remote-build success/failure behavior.

## Root cause

PR #150 repeatedly appeared to stall after different trivial tests, while each blamed test passed independently. Old runs also left XCTest survivors in the persistent checkout. Follow-up reproductions showed a second amplifier: the feature suite emits hundreds of KB of XCTest progress, and foreground streaming could stop mid-line while the same suite completed when run file-backed in a background process. The moving test name was therefore not evidence of a deterministic test deadlock.

This PR addresses both failure modes: scoped orphan cleanup before a run, and a bounded file-backed supervisor during the run. A genuinely stuck suite now fails in at most five minutes on the self-hosted runner and its entire process group is drained.

## Proof

Deterministic regressions:

```text
PASS: cleanup selection is user, state, name, ancestor, and workspace scoped
PASS: production cleanup terminates its xctest and preserves a sibling workspace
PASS: gate preserves status and drains signalled or leader-exited groups
PASS: gate accepts one validated workdir and denies unsafe reap commands
PASS: remote-build reaps one failed payload and leaves successful runs alone
PASS: supervisor captures output, preserves status, and drains exact groups
```

The supervisor regression proves success and exit-7 preservation, FIFO-triggered timeout status 124 without a wall-clock wait, stubborn leader/child cleanup, TERM status 143, leader-first descendant cleanup, and survival of an unrelated sibling process.

Commands:

```bash
./scripts/ci/test-cleanup-stale-test-processes.sh
./scripts/ci/test-build-gate-process-cleanup.sh
./scripts/ci/test-build-gate-reap-command.sh
./scripts/ci/test-remote-build-reap.sh
./scripts/ci/test-run-supervised-command.sh
bash -n scripts/remote-build.sh scripts/mac/localvoxtral-build-gate.sh scripts/ci/*.sh scripts/ci/fixtures/*.sh
git diff --check
```

- [x] Final self-hosted CI — run `29581331529`: all cleanup/supervisor regressions passed; the supervised full unit suite and log upload passed; coverage, live voxmlx integration, PolishHelper and SpeechHelper unit suites, packaging, signing, artifact upload, and copied-bundle launch smoke all passed.
- [x] Feature-stack proof — stacked PR #150 run `29581373237` completed `1757 tests, 10 skipped, 0 failures` in 102.8s under this supervisor, then passed every remaining integration/package/smoke lane. This is the previously failing large-suite shape.
- [x] Scope proof — the CI reaper remains current-UID + exact-workspace scoped; old SSH-builder processes under another UID are not selected.
- [x] LLM inference skipped on this infrastructure PR by the path gate: no prompt, request-shape, context, model, or eval behavior changes.

## Deployment note

CI cleanup and supervision take effect directly from this branch. Remote-build containment degrades safely through the client warning, but gate-v3 process-group supervision and the `reap` verb require installing the reviewed scripts using `scripts/mac/README.md` after merge.

PR #150 is based on this branch so the infrastructure fix stays reviewable separately from the large feature.
