### PR TITLE
One-click Claude remote enrollment: confirmed ssh-config insert + stdin-token remote setup

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -348,8 +348,8 @@ Key subsystems:
     `ClaudeRemoteHostRegistry` (0600 atomic file, token hashes only,
     constant-time compare, immediate revoke/rotate). No enrolled host ⇒ no port
     bound. `ClaudeRemoteEnrollmentService` generates the ssh-config snippet and
-    the `claude plugin` commands; it mutates nothing without an injected runner,
-    and nothing supplies one.
+    the `claude plugin` commands; Settings can apply either only after a second,
+    explicit confirmation that repeats the exact text.
   - Shared: `ClaudeSessionRegistry` (Mutex, injected clock) holds the prior
     prompt, cwd, recent files, remote snippets, and a broker-allocated marker,
     returned to the hook as an OSC 2 `terminalSequence` so the marker rides the
@@ -434,16 +434,24 @@ Key subsystems:
   them, so hosts cannot collide or forge each other's sessions. Bounded,
   sanitized remote prompt/file/tool excerpts may feed the same context budget,
   but there is no remote repository collector.
-- **Remote enrollment is copy-only: no host is ever mutated.**
-  `ClaudeRemoteEnrollmentService` generates a copyable plan (idempotent ssh
-  config block, `claude plugin` commands, verify/uninstall steps, caveats); its
-  `executeRemoteSetup` throws `.executionNotConfigured` unless a runner is
-  injected, and the app injects none — Settings shows the plan with Copy
-  buttons and runs nothing. Keep it that way: the install command carries the
-  token in argv, so any runner that spawns a process exposes it in the REMOTE
-  host's process list. `executeRemoteSetup` takes the token only to redact it
-  back out of what it throws; it cannot redact a runner's own argv. A runner
-  that must exist feeds the token via stdin/environment, not argv.
+- **Remote enrollment execution is opt-in, preview-first, and keeps the token
+  out of process arguments.** `ClaudeRemoteEnrollmentService` generates a
+  copyable plan (idempotent ssh config block, `claude plugin` commands,
+  verify/uninstall steps, caveats), and the Copy buttons remain available.
+  One-click actions require a separate confirmation that repeats the exact
+  ssh-config block or redacted command list. Local insertion replaces only the
+  matching host's marked block, preserves an existing config's permissions, and
+  atomically renames a same-directory temporary file; a missing `~/.ssh` and
+  config are created as 0700/0600. It refuses (with the copy path as the
+  documented out) when `~/.ssh/config` or `~/.ssh` is a symlink — a rename
+  would replace the link and desync a dotfiles setup — or when `~/.ssh` is not
+  owned by the user or is group/world-writable. Remote execution spawns only `ssh -o
+  BatchMode=yes <alias> /bin/sh -s` and sends the generated token-bearing script
+  through stdin — the token must never enter an argv. The whole action has a
+  finite timeout, and every captured result, thrown error, alert, and log string
+  is token-redacted before it leaves the service. Keep the filesystem and
+  process runners injected; the no-runner service must continue to throw
+  `.executionNotConfigured`.
   `ClaudeIntegrationSettingsModel` (`@MainActor @Observable`, all seams
   injected) owns the pane's logic, and `ClaudeRemoteListenerCoordinator` owns
   the bind/unbind decision — enrolling the first host binds immediately and
@@ -453,7 +461,7 @@ Key subsystems:
   A bind conflict is reported, never routed around onto another port: a
   squatter on 8473 receives the remote's bearer token before anything rejects
   it, so the user must learn it is there. Note also what is NOT defensible: a
-  malicious process running as the user on the REMOTE host can read
+  malicious process running as the user on the REMOTE host can still read
   `~/.claude/` and therefore the plugin's token no matter what we do. Say so
   rather than implying the token bounds it.
 

--- a/Sources/localvoxtral/ClaudeContext/ClaudeIntegrationSettingsModel.swift
+++ b/Sources/localvoxtral/ClaudeContext/ClaudeIntegrationSettingsModel.swift
@@ -37,6 +37,29 @@ public struct ClaudePluginActionFailure: Sendable, Equatable {
     }
 }
 
+public struct ClaudeEnrollmentActionFailure: Sendable, Equatable {
+    public var serviceError: ClaudeRemoteEnrollmentService.ServiceError?
+    public var describedError: String
+
+    public init(_ error: any Error) {
+        serviceError = error as? ClaudeRemoteEnrollmentService.ServiceError
+        describedError = String(describing: error)
+    }
+}
+
+public struct ClaudeEnrollmentActionAttempt: Sendable, Equatable {
+    public var steps: [ClaudeRemoteEnrollmentService.ExecutionStep]
+    public var failure: ClaudeEnrollmentActionFailure?
+
+    public init(
+        steps: [ClaudeRemoteEnrollmentService.ExecutionStep],
+        failure: ClaudeEnrollmentActionFailure?
+    ) {
+        self.steps = steps
+        self.failure = failure
+    }
+}
+
 /// Settings-pane state for both Claude Code integrations.
 ///
 /// `@MainActor @Observable`, per repo convention for stateful UI controllers.
