### PR TITLE
record-demo: refuse GUI takeover while the machine is in use; assert the scene owns the screen

### DIFF
--- a/scripts/record-demo.sh
+++ b/scripts/record-demo.sh
@@ -108,6 +108,10 @@ set -euo pipefail
 #   DEMO_SAY_INPUT_UID            audio-device UID the app's mic is pinned to;
 #                                 resolved automatically from DEMO_SAY_DEVICE
 #                                 when unset
+#   DEMO_IDLE_REQUIRED_SECONDS    hands-free only: minimum HID idle time before
+#                                 the script may take over the GUI (default 120)
+#   DEMO_FORCE                    1 = skip the idle guard for an attended
+#                                 hands-free rehearsal
 
 if [[ "$(uname)" != "Darwin" ]]; then
   echo "This script records a macOS app — run it on the Mac." >&2
@@ -500,6 +504,30 @@ if [[ "$TERMINAL_AGENT" == "claude" ]]; then
 else
   SCENE_APP="Terminal"
   SCENE_TELL="application \"Terminal\""
+fi
+
+# --- GUARD: never take over a machine someone is actively using ------------------
+# Field incident 2026-07-21: a hands-free run fired while the owner watched a
+# fullscreen video; every staged window landed on another Space and the region
+# capture recorded the owner's screen — which then went up as a run artifact.
+# The audible 3 s warning is not consent. In hands-free mode, require the
+# machine to have been untouched for DEMO_IDLE_REQUIRED_SECONDS (default 120);
+# an attended human take skips this (the operator at the keyboard IS the user).
+# DEMO_FORCE=1 overrides for an attended hands-free rehearsal.
+DEMO_IDLE_REQUIRED_SECONDS="${DEMO_IDLE_REQUIRED_SECONDS:-120}"
+DEMO_FORCE="${DEMO_FORCE:-0}"
+if [[ "$DEMO_HANDS_FREE" == 1 && "$DEMO_FORCE" != 1 ]]; then
+  HID_IDLE_SECONDS="$(ioreg -c IOHIDSystem 2>/dev/null \
+    | awk '/HIDIdleTime/ {print int($NF/1000000000); exit}' || true)"
+  if [[ -z "$HID_IDLE_SECONDS" ]]; then
+    echo "Cannot read HID idle time; refusing a hands-free takeover blind (DEMO_FORCE=1 overrides)." >&2
+    exit 1
+  fi
+  if (( HID_IDLE_SECONDS < DEMO_IDLE_REQUIRED_SECONDS )); then
+    echo "Machine in active use (idle ${HID_IDLE_SECONDS}s < ${DEMO_IDLE_REQUIRED_SECONDS}s) — refusing to take over the GUI. Rerun when idle, or DEMO_FORCE=1 for an attended rehearsal." >&2
+    exit 1
+  fi
+  echo "Idle guard: machine idle ${HID_IDLE_SECONDS}s (>= ${DEMO_IDLE_REQUIRED_SECONDS}s) — proceeding."
 fi
 
 # --- OWNER RULE: audible takeover warning BEFORE any focus-stealing action -------
@@ -973,6 +1001,17 @@ else
   osascript -e 'tell application "System Events" to key code 36' >/dev/null
 fi
 sleep 1.5
+
+# --- GUARD: the scene app must actually own the screen before frames roll -------
+# A region capture records the active Space, not the windows we staged — if a
+# fullscreen app (or anything the user raised meanwhile) is frontmost, staging
+# happened somewhere invisible and we would record the user's screen instead of
+# the scene. Assert frontmost == the scene process; abort loudly otherwise.
+FRONTMOST_APP="$(osascript -e 'tell application "System Events" to get name of first application process whose frontmost is true' 2>/dev/null || true)"
+if [[ "$(printf '%s' "$FRONTMOST_APP" | tr '[:upper:]' '[:lower:]')" != "$(printf '%s' "$SCENE_APP" | tr '[:upper:]' '[:lower:]')" ]]; then
+  echo "Frontmost app is '${FRONTMOST_APP:-unknown}', not the staged $SCENE_APP — the capture region does not show the scene (fullscreen app / another Space / user activity). Aborting before recording anything." >&2
+  exit 1
+fi
 
 # --- record ----------------------------------------------------------------------
 mkdir -p "$OUT_DIR"

--- a/scripts/record-demo.sh
+++ b/scripts/record-demo.sh
@@ -530,6 +530,18 @@ if [[ "$DEMO_HANDS_FREE" == 1 && "$DEMO_FORCE" != 1 ]]; then
   echo "Idle guard: machine idle ${HID_IDLE_SECONDS}s (>= ${DEMO_IDLE_REQUIRED_SECONDS}s) — proceeding."
 fi
 
+# Synthetic keystrokes land in whatever is frontmost. Assert it is the staged
+# scene app before every typing site — a user raising a window (or a fullscreen
+# Space) between staging and typing must abort, never type into their app.
+assert_scene_frontmost() {
+  local context="$1" front
+  front="$(osascript -e 'tell application "System Events" to get name of first application process whose frontmost is true' 2>/dev/null || true)"
+  if [[ "$(printf '%s' "$front" | tr '[:upper:]' '[:lower:]')" != "$(printf '%s' "$SCENE_APP" | tr '[:upper:]' '[:lower:]')" ]]; then
+    echo "Frontmost app is '${front:-unknown}', not the staged $SCENE_APP — refusing to send keystrokes ($context)." >&2
+    exit 1
+  fi
+}
+
 # --- OWNER RULE: audible takeover warning BEFORE any focus-stealing action -------
 # On the DEFAULT audio output (never the loopback — that device is inaudible).
 say "record demo taking control in 3" >/dev/null 2>&1 || true
