### PR TITLE
Fix the tier-0 hang class: XCTest modal guard on main + supervisor timeout forensics

### DIFF
--- a/Sources/localvoxtral/DictationViewModel+Session.swift
+++ b/Sources/localvoxtral/DictationViewModel+Session.swift
@@ -1668,6 +1668,15 @@ extension DictationViewModel {
             Log.dictation.error("connection-failure alert skipped: no NSApplication in this process")
             return
         }
+        // The nil guard above is NOT sufficient in a test process: any earlier
+        // test that touches NSApplication.shared initializes NSApp for the rest
+        // of the suite, and runModal() then stops the whole run dead waiting
+        // for a click that never comes (xctest sample 2026-07-19: this frame
+        // parked in _DPSBlockUntilNextEventMatchingListInMode mid-suite).
+        guard NSClassFromString("XCTestCase") == nil else {
+            Log.dictation.error("connection-failure alert skipped: XCTest process")
+            return
+        }
         NSApp.activate(ignoringOtherApps: true)
         let alert = NSAlert()
         alert.alertStyle = .warning

--- a/Tests/localvoxtralTests/TerminalTargetDetectorTests.swift
+++ b/Tests/localvoxtralTests/TerminalTargetDetectorTests.swift
@@ -1,3 +1,4 @@
+import AppKit
 import Carbon
 import Foundation
 import XCTest
@@ -524,6 +525,27 @@ final class TerminalTargetDetectorTests: XCTestCase {
 
         XCTAssertNil(viewModel.lastError)
         XCTAssertNotEqual(viewModel.menuBarIndicatorState, .secureInputWarning)
+        viewModel.isShowingConnectionFailureAlert = true
+    }
+
+    func testConnectionFailureAlertNeverRunsModalEvenWithNSAppInitialized() {
+        // Regression: presentConnectionFailureAlert's `NSApp != nil` guard is
+        // not enough in a test process — any earlier test touching
+        // NSApplication.shared initializes NSApp for the rest of the suite,
+        // after which an invalid-endpoint failure ran a REAL modal NSAlert and
+        // parked the whole run in _DPSBlockUntilNextEventMatchingListInMode
+        // (sampled 2026-07-19; hung tier-0 CI and the SSH gate). Returning
+        // from beginDictationSession at all is the proof; the assertions
+        // below just pin the early-exit failure surface it must still reach.
+        _ = NSApplication.shared
+        let viewModel = makeViewModel(outputMode: .overlayBuffer)
+        Self.retainedViewModels.append(viewModel)
+        viewModel.settings.dictationBackendMode = .externalURL
+        viewModel.settings.realtimeAPIEndpointURL = ""
+        viewModel.beginDictationSession()
+
+        XCTAssertFalse(viewModel.isDictating)
+        XCTAssertNotNil(viewModel.lastError, "the failure must still be surfaced")
         viewModel.isShowingConnectionFailureAlert = true
     }
 

--- a/scripts/ci/run-supervised-command.sh
+++ b/scripts/ci/run-supervised-command.sh
@@ -18,7 +18,11 @@ shift
 
 term_polls="${LOCALVOXTRAL_SUPERVISOR_TERM_POLLS:-50}"
 poll_seconds="${LOCALVOXTRAL_SUPERVISOR_TERM_POLL_SECONDS:-0.1}"
+# Hard cap on each forensic `sample` (polls x 0.1 s; default 8 s): a sampler
+# stuck on a badly wedged task must never postpone the kill it precedes.
+sample_polls="${LOCALVOXTRAL_SUPERVISOR_SAMPLE_POLLS:-80}"
 [[ "$term_polls" =~ ^[0-9]+$ ]] || usage
+[[ "$sample_polls" =~ ^[1-9][0-9]*$ ]] || usage
 
 mkdir -p "$(dirname "$log_file")"
 : >"$log_file"
