### PR TITLE
CI: suppress the real app's startup TCC prompts in the launch smokes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -540,6 +540,15 @@ jobs:
 
       - name: Smoke test packaged app launch (end-user simulation)
         if: steps.ci_scope.outputs.docs_only != 'true'
+        env:
+          # TCC attributes the launched app's permission checks to the
+          # runner's bundled node (the service's responsible process). A
+          # runner auto-update swaps that node and invalidates its
+          # Accessibility grant, so the app's startup prompt pops a REAL
+          # dialog on the runner's GUI session on every run (2026-07-24).
+          # Suppress only the startup prompts; the launch path stays
+          # production-shaped.
+          LOCALVOXTRAL_SUPPRESS_STARTUP_PERMISSION_PROMPTS: "1"
         run: |
           # Launch a COPY of the packaged app from outside the workspace with
           # the workspace .build renamed away. A same-tree launch silently

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -121,6 +121,11 @@ jobs:
         run: ./scripts/package_app.sh release "${{ steps.meta.outputs.version }}" "${{ github.run_number }}"
 
       - name: Gate — packaged app launch smoke test
+        env:
+          # Same rationale as ci.yml's launch smoke: keep the real app's
+          # startup TCC prompts off the runner's GUI session (node's
+          # Accessibility grant dies on every runner auto-update).
+          LOCALVOXTRAL_SUPPRESS_STARTUP_PERMISSION_PROMPTS: "1"
         run: |
           python3 - <<'PY'
           import subprocess, time

