### PR TITLE
Diagnostic: sample the unit-suite hang (do not merge)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -229,41 +229,39 @@ jobs:
           nc -z -G 3 127.0.0.1 1 && echo "port 1: CONNECT ACCEPTED" || echo "port 1: refused/timeout (exit $?)"
           time nc -z -G 8 127.0.0.1 1 || true
           echo "=== end probe ==="
-          # DIAGNOSTIC BRANCH ONLY (do not merge): run the suite unsupervised,
-          # detect the known output stall, and sample the wedged xctest so the
-          # hang's thread stacks land in the artifact.
+          # DIAGNOSTIC BRANCH ONLY (do not merge): reproduce the hang under
+          # the real supervisor, watch the log from OUTSIDE it, and sample the
+          # wedged xctest when output stalls.
           log="$RUNNER_TEMP/localvoxtral-unit-tests.log"
-          : > "$log"
-          swift test \
+          ./scripts/ci/run-supervised-command.sh \
+            600 "$log" -- \
+            swift test \
             --skip RealtimeAPIVLLMIntegrationTests \
             --skip SpeechHelperIntegrationTests \
             --skip AgentDictationE2EEvalTests \
-            --enable-code-coverage > "$log" 2>&1 &
-          swift_pid=$!
-          deadline=$((SECONDS + 600))
-          while kill -0 "$swift_pid" 2>/dev/null; do
+            --enable-code-coverage &
+          sup_pid=$!
+          stall=0
+          while kill -0 "$sup_pid" 2>/dev/null; do
             sleep 15
-            now_size=$(stat -f %z "$log")
+            now_size=$(stat -f %z "$log" 2>/dev/null || echo 0)
             if [[ "$now_size" == "${last_size:-}" ]]; then
               stall=$((stall + 15))
             else
               stall=0
             fi
             last_size="$now_size"
-            if (( stall >= 90 )) || (( SECONDS > deadline )); then
-              echo "STALL DETECTED (no log growth for ${stall}s) — sampling xctest" >&2
+            if (( stall >= 90 )); then
+              echo "STALL DETECTED — sampling xctest" >&2
               xctest_pid=$(pgrep -n xctest || true)
-              ps -ef | grep -i "[x]ctest\|swift" >&2 || true
+              ps -j -ww -A | grep -i "[x]ctest\|swift-package\|osascript" >&2 || true
               if [[ -n "$xctest_pid" ]]; then
                 sample "$xctest_pid" 5 -file "$RUNNER_TEMP/xctest-hang-sample.txt" || true
               fi
-              kill -9 "$swift_pid" 2>/dev/null || true
-              pkill -9 xctest 2>/dev/null || true
-              tail -n 5 "$log" >&2
-              exit 124
+              stall=0
             fi
           done
-          wait "$swift_pid"
+          wait "$sup_pid"
 
       - name: Upload complete unit-test log
         if: always()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -224,24 +224,50 @@ jobs:
           # eval-e2e.yml lane, never tier 0, and a leftover enable marker in
           # this persistent workspace must not turn the unit step into a
           # many-minute live-inference run.
-          timeout_seconds=900
-          if [[ "$RUNNER_ENVIRONMENT" == "self-hosted" ]]; then
-            timeout_seconds=300
-          fi
-          ./scripts/ci/run-supervised-command.sh \
-            "$timeout_seconds" "$RUNNER_TEMP/localvoxtral-unit-tests.log" -- \
-            swift test \
+          # DIAGNOSTIC BRANCH ONLY (do not merge): run the suite unsupervised,
+          # detect the known output stall, and sample the wedged xctest so the
+          # hang's thread stacks land in the artifact.
+          log="$RUNNER_TEMP/localvoxtral-unit-tests.log"
+          : > "$log"
+          swift test \
             --skip RealtimeAPIVLLMIntegrationTests \
             --skip SpeechHelperIntegrationTests \
             --skip AgentDictationE2EEvalTests \
