### PR TITLE
Join the focused Ghostty pane to its Claude session by TTY (title marker fallback)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -391,11 +391,20 @@ Key subsystems:
     filesystem" is a compile error — do not add one. Its only derivations
     (`ancestor`, `descendant`) preserve that, and `ClaudeRepoCollecting` takes
     it rather than a `String` for exactly this reason.
-  - The join is resolved ONCE per dictation, at start, from the marker in the
-    PID-pinned window title (`ClaudeSessionJoinResolver`), and every consumer —
-    raw screen attachment, the session block, repo collection — shares that one
-    answer. Three resolutions could each answer honestly about a different
-    moment; that is how one session's screen ends up next to another's repo.
+  - The join is resolved ONCE per dictation, at start
+    (`ClaudeSessionJoinResolver`), and every consumer — raw screen attachment,
+    the session block, repo collection — shares that one answer. Three
+    resolutions could each answer honestly about a different moment; that is
+    how one session's screen ends up next to another's repo. Resolution is
+    TTY-first: the focused Ghostty pane's controlling TTY (AppleScript,
+    Ghostty ≥ 1.4) matched exactly against the hook-reported session TTY,
+    LOCAL sessions only — the title is a fought-over channel (Claude Code's
+    own conversation titles clobber the marker mid-turn), the process table is
+    not. Any TTY non-answer falls through to the marker in the PID-pinned
+    window title, which remains the ONLY join for SSH-remote sessions: a
+    remote TTY names another machine's device, and `resolve(tty:)` refuses
+    remote candidates so an SSH host can never claim a local pane by echoing
+    its TTY.
   - Lookups abstain rather than guess: no marker, unknown, stale, or ambiguous
     means no context. There is deliberately no sole-session or cwd heuristic —
     it is wrong precisely when it matters.

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ On first launch, a setup wizard walks you through the microphone and Accessibili
 
 ## Privacy
 
-In the default Managed local mode, nothing you say or write is sent anywhere. Audio capture, transcription, and LLM polishing all run as local processes on your Mac, and the only network traffic is the one-time engine and model download. There is no telemetry, no account, and no cloud fallback. The context-aware polishing features (repo vocabulary, clipboard context) are opt-in and only ever talk to a loopback polishing endpoint, never a remote server. If you point localvoxtral at your own External URL server instead, your data goes only where you send it.
+In the default Managed local mode, nothing you say or write is sent anywhere. Audio capture, transcription, and LLM polishing all run as local processes on your Mac, and the only network traffic is the one-time engine and model download. There is no telemetry, no account, and no cloud fallback. The context-aware polishing features (repo vocabulary, clipboard context) are opt-in and by default only ever talk to a loopback polishing endpoint — a non-local endpoint receives context only if you additionally enable the explicit trusted-endpoint opt-in (default off). If you point localvoxtral at your own External URL server instead, your data goes only where you send it.
 
 ## Shortcuts
 

--- a/Sources/ClaudeHookPublisherCore/ClaudeHookPublisher.swift
+++ b/Sources/ClaudeHookPublisherCore/ClaudeHookPublisher.swift
@@ -7,6 +7,10 @@ import Darwin
 import Glibc
 #endif
 
+#if canImport(os)
+import os
+#endif
+
 /// Reads bounded stdin once, enriches with safe process/TTY metadata, and
 /// publishes one NDJSON line. Pure logic lives here so the executable's `main`
 /// stays a three-liner and every branch below is unit-testable.
