### PR TITLE
Agent-context hardening: registry liveness/quota, revocation race, broker and stdin deadlines

### DIFF
--- a/Sources/ClaudeHookPublisherCore/ClaudeHookPublisher.swift
+++ b/Sources/ClaudeHookPublisherCore/ClaudeHookPublisher.swift
@@ -241,17 +241,41 @@ public struct ClaudeHookPublisher: Sendable {
         }
     }
 
-    /// Read stdin to EOF, refusing to grow past `maxLineBytes`.
+    /// Read stdin until EOF or a short absolute deadline, refusing to grow past
+    /// `maxLineBytes`.
     ///
     /// Raw `read(2)`, not `FileHandle.availableData` (banned repo-wide: it
     /// aborts the process on descriptor errors — PR #60). Partial reads are the
-    /// norm on a pipe, so loop; a full buffer means a hostile/huge payload and
-    /// we stop reading rather than allocate for it.
-    public static func readBoundedStdin(limits: ClaudeHookLimits = .default) -> Data {
+    /// norm on a pipe, so loop; `poll` is recomputed from a monotonic deadline
+    /// so a producer that leaves the pipe open cannot park the hook forever. A
+    /// full buffer means a hostile/huge payload and we stop reading rather than
+    /// allocate for it.
+    ///
+    /// Kept equal to the socket publisher's default per-phase budget: stdin is
+    /// another inline hook phase, and being late is worse than being absent.
+    public static let stdinReadTimeout: TimeInterval = 0.25
+
+    public static func readBoundedStdin(
+        limits: ClaudeHookLimits = .default,
+        descriptor: Int32 = 0,
+        timeout: TimeInterval = stdinReadTimeout,
+        uptimeNanos: @Sendable () -> UInt64 = { DispatchTime.now().uptimeNanoseconds }
+    ) -> Data {
+        let deadline = uptimeNanos() &+ UInt64(max(0, timeout) * 1_000_000_000)
         var buffer = Data()
         var chunk = [UInt8](repeating: 0, count: 16 * 1024)
         while buffer.count <= limits.maxLineBytes {
-            let count = retryingOnEINTR { read(0, &chunk, chunk.count) }
+            let current = uptimeNanos()
+            guard current < deadline else { break }
+            let remainingMillis = (deadline - current) / 1_000_000
+            var descriptorPoll = pollfd(fd: descriptor, events: Int16(POLLIN), revents: 0)
+            let pollTimeout = Int32(min(remainingMillis, UInt64(Int32.max)))
+            let ready = poll(&descriptorPoll, 1, pollTimeout)
+            if ready < 0, errno == EINTR { continue }
+            guard ready > 0 else { break }
+
+            let count = read(descriptor, &chunk, chunk.count)
+            if count < 0, errno == EINTR { continue }
             if count <= 0 { break } // EOF, or an error we treat as EOF.
             buffer.append(contentsOf: chunk[0..<count])
         }

--- a/Sources/localvoxtral/ClaudeContext/ClaudeContextBroker.swift
+++ b/Sources/localvoxtral/ClaudeContext/ClaudeContextBroker.swift
@@ -526,7 +526,13 @@ public final class ClaudeContextBroker: Sendable {
         let remainingMillis = (deadline - current) / 1_000_000
         var descriptor = pollfd(fd: fd, events: Int16(POLLIN), revents: 0)
         let timeout = Int32(min(remainingMillis, UInt64(Int32.max)))
-        let ready = retryingOnEINTRInt32 { poll(&descriptor, 1, timeout) }
+        let ready = poll(&descriptor, 1, timeout)
+        if ready < 0, errno == EINTR {
+            // Re-enter rather than retry with the same timeout: the caller
+            // loops straight back in and the remaining budget is recomputed,
+            // so a late signal cannot extend the absolute deadline.
+            return true
+        }
         guard ready != 0 else {
             Log.claudeContext.error("Dropping Claude broker connection: read deadline expired")
             return false

--- a/Sources/localvoxtral/ClaudeContext/ClaudeContextBroker.swift
+++ b/Sources/localvoxtral/ClaudeContext/ClaudeContextBroker.swift
@@ -70,6 +70,7 @@ public final class ClaudeContextBroker: Sendable {
     private let socketPath: String
     private let registry: ClaudeSessionRegistry
     private let limits: ClaudeBrokerLimits
+    private let uptimeNanos: @Sendable () -> UInt64
 
     #if DEBUG
     /// Test seam: fires after each record is accepted or rejected, so a socket
@@ -77,11 +78,16 @@ public final class ClaudeContextBroker: Sendable {
     /// registry on a wall clock (AGENTS: no wall-clock in tests). Never used in
     /// production paths.
     private let debugIngestHook = Mutex<(@Sendable (Result<ClaudeHookRecord, ClaudeHookWireError>) -> Void)?>(nil)
+    private let debugReadHook = Mutex<(@Sendable (Int) -> Void)?>(nil)
 
     public func debugConfigureIngestHook(
         _ hook: (@Sendable (Result<ClaudeHookRecord, ClaudeHookWireError>) -> Void)?
     ) {
         debugIngestHook.withLock { $0 = hook }
+    }
+
+    public func debugConfigureReadHook(_ hook: (@Sendable (Int) -> Void)?) {
+        debugReadHook.withLock { $0 = hook }
     }
 
     private func debugNotify(_ result: Result<ClaudeHookRecord, ClaudeHookWireError>) {
@@ -93,11 +99,13 @@ public final class ClaudeContextBroker: Sendable {
     public init(
         socketPath: String,
         registry: ClaudeSessionRegistry,
-        limits: ClaudeBrokerLimits = .default
+        limits: ClaudeBrokerLimits = .default,
+        uptimeNanos: @escaping @Sendable () -> UInt64 = { DispatchTime.now().uptimeNanoseconds }
     ) {
         self.socketPath = socketPath
         self.registry = registry
         self.limits = limits
+        self.uptimeNanos = uptimeNanos
     }
 
     public enum StartFailure: Error, Equatable {
@@ -464,22 +472,18 @@ public final class ClaudeContextBroker: Sendable {
         }
         let origin = ClaudeTransportOrigin.localAuthenticated(peerUID: peerUID)
 
-        var timeout = timeval(
-            tv_sec: Int(limits.readTimeout),
-            tv_usec: Int32((limits.readTimeout - Double(Int(limits.readTimeout))) * 1_000_000)
-        )
-        setsockopt(fd, SOL_SOCKET, SO_RCVTIMEO, &timeout, socklen_t(MemoryLayout<timeval>.size))
         var noSigPipe: Int32 = 1
         setsockopt(fd, SOL_SOCKET, SO_NOSIGPIPE, &noSigPipe, socklen_t(MemoryLayout<Int32>.size))
+        let deadline = uptimeNanos() &+ UInt64(max(0, limits.readTimeout) * 1_000_000_000)
 
         var pending = Data()
         var recordCount = 0
         var chunk = [UInt8](repeating: 0, count: 8 * 1024)
 
         while true {
-            let count = retryingOnEINTRInt { read(fd, &chunk, chunk.count) }
-            if count <= 0 { break } // EOF, timeout, or error — all mean "done".
-            pending.append(contentsOf: chunk[0..<count])
+            guard readMore(fd: fd, into: &pending, using: &chunk, deadline: deadline) else {
+                break
+            }
 
             // Split FIRST, then bound only what is left over. The cap is on a
             // single LINE, not on how much a peer may send: a publisher is free
@@ -503,6 +507,46 @@ public final class ClaudeContextBroker: Sendable {
                 reply(to: fd, marker: handle(line: line, origin: origin))
             }
         }
+    }
+
+    /// Append one chunk under a whole-connection monotonic deadline. A
+    /// per-syscall `SO_RCVTIMEO` resets after every byte and lets a slowloris
+    /// retain a connection slot forever.
+    private func readMore(
+        fd: Int32,
+        into buffer: inout Data,
+        using chunk: inout [UInt8],
+        deadline: UInt64
+    ) -> Bool {
+        let current = uptimeNanos()
+        guard current < deadline else {
+            Log.claudeContext.error("Dropping Claude broker connection: read deadline expired")
+            return false
+        }
+        let remainingMillis = (deadline - current) / 1_000_000
+        var descriptor = pollfd(fd: fd, events: Int16(POLLIN), revents: 0)
+        let timeout = Int32(min(remainingMillis, UInt64(Int32.max)))
+        let ready = retryingOnEINTRInt32 { poll(&descriptor, 1, timeout) }
+        guard ready != 0 else {
+            Log.claudeContext.error("Dropping Claude broker connection: read deadline expired")
+            return false
+        }
+        guard ready > 0 else {
+            Log.claudeContext.error("Claude broker connection poll failed (\(errno, privacy: .public))")
+            return false
+        }
+
+        let count = retryingOnEINTRInt { read(fd, &chunk, chunk.count) }
+        guard count >= 0 else {
+            Log.claudeContext.error("Claude broker connection read failed (\(errno, privacy: .public))")
+            return false
+        }
+        guard count > 0 else { return false }
+        #if DEBUG
+        debugReadHook.withLock { $0 }?(count)
+        #endif
+        buffer.append(contentsOf: chunk[0..<count])
+        return true
     }
 
     /// Send the session's marker back to the publisher.

--- a/Sources/localvoxtral/ClaudeContext/ClaudeRemoteContextListener.swift
+++ b/Sources/localvoxtral/ClaudeContext/ClaudeRemoteContextListener.swift
@@ -425,11 +425,24 @@ public final class ClaudeRemoteContextListener: Sendable {
         let bodyEnd = buffer.index(bodyStart, offsetBy: request.contentLength)
         let body = Data(buffer[bodyStart..<bodyEnd])
 
+        // Parse and scope OUTSIDE the host lock: constant-time-hashing every
+        // stored token is already the lock's fixed cost per request, and
+        // serializing body parsing behind it would stall every other host's
+        // auth behind one slow payload. Only the COMMIT — the part the
+        // revocation race is about — re-authenticates under the lock.
+        guard let prepared = prepareIngest(body: body, request: request, host: host) else {
+            // Unparseable payloads never touch the session registry, so
+            // revocation has nothing to protect; same 200-with-no-marker the
+            // pre-race-fix path returned.
+            hosts.noteActivity(hostID: host.id)
+            respond(fd: fd, status: 200, body: ClaudeRemoteHTTPCodec.markerResponseBody(marker: nil))
+            return
+        }
         guard let marker = hosts.withAuthenticatedHost(
             token: token,
             expectedHostID: host.id,
-            { activeHost in
-                ingest(body: body, request: request, host: activeHost)
+            { _ in
+                commitIngest(prepared)
             }
         ) else {
             Log.claudeContext.error(
@@ -442,13 +455,18 @@ public final class ClaudeRemoteContextListener: Sendable {
         respond(fd: fd, status: 200, body: ClaudeRemoteHTTPCodec.markerResponseBody(marker: marker?.value))
     }
 
-    /// - Returns: the marker for the session, so the hook's response can carry
-    ///   it back down the SSH PTY as an OSC 2 title write.
-    private func ingest(
+    private struct PreparedIngest {
+        let record: ClaudeHookRecord
+        let snippets: [ClaudeContentSnippet]
+        let hostID: String
+    }
+
+    /// The parse/scope half of ingest, safe outside any lock.
+    private func prepareIngest(
         body: Data,
         request: ClaudeRemoteHTTPRequest,
         host: ClaudeRemoteHost
-    ) -> ClaudeSessionMarker? {
+    ) -> PreparedIngest? {
         guard let payload = ClaudeRemoteHookPayloadParser.parse(
             data: body,
             fallbackEvent: ClaudeRemoteHTTPCodec.eventName(inPath: request.path),
@@ -469,13 +487,26 @@ public final class ClaudeRemoteContextListener: Sendable {
             hostID: host.id,
             sessionID: record.sessionID
         )
-        let origin = ClaudeTransportOrigin.remote(channel: ClaudeRemoteSessionScope.channel(hostID: host.id))
+        return PreparedIngest(record: record, snippets: payload.snippets, hostID: host.id)
+    }
 
-        let snapshot = registry.ingest(record, origin: origin, snippets: payload.snippets)
+    /// The session-registry half of ingest. Runs under the host-registry lock
+    /// (`withAuthenticatedHost`) so revocation cannot commit between the
+    /// re-check and this write.
+    ///
+    /// - Returns: the marker for the session, so the hook's response can carry
+    ///   it back down the SSH PTY as an OSC 2 title write.
+    private func commitIngest(_ prepared: PreparedIngest) -> ClaudeSessionMarker? {
+        let origin = ClaudeTransportOrigin.remote(
+            channel: ClaudeRemoteSessionScope.channel(hostID: prepared.hostID)
+        )
+        let snapshot = registry.ingest(
+            prepared.record, origin: origin, snippets: prepared.snippets
+        )
         // Shape only. A remote record carries the user's prompt and excerpts of
         // their code; a log is the wrong place for either.
         Log.claudeContext.debug(
-            "Ingested remote \(record.event.rawValue, privacy: .public) from \(host.id, privacy: .public)"
+            "Ingested remote \(prepared.record.event.rawValue, privacy: .public) from \(prepared.hostID, privacy: .public)"
         )
         return snapshot?.marker
     }

--- a/Sources/localvoxtral/ClaudeContext/ClaudeRemoteContextListener.swift
+++ b/Sources/localvoxtral/ClaudeContext/ClaudeRemoteContextListener.swift
@@ -93,6 +93,14 @@ public final class ClaudeRemoteContextListener: Sendable {
     private let now: @Sendable () -> Date
     private let uptimeNanos: @Sendable () -> UInt64
 
+    #if DEBUG
+    private let debugPostAuthenticationHook = Mutex<(@Sendable () -> Void)?>(nil)
+
+    public func debugConfigurePostAuthenticationHook(_ hook: (@Sendable () -> Void)?) {
+        debugPostAuthenticationHook.withLock { $0 = hook }
+    }
+    #endif
+
     public enum StartFailure: Error, Equatable {
         case alreadyRunning
         case socketCreationFailed(errno: Int32)
@@ -397,6 +405,9 @@ public final class ClaudeRemoteContextListener: Sendable {
             respond(fd: fd, status: 401)
             return
         }
+        #if DEBUG
+        debugPostAuthenticationHook.withLock { $0 }?()
+        #endif
 
         guard ClaudeRemoteHTTPCodec.eventName(inPath: request.path) != nil else {
             respond(fd: fd, status: 404)
@@ -414,8 +425,20 @@ public final class ClaudeRemoteContextListener: Sendable {
         let bodyEnd = buffer.index(bodyStart, offsetBy: request.contentLength)
         let body = Data(buffer[bodyStart..<bodyEnd])
 
+        guard let marker = hosts.withAuthenticatedHost(
+            token: token,
+            expectedHostID: host.id,
+            { activeHost in
+                ingest(body: body, request: request, host: activeHost)
+            }
+        ) else {
+            Log.claudeContext.error(
+                "Rejected remote connection: host was revoked before ingest"
+            )
+            respond(fd: fd, status: 401)
+            return
+        }
         hosts.noteActivity(hostID: host.id)
-        let marker = ingest(body: body, request: request, host: host)
         respond(fd: fd, status: 200, body: ClaudeRemoteHTTPCodec.markerResponseBody(marker: marker?.value))
     }
 

--- a/Sources/localvoxtral/ClaudeContext/ClaudeRemoteHostRegistry.swift
+++ b/Sources/localvoxtral/ClaudeContext/ClaudeRemoteHostRegistry.swift
@@ -446,27 +446,48 @@ public final class ClaudeRemoteHostRegistry: Sendable {
     public func authenticate(token: String) -> ClaudeRemoteHost? {
         guard ClaudeRemoteTokenDigest.isWellFormed(token) else { return nil }
         return state.withLock { hosts in
-            var matched: StoredHost?
-            for host in hosts {
-                let candidate: String
-                switch host.hashVersion ?? 1 {
-                case 1:
-                    candidate = ClaudeRemoteTokenDigest.legacyHash(
-                        token: token, salt: host.tokenSalt
-                    )
-                case Self.currentHashVersion:
-                    candidate = ClaudeRemoteTokenDigest.hash(token: token, salt: host.tokenSalt)
-                default:
-                    // Still perform a fixed-length comparison for every host.
-                    candidate = String(repeating: "0", count: 64)
-                }
-                let equal = ClaudeRemoteTokenDigest.constantTimeEquals(candidate, host.tokenHash)
-                if equal, host.revokedAt == nil {
-                    matched = host
-                }
-            }
-            return matched?.publicView
+            authenticatedHostLocked(token: token, hosts: hosts)?.publicView
         }
+    }
+
+    /// Re-authenticate and perform one synchronous action under the same host
+    /// lock. Revocation cannot commit between the check and `body`, closing the
+    /// listener's authenticate-then-ingest race. `body` must not call back into
+    /// this host registry; the listener only writes to the separate session
+    /// registry here.
+    public func withAuthenticatedHost<Outcome>(
+        token: String,
+        expectedHostID: String,
+        _ body: (ClaudeRemoteHost) -> Outcome
+    ) -> Outcome? {
+        guard ClaudeRemoteTokenDigest.isWellFormed(token) else { return nil }
+        return state.withLock { hosts in
+            guard let host = authenticatedHostLocked(token: token, hosts: hosts),
+                  host.id == expectedHostID
+            else { return nil }
+            return body(host.publicView)
+        }
+    }
+
+    private func authenticatedHostLocked(token: String, hosts: [StoredHost]) -> StoredHost? {
+        var matched: StoredHost?
+        for host in hosts {
+            let candidate: String
+            switch host.hashVersion ?? 1 {
+            case 1:
+                candidate = ClaudeRemoteTokenDigest.legacyHash(token: token, salt: host.tokenSalt)
+            case Self.currentHashVersion:
+                candidate = ClaudeRemoteTokenDigest.hash(token: token, salt: host.tokenSalt)
+            default:
+                // Still perform a fixed-length comparison for every host.
+                candidate = String(repeating: "0", count: 64)
+            }
+            let equal = ClaudeRemoteTokenDigest.constantTimeEquals(candidate, host.tokenHash)
+            if equal, host.revokedAt == nil {
+                matched = host
+            }
+        }
+        return matched
     }
 
     /// Record that a host is alive. Best-effort and NOT persisted per request —

--- a/Sources/localvoxtral/ClaudeContext/ClaudeSessionRegistry.swift
+++ b/Sources/localvoxtral/ClaudeContext/ClaudeSessionRegistry.swift
@@ -23,17 +23,38 @@ public enum ClaudeMarkerResolution: Sendable, Equatable {
 }
 
 public struct ClaudeRegistryLimits: Sendable, Equatable {
+    /// A local session without a Claude pid cannot be probed for liveness. Five
+    /// minutes keeps brief publisher-metadata failures useful while bounding a
+    /// dead session's joinable exposure far below the normal four-hour TTL.
+    public static let defaultPIDLessLocalSessionTTL: TimeInterval = 5 * 60
+    /// When origins compete for the global cap, no one origin may retain more
+    /// than this many sessions. Eight covers a generous set of terminal tabs
+    /// while leaving most of the global registry available to other origins.
+    public static let defaultMaxSessionsPerOrigin = 8
+
     /// Hard cap on retained sessions. Beyond this, the least-recently-active is
     /// evicted — a user with hundreds of stale sessions must not grow the app.
     public var maxSessions: Int
+    /// Sub-quota applied per transport origin when more than one origin is
+    /// present. A lone origin may use the global cap; once another arrives,
+    /// churn is evicted from the bursting origin first.
+    public var maxSessionsPerOrigin: Int
     /// A session with no hook activity for this long is stale. Claude Code can
     /// die without firing SessionEnd (SIGKILL, a closed terminal), so TTL plus
     /// PID liveness — not SessionEnd alone — is what keeps the registry honest.
     public var sessionTTL: TimeInterval
+    public var pidlessLocalSessionTTL: TimeInterval
 
-    public init(maxSessions: Int = 32, sessionTTL: TimeInterval = 4 * 60 * 60) {
+    public init(
+        maxSessions: Int = 32,
+        maxSessionsPerOrigin: Int = Self.defaultMaxSessionsPerOrigin,
+        sessionTTL: TimeInterval = 4 * 60 * 60,
+        pidlessLocalSessionTTL: TimeInterval = Self.defaultPIDLessLocalSessionTTL
+    ) {
         self.maxSessions = maxSessions
+        self.maxSessionsPerOrigin = maxSessionsPerOrigin
         self.sessionTTL = sessionTTL
+        self.pidlessLocalSessionTTL = pidlessLocalSessionTTL
     }
 
     public static let `default` = ClaudeRegistryLimits()
@@ -286,7 +307,13 @@ public final class ClaudeSessionRegistry: Sendable {
     // MARK: - Locked helpers
 
     private func isFresh(_ snapshot: ClaudeSessionSnapshot, now: Date) -> Bool {
-        guard now.timeIntervalSince(snapshot.lastActivity) <= limits.sessionTTL else { return false }
+        let ttl: TimeInterval
+        if snapshot.origin.isLocalAuthenticated, snapshot.process?.claudePID == nil {
+            ttl = min(limits.sessionTTL, limits.pidlessLocalSessionTTL)
+        } else {
+            ttl = limits.sessionTTL
+        }
+        guard now.timeIntervalSince(snapshot.lastActivity) <= ttl else { return false }
         // `claudePID`, never `hookPID`. The publisher exits the instant it has
         // written its line, so probing its own pid would report every local
         // session dead microseconds after it was created — the registry would
@@ -313,11 +340,40 @@ public final class ClaudeSessionRegistry: Sendable {
     }
 
     private func enforceCapLocked(_ state: inout State) {
+        let grouped = Dictionary(grouping: state.sessions.values, by: \.origin)
+        if grouped.count > 1 {
+            // Always reserve at least one global slot for a competing origin,
+            // even when a caller configures a sub-quota above a small test cap.
+            let quota = min(
+                max(0, limits.maxSessionsPerOrigin),
+                max(0, limits.maxSessions - 1)
+            )
+            for sessions in grouped.values where sessions.count > quota {
+                for snapshot in sessions.sorted(by: Self.evictionPrecedes)
+                    .prefix(sessions.count - quota)
+                {
+                    removeLocked(&state, sessionID: snapshot.sessionID)
+                }
+            }
+        }
+
         guard state.sessions.count > limits.maxSessions else { return }
-        let ordered = state.sessions.values.sorted { $0.lastActivity < $1.lastActivity }
+        let ordered = state.sessions.values.sorted(by: Self.evictionPrecedes)
         for snapshot in ordered.prefix(state.sessions.count - limits.maxSessions) {
             removeLocked(&state, sessionID: snapshot.sessionID)
         }
+    }
+
+    /// Stable tie-breaking keeps eviction reproducible when a burst lands in
+    /// one clock tick (common in tests and possible for batched hook records).
+    private static func evictionPrecedes(
+        _ lhs: ClaudeSessionSnapshot,
+        _ rhs: ClaudeSessionSnapshot
+    ) -> Bool {
+        if lhs.lastActivity != rhs.lastActivity {
+            return lhs.lastActivity < rhs.lastActivity
+        }
+        return lhs.sessionID < rhs.sessionID
     }
 
     /// Never hand out a marker that is already indexed. The allocator is random

--- a/Sources/localvoxtral/ClaudeContext/ClaudeSessionRegistry.swift
+++ b/Sources/localvoxtral/ClaudeContext/ClaudeSessionRegistry.swift
@@ -158,7 +158,7 @@ public final class ClaudeSessionRegistry: Sendable {
             }
 
             state.sessions[record.sessionID] = snapshot
-            enforceCapLocked(&state)
+            enforceCapLocked(&state, keeping: record.sessionID)
             return snapshot
         }
     }
@@ -339,7 +339,12 @@ public final class ClaudeSessionRegistry: Sendable {
         state.markerIndex.removeValue(forKey: snapshot.marker.value)
     }
 
-    private func enforceCapLocked(_ state: inout State) {
+    /// `upserted` is the sessionID this upsert just wrote: on a lastActivity
+    /// tie (frozen test clocks, sub-tick batches) the sessionID tiebreak could
+    /// otherwise select the record that triggered the enforcement — evicting
+    /// the newest data is never the right answer, so it is pinned and the
+    /// next-oldest tied sibling goes instead.
+    private func enforceCapLocked(_ state: inout State, keeping upserted: String? = nil) {
         let grouped = Dictionary(grouping: state.sessions.values, by: \.origin)
         if grouped.count > 1 {
             // Always reserve at least one global slot for a competing origin,
@@ -349,9 +354,13 @@ public final class ClaudeSessionRegistry: Sendable {
                 max(0, limits.maxSessions - 1)
             )
             for sessions in grouped.values where sessions.count > quota {
-                for snapshot in sessions.sorted(by: Self.evictionPrecedes)
+                // The pin never relaxes the quota: with the pinned session
+                // excluded there are still at least `count - quota` evictable
+                // siblings whenever quota >= 1.
+                let evictable = sessions.sorted(by: Self.evictionPrecedes)
+                    .filter { $0.sessionID != upserted }
                     .prefix(sessions.count - quota)
-                {
+                for snapshot in evictable {
                     removeLocked(&state, sessionID: snapshot.sessionID)
                 }
             }

--- a/Tests/localvoxtralTests/ClaudeContextBrokerTests.swift
+++ b/Tests/localvoxtralTests/ClaudeContextBrokerTests.swift
@@ -1,6 +1,7 @@
 import ClaudeContextWire
 import ClaudeHookPublisherCore
 import Foundation
+import Synchronization
 import XCTest
 @testable import localvoxtral
 
@@ -375,6 +376,69 @@ final class ClaudeContextBrokerIntegrationTests: XCTestCase {
             "the abusive peer must not have produced a session"
         )
         XCTAssertTrue(broker.isRunning, "one abusive peer must not stop the broker")
+    }
+
+    func testTricklingPeerIsCutOffAtTheAbsoluteDeadline() throws {
+        let base: UInt64 = 1_000_000_000
+        let expired = Mutex(false)
+        let bytesRead = Mutex(0)
+        let firstRead = expectation(description: "broker consumed the first trickle byte")
+        broker = ClaudeContextBroker(
+            socketPath: socketPath,
+            registry: registry,
+            limits: ClaudeBrokerLimits(readTimeout: 100),
+            uptimeNanos: {
+                expired.withLock { $0 ? base + 200_000_000_000 : base }
+            }
+        )
+        broker.debugConfigureReadHook { count in
+            let total = bytesRead.withLock { bytes -> Int in
+                bytes += count
+                return bytes
+            }
+            expired.withLock { $0 = true }
+            if total == count { firstRead.fulfill() }
+        }
+        try broker.start()
+
+        let fd = socket(AF_UNIX, SOCK_STREAM, 0)
+        XCTAssertGreaterThanOrEqual(fd, 0)
+        defer { close(fd) }
+        var noSigPipe: Int32 = 1
+        XCTAssertEqual(
+            setsockopt(fd, SOL_SOCKET, SO_NOSIGPIPE, &noSigPipe, socklen_t(MemoryLayout<Int32>.size)),
+            0
+        )
+        var address = sockaddr_un()
+        address.sun_family = sa_family_t(AF_UNIX)
+        address.sun_len = UInt8(MemoryLayout<sockaddr_un>.size)
+        let pathBytes = Array(socketPath.utf8)
+        withUnsafeMutableBytes(of: &address.sun_path) { raw in
+            raw.copyBytes(from: pathBytes)
+            raw[pathBytes.count] = 0
+        }
+        let connected = withUnsafePointer(to: &address) { pointer in
+            pointer.withMemoryRebound(to: sockaddr.self, capacity: 1) {
+                connect(fd, $0, socklen_t(MemoryLayout<sockaddr_un>.size))
+            }
+        }
+        XCTAssertEqual(connected, 0)
+
+        var first: UInt8 = 0x7B
+        XCTAssertEqual(Darwin.send(fd, &first, 1, 0), 1)
+        wait(for: [firstRead], timeout: 5)
+
+        // The first byte advanced the injected monotonic clock beyond the
+        // connection deadline. A per-read timeout incorrectly accepts this
+        // second trickle byte; an absolute deadline closes before reading it.
+        var second: UInt8 = 0x22
+        _ = Darwin.send(fd, &second, 1, 0)
+        shutdown(fd, SHUT_WR)
+        var reply = [UInt8](repeating: 0, count: 16)
+        while read(fd, &reply, reply.count) > 0 {}
+
+        XCTAssertEqual(bytesRead.withLock { $0 }, 1)
+        XCTAssertTrue(registry.liveSessions().isEmpty)
     }
 
     // MARK: Publisher fail-open

--- a/Tests/localvoxtralTests/ClaudeHookPublisherTests.swift
+++ b/Tests/localvoxtralTests/ClaudeHookPublisherTests.swift
@@ -333,4 +333,36 @@ final class UnixSocketPublisherTimeoutTests: XCTestCase {
         // being absent.
         XCTAssertLessThanOrEqual(UnixSocketPublisher().timeout, 0.5)
     }
+
+    func testStdinReadConsultsAbsoluteDeadlineWhilePipeStaysOpenWithoutData() {
+        var descriptors: [Int32] = [-1, -1]
+        XCTAssertEqual(pipe(&descriptors), 0)
+        defer {
+            close(descriptors[0])
+            close(descriptors[1])
+        }
+        let flags = fcntl(descriptors[0], F_GETFL, 0)
+        XCTAssertGreaterThanOrEqual(flags, 0)
+        XCTAssertEqual(fcntl(descriptors[0], F_SETFL, flags | O_NONBLOCK), 0)
+
+        let calls = Mutex(0)
+        let base: UInt64 = 1_000_000_000
+        let data = ClaudeHookPublisher.readBoundedStdin(
+            descriptor: descriptors[0],
+            timeout: 0.25,
+            uptimeNanos: {
+                calls.withLock { count in
+                    count += 1
+                    return count == 1 ? base : base + 1_000_000_000
+                }
+            }
+        )
+
+        XCTAssertTrue(data.isEmpty)
+        XCTAssertGreaterThanOrEqual(
+            calls.withLock { $0 },
+            2,
+            "the reader must re-check its monotonic deadline instead of entering an unbounded read"
+        )
+    }
 }

--- a/Tests/localvoxtralTests/ClaudeRemoteContextListenerTests.swift
+++ b/Tests/localvoxtralTests/ClaudeRemoteContextListenerTests.swift
@@ -267,6 +267,28 @@ final class ClaudeRemoteContextListenerTests: XCTestCase {
         XCTAssertTrue(sessions.liveSessions().isEmpty, "revocation needs no restart to take effect")
     }
 
+    func testRevocationBetweenAuthenticationAndIngestCannotSeedASession() throws {
+        listener = ClaudeRemoteContextListener(
+            registry: sessions,
+            hosts: hosts,
+            limits: ClaudeRemoteListenerLimits(port: port)
+        )
+        let hostStore = hosts!
+        let revokedHostID = hostID!
+        listener.debugConfigurePostAuthenticationHook {
+            try! hostStore.revoke(hostID: revokedHostID)
+        }
+        try listener.start()
+
+        let response = try XCTUnwrap(try send(hookRequest(token: token)))
+
+        XCTAssertEqual(response.status, 401)
+        XCTAssertTrue(
+            sessions.liveSessions().isEmpty,
+            "an in-flight request must not recreate its host after revocation swept the registry"
+        )
+    }
+
     func testARotatedTokenSwapsWhichCredentialWorks() throws {
         try startListener()
         let rotated = try hosts.rotateToken(hostID: hostID)

--- a/Tests/localvoxtralTests/ClaudeSessionRegistryTests.swift
+++ b/Tests/localvoxtralTests/ClaudeSessionRegistryTests.swift
@@ -527,6 +527,41 @@ final class ClaudeSessionRegistryTests: XCTestCase {
         )
     }
 
+    /// A lastActivity tie plus a lexically-small sessionID must not make quota
+    /// eviction select the record that triggered it: the just-upserted session
+    /// is pinned and the oldest tied sibling goes instead.
+    func testQuotaEvictionNeverSelectsTheJustUpsertedSession() {
+        let clock = TestClock(epoch)
+        let quietOrigin = ClaudeTransportOrigin.remote(channel: "ssh:quiet")
+        let burstingOrigin = ClaudeTransportOrigin.remote(channel: "ssh:burst")
+        let registry = makeRegistry(
+            limits: ClaudeRegistryLimits(maxSessions: 4, sessionTTL: 10_000),
+            clock: clock,
+            markers: TestMarkers(["lvx-q", "lvx-z1", "lvx-z2", "lvx-z3", "lvx-a"])
+        )
+        registry.ingest(record(.sessionStart, session: "quiet"), origin: quietOrigin)
+        for index in 1...3 {
+            registry.ingest(
+                record(.sessionStart, session: "z-\(index)"),
+                origin: burstingOrigin
+            )
+        }
+        // Frozen clock: every bursting session shares one lastActivity, and
+        // "a-new" sorts lexically FIRST — the exact shape that made the
+        // sessionID tiebreak evict the newest data.
+        registry.ingest(record(.sessionStart, session: "a-new"), origin: burstingOrigin)
+
+        XCTAssertNotNil(
+            registry.snapshot(sessionID: "a-new"),
+            "the session that triggered quota enforcement must never be its victim"
+        )
+        XCTAssertNil(registry.snapshot(sessionID: "z-1"))
+        XCTAssertEqual(
+            registry.liveSessions().filter { $0.origin == burstingOrigin }.count,
+            3
+        )
+    }
+
     func testStaleSessionsArePrunedOnIngest() {
         let clock = TestClock(epoch)
         let registry = makeRegistry(

--- a/Tests/localvoxtralTests/ClaudeSessionRegistryTests.swift
+++ b/Tests/localvoxtralTests/ClaudeSessionRegistryTests.swift
@@ -286,6 +286,24 @@ final class ClaudeSessionRegistryTests: XCTestCase {
         XCTAssertEqual(registry.resolve(marker: marker), .stale)
     }
 
+    func testPIDLessLocalSessionUsesTheShortExposureTTL() {
+        let clock = TestClock(epoch)
+        let registry = makeRegistry(
+            limits: ClaudeRegistryLimits(maxSessions: 32, sessionTTL: 4 * 60 * 60),
+            clock: clock,
+            markers: TestMarkers(["lvx-1"])
+        )
+        registry.ingest(record(.sessionStart), origin: local)
+
+        clock.advance(5 * 60 + 1)
+
+        XCTAssertEqual(
+            registry.resolve(marker: ClaudeSessionMarker(value: "lvx-1")),
+            .stale,
+            "without a Claude pid to probe, a dead local session must not remain joinable for four hours"
+        )
+    }
+
     /// Regression, production-shaped: the publisher is a one-shot process, so
     /// by the time the app looks at a record the `hookPID` is ALWAYS dead. If
     /// liveness probes it, every local session is `.stale` the instant it is
@@ -478,6 +496,34 @@ final class ClaudeSessionRegistryTests: XCTestCase {
         XCTAssertEqual(
             registry.resolve(marker: ClaudeSessionMarker(value: "lvx-1")), .unknown,
             "the evicted session's marker must not linger in the index"
+        )
+    }
+
+    func testOneOriginsBurstCannotEvictAnotherOriginsLiveSession() {
+        let clock = TestClock(epoch)
+        let quietOrigin = ClaudeTransportOrigin.remote(channel: "ssh:quiet")
+        let burstingOrigin = ClaudeTransportOrigin.remote(channel: "ssh:burst")
+        let registry = makeRegistry(
+            limits: ClaudeRegistryLimits(maxSessions: 4, sessionTTL: 10_000),
+            clock: clock,
+            markers: TestMarkers(["lvx-q", "lvx-b1", "lvx-b2", "lvx-b3", "lvx-b4"])
+        )
+        registry.ingest(record(.sessionStart, session: "quiet"), origin: quietOrigin)
+        for index in 1...4 {
+            clock.advance(1)
+            registry.ingest(
+                record(.sessionStart, session: "burst-\(index)"),
+                origin: burstingOrigin
+            )
+        }
+
+        XCTAssertNotNil(
+            registry.snapshot(sessionID: "quiet"),
+            "one origin's churn must consume its own quota before evicting another origin"
+        )
+        XCTAssertEqual(
+            registry.liveSessions().filter { $0.origin == burstingOrigin }.count,
+            3
         )
     }
 


### PR DESCRIPTION
## What

Five deferred findings from the #150 adversarial review (fixed instead of filed, per owner), all in the Claude agent-context subsystem, plus a GLM-review round on the fixes themselves:

- **Pid-less local session liveness**: sessions that never captured a Claude pid were TTL-only for 4 hours after Claude Code exited; they now expire after a dedicated 5-minute exposure TTL.
- **Per-origin registry quota**: one origin bursting session IDs could evict every other origin's sessions through the global LRU; a per-origin sub-quota (8, active only when origins compete, one global slot always reserved) bounds it, with deterministic eviction (sessionID tiebreak, just-upserted session pinned).
- **Revocation race**: an in-flight request past auth when the user clicked Revoke could re-seed a revoked host's session after the eviction sweep. Ingest now re-authenticates and commits under the host-registry lock (`withAuthenticatedHost`); parsing stays outside the lock so a slow payload cannot stall other hosts' auth.
- **Broker slow-loris**: per-syscall `SO_RCVTIMEO` let a one-byte-trickle client hold a connection slot forever; reads now run under one absolute monotonic deadline (the pattern the remote listener already proved), with EINTR re-entering so the budget is recomputed.
- **Publisher stdin deadline**: the hook publisher's stdin read was size-bounded but time-unbounded; it now polls under a 0.25s monotonic deadline matching the socket phases (late is worse than absent; truncated payloads fail open, exit 0).

## Proof

- [x] Unit suite green — `./scripts/remote-build.sh test`:
  - `Executed 1805 tests, with 2 tests skipped and 0 failures (0 unexpected) in 62.467 (62.559) seconds`
- [x] Each of the five fixes has a regression test shown failing pre-fix (codex worker runs): `testPIDLessLocalSessionUsesTheShortExposureTTL`, `testOneOriginsBurstCannotEvictAnotherOriginsLiveSession`, `testRevocationBetweenAuthenticationAndIngestCannotSeedASession` (DEBUG post-auth hook reproduces the race deterministically), `testTricklingPeerIsCutOffAtTheAbsoluteDeadline`, `testStdinReadConsultsAbsoluteDeadlineWhilePipeStaysOpenWithoutData`. All use injected monotonic clocks — no wall-clock.
- [x] Review-fix round: quota self-eviction pin shown failing with the pin disabled (`Executed 40 tests, with 2 failures`), then `40 tests, 0 failures`; listener/broker suites re-run green (`25/0`, `22/0`).
- [x] Adversarial GLM review (opencode) over the full diff: 1 MEDIUM + 2 LOW found and fixed in the follow-up commit (parse-under-lock contention, EINTR deadline overshoot, self-eviction); lock-ordering deadlock hunt, deadline arithmetic, partial-record handling, Sendable soundness, and regression-test realness all verified clean.
- LLM lanes: not run — no model-input, prompt, or polish-path changes (registry/broker/publisher only).
