### PR TITLE
Build-host disk GC: gate v4 gc/disk verbs, per-use stamps, auto-gc after every remote run

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,7 +58,9 @@ jobs:
           ./scripts/ci/test-cleanup-stale-test-processes.sh
           ./scripts/ci/test-build-gate-process-cleanup.sh
           ./scripts/ci/test-build-gate-reap-command.sh
+          ./scripts/ci/test-build-gate-gc-command.sh
           ./scripts/ci/test-remote-build-reap.sh
+          ./scripts/ci/test-remote-build-gc.sh
           ./scripts/ci/test-run-supervised-command.sh
           ./scripts/ci/test-ui-smoke-guard.sh
           ./scripts/ci/test-clean-stale-outputs.sh
@@ -78,7 +80,9 @@ jobs:
           ./scripts/ci/test-cleanup-stale-test-processes.sh
           ./scripts/ci/test-build-gate-process-cleanup.sh
           ./scripts/ci/test-build-gate-reap-command.sh
+          ./scripts/ci/test-build-gate-gc-command.sh
           ./scripts/ci/test-remote-build-reap.sh
+          ./scripts/ci/test-remote-build-gc.sh
           ./scripts/ci/test-run-supervised-command.sh
 
       - name: Decide LLM eval lane (path filter + [run-llm-eval] marker)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -50,7 +50,11 @@ letting rsync hang or CI queue forever.
 
 Parallel agents are isolated automatically: the remote dir defaults to a
 per-worktree name derived from the local checkout path. `LV_BUILD_DIR`
-still overrides it when you need a specific dir.
+still overrides it when you need a specific dir. Abandoned remote dirs are
+garbage-collected by the gate's `gc` verb (fired best-effort after every
+run; 14-day unused window, live dirs and `EvalRecordings/` always kept), so
+minting a fresh dir is cheap — never hand-clean `~/work` on the Mac.
+`./scripts/remote-build.sh disk` shows per-dir sizes and last-used ages.
 
 - An interrupted remote run can leave a stale SwiftPM lock in its remote dir —
   don't debug it, switch to a fresh `LV_BUILD_DIR`.
@@ -93,7 +97,7 @@ Learned the hard way (2026-07-04) — use these instead of manual steps:
   confusion and theorize-first cost an hour on 2026-07-05. Deeper tools:
   `scripts/mac-diag.sh` on the Mac, Export Diagnostics… in Settings > About,
   and (once the v2 gate is installed — owner runbook: `scripts/mac/README.md`)
-  `./scripts/remote-build.sh diag|applog|voxlog|svc-status`.
+  `./scripts/remote-build.sh diag|applog|voxlog|svc-status|disk|gc`.
 - **README demo video**: `./scripts/record-demo.sh` on the Mac (GUI session)
   stages the scene, drives the real Right-Command tap/hold gesture with
   synthetic CGEvents, records, and encodes `dist/demo/demo.mp4`; the operator