@@ -20,17 +24,22 @@ public struct ClaudeHookPublisher: Sendable {
         public var now: @Sendable () -> Double
         public var pid: @Sendable () -> Int32
         public var ppid: @Sendable () -> Int32
-        public var ttyName: @Sendable () -> String?
+        /// The controlling-tty resolution for a GIVEN Claude pid. The pid is
+        /// an argument — supplied from `ppid()` at `processInfo()` time —
+        /// rather than re-resolved inside the default closure, so an injected
+        /// `ppid` seam and the published tty always describe the same process.
+        /// (The default used to call `claudeAncestorPID()` itself, which let a
+        /// test's injected ppid and the tty's process-table fallback silently
+        /// diverge.)
+        public var ttyName: @Sendable (Int32) -> String?
         public var variables: [String: String]
 
         public init(
             now: @escaping @Sendable () -> Double = { Date().timeIntervalSince1970 },
             pid: @escaping @Sendable () -> Int32 = { getpid() },
             ppid: @escaping @Sendable () -> Int32 = { ClaudeHookPublisher.claudeAncestorPID() },
-            ttyName: @escaping @Sendable () -> String? = {
-                ClaudeHookPublisher.controllingTTY(
-                    claudePID: ClaudeHookPublisher.claudeAncestorPID()
-                )
+            ttyName: @escaping @Sendable (Int32) -> String? = {
+                ClaudeHookPublisher.controllingTTY(claudePID: $0)
             },
             variables: [String: String] = ProcessInfo.processInfo.environment
         ) {
@@ -119,10 +128,13 @@ public struct ClaudeHookPublisher: Sendable {
     /// Safe metadata only: identity and location of the terminal, never its
     /// contents and never argv/env beyond `$TERM_PROGRAM`.
     func processInfo() -> ClaudeHookProcessInfo {
-        ClaudeHookProcessInfo(
+        // ONE ppid resolution feeds both fields: the published claudePID and
+        // the tty's process-table fallback must describe the same process.
+        let claudePID = environment.ppid()
+        return ClaudeHookProcessInfo(
             hookPID: environment.pid(),
-            claudePID: environment.ppid(),
-            tty: environment.ttyName(),
+            claudePID: claudePID,
+            tty: environment.ttyName(claudePID),
             termProgram: environment.variables["TERM_PROGRAM"].flatMap { $0.isEmpty ? nil : $0 }
         )
     }
@@ -176,9 +188,19 @@ public struct ClaudeHookPublisher: Sendable {
                 return String(cString: name)
             }
         }
-        if let claudePID {
-            return ttyDevicePath(forProcess: claudePID)
+        if let claudePID, let device = ttyDevicePath(forProcess: claudePID) {
+            return device
         }
+        // Outcome-only, never a path or pid: a silent nil here made a broken
+        // hook-side capture indistinguishable from a failed pane read in the
+        // field (2026-07-20) — the join's tty half simply never matched and
+        // nothing said why. Unified log only; stdout/stderr stay silent per
+        // the hook contract.
+        #if canImport(os)
+        Logger(subsystem: "com.localvoxtral", category: "ClaudeHook").info(
+            "controlling tty unresolved: fds piped, /dev/tty unanswering, process table has no device"
+        )
+        #endif
         return nil
     }
 

--- a/Sources/ClaudeHookPublisherCore/ClaudeHookPublisher.swift
+++ b/Sources/ClaudeHookPublisherCore/ClaudeHookPublisher.swift
@@ -27,7 +27,11 @@ public struct ClaudeHookPublisher: Sendable {
             now: @escaping @Sendable () -> Double = { Date().timeIntervalSince1970 },
             pid: @escaping @Sendable () -> Int32 = { getpid() },
             ppid: @escaping @Sendable () -> Int32 = { ClaudeHookPublisher.claudeAncestorPID() },
-            ttyName: @escaping @Sendable () -> String? = { ClaudeHookPublisher.controllingTTY() },
+            ttyName: @escaping @Sendable () -> String? = {
+                ClaudeHookPublisher.controllingTTY(
+                    claudePID: ClaudeHookPublisher.claudeAncestorPID()
+                )
+            },
             variables: [String: String] = ProcessInfo.processInfo.environment
         ) {
             self.now = now
@@ -149,13 +153,51 @@ public struct ClaudeHookPublisher: Sendable {
     /// The controlling TTY of this hook process, if any. Claude Code runs hooks
     /// as children of the session, so this is the session's terminal device —
     /// the eventual join point for a focus probe.
-    public static func controllingTTY() -> String? {
+    ///
+    /// Three sources, cheapest first, because the first one is a lie in the
+    /// field: Claude Code wires ALL THREE hook fds to pipes (stdin carries the
+    /// hook JSON, stdout carries the response), so `isatty` never fires and
+    /// every session published `tty: nil` — the focus join could not match
+    /// anything (field finding, 2026-07-20). The controlling terminal still
+    /// exists; `/dev/tty` names it without needing any fd to be it. The
+    /// process-table read is the true last resort: it reports CLAUDE's terminal
+    /// rather than ours, so it answers even for a hook fully detached from the
+    /// controlling terminal (setsid), and claude always sits on the pane's tty.
+    public static func controllingTTY(claudePID: Int32? = nil) -> String? {
         for fd in [Int32(0), 1, 2] where isatty(fd) == 1 {
             if let name = ttyname(fd) {
                 return String(cString: name)
             }
         }
+        let fd = open("/dev/tty", O_RDONLY | O_NONBLOCK | O_NOCTTY)
+        if fd >= 0 {
+            defer { close(fd) }
+            if let name = ttyname(fd) {
+                return String(cString: name)
+            }
+        }
+        if let claudePID {
+            return ttyDevicePath(forProcess: claudePID)
+        }
         return nil
+    }
+
+    /// The `/dev/…` path of `pid`'s controlling terminal from the process
+    /// table (`kinfo_proc.kp_eproc.e_tdev`), or nil when the process does not
+    /// exist or has no terminal. Reads metadata about a pid we already hold —
+    /// no fds, no signals, no assumptions about our own session.
+    static func ttyDevicePath(forProcess pid: pid_t) -> String? {
+        guard pid > 0 else { return nil }
+        var info = kinfo_proc()
+        var size = MemoryLayout<kinfo_proc>.stride
+        var mib: [Int32] = [CTL_KERN, KERN_PROC, KERN_PROC_PID, pid]
+        guard sysctl(&mib, UInt32(mib.count), &info, &size, nil, 0) == 0,
+              size > 0,
+              info.kp_proc.p_pid == pid
+        else { return nil }
+        let tdev = info.kp_eproc.e_tdev
+        guard tdev != -1, tdev != 0, let name = devname(tdev, S_IFCHR) else { return nil }
+        return "/dev/" + String(cString: name)
     }
 
     /// Write to stdout with raw `write(2)`, looping over partial writes.

--- a/Sources/localvoxtral/ClaudeContext/ClaudeSessionRegistry.swift
+++ b/Sources/localvoxtral/ClaudeContext/ClaudeSessionRegistry.swift
@@ -183,6 +183,36 @@ public final class ClaudeSessionRegistry: Sendable {
         }
     }
 
+    /// Look up by the focused pane's controlling TTY — the focus join.
+    ///
+    /// Only LOCAL sessions are candidates: a remote session's TTY names a
+    /// device on another machine, where it can collide with an unrelated local
+    /// pane — matching it here would let an SSH host claim a local pane by
+    /// publishing that pane's TTY. Abstains `.ambiguous` when two live local
+    /// sessions claim one TTY (a suspended Claude beneath a new one in the same
+    /// pane); the caller's marker fallback may still disambiguate.
+    public func resolve(tty: String) -> ClaudeMarkerResolution {
+        let timestamp = now()
+        return state.withLock { state in
+            let matches = state.sessions.values.filter { snapshot in
+                snapshot.origin.isLocalAuthenticated
+                    && snapshot.process?.tty == tty
+                    && isFresh(snapshot, now: timestamp)
+            }
+            switch matches.count {
+            case 0:
+                let hadStale = state.sessions.values.contains {
+                    $0.origin.isLocalAuthenticated && $0.process?.tty == tty
+                }
+                return hadStale ? .stale : .unknown
+            case 1:
+                return .resolved(matches[0])
+            default:
+                return .ambiguous
+            }
+        }
+    }
+
     public func snapshot(sessionID: String) -> ClaudeSessionSnapshot? {
         let timestamp = now()
         return state.withLock { state in

--- a/Sources/localvoxtral/ClaudeContext/TerminalScreenClaudeJoin.swift
+++ b/Sources/localvoxtral/ClaudeContext/TerminalScreenClaudeJoin.swift
@@ -73,6 +73,7 @@ struct ClaudeSessionJoinResolver {
     private let registry: ClaudeSessionRegistry
     private let markerInWindowTitle: (pid_t) -> TerminalScreenAXReader.FocusedWindowMarkerRead?
     private let focusedTerminalTTY: (String) -> String?
+    private let focusedWindowID: (pid_t) -> CGWindowID?
 
     /// - Parameters:
     ///   - markerInWindowTitle: reads the PID-pinned focused window title,
@@ -87,16 +88,26 @@ struct ClaudeSessionJoinResolver {
     ///     and a defaulted live reader would send real events (and hang the
     ///     suite on that prompt) from any test that forgets to inject. The app
     ///     wires `GhosttyFocusedTerminalTTYReader` explicitly.
+    ///   - focusedWindowID: the tty join's window identity. A marker join
+    ///     learns its window from the marker read itself, but a tty join never
+    ///     consults the title — so the focused window is identified by this
+    ///     separate PID-pinned AX read. Nil means unknown, which the
+    ///     authorizer refuses, exactly like a nil marker-read identity
+    ///     (review F2).
     init(
         registry: ClaudeSessionRegistry,
         markerInWindowTitle: @escaping (pid_t) -> TerminalScreenAXReader.FocusedWindowMarkerRead? = {
             TerminalScreenAXReader.markerInFocusedWindowTitle(applicationPID: $0)
         },
-        focusedTerminalTTY: @escaping (String) -> String? = { _ in nil }
+        focusedTerminalTTY: @escaping (String) -> String? = { _ in nil },
+        focusedWindowID: @escaping (pid_t) -> CGWindowID? = {
+            TerminalScreenAXReader.focusedWindowIdentity(applicationPID: $0)
+        }
     ) {
         self.registry = registry
         self.markerInWindowTitle = markerInWindowTitle
         self.focusedTerminalTTY = focusedTerminalTTY
+        self.focusedWindowID = focusedWindowID
     }
 
     /// The join for `target`, or nil on any abstention.
@@ -126,8 +137,15 @@ struct ClaudeSessionJoinResolver {
                 Log.claudeContext.info(
                     "Terminal pane joined to a live Claude session via focused-pane tty"
                 )
+                // The tty join carries a window identity exactly like the
+                // marker join: without one, the authorizer cannot tell two
+                // windows of one Ghostty process apart and must refuse raw
+                // attachment (review F2). Read here, once, at join time.
                 return ClaudeSessionJoin(
-                    target: target, marker: snapshot.marker, snapshot: snapshot, windowID: nil
+                    target: target,
+                    marker: snapshot.marker,
+                    snapshot: snapshot,
+                    windowID: focusedWindowID(target.pid)
                 )
             case .unknown:
                 abstainedTTYJoin(outcome: "no live session on this device")

--- a/Sources/localvoxtral/ClaudeContext/TerminalScreenClaudeJoin.swift
+++ b/Sources/localvoxtral/ClaudeContext/TerminalScreenClaudeJoin.swift
@@ -120,16 +120,38 @@ struct ClaudeSessionJoinResolver {
         // this app at all — not something to inherit on trust from a caller.
         guard TerminalScreenAllowlist.isSupported(target.bundleID) else { return nil }
 
-        if let tty = focusedTerminalTTY(target.bundleID),
-           case .resolved(let snapshot) = registry.resolve(tty: tty) {
-            Log.claudeContext.info(
-                "Terminal pane joined to a live Claude session via focused-pane tty"
-            )
-            return ClaudeSessionJoin(
-                target: target, marker: snapshot.marker, snapshot: snapshot, windowID: nil
-            )
+        if let tty = focusedTerminalTTY(target.bundleID) {
+            switch registry.resolve(tty: tty) {
+            case .resolved(let snapshot):
+                Log.claudeContext.info(
+                    "Terminal pane joined to a live Claude session via focused-pane tty"
+                )
+                return ClaudeSessionJoin(
+                    target: target, marker: snapshot.marker, snapshot: snapshot, windowID: nil
+                )
+            case .unknown:
+                abstainedTTYJoin(outcome: "no live session on this device")
+            case .stale:
+                abstainedTTYJoin(outcome: "stale")
+            case .ambiguous:
+                abstainedTTYJoin(outcome: "ambiguous")
+            }
         }
 
+        return resolveViaMarker(target: target)
+    }
+
+    /// Outcome only, never the device path. A silent abstention here made a
+    /// broken hook-side tty capture indistinguishable from a failed pane read
+    /// in the field (2026-07-20) — the marker fallback may still answer, but
+    /// the non-answer must say which side of the join went missing.
+    private func abstainedTTYJoin(outcome: String) {
+        Log.claudeContext.info(
+            "Focused-pane tty matched no session (\(outcome, privacy: .public)); trying title marker"
+        )
+    }
+
+    private func resolveViaMarker(target: TerminalScreenTarget) -> ClaudeSessionJoin? {
         guard let read = markerInWindowTitle(target.pid) else {
             // No marker on screen: this pane is not a joined Claude session, or
             // we cannot tell. Either way there is nothing to resolve.

--- a/Sources/localvoxtral/ClaudeContext/TerminalScreenClaudeJoin.swift
+++ b/Sources/localvoxtral/ClaudeContext/TerminalScreenClaudeJoin.swift
@@ -72,31 +72,63 @@ struct ClaudeSessionJoin: Sendable, Equatable {
 struct ClaudeSessionJoinResolver {
     private let registry: ClaudeSessionRegistry
     private let markerInWindowTitle: (pid_t) -> TerminalScreenAXReader.FocusedWindowMarkerRead?
+    private let focusedTerminalTTY: (String) -> String?
 
-    /// - Parameter markerInWindowTitle: reads the PID-pinned focused window
-    ///   title, parses a marker out of it, and reports which WINDOW it read.
-    ///   Injected so the whole truth table is unit-testable without a live AX
-    ///   tree — the same reason every other live read in this feature is a seam.
+    /// - Parameters:
+    ///   - markerInWindowTitle: reads the PID-pinned focused window title,
+    ///     parses a marker out of it, and reports which WINDOW it read.
+    ///     Injected so the whole truth table is unit-testable without a live
+    ///     AX tree — the same reason every other live read in this feature is
+    ///     a seam.
+    ///   - focusedTerminalTTY: reads the focused pane's controlling TTY for a
+    ///     bundle id (Ghostty ≥ 1.4 over AppleScript). Unlike the AX seam this
+    ///     DEFAULTS TO ABSTAIN, not to the live reader: an Apple event is not
+    ///     an AX read — the first one triggers the Automation consent prompt,
+    ///     and a defaulted live reader would send real events (and hang the
+    ///     suite on that prompt) from any test that forgets to inject. The app
+    ///     wires `GhosttyFocusedTerminalTTYReader` explicitly.
     init(
         registry: ClaudeSessionRegistry,
         markerInWindowTitle: @escaping (pid_t) -> TerminalScreenAXReader.FocusedWindowMarkerRead? = {
             TerminalScreenAXReader.markerInFocusedWindowTitle(applicationPID: $0)
-        }
+        },
+        focusedTerminalTTY: @escaping (String) -> String? = { _ in nil }
     ) {
         self.registry = registry
         self.markerInWindowTitle = markerInWindowTitle
+        self.focusedTerminalTTY = focusedTerminalTTY
     }
 
     /// The join for `target`, or nil on any abstention.
     ///
-    /// This is the ONLY function in the feature that reads a window title, and
-    /// it is called once per dictation, at start.
+    /// TTY first, marker second. The TTY compares the focused pane's device
+    /// against what the hook publisher reported from inside the session — the
+    /// process table cannot be clobbered by whoever wrote the window title
+    /// last, so it keeps joining while Claude Code's own conversation titles
+    /// own the visible one. Any TTY non-answer (old Ghostty, Automation
+    /// denied, no local session on that device, two sessions claiming it)
+    /// falls through to the marker path unchanged; remote sessions can ONLY
+    /// join via marker, because their TTY names another machine's device and
+    /// `resolve(tty:)` refuses remote candidates outright.
+    ///
+    /// This remains the only place a join is resolved, once per dictation, at
+    /// start — whichever mechanism answers.
     func resolve(target: TerminalScreenTarget) -> ClaudeSessionJoin? {
         // The allowlist is re-checked here even though the capture gate already
         // enforced it. This object is reachable independently of that gate, and
         // "only a verified single-AXTextArea grid" is a precondition of reading
         // this app at all — not something to inherit on trust from a caller.
         guard TerminalScreenAllowlist.isSupported(target.bundleID) else { return nil }
+
+        if let tty = focusedTerminalTTY(target.bundleID),
+           case .resolved(let snapshot) = registry.resolve(tty: tty) {
+            Log.claudeContext.info(
+                "Terminal pane joined to a live Claude session via focused-pane tty"
+            )
+            return ClaudeSessionJoin(
+                target: target, marker: snapshot.marker, snapshot: snapshot, windowID: nil
+            )
+        }
 
         guard let read = markerInWindowTitle(target.pid) else {
             // No marker on screen: this pane is not a joined Claude session, or
@@ -107,7 +139,7 @@ struct ClaudeSessionJoinResolver {
 
         switch registry.resolve(marker: read.marker) {
         case .resolved(let snapshot):
-            Log.claudeContext.info("Terminal pane joined to a live Claude session")
+            Log.claudeContext.info("Terminal pane joined to a live Claude session via title marker")
             return ClaudeSessionJoin(
                 target: target, marker: read.marker, snapshot: snapshot, windowID: read.windowID
             )

--- a/Sources/localvoxtral/DictationViewModel+Session.swift
+++ b/Sources/localvoxtral/DictationViewModel+Session.swift
@@ -2014,6 +2014,20 @@ extension DictationViewModel {
         )
     }
 
+    /// Whether this process is running as (or under) an XCTest host, decided
+    /// from BOTH available signals: the XCTest runtime being loaded, and the
+    /// `XCTestConfigurationFilePath` environment variable xctest sets for the
+    /// processes it launches. The class check alone misses a child process the
+    /// harness spawned without linking XCTest into it; either signal alone
+    /// means "no modal UI here, ever". Pure and injectable so the truth table
+    /// is assertable from inside a test process (where both signals are live).
+    nonisolated static func isTestProcess(
+        hasXCTestClass: Bool = NSClassFromString("XCTestCase") != nil,
+        environment: [String: String] = ProcessInfo.processInfo.environment
+    ) -> Bool {
+        hasXCTestClass || environment["XCTestConfigurationFilePath"] != nil
+    }
+
     func presentConnectionFailureAlert(
         title: String = "Realtime Connection Failed",
         message: String,
@@ -2038,7 +2052,7 @@ extension DictationViewModel {
         // of the suite, and runModal() then stops the whole run dead waiting
         // for a click that never comes (xctest sample 2026-07-19: this frame
         // parked in _DPSBlockUntilNextEventMatchingListInMode mid-suite).
-        guard NSClassFromString("XCTestCase") == nil else {
+        guard !Self.isTestProcess() else {
             Log.dictation.error("connection-failure alert skipped: XCTest process")
             return
         }

--- a/Sources/localvoxtral/DictationViewModel+Session.swift
+++ b/Sources/localvoxtral/DictationViewModel+Session.swift
@@ -624,7 +624,8 @@ extension DictationViewModel {
                 // inside the Task can take up to ~2 s, and a copy landing during
                 // that window must not make the context ground against different
                 // text than the payload macro substitutes. When the setting is
-                // off OR the polishing endpoint is not loopback, the pasteboard
+                // off OR the polishing endpoint is not permitted (loopback-only
+                // without the trusted-endpoint opt-in), the pasteboard
                 // is never read (privacy).
                 let capturedClipboardContext: PolishClipboardContext?
                 let capturedScreenDecision: TerminalScreenContextDecision
@@ -698,7 +699,7 @@ extension DictationViewModel {
                     }
 
                     // Clipboard vocabulary is grounded in the already
-                    // privacy-gated clipboard text (feature toggle ON + loopback
+                    // privacy-gated clipboard text (feature toggle ON + permitted
                     // endpoint + never concealed/transient — all enforced when
                     // it was captured; nil context means none of it runs).
                     //
@@ -735,7 +736,7 @@ extension DictationViewModel {
                     // reason: its git subprocesses and file reads run OFF the
                     // main actor under their own deadline, so a slow repo yields
                     // a smaller snapshot rather than a late commit. Every gate
-                    // (setting, loopback endpoint, live join, LOCAL workspace)
+                    // (setting, permitted endpoint, live join, LOCAL workspace)
                     // is inside `claudeRepoSnapshotIfEnabled`, ahead of the
                     // collector — an unjoined pane means no filesystem call at
                     // all, not a collector that reads and then discards.
@@ -755,7 +756,7 @@ extension DictationViewModel {
                     // the clipboard and the screen.
                     //
                     // Gated through `claudeSessionTextIfEnabled` on ALL THREE of
-                    // the repo block's gates — current setting, current loopback
+                    // the repo block's gates — current setting, currently permitted
                     // endpoint, this exact join still live — not just the
                     // setting. Both blocks attach the session's content, and
                     // consenting to one is consenting to both; it follows that
@@ -1483,7 +1484,7 @@ extension DictationViewModel {
             trustedEndpointEnabled: settings.polishContextTrustedEndpointEnabled
         ) else {
             Log.polishing.info(
-                "Polish clipboard context skipped: polishing endpoint is not local"
+                "Polish clipboard context skipped: polishing endpoint is not permitted (loopback-only without the trusted-endpoint opt-in)"
             )
             return nil
         }
@@ -1574,9 +1575,10 @@ extension DictationViewModel {
     /// Opt-in repo-vocabulary grounding: harvests file names / path components /
     /// the branch from the git repo in the focused terminal and returns the
     /// transcript-relevant ones as replacement entries — but ONLY when the
-    /// setting is on AND the polishing endpoint is loopback (repo file names must
-    /// never ride to a remote endpoint, same privacy stance as clipboard
-    /// context). Both gates short-circuit before any AX read or subprocess.
+    /// setting is on AND the polishing endpoint is permitted — loopback, or any
+    /// endpoint under the explicit trusted-endpoint opt-in (repo file names
+    /// never ride to an endpoint the user has not consented to, same privacy
+    /// stance as clipboard context). Both gates short-circuit before any AX read or subprocess.
     /// Only the AX title and captured-app identity reads happen on the main
     /// actor (with a 0.5 s AX messaging timeout); everything blocking-ish — FS
     /// stats on the title/process CWD candidates (possibly a stale network

--- a/Sources/localvoxtral/DictationViewModel+Session.swift
+++ b/Sources/localvoxtral/DictationViewModel+Session.swift
@@ -1478,7 +1478,10 @@ extension DictationViewModel {
     /// provider, which must never receive clipboard content.
     func polishClipboardContextIfEnabled(endpointURL: URL) -> PolishClipboardContext? {
         guard settings.polishClipboardContextEnabled else { return nil }
-        guard PolishContextClipboardReader.isLoopbackEndpoint(endpointURL) else {
+        guard PolishContextClipboardReader.isPermittedContextEndpoint(
+            endpointURL,
+            trustedEndpointEnabled: settings.polishContextTrustedEndpointEnabled
+        ) else {
             Log.polishing.info(
                 "Polish clipboard context skipped: polishing endpoint is not local"
             )
@@ -1593,7 +1596,10 @@ extension DictationViewModel {
         transcript: String
     ) async -> RepoVocabularyMatcher.GroundingOutcome? {
         guard settings.repoVocabularyEnabled else { return nil }
-        guard PolishContextClipboardReader.isLoopbackEndpoint(endpointURL) else {
+        guard PolishContextClipboardReader.isPermittedContextEndpoint(
+            endpointURL,
+            trustedEndpointEnabled: settings.polishContextTrustedEndpointEnabled
+        ) else {
             Log.polishing.info("Repo vocabulary skipped: polishing endpoint is not local")
             return nil
         }

--- a/Sources/localvoxtral/DictationViewModel.swift
+++ b/Sources/localvoxtral/DictationViewModel.swift
@@ -1774,7 +1774,8 @@ final class DictationViewModel {
         terminalScreenStartCapture = TerminalScreenContextSource.captureAtStart(
             settingEnabled: settings.terminalScreenContextEnabled,
             endpointURL: endpointURL,
-            isAccessibilityTrusted: textInsertion.isAccessibilityTrusted
+            isAccessibilityTrusted: textInsertion.isAccessibilityTrusted,
+            trustedEndpointEnabled: settings.polishContextTrustedEndpointEnabled
         )
         claudeSessionJoin = resolveClaudeSessionJoin(endpointURL: endpointURL)
     }
@@ -1799,11 +1800,16 @@ final class DictationViewModel {
         guard settings.terminalScreenContextEnabled || settings.claudeRepoContextEnabled else {
             return nil
         }
-        // Loopback only. Repository contents and a prior prompt must never ride
-        // to a remote endpoint, and this is the gate that guarantees no
-        // filesystem read even STARTS for one — the collector is downstream of
-        // the join, so an unresolved join means no git subprocess, no file read.
-        guard PolishContextClipboardReader.isLoopbackEndpoint(endpointURL) else { return nil }
+        // Permitted endpoints only (loopback, or any endpoint under the
+        // explicit trusted-endpoint opt-in). Repository contents and a prior
+        // prompt must never ride to an endpoint the user has not consented to,
+        // and this is the gate that guarantees no filesystem read even STARTS
+        // for one — the collector is downstream of the join, so an unresolved
+        // join means no git subprocess, no file read.
+        guard PolishContextClipboardReader.isPermittedContextEndpoint(
+            endpointURL,
+            trustedEndpointEnabled: settings.polishContextTrustedEndpointEnabled
+        ) else { return nil }
         guard textInsertion.isAccessibilityTrusted else { return nil }
         guard let target = TerminalScreenContextSource.frontmostTarget() else { return nil }
         return resolver.resolve(target: target)
@@ -1835,7 +1841,8 @@ final class DictationViewModel {
             start: start,
             settingEnabled: settings.terminalScreenContextEnabled,
             endpointURL: endpointURL,
-            isAccessibilityTrusted: textInsertion.isAccessibilityTrusted
+            isAccessibilityTrusted: textInsertion.isAccessibilityTrusted,
+            trustedEndpointEnabled: settings.polishContextTrustedEndpointEnabled
         )
     }
 
@@ -1866,7 +1873,10 @@ final class DictationViewModel {
         transcript: String
     ) async -> ClaudeRepoSnapshot? {
         guard settings.claudeRepoContextEnabled else { return nil }
-        guard PolishContextClipboardReader.isLoopbackEndpoint(endpointURL) else {
+        guard PolishContextClipboardReader.isPermittedContextEndpoint(
+            endpointURL,
+            trustedEndpointEnabled: settings.polishContextTrustedEndpointEnabled
+        ) else {
             Log.claudeContext.info("Claude repo context skipped: polishing endpoint is not loopback")
             return nil
         }
@@ -1921,7 +1931,10 @@ final class DictationViewModel {
     /// prior prompt's words reach the model as replacement entries.
     func claudeSessionTextIfEnabled(join: ClaudeSessionJoin?, endpointURL: URL) -> String {
         guard settings.claudeRepoContextEnabled else { return "" }
-        guard PolishContextClipboardReader.isLoopbackEndpoint(endpointURL) else {
+        guard PolishContextClipboardReader.isPermittedContextEndpoint(
+            endpointURL,
+            trustedEndpointEnabled: settings.polishContextTrustedEndpointEnabled
+        ) else {
             Log.claudeContext.info(
                 "Claude session context skipped: polishing endpoint is not loopback"
             )

--- a/Sources/localvoxtral/DictationViewModel.swift
+++ b/Sources/localvoxtral/DictationViewModel.swift
@@ -482,7 +482,7 @@ final class DictationViewModel {
     /// Test seam: injects the pasteboard the polish-context reader consults,
     /// replacing `SystemPasteboardReader` over `NSPasteboard.general` (global /
     /// unavailable in unit tests). Only resolved when the clipboard-context
-    /// setting is on AND the polishing endpoint is loopback, so a stub whose
+    /// setting is on AND the polishing endpoint is permitted, so a stub whose
     /// read methods were never called proves the no-read privacy guarantee for
     /// both the disabled toggle and a remote endpoint.
     @ObservationIgnored
@@ -497,7 +497,7 @@ final class DictationViewModel {
     /// Test seam: replaces the whole AX-title/process-cwd -> git-index -> match
     /// pipeline of
     /// `repoVocabularyGroundingIfEnabled` with a closure returning the grounding for
-    /// a given transcript, so VM tests exercise the setting + loopback gates
+    /// a given transcript, so VM tests exercise the setting + endpoint gates
     /// without touching live AX or a git subprocess. Consulted only AFTER those
     /// two gates pass, so "off"/"remote" tests still prove the no-op paths.
     /// Bypasses the deadline race entirely — to exercise that, use the
@@ -1877,7 +1877,9 @@ final class DictationViewModel {
             endpointURL,
             trustedEndpointEnabled: settings.polishContextTrustedEndpointEnabled
         ) else {
-            Log.claudeContext.info("Claude repo context skipped: polishing endpoint is not loopback")
+            Log.claudeContext.info(
+                "Claude repo context skipped: polishing endpoint is not permitted (loopback-only without the trusted-endpoint opt-in)"
+            )
             return nil
         }
         guard let join else { return nil }
@@ -1908,14 +1910,14 @@ final class DictationViewModel {
     }
 
     /// The Claude session block's text, re-gated at commit exactly like
-    /// `claudeRepoSnapshotIfEnabled` — current setting, current loopback
+    /// `claudeRepoSnapshotIfEnabled` — current setting, currently permitted
     /// endpoint, this exact join still live.
     ///
     /// The same three gates because it carries the same kind of thing: the
     /// session's workspace name, the PRIOR PROMPT the user typed to the agent,
     /// the paths it touched, and (remote only) bounded tool excerpts. That is
     /// the session's content, which is what the setting consents to and what a
-    /// non-loopback endpoint must never receive. The block previously checked
+    /// unpermitted endpoint must never receive. The block previously checked
     /// only the setting, so a session that died mid-sentence still had its
     /// prompt attached, and a Settings change to a remote endpoint sent it
     /// there.
@@ -1936,7 +1938,7 @@ final class DictationViewModel {
             trustedEndpointEnabled: settings.polishContextTrustedEndpointEnabled
         ) else {
             Log.claudeContext.info(
-                "Claude session context skipped: polishing endpoint is not loopback"
+                "Claude session context skipped: polishing endpoint is not permitted (loopback-only without the trusted-endpoint opt-in)"
             )
             return ""
         }

--- a/Sources/localvoxtral/PolishContextClipboardReader.swift
+++ b/Sources/localvoxtral/PolishContextClipboardReader.swift
@@ -231,6 +231,21 @@ enum PolishContextClipboardReader {
         return host == "127.0.0.1" || host == "localhost" || host == "::1"
     }
 
+    /// The ONE endpoint gate shared by every polish-context surface (clipboard,
+    /// terminal screen, repo vocabulary, Claude repo/session blocks): loopback
+    /// always passes, and anything else passes only when the user has
+    /// explicitly opted in to trusting their configured polishing endpoint
+    /// with context (`SettingsStore.polishContextTrustedEndpointEnabled`,
+    /// default off — e.g. a LAN inference box, or a provider they trust).
+    /// Every surface must route through this rather than calling
+    /// `isLoopbackEndpoint` directly, so the opt-in cannot apply to some
+    /// surfaces and not others.
+    static func isPermittedContextEndpoint(
+        _ url: URL, trustedEndpointEnabled: Bool
+    ) -> Bool {
+        trustedEndpointEnabled || isLoopbackEndpoint(url)
+    }
+
     /// The pasteboard's plain string with the sensitive-type and empty-content
     /// rules applied and NUL/control scalars stripped (newline/tab kept), or nil
     /// when the source marked the payload concealed/transient or there is

--- a/Sources/localvoxtral/PolishContextClipboardReader.swift
+++ b/Sources/localvoxtral/PolishContextClipboardReader.swift
@@ -71,9 +71,11 @@ struct SystemPasteboardReader: PasteboardReading {
 
 /// A capped, sanitized excerpt of the user's clipboard, fed to the polish LLM as
 /// reference context so it can ground near-miss STT of technical terms (file
-/// names, identifiers, URLs, error names) to their exact spelling. Opt-in and
-/// fully local — context is only ever attached when the polishing endpoint is
-/// loopback (`isLoopbackEndpoint`), so the excerpt never leaves this Mac.
+/// names, identifiers, URLs, error names) to their exact spelling. Opt-in, and
+/// local by default — context is only ever attached when the polishing endpoint
+/// is permitted (`isPermittedContextEndpoint`): loopback always, and any other
+/// endpoint only under the explicit trusted-endpoint opt-in
+/// (`SettingsStore.polishContextTrustedEndpointEnabled`, default off).
 struct PolishClipboardContext: Equatable {
     /// The COMPLETE sanitized clipboard text (bounded only by the safety cap),
     /// not the excerpt that gets rendered into the prompt.
@@ -215,14 +217,16 @@ enum PolishContextClipboardReader {
     }
 
     /// True when `url`'s host is a loopback destination — "127.0.0.1",
-    /// "localhost", or "::1". This is the privacy gate for clipboard context:
-    /// the polishing endpoint is user-configurable and may point at a cloud
-    /// provider, and the Settings copy promises the clipboard never leaves this
-    /// Mac, so context is only ever attached to loopback endpoints (the managed
-    /// polishd endpoint is 127.0.0.1). LAN IPs are deliberately NOT local for
-    /// this purpose — another machine is off-Mac. Foundation has returned IPv6
-    /// literal hosts both bare ("::1") and bracketed ("[::1]") across versions;
-    /// brackets are normalized away before comparing.
+    /// "localhost", or "::1". This is the DEFAULT half of the context privacy
+    /// gate (`isPermittedContextEndpoint`): the polishing endpoint is
+    /// user-configurable and may point at a cloud provider, so without the
+    /// explicit trusted-endpoint opt-in, context is only ever attached to
+    /// loopback endpoints (the managed polishd endpoint is 127.0.0.1). LAN IPs
+    /// are deliberately NOT loopback for this purpose — another machine is
+    /// off-Mac, and sending context there is exactly what the opt-in exists to
+    /// consent to. Foundation has returned IPv6 literal hosts both bare
+    /// ("::1") and bracketed ("[::1]") across versions; brackets are
+    /// normalized away before comparing.
     static func isLoopbackEndpoint(_ url: URL) -> Bool {
         guard var host = url.host?.lowercased() else { return false }
         if host.hasPrefix("["), host.hasSuffix("]") {

--- a/Sources/localvoxtral/SettingsStore.swift
+++ b/Sources/localvoxtral/SettingsStore.swift
@@ -254,6 +254,8 @@ final class SettingsStore {
         static let terminalScreenContextEnabled = "settings.terminal_screen_context_enabled"
         static let repoVocabularyEnabled = "settings.repo_vocabulary_enabled"
         static let claudeRepoContextEnabled = "settings.claude_repo_context_enabled"
+        static let polishContextTrustedEndpointEnabled =
+            "settings.polish_context_trusted_endpoint_enabled"
         /// Hidden debug toggle (no UI). When true, every received realtime
         /// event's raw payload is logged to the `Deltas` category before any
         /// merge/preprocess/insertion processing — instrumentation for
@@ -405,10 +407,11 @@ final class SettingsStore {
     /// polish LLM as reference context so it can ground near-miss STT of
     /// technical terms (file names, identifiers, URLs, error names) to their
     /// exact spelling. Opt-in (default false), and applied only when the
-    /// polishing endpoint is loopback
-    /// (`PolishContextClipboardReader.isLoopbackEndpoint`) — a remote endpoint
-    /// must never receive clipboard content. When off or remote, the pasteboard
-    /// is never read at all.
+    /// polishing endpoint is permitted (`PolishContextClipboardReader
+    /// .isPermittedContextEndpoint`: loopback, or any endpoint under the
+    /// explicit `polishContextTrustedEndpointEnabled` opt-in) — an endpoint the
+    /// user has not consented to must never receive clipboard content. When off
+    /// or the endpoint is not permitted, the pasteboard is never read at all.
     var polishClipboardContextEnabled: Bool {
         didSet {
             defaults.set(polishClipboardContextEnabled, forKey: Keys.polishClipboardContextEnabled)
@@ -433,11 +436,12 @@ final class SettingsStore {
     /// see while speaking. Opt-in (default false), Ghostty only
     /// (`TerminalScreenAllowlist` — NOT the broad terminal insertion allowlist,
     /// which spans editors like VS Code / Cursor), and applied only when the
-    /// polishing endpoint is loopback
-    /// (`PolishContextClipboardReader.isLoopbackEndpoint`) — a remote endpoint
-    /// must never receive screen content. When off, remote, or a non-Ghostty
-    /// app is focused, the screen is never read at all
-    /// (`TerminalScreenContext.shouldAttemptRead`).
+    /// polishing endpoint is permitted (`PolishContextClipboardReader
+    /// .isPermittedContextEndpoint`: loopback, or any endpoint under the
+    /// explicit `polishContextTrustedEndpointEnabled` opt-in) — an endpoint the
+    /// user has not consented to must never receive screen content. When off,
+    /// the endpoint is not permitted, or a non-Ghostty app is focused, the
+    /// screen is never read at all (`TerminalScreenContext.shouldAttemptRead`).
     ///
     /// Scope, in two tiers — and the help text must state the second one,
     /// because it is the one that SENDS text:
@@ -458,21 +462,23 @@ final class SettingsStore {
         }
     }
 
-    /// When true, and the polishing endpoint is loopback
-    /// (`PolishContextClipboardReader.isLoopbackEndpoint`), file names / path
+    /// When true, and the polishing endpoint is permitted
+    /// (`PolishContextClipboardReader.isPermittedContextEndpoint`), file names / path
     /// components / the branch name from the git repo in the focused terminal
     /// are harvested and the transcript-relevant ones injected into the polish
     /// prompt's replacement-dictionary section, so the model spells technical
     /// terms exactly. Opt-in (default false), prompt-context only (no
-    /// deterministic replacement), local endpoints only — repo file names must
-    /// never ride to a remote endpoint. See `RepoVocabulary`.
+    /// deterministic replacement), permitted endpoints only — repo file names
+    /// must never ride to an endpoint the user has not consented to. See
+    /// `RepoVocabulary`.
     var repoVocabularyEnabled: Bool {
         didSet {
             defaults.set(repoVocabularyEnabled, forKey: Keys.repoVocabularyEnabled)
         }
     }
 
-    /// When true, and the polishing endpoint is loopback, and the focused
+    /// When true, and the polishing endpoint is permitted (loopback, or any
+    /// endpoint under the `polishContextTrustedEndpointEnabled` opt-in), and the focused
     /// terminal pane positively joins to one live Claude Code session, that
     /// session's repository CONTENT — status, uncommitted diffs, and the
     /// contents of files the agent just read or edited — plus the previous
@@ -495,11 +501,34 @@ final class SettingsStore {
     /// who agreed to "spell my filenames right" has not thereby agreed to "send
     /// the body of the file I am editing", so reusing the existing toggle would
     /// silently widen a consent they already gave. Opt-in (default false),
-    /// loopback endpoints only — repository contents must never ride to a
-    /// remote endpoint. See `ClaudeRepoCollector`.
+    /// permitted endpoints only — repository contents must never ride to an
+    /// endpoint the user has not consented to. See `ClaudeRepoCollector`.
     var claudeRepoContextEnabled: Bool {
         didSet {
             defaults.set(claudeRepoContextEnabled, forKey: Keys.claudeRepoContextEnabled)
+        }
+    }
+
+    /// When true, the loopback-only endpoint gate that every polish-context
+    /// surface shares (clipboard, terminal screen, repo vocabulary, Claude
+    /// repo/session blocks — `PolishContextClipboardReader
+    /// .isPermittedContextEndpoint`) also admits the configured polishing
+    /// endpoint when it is NOT on this Mac: a machine on the user's LAN, or a
+    /// remote provider they trust with that content.
+    ///
+    /// Opt-in (default false), and deliberately a SEPARATE consent from each
+    /// context toggle: those decide WHAT may be collected, this decides WHERE
+    /// it may be sent. Off, the per-surface promises ("local polishing
+    /// endpoints only") hold unconditionally; on, the user has explicitly
+    /// traded them for their chosen endpoint, and the Settings row's help text
+    /// names exactly that trade. Each surface's own toggle still gates
+    /// collection — this flag alone never causes a read.
+    var polishContextTrustedEndpointEnabled: Bool {
+        didSet {
+            defaults.set(
+                polishContextTrustedEndpointEnabled,
+                forKey: Keys.polishContextTrustedEndpointEnabled
+            )
         }
     }
 
@@ -735,6 +764,8 @@ final class SettingsStore {
             defaults: defaults, key: Keys.repoVocabularyEnabled, fallback: false)
         claudeRepoContextEnabled = Self.loadBool(
             defaults: defaults, key: Keys.claudeRepoContextEnabled, fallback: false)
+        polishContextTrustedEndpointEnabled = Self.loadBool(
+            defaults: defaults, key: Keys.polishContextTrustedEndpointEnabled, fallback: false)
         debugLogRealtimeDeltas = Self.loadBool(
             defaults: defaults, key: Keys.debugLogRealtimeDeltas, fallback: false)
         modifierOnlyHotKeyEnabled = Self.loadBool(

--- a/Sources/localvoxtral/SettingsView.swift
+++ b/Sources/localvoxtral/SettingsView.swift
@@ -811,6 +811,27 @@ private struct TextProcessingSettingsPane: View {
                         }
                     }
 
+                    // A row in the EXISTING group, never a new group: pane group
+                    // structure is constant (owner rule, 2026-07-04).
+                    SettingsFieldRow(title: "Send polish context to non-local endpoints") {
+                        VStack(alignment: .leading, spacing: 6) {
+                            Toggle("", isOn: $settings.polishContextTrustedEndpointEnabled)
+                                .labelsHidden()
+                                .toggleStyle(.switch)
+
+                            // Names the trade in full: every "local polishing
+                            // endpoints only" promise above is exactly what
+                            // this toggle relaxes, so the help text says which
+                            // content classes ride and where they go. "You
+                            // trust" puts the judgment where it now lives —
+                            // with the user — instead of implying the app can
+                            // vouch for their endpoint.
+                            SettingsHelpText(
+                                "Off: clipboard, screen, and project context are only ever sent to a polisher on this Mac. On: the context enabled above is also sent to the polishing endpoint you configured — enable only for an endpoint you trust, such as a server on your own network."
+                            )
+                        }
+                    }
+
                     SettingsFieldRow(title: "Spoken clipboard paste") {
                         VStack(alignment: .leading, spacing: 6) {
                             Toggle("", isOn: $settings.clipboardPayloadMacroEnabled)

--- a/Sources/localvoxtral/TerminalFocusedTTYReader.swift
+++ b/Sources/localvoxtral/TerminalFocusedTTYReader.swift
@@ -52,7 +52,7 @@ struct GhosttyFocusedTerminalTTYReader: TerminalFocusedTTYReading {
             // quote window titles, and a title is content.
             // -1700: `tty` not in the dictionary (Ghostty < 1.4).
             // -1743: the user declined the Automation prompt.
-            let code = (error[NSAppleScriptErrorNumber] as? Int) ?? 0
+            let code = (error[NSAppleScript.errorNumber] as? Int) ?? 0
             Log.claudeContext.info(
                 "Focused-pane tty unavailable (AppleScript error \(code, privacy: .public))"
             )

--- a/Sources/localvoxtral/TerminalFocusedTTYReader.swift
+++ b/Sources/localvoxtral/TerminalFocusedTTYReader.swift
@@ -1,3 +1,4 @@
+import AppKit
 import Foundation
 
 /// Reads the controlling TTY of the FOCUSED terminal pane, so the Claude join
@@ -26,11 +27,16 @@ protocol TerminalFocusedTTYReading {
 /// The live reader: one bounded AppleScript question to Ghostty.
 @MainActor
 struct GhosttyFocusedTerminalTTYReader: TerminalFocusedTTYReading {
-    /// `with timeout` bounds the Apple event wait so a wedged Ghostty cannot
-    /// hold dictation start hostage — the same budget discipline as the AX
-    /// reader's per-message timeouts. `tell application id` of the frontmost
-    /// app never launches anything: the caller only asks about an app it just
-    /// observed as frontmost.
+    /// `with timeout` bounds GHOSTTY'S REPLY, so a wedged terminal cannot hold
+    /// dictation start hostage — the same budget discipline as the AX reader's
+    /// per-message timeouts. It does NOT bound TCC: the first Apple event ever
+    /// sent to Ghostty parks in the Automation consent sheet for as long as
+    /// the user leaves it open, timeout or no timeout. That first-run freeze
+    /// belongs at app launch, not mid-dictation, which is what
+    /// `GhosttyAutomationConsentPrewarm` exists for — by the time a session
+    /// start runs this read, the sheet has already come and gone.
+    /// `tell application id` of the frontmost app never launches anything: the
+    /// caller only asks about an app it just observed as frontmost.
     private static let source = """
     with timeout of 1 second
         tell application id "\(TerminalScreenAllowlist.ghosttyBundleID)"
@@ -39,12 +45,30 @@ struct GhosttyFocusedTerminalTTYReader: TerminalFocusedTTYReading {
     end timeout
     """
 
+    /// Compiled once, reused for every session start. A fresh `NSAppleScript`
+    /// recompiles the (constant) source on each call — avoidable milliseconds
+    /// on the dictation-start hot path. The per-start call itself stays
+    /// synchronous-but-bounded by design: a true off-main hop would make the
+    /// join resolution async and restructure session start, so it is
+    /// deliberately deferred.
+    private static var cachedScript: NSAppleScript?
+
+    private static func compiledScript() -> NSAppleScript? {
+        if let cachedScript { return cachedScript }
+        guard let script = NSAppleScript(source: source) else { return nil }
+        // Compile eagerly so later executes reuse the compiled form; a compile
+        // error is reported by executeAndReturnError below either way.
+        script.compileAndReturnError(nil)
+        cachedScript = script
+        return script
+    }
+
     func focusedTerminalTTY(bundleID: String) -> String? {
         // Ghostty-only, exact match: the script is Ghostty's dictionary, and
         // sending it anywhere else is at best an error and at worst a prompt
         // to automate an app the user never pointed us at.
         guard bundleID == TerminalScreenAllowlist.ghosttyBundleID else { return nil }
-        guard let script = NSAppleScript(source: Self.source) else { return nil }
+        guard let script = Self.compiledScript() else { return nil }
         var error: NSDictionary?
         let result = script.executeAndReturnError(&error)
         if let error {
@@ -53,9 +77,15 @@ struct GhosttyFocusedTerminalTTYReader: TerminalFocusedTTYReading {
             // -1700: `tty` not in the dictionary (Ghostty < 1.4).
             // -1743: the user declined the Automation prompt.
             let code = (error[NSAppleScript.errorNumber] as? Int) ?? 0
-            Log.claudeContext.info(
-                "Focused-pane tty unavailable (AppleScript error \(code, privacy: .public))"
-            )
+            if code == -1743 {
+                Log.claudeContext.info(
+                    "Automation permission denied — grant localvoxtral → Ghostty in System Settings > Privacy > Automation"
+                )
+            } else {
+                Log.claudeContext.info(
+                    "Focused-pane tty unavailable (AppleScript error \(code, privacy: .public))"
+                )
+            }
             return nil
         }
         return Self.validatedTTY(result.stringValue)
@@ -73,4 +103,89 @@ struct GhosttyFocusedTerminalTTYReader: TerminalFocusedTTYReading {
         else { return nil }
         return raw
     }
+}
+
+/// One-shot Automation consent pre-warm for the Ghostty tty read.
+///
+/// The first Apple event this app ever sends to Ghostty raises the TCC
+/// Automation consent sheet, and the send BLOCKS until the user answers — the
+/// script's `with timeout` bounds Ghostty's reply, not TCC. Left to happen
+/// naturally, that block lands in the middle of the user's first dictation
+/// into a Claude pane. So the app fires the same read once, at launch (or as
+/// soon as Ghostty launches), with the result discarded: the sheet appears at
+/// a moment when nothing is in flight, and every later per-start read finds
+/// consent already settled.
+///
+/// Fires at most once per app run, and only when Ghostty is actually running —
+/// `tell application id` would otherwise LAUNCH Ghostty, which a background
+/// pre-warm must never do. The caller gates on the context features being
+/// enabled, so an opted-out user is never prompted; a user who enables the
+/// feature mid-run gets pre-warmed on the next launch (a Settings-toggle
+/// pre-warm is deferred until someone hits it).
+@MainActor
+enum GhosttyAutomationConsentPrewarm {
+    private static var fired = false
+    private static var launchObserver: (any NSObjectProtocol)?
+    private static var observedCenter: NotificationCenter?
+
+    /// Fires the pre-warm now when Ghostty is running, otherwise arms a
+    /// one-shot launch observer that fires it when Ghostty appears.
+    static func fireOnceWhenGhosttyIsAvailable(
+        isGhosttyRunning: @escaping @MainActor @Sendable () -> Bool = {
+            !NSRunningApplication.runningApplications(
+                withBundleIdentifier: TerminalScreenAllowlist.ghosttyBundleID
+            ).isEmpty
+        },
+        execute: @escaping @MainActor @Sendable () -> Void = {
+            _ = GhosttyFocusedTerminalTTYReader().focusedTerminalTTY(
+                bundleID: TerminalScreenAllowlist.ghosttyBundleID
+            )
+        },
+        notificationCenter: NotificationCenter = NSWorkspace.shared.notificationCenter
+    ) {
+        guard !fired, launchObserver == nil else { return }
+        if isGhosttyRunning() {
+            fire(execute)
+            return
+        }
+        observedCenter = notificationCenter
+        launchObserver = notificationCenter.addObserver(
+            forName: NSWorkspace.didLaunchApplicationNotification,
+            object: nil,
+            queue: .main
+        ) { _ in
+            MainActor.assumeIsolated {
+                guard !fired, isGhosttyRunning() else { return }
+                removeObserver()
+                fire(execute)
+            }
+        }
+    }
+
+    private static func fire(_ execute: @escaping @MainActor @Sendable () -> Void) {
+        fired = true
+        // A Task, not an inline call: the pre-warm can park in the consent
+        // sheet, and the caller (broker startup) must not wait on that.
+        Task { @MainActor in
+            Log.claudeContext.info("Pre-warming Ghostty Automation consent (result discarded)")
+            execute()
+        }
+    }
+
+    private static func removeObserver() {
+        if let launchObserver, let observedCenter {
+            observedCenter.removeObserver(launchObserver)
+        }
+        launchObserver = nil
+        observedCenter = nil
+    }
+
+    #if DEBUG
+    /// Test-only: restore the untouched state so each test observes its own
+    /// one-shot semantics.
+    static func debugReset() {
+        removeObserver()
+        fired = false
+    }
+    #endif
 }

--- a/Sources/localvoxtral/TerminalFocusedTTYReader.swift
+++ b/Sources/localvoxtral/TerminalFocusedTTYReader.swift
@@ -1,0 +1,76 @@
+import Foundation
+
+/// Reads the controlling TTY of the FOCUSED terminal pane, so the Claude join
+/// can resolve from the process table instead of the window title.
+///
+/// The title is a fought-over channel: Claude Code writes its own
+/// conversation-derived titles and clobbers the `lvx-` marker whenever it is
+/// responding (field finding, 2026-07-17), so a title read mid-turn abstains
+/// even though the session is right there. A pane's TTY has no such war: the
+/// hook publisher already reports the session's controlling TTY
+/// (`ClaudeHookProcessInfo.tty`), Ghostty ≥ 1.4 exposes the focused pane's TTY
+/// over AppleScript (ghostty-org/ghostty#11922), and equality is exact — two
+/// sessions in the same repo sit on different TTYs, which is precisely the case
+/// the workspace lookup abstains on. The marker join stays as the fallback for
+/// older Ghostty and as the ONLY join for SSH-remote sessions, whose TTY names
+/// a device on another machine.
+@MainActor
+protocol TerminalFocusedTTYReading {
+    /// The `/dev/ttysNNN` path of the focused pane of `bundleID`'s frontmost
+    /// window, or nil when the app is unsupported, too old to expose `tty`,
+    /// Automation is denied, or the read failed. Nil means "fall back to the
+    /// marker", never "guess".
+    func focusedTerminalTTY(bundleID: String) -> String?
+}
+
+/// The live reader: one bounded AppleScript question to Ghostty.
+@MainActor
+struct GhosttyFocusedTerminalTTYReader: TerminalFocusedTTYReading {
+    /// `with timeout` bounds the Apple event wait so a wedged Ghostty cannot
+    /// hold dictation start hostage — the same budget discipline as the AX
+    /// reader's per-message timeouts. `tell application id` of the frontmost
+    /// app never launches anything: the caller only asks about an app it just
+    /// observed as frontmost.
+    private static let source = """
+    with timeout of 1 second
+        tell application id "\(TerminalScreenAllowlist.ghosttyBundleID)"
+            get tty of focused terminal of selected tab of front window
+        end tell
+    end timeout
+    """
+
+    func focusedTerminalTTY(bundleID: String) -> String? {
+        // Ghostty-only, exact match: the script is Ghostty's dictionary, and
+        // sending it anywhere else is at best an error and at worst a prompt
+        // to automate an app the user never pointed us at.
+        guard bundleID == TerminalScreenAllowlist.ghosttyBundleID else { return nil }
+        guard let script = NSAppleScript(source: Self.source) else { return nil }
+        var error: NSDictionary?
+        let result = script.executeAndReturnError(&error)
+        if let error {
+            // Code only, never the message — AppleScript error strings can
+            // quote window titles, and a title is content.
+            // -1700: `tty` not in the dictionary (Ghostty < 1.4).
+            // -1743: the user declined the Automation prompt.
+            let code = (error[NSAppleScriptErrorNumber] as? Int) ?? 0
+            Log.claudeContext.info(
+                "Focused-pane tty unavailable (AppleScript error \(code, privacy: .public))"
+            )
+            return nil
+        }
+        return Self.validatedTTY(result.stringValue)
+    }
+
+    /// Accepts only a plausible pty device path. The value crosses from another
+    /// process into a registry lookup; a reply that is not shaped like
+    /// `/dev/tty…` (empty, a title, an injection attempt via a renamed app)
+    /// must read as "no answer", not as a key.
+    static func validatedTTY(_ raw: String?) -> String? {
+        guard let raw,
+              raw.hasPrefix("/dev/tty"),
+              raw.count <= 64,
+              raw.allSatisfy({ $0.isASCII && !$0.isWhitespace })
+        else { return nil }
+        return raw
+    }
+}

--- a/Sources/localvoxtral/TerminalScreenAXReader.swift
+++ b/Sources/localvoxtral/TerminalScreenAXReader.swift
@@ -162,6 +162,24 @@ enum TerminalScreenAXReader {
         return FocusedWindowMarkerRead(marker: marker, windowID: read.windowID)
     }
 
+    /// The identity of `pid`'s focused window, or nil when it cannot be
+    /// established.
+    ///
+    /// This exists for the TTY join: the marker read reports the window it
+    /// parsed the marker from, but a tty-resolved join never touches the
+    /// marker — the title has typically been clobbered by Claude Code's own
+    /// conversation title — so the window the user was focused on is
+    /// identified by this separate bounded AX read. Nil abstains at the
+    /// authorizer, exactly like a nil marker-read identity (review F2).
+    static func focusedWindowIdentity(applicationPID pid: pid_t) -> CGWindowID? {
+        #if DEBUG
+        if let override = debugTitleWindowIDOverride { return override(pid) }
+        if TerminalTargetDetector.isRunningUnderXCTest { return nil }
+        #endif
+        guard AXIsProcessTrusted() else { return nil }
+        return copyFocusedWindowTitle(applicationPID: pid)?.windowID
+    }
+
     /// The AX round trip for the title. Returns the focused window's `AXTitle`
     /// and window identity, only if that window is still owned by `pid`.
     private static func copyFocusedWindowTitle(

--- a/Sources/localvoxtral/TerminalScreenAXReader.swift
+++ b/Sources/localvoxtral/TerminalScreenAXReader.swift
@@ -210,13 +210,48 @@ enum TerminalScreenAXReader {
     /// head is capped. Returns nil for text that is empty or whitespace-only —
     /// a freshly cleared terminal is not context.
     static func sanitizedScreenText(_ raw: String) -> String? {
-        let sanitized = PolishContextClipboardReader.sanitizeControlCharacters(raw)
+        let sanitized = compactedGridWhitespace(
+            PolishContextClipboardReader.sanitizeControlCharacters(raw)
+        )
         guard !sanitized.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
             return nil
         }
         return sanitized.count > screenCharacterCap
             ? String(sanitized.prefix(screenCharacterCap))
             : sanitized
+    }
+
+    /// The AX grid pads rows toward the pane width and reports every blank
+    /// viewport row, so a mostly-empty pane arrives as kilobytes of spaces
+    /// (field report 2026-07-20: an idle pane rendered ~40 blank padded lines
+    /// into the polish prompt). Trailing whitespace carries no term to ground
+    /// and a run of blank rows no structure worth more than one line, so both
+    /// are compacted — and BEFORE the cap, where padding could otherwise evict
+    /// real text from the capped head. Applied at the single sanitization seam
+    /// so matching, start/stop comparison, and the rendered excerpt all see
+    /// the same form (compaction is deterministic: identical screens stay
+    /// identical).
+    static func compactedGridWhitespace(_ text: String) -> String {
+        var lines: [Substring] = []
+        var pendingBlank = false
+        for line in text.split(separator: "\n", omittingEmptySubsequences: false) {
+            var trimmed = line
+            while let last = trimmed.last, last == " " || last == "\t" {
+                trimmed = trimmed.dropLast()
+            }
+            if trimmed.isEmpty {
+                // Leading and trailing blank runs vanish entirely (pending is
+                // only flushed when a later non-blank line arrives).
+                pendingBlank = !lines.isEmpty
+            } else {
+                if pendingBlank {
+                    lines.append("")
+                    pendingBlank = false
+                }
+                lines.append(trimmed)
+            }
+        }
+        return lines.joined(separator: "\n")
     }
 
     /// The AX round trip. Returns the raw (unsanitized) `AXValue` string of the

--- a/Sources/localvoxtral/TerminalScreenAXReader.swift
+++ b/Sources/localvoxtral/TerminalScreenAXReader.swift
@@ -254,7 +254,10 @@ enum TerminalScreenAXReader {
         var pendingBlank = false
         for line in text.split(separator: "\n", omittingEmptySubsequences: false) {
             var trimmed = line
-            while let last = trimmed.last, last == " " || last == "\t" {
+            // NBSP (U+00A0) alongside space/tab: terminal grids use it for
+            // padding that must not wrap, and a trailing run of it is padding
+            // like any other.
+            while let last = trimmed.last, last == " " || last == "\t" || last == "\u{00A0}" {
                 trimmed = trimmed.dropLast()
             }
             if trimmed.isEmpty {

--- a/Sources/localvoxtral/TerminalScreenContext.swift
+++ b/Sources/localvoxtral/TerminalScreenContext.swift
@@ -89,8 +89,9 @@ enum TerminalScreenStopSample: Equatable, Sendable {
     /// only our ability to confirm the screen is gone.
     case readFailed
     /// The gate REJECTED at stop: the setting was turned off, the endpoint is
-    /// no longer loopback, or Accessibility trust was revoked mid-session. The
-    /// user has withdrawn consent; nothing captured under it may be used.
+    /// no longer permitted (not loopback, and the trusted-endpoint opt-in is
+    /// off or was withdrawn), or Accessibility trust was revoked mid-session.
+    /// The user has withdrawn consent; nothing captured under it may be used.
     case policyRejected
     /// The start PID is gone, or now resolves to a different bundle ID.
     case targetChanged
@@ -168,8 +169,13 @@ enum TerminalScreenRawAttachmentPolicy {
 /// What to do with a terminal screen capture at commit time, after comparing
 /// the start-of-dictation sample against a stop-time re-read.
 enum TerminalScreenContextDecision: Equatable, Sendable {
-    /// The screen is byte-identical to what the user was looking at when they
-    /// started speaking. Safe to put the excerpt in the prompt AND use it for
+    /// The screen is identical — after the deterministic whitespace compaction
+    /// every read passes through (`TerminalScreenAXReader.sanitizedScreenText`)
+    /// — to what the user was looking at when they started speaking. NOT
+    /// byte-identical to the raw AX payload: a redraw that only changed row
+    /// padding or blank-row runs intentionally still renders, because the
+    /// compacted form is what both captures, the comparison, and the excerpt
+    /// all see. Safe to put the excerpt in the prompt AND use it for
     /// vocabulary grounding.
     case render(excerpt: String)
 
@@ -197,7 +203,8 @@ enum TerminalScreenContextDecision: Equatable, Sendable {
         /// with the commit is unsound.
         case targetChanged = "target-changed"
         /// The gate that authorized the start capture no longer holds: setting
-        /// off, endpoint no longer loopback, or trust revoked. Consent was
+        /// off, endpoint no longer permitted (loopback-only unless the
+        /// trusted-endpoint opt-in still holds), or trust revoked. Consent was
         /// withdrawn mid-session, so the capture taken under it is discarded
         /// entirely — not downgraded to matching-only.
         case policyRejected = "policy-rejected"

--- a/Sources/localvoxtral/TerminalScreenContext.swift
+++ b/Sources/localvoxtral/TerminalScreenContext.swift
@@ -236,17 +236,21 @@ enum TerminalScreenContext {
     /// non-Ghostty app means the app's screen is never touched at all.
     ///
     /// Order is deliberate and cheapest-first: the user's explicit opt-out wins
-    /// over everything, then the endpoint promise (screen text must never leave
-    /// this Mac), then the app allowlist, then trust — the only one that can
+    /// over everything, then the endpoint promise (screen text stays on this
+    /// Mac unless the trusted-endpoint opt-in relaxes it — default off, fails
+    /// closed), then the app allowlist, then trust — the only one that can
     /// prompt or vary at runtime.
     static func shouldAttemptRead(
         settingEnabled: Bool,
         endpointURL: URL,
         bundleID: String?,
-        isAccessibilityTrusted: Bool
+        isAccessibilityTrusted: Bool,
+        trustedEndpointEnabled: Bool = false
     ) -> Bool {
         guard settingEnabled else { return false }
-        guard PolishContextClipboardReader.isLoopbackEndpoint(endpointURL) else { return false }
+        guard PolishContextClipboardReader.isPermittedContextEndpoint(
+            endpointURL, trustedEndpointEnabled: trustedEndpointEnabled
+        ) else { return false }
         guard TerminalScreenAllowlist.isSupported(bundleID) else { return false }
         return isAccessibilityTrusted
     }

--- a/Sources/localvoxtral/TerminalScreenContextSource.swift
+++ b/Sources/localvoxtral/TerminalScreenContextSource.swift
@@ -102,7 +102,7 @@ enum TerminalScreenContextSource {
         // knows whether that gate still holds. Authorizing first would:
         //
         // - read a title after the user turned the setting off, repointed the
-        //   endpoint off-loopback, or revoked trust — i.e. after consent was
+        //   endpoint no longer permitted, or revoked trust — i.e. after consent was
         //   withdrawn (`.policyRejected`);
         // - read the title of a RECYCLED PID's new owner (`.targetChanged`).
         //   The authorizer allowlist-checks the START capture's bundle ID, so a

--- a/Sources/localvoxtral/TerminalScreenContextSource.swift
+++ b/Sources/localvoxtral/TerminalScreenContextSource.swift
@@ -57,14 +57,16 @@ enum TerminalScreenContextSource {
     static func captureAtStart(
         settingEnabled: Bool,
         endpointURL: URL,
-        isAccessibilityTrusted: Bool
+        isAccessibilityTrusted: Bool,
+        trustedEndpointEnabled: Bool = false
     ) -> TerminalScreenCapture? {
         guard let target = frontmostTarget() else { return nil }
         guard TerminalScreenContext.shouldAttemptRead(
             settingEnabled: settingEnabled,
             endpointURL: endpointURL,
             bundleID: target.bundleID,
-            isAccessibilityTrusted: isAccessibilityTrusted
+            isAccessibilityTrusted: isAccessibilityTrusted,
+            trustedEndpointEnabled: trustedEndpointEnabled
         ) else {
             return nil
         }
@@ -89,7 +91,8 @@ enum TerminalScreenContextSource {
         start: TerminalScreenCapture?,
         settingEnabled: Bool,
         endpointURL: URL,
-        isAccessibilityTrusted: Bool
+        isAccessibilityTrusted: Bool,
+        trustedEndpointEnabled: Bool = false
     ) -> TerminalScreenContextDecision {
         // ORDER IS LOAD-BEARING: sample first, authorize second.
         //
@@ -114,7 +117,8 @@ enum TerminalScreenContextSource {
             start: start,
             settingEnabled: settingEnabled,
             endpointURL: endpointURL,
-            isAccessibilityTrusted: isAccessibilityTrusted
+            isAccessibilityTrusted: isAccessibilityTrusted,
+            trustedEndpointEnabled: trustedEndpointEnabled
         )
         // Asked about the START capture's target — the pane the user was
         // actually looking at while speaking — never the frontmost app, which by
@@ -144,7 +148,8 @@ enum TerminalScreenContextSource {
         start: TerminalScreenCapture?,
         settingEnabled: Bool,
         endpointURL: URL,
-        isAccessibilityTrusted: Bool
+        isAccessibilityTrusted: Bool,
+        trustedEndpointEnabled: Bool
     ) -> TerminalScreenStopSample {
         // Irrelevant when start is nil (reconcile drops first); keeps the
         // signature total.
@@ -164,7 +169,8 @@ enum TerminalScreenContextSource {
             settingEnabled: settingEnabled,
             endpointURL: endpointURL,
             bundleID: stopTarget.bundleID,
-            isAccessibilityTrusted: isAccessibilityTrusted
+            isAccessibilityTrusted: isAccessibilityTrusted,
+            trustedEndpointEnabled: trustedEndpointEnabled
         ) else {
             return .policyRejected
         }

--- a/Sources/localvoxtral/localvoxtralApp.swift
+++ b/Sources/localvoxtral/localvoxtralApp.swift
@@ -229,6 +229,17 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                 focusedTerminalTTY: { ttyReader.focusedTerminalTTY(bundleID: $0) }
             )
             viewModel.claudeSessionJoinResolver = resolver
+            // Pre-warm the Automation consent sheet OFF the dictation-start
+            // path: the first Apple event to Ghostty blocks in TCC until the
+            // user answers, and that freeze must not land mid-dictation. Only
+            // for users who opted into a context feature — the pre-warm is
+            // itself the consent prompt, and an opted-out user must never see
+            // it.
+            if viewModel.settings.terminalScreenContextEnabled
+                || viewModel.settings.claudeRepoContextEnabled
+            {
+                GhosttyAutomationConsentPrewarm.fireOnceWhenGhosttyIsAvailable()
+            }
             // The join gate for raw terminal screen attachment. Installed only
             // now: without a running broker there are no markers to resolve, and
             // an authorizer over an empty registry would answer `.unknown` to

--- a/Sources/localvoxtral/localvoxtralApp.swift
+++ b/Sources/localvoxtral/localvoxtralApp.swift
@@ -220,7 +220,14 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             // the session's prior prompt, and the repository context describe the
             // same session — three resolvers would each answer honestly about a
             // different moment.
-            let resolver = ClaudeSessionJoinResolver(registry: claudeSessionRegistry)
+            // The tty seam is wired here, not defaulted: sending Apple events
+            // is a consented capability (Automation prompt), so only the app —
+            // never a test that forgot to inject — constructs the live reader.
+            let ttyReader = GhosttyFocusedTerminalTTYReader()
+            let resolver = ClaudeSessionJoinResolver(
+                registry: claudeSessionRegistry,
+                focusedTerminalTTY: { ttyReader.focusedTerminalTTY(bundleID: $0) }
+            )
             viewModel.claudeSessionJoinResolver = resolver
             // The join gate for raw terminal screen attachment. Installed only
             // now: without a running broker there are no markers to resolve, and

--- a/Tests/localvoxtralTests/ClaudeContextBrokerTests.swift
+++ b/Tests/localvoxtralTests/ClaudeContextBrokerTests.swift
@@ -185,7 +185,7 @@ final class ClaudeContextBrokerIntegrationTests: XCTestCase {
                 now: { 1 },
                 pid: { 31_337 },
                 ppid: { getpid() },
-                ttyName: { nil },
+                ttyName: { _ in nil },
                 variables: [ClaudeHookSocketPath.environmentKey: socketPath]
             )
         ).run(stdin: Data(json.utf8), fallbackEvent: nil)

--- a/Tests/localvoxtralTests/ClaudeHookPublisherTests.swift
+++ b/Tests/localvoxtralTests/ClaudeHookPublisherTests.swift
@@ -184,6 +184,47 @@ final class ClaudeHookSocketPathTests: XCTestCase {
     #endif
 }
 
+// MARK: - Controlling TTY capture
+
+final class ClaudeHookControllingTTYTests: XCTestCase {
+    // Claude Code wires all three hook fds to pipes, so the field capture
+    // depends on the /dev/tty and process-table fallbacks — these pin the
+    // process-table read's refusal cases deterministically (a positive read
+    // needs a controlling terminal, which CI runners don't have; the live
+    // proof is the hand-tested join).
+    func testProcessTableLookupRefusesInvalidPIDs() {
+        XCTAssertNil(ClaudeHookPublisher.ttyDevicePath(forProcess: 0))
+        XCTAssertNil(ClaudeHookPublisher.ttyDevicePath(forProcess: -1))
+    }
+
+    func testProcessTableLookupAnswersNilForATerminallessProcess() {
+        // launchd (pid 1) exists on every macOS system and never has a
+        // controlling terminal — a real process-table read that must answer
+        // "no device", not garbage.
+        XCTAssertNil(ClaudeHookPublisher.ttyDevicePath(forProcess: 1))
+    }
+
+    func testProcessTableLookupAnswersNilForADeadPID() {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/true")
+        try? process.run()
+        process.waitUntilExit()
+        XCTAssertNil(ClaudeHookPublisher.ttyDevicePath(forProcess: process.processIdentifier))
+    }
+
+    func testControllingTTYAgreesWithItsOwnProcessTableEntry() {
+        // Environment-independent invariant: whether this suite runs on a
+        // pty-attached dev shell (fds are the terminal), piped output (only
+        // /dev/tty answers), or a terminal-less CI runner (nothing answers),
+        // the capture chain and the process-table read of OUR OWN pid describe
+        // the same session — same device, or nil on both sides.
+        XCTAssertEqual(
+            ClaudeHookPublisher.controllingTTY(claudePID: getpid()),
+            ClaudeHookPublisher.ttyDevicePath(forProcess: getpid())
+        )
+    }
+}
+
 // MARK: - Timeout plumbing
 
 final class UnixSocketPublisherTimeoutTests: XCTestCase {

--- a/Tests/localvoxtralTests/ClaudeHookPublisherTests.swift
+++ b/Tests/localvoxtralTests/ClaudeHookPublisherTests.swift
@@ -1,5 +1,7 @@
 import ClaudeContextWire
+import Darwin
 import Foundation
+import Synchronization
 import XCTest
 @testable import ClaudeHookPublisherCore
 
@@ -14,7 +16,7 @@ final class ClaudeHookPublisherTests: XCTestCase {
             now: { 1_700_000_000 },
             pid: { 4242 },
             ppid: { 99 },
-            ttyName: { tty },
+            ttyName: { _ in tty },
             variables: variables
         )
     }
@@ -47,6 +49,31 @@ final class ClaudeHookPublisherTests: XCTestCase {
     func testEmptyTermProgramIsTreatedAsAbsent() {
         let info = publisher(variables: ["HOME": "/h", "TERM_PROGRAM": ""]).processInfo()
         XCTAssertNil(info.termProgram)
+    }
+
+    // The published claudePID and the tty resolution consume the SAME pid,
+    // from one `ppid()` call: the tty seam receives the pid the ppid seam
+    // yielded, so the two fields can never describe different processes (the
+    // old default re-resolved `claudeAncestorPID()` inside the tty closure,
+    // which let an injected ppid and the published tty silently diverge).
+    func testTTYResolutionConsumesTheSamePIDTheEnvironmentPublishes() {
+        let receivedPIDs = Mutex<[Int32]>([])
+        let environment = ClaudeHookPublisher.Environment(
+            now: { 1_700_000_000 },
+            pid: { 4242 },
+            ppid: { 31_337 },
+            ttyName: { pid in
+                receivedPIDs.withLock { $0.append(pid) }
+                return "/dev/ttys009"
+            },
+            variables: ["HOME": "/h"]
+        )
+        let info = ClaudeHookPublisher(environment: environment).processInfo()
+        XCTAssertEqual(info.claudePID, 31_337)
+        XCTAssertEqual(
+            receivedPIDs.withLock { $0 }, [31_337], "one ppid resolution feeds both fields"
+        )
+        XCTAssertEqual(info.tty, "/dev/ttys009")
     }
 
     // MARK: Fail-open
@@ -189,9 +216,10 @@ final class ClaudeHookSocketPathTests: XCTestCase {
 final class ClaudeHookControllingTTYTests: XCTestCase {
     // Claude Code wires all three hook fds to pipes, so the field capture
     // depends on the /dev/tty and process-table fallbacks — these pin the
-    // process-table read's refusal cases deterministically (a positive read
-    // needs a controlling terminal, which CI runners don't have; the live
-    // proof is the hand-tested join).
+    // process-table read's refusal cases deterministically, and the pty test
+    // below covers the positive path (as an invariant that tolerates a
+    // sandbox refusing the acquisition; the live end-to-end proof remains the
+    // hand-tested Ghostty join).
     func testProcessTableLookupRefusesInvalidPIDs() {
         XCTAssertNil(ClaudeHookPublisher.ttyDevicePath(forProcess: 0))
         XCTAssertNil(ClaudeHookPublisher.ttyDevicePath(forProcess: -1))
@@ -210,6 +238,72 @@ final class ClaudeHookControllingTTYTests: XCTestCase {
         try? process.run()
         process.waitUntilExit()
         XCTAssertNil(ClaudeHookPublisher.ttyDevicePath(forProcess: process.processIdentifier))
+    }
+
+    // The positive half: a child spawned into its own session with a pty we
+    // allocated as fd 0 acquires that pty as its controlling terminal, and the
+    // process-table read must name exactly that device. Structured as a
+    // refusal-vs-agreement invariant rather than a hard positive: a sandbox
+    // that denies pty allocation or controlling-terminal acquisition yields
+    // nil (a refusal, same as launchd's), and that is tolerated — but a
+    // NON-nil answer naming any device other than our pty is a lie and fails.
+    func testPTYAttachedChildProcessTableReadNamesThatPTYOrRefuses() throws {
+        var master: Int32 = -1
+        var slave: Int32 = -1
+        var nameBuffer = [CChar](repeating: 0, count: 128)
+        guard openpty(&master, &slave, &nameBuffer, nil, nil) == 0 else {
+            // No pty allocatable in this sandbox: there is no positive
+            // evidence to check and no device to be wrong about. The refusal
+            // cases stay covered by the sibling tests above.
+            return
+        }
+        let slavePath = String(cString: nameBuffer)
+        defer {
+            close(master)
+            close(slave)
+        }
+
+        var actions: posix_spawn_file_actions_t?
+        posix_spawn_file_actions_init(&actions)
+        defer { posix_spawn_file_actions_destroy(&actions) }
+        // Opened IN THE CHILD, after it became a session leader: the first
+        // tty a session leader opens without O_NOCTTY becomes its controlling
+        // terminal — the exact chain a real terminal emulator sets up.
+        slavePath.withCString {
+            _ = posix_spawn_file_actions_addopen(&actions, 0, $0, O_RDWR, 0)
+        }
+
+        var attributes: posix_spawnattr_t?
+        posix_spawnattr_init(&attributes)
+        defer { posix_spawnattr_destroy(&attributes) }
+        // POSIX_SPAWN_SETSID (spawn.h): the child starts its own session, so
+        // it CAN acquire a controlling terminal of its own.
+        posix_spawnattr_setflags(&attributes, Int16(0x0400))
+
+        var childPID: pid_t = 0
+        var argv: [UnsafeMutablePointer<CChar>?] = [strdup("/bin/sleep"), strdup("30"), nil]
+        defer { argv.compactMap { $0 }.forEach { free($0) } }
+        guard posix_spawn(&childPID, "/bin/sleep", &actions, &attributes, argv, nil) == 0 else {
+            return // Same tolerance as openpty: nothing spawned, nothing to lie.
+        }
+        defer {
+            kill(childPID, SIGKILL)
+            var status: Int32 = 0
+            waitpid(childPID, &status, 0)
+        }
+
+        // posix_spawn is one syscall on Darwin: the file actions (and with
+        // them the controlling-terminal acquisition) completed before it
+        // returned, so no polling is needed.
+        if let reported = ClaudeHookPublisher.ttyDevicePath(forProcess: childPID) {
+            XCTAssertEqual(
+                reported, slavePath,
+                "a positive process-table answer must name the pty we allocated, never another device"
+            )
+        }
+        // nil is the tolerated refusal (sandbox denied the acquisition) —
+        // deliberate: absence must stay deterministic here, and the live
+        // positive proof remains the hand-tested Ghostty join.
     }
 
     func testControllingTTYAgreesWithItsOwnProcessTableEntry() {

--- a/Tests/localvoxtralTests/ClaudeRepoContextGateTests.swift
+++ b/Tests/localvoxtralTests/ClaudeRepoContextGateTests.swift
@@ -429,6 +429,20 @@ final class ClaudeRepoContextGateTests: XCTestCase {
         )
     }
 
+    // The trusted-endpoint opt-in admits the session block to a remote
+    // endpoint — the same remote URL that just attached nothing now carries
+    // the prior prompt, because the user explicitly consented to this exact
+    // ride (mirror of `testTrustedEndpointOptInAdmitsRemoteEndpoint`).
+    func testTrustedEndpointOptInAttachesTheSessionBlockToRemoteEndpoint() async {
+        let (viewModel, join) = wiredWithPriorPrompt()
+        viewModel.settings.claudeRepoContextEnabled = true
+        viewModel.settings.polishContextTrustedEndpointEnabled = true
+
+        let outcome = await sessionBlockOutcome(viewModel, join: join, endpointURL: remote)
+        XCTAssertTrue(outcome.text.contains("rewrite the migration script"))
+        XCTAssertNotNil(outcome.block)
+    }
+
     // The session died between start and commit. Its prior prompt is no longer
     // what the user is continuing.
     func testSessionThatEndedSinceStartAttachesNoSessionBlock() async {
@@ -530,6 +544,44 @@ final class ClaudeRepoContextGateTests: XCTestCase {
 
         XCTAssertNil(viewModel.claudeSessionJoin)
         XCTAssertEqual(reads.withLock { $0 }, 0, "an opted-out user's title must never be read")
+    }
+
+    // The trusted-endpoint opt-in also admits the START-TIME join resolution:
+    // with a remote polishing endpoint, the resolver is consulted only under
+    // the opt-in — same gate, same order, as every commit-time surface. Both
+    // halves in one test so the opt-in is provably what flips the answer.
+    func testStartResolutionOverRemoteEndpointRequiresTheTrustedOptIn() {
+        let viewModel = makeViewModel()
+        viewModel.settings.llmPolishingEnabled = true
+        viewModel.settings.polishingBackendMode = .externalURL
+        viewModel.settings.llmPolishingEndpointURL = remote.absoluteString
+        viewModel.settings.claudeRepoContextEnabled = true
+        viewModel.textInsertion.debugSetAccessibilityTrusted(true)
+        addTeardownBlock { viewModel.textInsertion.debugSetAccessibilityTrusted(nil) }
+        let reads = Mutex(0)
+        viewModel.claudeSessionJoinResolver = ClaudeSessionJoinResolver(
+            registry: registry(),
+            markerInWindowTitle: { _ in
+                reads.withLock { $0 += 1 }
+                return TerminalScreenAXReader.FocusedWindowMarkerRead(
+                    marker: ClaudeSessionMarker(value: "lvx-abcd"), windowID: 101
+                )
+            }
+        )
+        TerminalScreenContextSource.debugFrontmostTargetOverride = { self.ghostty }
+
+        viewModel.settings.polishContextTrustedEndpointEnabled = false
+        viewModel.captureTerminalScreenContextForSession()
+        XCTAssertNil(viewModel.claudeSessionJoin)
+        XCTAssertEqual(
+            reads.withLock { $0 }, 0,
+            "a remote endpoint without the opt-in must not even read the title"
+        )
+
+        viewModel.settings.polishContextTrustedEndpointEnabled = true
+        viewModel.captureTerminalScreenContextForSession()
+        XCTAssertNotNil(viewModel.claudeSessionJoin, "the opt-in admits the join")
+        XCTAssertEqual(reads.withLock { $0 }, 1)
     }
 
     override func tearDown() async throws {

--- a/Tests/localvoxtralTests/ClaudeRepoContextGateTests.swift
+++ b/Tests/localvoxtralTests/ClaudeRepoContextGateTests.swift
@@ -182,6 +182,37 @@ final class ClaudeRepoContextGateTests: XCTestCase {
         )
     }
 
+    // The trusted-endpoint opt-in is the ONE way a non-loopback endpoint may
+    // receive repository content — explicit, default off, and it does not
+    // bypass any other gate (the setting itself still gates below).
+    func testTrustedEndpointOptInAdmitsRemoteEndpoint() async {
+        let (viewModel, collector, join) = wired()
+        viewModel.settings.claudeRepoContextEnabled = true
+        viewModel.settings.polishContextTrustedEndpointEnabled = true
+        let snapshot = await viewModel.claudeRepoSnapshotIfEnabled(
+            join: join, endpointURL: remote, transcript: "hello"
+        )
+        XCTAssertNotNil(snapshot)
+        XCTAssertFalse(
+            collector.collectedPaths.isEmpty,
+            "the explicit opt-in is consent for this exact ride"
+        )
+    }
+
+    func testTrustedEndpointOptInDoesNotBypassTheFeatureToggle() async {
+        let (viewModel, collector, join) = wired()
+        viewModel.settings.claudeRepoContextEnabled = false
+        viewModel.settings.polishContextTrustedEndpointEnabled = true
+        let snapshot = await viewModel.claudeRepoSnapshotIfEnabled(
+            join: join, endpointURL: remote, transcript: "hello"
+        )
+        XCTAssertNil(snapshot)
+        XCTAssertTrue(
+            collector.collectedPaths.isEmpty,
+            "trusting an endpoint is not consent to collect anything"
+        )
+    }
+
     // MARK: - Join gate
 
     // The common case: a plain terminal with no marker. No join, no read.

--- a/Tests/localvoxtralTests/ClaudeSessionRegistryTests.swift
+++ b/Tests/localvoxtralTests/ClaudeSessionRegistryTests.swift
@@ -60,7 +60,8 @@ final class ClaudeSessionRegistryTests: XCTestCase {
         prompt: String? = nil,
         files: [ClaudeFileTouch] = [],
         claudePID: Int32? = nil,
-        hookPID: Int32 = 777
+        hookPID: Int32 = 777,
+        tty: String? = nil
     ) -> ClaudeHookRecord {
         ClaudeHookRecord(
             event: event,
@@ -69,7 +70,7 @@ final class ClaudeSessionRegistryTests: XCTestCase {
             rawCwd: cwd,
             prompt: prompt,
             files: files,
-            process: claudePID.map { ClaudeHookProcessInfo(hookPID: hookPID, claudePID: $0) }
+            process: claudePID.map { ClaudeHookProcessInfo(hookPID: hookPID, claudePID: $0, tty: tty) }
         )
     }
 
@@ -324,6 +325,65 @@ final class ClaudeSessionRegistryTests: XCTestCase {
         guard case .resolved = registry.resolve(marker: ClaudeSessionMarker(value: "lvx-1")) else {
             return XCTFail("remote sessions rely on TTL, not local pid liveness")
         }
+    }
+
+    // MARK: TTY lookup — the focus join
+
+    func testTTYLookupResolvesTheLocalSessionOnThatDevice() throws {
+        let registry = makeRegistry()
+        registry.ingest(
+            record(.sessionStart, claudePID: 9001, tty: "/dev/ttys003"), origin: local
+        )
+        guard case .resolved(let snapshot) = registry.resolve(tty: "/dev/ttys003") else {
+            return XCTFail("expected the session on that device")
+        }
+        XCTAssertEqual(snapshot.sessionID, "s1")
+    }
+
+    func testTTYLookupNeverMatchesARemoteSession() {
+        // The spoof this closes: a remote session's TTY names a device on
+        // ANOTHER machine. If an SSH host could publish "/dev/ttys003" and
+        // match a local pane, it would claim that pane's dictations — so
+        // remote candidates are refused outright, even on exact match.
+        let registry = makeRegistry()
+        registry.ingest(
+            record(.sessionStart, claudePID: 9001, tty: "/dev/ttys003"),
+            origin: .remote(channel: "ssh")
+        )
+        XCTAssertEqual(registry.resolve(tty: "/dev/ttys003"), .unknown)
+    }
+
+    func testTwoLocalSessionsOnOneTTYAbstainAsAmbiguous() {
+        // A suspended Claude beneath a new one in the same pane. Guessing
+        // would attribute one session's repo to the other's dictation.
+        let registry = makeRegistry(markers: TestMarkers(["lvx-1", "lvx-2"]))
+        registry.ingest(
+            record(.sessionStart, session: "s1", claudePID: 9001, tty: "/dev/ttys003"),
+            origin: local
+        )
+        registry.ingest(
+            record(.sessionStart, session: "s2", claudePID: 9002, tty: "/dev/ttys003"),
+            origin: local
+        )
+        XCTAssertEqual(registry.resolve(tty: "/dev/ttys003"), .ambiguous)
+    }
+
+    func testTTYLookupReportsStaleWhenTheOnlyMatchIsDead() {
+        let liveness = TestLiveness()
+        let registry = makeRegistry(liveness: liveness)
+        registry.ingest(
+            record(.sessionStart, claudePID: 9001, tty: "/dev/ttys003"), origin: local
+        )
+        liveness.kill(9001)
+        XCTAssertEqual(registry.resolve(tty: "/dev/ttys003"), .stale)
+    }
+
+    func testTTYLookupIsUnknownForAnUnseenDevice() {
+        let registry = makeRegistry()
+        registry.ingest(
+            record(.sessionStart, claudePID: 9001, tty: "/dev/ttys003"), origin: local
+        )
+        XCTAssertEqual(registry.resolve(tty: "/dev/ttys007"), .unknown)
     }
 
     // MARK: Workspace lookup — ambiguity

--- a/Tests/localvoxtralTests/GhosttyAutomationConsentPrewarmTests.swift
+++ b/Tests/localvoxtralTests/GhosttyAutomationConsentPrewarmTests.swift
@@ -1,0 +1,91 @@
+import AppKit
+import Synchronization
+import XCTest
+@testable import localvoxtral
+
+/// The one-shot Automation consent pre-warm. What matters here is the shape,
+/// not the Apple event (which tests must never send): it fires exactly once,
+/// only while Ghostty is actually running (a pre-warm that LAUNCHES Ghostty
+/// would be worse than the freeze it prevents), and it arms a launch observer
+/// instead when Ghostty is not there yet.
+@MainActor
+final class GhosttyAutomationConsentPrewarmTests: XCTestCase {
+    override func setUp() async throws {
+        try await super.setUp()
+        GhosttyAutomationConsentPrewarm.debugReset()
+    }
+
+    override func tearDown() async throws {
+        GhosttyAutomationConsentPrewarm.debugReset()
+        try await super.tearDown()
+    }
+
+    func testFiresExactlyOnceWhenGhosttyIsRunning() async {
+        let executions = Mutex(0)
+        let (executed, signal) = AsyncStream.makeStream(of: Void.self)
+        let execute: @MainActor @Sendable () -> Void = {
+            executions.withLock { $0 += 1 }
+            signal.yield()
+        }
+        GhosttyAutomationConsentPrewarm.fireOnceWhenGhosttyIsAvailable(
+            isGhosttyRunning: { true },
+            execute: execute,
+            notificationCenter: NotificationCenter()
+        )
+        // A second call (a second broker start, a settings change) must not
+        // send a second event.
+        GhosttyAutomationConsentPrewarm.fireOnceWhenGhosttyIsAvailable(
+            isGhosttyRunning: { true },
+            execute: execute,
+            notificationCenter: NotificationCenter()
+        )
+        var iterator = executed.makeAsyncIterator()
+        _ = await iterator.next()
+        // Drain any (incorrect) second execution deterministically: the fire
+        // path enqueues on the main actor, so once we are running again after
+        // the first signal, a bounded yield burst flushes anything pending.
+        for _ in 0..<100 { await Task.yield() }
+        XCTAssertEqual(executions.withLock { $0 }, 1)
+    }
+
+    func testDoesNotFireWhileGhosttyIsNotRunning() async {
+        let executions = Mutex(0)
+        let center = NotificationCenter()
+        GhosttyAutomationConsentPrewarm.fireOnceWhenGhosttyIsAvailable(
+            isGhosttyRunning: { false },
+            execute: { executions.withLock { $0 += 1 } },
+            notificationCenter: center
+        )
+        // An unrelated app launching (Ghostty still absent) must not fire —
+        // firing would LAUNCH Ghostty via the tell.
+        center.post(name: NSWorkspace.didLaunchApplicationNotification, object: nil)
+        for _ in 0..<100 { await Task.yield() }
+        XCTAssertEqual(executions.withLock { $0 }, 0)
+    }
+
+    func testFiresWhenGhosttyLaunchesLater() async {
+        let executions = Mutex(0)
+        let (executed, signal) = AsyncStream.makeStream(of: Void.self)
+        let running = Mutex(false)
+        let center = NotificationCenter()
+        GhosttyAutomationConsentPrewarm.fireOnceWhenGhosttyIsAvailable(
+            isGhosttyRunning: { running.withLock { $0 } },
+            execute: {
+                executions.withLock { $0 += 1 }
+                signal.yield()
+            },
+            notificationCenter: center
+        )
+        XCTAssertEqual(executions.withLock { $0 }, 0, "precondition: nothing fires before launch")
+
+        running.withLock { $0 = true }
+        center.post(name: NSWorkspace.didLaunchApplicationNotification, object: nil)
+        var iterator = executed.makeAsyncIterator()
+        _ = await iterator.next()
+        // The observer is one-shot: another launch notification (Ghostty
+        // relaunching) must not re-fire.
+        center.post(name: NSWorkspace.didLaunchApplicationNotification, object: nil)
+        for _ in 0..<100 { await Task.yield() }
+        XCTAssertEqual(executions.withLock { $0 }, 1)
+    }
+}

--- a/Tests/localvoxtralTests/PolishContextClipboardReaderTests.swift
+++ b/Tests/localvoxtralTests/PolishContextClipboardReaderTests.swift
@@ -313,6 +313,26 @@ final class PolishContextClipboardReaderTests: XCTestCase {
         XCTAssertFalse(PolishContextClipboardReader.isLoopbackEndpoint(url))
     }
 
+    // The shared endpoint policy every context surface routes through:
+    // loopback always passes; anything else passes only under the explicit
+    // trusted-endpoint opt-in (default off).
+    func testPermittedContextEndpointTruthTable() {
+        let loopback = URL(string: "http://127.0.0.1:8472/v1/chat/completions")!
+        let lan = URL(string: "http://192.168.1.183:8080/v1/chat/completions")!
+        let cloud = URL(string: "https://api.example.com/v1/chat/completions")!
+
+        XCTAssertTrue(PolishContextClipboardReader.isPermittedContextEndpoint(
+            loopback, trustedEndpointEnabled: false))
+        XCTAssertFalse(PolishContextClipboardReader.isPermittedContextEndpoint(
+            lan, trustedEndpointEnabled: false))
+        XCTAssertFalse(PolishContextClipboardReader.isPermittedContextEndpoint(
+            cloud, trustedEndpointEnabled: false))
+        XCTAssertTrue(PolishContextClipboardReader.isPermittedContextEndpoint(
+            lan, trustedEndpointEnabled: true))
+        XCTAssertTrue(PolishContextClipboardReader.isPermittedContextEndpoint(
+            cloud, trustedEndpointEnabled: true))
+    }
+
     // MARK: - Experimental leak detector
 
     /// A verbatim clipboard echo (>= 24 normalized chars, absent from the

--- a/Tests/localvoxtralTests/PolishTokenGuardTests.swift
+++ b/Tests/localvoxtralTests/PolishTokenGuardTests.swift
@@ -818,6 +818,29 @@ final class DictationViewModelPolishTokenGuardTests: XCTestCase {
         XCTAssertNil(record?.polishContextSummary)
     }
 
+    /// The trusted-endpoint opt-in is the ONE way a non-loopback endpoint may
+    /// receive clipboard context: with the toggle ON and the opt-in ON, the
+    /// same remote endpoint that just skipped the pasteboard now reads it and
+    /// attaches the context message (mirror of
+    /// `testRemoteEndpointNeverReadsPasteboardAndSkipsContext`).
+    func testTrustedEndpointOptInAdmitsClipboardContextToRemoteEndpoint() async throws {
+        let pasteboard = PasteboardStub(string: "UserSessionManager.swift")
+        let (record, request) = await runClipboardContextSession(
+            clipboardEnabled: true,
+            pasteboard: pasteboard,
+            endpointURL: "https://example.com/v1/chat/completions",
+            trustedEndpointEnabled: true
+        )
+
+        XCTAssertGreaterThan(pasteboard.stringCallCount, 0, "the opt-in admits the read")
+        let prompts = try XCTUnwrap(request?.userPrompts)
+        XCTAssertTrue(
+            prompts.contains { $0.contains(PolishContextClipboardReader.contextMessageInstruction) }
+        )
+        XCTAssertTrue(prompts.contains { $0.contains("UserSessionManager.swift") })
+        XCTAssertNotNil(record?.polishContextSummary)
+    }
+
     /// Clipboard context is a model hint, not a reason to rewrite or reject
     /// the model response after inference.
     func testStandardProfileCommitsClipboardDerivedModelOutput() async {
@@ -937,7 +960,8 @@ final class DictationViewModelPolishTokenGuardTests: XCTestCase {
     private func runClipboardContextSession(
         clipboardEnabled: Bool,
         pasteboard: PasteboardStub,
-        endpointURL: String = "http://127.0.0.1:8472/v1/chat/completions"
+        endpointURL: String = "http://127.0.0.1:8472/v1/chat/completions",
+        trustedEndpointEnabled: Bool = false
     ) async -> (record: DictationSessionRecord?, request: LLMPolishingRequest?) {
         let settings = makeSettings(outputMode: .overlayBuffer)
         settings.llmPolishingEnabled = true
@@ -948,6 +972,7 @@ final class DictationViewModelPolishTokenGuardTests: XCTestCase {
         settings.polishingBackendMode = .externalURL
         settings.llmPolishingEndpointURL = endpointURL
         settings.polishClipboardContextEnabled = clipboardEnabled
+        settings.polishContextTrustedEndpointEnabled = trustedEndpointEnabled
 
         let mockConfig = MockAppConfigStore(
             promptTemplates: LLMPromptTemplates(
@@ -1340,6 +1365,29 @@ final class DictationViewModelPolishTokenGuardTests: XCTestCase {
         let prompts = try XCTUnwrap(request?.userPrompts)
         XCTAssertFalse(prompts.contains { $0.contains("Repository vocabulary") })
         XCTAssertNil(record?.polishContextSummary)
+    }
+
+    /// The trusted-endpoint opt-in admits repo vocabulary to a remote
+    /// endpoint: the same configuration that just skipped the seam now reaches
+    /// it and injects the section (mirror of
+    /// `testRepoVocabularyRemoteEndpointSkipsInjection`).
+    func testTrustedEndpointOptInAdmitsRepoVocabularyToRemoteEndpoint() async throws {
+        let counter = RepoVocabularyOverrideCounter()
+        let (record, request) = await runRepoVocabularySession(
+            repoVocabularyEnabled: true,
+            endpointURL: "https://example.com/v1/chat/completions",
+            trustedEndpointEnabled: true,
+            vocabularyEntries: [
+                ReplacementEntry(replaceWith: "useAuth.ts", matches: ["use auth dot t s"]),
+            ],
+            overrideCounter: counter
+        )
+
+        XCTAssertEqual(counter.count, 1, "the opt-in admits the vocabulary pipeline")
+        let joined = try XCTUnwrap(request?.userPrompts).joined(separator: "\n")
+        XCTAssertTrue(joined.contains("Repository vocabulary"))
+        XCTAssertTrue(joined.contains("useAuth.ts"))
+        XCTAssertEqual(record?.polishContextSummary, "vocab:1")
     }
 
     /// The user removed `{{replacement_dictionary}}` from their template
@@ -1741,6 +1789,7 @@ final class DictationViewModelPolishTokenGuardTests: XCTestCase {
     private func runRepoVocabularySession(
         repoVocabularyEnabled: Bool,
         endpointURL: String = "http://127.0.0.1:8472/v1/chat/completions",
+        trustedEndpointEnabled: Bool = false,
         templateUserContent: String =
             "Clean this up.\n{{replacement_dictionary}}\nWorking text:\n{{input_text}}",
         vocabularyEntries: [ReplacementEntry]?,
@@ -1751,6 +1800,7 @@ final class DictationViewModelPolishTokenGuardTests: XCTestCase {
         settings.polishingBackendMode = .externalURL
         settings.llmPolishingEndpointURL = endpointURL
         settings.repoVocabularyEnabled = repoVocabularyEnabled
+        settings.polishContextTrustedEndpointEnabled = trustedEndpointEnabled
 
         // Both profiles use the same template so the injected section (or its
         // absence) is observable regardless of the agent/standard switch.

--- a/Tests/localvoxtralTests/SettingsStoreOutOfBoxDefaultsTests.swift
+++ b/Tests/localvoxtralTests/SettingsStoreOutOfBoxDefaultsTests.swift
@@ -73,6 +73,9 @@ final class SettingsStoreOutOfBoxDefaultsTests: XCTestCase {
 
         XCTAssertFalse(store.repoVocabularyEnabled)
         XCTAssertFalse(store.polishClipboardContextEnabled)
+        // The endpoint trade is its own opt-in on top of those: fresh installs
+        // keep every context surface loopback-only.
+        XCTAssertFalse(store.polishContextTrustedEndpointEnabled)
     }
 
     func testFreshInstall_neverOverwritesAChoiceTheUserAlreadyMade() {

--- a/Tests/localvoxtralTests/TerminalScreenClaudeJoinTests.swift
+++ b/Tests/localvoxtralTests/TerminalScreenClaudeJoinTests.swift
@@ -88,7 +88,8 @@ final class TerminalScreenClaudeJoinTests: XCTestCase {
         registry: ClaudeSessionRegistry,
         title: String?,
         focusedTTY: String? = nil,
-        titleWindowID: CGWindowID? = 101
+        titleWindowID: CGWindowID? = 101,
+        ttyWindowID: CGWindowID? = 101
     ) -> ClaudeSessionJoinResolver {
         ClaudeSessionJoinResolver(
             registry: registry,
@@ -99,7 +100,8 @@ final class TerminalScreenClaudeJoinTests: XCTestCase {
                     )
                 }
             },
-            focusedTerminalTTY: { _ in focusedTTY }
+            focusedTerminalTTY: { _ in focusedTTY },
+            focusedWindowID: { _ in ttyWindowID }
         )
     }
 
@@ -196,7 +198,8 @@ final class TerminalScreenClaudeJoinTests: XCTestCase {
                 titleReads += 1
                 return nil
             },
-            focusedTerminalTTY: { _ in "/dev/ttys003" }
+            focusedTerminalTTY: { _ in "/dev/ttys003" },
+            focusedWindowID: { _ in self.windowA }
         )
         XCTAssertNotNil(joinResolver.resolve(target: ghostty))
         XCTAssertEqual(titleReads, 0)
@@ -252,6 +255,47 @@ final class TerminalScreenClaudeJoinTests: XCTestCase {
                 .resolve(target: ghostty)
         )
         XCTAssertEqual(join.snapshot.sessionID, "s2")
+    }
+
+    // The tty join carries the focused window's identity exactly like the
+    // marker join carries the title read's — and the authorizer holds both to
+    // the same compare. Without it, a tty join would either always refuse raw
+    // attachment (nil identity) or bypass the F2 window check entirely.
+    func testTTYJoinCarriesTheFocusedWindowIdentity() throws {
+        let registry = makeRegistry()
+        XCTAssertNotNil(registry.ingest(record(tty: "/dev/ttys003"), origin: local))
+        let joinResolver = resolver(
+            registry: registry, title: nil, focusedTTY: "/dev/ttys003", ttyWindowID: windowB
+        )
+        let join = joinResolver.resolve(target: ghostty)
+        XCTAssertEqual(join?.windowID, windowB)
+        let gate = TerminalScreenClaudeJoinAuthorizer(resolver: joinResolver, currentJoin: { join })
+        XCTAssertTrue(
+            gate.isAuthorized(target: ghostty, windowID: windowB),
+            "precondition: the tty-joined window itself authorizes"
+        )
+        XCTAssertFalse(
+            gate.isAuthorized(target: ghostty, windowID: windowA),
+            "a capture from another window of the same app must not inherit a tty join"
+        )
+    }
+
+    // A tty join whose window identity could not be established still joins —
+    // hook state and repo context remain usable — but raw screen attachment
+    // refuses, same as an unknown marker-read identity.
+    func testTTYJoinWithUnknownWindowIdentityRefusesRawAttachment() throws {
+        let registry = makeRegistry()
+        XCTAssertNotNil(registry.ingest(record(tty: "/dev/ttys003"), origin: local))
+        let joinResolver = resolver(
+            registry: registry, title: nil, focusedTTY: "/dev/ttys003", ttyWindowID: nil
+        )
+        let join = try XCTUnwrap(joinResolver.resolve(target: ghostty))
+        XCTAssertNil(join.windowID)
+        let gate = TerminalScreenClaudeJoinAuthorizer(
+            resolver: joinResolver, currentJoin: { join }
+        )
+        XCTAssertFalse(gate.isAuthorized(target: ghostty, windowID: windowA))
+        XCTAssertFalse(gate.isAuthorized(target: ghostty, windowID: nil))
     }
 
     func testRemoteSessionNeverJoinsViaTTY() {

--- a/Tests/localvoxtralTests/TerminalScreenClaudeJoinTests.swift
+++ b/Tests/localvoxtralTests/TerminalScreenClaudeJoinTests.swift
@@ -52,7 +52,8 @@ final class TerminalScreenClaudeJoinTests: XCTestCase {
 
     private func record(
         session: String = "s1",
-        claudePID: Int32? = 9001
+        claudePID: Int32? = 9001,
+        tty: String? = nil
     ) -> ClaudeHookRecord {
         ClaudeHookRecord(
             event: .sessionStart,
@@ -61,7 +62,7 @@ final class TerminalScreenClaudeJoinTests: XCTestCase {
             rawCwd: "/repo",
             prompt: nil,
             files: [],
-            process: claudePID.map { ClaudeHookProcessInfo(hookPID: 777, claudePID: $0) }
+            process: claudePID.map { ClaudeHookProcessInfo(hookPID: 777, claudePID: $0, tty: tty) }
         )
     }
 
@@ -86,6 +87,7 @@ final class TerminalScreenClaudeJoinTests: XCTestCase {
     private func resolver(
         registry: ClaudeSessionRegistry,
         title: String?,
+        focusedTTY: String? = nil,
         titleWindowID: CGWindowID? = 101
     ) -> ClaudeSessionJoinResolver {
         ClaudeSessionJoinResolver(
@@ -96,7 +98,8 @@ final class TerminalScreenClaudeJoinTests: XCTestCase {
                         marker: $0, windowID: titleWindowID
                     )
                 }
-            }
+            },
+            focusedTerminalTTY: { _ in focusedTTY }
         )
     }
 
@@ -158,6 +161,138 @@ final class TerminalScreenClaudeJoinTests: XCTestCase {
             join.localWorkspacePath,
             "a remote session must never hand a filesystem path to the collector"
         )
+    }
+
+    // MARK: - TTY join
+
+    // The title-war case this mechanism exists for: Claude Code's own
+    // conversation title has clobbered the marker, so the title read answers
+    // nothing — but the focused pane's device still names the session.
+    func testTTYJoinsWhenTheTitleCarriesNoMarker() throws {
+        let registry = makeRegistry()
+        XCTAssertNotNil(
+            registry.ingest(record(tty: "/dev/ttys003"), origin: local)
+        )
+        let joinResolver = resolver(
+            registry: registry, title: "Fixing the flaky supervisor test", focusedTTY: "/dev/ttys003"
+        )
+        let join = try XCTUnwrap(joinResolver.resolve(target: ghostty))
+        XCTAssertEqual(join.snapshot.sessionID, "s1")
+        XCTAssertEqual(join.marker, ClaudeSessionMarker(value: "lvx-abcd"))
+        // The tty-joined session revalidates at stop through the same
+        // marker-keyed liveness path as a title join.
+        XCTAssertTrue(joinResolver.isStillLive(join))
+    }
+
+    func testTTYJoinDoesNotReadTheTitleAtAll() throws {
+        // Precedence is observable: when the device answers, the title is not
+        // even consulted — a stale marker in it cannot compete.
+        let registry = makeRegistry()
+        XCTAssertNotNil(registry.ingest(record(tty: "/dev/ttys003"), origin: local))
+        var titleReads = 0
+        let joinResolver = ClaudeSessionJoinResolver(
+            registry: registry,
+            markerInWindowTitle: { _ in
+                titleReads += 1
+                return nil
+            },
+            focusedTerminalTTY: { _ in "/dev/ttys003" }
+        )
+        XCTAssertNotNil(joinResolver.resolve(target: ghostty))
+        XCTAssertEqual(titleReads, 0)
+    }
+
+    func testTTYJoinWinsOverAStaleMarkerNamingAnotherSession() throws {
+        // Pane recycling: claude #1 ended, its marker lingers in the title;
+        // claude #2 runs in the same pane on the same device. The process
+        // table is current, the title is history — the device must win.
+        let registry = makeRegistry(markers: ["lvx-aaaa", "lvx-bbbb"])
+        XCTAssertNotNil(
+            registry.ingest(record(session: "old", tty: "/dev/ttys009"), origin: local)
+        )
+        XCTAssertNotNil(
+            registry.ingest(
+                record(session: "new", claudePID: 9002, tty: "/dev/ttys003"), origin: local
+            )
+        )
+        let join = try XCTUnwrap(
+            resolver(registry: registry, title: "lvx-aaaa", focusedTTY: "/dev/ttys003")
+                .resolve(target: ghostty)
+        )
+        XCTAssertEqual(join.snapshot.sessionID, "new")
+    }
+
+    func testUnmatchedTTYFallsBackToTheTitleMarker() throws {
+        // Old Ghostty answers no tty; a device with no session answers
+        // `.unknown`. Either way the marker path must still join — the tty
+        // mechanism only ever adds joins, never removes one.
+        let registry = makeRegistry()
+        XCTAssertNotNil(registry.ingest(record(tty: "/dev/ttys003"), origin: local))
+        let join = try XCTUnwrap(
+            resolver(registry: registry, title: "lvx-abcd", focusedTTY: "/dev/ttys777")
+                .resolve(target: ghostty)
+        )
+        XCTAssertEqual(join.snapshot.sessionID, "s1")
+    }
+
+    func testAmbiguousTTYFallsBackToTheTitleMarker() throws {
+        // Two local sessions on one device abstain at the registry; the
+        // marker — which names exactly one of them — may still disambiguate.
+        let registry = makeRegistry(markers: ["lvx-aaaa", "lvx-bbbb"])
+        XCTAssertNotNil(
+            registry.ingest(record(session: "s1", tty: "/dev/ttys003"), origin: local)
+        )
+        XCTAssertNotNil(
+            registry.ingest(
+                record(session: "s2", claudePID: 9002, tty: "/dev/ttys003"), origin: local
+            )
+        )
+        let join = try XCTUnwrap(
+            resolver(registry: registry, title: "lvx-bbbb", focusedTTY: "/dev/ttys003")
+                .resolve(target: ghostty)
+        )
+        XCTAssertEqual(join.snapshot.sessionID, "s2")
+    }
+
+    func testRemoteSessionNeverJoinsViaTTY() {
+        // End-to-end shape of the registry's remote refusal: an SSH session
+        // publishing the local pane's device must not claim the pane. With no
+        // marker in the title either, there is no join at all.
+        let registry = makeRegistry()
+        XCTAssertNotNil(
+            registry.ingest(
+                record(tty: "/dev/ttys003"), origin: .remote(channel: "ssh")
+            )
+        )
+        XCTAssertNil(
+            resolver(registry: registry, title: nil, focusedTTY: "/dev/ttys003")
+                .resolve(target: ghostty)
+        )
+    }
+
+    // MARK: - TTY reply validation
+
+    func testValidatedTTYAcceptsOnlyPlausibleDevicePaths() {
+        XCTAssertEqual(
+            GhosttyFocusedTerminalTTYReader.validatedTTY("/dev/ttys000"), "/dev/ttys000"
+        )
+        XCTAssertNil(GhosttyFocusedTerminalTTYReader.validatedTTY(nil))
+        XCTAssertNil(GhosttyFocusedTerminalTTYReader.validatedTTY(""))
+        XCTAssertNil(
+            GhosttyFocusedTerminalTTYReader.validatedTTY("ttys000"),
+            "a bare name is not a device path"
+        )
+        XCTAssertNil(
+            GhosttyFocusedTerminalTTYReader.validatedTTY("/dev/ttys0 00"),
+            "whitespace means this is a title, not a device"
+        )
+        XCTAssertNil(
+            GhosttyFocusedTerminalTTYReader.validatedTTY(
+                "/dev/tty" + String(repeating: "s", count: 64)
+            ),
+            "a reply longer than any real pty path is not a device"
+        )
+        XCTAssertNil(GhosttyFocusedTerminalTTYReader.validatedTTY("/dev/ttys00é"))
     }
 
     // MARK: - Abstentions

--- a/Tests/localvoxtralTests/TerminalScreenClaudeJoinTests.swift
+++ b/Tests/localvoxtralTests/TerminalScreenClaudeJoinTests.swift
@@ -573,6 +573,29 @@ final class TerminalScreenClaudeJoinTests: XCTestCase {
         XCTAssertEqual(decision, .render(excerpt: "swift build"))
     }
 
+    // "Unchanged" means unchanged AFTER the deterministic whitespace
+    // compaction, not byte-identical raw AX payloads: a redraw that only
+    // changed row padding or blank-row runs still renders, because both reads
+    // pass through the same sanitize seam before comparison. This pins the
+    // `.render` contract's wording.
+    func testWhitespaceOnlyRedrawStillRendersThroughTheLiveSource() {
+        TerminalScreenRawAttachmentPolicy.debugAuthorizationOverride = {
+            $0 == self.ghostty && $1 == self.windowA
+        }
+        TerminalScreenContextSource.debugTargetForPIDOverride = { _ in self.ghostty }
+        // The stop-time raw grid re-padded the rows and grew a trailing blank
+        // run; the compacted form is identical to the start capture.
+        TerminalScreenAXReader.debugScreenReadOverride = { _ in "swift build   \u{00A0}\n\n\n\n" }
+        TerminalScreenAXReader.debugScreenWindowIDOverride = { _ in self.windowA }
+        let decision = TerminalScreenContextSource.reconcileAtStop(
+            start: TerminalScreenCapture(text: "swift build", target: ghostty, windowID: windowA),
+            settingEnabled: true,
+            endpointURL: URL(string: "http://127.0.0.1:8472/v1/chat/completions")!,
+            isAccessibilityTrusted: true
+        )
+        XCTAssertEqual(decision, .render(excerpt: "swift build"))
+    }
+
     // The stop-time confirmation read must describe the pane captured at
     // start. A different window of the same app can show byte-identical text
     // (two idle panes), and the text compare alone would then "confirm" a

--- a/Tests/localvoxtralTests/TerminalScreenContextTests.swift
+++ b/Tests/localvoxtralTests/TerminalScreenContextTests.swift
@@ -77,11 +77,40 @@ final class TerminalScreenContextTests: XCTestCase {
     // NUL, BEL, and escape scalars — which a terminal screen is full of — do
     // not.
     func testSanitizationStripsControlScalarsButKeepsLineStructure() {
+        // The trailing newline (a trailing blank grid row) is compacted away —
+        // see the whitespace tests below.
         let raw = "$ swift build\u{0}\u{7}\n\tCompiling \u{1B}[32mlocalvoxtral\u{1B}[0m\n"
         XCTAssertEqual(
             TerminalScreenAXReader.sanitizedScreenText(raw),
-            "$ swift build\n\tCompiling [32mlocalvoxtral[0m\n"
+            "$ swift build\n\tCompiling [32mlocalvoxtral[0m"
         )
+    }
+
+    // The AX grid pads rows and reports blank viewport rows; an idle pane
+    // arrived as ~40 blank padded lines in the polish prompt (field report
+    // 2026-07-20). Compaction: trailing spaces/tabs trimmed per line, interior
+    // blank runs collapse to ONE blank line, leading/trailing blank runs drop.
+    func testGridWhitespaceCompaction() {
+        let raw = "\n\n❯ hi   \n\n\n\n⏺ Hi! Test received.\t\n\n\n───\n\n\n"
+        XCTAssertEqual(
+            TerminalScreenAXReader.sanitizedScreenText(raw),
+            "❯ hi\n\n⏺ Hi! Test received.\n\n───"
+        )
+    }
+
+    func testCompactionPreservesInteriorSingleBlankLinesAndIndentation() {
+        let raw = "func a() {\n    body\n}\n\nfunc b() {}"
+        XCTAssertEqual(TerminalScreenAXReader.sanitizedScreenText(raw), raw)
+    }
+
+    func testCompactionIsDeterministicSoIdenticalScreensStayIdentical() {
+        // Start/stop reconciliation compares sanitized text; compaction must
+        // map equal inputs to equal outputs (and it is a pure function of the
+        // input, so re-sanitizing the sanitized form changes nothing).
+        let raw = "line   \n\n\nnext\n"
+        let once = TerminalScreenAXReader.sanitizedScreenText(raw)
+        XCTAssertEqual(once, TerminalScreenAXReader.sanitizedScreenText(raw))
+        XCTAssertEqual(once, once.flatMap { TerminalScreenAXReader.sanitizedScreenText($0) })
     }
 
     func testSanitizationCapsAtAbsoluteCap() {

--- a/Tests/localvoxtralTests/TerminalScreenContextTests.swift
+++ b/Tests/localvoxtralTests/TerminalScreenContextTests.swift
@@ -113,6 +113,41 @@ final class TerminalScreenContextTests: XCTestCase {
         XCTAssertEqual(once, once.flatMap { TerminalScreenAXReader.sanitizedScreenText($0) })
     }
 
+    // NBSP is grid padding too: terminals emit U+00A0 for non-wrapping pad
+    // cells, and a trailing run of it is as term-free as trailing spaces.
+    func testCompactionTrimsTrailingNonBreakingSpaces() {
+        let raw = "❯ swift build\u{00A0}\u{00A0}\u{00A0}\n\u{00A0}\u{00A0}\n\u{00A0}\t \nBuild complete! \u{00A0}\t"
+        XCTAssertEqual(
+            TerminalScreenAXReader.sanitizedScreenText(raw),
+            "❯ swift build\n\nBuild complete!"
+        )
+    }
+
+    // Compaction runs BEFORE the cap — the order is load-bearing. A padded
+    // grid can exceed the 24k cap on padding alone; capping first would evict
+    // the real text at the tail (exactly the term a user is most likely to be
+    // talking about: the latest output) in favor of retained pad bytes.
+    func testCompactionBeforeCapKeepsTailTermsPaddingWouldHaveEvicted() throws {
+        // ~30 real lines, each padded to 1000 characters with trailing spaces:
+        // raw is ~30k (over the cap), compacted content is ~1k (far under it).
+        var lines: [String] = []
+        for index in 0..<29 {
+            lines.append("line \(index)".padding(toLength: 1_000, withPad: " ", startingAt: 0))
+        }
+        lines.append("NeedleTailTerm.swift".padding(toLength: 1_000, withPad: " ", startingAt: 0))
+        let raw = lines.joined(separator: "\n")
+        XCTAssertGreaterThan(
+            raw.count, TerminalScreenAXReader.screenCharacterCap,
+            "precondition: the raw grid alone would blow the cap"
+        )
+        let sanitized = try XCTUnwrap(TerminalScreenAXReader.sanitizedScreenText(raw))
+        XCTAssertLessThanOrEqual(sanitized.count, TerminalScreenAXReader.screenCharacterCap)
+        XCTAssertTrue(
+            sanitized.contains("NeedleTailTerm.swift"),
+            "the tail term survives only because compaction runs before the cap"
+        )
+    }
+
     func testSanitizationCapsAtAbsoluteCap() {
         let raw = String(repeating: "x", count: TerminalScreenAXReader.screenCharacterCap + 500)
         let sanitized = TerminalScreenAXReader.sanitizedScreenText(raw)

--- a/Tests/localvoxtralTests/TerminalScreenContextTests.swift
+++ b/Tests/localvoxtralTests/TerminalScreenContextTests.swift
@@ -168,6 +168,40 @@ final class TerminalScreenContextTests: XCTestCase {
         ))
     }
 
+    // The trusted-endpoint opt-in admits a non-loopback endpoint — and ONLY
+    // relaxes the endpoint condition: every other gate condition still holds.
+    func testGateAcceptsLANEndpointUnderTrustedEndpointOptIn() {
+        XCTAssertTrue(TerminalScreenContext.shouldAttemptRead(
+            settingEnabled: true,
+            endpointURL: URL(string: "http://192.168.1.183:8080/v1/chat/completions")!,
+            bundleID: TerminalScreenAllowlist.ghosttyBundleID,
+            isAccessibilityTrusted: true,
+            trustedEndpointEnabled: true
+        ))
+    }
+
+    func testTrustedEndpointOptInRelaxesOnlyTheEndpointCondition() {
+        let lan = URL(string: "http://192.168.1.183:8080/v1/chat/completions")!
+        let cases: [(String, Bool, String?, Bool)] = [
+            ("setting off", false, TerminalScreenAllowlist.ghosttyBundleID, true),
+            ("unsupported app", true, "com.apple.Terminal", true),
+            ("no bundle", true, nil, true),
+            ("untrusted", true, TerminalScreenAllowlist.ghosttyBundleID, false),
+        ]
+        for (name, enabled, bundleID, trusted) in cases {
+            XCTAssertFalse(
+                TerminalScreenContext.shouldAttemptRead(
+                    settingEnabled: enabled,
+                    endpointURL: lan,
+                    bundleID: bundleID,
+                    isAccessibilityTrusted: trusted,
+                    trustedEndpointEnabled: true
+                ),
+                "trusted endpoint must not bypass: \(name)"
+            )
+        }
+    }
+
     // MARK: - Gate ordering: a rejected gate must make NO AX call
 
     /// Pins the AX seam to a counting stub and returns a reader for the count,

--- a/Tests/localvoxtralTests/TerminalTargetDetectorTests.swift
+++ b/Tests/localvoxtralTests/TerminalTargetDetectorTests.swift
@@ -567,6 +567,24 @@ final class TerminalTargetDetectorTests: XCTestCase {
         viewModel.isShowingConnectionFailureAlert = true
     }
 
+    func testTestProcessDetectionTreatsEitherSignalAsATestProcess() {
+        // The modal guard's truth table: the XCTest class in the runtime OR a
+        // set XCTestConfigurationFilePath env var each independently mean "no
+        // modal UI in this process" — a spawned child of the harness can carry
+        // the env var without linking XCTest.
+        XCTAssertTrue(DictationViewModel.isTestProcess(hasXCTestClass: true, environment: [:]))
+        XCTAssertTrue(
+            DictationViewModel.isTestProcess(
+                hasXCTestClass: false,
+                environment: ["XCTestConfigurationFilePath": "/tmp/config.xctestconfiguration"]
+            )
+        )
+        XCTAssertFalse(DictationViewModel.isTestProcess(hasXCTestClass: false, environment: [:]))
+        // The live defaults must recognize THIS process, whichever signal the
+        // harness happens to provide.
+        XCTAssertTrue(DictationViewModel.isTestProcess())
+    }
+
     func testStaleSecureIconDoesNotMaskEarlyExitFailuresOnNextAttempt() {
         // Codex finding on #90: refused start leaves the icon lit; a next
         // attempt that exits early (missing mic) BEFORE the verdict capture

--- a/integrations/claude-code/README.md
+++ b/integrations/claude-code/README.md
@@ -40,10 +40,25 @@ model touches without watching your whole tree.
 
 ## Which terminal am I dictating into?
 
-The app allocates a marker per session and replies with it on the socket. The
-publisher then asks Claude Code to write that marker into the window title (an
-OSC 2 sequence), with `suppressOutput` so it never appears in your transcript.
-That is how the app tells two Claude sessions in the same repo apart.
+Two mechanisms, tried in order:
+
+**TTY join (preferred — needs Ghostty 1.4 or a tip build).** The hooks report
+the session's controlling terminal device, and at dictation start the app asks
+Ghostty for the focused pane's `tty` over AppleScript (a one-time Automation
+consent prompt). Device equality is exact, works mid-response, and tells two
+sessions in the same repo apart. On Ghostty ≤ 1.3 this read fails gracefully
+(the `tty` property shipped for 1.4.0) — install Ghostty from tip if you want
+reliable joins while Claude Code is responding.
+
+**Title marker (fallback).** The app allocates a marker per session and replies
+with it on the socket. The publisher then asks Claude Code to write that marker
+into the window title (an OSC 2 sequence), with `suppressOutput` so it never
+appears in your transcript. Know its limits: Claude Code overwrites the title
+with its own conversation-derived text whenever it is responding, so the marker
+usually survives only until the first turn — unless you set
+`CLAUDE_CODE_DISABLE_TERMINAL_TITLE=1`. It remains the ONLY join for SSH-remote
+sessions (their tty names a device on another machine) and for pre-1.4 Ghostty,
+which is why it stays.
 
 The marker grammar is `lvx-<hex>` and nothing else is ever emitted — an escape
 sequence is code as much as data, so the marker is allowlist-validated and

--- a/scripts/ci/llm-lane-filter.sh
+++ b/scripts/ci/llm-lane-filter.sh
@@ -65,6 +65,7 @@ PATTERNS=(
   '*ClaudeHookInputParser*'                          # which hook fields become session state
   'integrations/claude-code/*'                       # the plugin that publishes those hooks
   '*TerminalScreenContext*'                          # screen context source/policy feeding the prompt
+  '*TerminalScreenAXReader*'                         # screen text sanitization/compaction: the excerpt's exact bytes
   '*DictationViewModel+Session.swift'                # polish-and-commit path
   '*LLMPolishEvalSupport*'                           # shared eval corpus + scorer
   '*PolishHelperIntegrationTests*'                   # the lane's own suite

--- a/scripts/package_app.sh
+++ b/scripts/package_app.sh
@@ -284,6 +284,8 @@ cat > "$APP_DIR/Contents/Info.plist" <<PLIST
   <string>localvoxtral needs microphone access for live dictation.</string>
   <key>NSLocalNetworkUsageDescription</key>
   <string>localvoxtral needs local network access to reach realtime transcription endpoints.</string>
+  <key>NSAppleEventsUsageDescription</key>
+  <string>localvoxtral asks Ghostty which terminal pane is focused, so dictation context comes from the Claude Code session you are actually talking to.</string>
 </dict>
 </plist>
 PLIST


### PR DESCRIPTION
> Stacked on #150 (base is `codex/agent-context` so this diff stays separate). Merge #150 first, then retarget to main.

## What

Adds a TTY-based focus join as the primary mechanism for resolving which Claude Code session owns the focused Ghostty pane, with the existing `lvx-` title-marker join as fallback.

- `GhosttyFocusedTerminalTTYReader`: one bounded AppleScript read (`with timeout of 1 second`) of `tty of focused terminal of selected tab of front window`, Ghostty-only by bundle id, reply validated as a plausible `/dev/tty…` device path. Error codes are logged, never messages (AppleScript error strings can quote window titles).
- `ClaudeSessionRegistry.resolve(tty:)`: exact match over live LOCAL sessions, with the established abstention semantics (`.ambiguous` for two sessions on one device, `.stale` for a dead process). Remote sessions never match — an SSH host must not be able to claim a local pane by echoing its device path.
- `ClaudeSessionJoinResolver`: tty first (on a hit the title is not read at all), marker fallback unchanged. The marker remains the only join for SSH-remote sessions and pre-1.4 Ghostty. The join is still resolved once per dictation, at start; `isStillLive` revalidation is unchanged (marker-keyed).
- The tty seam defaults to ABSTAIN, unlike the AX seam's default-live pattern: an Apple event triggers the macOS Automation consent prompt, and a defaulted live reader would send real events (and hang on that prompt) from any test that forgot to inject. Only `localvoxtralApp` wires the live reader.
- Packaging: `NSAppleEventsUsageDescription` added to Info.plist.
- AGENTS.md join invariant updated to describe tty-first resolution.

## Why

Field finding while hand-testing #150 (2026-07-17): Claude Code writes its own conversation-derived window titles and clobbers the marker whenever the model is responding — the title is a fought-over, last-writer-wins channel, so the marker-only join abstains exactly when the user dictates into a busy session. The process table has no such war: the hook publisher already reports the session's controlling TTY (`ClaudeHookProcessInfo.tty`), and Ghostty ≥ 1.4 exposes the focused pane's TTY over AppleScript (ghostty-org/ghostty#11592, merged in ghostty#11922 for the 1.4.0 milestone). Equality is exact, so two sessions in one repo — the case `resolve(workspace:)` deliberately abstains on — resolve correctly by device. This is the "focus join that is deliberately not built yet" that comment was waiting for.

## Proof

- [ ] CI unit suite on this branch — pending; the build host is temporarily unreachable from the dev box (moved to VPN), so the suite has not yet run on the final commit. Do not merge before it is green.
- [ ] Local `remote-build.sh test --filter Claude` — same blocker; will be run and pasted here when the host is reachable.
- [ ] Hand test of the live tty path — requires Ghostty ≥ 1.4 (tip channel today; stable is 1.3.1 where the `tty` property does not exist, verified on the owner's Mac: AppleScript error -1700). On 1.3.x this build must behave identically to the marker join.
- New regression tests (names, per proof culture):
  - Registry: `testTTYLookupResolvesTheLocalSessionOnThatDevice`, `testTTYLookupNeverMatchesARemoteSession` (spoof refusal), `testTwoLocalSessionsOnOneTTYAbstainAsAmbiguous`, `testTTYLookupReportsStaleWhenTheOnlyMatchIsDead`, `testTTYLookupIsUnknownForAnUnseenDevice`
  - Resolver: `testTTYJoinsWhenTheTitleCarriesNoMarker` (the title-war case), `testTTYJoinDoesNotReadTheTitleAtAll` (precedence observable), `testTTYJoinWinsOverAStaleMarkerNamingAnotherSession` (recycled pane), `testUnmatchedTTYFallsBackToTheTitleMarker`, `testAmbiguousTTYFallsBackToTheTitleMarker`, `testRemoteSessionNeverJoinsViaTTY`, `testValidatedTTYAcceptsOnlyPlausibleDevicePaths`

## Review notes

- The empirical probe behind the design: `working directory of focused terminal of selected tab of front window` resolves correctly on the owner's Ghostty 1.3.1 (focus chain + Automation grant proven); `tty` errors -1700 there, which is the exact fallback case the resolver tests pin.
- These paths are in `scripts/ci/llm-lane-filter.sh` already (`Sources/localvoxtral/ClaudeContext/*`, `*ClaudeSessionRegistry*`, `*TerminalScreenClaudeJoin*`), so the LLM lanes trigger on this diff by the existing rules.