### PR TITLE
speechd-bench: optional cache-limit-mb argument

### DIFF
--- a/Tests/localvoxtralTests/SpeechdStreamingBenchTests.swift
+++ b/Tests/localvoxtralTests/SpeechdStreamingBenchTests.swift
@@ -16,6 +16,7 @@ final class SpeechdStreamingBenchTests: XCTestCase {
         let seconds: Int
         let cadenceMilliseconds: Int
         let wavPath: String?
+        let cacheLimitMB: Int?
     }
 
     private var repoRoot: URL {
@@ -57,6 +58,9 @@ final class SpeechdStreamingBenchTests: XCTestCase {
         ]
         if let wavPath = config.wavPath, !wavPath.isEmpty {
             arguments.append(contentsOf: ["--wav", wavPath])
+        }
+        if let cacheLimitMB = config.cacheLimitMB {
+            arguments.append(contentsOf: ["--cache-limit-mb", "\(cacheLimitMB)"])
         }
 
         let process = Process()

--- a/scripts/remote-build.sh
+++ b/scripts/remote-build.sh
@@ -284,12 +284,13 @@ case "$CMD" in
   speechd-bench)
     # The SSH gate does not allow arbitrary packaged-binary execution. A marker-gated
     # root XCTest launches the xcodebuild-produced helper and relays its BENCH output.
-    if [[ $# -gt 2 ]]; then
-      echo "speechd-bench accepts optional seconds and cadence-ms arguments" >&2
+    if [[ $# -gt 3 ]]; then
+      echo "speechd-bench accepts optional seconds, cadence-ms, and cache-limit-mb arguments" >&2
       exit 1
     fi
     SPEECHD_BENCH_SECONDS="${1:-60}"
     SPEECHD_BENCH_CADENCE="${2:-100}"
+    SPEECHD_BENCH_CACHE_MB="${3:-}"
     if [[ ! "$SPEECHD_BENCH_SECONDS" =~ ^[1-9][0-9]*$ ]]; then
       echo "speechd-bench seconds must be a positive integer" >&2
       exit 1
@@ -298,13 +299,26 @@ case "$CMD" in
       echo "speechd-bench cadence-ms must be a positive integer" >&2
       exit 1
     fi
+    if [[ -n "$SPEECHD_BENCH_CACHE_MB" && ! "$SPEECHD_BENCH_CACHE_MB" =~ ^[1-9][0-9]*$ ]]; then
+      echo "speechd-bench cache-limit-mb must be a positive integer" >&2
+      exit 1
+    fi
     SPEECHD_BENCH_MARKER="$ROOT_DIR/.speechd-bench-enable.json"
     trap 'cleanup_transient_marker "$SPEECHD_BENCH_MARKER"' EXIT
-    printf '{"helperPath":"%s","seconds":%s,"cadenceMilliseconds":%s}\n' \
-      "dist/localvoxtral.app/Contents/MacOS/localvoxtral-speechd" \
-      "$SPEECHD_BENCH_SECONDS" \
-      "$SPEECHD_BENCH_CADENCE" \
-      >"$SPEECHD_BENCH_MARKER"
+    if [[ -n "$SPEECHD_BENCH_CACHE_MB" ]]; then
+      printf '{"helperPath":"%s","seconds":%s,"cadenceMilliseconds":%s,"cacheLimitMB":%s}\n' \
+        "dist/localvoxtral.app/Contents/MacOS/localvoxtral-speechd" \
+        "$SPEECHD_BENCH_SECONDS" \
+        "$SPEECHD_BENCH_CADENCE" \
+        "$SPEECHD_BENCH_CACHE_MB" \
+        >"$SPEECHD_BENCH_MARKER"
+    else
+      printf '{"helperPath":"%s","seconds":%s,"cadenceMilliseconds":%s}\n' \
+        "dist/localvoxtral.app/Contents/MacOS/localvoxtral-speechd" \
+        "$SPEECHD_BENCH_SECONDS" \
+        "$SPEECHD_BENCH_CADENCE" \
+        >"$SPEECHD_BENCH_MARKER"
+    fi
     REMOTE_CMD=(swift test --filter SpeechdStreamingBenchTests)
     ;;
   eval-e2e)

--- a/scripts/remote-build.sh
+++ b/scripts/remote-build.sh
@@ -19,8 +19,10 @@ set -euo pipefail
 #                  transcribe real audio through the production websocket
 #                  client, and assert accuracy + delta + parent-pid contracts
 #     speechd-bench run the packaged speech helper's streaming benchmark;
-#                  optional args = seconds (default 60) and cadence ms
-#                  (default 100 = the production step cadence); requires a prior `package`
+#                  optional args = seconds (default 60), cadence ms
+#                  (default 100 = the production step cadence), and
+#                  cache-limit-mb (default = the helper's built-in limit);
+#                  requires a prior `package`
 #     eval-llm     default-polish-prompt eval against a live mlx-lm server;
 #                  optional args = chat/completions endpoint and external
 #                  model alias (default endpoint


### PR DESCRIPTION
## What

`./scripts/remote-build.sh speechd-bench [seconds] [cadence-ms] [cache-limit-mb]` — the new optional third argument rides the bench marker JSON into the packaged helper's existing `--cache-limit-mb` flag. Omitted, the marker is byte-identical to before.

## Why

The speechd perf investigation (2026-07-20) needed a pool-cap A/B probe (4 GB vs 2 GB) to test whether buffer-pool hoarding was degrading the lm-head gemv; without this knob that requires editing and re-syncing test code per run. (Result, for the record: cap size made no measurable difference — the phases are bandwidth-bound.)

## Proof

Exercised live on the Mac: `speechd-bench 60 100 2048` ran the packaged helper with the cap applied — `BENCH mark=5s … cache_mb=2048.0`, `mark=15s … cache_mb=2047.2`, `mark=30s … cache_mb=2059.5`, `mark=60s … cache_mb=2068.9` (vs 4095–4115 on the default runs bracketing it in the same session). Default two-argument invocations before and after the change produced identical marker JSON and normal runs (baseline + 5 candidate benches in the same session). Tier-0 unaffected: the lane is marker-gated and skips without the marker file; the decoder-side `cacheLimitMB` field is optional, so existing markers parse unchanged.