### PR TITLE
Claude context: herdr as a first-class marker-free join target

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -419,6 +419,28 @@ Key subsystems:
     them unconditionally: a remote TTY names another machine's device, and
     `resolve(tty:)` refuses remote candidates so an SSH host can never claim a
     local pane by echoing its TTY.
+  - herdr (the tmux-like agent multiplexer) is a first-class join target with
+    its own arm, and it is MARKER-FREE by design (owner decision 2026-07-21):
+    herdr intercepts OSC 2 per pane, so a title marker can neither reach
+    Ghostty's title nor describe an inner pane — the broker never emits one to
+    a herdr-hosted session, even under the title-fallback opt-in. The arm runs
+    only after the surface TTY positively binds to herdr (a `herdr` client
+    process on the focused Ghostty surface's TTY, `HerdrClientTTYProbe` —
+    herdr's socket has no client introspection, so the process table is the
+    only binding), and from that point the join is herdr-or-nothing: no
+    marker fallback, because a lingering title marker could only mis-join.
+    The hook publishes `HERDR_PANE_ID`/`HERDR_SOCKET_PATH` from the pane env;
+    `HerdrSocketClient` (hand-written, read-only — herdr is AGPL, never vendor
+    its code) asks that one socket for the focused pane and the join is exact
+    pane-id equality (`resolve(herdrPaneID:)`, local sessions only), guarded
+    by two fail-closed cross-checks: herdr's own `agent_session` claim must
+    not disagree, and the registered Claude pid must be in the pane's
+    foreground process list (catches a suspended Claude with the user at the
+    shell). Two live herdr sessions (distinct sockets) abstain — there is no
+    way to tell which one the surface displays. A herdr join never authorizes
+    raw screen attachment: the AX capture is the composite herdr TUI, and
+    neighboring panes must not ride into this session's prompt (a clean
+    `pane.read` excerpt is a possible follow-up, not built).
   - Lookups abstain rather than guess: no marker, unknown, stale, or ambiguous
     means no context. There is deliberately no sole-session or cwd heuristic —
     it is wrong precisely when it matters.