@@ -118,15 +141,37 @@ public final class ClaudeIntegrationSettingsModel {
     /// call that made it. It is `private(set)`, it is cleared by `dismissPlan`,
     /// and nothing writes it anywhere. The registry cannot reissue it — that is
     /// the whole point of storing only hashes — so the user gets one chance to
-    /// copy it, and rotation is the recovery path.
+    /// copy it. It is not persisted locally; one-click setup only carries it in
+    /// the confirmed SSH process's stdin. Rotation is the recovery path.
     public struct EnrollmentPresentation: Identifiable, Equatable, Sendable {
         public var id: String { host.id }
         public var host: ClaudeRemoteHost
         public var token: String
+        public var sshHostAlias: String
         public var plan: ClaudeRemoteEnrollmentService.SetupPlan
         /// Rotation reuses this sheet; the copy differs because the user's
         /// situation does (their remote is currently broken, on purpose).
         public var isRotation: Bool
+    }
+
+    public enum EnrollmentAction: Sendable, Equatable {
+        case insertSSHConfig
+        case runRemoteSetup
+    }
+
+    public struct EnrollmentConfirmation: Identifiable, Equatable, Sendable {
+        public var id = UUID()
+        public var action: EnrollmentAction
+        public var title: String
+        public var preview: String
+        public var confirmButtonTitle: String
+    }
+
+    public struct EnrollmentStepStatus: Identifiable, Equatable, Sendable {
+        public var id: Int
+        public var text: String
+        public var succeeded: Bool
+        public var detail: String
     }
 
     /// Long-form detail. Alerts and the log take this; the pane never renders it
@@ -146,6 +191,9 @@ public final class ClaudeIntegrationSettingsModel {
     public private(set) var pluginResult: String?
     public private(set) var isPerformingPluginAction = false
     public private(set) var presentedPlan: EnrollmentPresentation?
+    public private(set) var enrollmentConfirmation: EnrollmentConfirmation?
+    public private(set) var enrollmentStepStatuses: [EnrollmentStepStatus] = []
+    public private(set) var isPerformingEnrollmentAction = false
     public var alert: DetailAlert?
 
     /// Enrollment form. Free-form because the user is typing; validated on
@@ -164,6 +212,7 @@ public final class ClaudeIntegrationSettingsModel {
     private let registry: ClaudeRemoteHostRegistry?
     private let listener: (any ClaudeRemoteListenerControlling)?
     private let pluginService: @Sendable () -> any ClaudePluginInstalling
+    private let enrollmentService: ClaudeRemoteEnrollmentService
     /// Runs one plugin action and returns its failure, or nil.
     ///
     /// Off the main actor by default: `claude plugin install` fetches, and 60s
@@ -171,6 +220,9 @@ public final class ClaudeIntegrationSettingsModel {
     /// production hop would make every assertion a race.
     private let performAsync:
         @Sendable (@escaping @Sendable () throws -> Void) async -> ClaudePluginActionFailure?
+    private let performEnrollmentAsync:
+        @Sendable (@escaping @Sendable () throws -> [ClaudeRemoteEnrollmentService.ExecutionStep]) async
+            -> ClaudeEnrollmentActionAttempt
 
     /// - Parameters:
     ///   - registry: nil when the host file could not be read at launch. The
@@ -182,6 +234,7 @@ public final class ClaudeIntegrationSettingsModel {
         registry: ClaudeRemoteHostRegistry?,
         listener: (any ClaudeRemoteListenerControlling)?,
         pluginService: @escaping @Sendable () -> any ClaudePluginInstalling,
+        enrollmentService: ClaudeRemoteEnrollmentService = ClaudeRemoteEnrollmentService(),
         performAsync: @escaping @Sendable (@escaping @Sendable () throws -> Void) async -> ClaudePluginActionFailure? = { body in
             await Task.detached(priority: .userInitiated) {
                 do {
@@ -191,12 +244,28 @@ public final class ClaudeIntegrationSettingsModel {
                     return ClaudePluginActionFailure(error)
                 }
             }.value
+        },
+        performEnrollmentAsync: @escaping @Sendable (
+            @escaping @Sendable () throws -> [ClaudeRemoteEnrollmentService.ExecutionStep]
+        ) async -> ClaudeEnrollmentActionAttempt = { body in
+            await Task.detached(priority: .userInitiated) {
+                do {
+                    return ClaudeEnrollmentActionAttempt(steps: try body(), failure: nil)
+                } catch {
+                    return ClaudeEnrollmentActionAttempt(
+                        steps: [],
+                        failure: ClaudeEnrollmentActionFailure(error)
+                    )
+                }
+            }.value
         }
     ) {
         self.registry = registry
         self.listener = listener
         self.pluginService = pluginService
+        self.enrollmentService = enrollmentService
         self.performAsync = performAsync
+        self.performEnrollmentAsync = performEnrollmentAsync
         refreshHosts()
         refreshListenerStatus()
     }
@@ -320,9 +389,15 @@ public final class ClaudeIntegrationSettingsModel {
                 token: enrollment.token,
                 port: listener?.boundPort ?? ClaudeRemoteListenerLimits.default.port
             )
+            // A fresh sheet must not inherit a previous host's step results —
+            // a still-running earlier action can repopulate the statuses after
+            // dismissPlan() cleared them.
+            enrollmentConfirmation = nil
+            enrollmentStepStatuses = []
             presentedPlan = EnrollmentPresentation(
                 host: enrollment.host,
                 token: enrollment.token,
+                sshHostAlias: alias,
                 plan: plan,
                 isRotation: false
             )
@@ -351,9 +426,14 @@ public final class ClaudeIntegrationSettingsModel {
                 token: enrollment.token,
                 port: listener?.boundPort ?? ClaudeRemoteListenerLimits.default.port
             )
+            enrollmentConfirmation = nil
+            enrollmentStepStatuses = []
             presentedPlan = EnrollmentPresentation(
                 host: enrollment.host,
                 token: enrollment.token,
+                sshHostAlias: ClaudeRemoteEnrollmentService.isValidHostAlias(enrollment.host.label)
+                    ? enrollment.host.label
+                    : "your-ssh-host",
                 plan: plan,
                 isRotation: true
             )
@@ -403,6 +483,172 @@ public final class ClaudeIntegrationSettingsModel {
     public func dismissPlan() {
         // The plaintext goes with it. Nothing else holds a copy.
         presentedPlan = nil
+        enrollmentConfirmation = nil
+        enrollmentStepStatuses = []
+    }
+
+    public func requestSSHConfigInsertion() {
+        guard let presentation = presentedPlan, !isPerformingEnrollmentAction else { return }
+        enrollmentStepStatuses = []
+        enrollmentConfirmation = EnrollmentConfirmation(
+            action: .insertSSHConfig,
+            title: "Insert this exact block into ~/.ssh/config?",
+            preview: presentation.plan.sshConfigSnippet,
+            confirmButtonTitle: "Confirm Insert"
+        )
+        Log.claudeContext.info("Claude remote ssh config confirmation requested")
+    }
+
+    public func requestRemoteSetup() {
+        guard let presentation = presentedPlan, !isPerformingEnrollmentAction else { return }
+        enrollmentStepStatuses = []
+        enrollmentConfirmation = EnrollmentConfirmation(
+            action: .runRemoteSetup,
+            title: "Run these commands on the SSH host?",
+            preview: Self.redactedRemoteCommands(for: presentation),
+            confirmButtonTitle: "Confirm Run"
+        )
+        Log.claudeContext.info("Claude remote setup confirmation requested")
+    }
+
+    public func cancelEnrollmentActionConfirmation() {
+        enrollmentConfirmation = nil
+    }
+
+    public func confirmEnrollmentAction() async {
+        guard let confirmation = enrollmentConfirmation,
+              let presentation = presentedPlan,
+              !isPerformingEnrollmentAction
+        else { return }
+        enrollmentConfirmation = nil
+        isPerformingEnrollmentAction = true
+        enrollmentStepStatuses = []
+        defer { isPerformingEnrollmentAction = false }
+
+        let service = enrollmentService
+        let attempt = await performEnrollmentAsync {
+            switch confirmation.action {
+            case .insertSSHConfig:
+                try service.insertSSHConfig(presentation.plan, hostID: presentation.host.id)
+                return []
+            case .runRemoteSetup:
+                return try service.executeRemoteSetup(
+                    presentation.plan,
+                    sshHostAlias: presentation.sshHostAlias,
+                    token: presentation.token
+                )
+            }
+        }
+
+        // The sheet may have been dismissed (window close) and even replaced
+        // while the detached work ran; a late result must not surface under a
+        // different host's sheet.
+        guard presentedPlan?.host.id == presentation.host.id else { return }
+
+        if let failure = attempt.failure {
+            enrollmentStepStatuses = Self.failureStatuses(
+                failure,
+                action: confirmation.action
+            )
+            alert = DetailAlert(
+                title: "Remote Claude Code setup",
+                detail: Self.enrollmentFailureDetail(failure)
+            )
+            Log.claudeContext.error(
+                "Claude remote enrollment action failed: \(failure.describedError, privacy: .public)"
+            )
+            return
+        }
+
+        switch confirmation.action {
+        case .insertSSHConfig:
+            enrollmentStepStatuses = [
+                EnrollmentStepStatus(
+                    id: 0, text: "SSH config updated.", succeeded: true, detail: ""
+                )
+            ]
+        case .runRemoteSetup:
+            enrollmentStepStatuses = attempt.steps.map {
+                EnrollmentStepStatus(
+                    id: $0.index,
+                    text: "Step \($0.index + 1) succeeded.",
+                    succeeded: true,
+                    detail: $0.message
+                )
+            }
+        }
+    }
+
+    public static func redactedRemoteCommands(for presentation: EnrollmentPresentation) -> String {
+        presentation.plan.remoteCommands
+            .map { ClaudeRemoteTokenRedaction.redact($0, token: presentation.token) }
+            .joined(separator: "\n")
+    }
+
+    private static func failureStatuses(
+        _ failure: ClaudeEnrollmentActionFailure,
+        action: EnrollmentAction
+    ) -> [EnrollmentStepStatus] {
+        guard action == .runRemoteSetup else {
+            return [EnrollmentStepStatus(id: 0, text: "SSH config update failed.", succeeded: false, detail: failure.describedError)]
+        }
+
+        let failedStep: Int
+        let detail: String
+        switch failure.serviceError {
+        case .commandFailed(let step, _, _, let message):
+            failedStep = step
+            detail = message
+        case .commandTimedOut(let step, _, _, let message):
+            failedStep = step
+            detail = message
+        case .runnerFailed(let step, _, let message):
+            failedStep = step
+            detail = message
+        default:
+            return [EnrollmentStepStatus(id: 0, text: "Remote setup failed.", succeeded: false, detail: failure.describedError)]
+        }
+        let succeeded = (0..<failedStep).map {
+            EnrollmentStepStatus(id: $0, text: "Step \($0 + 1) succeeded.", succeeded: true, detail: "")
+        }
+        return succeeded + [
+            EnrollmentStepStatus(
+                id: failedStep,
+                text: "Step \(failedStep + 1) failed.",
+                succeeded: false,
+                detail: detail
+            )
+        ]
+    }
+
+    static func enrollmentFailureDetail(_ failure: ClaudeEnrollmentActionFailure) -> String {
+        switch failure.serviceError {
+        case .commandTimedOut(_, _, let seconds, let message):
+            let output = message.isEmpty ? "" : "\n\n\(message)"
+            return "SSH setup did not finish within \(Int(seconds))s and was stopped.\(output)"
+        case .commandFailed(_, _, let exitCode, let message):
+            return "SSH setup exited with code \(exitCode).\n\n\(message)"
+        case .runnerFailed(_, _, let message):
+            return "SSH setup could not run.\n\n\(message)"
+        case .invalidSSHConfigEncoding:
+            return "~/.ssh/config is not valid UTF-8, so localvoxtral left it unchanged."
+        case .sshConfigIsSymlink:
+            return "~/.ssh/config (or ~/.ssh) is a symlink — likely a dotfiles setup. "
+                + "localvoxtral won't replace the link; use the Copy button and add the block "
+                + "to the real file yourself."
+        case .sshDirectoryNotTrusted:
+            return "~/.ssh is not exclusively writable by you (wrong owner or group/world-"
+                + "writable), so localvoxtral left it unchanged. Fix its permissions "
+                + "(chmod 700 ~/.ssh) or use the Copy button."
+        case .sshConfigEditingNotConfigured:
+            return "Editing ~/.ssh/config is not available in this build."
+        case .executionNotConfigured:
+            return "Running SSH setup is not available in this build."
+        case .invalidHostAlias:
+            return "The SSH host alias is invalid."
+        case .none:
+            return failure.describedError
+        }
     }
 
     private func reconcileListener(presentAlert: Bool = true) {

--- a/Sources/localvoxtral/ClaudeContext/ClaudeRemoteEnrollmentLiveIO.swift
+++ b/Sources/localvoxtral/ClaudeContext/ClaudeRemoteEnrollmentLiveIO.swift
@@ -1,0 +1,228 @@
+import Foundation
+
+#if canImport(Darwin)
+import Darwin
+
+struct LiveClaudeRemoteSSHConfigFileSystem: ClaudeRemoteSSHConfigFileSystem {
+    private let sshDirectoryURL: URL
+    private let configURL: URL
+
+    init(homeDirectoryURL: URL = FileManager.default.homeDirectoryForCurrentUser) {
+        sshDirectoryURL = homeDirectoryURL.appendingPathComponent(".ssh", isDirectory: true)
+        configURL = sshDirectoryURL.appendingPathComponent("config", isDirectory: false)
+    }
+
+    func readState() throws -> ClaudeRemoteSSHConfigState {
+        let fileManager = FileManager.default
+        // lstat, not stat: the service's trust gate needs to see symlinks as
+        // symlinks (a rename would replace the link, not its target).
+        let directoryMetadata = ClaudeSocketGuard.metadata(ofPath: sshDirectoryURL.path)
+        let configMetadata = ClaudeSocketGuard.metadata(ofPath: configURL.path)
+        let directoryExists = directoryMetadata?.isDirectory == true
+        let data: Data?
+        if configMetadata != nil, configMetadata?.isSymlink != true {
+            data = try Data(contentsOf: configURL)
+        } else {
+            data = nil
+        }
+        let permissions: UInt16?
+        if data != nil,
+           let number = try fileManager.attributesOfItem(atPath: configURL.path)[.posixPermissions]
+                as? NSNumber {
+            permissions = number.uint16Value
+        } else {
+            permissions = nil
+        }
+        return ClaudeRemoteSSHConfigState(
+            directoryExists: directoryExists,
+            configData: data,
+            configPermissions: permissions,
+            directoryIsSymlink: directoryMetadata?.isSymlink == true,
+            directoryOwnedByCurrentUser:
+                directoryMetadata.map { $0.ownerUID == UInt32(geteuid()) } ?? true,
+            directoryPermissions: directoryMetadata?.mode,
+            configIsSymlink: configMetadata?.isSymlink == true
+        )
+    }
+
+    func createSSHDirectory(permissions: UInt16) throws {
+        try FileManager.default.createDirectory(
+            at: sshDirectoryURL,
+            withIntermediateDirectories: true,
+            attributes: [.posixPermissions: NSNumber(value: permissions)]
+        )
+    }
+
+    func atomicWriteConfig(_ data: Data, permissions: UInt16) throws {
+        let temporaryURL = sshDirectoryURL.appendingPathComponent(
+            ".config.localvoxtral.\(UUID().uuidString)",
+            isDirectory: false
+        )
+        let descriptor = temporaryURL.path.withCString {
+            open($0, O_WRONLY | O_CREAT | O_EXCL | O_NOFOLLOW, 0o600)
+        }
+        guard descriptor >= 0 else { throw POSIXFailure(operation: "open", code: errno) }
+        var renamed = false
+        defer {
+            close(descriptor)
+            if !renamed { _ = temporaryURL.path.withCString { unlink($0) } }
+        }
+        guard fchmod(descriptor, mode_t(permissions)) == 0 else {
+            throw POSIXFailure(operation: "fchmod", code: errno)
+        }
+        try data.withUnsafeBytes { raw in
+            guard let baseAddress = raw.baseAddress else { return }
+            var offset = 0
+            while offset < raw.count {
+                let written = Self.retryingOnEINTR {
+                    Darwin.write(
+                        descriptor,
+                        baseAddress.advanced(by: offset),
+                        raw.count - offset
+                    )
+                }
+                guard written > 0 else {
+                    throw POSIXFailure(operation: "write", code: errno)
+                }
+                offset += written
+            }
+        }
+        guard fsync(descriptor) == 0 else { throw POSIXFailure(operation: "fsync", code: errno) }
+        let moved = temporaryURL.path.withCString { source in
+            configURL.path.withCString { destination in rename(source, destination) }
+        }
+        guard moved == 0 else {
+            throw POSIXFailure(operation: "rename", code: errno)
+        }
+        renamed = true
+    }
+
+    private struct POSIXFailure: Error, CustomStringConvertible {
+        var operation: String
+        var code: Int32
+        var description: String { "\(operation) failed with errno \(code)" }
+    }
+
+    private static func retryingOnEINTR(_ body: () -> Int) -> Int {
+        while true {
+            let result = body()
+            if result == -1, errno == EINTR { continue }
+            return result
+        }
+    }
+}
+
+extension ClaudeRemoteEnrollmentService {
+    static func live() -> ClaudeRemoteEnrollmentService {
+        ClaudeRemoteEnrollmentService(
+            runner: processRunner(),
+            sshConfigFileSystem: LiveClaudeRemoteSSHConfigFileSystem()
+        )
+    }
+
+    /// Runs `ssh` with stdin preloaded before launch, so the token-bearing
+    /// script is never written after a child could close its pipe.
+    static func processRunner(
+        sshExecutableURL: URL = URL(fileURLWithPath: "/usr/bin/ssh")
+    ) -> Runner {
+        { invocation in
+            // The preload below writes the whole script into the pipe before
+            // the child exists to drain it; past the kernel pipe buffer that
+            // write would block forever with no timeout running yet. Scripts
+            // here are a few hundred bytes — refuse loudly long before the
+            // buffer, rather than deadlock, if a future plan grows one.
+            guard invocation.standardInput.count <= 8 * 1024 else {
+                throw RunnerFailure.outputTooLarge(
+                    capBytes: 8 * 1024,
+                    message: "generated setup script exceeds the stdin preload budget"
+                )
+            }
+            let process = Process()
+            process.executableURL = sshExecutableURL
+            process.arguments = Array(invocation.argv.dropFirst())
+
+            let input = Pipe()
+            process.standardInput = input
+            try input.fileHandleForWriting.write(contentsOf: invocation.standardInput)
+            try input.fileHandleForWriting.close()
+
+            let output = Pipe()
+            process.standardOutput = output
+            process.standardError = output
+            let exited = DispatchSemaphore(value: 0)
+            process.terminationHandler = { _ in exited.signal() }
+            try process.run()
+
+            func waitForExit(_ window: TimeInterval) -> Bool {
+                exited.wait(timeout: .now() + max(window, 0)) == .success
+            }
+
+            func stopChild() {
+                _ = ClaudePluginInstallService.terminateBounded(
+                    gracePeriod: ClaudePluginInstallService.terminationGracePeriod,
+                    terminate: { process.terminate() },
+                    kill: {
+                        let pid = process.processIdentifier
+                        if pid > 0, process.isRunning { _ = Darwin.kill(pid, SIGKILL) }
+                    },
+                    waitForExit: waitForExit
+                )
+            }
+
+            let descriptor = output.fileHandleForReading.fileDescriptor
+            let deadline = Date().addingTimeInterval(max(invocation.timeout, 0))
+            var collected = Data()
+            var timedOut = false
+            var outputTooLarge = false
+
+            while true {
+                let remaining = deadline.timeIntervalSinceNow
+                if remaining <= 0 {
+                    timedOut = true
+                    break
+                }
+                var descriptorPoll = pollfd(fd: descriptor, events: Int16(POLLIN), revents: 0)
+                let ready = poll(&descriptorPoll, 1, Int32(remaining * 1_000))
+                if ready < 0 {
+                    if errno == EINTR { continue }
+                    break
+                }
+                if ready == 0 {
+                    timedOut = true
+                    break
+                }
+                let chunk = POSIXPipeRead.nextChunk(fromDescriptor: descriptor)
+                if chunk.isEmpty { break }
+                collected.append(chunk)
+                if collected.count > maxCapturedOutputBytes {
+                    outputTooLarge = true
+                    break
+                }
+            }
+
+            if !timedOut, !outputTooLarge,
+               !waitForExit(deadline.timeIntervalSinceNow) {
+                timedOut = true
+            }
+            let message = String(decoding: collected.prefix(maxCapturedOutputBytes), as: UTF8.self)
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+
+            if timedOut {
+                stopChild()
+                throw RunnerFailure.timedOut(seconds: invocation.timeout, message: message)
+            }
+            if outputTooLarge {
+                stopChild()
+                throw RunnerFailure.outputTooLarge(
+                    capBytes: maxCapturedOutputBytes,
+                    message: message
+                )
+            }
+            return RunResult(
+                exitCode: process.terminationStatus,
+                message: String(message.prefix(2_000))
+            )
+        }
+    }
+}
+#endif

--- a/Sources/localvoxtral/ClaudeContext/ClaudeRemoteEnrollmentService.swift
+++ b/Sources/localvoxtral/ClaudeContext/ClaudeRemoteEnrollmentService.swift
@@ -1,22 +1,46 @@
 import Foundation
 
-/// Generates — and, only when explicitly asked, executes — the setup for a
-/// remote Claude Code host.
-///
-/// The rule this type is built around: **localvoxtral never edits a config file
-/// it does not own.** Not `~/.ssh/config`, not `~/.claude/settings.json`, not the
-/// remote host's anything. Those files are the user's, they are load-bearing for
-/// work that has nothing to do with dictation, and a third-party app rewriting
-/// one is how a setup gets corrupted during an unrelated upgrade.
-///
-/// So the output is a PLAN: a snippet to paste, commands to run, and the exact
-/// steps to undo all of it. `applySSHConfigSnippet` exists for the day a UI
-/// wants to offer the edit, and it is a pure function over the file's text with
-/// a delimited block — but nothing here writes it, and `execute` refuses unless
-/// a caller supplied a runner on purpose.
-///
-/// Nothing in the app supplies one today. This task builds the surface; it
-/// mutates no host.
+public struct ClaudeRemoteSSHConfigState: Sendable, Equatable {
+    public var directoryExists: Bool
+    public var configData: Data?
+    public var configPermissions: UInt16?
+    /// lstat-derived trust facts. The live filesystem fills them so the pure
+    /// service can refuse to write through a path another principal controls;
+    /// the defaults describe the trustworthy case so existing fakes stay valid.
+    public var directoryIsSymlink: Bool
+    public var directoryOwnedByCurrentUser: Bool
+    public var directoryPermissions: UInt16?
+    public var configIsSymlink: Bool
+
+    public init(
+        directoryExists: Bool,
+        configData: Data?,
+        configPermissions: UInt16?,
+        directoryIsSymlink: Bool = false,
+        directoryOwnedByCurrentUser: Bool = true,
+        directoryPermissions: UInt16? = nil,
+        configIsSymlink: Bool = false
+    ) {
+        self.directoryExists = directoryExists
+        self.configData = configData
+        self.configPermissions = configPermissions
+        self.directoryIsSymlink = directoryIsSymlink
+        self.directoryOwnedByCurrentUser = directoryOwnedByCurrentUser
+        self.directoryPermissions = directoryPermissions
+        self.configIsSymlink = configIsSymlink
+    }
+}
+
+/// Filesystem seam for the one local file the enrollment flow may edit.
+public protocol ClaudeRemoteSSHConfigFileSystem: Sendable {
+    func readState() throws -> ClaudeRemoteSSHConfigState
+    func createSSHDirectory(permissions: UInt16) throws
+    func atomicWriteConfig(_ data: Data, permissions: UInt16) throws
+}
+
+/// Generates and, after a separate UI confirmation, applies the setup for a
+/// remote Claude Code host. Both mutation paths are injected so tests cannot
+/// reach the real home directory or a real SSH host.
 public struct ClaudeRemoteEnrollmentService: Sendable {
     /// Everything the user needs, in the order they need it.
     public struct SetupPlan: Sendable, Equatable {
@@ -46,24 +70,74 @@ public struct ClaudeRemoteEnrollmentService: Sendable {
         public var succeeded: Bool { exitCode == 0 }
     }
 
+    public struct Invocation: Sendable, Equatable {
+        /// Complete argv, including `ssh`, so a fake can prove no token reached
+        /// any process argument.
+        public var argv: [String]
+        public var standardInput: Data
+        public var timeout: TimeInterval
+
+        public init(argv: [String], standardInput: Data, timeout: TimeInterval) {
+            self.argv = argv
+            self.standardInput = standardInput
+            self.timeout = timeout
+        }
+    }
+
+    public struct ExecutionStep: Sendable, Equatable {
+        public var index: Int
+        /// Redacted; kept for diagnostics — the sheet renders only per-step
+        /// status text plus `message`.
+        public var command: String
+        public var message: String
+
+        public init(index: Int, command: String, message: String) {
+            self.index = index
+            self.command = command
+            self.message = message
+        }
+    }
+
+    /// Errors thrown by a runner before it can return an exit status. They are
+    /// caught and redacted by `executeRemoteSetup`; callers never receive one.
+    public enum RunnerFailure: Error, Equatable {
+        case timedOut(seconds: TimeInterval, message: String)
+        case outputTooLarge(capBytes: Int, message: String)
+    }
+
     public enum ServiceError: Error, Equatable {
         /// No runner was injected, which is the default. Executing setup is an
         /// opt-in a caller makes deliberately, never a fallback this type
         /// reaches for.
         case executionNotConfigured
+        case sshConfigEditingNotConfigured
+        case invalidSSHConfigEncoding
+        /// `~/.ssh/config` (or `~/.ssh` itself) is a symlink. A rename-based
+        /// atomic write would replace the link with a regular file and silently
+        /// desync a dotfiles-managed setup, so the app refuses and leaves the
+        /// copy path — which mutates nothing — as the way in.
+        case sshConfigIsSymlink
+        /// `~/.ssh` exists but is not exclusively the user's to write (wrong
+        /// owner, or group/world-writable). Report, never repair.
+        case sshDirectoryNotTrusted
         /// `command` and `message` are REDACTED (`ClaudeRemoteTokenRedaction`)
         /// before they reach this case. An `Error` is the single most-copied
         /// string in any app: it lands in alerts, in `Log`, in the user's bug
         /// report, and — because `localizedDescription` is free — in places
         /// nobody audited. A token that reaches an error is a token that leaks,
         /// so it never reaches one.
-        case commandFailed(command: [String], exitCode: Int32, message: String)
+        case commandFailed(step: Int, command: String, exitCode: Int32, message: String)
+        case commandTimedOut(step: Int, command: String, seconds: TimeInterval, message: String)
+        case runnerFailed(step: Int, command: String, message: String)
         case invalidHostAlias
     }
 
-    /// argv in, result out. Injected so tests pin the exact commands without
-    /// spawning anything, and so no code path can reach a real host by accident.
-    public typealias Runner = @Sendable ([String]) throws -> RunResult
+    /// Invocation in, result out. The stdin field is load-bearing: the bearer
+    /// token must never be placed in argv.
+    public typealias Runner = @Sendable (Invocation) throws -> RunResult
+
+    public static let defaultRemoteSetupTimeout: TimeInterval = 60
+    static let maxCapturedOutputBytes = 64 * 1024
 
     /// Marketplace reference for a remote host, which has no app bundle to
     /// register a local directory from. `claude plugin marketplace add` accepts
@@ -77,9 +151,14 @@ public struct ClaudeRemoteEnrollmentService: Sendable {
     public static let tokenConfigKey = "token"
 
     private let runner: Runner?
+    private let sshConfigFileSystem: (any ClaudeRemoteSSHConfigFileSystem)?
 
-    public init(runner: Runner? = nil) {
+    public init(
+        runner: Runner? = nil,
+        sshConfigFileSystem: (any ClaudeRemoteSSHConfigFileSystem)? = nil
+    ) {
         self.runner = runner
+        self.sshConfigFileSystem = sshConfigFileSystem
     }
 
     public static var remotePluginReference: String {
@@ -94,8 +173,8 @@ public struct ClaudeRemoteEnrollmentService: Sendable {
     ///   - sshHostAlias: the `Host` stanza name in `~/.ssh/config`. Validated,
     ///     not escaped — an alias is a bare token and anything else is a mistake
     ///     we should surface rather than quietly rewrite.
-    ///   - token: the plaintext, which exists only here and in the user's
-    ///     clipboard. Not stored, not logged.
+    ///   - token: the plaintext used to generate the copyable command and, after
+    ///     confirmation, its SSH stdin script. Not stored or logged.
     public static func plan(
         host: ClaudeRemoteHost,
         sshHostAlias: String,
@@ -193,7 +272,7 @@ public struct ClaudeRemoteEnrollmentService: Sendable {
                 + "into a local path.",
             "Revoking the host in localvoxtral is the real off switch and takes effect immediately. "
                 + "Uninstalling the remote plugin only stops it asking.",
-            "The install command puts the token in the remote shell's history unless your shell is "
+            "The copied install command puts the token in the remote shell's history unless your shell is "
                 + "set to ignore space-prefixed commands (HISTCONTROL=ignorespace / setopt "
                 + "HIST_IGNORE_SPACE). If it landed there, rotate the token — that is what rotation "
                 + "is for.",
@@ -210,7 +289,7 @@ public struct ClaudeRemoteEnrollmentService: Sendable {
         ]
     }
 
-    // MARK: - SSH config editing (pure; nothing here writes a file)
+    // MARK: - SSH config editing
 
     /// Insert or replace this host's block in an ssh config's text.
     ///
@@ -273,45 +352,171 @@ public struct ClaudeRemoteEnrollmentService: Sendable {
         return result.joined(separator: "\n")
     }
 
+    /// Atomically insert or replace one host's marked block in `~/.ssh/config`.
+    /// The caller is responsible for obtaining the user's explicit confirmation
+    /// immediately before calling this method.
+    public func insertSSHConfig(_ plan: SetupPlan, hostID: String) throws {
+        Log.claudeContext.info("Claude remote ssh config insertion requested")
+        guard let sshConfigFileSystem else {
+            Log.claudeContext.error("Claude remote ssh config insertion failed: editing not configured")
+            throw ServiceError.sshConfigEditingNotConfigured
+        }
+        do {
+            let state = try sshConfigFileSystem.readState()
+            // Trust gate before any write decision: never write through a
+            // symlink, and never into a directory another principal can also
+            // write. The copy path stays available for such setups.
+            guard !state.configIsSymlink, !state.directoryIsSymlink else {
+                throw ServiceError.sshConfigIsSymlink
+            }
+            if state.directoryExists {
+                guard state.directoryOwnedByCurrentUser,
+                      (state.directoryPermissions ?? 0) & 0o022 == 0
+                else { throw ServiceError.sshDirectoryNotTrusted }
+            }
+            let existing: String
+            if let data = state.configData {
+                guard let decoded = String(data: data, encoding: .utf8) else {
+                    throw ServiceError.invalidSSHConfigEncoding
+                }
+                existing = decoded
+            } else {
+                existing = ""
+            }
+            let updated = Self.applySSHConfigSnippet(
+                to: existing,
+                snippet: plan.sshConfigSnippet,
+                hostID: hostID
+            )
+            if !state.directoryExists {
+                try sshConfigFileSystem.createSSHDirectory(permissions: 0o700)
+            }
+            try sshConfigFileSystem.atomicWriteConfig(
+                Data(updated.utf8),
+                permissions: state.configPermissions ?? 0o600
+            )
+            Log.claudeContext.info("Claude remote ssh config insertion completed")
+        } catch {
+            Log.claudeContext.error(
+                "Claude remote ssh config insertion failed: \(String(describing: error), privacy: .public)"
+            )
+            throw error
+        }
+    }
+
     // MARK: - Execution (opt-in only)
 
     /// Run the plan's remote commands through the injected runner.
     ///
-    /// Throws `.executionNotConfigured` when no runner was supplied, which is
-    /// the default and the state the app ships in — the shipped Settings UI
-    /// hands the user copyable commands and executes nothing. The SSH config
-    /// snippet is never applied here either: it is the user's file, and the plan
-    /// hands them the text.
-    ///
-    /// **Process-argv exposure — read before injecting a runner.** The install
-    /// command carries the token as an argument, so any runner that spawns a
-    /// process makes that token visible in the REMOTE host's process list
-    /// (`ps`, `/proc/<pid>/cmdline`) for the lifetime of the command, to every
-    /// process on that host. `token` is passed separately rather than being
-    /// read back out of the plan so that this type can scrub it from anything it
-    /// throws; it cannot scrub the runner's own argv, which is why nothing in
-    /// the app supplies a runner. A runner that must exist should feed the token
-    /// over the child's stdin or environment instead of its argv, and take
-    /// `remoteCommands(token:)`'s output apart rather than shelling the string.
+    /// Throws `.executionNotConfigured` when no runner was supplied. Each plan
+    /// command is sent to `/bin/sh -s` over SSH stdin. The only spawned argv is
+    /// `ssh -o BatchMode=yes <alias> /bin/sh -s`, which contains no token.
     ///
     /// - Parameter token: the plaintext, used ONLY to redact it back out of any
     ///   failure. Nothing here logs or stores it.
-    public func executeRemoteSetup(_ plan: SetupPlan, sshHostAlias: String, token: String) throws {
-        guard let runner else { throw ServiceError.executionNotConfigured }
-        guard Self.isValidHostAlias(sshHostAlias) else { throw ServiceError.invalidHostAlias }
-        for command in plan.remoteCommands {
-            let argv = ["ssh", sshHostAlias, command.trimmingCharacters(in: .whitespaces)]
-            let result = try runner(argv)
+    @discardableResult
+    public func executeRemoteSetup(
+        _ plan: SetupPlan,
+        sshHostAlias: String,
+        token: String,
+        timeout: TimeInterval = defaultRemoteSetupTimeout
+    ) throws -> [ExecutionStep] {
+        Log.claudeContext.info("Claude remote setup execution requested")
+        guard let runner else {
+            Log.claudeContext.error("Claude remote setup execution failed: runner not configured")
+            throw ServiceError.executionNotConfigured
+        }
+        guard Self.isValidHostAlias(sshHostAlias) else {
+            Log.claudeContext.error("Claude remote setup execution failed: invalid host alias")
+            throw ServiceError.invalidHostAlias
+        }
+        let deadline = Date().addingTimeInterval(max(timeout, 0))
+        var completed: [ExecutionStep] = []
+        for (index, command) in plan.remoteCommands.enumerated() {
+            let displayCommand = ClaudeRemoteTokenRedaction.redact(
+                command.trimmingCharacters(in: .whitespaces),
+                token: token
+            )
+            let remaining = max(deadline.timeIntervalSinceNow, 0)
+            guard remaining > 0 else {
+                let failure = ServiceError.commandTimedOut(
+                    step: index, command: displayCommand, seconds: timeout, message: ""
+                )
+                Log.claudeContext.error(
+                    "Claude remote setup step \(index + 1, privacy: .public) failed: \(String(describing: failure), privacy: .public)"
+                )
+                throw failure
+            }
+            let invocation = Invocation(
+                argv: ["ssh", "-o", "BatchMode=yes", sshHostAlias, "/bin/sh", "-s"],
+                standardInput: Self.remoteScript(command: command),
+                timeout: remaining
+            )
+            Log.claudeContext.info(
+                "Claude remote setup step \(index + 1, privacy: .public) requested"
+            )
+            let result: RunResult
+            do {
+                result = try runner(invocation)
+            } catch let failure as RunnerFailure {
+                let error: ServiceError
+                switch failure {
+                case .timedOut(let seconds, let message):
+                    error = .commandTimedOut(
+                        step: index,
+                        command: displayCommand,
+                        seconds: seconds,
+                        message: ClaudeRemoteTokenRedaction.redact(message, token: token)
+                    )
+                case .outputTooLarge(_, let message):
+                    error = .runnerFailed(
+                        step: index,
+                        command: displayCommand,
+                        message: ClaudeRemoteTokenRedaction.redact(message, token: token)
+                    )
+                }
+                Log.claudeContext.error(
+                    "Claude remote setup step \(index + 1, privacy: .public) failed: \(String(describing: error), privacy: .public)"
+                )
+                throw error
+            } catch {
+                let redacted = ClaudeRemoteTokenRedaction.redact(String(describing: error), token: token)
+                let failure = ServiceError.runnerFailed(
+                    step: index, command: displayCommand, message: redacted
+                )
+                Log.claudeContext.error(
+                    "Claude remote setup step \(index + 1, privacy: .public) failed: \(String(describing: failure), privacy: .public)"
+                )
+                throw failure
+            }
             guard result.succeeded else {
-                // Redact BOTH halves. The argv contains the token by
-                // construction, and the runner's message is remote output that
-                // routinely echoes the command that failed.
-                throw ServiceError.commandFailed(
-                    command: argv.map { ClaudeRemoteTokenRedaction.redact($0, token: token) },
+                let failure = ServiceError.commandFailed(
+                    step: index,
+                    command: displayCommand,
                     exitCode: result.exitCode,
                     message: ClaudeRemoteTokenRedaction.redact(result.message, token: token)
                 )
+                Log.claudeContext.error(
+                    "Claude remote setup step \(index + 1, privacy: .public) failed: \(String(describing: failure), privacy: .public)"
+                )
+                throw failure
             }
+            completed.append(
+                ExecutionStep(
+                    index: index,
+                    command: displayCommand,
+                    message: ClaudeRemoteTokenRedaction.redact(result.message, token: token)
+                )
+            )
+            Log.claudeContext.info(
+                "Claude remote setup step \(index + 1, privacy: .public) completed"
+            )
         }
+        Log.claudeContext.info("Claude remote setup execution completed")
+        return completed
+    }
+
+    static func remoteScript(command: String) -> Data {
+        Data("set -eu\n\(command)\n".utf8)
     }
 }

--- a/Sources/localvoxtral/SettingsView.swift
+++ b/Sources/localvoxtral/SettingsView.swift
@@ -964,12 +964,7 @@ private struct ClaudePluginSettingsRow: View {
     }
 }
 
-/// Enrolled SSH hosts, and the copyable setup for each.
-///
-/// The pane never touches the user's `~/.ssh/config`, and never runs anything on
-/// a remote host. It hands over text. That is a deliberate limit, not an
-/// unfinished one: those files are load-bearing for work that has nothing to do
-/// with dictation.
+/// Enrolled SSH hosts, and the preview-first setup for each.
 private struct ClaudeRemoteHostsSettingsRow: View {
     @Bindable var model: ClaudeIntegrationSettingsModel
 
@@ -993,7 +988,8 @@ private struct ClaudeRemoteHostsSettingsRow: View {
             }
         }
         .sheet(item: Binding(get: { model.presentedPlan }, set: { if $0 == nil { model.dismissPlan() } })) { plan in
-            ClaudeRemoteEnrollmentSheet(presentation: plan) { model.dismissPlan() }
+            ClaudeRemoteEnrollmentSheet(model: model, presentation: plan) { model.dismissPlan() }
+                .interactiveDismissDisabled(model.isPerformingEnrollmentAction)
         }
         // The current API, not `alert(item:)` — that one is deprecated and the
         // repo builds warning-free. The detail lives HERE and never in the pane
@@ -1094,6 +1090,7 @@ private struct ClaudeRemoteHostsSettingsRow: View {
 /// plainly, and the recovery path (rotate) is one button away in the pane behind
 /// it.
 private struct ClaudeRemoteEnrollmentSheet: View {
+    @Bindable var model: ClaudeIntegrationSettingsModel
     let presentation: ClaudeIntegrationSettingsModel.EnrollmentPresentation
     let onDismiss: () -> Void
 
@@ -1120,13 +1117,20 @@ private struct ClaudeRemoteEnrollmentSheet: View {
                     section(
                         "1. Add to ~/.ssh/config on this Mac",
                         body: plan.sshConfigSnippet,
-                        note: "localvoxtral does not edit this file for you."
+                        note: "Insertion replaces only this host's marked block and writes the file atomically.",
+                        actionTitle: "Insert into ~/.ssh/config",
+                        action: { model.requestSSHConfigInsertion() }
                     )
                     section(
                         "2. Run on the remote host",
                         body: plan.remoteCommands.joined(separator: "\n"),
-                        note: "The leading space keeps the token out of your shell history."
+                        displayedBody: ClaudeIntegrationSettingsModel.redactedRemoteCommands(for: presentation),
+                        note: "One-click execution sends the token through SSH stdin, never process arguments.",
+                        actionTitle: "Run on SSH host",
+                        action: { model.requestRemoteSetup() }
                     )
+                    confirmationView
+                    enrollmentResults
                     section("Verify", body: plan.verifyCommands.joined(separator: "\n"), note: nil)
                     section("Uninstall", body: plan.uninstallCommands.joined(separator: "\n"), note: nil)
 
@@ -1141,15 +1145,77 @@ private struct ClaudeRemoteEnrollmentSheet: View {
             .frame(minHeight: 260)
 
             HStack {
+                if model.isPerformingEnrollmentAction {
+                    ProgressView().controlSize(.small)
+                }
                 Spacer()
                 Button("Done", action: onDismiss).keyboardShortcut(.defaultAction)
+                    .disabled(model.isPerformingEnrollmentAction)
             }
         }
         .padding(16)
         .frame(width: 560, height: 520)
     }
 
-    private func section(_ title: String, body: String, note: String?) -> some View {
+    @ViewBuilder
+    private var confirmationView: some View {
+        if let confirmation = model.enrollmentConfirmation {
+            VStack(alignment: .leading, spacing: 6) {
+                Text(confirmation.title).font(.subheadline).bold()
+                Text(confirmation.preview)
+                    .font(.system(.caption, design: .monospaced))
+                    .textSelection(.enabled)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .padding(6)
+                    .background(Color.orange.opacity(0.10), in: RoundedRectangle(cornerRadius: 4))
+                HStack {
+                    Button("Cancel") { model.cancelEnrollmentActionConfirmation() }
+                    Button(confirmation.confirmButtonTitle) {
+                        Task { await model.confirmEnrollmentAction() }
+                    }
+                    .buttonStyle(.borderedProminent)
+                }
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var enrollmentResults: some View {
+        if !model.enrollmentStepStatuses.isEmpty {
+            VStack(alignment: .leading, spacing: 4) {
+                ForEach(model.enrollmentStepStatuses) { step in
+                    Text("\(step.succeeded ? "✓" : "✗") \(step.text)")
+                        .font(.caption)
+                        .foregroundStyle(step.succeeded ? AnyShapeStyle(.secondary) : AnyShapeStyle(.orange))
+                        .lineLimit(1)
+                }
+                let details = model.enrollmentStepStatuses
+                    .map(\.detail)
+                    .filter { !$0.isEmpty }
+                    .joined(separator: "\n\n")
+                if !details.isEmpty {
+                    ScrollView {
+                        Text(details)
+                            .font(.system(.caption2, design: .monospaced))
+                            .textSelection(.enabled)
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                    }
+                    .frame(maxHeight: 90)
+                    .padding(6)
+                    .background(Color.secondary.opacity(0.08), in: RoundedRectangle(cornerRadius: 4))
+                }
+            }
+        }
+    }
+
+    private func section(
+        _ title: String,
+        body: String,
+        displayedBody: String? = nil,
+        note: String?,
+        actionTitle: String? = nil,
+        action: (() -> Void)? = nil
+    ) -> some View {
         VStack(alignment: .leading, spacing: 4) {
             HStack {
                 Text(title).font(.subheadline).bold()
@@ -1162,7 +1228,7 @@ private struct ClaudeRemoteEnrollmentSheet: View {
                 }
                 .controlSize(.small)
             }
-            Text(body)
+            Text(displayedBody ?? body)
                 .font(.system(.caption, design: .monospaced))
                 .textSelection(.enabled)
                 .frame(maxWidth: .infinity, alignment: .leading)
@@ -1170,6 +1236,11 @@ private struct ClaudeRemoteEnrollmentSheet: View {
                 .background(Color.secondary.opacity(0.08), in: RoundedRectangle(cornerRadius: 4))
             if let note {
                 Text(note).font(.caption2).foregroundStyle(.secondary)
+            }
+            if let actionTitle, let action {
+                Button(actionTitle, action: action)
+                    .controlSize(.small)
+                    .disabled(model.isPerformingEnrollmentAction)
             }
         }
     }

--- a/Sources/localvoxtral/localvoxtralApp.swift
+++ b/Sources/localvoxtral/localvoxtralApp.swift
@@ -306,7 +306,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         viewModel.claudeIntegrationSettings = ClaudeIntegrationSettingsModel(
             registry: registry,
             listener: coordinator,
-            pluginService: { ClaudePluginInstallService.live() }
+            pluginService: { ClaudePluginInstallService.live() },
+            enrollmentService: ClaudeRemoteEnrollmentService.live()
         )
 
         // Route launch through the same model that owns the Settings status.

--- a/Tests/localvoxtralTests/ClaudeIntegrationSettingsModelTests.swift
+++ b/Tests/localvoxtralTests/ClaudeIntegrationSettingsModelTests.swift
@@ -68,6 +68,31 @@ private final class MemoryStore: ClaudeRemoteHostStoreIO {
     func write(_ data: Data, to url: URL) throws { contents.withLock { $0[url.path] = data } }
 }
 
+private final class RecordingSSHConfigFileSystem: ClaudeRemoteSSHConfigFileSystem {
+    private let reads = Mutex(0)
+    private let writes = Mutex(0)
+
+    var readCount: Int { reads.withLock { $0 } }
+    var writeCount: Int { writes.withLock { $0 } }
+
+    func readState() throws -> ClaudeRemoteSSHConfigState {
+        reads.withLock { $0 += 1 }
+        return ClaudeRemoteSSHConfigState(
+            directoryExists: true,
+            configData: nil,
+            configPermissions: nil
+        )
+    }
+
+    func createSSHDirectory(permissions _: UInt16) throws {}
+
+    func atomicWriteConfig(_ data: Data, permissions: UInt16) throws {
+        XCTAssertFalse(data.isEmpty)
+        XCTAssertEqual(permissions, 0o600)
+        writes.withLock { $0 += 1 }
+    }
+}
+
 @MainActor
 final class ClaudeIntegrationSettingsModelTests: XCTestCase {
     private func makeRegistry() throws -> ClaudeRemoteHostRegistry {
@@ -81,12 +106,14 @@ final class ClaudeIntegrationSettingsModelTests: XCTestCase {
     private func makeModel(
         registry: ClaudeRemoteHostRegistry?,
         listener: (any ClaudeRemoteListenerControlling)?,
-        plugin: StubPluginService = StubPluginService()
+        plugin: StubPluginService = StubPluginService(),
+        enrollmentService: ClaudeRemoteEnrollmentService = ClaudeRemoteEnrollmentService()
     ) -> ClaudeIntegrationSettingsModel {
         ClaudeIntegrationSettingsModel(
             registry: registry,
             listener: listener,
             pluginService: { plugin },
+            enrollmentService: enrollmentService,
             // Synchronous: the production default hops to a detached task, which
             // would make every assertion below a race. The seam exists for
             // exactly this.
@@ -96,6 +123,16 @@ final class ClaudeIntegrationSettingsModelTests: XCTestCase {
                     return nil
                 } catch {
                     return ClaudePluginActionFailure(error)
+                }
+            },
+            performEnrollmentAsync: { body in
+                do {
+                    return ClaudeEnrollmentActionAttempt(steps: try body(), failure: nil)
+                } catch {
+                    return ClaudeEnrollmentActionAttempt(
+                        steps: [],
+                        failure: ClaudeEnrollmentActionFailure(error)
+                    )
                 }
             }
         )
@@ -300,6 +337,146 @@ final class ClaudeIntegrationSettingsModelTests: XCTestCase {
         XCTAssertNotEqual(rotated.token, first)
         XCTAssertNil(registry.authenticate(token: first), "rotation has no grace period")
         XCTAssertNotNil(registry.authenticate(token: rotated.token))
+    }
+
+    func testRemoteSetupDoesNotRunBeforeExplicitConfirmation() async throws {
+        let registry = try makeRegistry()
+        let calls = Mutex<[ClaudeRemoteEnrollmentService.Invocation]>([])
+        let service = ClaudeRemoteEnrollmentService(runner: { invocation in
+            calls.withLock { $0.append(invocation) }
+            return .init(exitCode: 0, message: "ok")
+        })
+        let model = makeModel(
+            registry: registry,
+            listener: StubListener(hosts: registry),
+            enrollmentService: service
+        )
+        model.enrollLabel = "buildhost"
+        model.enrollSSHAlias = "builder"
+        await model.enroll()
+        let token = try XCTUnwrap(model.presentedPlan).token
+
+        model.requestRemoteSetup()
+
+        XCTAssertTrue(calls.withLock { $0 }.isEmpty)
+        let confirmation = try XCTUnwrap(model.enrollmentConfirmation)
+        XCTAssertFalse(confirmation.preview.contains(token))
+        XCTAssertTrue(confirmation.preview.contains(ClaudeRemoteTokenRedaction.placeholder))
+
+        await model.confirmEnrollmentAction()
+
+        XCTAssertEqual(calls.withLock { $0 }.count, 2)
+        XCTAssertEqual(model.enrollmentStepStatuses.map(\.text), [
+            "Step 1 succeeded.", "Step 2 succeeded.",
+        ])
+    }
+
+    func testCancellingTheConfirmationRunsNothing() async throws {
+        let registry = try makeRegistry()
+        let calls = Mutex<[ClaudeRemoteEnrollmentService.Invocation]>([])
+        let service = ClaudeRemoteEnrollmentService(runner: { invocation in
+            calls.withLock { $0.append(invocation) }
+            return .init(exitCode: 0, message: "ok")
+        })
+        let model = makeModel(
+            registry: registry,
+            listener: StubListener(hosts: registry),
+            enrollmentService: service
+        )
+        model.enrollLabel = "buildhost"
+        model.enrollSSHAlias = "builder"
+        await model.enroll()
+
+        model.requestRemoteSetup()
+        model.cancelEnrollmentActionConfirmation()
+
+        XCTAssertNil(model.enrollmentConfirmation)
+        // Cancel is the user's only exit short of confirming: after it, the
+        // confirm entry point must be a no-op.
+        await model.confirmEnrollmentAction()
+        XCTAssertTrue(calls.withLock { $0 }.isEmpty)
+        XCTAssertTrue(model.enrollmentStepStatuses.isEmpty)
+    }
+
+    func testANewEnrollmentSheetDoesNotInheritThePreviousHostsStepResults() async throws {
+        let registry = try makeRegistry()
+        let service = ClaudeRemoteEnrollmentService(runner: { _ in
+            .init(exitCode: 0, message: "ok")
+        })
+        let model = makeModel(
+            registry: registry,
+            listener: StubListener(hosts: registry),
+            enrollmentService: service
+        )
+        model.enrollLabel = "first"
+        model.enrollSSHAlias = "builder"
+        await model.enroll()
+        model.requestRemoteSetup()
+        await model.confirmEnrollmentAction()
+        XCTAssertFalse(model.enrollmentStepStatuses.isEmpty)
+
+        model.dismissPlan()
+        model.enrollLabel = "second"
+        model.enrollSSHAlias = "builder2"
+        await model.enroll()
+
+        XCTAssertNotNil(model.presentedPlan)
+        XCTAssertTrue(model.enrollmentStepStatuses.isEmpty)
+        XCTAssertNil(model.enrollmentConfirmation)
+    }
+
+    func testSSHConfigInsertionDoesNotTouchFilesystemBeforeExplicitConfirmation() async throws {
+        let registry = try makeRegistry()
+        let fileSystem = RecordingSSHConfigFileSystem()
+        let service = ClaudeRemoteEnrollmentService(sshConfigFileSystem: fileSystem)
+        let model = makeModel(
+            registry: registry,
+            listener: StubListener(hosts: registry),
+            enrollmentService: service
+        )
+        model.enrollLabel = "buildhost"
+        model.enrollSSHAlias = "builder"
+        await model.enroll()
+
+        model.requestSSHConfigInsertion()
+
+        XCTAssertEqual(fileSystem.readCount, 0)
+        XCTAssertEqual(fileSystem.writeCount, 0)
+        XCTAssertEqual(
+            model.enrollmentConfirmation?.preview,
+            model.presentedPlan?.plan.sshConfigSnippet
+        )
+
+        await model.confirmEnrollmentAction()
+
+        XCTAssertEqual(fileSystem.readCount, 1)
+        XCTAssertEqual(fileSystem.writeCount, 1)
+        XCTAssertEqual(model.enrollmentStepStatuses.first?.text, "SSH config updated.")
+    }
+
+    func testRemoteSetupTimeoutHasShortStepStatusAndClearDetail() async throws {
+        let registry = try makeRegistry()
+        let service = ClaudeRemoteEnrollmentService(runner: { _ in
+            throw ClaudeRemoteEnrollmentService.RunnerFailure.timedOut(
+                seconds: 15,
+                message: "connection stalled"
+            )
+        })
+        let model = makeModel(
+            registry: registry,
+            listener: StubListener(hosts: registry),
+            enrollmentService: service
+        )
+        model.enrollLabel = "buildhost"
+        model.enrollSSHAlias = "builder"
+        await model.enroll()
+        model.requestRemoteSetup()
+
+        await model.confirmEnrollmentAction()
+
+        XCTAssertEqual(model.enrollmentStepStatuses.first?.text, "Step 1 failed.")
+        XCTAssertTrue(model.alert?.detail.contains("within 15s") ?? false)
+        XCTAssertTrue(model.alert?.detail.contains("connection stalled") ?? false)
     }
 
     // MARK: Validation and failures

--- a/Tests/localvoxtralTests/ClaudeRemoteEnrollmentServiceTests.swift
+++ b/Tests/localvoxtralTests/ClaudeRemoteEnrollmentServiceTests.swift
@@ -3,6 +3,41 @@ import Synchronization
 import XCTest
 @testable import localvoxtral
 
+private final class MemorySSHConfigFileSystem: ClaudeRemoteSSHConfigFileSystem {
+    struct Storage: Sendable {
+        var state: ClaudeRemoteSSHConfigState
+        var createdDirectoryPermissions: [UInt16] = []
+        var writes: [(data: Data, permissions: UInt16)] = []
+    }
+
+    private let storage: Mutex<Storage>
+
+    init(state: ClaudeRemoteSSHConfigState) {
+        storage = Mutex(Storage(state: state))
+    }
+
+    var snapshot: Storage { storage.withLock { $0 } }
+
+    func readState() throws -> ClaudeRemoteSSHConfigState {
+        storage.withLock { $0.state }
+    }
+
+    func createSSHDirectory(permissions: UInt16) throws {
+        storage.withLock {
+            $0.createdDirectoryPermissions.append(permissions)
+            $0.state.directoryExists = true
+        }
+    }
+
+    func atomicWriteConfig(_ data: Data, permissions: UInt16) throws {
+        storage.withLock {
+            $0.writes.append((data, permissions))
+            $0.state.configData = data
+            $0.state.configPermissions = permissions
+        }
+    }
+}
+
 final class ClaudeRemoteEnrollmentServiceTests: XCTestCase {
     private let host = ClaudeRemoteHost(
         id: "habc1234",
@@ -307,11 +342,166 @@ final class ClaudeRemoteEnrollmentServiceTests: XCTestCase {
         )
     }
 
+    // MARK: SSH config writing
+
+    func testSSHConfigInsertionCreatesFreshDirectoryAndFileWithPrivatePermissions() throws {
+        let fileSystem = MemorySSHConfigFileSystem(
+            state: ClaudeRemoteSSHConfigState(
+                directoryExists: false,
+                configData: nil,
+                configPermissions: nil
+            )
+        )
+        let service = ClaudeRemoteEnrollmentService(sshConfigFileSystem: fileSystem)
+
+        try service.insertSSHConfig(try plan(), hostID: host.id)
+
+        let snapshot = fileSystem.snapshot
+        XCTAssertEqual(snapshot.createdDirectoryPermissions, [0o700])
+        XCTAssertEqual(snapshot.writes.count, 1)
+        XCTAssertEqual(snapshot.writes.first?.permissions, 0o600)
+        XCTAssertTrue(String(decoding: snapshot.writes[0].data, as: UTF8.self).contains("Host builder"))
+    }
+
+    func testSSHConfigInsertionAppendsToExistingOtherContentAndPreservesPermissions() throws {
+        let existing = "Host github.com\n    User git\n"
+        let fileSystem = MemorySSHConfigFileSystem(
+            state: ClaudeRemoteSSHConfigState(
+                directoryExists: true,
+                configData: Data(existing.utf8),
+                configPermissions: 0o640
+            )
+        )
+        let service = ClaudeRemoteEnrollmentService(sshConfigFileSystem: fileSystem)
+
+        try service.insertSSHConfig(try plan(), hostID: host.id)
+
+        let snapshot = fileSystem.snapshot
+        let written = String(decoding: snapshot.writes[0].data, as: UTF8.self)
+        XCTAssertTrue(written.hasPrefix(existing))
+        XCTAssertTrue(written.contains("Host builder"))
+        XCTAssertEqual(snapshot.writes[0].permissions, 0o640)
+        XCTAssertTrue(snapshot.createdDirectoryPermissions.isEmpty)
+    }
+
+    func testSSHConfigInsertionReplacesExistingHostBlockWithoutDuplication() throws {
+        let old = try plan(alias: "old-builder").sshConfigSnippet
+        let existing = ClaudeRemoteEnrollmentService.applySSHConfigSnippet(
+            to: "Host other\n    User x\n",
+            snippet: old,
+            hostID: host.id
+        )
+        let fileSystem = MemorySSHConfigFileSystem(
+            state: ClaudeRemoteSSHConfigState(
+                directoryExists: true,
+                configData: Data(existing.utf8),
+                configPermissions: 0o600
+            )
+        )
+        let service = ClaudeRemoteEnrollmentService(sshConfigFileSystem: fileSystem)
+
+        try service.insertSSHConfig(try plan(alias: "new-builder"), hostID: host.id)
+
+        let written = String(decoding: fileSystem.snapshot.writes[0].data, as: UTF8.self)
+        XCTAssertTrue(written.contains("Host new-builder"))
+        XCTAssertFalse(written.contains("Host old-builder"))
+        XCTAssertEqual(written.components(separatedBy: ClaudeRemoteEnrollmentService.blockBegin(hostID: host.id)).count - 1, 1)
+        XCTAssertTrue(written.contains("Host other"))
+    }
+
+    func testSSHConfigInsertionRefusesASymlinkedConfigWithoutWriting() throws {
+        // A rename-based atomic write would replace the symlink with a regular
+        // file and silently desync a dotfiles-managed setup.
+        let fileSystem = MemorySSHConfigFileSystem(
+            state: ClaudeRemoteSSHConfigState(
+                directoryExists: true,
+                configData: nil,
+                configPermissions: nil,
+                configIsSymlink: true
+            )
+        )
+        let service = ClaudeRemoteEnrollmentService(sshConfigFileSystem: fileSystem)
+
+        XCTAssertThrowsError(try service.insertSSHConfig(try plan(alias: "builder"), hostID: host.id)) {
+            XCTAssertEqual(
+                $0 as? ClaudeRemoteEnrollmentService.ServiceError, .sshConfigIsSymlink
+            )
+        }
+        XCTAssertTrue(fileSystem.snapshot.writes.isEmpty)
+        XCTAssertTrue(fileSystem.snapshot.createdDirectoryPermissions.isEmpty)
+    }
+
+    func testSSHConfigInsertionRefusesASymlinkedSSHDirectoryWithoutWriting() throws {
+        let fileSystem = MemorySSHConfigFileSystem(
+            state: ClaudeRemoteSSHConfigState(
+                directoryExists: true,
+                configData: nil,
+                configPermissions: nil,
+                directoryIsSymlink: true
+            )
+        )
+        let service = ClaudeRemoteEnrollmentService(sshConfigFileSystem: fileSystem)
+
+        XCTAssertThrowsError(try service.insertSSHConfig(try plan(alias: "builder"), hostID: host.id)) {
+            XCTAssertEqual(
+                $0 as? ClaudeRemoteEnrollmentService.ServiceError, .sshConfigIsSymlink
+            )
+        }
+        XCTAssertTrue(fileSystem.snapshot.writes.isEmpty)
+    }
+
+    func testSSHConfigInsertionRefusesAnUntrustedSSHDirectoryWithoutWriting() throws {
+        for state in [
+            // group/world-writable
+            ClaudeRemoteSSHConfigState(
+                directoryExists: true,
+                configData: nil,
+                configPermissions: nil,
+                directoryPermissions: 0o770
+            ),
+            // not the user's directory
+            ClaudeRemoteSSHConfigState(
+                directoryExists: true,
+                configData: nil,
+                configPermissions: nil,
+                directoryOwnedByCurrentUser: false
+            ),
+        ] {
+            let fileSystem = MemorySSHConfigFileSystem(state: state)
+            let service = ClaudeRemoteEnrollmentService(sshConfigFileSystem: fileSystem)
+
+            XCTAssertThrowsError(
+                try service.insertSSHConfig(try plan(alias: "builder"), hostID: host.id)
+            ) {
+                XCTAssertEqual(
+                    $0 as? ClaudeRemoteEnrollmentService.ServiceError, .sshDirectoryNotTrusted
+                )
+            }
+            XCTAssertTrue(fileSystem.snapshot.writes.isEmpty)
+        }
+    }
+
+    func testSSHConfigInsertionAcceptsAConventionallyPermissionedDirectory() throws {
+        // 0700 and the common 0755 both lack group/world WRITE, which is the
+        // actual attack surface; refusing them would break ordinary setups.
+        for mode in [UInt16(0o700), UInt16(0o755)] {
+            let fileSystem = MemorySSHConfigFileSystem(
+                state: ClaudeRemoteSSHConfigState(
+                    directoryExists: true,
+                    configData: nil,
+                    configPermissions: nil,
+                    directoryPermissions: mode
+                )
+            )
+            let service = ClaudeRemoteEnrollmentService(sshConfigFileSystem: fileSystem)
+            try service.insertSSHConfig(try plan(alias: "builder"), hostID: host.id)
+            XCTAssertEqual(fileSystem.snapshot.writes.count, 1)
+        }
+    }
+
     // MARK: Execution
 
     func testExecutionIsRefusedWithoutAnInjectedRunner() throws {
-        // The default. Nothing in the app supplies a runner, so no code path can
-        // reach a real host by accident.
         let service = ClaudeRemoteEnrollmentService()
         XCTAssertThrowsError(
             try service.executeRemoteSetup(try plan(), sshHostAlias: "builder", token: token)
@@ -324,58 +514,98 @@ final class ClaudeRemoteEnrollmentServiceTests: XCTestCase {
     }
 
     func testExecutionRunsExactlyTheRemoteCommandsOverSSH() throws {
-        let calls = Mutex<[[String]]>([])
-        let service = ClaudeRemoteEnrollmentService { argv in
-            calls.withLock { $0.append(argv) }
+        let calls = Mutex<[ClaudeRemoteEnrollmentService.Invocation]>([])
+        let service = ClaudeRemoteEnrollmentService(runner: { invocation in
+            calls.withLock { $0.append(invocation) }
             return .init(exitCode: 0, message: "")
-        }
+        })
         try service.executeRemoteSetup(try plan(), sshHostAlias: "builder", token: token)
 
-        XCTAssertEqual(calls.withLock { $0 }, [
-            [
-                "ssh", "builder",
-                "claude plugin marketplace add \(ClaudeRemoteEnrollmentService.repositoryMarketplaceReference)",
-            ],
-            [
-                "ssh", "builder",
-                "claude plugin install localvoxtral-remote@localvoxtral --config 'token=\(token)'",
-            ],
-        ])
+        let recorded = calls.withLock { $0 }
+        XCTAssertEqual(recorded.count, 2)
+        for invocation in recorded {
+            XCTAssertEqual(
+                invocation.argv,
+                ["ssh", "-o", "BatchMode=yes", "builder", "/bin/sh", "-s"]
+            )
+            XCTAssertFalse(invocation.argv.joined(separator: " ").contains(token))
+        }
+        XCTAssertEqual(
+            recorded.map { String(decoding: $0.standardInput, as: UTF8.self) },
+            try plan().remoteCommands.map { "set -eu\n\($0)\n" }
+        )
+    }
+
+    func testRemoteSetupKeepsTokenInStdinAndOutOfEveryArgv() throws {
+        let calls = Mutex<[ClaudeRemoteEnrollmentService.Invocation]>([])
+        let service = ClaudeRemoteEnrollmentService(runner: { invocation in
+            calls.withLock { $0.append(invocation) }
+            return .init(exitCode: 0, message: "")
+        })
+
+        try service.executeRemoteSetup(try plan(), sshHostAlias: "builder", token: token)
+
+        let recorded = calls.withLock { $0 }
+        XCTAssertTrue(recorded.allSatisfy { !$0.argv.joined(separator: " ").contains(token) })
+        XCTAssertTrue(
+            recorded.contains { String(decoding: $0.standardInput, as: UTF8.self).contains(token) }
+        )
     }
 
     func testExecutionStopsAtTheFirstFailure() throws {
-        let calls = Mutex<[[String]]>([])
-        let service = ClaudeRemoteEnrollmentService { argv in
-            calls.withLock { $0.append(argv) }
+        let calls = Mutex<[ClaudeRemoteEnrollmentService.Invocation]>([])
+        let service = ClaudeRemoteEnrollmentService(runner: { invocation in
+            calls.withLock { $0.append(invocation) }
             return .init(exitCode: 1, message: "marketplace not found")
-        }
+        })
         XCTAssertThrowsError(
             try service.executeRemoteSetup(try plan(), sshHostAlias: "builder", token: token)
         ) { error in
-            guard case .commandFailed(_, let exitCode, let message)? =
+            guard case .commandFailed(let step, _, let exitCode, let message)? =
                 error as? ClaudeRemoteEnrollmentService.ServiceError
             else {
                 return XCTFail("expected commandFailed, got \(error)")
             }
+            XCTAssertEqual(step, 0)
             XCTAssertEqual(exitCode, 1)
             XCTAssertEqual(message, "marketplace not found")
         }
         XCTAssertEqual(calls.withLock { $0 }.count, 1, "an install after a failed marketplace add is noise")
     }
 
-    func testAFailureNeverCarriesTheTokenIntoTheError() throws {
-        // The install command embeds the token by construction, and a remote's
-        // stderr routinely echoes the command it was given. An Error is the most
-        // freely-copied string in the app — it reaches alerts, `Log`, and the
-        // user's bug report via a free `localizedDescription`. So the token has
-        // to be gone before it is thrown, not merely handled carefully by every
-        // present and future catch site.
-        // Bound locally: capturing `self.token` would drag a non-Sendable
-        // XCTestCase into a @Sendable runner closure.
+    func testSuccessfulCapturedOutputIsRedactedBeforeLeavingTheService() throws {
         let token = token
-        let service = ClaudeRemoteEnrollmentService { _ in
-            .init(exitCode: 1, message: "failed running: claude plugin install --config 'token=\(token)'")
+        let service = ClaudeRemoteEnrollmentService(runner: { _ in
+            .init(exitCode: 0, message: "remote echoed \(token)")
+        })
+
+        let steps = try service.executeRemoteSetup(
+            try plan(),
+            sshHostAlias: "builder",
+            token: token
+        )
+
+        XCTAssertEqual(steps.count, 2)
+        for step in steps {
+            XCTAssertFalse(step.message.contains(token))
+            XCTAssertTrue(step.message.contains(ClaudeRemoteTokenRedaction.placeholder))
         }
+    }
+
+    func testAFailureNeverCarriesTheTokenIntoTheError() throws {
+        let token = token
+        let calls = Mutex(0)
+        let service = ClaudeRemoteEnrollmentService(runner: { _ in
+            let call = calls.withLock { value -> Int in
+                defer { value += 1 }
+                return value
+            }
+            if call == 0 { return .init(exitCode: 0, message: "marketplace ready") }
+            return .init(
+                exitCode: 1,
+                message: "failed running: claude plugin install --config 'token=\(token)'"
+            )
+        })
         XCTAssertThrowsError(
             try service.executeRemoteSetup(
                 ClaudeRemoteEnrollmentService.SetupPlan(
@@ -387,14 +617,14 @@ final class ClaudeRemoteEnrollmentServiceTests: XCTestCase {
                 token: token
             )
         ) { error in
-            guard case .commandFailed(let command, _, let message)? =
+            guard case .commandFailed(_, let command, _, let message)? =
                 error as? ClaudeRemoteEnrollmentService.ServiceError
             else {
                 return XCTFail("expected commandFailed, got \(error)")
             }
             XCTAssertFalse(
-                command.joined(separator: " ").contains(token),
-                "the argv we throw must not carry the plaintext token"
+                command.contains(token),
+                "the displayed command in the error must not carry the plaintext token"
             )
             XCTAssertFalse(
                 message.contains(token),
@@ -411,9 +641,9 @@ final class ClaudeRemoteEnrollmentServiceTests: XCTestCase {
         // The catch-all: whatever else an error grows, interpolating it must
         // never print the secret.
         let token = token
-        let service = ClaudeRemoteEnrollmentService { _ in
+        let service = ClaudeRemoteEnrollmentService(runner: { _ in
             .init(exitCode: 1, message: "boom: token=\(token)")
-        }
+        })
         do {
             try service.executeRemoteSetup(
                 ClaudeRemoteEnrollmentService.SetupPlan(
@@ -431,11 +661,35 @@ final class ClaudeRemoteEnrollmentServiceTests: XCTestCase {
         }
     }
 
+    func testRemoteTimeoutMapsToClearRedactedServiceError() throws {
+        let token = token
+        let service = ClaudeRemoteEnrollmentService(runner: { _ in
+            throw ClaudeRemoteEnrollmentService.RunnerFailure.timedOut(
+                seconds: 12,
+                message: "last output contained \(token)"
+            )
+        })
+
+        XCTAssertThrowsError(
+            try service.executeRemoteSetup(try plan(), sshHostAlias: "builder", token: token)
+        ) { error in
+            guard case .commandTimedOut(let step, _, let seconds, let message)? =
+                error as? ClaudeRemoteEnrollmentService.ServiceError
+            else {
+                return XCTFail("expected commandTimedOut, got \(error)")
+            }
+            XCTAssertEqual(step, 0)
+            XCTAssertEqual(seconds, 12)
+            XCTAssertFalse(message.contains(token))
+            XCTAssertTrue(message.contains(ClaudeRemoteTokenRedaction.placeholder))
+        }
+    }
+
     func testExecutionRefusesAnInvalidAlias() {
-        let service = ClaudeRemoteEnrollmentService { _ in
+        let service = ClaudeRemoteEnrollmentService(runner: { _ in
             XCTFail("the runner must never be reached with an invalid alias")
             return .init(exitCode: 0, message: "")
-        }
+        })
         XCTAssertThrowsError(
             try service.executeRemoteSetup(
                 ClaudeRemoteEnrollmentService.SetupPlan(
@@ -449,15 +703,14 @@ final class ClaudeRemoteEnrollmentServiceTests: XCTestCase {
     }
 
     func testExecutionNeverTouchesTheSSHConfig() throws {
-        // The plan hands the user the text; writing it is their decision.
-        let calls = Mutex<[[String]]>([])
-        let service = ClaudeRemoteEnrollmentService { argv in
-            calls.withLock { $0.append(argv) }
+        let calls = Mutex<[ClaudeRemoteEnrollmentService.Invocation]>([])
+        let service = ClaudeRemoteEnrollmentService(runner: { invocation in
+            calls.withLock { $0.append(invocation) }
             return .init(exitCode: 0, message: "")
-        }
+        })
         try service.executeRemoteSetup(try plan(), sshHostAlias: "builder", token: token)
-        for argv in calls.withLock({ $0 }) {
-            XCTAssertFalse(argv.joined(separator: " ").contains(".ssh/config"))
+        for invocation in calls.withLock({ $0 }) {
+            XCTAssertFalse(invocation.argv.joined(separator: " ").contains(".ssh/config"))
         }
     }
 }

--- a/integrations/claude-code/README.md
+++ b/integrations/claude-code/README.md
@@ -218,9 +218,15 @@ and binds the listener immediately — there is no relaunch step. The list in th
 row shows each enrolled host, when it was last seen, and gives you **Rotate
 Token**, **Revoke** and **Remove**.
 
-The app **does not edit `~/.ssh/config` and does not run anything on the remote
-host.** It hands you the text. Those files are yours and are load-bearing for
-work that has nothing to do with dictation.
+The app hands you every command as copyable text, and can also do the two
+steps for you — **only after showing you exactly what will happen and asking
+you to confirm**: *Insert into ~/.ssh/config* previews the exact block (an
+idempotent, marker-delimited splice; the rest of the file is never touched)
+before atomically writing it, and *Run on SSH host* previews the commands
+(token redacted) before running them through `ssh -o BatchMode=yes` with the
+token fed over stdin — it never appears in any process's argument list, on
+either machine. Nothing runs or is written without that explicit confirmation,
+and the Copy buttons remain if you prefer to do it yourself.
 
 The token is shown exactly once, because only its hash is stored. If you lose it,
 rotate — that is what rotation is for. Then:
@@ -332,8 +338,9 @@ assuming it is a stale copy of the app, and rotate the tokens of any host that
 connected meanwhile.
 
 **Anyone who can write your `~/.ssh/config`.** They can point the forward
-somewhere else. That is true of every use of that file and is why the app will
-not write it for you.
+somewhere else. That is true of every use of that file and is why the app only
+ever writes it after showing you the exact block and getting your confirmation
+— and only its own marker-delimited block, never the rest of the file.
 
 ## Plain SSH still works exactly as before
 


### PR DESCRIPTION
## What

The remote-enrollment sheet gains two opt-in actions alongside the existing Copy buttons (which stay):

- **Insert into ~/.ssh/config** — previews the exact marker-delimited block and, only after an explicit Confirm, splices it idempotently (same-host block replaced in place, never duplicated, rest of the file untouched) via an atomic same-directory temp file + rename (`O_CREAT|O_EXCL|O_NOFOLLOW`, `fsync`), preserving existing permissions; missing `~/.ssh`/config are created 0700/0600. It **refuses** — pointing at the copy path — when `~/.ssh/config` or `~/.ssh` is a symlink (a rename would silently desync a dotfiles setup) or when `~/.ssh` isn't exclusively the user's to write.
- **Run on SSH host** — previews the redacted command list and, only after Confirm, runs each step as `ssh -o BatchMode=yes <alias> /bin/sh -s` with the token-bearing script fed **over stdin — the token never appears in any process's argv, on either machine**. Whole-run timeout, bounded output capture, per-step one-line status in the sheet, stop-at-first-failure, and every error/log/alert string passes `ClaudeRemoteTokenRedaction` before leaving the service.

Both mutation paths are injected seams (`ClaudeRemoteSSHConfigFileSystem`, evolved `Runner` carrying argv+stdin+timeout); the no-runner service still throws `.executionNotConfigured`. AGENTS.md's "copy-only" tradeoff paragraph and the plugin README are rewritten to the new reality (including what remains non-defensible: a same-user process on the remote host can still read `~/.claude/`).

Implementation: codex (gpt-5.6-sol); adversarial review: opencode (GLM-5.2) — **PASS**, with its 3 IMPORTANT findings fixed here: stale step-statuses could survive into a later host's sheet (now: `interactiveDismissDisabled` while running, statuses reset on present, and a host-identity guard on late results), symlinked config would be replaced by the rename (now refused with a clear message), and `~/.ssh` trust wasn't checked (now lstat-gated: owner + no group/world write — 0700 and 0755 both accepted, tested). Plus its INFO items: 8 KB stdin-preload guard (prevents a future pipe-buffer deadlock), cancel-path test, diagnostics comment.

## Proof

- [x] Unit suite green — `./scripts/remote-build.sh test`:
  ```
  Executed 1895 tests, with 2 tests skipped and 0 failures (0 unexpected) in 67.327 (67.413) seconds
  ```
  New coverage: token-in-stdin-never-argv, exact argv pinning, redaction on failing steps, confirm gating (no FS/runner call before Confirm; cancel makes confirm a no-op), idempotent block replacement, fresh-file/append/permissions via the fake seam, symlinked-config refusal, symlinked/untrusted-`~/.ssh` refusal, conventional-permissions acceptance (0700/0755), stale-status isolation across sheets, timeout mapping, `.executionNotConfigured` regression.
- [x] Existing tests strengthened, not weakened: the pre-change test asserting the token WAS in argv now proves it is NOT.
- [ ] UI change, owner hand-check on the Mac: enrollment sheet shows the two new buttons + confirm step; a real run against a scratch SSH host inserts the block once (rerun replaces, not duplicates) and installs the plugin; error path shows one-line step statuses with details in the alert.
- LLM lanes: not required — no prompt/model/request-shape change (enrollment/settings only).