### PR TITLE
eval-e2e coverage flag + shared stale-output cleanup (#157 review follow-up)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,21 +38,10 @@ jobs:
       - name: Clean stale outputs (keep build caches)
         # clean: false above skips git clean entirely, so outputs a previous
         # run generated must be removed by hand — but NOT the build caches.
-        # Also repair the smoke test's .build rename if a cancelled run died
-        # mid-smoke (its EXIT trap doesn't run on SIGKILL): a leftover
-        # .build.smoke-hidden would make the next run's `mv` nest one dir
-        # inside the other and silently corrupt the cache.
-        run: |
-          if [[ -d .build.smoke-hidden ]]; then
-            rm -rf .build
-            mv .build.smoke-hidden .build
-          fi
-          rm -rf dist format-lint.txt default.profraw
-          # Transient eval enable markers (gitignored, marker-through-the-tree
-          # pattern): clean: false preserves them across runs, and a stray one
-          # would flip a marker-gated live suite ON in the plain unit step.
-          rm -f .agent-eval-e2e-enable.json .llm-polish-eval-enable.json \
-            .polishd-integration-enable.json .speechd-integration-enable.json
+        # Shared with ui-smoke.yml/eval-e2e.yml (same persistent workspace);
+        # the removal list and the .build.smoke-hidden repair rationale live
+        # in the script.
+        run: ./scripts/ci/clean-stale-outputs.sh
 
       - name: Clean abandoned test processes in this workspace
         # A cancelled self-hosted job can outlive the Actions process cookie
@@ -72,6 +61,7 @@ jobs:
           ./scripts/ci/test-remote-build-reap.sh
           ./scripts/ci/test-run-supervised-command.sh
           ./scripts/ci/test-ui-smoke-guard.sh
+          ./scripts/ci/test-clean-stale-outputs.sh
 
       - name: Decide LLM eval lane (path filter + [run-llm-eval] marker)
         # CI must not pay ~8 min of 4B weight-loading + live inference on

--- a/.github/workflows/eval-e2e.yml
+++ b/.github/workflows/eval-e2e.yml
@@ -36,12 +36,9 @@ jobs:
           clean: false
 
       - name: Clean stale outputs (keep build caches)
-        run: |
-          if [[ -d .build.smoke-hidden ]]; then
-            rm -rf .build
-            mv .build.smoke-hidden .build
-          fi
-          rm -rf dist logs
+        # Shared repair-and-clean for the persistent workspace (see the
+        # script for the removal list and .build.smoke-hidden rationale).
+        run: ./scripts/ci/clean-stale-outputs.sh
 
       - name: Ensure Metal toolchain
         # Same probe as ci.yml: `xcrun --find metal` succeeding does NOT mean
@@ -82,7 +79,12 @@ jobs:
         run: |
           mkdir -p logs
           set -o pipefail
-          swift test --filter AgentDictationE2EEvalTests 2>&1 | tee logs/eval-e2e.log
+          # --enable-code-coverage matches ci.yml's build flags in the SHARED
+          # .build (clean: false): without it this nightly rebuilt the whole
+          # app+test module uninstrumented, and the next morning's ci.yml
+          # unit step rebuilt it back — the same flag-flip PR #157 fixed
+          # inside ci.yml (PR #157 review finding).
+          swift test --filter AgentDictationE2EEvalTests --enable-code-coverage 2>&1 | tee logs/eval-e2e.log
 
       - name: Scoreboard to step summary
         # Extract the section between the scoreboard markers (kept in sync

--- a/.github/workflows/ui-smoke.yml
+++ b/.github/workflows/ui-smoke.yml
@@ -71,25 +71,15 @@ jobs:
           fi
 
       - name: Clean stale outputs (keep build caches)
-        # Same repair-and-clean as ci.yml/eval-e2e.yml: clean: false skips git
-        # clean entirely, so outputs a previous run generated are removed by
-        # hand — but NOT the build caches. The .build.smoke-hidden rename is
-        # ci.yml's launch-smoke hideaway; restore it if a cancelled run died
-        # mid-smoke.
+        # Shared repair-and-clean for the persistent workspace (see the
+        # script for the removal list and .build.smoke-hidden rationale).
         #
         # The guard condition compares `!= 'false'` (not `== 'true'`) so a
         # missing output fails OPEN: if the guard ever exits 0 without
         # emitting run=..., the drill runs rather than every slot silently
         # skipping green forever. Same condition on the two steps below.
         if: github.event_name != 'schedule' || steps.guard.outputs.run != 'false'
-        run: |
-          if [[ -d .build.smoke-hidden ]]; then
-            rm -rf .build
-            mv .build.smoke-hidden .build
-          fi
-          rm -rf dist logs
-          rm -f .agent-eval-e2e-enable.json .llm-polish-eval-enable.json \
-            .polishd-integration-enable.json .speechd-integration-enable.json
+        run: ./scripts/ci/clean-stale-outputs.sh
 
       - name: Package app bundle
         if: github.event_name != 'schedule' || steps.guard.outputs.run != 'false'

--- a/scripts/ci/clean-stale-outputs.sh
+++ b/scripts/ci/clean-stale-outputs.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# Shared "Clean stale outputs (keep build caches)" for the persistent
+# self-hosted runner workspace, which ci.yml, ui-smoke.yml, and eval-e2e.yml
+# all share with `clean: false` checkouts. The three workflows previously
+# carried hand-copied variants of this block and the lists drifted (PR #157
+# review): ci.yml removed format-lint.txt/default.profraw but not logs,
+# the other two removed logs but left coverage/lint droppings behind.
+#
+# Removes every transient output any of the three can leave behind — safe
+# because none of them is a build cache — and repairs ci.yml's launch-smoke
+# `.build` rename if a cancelled run died mid-smoke (its EXIT trap doesn't
+# run on SIGKILL): a leftover .build.smoke-hidden would make the next run's
+# `mv` nest one dir inside the other and silently corrupt the cache.
+#
+# Operates on the repo root containing this script, so callers don't have
+# to be careful about their working directory.
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "$0")/../.." && pwd -P)"
+cd "$ROOT_DIR"
+
+if [[ -d .build.smoke-hidden ]]; then
+  rm -rf .build
+  mv .build.smoke-hidden .build
+fi
+
+rm -rf dist logs format-lint.txt default.profraw
+
+# Transient eval enable markers (gitignored, marker-through-the-tree
+# pattern): clean: false preserves them across runs, and a stray one would
+# flip a marker-gated live suite ON in a plain unit step.
+rm -f .agent-eval-e2e-enable.json .llm-polish-eval-enable.json \
+  .polishd-integration-enable.json .speechd-integration-enable.json