--- a/scripts/ci/test-build-gate-gc-command.sh
+++ b/scripts/ci/test-build-gate-gc-command.sh
@@ -1,0 +1,150 @@
+#!/usr/bin/env bash
+# Regression tests for the gate's work-dir GC: the per-use stamp verbs, the
+# age decision, the live-process and EvalRecordings keep-checks, and the
+# denial surface of the new gc/disk verbs.
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "$0")/../.." && pwd -P)"
+GATE="$ROOT_DIR/scripts/mac/localvoxtral-build-gate.sh"
+TMP_DIR="$(mktemp -d "${TMPDIR:-/tmp}/lv-gate-gc-test.XXXXXX")"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+fail() {
+  printf 'FAIL: %s\n' "$*" >&2
+  exit 1
+}
+
+FAKE_HOME="$TMP_DIR/home"
+WORK="$FAKE_HOME/work"
+OLD_TS="202001010000"
+mkdir -p "$WORK"
+
+run_gate() {
+  HOME="$FAKE_HOME" SSH_ORIGINAL_COMMAND="$1" bash "$GATE"
+}
+
+# Age every existing entry of a dir (files first-created, then all mtimes
+# forced old — touching an existing file does not bump its parent dir).
+age_tree() {
+  find "$1" -exec touch -t "$OLD_TS" {} +
+}
+
+# --- stamp verbs -------------------------------------------------------------
+
+run_gate 'mkdir -p work/localvoxtral-stamp-1' >/dev/null
+[[ -f "$WORK/localvoxtral-stamp-1/.lv-last-used" ]] \
+  || fail "mkdir verb did not create the last-used stamp"
+
+age_tree "$WORK/localvoxtral-stamp-1"
+old_ref="$TMP_DIR/old-ref"
+touch -t "$OLD_TS" "$old_ref"
+mkdir -p "$TMP_DIR/bin"
+cat >"$TMP_DIR/bin/swift" <<'STUB'
+#!/usr/bin/env bash
+exit 0
+STUB
+chmod +x "$TMP_DIR/bin/swift"
+HOME="$FAKE_HOME" PATH="$TMP_DIR/bin:$PATH" \
+  SSH_ORIGINAL_COMMAND='cd work/localvoxtral-stamp-1 && swift build' \
+  bash "$GATE" >/dev/null
+[[ "$WORK/localvoxtral-stamp-1/.lv-last-used" -nt "$old_ref" ]] \
+  || fail "cd verb did not refresh the last-used stamp"
+
+# --- gc: age decision --------------------------------------------------------
+
+# Stale in every way -> deleted.
+mkdir -p "$WORK/localvoxtral-stale-1/.build/arm64/debug"
+echo artifact >"$WORK/localvoxtral-stale-1/.build/arm64/debug/product"
+echo source >"$WORK/localvoxtral-stale-1/main.swift"
+age_tree "$WORK/localvoxtral-stale-1"
+
+# Fresh stamp -> kept.
+mkdir -p "$WORK/localvoxtral-fresh-1/.build"
+age_tree "$WORK/localvoxtral-fresh-1"
+touch "$WORK/localvoxtral-fresh-1/.lv-last-used"
+
+# Old stamp but a build wrote a fresh product (pre-stamp dirs rely on this) -> kept.
+mkdir -p "$WORK/localvoxtral-fresh-deep-1/.build/arm64/debug"
+echo artifact >"$WORK/localvoxtral-fresh-deep-1/.build/arm64/debug/old"
+age_tree "$WORK/localvoxtral-fresh-deep-1"
+echo artifact >"$WORK/localvoxtral-fresh-deep-1/.build/arm64/debug/rebuilt"
+
+# Stale but holds recordings -> pruned, EvalRecordings intact.
+mkdir -p "$WORK/localvoxtral-recordings-1/EvalRecordings/agent-dictation/owner"
+echo '{}' >"$WORK/localvoxtral-recordings-1/EvalRecordings/agent-dictation/owner/manifest.json"
+mkdir -p "$WORK/localvoxtral-recordings-1/.build"
+echo artifact >"$WORK/localvoxtral-recordings-1/.build/product"
+echo source >"$WORK/localvoxtral-recordings-1/main.swift"
+age_tree "$WORK/localvoxtral-recordings-1"
+
+# Not a gate-managed dir -> never touched, however stale.
+mkdir -p "$WORK/other-project"
+echo keep >"$WORK/other-project/file"
+age_tree "$WORK/other-project"
+
+gc_output="$(run_gate 'gc')"
+
+[[ ! -e "$WORK/localvoxtral-stale-1" ]] \
+  || fail "stale work dir survived gc"
+[[ -e "$WORK/localvoxtral-fresh-1" ]] \
+  || fail "fresh-stamp work dir was deleted"
+[[ -e "$WORK/localvoxtral-fresh-deep-1" ]] \
+  || fail "work dir with a fresh build product was deleted"
+[[ -f "$WORK/localvoxtral-recordings-1/EvalRecordings/agent-dictation/owner/manifest.json" ]] \
+  || fail "gc destroyed EvalRecordings in a stale dir"
+[[ ! -e "$WORK/localvoxtral-recordings-1/.build" \
+  && ! -e "$WORK/localvoxtral-recordings-1/main.swift" ]] \
+  || fail "gc did not prune build state around EvalRecordings"
+[[ -f "$WORK/other-project/file" ]] \
+  || fail "gc touched a non-localvoxtral dir"
+grep -q 'deleted 1, pruned 1' <<<"$gc_output" \
+  || fail "gc summary wrong: $gc_output"
+
+# --- gc: live-process keep-check --------------------------------------------
+
+mkdir -p "$WORK/localvoxtral-busy-1/.build"
+echo artifact >"$WORK/localvoxtral-busy-1/.build/product"
+age_tree "$WORK/localvoxtral-busy-1"
+cat >"$TMP_DIR/bin/lsof" <<STUB
+#!/usr/bin/env bash
+printf 'p123\nn$WORK/localvoxtral-busy-1/.build/product\n'
+STUB
+chmod +x "$TMP_DIR/bin/lsof"
+busy_output="$(HOME="$FAKE_HOME" PATH="$TMP_DIR/bin:$PATH" \
+  SSH_ORIGINAL_COMMAND='gc' bash "$GATE")"
+[[ -e "$WORK/localvoxtral-busy-1/.build/product" ]] \
+  || fail "gc deleted a work dir with live processes rooted in it"
+grep -q 'live processes' <<<"$busy_output" \
+  || fail "gc did not report the busy keep: $busy_output"
+rm -f "$TMP_DIR/bin/lsof"
+rm -rf "$WORK/localvoxtral-busy-1"
+
+# --- disk verb ---------------------------------------------------------------
+
+disk_output="$(run_gate 'disk')"
+grep -q '^Data volume free: [0-9]* GiB' <<<"$disk_output" \
+  || fail "disk verb missing the parseable free-space line: $disk_output"
+# A numeric age proves file_mtime works on this platform (GNU stat -f
+# "succeeds" with a mount point, which once rendered every age as "?").
+grep -q 'workdir localvoxtral-fresh-1 last-used 0d ago' <<<"$disk_output" \
+  || fail "disk verb missing a numeric last-used age: $disk_output"
+
+# --- denial surface ----------------------------------------------------------
+
+assert_denied() {
+  local command="$1" status=0
+  if HOME="$FAKE_HOME" SSH_ORIGINAL_COMMAND="$command" bash "$GATE" >/dev/null 2>&1; then
+    fail "unsafe command was accepted: $command"
+  else
+    status=$?
+  fi
+  [[ "$status" == "126" ]] \
+    || fail "unsafe command '$command' exited $status instead of 126"
+}
+
+assert_denied 'gc now'
+assert_denied 'gc;id'
+assert_denied 'disk /'
+assert_denied 'disk;id'
+
+printf 'PASS: gate stamps work dirs on use, gc reclaims only stale idle dirs, recordings survive\n'

--- a/scripts/ci/test-build-gate-gc-command.sh
+++ b/scripts/ci/test-build-gate-gc-command.sh
@@ -69,6 +69,16 @@ echo artifact >"$WORK/localvoxtral-fresh-deep-1/.build/arm64/debug/old"
 age_tree "$WORK/localvoxtral-fresh-deep-1"
 echo artifact >"$WORK/localvoxtral-fresh-deep-1/.build/arm64/debug/rebuilt"
 
+# Only fresh entry is a depth-8 xcodebuild product OVERWRITE (no ancestor dir
+# mtime bump) -> kept. Pins the find -maxdepth against the deepest real
+# build-product path.
+xcode_deep="$WORK/localvoxtral-fresh-xcode-1/.build/xcode/Build/Products/Release/app.app/Contents/MacOS"
+mkdir -p "$xcode_deep"
+echo binary >"$xcode_deep/app"
+age_tree "$WORK/localvoxtral-fresh-xcode-1"
+touch "$xcode_deep/app"
+find "$WORK/localvoxtral-fresh-xcode-1" -type d -exec touch -t "$OLD_TS" {} +
+
 # Stale but holds recordings -> pruned, EvalRecordings intact.
 mkdir -p "$WORK/localvoxtral-recordings-1/EvalRecordings/agent-dictation/owner"
 echo '{}' >"$WORK/localvoxtral-recordings-1/EvalRecordings/agent-dictation/owner/manifest.json"
@@ -90,6 +100,8 @@ gc_output="$(run_gate 'gc')"
   || fail "fresh-stamp work dir was deleted"
 [[ -e "$WORK/localvoxtral-fresh-deep-1" ]] \
   || fail "work dir with a fresh build product was deleted"
