### PR TITLE
speechd: switch mlx-audio-swift pin back to upstream (Blaizzy#232 merged)

### DIFF
--- a/Sources/localvoxtral/Backends/SpeechModelCatalog.swift
+++ b/Sources/localvoxtral/Backends/SpeechModelCatalog.swift
@@ -15,7 +15,7 @@ enum SpeechModelCatalog {
         // mlx-community pin, plus a 4-bit/g64-quantized tied embedding/LM head — the
         // decode loop's dominant per-token cost (~30 ms -> ~3 ms on M1 Pro). Loading it
         // requires the quantized-tied-embedding loader fix pinned in
-        // SpeechHelper/Package.swift (staged upstream as Blaizzy/mlx-audio-swift#232).
+        // SpeechHelper/Package.swift (upstreamed in Blaizzy/mlx-audio-swift#232).
         SpeechModelOption(
             repoID: "T0mSIlver/Voxtral-Mini-4B-Realtime-2602-4bit-qhead",
             revision: "247f2eeccf962fbcaf85e361731a5e75b2d8cac1",

--- a/SpeechHelper/DEPENDENCY.md
+++ b/SpeechHelper/DEPENDENCY.md
@@ -16,27 +16,25 @@ checkout — we no longer keep a copy here.
 
 ```
 .package(
-    url: "https://github.com/T0mSIlver/mlx-audio-swift.git",
-    revision: "791ab876c10b47cc9f8894ff4100240aa6d95bf7"
+    url: "https://github.com/Blaizzy/mlx-audio-swift.git",
+    revision: "8ed8188bf862062d2c6f4c6ecefbfed301f615a0"
 )
 ```
 
 Pinned to a full-SHA **revision**, not a tag, so the exact reviewed tree is reproducible and
 can't move under us.
 
-**Temporary fork pin.** `791ab87` is our fork's `fix/load-quantized-tied-embedding` branch:
-upstream main `6ea59e5` — which now contains everything the previous `localvoxtral-pin-e1-e2`
-pin carried as fork commits (upstream
-[#229](https://github.com/Blaizzy/mlx-audio-swift/pull/229): Metal-pool clear cadence,
-[#230](https://github.com/Blaizzy/mlx-audio-swift/pull/230): incremental mel/conv front end,
-[#231](https://github.com/Blaizzy/mlx-audio-swift/pull/231): hoisted attention invariants,
-all merged) — plus one commit: the quantized-tied-embedding loader fix staged upstream as
-[Blaizzy/mlx-audio-swift#232](https://github.com/Blaizzy/mlx-audio-swift/pull/232). That fix
-is required to load the catalog-pinned `-qhead` checkpoint (4-bit/g64-quantized tied
-embedding/LM head — see `SpeechModelCatalog.swift`); without it the loader rejects the
-checkpoint's `tok_embeddings.scales`/`.biases` under `verify: .all`. Switchback plan: once
-#232 merges, point the URL back at `Blaizzy/mlx-audio-swift` at the containing revision and
-delete the fork branch; nothing else changes.
+`8ed8188` is upstream main at the merge of
+[Blaizzy/mlx-audio-swift#232](https://github.com/Blaizzy/mlx-audio-swift/pull/232): the
+quantized-tied-embedding loader fix, required to load the catalog-pinned `-qhead` checkpoint
+(4-bit/g64-quantized tied embedding/LM head — see `SpeechModelCatalog.swift`); without it the
+loader rejects the checkpoint's `tok_embeddings.scales`/`.biases` under `verify: .all`. Its
+merge ended the temporary `T0mSIlver/mlx-audio-swift` fork pin that had staged the fix — every
+optimization the fork ever carried is upstream now (#229: Metal-pool clear cadence, #230:
+incremental mel/conv front end, #231: hoisted attention invariants, #232 above). Note the
+merged #232 is a review-evolved variant of the fork commit (module-routed
+`embedToken`/`logits` instead of raw-weight access, plus upstream regression tests), so the
+switchback re-ran the live speechd integration lane rather than assuming equivalence.
 
 ## What #226 upstreamed
 

--- a/SpeechHelper/Package.resolved
+++ b/SpeechHelper/Package.resolved
@@ -21,9 +21,9 @@
     {
       "identity": "mlx-audio-swift",
       "kind": "remoteSourceControl",
-      "location": "https://github.com/T0mSIlver/mlx-audio-swift.git",
+      "location": "https://github.com/Blaizzy/mlx-audio-swift.git",
       "state": {
-        "revision": "791ab876c10b47cc9f8894ff4100240aa6d95bf7"
+        "revision": "8ed8188bf862062d2c6f4c6ecefbfed301f615a0"
       }
     },
     {

--- a/SpeechHelper/Package.swift
+++ b/SpeechHelper/Package.swift
@@ -34,15 +34,13 @@ let package = Package(
         // #226). Pinned to a full-SHA revision, not a tag, so the exact reviewed tree is
         // reproducible — see DEPENDENCY.md for the upgrade procedure.
         //
-        // TEMPORARY FORK PIN: our fork's `fix/load-quantized-tied-embedding` = upstream
-        // main 6ea59e5 (which now contains everything the previous e1-e2 pin carried:
-        // upstream #229/#230/#231) plus the quantized-tied-embedding loader fix staged
-        // upstream as Blaizzy/mlx-audio-swift#232 — required by the catalog's -qhead model
-        // (SpeechModelCatalog). Switch the URL back to Blaizzy/mlx-audio-swift once #232
-        // merges.
+        // 8ed8188 is the merge of Blaizzy/mlx-audio-swift#232 (quantized-tied-embedding
+        // loader — required by the catalog's -qhead model, SpeechModelCatalog); with it
+        // upstream main carries everything the temporary T0mSIlver fork pin held, so the
+        // pin is back on upstream.
         .package(
-            url: "https://github.com/T0mSIlver/mlx-audio-swift.git",
-            revision: "791ab876c10b47cc9f8894ff4100240aa6d95bf7"
+            url: "https://github.com/Blaizzy/mlx-audio-swift.git",
+            revision: "8ed8188bf862062d2c6f4c6ecefbfed301f615a0"
         ),
     ],
     targets: [


### PR DESCRIPTION
## What

Switches the SpeechHelper `mlx-audio-swift` pin from the temporary `T0mSIlver/mlx-audio-swift` fork back to upstream `Blaizzy/mlx-audio-swift`, executing the switchback plan documented in `SpeechHelper/DEPENDENCY.md`: the quantized-tied-embedding loader fix the fork staged merged upstream yesterday as [Blaizzy/mlx-audio-swift#232](https://github.com/Blaizzy/mlx-audio-swift/pull/232) (merge commit `8ed8188`), which is the new pin.

Due diligence on the new revision (per the DEPENDENCY.md upgrade procedure):

- **Engine-tree diff fork-pin → `8ed8188`**: only `VoxtralRealtime.swift` and `VoxtralRealtimeDecoder.swift` changed among files we consume — the merged #232 is a review-evolved variant of the fork commit (module-routed `embedToken`/`logits` through `QuantizedEmbedding` instead of raw-weight access, plus upstream regression tests `VoxtralRealtimeTiedEmbeddingTests`). The only other change is a Chatterbox (TTS) fix in `MLXAudioTTS`, which we don't build. `VoxtralRealtimeStreamSession` is untouched, so the append-only delta-routing assumption holds.
- **Graph pins**: upstream's `Package.resolved` at `8ed8188` matches all four exact pins (mlx-swift 0.31.3 / `61b9e01`, mlx-swift-lm 3.31.3 / `1c05248`, swift-transformers 1.1.9 / `150169b`, swift-huggingface 0.8.1 / `de01c0a`) — no graph changes.
- Because the merged loader code differs from what the fork pin validated, the live speechd integration gate was re-run against the real `-qhead` checkpoint (below) rather than assuming equivalence.

Docs updated in the same commit: `DEPENDENCY.md` pin section, `Package.swift` pin comment, `SpeechModelCatalog.swift` "staged upstream" → "upstreamed". README already pointed at upstream — no change.

Post-merge cleanup: the fork's `fix/load-quantized-tied-embedding` branch can be deleted once this lands (nothing references it after this PR).

## Proof

- [x] SpeechHelper unit suite green, resolving the new upstream pin — `./scripts/remote-build.sh test --package-path SpeechHelper`:
  ```
  Working copy of https://github.com/Blaizzy/mlx-audio-swift.git resolved at 8ed8188bf862062d2c6f4c6ecefbfed301f615a0
  Test Suite 'SpeechHelperPackageTests.xctest' passed at 2026-07-23 18:44:59.742.
       Executed 47 tests, with 0 failures (0 unexpected) in 0.011 (0.013) seconds
  ```
- [x] Packaging green (xcodebuild Metal lane, both helpers) — `./scripts/remote-build.sh package`:
  ```
  Contents/MacOS:
    localvoxtral
    localvoxtral-claude-hook
    localvoxtral-polishd
    localvoxtral-speechd
  ```
- [x] Live speechd integration gate green — packaged speechd loading the real qhead checkpoint through the upstream (review-evolved) loader, real audio, append-only wire contract, parent tether — `./scripts/remote-build.sh integration-speechd`:
  ```
  Test Suite 'SpeechHelperIntegrationTests' passed at 2026-07-23 18:47:30.861.
       Executed 4 tests, with 0 failures (0 unexpected) in 17.454 (17.454) seconds
  speechd integration: word accuracy 0.759; transcript:  Hello from local VoxTroll real-time test. [...] end-to-end processing is confirmed.
  ```
- LLM polish lanes: skipped — no change to prompts, polish model pins, or anything that alters what reaches the polish model (speechd ASR dependency pin only; `speechd-lane-filter.sh` matches this diff, so CI runs the speechd lane too).