--- a/Sources/localvoxtral/DictationViewModel.swift
+++ b/Sources/localvoxtral/DictationViewModel.swift
@@ -820,7 +820,10 @@ final class DictationViewModel {
     private func requestStartupPermissionsIfNeeded() {
         guard managesRuntimeServices else { return }
         guard !suppressStartupPermissionPrompts else {
-            Log.dictation.info(
+            // .notice so the line persists in the unified log archive: it is
+            // the after-the-fact field proof that a CI smoke launch skipped
+            // the prompt pass (.info survives only in the memory buffer).
+            Log.dictation.notice(
                 "startup permission prompts suppressed (LOCALVOXTRAL_SUPPRESS_STARTUP_PERMISSION_PROMPTS=1)"
             )
             return

--- a/Sources/localvoxtral/DictationViewModel.swift
+++ b/Sources/localvoxtral/DictationViewModel.swift
@@ -573,6 +573,18 @@ final class DictationViewModel {
     private var lifecycleObservers: [NSObjectProtocol] = []
     @ObservationIgnored
     private let managesRuntimeServices: Bool
+    /// When true, the startup permission-prompt pass (microphone +
+    /// Accessibility) is skipped entirely. Driven by
+    /// `LOCALVOXTRAL_SUPPRESS_STARTUP_PERMISSION_PROMPTS=1` in production;
+    /// injectable for tests. CI's packaged-app launch smoke execs the real
+    /// binary inside the Actions runner's process tree, where TCC attributes
+    /// permission checks to the runner's bundled node — after a runner
+    /// auto-update invalidates node's Accessibility grant, the startup
+    /// prompt pops a REAL dialog on the runner's GUI session once per run
+    /// (2026-07-24). The env override silences only the prompts; the launch
+    /// path stays production-shaped.
+    @ObservationIgnored
+    private let suppressStartupPermissionPrompts: Bool
     @ObservationIgnored
     private let localNetworkPermissionPreflight: any LocalNetworkPermissionPreflighting
     // Tracks physical key state so repeat key-down events do not retrigger actions.
@@ -599,7 +611,9 @@ final class DictationViewModel {
         backendManager: (any ManagedBackendManaging)? = nil,
         overlayBufferCoordinator: OverlayBufferSessionCoordinating? = nil,
         localNetworkPermissionPreflight: (any LocalNetworkPermissionPreflighting)? = nil,
-        startRuntimeServices: Bool = true
+        startRuntimeServices: Bool = true,
+        suppressStartupPermissionPrompts: Bool =
+            DictationViewModel.startupPermissionPromptsSuppressed()
     ) {
         self.settings = settings
         self.backendManager =
@@ -610,6 +624,7 @@ final class DictationViewModel {
                 speechdStepCadenceProvider: { settings.speechdStepCadence.milliseconds }
             )
         self.managesRuntimeServices = startRuntimeServices
+        self.suppressStartupPermissionPrompts = suppressStartupPermissionPrompts
         self.localNetworkPermissionPreflight =
             localNetworkPermissionPreflight ?? LocalNetworkPermissionPreflight()
         if let overlayBufferCoordinator {
@@ -792,8 +807,24 @@ final class DictationViewModel {
         lifecycleObservers = [sleepObserver, terminateObserver]
     }
 
+    /// True when `LOCALVOXTRAL_SUPPRESS_STARTUP_PERMISSION_PROMPTS=1` — the
+    /// explicit opt-out CI's launch smoke sets so the real packaged app can
+    /// be launched without popping TCC dialogs on the runner's GUI session
+    /// (see `suppressStartupPermissionPrompts`).
+    nonisolated static func startupPermissionPromptsSuppressed(
+        environment: [String: String] = ProcessInfo.processInfo.environment
+    ) -> Bool {
+        environment["LOCALVOXTRAL_SUPPRESS_STARTUP_PERMISSION_PROMPTS"] == "1"
+    }
+
     private func requestStartupPermissionsIfNeeded() {
         guard managesRuntimeServices else { return }
+        guard !suppressStartupPermissionPrompts else {
+            Log.dictation.info(
+                "startup permission prompts suppressed (LOCALVOXTRAL_SUPPRESS_STARTUP_PERMISSION_PROMPTS=1)"
+            )
+            return
+        }
         guard settings.onboardingCompleted else {
             debugLog("startup permission prompts skipped until onboarding completes")
             return

--- a/Tests/localvoxtralTests/DictationViewModelFailFastUXTests.swift
+++ b/Tests/localvoxtralTests/DictationViewModelFailFastUXTests.swift
@@ -252,6 +252,38 @@ final class DictationViewModelFailFastUXTests: XCTestCase {
         XCTAssertFalse(viewModel.debugHasRequestedStartupPermissions)
     }
 
+    func testStartupPermissionPromptSuppressionParsesEnvironment() {
+        XCTAssertTrue(
+            DictationViewModel.startupPermissionPromptsSuppressed(
+                environment: ["LOCALVOXTRAL_SUPPRESS_STARTUP_PERMISSION_PROMPTS": "1"]))
+        XCTAssertFalse(
+            DictationViewModel.startupPermissionPromptsSuppressed(
+                environment: ["LOCALVOXTRAL_SUPPRESS_STARTUP_PERMISSION_PROMPTS": "0"]))
+        XCTAssertFalse(DictationViewModel.startupPermissionPromptsSuppressed(environment: [:]))
+    }
+
+    func testStartupPermissionPromptsAreSkippedWhenSuppressed() {
+        // CI's packaged-app launch smoke sets
+        // LOCALVOXTRAL_SUPPRESS_STARTUP_PERMISSION_PROMPTS=1: the real binary
+        // launched inside the runner's process tree must not reach the
+        // startup permission-prompt pass, or an untrusted responsible
+        // process (the runner's bundled node after an auto-update) pops a
+        // real TCC dialog on the runner's GUI session once per run.
+        let settings = makeSettings(outputMode: .overlayBuffer)
+        settings.onboardingCompleted = true
+        let viewModel = DictationViewModel(
+            settings: settings,
+            backendManager: FakeManagedBackendManager(),
+            overlayBufferCoordinator: NoopOverlayCoordinator(),
+            startRuntimeServices: true,
+            suppressStartupPermissionPrompts: true
+        )
+
+        XCTAssertFalse(
+            viewModel.debugHasRequestedStartupPermissions,
+            "suppression must return before the latch — no prompt task may be spawned")
+    }
+
     // MARK: - Managed backend startup
 
     func testStartDictationManagedBothWithPolishingEnabledRequestsBothBackends() async {


### PR DESCRIPTION
## What

Root cause of today's "node permission prompt again" during green CI runs: the packaged-app launch smoke (`ci.yml`, and the `release.yml` gate) execs the **real** app binary inside the runner's process tree, where TCC attributes permission checks to the runner's bundled node (the service's responsible process). This morning's runner auto-update (2.335.1 → 2.336.0, proven from run logs: run 30027438311 vs 30075071522) invalidated node's Accessibility grant, so the app's startup permission pass (`requestStartupAccessibilityPermissionIfNeeded` → `AccessibilityTrustManager.promptIfNeeded` → `AXIsProcessTrustedWithOptions(prompt:)`) popped one **real TCC dialog on the runner's GUI session per CI run**. #188 pinned the XCTest seams and is working; this was the remaining non-XCTest prompt path — deliberately live for end users, so it gets an explicit CI opt-out rather than a pin:

- `DictationViewModel` gains an injectable `suppressStartupPermissionPrompts` flag, defaulted from `LOCALVOXTRAL_SUPPRESS_STARTUP_PERMISSION_PROMPTS=1`, guarding the whole startup permission pass (mic + Accessibility) before the `hasRequestedStartupPermissions` latch, with a `Log.dictation` line when it fires.
- Both launch-smoke steps set that env var. End-user behavior is unchanged (env absent outside CI); the launch path itself stays production-shaped — only the startup prompts are silenced.

**Not covered, by design:** tier-2 lanes (ui-smoke/capture-assets) genuinely need live AX and stay hostage to runner auto-updates; the durable unblock there is re-granting the *externals* node path (`~/actions-runner/externals/node*/bin/node`) in System Settings → Accessibility and restarting the runner service.

## Proof

- Regression tests added (`DictationViewModelFailFastUXTests`): `testStartupPermissionPromptSuppressionParsesEnvironment` (=1 suppresses, =0/absent does not) and `testStartupPermissionPromptsAreSkippedWhenSuppressed` (suppressed construction with `startRuntimeServices: true` + `onboardingCompleted: true` asserts the permission pass never latches — before the guard, that construction latches unconditionally).
- Local before/after runs are not possible right now: the build host is off-LAN today (`./scripts/mac-health.sh`: `ssh: connect to host 192.168.1.167 port 22: No route to host`). Tier-0/1 proof is this PR's CI, which runs when the runner reconnects; the named unit tests demonstrate the behavior change. The definitive field proof is the next full CI run on the still-untrusted host popping **zero** dialogs — owner-observable, please confirm on the Mac.
- LLM lane note: `Sources/localvoxtral/DictationViewModel.swift` is on `llm-lane-filter.sh` (context-capture call sites), so the polishd lane will run; the change itself is prompt-flow-free (nothing that reaches the model changes — a startup permission guard only).
- UI change: none (no visible behavior outside CI; env defaults off).


## Proof — executed (CI run 30122052059, self-hosted, green in ~11 min)

- Unit suite: `Executed 2006 tests, with 11 tests skipped and 0 failures (0 unexpected) in 66.852 (67.007) seconds`
- New regression tests (from the `unit-test-log-macOS` artifact):
  ```
  Test Case '-[localvoxtralTests.DictationViewModelFailFastUXTests testStartupPermissionPromptSuppressionParsesEnvironment]' passed (0.000 seconds).
  Test Case '-[localvoxtralTests.DictationViewModelFailFastUXTests testStartupPermissionPromptsAreSkippedWhenSuppressed]' passed (0.004 seconds).
  ```
- Launch smoke ran with the env applied (step log): `env: LOCALVOXTRAL_SUPPRESS_STARTUP_PERMISSION_PROMPTS: 1` — step green.
- LLM lane decision: `LLM eval lane: RUNNING (matched Sources/localvoxtral/DictationViewModel.swift)` — polishd live-model integration ran and passed in this same run.
- Field check for the owner: this run executed on the still-untrusted host (node grant not yet re-added) — confirm no TCC dialog appeared on the Mac during it.


## Proof — field verification of zero TCC dialogs (log-observed, no owner check needed)

The `.info` suppression line never persisted to the unified log archive (verified via mac-crashlog run 30164473407: only Default/Error lines from the 2026-07-24 smoke window survive), so commit e4d46ba bumps it to `.notice`. With that in place, CI run 30164550832 (green; the one red was the known-flaky `testStopHonorsTERMWithoutRestarting` under host load, passed on quiet-host rerun) provides the definitive field proof, captured by mac-crashlog run 30164890411:

```
2026-07-25 18:03:43.163577+0200 ... localvoxtral: [com.localvoxtral:ModifierKeys] permission state: AXIsProcessTrusted=false inputMonitoring=unknown(2)
2026-07-25 18:03:43.171770+0200 ... localvoxtral: [com.localvoxtral:Dictation] startup permission prompts suppressed (LOCALVOXTRAL_SUPPRESS_STARTUP_PERMISSION_PROMPTS=1)
```

Same PID, inside the smoke window, on the still-untrusted host (`AXIsProcessTrusted=false`): the guard fired before the startup permission pass, so `AXIsProcessTrustedWithOptions(prompt:)` was never called — no dialog was possible from this path. This replaces the "owner, confirm on the Mac" ask above, and the `.notice` line makes the same check repeatable for any future run via `mac-crashlog.yml`.