+[[ -e "$WORK/localvoxtral-fresh-xcode-1" ]] \
+  || fail "work dir with only deep fresh xcodebuild output was deleted"
 [[ -f "$WORK/localvoxtral-recordings-1/EvalRecordings/agent-dictation/owner/manifest.json" ]] \
   || fail "gc destroyed EvalRecordings in a stale dir"
 [[ ! -e "$WORK/localvoxtral-recordings-1/.build" \
@@ -116,6 +128,23 @@ busy_output="$(HOME="$FAKE_HOME" PATH="$TMP_DIR/bin:$PATH" \
   || fail "gc deleted a work dir with live processes rooted in it"
 grep -q 'live processes' <<<"$busy_output" \
   || fail "gc did not report the busy keep: $busy_output"
+# The recordings skeleton from the earlier pass must not be re-reported as
+# "pruned" on every subsequent run.
+grep -q 'deleted 0, pruned 0' <<<"$busy_output" \
+  || fail "gc re-counted an already-pruned skeleton: $busy_output"
+rm -f "$TMP_DIR/bin/lsof"
+
+# lsof present but ERRORING -> evidence unavailable -> fail closed, keep.
+cat >"$TMP_DIR/bin/lsof" <<'STUB'
+#!/usr/bin/env bash
+echo 'lsof: simulated failure' >&2
+exit 1
+STUB
+chmod +x "$TMP_DIR/bin/lsof"
+HOME="$FAKE_HOME" PATH="$TMP_DIR/bin:$PATH" \
+  SSH_ORIGINAL_COMMAND='gc' bash "$GATE" >/dev/null
+[[ -e "$WORK/localvoxtral-busy-1/.build/product" ]] \
+  || fail "gc deleted a work dir when lsof evidence was unavailable"
 rm -f "$TMP_DIR/bin/lsof"
 rm -rf "$WORK/localvoxtral-busy-1"
 

--- a/scripts/ci/test-remote-build-gc.sh
+++ b/scripts/ci/test-remote-build-gc.sh
@@ -68,7 +68,7 @@ env "${common_env[@]}" LV_TEST_PAYLOAD_RESULT=success \
   "$REMOTE_BUILD" test --filter NoSuchTest >/dev/null
 await_gc_marker || fail "successful run did not request a remote gc"
 
-grep -qF -- '--filter=P .lv-last-used' "$rsync_log" \
+grep -qF -- '--filter=P /.lv-last-used' "$rsync_log" \
   || fail "tree sync does not protect the gate's last-used stamp from --delete"
 
 : >"$gc_marker"

--- a/scripts/ci/test-remote-build-gc.sh
+++ b/scripts/ci/test-remote-build-gc.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+# Regression test: every remote-build run fires one best-effort background
+# `gc` at the gate (success AND failure — disk fills either way), without
+# altering the payload's exit status, and the tree sync protects the gate's
+# .lv-last-used stamp from rsync --delete. All transport commands are stubbed.
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "$0")/../.." && pwd -P)"
+REMOTE_BUILD="$ROOT_DIR/scripts/remote-build.sh"
+TMP_DIR="$(mktemp -d "${TMPDIR:-/tmp}/lv-remote-gc-test.XXXXXX")"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+fail() {
+  printf 'FAIL: %s\n' "$*" >&2
+  exit 1
+}
+
+mkdir -p "$TMP_DIR/bin"
+cat >"$TMP_DIR/bin/ssh" <<'STUB'
+#!/usr/bin/env bash
+while [[ $# -gt 1 ]]; do shift; done
+command="$1"
+case "$command" in
+  mkdir\ -p\ *) exit 0 ;;
+  gc)
+    printf 'gc-requested\n' >>"$LV_TEST_GC_MARKER"
+    exit 0
+    ;;
+  cd\ *)
+    [[ "$LV_TEST_PAYLOAD_RESULT" == "success" ]] && exit 0
+    exit 42
+    ;;
+  *) exit 0 ;;
+esac
+STUB
+cat >"$TMP_DIR/bin/rsync" <<'STUB'
+#!/usr/bin/env bash
+printf '%s\n' "$@" >>"$LV_TEST_RSYNC_LOG"
+exit 0
+STUB
+chmod +x "$TMP_DIR/bin/ssh" "$TMP_DIR/bin/rsync"
+
+gc_marker="$TMP_DIR/gc.log"
+rsync_log="$TMP_DIR/rsync.log"
+common_env=(
+  "PATH=$TMP_DIR/bin:$PATH"
+  "LV_BUILD_HOST=fake-host"
+  "LV_BUILD_DIR=work/localvoxtral-gc-regression"
+  "LV_TEST_GC_MARKER=$gc_marker"
+  "LV_TEST_RSYNC_LOG=$rsync_log"
+  "LOCALVOXTRAL_REMOTE_LOG=$TMP_DIR/remote-build.log"
+  "LOCALVOXTRAL_GC_LOG=$TMP_DIR/last-gc.log"
+)
+
+# The gc ssh runs in a backgrounded subshell that outlives the script; poll
+# briefly for its marker instead of assuming completion order.
+await_gc_marker() {
+  local poll=0
+  while (( poll < 50 )); do
+    [[ -s "$gc_marker" ]] && return 0
+    sleep 0.1
+    poll=$((poll + 1))
+  done
+  return 1
+}
+
+env "${common_env[@]}" LV_TEST_PAYLOAD_RESULT=success \
+  "$REMOTE_BUILD" test --filter NoSuchTest >/dev/null
+await_gc_marker || fail "successful run did not request a remote gc"
+
+grep -qF -- '--filter=P .lv-last-used' "$rsync_log" \
+  || fail "tree sync does not protect the gate's last-used stamp from --delete"
+
+: >"$gc_marker"
+status=0
+if env "${common_env[@]}" LV_TEST_PAYLOAD_RESULT=failure \
+  "$REMOTE_BUILD" test --filter NoSuchTest >/dev/null 2>&1; then
+  fail "failed payload unexpectedly succeeded"
+else
+  status=$?
+fi
+[[ "$status" == "42" ]] || fail "payload exit status changed from 42 to $status"
+await_gc_marker || fail "failed run did not request a remote gc"
+
+printf 'PASS: remote-build fires one background gc per run and shields the stamp from --delete\n'

--- a/scripts/mac-health.sh
+++ b/scripts/mac-health.sh
@@ -30,6 +30,20 @@ if diag_output="$(timeout 20 ssh -o ConnectTimeout=8 -o BatchMode=yes "$HOST" di
   if echo "$diag_output" | grep -q 'Runner.Listener'; then
     echo "  actions runner: process visible"
   fi
