### PR TITLE
Mac test services: bundled speechd/polishd replace voxmlx/mlx-lm behind the on-demand infra

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -5,7 +5,7 @@
 Every PR and push to main: build, advisory format lint (`.swift-format`;
 flips to `--strict` after the one-shot tree reformat), unit tests with a
 coverage summary (`llvm-cov report` over Sources — visibility for the PR
-Proof section, not a gate), live voxmlx integration tests, app packaging,
+Proof section, not a gate), live STT-service integration tests, app packaging,
 launch smoke test, an installable app artifact (`localvoxtral-app`, fetch
 with `scripts/try-pr.sh`), and a `localvoxtral-dsym` artifact (30-day
 retention) for symbolicating field crashes. Same-repo branches run on the
@@ -21,7 +21,7 @@ One-command, gate-then-tag releases on the self-hosted runner:
 ```
 
 Pipeline: compute next version from the latest `v*` tag → release build →
-unit tests → live integration tests (voxmlx) → package app bundle → launch
+unit tests → live integration tests (speechd STT service) → package app bundle → launch
 smoke test → zip + dmg → **create tag** → publish GitHub release with
 auto-generated notes and both artifacts.
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,7 +94,7 @@ jobs:
         # scripts/ci/llm-lane-filter.sh (kept out of the workflow so it is
         # testable locally); the human-judgment rule is AGENTS.md
         # "When must the LLM lanes run?". The PolishHelper UNIT suite and the
-        # tier-1 voxmlx realtime integration stay per-push.
+        # tier-1 speechd realtime integration stay per-push.
         id: llm_lane
         if: runner.environment == 'self-hosted'
         env:
@@ -271,8 +271,8 @@ jobs:
           xcrun llvm-cov report "$BIN" -instr-profile "$PROF" \
             -ignore-filename-regex '(Tests|\.build)/'
 
-      - name: Warm on-demand voxmlx server
-        # The build host's voxmlx launchd service is launch-on-demand (its
+      - name: Warm on-demand speechd server
+        # The build host's speechd STT test service is launch-on-demand (its
         # multi-GB weights are not resident 24/7 — scripts/mac/lv-test-servers.sh).
         # Touch its trigger and block until port 8000 is healthy so the
         # integration suite below hits warm weights; this also resets the idle
@@ -280,25 +280,29 @@ jobs:
         # frees the RAM only after the machine goes quiet. Self-hosted only —
         # hosted runners have no backend and the suite self-skips.
         #
+        # The `ensure speechd` name works whether the host still runs the retired
+        # Python voxmlx plist or the swapped-in Swift speechd plist: both are
+        # triggered through the same run-dir path and answer a TCP probe on 8000.
+        #
         # Best-effort during rollout: the on-demand LaunchAgents + run dir are a
         # one-time owner install (scripts/mac/README.md). Until that's done the
-        # run dir is absent and there is nothing to warm — the still-always-on
-        # voxmlx serves the suite, so skip cleanly instead of failing CI. The
-        # integration step below is the real gate on voxmlx being reachable.
+        # run dir is absent and there is nothing to warm — the still-resident
+        # STT service serves the suite, so skip cleanly instead of failing CI.
+        # The integration step below is the real gate on the STT service.
         if: runner.environment == 'self-hosted'
         run: |
           if [ -d /Users/Shared/localvoxtral/run ]; then
-            ./scripts/mac/lv-test-servers.sh ensure voxmlx
+            ./scripts/mac/lv-test-servers.sh ensure speechd
           else
             echo "on-demand infra not installed (run dir absent) — relying on the" \
-                 "always-on voxmlx; see scripts/mac/README.md to enable on-demand."
+                 "resident STT service; see scripts/mac/README.md to enable on-demand."
           fi
 
-      - name: Integration tests (live voxmlx)
-        # The self-hosted runner has voxmlx serving locally (launchd service
-        # com.localvoxtral.voxmlx, warmed on-demand by the step above). On
-        # GitHub-hosted runners there is no backend and the suite self-skips,
-        # so this step is self-hosted only.
+      - name: Integration tests (live STT service)
+        # The self-hosted runner has the STT test service serving locally
+        # (launchd service com.localvoxtral.testspeechd, warmed on-demand by the
+        # step above). On GitHub-hosted runners there is no backend and the suite
+        # self-skips, so this step is self-hosted only.
         if: runner.environment == 'self-hosted'
         env:
           VLLM_REALTIME_TEST_ENABLE: "1"
@@ -373,7 +377,7 @@ jobs:
           SPEECHD_INTEGRATION_TEST_ENABLE: "1"
           SPEECHD_INTEGRATION_TEST_PATH: dist/localvoxtral.app/Contents/MacOS/localvoxtral-speechd
         # --enable-code-coverage matches the unit step's build flags (same
-        # rationale as the voxmlx step above): without it this step rebuilds
+        # rationale as the STT integration step above): without it this step rebuilds
         # the whole app+test module without coverage (~17 s), and the next
         # run's unit step rebuilds it back again.
         run: swift test --filter SpeechHelperIntegrationTests --enable-code-coverage

--- a/.github/workflows/eval-e2e.yml
+++ b/.github/workflows/eval-e2e.yml
@@ -1,7 +1,7 @@
 name: Agent Dictation E2E Eval
 
 # The wide agent-dictation eval (owner decision 2026-07-11): nightly + manual
-# only, NEVER per-PR — it runs live TTS -> voxmlx ASR -> polishd inference
+# only, NEVER per-PR — it runs live TTS -> speechd ASR -> polishd inference
 # over the ~160-case EvalCorpus/agent-dictation corpus and takes many minutes.
 # The operator-only human-WAV baseline uses remote-build.sh's optional
 # recording-set argument; CI intentionally keeps the repeatable TTS source.
@@ -59,16 +59,19 @@ jobs:
           LOCALVOXTRAL_CODESIGN_IDENTITY: localvoxtral-dev
         run: ./scripts/package_app.sh release
 
-      - name: Warm on-demand voxmlx server
+      - name: Warm on-demand speechd server
         # Launch-on-demand infra (scripts/mac/lv-test-servers.sh): touch the
-        # trigger and block until port 8000 is healthy. Best-effort during
-        # rollout — the eval itself fails loudly if voxmlx is really down.
+        # trigger and block until port 8000 is healthy. `ensure speechd` works
+        # against either the retired voxmlx plist or the swapped-in speechd plist.
+        # Best-effort during rollout (a warm timeout must not mask the eval) —
+        # the eval itself fails loudly if the STT service is really down.
+        continue-on-error: true
         run: |
           if [ -d /Users/Shared/localvoxtral/run ]; then
-            ./scripts/mac/lv-test-servers.sh ensure voxmlx
+            ./scripts/mac/lv-test-servers.sh ensure speechd
           else
             echo "on-demand infra not installed (run dir absent) — relying on the" \
-                 "always-on voxmlx; see scripts/mac/README.md to enable on-demand."
+                 "resident STT service; see scripts/mac/README.md to enable on-demand."
           fi
 
       - name: Run agent-dictation E2E eval

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,8 +28,8 @@ concurrency:
 
 jobs:
   release:
-    # Self-hosted for speed (warm build cache, live voxmlx for the integration
-    # gate). Releases stay ad-hoc signed: the runner's localvoxtral-dev cert
+    # Self-hosted for speed (warm build cache, live speechd STT service for the
+    # integration gate). Releases stay ad-hoc signed: the runner's localvoxtral-dev cert
     # is meaningless on users' machines, so we don't set the identity here.
     runs-on: [self-hosted, macOS, ARM64]
     timeout-minutes: 30
@@ -89,7 +89,24 @@ jobs:
           swift test \
             --skip RealtimeAPIVLLMIntegrationTests
 
-      - name: Gate — live integration (voxmlx)
+      - name: Warm on-demand speechd server
+        # The STT test service is launch-on-demand (scripts/mac/lv-test-servers.sh);
+        # its weights are not resident 24/7, so warm it before the live
+        # integration gate below (this release lane runs on the self-hosted Mac).
+        # `ensure speechd` works against either the retired voxmlx plist or the
+        # swapped-in speechd plist. Best-effort during rollout (a warm timeout
+        # must not mask the gate) — the integration gate itself fails loudly if
+        # the STT service is really down.
+        continue-on-error: true
+        run: |
+          if [ -d /Users/Shared/localvoxtral/run ]; then
+            ./scripts/mac/lv-test-servers.sh ensure speechd
+          else
+            echo "on-demand infra not installed (run dir absent) — relying on the" \
+                 "resident STT service; see scripts/mac/README.md to enable on-demand."
+          fi
+
+      - name: Gate — live integration (STT service)
         env:
           VLLM_REALTIME_TEST_ENABLE: "1"
           VLLM_REALTIME_TEST_MODEL: T0mSIlver/Voxtral-Mini-4B-Realtime-2602-MLX-4bit

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,9 +2,11 @@
 
 Native macOS menu bar app for realtime dictation (Swift 6.2 strict concurrency,
 SwiftPM, macOS 15+). Streams mic audio to an OpenAI Realtime-compatible backend
-(voxmlx / vLLM), merges partial transcripts, and inserts text into the focused
-app — either live ("Live Auto-Paste") or via an overlay committed on stop
-("Overlay Buffer", supports replacement dictionary + LLM polishing).
+(the bundled `localvoxtral-speechd` helper in managed mode; vLLM or any
+compatible server in External URL mode), merges partial transcripts, and
+inserts text into the focused app — either live ("Live Auto-Paste") or via an
+overlay committed on stop ("Overlay Buffer", supports replacement dictionary +
+LLM polishing).
 
 ## Build & test — read this first on a non-Mac dev box
 
@@ -16,12 +18,12 @@ is machine-local config, set once per clone (never committed):
 ```bash
 ./scripts/remote-build.sh                 # build + unit tests
 ./scripts/remote-build.sh test --filter TextMergingAlgorithmsTests
-./scripts/remote-build.sh integration     # realtime pipeline vs live voxmlx
+./scripts/remote-build.sh integration     # realtime pipeline vs the live speechd STT service
 ./scripts/remote-build.sh eval-llm        # default polish prompt eval vs a live chat/completions server
 ./scripts/remote-build.sh package         # build the .app bundle (also builds both MLX helpers)
 ./scripts/remote-build.sh integration-polishd [hf-repo]  # bundled polish helper vs real model + eval baseline (run package first); optional repo = per-model gate for PolishModelCatalog additions (self-provisions weights)
 ./scripts/remote-build.sh integration-speechd [hf-repo]  # packaged speech helper vs real audio/model: accuracy + append-only deltas + parent tether (run package first)
-./scripts/remote-build.sh eval-e2e [EvalRecordings/agent-dictation/<set>]  # agent-dictation E2E eval: human WAVs (optional) or TTS -> voxmlx -> polishd (run package first)
+./scripts/remote-build.sh eval-e2e [EvalRecordings/agent-dictation/<set>]  # agent-dictation E2E eval: human WAVs (optional) or TTS -> speechd -> polishd (run package first)
 ./scripts/run-agent-eval-local.sh [EvalRecordings/agent-dictation/<set>]   # same eval directly from a Mac checkout (run package_app.sh first)
 ./scripts/ablate-agent-eval.py .build/agent-eval-local.log                 # reuse one E2E log to compare pre/post-processing, prompts, and models without rerunning audio
 ./scripts/remote-build.sh build --package-path PolishHelper   # helper package alone
