### PR TITLE
CI cache fixes: match coverage flags in conditional lanes, stop ui-smoke's nightly cache wipe

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -359,7 +359,11 @@ jobs:
         env:
           SPEECHD_INTEGRATION_TEST_ENABLE: "1"
           SPEECHD_INTEGRATION_TEST_PATH: dist/localvoxtral.app/Contents/MacOS/localvoxtral-speechd
-        run: swift test --filter SpeechHelperIntegrationTests
+        # --enable-code-coverage matches the unit step's build flags (same
+        # rationale as the voxmlx step above): without it this step rebuilds
+        # the whole app+test module without coverage (~17 s), and the next
+        # run's unit step rebuilds it back again.
+        run: swift test --filter SpeechHelperIntegrationTests --enable-code-coverage
 
       - name: Polishing helper integration (live model + eval baseline)
         # Spawns the helper built by the packaging step with the real pinned
@@ -373,7 +377,9 @@ jobs:
         env:
           LOCALVOXTRAL_POLISHD_TEST_ENABLE: "1"
           LOCALVOXTRAL_POLISHD_TEST_PATH: PolishHelper/.build/xcode/Build/Products/Release/localvoxtral-polishd
-        run: swift test --filter PolishHelperIntegrationTests
+        # --enable-code-coverage: same flag-matching rationale as the speechd
+        # step above.
+        run: swift test --filter PolishHelperIntegrationTests --enable-code-coverage
 
       - name: Zip app for artifact upload
         # upload-artifact mangles symlinks/exec bits in .app bundles; ditto-zip

--- a/.github/workflows/ui-smoke.yml
+++ b/.github/workflows/ui-smoke.yml
@@ -26,6 +26,29 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          # Keep gitignored build state between runs on the persistent
+          # self-hosted runner (same rationale as ci.yml/eval-e2e.yml). The
+          # workspace is shared with ci.yml, so the default `git clean -ffdx`
+          # here wiped .build and both helper DerivedData trees every night —
+          # the first CI run each morning then paid ~7 min of cold MLX C++ +
+          # Metal helper rebuilds (observed run 29763957545, 2026-07-20).
+          clean: false
+
+      - name: Clean stale outputs (keep build caches)
+        # Same repair-and-clean as ci.yml/eval-e2e.yml: clean: false skips git
+        # clean entirely, so outputs a previous run generated are removed by
+        # hand — but NOT the build caches. The .build.smoke-hidden rename is
+        # ci.yml's launch-smoke hideaway; restore it if a cancelled run died
+        # mid-smoke.
+        run: |
+          if [[ -d .build.smoke-hidden ]]; then
+            rm -rf .build
+            mv .build.smoke-hidden .build
+          fi
+          rm -rf dist logs
+          rm -f .agent-eval-e2e-enable.json .llm-polish-eval-enable.json \
+            .polishd-integration-enable.json .speechd-integration-enable.json
 
       - name: Package app bundle
         env:


### PR DESCRIPTION
## What

Two verified CI cache losses, found while profiling why PR #154's runs felt slow:

1. **Coverage-flag mismatch in the conditional live-model lanes.** The speechd and polishd integration steps ran `swift test --filter ...` without `--enable-code-coverage`, while the unit step builds with coverage. SwiftPM treats the products as stale, so the speechd step rebuilt the whole app+test module without coverage — 109 compile tasks, ~17 s in run [29694638494](https://github.com/T0mSIlver/localvoxtral/actions/runs/29694638494) — and flipped `.build` back so the *next* run's unit step rebuilt it again. This is exactly the fix the voxmlx integration step already carries (its comment documents the same ~12 s waste). Both steps now pass the flag.

2. **ui-smoke.yml wiped the shared build caches every night.** Its checkout used the default `git clean -ffdx` in the workspace it shares with ci.yml, deleting `.build` and both helper DerivedData trees at 04:00 daily. The first CI run each morning then paid ~7 min of cold MLX C++ + Metal helper rebuilds — run [29763957545](https://github.com/T0mSIlver/localvoxtral/actions/runs/29763957545) (2026-07-20, one trivial commit after a warm 6m14s run): PolishHelper unit tests 12 s → 2 m 17 s, SpeechHelper unit tests 18 s → 3 m 19 s, packaging 34 s → 2 m 15 s. eval-e2e.yml already got `clean: false` for exactly this reason; ui-smoke was missed. Mirrored eval-e2e's `clean: false` + stale-output cleanup (including the `.build.smoke-hidden` repair and eval-marker removal, since ui-smoke shares the workspace where ci.yml hides `.build` during the launch smoke).

Not touched, deliberately: release.yml keeps its default clean (pristine-tree guarantee, per the ci.yml comment). dmg-test / record-demo / capture-assets / mac-crashlog also default-clean the same workspace but are manual-dispatch and rare — cheap follow-up if their wipes ever show up in practice.

This PR body carries `[run-llm-eval]` and `[run-speechd-integration]` so both conditional lanes run and prove fix 1 on this very run: the speechd integration step's build should complete in ~1–3 s instead of a ~17 s full-module rebuild.

## Proof

- Baseline (before): run 29694638494, speechd integration step log — `Build complete! (16.93s)` rebuilding 109+ tasks of the app module; the polishd step right after reuses it (`Build complete! (0.90s)`), confirming the rebuild is pure flag flip.
- Baseline (before): run 29763957545 step timings after the 04:00 ui-smoke nightly — cold helper rebuilds listed above, with no helper-relevant diff between the two runs (single commit `c7ce003`, app-side Swift + tests only, no `Package.resolved` change).
- After: this PR's own CI run [29765205685](https://github.com/T0mSIlver/localvoxtral/actions/runs/29765205685) (green, 7 m 11 s, both lanes forced via the markers). Speechd integration step: `Build complete! (0.93s)` (was `Build complete! (16.93s)` rebuilding 109+ tasks); polishd step: `Build complete! (0.98s)`. Zero `Compiling localvoxtral` tasks inside either lane — no module rebuild. Step wall time 65 s → 34 s.
- The ui-smoke fix is proven by construction (identical to eval-e2e.yml's shipped pattern) and by the next nightly → morning CI sequence; the first morning run should keep warm-cache step times (~12–34 s for helper tests/packaging).

[run-llm-eval] [run-speechd-integration]
