### PR TITLE
CI fast path: docs/scripts-only diffs skip the Swift build/test/package lanes

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -2,7 +2,7 @@
 
 ## `ci.yml`
 
-Every PR and push to main: build, advisory format lint (`.swift-format`;
+Every non-fast-path PR and push to main: build, advisory format lint (`.swift-format`;
 flips to `--strict` after the one-shot tree reformat), unit tests with a
 coverage summary (`llvm-cov report` over Sources — visibility for the PR
 Proof section, not a gate), live STT-service integration tests, app packaging,
@@ -10,6 +10,14 @@ launch smoke test, an installable app artifact (`localvoxtral-app`, fetch
 with `scripts/try-pr.sh`), and a `localvoxtral-dsym` artifact (30-day
 retention) for symbolicating field crashes. Same-repo branches run on the
 self-hosted Mac runner; fork PRs run on GitHub-hosted macOS.
+
+The same `build-test` check takes a docs/scripts-only fast path when every
+changed file passes `scripts/ci/docs-only-filter.sh`; it then skips all Swift,
+helper, packaging, artifact, smoke, warm, and integration steps. The filter
+fails open to the full run for unknown or ambiguous diffs and excludes CI
+control files, packaging inputs (`assets/icons/**`), and every path selected
+by the LLM/speechd lane filters; an explicit `[run-llm-eval]` /
+`[run-speechd-integration]` marker also forces the full run.
 
 ## `release.yml`
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,94 @@ jobs:
           # fix: `git clean -ffdx` in the runner's _work/localvoxtral tree.
           clean: false
 
+      - name: Decide CI fast path
+        id: ci_scope
+        env:
+          PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          PUSH_BEFORE_SHA: ${{ github.event.before }}
+          PUSH_AFTER_SHA: ${{ github.event.after }}
+          # env indirection, not inline ${{ }} in the script body: PR bodies
+          # and commit messages are attacker-shaped strings (same discipline as
+          # the lane-decide steps below).
+          PR_BODY: ${{ github.event.pull_request.body }}
+          PUSH_HEAD_MESSAGE: ${{ github.event.head_commit.message }}
+        run: |
+          set -uo pipefail
+          FILES="$RUNNER_TEMP/ci-fast-path-changed-files.txt"
+
+          full_run() {
+            local reason="$1"
+            echo "docs_only=false" >> "$GITHUB_OUTPUT"
+            echo "CI fast path: full run ($reason)" | tee -a "$GITHUB_STEP_SUMMARY"
+            exit 0
+          }
+
+          # Both runner types use the same job. Fetch the event's exact diff
+          # endpoints explicitly: the persistent checkout uses clean: false,
+          # and checkout/history behavior must never be trusted as a skip gate.
+          if [[ "$GITHUB_EVENT_NAME" == "pull_request" ]]; then
+            if [[ -z "$PR_BASE_SHA" ]] \
+                || ! git fetch --no-tags origin "$PR_BASE_SHA" \
+                || ! git cat-file -e "$PR_BASE_SHA^{commit}" 2>/dev/null; then
+              full_run "PR base unavailable — failing open"
+            fi
+            BASE="$PR_BASE_SHA"
+            TARGET="HEAD"
+          elif [[ "$GITHUB_EVENT_NAME" == "push" ]]; then
+            if [[ -z "$PUSH_BEFORE_SHA" || "$PUSH_BEFORE_SHA" =~ ^0+$ ]]; then
+              full_run "push before SHA is empty/all-zero — failing open"
+            fi
+            if [[ -z "$PUSH_AFTER_SHA" ]] \
+                || ! git fetch --no-tags origin "$PUSH_AFTER_SHA" \
+                || ! git cat-file -e "$PUSH_AFTER_SHA^{commit}" 2>/dev/null; then
+              full_run "push after SHA unavailable — failing open"
+            fi
+            if ! git cat-file -e "$PUSH_BEFORE_SHA^{commit}" 2>/dev/null \
+                && ! git fetch --no-tags origin "$PUSH_BEFORE_SHA"; then
+              full_run "push before SHA unavailable — failing open"
+            fi
+            if ! git cat-file -e "$PUSH_BEFORE_SHA^{commit}" 2>/dev/null; then
+              full_run "push before SHA is not a commit — failing open"
+            fi
+            BASE="$PUSH_BEFORE_SHA"
+            TARGET="$PUSH_AFTER_SHA"
+          else
+            full_run "unsupported event $GITHUB_EVENT_NAME — failing open"
+          fi
+
+          if ! git diff --name-only "$BASE" "$TARGET" -- > "$FILES"; then
+            full_run "changed-file diff failed — failing open"
+          fi
+          # The explicit lane markers are an opt-in contract (AGENTS.md "When
+          # must the LLM lanes run?"): they must keep working even when the
+          # diff itself is docs-only, so they force the full path BEFORE the
+          # filter can decide otherwise.
+          MARKER_TEXT="${PR_BODY}"$'\n'"${PUSH_HEAD_MESSAGE}"
+          if grep -qF '[run-llm-eval]' <<<"$MARKER_TEXT" \
+              || grep -qF '[run-speechd-integration]' <<<"$MARKER_TEXT"; then
+            full_run "explicit lane marker present in PR body / head commit"
+          fi
+
+          if ! DECISION="$(./scripts/ci/docs-only-filter.sh "$FILES")"; then
+            full_run "docs-only filter failed — failing open"
+          fi
+
+          DOCS_ONLY="$(sed -n 's/^docs_only=//p' <<<"$DECISION")"
+          COUNT="$(sed -n 's/^count=//p' <<<"$DECISION")"
+          REASON="$(sed -n 's/^reason=//p' <<<"$DECISION")"
+          if [[ "$DOCS_ONLY" != "true" && "$DOCS_ONLY" != "false" ]] \
+              || [[ ! "$COUNT" =~ ^[0-9]+$ ]] || [[ -z "$REASON" ]]; then
+            full_run "docs-only filter returned an ambiguous decision — failing open"
+          fi
+
+          echo "$DECISION" >> "$GITHUB_OUTPUT"
+          if [[ "$DOCS_ONLY" == "true" ]]; then
+            echo "CI fast path: docs/scripts-only diff — Swift lanes skipped ($COUNT changed file(s))" \
+              | tee -a "$GITHUB_STEP_SUMMARY"
+          else
+            echo "CI fast path: full run ($REASON)" | tee -a "$GITHUB_STEP_SUMMARY"
+          fi
+
       - name: Clean stale outputs (keep build caches)
         # clean: false above skips git clean entirely, so outputs a previous
         # run generated must be removed by hand — but NOT the build caches.
@@ -54,6 +142,9 @@ jobs:
       - name: Process-cleanup regression tests
         # Pure shell tests for the workspace selector and the SSH build gate's
         # TERM -> KILL process-group teardown. Runs on hosted fork PRs too.
+        # Deliberately NOT gated on the docs-only fast path: the gate script is
+        # fast-path-eligible, so these seconds-cheap tests are what still
+        # exercises a gate-only diff.
         run: |
           ./scripts/ci/test-cleanup-stale-test-processes.sh
           ./scripts/ci/test-build-gate-process-cleanup.sh
@@ -76,6 +167,9 @@ jobs:
       - name: Process-cleanup regression tests
         # Pure shell tests for the workspace selector and the SSH build gate's
         # TERM -> KILL process-group teardown. Runs on hosted fork PRs too.
+        # Deliberately NOT gated on the docs-only fast path: the gate script is
+        # fast-path-eligible, so these seconds-cheap tests are what still
+        # exercises a gate-only diff.
         run: |
           ./scripts/ci/test-cleanup-stale-test-processes.sh
           ./scripts/ci/test-build-gate-process-cleanup.sh
@@ -96,7 +190,7 @@ jobs:
         # "When must the LLM lanes run?". The PolishHelper UNIT suite and the
         # tier-1 speechd realtime integration stay per-push.
         id: llm_lane
-        if: runner.environment == 'self-hosted'
+        if: runner.environment == 'self-hosted' && steps.ci_scope.outputs.docs_only != 'true'
         env:
           # env indirection, not inline ${{ }} in the script body: PR bodies
           # and commit messages are attacker-shaped strings.
@@ -154,7 +248,7 @@ jobs:
         # Real speechd inference loads the multi-GB Voxtral model on the
         # personal-Mac runner, so keep it conditional just like polishd.
         id: speechd_lane
-        if: runner.environment == 'self-hosted'
+        if: runner.environment == 'self-hosted' && steps.ci_scope.outputs.docs_only != 'true'
         env:
           PR_BODY: ${{ github.event.pull_request.body }}
           PUSH_HEAD_MESSAGE: ${{ github.event.head_commit.message }}
@@ -197,13 +291,13 @@ jobs:
           fi
 
       - name: Setup Swift
-        if: runner.environment == 'github-hosted'
+        if: runner.environment == 'github-hosted' && steps.ci_scope.outputs.docs_only != 'true'
         uses: swift-actions/setup-swift@v2
         with:
           swift-version: "6.2"
 
       - name: Cache SwiftPM build
-        if: runner.environment == 'github-hosted'
+        if: runner.environment == 'github-hosted' && steps.ci_scope.outputs.docs_only != 'true'
         uses: actions/cache@v4
         with:
           path: .build
@@ -218,6 +312,7 @@ jobs:
         # Advisory until the one-shot tree reformat lands: swift-format exits 0
         # on findings without --strict. After the reformat, add --strict here
         # to make style regressions block.
+        if: steps.ci_scope.outputs.docs_only != 'true'
         run: |
           swift format lint --recursive --parallel Sources Tests Package.swift 2>&1 \
             | tee format-lint.txt | tail -n 5
@@ -229,6 +324,7 @@ jobs:
         # old standalone `swift build` step built plain-debug products that
         # nothing downstream consumed (tests rebuild with coverage flags,
         # packaging builds release), so it was pure duplicate compilation.
+        if: steps.ci_scope.outputs.docs_only != 'true'
         env:
           RUNNER_ENVIRONMENT: ${{ runner.environment }}
         run: |
@@ -250,7 +346,7 @@ jobs:
             --enable-code-coverage
 
       - name: Upload complete unit-test log
-        if: always()
+        if: ${{ always() && steps.ci_scope.outputs.docs_only != 'true' }}
         uses: actions/upload-artifact@v4
         with:
           name: unit-test-log-${{ runner.os }}
@@ -261,6 +357,7 @@ jobs:
       - name: Coverage summary
         # Visibility, not a gate: lets a PR's Proof section cite real coverage
         # of the changed files instead of "a test exists".
+        if: steps.ci_scope.outputs.docs_only != 'true'
         run: |
           set -euo pipefail
           BIN="$(find .build -type f -name localvoxtralPackageTests -path '*.xctest/Contents/MacOS/*' | head -n 1)"
@@ -289,7 +386,7 @@ jobs:
         # run dir is absent and there is nothing to warm — the still-resident
         # STT service serves the suite, so skip cleanly instead of failing CI.
         # The integration step below is the real gate on the STT service.
-        if: runner.environment == 'self-hosted'
+        if: runner.environment == 'self-hosted' && steps.ci_scope.outputs.docs_only != 'true'
         run: |
           if [ -d /Users/Shared/localvoxtral/run ]; then
             ./scripts/mac/lv-test-servers.sh ensure speechd
@@ -303,7 +400,7 @@ jobs:
         # (launchd service com.localvoxtral.testspeechd, warmed on-demand by the
         # step above). On GitHub-hosted runners there is no backend and the suite
         # self-skips, so this step is self-hosted only.
-        if: runner.environment == 'self-hosted'
+        if: runner.environment == 'self-hosted' && steps.ci_scope.outputs.docs_only != 'true'
         env:
           VLLM_REALTIME_TEST_ENABLE: "1"
           VLLM_REALTIME_TEST_MODEL: T0mSIlver/Voxtral-Mini-4B-Realtime-2602-MLX-4bit
@@ -317,14 +414,14 @@ jobs:
         # Self-hosted only: hosted runners would pay a cold Cmlx C++ compile
         # every fork PR. These tests are Metal-free (HTTP layer, router,
         # cache locator, watchdog); the Metal path is covered below.
-        if: runner.environment == 'self-hosted'
+        if: runner.environment == 'self-hosted' && steps.ci_scope.outputs.docs_only != 'true'
         run: swift test --package-path PolishHelper
 
       - name: Speech helper unit tests (SpeechHelper package)
         # Self-hosted only, matching PolishHelper: this is the per-push,
         # Metal-free codec/delta/watchdog suite. Real Metal inference is the
         # conditional post-packaging lane below.
-        if: runner.environment == 'self-hosted'
+        if: runner.environment == 'self-hosted' && steps.ci_scope.outputs.docs_only != 'true'
         run: swift test --package-path SpeechHelper
 
       - name: Ensure Metal toolchain
@@ -334,7 +431,7 @@ jobs:
         # (`xcrun --find metal` succeeds even when the component is missing)
         # and self-provision loudly; the asset is cached system-wide, so a
         # re-activation here is quick.
-        if: runner.environment == 'self-hosted'
+        if: runner.environment == 'self-hosted' && steps.ci_scope.outputs.docs_only != 'true'
         run: |
           if ! xcrun metal --version >/dev/null 2>&1; then
             echo "Metal toolchain not active for $(whoami); installing component..."
@@ -355,6 +452,7 @@ jobs:
         # Hosted runners skip both bundled MLX helpers (no MetalToolchain
         # component + cold MLX C++ builds would dominate fork-PR CI); every
         # self-hosted lane (same-repo PRs, main, releases) builds them.
+        if: steps.ci_scope.outputs.docs_only != 'true'
         env:
           LOCALVOXTRAL_CODESIGN_IDENTITY: localvoxtral-dev
           LOCALVOXTRAL_SKIP_POLISHD: ${{ runner.environment == 'github-hosted' && '1' || '0' }}
@@ -372,7 +470,7 @@ jobs:
         # Runs packaged speechd through RealtimeAPIWebSocketClient with the
         # tier-1 spoken fixture. Conditional because it loads the multi-GB
         # Voxtral model. Local equivalent: remote-build.sh integration-speechd.
-        if: runner.environment == 'self-hosted' && steps.speechd_lane.outputs.run == 'true'
+        if: runner.environment == 'self-hosted' && steps.ci_scope.outputs.docs_only != 'true' && steps.speechd_lane.outputs.run == 'true'
         env:
           SPEECHD_INTEGRATION_TEST_ENABLE: "1"
           SPEECHD_INTEGRATION_TEST_PATH: dist/localvoxtral.app/Contents/MacOS/localvoxtral-speechd
@@ -390,7 +488,7 @@ jobs:
         # above (path filter + [run-llm-eval] marker) says whether this
         # change can affect what the lane measures. Local equivalent:
         # ./scripts/remote-build.sh integration-polishd
-        if: runner.environment == 'self-hosted' && steps.llm_lane.outputs.run == 'true'
+        if: runner.environment == 'self-hosted' && steps.ci_scope.outputs.docs_only != 'true' && steps.llm_lane.outputs.run == 'true'
         env:
           LOCALVOXTRAL_POLISHD_TEST_ENABLE: "1"
           LOCALVOXTRAL_POLISHD_TEST_PATH: PolishHelper/.build/xcode/Build/Products/Release/localvoxtral-polishd
@@ -401,9 +499,11 @@ jobs:
       - name: Zip app for artifact upload
         # upload-artifact mangles symlinks/exec bits in .app bundles; ditto-zip
         # first so the downloaded app keeps a valid signature.
+        if: steps.ci_scope.outputs.docs_only != 'true'
         run: ditto -c -k --sequesterRsrc --keepParent dist/localvoxtral.app dist/localvoxtral-app.zip
 
       - name: Upload app artifact
+        if: steps.ci_scope.outputs.docs_only != 'true'
         uses: actions/upload-artifact@v4
         with:
           name: localvoxtral-app
@@ -414,6 +514,7 @@ jobs:
         # Includes helper dSYMs when present (self-hosted lanes) — helper
         # crashes (MLX C++/Metal) are the likeliest field
         # crashes, and a dSYM that never leaves the runner symbolizes nothing.
+        if: steps.ci_scope.outputs.docs_only != 'true'
         run: |
           ditto -c -k --keepParent dist/localvoxtral.dSYM dist/localvoxtral-dSYM.zip
           if [[ -d dist/localvoxtral-polishd.dSYM ]]; then
@@ -426,6 +527,7 @@ jobs:
       - name: Upload dSYM artifact
         # Longer retention than the app: field crashes surface days after the
         # try-pr build that produced them.
+        if: steps.ci_scope.outputs.docs_only != 'true'
         uses: actions/upload-artifact@v4
         with:
           name: localvoxtral-dsym
@@ -436,6 +538,7 @@ jobs:
           retention-days: 30
 
       - name: Smoke test packaged app launch (end-user simulation)
+        if: steps.ci_scope.outputs.docs_only != 'true'
         run: |
           # Launch a COPY of the packaged app from outside the workspace with
           # the workspace .build renamed away. A same-tree launch silently

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -143,8 +143,8 @@ This is a real app with daily users. Nothing ships on "it compiles".
 
 | Tier | What | When | Cost |
 |---|---|---|---|
-| 0 | Unit suite (500+ tests) + PolishHelper/SpeechHelper unit suites + packaging + launch smoke | every PR/push, CI (helper unit suites: self-hosted lanes only) | ~1 min |
-| 1 | `RealtimeAPIVLLMIntegrationTests` vs the live local speechd STT test service: real inference through the production websocket client, word-accuracy asserted | every PR/push on the self-hosted runner; locally via `remote-build.sh integration` | ~20 s |
+| 0 | Unit suite (500+ tests) + PolishHelper/SpeechHelper unit suites + packaging + launch smoke | every non-fast-path PR/push, CI (helper unit suites: self-hosted lanes only) | ~1 min |
+| 1 | `RealtimeAPIVLLMIntegrationTests` vs the live local speechd STT test service: real inference through the production websocket client, word-accuracy asserted | every non-fast-path PR/push on the self-hosted runner; locally via `remote-build.sh integration` | ~20 s |
 | 1 | `PolishHelperIntegrationTests`: the packaged polishing helper vs the real pinned model — production request path, shared eval baseline, parent-pid tether | conditional in CI (self-hosted, after packaging): only when the diff touches LLM-relevant paths or the PR opts in with `[run-llm-eval]` — see "When must the LLM lanes run?"; locally via `remote-build.sh integration-polishd` | minutes (4B weights + live inference) |
 | 1 | `SpeechHelperIntegrationTests`: packaged speechd vs real spoken audio/model through the production realtime client — word accuracy, append-only delta/done parity, parent-pid tether | conditional in CI (self-hosted, after packaging): only when the diff touches speechd-relevant paths or the PR opts in with `[run-speechd-integration]`; locally via `remote-build.sh integration-speechd` | minutes (4B weights + live inference) |
 | 2 | `ui-smoke.yml` AX smoke drill (status item, settings tabs, lazy managed-backend launch invariant); dictation-with-audio remains future work | evening lock-aware slots (18:00/19:30/21:00 UTC; `ui-smoke-guard.sh` skips green when the screen is locked or a slot's drill already ran and passed that day — the drill needs an unlocked GUI session) + manual on the self-hosted GUI runner | — |
@@ -273,11 +273,19 @@ rather than silently treating it as a model failure.
 
 ## CI / shipping
 
-- `ci.yml` runs tiers 0–1 on every PR and push to main (the polishd
+- `ci.yml` runs tiers 0–1 on every non-fast-path PR and push to main (the polishd
   live-model lane conditionally — see "When must the LLM lanes run?").
   Same-repo branches run on the self-hosted Mac runner (fast, warm cache);
   fork PRs run on GitHub-hosted macOS. Never move fork-PR jobs to the
   self-hosted runner — it is a personal machine.
+- The `build-test` check stays present but skips every Swift, helper, package,
+  artifact, smoke, warm, and integration lane when every changed path is a
+  documentation, presentation, or operational-script path per the conservative
+  allowlist in `scripts/ci/docs-only-filter.sh`. Unknown/ambiguous diffs,
+  packaging inputs (`assets/icons/**`), lane-filter-relevant paths, the
+  `[run-llm-eval]`/`[run-speechd-integration]` markers, and changes to the
+  filter or other `scripts/ci/**` paths all fail open to the full run. Release
+  and all other workflows remain fully gated.
 - Watch a PR's checks with `./scripts/watch-checks.sh <n>` (or `--run
   <run-id>` for a push/rerun). It polls like `gh pr checks --watch` but also
   probes the build host over SSH and fail-fasts in ~30 s with a wake-the-Mac

--- a/scripts/ci/docs-only-filter.sh
+++ b/scripts/ci/docs-only-filter.sh
@@ -1,0 +1,156 @@
+#!/bin/bash
+# Decides whether the normal CI job may take the docs/scripts-only fast path.
+#
+# Usage:
+#   scripts/ci/docs-only-filter.sh <changed-files-file>
+#
+#   <changed-files-file>  one changed path per line (git diff --name-only)
+#
+# stdout is $GITHUB_OUTPUT-shaped:
+#   docs_only=true|false
+#   count=<number of non-empty changed paths>
+#   reason=<one line, safe for a step summary>
+#
+# Exits 0 for both decisions; non-zero only on usage errors. The workflow owns
+# fail-open behavior when it cannot compute the diff or invoke this filter.
+set -euo pipefail
+
+if [[ $# -ne 1 ]]; then
+  echo "usage: $0 <changed-files-file>" >&2
+  exit 2
+fi
+
+CHANGED_FILES_FILE="$1"
+if [[ ! -f "$CHANGED_FILES_FILE" ]]; then
+  echo "changed-files file not found: $CHANGED_FILES_FILE" >&2
+  exit 2
+fi
+
+emit_full_run() {
+  local reason="$1"
+  local count="$2"
+  echo "docs_only=false"
+  echo "count=$count"
+  echo "reason=$reason"
+}
+
+# This is an allowlist, not a list of known-dangerous paths: an unknown path
+# must run full CI. Exclusions are checked first so a Markdown suffix cannot
+# make workflow, source, package, or CI-control files eligible.
+#
+# scripts/ci/** is intentionally excluded. That includes this filter, so every
+# edit to CI decision logic proves the full workflow on its first real run.
+# scripts/package_app.sh is also excluded because tier 0 directly exercises it.
+# scripts/mac/localvoxtral-build-gate.sh remains eligible: it is deployed and
+# run out of band rather than exercised by tier-0 Swift/package lanes.
+REJECTION_REASON=""
+is_fast_path_allowlisted() {
+  local path="$1"
+
+  case "$path" in
+    .github/*)
+      REJECTION_REASON="workflow path: $path"
+      return 1
+      ;;
+    scripts/ci/*)
+      REJECTION_REASON="CI decision path: $path"
+      return 1
+      ;;
+    scripts/package_app.sh)
+      REJECTION_REASON="tier-0 packaging path: $path"
+      return 1
+      ;;
+    scripts/mac/lv-test-servers.sh)
+      # Only exercised by the (gated) warm + integration steps — no un-gated
+      # shell test covers it, unlike the build gate. Full run.
+      REJECTION_REASON="warm-infra path with gated-only coverage: $path"
+      return 1
+      ;;
+    assets/icons/*)
+      # package_app.sh hard-requires and transforms these (app + menubar
+      # icons); an icon-only diff must prove the gated package step.
+      REJECTION_REASON="packaging input path: $path"
+      return 1
+      ;;
+    # ORDER MATTERS: this arm must precede `Package.*` so helper manifests
+    # (PolishHelper/Package.swift) are caught here; `Package.*` then only
+    # matches the root manifest/lockfile.
+    Sources/*|Tests/*|PolishHelper/*|SpeechHelper/*)
+      REJECTION_REASON="Swift source/test/helper path: $path"
+      return 1
+      ;;
+    Package.*)
+      REJECTION_REASON="Swift package manifest/lock path: $path"
+      return 1
+      ;;
+    *.toml)
+      REJECTION_REASON="bundled/config TOML path: $path"
+      return 1
+      ;;
+    integrations/*)
+      if [[ "$path" == *.md ]]; then
+        return 0
+      fi
+      REJECTION_REASON="shipped integration path: $path"
+      return 1
+      ;;
+    EvalRecordings/*|EvalCorpus/*)
+      if [[ "$path" == *.md ]]; then
+        return 0
+      fi
+      REJECTION_REASON="evaluation data/code path: $path"
+      return 1
+      ;;
+    *.md|scripts/*|assets/*|LICENSE|.gitignore)
+      return 0
+      ;;
+    *)
+      REJECTION_REASON="path is not allowlisted: $path"
+      return 1
+      ;;
+  esac
+}
+
+count=0
+while IFS= read -r file; do
+  [[ -z "$file" ]] && continue
+  count=$((count + 1))
+  if ! is_fast_path_allowlisted "$file"; then
+    emit_full_run "$REJECTION_REASON" "$count"
+    exit 0
+  fi
+done <"$CHANGED_FILES_FILE"
+
+if [[ "$count" -eq 0 ]]; then
+  emit_full_run "empty changed-file list — failing open" 0
+  exit 0
+fi
+
+# Invariant: the fast-path allowlist and both live-model lane path lists must
+# be disjoint. Reuse the authoritative filters so future additions there
+# automatically force full CI here. This notably excludes LLM-relevant
+# Markdown under EvalCorpus/ or integrations/claude-code/ even though ordinary
+# Markdown in those parent trees is otherwise eligible.
+if ! llm_decision="$("$(dirname "$0")/llm-lane-filter.sh" "$CHANGED_FILES_FILE")"; then
+  emit_full_run "LLM lane filter failed — failing open" "$count"
+  exit 0
+fi
+if [[ "$(sed -n 's/^run=//p' <<<"$llm_decision")" == "true" ]]; then
+  llm_reason="$(sed -n 's/^reason=//p' <<<"$llm_decision")"
+  emit_full_run "LLM-lane-relevant path: $llm_reason" "$count"
+  exit 0
+fi
+
+if ! speechd_decision="$("$(dirname "$0")/speechd-lane-filter.sh" "$CHANGED_FILES_FILE")"; then
+  emit_full_run "speechd lane filter failed — failing open" "$count"
+  exit 0
+fi
+if [[ "$(sed -n 's/^run=//p' <<<"$speechd_decision")" == "true" ]]; then
+  speechd_reason="$(sed -n 's/^reason=//p' <<<"$speechd_decision")"
+  emit_full_run "speechd-lane-relevant path: $speechd_reason" "$count"
+  exit 0
+fi
+
+echo "docs_only=true"
+echo "count=$count"
+echo "reason=all $count changed path(s) are docs/scripts-only"


### PR DESCRIPTION
## What

The `build-test` job gains an early "Decide CI fast path" step: when every changed file passes the new conservative allowlist (`scripts/ci/docs-only-filter.sh`), all expensive steps — Swift build, unit suite, helper suites, packaging (the PolishHelper/SpeechHelper xcodebuild lanes), artifacts, launch smoke, warm + integration lanes — are skipped, and the check succeeds with a self-explanatory step summary, mirroring the LLM-lane-skip convention. Rationale: the runner is the owner's personal MacBook Pro, and a `record-demo.sh` or README diff was costing a full multi-minute Swift pipeline.

Design points:
- **Fail-open everywhere.** Unknown paths, empty diffs, zero-SHA pushes, unfetchable bases, filter errors, ambiguous outputs → full run. The decide step diffs the event's exact endpoints (PR base SHA / push before..after) with explicit fetches; a stale PR base over-includes changes, which errs toward full runs.
- **Allowlist, not a denylist** — with explicit exclusions for: `.github/**`, `scripts/ci/**` (including this filter — editing CI decision logic forces a proven full run), `scripts/package_app.sh`, `scripts/mac/lv-test-servers.sh` (its only CI exercise is the gated warm/integration steps), `assets/icons/**` (hard-required packaging inputs), all `*.toml` (bundled-config hash test), `Package.*`, `Sources/Tests/PolishHelper/SpeechHelper`, non-md `integrations/**` and `EvalCorpus/EvalRecordings/**`.
- **Disjointness with the live-model lanes is enforced, not asserted:** the filter *runs* `llm-lane-filter.sh` and `speechd-lane-filter.sh` over the same changed-file list and full-runs if either matches — so future lane-filter additions automatically block the fast path. The explicit `[run-llm-eval]`/`[run-speechd-integration]` markers also force the full path before the filter is consulted (env-indirected, same attacker-shaped-string discipline as the lane steps).
- The seconds-cheap shell regression tests (gate/process-cleanup, installer asset resolution) stay un-gated — they are what still exercises a gate-script-only diff.

Implementation: codex (gpt-5.6-sol). Adversarial review: opencode (GLM-5.2) — **FAIL → fixed**: its blocker (an `AppIcon.png`-only diff went fast-path while packaging hard-requires those files) and both IMPORTANT findings (`lv-test-servers.sh` had gated-only coverage; the lane markers were silently inert on docs-only diffs) are all fixed in this diff, plus its doc-consistency and arm-ordering notes.

## Proof

- [x] Filter exercised against 12+ synthetic changed-file lists (docs-only, mixed, `scripts/ci`, TOML, empty, packaging icons, warm-infra script, EvalCorpus markdown → correctly full-run via the LLM-lane disjointness check, helper manifests via arm ordering). Sample:
  ```
  README.md + scripts/record-demo.sh + assets/settings-general.png → docs_only=true
  assets/icons/app/AppIcon.png → docs_only=false (packaging input path)
  EvalCorpus/agent-dictation/README.md → docs_only=false (LLM-lane-relevant)
  scripts/ci/docs-only-filter.sh → docs_only=false (CI decision path)
  ```
- [x] `bash -n` clean; workflow YAML parses.
- [x] This PR itself touches `.github/**` + `scripts/ci/**`, so its own CI run is deliberately the full path — the check name and green semantics are unchanged for branch protection and `watch-checks.sh`.
- [ ] First real fast-path run: the next docs-only PR/push should show "CI fast path: docs/scripts-only diff — Swift lanes skipped" in the step summary with a green check in well under a minute.
- Lanes: CI-control change; no app code, no prompts, no models.