### PR TITLE
Agent-context hardening: distinct output-cap error, wider whitespace trim, test-quality cleanup

### DIFF
--- a/Sources/localvoxtral/ClaudeContext/ClaudeIntegrationSettingsModel.swift
+++ b/Sources/localvoxtral/ClaudeContext/ClaudeIntegrationSettingsModel.swift
@@ -249,6 +249,7 @@ public final class ClaudeIntegrationSettingsModel {
         case .claudeCLINotFound: return "Claude Code CLI not found."
         case .marketplaceUnavailable: return "Plugin files missing from the app."
         case .commandTimedOut: return "Claude Code did not respond."
+        case .outputTooLarge: return "Claude Code produced too much output."
         case .commandFailed, .none: return "Claude Code reported an error."
         }
     }
@@ -262,6 +263,8 @@ public final class ClaudeIntegrationSettingsModel {
             return "The bundled plugin files are missing from this build of localvoxtral. Reinstall the app."
         case .commandTimedOut(_, _, let seconds):
             return "`claude plugin` did not finish within \(Int(seconds))s and was stopped."
+        case .outputTooLarge(_, let capBytes):
+            return "`claude plugin` produced more than \(capBytes / 1024) KB of output and was stopped."
         case .commandFailed(_, let exitCode, let message):
             return "`claude plugin` exited with code \(exitCode).\n\n\(message)"
         case .none:

--- a/Sources/localvoxtral/ClaudeContext/ClaudePluginInstallService.swift
+++ b/Sources/localvoxtral/ClaudeContext/ClaudePluginInstallService.swift
@@ -61,6 +61,11 @@ public struct ClaudePluginInstallService: Sendable {
         /// `action` is nil when the runner itself timed out before the service
         /// could attribute the call.
         case commandTimedOut(action: Action?, arguments: [String], seconds: TimeInterval)
+        /// The CLI produced more output than `maxCapturedOutputBytes` and was
+        /// terminated. Distinct from `commandTimedOut` on purpose: a verbose but
+        /// healthy CLI overran the capture cap, it did NOT hang — conflating the
+        /// two makes a chatty command look like a wedged one.
+        case outputTooLarge(arguments: [String], capBytes: Int)
     }
 
     /// Ceiling for one `claude plugin …` call. Generous — a marketplace add can
@@ -338,10 +343,15 @@ public extension ClaudePluginInstallService {
                 )
             }
 
+            // Why the child was torn down, so a verbose-but-healthy CLI is not
+            // reported as a hang. Both reasons take the identical teardown; only
+            // the error thrown differs.
+            enum StopReason { case timedOut, outputTooLarge }
+
             let descriptor = output.fileHandleForReading.fileDescriptor
             let deadline = Date().addingTimeInterval(timeout)
             var collected = Data()
-            var timedOut = false
+            var stopReason: StopReason?
 
             // Drain until EOF. The child holds the only other write end, so EOF
             // arrives when it exits — which is also how we learn it is done.