@@ -43,10 +47,34 @@ group_is_alive() {
 # which CI already uploads as an artifact even on failure. xctest is sampled
 # first (the interesting process for test hangs), then remaining group
 # members, capped so forensics never delay the kill by more than ~10 s.
+# One bounded sample: run the sampler in its own background group and kill
+# it after sample_polls x 0.1 s. `sample` itself can stall on a badly wedged
+# task, and an unbounded sampler here would postpone terminate_group —
+# recreating the very blind hang this forensics exists to diagnose.
+sample_one_bounded() {
+  local pid="$1" sampler waited=0
+  echo "--- sample pid $pid ($(ps -o ucomm= -p "$pid" 2>/dev/null || echo unknown)) ---" >>"$log_file"
+  ( sample "$pid" 2 -mayDie 2>&1 ) >>"$log_file" 2>&1 &
+  sampler=$!
+  while kill -0 "$sampler" 2>/dev/null && (( waited < sample_polls )); do
+    sleep 0.1
+    waited=$((waited + 1))
+  done
+  if kill -0 "$sampler" 2>/dev/null; then
+    kill -KILL -- "-$sampler" 2>/dev/null || kill -KILL "$sampler" 2>/dev/null || true
+    echo "--- sampler for pid $pid killed at the ${sample_polls}00 ms cap ---" >>"$log_file"
+  fi
+  wait "$sampler" 2>/dev/null || true
+}
+
 sample_group_for_forensics() {
-  local pgid="$1" sampled=0 pid
+  local pgid="$1" sampled=0 pid seen_pids=""
   [[ -n "$pgid" ]] || return 0
   command -v sample >/dev/null 2>&1 || return 0
+  if ! command -v pgrep >/dev/null 2>&1; then
+    echo "=== supervisor timeout forensics skipped: pgrep unavailable ===" >>"$log_file"
+    return 0
+  fi
   {
     echo ""
     echo "=== supervisor timeout forensics: sampling process group $pgid ==="
@@ -54,12 +82,9 @@ sample_group_for_forensics() {
   for pid in $(pgrep -g "$pgid" -x xctest 2>/dev/null; pgrep -g "$pgid" 2>/dev/null); do
     (( sampled >= 3 )) && break
     kill -0 "$pid" 2>/dev/null || continue
-    case " ${seen_pids:-} " in *" $pid "*) continue ;; esac
-    seen_pids="${seen_pids:-} $pid"
-    {
-      echo "--- sample pid $pid ($(ps -o ucomm= -p "$pid" 2>/dev/null || echo unknown)) ---"
-      sample "$pid" 2 -mayDie 2>&1
-    } >>"$log_file" || true
+    case " $seen_pids " in *" $pid "*) continue ;; esac
+    seen_pids="$seen_pids $pid"
+    sample_one_bounded "$pid"
     sampled=$((sampled + 1))
   done
   return 0
@@ -116,8 +141,14 @@ command_pgid=$command_pid
   else
     sleep "$timeout_seconds"
   fi
-  : >"$timeout_marker"
+  # Sample BEFORE the marker/kill, and only mark the run as a timeout if the
+  # group is still alive afterwards: forensics can take seconds, and a
+  # command that finished naturally inside that window must keep its real
+  # exit status instead of a mislabeled 124 (PR #160 review finding).
+  group_is_alive "$command_pgid" || exit 0
   sample_group_for_forensics "$command_pgid"
+  group_is_alive "$command_pgid" || exit 0
+  : >"$timeout_marker"
   terminate_group "$command_pgid"
 ) &
 watchdog_pid=$!

--- a/scripts/ci/run-supervised-command.sh
+++ b/scripts/ci/run-supervised-command.sh
@@ -36,6 +36,35 @@ group_is_alive() {
   [[ -n "$pgid" ]] && kill -0 -- "-$pgid" 2>/dev/null
 }
 
+# On timeout, capture WHERE the command is stuck before killing it: the
+# 2026-07-19/20 tier-0 hangs cost a blind rerun each because the group was
+# killed with no stack evidence (the 07-19 NSAlert.runModal culprit was only
+# found by hand-sampling a wedged xctest). Samples land in the log file,
+# which CI already uploads as an artifact even on failure. xctest is sampled
+# first (the interesting process for test hangs), then remaining group
+# members, capped so forensics never delay the kill by more than ~10 s.
+sample_group_for_forensics() {
+  local pgid="$1" sampled=0 pid
+  [[ -n "$pgid" ]] || return 0
+  command -v sample >/dev/null 2>&1 || return 0
+  {
+    echo ""
+    echo "=== supervisor timeout forensics: sampling process group $pgid ==="
+  } >>"$log_file"
+  for pid in $(pgrep -g "$pgid" -x xctest 2>/dev/null; pgrep -g "$pgid" 2>/dev/null); do
+    (( sampled >= 3 )) && break
+    kill -0 "$pid" 2>/dev/null || continue
+    case " ${seen_pids:-} " in *" $pid "*) continue ;; esac
+    seen_pids="${seen_pids:-} $pid"
+    {
+      echo "--- sample pid $pid ($(ps -o ucomm= -p "$pid" 2>/dev/null || echo unknown)) ---"
+      sample "$pid" 2 -mayDie 2>&1
+    } >>"$log_file" || true
+    sampled=$((sampled + 1))
+  done
+  return 0
+}
+
 terminate_group() {
   local pgid="$1" poll=0
   [[ -n "$pgid" ]] || return 0
@@ -88,6 +117,7 @@ command_pgid=$command_pid
     sleep "$timeout_seconds"
   fi
   : >"$timeout_marker"
+  sample_group_for_forensics "$command_pgid"
   terminate_group "$command_pgid"
 ) &
 watchdog_pid=$!