--- a/scripts/ci/test-clean-stale-outputs.sh
+++ b/scripts/ci/test-clean-stale-outputs.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# Regression test for clean-stale-outputs.sh: transient outputs go, build
+# caches stay, and the .build.smoke-hidden repair restores the cache instead
+# of nesting it. Runs against a copy of the script in a throwaway tree.
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "$0")/../.." && pwd -P)"
+TMP_DIR="$(mktemp -d "${TMPDIR:-/tmp}/lv-clean-stale-test.XXXXXX")"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+fail() {
+  printf 'FAIL: %s\n' "$*" >&2
+  exit 1
+}
+
+stage() {
+  rm -rf "$TMP_DIR/tree"
+  mkdir -p "$TMP_DIR/tree/scripts/ci"
+  cp "$ROOT_DIR/scripts/ci/clean-stale-outputs.sh" "$TMP_DIR/tree/scripts/ci/"
+}
+
+# Normal case: transient outputs removed, caches preserved.
+stage
+mkdir -p "$TMP_DIR/tree/.build" "$TMP_DIR/tree/PolishHelper/.build" \
+  "$TMP_DIR/tree/dist" "$TMP_DIR/tree/logs"
+touch "$TMP_DIR/tree/.build/cache-marker" \
+  "$TMP_DIR/tree/format-lint.txt" "$TMP_DIR/tree/default.profraw" \
+  "$TMP_DIR/tree/.agent-eval-e2e-enable.json" \
+  "$TMP_DIR/tree/.speechd-integration-enable.json"
+"$TMP_DIR/tree/scripts/ci/clean-stale-outputs.sh"
+[[ -f "$TMP_DIR/tree/.build/cache-marker" ]] || fail "build cache was removed"
+[[ -d "$TMP_DIR/tree/PolishHelper/.build" ]] || fail "helper build cache was removed"
+for gone in dist logs format-lint.txt default.profraw \
+  .agent-eval-e2e-enable.json .speechd-integration-enable.json; do
+  [[ ! -e "$TMP_DIR/tree/$gone" ]] || fail "$gone survived cleanup"
+done
+echo "PASS: transient outputs removed, build caches preserved"
+
+# Repair case: a SIGKILLed smoke left .build.smoke-hidden AND a fresh .build
+# was recreated after; the hidden (real) cache must win, not nest.
+stage
+mkdir -p "$TMP_DIR/tree/.build.smoke-hidden" "$TMP_DIR/tree/.build"
+touch "$TMP_DIR/tree/.build.smoke-hidden/real-cache" \
+  "$TMP_DIR/tree/.build/imposter"
+"$TMP_DIR/tree/scripts/ci/clean-stale-outputs.sh"
+[[ -f "$TMP_DIR/tree/.build/real-cache" ]] || fail "smoke-hidden cache was not restored"
+[[ ! -e "$TMP_DIR/tree/.build/imposter" ]] || fail "imposter .build survived the repair"
+[[ ! -d "$TMP_DIR/tree/.build.smoke-hidden" ]] || fail ".build.smoke-hidden left behind"
+echo "PASS: smoke-hidden repair restores the real cache without nesting"
+
+# Caller-cwd independence: invoked from a subdirectory, it still cleans the
+# repo root the script lives in.
+stage
+mkdir -p "$TMP_DIR/tree/dist" "$TMP_DIR/elsewhere"
+(cd "$TMP_DIR/elsewhere" && "$TMP_DIR/tree/scripts/ci/clean-stale-outputs.sh")
+[[ ! -e "$TMP_DIR/tree/dist" ]] || fail "cleanup did not operate on the script's repo root"
+echo "PASS: operates on the script's repo root regardless of caller cwd"
+
+echo "clean-stale-outputs tests passed"


