### PR TITLE
README: herdr pane-join demo video

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ The result is dictation that gets the hard part right: the misheard `useAuth.ts`
 Here it is inside a [herdr](https://herdr.dev) multiplexer — the join binds to the exact Claude pane and grounds the dictation in that pane's screen, while the neighboring pane stays out of the prompt:
 
 <!-- herdr demo video: recorded by record-demo.yml (terminal_agent=herdr); regenerate via that workflow and replace the URL below. -->
-HERDR_DEMO_VIDEO_URL_PLACEHOLDER
+https://github.com/user-attachments/assets/15e71c26-3d8b-490f-90d0-f5c507daf5eb
 
 Install is one click: **Settings → Text Processing → Claude Code plugin → Install**. The app registers its bundled plugin marketplace through Claude Code's own CLI and never edits `~/.claude/settings.json` behind your back.
 

--- a/README.md
+++ b/README.md
@@ -104,6 +104,11 @@ localvoxtral ships a [Claude Code plugin](integrations/claude-code/README.md) th
 
 The result is dictation that gets the hard part right: the misheard `useAuth.ts`, the branch name you mentioned two turns ago, the flag Claude just wrote into a file.
 
+Here it is inside a [herdr](https://herdr.dev) multiplexer — the join binds to the exact Claude pane and grounds the dictation in that pane's screen, while the neighboring pane stays out of the prompt:
+
+<!-- herdr demo video: recorded by record-demo.yml (terminal_agent=herdr); regenerate via that workflow and replace the URL below. -->
+HERDR_DEMO_VIDEO_URL_PLACEHOLDER
+
 Install is one click: **Settings → Text Processing → Claude Code plugin → Install**. The app registers its bundled plugin marketplace through Claude Code's own CLI and never edits `~/.claude/settings.json` behind your back.
 
 **Working over SSH?** A second plugin, `localvoxtral-remote`, covers Claude Code sessions on other machines: its hooks POST through an SSH `RemoteForward` back to your Mac — nothing to install on the host beyond the plugin's two JSON files, authenticated by a per-host token you can rotate or revoke in Settings at any time. Remote context is bounded and opaque by construction: labels and short sanitized excerpts only, and the app never reaches into the remote filesystem.

--- a/README.md
+++ b/README.md
@@ -107,6 +107,7 @@ The result is dictation that gets the hard part right: the misheard `useAuth.ts`
 Here it is inside a [herdr](https://herdr.dev) multiplexer — the join binds to the exact Claude pane and grounds the dictation in that pane's screen, while the neighboring pane stays out of the prompt:
 
 <!-- herdr demo video: recorded by record-demo.yml (terminal_agent=herdr); regenerate via that workflow and replace the URL below. -->
+
 https://github.com/user-attachments/assets/15e71c26-3d8b-490f-90d0-f5c507daf5eb
 
 Install is one click: **Settings → Text Processing → Claude Code plugin → Install**. The app registers its bundled plugin marketplace through Claude Code's own CLI and never edits `~/.claude/settings.json` behind your back.


### PR DESCRIPTION
## What

Adds the herdr pane-join demo video to the "Dictating into Claude Code" README section, showing dictation into a Claude pane inside a herdr split — the pane-exact join and screen grounding in action.

The committed line is a placeholder: GitHub only renders inline video from user-attachments URLs, which have no upload API. **Owner action: drag-drop the trimmed `demo.mp4` (from run [29992546502](https://github.com/T0mSIlver/localvoxtral/actions/runs/29992546502), artifact `readme-demo`) into a comment on this PR**, then the placeholder gets replaced with the resulting URL before merge.

## Proof

- Docs-only change (README placeholder) — no behavior; heavy lanes skip via `docs-only-filter.sh`.
- The video itself was produced by `record-demo.yml` run 29992546502 (`terminal_agent=herdr`), which log-asserts the join before keeping the capture:
  ```
  herdr initial pane: w1:p1
  herdr decoy pane:   w1:p2
  Starting claude inside herdr pane w1:p1...
  Verifying the herdr pane join from the app log...
  herdr join verified: pane join + pane-exact screen context both present in the app log.
  Encoded:     dist/demo/demo.mp4 (3.0M)
  ```
- Do not merge until the placeholder is replaced with the real user-attachments URL.