### PR TITLE
Tests: pin live Accessibility-trust sampling under XCTest (runner auto-update TCC invalidation)

### DIFF
--- a/Sources/localvoxtral/AccessibilityTrustManager.swift
+++ b/Sources/localvoxtral/AccessibilityTrustManager.swift
@@ -33,12 +33,35 @@ final class AccessibilityTrustManager {
     /// does not clobber the injected state. Always nil in release builds.
     @ObservationIgnored private var debugTrustOverride: Bool?
 
+    /// Default live trust probe. Under XCTest it resolves to a fixed
+    /// `trusted` verdict: an unpinned live sample ties the unit suite to the
+    /// HOST's Accessibility grant for the test runner, and a runner
+    /// auto-update swaps its bundled node binary and silently invalidates
+    /// that grant (2026-07-24 red CI; same class as the locked-screen seams
+    /// pinned in TerminalTargetDetector, PR #122). Injected checkers and
+    /// `debugSetTrustOverride` still win.
+    nonisolated static func defaultTrustChecker() -> Bool {
+        #if DEBUG
+        if TerminalTargetDetector.isRunningUnderXCTest { return true }
+        #endif
+        return AXIsProcessTrusted()
+    }
+
+    /// Default live prompter. Pinned to a no-op under XCTest: on an
+    /// untrusted host the real `AXIsProcessTrustedWithOptions` prompt pops
+    /// an actual TCC dialog in the runner's GUI session on every unit run.
+    nonisolated static func defaultPermissionPrompter() {
+        #if DEBUG
+        if TerminalTargetDetector.isRunningUnderXCTest { return }
+        #endif
+        let options = ["AXTrustedCheckOptionPrompt": true] as CFDictionary
+        _ = AXIsProcessTrustedWithOptions(options)
+    }
+
     init(
-        trustChecker: @escaping TrustChecker = { AXIsProcessTrusted() },
-        permissionPrompter: @escaping PermissionPrompter = {
-            let options = ["AXTrustedCheckOptionPrompt": true] as CFDictionary
-            _ = AXIsProcessTrustedWithOptions(options)
-        },
+        trustChecker: @escaping TrustChecker = AccessibilityTrustManager.defaultTrustChecker,
+        permissionPrompter: @escaping PermissionPrompter =
+            AccessibilityTrustManager.defaultPermissionPrompter,
         sleepFor: @escaping SleepClosure = { duration in
             try? await Task.sleep(for: duration)
         },

--- a/Sources/localvoxtral/EscapeCancelHandler.swift
+++ b/Sources/localvoxtral/EscapeCancelHandler.swift
@@ -63,16 +63,29 @@ final class EscapeCancelHandler {
         }
     }
 
-    func start() {
+    /// Diagnostic-only probe of the host's live permission state. Pinned off
+    /// under XCTest: the unit suite must never sample live TCC state (PR #188
+    /// review finding — same invariant as the AccessibilityTrustManager and
+    /// ModifierOnlyHotKeyManager pins). Registration below stays REAL either
+    /// way: Carbon hotkeys are trust-independent, so pinning only the probe
+    /// keeps the existing registration coverage.
+    private func logLivePermissionState() {
         #if DEBUG
-        Self.startCallCount += 1
+        if TerminalTargetDetector.isRunningUnderXCTest { return }
         #endif
-
         let trusted = AXIsProcessTrusted()
         let inputMonitoring = IOHIDCheckAccess(kIOHIDRequestTypeListenEvent)
         Log.escape.notice(
             "permission state: AXIsProcessTrusted=\(trusted, privacy: .public) inputMonitoring=\(Self.describeHIDAccess(inputMonitoring), privacy: .public)"
         )
+    }
+
+    func start() {
+        #if DEBUG
+        Self.startCallCount += 1
+        #endif
+
+        logLivePermissionState()
 
         guard !isRegistered else {
             Self.record(.registered)

--- a/Sources/localvoxtral/ModifierOnlyHotKeyManager.swift
+++ b/Sources/localvoxtral/ModifierOnlyHotKeyManager.swift
@@ -66,6 +66,21 @@ final class ModifierOnlyHotKeyManager {
             Self.record(forcedStartOutcome)
             return forcedStartOutcome
         }
+        // Unpinned, the live path below samples the HOST's Accessibility
+        // grant to the test runner — a runner auto-update swaps its bundled
+        // node binary and silently invalidates that grant, which turned the
+        // whole unit suite red (2026-07-24; same class as the locked-screen
+        // seams pinned in TerminalTargetDetector, PR #122). Under XCTest the
+        // registration resolves to a fixed success without installing real
+        // NSEvent monitors; tests exercising failure outcomes pin
+        // `forcedStartOutcome` above, and gesture logic drives the
+        // debug*ForTesting entry points directly.
+        if TerminalTargetDetector.isRunningUnderXCTest {
+            stop()
+            configureGestureState(modifier: modifier)
+            Self.record(.created)
+            return .created
+        }
         #endif
 
         stop()
@@ -381,6 +396,13 @@ final class ModifierOnlyHotKeyManager {
         startCallCount = 0
         stopCallCount = 0
         forcedStartOutcome = nil
+    }
+
+    /// Number of live NSEvent monitors currently installed. Lets tests prove
+    /// the XCTest-pinned `start()` never touched the real monitor APIs.
+    var debugInstalledMonitorCount: Int {
+        [globalFlagsMonitor, localFlagsMonitor, globalKeyDownMonitor, localKeyDownMonitor]
+            .compactMap { $0 }.count
     }
 
     func debugStartGestureForTesting(modifier: ModifierKey) {

--- a/Sources/localvoxtral/TerminalTargetDetector.swift
+++ b/Sources/localvoxtral/TerminalTargetDetector.swift
@@ -220,6 +220,8 @@ enum TerminalTargetDetector {
     // three seams resolve to fixed defaults under XCTest: secure input off,
     // no frontmost bundle, probe unavailable. Tests that exercise the live
     // behaviors pin the overrides explicitly.
-    static let isRunningUnderXCTest = NSClassFromString("XCTestCase") != nil
+    // nonisolated: consulted from nonisolated pinned defaults too
+    // (AccessibilityTrustManager) — an immutable Bool is safe anywhere.
+    nonisolated static let isRunningUnderXCTest = NSClassFromString("XCTestCase") != nil
     #endif
 }

--- a/Tests/localvoxtralTests/AccessibilityTrustManagerTests.swift
+++ b/Tests/localvoxtralTests/AccessibilityTrustManagerTests.swift
@@ -97,4 +97,27 @@ final class AccessibilityTrustManagerTests: XCTestCase {
         XCTAssertTrue(manager.isTrusted)
         XCTAssertGreaterThanOrEqual(sleepCalls, 1)
     }
+
+    // MARK: - XCTest-pinned defaults (live TCC sampling must never reach tests)
+
+    func testDefaultTrustCheckerIsPinnedTrustedUnderXCTest() {
+        // Before the pin this sampled the HOST's live AXIsProcessTrusted() —
+        // the whole unit suite went red when a runner auto-update swapped the
+        // bundled node binary and invalidated its Accessibility grant
+        // (2026-07-24). Deterministic on every host by construction now.
+        XCTAssertTrue(AccessibilityTrustManager.defaultTrustChecker())
+    }
+
+    func testDefaultInitializedManagerIsTrustedUnderXCTest() {
+        // A manager built with the production defaults (no injected checker,
+        // the path DictationViewModel takes) must resolve trusted under
+        // XCTest so session-start warnings stay deterministic; tests that
+        // exercise the untrusted paths pin debugSetTrustOverride(false).
+        let manager = AccessibilityTrustManager(pollingTimeoutSeconds: 0)
+
+        manager.refresh()
+
+        XCTAssertTrue(manager.isTrusted)
+        XCTAssertNil(manager.lastError)
+    }
 }

--- a/Tests/localvoxtralTests/ModifierOnlyHotKeyManagerTests.swift
+++ b/Tests/localvoxtralTests/ModifierOnlyHotKeyManagerTests.swift
@@ -428,6 +428,33 @@ final class ModifierOnlyHotKeyManagerTests: XCTestCase {
         XCTAssertEqual(manager1TapCount, 1)
         XCTAssertEqual(manager2TapCount, 1)
     }
+
+    // MARK: - XCTest-pinned start (live TCC sampling must never reach tests)
+
+    func testUnforcedStartUnderXCTestPinsToCreatedWithoutRealMonitors() {
+        // No forcedStartOutcome: this exercises start()'s default path, which
+        // before the pin sampled the HOST's live Accessibility grant — red
+        // whenever a runner auto-update invalidated the grant (2026-07-24),
+        // and installing REAL NSEvent monitors when the host happened to be
+        // trusted. Both are wrong in a unit suite; the pinned path must
+        // report success and touch no monitor APIs.
+        let manager = ModifierOnlyHotKeyManager()
+        ModifierOnlyHotKeyManager.resetDebugState()
+        defer { ModifierOnlyHotKeyManager.resetDebugState() }
+
+        let outcome = manager.start(modifier: .rightCommand)
+
+        XCTAssertEqual(outcome, .created)
+        XCTAssertEqual(
+            manager.debugInstalledMonitorCount, 0,
+            "the XCTest-pinned start() must never install live NSEvent monitors"
+        )
+        // The pinned registration is a real one from the caller's view:
+        // gesture state is configured and stop() tears it down cleanly.
+        XCTAssertEqual(manager.debugGestureSnapshotForTesting().targetModifier, .rightCommand)
+        manager.stop()
+        XCTAssertNil(manager.debugGestureSnapshotForTesting().targetModifier)
+    }
 }
 
 @MainActor


### PR DESCRIPTION
## What

Follow-up to #187's CI investigation. The unit suite sampled the HOST's live TCC state in two places, and both went red on 2026-07-24 when the self-hosted runner auto-updated 2.335.1 → 2.336.0: a runner update swaps its **bundled** node binary (`~/actions-runner/externals/`), macOS silently invalidates that binary's Accessibility grant, four tests failed, and every unit run popped a **real TCC prompt** in the runner's GUI session. This recurs on every future runner auto-update, so this PR gives the two leaking probes the same XCTest-pinned-default treatment #122 gave `TerminalTargetDetector`'s seams:

- `ModifierOnlyHotKeyManager.start()`: under XCTest (and no `forcedStartOutcome` override) registration resolves to a fixed `.created` without sampling `AXIsProcessTrusted()` or installing real NSEvent monitors. Failure outcomes stay reachable via the existing `forcedStartOutcome` seam; gesture logic keeps driving the `debug*ForTesting` entry points.
- `AccessibilityTrustManager`: the **default** `trustChecker` resolves to trusted under XCTest, and the **default** `permissionPrompter` becomes a no-op (`AXIsProcessTrustedWithOptions(prompt:)` was the source of the per-run TCC dialog storm). Injected closures and `debugSetTrustOverride` still win, so every existing untrusted-path test is unchanged — all current tests either inject closures or set `forcedStartOutcome` (verified by grep).
- `TerminalTargetDetector.isRunningUnderXCTest` becomes `nonisolated` (immutable `Bool`) so the nonisolated pinned defaults can consult it.

Production behavior is untouched: the pins are `#if DEBUG` + XCTest-presence-gated, release builds compile the live paths verbatim, and a DEBUG app run has no `XCTestCase` class loaded.

## Proof

This is a bug fix with the regression shown failing before and passing after, on the exact broken host:

**Failing before** — CI runs [30076914253](https://github.com/T0mSIlver/localvoxtral/actions/runs/30076914253) and [30077627616](https://github.com/T0mSIlver/localvoxtral/actions/runs/30077627616) (5 attempts total on runner 2.336.0, all identical):

```
Executed 2001 tests, with 11 tests skipped and 4 failures (0 unexpected)
Test Case '-[localvoxtralTests.DictationViewModelFailFastUXTests testBeginDictationSessionSkipsAccessibilityWarningWhenTrustedInLiveMode]' failed
Test Case '-[localvoxtralTests.DictationViewModelFailFastUXTests testDelayedSecureInputRefusalAfterManagedStartupDoesNotWedgeTheIcon]' failed
Test Case '-[localvoxtralTests.TerminalTargetDetectorTests testLiveSessionStartRefusedUnderSecureInput]' failed
Test Case '-[localvoxtralTests.TerminalTargetDetectorTests testRefusedStartWarningClearsAtNextSessionStartWithSecureInputOff]' failed
```

**Passing after** — this PR's own CI run executes the full unit suite on the same runner while its node grant is still invalid (the owner has NOT repaired TCC): a green `Test (unit suite)` step on this branch *is* the demonstration that the suite no longer depends on host TCC state. The two new regression tests additionally pin the contract on healthy hosts, where the old code would silently install real NSEvent monitors during tests:

- `testUnforcedStartUnderXCTestPinsToCreatedWithoutRealMonitors` — unforced `start()` returns `.created` with **zero** live monitors installed (new `debugInstalledMonitorCount` accessor).
- `testDefaultTrustCheckerIsPinnedTrustedUnderXCTest` / `testDefaultInitializedManagerIsTrustedUnderXCTest` — the production-default trust path resolves trusted deterministically.

Not independently assertable: that the pinned default prompter stops the TCC dialog storm (no API observes "a dialog would have popped"). Evidence is structural — the prompter is the only `AXIsProcessTrustedWithOptions` call site in the codebase — plus the owner can confirm no prompts appear during this PR's CI run.

- [x] LLM lanes: skipped — no lane-filter path touched (verified against `scripts/ci/llm-lane-filter.sh` / `speechd-lane-filter.sh`); nothing that reaches the model.
- [x] UI change: none — DEBUG/XCTest-gated seams only.

## Relation to #187

Independent (branched off main). #187 is blocked on this same host-state breakage; once this merges, rebasing #187 (or just rerunning after main merges into its CI base) should give it a green run without any manual TCC repair. The manual repair (re-adding `~/actions-runner/externals/node*/bin/node` in the Accessibility pane + runner restart) remains worth doing for tier-2 lanes that legitimately need AX, but the unit suite stops depending on it.