@@ -790,15 +802,17 @@ if [[ "$TERMINAL_AGENT" == "claude" ]]; then
     fi
   fi
 
-  pgrep -xiq ghostty || LAUNCHED_GHOSTTY=1
-  # If Ghostty is already running, snapshot its existing pane ttys so we can
-  # later identify OUR new pane by set difference. (Skip the snapshot when it is
-  # NOT running — `tell application id` would launch it, and once we launch it
-  # ourselves the only pane is unambiguously ours anyway.)
-  TTYS_BEFORE=""
-  if [[ "$LAUNCHED_GHOSTTY" != 1 ]]; then
-    TTYS_BEFORE="$(ghostty_pane_ttys)"
+  # `open -na … --args` delivers the args ONLY to a freshly launched instance.
+  # Against an already-running Ghostty it degrades to a bare reopen: a new tab
+  # in the existing window, no --working-directory, no `-e claude` — the scene
+  # silently never exists (field incident 2026-07-21, the run "succeeded").
+  # Refuse instead: the claude scene requires launching Ghostty ourselves.
+  if pgrep -xiq ghostty; then
+    echo "Ghostty is already running — its instance would swallow our launch args (no staged window, no claude). Quit Ghostty (or record from a machine/session where it is closed) and rerun." >&2
+    exit 1
   fi
+  LAUNCHED_GHOSTTY=1
+  TTYS_BEFORE=""
   echo "Launching Ghostty ($GHOSTTY_APP) in $REPO_DIR with claude ($CLAUDE_BIN)..."
   # Ghostty opens the pane directly on claude, cwd pinned to the staged repo,
   # with an opaque dark look + big font passed as CLI config (Ghostty has no
@@ -826,6 +840,7 @@ if [[ "$TERMINAL_AGENT" == "claude" ]]; then
   # Address Ghostty by bundle id (not display name) — the app's own reader does
   # too, and a by-name tell is fragile under localization / name collisions.
   osascript -e "tell application id \"$GHOSTTY_BUNDLE_ID\" to activate" >/dev/null 2>&1 || true
+  assert_scene_frontmost "folder-trust Return"
   osascript -e 'tell application "System Events" to key code 36' >/dev/null 2>&1 || true
   sleep 3
 
@@ -884,6 +899,7 @@ if [[ "$TERMINAL_AGENT" == "claude" ]]; then
   echo "Submitting the staged setup prompt (grounds beat 2): \"$DEMO_LINE_CLAUDE_SETUP\""
   osascript -e "tell application id \"$GHOSTTY_BUNDLE_ID\" to activate" >/dev/null 2>&1 || true
   sleep 1
+  assert_scene_frontmost "staged setup prompt"
   osascript "$KEYSTROKE_OSA" "$DEMO_LINE_CLAUDE_SETUP" \
     || { echo "Setup-prompt keystroke failed (focus lost?); beat 2 would ground on nothing. Aborting." >&2; exit 1; }
   sleep 0.5
@@ -1076,6 +1092,7 @@ sleep 3 # let the committed text sit on screen
 if [[ "$TERMINAL_AGENT" == "claude" && "$DEMO_SUBMIT_PROMPT" == 1 ]]; then
   echo "Submitting the polished prompt to claude (recording the response for ${DEMO_RESPONSE_SECONDS}s)..."
   osascript -e "tell $SCENE_TELL to activate" >/dev/null 2>&1 || true
+  assert_scene_frontmost "polished-prompt submit"
   osascript -e 'tell application "System Events" to key code 36' >/dev/null
   sleep "$DEMO_RESPONSE_SECONDS"
 fi


### PR DESCRIPTION
## What

Safety + correctness guards for the demo recorder, from tonight's incident: a hands-free `record-demo.yml` run (claude mode) fired while the owner was at the Mac watching a fullscreen video. Two distinct failures compounded:

1. **The GUI takeover recorded the owner's screen.** All staging landed on another Space; the fixed-region `screencapture` recorded the active Space and uploaded it as a public run artifact (deleted within minutes; exposure ≈ 7 min).
2. **The scene never existed in the first place** (owner field report): Ghostty was already running, and `open -na … --args` only delivers `--args` to a freshly launched instance — an existing one gets a bare reopen, i.e. a new tab in the existing window with no `--working-directory` and no `-e claude`. The tty probe then read whatever pane was focused, and the staged-prompt keystrokes went to whatever was frontmost.

Guards added:

- **Idle guard (hands-free only):** refuse the takeover unless HID idle ≥ `DEMO_IDLE_REQUIRED_SECONDS` (default 120); unreadable idle time refuses too (fail closed). `DEMO_FORCE=1` for attended rehearsals.
- **Pre-running Ghostty refusal (claude mode):** if Ghostty is already running, abort with an explanation instead of launching into swallowed args — the claude scene requires the script to launch Ghostty itself (which also makes the pane/tty unambiguously ours; the pane-snapshot diffing is gone with the ambiguity).
- **Frontmost asserts at every synthetic-keystroke site** (folder-trust Return, staged setup prompt, polished-prompt submit) **and immediately before recording starts**: if the staged scene app is not frontmost, abort loudly — never type into, or record, someone else's window.

The audible-warning owner rule is unchanged.

## Proof

- [x] `bash -n` clean.
- [x] Incident forensics: run 29870103973's log shows the scene "succeeding" (tty probed, prompts "submitted") while the artifact's frames show a fullscreen YouTube page — each guard above maps to a specific link in that failure chain, and the owner's report (new tab, wrong location, no claude) confirms the `open --args` mechanism.
- [ ] Mac verification with the next legitimate recording: in-use machine → idle-guard refusal; Ghostty open → pre-running refusal; idle machine with Ghostty closed → both guards pass and the scene records.
- Lanes: script-only; no app code.
