### PR TITLE
ablate-agent-eval: context-decomposition variants (tooling only)

### DIFF
--- a/Tests/localvoxtralTests/AgentDictationE2EEvalSupportTests.swift
+++ b/Tests/localvoxtralTests/AgentDictationE2EEvalSupportTests.swift
@@ -696,6 +696,21 @@ final class AgentDictationE2EEvalSupportTests: XCTestCase {
         assert "Reference context" in messages[-1]["content"]
         assert "- DictationViewModel.swift: Dictation View Model" in messages[-1]["content"]
         assert "Working text:\nOpen Dictation View Model." in messages[-1]["content"]
+        no_context = module.current_production_messages(
+            record, system, user, include_vocabulary=False, include_context=False
+        )
+        assert "Reference context" not in no_context[-1]["content"]
+        assert "Repository vocabulary" not in no_context[-1]["content"]
+        vocabulary_only = module.current_production_messages(
+            record, system, user, include_context=False
+        )
+        assert "Reference context" not in vocabulary_only[-1]["content"]
+        assert "Repository vocabulary" in vocabulary_only[-1]["content"]
+        context_only = module.current_production_messages(
+            record, system, user, include_vocabulary=False
+        )
+        assert "Reference context" in context_only[-1]["content"]
+        assert "Repository vocabulary" not in context_only[-1]["content"]
         oracle = module.current_production_messages(record, system, user, oracle=True)
         assert "Evaluation-only oracle technical spellings" in oracle[-1]["content"]
         assert "- DictationViewModel.swift" in oracle[-1]["content"]

--- a/scripts/ablate-agent-eval.py
+++ b/scripts/ablate-agent-eval.py
@@ -87,6 +87,9 @@ VARIANT_HELP = {
     "pre-compact": "production deterministic pre-processing -> compact language-preserving prompt -> model",
     "raw-production-v2": "raw ASR -> Markdown-friendly production prompt with missing literal examples -> model",
     "current-production": "production pre-LLM text -> current checked-in production prompt/context -> model",
+    "current-production-no-context": "current production request without vocabulary pairs or reference context",
+    "current-production-vocabulary-only": "current production request with vocabulary pairs but no reference context",
+    "current-production-context-only": "current production request with reference context but no vocabulary pairs",
     "current-production-oracle": "current production request + exact evaluation-only technical spelling hints",
     "current-production-grounded": "current production request + broad grounded repo/context candidates",
     "current-production-oracle-strict": "current production request + mandatory evaluation-only exact literals",
@@ -384,11 +387,17 @@ def rendered_user_prompts(
 def current_production_messages(
     record: dict[str, Any], system_prompt: str, user_template: str, oracle: bool = False,
     extra_dictionary: str = "",
+    include_vocabulary: bool = True,
+    include_context: bool = True,
 ) -> list[dict[str, str]]:
     input_text = record.get("polishInputText") or record.get("transcript")
     if not isinstance(input_text, str):
         raise ValueError("case has no production polish input")
     replacement_dictionary, clipboard_context = recorded_dynamic_sections(record)
+    if not include_vocabulary:
+        replacement_dictionary = ""
+    if not include_context:
+        clipboard_context = ""
     if extra_dictionary:
         replacement_dictionary = "\n\n".join(
             value for value in (replacement_dictionary, extra_dictionary) if value
@@ -865,6 +874,10 @@ def messages_for(
                 "current-production-oracle-strict",
             },
             extra_dictionary=extra_dictionary,
+            include_vocabulary=variant != "current-production-no-context"
+            and variant != "current-production-context-only",
+            include_context=variant != "current-production-no-context"
+            and variant != "current-production-vocabulary-only",
         )
         if variant == "current-production-grounded":
             return append_grounded_candidate_check(messages, record)


### PR DESCRIPTION
## What

Three tooling-only ablation variants for `scripts/ablate-agent-eval.py` — `current-production-no-context`, `current-production-vocabulary-only`, `current-production-context-only` — so the Claude-context feature's incremental contribution can be measured per component. Production prompts and code untouched; the `include_*` parameters default to prior behavior.

These variants produced the 2026-07-21 context-decomposition eval (nightly run 29810140788, 163/163 cases). Headlines, full report in the eval workspace:
- 4B production 80/163 @76.3% → 4B + exact-evidence oracle **117/163 @82.0%** (+37/-0 cases). The 27B ceiling adds only one case over 4B-with-oracle — headroom is evidence quality, not model size.
- Clipboard excerpt-only 13/13 @91.8% beats excerpt+pairs 12/13 @88.4% — redundant pairs after preapplication can hurt.
- The conflicting-mishearing-pair field failure reproduces and survives two prompt-only fixes — the fix must be deterministic filtering before rendering (separate follow-up).

## Proof

- [x] opencode (GLM-5.2) review: **PASS** — reviewer executed the module: existing variants' request payloads byte-identical (cache identity `(case, endpoint, variant, payload)` unchanged, warm caches still hit); the six new test assertions all evaluate true against the implementation.
- [x] Tier-0 suite covers the embedded-module test (`AgentDictationE2EEvalSupportTests`); CI runs it per-push.
- LLM lanes: the eval-support test file is in the llm-lane-filter list, so CI decides; the change alters only evaluation tooling, never what production sends to a model.
