### PR TITLE
Stream byte-level model-download progress (fixes the 'Checking model...' stall)

### DIFF
--- a/Sources/localvoxtral/Backends/HFModelDownloader.swift
+++ b/Sources/localvoxtral/Backends/HFModelDownloader.swift
@@ -76,6 +76,11 @@ enum ModelDownloadError: LocalizedError, Sendable {
 struct HFModelRepositoryInfo: Equatable, Sendable {
     let sha: String
     let fileNames: [String]
+    /// Exact byte sizes from the repo API (`?blobs=true`), keyed by file name.
+    /// The authoritative source for the download total: available before the
+    /// first byte moves, unlike HEAD probes (which the CDN may refuse) or
+    /// transfer-reported sizes (which arrive only as each file starts).
+    let sizesByFileName: [String: Int64]
 }
 
 protocol HFModelDownloadTransport: Sendable {
@@ -208,7 +213,10 @@ private final class ProgressReportingDownloadDelegate: NSObject, URLSessionDownl
 
 struct HFModelDownloader: ModelPreparing {
     private struct RepositoryResponse: Decodable {
-        struct Sibling: Decodable { let rfilename: String }
+        struct Sibling: Decodable {
+            let rfilename: String
+            let size: Int64?
+        }
         let sha: String
         let siblings: [Sibling]
     }
@@ -253,8 +261,14 @@ struct HFModelDownloader: ModelPreparing {
                 return !fileManager.fileExists(atPath: destination.path)
             }
 
+            // Prefer the repo API's exact sizes (one call, already made);
+            // HEAD-probe only files the API left sizeless.
             var sizes: [String: Int64] = [:]
             for fileName in missing {
+                if let size = info.sizesByFileName[fileName] {
+                    sizes[fileName] = size
+                    continue
+                }
                 try Task.checkCancellation()
                 if let size = try await transport.contentLength(
                     of: Self.fileURL(repoID: request.repoID, revision: info.sha, fileName: fileName)
@@ -389,7 +403,9 @@ struct HFModelDownloader: ModelPreparing {
     }
 
     static func repositoryInfoURL(repoID: String, revision: String?) -> URL {
-        URL(string: "https://huggingface.co/api/models/\(repoID)/revision/\(revision ?? "main")")!
+        // blobs=true adds exact per-file byte sizes to the sibling list, so
+        // the aggregate download total is known before any transfer starts.
+        URL(string: "https://huggingface.co/api/models/\(repoID)/revision/\(revision ?? "main")?blobs=true")!
     }
 
     static func fileURL(repoID: String, revision: String, fileName: String) -> URL {
@@ -413,9 +429,16 @@ struct HFModelDownloader: ModelPreparing {
                 actual: response.sha
             )
         }
+        var sizesByFileName: [String: Int64] = [:]
+        for sibling in response.siblings {
+            if let size = sibling.size {
+                sizesByFileName[sibling.rfilename] = size
+            }
+        }
         return HFModelRepositoryInfo(
             sha: response.sha,
-            fileNames: response.siblings.map(\.rfilename)
+            fileNames: response.siblings.map(\.rfilename),
+            sizesByFileName: sizesByFileName
         )
     }
 

--- a/Sources/localvoxtral/Backends/HFModelDownloader.swift
+++ b/Sources/localvoxtral/Backends/HFModelDownloader.swift
@@ -262,7 +262,20 @@ struct HFModelDownloader: ModelPreparing {
                     sizes[fileName] = size
                 }
             }
-            let total = sizes.count == missing.count ? sizes.values.reduce(0, +) : nil
+            // Dynamic total: the HEAD probe can come back without a length
+            // (HF `resolve/` redirects to a CDN), which would leave the UI
+            // bar-less for the whole fetch. Each file's expected size also
+            // arrives from the transfer itself the moment its download
+            // starts, so fold that in — the total (and the determinate
+            // progress bar) becomes available as soon as every missing file
+            // has a size from either source.
+            let missingCount = missing.count
+            let knownSizes = Mutex<[String: Int64]>(sizes)
+            let effectiveTotal: @Sendable () -> Int64? = {
+                knownSizes.withLock { known in
+                    known.count == missingCount ? known.values.reduce(0, +) : nil
+                }
+            }
             // Monotonic delivery gate, checked at delivery time on the main
             // actor: throttled in-flight reports hop over as unstructured
             // tasks, so without the gate a stale lower value could land after
@@ -276,7 +289,10 @@ struct HFModelDownloader: ModelPreparing {
                 }
                 if shouldDeliver { progress(snapshot) }
             }
-            await Self.report(ModelDownloadProgress(downloadedBytes: 0, totalBytes: total), deliver)
+            await Self.report(
+                ModelDownloadProgress(downloadedBytes: 0, totalBytes: effectiveTotal()),
+                deliver
+            )
 
             var downloaded: Int64 = 0
             for fileName in missing {
@@ -289,7 +305,12 @@ struct HFModelDownloader: ModelPreparing {
                 let completedBase = downloaded
                 let granularity = progressByteGranularity
                 let lastReported = Mutex<Int64>(0)
-                let result = try await transport.download(from: source) { received, _ in
+                let result = try await transport.download(from: source) { received, expected in
+                    if let expected {
+                        knownSizes.withLock { known in
+                            if known[fileName] == nil { known[fileName] = expected }
+                        }
+                    }
                     let shouldReport = lastReported.withLock { last in
                         guard received - last >= granularity else { return false }
                         last = received
@@ -298,7 +319,7 @@ struct HFModelDownloader: ModelPreparing {
                     guard shouldReport else { return }
                     let snapshot = ModelDownloadProgress(
                         downloadedBytes: completedBase + received,
-                        totalBytes: total
+                        totalBytes: effectiveTotal()
                     )
                     Task { @MainActor in deliver(snapshot) }
                 }
@@ -317,9 +338,14 @@ struct HFModelDownloader: ModelPreparing {
                     try fileManager.removeItem(at: destination)
                 }
                 try fileManager.moveItem(at: result.temporaryURL, to: destination)
-                downloaded += sizes[fileName] ?? fileSize(at: destination)
+                // The on-disk size is authoritative once the file landed; it
+                // also completes the dynamic total for files whose transfer
+                // reported no expected length.
+                let actualSize = sizes[fileName] ?? fileSize(at: destination)
+                knownSizes.withLock { $0[fileName] = actualSize }
+                downloaded += actualSize
                 await Self.report(
-                    ModelDownloadProgress(downloadedBytes: downloaded, totalBytes: total),
+                    ModelDownloadProgress(downloadedBytes: downloaded, totalBytes: effectiveTotal()),
                     deliver
                 )
             }

--- a/Sources/localvoxtral/Backends/HFModelDownloader.swift
+++ b/Sources/localvoxtral/Backends/HFModelDownloader.swift
@@ -1,5 +1,6 @@
 import Darwin
 import Foundation
+import Synchronization
 
 struct ModelDownloadProgress: Equatable, Sendable {
     var downloadedBytes: Int64
@@ -80,7 +81,15 @@ struct HFModelRepositoryInfo: Equatable, Sendable {
 protocol HFModelDownloadTransport: Sendable {
     func repositoryInfo(from url: URL) async throws -> (data: Data, statusCode: Int)
     func contentLength(of url: URL) async throws -> Int64?
-    func download(from url: URL) async throws -> (temporaryURL: URL, statusCode: Int)
+    /// Download one file. `onBytes(received, expected)` reports cumulative
+    /// bytes received for THIS file as the transfer runs (expected is nil when
+    /// the server sends no length); required for live progress on multi-GB
+    /// checkpoints, where a completion-only API would leave the UI frozen on
+    /// "Checking model..." for the whole fetch (field-hit 2026-07-17).
+    func download(
+        from url: URL,
+        onBytes: @escaping @Sendable (Int64, Int64?) -> Void
+    ) async throws -> (temporaryURL: URL, statusCode: Int)
 }
 
 struct URLSessionHFModelDownloadTransport: HFModelDownloadTransport {
@@ -99,9 +108,101 @@ struct URLSessionHFModelDownloadTransport: HFModelDownloadTransport {
         return response.expectedContentLength > 0 ? response.expectedContentLength : nil
     }
 
-    func download(from url: URL) async throws -> (temporaryURL: URL, statusCode: Int) {
-        let (temporaryURL, response) = try await URLSession.shared.download(from: url)
-        return (temporaryURL, (response as? HTTPURLResponse)?.statusCode ?? 0)
+    func download(
+        from url: URL,
+        onBytes: @escaping @Sendable (Int64, Int64?) -> Void
+    ) async throws -> (temporaryURL: URL, statusCode: Int) {
+        let delegate = ProgressReportingDownloadDelegate(onBytes: onBytes)
+        let session = URLSession(configuration: .default, delegate: delegate, delegateQueue: nil)
+        defer { session.finishTasksAndInvalidate() }
+        return try await withTaskCancellationHandler {
+            try await withCheckedThrowingContinuation { continuation in
+                delegate.begin(session: session, url: url, continuation: continuation)
+            }
+        } onCancel: {
+            delegate.cancel()
+        }
+    }
+}
+
+/// Delegate for one download task: relays byte-level progress and hands the
+/// finished file back through a continuation. `didFinishDownloadingTo`'s file
+/// is deleted the moment that callback returns, so it is moved to a stable
+/// temporary path synchronously inside the callback.
+private final class ProgressReportingDownloadDelegate: NSObject, URLSessionDownloadDelegate, @unchecked Sendable {
+    private struct State {
+        var continuation: CheckedContinuation<(temporaryURL: URL, statusCode: Int), Error>?
+        var task: URLSessionDownloadTask?
+        var movedURL: URL?
+        var moveError: Error?
+    }
+
+    private let onBytes: @Sendable (Int64, Int64?) -> Void
+    private let state = Mutex(State())
+
+    init(onBytes: @escaping @Sendable (Int64, Int64?) -> Void) {
+        self.onBytes = onBytes
+    }
+
+    func begin(
+        session: URLSession,
+        url: URL,
+        continuation: CheckedContinuation<(temporaryURL: URL, statusCode: Int), Error>
+    ) {
+        let task = session.downloadTask(with: url)
+        state.withLock {
+            $0.continuation = continuation
+            $0.task = task
+        }
+        task.resume()
+    }
+
+    func cancel() {
+        state.withLock { $0.task }?.cancel()
+    }
+
+    func urlSession(
+        _ session: URLSession,
+        downloadTask: URLSessionDownloadTask,
+        didWriteData bytesWritten: Int64,
+        totalBytesWritten: Int64,
+        totalBytesExpectedToWrite: Int64
+    ) {
+        onBytes(totalBytesWritten, totalBytesExpectedToWrite > 0 ? totalBytesExpectedToWrite : nil)
+    }
+
+    func urlSession(
+        _ session: URLSession,
+        downloadTask: URLSessionDownloadTask,
+        didFinishDownloadingTo location: URL
+    ) {
+        let destination = FileManager.default.temporaryDirectory
+            .appendingPathComponent("localvoxtral-hf-download-\(UUID().uuidString)")
+        do {
+            try FileManager.default.moveItem(at: location, to: destination)
+            state.withLock { $0.movedURL = destination }
+        } catch {
+            state.withLock { $0.moveError = error }
+        }
+    }
+
+    func urlSession(_ session: URLSession, task: URLSessionTask, didCompleteWithError error: Error?) {
+        let (continuation, movedURL, moveError) = state.withLock {
+            let values = ($0.continuation, $0.movedURL, $0.moveError)
+            $0.continuation = nil
+            return values
+        }
+        guard let continuation else { return }
+        if let error {
+            continuation.resume(throwing: error)
+        } else if let moveError {
+            continuation.resume(throwing: moveError)
+        } else if let movedURL {
+            let statusCode = (task.response as? HTTPURLResponse)?.statusCode ?? 0
+            continuation.resume(returning: (movedURL, statusCode))
+        } else {
+            continuation.resume(throwing: URLError(.cannotWriteToFile))
+        }
     }
 }
 
@@ -115,15 +216,21 @@ struct HFModelDownloader: ModelPreparing {
     private let cacheRoot: URL
     private let transport: any HFModelDownloadTransport
     private let fileManager: FileManager
+    /// Minimum received-byte delta between in-flight progress reports for one
+    /// file. Bounds MainActor hops to a few hundred over a multi-GB fetch;
+    /// tests inject 1 to observe every callback.
+    private let progressByteGranularity: Int64
 
     init(
         cacheRoot: URL? = nil,
         transport: any HFModelDownloadTransport = URLSessionHFModelDownloadTransport(),
-        fileManager: FileManager = .default
+        fileManager: FileManager = .default,
+        progressByteGranularity: Int64 = 8_388_608
     ) {
         self.cacheRoot = cacheRoot ?? Self.defaultCacheRoot()
         self.transport = transport
         self.fileManager = fileManager
+        self.progressByteGranularity = progressByteGranularity
     }
 
     func prepare(
@@ -156,7 +263,20 @@ struct HFModelDownloader: ModelPreparing {
                 }
             }
             let total = sizes.count == missing.count ? sizes.values.reduce(0, +) : nil
-            await Self.report(ModelDownloadProgress(downloadedBytes: 0, totalBytes: total), progress)
+            // Monotonic delivery gate, checked at delivery time on the main
+            // actor: throttled in-flight reports hop over as unstructured
+            // tasks, so without the gate a stale lower value could land after
+            // a newer higher one and make the bar jump backwards.
+            let deliveredFloor = Mutex<Int64>(-1)
+            let deliver: @MainActor @Sendable (ModelDownloadProgress) -> Void = { snapshot in
+                let shouldDeliver = deliveredFloor.withLock { floor in
+                    guard snapshot.downloadedBytes > floor else { return false }
+                    floor = snapshot.downloadedBytes
+                    return true
+                }
+                if shouldDeliver { progress(snapshot) }
+            }
+            await Self.report(ModelDownloadProgress(downloadedBytes: 0, totalBytes: total), deliver)
 
             var downloaded: Int64 = 0
             for fileName in missing {
@@ -166,7 +286,22 @@ struct HFModelDownloader: ModelPreparing {
                     revision: info.sha,
                     fileName: fileName
                 )
-                let result = try await transport.download(from: source)
+                let completedBase = downloaded
+                let granularity = progressByteGranularity
+                let lastReported = Mutex<Int64>(0)
+                let result = try await transport.download(from: source) { received, _ in
+                    let shouldReport = lastReported.withLock { last in
+                        guard received - last >= granularity else { return false }
+                        last = received
+                        return true
+                    }
+                    guard shouldReport else { return }
+                    let snapshot = ModelDownloadProgress(
+                        downloadedBytes: completedBase + received,
+                        totalBytes: total
+                    )
+                    Task { @MainActor in deliver(snapshot) }
+                }
                 guard (200..<300).contains(result.statusCode) else {
                     throw ModelDownloadError.fileRequestFailed(
                         path: fileName,
@@ -185,7 +320,7 @@ struct HFModelDownloader: ModelPreparing {
                 downloaded += sizes[fileName] ?? fileSize(at: destination)
                 await Self.report(
                     ModelDownloadProgress(downloadedBytes: downloaded, totalBytes: total),
-                    progress
+                    deliver
                 )
             }
 

--- a/Sources/localvoxtral/Onboarding/OnboardingBootstrapDriving.swift
+++ b/Sources/localvoxtral/Onboarding/OnboardingBootstrapDriving.swift
@@ -86,6 +86,12 @@ extension OnboardingItemState {
 
     private static func modelDownloadDetail(_ progress: ModelDownloadProgress) -> String {
         guard let totalBytes = progress.totalBytes, totalBytes > 0 else {
+            // Bytes moving but no total (CDN sent no length): show movement
+            // rather than pretending we are still checking.
+            if progress.downloadedBytes > 0 {
+                let megabytes = progress.downloadedBytes / 1_048_576
+                return "Downloading model - \(megabytes) MB"
+            }
             return "Checking model..."
         }
         return "Downloading model \(Int(((progress.fraction ?? 0) * 100).rounded()))%"

--- a/Sources/localvoxtral/SettingsView.swift
+++ b/Sources/localvoxtral/SettingsView.swift
@@ -442,6 +442,11 @@ private struct ManagedBackendStatusLabel: View {
 
     private func modelDownloadText(_ progress: ModelDownloadProgress) -> String {
         guard let totalBytes = progress.totalBytes, totalBytes > 0 else {
+            // Bytes moving but no total (CDN sent no length for some file):
+            // show movement rather than pretending we are still checking.
+            if progress.downloadedBytes > 0 {
+                return "Downloading model - \(Self.byteText(progress.downloadedBytes))"
+            }
             // No total yet: the downloader is still resolving what (if
             // anything) needs fetching — on a warm cache this phase is all
             // the user ever sees, so don't claim a download is happening.

--- a/Tests/localvoxtralTests/HFModelDownloaderTests.swift
+++ b/Tests/localvoxtralTests/HFModelDownloaderTests.swift
@@ -78,6 +78,49 @@ final class HFModelDownloaderTests: XCTestCase {
         )
     }
 
+    /// Regression (field-hit 2026-07-17): a single multi-gigabyte file must
+    /// surface in-flight progress. The completion-only transport reported
+    /// bytes only at whole-file boundaries, so the UI sat on "Checking
+    /// model..." for the entire 2.5 GB fetch.
+    func testDownloadReportsInFlightProgressWithinASingleFile() async throws {
+        let cache = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: cache) }
+        let pin = "0123456789abcdef0123456789abcdef01234567"
+        let transport = FakeHFModelDownloadTransport(
+            repositoryJSON: repositoryJSON(sha: pin, files: ["model.safetensors"]),
+            payloads: ["model.safetensors": Data("weights-payload".utf8)]
+        )
+        let downloader = HFModelDownloader(
+            cacheRoot: cache,
+            transport: transport,
+            progressByteGranularity: 1
+        )
+        var progress: [ModelDownloadProgress] = []
+
+        try await downloader.prepare(
+            ModelPreparationRequest(
+                backendID: "speechd",
+                displayName: "Dictation engine",
+                repoID: "org/model",
+                revision: pin,
+                includePatterns: ["model*.safetensors"]
+            )
+        ) { progress.append($0) }
+        // In-flight reports hop to the main actor as unstructured tasks;
+        // drain them before asserting.
+        for _ in 0..<10 { await Task.yield() }
+
+        let bytes = progress.map(\.downloadedBytes)
+        XCTAssertEqual(bytes.first, 0)
+        XCTAssertEqual(bytes.last, 15)
+        XCTAssertEqual(bytes, bytes.sorted(), "delivered progress must be monotonic")
+        XCTAssertEqual(Set(bytes).count, bytes.count, "no duplicate deliveries")
+        XCTAssertTrue(
+            bytes.contains { $0 > 0 && $0 < 15 },
+            "expected an in-flight report between 0 and total, got \(bytes)"
+        )
+    }
+
     func testUnpinnedPreparationTracksMainAndWritesResolvedRef() async throws {
         let cache = try makeTemporaryDirectory()
         defer { try? FileManager.default.removeItem(at: cache) }
@@ -204,12 +247,22 @@ private final class FakeHFModelDownloadTransport: HFModelDownloadTransport, @unc
         Int64(payloads[url.lastPathComponent]?.count ?? 0)
     }
 
-    func download(from url: URL) async throws -> (temporaryURL: URL, statusCode: Int) {
+    func download(
+        from url: URL,
+        onBytes: @escaping @Sendable (Int64, Int64?) -> Void
+    ) async throws -> (temporaryURL: URL, statusCode: Int) {
         let fileName = url.lastPathComponent
         state.withLock { $0.downloadedFileNames.append(fileName) }
+        let payload = payloads[fileName] ?? Data()
+        // Report the file in two halves so incremental-progress tests can
+        // observe an in-flight (non-boundary) update.
+        if !payload.isEmpty {
+            onBytes(Int64(payload.count / 2), Int64(payload.count))
+            onBytes(Int64(payload.count), Int64(payload.count))
+        }
         let temporary = FileManager.default.temporaryDirectory
             .appendingPathComponent("fake-hf-download-\(UUID().uuidString)")
-        try (payloads[fileName] ?? Data()).write(to: temporary)
+        try payload.write(to: temporary)
         return (temporary, 200)
     }
 }

--- a/Tests/localvoxtralTests/HFModelDownloaderTests.swift
+++ b/Tests/localvoxtralTests/HFModelDownloaderTests.swift
@@ -121,6 +121,51 @@ final class HFModelDownloaderTests: XCTestCase {
         )
     }
 
+    /// When the HEAD probe returns no Content-Length (CDN behavior), the
+    /// total — and therefore the determinate progress bar — must still become
+    /// available from the transfer's own expected-size callback.
+    func testTotalIsLearnedFromTransferWhenHEADProbeHasNoLength() async throws {
+        let cache = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: cache) }
+        let pin = "0123456789abcdef0123456789abcdef01234567"
+        let transport = FakeHFModelDownloadTransport(
+            repositoryJSON: repositoryJSON(sha: pin, files: ["model.safetensors"]),
+            payloads: ["model.safetensors": Data("weights-payload".utf8)],
+            headlessFiles: ["model.safetensors"]
+        )
+        let downloader = HFModelDownloader(
+            cacheRoot: cache,
+            transport: transport,
+            progressByteGranularity: 1
+        )
+        var progress: [ModelDownloadProgress] = []
+
+        try await downloader.prepare(
+            ModelPreparationRequest(
+                backendID: "speechd",
+                displayName: "Dictation engine",
+                repoID: "org/model",
+                revision: pin,
+                includePatterns: ["model*.safetensors"]
+            )
+        ) { progress.append($0) }
+        for _ in 0..<10 { await Task.yield() }
+
+        // The pre-download report cannot know a total (HEAD gave none)...
+        XCTAssertEqual(progress.first, ModelDownloadProgress(downloadedBytes: 0, totalBytes: nil))
+        // ...but every report from the transfer onward carries the learned
+        // total, and the final report is exact.
+        XCTAssertEqual(progress.last, ModelDownloadProgress(downloadedBytes: 15, totalBytes: 15))
+        XCTAssertTrue(
+            progress.dropFirst().allSatisfy { $0.totalBytes == 15 },
+            "expected all post-start reports to carry the learned total, got \(progress)"
+        )
+        XCTAssertTrue(
+            progress.contains { $0.downloadedBytes > 0 && $0.downloadedBytes < 15 && $0.fraction != nil },
+            "expected an in-flight report with a computable fraction, got \(progress)"
+        )
+    }
+
     func testUnpinnedPreparationTracksMainAndWritesResolvedRef() async throws {
         let cache = try makeTemporaryDirectory()
         defer { try? FileManager.default.removeItem(at: cache) }
@@ -228,11 +273,16 @@ private final class FakeHFModelDownloadTransport: HFModelDownloadTransport, @unc
 
     private let repositoryJSON: Data
     private let payloads: [String: Data]
+    /// Files whose HEAD probe returns no Content-Length (the CDN behavior
+    /// behind HF `resolve/` redirects); their size is only learned from the
+    /// transfer itself via `onBytes`.
+    private let headlessFiles: Set<String>
     private let state = Mutex(State())
 
-    init(repositoryJSON: Data, payloads: [String: Data]) {
+    init(repositoryJSON: Data, payloads: [String: Data], headlessFiles: Set<String> = []) {
         self.repositoryJSON = repositoryJSON
         self.payloads = payloads
+        self.headlessFiles = headlessFiles
     }
 
     var repositoryInfoURLs: [URL] { state.withLock { $0.repositoryInfoURLs } }
@@ -244,7 +294,9 @@ private final class FakeHFModelDownloadTransport: HFModelDownloadTransport, @unc
     }
 
     func contentLength(of url: URL) async throws -> Int64? {
-        Int64(payloads[url.lastPathComponent]?.count ?? 0)
+        let fileName = url.lastPathComponent
+        guard !headlessFiles.contains(fileName) else { return nil }
+        return Int64(payloads[fileName]?.count ?? 0)
     }
 
     func download(

--- a/Tests/localvoxtralTests/HFModelDownloaderTests.swift
+++ b/Tests/localvoxtralTests/HFModelDownloaderTests.swift
@@ -166,6 +166,47 @@ final class HFModelDownloaderTests: XCTestCase {
         )
     }
 
+    /// The repo API (`?blobs=true`) carries exact per-file sizes, so the total
+    /// — and the determinate bar — must be available from the very first
+    /// report, with no per-file HEAD probes at all.
+    func testRepoAPISizesProvideTheTotalUpfrontWithoutHEADProbes() async throws {
+        let cache = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: cache) }
+        let pin = "0123456789abcdef0123456789abcdef01234567"
+        let transport = FakeHFModelDownloadTransport(
+            repositoryJSON: repositoryJSON(
+                sha: pin,
+                files: ["model.safetensors"],
+                sizes: ["model.safetensors": 15]
+            ),
+            payloads: ["model.safetensors": Data("weights-payload".utf8)]
+        )
+        let downloader = HFModelDownloader(
+            cacheRoot: cache,
+            transport: transport,
+            progressByteGranularity: 1
+        )
+        var progress: [ModelDownloadProgress] = []
+
+        try await downloader.prepare(
+            ModelPreparationRequest(
+                backendID: "speechd",
+                displayName: "Dictation engine",
+                repoID: "org/model",
+                revision: pin,
+                includePatterns: ["model*.safetensors"]
+            )
+        ) { progress.append($0) }
+        for _ in 0..<10 { await Task.yield() }
+
+        XCTAssertEqual(progress.first, ModelDownloadProgress(downloadedBytes: 0, totalBytes: 15))
+        XCTAssertTrue(
+            transport.contentLengthProbes.isEmpty,
+            "API sizes must make HEAD probes unnecessary, probed \(transport.contentLengthProbes)"
+        )
+        XCTAssertEqual(progress.last, ModelDownloadProgress(downloadedBytes: 15, totalBytes: 15))
+    }
+
     func testUnpinnedPreparationTracksMainAndWritesResolvedRef() async throws {
         let cache = try makeTemporaryDirectory()
         defer { try? FileManager.default.removeItem(at: cache) }
@@ -259,8 +300,16 @@ final class HFModelDownloaderTests: XCTestCase {
         return url
     }
 
-    private func repositoryJSON(sha: String, files: [String]) -> Data {
-        let siblings = files.map { ["rfilename": $0] }
+    private func repositoryJSON(
+        sha: String,
+        files: [String],
+        sizes: [String: Int64] = [:]
+    ) -> Data {
+        let siblings = files.map { file -> [String: Any] in
+            var sibling: [String: Any] = ["rfilename": file]
+            if let size = sizes[file] { sibling["size"] = size }
+            return sibling
+        }
         return try! JSONSerialization.data(withJSONObject: ["sha": sha, "siblings": siblings])
     }
 }
@@ -268,6 +317,7 @@ final class HFModelDownloaderTests: XCTestCase {
 private final class FakeHFModelDownloadTransport: HFModelDownloadTransport, @unchecked Sendable {
     private struct State {
         var repositoryInfoURLs: [URL] = []
+        var contentLengthProbes: [String] = []
         var downloadedFileNames: [String] = []
     }
 
@@ -286,6 +336,7 @@ private final class FakeHFModelDownloadTransport: HFModelDownloadTransport, @unc
     }
 
     var repositoryInfoURLs: [URL] { state.withLock { $0.repositoryInfoURLs } }
+    var contentLengthProbes: [String] { state.withLock { $0.contentLengthProbes } }
     var downloadedFileNames: [String] { state.withLock { $0.downloadedFileNames } }
 
     func repositoryInfo(from url: URL) async throws -> (data: Data, statusCode: Int) {
@@ -295,6 +346,7 @@ private final class FakeHFModelDownloadTransport: HFModelDownloadTransport, @unc
 
     func contentLength(of url: URL) async throws -> Int64? {
         let fileName = url.lastPathComponent
+        state.withLock { $0.contentLengthProbes.append(fileName) }
         guard !headlessFiles.contains(fileName) else { return nil }
         return Int64(payloads[fileName]?.count ?? 0)
     }


### PR DESCRIPTION
## What

Owner hand-test of #147's empty-cache first run (2026-07-17) found the UI stuck on "Checking model..." for the entire 2.5 GB fetch — the download worked; the progress display didn't. Two stacked causes:

1. `URLSessionHFModelDownloadTransport.download` was completion-only, so progress advanced only at whole-file boundaries — and the pinned snapshot is essentially one 2.5 GB safetensors file.
2. If any file's HEAD probe returns no Content-Length (HF `resolve/` URLs redirect to a CDN), the aggregate total goes nil, and both progress labels map (anything, nil-total) to "Checking model...".

Fix:
- Transport gains `onBytes` via a delegate-backed `URLSession` (cumulative bytes per file; the `didFinishDownloadingTo` temp file is moved synchronously inside the callback, since it dies when the callback returns; cancellation propagates to the task).
- `prepare()` aggregates with an 8 MB report throttle (injectable for tests) and a single monotonic main-actor delivery gate, so the bar never jumps backwards despite unordered task hops.
- Settings + onboarding labels show "Downloading model - X MB" when bytes move without a known total, reserving "Checking model..." for the genuine pre-download phase.

Stacked on #151 (last of the merge train).

## Proof

- [x] Full unit suite green: `Executed 991 tests, with 2 tests skipped and 0 failures`
- [x] New regression test `testDownloadReportsInFlightProgressWithinASingleFile`: single-file download at granularity 1 must produce an in-flight report strictly between 0 and total, delivered monotonically with no duplicates — exactly the field failure's shape.
- [x] Existing exact-sequence progress test unchanged and green (default granularity throttles the fake's tiny in-flight callbacks, preserving the boundary-report contract).
- [x] LLM lanes: not required — download/UI path.

## Owner hand-verification (try-pr.sh)

Repeat test B: quit app, `mv` the mlx-community snapshot dir out of `~/.cache/huggingface/hub`, relaunch, go Managed — expect byte/percent progress counting up through the ~2.5 GB fetch (or bytes-only if the CDN omits lengths), then Ready.

## Update (second commit): dynamic total → the bar always appears

Owner feedback: byte text alone isn't glanceable. The determinate bars already exist in Settings/onboarding but require a known total, and the CDN can omit Content-Length on the HEAD probe. `prepare()` now folds each file's transfer-reported expected size (`totalBytesExpectedToWrite`) into a dynamic total, so the bar and "X of Y" label appear as soon as every missing file has a size from either source. New regression test: HEAD-less file → first report total-less, every post-start report carries the learned total with computable fraction. Suite: `Executed 992 tests, with 0 failures`.


## Update (third commit): total from the repo API — bar from second zero

Owner retest still had no bar: HEAD probes return no length in-app (signed-CDN redirect), and the transfer-learned fallback couldn't complete the total while `model.safetensors` (downloaded before `index.json`/`tekken.json`) was in flight. `?blobs=true` on the existing repo-info request returns exact per-file sizes (verified live against the pinned revision: `model.safetensors` = 3,133,798,126 B), so the total exists before the first byte — the Settings bar, "X of Y" label, and popover percent all render from the start regardless of CDN behavior or file order. HEAD probes remain only for API-sizeless files; transfer-learned stays as the last belt. New test: first report carries the full total with zero HEAD probes. Suite: `Executed 993 tests, with 0 failures`.
