### PR TITLE
record-demo.yml: pre-build locked-screen refusal

### DIFF
--- a/.github/workflows/record-demo.yml
+++ b/.github/workflows/record-demo.yml
@@ -99,7 +99,24 @@ jobs:
             echo "Ghostty is already running — the claude scene must launch it itself. Quit Ghostty and rerun." >&2
             exit 1
           fi
-          echo "Idle guard (pre-build): machine idle ${IDLE}s (>= ${REQUIRED}s)."
+          # And for a locked screen: the recorder fails fast on Secure
+          # Keyboard Entry anyway, but only AFTER packaging. Same probe as
+          # scripts/ci/ui-smoke-guard.sh; probe errors fail open (an
+          # uncomputable state must not silently disable the lane).
+          LOCK_STATE="$(swift - <<'SWIFT' 2>/dev/null || echo error
+          import CoreGraphics
+          guard let session = CGSessionCopyCurrentDictionary() as? [String: Any] else {
+            print("no-session")
+            exit(0)
+          }
+          print(session["CGSSessionScreenIsLocked"] != nil ? "locked" : "unlocked")
+          SWIFT
+          )"
+          if [[ "$LOCK_STATE" == "locked" || "$LOCK_STATE" == "no-session" ]]; then
+            echo "GUI session is $LOCK_STATE — the recorder needs an unlocked session. Refusing before the build." >&2
+            exit 1
+          fi
+          echo "Idle guard (pre-build): machine idle ${IDLE}s (>= ${REQUIRED}s), session unlocked."
 
       - name: Package app bundle
         if: steps.guard.outputs.present == 'true'


### PR DESCRIPTION
## What

Completes the pre-build guard trio in `record-demo.yml`: after tonight's retry-loop evidence (6 attempts, all refused in seconds — first on active use, later on a still-running Ghostty), the one remaining state that still burns a ~7-minute packaging build before refusing is idle + Ghostty-quit + **screen locked** (the recorder fails fast on Secure Keyboard Entry, but only after the build). Adds the same `CGSessionCopyCurrentDictionary` lock probe `scripts/ci/ui-smoke-guard.sh` uses; `locked`/`no-session` refuse pre-build, probe errors fail open. With this, every known refusal path costs seconds, making unattended retry dispatches free.

## Proof

- [x] YAML parses; the step's generated script extracted via yaml.safe_load and `bash -n` clean (heredoc de-indentation verified — terminator lands at column 0).
- [x] Probe copied from the tested `ui-smoke-guard.sh` implementation (its behavior on this exact runner is pinned by `scripts/ci/test-ui-smoke-guard.sh` and nightly use).
- [x] Field evidence for the economics: runs 29874551654…29880605881 (pre-build refusals, seconds each) vs run 29873261193 (pre-#179: full build before refusal).
- Lanes: workflow-only. This diff touches `.github/**`, so its own CI run takes the full path by design.