@@ -142,25 +144,29 @@ This is a real app with daily users. Nothing ships on "it compiles".
 | Tier | What | When | Cost |
 |---|---|---|---|
 | 0 | Unit suite (500+ tests) + PolishHelper/SpeechHelper unit suites + packaging + launch smoke | every PR/push, CI (helper unit suites: self-hosted lanes only) | ~1 min |
-| 1 | `RealtimeAPIVLLMIntegrationTests` vs live local voxmlx: real inference through the production websocket client, word-accuracy asserted | every PR/push on the self-hosted runner; locally via `remote-build.sh integration` | ~20 s |
+| 1 | `RealtimeAPIVLLMIntegrationTests` vs the live local speechd STT test service: real inference through the production websocket client, word-accuracy asserted | every PR/push on the self-hosted runner; locally via `remote-build.sh integration` | ~20 s |
 | 1 | `PolishHelperIntegrationTests`: the packaged polishing helper vs the real pinned model — production request path, shared eval baseline, parent-pid tether | conditional in CI (self-hosted, after packaging): only when the diff touches LLM-relevant paths or the PR opts in with `[run-llm-eval]` — see "When must the LLM lanes run?"; locally via `remote-build.sh integration-polishd` | minutes (4B weights + live inference) |
 | 1 | `SpeechHelperIntegrationTests`: packaged speechd vs real spoken audio/model through the production realtime client — word accuracy, append-only delta/done parity, parent-pid tether | conditional in CI (self-hosted, after packaging): only when the diff touches speechd-relevant paths or the PR opts in with `[run-speechd-integration]`; locally via `remote-build.sh integration-speechd` | minutes (4B weights + live inference) |
 | 2 | `ui-smoke.yml` AX smoke drill (status item, settings tabs, lazy managed-backend launch invariant); dictation-with-audio remains future work | evening lock-aware slots (18:00/19:30/21:00 UTC; `ui-smoke-guard.sh` skips green when the screen is locked or a slot's drill already ran and passed that day — the drill needs an unlocked GUI session) + manual on the self-hosted GUI runner | — |
-| 2 | `AgentDictationE2EEvalTests` (`eval-e2e.yml`): wide agent-dictation eval — human WAVs or TTS(`say`) → live voxmlx ASR → bundled polishd through the production stop-commit path, scored against `EvalCorpus/agent-dictation/` (7 migrated required cases asserted; the rest XFAIL; WER informational; raw-model pre-safety diagnostic column) | nightly + manual, NEVER per-PR (owner decision 2026-07-11); locally via `remote-build.sh eval-e2e [EvalRecordings/agent-dictation/<set>]` (run `package` first) | many minutes (live ASR/4B polish over ~160 cases; TTS WAVs cached on the host) |
+| 2 | `AgentDictationE2EEvalTests` (`eval-e2e.yml`): wide agent-dictation eval — human WAVs or TTS(`say`) → live speechd ASR → bundled polishd through the production stop-commit path, scored against `EvalCorpus/agent-dictation/` (7 migrated required cases asserted; the rest XFAIL; WER informational; raw-model pre-safety diagnostic column) | nightly + manual, NEVER per-PR (owner decision 2026-07-11); locally via `remote-build.sh eval-e2e [EvalRecordings/agent-dictation/<set>]` (run `package` first) | many minutes (live ASR/4B polish over ~160 cases; TTS WAVs cached on the host) |
 
 Tier 1 details: the suite is env-gated (`VLLM_REALTIME_TEST_ENABLE=1`) and
-expects voxmlx at `ws://127.0.0.1:8000/v1/realtime` — on the build host it runs
-as the launchd service `com.localvoxtral.voxmlx` (logs:
-`~/Library/Logs/voxmlx.log`). Fork PRs run on GitHub-hosted runners with no
-backend, where the suite self-skips. The mic-capture tests
-(`LOCALVOXTRAL_MIC_CAPTURE_TEST_ENABLE`) stay off in CI until tier 2.
+expects an STT server at `ws://127.0.0.1:8000/v1/realtime` — on the build host it
+runs as the launchd test service `com.localvoxtral.testspeechd` (the bundled
+`localvoxtral-speechd`; logs: `/Users/Shared/localvoxtral/speechd.log`). Fork PRs
+run on GitHub-hosted runners with no backend, where the suite self-skips. The
+mic-capture tests (`LOCALVOXTRAL_MIC_CAPTURE_TEST_ENABLE`) stay off in CI until
+tier 2.
 
-On-demand test servers: the voxmlx (8000) and mlxlm (8080) launchd services are
+On-demand test servers: the speechd (8000, STT) and polishd (8080,
+chat/completions) launchd test services — the app's OWN bundled Swift helpers,
+which replaced the retired Python voxmlx/mlx-lm services in 2026-07 — are
 launch-on-demand (a trigger file + idle reaper — `scripts/mac/lv-test-servers.sh`,
 owner runbook `scripts/mac/README.md`), so their weights are not resident 24/7.
-This is hands-free: CI warms voxmlx in a step before the integration suite, and
+This is hands-free: CI warms speechd in a step before the integration suite, and
 `remote-build.sh integration|eval-llm|eval-e2e` warm the right server through the gate's
-`ensure` verb first, blocking until the port is healthy. A burst of runs reuses
+`ensure` verb first (names `speechd`/`polishd`, with `voxmlx`/`mlxlm` accepted as
+deprecated aliases), blocking until the port is healthy. A burst of runs reuses
 one warm process (each `ensure` resets a ~20 min idle window); the reaper frees
 the RAM once the machine goes quiet.
 
@@ -168,8 +174,9 @@ LLM polish prompt eval: `LLMPolishPromptEvalTests` scores the bundled default
 polishing prompt (punctuation-spacing cases, French vs English) against a live
 chat/completions server through the production request path. Run it with
 `./scripts/remote-build.sh eval-llm [endpoint]` — default endpoint is the
-on-demand `com.localvoxtral.mlxlm` launchd service on port 8080, which the lane
-warms first via the gate's `ensure` verb (owner runbook: `scripts/mac/README.md`);
+on-demand `com.localvoxtral.testpolishd` launchd service on port 8080 (the
+bundled `localvoxtral-polishd`, running the production default model), which the
+lane warms first via the gate's `ensure` verb (owner runbook: `scripts/mac/README.md`);
 a custom endpoint is left untouched. Don't point it at the app-managed instance
 on 8472, which dies whenever the app quits. Enablement is env
 (`LLM_POLISH_EVAL_ENABLE=1`) or the marker file the script writes into the
@@ -197,7 +204,7 @@ prompt warmup, clipboard context/macro, repo vocabulary, the polish-commit
 path (`DictationViewModel+Session.swift`), and the eval support/corpus. The
 decide step writes "LLM eval lane: RUNNING (…)" or "SKIPPED (…)" to the
 run's step summary so a skipped run is self-explanatory. The PolishHelper
-UNIT suite (Metal-free) and the tier-1 voxmlx realtime integration stay
+UNIT suite (Metal-free) and the tier-1 speechd realtime integration stay
 per-push.
 
 The rule behind the list — the LLM lanes are REQUIRED for changes to:

--- a/Tests/localvoxtralTests/AgentDictationE2EEvalSupport.swift
+++ b/Tests/localvoxtralTests/AgentDictationE2EEvalSupport.swift
@@ -31,8 +31,8 @@ enum AgentDictationE2EEvalSupport {
     static let defaultHelperPath =
         "PolishHelper/.build/xcode/Build/Products/Release/localvoxtral-polishd"
     static let defaultVoxmlxEndpoint = "ws://127.0.0.1:8000/v1/realtime"
-    /// The realtime model the build host's voxmlx service serves (same pin as
-    /// the tier-1 integration lane in `remote-build.sh integration`).
+    /// The realtime model the build host's speechd STT service serves (same pin
+    /// as the tier-1 integration lane in `remote-build.sh integration`).
     static let defaultASRModel = "T0mSIlver/Voxtral-Mini-4B-Realtime-2602-MLX-4bit"
 
     struct MarkerConfig: Decodable, Equatable {

--- a/Tests/localvoxtralTests/AgentDictationE2EEvalTests.swift
+++ b/Tests/localvoxtralTests/AgentDictationE2EEvalTests.swift
@@ -9,14 +9,14 @@ import XCTest
 /// corpus and its contract are Phase 1, `EvalCorpus/agent-dictation/`):
 ///
 ///   recorded human WAV OR TTS(spokenForm, /usr/bin/say)
-///     -> production websocket ASR (voxmlx)
+///     -> production websocket ASR (speechd STT service)
 ///     -> production polish stop-commit path (bundled polishd helper or an
 ///        explicitly selected OpenAI-compatible endpoint)
 ///     -> corpus-contract scoring -> scoreboard
 ///
 /// What each stage exercises (documented per the Phase-2 contract):
-/// - ASR: the production `RealtimeAPIWebSocketClient` against a live voxmlx
-///   (same chunking + final-transcript assembly as the tier-1 integration
+/// - ASR: the production `RealtimeAPIWebSocketClient` against a live speechd STT
+///   service (same chunking + final-transcript assembly as the tier-1 integration
 ///   suite). The live-session transcript MERGE (DictationViewModel+
 ///   RealtimeEvents overlap merge) is NOT in the loop — finals are joined
 ///   directly; a Phase-3 candidate.
@@ -683,7 +683,7 @@ final class AgentDictationE2EEvalTests: XCTestCase {
         )
     }
 
-    // MARK: - ASR (production websocket client vs live voxmlx)
+    // MARK: - ASR (production websocket client vs live speechd STT service)
 
     private func transcribe(
         pcm: Data,

--- a/Tests/localvoxtralTests/LLMPolishPromptEvalTests.swift
+++ b/Tests/localvoxtralTests/LLMPolishPromptEvalTests.swift
@@ -24,9 +24,10 @@ import XCTest
 ///   pinned per-command), so from the Linux box the enablement has to travel
 ///   inside the synced tree instead of the SSH command line.
 ///
-/// Default endpoint is the build-host eval service `com.localvoxtral.mlxlm`
-/// (port 8080, owner runbook: scripts/mac/README.md); the app-managed
-/// instance on 8472 works too while the app is running with polishing on.
+/// Default endpoint is the build-host eval service `com.localvoxtral.testpolishd`
+/// (the bundled polishd helper on port 8080, owner runbook:
+/// scripts/mac/README.md); the app-managed instance on 8472 works too while the
+/// app is running with polishing on.
 @MainActor
 final class LLMPolishPromptEvalTests: XCTestCase {
     private static let enableEnv = "LLM_POLISH_EVAL_ENABLE"

--- a/Tests/localvoxtralTests/RealtimeAPIVLLMIntegrationTests.swift
+++ b/Tests/localvoxtralTests/RealtimeAPIVLLMIntegrationTests.swift
@@ -290,7 +290,7 @@ final class RealtimeAPIVLLMIntegrationTests: XCTestCase {
             actual: combinedFinalTranscript
         )
         print(
-            "voxmlx integration: word accuracy \(String(format: "%.3f", wordAccuracy)); "
+            "speechd integration: word accuracy \(String(format: "%.3f", wordAccuracy)); "
                 + "transcript: \(combinedFinalTranscript)"
         )
         XCTAssertGreaterThanOrEqual(

--- a/scripts/ablate-agent-eval.py
+++ b/scripts/ablate-agent-eval.py
@@ -1,7 +1,8 @@
 #!/usr/bin/env python3
 """Run stage and model ablations from an agent-e2e inspection log.
 
-The live macOS eval is expensive because audio must pass through voxmlx. Its
+The live macOS eval is expensive because audio must pass through the speechd
+ASR service. Its
 inspection report already retains the ASR transcript, production pre-LLM text,
 exact request, raw model output, and committed output. This script reuses those
 artifacts to answer a narrower question quickly: which processing stages improve

--- a/scripts/mac/README.md
+++ b/scripts/mac/README.md
@@ -20,15 +20,30 @@ metal` succeeds even when the component is missing (the shim exists), so
 only an actual invocation (`xcrun metal --version`) proves it works. Runs
 as a normal user, no sudo needed.
 
-## On-demand test servers (voxmlx + mlxlm) — owner runbook
+## On-demand test servers (speechd + polishd) — owner runbook
 
-The two build-host model servers used by the integration/eval suites —
-`com.localvoxtral.voxmlx` (port 8000, tier-1 realtime STT) and
-`com.localvoxtral.mlxlm` (port 8080, LLM polish eval) — used to run
-`RunAtLoad`/`KeepAlive` always-on, keeping multi-GB weights resident 24/7.
-They are now **launch-on-demand with an idle reaper** so that RAM is only
-spent around actual test runs. This is hands-free for both CI and
-`remote-build.sh` — nobody has to remember to start/stop anything.
+The two build-host model servers used by the integration/eval suites are the
+app's OWN bundled Swift helpers (they replaced the retired Python voxmlx /
+mlx-lm services in the 2026-07 migration — see "Migration" below):
+
+- `com.localvoxtral.testspeechd` — `localvoxtral-speechd` on **port 8000**,
+  tier-1 realtime STT (the same OpenAI-Realtime websocket the app ships).
+- `com.localvoxtral.testpolishd` — `localvoxtral-polishd` on **port 8080**,
+  the LLM-polish-eval reference chat/completions endpoint.
+
+Short service names are `speechd` / `polishd` (the retired `voxmlx` / `mlxlm`
+are still accepted as deprecated aliases). They run **launch-on-demand with an
+idle reaper** so RAM is only spent around actual test runs — hands-free for
+both CI and `remote-build.sh`.
+
+Because they are Metal-using MLX helpers, they MUST run from a PACKAGED
+(xcodebuild) `.app` — a bare `swift build` binary cannot load its metallib.
+The plists point at helper binaries inside a stable installed copy at
+`/Users/Shared/localvoxtral/testservers/localvoxtral.app`, refreshed with
+`lv-test-servers.sh install-helpers <path-to-.app>`. The helpers also NEVER
+auto-download weights: the pinned models must be pre-downloaded into the
+service account's Hugging Face cache (below), or `ensure` just times out with a
+clear log line.
 
 How it works (`scripts/mac/lv-test-servers.sh` is the single source of truth):
 
@@ -54,10 +69,12 @@ How it works (`scripts/mac/lv-test-servers.sh` is the single source of truth):
   in the GUI-owner domain, so the `launchctl kill` is permitted. The
   compromise: warm within a work session / CI burst, RAM freed once the machine
   goes quiet — next use pays one cold model load.
-- **Manual unload:** `lv-test-servers.sh stop [voxmlx|mlxlm|all]` frees the
+- **Manual unload:** `lv-test-servers.sh stop [speechd|polishd|all]` frees the
   weights NOW without waiting for the idle window — same stop path as reap
   (trigger removed, `SIGTERM`→`SIGKILL`, blocks until the port closes). Default
-  target is `all`.
+  target is `all`. Stop signals BOTH the new (`testspeechd`/`testpolishd`) and
+  retired (`voxmlx`/`mlxlm`) labels plus a port-bound fallback, so it works
+  whichever generation is loaded.
 - **Robustness:** an interrupted run or a sleeping Mac just leaves the trigger
   behind; the server stays warm and the reaper collects it later. There is no
   lock to get stuck and no orphan process (launchd owns each server; the reaper
@@ -78,40 +95,56 @@ How it works (`scripts/mac/lv-test-servers.sh` is the single source of truth):
 sudo install -d -m 1777 -o "$(id -un)" /Users/Shared/localvoxtral/run
 sudo install -d -m 0755 /Users/Shared/localvoxtral        # log dir, if absent
 
-# 2. mlxlm venv with the pinned fork wheel. Since the bundled MLX Swift helper
-#    replaced the app-managed mlx-lm wheel (2026-07), the app no longer
-#    installs mlx-lm — this pin exists only for the eval reference endpoint.
-uv venv --python 3.12 ~/.local/share/localvoxtral-eval/mlx-lm
-uv pip install --python ~/.local/share/localvoxtral-eval/mlx-lm/bin/python \
-  'mlx-lm @ https://github.com/T0mSIlver/mlx-lm/releases/download/v0.31.3.post4/mlx_lm-0.31.3.post4-py3-none-any.whl'
+# 2. Stable installed .app whose Metal-capable helper binaries the plists run.
+#    Build a bundle WITH the helpers (never SKIP_SPEECHD/POLISHD), then install:
+#      ./scripts/package_app.sh release           # produces dist/localvoxtral.app
+#      scripts/mac/lv-test-servers.sh install-helpers dist/localvoxtral.app
+#    (or point install-helpers at a try-pr.sh download / a release .app). This
+#    copies to /Users/Shared/localvoxtral/testservers/localvoxtral.app. Refresh
+#    it the same way whenever the helpers change; `stop all` then makes the next
+#    `ensure` cold-start from the new copy.
+
+# 3. Pre-download the pinned models into the OWNER's HF cache (the account whose
+#    launchd domain runs the services — the one bootstrapping the plists below).
+#    The helpers NEVER auto-download: a missing model makes speechd/polishd log
+#    an error and exit, launchd relaunch-loops it, and `ensure` times out with a
+#    clear message. Keep these pins in sync with SpeechModelCatalog.defaultOption
+#    and PolishModelCatalog.defaultOption in the app source.
+python3 -m pip install --user -U 'huggingface_hub[cli]'   # or: uv tool install huggingface_hub
+hf download mlx-community/Voxtral-Mini-4B-Realtime-2602-4bit \
+  --revision fdebf7b2af834a1db4b8a3c99ab7480b333adf9e     # speechd (STT, 8000)
+hf download mlx-community/Qwen3.5-4B-OptiQ-4bit \
+  --revision 41eccc3316fd4bf4b27cedf4924fe23ce44e77d9     # polishd (polish, 8080)
 ```
 
-> This mlxlm service is the *prompt-eval reference endpoint* for
-> `LLMPolishPromptEvalTests` / `remote-build.sh eval-llm` — the app itself no
-> longer installs or runs mlx-lm; production-engine parity is covered by
-> `./scripts/remote-build.sh integration-polishd` instead, and the
-> `--prompt-cache-*` flags below are mlx-lm-specific and don't mirror app
-> behavior. Don't point evals at the app-managed server on 8472 — it only
-> exists while the app is running with polishing enabled, so it vanishes
-> whenever the app quits.
+> The polishd service is the *prompt-eval reference endpoint* for
+> `LLMPolishPromptEvalTests` / `remote-build.sh eval-llm`. It now runs the SAME
+> bundled engine and default 4B model as production (so eval-llm measures the
+> shipped prompt+model combo; production-engine parity is also covered by
+> `./scripts/remote-build.sh integration-polishd`). Don't point evals at the
+> app-managed server on 8472 — it only exists while the app is running with
+> polishing enabled, so it vanishes whenever the app quits.
 
-### mlxlm LaunchAgent (on-demand)
+### polishd LaunchAgent (on-demand)
+
+Note the trigger path: it stays `run/mlxlm.want` (the retired name) on purpose —
+that is the stable cross-generation rendezvous so an already-installed gate and
+un-updated reaper keep working through the swap (see the `lv-test-servers.sh`
+header). Only the Label + ProgramArguments changed.
 
 ```bash
-cat > ~/Library/LaunchAgents/com.localvoxtral.mlxlm.plist <<'PLIST'
+cat > ~/Library/LaunchAgents/com.localvoxtral.testpolishd.plist <<'PLIST'
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-  <key>Label</key><string>com.localvoxtral.mlxlm</string>
+  <key>Label</key><string>com.localvoxtral.testpolishd</string>
   <key>ProgramArguments</key>
   <array>
-    <string>/Users/REPLACE_ME/.local/share/localvoxtral-eval/mlx-lm/bin/mlx_lm.server</string>
-    <string>--model</string><string>mlx-community/Qwen3.5-0.8B-8bit</string>
-    <string>--host</string><string>127.0.0.1</string>
+    <string>/Users/Shared/localvoxtral/testservers/localvoxtral.app/Contents/MacOS/localvoxtral-polishd</string>
+    <string>--model</string><string>mlx-community/Qwen3.5-4B-OptiQ-4bit</string>
+    <string>--model-revision</string><string>41eccc3316fd4bf4b27cedf4924fe23ce44e77d9</string>
     <string>--port</string><string>8080</string>
-    <string>--prompt-cache-size</string><string>1</string>
-    <string>--prompt-cache-bytes</string><string>1GB</string>
   </array>
   <!-- On-demand: launchd starts this while the trigger file exists and stops
        it (freeing the weights) when lv-test-servers.sh reap removes it. -->
@@ -121,36 +154,53 @@ cat > ~/Library/LaunchAgents/com.localvoxtral.mlxlm.plist <<'PLIST'
     <key>PathState</key>
     <dict><key>/Users/Shared/localvoxtral/run/mlxlm.want</key><true/></dict>
   </dict>
-  <key>StandardOutPath</key><string>/Users/Shared/localvoxtral/mlxlm.log</string>
-  <key>StandardErrorPath</key><string>/Users/Shared/localvoxtral/mlxlm.log</string>
+  <key>StandardOutPath</key><string>/Users/Shared/localvoxtral/polishd.log</string>
+  <key>StandardErrorPath</key><string>/Users/Shared/localvoxtral/polishd.log</string>
 </dict>
 </plist>
 PLIST
 
-launchctl bootstrap "gui/$(id -u)" ~/Library/LaunchAgents/com.localvoxtral.mlxlm.plist
+launchctl bootstrap "gui/$(id -u)" ~/Library/LaunchAgents/com.localvoxtral.testpolishd.plist
 ```
 
-### voxmlx LaunchAgent — convert existing to on-demand
+### speechd LaunchAgent (on-demand)
 
-The voxmlx agent already exists (`com.localvoxtral.voxmlx`, port 8000, its
-`StandardOutPath` pointed at `/Users/Shared/localvoxtral/voxmlx.log` for the
-gate — see below). To make it on-demand, edit its plist to **replace**
-`<key>RunAtLoad</key><true/>` and `<key>KeepAlive</key><true/>` with:
+Same as polishd, the trigger path stays `run/voxmlx.want` (retired name) as the
+stable cross-generation rendezvous — the CI warm step (`ensure speechd`), the
+gate, and an un-updated reaper all touch/read exactly this path, so the STT lane
+keeps warming with no gate/reaper reinstall. `StandardOutPath` is the file the
+gate's `voxlog`/`VOXLOG_FILE` reads.
 
-```xml
+```bash
+cat > ~/Library/LaunchAgents/com.localvoxtral.testspeechd.plist <<'PLIST'
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key><string>com.localvoxtral.testspeechd</string>
+  <key>ProgramArguments</key>
+  <array>
+    <string>/Users/Shared/localvoxtral/testservers/localvoxtral.app/Contents/MacOS/localvoxtral-speechd</string>
+    <string>--model</string><string>mlx-community/Voxtral-Mini-4B-Realtime-2602-4bit</string>
+    <string>--model-revision</string><string>fdebf7b2af834a1db4b8a3c99ab7480b333adf9e</string>
+    <string>--port</string><string>8000</string>
+    <string>--cache-limit-mb</string><string>4096</string>
+  </array>
+  <!-- On-demand: launchd starts this while the trigger file exists and stops
+       it (freeing the weights) when lv-test-servers.sh reap removes it. -->
   <key>RunAtLoad</key><false/>
   <key>KeepAlive</key>
   <dict>
     <key>PathState</key>
     <dict><key>/Users/Shared/localvoxtral/run/voxmlx.want</key><true/></dict>
   </dict>
-```
+  <key>StandardOutPath</key><string>/Users/Shared/localvoxtral/speechd.log</string>
+  <key>StandardErrorPath</key><string>/Users/Shared/localvoxtral/speechd.log</string>
+</dict>
+</plist>
+PLIST
 
-then re-bootstrap it:
-
-```bash
-launchctl bootout "gui/$(id -u)/com.localvoxtral.voxmlx" || true
-launchctl bootstrap "gui/$(id -u)" ~/Library/LaunchAgents/com.localvoxtral.voxmlx.plist
+launchctl bootstrap "gui/$(id -u)" ~/Library/LaunchAgents/com.localvoxtral.testspeechd.plist
 ```
 
 ### Idle-reaper LaunchAgent
@@ -183,32 +233,39 @@ launchctl bootstrap "gui/$(id -u)" ~/Library/LaunchAgents/com.localvoxtral.tests
 
 (Point the script path at a stable checkout of this repo, or copy
 `lv-test-servers.sh` to a fixed location. Override the idle window by adding an
-`EnvironmentVariables` dict with `LV_TEST_SERVER_IDLE_SECONDS`.)
+`EnvironmentVariables` dict with `LV_TEST_SERVER_IDLE_SECONDS`. During the
+migration, `git pull` that stable checkout so the reaper runs the new script —
+though an OLD reaper still reaps the new services via its port-bound fallback,
+since it keeps reading the same `run/voxmlx.want` / `run/mlxlm.want` triggers.)
 
 ### Verify (owner-side proof)
 
 ```bash
 scripts/mac/lv-test-servers.sh status                 # both: trigger absent, down
-scripts/mac/lv-test-servers.sh ensure voxmlx          # cold-starts, blocks to warm
-scripts/mac/lv-test-servers.sh status                 # voxmlx: trigger present, up
+scripts/mac/lv-test-servers.sh ensure speechd         # cold-starts, blocks to warm
+scripts/mac/lv-test-servers.sh status                 # speechd: trigger present, up
 # Warm reuse: a second ensure returns instantly ("already warm") and resets idle.
-scripts/mac/lv-test-servers.sh ensure voxmlx
+scripts/mac/lv-test-servers.sh ensure speechd
 # Idle reap: age the trigger AND the stamps past the window, then reap (or just
 # wait for the reaper agent), and confirm launchd stopped the server / freed
 # RAM. Age both — reap keys off the NEWEST of the trigger + stamps, so a
 # freshly cold-started trigger (recent mtime) would otherwise keep it "warm".
+# The trigger/stamp filesystem key stays `voxmlx` for speechd (stable rendezvous).
 # reap BLOCKS until the port actually closes (SIGTERM drains the MLX server in
 # ~2-3s; it escalates to SIGKILL after STOP_GRACE), so the status right after
 # reflects the real state — no need to sleep.
 touch -t 202001010000 /Users/Shared/localvoxtral/run/voxmlx.*   # .want + .seen.*
 scripts/mac/lv-test-servers.sh reap                   # removes trigger + stamps, TERM→KILL
-scripts/mac/lv-test-servers.sh status                 # voxmlx: absent, down
+scripts/mac/lv-test-servers.sh status                 # speechd: absent, down
+# polishd (8080) is the same, keyed on run/mlxlm.want:
+scripts/mac/lv-test-servers.sh ensure polishd
 ```
 
 If the SSH build gate is installed, `remote-build.sh integration|eval-llm|eval-e2e`
-warm the right server through the gate's `ensure` verb automatically; CI warms
-voxmlx in its own step before the integration suite (and `eval-e2e.yml` before
-the nightly agent-dictation eval). The
+warm the right server through the gate's `ensure` verb automatically (it sends
+`ensure speechd`/`polishd`, falling back to the `voxmlx`/`mlxlm` alias for an
+un-reinstalled gate); CI warms speechd in its own step before the integration
+suite (and `eval-e2e.yml` before the nightly agent-dictation eval). The
 `svc-status`/`diag`/`voxlog` verbs still probe ports 8000/8080.
 
 No gate change is needed for the `eval-e2e` lane: its payload is a plain
@@ -225,15 +282,73 @@ When capture happens in a Mac checkout, `scripts/run-agent-eval-local.sh`
 runs the same env-gated suite directly and avoids copying the voice set through
 another source checkout.
 
+### Migration: retire the Python voxmlx/mlx-lm services
+
+One-time owner steps to swap the two Python test services for the bundled Swift
+helpers. The trigger paths (`run/voxmlx.want` / `run/mlxlm.want`) are unchanged,
+so CI stays green throughout — do these in a trusted GUI-owner session on the
+Mac. `$UID` is the owner's uid (`id -u`).
+
+```bash
+# 0. Prereqs (skip if already present from the on-demand install above):
+sudo install -d -m 1777 -o "$(id -un)" /Users/Shared/localvoxtral/run
+sudo install -d -m 0755 -o "$(id -un)" /Users/Shared/localvoxtral
+
+# 1. Install the Metal-capable helper binaries (from a bundle built WITH them):
+cd ~/work/localvoxtral && git pull
+./scripts/package_app.sh release
+scripts/mac/lv-test-servers.sh install-helpers dist/localvoxtral.app
+
+# 2. Pre-download the pinned models into THIS account's HF cache (see step 3 of
+#    the on-demand install above — hf download the Voxtral + Qwen3.5-4B pins).
+
+# 3. Bootout the retired Python services and remove their plists:
+launchctl bootout "gui/$UID/com.localvoxtral.voxmlx" 2>/dev/null || true
+launchctl bootout "gui/$UID/com.localvoxtral.mlxlm"  2>/dev/null || true
+rm -f ~/Library/LaunchAgents/com.localvoxtral.voxmlx.plist \
+      ~/Library/LaunchAgents/com.localvoxtral.mlxlm.plist
+
+# 4. Bootstrap the new helper plists (templates above). The bootout lines make
+#    a rerun of this step safe — bootstrap fails with "5: Input/output error"
+#    when the label is already loaded:
+launchctl bootout "gui/$UID/com.localvoxtral.testspeechd" 2>/dev/null || true
+launchctl bootout "gui/$UID/com.localvoxtral.testpolishd" 2>/dev/null || true
+launchctl bootstrap "gui/$UID" ~/Library/LaunchAgents/com.localvoxtral.testspeechd.plist
+launchctl bootstrap "gui/$UID" ~/Library/LaunchAgents/com.localvoxtral.testpolishd.plist
+
+# 5. Delete the retired mlx-lm venv/wheel (no longer used by anything):
+rm -rf ~/.local/share/localvoxtral-eval/mlx-lm
+
+# 6. Reinstall the SSH build gate so `ensure speechd|polishd`, the /health probe
+#    arm on 8080, and the new process/label reporting take effect (see the gate
+#    install section below), and `git pull` the reaper's stable checkout.
+
+# 7. Point the gate's voxlog verb at the new STT log (gate account = the user
+#    the SSH forced command runs as; same file as the "Config" section below):
+echo 'VOXLOG_FILE=/Users/Shared/localvoxtral/speechd.log' >> ~/.localvoxtral-gate.conf
+
+# 8. Verify (the "Verify" block above):
+scripts/mac/lv-test-servers.sh ensure speechd && scripts/mac/lv-test-servers.sh ensure polishd
+scripts/mac/lv-test-servers.sh status
+```
+
+Verification: `RealtimeAPIVLLMIntegrationTests` (via `remote-build.sh
+integration`, or CI) must stay green against the new speechd service, and
+`remote-build.sh eval-llm` scores the default prompt against polishd — re-run it
+and confirm the scoreboard (the 4B reference replaces the old 0.8B mlx-lm
+reference, so expect equal-or-better numbers). Both are OWNER-verified: the
+repo-side changes are compatible with either generation behind the ports, but
+only a live run on the swapped host proves accuracy parity.
+
 ## `localvoxtral-build-gate.sh` — SSH build gate (v4)
 
 Forced command for the Linux dev box's build key on the Mac build host. It
 allowlists the `remote-build.sh` loop (rsync in, `swift build|test`,
 `package_app.sh release`), the v2 read-only diagnostic verbs `diag`,
 `applog [minutes]`, `voxlog [lines]`, `svc-status`, and the on-demand
-test-server verb `ensure <voxmlx|mlxlm|all>` (touches a trigger file in the
-world-writable run dir and polls the port until warm — see the on-demand
-section above). The `reap work/localvoxtral-<id>` recovery verb accepts one
+test-server verb `ensure <speechd|polishd|all>` (retired `voxmlx`/`mlxlm` names
+accepted as aliases; touches a trigger file in the world-writable run dir and
+polls the port until warm — see the on-demand section above). The `reap work/localvoxtral-<id>` recovery verb accepts one
 validated work directory and terminates only stale test processes proven by
 UID plus cwd/mapped-text evidence to belong to it. Everything else is denied
 and logged to `~/Library/Logs/localvoxtral-build-gate.log`.
@@ -311,8 +426,8 @@ differ per machine and are read from an optional, never-committed conf file:
 
 ```bash
 # /Users/<gate-account>/.localvoxtral-gate.conf
-VOXLOG_FILE=/Users/Shared/localvoxtral/voxmlx.log
-VOXMLX_GUI_UID=501        # uid of the GUI user running com.localvoxtral.voxmlx
+VOXLOG_FILE=/Users/Shared/localvoxtral/speechd.log   # STT test-service log (was voxmlx.log)
+VOXMLX_GUI_UID=501        # uid of the GUI user running com.localvoxtral.testspeechd
 # LV_RUN_DIR=/Users/Shared/localvoxtral/run   # only if you moved the triggers
 ```
 
@@ -320,17 +435,9 @@ The `ensure` verb needs no `VOXMLX_GUI_UID` — it never calls `launchctl`, it
 just touches a trigger file the owner-domain launchd watches, so the default
 run dir works as-is once the owner has created it (mode 1777).
 
-For `voxlog` to work across accounts, point the voxmlx LaunchAgent's
-`StandardOutPath`/`StandardErrorPath` at a shared location and set
-`VOXLOG_FILE` to match:
-
-```bash
-sudo install -d -m 0755 -o "$(id -un)" /Users/Shared/localvoxtral
-# edit ~/Library/LaunchAgents/com.localvoxtral.voxmlx.plist: StandardOutPath +
-# StandardErrorPath -> /Users/Shared/localvoxtral/voxmlx.log, then:
-launchctl bootout "gui/$(id -u)/com.localvoxtral.voxmlx" || true
-launchctl bootstrap "gui/$(id -u)" ~/Library/LaunchAgents/com.localvoxtral.voxmlx.plist
-```
+The `voxlog` verb tails the STT test-service log. The speechd plist template
+above already writes `/Users/Shared/localvoxtral/speechd.log` (a shared
+location), so across-account reads just work once `VOXLOG_FILE` points there.
 
 (The alternative — ACL read grants on the owner's `~/Library/Logs` chain — is
 fiddlier and breaks when the log file is rotated/recreated.)
@@ -340,12 +447,12 @@ fiddlier and breaks when the log file is rotated/recreated.)
 ```bash
 ./scripts/remote-build.sh diag        # versions, processes, ports, disk, logs
 ./scripts/remote-build.sh applog 30   # app unified log, last 30 minutes
-./scripts/remote-build.sh voxlog 100  # voxmlx log tail
-./scripts/remote-build.sh svc-status  # voxmlx service/process/port status
+./scripts/remote-build.sh voxlog 100  # speechd STT test-service log tail
+./scripts/remote-build.sh svc-status  # speechd/polishd service/process/port status
 ./scripts/remote-build.sh disk        # df + per-work-dir du and last-used ages
 ./scripts/remote-build.sh gc          # reclaim stale work dirs now (also runs
                                       # automatically after every build/test)
-ssh <gate-destination> 'ensure voxmlx' # warm the on-demand STT server
+ssh <gate-destination> 'ensure speechd' # warm the on-demand STT server
 ssh <gate-destination> 'reap work/localvoxtral-<id>' # scoped stale-test cleanup
 ssh <gate-destination> 'echo pwned'   # must print "denied command"
 ```

--- a/scripts/mac/localvoxtral-build-gate.sh
+++ b/scripts/mac/localvoxtral-build-gate.sh
@@ -15,15 +15,25 @@ set -euo pipefail
 #   applog [minutes]    # integer, clamped to 1..120, default 10
 #   voxlog [lines]      # integer, clamped to 1..500, default 80
 #   svc-status
-#   ensure <voxmlx|mlxlm|all>   # warm an on-demand test server (touch + poll)
+#   ensure <speechd|polishd|all>  # warm an on-demand test server (touch + poll;
+#                                 # retired voxmlx/mlxlm names accepted as aliases)
 #   reap work/localvoxtral-<id>  # terminate stale tests in one exact work dir
 #   disk                # df + per-work-dir du (du can take a while — on demand)
 #   gc                  # delete work dirs unused > LV_GC_MAX_AGE_DAYS (v4)
 
 LOG_FILE="$HOME/Library/Logs/localvoxtral-build-gate.log"
+# `voxlog` tails the STT test-service log. Post-migration the on-demand STT
+# service is the bundled Swift speechd (com.localvoxtral.testspeechd,
+# StandardOutPath /Users/Shared/localvoxtral/speechd.log); the owner points
+# VOXLOG_FILE at it in ~/.localvoxtral-gate.conf. The default keeps the retired
+# voxmlx.log so an un-reconfigured gate still finds something.
 VOXLOG_FILE="$HOME/Library/Logs/voxmlx.log"
-VOXMLX_SERVICE="com.localvoxtral.voxmlx"
-# The GUI-session uid whose launchd domain hosts the voxmlx service. The gate
+# launchctl labels the STT/polish TEST services may be loaded under: the new
+# bundled-helper plists (testspeechd/testpolishd) and the retired Python ones
+# (voxmlx/mlxlm). svc-status prints whichever the owner's domain actually holds.
+TEST_SERVICE_LABELS=(com.localvoxtral.testspeechd com.localvoxtral.testpolishd \
+  com.localvoxtral.voxmlx com.localvoxtral.mlxlm)
+# The GUI-session uid whose launchd domain hosts the test services. The gate
 # account is deliberately not that user, so launchctl needs to be told.
 VOXMLX_GUI_UID="$(id -u)"
 
@@ -111,7 +121,7 @@ clamp_integer() {
 }
 
 launchctl_target() {
-  printf 'gui/%s/%s\n' "$VOXMLX_GUI_UID" "$VOXMLX_SERVICE"
+  printf 'gui/%s/%s\n' "$VOXMLX_GUI_UID" "$1"
 }
 
 # BSD stat on the Mac; GNU stat only so the shell regression tests can run on
@@ -336,11 +346,16 @@ show_versions() {
 show_processes() {
   section "Processes"
   local process pattern pids
-  for process in localvoxtral voxmlx-serve mlx_lm.server; do
+  # localvoxtral(-speechd/-polishd) are the bundled Swift helpers (the current
+  # test services); voxmlx-serve / mlx_lm.server are the retired Python ones,
+  # kept so a pre-migration host still reports.
+  for process in localvoxtral localvoxtral-speechd localvoxtral-polishd voxmlx-serve mlx_lm.server; do
     printf -- '-- %s --\n' "$process"
     if command -v pgrep >/dev/null 2>&1; then
       case "$process" in
         localvoxtral) pattern='(^|/)localvoxtral( |$)' ;;
+        localvoxtral-speechd) pattern='(^|/)localvoxtral-speechd( |$)' ;;
+        localvoxtral-polishd) pattern='(^|/)localvoxtral-polishd( |$)' ;;
         voxmlx-serve) pattern='(^|/)voxmlx-serve( |$)' ;;
         mlx_lm.server) pattern='(^|/)mlx_lm[.]server( |$)' ;;
       esac
@@ -364,8 +379,8 @@ show_processes() {
 show_ports() {
   section "Ports"
   local port
-  # 8000 = voxmlx launchd service, 8080 = mlx-lm eval launchd service,
-  # 8471/8472 = app-managed voxmlx/mlx-lm.
+  # 8000 = speechd test service (STT), 8080 = polishd test service (eval),
+  # 8471/8472 = app-managed speechd/polishd.
   for port in 8000 8080 8471 8472; do
     printf -- '-- port %s --\n' "$port"
     # Connect test first: lsof only sees this account's sockets, so it
@@ -385,20 +400,27 @@ show_ports() {
 }
 
 show_voxmlx_service() {
-  local lines="$1"
+  local lines="$1" label
 
-  section "launchctl ${VOXMLX_SERVICE}"
-  if command -v launchctl >/dev/null 2>&1; then
-    (launchctl print "$(launchctl_target)" 2>&1 || true) | head -n "$lines"
-  else
+  if ! command -v launchctl >/dev/null 2>&1; then
+    section "launchctl test services"
     printf 'launchctl: not found\n'
+    return
   fi
+  # launchctl print cannot read another user's GUI domain, so most of these
+  # come back empty from the gate account — processes/ports (below in
+  # svc-status/diag) are the real signal. Print each candidate label so
+  # whichever generation is loaded in the owner's domain is visible.
+  for label in "${TEST_SERVICE_LABELS[@]}"; do
+    section "launchctl ${label}"
+    (launchctl print "$(launchctl_target "$label")" 2>&1 || true) | head -n "$lines"
+  done
 }
 
 show_voxlog() {
   local lines="$1"
 
-  section "voxmlx.log"
+  section "STT service log (${VOXLOG_FILE##*/})"
   if [[ -f "$VOXLOG_FILE" ]]; then
     # Size/mtime line so an empty file is distinguishable from a missing one
     # when diagnosing remotely.
@@ -465,32 +487,56 @@ run_svc_status() {
 
 # Map an on-demand service name to its trigger file, port, and readiness probe.
 # Mirrors scripts/mac/lv-test-servers.sh; changing one means changing both.
-lv_service_trigger() {
+# The current names are speechd/polishd; voxmlx/mlxlm are deprecated aliases.
+# The trigger/stamp filesystem KEYS stay at the retired names (voxmlx.want /
+# mlxlm.want) so this gate and the newly-bootstrapped testspeechd/testpolishd
+# plists rendezvous on the same paths (see lv-test-servers.sh header).
+lv_service_canonical() {
   case "$1" in
-    voxmlx) printf '%s/voxmlx.want\n' "$LV_RUN_DIR" ;;
-    mlxlm)  printf '%s/mlxlm.want\n' "$LV_RUN_DIR" ;;
+    speechd|voxmlx) printf 'speechd\n' ;;
+    polishd|mlxlm)  printf 'polishd\n' ;;
     *) return 1 ;;
   esac
 }
+lv_service_fskey() {
+  case "$(lv_service_canonical "$1" 2>/dev/null)" in
+    speechd) printf 'voxmlx\n' ;;
+    polishd) printf 'mlxlm\n' ;;
+    *) return 1 ;;
+  esac
+}
+lv_service_trigger() {
+  local key
+  key="$(lv_service_fskey "$1")" || return 1
+  printf '%s/%s.want\n' "$LV_RUN_DIR" "$key"
+}
 lv_service_port() {
-  case "$1" in
-    voxmlx) printf '8000\n' ;;
-    mlxlm)  printf '8080\n' ;;
+  case "$(lv_service_canonical "$1" 2>/dev/null)" in
+    speechd) printf '8000\n' ;;
+    polishd) printf '8080\n' ;;
     *) return 1 ;;
   esac
 }
 lv_service_healthy() {
-  # voxmlx: TCP accept (uvicorn binds only after model load, no HTTP route).
-  # mlxlm: GET /v1/models returns 200 once weights are resident.
+  # speechd (8000): TCP accept (model loads before the listener binds, no HTTP
+  #   route) — same signal the retired voxmlx uvicorn gave.
+  # polishd (8080): GET /health once the model is resident. Accept /v1/models
+  #   too so the probe is correct against BOTH the new polishd and the retired
+  #   mlx-lm behind the port. NOTE: an INSTALLED gate only gains the /health arm
+  #   when the owner reinstalls it (scripts/mac/README.md) — until then it
+  #   probes /v1/models only, so `ensure polishd` against a swapped-in polishd
+  #   times out (best-effort; the eval itself still reaches /v1/chat/completions).
   local name="$1" port
   port="$(lv_service_port "$name")" || return 1
-  case "$name" in
-    voxmlx)
+  case "$(lv_service_canonical "$name" 2>/dev/null)" in
+    speechd)
       nc -z -G "$LV_ENSURE_PROBE_TIMEOUT" -w "$LV_ENSURE_PROBE_TIMEOUT" \
         127.0.0.1 "$port" >/dev/null 2>&1
       ;;
-    mlxlm)
+    polishd)
       curl -fsS -o /dev/null --max-time "$LV_ENSURE_PROBE_TIMEOUT" \
+        "http://127.0.0.1:${port}/health" >/dev/null 2>&1 \
+      || curl -fsS -o /dev/null --max-time "$LV_ENSURE_PROBE_TIMEOUT" \
         "http://127.0.0.1:${port}/v1/models" >/dev/null 2>&1
       ;;
     *) return 1 ;;
@@ -498,10 +544,12 @@ lv_service_healthy() {
 }
 
 ensure_one_service() {
-  local name="$1" trigger port stamp waited=0
-  trigger="$(lv_service_trigger "$name")" || { printf 'ensure: unknown service %s\n' "$name" >&2; return 2; }
-  port="$(lv_service_port "$name")"
-  stamp="$LV_RUN_DIR/${name}.seen.$(id -u)"
+  local name="$1" cname trigger port stamp waited=0
+  cname="$(lv_service_canonical "$name")" || { printf 'ensure: unknown service %s\n' "$name" >&2; return 2; }
+  trigger="$(lv_service_trigger "$cname")"
+  port="$(lv_service_port "$cname")"
+  stamp="$LV_RUN_DIR/$(lv_service_fskey "$cname").seen.$(id -u)"
+  name="$cname"
 
   if [[ ! -d "$LV_RUN_DIR" ]]; then
     printf 'ensure %s: run dir %s missing — owner must create it (see scripts/mac/README.md)\n' \
@@ -543,19 +591,25 @@ ensure_one_service() {
     waited=$((waited + 2))
   done
 
-  printf 'ensure %s: NOT ready after %ss (port %s) — is com.localvoxtral.%s bootstrapped?\n' \
-    "$name" "$LV_ENSURE_READY_TIMEOUT" "$port" "$name" >&2
+  local label
+  case "$name" in
+    speechd) label="com.localvoxtral.testspeechd" ;;
+    polishd) label="com.localvoxtral.testpolishd" ;;
+    *) label="com.localvoxtral.test${name}" ;;
+  esac
+  printf 'ensure %s: NOT ready after %ss (port %s) — is %s bootstrapped and its model cached?\n' \
+    "$name" "$LV_ENSURE_READY_TIMEOUT" "$port" "$label" >&2
   return 1
 }
 
 run_ensure_command() {
   local target="$1"
   case "$target" in
-    voxmlx|mlxlm) ensure_one_service "$target" ;;
+    speechd|polishd|voxmlx|mlxlm) ensure_one_service "$target" ;;
     all)
       local rc=0
-      ensure_one_service voxmlx || rc=$?
-      ensure_one_service mlxlm || rc=$?
+      ensure_one_service speechd || rc=$?
+      ensure_one_service polishd || rc=$?
       return "$rc"
       ;;
     *) deny ;;

--- a/scripts/mac/lv-test-servers.sh
+++ b/scripts/mac/lv-test-servers.sh
@@ -5,21 +5,29 @@ set -euo pipefail
 # serving TEST services (NOT the app-managed backends).
 #
 # Two launchd LaunchAgents in the GUI-owner domain serve the integration/eval
-# suites:
-#   com.localvoxtral.voxmlx  port 8000  websocket realtime STT (tier-1)
-#   com.localvoxtral.mlxlm   port 8080  http chat/completions  (eval-llm)
-#
-# Keeping their multi-GB weights resident 24/7 wastes RAM. Instead both agents
-# are configured launch-on-demand via a KeepAlive `PathState` TRIGGER FILE
-# (RunAtLoad false, KeepAlive { PathState { <trigger>: true } }): launchd runs
-# the server while the trigger file EXISTS and stops it (freeing the weights)
-# when it is removed. See scripts/mac/README.md for the plists.
+# suites. As of the 2026-07 migration these are the app's OWN bundled Swift
+# helpers (the retired Python voxmlx/mlx-lm services ran here before):
+#   com.localvoxtral.testspeechd  port 8000  websocket realtime STT  (speechd)
+#   com.localvoxtral.testpolishd  port 8080  http chat/completions   (polishd)
+# The short service names are `speechd` / `polishd`; `voxmlx` / `mlxlm` remain
+# accepted as DEPRECATED ALIASES so already-installed gates and un-updated
+# checkouts keep working across the swap.
 #
 # Two file kinds live in the world-writable run dir:
-#   <name>.want         the launchd trigger — its EXISTENCE means "run".
-#   <name>.seen.<uid>   a per-caller activity stamp — its MTIME means "last
-#                       used by uid". The idle reaper keys off the NEWEST
-#                       stamp across all callers.
+#   <fskey>.want         the launchd trigger — its EXISTENCE means "run".
+#   <fskey>.seen.<uid>   a per-caller activity stamp — its MTIME means "last
+#                        used by uid". The idle reaper keys off the NEWEST
+#                        stamp across all callers.
+# The trigger/stamp FILESYSTEM KEYS are deliberately kept at the retired names
+# `voxmlx` / `mlxlm` (voxmlx.want / mlxlm.want) even though the services are
+# now speechd/polishd: these paths are the cross-generation rendezvous. An
+# already-installed gate and an un-updated reaper touch and read exactly these
+# paths, and the newly-bootstrapped testspeechd/testpolishd plists watch the
+# SAME paths (see scripts/mac/README.md) — so warming and idle-accounting keep
+# working through the swap with no gate/reaper reinstall required. Renaming
+# them would break that window; do not, without also renaming the plist
+# PathState keys AND reinstalling the gate + reaper in the same change.
+#
 # They are split because the run dir is a shared, sticky, world-writable dir:
 # any account can CREATE a file, but only its owner (or the dir owner) can
 # update/delete it. So each caller starts a server by creating the shared
@@ -54,6 +62,12 @@ set -euo pipefail
 # the ensure logic INLINE rather than exec'ing this script, so its security
 # review stays self-contained; keep the paths/ports/probes below in sync.
 #
+# The bundled helpers NEVER auto-download weights (a missing model makes
+# speechd/polishd log an error and exit, so launchd relaunch-loops it and the
+# health probe just times out with a clear "NOT ready" message — never a silent
+# serve of the wrong thing). The owner pre-downloads the pinned models into the
+# service account's Hugging Face cache once — see scripts/mac/README.md.
+#
 # Robustness: an interrupted run or a sleeping Mac just leaves the trigger and
 # stamps in place — the server stays warm and the reaper collects it after the
 # idle window. There is no lock to get stuck and no process to orphan: launchd
@@ -75,30 +89,61 @@ READY_TIMEOUT="${LV_TEST_SERVER_READY_TIMEOUT:-180}"
 STOP_GRACE="${LV_TEST_SERVER_STOP_GRACE:-8}"
 PORT_TIMEOUT=2
 
-ALL_SERVICES=(voxmlx mlxlm)
+# Stable installed copy of the packaged .app whose Metal-capable helper
+# binaries the plists run. The helpers MUST come from a packaged (xcodebuild)
+# bundle — a bare `swift build` binary cannot load its metallib at runtime — so
+# `install-helpers` copies a package_app.sh / try-pr.sh / release .app here and
+# the plists point at
+#   $STABLE_APP/Contents/MacOS/localvoxtral-speechd   (port 8000)
+#   $STABLE_APP/Contents/MacOS/localvoxtral-polishd   (port 8080)
+STABLE_APP="${LV_TEST_SERVER_APP:-/Users/Shared/localvoxtral/testservers/localvoxtral.app}"
 
-trigger_for() {
+# Canonical service names, iterated by reap/status. Deprecated aliases
+# (voxmlx→speechd, mlxlm→polishd) are accepted on the command line via canonical().
+ALL_SERVICES=(speechd polishd)
+
+# Normalize a canonical name or a deprecated alias to the canonical name.
+canonical() {
   case "$1" in
-    voxmlx) printf '%s/voxmlx.want\n' "$RUN_DIR" ;;
-    mlxlm)  printf '%s/mlxlm.want\n' "$RUN_DIR" ;;
+    speechd|voxmlx) printf 'speechd\n' ;;
+    polishd|mlxlm)  printf 'polishd\n' ;;
     *) return 1 ;;
   esac
+}
+# Stable trigger/stamp filesystem key (see header) — retained at the retired
+# names so old gates/reapers/plists keep rendezvousing on the same paths.
+fskey_for() {
+  case "$(canonical "$1" 2>/dev/null)" in
+    speechd) printf 'voxmlx\n' ;;
+    polishd) printf 'mlxlm\n' ;;
+    *) return 1 ;;
+  esac
+}
+trigger_for() {
+  local key
+  key="$(fskey_for "$1")" || return 1
+  printf '%s/%s.want\n' "$RUN_DIR" "$key"
+}
+stamp_prefix_for() {
+  local key
+  key="$(fskey_for "$1")" || return 1
+  printf '%s/%s.seen.' "$RUN_DIR" "$key"
 }
 port_for() {
-  case "$1" in
-    voxmlx) printf '8000\n' ;;
-    mlxlm)  printf '8080\n' ;;
+  case "$(canonical "$1" 2>/dev/null)" in
+    speechd) printf '8000\n' ;;
+    polishd) printf '8080\n' ;;
     *) return 1 ;;
   esac
 }
-# voxmlx exposes a websocket, not a documented HTTP readiness route, so it uses
-# a TCP-accept probe (uvicorn binds the port only after startup/model-load).
-# mlxlm answers GET /v1/models once weights are resident — a real readiness
-# signal — so it uses http.
-probe_for() {
-  case "$1" in
-    voxmlx) printf 'tcp\n' ;;
-    mlxlm)  printf 'http:/v1/models\n' ;;
+# launchd labels to signal on stop. Both generations are listed so the reaper
+# tears down whichever plist is currently loaded (the retired Python
+# voxmlx/mlxlm, or the new testspeechd/testpolishd) — plus the port-bound
+# fallback below covers anything launchctl can't reach.
+labels_for() {
+  case "$(canonical "$1" 2>/dev/null)" in
+    speechd) printf 'com.localvoxtral.testspeechd com.localvoxtral.voxmlx\n' ;;
+    polishd) printf 'com.localvoxtral.testpolishd com.localvoxtral.mlxlm\n' ;;
     *) return 1 ;;
   esac
 }
@@ -116,13 +161,23 @@ http_ok() {
     "http://127.0.0.1:${port}${path}" >/dev/null 2>&1
 }
 
+# speechd (8000) exposes a websocket, not a documented HTTP readiness route, and
+# loads its model BEFORE binding the listener, so a TCP-accept probe is a real
+# readiness signal (matching the retired voxmlx uvicorn behavior).
+#
+# polishd (8080) serves GET /health once its model is resident — its readiness
+# contract, and the probe to use going forward. The retired mlx-lm answered GET
+# /v1/models instead. So the 8080 probe accepts EITHER route: /health OR
+# /v1/models. This makes the probe correct against BOTH generations behind the
+# port, so warming stays green before AND after the owner swaps the plist. (The
+# gate mirrors this — see localvoxtral-build-gate.sh; the INSTALLED gate only
+# picks up the /health arm when the owner reinstalls it.)
 healthy() {
-  local name="$1" port probe
-  port="$(port_for "$name")"
-  probe="$(probe_for "$name")"
-  case "$probe" in
-    tcp) tcp_ok "$port" ;;
-    http:*) http_ok "$port" "${probe#http:}" ;;
+  local name="$1" port
+  port="$(port_for "$name")" || return 1
+  case "$(canonical "$name" 2>/dev/null)" in
+    speechd) tcp_ok "$port" ;;
+    polishd) http_ok "$port" "/health" || http_ok "$port" "/v1/models" ;;
     *) return 1 ;;
   esac
 }
@@ -131,9 +186,11 @@ healthy() {
 # empty if none exists. The trigger is included as a fallback so a
 # manually-created trigger with no stamp still ages out.
 newest_activity() {
-  local name="$1"
+  local name="$1" prefix trigger
+  prefix="$(stamp_prefix_for "$name")" || return 1
+  trigger="$(trigger_for "$name")"
   # shellcheck disable=SC2012
-  ls -1 "$RUN_DIR/${name}.seen."* "$(trigger_for "$name")" 2>/dev/null \
+  ls -1 "${prefix}"* "$trigger" 2>/dev/null \
     | while read -r f; do stat -f %m "$f" 2>/dev/null || true; done \
     | sort -n | tail -1
 }
@@ -141,10 +198,11 @@ newest_activity() {
 # ---- commands ----------------------------------------------------------------
 
 ensure_one() {
-  local name="$1" trigger port stamp
-  trigger="$(trigger_for "$name")" || { echo "unknown service: $name" >&2; return 2; }
-  port="$(port_for "$name")"
-  stamp="$RUN_DIR/${name}.seen.$(id -u)"
+  local name="$1" cname trigger port stamp
+  cname="$(canonical "$name")" || { echo "unknown service: $name" >&2; return 2; }
+  trigger="$(trigger_for "$cname")"
+  port="$(port_for "$cname")"
+  stamp="$(stamp_prefix_for "$cname")$(id -u)"
 
   if [[ ! -d "$RUN_DIR" ]]; then
     cat >&2 <<MSG
@@ -179,29 +237,32 @@ MSG
   }
 
   # Warm path: already serving — return immediately so bursts are cheap.
-  if healthy "$name"; then
-    echo "ensure $name: already warm (port $port)"
+  if healthy "$cname"; then
+    echo "ensure $cname: already warm (port $port)"
     return 0
   fi
 
-  echo "ensure $name: cold — waiting up to ${READY_TIMEOUT}s for port $port..."
+  echo "ensure $cname: cold — waiting up to ${READY_TIMEOUT}s for port $port..."
   local waited=0
   while (( waited < READY_TIMEOUT )); do
-    if healthy "$name"; then
-      echo "ensure $name: ready after ${waited}s (port $port)"
+    if healthy "$cname"; then
+      echo "ensure $cname: ready after ${waited}s (port $port)"
       return 0
     fi
     sleep 2
     waited=$((waited + 2))
   done
 
+  local labels
+  labels="$(labels_for "$cname")"
   cat >&2 <<MSG
-ensure $name: NOT ready after ${READY_TIMEOUT}s (port $port).
-Likely the LaunchAgent com.localvoxtral.${name} is not bootstrapped in the
-owner's GUI domain, or the model failed to load. Check:
-  launchctl print gui/\$(id -u)/com.localvoxtral.${name}
-  tail /Users/Shared/localvoxtral/${name}.log
-See scripts/mac/README.md.
+ensure $cname: NOT ready after ${READY_TIMEOUT}s (port $port).
+Likely one of these LaunchAgents is not bootstrapped in the owner's GUI domain,
+or the pinned model is not in the service account's HF cache (the helpers do
+not auto-download). Check:
+  launchctl print gui/\$(id -u)/com.localvoxtral.testspeechd  # or testpolishd
+  tail /Users/Shared/localvoxtral/${cname}.log
+See scripts/mac/README.md (labels tried: ${labels}).
 MSG
   return 1
 }
@@ -225,26 +286,34 @@ cmd_ensure() {
 # `stop` (manual/immediate). Removing the PathState trigger stops launchd from
 # RESTARTING the job, but launchd does NOT reliably terminate an already-running
 # process when a KeepAlive condition flips false — so we drop the trigger FIRST
-# (so launchd won't relaunch the instant we kill it) then SIGTERM the job, which
-# tears down its whole process tree (the job is a uv/uvx wrapper around the real
-# server child). The MLX server drains gracefully in ~2-3s; block until the port
-# closes, and escalate to SIGKILL — plus, as a last resort, kill whatever still
-# binds the port (only this test service does) — if it's still up after
-# STOP_GRACE. The kill MUST finish here: once the trigger is gone a later reap
-# run skips this service, so a server that ignored SIGTERM would leak forever.
-# Must run as the GUI-owner (the reaper's user): `launchctl kill` into
-# gui/$(id -u) needs the owning domain, and the sticky run-dir owner can delete
-# any account's trigger/stamps. Echoes a short outcome fragment for the caller.
+# (so launchd won't relaunch the instant we kill it) then SIGTERM the job(s),
+# which tears down its whole process tree. The MLX server drains gracefully in
+# ~2-3s; block until the port closes, and escalate to SIGKILL — plus, as a last
+# resort, kill whatever still binds the port (only this test service does) — if
+# it's still up after STOP_GRACE. Both generation labels are signaled so this
+# works whether the retired Python plist or the new helper plist is loaded; the
+# port-bound fallback covers any label launchctl cannot reach. The kill MUST
+# finish here: once the trigger is gone a later reap run skips this service, so
+# a server that ignored SIGTERM would leak forever. Must run as the GUI-owner
+# (the reaper's user): `launchctl kill` into gui/$(id -u) needs the owning
+# domain, and the sticky run-dir owner can delete any account's trigger/stamps.
+# Echoes a short outcome fragment for the caller.
 stop_one() {
-  local name="$1" trigger uid port pids waited=0
-  trigger="$(trigger_for "$name")" || return 2
+  local name="$1" cname trigger prefix uid port label pids waited=0
+  cname="$(canonical "$name")" || return 2
+  trigger="$(trigger_for "$cname")"
+  prefix="$(stamp_prefix_for "$cname")"
   uid="$(id -u)"
-  port="$(port_for "$name")"
-  rm -f "$trigger" "$RUN_DIR/${name}.seen."* 2>/dev/null || true
-  launchctl kill SIGTERM "gui/${uid}/com.localvoxtral.${name}" 2>/dev/null || true
-  while (( waited < STOP_GRACE )) && healthy "$name"; do sleep 1; waited=$((waited + 1)); done
-  if healthy "$name"; then
-    launchctl kill SIGKILL "gui/${uid}/com.localvoxtral.${name}" 2>/dev/null || true
+  port="$(port_for "$cname")"
+  rm -f "$trigger" "${prefix}"* 2>/dev/null || true
+  for label in $(labels_for "$cname"); do
+    launchctl kill SIGTERM "gui/${uid}/${label}" 2>/dev/null || true
+  done
+  while (( waited < STOP_GRACE )) && healthy "$cname"; do sleep 1; waited=$((waited + 1)); done
+  if healthy "$cname"; then
+    for label in $(labels_for "$cname"); do
+      launchctl kill SIGKILL "gui/${uid}/${label}" 2>/dev/null || true
+    done
     pids="$(lsof -nP -tiTCP:"$port" -sTCP:LISTEN 2>/dev/null || true)"
     [[ -n "$pids" ]] && kill -KILL $pids 2>/dev/null || true
     echo "stopped (SIGTERM ignored → SIGKILL after ${waited}s)"
@@ -278,13 +347,13 @@ cmd_stop() {
   if [[ "$target" == "all" ]]; then names=("${ALL_SERVICES[@]}"); else names=("$target"); fi
   local rc=0
   for name in "${names[@]}"; do
-    if ! trigger_for "$name" >/dev/null 2>&1; then
+    if ! canonical "$name" >/dev/null 2>&1; then
       echo "unknown service: $name" >&2; rc=2; continue
     fi
     if [[ -e "$(trigger_for "$name")" ]] || healthy "$name"; then
-      printf 'stop %s: %s\n' "$name" "$(stop_one "$name")"
+      printf 'stop %s: %s\n' "$(canonical "$name")" "$(stop_one "$name")"
     else
-      echo "stop $name: already down"
+      echo "stop $(canonical "$name"): already down"
     fi
   done
   return "$rc"
@@ -308,9 +377,74 @@ cmd_status() {
   done
 }
 
+# Install/refresh the stable .app copy whose helper binaries the plists run.
+# Point it at a freshly packaged / try-pr'd / released bundle; the helpers must
+# be from a packaged (xcodebuild) build so their Metal kernels load. Copies with
+# `ditto` (preserves the bundle's code signature) into a temp sibling, then
+# swaps via mv-aside + mv-in — not a single atomic rename, so the path is
+# briefly absent; an already-running server keeps serving its open copy, and a
+# concurrent launchd cold-start in that window just retries on the next ensure.
+cmd_install_helpers() {
+  local src="${1:-}"
+  if [[ -z "$src" ]]; then
+    echo "install-helpers: usage: lv-test-servers.sh install-helpers <path-to-.app>" >&2
+    return 2
+  fi
+  src="${src%/}"
+  if [[ ! -d "$src" ]]; then
+    echo "install-helpers: source app not found: $src" >&2
+    return 1
+  fi
+  local speechd_bin="$src/Contents/MacOS/localvoxtral-speechd"
+  local polishd_bin="$src/Contents/MacOS/localvoxtral-polishd"
+  if [[ ! -x "$speechd_bin" || ! -x "$polishd_bin" ]]; then
+    cat >&2 <<MSG
+install-helpers: $src is missing a bundled helper binary.
+Expected both:
+  $speechd_bin
+  $polishd_bin
+Package with helpers first (scripts/package_app.sh release, or a CI artifact via
+scripts/try-pr.sh) — a bundle built with LOCALVOXTRAL_SKIP_SPEECHD/POLISHD=1 will
+not contain them.
+MSG
+    return 1
+  fi
+
+  local dest_dir tmp
+  dest_dir="$(dirname "$STABLE_APP")"
+  if ! mkdir -p "$dest_dir" 2>/dev/null; then
+    echo "install-helpers: cannot create $dest_dir (need: sudo install -d -m 0755 -o \"\$(id -un)\" $dest_dir)" >&2
+    return 1
+  fi
+  tmp="${STABLE_APP}.new.$$"
+  rm -rf "$tmp" 2>/dev/null || true
+  echo "install-helpers: copying $src -> $STABLE_APP"
+  if ! ditto "$src" "$tmp"; then
+    echo "install-helpers: ditto copy failed" >&2
+    rm -rf "$tmp" 2>/dev/null || true
+    return 1
+  fi
+  rm -rf "${STABLE_APP}.old.$$" 2>/dev/null || true
+  if [[ -e "$STABLE_APP" ]]; then
+    # A swallowed mv-aside would make the next mv nest the new bundle INSIDE
+    # the old one (mv dir existing-dir), leaving the plist path serving the old
+    # binary while looking freshly installed. Fail loudly instead.
+    if ! mv "$STABLE_APP" "${STABLE_APP}.old.$$"; then
+      echo "install-helpers: cannot move aside existing $STABLE_APP (permissions? root-owned from an earlier sudo?)" >&2
+      rm -rf "$tmp" 2>/dev/null || true
+      return 1
+    fi
+  fi
+  mv "$tmp" "$STABLE_APP"
+  rm -rf "${STABLE_APP}.old.$$" 2>/dev/null || true
+  echo "install-helpers: installed. Restart the services to pick it up:"
+  echo "  lv-test-servers.sh stop all   # next ensure cold-starts from the new copy"
+}
+
 usage() {
   cat >&2 <<'MSG'
-usage: lv-test-servers.sh <ensure [voxmlx|mlxlm|all] | stop [voxmlx|mlxlm|all] | reap | status>
+usage: lv-test-servers.sh <ensure [speechd|polishd|all] | stop [speechd|polishd|all]
+                            | reap | status | install-helpers <path-to-.app>>
   ensure  start (if down) and block until the named server(s) are warm;
           resets the idle window. Default target: all.
   stop    unload the named server(s) NOW regardless of the idle window, freeing
@@ -318,6 +452,13 @@ usage: lv-test-servers.sh <ensure [voxmlx|mlxlm|all] | stop [voxmlx|mlxlm|all] |
   reap    stop any server idle longer than the idle window (reaper LaunchAgent;
           must run as the run-dir owner).
   status  print trigger + activity + port health for both services.
+  install-helpers  copy a packaged .app's helper binaries to the stable path
+          the plists run ($LV_TEST_SERVER_APP; default
+          /Users/Shared/localvoxtral/testservers/localvoxtral.app).
+
+  Service names: speechd (8000, realtime STT) and polishd (8080, chat
+  completions). The retired names voxmlx/mlxlm are accepted as deprecated
+  aliases during the migration.
 MSG
 }
 
@@ -326,6 +467,7 @@ case "${1:-}" in
   stop)   shift; cmd_stop "${1:-all}" ;;
   reap)   cmd_reap ;;
   status) cmd_status ;;
+  install-helpers) shift; cmd_install_helpers "${1:-}" ;;
   ""|-h|--help) usage; exit 2 ;;
   *) echo "unknown command: $1" >&2; usage; exit 2 ;;
 esac

--- a/scripts/remote-build.sh
+++ b/scripts/remote-build.sh
@@ -9,7 +9,7 @@ set -euo pipefail
 #   ./scripts/remote-build.sh [build|test|integration|integration-polishd|integration-speechd|speechd-bench|eval-llm|eval-e2e|package|exec|diag|applog|voxlog|svc-status|disk|gc] [extra args...]
 #     build        swift build
 #     test         swift build + unit tests (default; skips live-backend suites)
-#     integration  realtime pipeline tests against the live voxmlx service
+#     integration  realtime pipeline tests against the live speechd STT service
 #     integration-polishd
 #                  spawn the bundled polishing helper (built by `package`)
 #                  with the real model and score it against the polish eval
@@ -23,11 +23,12 @@ set -euo pipefail
 #                  (default 100 = the production step cadence), and
 #                  cache-limit-mb (default = the helper's built-in limit);
 #                  requires a prior `package`
-#     eval-llm     default-polish-prompt eval against a live mlx-lm server;
+#     eval-llm     default-polish-prompt eval against a live chat/completions
+#                  server (the bundled polishd test service by default);
 #                  optional args = chat/completions endpoint and external
 #                  model alias (default endpoint
 #                  http://127.0.0.1:8080/v1/chat/completions, the
-#                  com.localvoxtral.mlxlm service — runbook scripts/mac/README.md)
+#                  com.localvoxtral.testpolishd service — runbook scripts/mac/README.md)
 #     eval-e2e     agent-dictation end-to-end eval: human WAVs or TTS -> live
 #                  voxmlx ASR -> bundled polishd via the production stop-commit
 #                  path, scored against EvalCorpus/agent-dictation (run
@@ -37,8 +38,10 @@ set -euo pipefail
 #     exec         run the extra args verbatim in the remote work dir
 #     diag         build-host diagnostic summary (gate v2 required)
 #     applog       unified log for process == "localvoxtral" (gate v2 required)
-#     voxlog       tail ~/Library/Logs/voxmlx.log (gate v2 required)
-#     svc-status   launchctl status for com.localvoxtral.voxmlx (gate v2 required)
+#     voxlog       tail the STT test-service log (gate v2 required; VOXLOG_FILE
+#                  in the gate's conf, default the speechd service log)
+#     svc-status   launchctl/process/port status for the speechd/polishd test
+#                  services (gate v2 required)
 #     disk         df + du of the remote build work dirs (gate v4 required;
 #                  du over the build trees can take a while)
 #     gc           delete remote work dirs unused > 14 days (gate v4 required;
@@ -126,24 +129,40 @@ trap 'handle_remote_signal 130' INT
 trap 'handle_remote_signal 143' TERM
 
 # Bring an on-demand test server up (and warm) before a suite that needs it.
-# The build host's voxmlx (8000) and mlxlm (8080) launchd services are
-# launch-on-demand (scripts/mac/lv-test-servers.sh) so their model weights are
-# not resident 24/7; this asks the SSH build gate's `ensure` verb to touch the
-# trigger and block until the port is healthy. It also resets the idle window,
-# so a burst of runs reuses the warm process.
+# The build host's speechd (8000, STT) and polishd (8080, chat/completions)
+# launchd test services are launch-on-demand (scripts/mac/lv-test-servers.sh)
+# so their model weights are not resident 24/7; this asks the SSH build gate's
+# `ensure` verb to touch the trigger and block until the port is healthy. It
+# also resets the idle window, so a burst of runs reuses the warm process.
+#
+# Names: we send the current name (speechd/polishd) first, then fall back to the
+# deprecated alias (voxmlx/mlxlm) if the INSTALLED gate is old and denies the
+# new one — the new gate accepts both, an un-reinstalled gate accepts only the
+# old ones, so this bridges the reinstall window either way.
 #
 # Best-effort: warming is an optimization, not the gate — the test suite itself
 # fails loudly if the server is actually unreachable. During rollout the
 # on-demand infra is a one-time owner install (scripts/mac/README.md); until
-# then the gate's `ensure` errors (run dir absent) but the still-always-on
-# server serves the suite, so a warm failure must NOT abort the run.
+# then the gate's `ensure` errors (run dir absent) but the server still serves
+# the suite, so a warm failure must NOT abort the run.
 ensure_remote_server() {
-  local name="$1"
+  local name="$1" alias=""
+  case "$name" in
+    speechd) alias="voxmlx" ;;
+    polishd) alias="mlxlm" ;;
+  esac
   echo "==> Ensuring on-demand test server '$name' is warm on $HOST"
-  if ! ssh "$HOST" "ensure $name"; then
-    echo "==> WARN: could not warm '$name' on-demand (infra not installed, or gate" \
-         "lacks the ensure verb). Continuing — the suite will fail if it's really down." >&2
+  if ssh "$HOST" "ensure $name"; then
+    return 0
   fi
+  if [[ -n "$alias" ]]; then
+    echo "==> '$name' not accepted; retrying with deprecated alias '$alias' (old gate)"
+    if ssh "$HOST" "ensure $alias"; then
+      return 0
+    fi
+  fi
+  echo "==> WARN: could not warm '$name' on-demand (infra not installed, or gate" \
+       "lacks the ensure verb). Continuing — the suite will fail if it's really down." >&2
 }
 
 # Transient enable markers ride the rsynced tree because the gate can't pass
@@ -224,16 +243,16 @@ UNIT_TEST_SKIPS=(--skip RealtimeAPIVLLMIntegrationTests --skip LLMPolishPromptEv
   --skip SpeechdStreamingBenchTests --skip AgentDictationE2EEvalTests)
 
 # On-demand test server to warm before the suite runs (empty = none). The
-# build host's voxmlx/mlxlm launchd services are launch-on-demand to keep their
-# weights out of RAM when idle; the lanes that hit them ask the gate to start
-# and warm them first. See scripts/mac/lv-test-servers.sh + scripts/mac/README.md.
+# build host's speechd/polishd launchd test services are launch-on-demand to
+# keep their weights out of RAM when idle; the lanes that hit them ask the gate
+# to start and warm them first. See scripts/mac/lv-test-servers.sh + README.md.
 ENSURE_SERVER=""
 
 case "$CMD" in
   build)   REMOTE_CMD=(swift build "$@") ;;
   test)    REMOTE_CMD=(swift test "${UNIT_TEST_SKIPS[@]}" "$@") ;;
   integration)
-    ENSURE_SERVER="voxmlx"
+    ENSURE_SERVER="speechd"
     REMOTE_CMD=(env VLLM_REALTIME_TEST_ENABLE=1
       VLLM_REALTIME_TEST_MODEL=T0mSIlver/Voxtral-Mini-4B-Realtime-2602-MLX-4bit
       swift test --filter RealtimeAPIVLLMIntegrationTests "$@")
@@ -331,7 +350,7 @@ case "$CMD" in
     ;;
   eval-e2e)
     # Agent-dictation end-to-end eval (nightly + manual, never tier 0):
-    # human WAVs (when supplied) or TTS -> live voxmlx ASR -> bundled polishd
+    # human WAVs (when supplied) or TTS -> live speechd ASR -> bundled polishd
     # helper through the production stop-commit path, scored against
     # EvalCorpus/agent-dictation. Requires a helper binary from a prior
     # `./scripts/remote-build.sh package` run.
@@ -358,7 +377,7 @@ case "$CMD" in
         exit 1
       fi
     fi
-    ENSURE_SERVER="voxmlx"
+    ENSURE_SERVER="speechd"
     E2E_MARKER="$ROOT_DIR/.agent-eval-e2e-enable.json"
     # Trap registered before the marker exists, so no kill window leaves a
     # stale marker behind (locally or in the remote work dir).
@@ -387,10 +406,10 @@ case "$CMD" in
     fi
     EVAL_ENDPOINT="${1:-http://127.0.0.1:8080/v1/chat/completions}"
     EVAL_MODEL="${2:-}"
-    # Only warm the local on-demand mlxlm service when the eval targets it; a
+    # Only warm the local on-demand polishd service when the eval targets it; a
     # custom endpoint is the caller's own server and we must not touch it.
     if [[ "$EVAL_ENDPOINT" == *"127.0.0.1:8080"* || "$EVAL_ENDPOINT" == *"localhost:8080"* ]]; then
-      ENSURE_SERVER="mlxlm"
+      ENSURE_SERVER="polishd"
     fi
     EVAL_MARKER="$ROOT_DIR/.llm-polish-eval-enable.json"
     # Trap registered before the marker exists, so no kill window leaves a


### PR DESCRIPTION
## What

Retires the two Python on-demand Mac test services and points the same launch-on-demand launchd infrastructure at the app's own packaged helpers:

- port 8000: `localvoxtral-speechd` (label `com.localvoxtral.testspeechd`) replaces the voxmlx venv
- port 8080: `localvoxtral-polishd` running the production 4B pin (label `com.localvoxtral.testpolishd`) replaces the unmaintained mlx-lm server + its venv/wheel

**Unchanged by design:** ports, all test endpoint strings and env vars, the trigger-file + reaper model, and the trigger *filenames* (`voxmlx.want`/`mlxlm.want`) — the cross-generation rendezvous that keeps CI green in every rollout state. `lv-test-servers.sh` and the gate accept `speechd|polishd` with `voxmlx|mlxlm` as deprecated aliases; `remote-build.sh` sends the new name and falls back to the alias so an old installed gate keeps working. New `install-helpers <path-to-.app>` verb maintains the stable packaged bundle the plists exec (helpers need the xcodebuild Metal lane). 8080 health probe accepts `/health` (polishd) or `/v1/models` (mlx-lm) so it's correct against both generations. `release.yml` gains the warm step it always needed (latent gap: its live gate assumed a resident server). `scripts/mac/README.md` carries the rewritten plist templates and an ordered, rerunnable owner migration runbook. Swift test-file edits are doc-comment/label-only; no assertion, identifier, or wire contract changed.

Adversarial review (opencode GLM-5.2): **PASS, no blockers** — it independently traced the transition chain in both rollout states (checked-out script → trigger file → old plist WatchPaths; new gate name → old-gate alias fallback). Its findings are fixed here: `install-helpers` mv-aside failure could nest the new bundle inside the old one (now fails loudly), an "atomic rename" comment overstated the swap, the new warm steps' best-effort claim is now real (`continue-on-error`), the runbook's `VOXLOG_FILE` step was a comment rather than a command, bootstrap steps are now rerunnable (`bootout` first), and AGENTS.md's intro no longer names voxmlx as the production backend.

## Why

Everything the app ships goes through these Swift helpers; mlx-lm upstream is unmaintained (2026-07) and its venv/wheel maintenance goes away. The prompt eval now scores against the same engine + 4B model the app actually bundles (previous default on this service was the 0.8B — the shared baseline passes with more headroom; nothing weakened).

## Proof

- [x] `bash -n` clean on all three scripts; workflow YAML + plist templates parse; the four `scripts/ci/` gate regression tests pass (run locally).
- [x] Functional smoke on Linux: `ensure speechd` creates the stable `voxmlx.want` trigger; alias + `install-helpers` validation paths exercised.
- [x] Tier-0 compiles the doc-comment-only Swift edits on this PR's CI run.
- [ ] Owner steps (runbook §Migration in `scripts/mac/README.md`): `install-helpers`, plist swap, gate reinstall — then `remote-build.sh integration` (speechd on 8000) and `eval-llm` (polishd 4B on 8080, paste scoreboard) as live parity proof. Until the swap, CI keeps warming the old services through the unchanged trigger files.
- LLM lanes: no prompt/model/request-shape change in the app; `LLMPolishPromptEvalTests`' default endpoint/model are untouched. The eval-llm scoreboard lands with the owner's post-swap verification (it needs the swapped Mac).

Follow-up flagged, not in this diff: `mac-crashlog.yml` should also pgrep `localvoxtral-speechd`.