--- a/scripts/ci/test-run-supervised-command.sh
+++ b/scripts/ci/test-run-supervised-command.sh
@@ -82,6 +82,42 @@ is_live_non_zombie "$stubborn_pid" && fail "descendant survived its leader"
 fixture_pid=""
 stubborn_pid=""
 
+# On timeout, the watchdog samples the wedged group into the log BEFORE
+# killing it (2026-07-20 hang forensics). `sample` is stubbed on PATH so the
+# test is deterministic and runs on non-macOS too; the stub proves the
+# sampled pid belongs to the command's group and its output lands in the log.
+pid_fifo="$TMP_DIR/forensics-pids"
+timeout_fifo="$TMP_DIR/forensics-trigger"
+mkfifo "$pid_fifo" "$timeout_fifo"
+mkdir -p "$TMP_DIR/bin"
+cat >"$TMP_DIR/bin/sample" <<'STUB'
+#!/usr/bin/env bash
+echo "stub-sample-of-pid-$1"
+STUB
+chmod +x "$TMP_DIR/bin/sample"
+PATH="$TMP_DIR/bin:$PATH" \
+LOCALVOXTRAL_SUPERVISOR_TIMEOUT_FIFO="$timeout_fifo" \
+LOCALVOXTRAL_SUPERVISOR_TERM_POLLS=0 \
+  "$SUPERVISOR" 999 "$TMP_DIR/forensics.log" -- "$FIXTURE" "$pid_fifo" &
+supervisor_pid=$!
+read -r fixture_pid stubborn_pid <"$pid_fifo"
+printf 'fire\n' >"$timeout_fifo"
+if wait "$supervisor_pid"; then
+  fail "forensics-run command unexpectedly succeeded"
+else
+  status=$?
+fi
+supervisor_pid=""
+[[ "$status" == "124" ]] || fail "forensics run: timeout status changed from 124 to $status"
+grep -q 'supervisor timeout forensics' "$TMP_DIR/forensics.log" \
+  || fail "timeout log is missing the forensics marker"
+grep -qE "stub-sample-of-pid-($fixture_pid|$stubborn_pid)" "$TMP_DIR/forensics.log" \
+  || fail "no group member was sampled into the log"
+is_live_non_zombie "$fixture_pid" && fail "forensics run: leader survived"
+is_live_non_zombie "$stubborn_pid" && fail "forensics run: descendant survived"
+fixture_pid=""
+stubborn_pid=""
+
 # Signal cancellation preserves the conventional status and drains the tree.
 pid_fifo="$TMP_DIR/signal-pids"
 mkfifo "$pid_fifo"