-            --enable-code-coverage
+            --enable-code-coverage > "$log" 2>&1 &
+          swift_pid=$!
+          deadline=$((SECONDS + 600))
+          while kill -0 "$swift_pid" 2>/dev/null; do
+            sleep 15
+            now_size=$(stat -f %z "$log")
+            if [[ "$now_size" == "${last_size:-}" ]]; then
+              stall=$((stall + 15))
+            else
+              stall=0
+            fi
+            last_size="$now_size"
+            if (( stall >= 90 )) || (( SECONDS > deadline )); then
+              echo "STALL DETECTED (no log growth for ${stall}s) — sampling xctest" >&2
+              xctest_pid=$(pgrep -n xctest || true)
+              ps -ef | grep -i "[x]ctest\|swift" >&2 || true
+              if [[ -n "$xctest_pid" ]]; then
+                sample "$xctest_pid" 5 -file "$RUNNER_TEMP/xctest-hang-sample.txt" || true
+              fi
+              kill -9 "$swift_pid" 2>/dev/null || true
+              pkill -9 xctest 2>/dev/null || true
+              tail -n 5 "$log" >&2
+              exit 124
+            fi
+          done
+          wait "$swift_pid"
 
       - name: Upload complete unit-test log
         if: always()
         uses: actions/upload-artifact@v4
         with:
           name: unit-test-log-${{ runner.os }}
-          path: ${{ runner.temp }}/localvoxtral-unit-tests.log
+          path: |
+            ${{ runner.temp }}/localvoxtral-unit-tests.log
+            ${{ runner.temp }}/xctest-hang-sample.txt
           if-no-files-found: error
           retention-days: 7
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -224,6 +224,11 @@ jobs:
           # eval-e2e.yml lane, never tier 0, and a leftover enable marker in
           # this persistent workspace must not turn the unit step into a
           # many-minute live-inference run.
+          echo "=== port 1 probe ==="
+          lsof -nP -i :1 || echo "lsof: no visible listener on port 1"
+          nc -z -G 3 127.0.0.1 1 && echo "port 1: CONNECT ACCEPTED" || echo "port 1: refused/timeout (exit $?)"
+          time nc -z -G 8 127.0.0.1 1 || true
+          echo "=== end probe ==="
           # DIAGNOSTIC BRANCH ONLY (do not merge): run the suite unsupervised,
           # detect the known output stall, and sample the wedged xctest so the
           # hang's thread stacks land in the artifact.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -390,11 +390,20 @@ Key subsystems:
     filesystem" is a compile error — do not add one. Its only derivations
     (`ancestor`, `descendant`) preserve that, and `ClaudeRepoCollecting` takes
     it rather than a `String` for exactly this reason.
-  - The join is resolved ONCE per dictation, at start, from the marker in the
-    PID-pinned window title (`ClaudeSessionJoinResolver`), and every consumer —
-    raw screen attachment, the session block, repo collection — shares that one
-    answer. Three resolutions could each answer honestly about a different
-    moment; that is how one session's screen ends up next to another's repo.
+  - The join is resolved ONCE per dictation, at start
+    (`ClaudeSessionJoinResolver`), and every consumer — raw screen attachment,
+    the session block, repo collection — shares that one answer. Three
+    resolutions could each answer honestly about a different moment; that is
+    how one session's screen ends up next to another's repo. Resolution is
+    TTY-first: the focused Ghostty pane's controlling TTY (AppleScript,
+    Ghostty ≥ 1.4) matched exactly against the hook-reported session TTY,
+    LOCAL sessions only — the title is a fought-over channel (Claude Code's
+    own conversation titles clobber the marker mid-turn), the process table is
+    not. Any TTY non-answer falls through to the marker in the PID-pinned
+    window title, which remains the ONLY join for SSH-remote sessions: a
+    remote TTY names another machine's device, and `resolve(tty:)` refuses
+    remote candidates so an SSH host can never claim a local pane by echoing
+    its TTY.
   - Lookups abstain rather than guess: no marker, unknown, stale, or ambiguous
     means no context. There is deliberately no sole-session or cwd heuristic —
     it is wrong precisely when it matters.

