### PR TITLE
TTY join off the main actor; consent prewarm follows mid-run setting toggles

### DIFF
--- a/Sources/localvoxtral/ClaudeContext/TerminalScreenClaudeJoin.swift
+++ b/Sources/localvoxtral/ClaudeContext/TerminalScreenClaudeJoin.swift
@@ -72,7 +72,7 @@ struct ClaudeSessionJoin: Sendable, Equatable {
 struct ClaudeSessionJoinResolver {
     private let registry: ClaudeSessionRegistry
     private let markerInWindowTitle: (pid_t) -> TerminalScreenAXReader.FocusedWindowMarkerRead?
-    private let focusedTerminalTTY: (String) -> String?
+    private let focusedTerminalTTY: (String) async -> String?
     private let focusedWindowID: (pid_t) -> CGWindowID?
 
     /// - Parameters:
@@ -99,7 +99,7 @@ struct ClaudeSessionJoinResolver {
         markerInWindowTitle: @escaping (pid_t) -> TerminalScreenAXReader.FocusedWindowMarkerRead? = {
             TerminalScreenAXReader.markerInFocusedWindowTitle(applicationPID: $0)
         },
-        focusedTerminalTTY: @escaping (String) -> String? = { _ in nil },
+        focusedTerminalTTY: @escaping (String) async -> String? = { _ in nil },
         focusedWindowID: @escaping (pid_t) -> CGWindowID? = {
             TerminalScreenAXReader.focusedWindowIdentity(applicationPID: $0)
         }
@@ -124,14 +124,14 @@ struct ClaudeSessionJoinResolver {
     ///
     /// This remains the only place a join is resolved, once per dictation, at
     /// start — whichever mechanism answers.
-    func resolve(target: TerminalScreenTarget) -> ClaudeSessionJoin? {
+    func resolve(target: TerminalScreenTarget) async -> ClaudeSessionJoin? {
         // The allowlist is re-checked here even though the capture gate already
         // enforced it. This object is reachable independently of that gate, and
         // "only a verified single-AXTextArea grid" is a precondition of reading
         // this app at all — not something to inherit on trust from a caller.
         guard TerminalScreenAllowlist.isSupported(target.bundleID) else { return nil }
 
-        if let tty = focusedTerminalTTY(target.bundleID) {
+        if let tty = await focusedTerminalTTY(target.bundleID) {
             switch registry.resolve(tty: tty) {
             case .resolved(let snapshot):
                 Log.claudeContext.info(

--- a/Sources/localvoxtral/DictationViewModel+Session.swift
+++ b/Sources/localvoxtral/DictationViewModel+Session.swift
@@ -74,7 +74,20 @@ extension DictationViewModel {
         let needsManagedPolishing = isManagedPolishingRequired(outputMode: requestedOutputMode)
 
         guard needsManagedDictation || needsManagedPolishing else {
-            beginDictationSession(outputMode: outputMode)
+            isConnectingRealtimeSession = true
+            managedStartupTask?.cancel()
+            let startupTaskID = UUID()
+            managedStartupTaskID = startupTaskID
+            managedStartupTask = Task { @MainActor [weak self, startupTaskID] in
+                guard let self else { return }
+                defer {
+                    if self.managedStartupTaskID == startupTaskID {
+                        self.managedStartupTask = nil
+                        self.managedStartupTaskID = nil
+                    }
+                }
+                await self.beginDictationSession(outputMode: outputMode)
+            }
             return
         }
 
@@ -136,7 +149,7 @@ extension DictationViewModel {
                           && self.settings.polishingBackendMode == .managedLocal)),
                   self.isConnectingRealtimeSession
             else { return }
-            self.beginDictationSession(outputMode: outputMode)
+            await self.beginDictationSession(outputMode: outputMode)
             // beginDictationSession re-checks secure input and may refuse
             // HERE — long after the initiating gesture ended (a toggle tap
             // ends immediately; a hold may release while the backend boots).
@@ -209,7 +222,7 @@ extension DictationViewModel {
         )
     }
 
-    func beginDictationSession(outputMode: DictationOutputMode? = nil) {
+    func beginDictationSession(outputMode: DictationOutputMode? = nil) async {
         lastSocketErrorMessage = nil
         // A new session starts: retire any prior "Copy raw transcript"
         // affordance so it never references a stale, unrelated transcript.
@@ -303,7 +316,13 @@ extension DictationViewModel {
         // Same timing rationale again, and the last chance to take it: the
         // overlay takes focus once the socket connects, and screen context must
         // record what the user could see as they chose their words.
-        captureTerminalScreenContextForSession()
+        isConnectingRealtimeSession = true
+        await captureTerminalScreenContextForSession()
+        guard !Task.isCancelled, isConnectingRealtimeSession else {
+            discardTerminalScreenCapture()
+            clearLatchedSessionMetadata()
+            return
+        }
         refreshInsertionScalarTracingForSession()
 
         audioChunkBuffer.clear()
@@ -316,7 +335,6 @@ extension DictationViewModel {
         textInsertion.clearPendingText()
         textInsertion.resetDiagnostics()
 
-        isConnectingRealtimeSession = true
         // Keep the Accessibility warning as the status line when it applies, so
         // the warning isn't clobbered by the generic "Connecting..." text.
         if !accessibilityBlockedAtStart {

--- a/Sources/localvoxtral/DictationViewModel+Session.swift
+++ b/Sources/localvoxtral/DictationViewModel+Session.swift
@@ -86,6 +86,12 @@ extension DictationViewModel {
                         self.managedStartupTaskID = nil
                     }
                 }
+                // Same staleness pre-check as the managed path below: a start
+                // that was cancelled or superseded before this task ran must
+                // not enter beginDictationSession at all — its cleanup would
+                // otherwise run against the successor's freshly-latched state.
+                guard !Task.isCancelled, self.managedStartupTaskID == startupTaskID
+                else { return }
                 await self.beginDictationSession(outputMode: outputMode)
             }
             return
@@ -316,11 +322,24 @@ extension DictationViewModel {
         // Same timing rationale again, and the last chance to take it: the
         // overlay takes focus once the socket connects, and screen context must
         // record what the user could see as they chose their words.
+        let ownerTaskID = managedStartupTaskID
         isConnectingRealtimeSession = true
         await captureTerminalScreenContextForSession()
-        guard !Task.isCancelled, isConnectingRealtimeSession else {
-            discardTerminalScreenCapture()
-            clearLatchedSessionMetadata()
+        // Both spawn paths register their managedStartupTaskID before this
+        // method runs, so a changed (non-nil) ID means a NEWER session start
+        // owns the shared capture/metadata now — a cancelled predecessor must
+        // not wipe the successor's state, and must not proceed either. A nil
+        // ID means the canceller merely cleared the slot: cleanup is ours, and
+        // resetting the connecting flag here also heals any cancel path that
+        // never called abortConnectingSession.
+        let ownsSharedSessionState =
+            managedStartupTaskID == ownerTaskID || managedStartupTaskID == nil
+        guard !Task.isCancelled, isConnectingRealtimeSession, ownsSharedSessionState else {
+            if ownsSharedSessionState {
+                discardTerminalScreenCapture()
+                clearLatchedSessionMetadata()
+                isConnectingRealtimeSession = false
+            }
             return
         }
         refreshInsertionScalarTracingForSession()

--- a/Sources/localvoxtral/DictationViewModel.swift
+++ b/Sources/localvoxtral/DictationViewModel.swift
@@ -1765,7 +1765,7 @@ final class DictationViewModel {
     /// an opted-out user, a remote polishing endpoint, or a non-Ghostty app
     /// means the screen is never read. A nil polishing configuration also means
     /// no read: with no endpoint there is nothing to ground for.
-    func captureTerminalScreenContextForSession() {
+    func captureTerminalScreenContextForSession() async {
         guard let endpointURL = settings.llmPolishingConfiguration?.endpointURL else {
             terminalScreenStartCapture = nil
             claudeSessionJoin = nil
@@ -1777,7 +1777,7 @@ final class DictationViewModel {
             isAccessibilityTrusted: textInsertion.isAccessibilityTrusted,
             trustedEndpointEnabled: settings.polishContextTrustedEndpointEnabled
         )
-        claudeSessionJoin = resolveClaudeSessionJoin(endpointURL: endpointURL)
+        claudeSessionJoin = await resolveClaudeSessionJoin(endpointURL: endpointURL)
     }
 
     /// Resolves this dictation's Claude session join, ONCE, here at start.
@@ -1792,7 +1792,7 @@ final class DictationViewModel {
     /// Every gate is checked BEFORE the resolver is asked, because asking is not
     /// passive — it makes a live AX round trip for the window title. An opted-out
     /// user, a remote endpoint, or a revoked Accessibility grant means no read.
-    private func resolveClaudeSessionJoin(endpointURL: URL) -> ClaudeSessionJoin? {
+    private func resolveClaudeSessionJoin(endpointURL: URL) async -> ClaudeSessionJoin? {
         guard let resolver = claudeSessionJoinResolver else { return nil }
         // Either context feature can want a join: the screen needs it to
         // authorize a raw excerpt, the repo/session blocks ARE the join's
@@ -1812,7 +1812,7 @@ final class DictationViewModel {
         ) else { return nil }
         guard textInsertion.isAccessibilityTrusted else { return nil }
         guard let target = TerminalScreenContextSource.frontmostTarget() else { return nil }
-        return resolver.resolve(target: target)
+        return await resolver.resolve(target: target)
     }
 
     /// Drops any retained screen capture. Idempotent, and safe to call on a

--- a/Sources/localvoxtral/DictationViewModel.swift
+++ b/Sources/localvoxtral/DictationViewModel.swift
@@ -1105,6 +1105,13 @@ final class DictationViewModel {
         if previousMode == .managedLocal, mode == .externalURL {
             Log.backends.info("polishing backend mode switched to external; stopping managed polishd")
             cancelManagedStartupTask()
+            // Mirror the dictation sibling above: cancelling the startup task
+            // mid-connect without aborting would leave the connecting flag
+            // latched and block every later start.
+            if isConnectingRealtimeSession {
+                abortConnectingSession()
+                statusText = StatusStrings.ready
+            }
             polishingWarmupTask?.cancel()
             polishingShutdownTask?.cancel()
             polishingShutdownTask = Task { @MainActor [backendManager] in

--- a/Sources/localvoxtral/TerminalFocusedTTYReader.swift
+++ b/Sources/localvoxtral/TerminalFocusedTTYReader.swift
@@ -1,5 +1,6 @@
 import AppKit
 import Foundation
+import Observation
 
 /// Reads the controlling TTY of the FOCUSED terminal pane, so the Claude join
 /// can resolve from the process table instead of the window title.
@@ -21,12 +22,17 @@ protocol TerminalFocusedTTYReading {
     /// window, or nil when the app is unsupported, too old to expose `tty`,
     /// Automation is denied, or the read failed. Nil means "fall back to the
     /// marker", never "guess".
-    func focusedTerminalTTY(bundleID: String) -> String?
+    func focusedTerminalTTY(bundleID: String) async -> String?
 }
 
 /// The live reader: one bounded AppleScript question to Ghostty.
 @MainActor
 struct GhosttyFocusedTerminalTTYReader: TerminalFocusedTTYReading {
+    enum ExecutionResult: Sendable {
+        case success(String?)
+        case failure(code: Int)
+    }
+
     /// `with timeout` bounds GHOSTTY'S REPLY, so a wedged terminal cannot hold
     /// dictation start hostage — the same budget discipline as the AX reader's
     /// per-message timeouts. It does NOT bound TCC: the first Apple event ever
@@ -45,38 +51,74 @@ struct GhosttyFocusedTerminalTTYReader: TerminalFocusedTTYReading {
     end timeout
     """
 
-    /// Compiled once, reused for every session start. A fresh `NSAppleScript`
-    /// recompiles the (constant) source on each call — avoidable milliseconds
-    /// on the dictation-start hot path. The per-start call itself stays
-    /// synchronous-but-bounded by design: a true off-main hop would make the
-    /// join resolution async and restructure session start, so it is
-    /// deliberately deferred.
-    private static var cachedScript: NSAppleScript?
+    /// Owns both the serial execution context and the compiled script cache.
+    /// `NSAppleScript` is not thread-safe, so it is constructed, compiled, and
+    /// executed only inside this queue. Only `ExecutionResult` crosses back to
+    /// the caller.
+    private final class SerialExecutor: @unchecked Sendable {
+        private let queue = DispatchQueue(label: "com.localvoxtral.ghostty-tty-applescript")
+        private let source: String
+        private let executeOverride: (@Sendable () -> ExecutionResult)?
+        private var cachedScript: NSAppleScript?
 
-    private static func compiledScript() -> NSAppleScript? {
-        if let cachedScript { return cachedScript }
-        guard let script = NSAppleScript(source: source) else { return nil }
-        // Compile eagerly so later executes reuse the compiled form; a compile
-        // error is reported by executeAndReturnError below either way.
-        script.compileAndReturnError(nil)
-        cachedScript = script
-        return script
+        init(
+            source: String,
+            executeOverride: (@Sendable () -> ExecutionResult)? = nil
+        ) {
+            self.source = source
+            self.executeOverride = executeOverride
+        }
+
+        func execute() async -> ExecutionResult {
+            await withCheckedContinuation { continuation in
+                queue.async { [self] in
+                    continuation.resume(returning: executeOnQueue())
+                }
+            }
+        }
+
+        private func executeOnQueue() -> ExecutionResult {
+            if let executeOverride { return executeOverride() }
+            guard let script = compiledScriptOnQueue() else { return .failure(code: 0) }
+            var error: NSDictionary?
+            let result = script.executeAndReturnError(&error)
+            if let error {
+                return .failure(code: (error[NSAppleScript.errorNumber] as? Int) ?? 0)
+            }
+            return .success(result.stringValue)
+        }
+
+        private func compiledScriptOnQueue() -> NSAppleScript? {
+            if let cachedScript { return cachedScript }
+            guard let script = NSAppleScript(source: source)
+            else { return nil }
+            // Compile eagerly so later executes reuse the compiled form; a
+            // compile error is reported by executeAndReturnError either way.
+            script.compileAndReturnError(nil)
+            cachedScript = script
+            return script
+        }
     }
 
-    func focusedTerminalTTY(bundleID: String) -> String? {
+    private let executor: SerialExecutor
+
+    init(
+        executeScript: (@Sendable () -> ExecutionResult)? = nil
+    ) {
+        executor = SerialExecutor(source: Self.source, executeOverride: executeScript)
+    }
+
+    func focusedTerminalTTY(bundleID: String) async -> String? {
         // Ghostty-only, exact match: the script is Ghostty's dictionary, and
         // sending it anywhere else is at best an error and at worst a prompt
         // to automate an app the user never pointed us at.
         guard bundleID == TerminalScreenAllowlist.ghosttyBundleID else { return nil }
-        guard let script = Self.compiledScript() else { return nil }
-        var error: NSDictionary?
-        let result = script.executeAndReturnError(&error)
-        if let error {
+        switch await executor.execute() {
+        case .failure(let code):
             // Code only, never the message — AppleScript error strings can
             // quote window titles, and a title is content.
             // -1700: `tty` not in the dictionary (Ghostty < 1.4).
             // -1743: the user declined the Automation prompt.
-            let code = (error[NSAppleScript.errorNumber] as? Int) ?? 0
             if code == -1743 {
                 Log.claudeContext.info(
                     "Automation permission denied — grant localvoxtral → Ghostty in System Settings > Privacy > Automation"
@@ -87,8 +129,9 @@ struct GhosttyFocusedTerminalTTYReader: TerminalFocusedTTYReading {
                 )
             }
             return nil
+        case .success(let rawTTY):
+            return Self.validatedTTY(rawTTY)
         }
-        return Self.validatedTTY(result.stringValue)
     }
 
     /// Accepts only a plausible pty device path. The value crosses from another
@@ -105,23 +148,73 @@ struct GhosttyFocusedTerminalTTYReader: TerminalFocusedTTYReading {
     }
 }
 
+/// Owns the Observation subscription that mirrors the two settings which can
+/// need a focused-pane join. AppDelegate retains one for the app run.
+@MainActor
+final class GhosttyAutomationConsentPrewarmSettingsObserver {
+    private let settings: SettingsStore
+    private let prewarm: @MainActor @Sendable () -> Void
+    private var started = false
+    private var wasEnabled = false
+
+    init(
+        settings: SettingsStore,
+        prewarm: @escaping @MainActor @Sendable () -> Void
+    ) {
+        self.settings = settings
+        self.prewarm = prewarm
+    }
+
+    func start() {
+        guard !started else { return }
+        started = true
+        wasEnabled = isEnabled
+        if wasEnabled {
+            prewarm()
+        }
+        observeSettings()
+    }
+
+    private var isEnabled: Bool {
+        settings.terminalScreenContextEnabled || settings.claudeRepoContextEnabled
+    }
+
+    /// Observation's onChange fires once, immediately before a tracked value
+    /// mutates. Re-read and re-arm on the next main-actor turn, matching the
+    /// app's existing status-observation discipline.
+    private func observeSettings() {
+        withObservationTracking {
+            _ = settings.terminalScreenContextEnabled
+            _ = settings.claudeRepoContextEnabled
+        } onChange: { [weak self] in
+            Task { @MainActor in
+                guard let self else { return }
+                let enabled = self.isEnabled
+                if !self.wasEnabled, enabled {
+                    self.prewarm()
+                }
+                self.wasEnabled = enabled
+                self.observeSettings()
+            }
+        }
+    }
+}
+
 /// One-shot Automation consent pre-warm for the Ghostty tty read.
 ///
 /// The first Apple event this app ever sends to Ghostty raises the TCC
 /// Automation consent sheet, and the send BLOCKS until the user answers — the
 /// script's `with timeout` bounds Ghostty's reply, not TCC. Left to happen
 /// naturally, that block lands in the middle of the user's first dictation
-/// into a Claude pane. So the app fires the same read once, at launch (or as
-/// soon as Ghostty launches), with the result discarded: the sheet appears at
-/// a moment when nothing is in flight, and every later per-start read finds
-/// consent already settled.
+/// into a Claude pane. So the app fires the same read once, at launch, when a
+/// relevant setting is enabled, or as soon as Ghostty launches, with the result
+/// discarded: the sheet appears at a moment when nothing is in flight, and
+/// every later per-start read finds consent already settled.
 ///
 /// Fires at most once per app run, and only when Ghostty is actually running —
 /// `tell application id` would otherwise LAUNCH Ghostty, which a background
 /// pre-warm must never do. The caller gates on the context features being
-/// enabled, so an opted-out user is never prompted; a user who enables the
-/// feature mid-run gets pre-warmed on the next launch (a Settings-toggle
-/// pre-warm is deferred until someone hits it).
+/// enabled, so an opted-out user is never prompted.
 @MainActor
 enum GhosttyAutomationConsentPrewarm {
     private static var fired = false
@@ -136,8 +229,8 @@ enum GhosttyAutomationConsentPrewarm {
                 withBundleIdentifier: TerminalScreenAllowlist.ghosttyBundleID
             ).isEmpty
         },
-        execute: @escaping @MainActor @Sendable () -> Void = {
-            _ = GhosttyFocusedTerminalTTYReader().focusedTerminalTTY(
+        execute: @escaping @MainActor @Sendable () async -> Void = {
+            _ = await GhosttyFocusedTerminalTTYReader().focusedTerminalTTY(
                 bundleID: TerminalScreenAllowlist.ghosttyBundleID
             )
         },
@@ -162,13 +255,15 @@ enum GhosttyAutomationConsentPrewarm {
         }
     }
 
-    private static func fire(_ execute: @escaping @MainActor @Sendable () -> Void) {
+    private static func fire(
+        _ execute: @escaping @MainActor @Sendable () async -> Void
+    ) {
         fired = true
         // A Task, not an inline call: the pre-warm can park in the consent
         // sheet, and the caller (broker startup) must not wait on that.
         Task { @MainActor in
             Log.claudeContext.info("Pre-warming Ghostty Automation consent (result discarded)")
-            execute()
+            await execute()
         }
     }
 

--- a/Sources/localvoxtral/localvoxtralApp.swift
+++ b/Sources/localvoxtral/localvoxtralApp.swift
@@ -136,6 +136,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     /// records it exists to collect.
     private let claudeSessionRegistry = ClaudeSessionRegistry()
     private var claudeContextBroker: ClaudeContextBroker?
+    private var ghosttyConsentPrewarmObserver:
+        GhosttyAutomationConsentPrewarmSettingsObserver?
     /// Remote (SSH) Claude Code sessions. Both the host registry and the
     /// listener are lazy and optional: a user who has never enrolled a host has
     /// no file to read and no port bound.
@@ -183,6 +185,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         // nothing is accepting on.
         claudeContextBroker?.stop()
         claudeContextBroker = nil
+        ghosttyConsentPrewarmObserver = nil
         // Closes the port, so a hook from a surviving remote session gets a
         // connection refused through the tunnel and fails open. Quitting says
         // nothing about enrollment — the hosts stay enrolled for next launch.
@@ -226,7 +229,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             let ttyReader = GhosttyFocusedTerminalTTYReader()
             let resolver = ClaudeSessionJoinResolver(
                 registry: claudeSessionRegistry,
-                focusedTerminalTTY: { ttyReader.focusedTerminalTTY(bundleID: $0) }
+                focusedTerminalTTY: { await ttyReader.focusedTerminalTTY(bundleID: $0) }
             )
             viewModel.claudeSessionJoinResolver = resolver
             // Pre-warm the Automation consent sheet OFF the dictation-start
@@ -235,11 +238,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             // for users who opted into a context feature — the pre-warm is
             // itself the consent prompt, and an opted-out user must never see
             // it.
-            if viewModel.settings.terminalScreenContextEnabled
-                || viewModel.settings.claudeRepoContextEnabled
-            {
-                GhosttyAutomationConsentPrewarm.fireOnceWhenGhosttyIsAvailable()
-            }
+            let prewarmObserver = GhosttyAutomationConsentPrewarmSettingsObserver(
+                settings: viewModel.settings,
+                prewarm: { GhosttyAutomationConsentPrewarm.fireOnceWhenGhosttyIsAvailable() }
+            )
+            ghosttyConsentPrewarmObserver = prewarmObserver
+            prewarmObserver.start()
             // The join gate for raw terminal screen attachment. Installed only
             // now: without a running broker there are no markers to resolve, and
             // an authorizer over an empty registry would answer `.unknown` to

--- a/Tests/localvoxtralTests/ClaudeRepoContextGateTests.swift
+++ b/Tests/localvoxtralTests/ClaudeRepoContextGateTests.swift
@@ -80,7 +80,7 @@ final class ClaudeRepoContextGateTests: XCTestCase {
     private func wired(
         cwd: String? = "/repo",
         origin: ClaudeTransportOrigin = .localAuthenticated(peerUID: 501)
-    ) -> (DictationViewModel, GateSpyCollector, ClaudeSessionJoin?) {
+    ) async -> (DictationViewModel, GateSpyCollector, ClaudeSessionJoin?) {
         let viewModel = makeViewModel()
         let collector = GateSpyCollector()
         viewModel.claudeRepoCollector = collector
@@ -109,7 +109,7 @@ final class ClaudeRepoContextGateTests: XCTestCase {
             }
         )
         viewModel.claudeSessionJoinResolver = resolver
-        let join = resolver.resolve(target: ghostty)
+        let join = await resolver.resolve(target: ghostty)
         viewModel.claudeSessionJoin = join
         return (viewModel, collector, join)
     }
@@ -119,7 +119,7 @@ final class ClaudeRepoContextGateTests: XCTestCase {
     // Without this, every gate test below would pass just as well if the
     // collector were never reachable at all.
     func testEnabledLoopbackLiveLocalJoinReachesTheCollector() async {
-        let (viewModel, collector, join) = wired()
+        let (viewModel, collector, join) = await wired()
         viewModel.settings.claudeRepoContextEnabled = true
         let snapshot = await viewModel.claudeRepoSnapshotIfEnabled(
             join: join, endpointURL: loopback, transcript: "hello"
@@ -139,7 +139,7 @@ final class ClaudeRepoContextGateTests: XCTestCase {
     }
 
     func testSettingOffMakesNoFilesystemCall() async {
-        let (viewModel, collector, join) = wired()
+        let (viewModel, collector, join) = await wired()
         viewModel.settings.claudeRepoContextEnabled = false
         let snapshot = await viewModel.claudeRepoSnapshotIfEnabled(
             join: join, endpointURL: loopback, transcript: "hello"
@@ -155,7 +155,7 @@ final class ClaudeRepoContextGateTests: XCTestCase {
     // toggle it off while they are speaking, and that is a withdrawal of consent
     // that must land before a single file is read.
     func testSettingToggledOffMidSessionMakesNoFilesystemCall() async {
-        let (viewModel, collector, join) = wired()
+        let (viewModel, collector, join) = await wired()
         viewModel.settings.claudeRepoContextEnabled = true
         XCTAssertNotNil(join, "precondition: the join resolved while the setting was on")
         viewModel.settings.claudeRepoContextEnabled = false
@@ -170,7 +170,7 @@ final class ClaudeRepoContextGateTests: XCTestCase {
     // Repository contents must never ride to a remote endpoint, and the gate is
     // what guarantees no filesystem read even STARTS for one.
     func testRemoteEndpointMakesNoFilesystemCall() async {
-        let (viewModel, collector, join) = wired()
+        let (viewModel, collector, join) = await wired()
         viewModel.settings.claudeRepoContextEnabled = true
         let snapshot = await viewModel.claudeRepoSnapshotIfEnabled(
             join: join, endpointURL: remote, transcript: "hello"
@@ -186,7 +186,7 @@ final class ClaudeRepoContextGateTests: XCTestCase {
     // receive repository content — explicit, default off, and it does not
     // bypass any other gate (the setting itself still gates below).
     func testTrustedEndpointOptInAdmitsRemoteEndpoint() async {
-        let (viewModel, collector, join) = wired()
+        let (viewModel, collector, join) = await wired()
         viewModel.settings.claudeRepoContextEnabled = true
         viewModel.settings.polishContextTrustedEndpointEnabled = true
         let snapshot = await viewModel.claudeRepoSnapshotIfEnabled(
@@ -200,7 +200,7 @@ final class ClaudeRepoContextGateTests: XCTestCase {
     }
 
     func testTrustedEndpointOptInDoesNotBypassTheFeatureToggle() async {
-        let (viewModel, collector, join) = wired()
+        let (viewModel, collector, join) = await wired()
         viewModel.settings.claudeRepoContextEnabled = false
         viewModel.settings.polishContextTrustedEndpointEnabled = true
         let snapshot = await viewModel.claudeRepoSnapshotIfEnabled(
@@ -217,7 +217,7 @@ final class ClaudeRepoContextGateTests: XCTestCase {
 
     // The common case: a plain terminal with no marker. No join, no read.
     func testNoJoinMakesNoFilesystemCall() async {
-        let (viewModel, collector, _) = wired()
+        let (viewModel, collector, _) = await wired()
         viewModel.settings.claudeRepoContextEnabled = true
         let snapshot = await viewModel.claudeRepoSnapshotIfEnabled(
             join: nil, endpointURL: loopback, transcript: "hello"
@@ -262,7 +262,7 @@ final class ClaudeRepoContextGateTests: XCTestCase {
             }
         )
         viewModel.claudeSessionJoinResolver = resolver
-        let join = resolver.resolve(target: ghostty)
+        let join = await resolver.resolve(target: ghostty)
         XCTAssertNotNil(join, "precondition: live at join time")
 
         dead.withLock { $0 = true }
@@ -276,7 +276,7 @@ final class ClaudeRepoContextGateTests: XCTestCase {
     // Without a resolver (broker startup failed) there is nothing vouching for
     // the join, so it must not be acted on.
     func testNoResolverMakesNoFilesystemCall() async {
-        let (viewModel, collector, join) = wired()
+        let (viewModel, collector, join) = await wired()
         viewModel.settings.claudeRepoContextEnabled = true
         viewModel.claudeSessionJoinResolver = nil
         _ = await viewModel.claudeRepoSnapshotIfEnabled(
@@ -291,7 +291,7 @@ final class ClaudeRepoContextGateTests: XCTestCase {
     // collector — enforced by `ClaudeWorkspaceReference.make` never building one
     // for a remote origin, not by a check here.
     func testRemoteSessionMakesNoFilesystemCall() async {
-        let (viewModel, collector, join) = wired(
+        let (viewModel, collector, join) = await wired(
             cwd: "/srv/repo", origin: .remote(channel: "ssh")
         )
         viewModel.settings.claudeRepoContextEnabled = true
@@ -309,7 +309,7 @@ final class ClaudeRepoContextGateTests: XCTestCase {
 
     // A session with no cwd at all has no workspace to collect.
     func testSessionWithNoWorkspaceMakesNoFilesystemCall() async {
-        let (viewModel, collector, join) = wired(cwd: nil)
+        let (viewModel, collector, join) = await wired(cwd: nil)
         viewModel.settings.claudeRepoContextEnabled = true
         _ = await viewModel.claudeRepoSnapshotIfEnabled(
             join: join, endpointURL: loopback, transcript: "hello"
@@ -350,7 +350,7 @@ final class ClaudeRepoContextGateTests: XCTestCase {
 
     /// A live join whose session has already submitted a prompt, so the block
     /// has something to leak if a gate fails open.
-    private func wiredWithPriorPrompt() -> (DictationViewModel, ClaudeSessionJoin?) {
+    private func wiredWithPriorPrompt() async -> (DictationViewModel, ClaudeSessionJoin?) {
         let viewModel = makeViewModel()
         let registry = ClaudeSessionRegistry(
             now: { Date(timeIntervalSince1970: 1_000) },
@@ -385,7 +385,7 @@ final class ClaudeRepoContextGateTests: XCTestCase {
             }
         )
         viewModel.claudeSessionJoinResolver = resolver
-        let join = resolver.resolve(target: ghostty)
+        let join = await resolver.resolve(target: ghostty)
         viewModel.claudeSessionJoin = join
         return (viewModel, join)
     }
@@ -393,7 +393,7 @@ final class ClaudeRepoContextGateTests: XCTestCase {
     // The positive control. Without it every gate test below would pass just as
     // well if the block were unreachable entirely.
     func testEnabledLoopbackLiveJoinAttachesTheSessionBlock() async {
-        let (viewModel, join) = wiredWithPriorPrompt()
+        let (viewModel, join) = await wiredWithPriorPrompt()
         viewModel.settings.claudeRepoContextEnabled = true
         let outcome = await sessionBlockOutcome(viewModel, join: join, endpointURL: loopback)
         XCTAssertTrue(outcome.text.contains("rewrite the migration script"))
@@ -403,7 +403,7 @@ final class ClaudeRepoContextGateTests: XCTestCase {
     // Consent withdrawn while they were speaking. It must land on this block
     // too, not just on the repository read.
     func testSettingToggledOffMidSessionAttachesNoSessionBlock() async {
-        let (viewModel, join) = wiredWithPriorPrompt()
+        let (viewModel, join) = await wiredWithPriorPrompt()
         viewModel.settings.claudeRepoContextEnabled = true
         XCTAssertNotNil(join, "precondition: the join resolved while the setting was on")
         viewModel.settings.claudeRepoContextEnabled = false
@@ -417,7 +417,7 @@ final class ClaudeRepoContextGateTests: XCTestCase {
     // Settings changed the endpoint to a remote one after the join resolved. The
     // user's typed prompt must not ride to it.
     func testRemoteEndpointAttachesNoSessionBlock() async {
-        let (viewModel, join) = wiredWithPriorPrompt()
+        let (viewModel, join) = await wiredWithPriorPrompt()
         viewModel.settings.claudeRepoContextEnabled = true
 
         let outcome = await sessionBlockOutcome(viewModel, join: join, endpointURL: remote)
@@ -434,7 +434,7 @@ final class ClaudeRepoContextGateTests: XCTestCase {
     // the prior prompt, because the user explicitly consented to this exact
     // ride (mirror of `testTrustedEndpointOptInAdmitsRemoteEndpoint`).
     func testTrustedEndpointOptInAttachesTheSessionBlockToRemoteEndpoint() async {
-        let (viewModel, join) = wiredWithPriorPrompt()
+        let (viewModel, join) = await wiredWithPriorPrompt()
         viewModel.settings.claudeRepoContextEnabled = true
         viewModel.settings.polishContextTrustedEndpointEnabled = true
 
@@ -475,7 +475,7 @@ final class ClaudeRepoContextGateTests: XCTestCase {
             }
         )
         viewModel.claudeSessionJoinResolver = resolver
-        let join = resolver.resolve(target: ghostty)
+        let join = await resolver.resolve(target: ghostty)
         XCTAssertNotNil(join, "precondition: live at join time")
 
         dead.withLock { $0 = true }
@@ -488,7 +488,7 @@ final class ClaudeRepoContextGateTests: XCTestCase {
     // No resolver means nothing vouches for the join — the same abstention the
     // repository read makes.
     func testNoResolverAttachesNoSessionBlock() async {
-        let (viewModel, join) = wiredWithPriorPrompt()
+        let (viewModel, join) = await wiredWithPriorPrompt()
         viewModel.settings.claudeRepoContextEnabled = true
         viewModel.claudeSessionJoinResolver = nil
 
@@ -502,8 +502,8 @@ final class ClaudeRepoContextGateTests: XCTestCase {
     // The join names a session and a pane belonging to the session being
     // abandoned. A stale one surviving is how the wrong repo's context would get
     // attached to an unrelated sentence.
-    func testDiscardingTheScreenCaptureAlsoDropsTheJoin() {
-        let (viewModel, _, join) = wired()
+    func testDiscardingTheScreenCaptureAlsoDropsTheJoin() async {
+        let (viewModel, _, join) = await wired()
         viewModel.claudeSessionJoin = join
         viewModel.discardTerminalScreenCapture()
         XCTAssertNil(viewModel.claudeSessionJoin)
@@ -511,8 +511,8 @@ final class ClaudeRepoContextGateTests: XCTestCase {
 
     // Consuming hands the join over exactly once, so a later session cannot
     // inherit it.
-    func testConsumingTheJoinClearsIt() {
-        let (viewModel, _, join) = wired()
+    func testConsumingTheJoinClearsIt() async {
+        let (viewModel, _, join) = await wired()
         viewModel.claudeSessionJoin = join
         XCTAssertEqual(viewModel.consumeClaudeSessionJoin()?.marker, join?.marker)
         XCTAssertNil(viewModel.claudeSessionJoin)
@@ -524,7 +524,7 @@ final class ClaudeRepoContextGateTests: XCTestCase {
     // Resolving is not passive: it makes a live AX round trip for the window
     // title. Every gate must sit in front of it, exactly as they do for the
     // screen read.
-    func testStartResolutionNeverReadsTheTitleWhenBothFeaturesAreOff() {
+    func testStartResolutionNeverReadsTheTitleWhenBothFeaturesAreOff() async {
         let viewModel = makeViewModel()
         let reads = Mutex(0)
         viewModel.claudeSessionJoinResolver = ClaudeSessionJoinResolver(
@@ -540,7 +540,7 @@ final class ClaudeRepoContextGateTests: XCTestCase {
         viewModel.settings.claudeRepoContextEnabled = false
         TerminalScreenContextSource.debugFrontmostTargetOverride = { self.ghostty }
 
-        viewModel.captureTerminalScreenContextForSession()
+        await viewModel.captureTerminalScreenContextForSession()
 
         XCTAssertNil(viewModel.claudeSessionJoin)
         XCTAssertEqual(reads.withLock { $0 }, 0, "an opted-out user's title must never be read")
@@ -550,7 +550,7 @@ final class ClaudeRepoContextGateTests: XCTestCase {
     // with a remote polishing endpoint, the resolver is consulted only under
     // the opt-in — same gate, same order, as every commit-time surface. Both
     // halves in one test so the opt-in is provably what flips the answer.
-    func testStartResolutionOverRemoteEndpointRequiresTheTrustedOptIn() {
+    func testStartResolutionOverRemoteEndpointRequiresTheTrustedOptIn() async {
         let viewModel = makeViewModel()
         viewModel.settings.llmPolishingEnabled = true
         viewModel.settings.polishingBackendMode = .externalURL
@@ -571,7 +571,7 @@ final class ClaudeRepoContextGateTests: XCTestCase {
         TerminalScreenContextSource.debugFrontmostTargetOverride = { self.ghostty }
 
         viewModel.settings.polishContextTrustedEndpointEnabled = false
-        viewModel.captureTerminalScreenContextForSession()
+        await viewModel.captureTerminalScreenContextForSession()
         XCTAssertNil(viewModel.claudeSessionJoin)
         XCTAssertEqual(
             reads.withLock { $0 }, 0,
@@ -579,7 +579,7 @@ final class ClaudeRepoContextGateTests: XCTestCase {
         )
 
         viewModel.settings.polishContextTrustedEndpointEnabled = true
-        viewModel.captureTerminalScreenContextForSession()
+        await viewModel.captureTerminalScreenContextForSession()
         XCTAssertNotNil(viewModel.claudeSessionJoin, "the opt-in admits the join")
         XCTAssertEqual(reads.withLock { $0 }, 1)
     }

--- a/Tests/localvoxtralTests/DictationViewModelFailFastUXTests.swift
+++ b/Tests/localvoxtralTests/DictationViewModelFailFastUXTests.swift
@@ -187,7 +187,7 @@ final class DictationViewModelFailFastUXTests: XCTestCase {
         XCTAssertEqual(token, .accessibilityPermissionRequired)
     }
 
-    func testBeginDictationSessionSurfacesAccessibilityWarningInLiveMode() {
+    func testBeginDictationSessionSurfacesAccessibilityWarningInLiveMode() async {
         let viewModel = makeViewModel(outputMode: .liveAutoPaste)
         // Point at a closed port so the async connect fails fast and does not
         // hit a real backend. The AX warning is asserted synchronously, before
@@ -197,7 +197,7 @@ final class DictationViewModelFailFastUXTests: XCTestCase {
         viewModel.textInsertion.debugSetAccessibilityTrusted(false)
         retainForTestProcessLifetime(viewModel)
 
-        viewModel.beginDictationSession()
+        await viewModel.beginDictationSession()
 
         // Fail-fast warning surfaces at start and is not clobbered by the
         // generic "Connecting..." status.
@@ -208,14 +208,14 @@ final class DictationViewModelFailFastUXTests: XCTestCase {
         viewModel.abortConnectingSession()
     }
 
-    func testBeginDictationSessionSkipsAccessibilityWarningWhenTrustedInLiveMode() {
+    func testBeginDictationSessionSkipsAccessibilityWarningWhenTrustedInLiveMode() async {
         let viewModel = makeViewModel(outputMode: .liveAutoPaste)
         viewModel.settings.realtimeAPIEndpointURL = "ws://127.0.0.1:65535/realtime"
         viewModel.isShowingConnectionFailureAlert = true
         viewModel.textInsertion.debugSetAccessibilityTrusted(true)
         retainForTestProcessLifetime(viewModel)
 
-        viewModel.beginDictationSession()
+        await viewModel.beginDictationSession()
 
         XCTAssertEqual(viewModel.statusText, "Connecting to realtime backend...")
         XCTAssertNil(viewModel.lastError)
@@ -223,14 +223,14 @@ final class DictationViewModelFailFastUXTests: XCTestCase {
         viewModel.abortConnectingSession()
     }
 
-    func testBeginDictationSessionSkipsAccessibilityWarningInOverlayMode() {
+    func testBeginDictationSessionSkipsAccessibilityWarningInOverlayMode() async {
         let viewModel = makeViewModel(outputMode: .overlayBuffer)
         viewModel.settings.realtimeAPIEndpointURL = "ws://127.0.0.1:65535/realtime"
         viewModel.isShowingConnectionFailureAlert = true
         viewModel.textInsertion.debugSetAccessibilityTrusted(false)
         retainForTestProcessLifetime(viewModel)
 
-        viewModel.beginDictationSession()
+        await viewModel.beginDictationSession()
 
         XCTAssertEqual(viewModel.statusText, "Connecting to realtime backend...")
         XCTAssertNil(viewModel.lastError)
@@ -395,7 +395,7 @@ final class DictationViewModelFailFastUXTests: XCTestCase {
         await viewModel.managedStartupTask?.value
     }
 
-    func testStartDictationInExternalModeNeverTouchesManagedBackendManager() {
+    func testStartDictationInExternalModeNeverTouchesManagedBackendManager() async {
         let backendManager = FakeManagedBackendManager()
         let viewModel = makeViewModel(outputMode: .overlayBuffer, backendManager: backendManager)
         viewModel.settings.dictationBackendMode = .externalURL
@@ -406,6 +406,10 @@ final class DictationViewModelFailFastUXTests: XCTestCase {
         retainForTestProcessLifetime(viewModel)
 
         viewModel.startDictation()
+        // The external path now hops through the startup task before
+        // beginDictationSession runs; the endpoint error surfaces when it
+        // completes, and the backend manager must still never be touched.
+        await viewModel.managedStartupTask?.value
 
         XCTAssertTrue(backendManager.ensureCalls.isEmpty)
         XCTAssertEqual(viewModel.statusText, "Invalid endpoint URL.")

--- a/Tests/localvoxtralTests/DictationViewModelFailFastUXTests.swift
+++ b/Tests/localvoxtralTests/DictationViewModelFailFastUXTests.swift
@@ -1,3 +1,4 @@
+import ClaudeContextWire
 import Foundation
 import XCTest
 @testable import localvoxtral
@@ -529,6 +530,91 @@ final class DictationViewModelFailFastUXTests: XCTestCase {
         XCTAssertEqual(backendManager.stopDictationCallCount, 0)
         XCTAssertEqual(backendManager.stopPolishingCallCount, 1)
         XCTAssertEqual(backendManager.stopAllCallCount, 0)
+    }
+
+    /// Flipping the polishing backend to External mid-connect must release the
+    /// connecting latch exactly like the dictation sibling: before the fix the
+    /// cancel path left `isConnectingRealtimeSession` latched forever, so
+    /// every later start was blocked until app restart.
+    func testPolishingModeSwitchAwayFromManagedMidConnectReleasesTheConnectingLatch() async {
+        let backendManager = FakeManagedBackendManager()
+        let viewModel = makeViewModel(outputMode: .overlayBuffer, backendManager: backendManager)
+        viewModel.settings.dictationBackendMode = .managedLocal
+        viewModel.settings.polishingBackendMode = .managedLocal
+        viewModel.isShowingConnectionFailureAlert = true
+        retainForTestProcessLifetime(viewModel)
+
+        viewModel.isConnectingRealtimeSession = true
+        viewModel.applyPolishingBackendModeChange(.externalURL)
+
+        XCTAssertFalse(
+            viewModel.isConnectingRealtimeSession,
+            "cancelling a mid-connect startup must not latch the connecting flag"
+        )
+        XCTAssertEqual(viewModel.statusText, DictationViewModel.StatusStrings.ready)
+        await backendManager.waitForStopPolishingCallCount(1)
+    }
+
+    /// A start that was cancelled and superseded BEFORE its startup task ran
+    /// must never enter `beginDictationSession`: its cleanup would wipe the
+    /// successor session's freshly-resolved join.
+    func testCancelledAndSupersededStartupTaskLeavesSuccessorSessionStateAlone() async {
+        let viewModel = makeViewModel(outputMode: .overlayBuffer)
+        viewModel.settings.dictationBackendMode = .externalURL
+        viewModel.settings.polishingBackendMode = .externalURL
+        viewModel.settings.realtimeAPIEndpointURL = "ws://127.0.0.1:65535/realtime"
+        viewModel.isShowingConnectionFailureAlert = true
+        viewModel.debugMicrophoneAuthorizationStatusOverride = .authorized
+        retainForTestProcessLifetime(viewModel)
+
+        // Spawn the startup task but do not let it run yet — the test holds
+        // the main actor, so nothing after this line has interleaved.
+        viewModel.startDictation()
+        let staleTask = viewModel.managedStartupTask
+        XCTAssertNotNil(staleTask)
+
+        // A canceller retires it, and a successor start takes the slot with a
+        // freshly resolved join — all before the stale task ever runs.
+        staleTask?.cancel()
+        viewModel.abortConnectingSession()
+        viewModel.managedStartupTaskID = UUID()
+        let registry = ClaudeSessionRegistry(
+            now: { Date(timeIntervalSince1970: 1_000) },
+            isProcessAlive: { _ in true },
+            allocateMarkerValue: { "lvx-successor" }
+        )
+        registry.ingest(
+            ClaudeHookRecord(
+                event: .sessionStart,
+                sessionID: "s-successor",
+                timestamp: 0,
+                rawCwd: "/repo",
+                process: ClaudeHookProcessInfo(hookPID: 777, claudePID: 9001)
+            ),
+            origin: .localAuthenticated(peerUID: 501)
+        )
+        let resolver = ClaudeSessionJoinResolver(
+            registry: registry,
+            markerInWindowTitle: { _ in
+                TerminalScreenAXReader.FocusedWindowMarkerRead(
+                    marker: ClaudeSessionMarker(value: "lvx-successor"), windowID: 7
+                )
+            }
+        )
+        let join = await resolver.resolve(
+            target: TerminalScreenTarget(
+                pid: 4242, bundleID: TerminalScreenAllowlist.ghosttyBundleID
+            )
+        )
+        XCTAssertNotNil(join)
+        viewModel.claudeSessionJoin = join
+
+        _ = await staleTask?.value
+
+        XCTAssertEqual(
+            viewModel.claudeSessionJoin, join,
+            "a stale startup task must not wipe the successor's join"
+        )
     }
 
     func testManagedPolishingModelChangePersistsAndStopsPolishingWhenDisabled() async {

--- a/Tests/localvoxtralTests/DictationViewModelModifierGestureTests.swift
+++ b/Tests/localvoxtralTests/DictationViewModelModifierGestureTests.swift
@@ -72,7 +72,7 @@ final class DictationViewModelModifierGestureTests: XCTestCase {
         )
     }
 
-    func testFailedModifierHoldStartDoesNotLatchLiveModeForNextSettingsBasedSession() {
+    func testFailedModifierHoldStartDoesNotLatchLiveModeForNextSettingsBasedSession() async {
         let settings = makeSettings(outputMode: .liveAutoPaste)
         let viewModel = makeViewModel(settings: settings)
 
@@ -89,7 +89,7 @@ final class DictationViewModelModifierGestureTests: XCTestCase {
         viewModel.isAwaitingMicrophonePermission = false
         viewModel.textInsertion.debugSetAccessibilityTrusted(true)
 
-        viewModel.beginDictationSession()
+        await viewModel.beginDictationSession()
 
         XCTAssertEqual(
             viewModel.sessionOutputMode, .overlayBuffer,

--- a/Tests/localvoxtralTests/DictationViewModelOverlayLifecycleTests.swift
+++ b/Tests/localvoxtralTests/DictationViewModelOverlayLifecycleTests.swift
@@ -31,7 +31,7 @@ final class DictationViewModelOverlayLifecycleTests: XCTestCase {
         XCTAssertTrue(viewModel.isLiveAutoPasteModeEnabled)
     }
 
-    func testExplicitOutputModeSurvivesBeginDictationSession() {
+    func testExplicitOutputModeSurvivesBeginDictationSession() async {
         let settings = makeSettings(outputMode: .liveAutoPaste)
         settings.realtimeAPIEndpointURL = "ws://127.0.0.1:1/realtime"
         let overlayCoordinator = MockOverlayCoordinator()
@@ -42,7 +42,7 @@ final class DictationViewModelOverlayLifecycleTests: XCTestCase {
         )
         retainForTestProcessLifetime(viewModel)
 
-        viewModel.beginDictationSession(outputMode: .overlayBuffer)
+        await viewModel.beginDictationSession(outputMode: .overlayBuffer)
 
         XCTAssertEqual(viewModel.sessionOutputMode, .overlayBuffer)
         XCTAssertTrue(viewModel.isOverlayBufferModeEnabled)

--- a/Tests/localvoxtralTests/GhosttyAutomationConsentPrewarmTests.swift
+++ b/Tests/localvoxtralTests/GhosttyAutomationConsentPrewarmTests.swift
@@ -105,4 +105,38 @@ final class GhosttyAutomationConsentPrewarmTests: XCTestCase {
         await drainMainActorQueue()
         XCTAssertEqual(executions.withLock { $0 }, 1)
     }
+
+    func testSettingsOffToOnTransitionPrewarmsOnlyOncePerAppRun() async {
+        let suiteName = "localvoxtral.GhosttyPrewarmSettings.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defaults.removePersistentDomain(forName: suiteName)
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        let settings = SettingsStore(defaults: defaults, environment: [:])
+        let executions = Mutex(0)
+        let observer = GhosttyAutomationConsentPrewarmSettingsObserver(settings: settings) {
+            GhosttyAutomationConsentPrewarm.fireOnceWhenGhosttyIsAvailable(
+                isGhosttyRunning: { true },
+                execute: { executions.withLock { $0 += 1 } },
+                notificationCenter: NotificationCenter()
+            )
+        }
+        observer.start()
+
+        settings.terminalScreenContextEnabled = true
+        for _ in 0..<100 { await Task.yield() }
+        XCTAssertEqual(
+            executions.withLock { $0 }, 1,
+            "enabling a context setting after launch must pre-warm before dictation"
+        )
+
+        settings.terminalScreenContextEnabled = false
+        settings.terminalScreenContextEnabled = true
+        settings.claudeRepoContextEnabled = true
+        for _ in 0..<100 { await Task.yield() }
+        XCTAssertEqual(
+            executions.withLock { $0 }, 1,
+            "a successful pre-warm must remain at-most-once for the app run"
+        )
+        _ = observer
+    }
 }

--- a/Tests/localvoxtralTests/TerminalScreenClaudeJoinTests.swift
+++ b/Tests/localvoxtralTests/TerminalScreenClaudeJoinTests.swift
@@ -112,9 +112,9 @@ final class TerminalScreenClaudeJoinTests: XCTestCase {
         title: String?,
         target: TerminalScreenTarget? = nil,
         titleWindowID: CGWindowID? = 101
-    ) -> TerminalScreenClaudeJoinAuthorizer {
+    ) async -> TerminalScreenClaudeJoinAuthorizer {
         let resolver = resolver(registry: registry, title: title, titleWindowID: titleWindowID)
-        let join = resolver.resolve(target: target ?? ghostty)
+        let join = await resolver.resolve(target: target ?? ghostty)
         return TerminalScreenClaudeJoinAuthorizer(resolver: resolver, currentJoin: { join })
     }
 
@@ -123,42 +123,44 @@ final class TerminalScreenClaudeJoinTests: XCTestCase {
     // The one case that joins: the broker issued this marker to a session it
     // authenticated from peer credentials, Claude wrote it into the title, and
     // the session is still live.
-    func testKnownLiveMarkerInTitleResolvesAndAuthorizes() throws {
+    func testKnownLiveMarkerInTitleResolvesAndAuthorizes() async throws {
         let registry = makeRegistry()
         XCTAssertNotNil(registry.ingest(record(), origin: local))
-        let join = try XCTUnwrap(
-            resolver(registry: registry, title: "lvx-abcd — ~/repo").resolve(target: ghostty)
-        )
+        let resolved = await resolver(
+            registry: registry, title: "lvx-abcd — ~/repo"
+        ).resolve(target: ghostty)
+        let join = try XCTUnwrap(resolved)
         XCTAssertEqual(join.marker, ClaudeSessionMarker(value: "lvx-abcd"))
         XCTAssertEqual(join.snapshot.sessionID, "s1")
         XCTAssertEqual(join.target, ghostty)
-        XCTAssertTrue(
-            authorizer(registry: registry, title: "lvx-abcd — ~/repo").isAuthorized(target: ghostty, windowID: windowA)
-        )
+        let gate = await authorizer(registry: registry, title: "lvx-abcd — ~/repo")
+        XCTAssertTrue(gate.isAuthorized(target: ghostty, windowID: windowA))
     }
 
     // The join carries the session's LOCAL workspace, which is what the repo
     // collector needs and the only thing that can reach the filesystem.
-    func testLocalSessionJoinExposesTheWorkspacePath() throws {
+    func testLocalSessionJoinExposesTheWorkspacePath() async throws {
         let registry = makeRegistry()
         XCTAssertNotNil(registry.ingest(record(), origin: local))
-        let join = try XCTUnwrap(
-            resolver(registry: registry, title: "lvx-abcd").resolve(target: ghostty)
-        )
+        let resolved = await resolver(
+            registry: registry, title: "lvx-abcd"
+        ).resolve(target: ghostty)
+        let join = try XCTUnwrap(resolved)
         XCTAssertEqual(join.localWorkspacePath?.path, "/repo")
     }
 
     // A REMOTE session joins (its marker is real and its context is usable as
     // opaque text) but exposes no path — so the collector cannot be called for
     // it, and that is enforced by the type, not by a check.
-    func testRemoteSessionJoinExposesNoWorkspacePath() throws {
+    func testRemoteSessionJoinExposesNoWorkspacePath() async throws {
         let registry = makeRegistry()
         XCTAssertNotNil(
             registry.ingest(record(), origin: .remote(channel: "ssh"))
         )
-        let join = try XCTUnwrap(
-            resolver(registry: registry, title: "lvx-abcd").resolve(target: ghostty)
-        )
+        let resolved = await resolver(
+            registry: registry, title: "lvx-abcd"
+        ).resolve(target: ghostty)
+        let join = try XCTUnwrap(resolved)
         XCTAssertNil(
             join.localWorkspacePath,
             "a remote session must never hand a filesystem path to the collector"
@@ -170,7 +172,7 @@ final class TerminalScreenClaudeJoinTests: XCTestCase {
     // The title-war case this mechanism exists for: Claude Code's own
     // conversation title has clobbered the marker, so the title read answers
     // nothing — but the focused pane's device still names the session.
-    func testTTYJoinsWhenTheTitleCarriesNoMarker() throws {
+    func testTTYJoinsWhenTheTitleCarriesNoMarker() async throws {
         let registry = makeRegistry()
         XCTAssertNotNil(
             registry.ingest(record(tty: "/dev/ttys003"), origin: local)
@@ -178,7 +180,8 @@ final class TerminalScreenClaudeJoinTests: XCTestCase {
         let joinResolver = resolver(
             registry: registry, title: "Fixing the flaky supervisor test", focusedTTY: "/dev/ttys003"
         )
-        let join = try XCTUnwrap(joinResolver.resolve(target: ghostty))
+        let resolved = await joinResolver.resolve(target: ghostty)
+        let join = try XCTUnwrap(resolved)
         XCTAssertEqual(join.snapshot.sessionID, "s1")
         XCTAssertEqual(join.marker, ClaudeSessionMarker(value: "lvx-abcd"))
         // The tty-joined session revalidates at stop through the same
@@ -186,7 +189,7 @@ final class TerminalScreenClaudeJoinTests: XCTestCase {
         XCTAssertTrue(joinResolver.isStillLive(join))
     }
 
-    func testTTYJoinDoesNotReadTheTitleAtAll() throws {
+    func testTTYJoinDoesNotReadTheTitleAtAll() async throws {
         // Precedence is observable: when the device answers, the title is not
         // even consulted — a stale marker in it cannot compete.
         let registry = makeRegistry()
@@ -201,11 +204,12 @@ final class TerminalScreenClaudeJoinTests: XCTestCase {
             focusedTerminalTTY: { _ in "/dev/ttys003" },
             focusedWindowID: { _ in self.windowA }
         )
-        XCTAssertNotNil(joinResolver.resolve(target: ghostty))
+        let join = await joinResolver.resolve(target: ghostty)
+        XCTAssertNotNil(join)
         XCTAssertEqual(titleReads, 0)
     }
 
-    func testTTYJoinWinsOverAStaleMarkerNamingAnotherSession() throws {
+    func testTTYJoinWinsOverAStaleMarkerNamingAnotherSession() async throws {
         // Pane recycling: claude #1 ended, its marker lingers in the title;
         // claude #2 runs in the same pane on the same device. The process
         // table is current, the title is history — the device must win.
@@ -218,27 +222,27 @@ final class TerminalScreenClaudeJoinTests: XCTestCase {
                 record(session: "new", claudePID: 9002, tty: "/dev/ttys003"), origin: local
             )
         )
-        let join = try XCTUnwrap(
-            resolver(registry: registry, title: "lvx-aaaa", focusedTTY: "/dev/ttys003")
-                .resolve(target: ghostty)
-        )
+        let resolved = await resolver(
+            registry: registry, title: "lvx-aaaa", focusedTTY: "/dev/ttys003"
+        ).resolve(target: ghostty)
+        let join = try XCTUnwrap(resolved)
         XCTAssertEqual(join.snapshot.sessionID, "new")
     }
 
-    func testUnmatchedTTYFallsBackToTheTitleMarker() throws {
+    func testUnmatchedTTYFallsBackToTheTitleMarker() async throws {
         // Old Ghostty answers no tty; a device with no session answers
         // `.unknown`. Either way the marker path must still join — the tty
         // mechanism only ever adds joins, never removes one.
         let registry = makeRegistry()
         XCTAssertNotNil(registry.ingest(record(tty: "/dev/ttys003"), origin: local))
-        let join = try XCTUnwrap(
-            resolver(registry: registry, title: "lvx-abcd", focusedTTY: "/dev/ttys777")
-                .resolve(target: ghostty)
-        )
+        let resolved = await resolver(
+            registry: registry, title: "lvx-abcd", focusedTTY: "/dev/ttys777"
+        ).resolve(target: ghostty)
+        let join = try XCTUnwrap(resolved)
         XCTAssertEqual(join.snapshot.sessionID, "s1")
     }
 
-    func testAmbiguousTTYFallsBackToTheTitleMarker() throws {
+    func testAmbiguousTTYFallsBackToTheTitleMarker() async throws {
         // Two local sessions on one device abstain at the registry; the
         // marker — which names exactly one of them — may still disambiguate.
         let registry = makeRegistry(markers: ["lvx-aaaa", "lvx-bbbb"])
@@ -250,10 +254,10 @@ final class TerminalScreenClaudeJoinTests: XCTestCase {
                 record(session: "s2", claudePID: 9002, tty: "/dev/ttys003"), origin: local
             )
         )
-        let join = try XCTUnwrap(
-            resolver(registry: registry, title: "lvx-bbbb", focusedTTY: "/dev/ttys003")
-                .resolve(target: ghostty)
-        )
+        let resolved = await resolver(
+            registry: registry, title: "lvx-bbbb", focusedTTY: "/dev/ttys003"
+        ).resolve(target: ghostty)
+        let join = try XCTUnwrap(resolved)
         XCTAssertEqual(join.snapshot.sessionID, "s2")
     }
 
@@ -261,13 +265,13 @@ final class TerminalScreenClaudeJoinTests: XCTestCase {
     // marker join carries the title read's — and the authorizer holds both to
     // the same compare. Without it, a tty join would either always refuse raw
     // attachment (nil identity) or bypass the F2 window check entirely.
-    func testTTYJoinCarriesTheFocusedWindowIdentity() throws {
+    func testTTYJoinCarriesTheFocusedWindowIdentity() async throws {
         let registry = makeRegistry()
         XCTAssertNotNil(registry.ingest(record(tty: "/dev/ttys003"), origin: local))
         let joinResolver = resolver(
             registry: registry, title: nil, focusedTTY: "/dev/ttys003", ttyWindowID: windowB
         )
-        let join = joinResolver.resolve(target: ghostty)
+        let join = await joinResolver.resolve(target: ghostty)
         XCTAssertEqual(join?.windowID, windowB)
         let gate = TerminalScreenClaudeJoinAuthorizer(resolver: joinResolver, currentJoin: { join })
         XCTAssertTrue(
@@ -283,13 +287,14 @@ final class TerminalScreenClaudeJoinTests: XCTestCase {
     // A tty join whose window identity could not be established still joins —
     // hook state and repo context remain usable — but raw screen attachment
     // refuses, same as an unknown marker-read identity.
-    func testTTYJoinWithUnknownWindowIdentityRefusesRawAttachment() throws {
+    func testTTYJoinWithUnknownWindowIdentityRefusesRawAttachment() async throws {
         let registry = makeRegistry()
         XCTAssertNotNil(registry.ingest(record(tty: "/dev/ttys003"), origin: local))
         let joinResolver = resolver(
             registry: registry, title: nil, focusedTTY: "/dev/ttys003", ttyWindowID: nil
         )
-        let join = try XCTUnwrap(joinResolver.resolve(target: ghostty))
+        let resolved = await joinResolver.resolve(target: ghostty)
+        let join = try XCTUnwrap(resolved)
         XCTAssertNil(join.windowID)
         let gate = TerminalScreenClaudeJoinAuthorizer(
             resolver: joinResolver, currentJoin: { join }
@@ -298,7 +303,7 @@ final class TerminalScreenClaudeJoinTests: XCTestCase {
         XCTAssertFalse(gate.isAuthorized(target: ghostty, windowID: nil))
     }
 
-    func testRemoteSessionNeverJoinsViaTTY() {
+    func testRemoteSessionNeverJoinsViaTTY() async {
         // End-to-end shape of the registry's remote refusal: an SSH session
         // publishing the local pane's device must not claim the pane. With no
         // marker in the title either, there is no join at all.
@@ -308,13 +313,29 @@ final class TerminalScreenClaudeJoinTests: XCTestCase {
                 record(tty: "/dev/ttys003"), origin: .remote(channel: "ssh")
             )
         )
-        XCTAssertNil(
-            resolver(registry: registry, title: nil, focusedTTY: "/dev/ttys003")
-                .resolve(target: ghostty)
-        )
+        let join = await resolver(
+            registry: registry, title: nil, focusedTTY: "/dev/ttys003"
+        ).resolve(target: ghostty)
+        XCTAssertNil(join)
     }
 
     // MARK: - TTY reply validation
+
+    func testFocusedTTYAppleScriptExecutesOffTheMainThread() async {
+        let reader = GhosttyFocusedTerminalTTYReader {
+            XCTAssertFalse(
+                Thread.isMainThread,
+                "the blocking AppleScript execute must not run on the main thread"
+            )
+            return .success("/dev/ttys123")
+        }
+
+        let tty = await reader.focusedTerminalTTY(
+            bundleID: TerminalScreenAllowlist.ghosttyBundleID
+        )
+
+        XCTAssertEqual(tty, "/dev/ttys123")
+    }
 
     func testValidatedTTYAcceptsOnlyPlausibleDevicePaths() {
         XCTAssertEqual(
@@ -344,65 +365,75 @@ final class TerminalScreenClaudeJoinTests: XCTestCase {
     // Plain Ghostty: a terminal the user opened themselves, no Claude session,
     // nothing in the title. This is the common case and the one that keeps
     // arbitrary scrollback out of prompts.
-    func testPlainGhosttyWithNoMarkerInTitleDoesNotJoin() {
+    func testPlainGhosttyWithNoMarkerInTitleDoesNotJoin() async {
         let registry = makeRegistry()
         XCTAssertNotNil(registry.ingest(record(), origin: local))
         // A live session EXISTS — it is just not this window. The join must
         // still fail: "a Claude session is running somewhere" is not a join, and
         // a sole-session heuristic is exactly what this asserts we do not have.
-        XCTAssertNil(resolver(registry: registry, title: "~/repo — zsh").resolve(target: ghostty))
-        XCTAssertFalse(
-            authorizer(registry: registry, title: "~/repo — zsh").isAuthorized(target: ghostty, windowID: windowA)
-        )
+        let join = await resolver(
+            registry: registry, title: "~/repo — zsh"
+        ).resolve(target: ghostty)
+        XCTAssertNil(join)
+        let gate = await authorizer(registry: registry, title: "~/repo — zsh")
+        XCTAssertFalse(gate.isAuthorized(target: ghostty, windowID: windowA))
     }
 
-    func testAbsentTitleDoesNotJoin() {
+    func testAbsentTitleDoesNotJoin() async {
         let registry = makeRegistry()
         XCTAssertNotNil(registry.ingest(record(), origin: local))
-        XCTAssertNil(resolver(registry: registry, title: nil).resolve(target: ghostty))
-        XCTAssertFalse(authorizer(registry: registry, title: nil).isAuthorized(target: ghostty, windowID: windowA))
+        let join = await resolver(registry: registry, title: nil).resolve(target: ghostty)
+        XCTAssertNil(join)
+        let gate = await authorizer(registry: registry, title: nil)
+        XCTAssertFalse(gate.isAuthorized(target: ghostty, windowID: windowA))
     }
 
     // A marker we never issued — or one left in a title after the session ended
     // and was evicted. Both arrive here as `.unknown`.
-    func testUnknownMarkerDoesNotJoin() {
+    func testUnknownMarkerDoesNotJoin() async {
         let registry = makeRegistry()
         XCTAssertNotNil(registry.ingest(record(), origin: local))
-        XCTAssertNil(resolver(registry: registry, title: "lvx-9999").resolve(target: ghostty))
-        XCTAssertFalse(
-            authorizer(registry: registry, title: "lvx-9999").isAuthorized(target: ghostty, windowID: windowA)
-        )
+        let join = await resolver(
+            registry: registry, title: "lvx-9999"
+        ).resolve(target: ghostty)
+        XCTAssertNil(join)
+        let gate = await authorizer(registry: registry, title: "lvx-9999")
+        XCTAssertFalse(gate.isAuthorized(target: ghostty, windowID: windowA))
     }
 
     // Past TTL: the title still shows the marker, but the registry no longer
     // vouches for the session. A stale title is exactly how a pane that WAS a
     // Claude session goes on looking like one.
-    func testStaleMarkerPastTTLDoesNotJoin() {
+    func testStaleMarkerPastTTLDoesNotJoin() async {
         let clock = JoinTestClock(epoch)
         let registry = makeRegistry(limits: ClaudeRegistryLimits(sessionTTL: 60), clock: clock)
         XCTAssertNotNil(registry.ingest(record(), origin: local))
         let gate = resolver(registry: registry, title: "lvx-abcd")
-        XCTAssertNotNil(gate.resolve(target: ghostty), "precondition: live before the TTL")
+        let liveJoin = await gate.resolve(target: ghostty)
+        XCTAssertNotNil(liveJoin, "precondition: live before the TTL")
         clock.advance(61)
-        XCTAssertNil(gate.resolve(target: ghostty))
+        let staleJoin = await gate.resolve(target: ghostty)
+        XCTAssertNil(staleJoin)
     }
 
     // The Claude process died without firing SessionEnd (SIGKILL, closed
     // terminal). TTL alone would still call this live; the liveness probe is
     // what makes it stale.
-    func testStaleMarkerWhoseProcessIsGoneDoesNotJoin() {
+    func testStaleMarkerWhoseProcessIsGoneDoesNotJoin() async {
         let liveness = JoinTestLiveness()
         let registry = makeRegistry(liveness: liveness)
         XCTAssertNotNil(registry.ingest(record(claudePID: 9001), origin: local))
         let gate = resolver(registry: registry, title: "lvx-abcd")
-        XCTAssertNotNil(gate.resolve(target: ghostty), "precondition: live while the pid is alive")
+        let liveJoin = await gate.resolve(target: ghostty)
+        XCTAssertNotNil(liveJoin, "precondition: live while the pid is alive")
         liveness.kill(9001)
-        XCTAssertNil(gate.resolve(target: ghostty))
+        let staleJoin = await gate.resolve(target: ghostty)
+        XCTAssertNil(staleJoin)
     }
 
     // Two markers in one title: we cannot tell which session owns the window.
     // The parser abstains and so must the join.
-    func testAmbiguousTitleCarryingTwoMarkersDoesNotJoin() {
+    func testAmbiguousTitleCarryingTwoMarkersDoesNotJoin() async {
         let registry = makeRegistry(markers: ["lvx-abcd", "lvx-beef"])
         XCTAssertNotNil(registry.ingest(record(session: "s1"), origin: local))
         XCTAssertNotNil(registry.ingest(record(session: "s2"), origin: local))
@@ -410,9 +441,10 @@ final class TerminalScreenClaudeJoinTests: XCTestCase {
             ClaudeMarkerTitleParser.marker(inTitle: "lvx-abcd lvx-beef"),
             "precondition: the parser abstains on two markers"
         )
-        XCTAssertNil(
-            resolver(registry: registry, title: "lvx-abcd lvx-beef").resolve(target: ghostty)
-        )
+        let join = await resolver(
+            registry: registry, title: "lvx-abcd lvx-beef"
+        ).resolve(target: ghostty)
+        XCTAssertNil(join)
     }
 
     // MARK: - App identity
@@ -420,15 +452,15 @@ final class TerminalScreenClaudeJoinTests: XCTestCase {
     // The marker join does not override the allowlist. A non-Ghostty app whose
     // title happens to carry a valid marker (an editor showing the terminal's
     // title, a window named after a log line) must not become readable.
-    func testNonGhosttyAppDoesNotJoinEvenWithALiveMarkerInTitle() {
+    func testNonGhosttyAppDoesNotJoinEvenWithALiveMarkerInTitle() async {
         let registry = makeRegistry()
         XCTAssertNotNil(registry.ingest(record(), origin: local))
         for bundleID in TerminalScreenAllowlist.explicitlyExcludedBundleIDs {
             let editor = TerminalScreenTarget(pid: 4242, bundleID: bundleID)
-            XCTAssertNil(
-                resolver(registry: registry, title: "lvx-abcd").resolve(target: editor),
-                "\(bundleID) must never join a Claude session"
-            )
+            let join = await resolver(
+                registry: registry, title: "lvx-abcd"
+            ).resolve(target: editor)
+            XCTAssertNil(join, "\(bundleID) must never join a Claude session")
         }
     }
 
@@ -439,7 +471,7 @@ final class TerminalScreenClaudeJoinTests: XCTestCase {
     // answer honestly about a different moment — the user can switch tabs
     // mid-sentence — and the prompt would then describe one session's screen
     // next to another's repository.
-    func testTheWindowTitleIsReadExactlyOncePerDictation() {
+    func testTheWindowTitleIsReadExactlyOncePerDictation() async {
         let registry = makeRegistry()
         XCTAssertNotNil(registry.ingest(record(), origin: local))
         let reads = Mutex(0)
@@ -452,7 +484,7 @@ final class TerminalScreenClaudeJoinTests: XCTestCase {
                 )
             }
         )
-        let join = resolver.resolve(target: ghostty)
+        let join = await resolver.resolve(target: ghostty)
         XCTAssertNotNil(join)
         XCTAssertEqual(reads.withLock { $0 }, 1)
 
@@ -468,33 +500,32 @@ final class TerminalScreenClaudeJoinTests: XCTestCase {
 
     // A join describes ONE pane. A different target — including a recycled pid
     // now owned by another app — inherits nothing from it.
-    func testJoinDoesNotAuthorizeADifferentTarget() {
+    func testJoinDoesNotAuthorizeADifferentTarget() async {
         let registry = makeRegistry()
         XCTAssertNotNil(registry.ingest(record(), origin: local))
         let other = TerminalScreenTarget(pid: 777, bundleID: TerminalScreenAllowlist.ghosttyBundleID)
-        let gate = authorizer(registry: registry, title: "lvx-abcd")
+        let gate = await authorizer(registry: registry, title: "lvx-abcd")
         XCTAssertTrue(gate.isAuthorized(target: ghostty, windowID: windowA), "precondition: the joined pane authorizes")
         XCTAssertFalse(gate.isAuthorized(target: other, windowID: windowA))
     }
 
     // Same pid, different app: the bundle id is part of the identity compare,
     // so a quit-and-relaunch that recycled the pid cannot inherit the join.
-    func testJoinDoesNotAuthorizeARecycledPIDOwnedByAnotherApp() {
+    func testJoinDoesNotAuthorizeARecycledPIDOwnedByAnotherApp() async {
         let registry = makeRegistry()
         XCTAssertNotNil(registry.ingest(record(), origin: local))
         let recycled = TerminalScreenTarget(pid: ghostty.pid, bundleID: "com.apple.Terminal")
-        XCTAssertFalse(
-            authorizer(registry: registry, title: "lvx-abcd").isAuthorized(target: recycled, windowID: windowA)
-        )
+        let gate = await authorizer(registry: registry, title: "lvx-abcd")
+        XCTAssertFalse(gate.isAuthorized(target: recycled, windowID: windowA))
     }
 
     // The session can end between start and stop. The marker is fixed by the
     // start read — what is re-checked is whether it still names a live session.
-    func testSessionEndingAfterTheJoinWithdrawsAuthorization() {
+    func testSessionEndingAfterTheJoinWithdrawsAuthorization() async {
         let liveness = JoinTestLiveness()
         let registry = makeRegistry(liveness: liveness)
         XCTAssertNotNil(registry.ingest(record(claudePID: 9001), origin: local))
-        let gate = authorizer(registry: registry, title: "lvx-abcd")
+        let gate = await authorizer(registry: registry, title: "lvx-abcd")
         XCTAssertTrue(gate.isAuthorized(target: ghostty, windowID: windowA), "precondition: live at join time")
         liveness.kill(9001)
         XCTAssertFalse(
@@ -519,10 +550,10 @@ final class TerminalScreenClaudeJoinTests: XCTestCase {
     // title read are two separate AX reads: focus moving between them pairs
     // window A's SCREEN with window B's SESSION. The window identity is what
     // must refuse that.
-    func testJoinDoesNotAuthorizeADifferentWindowOfTheSameApp() {
+    func testJoinDoesNotAuthorizeADifferentWindowOfTheSameApp() async {
         let registry = makeRegistry()
         XCTAssertNotNil(registry.ingest(record(), origin: local))
-        let gate = authorizer(registry: registry, title: "lvx-abcd", titleWindowID: windowB)
+        let gate = await authorizer(registry: registry, title: "lvx-abcd", titleWindowID: windowB)
         XCTAssertTrue(
             gate.isAuthorized(target: ghostty, windowID: windowB),
             "precondition: the joined window itself authorizes"
@@ -535,22 +566,21 @@ final class TerminalScreenClaudeJoinTests: XCTestCase {
 
     // Unknown identity never authorizes: two unknowns are not "the same
     // window", they are two questions nobody answered.
-    func testMissingWindowIdentityRefusesRawAttachment() {
+    func testMissingWindowIdentityRefusesRawAttachment() async {
         let registry = makeRegistry()
         XCTAssertNotNil(registry.ingest(record(), origin: local))
+        let nilIdentityGate = await authorizer(
+            registry: registry, title: "lvx-abcd", titleWindowID: nil
+        )
         XCTAssertFalse(
-            authorizer(registry: registry, title: "lvx-abcd", titleWindowID: nil)
-                .isAuthorized(target: ghostty, windowID: nil),
+            nilIdentityGate.isAuthorized(target: ghostty, windowID: nil),
             "nil join identity + nil capture identity must abstain, never match"
         )
-        XCTAssertFalse(
-            authorizer(registry: registry, title: "lvx-abcd", titleWindowID: windowA)
-                .isAuthorized(target: ghostty, windowID: nil)
+        let knownIdentityGate = await authorizer(
+            registry: registry, title: "lvx-abcd", titleWindowID: windowA
         )
-        XCTAssertFalse(
-            authorizer(registry: registry, title: "lvx-abcd", titleWindowID: nil)
-                .isAuthorized(target: ghostty, windowID: windowA)
-        )
+        XCTAssertFalse(knownIdentityGate.isAuthorized(target: ghostty, windowID: nil))
+        XCTAssertFalse(nilIdentityGate.isAuthorized(target: ghostty, windowID: windowA))
     }
 
     // MARK: - Wiring into the reconciler

--- a/Tests/localvoxtralTests/TerminalScreenContextTests.swift
+++ b/Tests/localvoxtralTests/TerminalScreenContextTests.swift
@@ -766,14 +766,14 @@ final class TerminalScreenContextLifecycleTests: XCTestCase {
 
     // The default install must never read a screen, and under XCTest the live
     // seams are pinned off regardless.
-    func testSessionStartCaptureIsNilWithSettingOff() {
+    func testSessionStartCaptureIsNilWithSettingOff() async {
         let viewModel = makeViewModel()
         XCTAssertFalse(viewModel.settings.terminalScreenContextEnabled)
-        viewModel.captureTerminalScreenContextForSession()
+        await viewModel.captureTerminalScreenContextForSession()
         XCTAssertNil(viewModel.terminalScreenStartCapture)
     }
 
-    func testSessionStartCaptureNeverCallsAXWhenSettingIsOff() {
+    func testSessionStartCaptureNeverCallsAXWhenSettingIsOff() async {
         var reads = 0
         TerminalScreenAXReader.debugScreenReadOverride = { _ in
             reads += 1
@@ -784,7 +784,7 @@ final class TerminalScreenContextLifecycleTests: XCTestCase {
         }
         let viewModel = makeViewModel()
         viewModel.settings.terminalScreenContextEnabled = false
-        viewModel.captureTerminalScreenContextForSession()
+        await viewModel.captureTerminalScreenContextForSession()
         XCTAssertEqual(reads, 0)
         XCTAssertNil(viewModel.terminalScreenStartCapture)
     }

--- a/Tests/localvoxtralTests/TerminalTargetDetectorTests.swift
+++ b/Tests/localvoxtralTests/TerminalTargetDetectorTests.swift
@@ -262,7 +262,7 @@ final class TerminalTargetDetectorTests: XCTestCase {
 
     // MARK: - Capture-at-begin / consume-at-audio-start lifecycle
 
-    func testBeginDictationSessionCapturesVerdictBeforeConnect() {
+    func testBeginDictationSessionCapturesVerdictBeforeConnect() async {
         // Pins the wiring: the verdict must be sampled inside
         // beginDictationSession (before the socket opens), like
         // preResolvedOverlayAnchor. Overlay mode avoids the live-auto-paste
@@ -275,7 +275,7 @@ final class TerminalTargetDetectorTests: XCTestCase {
         viewModel.isShowingConnectionFailureAlert = true
         Self.retainedViewModels.append(viewModel)
 
-        viewModel.beginDictationSession(outputMode: .overlayBuffer)
+        await viewModel.beginDictationSession(outputMode: .overlayBuffer)
         XCTAssertFalse(
             viewModel.debugHasInitializedMicrophoneForTesting,
             "connecting must not eagerly initialize CoreAudio"
@@ -503,7 +503,7 @@ final class TerminalTargetDetectorTests: XCTestCase {
 
     // MARK: - Session start under Secure Keyboard Entry (#89 split behavior)
 
-    func testLiveSessionStartRefusedUnderSecureInput() {
+    func testLiveSessionStartRefusedUnderSecureInput() async {
         TerminalTargetDetector.debugFrontmostBundleIDOverride = { "com.apple.Terminal" }
         TerminalTargetDetector.debugSecureEventInputOverride = { true }
 
@@ -512,7 +512,7 @@ final class TerminalTargetDetectorTests: XCTestCase {
         var soundPlays = 0
         viewModel.secureInputWarningSound = { soundPlays += 1 }
 
-        viewModel.beginDictationSession()
+        await viewModel.beginDictationSession()
 
         XCTAssertFalse(viewModel.isDictating, "a live session that can only type into the void must not start")
         XCTAssertFalse(viewModel.isConnectingRealtimeSession, "no socket attempt for a refused start")
@@ -525,14 +525,14 @@ final class TerminalTargetDetectorTests: XCTestCase {
         viewModel.isShowingConnectionFailureAlert = true
     }
 
-    func testRefusedStartWarningClearsAtNextSessionStartWithSecureInputOff() {
+    func testRefusedStartWarningClearsAtNextSessionStartWithSecureInputOff() async {
         TerminalTargetDetector.debugFrontmostBundleIDOverride = { "com.apple.Terminal" }
         TerminalTargetDetector.debugSecureEventInputOverride = { true }
 
         let viewModel = makeViewModel(outputMode: .liveAutoPaste)
         Self.retainedViewModels.append(viewModel)
         viewModel.secureInputWarningSound = {}
-        viewModel.beginDictationSession()
+        await viewModel.beginDictationSession()
         XCTAssertEqual(viewModel.menuBarIndicatorState, .secureInputWarning)
 
         // The password prompt is gone; the stale-warning path at the next
@@ -546,7 +546,7 @@ final class TerminalTargetDetectorTests: XCTestCase {
         viewModel.isShowingConnectionFailureAlert = true
     }
 
-    func testConnectionFailureAlertNeverRunsModalEvenWithNSAppInitialized() {
+    func testConnectionFailureAlertNeverRunsModalEvenWithNSAppInitialized() async {
         // Regression: presentConnectionFailureAlert's `NSApp != nil` guard is
         // not enough in a test process — any earlier test touching
         // NSApplication.shared initializes NSApp for the rest of the suite,
@@ -560,7 +560,7 @@ final class TerminalTargetDetectorTests: XCTestCase {
         Self.retainedViewModels.append(viewModel)
         viewModel.settings.dictationBackendMode = .externalURL
         viewModel.settings.realtimeAPIEndpointURL = ""
-        viewModel.beginDictationSession()
+        await viewModel.beginDictationSession()
 
         XCTAssertFalse(viewModel.isDictating)
         XCTAssertNotNil(viewModel.lastError, "the failure must still be surfaced")
@@ -585,7 +585,7 @@ final class TerminalTargetDetectorTests: XCTestCase {
         XCTAssertTrue(DictationViewModel.isTestProcess())
     }
 
-    func testStaleSecureIconDoesNotMaskEarlyExitFailuresOnNextAttempt() {
+    func testStaleSecureIconDoesNotMaskEarlyExitFailuresOnNextAttempt() async {
         // Codex finding on #90: refused start leaves the icon lit; a next
         // attempt that exits early (missing mic) BEFORE the verdict capture
         // must not keep reporting a secure-input warning that is now off.
@@ -595,7 +595,7 @@ final class TerminalTargetDetectorTests: XCTestCase {
         let viewModel = makeViewModel(outputMode: .liveAutoPaste)
         Self.retainedViewModels.append(viewModel)
         viewModel.secureInputWarningSound = {}
-        viewModel.beginDictationSession()
+        await viewModel.beginDictationSession()
         XCTAssertEqual(viewModel.menuBarIndicatorState, .secureInputWarning)
 
         TerminalTargetDetector.debugSecureEventInputOverride = { false }
@@ -603,7 +603,7 @@ final class TerminalTargetDetectorTests: XCTestCase {
         // verdict capture: custom backend mode with an empty endpoint URL.
         viewModel.settings.dictationBackendMode = .externalURL
         viewModel.settings.realtimeAPIEndpointURL = ""
-        viewModel.beginDictationSession()
+        await viewModel.beginDictationSession()
 
         XCTAssertNotEqual(
             viewModel.menuBarIndicatorState, .secureInputWarning,
@@ -613,7 +613,7 @@ final class TerminalTargetDetectorTests: XCTestCase {
         viewModel.isShowingConnectionFailureAlert = true
     }
 
-    func testRefusedLiveStartResetsStaleOverlayPanel() {
+    func testRefusedLiveStartResetsStaleOverlayPanel() async {
         // Codex finding on #90 (round 3): a prior overlay commit failure
         // intentionally leaves its panel visible until the NEXT session
         // resets the coordinator — a refused live start must still perform
@@ -626,14 +626,14 @@ final class TerminalTargetDetectorTests: XCTestCase {
         Self.retainedViewModels.append(viewModel)
         viewModel.secureInputWarningSound = {}
 
-        viewModel.beginDictationSession()
+        await viewModel.beginDictationSession()
 
         XCTAssertFalse(viewModel.isDictating)
         XCTAssertGreaterThanOrEqual(coordinator.resetCallCount, 1)
         viewModel.isShowingConnectionFailureAlert = true
     }
 
-    func testOverlaySessionStartProceedsUnderSecureInput() {
+    func testOverlaySessionStartProceedsUnderSecureInput() async {
         TerminalTargetDetector.debugFrontmostBundleIDOverride = { "com.apple.Terminal" }
         TerminalTargetDetector.debugSecureEventInputOverride = { true }
 
@@ -641,7 +641,7 @@ final class TerminalTargetDetectorTests: XCTestCase {
         Self.retainedViewModels.append(viewModel)
         viewModel.secureInputWarningSound = {}
 
-        viewModel.beginDictationSession()
+        await viewModel.beginDictationSession()
 
         XCTAssertTrue(
             viewModel.isConnectingRealtimeSession,


### PR DESCRIPTION
## What

Two deferred findings from the #150/#154 review (fixed instead of filed, per owner), plus a GLM-review round that caught two real interleaving bugs in the first cut:

- **TTY read off the main actor**: the Ghostty focused-pane AppleScript ran synchronously on the main actor at dictation start (its own comment called the async move "deliberately deferred"). `NSAppleScript` now compiles and executes on a reader-owned serial queue; only a Sendable result crosses back; `beginDictationSession` became async and awaits it without blocking the main actor. Abstention/fallback/code-only-logging contracts unchanged.
- **Consent prewarm on mid-run toggles**: the Automation-consent prewarm fired only at app launch, so enabling a context feature later deferred the blocking TCC sheet into the user's next dictation. An Observation-based observer now fires it on either context setting's off→on transition, preserving once-per-run semantics.
- **Review round**: (1) flipping the polishing backend to External mid-connect cancelled the startup task without aborting — `isConnectingRealtimeSession` stayed latched forever, blocking every later start; now mirrors the dictation sibling's abort and the post-await cleanup self-heals. (2) a cancelled startup task could wipe a successor session's freshly-latched join/capture/metadata; the wrapper now pre-checks staleness and the cleanup is ownership-gated.

## Proof

- [x] Unit suite green — `./scripts/remote-build.sh test`:
  - `Executed 1803 tests, with 2 tests skipped and 0 failures (0 unexpected) in 60.685 (60.778) seconds`
- [x] Worker regression tests shown failing pre-fix: `testFocusedTTYAppleScriptExecutesOffTheMainThread` (asserts the read leaves the main thread), `testSettingsOffToOnTransitionPrewarmsOnlyOncePerAppRun`; focused suites `TerminalScreenClaudeJoinTests` 32/0, `GhosttyAutomationConsentPrewarmTests` 4/0, `ClaudeRepoContextGateTests` 22/0.
- [x] Review-round regression tests shown failing with the fixes reverted (`Executed 71 tests, with 2 failures`, then `71/0`):
  - `testPolishingModeSwitchAwayFromManagedMidConnectReleasesTheConnectingLatch`: `XCTAssertFalse failed - cancelling a mid-connect startup must not latch the connecting flag`
  - `testCancelledAndSupersededStartupTaskLeavesSuccessorSessionStateAlone`: `XCTAssertEqual failed: ("nil") is not equal to ("Optional(...ClaudeSessionJoin...)") - a stale startup task must not wipe the successor's join`
- [x] All three modified-but-unrun `DictationViewModel*` suites re-run green during orchestrator review (FailFast 69→71/0, ModifierGesture 6/0, OverlayLifecycle 36/0).
- [x] Adversarial GLM review (opencode) over the diff: the two interleaving findings above (both fixed); SerialExecutor Sendable soundness, continuation exactly-once, Observation re-arm/retain-cycle, once-per-run semantics, async conformance, and no-weakened-assertions all verified clean.
- Not a UI-structure change; the mid-await session-start behavior is the one product-visible timing change (endpoint errors surface one main-actor hop later, asserted in the updated FailFast test).
- LLM lanes: not run — no model-input/prompt changes (session-start concurrency + prewarm only).
