### PR TITLE
Proactive Local Network permission preflight for LAN endpoints; permission audit

### DIFF
--- a/Sources/localvoxtral/DictationViewModel.swift
+++ b/Sources/localvoxtral/DictationViewModel.swift
@@ -564,6 +564,8 @@ final class DictationViewModel {
     private var lifecycleObservers: [NSObjectProtocol] = []
     @ObservationIgnored
     private let managesRuntimeServices: Bool
+    @ObservationIgnored
+    private let localNetworkPermissionPreflight: any LocalNetworkPermissionPreflighting
     // Tracks physical key state so repeat key-down events do not retrigger actions.
     @ObservationIgnored
     private var isPushToTalkShortcutHeld = false
@@ -587,6 +589,7 @@ final class DictationViewModel {
         settings: SettingsStore,
         backendManager: (any ManagedBackendManaging)? = nil,
         overlayBufferCoordinator: OverlayBufferSessionCoordinating? = nil,
+        localNetworkPermissionPreflight: (any LocalNetworkPermissionPreflighting)? = nil,
         startRuntimeServices: Bool = true
     ) {
         self.settings = settings
@@ -598,6 +601,8 @@ final class DictationViewModel {
                 speechdStepCadenceProvider: { settings.speechdStepCadence.milliseconds }
             )
         self.managesRuntimeServices = startRuntimeServices
+        self.localNetworkPermissionPreflight =
+            localNetworkPermissionPreflight ?? LocalNetworkPermissionPreflight()
         if let overlayBufferCoordinator {
             self.overlayBufferCoordinator = overlayBufferCoordinator
         } else {
@@ -1070,6 +1075,10 @@ final class DictationViewModel {
         let previousMode = settings.dictationBackendMode
         settings.dictationBackendMode = mode
 
+        if mode == .externalURL {
+            preflightDictationEndpoint(reason: "dictation backend switched to external")
+        }
+
         if previousMode == .externalURL, mode == .managedLocal {
             startManagedBackendWarmup(dictation: true, polishing: false)
             return
@@ -1095,6 +1104,10 @@ final class DictationViewModel {
         let previousMode = settings.polishingBackendMode
         settings.polishingBackendMode = mode
 
+        if mode == .externalURL {
+            preflightPolishingEndpoint(reason: "polishing backend switched to external")
+        }
+
         if previousMode == .externalURL, mode == .managedLocal {
             if isManagedPolishingWarmupWanted {
                 startPolishingWarmup()
@@ -1119,6 +1132,43 @@ final class DictationViewModel {
                 await backendManager.stopPolishing()
             }
         }
+    }
+
+    func applyRealtimeEndpointChange(_ endpoint: String) {
+        settings.realtimeAPIEndpointURL = endpoint
+        guard settings.dictationBackendMode == .externalURL else { return }
+        preflightDictationEndpoint(reason: "dictation endpoint updated")
+    }
+
+    func applyLLMPolishingEndpointChange(_ endpoint: String) {
+        settings.llmPolishingEndpointURL = endpoint
+        guard settings.polishingBackendMode == .externalURL else { return }
+        preflightPolishingEndpoint(reason: "polishing endpoint updated")
+    }
+
+    func preflightConfiguredLocalNetworkEndpoints() {
+        if settings.dictationBackendMode == .externalURL {
+            preflightDictationEndpoint(reason: "configured external dictation endpoint")
+        }
+        if settings.polishingBackendMode == .externalURL {
+            preflightPolishingEndpoint(reason: "configured external polishing endpoint")
+        }
+    }
+
+    private func preflightDictationEndpoint(reason: String) {
+        guard let endpoint = settings.resolvedWebSocketURL(for: settings.realtimeProvider),
+              LocalNetworkEndpointPolicy.preflightTarget(for: endpoint) != nil
+        else { return }
+        localNetworkPermissionPreflight.preflight(endpoint: endpoint, reason: reason)
+    }
+
+    private func preflightPolishingEndpoint(reason: String) {
+        let configuredEndpoint = settings.llmPolishingEndpointURL.trimmed
+        guard settings.polishingBackendMode == .externalURL,
+              let endpoint = URL(string: configuredEndpoint),
+              LocalNetworkEndpointPolicy.preflightTarget(for: endpoint) != nil
+        else { return }
+        localNetworkPermissionPreflight.preflight(endpoint: endpoint, reason: reason)
     }
 
     /// Managed speechd's launch arguments carry this setting; a running engine

--- a/Sources/localvoxtral/LocalNetworkPermissionPreflight.swift
+++ b/Sources/localvoxtral/LocalNetworkPermissionPreflight.swift
@@ -1,0 +1,206 @@
+import Foundation
+import Network
+
+/// Identifies endpoints for which an outbound TCP connection can settle the
+/// macOS 15 Local Network permission before a dictation or polish request is in
+/// flight. Public Internet and loopback destinations are deliberately excluded.
+enum LocalNetworkEndpointPolicy {
+    struct Target: Hashable, Sendable {
+        let host: String
+        let port: UInt16
+    }
+
+    static func preflightTarget(for endpoint: URL) -> Target? {
+        guard let scheme = endpoint.scheme?.lowercased(),
+              ["http", "https", "ws", "wss"].contains(scheme),
+              var host = endpoint.host?.lowercased(),
+              !host.isEmpty
+        else { return nil }
+
+        if host.hasPrefix("["), host.hasSuffix("]") {
+            host = String(host.dropFirst().dropLast())
+        }
+        if let scopeMarker = host.firstIndex(of: "%") {
+            host = String(host[..<scopeMarker])
+        }
+        host = host.trimmingCharacters(in: CharacterSet(charactersIn: "."))
+
+        guard isLocalNetworkHost(host) else { return nil }
+
+        let resolvedPort = endpoint.port ?? defaultPort(for: scheme)
+        guard let resolvedPort,
+              (1...Int(UInt16.max)).contains(resolvedPort)
+        else { return nil }
+
+        return Target(host: host, port: UInt16(resolvedPort))
+    }
+
+    private static func defaultPort(for scheme: String) -> Int? {
+        switch scheme {
+        case "http", "ws": return 80
+        case "https", "wss": return 443
+        default: return nil
+        }
+    }
+
+    private static func isLocalNetworkHost(_ host: String) -> Bool {
+        if let ipv4 = IPv4Address(host) {
+            return isPrivateOrLinkLocalIPv4(Array(ipv4.rawValue))
+        }
+
+        if let ipv6 = IPv6Address(host) {
+            return isPrivateOrLinkLocalIPv6(Array(ipv6.rawValue))
+        }
+
+        guard host != "localhost" else { return false }
+        return !host.contains(".")
+            || host.hasSuffix(".local")
+            || host.hasSuffix(".lan")
+            || host.hasSuffix(".home.arpa")
+    }
+
+    private static func isPrivateOrLinkLocalIPv4(_ bytes: [UInt8]) -> Bool {
+        guard bytes.count == 4 else { return false }
+        switch (bytes[0], bytes[1]) {
+        case (10, _):
+            return true
+        case (100, 64...127):
+            return true
+        case (169, 254):
+            return true
+        case (172, 16...31):
+            return true
+        case (192, 168):
+            return true
+        default:
+            return false
+        }
+    }
+
+    private static func isPrivateOrLinkLocalIPv6(_ bytes: [UInt8]) -> Bool {
+        guard bytes.count == 16 else { return false }
+
+        // Unique-local (fc00::/7) and link-local (fe80::/10). ::1 remains
+        // excluded, as do globally routable IPv6 addresses.
+        if bytes[0] & 0xFE == 0xFC { return true }
+        if bytes[0] == 0xFE, bytes[1] & 0xC0 == 0x80 { return true }
+
+        // IPv4-mapped IPv6 literals use the same private/link-local policy.
+        let isIPv4Mapped = bytes[0..<10].allSatisfy { $0 == 0 }
+            && bytes[10] == 0xFF && bytes[11] == 0xFF
+        if isIPv4Mapped {
+            return isPrivateOrLinkLocalIPv4(Array(bytes[12..<16]))
+        }
+        return false
+    }
+}
+
+@MainActor
+protocol LocalNetworkPermissionPreflighting: AnyObject {
+    func preflight(endpoint: URL, reason: String)
+}
+
+/// Starts a payload-free TCP connection and retains it while macOS presents a
+/// Local Network consent sheet. Ready and terminal failures are both sufficient:
+/// the permission decision has happened before the real feature needs the host.
+@MainActor
+final class LocalNetworkPermissionPreflight: LocalNetworkPermissionPreflighting {
+    private enum Completion: Sendable {
+        case ready
+        case failed(String)
+        case cancelled
+    }
+
+    private static let queue = DispatchQueue(
+        label: "com.localvoxtral.local-network-permission-preflight",
+        qos: .utility
+    )
+
+    private var attemptedTargets: Set<LocalNetworkEndpointPolicy.Target> = []
+    private var activeConnections: [LocalNetworkEndpointPolicy.Target: NWConnection] = [:]
+    private var loggedWaitingTargets: Set<LocalNetworkEndpointPolicy.Target> = []
+
+    func preflight(endpoint: URL, reason: String) {
+        guard let target = LocalNetworkEndpointPolicy.preflightTarget(for: endpoint) else {
+            return
+        }
+        guard attemptedTargets.insert(target).inserted else {
+            Log.backends.info(
+                "local-network permission preflight already requested for \(target.host, privacy: .private):\(target.port, privacy: .public)"
+            )
+            return
+        }
+
+        guard let port = NWEndpoint.Port(rawValue: target.port) else {
+            Log.backends.error(
+                "local-network permission preflight rejected invalid port \(target.port, privacy: .public)"
+            )
+            return
+        }
+
+        Log.backends.info(
+            "local-network permission preflight requested reason=\(reason, privacy: .public) host=\(target.host, privacy: .private) port=\(target.port, privacy: .public)"
+        )
+        let connection = NWConnection(host: NWEndpoint.Host(target.host), port: port, using: .tcp)
+        activeConnections[target] = connection
+        connection.stateUpdateHandler = { [weak self] state in
+            switch state {
+            case .ready:
+                Task { @MainActor [weak self] in self?.finish(target, completion: .ready) }
+            case .failed(let error):
+                let detail = String(describing: error)
+                Task {
+                    @MainActor [weak self] in
+                    self?.finish(target, completion: .failed(detail))
+                }
+            case .cancelled:
+                Task { @MainActor [weak self] in self?.finish(target, completion: .cancelled) }
+            case .waiting(let error):
+                let detail = String(describing: error)
+                Task { @MainActor [weak self] in self?.logWaiting(target, detail: detail) }
+            default:
+                break
+            }
+        }
+        connection.start(queue: Self.queue)
+    }
+
+    private func logWaiting(_ target: LocalNetworkEndpointPolicy.Target, detail: String) {
+        guard loggedWaitingTargets.insert(target).inserted else { return }
+        Log.backends.info(
+            "local-network permission preflight waiting host=\(target.host, privacy: .private) port=\(target.port, privacy: .public) detail=\(detail, privacy: .public)"
+        )
+    }
+
+    private func finish(
+        _ target: LocalNetworkEndpointPolicy.Target,
+        completion: Completion
+    ) {
+        guard let connection = activeConnections.removeValue(forKey: target) else { return }
+        loggedWaitingTargets.remove(target)
+        connection.stateUpdateHandler = nil
+        connection.cancel()
+
+        switch completion {
+        case .ready:
+            Log.backends.info(
+                "local-network permission preflight connected host=\(target.host, privacy: .private) port=\(target.port, privacy: .public)"
+            )
+        case .failed(let detail):
+            Log.backends.error(
+                "local-network permission preflight failed host=\(target.host, privacy: .private) port=\(target.port, privacy: .public) detail=\(detail, privacy: .public)"
+            )
+        case .cancelled:
+            Log.backends.info(
+                "local-network permission preflight cancelled host=\(target.host, privacy: .private) port=\(target.port, privacy: .public)"
+            )
+        }
+    }
+
+    deinit {
+        for connection in activeConnections.values {
+            connection.stateUpdateHandler = nil
+            connection.cancel()
+        }
+    }
+}

--- a/Sources/localvoxtral/LocalNetworkPermissionPreflight.swift
+++ b/Sources/localvoxtral/LocalNetworkPermissionPreflight.swift
@@ -120,6 +120,12 @@ final class LocalNetworkPermissionPreflight: LocalNetworkPermissionPreflighting 
     private var activeConnections: [LocalNetworkEndpointPolicy.Target: NWConnection] = [:]
     private var loggedWaitingTargets: Set<LocalNetworkEndpointPolicy.Target> = []
 
+    #if DEBUG
+    /// Test seam: when set, called instead of opening a real NWConnection, so
+    /// tier-0 tests can drive the production dedupe/policy path networkless.
+    var debugProbeStarter: ((LocalNetworkEndpointPolicy.Target) -> Void)?
+    #endif
+
     func preflight(endpoint: URL, reason: String) {
         guard let target = LocalNetworkEndpointPolicy.preflightTarget(for: endpoint) else {
             return
@@ -141,6 +147,12 @@ final class LocalNetworkPermissionPreflight: LocalNetworkPermissionPreflighting 
         Log.backends.info(
             "local-network permission preflight requested reason=\(reason, privacy: .public) host=\(target.host, privacy: .private) port=\(target.port, privacy: .public)"
         )
+        #if DEBUG
+        if let debugProbeStarter {
+            debugProbeStarter(target)
+            return
+        }
+        #endif
         let connection = NWConnection(host: NWEndpoint.Host(target.host), port: port, using: .tcp)
         activeConnections[target] = connection
         connection.stateUpdateHandler = { [weak self] state in
@@ -197,6 +209,7 @@ final class LocalNetworkPermissionPreflight: LocalNetworkPermissionPreflighting 
         }
     }
 
+    @MainActor
     deinit {
         for connection in activeConnections.values {
             connection.stateUpdateHandler = nil

--- a/Sources/localvoxtral/SettingsView.swift
+++ b/Sources/localvoxtral/SettingsView.swift
@@ -33,7 +33,7 @@ struct SettingsView: View {
                 settings.endpointURL(for: settings.realtimeProvider)
             },
             set: { newValue in
-                settings.realtimeAPIEndpointURL = newValue
+                viewModel.applyRealtimeEndpointChange(newValue)
             }
         )
     }
@@ -183,6 +183,13 @@ private struct ConnectionSettingsPane: View {
     let endpointBinding: Binding<String>
     let modelBinding: Binding<String>
 
+    private var polishingEndpointBinding: Binding<String> {
+        Binding(
+            get: { settings.llmPolishingEndpointURL },
+            set: { viewModel.applyLLMPolishingEndpointChange($0) }
+        )
+    }
+
     private var dictationBackendModeBinding: Binding<BackendMode> {
         Binding(
             get: { settings.dictationBackendMode },
@@ -313,7 +320,7 @@ private struct ConnectionSettingsPane: View {
                     SettingsFieldRow(title: "Endpoint") {
                         TextField(
                             "http://127.0.0.1:8080/v1/chat/completions",
-                            text: $settings.llmPolishingEndpointURL
+                            text: polishingEndpointBinding
                         )
                         .textFieldStyle(.roundedBorder)
                     }

--- a/Sources/localvoxtral/localvoxtralApp.swift
+++ b/Sources/localvoxtral/localvoxtralApp.swift
@@ -175,6 +175,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         startClaudeContextBroker()
         startClaudeRemoteListener()
         reconcileBundledConfigDefaults()
+        viewModel.preflightConfiguredLocalNetworkEndpoints()
         guard !settingsStore.onboardingCompleted else { return }
         presentOnboarding()
     }

--- a/Tests/localvoxtralTests/LocalNetworkPermissionPreflightTests.swift
+++ b/Tests/localvoxtralTests/LocalNetworkPermissionPreflightTests.swift
@@ -15,7 +15,9 @@ final class LocalNetworkPermissionPreflightTests: XCTestCase {
             ("ws://[fe80::1234]:8000/realtime", "fe80::1234", 8000),
             ("ws://dictation-box.local:8000/realtime", "dictation-box.local", 8000),
             ("http://polisher.home.arpa:8080/v1/chat/completions", "polisher.home.arpa", 8080),
+            ("http://router.lan:8080/v1/chat/completions", "router.lan", 8080),
             ("ws://speech-server:8000/realtime", "speech-server", 8000),
+            ("http://[::ffff:10.0.0.5]:8080/v1/chat/completions", "::ffff:10.0.0.5", 8080),
         ]
 
         for (rawURL, expectedHost, expectedPort) in cases {
@@ -38,6 +40,7 @@ final class LocalNetworkPermissionPreflightTests: XCTestCase {
             "wss://api.openai.com/v1/realtime",
             "https://8.8.8.8/v1/chat/completions",
             "https://[2606:4700:4700::1111]/v1/chat/completions",
+            "http://[::ffff:8.8.8.8]:8080/v1/chat/completions",
             "file:///tmp/realtime.sock",
         ]
 
@@ -136,7 +139,9 @@ final class LocalNetworkPermissionPreflightTests: XCTestCase {
         )
     }
 
-    func testPackagedInfoPlistDeclaresLocalNetworkUsageWithoutBonjourBrowsing() throws {
+    func testPackagingScriptDeclaresLocalNetworkUsageWithoutBonjourBrowsing() throws {
+        // Asserts on the script text (the packaged-plist source of truth);
+        // the built bundle itself is covered by the packaging smoke lane.
         let repoRoot = URL(fileURLWithPath: #filePath)
             .deletingLastPathComponent()
             .deletingLastPathComponent()
@@ -164,6 +169,23 @@ final class LocalNetworkPermissionPreflightTests: XCTestCase {
         let defaults = UserDefaults(suiteName: suiteName)!
         defaults.removePersistentDomain(forName: suiteName)
         return (SettingsStore(defaults: defaults, environment: [:]), suiteName)
+    }
+
+    func testProductionPreflightDedupesRepeatedTargetsWithoutOpeningConnections() throws {
+        let preflight = LocalNetworkPermissionPreflight()
+        var probed: [LocalNetworkEndpointPolicy.Target] = []
+        preflight.debugProbeStarter = { probed.append($0) }
+
+        let lan = try XCTUnwrap(URL(string: "ws://192.168.50.4:8000/realtime"))
+        preflight.preflight(endpoint: lan, reason: "edit")
+        preflight.preflight(endpoint: lan, reason: "launch")
+        let loopback = try XCTUnwrap(URL(string: "ws://127.0.0.1:8000/realtime"))
+        preflight.preflight(endpoint: loopback, reason: "edit")
+        let otherPort = try XCTUnwrap(URL(string: "ws://192.168.50.4:8080/realtime"))
+        preflight.preflight(endpoint: otherPort, reason: "edit")
+
+        XCTAssertEqual(probed.map(\.host), ["192.168.50.4", "192.168.50.4"])
+        XCTAssertEqual(probed.map(\.port), [8000, 8080])
     }
 }
 

--- a/Tests/localvoxtralTests/LocalNetworkPermissionPreflightTests.swift
+++ b/Tests/localvoxtralTests/LocalNetworkPermissionPreflightTests.swift
@@ -1,0 +1,184 @@
+import Foundation
+import XCTest
+@testable import localvoxtral
+
+@MainActor
+final class LocalNetworkPermissionPreflightTests: XCTestCase {
+    func testPolicySelectsPrivateAndLocalOnlyEndpoints() throws {
+        let cases: [(String, String, UInt16)] = [
+            ("ws://10.0.0.8/realtime", "10.0.0.8", 80),
+            ("wss://172.31.255.2/realtime", "172.31.255.2", 443),
+            ("http://192.168.50.4:8080/v1/chat/completions", "192.168.50.4", 8080),
+            ("http://169.254.4.2:8472/v1/chat/completions", "169.254.4.2", 8472),
+            ("http://100.64.1.2:9000/v1/chat/completions", "100.64.1.2", 9000),
+            ("http://[fd00::5]:8080/v1/chat/completions", "fd00::5", 8080),
+            ("ws://[fe80::1234]:8000/realtime", "fe80::1234", 8000),
+            ("ws://dictation-box.local:8000/realtime", "dictation-box.local", 8000),
+            ("http://polisher.home.arpa:8080/v1/chat/completions", "polisher.home.arpa", 8080),
+            ("ws://speech-server:8000/realtime", "speech-server", 8000),
+        ]
+
+        for (rawURL, expectedHost, expectedPort) in cases {
+            let endpoint = try XCTUnwrap(URL(string: rawURL))
+            let target = try XCTUnwrap(
+                LocalNetworkEndpointPolicy.preflightTarget(for: endpoint),
+                "expected a preflight target for \(rawURL)"
+            )
+            XCTAssertEqual(target.host, expectedHost, rawURL)
+            XCTAssertEqual(target.port, expectedPort, rawURL)
+        }
+    }
+
+    func testPolicyRejectsLoopbackPublicAndUnsupportedEndpoints() throws {
+        let endpoints = [
+            "ws://127.0.0.1:8000/realtime",
+            "ws://127.22.4.9:8000/realtime",
+            "http://localhost:8080/v1/chat/completions",
+            "http://[::1]:8080/v1/chat/completions",
+            "wss://api.openai.com/v1/realtime",
+            "https://8.8.8.8/v1/chat/completions",
+            "https://[2606:4700:4700::1111]/v1/chat/completions",
+            "file:///tmp/realtime.sock",
+        ]
+
+        for rawURL in endpoints {
+            let endpoint = try XCTUnwrap(URL(string: rawURL))
+            XCTAssertNil(
+                LocalNetworkEndpointPolicy.preflightTarget(for: endpoint),
+                "must not probe \(rawURL)"
+            )
+        }
+    }
+
+    func testEndpointEditsProbeOnlyEligibleActiveExternalBackends() {
+        let (settings, suiteName) = makeSettings()
+        defer { UserDefaults.standard.removePersistentDomain(forName: suiteName) }
+        settings.dictationBackendMode = .externalURL
+        settings.polishingBackendMode = .externalURL
+        settings.llmPolishingEnabled = false
+        let preflight = RecordingLocalNetworkPermissionPreflight()
+        let viewModel = DictationViewModel(
+            settings: settings,
+            localNetworkPermissionPreflight: preflight,
+            startRuntimeServices: false
+        )
+
+        viewModel.applyRealtimeEndpointChange("ws://192.168.1.20:8000/v1/realtime")
+        viewModel.applyLLMPolishingEndpointChange("http://10.0.0.9:8080/v1/chat/completions")
+        viewModel.applyRealtimeEndpointChange("ws://127.0.0.1:8000/v1/realtime")
+        viewModel.applyLLMPolishingEndpointChange("https://api.example.com/v1/chat/completions")
+
+        XCTAssertEqual(
+            preflight.requests.map(\.endpoint.absoluteString),
+            [
+                "ws://192.168.1.20:8000/v1/realtime",
+                "http://10.0.0.9:8080/v1/chat/completions",
+            ]
+        )
+        XCTAssertEqual(
+            preflight.requests.map(\.reason),
+            ["dictation endpoint updated", "polishing endpoint updated"]
+        )
+    }
+
+    func testEndpointEditWhileManagedWaitsUntilExternalModeSwitch() {
+        let (settings, suiteName) = makeSettings()
+        defer { UserDefaults.standard.removePersistentDomain(forName: suiteName) }
+        settings.dictationBackendMode = .managedLocal
+        settings.polishingBackendMode = .managedLocal
+        settings.llmPolishingEnabled = false
+        let preflight = RecordingLocalNetworkPermissionPreflight()
+        let viewModel = DictationViewModel(
+            settings: settings,
+            localNetworkPermissionPreflight: preflight,
+            startRuntimeServices: false
+        )
+
+        viewModel.applyRealtimeEndpointChange("ws://192.168.2.30:8000/v1/realtime")
+        viewModel.applyLLMPolishingEndpointChange("http://10.2.0.4:8080/v1/chat/completions")
+        XCTAssertTrue(preflight.requests.isEmpty)
+
+        viewModel.applyDictationBackendModeChange(.externalURL)
+        viewModel.applyPolishingBackendModeChange(.externalURL)
+
+        XCTAssertEqual(
+            preflight.requests.map(\.endpoint.absoluteString),
+            [
+                "ws://192.168.2.30:8000/v1/realtime",
+                "http://10.2.0.4:8080/v1/chat/completions",
+            ]
+        )
+    }
+
+    func testConfiguredExternalEndpointsArePreflightedBeforeUse() {
+        let (settings, suiteName) = makeSettings()
+        defer { UserDefaults.standard.removePersistentDomain(forName: suiteName) }
+        settings.dictationBackendMode = .externalURL
+        settings.polishingBackendMode = .externalURL
+        settings.realtimeAPIEndpointURL = "ws://192.168.3.5:8000/v1/realtime"
+        settings.llmPolishingEndpointURL = "http://polisher.local:8080/v1/chat/completions"
+        settings.llmPolishingEnabled = false
+        let preflight = RecordingLocalNetworkPermissionPreflight()
+        let viewModel = DictationViewModel(
+            settings: settings,
+            localNetworkPermissionPreflight: preflight,
+            startRuntimeServices: false
+        )
+
+        viewModel.preflightConfiguredLocalNetworkEndpoints()
+
+        XCTAssertEqual(
+            preflight.requests.map(\.endpoint.absoluteString),
+            [
+                "ws://192.168.3.5:8000/v1/realtime",
+                "http://polisher.local:8080/v1/chat/completions",
+            ]
+        )
+    }
+
+    func testPackagedInfoPlistDeclaresLocalNetworkUsageWithoutBonjourBrowsing() throws {
+        let repoRoot = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+        let packageScript = repoRoot.appendingPathComponent("scripts/package_app.sh")
+        let source = try String(contentsOf: packageScript, encoding: .utf8)
+
+        XCTAssertTrue(source.contains("<key>NSLocalNetworkUsageDescription</key>"))
+        XCTAssertTrue(source.contains("transcription and polishing servers you configure"))
+        XCTAssertFalse(source.contains("<key>NSBonjourServices</key>"))
+
+        for key in [
+            "NSDesktopFolderUsageDescription",
+            "NSDocumentsFolderUsageDescription",
+            "NSDownloadsFolderUsageDescription",
+            "NSNetworkVolumesUsageDescription",
+            "NSRemovableVolumesUsageDescription",
+        ] {
+            XCTAssertTrue(source.contains("<key>\(key)</key>"), "missing \(key)")
+        }
+    }
+
+    private func makeSettings() -> (SettingsStore, String) {
+        let suiteName = "localvoxtral.LocalNetworkPreflight.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defaults.removePersistentDomain(forName: suiteName)
+        return (SettingsStore(defaults: defaults, environment: [:]), suiteName)
+    }
+}
+
+@MainActor
+private final class RecordingLocalNetworkPermissionPreflight:
+    LocalNetworkPermissionPreflighting
+{
+    struct Request {
+        let endpoint: URL
+        let reason: String
+    }
+
+    private(set) var requests: [Request] = []
+
+    func preflight(endpoint: URL, reason: String) {
+        requests.append(Request(endpoint: endpoint, reason: reason))
+    }
+}

--- a/scripts/package_app.sh
+++ b/scripts/package_app.sh
@@ -283,9 +283,19 @@ cat > "$APP_DIR/Contents/Info.plist" <<PLIST
   <key>NSMicrophoneUsageDescription</key>
   <string>localvoxtral needs microphone access for live dictation.</string>
   <key>NSLocalNetworkUsageDescription</key>
-  <string>localvoxtral needs local network access to reach realtime transcription endpoints.</string>
+  <string>localvoxtral needs local network access to connect to transcription and polishing servers you configure.</string>
   <key>NSAppleEventsUsageDescription</key>
   <string>localvoxtral asks Ghostty which terminal pane is focused, so dictation context comes from the Claude Code session you are actually talking to.</string>
+  <key>NSDesktopFolderUsageDescription</key>
+  <string>localvoxtral reads project files from Claude Code sessions when project context is enabled.</string>
+  <key>NSDocumentsFolderUsageDescription</key>
+  <string>localvoxtral reads project files from Claude Code sessions when project context is enabled.</string>
+  <key>NSDownloadsFolderUsageDescription</key>
+  <string>localvoxtral reads project files from Claude Code sessions when project context is enabled.</string>
+  <key>NSNetworkVolumesUsageDescription</key>
+  <string>localvoxtral reads project files from Claude Code sessions when project context is enabled.</string>
+  <key>NSRemovableVolumesUsageDescription</key>
+  <string>localvoxtral reads project files from Claude Code sessions when project context is enabled.</string>
 </dict>
 </plist>
 PLIST


### PR DESCRIPTION
### What

Proactively request macOS 15 Local Network permission when a user configures a custom LAN transcription or polishing endpoint, instead of allowing the first permission sheet/denial to surface during dictation.

- Add a pure local-endpoint classifier and injected, payload-free `NWConnection` preflight.
- Trigger it when an eligible External URL is edited, when a backend switches to External URL, and at launch for stored external endpoints.
- Exclude loopback, managed helpers, public internet endpoints, and unsupported schemes; deduplicate host/port attempts and log outcomes through `Log.backends`.
- Expand `NSLocalNetworkUsageDescription`; omit `NSBonjourServices` because no Bonjour APIs are used.
- Add the missing protected-folder purpose strings used by opt-in Claude repository collection.
- Add six no-network unit tests for classification, trigger wiring, mode gating, startup behavior, and packaged plist declarations.

The permissions audit found no current need for Input Monitoring, Screen Recording, Speech Recognition, Camera, Keychain, or Full Disk Access. PR #167's Ghostty Automation consent prewarm covers both relevant settings and the delayed-Ghostty-launch case.

### Proof

- [x] Unit suite green — `./scripts/remote-build.sh test`

  ```text
  Executed 1833 tests, with 2 tests skipped and 0 failures (0 unexpected) in 62.876 (62.968) seconds
  ```

- [ ] Realtime integration green — not required for a permission-preflight/plist change; no realtime protocol or inference behavior changed.
- [x] Bug fix: regression test added — controlled failing run before restoring the implementation:

  ```text
  Executed 1 test, with 2 failures (0 unexpected) in 0.184 (0.185) seconds
  ```

  Focused passing run after the fix:

  ```text
  Executed 6 tests, with 0 failures (0 unexpected) in 0.070 (0.071) seconds
  ```

- [ ] UI change: owner-Mac TCC hand test pending. Follow the exact checklist in `.agent-runs/w1-permissions/final.md`, including fresh-user/VM Local Network cases and public/loopback negative cases.

Health gate before verification:

```text
OK: SSH gate reachable (gate v2)
WARN: build host low on disk (23 GiB free < 25 GiB)
```

LLM polish live-model lane: skipped locally — this changes endpoint permission preflight and plist copy, not prompts, models, sampling, request payloads, context attachment, or output semantics.

Speechd live-model lane: skipped locally — no helper engine, model pin, or realtime integration contract changed. CI may conservatively run it because the packaged plist source changed.

Nightly agent-dictation E2E: skipped — neither the ASR→polish feature pipeline nor its eval harness/corpus changed.

### Review round (opencode GLM-5.2)

Initial verdict FAIL with 5 findings, all addressed in the follow-up commit: `@MainActor deinit` (house pattern — note the plain deinit did compile and pass the full suite, so "compile-blocking" was overstated, but isolation is the correct shape), IPv4-mapped-IPv6 positive+negative and `.lan` classifier test rows, packaging test renamed to say what it actually asserts, and a DEBUG probe seam so the production class's dedupe runs networkless in tier 0 (`testProductionPreflightDedupesRepeatedTargetsWithoutOpeningConnections`).

Post-fix suite:
```
Executed 1834 tests, with 2 tests skipped and 0 failures (0 unexpected) in 59.726 (59.806) seconds
```

The full permission matrix (permission × plist key × trigger before/after), Apple references, and the owner-Mac hand-test checklist (fresh-user/VM Local Network cases) are in the PR discussion below.