--- a/Sources/localvoxtral/ClaudeContext/ClaudeSessionRegistry.swift
+++ b/Sources/localvoxtral/ClaudeContext/ClaudeSessionRegistry.swift
@@ -183,6 +183,36 @@ public final class ClaudeSessionRegistry: Sendable {
         }
     }
 
+    /// Look up by the focused pane's controlling TTY — the focus join.
+    ///
+    /// Only LOCAL sessions are candidates: a remote session's TTY names a
+    /// device on another machine, where it can collide with an unrelated local
+    /// pane — matching it here would let an SSH host claim a local pane by
+    /// publishing that pane's TTY. Abstains `.ambiguous` when two live local
+    /// sessions claim one TTY (a suspended Claude beneath a new one in the same
+    /// pane); the caller's marker fallback may still disambiguate.
+    public func resolve(tty: String) -> ClaudeMarkerResolution {
+        let timestamp = now()
+        return state.withLock { state in
+            let matches = state.sessions.values.filter { snapshot in
+                snapshot.origin.isLocalAuthenticated
+                    && snapshot.process?.tty == tty
+                    && isFresh(snapshot, now: timestamp)
+            }
+            switch matches.count {
+            case 0:
+                let hadStale = state.sessions.values.contains {
+                    $0.origin.isLocalAuthenticated && $0.process?.tty == tty
+                }
+                return hadStale ? .stale : .unknown
+            case 1:
+                return .resolved(matches[0])
+            default:
+                return .ambiguous
+            }
+        }
+    }
+
     public func snapshot(sessionID: String) -> ClaudeSessionSnapshot? {
         let timestamp = now()
         return state.withLock { state in

--- a/Sources/localvoxtral/ClaudeContext/TerminalScreenClaudeJoin.swift
+++ b/Sources/localvoxtral/ClaudeContext/TerminalScreenClaudeJoin.swift
@@ -65,31 +65,62 @@ struct ClaudeSessionJoin: Sendable, Equatable {
 struct ClaudeSessionJoinResolver {
     private let registry: ClaudeSessionRegistry
     private let markerInWindowTitle: (pid_t) -> ClaudeSessionMarker?
+    private let focusedTerminalTTY: (String) -> String?
 
-    /// - Parameter markerInWindowTitle: reads the PID-pinned focused window
-    ///   title and parses a marker out of it. Injected so the whole truth table
-    ///   is unit-testable without a live AX tree — the same reason every other
-    ///   live read in this feature is a seam.
+    /// - Parameters:
+    ///   - markerInWindowTitle: reads the PID-pinned focused window title and
+    ///     parses a marker out of it. Injected so the whole truth table is
+    ///     unit-testable without a live AX tree — the same reason every other
+    ///     live read in this feature is a seam.
+    ///   - focusedTerminalTTY: reads the focused pane's controlling TTY for a
+    ///     bundle id (Ghostty ≥ 1.4 over AppleScript). Unlike the AX seam this
+    ///     DEFAULTS TO ABSTAIN, not to the live reader: an Apple event is not
+    ///     an AX read — the first one triggers the Automation consent prompt,
+    ///     and a defaulted live reader would send real events (and hang the
+    ///     suite on that prompt) from any test that forgets to inject. The app
+    ///     wires `GhosttyFocusedTerminalTTYReader` explicitly.
     init(
         registry: ClaudeSessionRegistry,
         markerInWindowTitle: @escaping (pid_t) -> ClaudeSessionMarker? = {
             TerminalScreenAXReader.markerInFocusedWindowTitle(applicationPID: $0)
-        }
+        },
+        focusedTerminalTTY: @escaping (String) -> String? = { _ in nil }
     ) {
         self.registry = registry
         self.markerInWindowTitle = markerInWindowTitle
+        self.focusedTerminalTTY = focusedTerminalTTY
     }
 
     /// The join for `target`, or nil on any abstention.
     ///
-    /// This is the ONLY function in the feature that reads a window title, and
-    /// it is called once per dictation, at start.
+    /// TTY first, marker second. The TTY compares the focused pane's device
+    /// against what the hook publisher reported from inside the session — the
+    /// process table cannot be clobbered by whoever wrote the window title
+    /// last, so it keeps joining while Claude Code's own conversation titles
+    /// own the visible one. Any TTY non-answer (old Ghostty, Automation
+    /// denied, no local session on that device, two sessions claiming it)
+    /// falls through to the marker path unchanged; remote sessions can ONLY
+    /// join via marker, because their TTY names another machine's device and
+    /// `resolve(tty:)` refuses remote candidates outright.
+    ///
+    /// This remains the only place a join is resolved, once per dictation, at
+    /// start — whichever mechanism answers.
     func resolve(target: TerminalScreenTarget) -> ClaudeSessionJoin? {
         // The allowlist is re-checked here even though the capture gate already
         // enforced it. This object is reachable independently of that gate, and
         // "only a verified single-AXTextArea grid" is a precondition of reading
         // this app at all — not something to inherit on trust from a caller.
         guard TerminalScreenAllowlist.isSupported(target.bundleID) else { return nil }
+
+        if let tty = focusedTerminalTTY(target.bundleID),
+           case .resolved(let snapshot) = registry.resolve(tty: tty) {
+            Log.claudeContext.info(
+                "Terminal pane joined to a live Claude session via focused-pane tty"
+            )
+            return ClaudeSessionJoin(
+                target: target, marker: snapshot.marker, snapshot: snapshot
+            )
+        }
 
         guard let marker = markerInWindowTitle(target.pid) else {
             // No marker on screen: this pane is not a joined Claude session, or
@@ -100,7 +131,7 @@ struct ClaudeSessionJoinResolver {
 
         switch registry.resolve(marker: marker) {
         case .resolved(let snapshot):
-            Log.claudeContext.info("Terminal pane joined to a live Claude session")
+            Log.claudeContext.info("Terminal pane joined to a live Claude session via title marker")
             return ClaudeSessionJoin(target: target, marker: marker, snapshot: snapshot)
         case .unknown, .stale, .ambiguous:
             // Count-only: the marker itself is not logged. It is a live handle

--- a/Sources/localvoxtral/TerminalFocusedTTYReader.swift
+++ b/Sources/localvoxtral/TerminalFocusedTTYReader.swift
@@ -52,7 +52,7 @@ struct GhosttyFocusedTerminalTTYReader: TerminalFocusedTTYReading {
             // quote window titles, and a title is content.
             // -1700: `tty` not in the dictionary (Ghostty < 1.4).
             // -1743: the user declined the Automation prompt.
-            let code = (error[NSAppleScriptErrorNumber] as? Int) ?? 0
+            let code = (error[NSAppleScript.errorNumber] as? Int) ?? 0
             Log.claudeContext.info(
                 "Focused-pane tty unavailable (AppleScript error \(code, privacy: .public))"
             )

--- a/Sources/localvoxtral/TerminalFocusedTTYReader.swift
+++ b/Sources/localvoxtral/TerminalFocusedTTYReader.swift
@@ -1,0 +1,76 @@
+import Foundation
+
+/// Reads the controlling TTY of the FOCUSED terminal pane, so the Claude join
+/// can resolve from the process table instead of the window title.
+///
+/// The title is a fought-over channel: Claude Code writes its own
+/// conversation-derived titles and clobbers the `lvx-` marker whenever it is
+/// responding (field finding, 2026-07-17), so a title read mid-turn abstains
+/// even though the session is right there. A pane's TTY has no such war: the
+/// hook publisher already reports the session's controlling TTY
+/// (`ClaudeHookProcessInfo.tty`), Ghostty ≥ 1.4 exposes the focused pane's TTY
+/// over AppleScript (ghostty-org/ghostty#11922), and equality is exact — two
+/// sessions in the same repo sit on different TTYs, which is precisely the case
+/// the workspace lookup abstains on. The marker join stays as the fallback for
+/// older Ghostty and as the ONLY join for SSH-remote sessions, whose TTY names
+/// a device on another machine.
+@MainActor
+protocol TerminalFocusedTTYReading {
+    /// The `/dev/ttysNNN` path of the focused pane of `bundleID`'s frontmost
+    /// window, or nil when the app is unsupported, too old to expose `tty`,
+    /// Automation is denied, or the read failed. Nil means "fall back to the
+    /// marker", never "guess".
+    func focusedTerminalTTY(bundleID: String) -> String?
+}
+
+/// The live reader: one bounded AppleScript question to Ghostty.
+@MainActor
+struct GhosttyFocusedTerminalTTYReader: TerminalFocusedTTYReading {
+    /// `with timeout` bounds the Apple event wait so a wedged Ghostty cannot
+    /// hold dictation start hostage — the same budget discipline as the AX
+    /// reader's per-message timeouts. `tell application id` of the frontmost
+    /// app never launches anything: the caller only asks about an app it just
+    /// observed as frontmost.
+    private static let source = """
+    with timeout of 1 second
+        tell application id "\(TerminalScreenAllowlist.ghosttyBundleID)"
+            get tty of focused terminal of selected tab of front window
+        end tell
+    end timeout
+    """
+
+    func focusedTerminalTTY(bundleID: String) -> String? {
+        // Ghostty-only, exact match: the script is Ghostty's dictionary, and
+        // sending it anywhere else is at best an error and at worst a prompt
+        // to automate an app the user never pointed us at.
+        guard bundleID == TerminalScreenAllowlist.ghosttyBundleID else { return nil }
+        guard let script = NSAppleScript(source: Self.source) else { return nil }
+        var error: NSDictionary?
+        let result = script.executeAndReturnError(&error)
+        if let error {
+            // Code only, never the message — AppleScript error strings can
+            // quote window titles, and a title is content.
+            // -1700: `tty` not in the dictionary (Ghostty < 1.4).
+            // -1743: the user declined the Automation prompt.
+            let code = (error[NSAppleScriptErrorNumber] as? Int) ?? 0
+            Log.claudeContext.info(
+                "Focused-pane tty unavailable (AppleScript error \(code, privacy: .public))"
+            )
+            return nil
+        }
+        return Self.validatedTTY(result.stringValue)
+    }
+
+    /// Accepts only a plausible pty device path. The value crosses from another
+    /// process into a registry lookup; a reply that is not shaped like
+    /// `/dev/tty…` (empty, a title, an injection attempt via a renamed app)
+    /// must read as "no answer", not as a key.
+    static func validatedTTY(_ raw: String?) -> String? {
+        guard let raw,
+              raw.hasPrefix("/dev/tty"),
+              raw.count <= 64,
+              raw.allSatisfy({ $0.isASCII && !$0.isWhitespace })
+        else { return nil }
+        return raw
+    }
+}

--- a/Sources/localvoxtral/localvoxtralApp.swift
+++ b/Sources/localvoxtral/localvoxtralApp.swift
@@ -218,7 +218,14 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             // the session's prior prompt, and the repository context describe the
             // same session — three resolvers would each answer honestly about a
             // different moment.
-            let resolver = ClaudeSessionJoinResolver(registry: claudeSessionRegistry)
+            // The tty seam is wired here, not defaulted: sending Apple events
+            // is a consented capability (Automation prompt), so only the app —
+            // never a test that forgot to inject — constructs the live reader.
+            let ttyReader = GhosttyFocusedTerminalTTYReader()
+            let resolver = ClaudeSessionJoinResolver(
+                registry: claudeSessionRegistry,
+                focusedTerminalTTY: { ttyReader.focusedTerminalTTY(bundleID: $0) }
+            )
             viewModel.claudeSessionJoinResolver = resolver
             // The join gate for raw terminal screen attachment. Installed only
             // now: without a running broker there are no markers to resolve, and

--- a/Tests/localvoxtralTests/ClaudeSessionRegistryTests.swift
+++ b/Tests/localvoxtralTests/ClaudeSessionRegistryTests.swift
@@ -60,7 +60,8 @@ final class ClaudeSessionRegistryTests: XCTestCase {
         prompt: String? = nil,
         files: [ClaudeFileTouch] = [],
         claudePID: Int32? = nil,
-        hookPID: Int32 = 777
+        hookPID: Int32 = 777,
+        tty: String? = nil
     ) -> ClaudeHookRecord {
         ClaudeHookRecord(
             event: event,
@@ -69,7 +70,7 @@ final class ClaudeSessionRegistryTests: XCTestCase {
             rawCwd: cwd,
             prompt: prompt,
             files: files,
-            process: claudePID.map { ClaudeHookProcessInfo(hookPID: hookPID, claudePID: $0) }
+            process: claudePID.map { ClaudeHookProcessInfo(hookPID: hookPID, claudePID: $0, tty: tty) }
         )
     }
 
@@ -324,6 +325,65 @@ final class ClaudeSessionRegistryTests: XCTestCase {
         guard case .resolved = registry.resolve(marker: ClaudeSessionMarker(value: "lvx-1")) else {
             return XCTFail("remote sessions rely on TTL, not local pid liveness")
         }
+    }
+
+    // MARK: TTY lookup — the focus join
+
+    func testTTYLookupResolvesTheLocalSessionOnThatDevice() throws {
+        let registry = makeRegistry()
+        registry.ingest(
+            record(.sessionStart, claudePID: 9001, tty: "/dev/ttys003"), origin: local
+        )
+        guard case .resolved(let snapshot) = registry.resolve(tty: "/dev/ttys003") else {
+            return XCTFail("expected the session on that device")
+        }
+        XCTAssertEqual(snapshot.sessionID, "s1")
+    }
+
+    func testTTYLookupNeverMatchesARemoteSession() {
+        // The spoof this closes: a remote session's TTY names a device on
+        // ANOTHER machine. If an SSH host could publish "/dev/ttys003" and
+        // match a local pane, it would claim that pane's dictations — so
+        // remote candidates are refused outright, even on exact match.
+        let registry = makeRegistry()
+        registry.ingest(
+            record(.sessionStart, claudePID: 9001, tty: "/dev/ttys003"),
+            origin: .remote(channel: "ssh")
+        )
+        XCTAssertEqual(registry.resolve(tty: "/dev/ttys003"), .unknown)
+    }
+
+    func testTwoLocalSessionsOnOneTTYAbstainAsAmbiguous() {
+        // A suspended Claude beneath a new one in the same pane. Guessing
+        // would attribute one session's repo to the other's dictation.
+        let registry = makeRegistry(markers: TestMarkers(["lvx-1", "lvx-2"]))
+        registry.ingest(
+            record(.sessionStart, session: "s1", claudePID: 9001, tty: "/dev/ttys003"),
+            origin: local
+        )
+        registry.ingest(
+            record(.sessionStart, session: "s2", claudePID: 9002, tty: "/dev/ttys003"),
+            origin: local
+        )
+        XCTAssertEqual(registry.resolve(tty: "/dev/ttys003"), .ambiguous)
+    }
+
+    func testTTYLookupReportsStaleWhenTheOnlyMatchIsDead() {
+        let liveness = TestLiveness()
+        let registry = makeRegistry(liveness: liveness)
+        registry.ingest(
+            record(.sessionStart, claudePID: 9001, tty: "/dev/ttys003"), origin: local
+        )
+        liveness.kill(9001)
+        XCTAssertEqual(registry.resolve(tty: "/dev/ttys003"), .stale)
+    }
+
+    func testTTYLookupIsUnknownForAnUnseenDevice() {
+        let registry = makeRegistry()
+        registry.ingest(
+            record(.sessionStart, claudePID: 9001, tty: "/dev/ttys003"), origin: local
+        )
+        XCTAssertEqual(registry.resolve(tty: "/dev/ttys007"), .unknown)
     }
 
     // MARK: Workspace lookup — ambiguity

--- a/Tests/localvoxtralTests/TerminalScreenClaudeJoinTests.swift
+++ b/Tests/localvoxtralTests/TerminalScreenClaudeJoinTests.swift
@@ -48,7 +48,8 @@ final class TerminalScreenClaudeJoinTests: XCTestCase {
 
     private func record(
         session: String = "s1",
-        claudePID: Int32? = 9001
+        claudePID: Int32? = 9001,
+        tty: String? = nil
     ) -> ClaudeHookRecord {
         ClaudeHookRecord(
             event: .sessionStart,
@@ -57,7 +58,7 @@ final class TerminalScreenClaudeJoinTests: XCTestCase {
             rawCwd: "/repo",
             prompt: nil,
             files: [],
-            process: claudePID.map { ClaudeHookProcessInfo(hookPID: 777, claudePID: $0) }
+            process: claudePID.map { ClaudeHookProcessInfo(hookPID: 777, claudePID: $0, tty: tty) }
         )
     }
 
@@ -81,13 +82,15 @@ final class TerminalScreenClaudeJoinTests: XCTestCase {
 
     private func resolver(
         registry: ClaudeSessionRegistry,
-        title: String?
+        title: String?,
+        focusedTTY: String? = nil
     ) -> ClaudeSessionJoinResolver {
         ClaudeSessionJoinResolver(
             registry: registry,
             markerInWindowTitle: { _ in
                 title.flatMap { ClaudeMarkerTitleParser.marker(inTitle: $0) }
-            }
+            },
+            focusedTerminalTTY: { _ in focusedTTY }
         )
     }
 
@@ -148,6 +151,138 @@ final class TerminalScreenClaudeJoinTests: XCTestCase {
             join.localWorkspacePath,
             "a remote session must never hand a filesystem path to the collector"
         )
+    }
+
+    // MARK: - TTY join
+
+    // The title-war case this mechanism exists for: Claude Code's own
+    // conversation title has clobbered the marker, so the title read answers
+    // nothing — but the focused pane's device still names the session.
+    func testTTYJoinsWhenTheTitleCarriesNoMarker() throws {
+        let registry = makeRegistry()
+        XCTAssertNotNil(
+            registry.ingest(record(tty: "/dev/ttys003"), origin: local)
+        )
+        let joinResolver = resolver(
+            registry: registry, title: "Fixing the flaky supervisor test", focusedTTY: "/dev/ttys003"
+        )
+        let join = try XCTUnwrap(joinResolver.resolve(target: ghostty))
+        XCTAssertEqual(join.snapshot.sessionID, "s1")
+        XCTAssertEqual(join.marker, ClaudeSessionMarker(value: "lvx-abcd"))
+        // The tty-joined session revalidates at stop through the same
+        // marker-keyed liveness path as a title join.
+        XCTAssertTrue(joinResolver.isStillLive(join))
+    }
+
+    func testTTYJoinDoesNotReadTheTitleAtAll() throws {
+        // Precedence is observable: when the device answers, the title is not
+        // even consulted — a stale marker in it cannot compete.
+        let registry = makeRegistry()
+        XCTAssertNotNil(registry.ingest(record(tty: "/dev/ttys003"), origin: local))
+        var titleReads = 0
+        let joinResolver = ClaudeSessionJoinResolver(
+            registry: registry,
+            markerInWindowTitle: { _ in
+                titleReads += 1
+                return nil
+            },
+            focusedTerminalTTY: { _ in "/dev/ttys003" }
+        )
+        XCTAssertNotNil(joinResolver.resolve(target: ghostty))
+        XCTAssertEqual(titleReads, 0)
+    }
+
+    func testTTYJoinWinsOverAStaleMarkerNamingAnotherSession() throws {
+        // Pane recycling: claude #1 ended, its marker lingers in the title;
+        // claude #2 runs in the same pane on the same device. The process
+        // table is current, the title is history — the device must win.
+        let registry = makeRegistry(markers: ["lvx-aaaa", "lvx-bbbb"])
+        XCTAssertNotNil(
+            registry.ingest(record(session: "old", tty: "/dev/ttys009"), origin: local)
+        )
+        XCTAssertNotNil(
+            registry.ingest(
+                record(session: "new", claudePID: 9002, tty: "/dev/ttys003"), origin: local
+            )
+        )
+        let join = try XCTUnwrap(
+            resolver(registry: registry, title: "lvx-aaaa", focusedTTY: "/dev/ttys003")
+                .resolve(target: ghostty)
+        )
+        XCTAssertEqual(join.snapshot.sessionID, "new")
+    }
+
+    func testUnmatchedTTYFallsBackToTheTitleMarker() throws {
+        // Old Ghostty answers no tty; a device with no session answers
+        // `.unknown`. Either way the marker path must still join — the tty
+        // mechanism only ever adds joins, never removes one.
+        let registry = makeRegistry()
+        XCTAssertNotNil(registry.ingest(record(tty: "/dev/ttys003"), origin: local))
+        let join = try XCTUnwrap(
+            resolver(registry: registry, title: "lvx-abcd", focusedTTY: "/dev/ttys777")
+                .resolve(target: ghostty)
+        )
+        XCTAssertEqual(join.snapshot.sessionID, "s1")
+    }
+
+    func testAmbiguousTTYFallsBackToTheTitleMarker() throws {
+        // Two local sessions on one device abstain at the registry; the
+        // marker — which names exactly one of them — may still disambiguate.
+        let registry = makeRegistry(markers: ["lvx-aaaa", "lvx-bbbb"])
+        XCTAssertNotNil(
+            registry.ingest(record(session: "s1", tty: "/dev/ttys003"), origin: local)
+        )
+        XCTAssertNotNil(
+            registry.ingest(
+                record(session: "s2", claudePID: 9002, tty: "/dev/ttys003"), origin: local
+            )
+        )
+        let join = try XCTUnwrap(
+            resolver(registry: registry, title: "lvx-bbbb", focusedTTY: "/dev/ttys003")
+                .resolve(target: ghostty)
+        )
+        XCTAssertEqual(join.snapshot.sessionID, "s2")
+    }
+
+    func testRemoteSessionNeverJoinsViaTTY() {
+        // End-to-end shape of the registry's remote refusal: an SSH session
+        // publishing the local pane's device must not claim the pane. With no
+        // marker in the title either, there is no join at all.
+        let registry = makeRegistry()
+        XCTAssertNotNil(
+            registry.ingest(
+                record(tty: "/dev/ttys003"), origin: .remote(channel: "ssh")
+            )
+        )
+        XCTAssertNil(
+            resolver(registry: registry, title: nil, focusedTTY: "/dev/ttys003")
+                .resolve(target: ghostty)
+        )
+    }
+
+    // MARK: - TTY reply validation
+
+    func testValidatedTTYAcceptsOnlyPlausibleDevicePaths() {
+        XCTAssertEqual(
+            GhosttyFocusedTerminalTTYReader.validatedTTY("/dev/ttys000"), "/dev/ttys000"
+        )
+        XCTAssertNil(GhosttyFocusedTerminalTTYReader.validatedTTY(nil))
+        XCTAssertNil(GhosttyFocusedTerminalTTYReader.validatedTTY(""))
+        XCTAssertNil(
+            GhosttyFocusedTerminalTTYReader.validatedTTY("ttys000"),
+            "a bare name is not a device path"
+        )
+        XCTAssertNil(
+            GhosttyFocusedTerminalTTYReader.validatedTTY("/dev/ttys0 00"),
+            "whitespace means this is a title, not a device"
+        )
+        XCTAssertNil(
+            GhosttyFocusedTerminalTTYReader.validatedTTY(
+                "/dev/tty" + String(repeating: "s", count: 64)
+            ),
+            "a reply longer than any real pty path is not a device"
+        )
+        XCTAssertNil(GhosttyFocusedTerminalTTYReader.validatedTTY("/dev/ttys00é"))
     }
 
     // MARK: - Abstentions

--- a/scripts/package_app.sh
+++ b/scripts/package_app.sh
@@ -284,6 +284,8 @@ cat > "$APP_DIR/Contents/Info.plist" <<PLIST
   <string>localvoxtral needs microphone access for live dictation.</string>
   <key>NSLocalNetworkUsageDescription</key>
   <string>localvoxtral needs local network access to reach realtime transcription endpoints.</string>
+  <key>NSAppleEventsUsageDescription</key>
+  <string>localvoxtral asks Ghostty which terminal pane is focused, so dictation context comes from the Claude Code session you are actually talking to.</string>
 </dict>
 </plist>
 PLIST


### PR DESCRIPTION
Captures thread stacks of the deterministic unit-suite hang on the agent-context lineage (#154 investigation). Will be closed after one run.