--- a/scripts/ci/test-run-supervised-command.sh
+++ b/scripts/ci/test-run-supervised-command.sh
@@ -118,6 +118,67 @@ is_live_non_zombie "$stubborn_pid" && fail "forensics run: descendant survived"
 fixture_pid=""
 stubborn_pid=""
 
+# A sampler that hangs must be killed at the cap and never postpone the
+# group kill (PR #160 review: an unbounded `sample` on a badly wedged task
+# would recreate the blind hang the forensics exist to diagnose).
+pid_fifo="$TMP_DIR/hung-sampler-pids"
+timeout_fifo="$TMP_DIR/hung-sampler-trigger"
+mkfifo "$pid_fifo" "$timeout_fifo"
+cat >"$TMP_DIR/bin/sample" <<'STUB'
+#!/usr/bin/env bash
+echo "stub-sample-hanging-on-pid-$1"
+exec sleep 300
+STUB
+chmod +x "$TMP_DIR/bin/sample"
+PATH="$TMP_DIR/bin:$PATH" \
+LOCALVOXTRAL_SUPERVISOR_TIMEOUT_FIFO="$timeout_fifo" \
+LOCALVOXTRAL_SUPERVISOR_TERM_POLLS=0 \
+LOCALVOXTRAL_SUPERVISOR_SAMPLE_POLLS=3 \
+  "$SUPERVISOR" 999 "$TMP_DIR/hung-sampler.log" -- "$FIXTURE" "$pid_fifo" &
+supervisor_pid=$!
+read -r fixture_pid stubborn_pid <"$pid_fifo"
+printf 'fire\n' >"$timeout_fifo"
+if wait "$supervisor_pid"; then
+  fail "hung-sampler run unexpectedly succeeded"
+else
+  status=$?
+fi
+supervisor_pid=""
+[[ "$status" == "124" ]] || fail "hung-sampler run: timeout status changed from 124 to $status"
+grep -q 'killed at the 300 ms cap' "$TMP_DIR/hung-sampler.log" \
+  || fail "hung sampler was not killed at the cap"
+is_live_non_zombie "$fixture_pid" && fail "hung-sampler run: leader survived"
+is_live_non_zombie "$stubborn_pid" && fail "hung-sampler run: descendant survived"
+fixture_pid=""
+stubborn_pid=""
+
+# A command that finishes naturally while forensics are running must keep
+# its real exit status — the timeout marker is only written if the group is
+# still alive after sampling (PR #160 review: the marker used to be written
+# before sampling, widening the 124-mislabel race to seconds).
+timeout_fifo="$TMP_DIR/natural-finish-trigger"
+mkfifo "$timeout_fifo"
+flag_file="$TMP_DIR/natural-finish-flag"
+cat >"$TMP_DIR/bin/sample" <<STUB
+#!/usr/bin/env bash
+echo "stub-sample-releasing-command"
+touch "$flag_file"
+sleep 1
+STUB
+chmod +x "$TMP_DIR/bin/sample"
+PATH="$TMP_DIR/bin:$PATH" \
+LOCALVOXTRAL_SUPERVISOR_TIMEOUT_FIFO="$timeout_fifo" \
+LOCALVOXTRAL_SUPERVISOR_TERM_POLLS=0 \
+LOCALVOXTRAL_SUPERVISOR_SAMPLE_POLLS=50 \
+  "$SUPERVISOR" 999 "$TMP_DIR/natural-finish.log" -- \
+  /bin/bash -c "while [[ ! -f '$flag_file' ]]; do sleep 0.05; done; echo finished-naturally; exit 0" &
+supervisor_pid=$!
+printf 'fire\n' >"$timeout_fifo"
+wait "$supervisor_pid" || fail "natural finish during forensics was mislabeled as status $?"
+supervisor_pid=""
+grep -q '^finished-naturally$' "$TMP_DIR/natural-finish.log" \
+  || fail "natural-finish output missing from the log"
+
 # Signal cancellation preserves the conventional status and drains the tree.
 pid_fifo="$TMP_DIR/signal-pids"
 mkfifo "$pid_fifo"


