### PR TITLE
Polishing endpoint accepts a base URL

### DIFF
--- a/Sources/localvoxtral/DiagnosticsExporter.swift
+++ b/Sources/localvoxtral/DiagnosticsExporter.swift
@@ -81,6 +81,9 @@ enum DiagnosticsExporter {
 
         let polishingSummary: String
         if let polishing = settings.llmPolishingConfiguration {
+            // Deliberately the pre-normalization URL as the user typed it; the
+            // wire request appends /v1/chat/completions to a base URL
+            // (LLMPolishingService.normalizedChatCompletionsURL).
             polishingSummary = sanitizedEndpointDescription(from: polishing.endpointURL)
         } else {
             polishingSummary = "<disabled>"

--- a/Sources/localvoxtral/LLMPolishingService.swift
+++ b/Sources/localvoxtral/LLMPolishingService.swift
@@ -158,13 +158,75 @@ struct LLMPolishingService: LLMPolishingServicing {
         )
     }
 
+    /// Maps a user-entered polishing endpoint to the effective OpenAI-compatible
+    /// `chat/completions` URL, so the Settings field accepts a bare base URL
+    /// (the convention every OpenAI-compatible client follows) while remaining
+    /// backward compatible with the full `/v1/chat/completions` URLs users used
+    /// to have to type.
+    ///
+    /// The path is inspected case-insensitively; the scheme, host, port, and
+    /// query are never altered — only the path is rewritten, so the Local
+    /// Network preflight (which classifies by host/port) sees the same target.
+    /// Rules:
+    /// - A path already ending in `/chat/completions` (with or without a
+    ///   trailing slash) is returned exactly as given. llama.cpp, vLLM, LM
+    ///   Studio, and Ollama's OpenAI-compat surface all expose
+    ///   `/v1/chat/completions`, so any full URL round-trips unchanged.
+    /// - An empty path or `/` (the base-URL case) gets `/v1/chat/completions`
+    ///   appended: `http://127.0.0.1:8080` → `http://127.0.0.1:8080/v1/chat/completions`.
+    /// - A path ending in `/v1` (or `/v1/`) gets `/chat/completions` appended.
+    ///   This also covers proxy prefixes that still mount the OpenAI API under
+    ///   `/v1` (`/proxy/v1` → `/proxy/v1/chat/completions`).
+    /// - Any other non-empty path is treated as a base and gets
+    ///   `/v1/chat/completions` appended, since that is where every server above
+    ///   mounts the OpenAI API.
+    ///
+    /// Appending never introduces a new double slash (a `//` already inside the
+    /// input path is preserved as typed). Query and fragment are preserved. If
+    /// the input cannot be broken into URL components it is returned unchanged,
+    /// so the existing failure handling (an invalid endpoint yields a nil
+    /// configuration and no request) still applies.
+    static func normalizedChatCompletionsURL(_ url: URL) -> URL {
+        guard var components = URLComponents(url: url, resolvingAgainstBaseURL: false)
+        else { return url }
+
+        // Trailing slashes are insignificant for the decision; collapse them to
+        // a single canonical path before matching so `/v1/` and `/v1` behave
+        // alike and appended segments never produce `//`.
+        var path = components.path
+        while path.count > 1, path.hasSuffix("/") {
+            path.removeLast()
+        }
+        let lowered = path.lowercased()
+
+        if lowered.hasSuffix("/chat/completions") {
+            // Already a full chat/completions URL — leave the user's input
+            // exactly as typed (including any trailing slash).
+            return url
+        }
+
+        let effectivePath: String
+        if path.isEmpty || path == "/" {
+            effectivePath = "/v1/chat/completions"
+        } else if lowered.hasSuffix("/v1") {
+            effectivePath = path + "/chat/completions"
+        } else {
+            effectivePath = path + "/v1/chat/completions"
+        }
+
+        components.path = effectivePath
+        return components.url ?? url
+    }
+
     /// The full URLRequest for one polish call — the single construction path
     /// (and the test seam pinning the timeout without networking).
     static func makeURLRequest(
         request: LLMPolishingRequest,
         configuration: LLMPolishingConfiguration
     ) throws -> URLRequest {
-        var urlRequest = URLRequest(url: configuration.endpointURL)
+        var urlRequest = URLRequest(
+            url: normalizedChatCompletionsURL(configuration.endpointURL)
+        )
         urlRequest.httpMethod = "POST"
         urlRequest.setValue("application/json", forHTTPHeaderField: "Content-Type")
         if !configuration.apiKey.isEmpty {

--- a/Sources/localvoxtral/SettingsView.swift
+++ b/Sources/localvoxtral/SettingsView.swift
@@ -319,10 +319,16 @@ private struct ConnectionSettingsPane: View {
                 case .externalURL:
                     SettingsFieldRow(title: "Endpoint") {
                         TextField(
-                            "http://127.0.0.1:8080/v1/chat/completions",
+                            "http://127.0.0.1:8080",
                             text: polishingEndpointBinding
                         )
                         .textFieldStyle(.roundedBorder)
+
+                        SettingsHelpText(
+                            "Enter a base URL (e.g. http://127.0.0.1:8080); "
+                                + "/v1/chat/completions is appended automatically. "
+                                + "A full …/v1/chat/completions URL still works."
+                        )
                     }
 
                     SettingsFieldRow(title: "API key") {

--- a/Tests/localvoxtralTests/LLMPolishingServiceTests.swift
+++ b/Tests/localvoxtralTests/LLMPolishingServiceTests.swift
@@ -199,4 +199,146 @@ final class LLMPolishingServiceTests: XCTestCase {
         XCTAssertNil(legacyJSON["thinking_budget_tokens"])
         XCTAssertNil(legacyRequest.value(forHTTPHeaderField: "x-bf-passthrough-extra-params"))
     }
+
+    // MARK: - Base-URL normalization
+
+    /// The endpoint field accepts a bare base URL (the OpenAI-compatible
+    /// convention) while still round-tripping the full `/v1/chat/completions`
+    /// URLs users used to have to type. Table-driven so every documented shape
+    /// is pinned in one place.
+    func testNormalizedChatCompletionsURLMapsEveryEndpointShape() {
+        let cases: [(input: String, expected: String)] = [
+            // Base URL (empty path) — port present and absent.
+            ("http://127.0.0.1:8080", "http://127.0.0.1:8080/v1/chat/completions"),
+            ("http://127.0.0.1:8080/", "http://127.0.0.1:8080/v1/chat/completions"),
+            ("https://api.example.com", "https://api.example.com/v1/chat/completions"),
+            // Ollama-style base URL.
+            ("http://localhost:11434", "http://localhost:11434/v1/chat/completions"),
+            // Path ending in /v1 (with and without trailing slash).
+            ("http://127.0.0.1:8080/v1", "http://127.0.0.1:8080/v1/chat/completions"),
+            ("http://127.0.0.1:8080/v1/", "http://127.0.0.1:8080/v1/chat/completions"),
+            // Proxy prefix that still mounts the OpenAI API under /v1.
+            ("http://gw.example/proxy/v1", "http://gw.example/proxy/v1/chat/completions"),
+            ("http://gw.example/proxy/v1/", "http://gw.example/proxy/v1/chat/completions"),
+            // Other non-empty base path — appended under /v1.
+            ("http://gw.example/openai", "http://gw.example/openai/v1/chat/completions"),
+            ("http://gw.example/openai/", "http://gw.example/openai/v1/chat/completions"),
+            // Full URL passthrough (with and without trailing slash — unchanged).
+            (
+                "https://api.openai.com/v1/chat/completions",
+                "https://api.openai.com/v1/chat/completions"
+            ),
+            (
+                "https://api.openai.com/v1/chat/completions/",
+                "https://api.openai.com/v1/chat/completions/"
+            ),
+            // A full URL under a non-/v1 mount also passes through unchanged.
+            (
+                "http://gw.example/proxy/chat/completions",
+                "http://gw.example/proxy/chat/completions"
+            ),
+            // Uppercase path: append case-insensitively, preserve the base case.
+            ("http://127.0.0.1:8080/V1", "http://127.0.0.1:8080/V1/chat/completions"),
+            (
+                "https://api.openai.com/V1/CHAT/COMPLETIONS",
+                "https://api.openai.com/V1/CHAT/COMPLETIONS"
+            ),
+            // Scheme is irrelevant to the path rewrite — a ws:// URL is
+            // rewritten identically (the config guard rejects it upstream; this
+            // pins that normalization itself is scheme-agnostic).
+            ("ws://127.0.0.1:8080", "ws://127.0.0.1:8080/v1/chat/completions"),
+            ("ws://127.0.0.1:8080/v1", "ws://127.0.0.1:8080/v1/chat/completions"),
+        ]
+
+        for testCase in cases {
+            let input = URL(string: testCase.input)!
+            let normalized = LLMPolishingService.normalizedChatCompletionsURL(input)
+            XCTAssertEqual(
+                normalized.absoluteString,
+                testCase.expected,
+                "normalizing \(testCase.input)"
+            )
+            XCTAssertFalse(
+                normalized.path.contains("//"),
+                "normalizing \(testCase.input) produced a double slash: \(normalized.path)"
+            )
+        }
+    }
+
+    /// Normalization only rewrites the path — host and port (which the Local
+    /// Network permission preflight classifies on) are never altered, so a base
+    /// URL and its normalized form preflight the same target.
+    func testNormalizedChatCompletionsURLPreservesHostAndPort() {
+        let cases = [
+            "http://127.0.0.1:8080",
+            "http://192.168.1.50:1234/v1",
+            "https://api.example.com",
+            "http://gw.example/proxy/v1",
+            "http://[fd00::5]:8080/v1",
+        ]
+        for input in cases {
+            let url = URL(string: input)!
+            let normalized = LLMPolishingService.normalizedChatCompletionsURL(url)
+            XCTAssertEqual(normalized.host, url.host, "host changed for \(input)")
+            XCTAssertEqual(normalized.port, url.port, "port changed for \(input)")
+            XCTAssertEqual(normalized.scheme, url.scheme, "scheme changed for \(input)")
+        }
+    }
+
+    /// A query string is carried through untouched when the path is rewritten.
+    func testNormalizedChatCompletionsURLPreservesQuery() {
+        let url = URL(string: "http://127.0.0.1:8080?tenant=acme")!
+        XCTAssertEqual(
+            LLMPolishingService.normalizedChatCompletionsURL(url).absoluteString,
+            "http://127.0.0.1:8080/v1/chat/completions?tenant=acme"
+        )
+    }
+
+    /// Degenerate / opaque input must never trap and must never change the
+    /// scheme: upstream endpoint validation (which rejects anything
+    /// `URL(string:)` cannot parse, and anything that is not http/https) stays
+    /// the sole gate on what is actually requested. Normalization here is
+    /// path-only and total.
+    func testNormalizedChatCompletionsURLPreservesSchemeForOpaqueInput() {
+        let opaque = URL(string: "mailto:polish@example.com")!
+        let normalized = LLMPolishingService.normalizedChatCompletionsURL(opaque)
+        XCTAssertEqual(normalized.scheme, "mailto")
+    }
+
+    /// End-to-end proof that a base-URL configuration produces a request whose
+    /// URL targets `/v1/chat/completions` — the whole point of accepting a base
+    /// URL in Settings.
+    func testMakeURLRequestNormalizesBaseURLConfigurationToChatCompletions() throws {
+        let configuration = LLMPolishingConfiguration(
+            endpointURL: URL(string: "http://127.0.0.1:8080")!,
+            apiKey: "",
+            model: "model"
+        )
+        let urlRequest = try LLMPolishingService.makeURLRequest(
+            request: request,
+            configuration: configuration
+        )
+        XCTAssertEqual(
+            urlRequest.url?.absoluteString,
+            "http://127.0.0.1:8080/v1/chat/completions"
+        )
+    }
+
+    /// A full-URL configuration reaches the wire byte-for-byte unchanged
+    /// (backward compatibility for everyone who already typed the full path).
+    func testMakeURLRequestLeavesFullURLConfigurationUnchanged() throws {
+        let configuration = LLMPolishingConfiguration(
+            endpointURL: URL(string: "https://api.openai.com/v1/chat/completions")!,
+            apiKey: "",
+            model: "model"
+        )
+        let urlRequest = try LLMPolishingService.makeURLRequest(
+            request: request,
+            configuration: configuration
+        )
+        XCTAssertEqual(
+            urlRequest.url?.absoluteString,
+            "https://api.openai.com/v1/chat/completions"
+        )
+    }
 }


### PR DESCRIPTION
## What

The External URL polishing endpoint field now accepts a plain base URL (`http://127.0.0.1:8080`), matching how OpenAI-compatible clients are conventionally configured. A new pure `LLMPolishingService.normalizedChatCompletionsURL(_:)` derives the request URL at the single request-construction point (`makeURLRequest`):

- path already ends in `/chat/completions` → passed through verbatim (full URLs keep working, byte-identical requests)
- empty path → `/v1/chat/completions` appended
- path ending in `/v1` (proxy prefixes included) → `/chat/completions` appended
- any other base path → `/v1/chat/completions` appended (llama.cpp, vLLM, LM Studio, and Ollama's OpenAI compat all mount there)

The stored setting is never rewritten — normalization is request-side only. The Settings placeholder/help text now shows the base-URL form. The Local Network preflight is unaffected: it classifies on scheme/host/port only, which normalization never touches (pinned by test).

## Proof

- [x] Unit suite green — `./scripts/remote-build.sh test` (run twice: after implementation, and after review fixes):
  ```
  Executed 1886 tests, with 2 tests skipped and 0 failures (0 unexpected) in 71.885 (71.978) seconds
  ```
  New tier-0 coverage: `testNormalizedChatCompletionsURLMapsEveryEndpointShape` (table-driven: bare host, trailing slashes, `/v1`, proxy prefix, case-insensitivity, ws scheme), `testNormalizedChatCompletionsURLPreservesHostAndPort` (incl. IPv6 literal), `testNormalizedChatCompletionsURLPreservesQuery`, `testNormalizedChatCompletionsURLPreservesSchemeForOpaqueInput`, `testMakeURLRequestNormalizesBaseURLConfigurationToChatCompletions`, `testMakeURLRequestLeavesFullURLConfigurationUnchanged`.
- [x] Adversarial review (opencode GLM-5.2): **PASS**, no blockers; its INFO findings (doc-comment overclaim on internal double slashes, opaque-input test name wider than its assertion, missing IPv6 case, redundant `VStack`, diagnostics showing the pre-normalization URL without saying so) are addressed in this diff. Deliberate non-changes: full-URL passthrough keeps a trailing slash exactly as before (backward compat), and a non-`/v1` proxy base gets `/v1/chat/completions` per the documented rule — users with exotic mounts type the full URL, which passes through.
- [x] LLM lane: `LLMPolishingService.swift` matches `llm-lane-filter.sh`, so the polishd live lane runs on this PR. Managed mode is provably unaffected (its constant endpoint already ends in `/chat/completions` → verbatim passthrough).
- Settings pane: group count/identity unchanged (help text lives inside the existing Endpoint field row).