@@ -353,7 +363,7 @@ public extension ClaudePluginInstallService {
             while true {
                 let remaining = deadline.timeIntervalSinceNow
                 if remaining <= 0 {
-                    timedOut = true
+                    stopReason = .timedOut
                     break
                 }
                 var descriptorPoll = pollfd(fd: descriptor, events: Int16(POLLIN), revents: 0)
@@ -363,7 +373,7 @@ public extension ClaudePluginInstallService {
                     break // Treat an unusable pipe as EOF, per POSIXPipeRead.
                 }
                 if ready == 0 {
-                    timedOut = true
+                    stopReason = .timedOut
                     break
                 }
                 let chunk = POSIXPipeRead.nextChunk(fromDescriptor: descriptor)
@@ -373,24 +383,33 @@ public extension ClaudePluginInstallService {
                     // Stop reading and tear the child down. Nothing drains the
                     // pipe after this, so a child that keeps writing blocks in
                     // the kernel on a full buffer — and if it also ignores
-                    // SIGTERM it stays there. Hence the SIGKILL escalation.
-                    timedOut = true
+                    // SIGTERM it stays there. Hence the SIGKILL escalation. But
+                    // this is an overrun, not a hang — the distinct reason keeps
+                    // the two apart at the throw site below.
+                    stopReason = .outputTooLarge
                     break
                 }
             }
 
-            if !timedOut {
+            if stopReason == nil {
                 // EOF is not proof of exit — a child can close its pipes and
                 // live on — so this wait carries the same deadline as the drain
                 // rather than blocking on waitUntilExit().
-                timedOut = !waitForExit(deadline.timeIntervalSinceNow)
+                if !waitForExit(deadline.timeIntervalSinceNow) { stopReason = .timedOut }
             }
 
-            if timedOut {
+            if let stopReason {
                 stopChild()
-                throw ServiceError.commandTimedOut(
-                    action: nil, arguments: invocation.arguments, seconds: timeout
-                )
+                switch stopReason {
+                case .timedOut:
+                    throw ServiceError.commandTimedOut(
+                        action: nil, arguments: invocation.arguments, seconds: timeout
+                    )
+                case .outputTooLarge:
+                    throw ServiceError.outputTooLarge(
+                        arguments: invocation.arguments, capBytes: maxCapturedOutputBytes
+                    )
+                }
             }
 
             let raw = String(decoding: collected, as: UTF8.self)

--- a/Sources/localvoxtral/TerminalScreenAXReader.swift
+++ b/Sources/localvoxtral/TerminalScreenAXReader.swift
@@ -254,10 +254,15 @@ enum TerminalScreenAXReader {
         var pendingBlank = false
         for line in text.split(separator: "\n", omittingEmptySubsequences: false) {
             var trimmed = line
-            // NBSP (U+00A0) alongside space/tab: terminal grids use it for
-            // padding that must not wrap, and a trailing run of it is padding
-            // like any other.
-            while let last = trimmed.last, last == " " || last == "\t" || last == "\u{00A0}" {
+            // Every trailing whitespace scalar except newline is padding: plain
+            // space/tab, NBSP (U+00A0, which grids use for padding that must not
+            // wrap), and the wider Unicode space separators (U+2000–U+200A,
+            // U+3000) a terminal may emit. `isWhitespace` minus newline is that
+            // class — we split on "\n" already, so a line-internal newline is
+            // out of scope and preserved. A line that is ALL such whitespace
+            // trims to empty and is treated as blank below, so blank-line
+            // detection widens with the trim, at no extra cost.
+            while let last = trimmed.last, last.isWhitespace, !last.isNewline {
                 trimmed = trimmed.dropLast()
             }
             if trimmed.isEmpty {

--- a/Tests/localvoxtralTests/ClaudePluginInstallServiceTests.swift
+++ b/Tests/localvoxtralTests/ClaudePluginInstallServiceTests.swift
@@ -396,6 +396,27 @@ final class ClaudePluginInstallServiceTests: XCTestCase {
         }
     }
 
+    /// A verbose-but-healthy CLI that overruns the capture cap must be reported
+    /// as an overrun, NOT as a timeout. Before the fix both paths set the same
+    /// `timedOut` flag and threw `.commandTimedOut`, so a chatty command looked
+    /// exactly like a wedged one.
+    func testProcessRunnerReportsOutputOverrunDistinctlyFromATimeout() {
+        let runner = ClaudePluginInstallService.processRunner(
+            executableURL: URL(fileURLWithPath: "/bin/cat"),
+            timeout: 5
+        )
+        // `cat /dev/zero` streams without end and overruns the 64 KiB cap almost
+        // immediately — it is not hanging, it is producing too much. The
+        // generous timeout proves the cap fires first: a broken cap would stall
+        // until the deadline and throw `.commandTimedOut` instead.
+        XCTAssertThrowsError(try runner(.init(arguments: ["/dev/zero"]))) { error in
+            guard case .outputTooLarge(_, let capBytes)? = error as? ClaudePluginInstallService.ServiceError else {
+                return XCTFail("expected .outputTooLarge, got \(error)")
+            }
+            XCTAssertEqual(capBytes, ClaudePluginInstallService.maxCapturedOutputBytes)
+        }
+    }
+
     func testProcessRunnerDoesNotHangOnAChildHoldingThePipeOpen() throws {
         // A child that exits but leaves a grandchild holding the write end.
         // EOF never arrives, so only the deadline ends this.

--- a/Tests/localvoxtralTests/ClaudePluginManifestTests.swift
+++ b/Tests/localvoxtralTests/ClaudePluginManifestTests.swift
@@ -24,6 +24,23 @@ final class ClaudePluginManifestTests: XCTestCase {
         return try XCTUnwrap(try JSONSerialization.jsonObject(with: data) as? [String: Any])
     }
 
+    /// Every string that appears as a KEY or VALUE anywhere in a parsed JSON
+    /// tree. Lets a check assert on the manifest's actual content rather than
+    /// its raw file text — a structural read that cannot be fooled by, or trip
+    /// over, formatting.
+    private static func jsonStrings(in object: Any) -> [String] {
+        switch object {
+        case let string as String:
+            return [string]
+        case let array as [Any]:
+            return array.flatMap { jsonStrings(in: $0) }
+        case let dictionary as [String: Any]:
+            return dictionary.flatMap { key, value in [key] + jsonStrings(in: value) }
+        default:
+            return []
+        }
+    }
+
     private var marketplaceManifest: URL {
         marketplace.appendingPathComponent(".claude-plugin/marketplace.json")
     }
@@ -129,6 +146,12 @@ final class ClaudePluginManifestTests: XCTestCase {
     func testNoUserFacingManifestURLPointsAtTheOldOwner() throws {
         // The repo moved to T0mSIlver; a stale owner in a manifest is a link
         // users click and a marketplace reference that resolves to nothing.
+        //
+        // Structural, not a raw-text grep: parse each manifest and inspect every
+        // string it actually declares (keys and values, recursively). That both
+        // proves the file is valid JSON and — matching case-insensitively —
+        // catches a `TomVaucourt`/`tomvaucourt` a case-sensitive substring scan
+        // would miss, so it is strictly stronger than the old text search.
         let root = try XCTUnwrap(ClaudePluginAssets.rootMarketplaceURL())
         let manifests = [
             marketplaceManifest,
@@ -137,11 +160,12 @@ final class ClaudePluginManifestTests: XCTestCase {
             remotePluginRoot.appendingPathComponent(".claude-plugin/plugin.json"),
         ]
         for manifest in manifests {
-            let text = try String(contentsOf: manifest, encoding: .utf8)
-            XCTAssertFalse(
-                text.contains("tomvaucourt"),
-                "\(manifest.lastPathComponent) still points at the old repo owner"
-            )
+            for string in Self.jsonStrings(in: try json(at: manifest)) {
+                XCTAssertFalse(
+                    string.lowercased().contains("tomvaucourt"),
+                    "\(manifest.lastPathComponent) still points at the old repo owner via \"\(string)\""
+                )
+            }
         }
     }
 
@@ -315,20 +339,86 @@ final class ClaudePluginManifestTests: XCTestCase {
 
     func testShimIsExecutableAndFailsOpen() throws {
         let shim = pluginRoot.appendingPathComponent("hooks/publish.sh")
+        // Mode bits: Claude Code execs this directly; without +x every hook errors.
         XCTAssertTrue(
             FileManager.default.isExecutableFile(atPath: shim.path),
             "Claude Code executes this directly; without +x every hook errors"
         )
-        let source = try String(contentsOf: shim, encoding: .utf8)
-        XCTAssertTrue(source.hasPrefix("#!/bin/sh"), "must be POSIX sh, not bash")
-        XCTAssertTrue(
-            source.contains("exit 0"),
-            "the shim must exit 0 when the publisher is absent"
+        // Shebang anchored to the exact first line, not a loose substring that a
+        // stray `#!/bin/sh` in a later comment could satisfy.
+        let firstLine = try String(contentsOf: shim, encoding: .utf8)
+            .split(separator: "\n", maxSplits: 1, omittingEmptySubsequences: false)
+            .first.map(String.init)
+        XCTAssertEqual(firstLine, "#!/bin/sh", "must be POSIX sh, not bash")
+
+        // Beyond reading the source: RUN the shim and prove the exit contract.
+        // `LOCALVOXTRAL_CLAUDE_HOOK_BIN` is candidate #1 in the shim's search, so
+        // injecting a fake publisher through it both selects our stub before any
+        // host path and proves that documented override actually works — a
+        // stronger check than `source.contains("LOCALVOXTRAL_CLAUDE_HOOK_BIN")`.
+        let temporary = try temporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: temporary) }
+
+        // (1) A publisher that FAILS must not fail the hook: the shim runs it as a
+        // child (never exec) precisely so it can swallow this and still exit 0.
+        let failing = try writeExecutable(
+            "#!/bin/sh\nexit 7\n", named: "failing-publisher", in: temporary
         )
-        XCTAssertTrue(
-            source.contains("LOCALVOXTRAL_CLAUDE_HOOK_BIN"),
-            "remote/non-standard installs need the override"
+        XCTAssertEqual(
+            try runShim(shim, hookBin: failing.path, event: "SessionStart").exitCode, 0,
+            "the shim must exit 0 even when the publisher exits non-zero"
         )
+
+        // (2) The publisher is invoked as a child and receives `--event <Event>`.
+        let argumentsFile = temporary.appendingPathComponent("args")
+        let recorder = try writeExecutable(
+            "#!/bin/sh\nprintf '%s' \"$*\" > \(argumentsFile.path)\nexit 0\n",
+            named: "recording-publisher", in: temporary
+        )
+        let run = try runShim(shim, hookBin: recorder.path, event: "Stop")
+        XCTAssertEqual(run.exitCode, 0, "the shim always exits 0")
+        XCTAssertEqual(
+            try String(contentsOf: argumentsFile, encoding: .utf8), "--event Stop",
+            "the shim must pass the event through to the publisher as --event <Event>"
+        )
+    }
+
+    // MARK: Shim execution helpers
+
+    private func temporaryDirectory() throws -> URL {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("shim-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+        return url
+    }
+
+    private func writeExecutable(_ contents: String, named name: String, in directory: URL) throws -> URL {
+        let url = directory.appendingPathComponent(name)
+        try contents.write(to: url, atomically: true, encoding: .utf8)
+        try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: url.path)
+        return url
+    }
+
+    /// Runs the shim under `/bin/sh` with a chosen publisher and event, returning
+    /// its exit code. stdin is /dev/null so the shim's stdin drain never blocks;
+    /// stdout/stderr are captured and discarded (Claude Code parses stdout, so
+    /// the shim's own paths must stay silent — not asserted here, but kept off
+    /// the test's console).
+    private func runShim(_ shim: URL, hookBin: String, event: String) throws -> (exitCode: Int32, stdout: String) {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/bin/sh")
+        process.arguments = [shim.path, event]
+        var environment = ProcessInfo.processInfo.environment
+        environment["LOCALVOXTRAL_CLAUDE_HOOK_BIN"] = hookBin
+        process.environment = environment
+        process.standardInput = FileHandle.nullDevice
+        let output = Pipe()
+        process.standardOutput = output
+        process.standardError = FileHandle.nullDevice
+        try process.run()
+        let data = output.fileHandleForReading.readDataToEndOfFile()
+        process.waitUntilExit()
+        return (process.terminationStatus, String(decoding: data, as: UTF8.self))
     }
 
     func testShimRunsPublisherAsAChildSoExecFailureStillFailsOpen() throws {

--- a/Tests/localvoxtralTests/ClaudeRemotePluginManifestTests.swift
+++ b/Tests/localvoxtralTests/ClaudeRemotePluginManifestTests.swift
@@ -283,62 +283,110 @@ final class ClaudeRemotePluginManifestTests: XCTestCase {
         try String(contentsOf: marketplace.appendingPathComponent("README.md"), encoding: .utf8)
     }
 
-    func testReadmeDocumentsTheTunnelAndTheInstallSide() throws {
-        let readme = try readme()
-        XCTAssertTrue(readme.contains("RemoteForward 8473 127.0.0.1:8473"))
+    private func readmeLines() throws -> [String] {
+        try readme().split(separator: "\n", omittingEmptySubsequences: false)
+            .map { $0.trimmingCharacters(in: .whitespaces) }
+    }
+
+    /// Asserts some README line, trimmed, EQUALS `expected`. For commands and
+    /// config directives that stand on their own line: strictly stronger than a
+    /// document-wide substring, which a fragment buried in prose could satisfy.
+    private func assertReadmeHasLine(
+        equalTo expected: String, _ message: String = "", line: UInt = #line
+    ) throws {
         XCTAssertTrue(
-            readme.contains("claude plugin marketplace add ")
-                && readme.contains(ClaudeRemoteEnrollmentService.repositoryMarketplaceReference),
+            try readmeLines().contains(expected),
+            message.isEmpty ? "no README line equals \"\(expected)\"" : message,
+            line: line
+        )
+    }
+
+    /// Asserts some README line, trimmed, BEGINS with `expected`. For a command
+    /// that carries a trailing suffix on its line (e.g. `--config …`): anchored
+    /// to line start, so a match cannot drift across a line boundary.
+    private func assertReadmeHasLine(
+        startingWith expected: String, _ message: String = "", line: UInt = #line
+    ) throws {
+        XCTAssertTrue(
+            try readmeLines().contains { $0.hasPrefix(expected) },
+            message.isEmpty ? "no README line begins with \"\(expected)\"" : message,
+            line: line
+        )
+    }
+
+    /// Asserts some single README line contains `fragment`. Used where the point
+    /// IS the prose wording (a caveat inside a sentence): scoping to one line
+    /// pins that the phrase lives together, and documents that the wording — not
+    /// a structural fact — is deliberately being held.
+    private func assertReadmeHasLine(
+        containing fragment: String, _ message: String = "", line: UInt = #line
+    ) throws {
+        XCTAssertTrue(
+            try readmeLines().contains { $0.contains(fragment) },
+            message.isEmpty ? "no README line contains \"\(fragment)\"" : message,
+            line: line
+        )
+    }
+
+    func testReadmeDocumentsTheTunnelAndTheInstallSide() throws {
+        // Config/command directives are anchored to their own line; the install-
+        // side caveat is prose, so it is pinned to a single line as wording.
+        try assertReadmeHasLine(equalTo: "RemoteForward 8473 127.0.0.1:8473")
+        try assertReadmeHasLine(
+            equalTo: "claude plugin marketplace add "
+                + ClaudeRemoteEnrollmentService.repositoryMarketplaceReference,
             "a remote host installs from the repo, not from an app bundle it does not have"
         )
-        XCTAssertTrue(readme.contains("claude plugin install localvoxtral-remote@localvoxtral"))
+        try assertReadmeHasLine(startingWith: "claude plugin install localvoxtral-remote@localvoxtral")
         // Installing the wrong plugin on the wrong side fails open forever and
         // looks exactly like a tunnel problem.
-        XCTAssertTrue(readme.contains("Install it on the REMOTE host, not on your Mac"))
+        try assertReadmeHasLine(containing: "Install it on the REMOTE host, not on your Mac")
     }
 
     func testReadmeDocumentsTheExitOnForwardFailureTradeoff() throws {
-        let readme = try readme()
-        XCTAssertTrue(readme.contains("ExitOnForwardFailure no"))
-        XCTAssertTrue(
-            readme.lowercased().contains("silent"),
+        try assertReadmeHasLine(equalTo: "ExitOnForwardFailure no")
+        try assertReadmeHasLine(
+            containing: "silent",
             "the cost of `no` is a silently absent tunnel; a user who is not told will not look"
         )
     }
 
     func testReadmeDocumentsTheTmuxTitlePassthroughCaveat() throws {
-        let readme = try readme()
-        XCTAssertTrue(readme.contains("tmux"))
-        XCTAssertTrue(readme.contains("set-titles on"), "the fix, not just the symptom")
-        XCTAssertTrue(
-            readme.lowercased().contains("unjoined"),
+        try assertReadmeHasLine(containing: "tmux")
+        try assertReadmeHasLine(containing: "set-titles on", "the fix, not just the symptom")
+        try assertReadmeHasLine(
+            containing: "unjoined",
             "and what you lose without it: the screen join, not the off-screen context"
         )
     }
 
     func testReadmeDocumentsUninstallAndRevocation() throws {
-        let readme = try readme()
-        XCTAssertTrue(readme.contains("claude plugin uninstall localvoxtral-remote@localvoxtral"))
-        XCTAssertTrue(readme.contains("claude plugin marketplace remove localvoxtral"))
-        XCTAssertTrue(
-            readme.contains("revoke the host in localvoxtral"),
+        // The commands are inside `ssh builder '…'` wrappers, so anchor to the
+        // wrapper line; the revocation caveat is prose held as wording.
+        try assertReadmeHasLine(
+            equalTo: "ssh builder 'claude plugin uninstall localvoxtral-remote@localvoxtral'"
+        )
+        try assertReadmeHasLine(
+            equalTo: "ssh builder 'claude plugin marketplace remove localvoxtral'"
+        )
+        try assertReadmeHasLine(
+            containing: "revoke the host in localvoxtral",
             "revocation is the real off switch and must not read as an optional last step"
         )
-        XCTAssertTrue(readme.lowercased().contains("rotat"))
+        try assertReadmeHasLine(containing: "rotat")
     }
 
     func testReadmeDocumentsThatPlainSSHIsUnchangedAndNothingIsOnByDefault() throws {
-        let readme = try readme()
-        XCTAssertTrue(readme.contains("Plain SSH still works exactly as before"))
-        XCTAssertTrue(
-            readme.contains("binds no port at all"),
+        // A section heading — its own line — so anchor it exactly.
+        try assertReadmeHasLine(equalTo: "## Plain SSH still works exactly as before")
+        try assertReadmeHasLine(
+            containing: "binds no port at all",
             "a user must be able to confirm that not enrolling costs them nothing"
         )
     }
 
     func testReadmeStatesTheTokensLimits() throws {
-        let readme = try readme()
-        XCTAssertTrue(readme.contains("cannot make the app read a local file"))
-        XCTAssertTrue(readme.contains("HISTCONTROL=ignorespace"), "the token-in-history caveat")
+        try assertReadmeHasLine(containing: "cannot make the app read a local file")
+        try assertReadmeHasLine(containing: "HISTCONTROL=ignorespace", "the token-in-history caveat")
     }
 }

--- a/Tests/localvoxtralTests/GhosttyAutomationConsentPrewarmTests.swift
+++ b/Tests/localvoxtralTests/GhosttyAutomationConsentPrewarmTests.swift
@@ -20,6 +20,23 @@ final class GhosttyAutomationConsentPrewarmTests: XCTestCase {
         try await super.tearDown()
     }
 
+    /// Deterministic quiescence: the pre-warm enqueues its `execute` on a
+    /// `Task { @MainActor in … }` synchronously inside `fireOnceWhenGhosttyIsAvailable`,
+    /// so any such Task is already on the main actor's serial queue AHEAD of the
+    /// barrier this awaits. Same-priority jobs run FIFO, so when the barrier
+    /// resumes, every pre-warm Task enqueued before it has run — including a
+    /// buggy SECOND one, which is exactly what "did not fire again" must catch.
+    /// Replaces a fixed `for _ in 0..<100 { await Task.yield() }` burst that only
+    /// hoped to outlast the enqueue.
+    ///
+    /// NOTE: the stronger form — the production seam signalling a continuation
+    /// after its decision point — needs a change to `GhosttyAutomationConsentPrewarm`,
+    /// which another worker owns concurrently; that is deferred to them. This
+    /// barrier is the deterministic improvement available from the test alone.
+    private func drainMainActorQueue() async {
+        await Task { @MainActor in }.value
+    }
+
     func testFiresExactlyOnceWhenGhosttyIsRunning() async {
         let executions = Mutex(0)
         let (executed, signal) = AsyncStream.makeStream(of: Void.self)
@@ -42,9 +59,9 @@ final class GhosttyAutomationConsentPrewarmTests: XCTestCase {
         var iterator = executed.makeAsyncIterator()
         _ = await iterator.next()
         // Drain any (incorrect) second execution deterministically: the fire
-        // path enqueues on the main actor, so once we are running again after
-        // the first signal, a bounded yield burst flushes anything pending.
-        for _ in 0..<100 { await Task.yield() }
+        // path enqueues on the main actor ahead of this barrier, so once the
+        // barrier resumes anything pending has run.
+        await drainMainActorQueue()
         XCTAssertEqual(executions.withLock { $0 }, 1)
     }
 
@@ -59,7 +76,7 @@ final class GhosttyAutomationConsentPrewarmTests: XCTestCase {
         // An unrelated app launching (Ghostty still absent) must not fire —
         // firing would LAUNCH Ghostty via the tell.
         center.post(name: NSWorkspace.didLaunchApplicationNotification, object: nil)
-        for _ in 0..<100 { await Task.yield() }
+        await drainMainActorQueue()
         XCTAssertEqual(executions.withLock { $0 }, 0)
     }
 
@@ -85,7 +102,7 @@ final class GhosttyAutomationConsentPrewarmTests: XCTestCase {
         // The observer is one-shot: another launch notification (Ghostty
         // relaunching) must not re-fire.
         center.post(name: NSWorkspace.didLaunchApplicationNotification, object: nil)
-        for _ in 0..<100 { await Task.yield() }
+        await drainMainActorQueue()
         XCTAssertEqual(executions.withLock { $0 }, 1)
     }
 }

--- a/Tests/localvoxtralTests/TerminalScreenContextTests.swift
+++ b/Tests/localvoxtralTests/TerminalScreenContextTests.swift
@@ -123,6 +123,19 @@ final class TerminalScreenContextTests: XCTestCase {
         )
     }
 
+    // Wider Unicode space separators are grid padding too: a terminal may emit
+    // U+2000–U+200A (en/em/thin spaces) or U+3000 (ideographic space) for pad
+    // cells. Before the fix only space/tab/NBSP were trimmed, so a row padded
+    // with these carried the pad bytes AND a run of them read as a non-blank
+    // content line — neither trimmed nor collapsed.
+    func testCompactionTrimsTrailingWideUnicodeSpaces() {
+        let raw = "❯ swift build\u{2000}\u{2000}\u{2003}\n\u{2000}\u{2000}\n\u{3000}\t \nBuild complete!\u{2009}\u{3000}"
+        XCTAssertEqual(
+            TerminalScreenAXReader.sanitizedScreenText(raw),
+            "❯ swift build\n\nBuild complete!"
+        )
+    }
+
     // Compaction runs BEFORE the cap — the order is load-bearing. A padded
     // grid can exceed the 24k cap on padding alone; capping first would evict
     // the real text at the tail (exactly the term a user is most likely to be


### PR DESCRIPTION
## What

Three deferred findings from the #150 adversarial review (fixed instead of filed, per owner):

- **Output cap ≠ timeout** (`ClaudePluginInstallService`): the 64 KiB capture cap and the wall-clock deadline both threw `commandTimedOut`, so a verbose-but-healthy `claude plugin` call was reported as a hang. A `StopReason` keeps teardown identical but throws a distinct `outputTooLarge` with its own one-sentence UI message.
- **Wider whitespace trim** (`TerminalScreenAXReader.compactedGridWhitespace`): trailing trim now covers every whitespace scalar except newline (U+2000–U+200A, U+3000 etc., not just space/tab/NBSP); blank-line collapsing widens with it. Internal runs and leading indentation deliberately untouched.
- **Test-quality cleanup, nothing weakened**: old-owner-URL manifest check → recursive JSON-string walk (case-insensitive, strictly stronger); shim test → mode bits + real shim execution (fail-open exit + `--event` passthrough via injected `LOCALVOXTRAL_CLAUDE_HOOK_BIN` stub); README assertions anchored to full lines; prewarm tests' 100-yield bursts → deterministic main-actor FIFO barrier.

## Proof

- [x] Unit suite green — `./scripts/remote-build.sh test`:
  - `Executed 1801 tests, with 2 tests skipped and 0 failures (0 unexpected) in 63.281 (63.379) seconds`
- [x] Regression tests shown failing pre-fix:
  - F8 `testProcessRunnerReportsOutputOverrunDistinctlyFromATimeout`: pre-fix `failed - expected .outputTooLarge, got commandTimedOut(...)` (drives `/bin/cat /dev/zero` through the real runner); post-fix suite `25 tests, 0 failures`.
  - F14 `testCompactionTrimsTrailingWideUnicodeSpaces`: pre-fix `XCTAssertEqual failed` on U+2000/U+3000-padded grid; post-fix suite `53 tests, 0 failures`.
- [x] Adversarial GLM review (opencode) over the full diff: clean bill — teardown ordering, whitespace semantics (newline-class chars preserved), shim-test hermeticism, JSON-walk strictness, FIFO-barrier soundness, strict concurrency, and no weakened assertions all verified clean.
- LLM lanes: not run — the only model-input change is trailing-whitespace trimming of screen excerpts (no term/prompt semantics change); CI's path filter decides the conditional lane.