### PR DESCRIPTION
## What

Follow-up to the adversarial review of merged #157 (opencode / glm-5.2), which found the flag-mismatch fix **incomplete** plus one drift issue:

1. **eval-e2e.yml still had the coverage flag flip** (`eval-e2e.yml:85`): its nightly `swift test --filter AgentDictationE2EEvalTests` ran **without** `--enable-code-coverage` in the same `clean: false` shared `.build`. Every night it rebuilt the whole app+test module uninstrumented, and the next morning's ci.yml unit step rebuilt it back with coverage — the exact ~17 s-per-side flag flip #157 fixed inside ci.yml, still firing daily from the sibling workflow. Flag added. (release.yml also lacks the flag but keeps the default *clean* checkout, so its build never touches the shared cache — left alone, per the review.)
2. **The three "Clean stale outputs" blocks had drifted**: ci.yml removed `format-lint.txt`/`default.profraw` but not `logs`; ui-smoke.yml/eval-e2e.yml the reverse — so ci.yml's coverage/lint droppings (now also written by the #157-instrumented speechd/polishd steps) sat as clutter through the other workflows' runs. Extracted the union into `scripts/ci/clean-stale-outputs.sh` (including the `.build.smoke-hidden` repair), called by all three workflows, so the list can't drift again.

Review's "checked and fine" highlights (no action needed): coverage-summary ordering is safe (summary runs before the instrumented lanes); env-gated enablement has no `clean: false` interaction; the `.build.smoke-hidden` repair is race-free under the verified single registered runner; #158's guard conditions preserve the cleanup semantics.

## Proof

- New `scripts/ci/test-clean-stale-outputs.sh` (wired into ci.yml's per-push shell-test step), local run:

  ```
  PASS: transient outputs removed, build caches preserved
  PASS: smoke-hidden repair restores the real cache without nesting
  PASS: operates on the script's repo root regardless of caller cwd
  clean-stale-outputs tests passed
  ```

- The eval-e2e flag fix is the same verified mechanism as #157 (flag parity = no rebuild): #157's own run [29765205685](https://github.com/T0mSIlver/localvoxtral/actions/runs/29765205685) demonstrated `Build complete! (0.93s)` vs `16.93s` once flags match. Post-merge confirmation: tonight's 04:45 eval-e2e run should show a seconds-scale `Build complete!` instead of a full module rebuild, and tomorrow's first ci.yml unit step should stay at warm-cache time (~35 s).
- No Swift or app code touched (workflow YAML + two shell scripts); CI tier 0/1 on this PR covers the tree. LLM lanes: correctly skipped, no relevant paths.