+  # Disk pressure (gate v4 diag prints this line; older gates just lack it).
+  # Stale build work dirs are gc'd automatically after each remote run, so a
+  # low-disk warning here usually means something OUTSIDE work/ is growing —
+  # `./scripts/remote-build.sh disk` shows the work-dir share of it.
+  free_line="$(echo "$diag_output" | grep -m1 '^Data volume free:' || true)"
+  if [[ -n "$free_line" ]]; then
+    echo "  $free_line"
+    free_gib="$(echo "$free_line" | awk '{print $4}')"
+    min_free_gib="${LV_MIN_FREE_GIB:-25}"
+    if [[ "$free_gib" =~ ^[0-9]+$ ]] && (( free_gib < min_free_gib )); then
+      echo "WARN: build host low on disk (${free_gib} GiB free < ${min_free_gib} GiB) —" \
+        "'./scripts/remote-build.sh disk' for sizes, 'gc' to reclaim stale work dirs" >&2
+    fi
+  fi
 elif echo "$diag_output" | grep -qi 'denied command\|command not allowed'; then
   echo "OK: SSH gate reachable (gate v1 — no diagnostics; install v2, see scripts/mac/README.md)"
 else

--- a/scripts/mac/README.md
+++ b/scripts/mac/README.md
@@ -225,7 +225,7 @@ When capture happens in a Mac checkout, `scripts/run-agent-eval-local.sh`
 runs the same env-gated suite directly and avoids copying the voice set through
 another source checkout.
 
-## `localvoxtral-build-gate.sh` — SSH build gate (v3)
+## `localvoxtral-build-gate.sh` — SSH build gate (v4)
 
 Forced command for the Linux dev box's build key on the Mac build host. It
 allowlists the `remote-build.sh` loop (rsync in, `swift build|test`,
@@ -237,6 +237,41 @@ section above). The `reap work/localvoxtral-<id>` recovery verb accepts one
 validated work directory and terminates only stale test processes proven by
 UID plus cwd/mapped-text evidence to belong to it. Everything else is denied
 and logged to `~/Library/Logs/localvoxtral-build-gate.log`.
+
+### v4: work-dir garbage collection (`gc`) and disk visibility (`disk`)
+
+Every Linux worktree mints its own `~/work/localvoxtral-<slug>-<hash>` build
+dir on the gate account (remote-build.sh derives the name from the local
+checkout path so parallel agents never contend), and agent worktrees are
+ephemeral — so multi-GB SwiftPM/xcodebuild trees used to accumulate until the
+disk filled. v4 closes the loop:
+
+- Every gated use of a work dir (mkdir, rsync, build/test payload) touches a
+  `.lv-last-used` stamp at its root, so staleness never depends on
+  rsync-preserved source mtimes. remote-build.sh protects the stamp from its
+  `rsync --delete`.
+- `gc` (no arguments) deletes any `work/localvoxtral-*` dir with no entry
+  modified in the last `LV_GC_MAX_AGE_DAYS` days (default 14, overridable in
+  `~/.localvoxtral-gate.conf`). Three keep-checks each fail toward "keep":
+  recent activity (stamp or fresh build products), live processes rooted in
+  the dir (lsof cwd/mapped-text evidence — same as `reap`), and
+  `EvalRecordings/` presence, which downgrades deletion to a prune that
+  preserves the recordings in place (private human WAVs may exist only in
+  that remote copy).
+- remote-build.sh fires `gc` automatically after every run, backgrounded and
+  best-effort — the disk only fills while agents build, which is exactly when
+  it runs. No cron/LaunchDaemon needed. A pre-v4 installed gate just denies
+  the verb (a `DENY gc` line per run in the gate log until the upgrade).
+- `disk` prints `df` plus per-work-dir `du` and last-used ages on demand;
+  `diag` gained a cheap Disk section (df + ages, no du) whose
+  `Data volume free: N GiB` line `mac-health.sh` parses to warn below
+  `LV_MIN_FREE_GIB` (default 25).
+
+Not covered by `gc` (occasional owner attention): the gate account's Hugging
+Face cache accumulates a multi-GB snapshot per model pin ever tested — prune
+retired pins by hand, but keep the current ones or the next integration run
+re-downloads them — and `~/Library/Caches/localvoxtral-eval/wav` (TTS cache,
+safe to delete any time, regenerates).
 
 Allowed build payloads run in a dedicated process group. Whenever the payload
 leader exits — including a SIGPIPE after its SSH output channel closes — the
