### PR TITLE
Quantized LM-head speechd: Blaizzy#232 fork pin + qhead model catalog switch (promoted from try)

### DIFF
--- a/Sources/localvoxtral/Backends/SpeechModelCatalog.swift
+++ b/Sources/localvoxtral/Backends/SpeechModelCatalog.swift
@@ -11,16 +11,21 @@ struct SpeechModelOption: Equatable, Sendable {
 
 enum SpeechModelCatalog {
     static let options: [SpeechModelOption] = [
+        // Same mistralai/Voxtral-Mini-4B-Realtime-2602 4-bit conversion as the previous
+        // mlx-community pin, plus a 4-bit/g64-quantized tied embedding/LM head — the
+        // decode loop's dominant per-token cost (~30 ms -> ~3 ms on M1 Pro). Loading it
+        // requires the quantized-tied-embedding loader fix pinned in
+        // SpeechHelper/Package.swift (staged upstream as Blaizzy/mlx-audio-swift#232).
         SpeechModelOption(
-            repoID: "mlx-community/Voxtral-Mini-4B-Realtime-2602-4bit",
-            revision: "fdebf7b2af834a1db4b8a3c99ab7480b333adf9e",
-            displayName: "Voxtral Mini 4B Realtime (4-bit)"
+            repoID: "T0mSIlver/Voxtral-Mini-4B-Realtime-2602-4bit-qhead",
+            revision: "247f2eeccf962fbcaf85e361731a5e75b2d8cac1",
+            displayName: "Voxtral Mini 4B Realtime (4-bit, quantized head)"
         ),
     ]
 
     static let defaultOption: SpeechModelOption = {
         guard let option = option(
-            forRepoID: "mlx-community/Voxtral-Mini-4B-Realtime-2602-4bit"
+            forRepoID: "T0mSIlver/Voxtral-Mini-4B-Realtime-2602-4bit-qhead"
         ) else {
             preconditionFailure("Default speech model missing from the catalog.")
         }

--- a/SpeechHelper/DEPENDENCY.md
+++ b/SpeechHelper/DEPENDENCY.md
@@ -17,23 +17,26 @@ checkout — we no longer keep a copy here.
 ```
 .package(
     url: "https://github.com/T0mSIlver/mlx-audio-swift.git",
-    revision: "03890317975a2371fe0a0a9b13ad6a790f929814"
+    revision: "791ab876c10b47cc9f8894ff4100240aa6d95bf7"
 )
 ```
 
 Pinned to a full-SHA **revision**, not a tag, so the exact reviewed tree is reproducible and
 can't move under us.
 
-**Temporary fork pin.** `0389031` is our fork's `localvoxtral-pin-e1-e2` branch: upstream
-`3b0b114` (the merge of
-[Blaizzy/mlx-audio-swift#226](https://github.com/Blaizzy/mlx-audio-swift/pull/226),
-"Fix float32 leak in VoxtralRealtime streaming", authored by us) plus two
-streaming-performance fixes staged for upstream as fork PRs
-([#2](https://github.com/T0mSIlver/mlx-audio-swift/pull/2): Metal-pool clear cadence,
-[#3](https://github.com/T0mSIlver/mlx-audio-swift/pull/3): incremental mel/conv front end —
-both with bench evidence in the PR threads). Switchback plan: once both merge upstream, point
-the URL back at `Blaizzy/mlx-audio-swift` at the containing revision and delete the fork
-branch; nothing else changes.
+**Temporary fork pin.** `791ab87` is our fork's `fix/load-quantized-tied-embedding` branch:
+upstream main `6ea59e5` — which now contains everything the previous `localvoxtral-pin-e1-e2`
+pin carried as fork commits (upstream
+[#229](https://github.com/Blaizzy/mlx-audio-swift/pull/229): Metal-pool clear cadence,
+[#230](https://github.com/Blaizzy/mlx-audio-swift/pull/230): incremental mel/conv front end,
+[#231](https://github.com/Blaizzy/mlx-audio-swift/pull/231): hoisted attention invariants,
+all merged) — plus one commit: the quantized-tied-embedding loader fix staged upstream as
+[Blaizzy/mlx-audio-swift#232](https://github.com/Blaizzy/mlx-audio-swift/pull/232). That fix
+is required to load the catalog-pinned `-qhead` checkpoint (4-bit/g64-quantized tied
+embedding/LM head — see `SpeechModelCatalog.swift`); without it the loader rejects the
+checkpoint's `tok_embeddings.scales`/`.biases` under `verify: .all`. Switchback plan: once
+#232 merges, point the URL back at `Blaizzy/mlx-audio-swift` at the containing revision and
+delete the fork branch; nothing else changes.
 
 ## What #226 upstreamed
 

--- a/SpeechHelper/Package.resolved
+++ b/SpeechHelper/Package.resolved
@@ -23,7 +23,7 @@
       "kind": "remoteSourceControl",
       "location": "https://github.com/T0mSIlver/mlx-audio-swift.git",
       "state": {
-        "revision": "03890317975a2371fe0a0a9b13ad6a790f929814"
+        "revision": "791ab876c10b47cc9f8894ff4100240aa6d95bf7"
       }
     },
     {

--- a/SpeechHelper/Package.swift
+++ b/SpeechHelper/Package.swift
@@ -34,14 +34,15 @@ let package = Package(
         // #226). Pinned to a full-SHA revision, not a tag, so the exact reviewed tree is
         // reproducible — see DEPENDENCY.md for the upgrade procedure.
         //
-        // TEMPORARY FORK PIN: our fork's `localvoxtral-pin-e1-e2` = upstream 3b0b114 plus two
-        // streaming-performance fixes staged for upstream (fork PRs; see DEPENDENCY.md):
-        // cache-clear cadence (per-step -> per-256-tokens + finish) and the incremental
-        // mel/conv front end (O(N^2) -> O(N) per utterance). Switch the URL back to
-        // Blaizzy/mlx-audio-swift once both merge upstream.
+        // TEMPORARY FORK PIN: our fork's `fix/load-quantized-tied-embedding` = upstream
+        // main 6ea59e5 (which now contains everything the previous e1-e2 pin carried:
+        // upstream #229/#230/#231) plus the quantized-tied-embedding loader fix staged
+        // upstream as Blaizzy/mlx-audio-swift#232 — required by the catalog's -qhead model
+        // (SpeechModelCatalog). Switch the URL back to Blaizzy/mlx-audio-swift once #232
+        // merges.
         .package(
             url: "https://github.com/T0mSIlver/mlx-audio-swift.git",
-            revision: "03890317975a2371fe0a0a9b13ad6a790f929814"
+            revision: "791ab876c10b47cc9f8894ff4100240aa6d95bf7"
         ),
     ],
     targets: [

--- a/Tests/localvoxtralTests/SpeechModelCatalogTests.swift
+++ b/Tests/localvoxtralTests/SpeechModelCatalogTests.swift
@@ -13,7 +13,7 @@ final class SpeechModelCatalogTests: XCTestCase {
 
     func testSpeechModelCatalogPinsFullCommitSHA() {
         let option = SpeechModelCatalog.defaultOption
-        XCTAssertEqual(option.repoID, "mlx-community/Voxtral-Mini-4B-Realtime-2602-4bit")
+        XCTAssertEqual(option.repoID, "T0mSIlver/Voxtral-Mini-4B-Realtime-2602-4bit-qhead")
         XCTAssertEqual(option.revision.count, 40)
         XCTAssertTrue(option.revision.allSatisfy(\.isHexDigit))
     }


### PR DESCRIPTION
## What

Try-build for the quantized tied-embedding/LM-head speedup, **stacked on #164** (phonetic grounding) so one `try-pr.sh` artifact carries both.

Two changes, one commit:

- **SpeechHelper pin** → fork branch `fix/load-quantized-tied-embedding` (`791ab87`). That is upstream main `6ea59e5` — which already contains everything the old `localvoxtral-pin-e1-e2` pin carried, now merged as Blaizzy/mlx-audio-swift#229/#230/#231 — plus one commit: the quantized-tied-embedding loader fix staged upstream as [Blaizzy/mlx-audio-swift#232](https://github.com/Blaizzy/mlx-audio-swift/pull/232).
- **SpeechModelCatalog** → `T0mSIlver/Voxtral-Mini-4B-Realtime-2602-4bit-qhead` @ `247f2ee`: the same 4-bit conversion with a 4-bit/g64-quantized tied embedding/LM head. Per the #232 measurements this takes the LM-head projection from ~30 ms to ~3 ms per decoded token (the largest decode-loop phase), the 100 ms-cadence streaming step from 92–104 ms to 64–74 ms, and frees ~530 MiB resident, at level eval quality.

This closes the HOLD left on fork PR T0mSIlver/mlx-audio-swift#12: "merge order #11 → #12 → localvoxtral catalog pin switch, per-model gate once the `-qhead` repo exists" — the gate run is in the Proof below.

**Not production-ready by design** (owner call): the pin stays on the fork until #232 merges upstream; the switchback plan is in `SpeechHelper/DEPENDENCY.md`. README "Under the hood" model copy is deliberately untouched until this is promoted from try to keep.

## Proof

- [x] Unit suite green — `./scripts/remote-build.sh test`
  ```
  Executed 1842 tests, with 2 tests skipped and 0 failures (0 unexpected) in 65.032 (65.139) seconds
  ```
  (includes the updated `SpeechModelCatalogTests` default-pin assertion)
- [x] SpeechHelper unit suite green with the new pin resolved — `./scripts/remote-build.sh test --package-path SpeechHelper`
  ```
  Executed 47 tests, with 0 failures (0 unexpected) in 0.010 (0.012) seconds
  ```
- [x] Packaging green — `./scripts/remote-build.sh package` (all four products, xcodebuild Metal lane)
- [x] Per-model speechd gate vs the real qhead checkpoint — `./scripts/remote-build.sh integration-speechd T0mSIlver/Voxtral-Mini-4B-Realtime-2602-4bit-qhead` (self-provisioned the weights, packaged helper, production realtime client):
  ```
  Test Suite 'SpeechHelperIntegrationTests' passed at 2026-07-21 15:39:02.401.
       Executed 4 tests, with 0 failures (0 unexpected) in 1012.510 (1012.511) seconds
  speechd integration: model provisioned (4 files)
  speechd integration: word accuracy 0.759; transcript:  Hello from local VoxTroll real-time test. [...] end-to-end processing is confirmed.
  ```
  0.759 on the synthetic TTS fixture vs 0.789 for the fp16-head pin (same-family error: "VoxTroll", "WID socket by"); the human-eval comparison in #232 held level (50/156 vs 49/156 hard cases, mean word accuracy 0.73 vs 0.72 on the stress subset).
- [x] CI speechd live lane runs automatically on this diff (`SpeechHelper/*` + `SpeechModelCatalog.swift` match `speechd-lane-filter.sh`).
- LLM polish lanes: skipped — no polish-side change in this commit; the #164 base carries its own proof.

## Try it

```
./scripts/try-pr.sh <this PR number>
```

First launch re-downloads the qhead model (~2.4 GB) via the normal managed-backend provisioning.