--- a/Sources/ClaudeContextWire/ClaudeHookWire.swift
+++ b/Sources/ClaudeContextWire/ClaudeHookWire.swift
@@ -95,12 +95,25 @@ public struct ClaudeHookProcessInfo: Sendable, Equatable, Codable {
     public var tty: String?
     /// `$TERM_PROGRAM` (e.g. `ghostty`, `iTerm.app`), when set.
     public var termProgram: String?
+    /// herdr pane identity, published only when the hook ran inside a herdr pane.
+    public var herdrPaneID: String?
+    /// The herdr JSON API socket path herdr injected into the pane environment.
+    public var herdrSocketPath: String?
 
-    public init(hookPID: Int32, claudePID: Int32, tty: String? = nil, termProgram: String? = nil) {
+    public init(
+        hookPID: Int32,
+        claudePID: Int32,
+        tty: String? = nil,
+        termProgram: String? = nil,
+        herdrPaneID: String? = nil,
+        herdrSocketPath: String? = nil
+    ) {
         self.hookPID = hookPID
         self.claudePID = claudePID
         self.tty = tty
         self.termProgram = termProgram
+        self.herdrPaneID = herdrPaneID
+        self.herdrSocketPath = herdrSocketPath
     }
 
     enum CodingKeys: String, CodingKey {
@@ -108,6 +121,8 @@ public struct ClaudeHookProcessInfo: Sendable, Equatable, Codable {
         case claudePID = "claude_pid"
         case tty
         case termProgram = "term_program"
+        case herdrPaneID = "herdr_pane_id"
+        case herdrSocketPath = "herdr_socket_path"
     }
 }
 
@@ -310,6 +325,12 @@ public enum ClaudeHookWireCodec {
         if var process = record.process {
             process.tty = process.tty.map { truncate($0, toUTF8Bytes: limits.maxPathBytes) }
             process.termProgram = process.termProgram.map {
+                truncate($0, toUTF8Bytes: limits.maxPathBytes)
+            }
+            process.herdrPaneID = process.herdrPaneID.map {
+                truncate($0, toUTF8Bytes: limits.maxPathBytes)
+            }
+            process.herdrSocketPath = process.herdrSocketPath.map {
                 truncate($0, toUTF8Bytes: limits.maxPathBytes)
             }
             clamped.process = process

--- a/Sources/ClaudeHookPublisherCore/ClaudeHookPublisher.swift
+++ b/Sources/ClaudeHookPublisherCore/ClaudeHookPublisher.swift
@@ -126,7 +126,8 @@ public struct ClaudeHookPublisher: Sendable {
     }
 
     /// Safe metadata only: identity and location of the terminal, never its
-    /// contents and never argv/env beyond `$TERM_PROGRAM`.
+    /// contents and never argv/env beyond `$TERM_PROGRAM`,
+    /// `$HERDR_PANE_ID`, and `$HERDR_SOCKET_PATH`.
     func processInfo() -> ClaudeHookProcessInfo {
         // ONE ppid resolution feeds both fields: the published claudePID and
         // the tty's process-table fallback must describe the same process.
@@ -135,7 +136,11 @@ public struct ClaudeHookPublisher: Sendable {
             hookPID: environment.pid(),
             claudePID: claudePID,
             tty: environment.ttyName(claudePID),
-            termProgram: environment.variables["TERM_PROGRAM"].flatMap { $0.isEmpty ? nil : $0 }
+            termProgram: environment.variables["TERM_PROGRAM"].flatMap { $0.isEmpty ? nil : $0 },
+            herdrPaneID: environment.variables["HERDR_PANE_ID"].flatMap { $0.isEmpty ? nil : $0 },
+            herdrSocketPath: environment.variables["HERDR_SOCKET_PATH"].flatMap {
+                $0.isEmpty ? nil : $0
+            }
         )
     }
 

--- a/Sources/localvoxtral/ClaudeContext/ClaudeContextBroker.swift
+++ b/Sources/localvoxtral/ClaudeContext/ClaudeContextBroker.swift
@@ -507,7 +507,8 @@ public final class ClaudeContextBroker: Sendable {
                     Log.claudeContext.error("Dropping connection: too many records")
                     return
                 }
-                reply(to: fd, marker: handle(line: line, origin: origin))
+                let handled = handle(line: line, origin: origin)
+                reply(to: fd, marker: handled.marker, isHerdrHosted: handled.isHerdrHosted)
             }
         }
     }
@@ -564,11 +565,14 @@ public final class ClaudeContextBroker: Sendable {
     /// a marker to turn into a terminal title sequence when the user opted into
     /// that fallback. Registry ingestion and marker allocation are unchanged,
     /// so TTY joins keep the same marker-keyed liveness checks either way.
+    /// herdr records never receive one: herdr intercepts OSC 2 inside its pane,
+    /// so the marker cannot describe the outer Ghostty surface and would only
+    /// contaminate herdr's own pane-title state.
     ///
     /// Best-effort by design — a publisher that has already exited is normal,
     /// not an error.
-    private func reply(to fd: Int32, marker: ClaudeSessionMarker?) {
-        let responseMarker = shouldEmitLocalTitleMarker() ? marker?.value : nil
+    private func reply(to fd: Int32, marker: ClaudeSessionMarker?, isHerdrHosted: Bool) {
+        let responseMarker = shouldEmitLocalTitleMarker() && !isHerdrHosted ? marker?.value : nil
         guard let line = ClaudeBrokerResponse.encodeLine(
             ClaudeBrokerResponse(marker: responseMarker)
         ) else { return }
@@ -586,10 +590,14 @@ public final class ClaudeContextBroker: Sendable {
         }
     }
 
-    /// - Returns: the marker for the session this record belongs to, or nil if
-    ///   the record was rejected.
+    /// - Returns: the marker for the session this record belongs to and whether
+    ///   herdr must intercept title changes, or nil marker metadata when the
+    ///   record was rejected.
     @discardableResult
-    private func handle(line: Data, origin: ClaudeTransportOrigin) -> ClaudeSessionMarker? {
+    private func handle(
+        line: Data,
+        origin: ClaudeTransportOrigin
+    ) -> (marker: ClaudeSessionMarker?, isHerdrHosted: Bool) {
         do {
             let record = try ClaudeHookWireCodec.decodeLine(line, limits: limits.wire)
             let snapshot = registry.ingest(record, origin: origin)
@@ -599,19 +607,19 @@ public final class ClaudeContextBroker: Sendable {
             #if DEBUG
             debugNotify(.success(record))
             #endif
-            return snapshot?.marker
+            return (snapshot?.marker, record.process?.herdrPaneID != nil)
         } catch let error as ClaudeHookWireError {
             Log.claudeContext.error("Rejected record: \(String(describing: error), privacy: .public)")
             #if DEBUG
             debugNotify(.failure(error))
             #endif
-            return nil
+            return (nil, false)
         } catch {
             Log.claudeContext.error("Rejected record: undecodable")
             #if DEBUG
             debugNotify(.failure(.malformed))
             #endif
-            return nil
+            return (nil, false)
         }
     }
 }

--- a/Sources/localvoxtral/ClaudeContext/ClaudeSessionRegistry.swift
+++ b/Sources/localvoxtral/ClaudeContext/ClaudeSessionRegistry.swift
@@ -234,6 +234,47 @@ public final class ClaudeSessionRegistry: Sendable {
         }
     }
 
+    /// Look up by herdr pane id — the herdr focus join. LOCAL sessions only: a
+    /// remote host's pane ids live in another machine's herdr and could collide
+    /// with (or deliberately mirror) a local pane's id; matching them here would
+    /// let an SSH host claim a local pane by echoing its pane id.
+    public func resolve(herdrPaneID: String) -> ClaudeMarkerResolution {
+        let timestamp = now()
+        return state.withLock { state in
+            let matches = state.sessions.values.filter { snapshot in
+                snapshot.origin.isLocalAuthenticated
+                    && snapshot.process?.herdrPaneID == herdrPaneID
+                    && isFresh(snapshot, now: timestamp)
+            }
+            switch matches.count {
+            case 0:
+                let hadStale = state.sessions.values.contains {
+                    $0.origin.isLocalAuthenticated && $0.process?.herdrPaneID == herdrPaneID
+                }
+                return hadStale ? .stale : .unknown
+            case 1:
+                return .resolved(matches[0])
+            default:
+                return .ambiguous
+            }
+        }
+    }
+
+    /// Distinct herdr socket paths across live LOCAL sessions. The resolver
+    /// refuses to guess between multiple herdr sessions, so it needs the count,
+    /// not just one path.
+    public func liveLocalHerdrSocketPaths() -> Set<String> {
+        let timestamp = now()
+        return state.withLock { state in
+            Set(state.sessions.values.compactMap { snapshot in
+                guard snapshot.origin.isLocalAuthenticated,
+                      isFresh(snapshot, now: timestamp)
+                else { return nil }
+                return snapshot.process?.herdrSocketPath
+            })
+        }
+    }
+
     public func snapshot(sessionID: String) -> ClaudeSessionSnapshot? {
         let timestamp = now()
         return state.withLock { state in

--- a/Sources/localvoxtral/ClaudeContext/HerdrClientTTYProbe.swift
+++ b/Sources/localvoxtral/ClaudeContext/HerdrClientTTYProbe.swift
@@ -1,0 +1,74 @@
+import Foundation
+
+#if canImport(Darwin)
+import Darwin
+
+/// Is a herdr client (app-mode `herdr` process) attached to this TTY device?
+/// This is what binds "Ghostty's focused surface" to "herdr is what that
+/// surface displays" — the socket API has no client introspection.
+protocol HerdrClientTTYProbing: Sendable {
+    func isHerdrClient(onTTYDevicePath: String) -> Bool
+}
+
+/// Same-user process-table probe used only after Ghostty positively identifies
+/// its focused surface's TTY. Every metadata failure abstains; absence is safer
+/// than treating an unrelated or unreadable surface as herdr.
+enum HerdrClientTTYProbe {
+    static func isHerdrClient(onTTYDevicePath path: String) -> Bool {
+        isHerdrClient(
+            onTTYDevicePath: path,
+            deviceID: liveDeviceID,
+            processNames: liveProcessNames
+        )
+    }
+
+    static func isHerdrClient(
+        onTTYDevicePath path: String,
+        deviceID: @Sendable (String) -> dev_t?,
+        processNames: @Sendable (dev_t) -> [String]?
+    ) -> Bool {
+        guard let device = deviceID(path),
+              let names = processNames(device)
+        else { return false }
+        return names.contains("herdr")
+    }
+
+    private static let liveDeviceID: @Sendable (String) -> dev_t? = { path in
+        // `lstat`, matching ClaudeSocketGuard: `Darwin.stat` resolves to the
+        // struct type, not the function, and a /dev node is never a symlink.
+        var metadata = stat()
+        guard lstat(path, &metadata) == 0 else { return nil }
+        return metadata.st_rdev
+    }
+
+    private static let liveProcessNames: @Sendable (dev_t) -> [String]? = { device in
+        // dev_t is Int32 on Darwin, so this is an identity conversion today —
+        // but if the type ever widens, a device that does not fit must abstain,
+        // not trap mid-dictation.
+        guard let deviceMib = Int32(exactly: device) else { return nil }
+        var mib = [Int32(CTL_KERN), Int32(KERN_PROC), Int32(KERN_PROC_TTY), deviceMib]
+        var byteCount = 0
+        guard sysctl(&mib, u_int(mib.count), nil, &byteCount, nil, 0) == 0,
+              byteCount > 0
+        else { return nil }
+
+        let stride = MemoryLayout<kinfo_proc>.stride
+        var processes = [kinfo_proc](
+            repeating: kinfo_proc(), count: (byteCount + stride - 1) / stride
+        )
+        var fetchedBytes = processes.count * stride
+        let status = processes.withUnsafeMutableBytes { buffer in
+            sysctl(&mib, u_int(mib.count), buffer.baseAddress, &fetchedBytes, nil, 0)
+        }
+        guard status == 0 else { return nil }
+
+        return processes.prefix(fetchedBytes / stride).map { process in
+            // Bounded decode: `String(cString:)` would walk past the fixed-size
+            // p_comm tuple if a corrupted entry ever arrived without its NUL.
+            withUnsafeBytes(of: process.kp_proc.p_comm) { raw in
+                String(decoding: raw.prefix(while: { $0 != 0 }), as: UTF8.self)
+            }
+        }
+    }
+}
+#endif

--- a/Sources/localvoxtral/ClaudeContext/HerdrSocketClient.swift
+++ b/Sources/localvoxtral/ClaudeContext/HerdrSocketClient.swift
@@ -1,0 +1,407 @@
+import Foundation
+
+#if canImport(Darwin)
+import Darwin
+
+/// What the resolver needs to know about herdr's focused pane.
+struct HerdrFocusedPane: Sendable, Equatable {
+    var paneID: String
+    /// herdr's own Claude-session claim for the pane, when its integration is
+    /// installed: (kind "id" → sessionID). nil when absent or kind == "path".
+    var claimedClaudeSessionID: String?
+}
+
+struct HerdrPaneForegroundInfo: Sendable, Equatable {
+    var shellPID: Int32?
+    /// nil ⇒ the `foreground_processes` key was ABSENT (detection unavailable);
+    /// distinct from [] which cannot occur on the wire.
+    var foregroundPIDs: [Int32]?
+}
+
+protocol HerdrPaneQuerying: Sendable {
+    func focusedPane(socketPath: String) async -> HerdrFocusedPane?
+    func paneForegroundInfo(socketPath: String, paneID: String) async -> HerdrPaneForegroundInfo?
+}
+
+/// Minimal read-only client for herdr's one-request-per-connection JSON API.
+///
+/// Every syscall shares one absolute monotonic deadline. A per-phase timeout
+/// would let a slow connect, write, and response each consume the whole budget,
+/// while a per-read timeout would let a trickling peer retain the task forever.
+struct HerdrSocketClient: HerdrPaneQuerying {
+    private let timeout: TimeInterval
+    private let uptimeNanos: @Sendable () -> UInt64
+    private let socketMetadata: @Sendable (String) -> ClaudeSocketGuard.PathMetadata?
+
+    /// - Parameter socketMetadata: injectable so the ownership refusal is
+    ///   testable — a real foreign-uid socket cannot be created from a
+    ///   single-user test process.
+    init(
+        timeout: TimeInterval = 0.5,
+        uptimeNanos: @escaping @Sendable () -> UInt64 = {
+            DispatchTime.now().uptimeNanoseconds
+        },
+        socketMetadata: @escaping @Sendable (String) -> ClaudeSocketGuard.PathMetadata? = {
+            ClaudeSocketGuard.metadata(ofPath: $0)
+        }
+    ) {
+        self.timeout = timeout
+        self.uptimeNanos = uptimeNanos
+        self.socketMetadata = socketMetadata
+    }
+
+    func focusedPane(socketPath: String) async -> HerdrFocusedPane? {
+        await Task.detached(priority: .userInitiated) { [self] in
+            let request = Request(
+                id: Self.requestID(), method: "pane.current", params: [:]
+            )
+            guard let line = query(socketPath: socketPath, request: request),
+                  let envelope = try? JSONDecoder().decode(
+                    Envelope<PaneCurrentResult>.self, from: line
+                  ),
+                  envelope.id == request.id,
+                  let result = envelope.result,
+                  result.type == "pane_current",
+                  result.pane.focused
+            else {
+                Log.claudeContext.info("Herdr focused-pane query abstained: invalid response")
+                return nil
+            }
+            let claim = result.pane.agentSession.flatMap {
+                $0.kind == "id" ? $0.value : nil
+            }
+            return HerdrFocusedPane(
+                paneID: result.pane.paneID,
+                claimedClaudeSessionID: claim
+            )
+        }.value
+    }
+
+    func paneForegroundInfo(
+        socketPath: String,
+        paneID: String
+    ) async -> HerdrPaneForegroundInfo? {
+        await Task.detached(priority: .userInitiated) { [self] in
+            let request = Request(
+                id: Self.requestID(),
+                method: "pane.process_info",
+                params: ["pane_id": paneID]
+            )
+            guard let line = query(socketPath: socketPath, request: request),
+                  let envelope = try? JSONDecoder().decode(
+                    Envelope<PaneProcessInfoResult>.self, from: line
+                  ),
+                  envelope.id == request.id,
+                  let result = envelope.result,
+                  result.type == "pane_process_info",
+                  result.processInfo.paneID == paneID
+            else {
+                Log.claudeContext.info("Herdr foreground-process query abstained: invalid response")
+                return nil
+            }
+            return HerdrPaneForegroundInfo(
+                shellPID: result.processInfo.shellPID,
+                foregroundPIDs: result.processInfo.foregroundProcesses?.map(\.pid)
+            )
+        }.value
+    }
+
+    private func query(socketPath: String, request: Request) -> Data? {
+        let deadline = makeDeadline()
+        guard socketPath.hasPrefix("/"),
+              let metadata = socketMetadata(socketPath),
+              metadata.isSocket,
+              metadata.ownerUID == UInt32(getuid())
+        else {
+            // Outcome only: a pane id or socket path is a live join handle and
+            // must never escape into the unified log.
+            Log.claudeContext.info("Herdr query abstained: socket path refused")
+            return nil
+        }
+
+        guard let requestLine = try? Self.encodedLine(request),
+              let fd = openConnection(to: socketPath, deadline: deadline)
+        else {
+            Log.claudeContext.info("Herdr query abstained: connection unavailable")
+            return nil
+        }
+        defer { close(fd) }
+
+        guard writeAll(fd: fd, data: requestLine, deadline: deadline) else {
+            Log.claudeContext.info("Herdr query abstained: request deadline or write failure")
+            return nil
+        }
+        // The protocol is exactly one request. Half-closing makes that
+        // invariant explicit without preventing the response half from being
+        // read.
+        shutdown(fd, SHUT_WR)
+        guard let response = readLine(fd: fd, deadline: deadline) else {
+            Log.claudeContext.info("Herdr query abstained: response deadline, framing, or size failure")
+            return nil
+        }
+        return response
+    }
+
+    private func openConnection(to socketPath: String, deadline: UInt64) -> Int32? {
+        var address = sockaddr_un()
+        address.sun_family = sa_family_t(AF_UNIX)
+        address.sun_len = UInt8(MemoryLayout<sockaddr_un>.size)
+        let pathBytes = Array(socketPath.utf8)
+        let capacity = MemoryLayout.size(ofValue: address.sun_path)
+        guard pathBytes.count < capacity else { return nil }
+        withUnsafeMutableBytes(of: &address.sun_path) { raw in
+            raw.copyBytes(from: pathBytes)
+            raw[pathBytes.count] = 0
+        }
+
+        let fd = socket(AF_UNIX, SOCK_STREAM, 0)
+        guard fd >= 0 else { return nil }
+        guard makeNonBlocking(fd) else {
+            close(fd)
+            return nil
+        }
+        // A failed SO_NOSIGPIPE is fatal to the CALLER, not just this query: a
+        // peer closing mid-write would then SIGPIPE the whole app (the same
+        // class of crash as the FileHandle field bug, PR #60). Abstain instead.
+        var noSigPipe: Int32 = 1
+        guard setsockopt(
+            fd, SOL_SOCKET, SO_NOSIGPIPE, &noSigPipe,
+            socklen_t(MemoryLayout<Int32>.size)
+        ) == 0 else {
+            close(fd)
+            return nil
+        }
+
+        let status = withUnsafePointer(to: &address) { pointer in
+            pointer.withMemoryRebound(to: sockaddr.self, capacity: 1) {
+                Darwin.connect(fd, $0, socklen_t(MemoryLayout<sockaddr_un>.size))
+            }
+        }
+        if status == 0 { return fd }
+        guard errno == EINPROGRESS || errno == EINTR,
+              wait(fd: fd, events: Int16(POLLOUT), deadline: deadline)
+        else {
+            close(fd)
+            return nil
+        }
+
+        // Writability also reports a failed non-blocking connect. SO_ERROR is
+        // the only authoritative completion result.
+        var socketError: Int32 = 0
+        var length = socklen_t(MemoryLayout<Int32>.size)
+        guard getsockopt(fd, SOL_SOCKET, SO_ERROR, &socketError, &length) == 0,
+              socketError == 0
+        else {
+            close(fd)
+            return nil
+        }
+        return fd
+    }
+
+    private func writeAll(fd: Int32, data: Data, deadline: UInt64) -> Bool {
+        data.withUnsafeBytes { raw in
+            // Zero-length Data has a nil baseAddress; an empty write is
+            // vacuously complete, not a failure.
+            if raw.isEmpty { return true }
+            guard let base = raw.baseAddress else { return false }
+            var offset = 0
+            while offset < raw.count {
+                let written = Darwin.send(fd, base.advanced(by: offset), raw.count - offset, 0)
+                if written > 0 {
+                    offset += written
+                    continue
+                }
+                if written < 0, errno == EINTR { continue }
+                if written < 0, errno == EAGAIN || errno == EWOULDBLOCK {
+                    guard wait(fd: fd, events: Int16(POLLOUT), deadline: deadline) else {
+                        return false
+                    }
+                    continue
+                }
+                return false
+            }
+            return true
+        }
+    }
+
+    private func readLine(fd: Int32, deadline: UInt64) -> Data? {
+        var buffer = Data()
+        var chunk = [UInt8](repeating: 0, count: 8 * 1024)
+
+        while true {
+            guard wait(fd: fd, events: Int16(POLLIN), deadline: deadline) else { return nil }
+            // Read at most one byte beyond the advertised line cap: that byte
+            // is needed to distinguish an exactly-1-MiB line followed by `\n`
+            // from an oversized line, but no peer can make the buffer grow by
+            // whole extra chunks past the limit.
+            let remainingThroughSentinel = Self.maxResponseLineBytes + 1 - buffer.count
+            guard remainingThroughSentinel > 0 else { return nil }
+            let readCapacity = min(chunk.count, remainingThroughSentinel)
+            let count = Darwin.read(fd, &chunk, readCapacity)
+            if count < 0 {
+                if errno == EINTR || errno == EAGAIN || errno == EWOULDBLOCK { continue }
+                return nil
+            }
+            guard count > 0 else { return nil } // A response must be newline-terminated.
+            buffer.append(contentsOf: chunk[0..<count])
+            if let newline = buffer.firstIndex(of: 0x0A) {
+                let lineLength = buffer.distance(from: buffer.startIndex, to: newline)
+                guard lineLength <= Self.maxResponseLineBytes else { return nil }
+                return Data(buffer[buffer.startIndex..<newline])
+            }
+            guard buffer.count <= Self.maxResponseLineBytes else { return nil }
+        }
+    }
+
+    private func wait(fd: Int32, events: Int16, deadline: UInt64) -> Bool {
+        while true {
+            let current = uptimeNanos()
+            guard current < deadline else { return false }
+            let remaining = deadline - current
+            let roundedMillis = remaining / 1_000_000 + (remaining % 1_000_000 == 0 ? 0 : 1)
+            let timeoutMillis = Int32(min(roundedMillis, UInt64(Int32.max)))
+            var descriptor = pollfd(fd: fd, events: events, revents: 0)
+            let ready = Darwin.poll(&descriptor, 1, timeoutMillis)
+            if ready < 0, errno == EINTR { continue }
+            return ready > 0
+        }
+    }
+
+    private func makeDeadline() -> UInt64 {
+        // The live value is 500 ms. A finite defensive ceiling keeps an
+        // injected infinity/NaN or absurd duration from trapping during the
+        // Double→UInt64 conversion; it does not widen the production budget.
+        let boundedSeconds = timeout.isFinite ? min(max(0, timeout), 60) : 0
+        let duration = UInt64(boundedSeconds * 1_000_000_000)
+        let (deadline, overflow) = uptimeNanos().addingReportingOverflow(duration)
+        return overflow ? UInt64.max : deadline
+    }
+
+    private func makeNonBlocking(_ fd: Int32) -> Bool {
+        let flags = fcntl(fd, F_GETFL, 0)
+        guard flags >= 0 else { return false }
+        return fcntl(fd, F_SETFL, flags | O_NONBLOCK) == 0
+    }
+
+    private static func requestID() -> String {
+        "lvx-" + UUID().uuidString.lowercased()
+    }
+
+    private static func encodedLine(_ request: Request) throws -> Data {
+        var data = try JSONEncoder().encode(request)
+        data.append(0x0A)
+        return data
+    }
+
+    private static let maxResponseLineBytes = 1024 * 1024
+
+    private struct Request: Encodable {
+        var id: String
+        var method: String
+        /// Required even for methods with no arguments; herdr rejects a
+        /// request that omits this key.
+        var params: [String: String]
+    }
+
+    private struct Envelope<Result: Decodable>: Decodable {
+        var id: String
+        var result: Result?
+
+        enum CodingKeys: String, CodingKey { case id, result, error }
+
+        init(from decoder: Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+            id = try container.decode(String.self, forKey: .id)
+            let hasResult = container.contains(.result)
+            let hasError = container.contains(.error)
+            guard hasResult != hasError else {
+                throw DecodingError.dataCorruptedError(
+                    forKey: .result,
+                    in: container,
+                    debugDescription: "expected exactly one of result or error"
+                )
+            }
+            if hasError {
+                _ = try container.decode(ErrorBody.self, forKey: .error)
+                result = nil
+            } else {
+                result = try container.decode(Result.self, forKey: .result)
+            }
+        }
+    }
+
+    private struct ErrorBody: Decodable {
+        var code: String
+        var message: String
+    }
+
+    private struct PaneCurrentResult: Decodable {
+        var type: String
+        var pane: Pane
+    }
+
+    private struct Pane: Decodable {
+        var paneID: String
+        var focused: Bool
+        var agentSession: AgentSession?
+
+        enum CodingKeys: String, CodingKey {
+            case paneID = "pane_id"
+            case focused
+            case agentSession = "agent_session"
+        }
+
+        init(from decoder: Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+            paneID = try container.decode(String.self, forKey: .paneID)
+            focused = try container.decode(Bool.self, forKey: .focused)
+            agentSession = container.contains(.agentSession)
+                ? try container.decode(AgentSession.self, forKey: .agentSession)
+                : nil
+        }
+    }
+
+    private struct AgentSession: Decodable {
+        var kind: String
+        var value: String
+    }
+
+    private struct PaneProcessInfoResult: Decodable {
+        var type: String
+        var processInfo: ProcessInfo
+
+        enum CodingKeys: String, CodingKey {
+            case type
+            case processInfo = "process_info"
+        }
+    }
+
+    private struct ProcessInfo: Decodable {
+        var paneID: String
+        var shellPID: Int32?
+        var foregroundProcesses: [ForegroundProcess]?
+
+        enum CodingKeys: String, CodingKey {
+            case paneID = "pane_id"
+            case shellPID = "shell_pid"
+            case foregroundProcesses = "foreground_processes"
+        }
+
+        init(from decoder: Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+            paneID = try container.decode(String.self, forKey: .paneID)
+            shellPID = try container.decodeIfPresent(Int32.self, forKey: .shellPID)
+            // Presence is meaningful: absent means herdr could not detect a
+            // foreground set. A present null is not the documented wire shape
+            // and must not be silently upgraded into the same state.
+            foregroundProcesses = container.contains(.foregroundProcesses)
+                ? try container.decode([ForegroundProcess].self, forKey: .foregroundProcesses)
+                : nil
+        }
+    }
+
+    private struct ForegroundProcess: Decodable {
+        var pid: Int32
+    }
+}
+#endif

--- a/Sources/localvoxtral/ClaudeContext/TerminalScreenClaudeJoin.swift
+++ b/Sources/localvoxtral/ClaudeContext/TerminalScreenClaudeJoin.swift
@@ -14,11 +14,18 @@ import Foundation
 /// different moment. So the marker is read at START, from the pane the user was
 /// looking at when they began speaking, and that answer is what every consumer
 /// gets.
+enum ClaudeSessionJoinMechanism: Sendable, Equatable {
+    case ttyDevice
+    case titleMarker
+    case herdrPane
+}
+
 struct ClaudeSessionJoin: Sendable, Equatable {
-    /// The pane the marker was read from. Consumers re-check this rather than
+    /// The pane the join was resolved for. Consumers re-check this rather than
     /// assuming the join is about whatever target they happen to hold.
     let target: TerminalScreenTarget
-    /// The broker-allocated marker, read out of the PID-pinned window title.
+    /// The broker-allocated marker used for commit-time liveness. A title join
+    /// reads it from AX; TTY and herdr joins take it from the resolved snapshot.
     let marker: ClaudeSessionMarker
     /// The session as the registry described it at start.
     let snapshot: ClaudeSessionSnapshot
@@ -28,6 +35,10 @@ struct ClaudeSessionJoin: Sendable, Equatable {
     /// between the two — so authorization compares windows, not just targets
     /// (review F2). Nil means unknown, which never authorizes.
     let windowID: CGWindowID?
+    /// Positive evidence that selected this session. In particular, a herdr
+    /// pane join is useful for session/repository context but can never license
+    /// a composite raw TUI capture.
+    let mechanism: ClaudeSessionJoinMechanism
 
     /// The workspace path, non-nil only for a locally authenticated session.
     /// The type is what keeps a remote session's cwd away from the filesystem;
@@ -74,6 +85,8 @@ struct ClaudeSessionJoinResolver {
     private let markerInWindowTitle: (pid_t) -> TerminalScreenAXReader.FocusedWindowMarkerRead?
     private let focusedTerminalTTY: (String) async -> String?
     private let focusedWindowID: (pid_t) -> CGWindowID?
+    private let herdrClientProbe: @Sendable (String) -> Bool
+    private let herdrPanes: HerdrPaneQuerying?
 
     /// - Parameters:
     ///   - markerInWindowTitle: reads the PID-pinned focused window title,
@@ -94,6 +107,14 @@ struct ClaudeSessionJoinResolver {
     ///     separate PID-pinned AX read. Nil means unknown, which the
     ///     authorizer refuses, exactly like a nil marker-read identity
     ///     (review F2).
+    ///   - herdrClientProbe: reads the local process table to bind the focused
+    ///     Ghostty surface to a herdr client. It DEFAULTS TO ABSTAIN: a test
+    ///     that forgets to inject must never consult the live process table.
+    ///     The app wires the live probe explicitly.
+    ///   - herdrPanes: queries herdr's local JSON socket after that surface
+    ///     binding succeeds. It likewise DEFAULTS TO ABSTAIN so a test that
+    ///     forgets to inject cannot connect to a real user socket. The app is
+    ///     the only place that installs the live client.
     init(
         registry: ClaudeSessionRegistry,
         markerInWindowTitle: @escaping (pid_t) -> TerminalScreenAXReader.FocusedWindowMarkerRead? = {
@@ -102,25 +123,31 @@ struct ClaudeSessionJoinResolver {
         focusedTerminalTTY: @escaping (String) async -> String? = { _ in nil },
         focusedWindowID: @escaping (pid_t) -> CGWindowID? = {
             TerminalScreenAXReader.focusedWindowIdentity(applicationPID: $0)
-        }
+        },
+        herdrClientProbe: @escaping @Sendable (String) -> Bool = { _ in false },
+        herdrPanes: HerdrPaneQuerying? = nil
     ) {
         self.registry = registry
         self.markerInWindowTitle = markerInWindowTitle
         self.focusedTerminalTTY = focusedTerminalTTY
         self.focusedWindowID = focusedWindowID
+        self.herdrClientProbe = herdrClientProbe
+        self.herdrPanes = herdrPanes
     }
 
     /// The join for `target`, or nil on any abstention.
     ///
-    /// TTY first, marker second. The TTY compares the focused pane's device
+    /// TTY first, then herdr when that TTY belongs to an attached client, then
+    /// marker. The TTY compares the focused pane's device
     /// against what the hook publisher reported from inside the session — the
     /// process table cannot be clobbered by whoever wrote the window title
     /// last, so it keeps joining while Claude Code's own conversation titles
-    /// own the visible one. Any TTY non-answer (old Ghostty, Automation
-    /// denied, no local session on that device, two sessions claiming it)
-    /// falls through to the marker path unchanged; remote sessions can ONLY
-    /// join via marker, because their TTY names another machine's device and
-    /// `resolve(tty:)` refuses remote candidates outright.
+    /// own the visible one. A TTY non-answer falls through to the marker path
+    /// unless the outer surface is positively bound to herdr; that path is
+    /// herdr-or-nothing because Ghostty's title cannot identify an inner pane.
+    /// No TTY answer at all still uses the marker unchanged. Remote sessions
+    /// can ONLY join via marker, because their TTY names another machine's
+    /// device and `resolve(tty:)` refuses remote candidates outright.
     ///
     /// This remains the only place a join is resolved, once per dictation, at
     /// start — whichever mechanism answers.
@@ -145,7 +172,8 @@ struct ClaudeSessionJoinResolver {
                     target: target,
                     marker: snapshot.marker,
                     snapshot: snapshot,
-                    windowID: focusedWindowID(target.pid)
+                    windowID: focusedWindowID(target.pid),
+                    mechanism: .ttyDevice
                 )
             case .unknown:
                 abstainedTTYJoin(outcome: "no live session on this device")
@@ -153,6 +181,13 @@ struct ClaudeSessionJoinResolver {
                 abstainedTTYJoin(outcome: "stale")
             case .ambiguous:
                 abstainedTTYJoin(outcome: "ambiguous")
+            }
+
+            // A focused surface positively bound to herdr is herdr-or-nothing.
+            // Ghostty's title describes the outer client, not an inner pane; a
+            // lingering marker there could only mis-join the pane now visible.
+            if herdrClientProbe(tty) {
+                return await resolveViaHerdr(target: target)
             }
         }
 
@@ -169,6 +204,92 @@ struct ClaudeSessionJoinResolver {
         )
     }
 
+    private func resolveViaHerdr(target: TerminalScreenTarget) async -> ClaudeSessionJoin? {
+        let sockets = registry.liveLocalHerdrSocketPaths()
+        guard sockets.count == 1, let socketPath = sockets.first else {
+            Self.abstainedHerdrJoin(
+                outcome: sockets.isEmpty ? "no live registered socket" : "multiple live sockets"
+            )
+            return nil
+        }
+        guard let herdrPanes else {
+            Self.abstainedHerdrJoin(outcome: "pane query capability unavailable")
+            return nil
+        }
+        guard let pane = await herdrPanes.focusedPane(socketPath: socketPath) else {
+            Self.abstainedHerdrJoin(outcome: "focused pane unavailable")
+            return nil
+        }
+
+        let snapshot: ClaudeSessionSnapshot
+        switch registry.resolve(herdrPaneID: pane.paneID) {
+        case .resolved(let resolved):
+            snapshot = resolved
+        case .unknown:
+            Self.abstainedHerdrJoin(outcome: "focused pane has no live session")
+            return nil
+        case .stale:
+            Self.abstainedHerdrJoin(outcome: "focused pane session stale")
+            return nil
+        case .ambiguous:
+            Self.abstainedHerdrJoin(outcome: "focused pane session ambiguous")
+            return nil
+        }
+
+        if let claimed = pane.claimedClaudeSessionID, claimed != snapshot.sessionID {
+            Self.abstainedHerdrJoin(outcome: "pane session claim disagrees")
+            return nil
+        }
+        guard let foreground = await herdrPanes.paneForegroundInfo(
+            socketPath: socketPath, paneID: pane.paneID
+        ) else {
+            Self.abstainedHerdrJoin(outcome: "foreground process query unavailable")
+            return nil
+        }
+        guard let foregroundPIDs = foreground.foregroundPIDs else {
+            Self.abstainedHerdrJoin(outcome: "foreground process detection unavailable")
+            return nil
+        }
+        guard Self.registeredClaudeIsForeground(
+            snapshot: snapshot, foregroundPIDs: foregroundPIDs
+        ) else { return nil }
+
+        Log.claudeContext.info("Terminal pane joined to a live Claude session via herdr pane")
+        return ClaudeSessionJoin(
+            target: target,
+            marker: snapshot.marker,
+            snapshot: snapshot,
+            windowID: focusedWindowID(target.pid),
+            mechanism: .herdrPane
+        )
+    }
+
+    /// Pure pid cross-check kept visible to tests because a snapshot with no
+    /// process cannot be produced by a successful pane-id registry lookup, but
+    /// the resolver must still fail closed if that invariant ever changes.
+    static func registeredClaudeIsForeground(
+        snapshot: ClaudeSessionSnapshot,
+        foregroundPIDs: [Int32]
+    ) -> Bool {
+        guard let process = snapshot.process else {
+            abstainedHerdrJoin(outcome: "registered session has no process metadata")
+            return false
+        }
+        guard foregroundPIDs.contains(process.claudePID) else {
+            abstainedHerdrJoin(outcome: "registered Claude process is not foreground")
+            return false
+        }
+        return true
+    }
+
+    /// Outcome only: pane ids, socket paths, tty paths, and payload contents are
+    /// all live join material and never belong in the unified log.
+    private static func abstainedHerdrJoin(outcome: String) {
+        Log.claudeContext.info(
+            "Herdr pane matched no session (\(outcome, privacy: .public)); Claude context withheld"
+        )
+    }
+
     private func resolveViaMarker(target: TerminalScreenTarget) -> ClaudeSessionJoin? {
         guard let read = markerInWindowTitle(target.pid) else {
             // No marker on screen: this pane is not a joined Claude session, or
@@ -181,7 +302,11 @@ struct ClaudeSessionJoinResolver {
         case .resolved(let snapshot):
             Log.claudeContext.info("Terminal pane joined to a live Claude session via title marker")
             return ClaudeSessionJoin(
-                target: target, marker: read.marker, snapshot: snapshot, windowID: read.windowID
+                target: target,
+                marker: read.marker,
+                snapshot: snapshot,
+                windowID: read.windowID,
+                mechanism: .titleMarker
             )
         case .unknown, .stale, .ambiguous:
             // Count-only: the marker itself is not logged. It is a live handle
@@ -231,6 +356,15 @@ struct TerminalScreenClaudeJoinAuthorizer: TerminalScreenRawAttachmentAuthorizin
 
     func isAuthorized(target: TerminalScreenTarget, windowID: CGWindowID?) -> Bool {
         guard let join = currentJoin() else { return false }
+        // AX sees herdr's composite TUI. Attaching it would let neighboring
+        // panes — potentially other Claude sessions — ride into this session's
+        // prompt, so a correct pane join still cannot authorize raw capture.
+        guard join.mechanism != .herdrPane else {
+            Log.claudeContext.info(
+                "Herdr pane join cannot authorize composite raw screen attachment; withheld"
+            )
+            return false
+        }
         // The join must be about THIS pane. A join resolved for one target
         // says nothing about another, and a recycled PID must not inherit the
         // previous owner's authorization — hence the full target compare

--- a/Sources/localvoxtral/localvoxtralApp.swift
+++ b/Sources/localvoxtral/localvoxtralApp.swift
@@ -229,13 +229,18 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             // the session's prior prompt, and the repository context describe the
             // same session — three resolvers would each answer honestly about a
             // different moment.
-            // The tty seam is wired here, not defaulted: sending Apple events
-            // is a consented capability (Automation prompt), so only the app —
-            // never a test that forgot to inject — constructs the live reader.
+            // The tty/herdr seams are wired here, not defaulted: sending Apple
+            // events, reading the process table, and connecting to a user's
+            // local socket are live capabilities, so only the app — never a
+            // test that forgot to inject — constructs them.
             let ttyReader = GhosttyFocusedTerminalTTYReader()
             let resolver = ClaudeSessionJoinResolver(
                 registry: claudeSessionRegistry,
-                focusedTerminalTTY: { await ttyReader.focusedTerminalTTY(bundleID: $0) }
+                focusedTerminalTTY: { await ttyReader.focusedTerminalTTY(bundleID: $0) },
+                herdrClientProbe: {
+                    HerdrClientTTYProbe.isHerdrClient(onTTYDevicePath: $0)
+                },
+                herdrPanes: HerdrSocketClient()
             )
             viewModel.claudeSessionJoinResolver = resolver
             // Pre-warm the Automation consent sheet OFF the dictation-start

--- a/Tests/localvoxtralTests/ClaudeContextBrokerTests.swift
+++ b/Tests/localvoxtralTests/ClaudeContextBrokerTests.swift
@@ -144,7 +144,7 @@ final class ClaudeContextBrokerIntegrationTests: XCTestCase {
 
     // MARK: Marker roundtrip — the focus join
 
-    func testBrokerRepliesWithTheAllocatedMarker() throws {
+    func testBrokerRepliesWithTheAllocatedMarkerForANonHerdrRecord() throws {
         try broker.start()
         let record = ClaudeHookRecord(
             event: .sessionStart, sessionID: "joined", timestamp: 1, rawCwd: "/repo"
@@ -166,6 +166,39 @@ final class ClaudeContextBrokerIntegrationTests: XCTestCase {
         guard case .resolved = registry.resolve(marker: ClaudeSessionMarker(value: "lvx-deadbeef")) else {
             return XCTFail("the replied marker must resolve back to the session")
         }
+    }
+
+    func testBrokerWithholdsTheMarkerForAHerdrHostedRecord() throws {
+        // Even with title fallback opted in, herdr intercepts OSC 2 inside the
+        // pane, so emitting this marker could never identify Ghostty's surface.
+        try broker.start()
+        let record = ClaudeHookRecord(
+            event: .sessionStart,
+            sessionID: "herdr-hosted",
+            timestamp: 1,
+            rawCwd: "/repo",
+            process: ClaudeHookProcessInfo(
+                hookPID: 31_337,
+                claudePID: getpid(),
+                herdrPaneID: "pane-7",
+                herdrSocketPath: "/tmp/herdr.sock"
+            )
+        )
+        let result = UnixSocketPublisher(timeout: 2.0).publishAndReadReply(
+            line: try XCTUnwrap(ClaudeHookWireCodec.encodeLine(record)),
+            to: socketPath
+        )
+        guard case .success(let reply) = result else {
+            return XCTFail("publish failed: \(result)")
+        }
+
+        let response = try XCTUnwrap(ClaudeBrokerResponse.decodeLine(try XCTUnwrap(reply)))
+        XCTAssertNil(response.marker)
+        XCTAssertEqual(
+            registry.snapshot(sessionID: "herdr-hosted")?.marker,
+            ClaudeSessionMarker(value: "lvx-deadbeef"),
+            "herdr changes reply emission only; registry identity remains allocated"
+        )
     }
 
     func testRejectedRecordRepliesWithNoMarker() throws {

--- a/Tests/localvoxtralTests/ClaudeHookPublisherTests.swift
+++ b/Tests/localvoxtralTests/ClaudeHookPublisherTests.swift
@@ -51,6 +51,43 @@ final class ClaudeHookPublisherTests: XCTestCase {
         XCTAssertNil(info.termProgram)
     }
 
+    func testHerdrEnvironmentValuesArePublished() {
+        let info = publisher(variables: [
+            "HOME": "/h",
+            "HERDR_PANE_ID": "pane-7",
+            "HERDR_SOCKET_PATH": "/tmp/herdr.sock",
+        ]).processInfo()
+        XCTAssertEqual(info.herdrPaneID, "pane-7")
+        XCTAssertEqual(info.herdrSocketPath, "/tmp/herdr.sock")
+    }
+
+    func testHerdrEnvironmentValuesArePublishedIndependently() {
+        let paneOnly = publisher(variables: ["HERDR_PANE_ID": "pane-7"]).processInfo()
+        XCTAssertEqual(paneOnly.herdrPaneID, "pane-7")
+        XCTAssertNil(paneOnly.herdrSocketPath)
+
+        let socketOnly = publisher(
+            variables: ["HERDR_SOCKET_PATH": "/tmp/herdr.sock"]
+        ).processInfo()
+        XCTAssertNil(socketOnly.herdrPaneID)
+        XCTAssertEqual(socketOnly.herdrSocketPath, "/tmp/herdr.sock")
+    }
+
+    func testEmptyHerdrEnvironmentValuesAreTreatedAsAbsent() {
+        let info = publisher(variables: [
+            "HERDR_PANE_ID": "",
+            "HERDR_SOCKET_PATH": "",
+        ]).processInfo()
+        XCTAssertNil(info.herdrPaneID)
+        XCTAssertNil(info.herdrSocketPath)
+    }
+
+    func testAbsentHerdrEnvironmentValuesAreNil() {
+        let info = publisher(variables: ["HOME": "/h"]).processInfo()
+        XCTAssertNil(info.herdrPaneID)
+        XCTAssertNil(info.herdrSocketPath)
+    }
+
     // The published claudePID and the tty resolution consume the SAME pid,
     // from one `ppid()` call: the tty seam receives the pid the ppid seam
     // yielded, so the two fields can never describe different processes (the

--- a/Tests/localvoxtralTests/ClaudeHookWireTests.swift
+++ b/Tests/localvoxtralTests/ClaudeHookWireTests.swift
@@ -46,6 +46,75 @@ final class ClaudeHookWireCodecTests: XCTestCase {
         XCTAssertEqual(try ClaudeHookWireCodec.decodeLine(encoded), original)
     }
 
+    func testHerdrProcessFieldsUseGoldenWireNamesAndDecode() throws {
+        let record = ClaudeHookRecord(
+            event: .sessionStart,
+            sessionID: "sess-herdr",
+            timestamp: 1.5,
+            process: ClaudeHookProcessInfo(
+                hookPID: 42,
+                claudePID: 41,
+                herdrPaneID: "pane-7",
+                herdrSocketPath: "herdr.sock"
+            )
+        )
+
+        let encoded = try XCTUnwrap(ClaudeHookWireCodec.encodeLine(record))
+        XCTAssertEqual(
+            String(decoding: encoded, as: UTF8.self),
+            #"{"event":"SessionStart","files":[],"process":{"claude_pid":41,"herdr_pane_id":"pane-7","herdr_socket_path":"herdr.sock","hook_pid":42},"session_id":"sess-herdr","ts":1.5,"v":1}"# + "\n"
+        )
+        let decoded = try ClaudeHookWireCodec.decodeLine(encoded)
+        XCTAssertEqual(decoded.process?.herdrPaneID, "pane-7")
+        XCTAssertEqual(decoded.process?.herdrSocketPath, "herdr.sock")
+    }
+
+    func testClampTruncatesBothHerdrProcessFields() {
+        let record = ClaudeHookRecord(
+            event: .sessionStart,
+            sessionID: "s",
+            timestamp: 1,
+            process: ClaudeHookProcessInfo(
+                hookPID: 2,
+                claudePID: 1,
+                herdrPaneID: String(repeating: "p", count: 20),
+                herdrSocketPath: String(repeating: "s", count: 20)
+            )
+        )
+
+        let clamped = ClaudeHookWireCodec.clamp(
+            record,
+            limits: ClaudeHookLimits(maxPathBytes: 5)
+        )
+        XCTAssertEqual(clamped.process?.herdrPaneID, "ppppp")
+        XCTAssertEqual(clamped.process?.herdrSocketPath, "sssss")
+    }
+
+    func testAbsentHerdrProcessFieldsDecodeAsNil() throws {
+        let json = validJSON(
+            event: "SessionStart",
+            extra: #","process":{"hook_pid":2,"claude_pid":1}"#
+        )
+        let record = try ClaudeHookWireCodec.decodeLine(line(json))
+        XCTAssertNil(record.process?.herdrPaneID)
+        XCTAssertNil(record.process?.herdrSocketPath)
+    }
+
+    func testOldWireLineWithoutHerdrFieldsRemainsCompatible() throws {
+        let oldLine = line(
+            #"{"event":"SessionStart","process":{"claude_pid":1,"hook_pid":2,"term_program":"ghostty","tty":"device"},"session_id":"old","ts":1,"v":1}"#
+        )
+        let record = try ClaudeHookWireCodec.decodeLine(oldLine)
+        XCTAssertEqual(record.process?.tty, "device")
+        XCTAssertEqual(record.process?.termProgram, "ghostty")
+        XCTAssertNil(record.process?.herdrPaneID)
+        XCTAssertNil(record.process?.herdrSocketPath)
+
+        let reencoded = String(decoding: try XCTUnwrap(ClaudeHookWireCodec.encodeLine(record)), as: UTF8.self)
+        XCTAssertFalse(reencoded.contains("herdr_pane_id"))
+        XCTAssertFalse(reencoded.contains("herdr_socket_path"))
+    }
+
     // MARK: Version gating
 
     func testRejectsFutureVersion() {

--- a/Tests/localvoxtralTests/ClaudeSessionRegistryTests.swift
+++ b/Tests/localvoxtralTests/ClaudeSessionRegistryTests.swift
@@ -61,7 +61,9 @@ final class ClaudeSessionRegistryTests: XCTestCase {
         files: [ClaudeFileTouch] = [],
         claudePID: Int32? = nil,
         hookPID: Int32 = 777,
-        tty: String? = nil
+        tty: String? = nil,
+        herdrPaneID: String? = nil,
+        herdrSocketPath: String? = nil
     ) -> ClaudeHookRecord {
         ClaudeHookRecord(
             event: event,
@@ -70,7 +72,15 @@ final class ClaudeSessionRegistryTests: XCTestCase {
             rawCwd: cwd,
             prompt: prompt,
             files: files,
-            process: claudePID.map { ClaudeHookProcessInfo(hookPID: hookPID, claudePID: $0, tty: tty) }
+            process: claudePID.map {
+                ClaudeHookProcessInfo(
+                    hookPID: hookPID,
+                    claudePID: $0,
+                    tty: tty,
+                    herdrPaneID: herdrPaneID,
+                    herdrSocketPath: herdrSocketPath
+                )
+            }
         )
     }
 
@@ -402,6 +412,109 @@ final class ClaudeSessionRegistryTests: XCTestCase {
             record(.sessionStart, claudePID: 9001, tty: "/dev/ttys003"), origin: local
         )
         XCTAssertEqual(registry.resolve(tty: "/dev/ttys007"), .unknown)
+    }
+
+    // MARK: herdr pane lookup — the marker-free focus join
+
+    func testHerdrPaneLookupResolvesTheLocalSessionInThatPane() {
+        let registry = makeRegistry()
+        registry.ingest(
+            record(.sessionStart, claudePID: 9001, herdrPaneID: "pane-7"),
+            origin: local
+        )
+        guard case .resolved(let snapshot) = registry.resolve(herdrPaneID: "pane-7") else {
+            return XCTFail("expected the session in that herdr pane")
+        }
+        XCTAssertEqual(snapshot.sessionID, "s1")
+    }
+
+    func testHerdrPaneLookupIsUnknownForAnUnseenPane() {
+        let registry = makeRegistry()
+        registry.ingest(
+            record(.sessionStart, claudePID: 9001, herdrPaneID: "pane-7"),
+            origin: local
+        )
+        XCTAssertEqual(registry.resolve(herdrPaneID: "pane-other"), .unknown)
+    }
+
+    func testHerdrPaneLookupReportsStaleWhenTheOnlyMatchIsDead() {
+        let liveness = TestLiveness()
+        let registry = makeRegistry(liveness: liveness)
+        registry.ingest(
+            record(.sessionStart, claudePID: 9001, herdrPaneID: "pane-7"),
+            origin: local
+        )
+        liveness.kill(9001)
+        XCTAssertEqual(registry.resolve(herdrPaneID: "pane-7"), .stale)
+    }
+
+    func testTwoLocalSessionsInOneHerdrPaneAbstainAsAmbiguous() {
+        let registry = makeRegistry(markers: TestMarkers(["lvx-1", "lvx-2"]))
+        registry.ingest(
+            record(.sessionStart, session: "s1", claudePID: 9001, herdrPaneID: "pane-7"),
+            origin: local
+        )
+        registry.ingest(
+            record(.sessionStart, session: "s2", claudePID: 9002, herdrPaneID: "pane-7"),
+            origin: local
+        )
+        XCTAssertEqual(registry.resolve(herdrPaneID: "pane-7"), .ambiguous)
+    }
+
+    func testHerdrPaneLookupNeverMatchesARemoteSession() {
+        // Pane ids belong to one machine's herdr. A remote host echoing a local
+        // id must not be able to claim dictation focused in that local pane.
+        let registry = makeRegistry()
+        registry.ingest(
+            record(.sessionStart, claudePID: 9001, herdrPaneID: "pane-7"),
+            origin: .remote(channel: "ssh")
+        )
+        XCTAssertEqual(registry.resolve(herdrPaneID: "pane-7"), .unknown)
+    }
+
+    func testLiveLocalHerdrSocketPathsAreDistinct() {
+        let registry = makeRegistry(markers: TestMarkers(["lvx-1", "lvx-2", "lvx-3"]))
+        registry.ingest(
+            record(.sessionStart, session: "s1", claudePID: 9001, herdrSocketPath: "/tmp/a.sock"),
+            origin: local
+        )
+        registry.ingest(
+            record(.sessionStart, session: "s2", claudePID: 9002, herdrSocketPath: "/tmp/a.sock"),
+            origin: local
+        )
+        registry.ingest(
+            record(.sessionStart, session: "s3", claudePID: 9003, herdrSocketPath: "/tmp/b.sock"),
+            origin: local
+        )
+        XCTAssertEqual(registry.liveLocalHerdrSocketPaths(), ["/tmp/a.sock", "/tmp/b.sock"])
+    }
+
+    func testLiveLocalHerdrSocketPathsExcludeStaleSessions() {
+        let liveness = TestLiveness()
+        let registry = makeRegistry(liveness: liveness, markers: TestMarkers(["lvx-1", "lvx-2"]))
+        registry.ingest(
+            record(.sessionStart, session: "live", claudePID: 9001, herdrSocketPath: "/tmp/live.sock"),
+            origin: local
+        )
+        registry.ingest(
+            record(.sessionStart, session: "dead", claudePID: 9002, herdrSocketPath: "/tmp/dead.sock"),
+            origin: local
+        )
+        liveness.kill(9002)
+        XCTAssertEqual(registry.liveLocalHerdrSocketPaths(), ["/tmp/live.sock"])
+    }
+
+    func testLiveLocalHerdrSocketPathsExcludeRemoteSessions() {
+        let registry = makeRegistry(markers: TestMarkers(["lvx-1", "lvx-2"]))
+        registry.ingest(
+            record(.sessionStart, session: "local", claudePID: 9001, herdrSocketPath: "/tmp/local.sock"),
+            origin: local
+        )
+        registry.ingest(
+            record(.sessionStart, session: "remote", claudePID: 9002, herdrSocketPath: "/tmp/remote.sock"),
+            origin: .remote(channel: "ssh")
+        )
+        XCTAssertEqual(registry.liveLocalHerdrSocketPaths(), ["/tmp/local.sock"])
     }
 
     // MARK: Workspace lookup — ambiguity

--- a/Tests/localvoxtralTests/HerdrClientTTYProbeTests.swift
+++ b/Tests/localvoxtralTests/HerdrClientTTYProbeTests.swift
@@ -1,0 +1,50 @@
+import Darwin
+import Synchronization
+import XCTest
+@testable import localvoxtral
+
+#if canImport(Darwin)
+final class HerdrClientTTYProbeTests: XCTestCase {
+    func testStatFailureRefusesWithoutReadingProcessTable() {
+        let processTableReads = Mutex(0)
+        let result = HerdrClientTTYProbe.isHerdrClient(
+            onTTYDevicePath: "/dev/not-present",
+            deviceID: { _ in nil },
+            processNames: { _ in
+                processTableReads.withLock { $0 += 1 }
+                return ["herdr"]
+            }
+        )
+
+        XCTAssertFalse(result)
+        XCTAssertEqual(processTableReads.withLock { $0 }, 0)
+    }
+
+    func testProcessTableFailureRefuses() {
+        XCTAssertFalse(
+            HerdrClientTTYProbe.isHerdrClient(
+                onTTYDevicePath: "/dev/ttys001",
+                deviceID: { _ in dev_t(123) },
+                processNames: { _ in nil }
+            )
+        )
+    }
+
+    func testHerdrDecisionRequiresExactProcessCommandMatch() {
+        XCTAssertTrue(
+            HerdrClientTTYProbe.isHerdrClient(
+                onTTYDevicePath: "/dev/ttys001",
+                deviceID: { _ in dev_t(123) },
+                processNames: { _ in ["zsh", "herdr"] }
+            )
+        )
+        XCTAssertFalse(
+            HerdrClientTTYProbe.isHerdrClient(
+                onTTYDevicePath: "/dev/ttys001",
+                deviceID: { _ in dev_t(123) },
+                processNames: { _ in ["zsh", "herdr-helper"] }
+            )
+        )
+    }
+}
+#endif

--- a/Tests/localvoxtralTests/HerdrSocketClientTests.swift
+++ b/Tests/localvoxtralTests/HerdrSocketClientTests.swift
@@ -1,0 +1,365 @@
+import Darwin
+import Foundation
+import Synchronization
+import XCTest
+@testable import localvoxtral
+
+#if canImport(Darwin)
+
+/// One real AF_UNIX connection per fixture, matching herdr's protocol rather
+/// than hiding framing or lifecycle behavior behind a mock transport.
+private final class HerdrOneShotServer: @unchecked Sendable {
+    private struct State {
+        var listenerFD: Int32
+    }
+
+    private let state: Mutex<State>
+    private let response: @Sendable (Data) -> Data?
+    private let finished = DispatchSemaphore(value: 0)
+    private let receivedLine = Mutex<Data?>(nil)
+    private let directory: URL
+    let socketPath: String
+
+    init(response: @escaping @Sendable (Data) -> Data?) throws {
+        self.response = response
+        let createdDirectory = URL(
+            fileURLWithPath: "/tmp/lvx-herdr-\(UUID().uuidString.prefix(8))"
+        )
+        let createdSocketPath = createdDirectory.appendingPathComponent("herdr.sock").path
+        directory = createdDirectory
+        socketPath = createdSocketPath
+        try FileManager.default.createDirectory(
+            at: createdDirectory,
+            withIntermediateDirectories: true,
+            attributes: [.posixPermissions: NSNumber(value: Int16(0o700))]
+        )
+
+        let listener = socket(AF_UNIX, SOCK_STREAM, 0)
+        guard listener >= 0 else { throw POSIXError(.ENFILE) }
+        var address = sockaddr_un()
+        address.sun_family = sa_family_t(AF_UNIX)
+        address.sun_len = UInt8(MemoryLayout<sockaddr_un>.size)
+        let bytes = Array(createdSocketPath.utf8)
+        withUnsafeMutableBytes(of: &address.sun_path) { raw in
+            raw.copyBytes(from: bytes)
+            raw[bytes.count] = 0
+        }
+        let bound = withUnsafePointer(to: &address) { pointer in
+            pointer.withMemoryRebound(to: sockaddr.self, capacity: 1) {
+                Darwin.bind(listener, $0, socklen_t(MemoryLayout<sockaddr_un>.size))
+            }
+        }
+        guard bound == 0, listen(listener, 1) == 0 else {
+            let code = POSIXErrorCode(rawValue: errno) ?? .EIO
+            close(listener)
+            try? FileManager.default.removeItem(at: createdDirectory)
+            throw POSIXError(code)
+        }
+        _ = chmod(createdSocketPath, 0o600)
+        state = Mutex(State(listenerFD: listener))
+
+        Thread.detachNewThread { [self] in serve(listener: listener) }
+    }
+
+    var requestLine: Data? { receivedLine.withLock { $0 } }
+
+    func stop() {
+        state.withLock { state in
+            if state.listenerFD >= 0 {
+                shutdown(state.listenerFD, SHUT_RDWR)
+            }
+        }
+        // Cleanup-only wall clock, same precedent as the broker tests: no
+        // assertion depends on it, it just bounds a hung serve thread so one
+        // broken fixture cannot wedge the suite.
+        _ = finished.wait(timeout: .now() + 2)
+        try? FileManager.default.removeItem(at: directory)
+    }
+
+    private func serve(listener: Int32) {
+        defer {
+            state.withLock { state in
+                if state.listenerFD >= 0 {
+                    close(state.listenerFD)
+                    state.listenerFD = -1
+                }
+            }
+            finished.signal()
+        }
+
+        let client = accept(listener, nil, nil)
+        guard client >= 0 else { return }
+        defer { close(client) }
+        var noSigPipe: Int32 = 1
+        _ = setsockopt(
+            client, SOL_SOCKET, SO_NOSIGPIPE, &noSigPipe,
+            socklen_t(MemoryLayout<Int32>.size)
+        )
+
+        var line = Data()
+        var chunk = [UInt8](repeating: 0, count: 4096)
+        while line.count <= 64 * 1024 {
+            let count = Darwin.read(client, &chunk, chunk.count)
+            guard count > 0 else { return }
+            line.append(contentsOf: chunk[0..<count])
+            if let newline = line.firstIndex(of: 0x0A) {
+                line = Data(line[line.startIndex..<newline])
+                break
+            }
+        }
+        receivedLine.withLock { $0 = line }
+        guard let reply = response(line) else { return }
+
+        reply.withUnsafeBytes { raw in
+            guard let base = raw.baseAddress else { return }
+            var offset = 0
+            while offset < raw.count {
+                let count = Darwin.send(client, base.advanced(by: offset), raw.count - offset, 0)
+                if count < 0, errno == EINTR { continue }
+                guard count > 0 else { return }
+                offset += count
+            }
+        }
+        shutdown(client, SHUT_WR)
+    }
+}
+
+private func herdrRequest(_ data: Data) -> [String: Any]? {
+    guard let object = try? JSONSerialization.jsonObject(with: data) else { return nil }
+    return object as? [String: Any]
+}
+
+private func herdrResponse(
+    for request: Data,
+    result: [String: Any]? = nil,
+    error: [String: Any]? = nil
+) -> Data? {
+    guard let id = herdrRequest(request)?["id"] as? String else { return nil }
+    var object: [String: Any] = ["id": id]
+    if let result { object["result"] = result }
+    if let error { object["error"] = error }
+    guard var data = try? JSONSerialization.data(withJSONObject: object) else { return nil }
+    data.append(0x0A)
+    return data
+}
+
+@MainActor
+final class HerdrSocketClientTests: XCTestCase {
+    func testFocusedPaneHappyPathUsesStringIDAndRequiredEmptyParams() async throws {
+        let server = try HerdrOneShotServer { request in
+            herdrResponse(
+                for: request,
+                result: [
+                    "type": "pane_current",
+                    "pane": [
+                        "pane_id": "pane-a",
+                        "focused": true,
+                        "workspace_id": "ignored",
+                        "agent_session": [
+                            "source": "hook",
+                            "agent": "claude",
+                            "kind": "id",
+                            "value": "session-a",
+                        ],
+                    ],
+                ]
+            )
+        }
+        defer { server.stop() }
+
+        let pane = await HerdrSocketClient().focusedPane(socketPath: server.socketPath)
+
+        XCTAssertEqual(
+            pane,
+            HerdrFocusedPane(paneID: "pane-a", claimedClaudeSessionID: "session-a")
+        )
+        let request = try XCTUnwrap(server.requestLine.flatMap(herdrRequest))
+        XCTAssertTrue(request["id"] is String)
+        XCTAssertTrue((request["id"] as? String)?.hasPrefix("lvx-") == true)
+        XCTAssertEqual(request["method"] as? String, "pane.current")
+        XCTAssertEqual((request["params"] as? [String: Any])?.count, 0)
+    }
+
+    func testErrorEnvelopeAbstains() async throws {
+        let server = try HerdrOneShotServer { request in
+            herdrResponse(
+                for: request,
+                error: ["code": "pane_not_found", "message": "not found"]
+            )
+        }
+        defer { server.stop() }
+
+        let pane = await HerdrSocketClient().focusedPane(socketPath: server.socketPath)
+        XCTAssertNil(pane)
+    }
+
+    func testWrongResultTypeAbstains() async throws {
+        let server = try HerdrOneShotServer { request in
+            herdrResponse(
+                for: request,
+                result: [
+                    "type": "pane_process_info",
+                    "pane": ["pane_id": "pane-a", "focused": true],
+                ]
+            )
+        }
+        defer { server.stop() }
+
+        let pane = await HerdrSocketClient().focusedPane(socketPath: server.socketPath)
+        XCTAssertNil(pane)
+    }
+
+    func testOversizedResponseLineAbstains() async throws {
+        let server = try HerdrOneShotServer { _ in
+            var data = Data(repeating: 0x61, count: 1024 * 1024 + 1)
+            data.append(0x0A)
+            return data
+        }
+        defer { server.stop() }
+
+        let pane = await HerdrSocketClient().focusedPane(socketPath: server.socketPath)
+        XCTAssertNil(pane)
+    }
+
+    func testShortInjectedDeadlineExpiresWhenServerDoesNotReply() async throws {
+        let release = DispatchSemaphore(value: 0)
+        let server = try HerdrOneShotServer { _ in
+            release.wait()
+            return nil
+        }
+        defer {
+            release.signal()
+            server.stop()
+        }
+
+        let pane = await HerdrSocketClient(timeout: 0.01).focusedPane(
+            socketPath: server.socketPath
+        )
+        XCTAssertNil(pane)
+    }
+
+    func testNonSocketPathIsRefused() async throws {
+        let directory = URL(fileURLWithPath: "/tmp/lvx-herdr-file-\(UUID().uuidString.prefix(8))")
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        let file = directory.appendingPathComponent("not-a-socket")
+        XCTAssertTrue(FileManager.default.createFile(atPath: file.path, contents: Data()))
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let pane = await HerdrSocketClient().focusedPane(socketPath: file.path)
+        XCTAssertNil(pane)
+    }
+
+    func testEmptySocketPathIsRefused() async {
+        let pane = await HerdrSocketClient().focusedPane(socketPath: "")
+        XCTAssertNil(pane)
+    }
+
+    func testForeignOwnerSocketIsRefused() async throws {
+        // A real foreign-uid socket cannot be created from a single-user test
+        // process, so ownership refusal is exercised through the injected
+        // metadata seam: a live server whose stat lies about the owner must
+        // never be queried.
+        let server = try HerdrOneShotServer { request in
+            herdrResponse(
+                for: request,
+                result: [
+                    "type": "pane_current",
+                    "pane": ["pane_id": "pane-a", "focused": true],
+                ]
+            )
+        }
+        defer { server.stop() }
+
+        let client = HerdrSocketClient(socketMetadata: { _ in
+            ClaudeSocketGuard.PathMetadata(
+                isDirectory: false,
+                isSymlink: false,
+                isSocket: true,
+                ownerUID: UInt32(getuid()) &+ 1,
+                mode: 0o600
+            )
+        })
+        let pane = await client.focusedPane(socketPath: server.socketPath)
+        XCTAssertNil(pane)
+        XCTAssertNil(server.requestLine, "a refused socket must never receive a request")
+    }
+
+    func testPathAgentSessionDoesNotBecomeSessionIDClaim() async throws {
+        let server = try HerdrOneShotServer { request in
+            herdrResponse(
+                for: request,
+                result: [
+                    "type": "pane_current",
+                    "pane": [
+                        "pane_id": "pane-a",
+                        "focused": true,
+                        "agent_session": [
+                            "source": "hook",
+                            "agent": "claude",
+                            "kind": "path",
+                            "value": "/tmp/session.json",
+                        ],
+                    ],
+                ]
+            )
+        }
+        defer { server.stop() }
+
+        let pane = await HerdrSocketClient().focusedPane(socketPath: server.socketPath)
+        XCTAssertEqual(pane?.paneID, "pane-a")
+        XCTAssertNil(pane?.claimedClaudeSessionID)
+    }
+
+    func testForegroundProcessesAbsentRemainsNil() async throws {
+        let server = try HerdrOneShotServer { request in
+            herdrResponse(
+                for: request,
+                result: [
+                    "type": "pane_process_info",
+                    "process_info": [
+                        "pane_id": "pane-a",
+                        "shell_pid": 7001,
+                        "tty": NSNull(),
+                    ],
+                ]
+            )
+        }
+        defer { server.stop() }
+
+        let info = await HerdrSocketClient().paneForegroundInfo(
+            socketPath: server.socketPath, paneID: "pane-a"
+        )
+        XCTAssertEqual(info?.shellPID, 7001)
+        XCTAssertNil(info?.foregroundPIDs)
+        let request = try XCTUnwrap(server.requestLine.flatMap(herdrRequest))
+        XCTAssertEqual(request["method"] as? String, "pane.process_info")
+        XCTAssertEqual((request["params"] as? [String: Any])?["pane_id"] as? String, "pane-a")
+    }
+
+    func testForegroundProcessesPresentDecodePIDs() async throws {
+        let server = try HerdrOneShotServer { request in
+            herdrResponse(
+                for: request,
+                result: [
+                    "type": "pane_process_info",
+                    "process_info": [
+                        "pane_id": "pane-a",
+                        "tty": NSNull(),
+                        "foreground_processes": [
+                            ["pid": 9001, "name": "claude", "argv0": "ignored"],
+                            ["pid": 9002, "name": "helper"],
+                        ],
+                    ],
+                ]
+            )
+        }
+        defer { server.stop() }
+
+        let info = await HerdrSocketClient().paneForegroundInfo(
+            socketPath: server.socketPath, paneID: "pane-a"
+        )
+        XCTAssertNil(info?.shellPID)
+        XCTAssertEqual(info?.foregroundPIDs, [9001, 9002])
+    }
+}
+#endif

--- a/Tests/localvoxtralTests/TerminalScreenClaudeJoinTests.swift
+++ b/Tests/localvoxtralTests/TerminalScreenClaudeJoinTests.swift
@@ -29,6 +29,24 @@ private final class JoinTestMarkers: Sendable {
     }
 }
 
+private struct JoinTestHerdrPanes: HerdrPaneQuerying {
+    var focused: HerdrFocusedPane?
+    var foreground: HerdrPaneForegroundInfo?
+    var onFocused: @Sendable () -> Void = {}
+
+    func focusedPane(socketPath _: String) async -> HerdrFocusedPane? {
+        onFocused()
+        return focused
+    }
+
+    func paneForegroundInfo(
+        socketPath _: String,
+        paneID _: String
+    ) async -> HerdrPaneForegroundInfo? {
+        foreground
+    }
+}
+
 /// The gate that decides which Claude session a dictation is about, and
 /// whether a captured Ghostty pane's raw text may be rendered into a prompt.
 ///
@@ -53,7 +71,9 @@ final class TerminalScreenClaudeJoinTests: XCTestCase {
     private func record(
         session: String = "s1",
         claudePID: Int32? = 9001,
-        tty: String? = nil
+        tty: String? = nil,
+        herdrPaneID: String? = nil,
+        herdrSocketPath: String? = nil
     ) -> ClaudeHookRecord {
         ClaudeHookRecord(
             event: .sessionStart,
@@ -62,7 +82,15 @@ final class TerminalScreenClaudeJoinTests: XCTestCase {
             rawCwd: "/repo",
             prompt: nil,
             files: [],
-            process: claudePID.map { ClaudeHookProcessInfo(hookPID: 777, claudePID: $0, tty: tty) }
+            process: claudePID.map {
+                ClaudeHookProcessInfo(
+                    hookPID: 777,
+                    claudePID: $0,
+                    tty: tty,
+                    herdrPaneID: herdrPaneID,
+                    herdrSocketPath: herdrSocketPath
+                )
+            }
         )
     }
 
@@ -89,7 +117,9 @@ final class TerminalScreenClaudeJoinTests: XCTestCase {
         title: String?,
         focusedTTY: String? = nil,
         titleWindowID: CGWindowID? = 101,
-        ttyWindowID: CGWindowID? = 101
+        ttyWindowID: CGWindowID? = 101,
+        herdrClient: Bool = false,
+        herdrPanes: HerdrPaneQuerying? = nil
     ) -> ClaudeSessionJoinResolver {
         ClaudeSessionJoinResolver(
             registry: registry,
@@ -101,7 +131,9 @@ final class TerminalScreenClaudeJoinTests: XCTestCase {
                 }
             },
             focusedTerminalTTY: { _ in focusedTTY },
-            focusedWindowID: { _ in ttyWindowID }
+            focusedWindowID: { _ in ttyWindowID },
+            herdrClientProbe: { _ in herdrClient },
+            herdrPanes: herdrPanes
         )
     }
 
@@ -133,6 +165,7 @@ final class TerminalScreenClaudeJoinTests: XCTestCase {
         XCTAssertEqual(join.marker, ClaudeSessionMarker(value: "lvx-abcd"))
         XCTAssertEqual(join.snapshot.sessionID, "s1")
         XCTAssertEqual(join.target, ghostty)
+        XCTAssertEqual(join.mechanism, .titleMarker)
         let gate = await authorizer(registry: registry, title: "lvx-abcd — ~/repo")
         XCTAssertTrue(gate.isAuthorized(target: ghostty, windowID: windowA))
     }
@@ -184,6 +217,7 @@ final class TerminalScreenClaudeJoinTests: XCTestCase {
         let join = try XCTUnwrap(resolved)
         XCTAssertEqual(join.snapshot.sessionID, "s1")
         XCTAssertEqual(join.marker, ClaudeSessionMarker(value: "lvx-abcd"))
+        XCTAssertEqual(join.mechanism, .ttyDevice)
         // The tty-joined session revalidates at stop through the same
         // marker-keyed liveness path as a title join.
         XCTAssertTrue(joinResolver.isStillLive(join))
@@ -240,6 +274,7 @@ final class TerminalScreenClaudeJoinTests: XCTestCase {
         ).resolve(target: ghostty)
         let join = try XCTUnwrap(resolved)
         XCTAssertEqual(join.snapshot.sessionID, "s1")
+        XCTAssertEqual(join.mechanism, .titleMarker)
     }
 
     func testAmbiguousTTYFallsBackToTheTitleMarker() async throws {
@@ -273,6 +308,7 @@ final class TerminalScreenClaudeJoinTests: XCTestCase {
         )
         let join = await joinResolver.resolve(target: ghostty)
         XCTAssertEqual(join?.windowID, windowB)
+        XCTAssertEqual(join?.mechanism, .ttyDevice)
         let gate = TerminalScreenClaudeJoinAuthorizer(resolver: joinResolver, currentJoin: { join })
         XCTAssertTrue(
             gate.isAuthorized(target: ghostty, windowID: windowB),
@@ -317,6 +353,366 @@ final class TerminalScreenClaudeJoinTests: XCTestCase {
             registry: registry, title: nil, focusedTTY: "/dev/ttys003"
         ).resolve(target: ghostty)
         XCTAssertNil(join)
+    }
+
+    // MARK: - herdr join
+
+    private func herdrRecord(
+        session: String = "s1",
+        claudePID: Int32 = 9001,
+        paneID: String = "pane-a",
+        socketPath: String = "/tmp/herdr-a.sock"
+    ) -> ClaudeHookRecord {
+        record(
+            session: session,
+            claudePID: claudePID,
+            tty: "/dev/ttys-inner",
+            herdrPaneID: paneID,
+            herdrSocketPath: socketPath
+        )
+    }
+
+    private func herdrPanes(
+        paneID: String = "pane-a",
+        claim: String? = nil,
+        foregroundPIDs: [Int32]? = [9001]
+    ) -> JoinTestHerdrPanes {
+        JoinTestHerdrPanes(
+            focused: HerdrFocusedPane(
+                paneID: paneID, claimedClaudeSessionID: claim
+            ),
+            foreground: HerdrPaneForegroundInfo(
+                shellPID: 8000, foregroundPIDs: foregroundPIDs
+            )
+        )
+    }
+
+    func testTTYResolutionWinsBeforeHerdrProbe() async throws {
+        let registry = makeRegistry()
+        XCTAssertNotNil(
+            registry.ingest(
+                record(
+                    tty: "/dev/ttys003",
+                    herdrPaneID: "pane-a",
+                    herdrSocketPath: "/tmp/herdr.sock"
+                ),
+                origin: local
+            )
+        )
+        let probeCalls = Mutex(0)
+        let joinResolver = ClaudeSessionJoinResolver(
+            registry: registry,
+            markerInWindowTitle: { _ in nil },
+            focusedTerminalTTY: { _ in "/dev/ttys003" },
+            focusedWindowID: { _ in self.windowA },
+            herdrClientProbe: { _ in
+                probeCalls.withLock { $0 += 1 }
+                return true
+            },
+            herdrPanes: herdrPanes()
+        )
+
+        let resolved = await joinResolver.resolve(target: ghostty)
+        let join = try XCTUnwrap(resolved)
+        XCTAssertEqual(join.mechanism, .ttyDevice)
+        XCTAssertEqual(probeCalls.withLock { $0 }, 0)
+    }
+
+    func testHerdrPaneJoinsWhenPaneAndForegroundPIDMatch() async throws {
+        let registry = makeRegistry()
+        XCTAssertNotNil(registry.ingest(herdrRecord(), origin: local))
+        let joinResolver = resolver(
+            registry: registry,
+            title: nil,
+            focusedTTY: "/dev/ttys-outer",
+            herdrClient: true,
+            herdrPanes: herdrPanes(claim: "s1")
+        )
+
+        let resolved = await joinResolver.resolve(target: ghostty)
+        let join = try XCTUnwrap(resolved)
+        XCTAssertEqual(join.snapshot.sessionID, "s1")
+        XCTAssertEqual(join.mechanism, .herdrPane)
+        XCTAssertEqual(join.windowID, windowA)
+        XCTAssertTrue(joinResolver.isStillLive(join))
+    }
+
+    func testHerdrPaneWithNilSessionClaimStillJoins() async throws {
+        let registry = makeRegistry()
+        XCTAssertNotNil(registry.ingest(herdrRecord(), origin: local))
+        let join = await resolver(
+            registry: registry,
+            title: nil,
+            focusedTTY: "/dev/ttys-outer",
+            herdrClient: true,
+            herdrPanes: herdrPanes(claim: nil)
+        ).resolve(target: ghostty)
+
+        XCTAssertEqual(try XCTUnwrap(join).mechanism, .herdrPane)
+    }
+
+    func testHerdrSurfaceNeverFallsBackToTitleMarker() async {
+        let registry = makeRegistry()
+        XCTAssertNotNil(registry.ingest(herdrRecord(), origin: local))
+        let titleReads = Mutex(0)
+        let joinResolver = ClaudeSessionJoinResolver(
+            registry: registry,
+            markerInWindowTitle: { _ in
+                titleReads.withLock { $0 += 1 }
+                return TerminalScreenAXReader.FocusedWindowMarkerRead(
+                    marker: ClaudeSessionMarker(value: "lvx-abcd"), windowID: self.windowA
+                )
+            },
+            focusedTerminalTTY: { _ in "/dev/ttys-outer" },
+            herdrClientProbe: { _ in true },
+            herdrPanes: JoinTestHerdrPanes(focused: nil, foreground: nil)
+        )
+
+        let join = await joinResolver.resolve(target: ghostty)
+        XCTAssertNil(join)
+        XCTAssertEqual(titleReads.withLock { $0 }, 0)
+    }
+
+    func testHerdrJoinAbstainsWithNoRegisteredSocket() async {
+        let registry = makeRegistry()
+        let join = await resolver(
+            registry: registry,
+            title: nil,
+            focusedTTY: "/dev/ttys-outer",
+            herdrClient: true,
+            herdrPanes: herdrPanes()
+        ).resolve(target: ghostty)
+        XCTAssertNil(join)
+    }
+
+    func testHerdrJoinAbstainsWithMultipleRegisteredSockets() async {
+        let registry = makeRegistry(markers: ["lvx-aaaa", "lvx-bbbb"])
+        XCTAssertNotNil(registry.ingest(herdrRecord(), origin: local))
+        XCTAssertNotNil(
+            registry.ingest(
+                herdrRecord(
+                    session: "s2",
+                    claudePID: 9002,
+                    paneID: "pane-b",
+                    socketPath: "/tmp/herdr-b.sock"
+                ),
+                origin: local
+            )
+        )
+        let join = await resolver(
+            registry: registry,
+            title: nil,
+            focusedTTY: "/dev/ttys-outer",
+            herdrClient: true,
+            herdrPanes: herdrPanes()
+        ).resolve(target: ghostty)
+        XCTAssertNil(join)
+    }
+
+    func testHerdrJoinAbstainsWhenLivePaneQueryIsNotInjected() async {
+        let registry = makeRegistry()
+        XCTAssertNotNil(registry.ingest(herdrRecord(), origin: local))
+        let join = await resolver(
+            registry: registry,
+            title: nil,
+            focusedTTY: "/dev/ttys-outer",
+            herdrClient: true
+        ).resolve(target: ghostty)
+        XCTAssertNil(join)
+    }
+
+    func testDefaultHerdrProbeAbstains() async {
+        let registry = makeRegistry()
+        XCTAssertNotNil(registry.ingest(herdrRecord(), origin: local))
+        let joinResolver = ClaudeSessionJoinResolver(
+            registry: registry,
+            markerInWindowTitle: { _ in nil },
+            focusedTerminalTTY: { _ in "/dev/ttys-outer" }
+        )
+        let join = await joinResolver.resolve(target: ghostty)
+        XCTAssertNil(join)
+    }
+
+    func testHerdrJoinAbstainsWhenFocusedPaneIsUnavailable() async {
+        let registry = makeRegistry()
+        XCTAssertNotNil(registry.ingest(herdrRecord(), origin: local))
+        let join = await resolver(
+            registry: registry,
+            title: nil,
+            focusedTTY: "/dev/ttys-outer",
+            herdrClient: true,
+            herdrPanes: JoinTestHerdrPanes(focused: nil, foreground: nil)
+        ).resolve(target: ghostty)
+        XCTAssertNil(join)
+    }
+
+    func testHerdrJoinAbstainsWhenFocusedPaneIsUnmatched() async {
+        let registry = makeRegistry()
+        XCTAssertNotNil(registry.ingest(herdrRecord(), origin: local))
+        let join = await resolver(
+            registry: registry,
+            title: nil,
+            focusedTTY: "/dev/ttys-outer",
+            herdrClient: true,
+            herdrPanes: herdrPanes(paneID: "pane-unregistered")
+        ).resolve(target: ghostty)
+        XCTAssertNil(join)
+    }
+
+    func testHerdrJoinAbstainsWhenFocusedPaneIsAmbiguous() async {
+        let registry = makeRegistry(markers: ["lvx-aaaa", "lvx-bbbb"])
+        XCTAssertNotNil(registry.ingest(herdrRecord(), origin: local))
+        XCTAssertNotNil(
+            registry.ingest(
+                herdrRecord(session: "s2", claudePID: 9002), origin: local
+            )
+        )
+        let join = await resolver(
+            registry: registry,
+            title: nil,
+            focusedTTY: "/dev/ttys-outer",
+            herdrClient: true,
+            herdrPanes: herdrPanes()
+        ).resolve(target: ghostty)
+        XCTAssertNil(join)
+    }
+
+    func testHerdrJoinAbstainsWhenFocusedPaneTurnsStaleDuringQuery() async {
+        let clock = JoinTestClock(epoch)
+        let registry = makeRegistry(
+            limits: ClaudeRegistryLimits(sessionTTL: 60), clock: clock
+        )
+        XCTAssertNotNil(registry.ingest(herdrRecord(), origin: local))
+        let panes = JoinTestHerdrPanes(
+            focused: HerdrFocusedPane(paneID: "pane-a", claimedClaudeSessionID: nil),
+            foreground: HerdrPaneForegroundInfo(shellPID: nil, foregroundPIDs: [9001]),
+            onFocused: { clock.advance(61) }
+        )
+        let join = await resolver(
+            registry: registry,
+            title: nil,
+            focusedTTY: "/dev/ttys-outer",
+            herdrClient: true,
+            herdrPanes: panes
+        ).resolve(target: ghostty)
+        XCTAssertNil(join)
+    }
+
+    func testHerdrJoinAbstainsWhenSessionClaimDisagrees() async {
+        let registry = makeRegistry()
+        XCTAssertNotNil(registry.ingest(herdrRecord(), origin: local))
+        let join = await resolver(
+            registry: registry,
+            title: nil,
+            focusedTTY: "/dev/ttys-outer",
+            herdrClient: true,
+            herdrPanes: herdrPanes(claim: "another-session")
+        ).resolve(target: ghostty)
+        XCTAssertNil(join)
+    }
+
+    func testHerdrJoinAbstainsWhenForegroundQueryIsUnavailable() async {
+        let registry = makeRegistry()
+        XCTAssertNotNil(registry.ingest(herdrRecord(), origin: local))
+        let panes = JoinTestHerdrPanes(
+            focused: HerdrFocusedPane(paneID: "pane-a", claimedClaudeSessionID: nil),
+            foreground: nil
+        )
+        let join = await resolver(
+            registry: registry,
+            title: nil,
+            focusedTTY: "/dev/ttys-outer",
+            herdrClient: true,
+            herdrPanes: panes
+        ).resolve(target: ghostty)
+        XCTAssertNil(join)
+    }
+
+    func testHerdrJoinAbstainsWhenForegroundDetectionIsUnavailable() async {
+        let registry = makeRegistry()
+        XCTAssertNotNil(registry.ingest(herdrRecord(), origin: local))
+        let join = await resolver(
+            registry: registry,
+            title: nil,
+            focusedTTY: "/dev/ttys-outer",
+            herdrClient: true,
+            herdrPanes: herdrPanes(foregroundPIDs: nil)
+        ).resolve(target: ghostty)
+        XCTAssertNil(join)
+    }
+
+    func testHerdrJoinAbstainsWhenClaudePIDIsNotForeground() async {
+        let registry = makeRegistry()
+        XCTAssertNotNil(registry.ingest(herdrRecord(), origin: local))
+        let join = await resolver(
+            registry: registry,
+            title: nil,
+            focusedTTY: "/dev/ttys-outer",
+            herdrClient: true,
+            herdrPanes: herdrPanes(foregroundPIDs: [7777])
+        ).resolve(target: ghostty)
+        XCTAssertNil(join)
+    }
+
+    func testHerdrForegroundCrossCheckRefusesSnapshotWithoutProcessInfo() {
+        let snapshot = ClaudeSessionSnapshot(
+            sessionID: "s1",
+            origin: local,
+            marker: ClaudeSessionMarker(value: "lvx-abcd"),
+            firstSeen: epoch
+        )
+        XCTAssertNil(snapshot.process, "precondition")
+        XCTAssertFalse(
+            ClaudeSessionJoinResolver.registeredClaudeIsForeground(
+                snapshot: snapshot, foregroundPIDs: [9001]
+            )
+        )
+    }
+
+    func testNoTTYAnswerUsesMarkerWithoutCallingHerdrProbe() async throws {
+        let registry = makeRegistry()
+        XCTAssertNotNil(registry.ingest(herdrRecord(), origin: local))
+        let probeCalls = Mutex(0)
+        let joinResolver = ClaudeSessionJoinResolver(
+            registry: registry,
+            markerInWindowTitle: { _ in
+                TerminalScreenAXReader.FocusedWindowMarkerRead(
+                    marker: ClaudeSessionMarker(value: "lvx-abcd"), windowID: self.windowA
+                )
+            },
+            focusedTerminalTTY: { _ in nil },
+            herdrClientProbe: { _ in
+                probeCalls.withLock { $0 += 1 }
+                return true
+            },
+            herdrPanes: herdrPanes()
+        )
+
+        let resolved = await joinResolver.resolve(target: ghostty)
+        let join = try XCTUnwrap(resolved)
+        XCTAssertEqual(join.mechanism, .titleMarker)
+        XCTAssertEqual(probeCalls.withLock { $0 }, 0)
+    }
+
+    func testHerdrJoinNeverAuthorizesCompositeRawScreen() async throws {
+        let registry = makeRegistry()
+        XCTAssertNotNil(registry.ingest(herdrRecord(), origin: local))
+        let joinResolver = resolver(
+            registry: registry,
+            title: nil,
+            focusedTTY: "/dev/ttys-outer",
+            herdrClient: true,
+            herdrPanes: herdrPanes()
+        )
+        let resolved = await joinResolver.resolve(target: ghostty)
+        let join = try XCTUnwrap(resolved)
+        let gate = TerminalScreenClaudeJoinAuthorizer(
+            resolver: joinResolver, currentJoin: { join }
+        )
+
+        XCTAssertEqual(join.mechanism, .herdrPane)
+        XCTAssertEqual(join.windowID, windowA)
+        XCTAssertFalse(gate.isAuthorized(target: ghostty, windowID: windowA))
     }
 
     // MARK: - TTY reply validation

--- a/scripts/ci/llm-lane-filter.sh
+++ b/scripts/ci/llm-lane-filter.sh
@@ -65,6 +65,7 @@ PATTERNS=(
   '*ClaudeContextBroker*'                            # the socket that feeds the registry
   '*ClaudeHookWire*'                                 # the record shape the snapshot is reduced from
   '*ClaudeHookInputParser*'                          # which hook fields become session state
+  '*ClaudeHookPublisher*'                            # the identity metadata (tty/pid/herdr pane) joins key on
   'integrations/claude-code/*'                       # the plugin that publishes those hooks
   '*TerminalScreenContext*'                          # screen context source/policy feeding the prompt
   '*TerminalScreenAXReader*'                         # screen text sanitization/compaction: the excerpt's exact bytes


### PR DESCRIPTION
## What

herdr (the tmux-like agent multiplexer) becomes a **first-class Claude-context join target**, marker-free by design. Running Claude Code inside herdr previously broke the join exactly the way tmux does: herdr interposes its own PTY per pane, so the Ghostty focused-surface TTY never matches the hook-reported inner TTY, and herdr intercepts OSC 2 so a title marker can neither reach Ghostty's title nor describe an inner pane. Design report: `docs/herdr-integration-research.md`, corrected by a source-pinned protocol read (herdr @ `0f161fa`): the JSON socket has **no handshake and is one-request-per-connection**, `pane.process_info.tty` is **always null**, and there is **no client introspection** — so surface binding must come from the local process table.

The join chain, all exact-match/abstain-not-guess:

1. The in-pane hook publishes `HERDR_PANE_ID` + `HERDR_SOCKET_PATH` (additive optional wire fields, version unchanged; old lines still decode).
2. At dictation start, after the TTY arm misses, `HerdrClientTTYProbe` (sysctl `KERN_PROC_TTY`) binds the focused Ghostty surface to a live `herdr` client. From that point the join is **herdr-or-nothing** — the `lvx-` title-marker fallback is unreachable (a lingering marker could only mis-join), and the broker never emits a marker to a herdr-hosted session even under the title-fallback opt-in.
3. `HerdrSocketClient` (hand-written, read-only; herdr is AGPL — no code vendored, arm's-length IPC only) asks the **single** registered socket for the focused pane (`pane.current`); two live herdr sessions abstain. The socket path is refused unless it is an owner-uid socket file.
4. Join = exact pane-id equality against the registry (`resolve(herdrPaneID:)`, LOCAL sessions only — a remote host echoing a pane id never matches), cross-checked fail-closed: herdr's own `agent_session` claim must not disagree, and the registered Claude pid must be in the pane's foreground process list (`pane.process_info`) — which also catches a suspended Claude with the user at the shell prompt.
5. A herdr join **never authorizes raw screen attachment**: the AX capture is the composite herdr TUI and neighboring panes must not ride into this session's prompt. Session/repo context blocks and input-side grounding work as for any join. (A clean `pane.read`-based excerpt is a possible follow-up.)

Also: `scripts/ci/llm-lane-filter.sh` gains `*ClaudeHookPublisher*` (join-key identity now originates there), and AGENTS.md documents the herdr arm's invariants.

Reviewed by GLM-5.2 (opencode): verdict SHIP; its findings (dev_t overflow abstention, SIGPIPE-on-failed-setsockopt, bounded `p_comm` decode, ownership-refusal testability seam) are all addressed in this diff. Known accepted tradeoff, flagged by review: the sysctl probe runs synchronously on the main actor like the existing AX title read — sub-millisecond in practice.

## Proof

- [x] Unit suite green — `./scripts/remote-build.sh` (includes all new herdr suites):
  `Executed 1951 tests, with 2 tests skipped and 0 failures (0 unexpected) in 67.735 (67.819) seconds`
- [x] Realtime integration green — `./scripts/remote-build.sh integration`:
  `Test Suite 'RealtimeAPIVLLMIntegrationTests' passed — Executed 7 tests, with 2 tests skipped and 0 failures (0 unexpected) in 16.540 (16.545) seconds`
- New-behavior tests (names, all in the suites above): resolver truth table `testHerdrPaneJoinsWhenPaneAndForegroundPIDMatch`, `testHerdrSurfaceNeverFallsBackToTitleMarker`, `testHerdrJoinAbstainsWithMultipleRegisteredSockets`, `testHerdrJoinAbstainsWhenClaudePIDIsNotForeground`, `testHerdrJoinNeverAuthorizesCompositeRawScreen`; registry `testHerdrPaneLookupNeverMatchesARemoteSession`; broker `testBrokerWithholdsTheMarkerForAHerdrHostedRecord`; client `testForeignOwnerSocketIsRefused`, `testShortInjectedDeadlineExpiresWhenServerDoesNotReply`.
- LLM lanes: the diff touches `ClaudeContext/*` so the polishd lane runs via the path filter. No prompt, model pin, sampling, or eval-corpus change — the join decides *whether* the same context blocks attach, not their content; no scoreboard expected to move, deferring to the per-PR lane + nightly eval-e2e.
- Not yet verified by hand: a live end-to-end run against a real herdr instance on the Mac (herdr is not installed on the build host). The protocol facts the client encodes are source-pinned to herdr `0f161fa`; the client abstains on any mismatch. Recommend one hand-test with herdr + the herdr Claude integration before enabling by default in a release — happy to script it as a follow-up.