@@ -303,10 +338,13 @@ fiddlier and breaks when the log file is rotated/recreated.)
 ### Verifying from the Linux box
 
 ```bash
-./scripts/remote-build.sh diag        # versions, processes, ports, logs
+./scripts/remote-build.sh diag        # versions, processes, ports, disk, logs
 ./scripts/remote-build.sh applog 30   # app unified log, last 30 minutes
 ./scripts/remote-build.sh voxlog 100  # voxmlx log tail
 ./scripts/remote-build.sh svc-status  # voxmlx service/process/port status
+./scripts/remote-build.sh disk        # df + per-work-dir du and last-used ages
+./scripts/remote-build.sh gc          # reclaim stale work dirs now (also runs
+                                      # automatically after every build/test)
 ssh <gate-destination> 'ensure voxmlx' # warm the on-demand STT server
 ssh <gate-destination> 'reap work/localvoxtral-<id>' # scoped stale-test cleanup
 ssh <gate-destination> 'echo pwned'   # must print "denied command"

--- a/scripts/mac/localvoxtral-build-gate.sh
+++ b/scripts/mac/localvoxtral-build-gate.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# localvoxtral build gate v3.
+# localvoxtral build gate v4.
 #
 # This script is intended to be installed as the forced command for the Mac
 # build-host SSH key. It keeps the existing build/test/package allowlist and
@@ -17,6 +17,8 @@ set -euo pipefail
 #   svc-status
 #   ensure <voxmlx|mlxlm|all>   # warm an on-demand test server (touch + poll)
 #   reap work/localvoxtral-<id>  # terminate stale tests in one exact work dir
+#   disk                # df + per-work-dir du (du can take a while — on demand)
+#   gc                  # delete work dirs unused > LV_GC_MAX_AGE_DAYS (v4)
 
 LOG_FILE="$HOME/Library/Logs/localvoxtral-build-gate.log"
 VOXLOG_FILE="$HOME/Library/Logs/voxmlx.log"
@@ -35,6 +37,19 @@ LV_RUN_DIR="/Users/Shared/localvoxtral/run"
 LV_ENSURE_READY_TIMEOUT=180
 LV_ENSURE_PROBE_TIMEOUT=2
 REAPER="$HOME/bin/localvoxtral-cleanup-stale-test-processes.sh"
+
+# Work-dir garbage collection (`gc` verb): every ephemeral Linux worktree
+# mints one ~/work/localvoxtral-* dir (remote-build.sh derives the name from
+# the local checkout path) and nothing else ever deletes them, so stale
+# multi-GB SwiftPM/xcodebuild trees accumulate until the disk fills. A dir
+# whose newest activity is older than this many days is reclaimed.
+LV_GC_MAX_AGE_DAYS=14
+
+# Every gated use of a work dir refreshes this stamp file at its root, so gc
+# staleness never depends on rsync-preserved source mtimes (rsync -a copies
+# the SENDER's mtimes — a tree synced five minutes ago can look weeks old
+# without it). remote-build.sh protects the stamp from its rsync --delete.
+LV_LAST_USED_STAMP=".lv-last-used"
 
 # Machine-local overrides (never committed): the gate account is separate
 # from the GUI owner account, so voxmlx's log path and GUI uid differ per
@@ -97,6 +112,166 @@ clamp_integer() {
 
 launchctl_target() {
   printf 'gui/%s/%s\n' "$VOXMLX_GUI_UID" "$VOXMLX_SERVICE"
+}
+
+# BSD stat on the Mac; GNU stat only so the shell regression tests can run on
+# a Linux dev box. GNU must be tried FIRST: BSD's -f flag exists on GNU too
+# but means "filesystem status" there, succeeding with a mount point instead
+# of an mtime — while -c fails cleanly on BSD.
+file_mtime() {
+  stat -c %Y "$1" 2>/dev/null || stat -f %m "$1" 2>/dev/null
+}
+
+# Epoch seconds -> a `touch -t` timestamp. BSD `date -r <epoch>` on the Mac;
+# GNU date treats -r as --reference=<file> and fails, so -d "@epoch" answers.
+touch_timestamp_for_epoch() {
+  date -r "$1" +%Y%m%d%H%M.%S 2>/dev/null || date -d "@$1" +%Y%m%d%H%M.%S
+}
+
+touch_workdir_stamp() {
+  local dir="$1"
+  if [[ -d "$dir" ]]; then
+    touch "$dir/$LV_LAST_USED_STAMP" 2>/dev/null || true
+  fi
+}
+
+format_kib() {
+  awk -v kb="$1" 'BEGIN {
+    if (kb >= 1048576) printf "%.1f GiB", kb / 1048576
+    else printf "%d MiB", kb / 1024
+  }'
+}
+
+# Both BSD and GNU `df -k` print Available in column 4 and Capacity/Use% in
+# column 5. mac-health.sh greps this exact line prefix — keep it stable.
+show_disk_free_line() {
+  df -k "$HOME" 2>/dev/null \
+    | awk 'NR == 2 { printf "Data volume free: %d GiB (%s used)\n", $4 / 1048576, $5 }'
+}
+
+show_disk_summary() {
+  section "Disk"
+  run_or_note df -h "$HOME"
+  show_disk_free_line
+  local dir now mtime age
+  now="$(date +%s)"
+  for dir in "$HOME"/work/localvoxtral-*; do
+    [[ -d "$dir" ]] || continue
+    mtime="$(file_mtime "$dir/$LV_LAST_USED_STAMP" || true)"
+    if [[ ! "$mtime" =~ ^[0-9]+$ ]]; then
+      mtime="$(file_mtime "$dir" || true)"
+    fi
+    if [[ "$mtime" =~ ^[0-9]+$ ]]; then
+      age="$(( (now - mtime) / 86400 ))d"
+    else
+      age="?"
+    fi
+    printf 'workdir %s last-used %s ago\n' "${dir##*/}" "$age"
+  done
+}
+
+# `du` over multi-GB build trees can take a while, so sizes are a separate
+# on-demand verb rather than part of diag (mac-health runs diag under a
+# 20-second timeout).
+run_disk_command() {
+  show_disk_summary
+  section "Build work dir sizes"
+  local dir
+  for dir in "$HOME"/work/localvoxtral-*; do
+    [[ -d "$dir" ]] || continue
+    run_or_note du -sh "$dir"
+  done
+}
+
+# A work dir is "in use" when any of this account's live processes has its
+# cwd or a mapped executable inside it — the same evidence the reaper trusts.
+# Fail CLOSED: without lsof we cannot prove the dir idle, so gc keeps it.
+workdir_in_use() {
+  local dir="$1"
+  command -v lsof >/dev/null 2>&1 || return 0
+  lsof -n -P -u "$(id -u)" -a -d cwd,txt -F n 2>/dev/null \
+    | awk -v prefix="n$dir" '
+        index($0, prefix "/") == 1 || $0 == prefix { found = 1; exit }
+        END { exit found ? 0 : 1 }'
+}
+
+# Delete a stale work dir's contents but keep EvalRecordings: the rsync in
+# remote-build.sh receiver-protects that subtree because private human WAVs
+# may exist ONLY in this remote copy — reclaiming build state must never
+# destroy them. The skeleton dir that remains is tiny and harmless.
+prune_workdir_keep_recordings() {
+  local dir="$1" entry
+  for entry in "$dir"/* "$dir"/.[!.]* "$dir"/..?*; do
+    if [[ ! -e "$entry" && ! -L "$entry" ]]; then
+      continue
+    fi
+    if [[ "${entry##*/}" == "EvalRecordings" ]]; then
+      continue
+    fi
+    rm -rf "$entry"
+  done
+}
+
+# Age-based garbage collection for ~/work/localvoxtral-* build dirs. Getting
+# deletion wrong is asymmetric: a live or recent dir must never go, a stale
+# one costs only a cold rebuild — so three independent checks each fail
+# toward "keep": (1) any entry modified since the cutoff, down to the
+# build-product level (the per-use stamp guarantees a fresh depth-1 mtime for
+# every gated run; the find catches pre-stamp dirs whose builds rewrote
+# .build metadata); (2) live processes rooted in the dir; (3) EvalRecordings
+# presence downgrades delete to a prune that keeps the recordings.
+run_gc_command() {
+  local max_age_days="$LV_GC_MAX_AGE_DAYS"
+  if [[ ! "$max_age_days" =~ ^[1-9][0-9]*$ ]]; then
+    printf 'gc: invalid LV_GC_MAX_AGE_DAYS: %s\n' "$max_age_days" >&2
+    return 1
+  fi
+  local now cutoff ref dir recent size_kb remaining_kb
+  local deleted=0 pruned=0 kept_active=0 kept_busy=0 freed_kb=0
+  now="$(date +%s)"
+  cutoff=$((now - max_age_days * 86400))
+  ref="$(mktemp "${TMPDIR:-/tmp}/lv-gc-cutoff.XXXXXX")" || return 1
+  touch -t "$(touch_timestamp_for_epoch "$cutoff")" "$ref" || { rm -f "$ref"; return 1; }
+
+  for dir in "$HOME"/work/localvoxtral-*; do
+    [[ -d "$dir" ]] || continue
+    validate_work_dir "work/${dir##*/}" || continue
+    # -mindepth 1 skips the dir's own mtime, which gc's pruning refreshes —
+    # a pruned skeleton must not look active for another whole window.
+    recent="$(find "$dir" -mindepth 1 -maxdepth 4 -newer "$ref" -print -quit 2>/dev/null || true)"
+    if [[ -n "$recent" ]]; then
+      kept_active=$((kept_active + 1))
+      continue
+    fi
+    if workdir_in_use "$dir"; then
+      printf 'gc %s: stale but has live processes — kept\n' "${dir##*/}"
+      kept_busy=$((kept_busy + 1))
+      continue
+    fi
+    size_kb="$(du -sk "$dir" 2>/dev/null | awk '{print $1}')"
+    [[ "$size_kb" =~ ^[0-9]+$ ]] || size_kb=0
+    if [[ -e "$dir/EvalRecordings" ]]; then
+      prune_workdir_keep_recordings "$dir"
+      remaining_kb="$(du -sk "$dir" 2>/dev/null | awk '{print $1}')"
+      [[ "$remaining_kb" =~ ^[0-9]+$ ]] || remaining_kb=0
+      if (( size_kb > remaining_kb )); then
+        freed_kb=$((freed_kb + size_kb - remaining_kb))
+      fi
+      printf 'gc %s: unused >= %sd — pruned (EvalRecordings kept)\n' \
+        "${dir##*/}" "$max_age_days"
+      pruned=$((pruned + 1))
+    else
+      rm -rf "$dir"
+      freed_kb=$((freed_kb + size_kb))
+      printf 'gc %s: unused >= %sd — deleted (%s)\n' \
+        "${dir##*/}" "$max_age_days" "$(format_kib "$size_kb")"
+      deleted=$((deleted + 1))
+    fi
+  done
+  rm -f "$ref"
+  printf 'gc: deleted %d, pruned %d, active %d, busy %d, freed ~%s\n' \
+    "$deleted" "$pruned" "$kept_active" "$kept_busy" "$(format_kib "$freed_kb")"
+  show_disk_free_line
 }
 
 show_versions() {
@@ -225,6 +400,7 @@ run_diag() {
   show_versions
   show_processes
   show_ports
+  show_disk_summary
   show_voxmlx_service 20
   show_voxlog 20
   show_applog 10 60
@@ -492,6 +668,7 @@ run_cd_command() {
   allow_build_payload "$payload" || deny
 
   cd "$HOME/${dir%/}"
+  touch_workdir_stamp "$PWD"
   run_payload_with_cleanup "$payload"
 }
 
@@ -519,6 +696,7 @@ run_mkdir_command() {
 
   validate_work_dir "$dir" || deny
   mkdir -p "$HOME/${dir%/}"
+  touch_workdir_stamp "$HOME/${dir%/}"
 }
 
 run_rsync_command() {
@@ -543,6 +721,7 @@ run_rsync_command() {
   dest="${argv[argc - 1]}"
   validate_work_dir "$dest" || deny
 
+  touch_workdir_stamp "$HOME/${dest%/}"
   cd "$HOME"
   exec rsync "${argv[@]:1}"
 }
@@ -579,6 +758,12 @@ case "$original_command" in
     ;;
   svc-status)
     run_svc_status
+    ;;
+  disk)
+    run_disk_command
+    ;;
+  gc)
+    run_gc_command
     ;;
   ensure\ *)
     arg="${original_command#ensure }"

--- a/scripts/mac/localvoxtral-build-gate.sh
+++ b/scripts/mac/localvoxtral-build-gate.sh
@@ -144,9 +144,12 @@ format_kib() {
 
 # Both BSD and GNU `df -k` print Available in column 4 and Capacity/Use% in
 # column 5. mac-health.sh greps this exact line prefix — keep it stable.
+# Never let a df hiccup abort diag under set -e: mac-health would misread the
+# resulting non-zero ssh exit as "build host unreachable".
 show_disk_free_line() {
   df -k "$HOME" 2>/dev/null \
-    | awk 'NR == 2 { printf "Data volume free: %d GiB (%s used)\n", $4 / 1048576, $5 }'
+    | awk 'NR == 2 { printf "Data volume free: %d GiB (%s used)\n", $4 / 1048576, $5 }' \
+    || true
 }
 
 show_disk_summary() {
@@ -185,14 +188,18 @@ run_disk_command() {
 
 # A work dir is "in use" when any of this account's live processes has its
 # cwd or a mapped executable inside it — the same evidence the reaper trusts.
-# Fail CLOSED: without lsof we cannot prove the dir idle, so gc keeps it.
+# Fail CLOSED: whenever lsof is missing OR did not run cleanly we cannot
+# prove the dir idle, so gc keeps it. lsof exits non-zero both on errors and
+# when it selects no files at all — but this account's own gate shell always
+# contributes at least its cwd record, so a healthy run selects something
+# and exits 0; a non-zero exit here genuinely means "evidence unavailable".
 workdir_in_use() {
-  local dir="$1"
+  local dir="$1" records
   command -v lsof >/dev/null 2>&1 || return 0
-  lsof -n -P -u "$(id -u)" -a -d cwd,txt -F n 2>/dev/null \
-    | awk -v prefix="n$dir" '
-        index($0, prefix "/") == 1 || $0 == prefix { found = 1; exit }
-        END { exit found ? 0 : 1 }'
+  records="$(lsof -n -P -u "$(id -u)" -a -d cwd,txt -F n 2>/dev/null)" || return 0
+  awk -v prefix="n$dir" '
+    index($0, prefix "/") == 1 || $0 == prefix { found = 1; exit }
+    END { exit found ? 0 : 1 }' <<<"$records"
 }
 
 # Delete a stale work dir's contents but keep EvalRecordings: the rsync in
@@ -208,8 +215,26 @@ prune_workdir_keep_recordings() {
     if [[ "${entry##*/}" == "EvalRecordings" ]]; then
       continue
     fi
-    rm -rf "$entry"
+    # An un-removable entry (foreign owner, odd perms) must not abort the
+    # rest of the prune — or, via set -e, the whole gc pass.
+    rm -rf "$entry" 2>/dev/null || true
   done
+}
+
+# Does the dir hold anything BESIDES EvalRecordings? An already-pruned
+# skeleton fails this, so repeat gc passes neither re-prune it nor report it.
+workdir_has_prunable_entries() {
+  local dir="$1" entry
+  for entry in "$dir"/* "$dir"/.[!.]* "$dir"/..?*; do
+    if [[ ! -e "$entry" && ! -L "$entry" ]]; then
+      continue
+    fi
+    if [[ "${entry##*/}" == "EvalRecordings" ]]; then
+      continue
+    fi
+    return 0
+  done
+  return 1
 }
 
 # Age-based garbage collection for ~/work/localvoxtral-* build dirs. Getting
@@ -238,7 +263,11 @@ run_gc_command() {
     validate_work_dir "work/${dir##*/}" || continue
     # -mindepth 1 skips the dir's own mtime, which gc's pruning refreshes —
     # a pruned skeleton must not look active for another whole window.
-    recent="$(find "$dir" -mindepth 1 -maxdepth 4 -newer "$ref" -print -quit 2>/dev/null || true)"
+    # -maxdepth 9 reaches the deepest build products (xcodebuild packages:
+    # .build/xcode/Build/Products/Release/<app>/Contents/MacOS/<bin> is depth
+    # 8; an incremental rebuild overwrites files there without bumping any
+    # shallower dir mtime). -quit bounds the cost at the first fresh entry.
+    recent="$(find "$dir" -mindepth 1 -maxdepth 9 -newer "$ref" -print -quit 2>/dev/null || true)"
     if [[ -n "$recent" ]]; then
       kept_active=$((kept_active + 1))
       continue
@@ -248,11 +277,14 @@ run_gc_command() {
       kept_busy=$((kept_busy + 1))
       continue
     fi
-    size_kb="$(du -sk "$dir" 2>/dev/null | awk '{print $1}')"
+    size_kb="$(du -sk "$dir" 2>/dev/null | awk '{print $1}')" || size_kb=""
     [[ "$size_kb" =~ ^[0-9]+$ ]] || size_kb=0
     if [[ -e "$dir/EvalRecordings" ]]; then
+      # Already-pruned skeletons stay silent — reporting "pruned" every run
+      # for a dir holding only recordings would misread as repeated action.
+      workdir_has_prunable_entries "$dir" || continue
       prune_workdir_keep_recordings "$dir"
-      remaining_kb="$(du -sk "$dir" 2>/dev/null | awk '{print $1}')"
+      remaining_kb="$(du -sk "$dir" 2>/dev/null | awk '{print $1}')" || remaining_kb=""
       [[ "$remaining_kb" =~ ^[0-9]+$ ]] || remaining_kb=0
       if (( size_kb > remaining_kb )); then
         freed_kb=$((freed_kb + size_kb - remaining_kb))
@@ -261,7 +293,9 @@ run_gc_command() {
         "${dir##*/}" "$max_age_days"
       pruned=$((pruned + 1))
     else
-      rm -rf "$dir"
+      # An un-removable entry must not abort the pass; whatever survived
+      # will be reported (and retried) by later runs.
+      rm -rf "$dir" 2>/dev/null || true
       freed_kb=$((freed_kb + size_kb))
       printf 'gc %s: unused >= %sd — deleted (%s)\n' \
         "${dir##*/}" "$max_age_days" "$(format_kib "$size_kb")"

--- a/scripts/remote-build.sh
+++ b/scripts/remote-build.sh
@@ -163,7 +163,7 @@ cleanup_transient_marker() {
     # A recording set may exist only in the remote Mac checkout. Protect it
     # from --delete during marker cleanup just as in the main tree sync.
     rsync -az --delete \
-      --filter='P .lv-last-used' \
+      --filter='P /.lv-last-used' \
       --filter='P EvalRecordings/***' \
       --exclude '.git/' --exclude '.build/' --exclude 'dist/' \
       "$ROOT_DIR/" "$HOST:$DIR/" 2>/dev/null || true
@@ -422,7 +422,7 @@ ssh "$HOST" "mkdir -p $(printf '%q' "$DIR")"
 # tree) — without the protect, --delete would strip it and the gc verb's age
 # decision would fall back to rsync-preserved (old) source mtimes.
 rsync -az --delete \
-  --filter='P .lv-last-used' \
+  --filter='P /.lv-last-used' \
   --filter='P EvalRecordings/***' \
   --exclude '.git/' --exclude '.build/' --exclude 'dist/' \
   "$ROOT_DIR/" "$HOST:$DIR/"

--- a/scripts/remote-build.sh
+++ b/scripts/remote-build.sh
@@ -6,7 +6,7 @@ set -euo pipefail
 # tree (no commit needed) and runs the toolchain remotely over SSH.
 #
 # Usage:
-#   ./scripts/remote-build.sh [build|test|integration|integration-polishd|integration-speechd|speechd-bench|eval-llm|eval-e2e|package|exec|diag|applog|voxlog|svc-status] [extra args...]
+#   ./scripts/remote-build.sh [build|test|integration|integration-polishd|integration-speechd|speechd-bench|eval-llm|eval-e2e|package|exec|diag|applog|voxlog|svc-status|disk|gc] [extra args...]
 #     build        swift build
 #     test         swift build + unit tests (default; skips live-backend suites)
 #     integration  realtime pipeline tests against the live voxmlx service
@@ -37,6 +37,11 @@ set -euo pipefail
 #     applog       unified log for process == "localvoxtral" (gate v2 required)
 #     voxlog       tail ~/Library/Logs/voxmlx.log (gate v2 required)
 #     svc-status   launchctl status for com.localvoxtral.voxmlx (gate v2 required)
+#     disk         df + du of the remote build work dirs (gate v4 required;
+#                  du over the build trees can take a while)
+#     gc           delete remote work dirs unused > 14 days (gate v4 required;
+#                  also fired automatically, best-effort, after every run —
+#                  EvalRecordings inside a stale dir are always preserved)
 #
 # Examples:
 #   ./scripts/remote-build.sh
@@ -158,6 +163,7 @@ cleanup_transient_marker() {
     # A recording set may exist only in the remote Mac checkout. Protect it
     # from --delete during marker cleanup just as in the main tree sync.
     rsync -az --delete \
+      --filter='P .lv-last-used' \
       --filter='P EvalRecordings/***' \
       --exclude '.git/' --exclude '.build/' --exclude 'dist/' \
       "$ROOT_DIR/" "$HOST:$DIR/" 2>/dev/null || true
@@ -193,7 +199,7 @@ quote_remote_command() {
 }
 
 case "$CMD" in
-  diag|svc-status)
+  diag|svc-status|disk|gc)
     if [[ $# -ne 0 ]]; then
       echo "$CMD does not accept extra arguments" >&2
       exit 1
@@ -412,7 +418,11 @@ ssh "$HOST" "mkdir -p $(printf '%q' "$DIR")"
 # .build/ and dist/ are excluded from deletion too, so the remote incremental
 # build state survives between runs. EvalRecordings is receiver-protected:
 # private human WAVs may live only on the Mac and must survive a Linux sync.
+# .lv-last-used is the gate's per-use staleness stamp (never in the source
+# tree) — without the protect, --delete would strip it and the gc verb's age
+# decision would fall back to rsync-preserved (old) source mtimes.
 rsync -az --delete \
+  --filter='P .lv-last-used' \
   --filter='P EvalRecordings/***' \
   --exclude '.git/' --exclude '.build/' --exclude 'dist/' \
   "$ROOT_DIR/" "$HOST:$DIR/"
@@ -420,4 +430,19 @@ rsync -az --delete \
 # cleanup rsync now has something to delete.
 TREE_SYNCED=1
 
-run_remote_payload "cd $(printf '%q' "$DIR") && $(printf '%q ' "${REMOTE_CMD[@]}")"
+PAYLOAD_STATUS=0
+run_remote_payload "cd $(printf '%q' "$DIR") && $(printf '%q ' "${REMOTE_CMD[@]}")" \
+  || PAYLOAD_STATUS=$?
+
+# Opportunistic remote work-dir GC (gate v4 `gc` verb): reclaim stale sibling
+# dirs while the host is known awake — the disk only fills when agents build,
+# which is exactly when this fires. Backgrounded and best-effort: it must
+# never delay the inner loop or fail the run, and a pre-v4 gate just denies
+# the verb. Output lands in .build/last-gc.log for the curious.
+GC_LOG="${LOCALVOXTRAL_GC_LOG:-$ROOT_DIR/.build/last-gc.log}"
+(
+  mkdir -p "$(dirname "$GC_LOG")" 2>/dev/null || true
+  ssh -o BatchMode=yes -o ConnectTimeout=10 "$HOST" gc >"$GC_LOG" 2>&1 || true
+) &
+
+exit "$PAYLOAD_STATUS"


### PR DESCRIPTION
## What

`/Users/builder/work` on the build host fills the disk: every ephemeral Linux worktree mints its own `work/localvoxtral-<slug>-<hash>` dir (deliberate parallel-agent isolation), each keeps a multi-GB SwiftPM/xcodebuild tree alive across runs (deliberate incremental-build cache), and nothing ever deleted them. This adds the missing garbage collection plus disk visibility:

- **Gate v4** (`scripts/mac/localvoxtral-build-gate.sh`):
  - Every gated use of a work dir (`mkdir` / rsync / build payload) touches a `.lv-last-used` stamp, so staleness never depends on rsync-preserved source mtimes (`rsync -a` copies the *sender's* old mtimes).
  - New `gc` verb: deletes `work/localvoxtral-*` dirs with no entry modified in `LV_GC_MAX_AGE_DAYS` (default 14, overridable in `~/.localvoxtral-gate.conf`). Three independent keep-checks, each failing toward "keep": recent activity (stamp or fresh build products, for pre-stamp dirs), live processes rooted in the dir (lsof cwd/mapped-text evidence, same as `reap`), and **`EvalRecordings/` presence, which downgrades deletion to a prune that preserves the recordings in place** — private human WAVs may exist only in that remote copy.
  - New `disk` verb (df + per-dir du + last-used ages), a cheap Disk section in `diag`, and its `Data volume free: N GiB` line.
- **remote-build.sh** fires `gc` backgrounded/best-effort after every run — the disk only fills while agents build, which is exactly when it runs; no cron/LaunchDaemon. Both client rsyncs gain `--filter='P .lv-last-used'`. New `disk`/`gc` pass-through verbs.
- **mac-health.sh** surfaces the free-space line and warns below `LV_MIN_FREE_GIB` (default 25 GiB).
- Portability bug fixed along the way: GNU `stat -f %m` *succeeds* with a mount point instead of an mtime, so `file_mtime` tries `-c` first (BSD fails `-c` cleanly).
- Docs: `scripts/mac/README.md` v4 section (+ HF-cache / TTS-cache notes), AGENTS.md.

**Owner action to activate**: reinstall the gate script on the Mac (same flow as v3, `scripts/mac/README.md` "Installing / upgrading the gate"). Until then the auto-`gc` is denied and logged (`DENY gc` once per run) — verified fail-open below.

## Proof

- [x] New regression tests (run on this Linux box; also wired into both ci.yml shell-test blocks):

```
$ ./scripts/ci/test-build-gate-gc-command.sh
PASS: gate stamps work dirs on use, gc reclaims only stale idle dirs, recordings survive
$ ./scripts/ci/test-remote-build-gc.sh
PASS: remote-build fires one background gc per run and shields the stamp from --delete
```

Covers: stamp created by `mkdir` verb and refreshed by the `cd`+payload verb; stale dir deleted; fresh-stamp dir kept; old-stamp-but-fresh-build-product dir kept (pre-stamp fallback); stale dir with `EvalRecordings/` pruned around the intact recordings; stale dir with live processes (stubbed lsof) kept; non-`localvoxtral-*` dirs untouched; `gc`/`disk` argument injection denied with exit 126; `disk` prints a numeric last-used age (regression-pins the GNU-stat fix).

- [x] Existing gate/remote-build tests still green:

```
PASS: remote-build reaps one failed payload and leaves successful runs alone
PASS: gate accepts one validated workdir and denies unsafe reap commands
PASS: gate preserves status and drains signalled or leader-exited groups
```

(+ test-cleanup-stale-test-processes, test-run-supervised-command, test-ui-smoke-guard, test-clean-stale-outputs all PASS.)

- [x] Live against the **deployed v3 gate** — the added rsync protect filter does not disturb the pinned server-argv check, and auto-`gc` fails open:

```
$ ./scripts/remote-build.sh test --filter TextMergingAlgorithmsTests
Test Suite 'TextMergingAlgorithmsTests' passed at 2026-07-21 09:41:25.598.
	 Executed 84 tests, with 0 failures (0 unexpected) in 0.009 (0.012) seconds
$ cat .build/last-gc.log
localvoxtral build gate: denied command
$ ./scripts/mac-health.sh    # still parses old-gate diag, no disk line, no warning
OK: SSH gate reachable (gate v2)
```

- LLM lanes: skipped — build-infrastructure/shell-only change, nothing that reaches the model.