### PR DESCRIPTION
## What

Fixes the tier-0 unit-suite hang class (three 300 s-timeout kills in two days: runs [29690098130](https://github.com/T0mSIlver/localvoxtral/actions/runs/29690098130), [29693730846](https://github.com/T0mSIlver/localvoxtral/actions/runs/29693730846), [29770530435](https://github.com/T0mSIlver/localvoxtral/actions/runs/29770530435) attempt 1) in two parts:

1. **Cherry-pick the sample-proven modal guard to main** (`201bfdb` from `tty-session-join`, PR #154's branch): `presentConnectionFailureAlert`'s `NSApp != nil` guard is insufficient in an xctest process — once any earlier test touches `NSApplication.shared`, NSApp is non-nil for the rest of the suite, and a connect failure then runs a REAL `NSAlert.runModal()`, parking the whole run in `_DPSBlockUntilNextEventMatchingListInMode` (hand-sampled on the wedged xctest, 2026-07-19). Main has the identical unguarded `runModal` — a survey of the codebase shows it is the only unbounded main-thread parker (`localvoxtralApp.swift`'s is app-startup-only; `RepoVocabulary`'s semaphore waits are bounded). The guard on `NSClassFromString("XCTestCase")` plus the regression test come with the cherry-pick.

2. **Timeout forensics in `run-supervised-command.sh`**: the watchdog now `sample`s up to three members of the wedged process group (xctest first) into the log file — which CI already uploads as the `unit-test-log-macOS` artifact even on failure — *before* killing the group. Forensic evidence for this: the 07-20 hang on the main lineage (attempt 1 of run 29770530435) froze **entering `BackendManagerTests`** — a *different* signature from the 07-19 NSAlert hangs (which both froze right before `testStaleSecureIconDoesNotMaskEarlyExitFailures…`, the alert-driving test). I traced the 07-20 wedge's candidates (connect-timeout timer arithmetic, `ensureReady` single-flight, `isReady`, the port defense, the test fakes' continuation machinery) and ruled each out from the logs and code — its true trigger is unidentified, so the next occurrence must self-diagnose instead of costing another blind rerun.

Investigation record: the 07-19 hang logs both stop at the same alert-driving test (NSAlert signature, fix #1); the 07-20 log stops milliseconds into the first `@MainActor` test after three non-MainActor suites, at 21:06:06.910, with no view-model-owning suite having run — consistent with a parked main thread of unknown origin (fix #2 captures it next time).

## Proof

- **Modal guard, before**: PR #154's branch hung deterministically pre-fix (runs 29690098130 / 29693730846 — unit-log artifacts stop at the alert-driving test; xctest hand-sample showed `runModal` parked in `_DPSBlockUntilNextEventMatchingListInMode`) and went green immediately after `201bfdb` landed on it (run [29694638494](https://github.com/T0mSIlver/localvoxtral/actions/runs/29694638494)). That is the failing-before/passing-after pair for this exact commit; the failing mode is a 300 s hang, so it is not reproduced fresh here.
- **Modal guard, after (on main lineage)**: `./scripts/remote-build.sh test --filter TerminalTargetDetectorTests` — `Executed 38 tests, with 0 failures`, including:
  ```
  Test Case '-[localvoxtralTests.TerminalTargetDetectorTests testConnectionFailureAlertNeverRunsModalEvenWithNSAppInitialized]' passed (0.020 seconds).
  ```
- **Forensics**: `./scripts/ci/test-run-supervised-command.sh` (new case: PATH-stubbed `sample`, deterministic FIFO-triggered timeout):
  ```
  === supervisor timeout forensics: sampling process group 2986747 ===
  --- sample pid 2986747 (bash) ---
  stub-sample-of-pid-2986747
  --- sample pid 2986749 (sleep) ---
  stub-sample-of-pid-2986749
  PASS: supervisor captures output, preserves status, and drains exact groups
  ```
- Full unit suite runs on this PR's CI (tier 0).

Note for the #150/#154 stack: `201bfdb` is cherry-picked with `-x`; when those PRs merge, the identical hunk should auto-resolve.
