### PR TITLE
Dogfood context capture: record + store behind a compile gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -424,6 +424,20 @@ jobs:
         if: runner.environment == 'self-hosted' && steps.ci_scope.outputs.docs_only != 'true'
         run: swift test --package-path SpeechHelper
 
+      - name: Dogfood capture suite (instrumented build)
+        # The dogfooding capture is behind a COMPILE flag (Package.swift), so
+        # neither it nor its tests exist in any of the lanes above — the normal
+        # unit suite compiles the shipping shape, which is the point. Without
+        # this step the capture would rot silently: nothing else in CI ever
+        # builds it, and it is only ever exercised by hand.
+        #
+        # Self-hosted only, matching the helper suites: it is a second full
+        # compile of the app target, which a fork PR should not pay for.
+        if: runner.environment == 'self-hosted' && steps.ci_scope.outputs.docs_only != 'true'
+        env:
+          LOCALVOXTRAL_DOGFOOD: "1"
+        run: swift test --filter 'Dogfood'
+
       - name: Ensure Metal toolchain
         # Xcode 26 ships the Metal compiler as a separate component, and its
         # activation is per-user — installing it for the SSH build user does

--- a/.gitignore
+++ b/.gitignore
@@ -23,8 +23,11 @@ DerivedData/
 .opencode/
 
 # Transient enable markers written by remote-build.sh eval-llm /
-# integration-polishd / integration-speechd / eval-e2e
+# integration-polishd / integration-speechd / eval-e2e / dogfood
 /.llm-polish-eval-enable.json
 /.polishd-integration-enable.json
 /.speechd-integration-enable.json
 /.agent-eval-e2e-enable.json
+# Compile gate for the dogfooding context capture (Package.swift reads it).
+# Never commit: its presence changes what the app is compiled to do.
+/.dogfood-capture-enable

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,6 +26,8 @@ is machine-local config, set once per clone (never committed):
 ./scripts/remote-build.sh eval-e2e [EvalRecordings/agent-dictation/<set>]  # agent-dictation E2E eval: human WAVs (optional) or TTS -> speechd -> polishd (run package first)
 ./scripts/run-agent-eval-local.sh [EvalRecordings/agent-dictation/<set>]   # same eval directly from a Mac checkout (run package_app.sh first)
 ./scripts/ablate-agent-eval.py .build/agent-eval-local.log                 # reuse one E2E log to compare pre/post-processing, prompts, and models without rerunning audio
+./scripts/remote-build.sh dogfood          # build the instrumented tree + run the context-capture suite
+./scripts/remote-build.sh dogfood-package  # package an instrumented .app for hand-dogfooding
 ./scripts/remote-build.sh build --package-path PolishHelper   # helper package alone
 ./scripts/remote-build.sh test  --package-path PolishHelper   # helper unit tests (Metal-free)
 ./scripts/remote-build.sh test  --package-path SpeechHelper   # speech helper unit tests (Metal-free)
@@ -113,6 +115,21 @@ Learned the hard way (2026-07-04) — use these instead of manual steps:
   `DEMO_TERMINAL_AGENT=herdr` (explicit only, never auto) records the herdr
   pane-join scene — split panes in an isolated named herdr session, dictation
   into the focused Claude pane, log-asserted herdr join + pane.read context.
+- **Dogfooding context capture** (`Sources/localvoxtral/Dogfood`): the app logs
+  context COUNTS only, on purpose, which also makes a retrieval miss
+  unattributable after the fact. The capture is the gated exception — it records
+  the join outcome, the screen decision and its cause, each source's harvest and
+  proposals, budget demands vs. grants, the rendered prompts, and the model's
+  reply, so a wrong term can be blamed on exactly one of four stages
+  (retrieval / matcher / conflict / budget). It is behind a COMPILE flag
+  (`LOCALVOXTRAL_DOGFOOD`, or the gitignored `.dogfood-capture-enable` marker
+  that crosses the build gate) plus a runtime opt-in
+  (`defaults write com.localvoxtral.app debug.dogfood_capture_enabled -bool true`).
+  Shipped releases do not contain it, and there is deliberately no uploader —
+  records are local files under Application Support. Use `dogfood-package` for a
+  hand-testable build; it keeps the bundle id so the TCC grant survives and
+  stamps `LVXDogfoodCapture` into Info.plist so you can tell which binary you
+  are running.
 - **Pipes from child processes**: never read with
   `FileHandle.availableData` — it raises an uncatchable ObjC exception on
   descriptor errors and aborts the app (field crash, PR #60). Use

--- a/Package.swift
+++ b/Package.swift
@@ -1,6 +1,38 @@
 // swift-tools-version: 6.2
 
 import PackageDescription
+import Foundation
+
+/// Opt-in dogfooding instrumentation (`Sources/localvoxtral/Dogfood`), compiled
+/// ONLY when the environment asks for it: `LOCALVOXTRAL_DOGFOOD=1 swift build`.
+///
+/// It is a compile gate rather than a settings-only feature on purpose. The
+/// capture writes repository contents, terminal screen text, clipboard text, and
+/// fully rendered prompts to disk — exactly the material the shipped app refuses
+/// to log. Keeping it out of the released binary makes "this build cannot record
+/// your context" a property of the artifact instead of a promise about a
+/// default, and leaves the README's privacy section literally true.
+///
+/// Inside such a build the capture is still off until the runtime opt-in is
+/// armed. Two locks, and the outer one is not a checkbox.
+/// Enablement travels EITHER as the environment variable (local builds, CI)
+/// OR as a gitignored marker file in the package root — the same dual form the
+/// LLM eval lanes use, and for the same reason: the Mac build gate allowlists
+/// exact `swift test …` payloads, so an env prefix cannot cross the SSH
+/// boundary. `remote-build.sh dogfood` writes the marker, syncs, and removes it
+/// again on exit.
+///
+/// The marker cannot leak into a release: `release.yml` builds from a clean
+/// checkout, the file is gitignored, and `package_app.sh` prints which mode it
+/// built in and stamps `LVXDogfoodCapture` into the bundle's Info.plist.
+let dogfoodMarkerURL = URL(fileURLWithPath: #filePath)
+    .deletingLastPathComponent()
+    .appendingPathComponent(".dogfood-capture-enable")
+let dogfoodCaptureEnabled =
+    ProcessInfo.processInfo.environment["LOCALVOXTRAL_DOGFOOD"] == "1"
+    || FileManager.default.fileExists(atPath: dogfoodMarkerURL.path)
+let dogfoodSwiftSettings: [SwiftSetting] =
+    dogfoodCaptureEnabled ? [.define("LOCALVOXTRAL_DOGFOOD")] : []
 
 let package = Package(
     name: "localvoxtral",
@@ -39,7 +71,8 @@ let package = Package(
             ],
             resources: [
                 .process("Resources"),
-            ]
+            ],
+            swiftSettings: dogfoodSwiftSettings
         ),
         .testTarget(
             name: "localvoxtralTests",
@@ -47,7 +80,8 @@ let package = Package(
                 "localvoxtral",
                 "ClaudeContextWire",
                 "ClaudeHookPublisherCore",
-            ]
+            ],
+            swiftSettings: dogfoodSwiftSettings
         ),
     ]
 )

--- a/Sources/localvoxtral/Dogfood/DogfoodCaptureRecord.swift
+++ b/Sources/localvoxtral/Dogfood/DogfoodCaptureRecord.swift
@@ -1,0 +1,191 @@
+#if LOCALVOXTRAL_DOGFOOD
+
+import Foundation
+
+/// One dictation's complete context-pipeline record, written locally by an
+/// opt-in dogfooding build so a retrieval miss can be attributed after the fact.
+///
+/// The app deliberately logs context COUNTS only (`Log.polishing` /
+/// `Log.claudeContext`): repository contents, screen text, clipboard text, and
+/// rendered prompts must never reach the unified log. That policy is what makes
+/// the shipped app's privacy claims true, and it is also why a term that came
+/// out wrong is unattributable today — by commit time every intermediate the
+/// answer depends on has been reduced to an integer.
+///
+/// This type is the deliberate, gated exception. It exists only in a build
+/// compiled with `LOCALVOXTRAL_DOGFOOD` (see `Package.swift`), and within such a
+/// build it is populated only while the runtime opt-in is armed. Records are
+/// written to a 0700 directory as 0600 files and are never transmitted
+/// anywhere — there is no uploader, and adding one would defeat the point of
+/// the compile gate.
+///
+/// ## What it is for
+///
+/// A missed technical term was lost by exactly one of four stages, and the fix
+/// differs completely between them:
+///
+/// 1. `.retrieval` — the term never entered the harvest. The collector, screen
+///    read, or `pane.read` did not surface it; matching never had a chance.
+/// 2. `.matcher` — the term was in the harvest but no tier matched the heard
+///    span (exact, edit-distance-one, phonetic, bounded aligned fallback).
+/// 3. `.conflict` — a tier matched, but the cross-source merge abstained or
+///    demoted it (`PolishContextGrounding`).
+/// 4. `.budget` — it survived the merge but the render allocation cut the
+///    excerpt that carried its evidence.
+///
+/// Every field below exists to make that four-way question answerable from the
+/// record alone, without re-running the dictation.
+struct DogfoodCaptureRecord: Codable, Equatable, Sendable {
+    /// Bumped whenever a field changes meaning. The reviewer and the corpus
+    /// converter both refuse records they were not written for rather than
+    /// silently misreading an older shape.
+    static let currentSchemaVersion = 1
+
+    var schemaVersion: Int = DogfoodCaptureRecord.currentSchemaVersion
+    var id: String
+    var capturedAt: Date
+
+    /// Set by the "flag last dictation" affordance. Flagged records are the
+    /// review queue and the corpus-conversion candidates, and retention treats
+    /// them differently — see `DogfoodCaptureStore`.
+    var flagged: Bool = false
+
+    var session: Session
+    var join: Join?
+    var screen: Screen?
+    var allocation: [Allocation]
+    var sources: [Source]
+    var text: Text
+    var timings: Timings
+
+    struct Session: Codable, Equatable, Sendable {
+        /// Bundle identifier of the app the text was inserted into.
+        var targetBundleID: String?
+        /// `TerminalTargetDetector`'s verdict, as its own description.
+        var targetKind: String?
+        /// Overlay Buffer vs Live Auto-Paste.
+        var outputMode: String
+        /// Which polish profile rendered the prompt.
+        var promptProfile: String?
+        /// Loopback vs LAN vs remote, never the URL itself.
+        var endpointClass: String?
+        var polishModel: String?
+    }
+
+    /// How (or whether) the dictation joined a Claude Code session. An
+    /// abstention is as interesting as a join: "never joins" is the failure mode
+    /// the herdr and TTY arms fail into, and it is invisible without the reason.
+    struct Join: Codable, Equatable, Sendable {
+        /// `tty`, `herdrPane`, `titleMarker`, or `none`.
+        var arm: String
+        /// Populated when `arm == "none"`, or when an arm was attempted and
+        /// abstained: the exact abstention cause, not a generic failure.
+        var abstentionReason: String?
+        /// `local` or `remote`. Governs which context is even eligible.
+        var origin: String?
+        /// Terminal the surface belonged to (Ghostty, iTerm2, Terminal.app).
+        var terminal: String?
+        /// True when the surface TTY positively bound to a herdr client, which
+        /// makes the join herdr-or-nothing from that point.
+        var herdrBound: Bool?
+        var workspaceIsLocal: Bool?
+    }
+
+    /// The screen read and what the reconciliation decided to do with it.
+    struct Screen: Codable, Equatable, Sendable {
+        /// `axGrid`, `appleScriptContents`, or `herdrPaneRead`.
+        var route: String?
+        /// `render`, `vocabularyOnly`, or `drop`.
+        var decision: String
+        /// The `VocabularyOnlyCause` / `DropReason` when either applies. This is
+        /// the field that distinguishes "the feature is off" from "the read
+        /// failed" from "the pane churned" — three very different bugs that all
+        /// present to the user as no context.
+        var cause: String?
+        /// Characters after sanitization, before excerpt selection.
+        var sanitizedCharacterCount: Int
+        /// The sanitized screen as it entered matching. Bucket 1 is unanswerable
+        /// without it: whether a term was ON the screen at all is exactly the
+        /// retrieval question.
+        var sanitizedText: String?
+        var sanitizedTextTruncated: Bool = false
+    }
+
+    /// One source's demand and grant from the shared render budget.
+    ///
+    /// Present for every source that ran, including those granted zero — a
+    /// source starved to nothing is the whole of bucket 4 and it leaves no other
+    /// trace.
+    struct Allocation: Codable, Equatable, Sendable {
+        var source: String
+        var demandedCharacters: Int
+        var grantedCharacters: Int
+        /// Characters actually rendered into the prompt block.
+        var renderedCharacters: Int
+        /// True when the excerpt selector had to choose, i.e. demand exceeded
+        /// the grant and evidence was necessarily dropped.
+        var excerptWasSelected: Bool
+    }
+
+    /// One context source's harvest and everything it proposed from it.
+    struct Source: Codable, Equatable, Sendable {
+        var source: String
+
+        /// The candidate term pool matching ran against. Bounded — see
+        /// `harvestTruncated`, which is recorded rather than applied silently so
+        /// a review never mistakes a truncated harvest for a retrieval miss.
+        var harvest: [String]
+        var harvestCount: Int
+        var harvestTruncated: Bool = false
+
+        /// Pre-apply eligible matches from the exact / edit-distance-one tiers.
+        var entries: [Entry]
+        /// Exact unambiguous phonetic matches — guess grade once sources are
+        /// reconciled, so they can be dropped by the merge even when correct.
+        var phoneticEntries: [Entry]
+        /// Prompt-only mishearing suggestions; never pre-applied.
+        var verificationEntries: [Entry]
+        /// True when `entries` came from the bounded aligned fallback rather
+        /// than a solid tier.
+        var isFallbackOnly: Bool
+
+        /// The excerpt this source rendered into the prompt, if any.
+        var renderedExcerpt: String?
+
+        struct Entry: Codable, Equatable, Sendable {
+            /// The exact local term the matcher proposes.
+            var term: String
+            /// The transcript spans it claims, as heard.
+            var heard: [String]
+        }
+    }
+
+    /// Every text stage, in pipeline order. The diff between consecutive stages
+    /// is what a review actually reads.
+    struct Text: Codable, Equatable, Sendable {
+        /// Raw ASR, before the replacement dictionary and before grounding.
+        var rawTranscript: String
+        /// After the replacement dictionary, before grounding pre-application.
+        var workingText: String
+        /// After merged grounding entries were pre-applied — the exact string
+        /// sent to the model.
+        var groundedText: String
+        var systemPrompt: String?
+        /// Rendered user messages including every attached context block: the
+        /// literal payload the model saw.
+        var userPrompts: [String]
+        /// The model's reply, before any commit-side integrity handling.
+        var polishedOutput: String?
+        /// What was actually committed to the focused app.
+        var committedText: String?
+    }
+
+    struct Timings: Codable, Equatable, Sendable {
+        var polishSeconds: Double?
+        /// Wall time the capture itself added to the commit path. Recorded so a
+        /// dogfooding build cannot quietly change the latency it is measuring.
+        var captureMilliseconds: Double?
+    }
+}
+
+#endif

--- a/Sources/localvoxtral/Dogfood/DogfoodCaptureStore.swift
+++ b/Sources/localvoxtral/Dogfood/DogfoodCaptureStore.swift
@@ -1,0 +1,424 @@
+#if LOCALVOXTRAL_DOGFOOD
+
+import Foundation
+
+/// Directory operations the store needs beyond writing one file. Split out as a
+/// protocol for the same reason the registry splits its own IO: the pruning
+/// rules are the part worth testing, and they should be testable without a real
+/// directory or a real clock.
+protocol DogfoodCaptureDirectoryIO: Sendable {
+    /// File names directly inside `url`, or nil when the directory is absent.
+    func contents(of url: URL) throws -> [String]?
+    func remove(at url: URL) throws
+    func read(from url: URL) throws -> Data?
+}
+
+struct DogfoodCaptureFileDirectoryIO: DogfoodCaptureDirectoryIO {
+    func contents(of url: URL) throws -> [String]? {
+        guard FileManager.default.fileExists(atPath: url.path) else { return nil }
+        return try FileManager.default.contentsOfDirectory(atPath: url.path)
+    }
+
+    func remove(at url: URL) throws {
+        try FileManager.default.removeItem(at: url)
+    }
+
+    func read(from url: URL) throws -> Data? {
+        guard FileManager.default.fileExists(atPath: url.path) else { return nil }
+        return try Data(contentsOf: url)
+    }
+}
+
+/// Writes and prunes `DogfoodCaptureRecord`s on disk.
+///
+/// Compiled only into a `LOCALVOXTRAL_DOGFOOD` build. Within one, records are
+/// still written only while the runtime opt-in is armed — the compile gate keeps
+/// the code out of shipped builds, and the setting keeps it off until the owner
+/// deliberately turns it on.
+///
+/// Design notes worth keeping:
+///
+/// * **The hardened write is reused, not reimplemented.**
+///   `ClaudeRemoteHostFileStoreIO` already creates the directory 0700 (refusing
+///   a symlinked, foreign-owned, or group-writable one), writes the temp file
+///   `O_CREAT|O_EXCL|O_NOFOLLOW` at 0600, fsyncs, and replaces by `rename(2)`.
+///   These records hold repository contents and screen text; they deserve the
+///   same handling as the token store, and a second implementation of it would
+///   only be a second thing to get wrong.
+/// * **The flag lives in the FILE NAME, not the JSON.** Pruning has to know
+///   which records are flagged, and reading every record to find out would make
+///   a routine prune read every captured prompt back off disk. Flagging renames
+///   the file instead, so the retention pass is a directory listing.
+/// * **There is no uploader and must never be one.** The compile gate exists to
+///   make "this build cannot exfiltrate context" a property of the artifact
+///   rather than a promise about a setting.
+struct DogfoodCaptureStore: Sendable {
+    struct Retention: Sendable, Equatable {
+        /// Unflagged records kept, newest first. Flagged records are never
+        /// counted against this — they are the review queue and the corpus
+        /// candidates, and silently deleting one would lose the exact case the
+        /// cycle exists to find.
+        var maximumUnflaggedRecords: Int
+        /// Unflagged records older than this are removed. Flagged records are
+        /// exempt for the same reason.
+        var maximumUnflaggedAge: TimeInterval
+
+        static let `default` = Retention(
+            maximumUnflaggedRecords: 500,
+            maximumUnflaggedAge: 14 * 24 * 60 * 60
+        )
+    }
+
+    enum StoreError: Error, Equatable {
+        case encodingFailed
+        /// The record exists but could not be read back or decoded. Flagging
+        /// refuses rather than proceeding — see `flagMostRecentRecord`.
+        case unreadableRecord(path: String)
+    }
+
+    private let directoryURL: URL
+    private let io: ClaudeRemoteHostStoreIO
+    private let directoryIO: DogfoodCaptureDirectoryIO
+    private let retention: Retention
+    private let now: @Sendable () -> Date
+
+    init(
+        directoryURL: URL? = nil,
+        io: ClaudeRemoteHostStoreIO = ClaudeRemoteHostFileStoreIO(),
+        directoryIO: DogfoodCaptureDirectoryIO = DogfoodCaptureFileDirectoryIO(),
+        retention: Retention = .default,
+        now: @escaping @Sendable () -> Date = { Date() }
+    ) {
+        self.directoryURL = directoryURL ?? DogfoodCaptureStore.defaultDirectoryURL()
+        self.io = io
+        self.directoryIO = directoryIO
+        self.retention = retention
+        self.now = now
+    }
+
+    static func defaultDirectoryURL() -> URL {
+        let applicationSupport = FileManager.default.urls(
+            for: .applicationSupportDirectory,
+            in: .userDomainMask
+        ).first ?? FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent("Library", isDirectory: true)
+            .appendingPathComponent("Application Support", isDirectory: true)
+
+        return applicationSupport
+            .appendingPathComponent("localvoxtral", isDirectory: true)
+            .appendingPathComponent("dogfood", isDirectory: true)
+    }
+
+    var directory: URL { directoryURL }
+
+    // MARK: - Writing
+
+    /// Writes `record` and prunes. Returns the file it wrote.
+    @discardableResult
+    func write(_ record: DogfoodCaptureRecord) throws -> URL {
+        var redacted = record
+        let redactions = DogfoodCaptureRedaction.redact(&redacted)
+        if redactions > 0 {
+            // Never silent: a review that finds `<redacted>` in an excerpt needs
+            // to know it was the redactor, not the pipeline, that put it there.
+            Log.diagnostics.info(
+                "Dogfood capture: redacted \(redactions, privacy: .public) token-shaped run(s)"
+            )
+        }
+
+        guard let data = try? makeEncoder().encode(redacted) else {
+            throw StoreError.encodingFailed
+        }
+
+        let url = directoryURL.appendingPathComponent(
+            DogfoodCaptureFileName.name(for: redacted, flagged: redacted.flagged),
+            isDirectory: false
+        )
+        try io.write(data, to: url)
+        try? prune()
+        return url
+    }
+
+    // MARK: - Flagging
+
+    /// Marks the most recently captured record for review, returning its new
+    /// location. Nil when nothing has been captured yet.
+    ///
+    /// Flagging an already-flagged record is a no-op rather than an error: the
+    /// affordance is a single menu item and pressing it twice should not fail.
+    /// Refuses rather than guessing when the record cannot be read back or
+    /// decoded. The obvious alternative — rename the file and leave its bytes
+    /// alone — produces a record whose NAME says flagged and whose JSON says it
+    /// is not, and the name is what every later `listRecords` believes. That
+    /// contradiction is permanent (a second flag call sees "already flagged" and
+    /// no-ops) and it silently disarms retention's flagged exemption on a
+    /// record the owner explicitly asked to keep. Better to fail loudly.
+    @discardableResult
+    func flagMostRecentRecord() throws -> URL? {
+        guard let latest = try listRecords().first else { return nil }
+        guard !latest.flagged else { return latest.url }
+
+        guard
+            let data = try directoryIO.read(from: latest.url),
+            var record = try? makeDecoder().decode(DogfoodCaptureRecord.self, from: data)
+        else {
+            throw StoreError.unreadableRecord(path: latest.url.path)
+        }
+
+        // The name is the index; the JSON is the truth. Both are updated, so a
+        // record read on its own still reports its own flagged state.
+        record.flagged = true
+        guard let updated = try? makeEncoder().encode(record) else {
+            throw StoreError.encodingFailed
+        }
+
+        // Anchored to the suffix, not `replacingOccurrences`: an unanchored
+        // replacement rewrites the first `.json` anywhere in the name.
+        let base = String(latest.fileName.dropLast(DogfoodCaptureFileName.plainSuffix.count))
+        let destination = directoryURL.appendingPathComponent(
+            base + DogfoodCaptureFileName.flaggedSuffix,
+            isDirectory: false
+        )
+        try io.write(updated, to: destination)
+        try? directoryIO.remove(at: latest.url)
+        return destination
+    }
+
+    private func makeEncoder() -> JSONEncoder {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys, .withoutEscapingSlashes]
+        encoder.dateEncodingStrategy = .iso8601
+        return encoder
+    }
+
+    private func makeDecoder() -> JSONDecoder {
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        return decoder
+    }
+
+    // MARK: - Listing & pruning
+
+    struct Entry: Sendable, Equatable {
+        var fileName: String
+        var url: URL
+        var capturedAt: Date
+        var flagged: Bool
+    }
+
+    /// Every record in the directory, newest first. Files that do not parse as
+    /// capture names are ignored rather than deleted — the directory is the
+    /// owner's, and pruning has no business removing something it cannot read.
+    func listRecords() throws -> [Entry] {
+        guard let names = try directoryIO.contents(of: directoryURL) else { return [] }
+        return names.compactMap { name -> Entry? in
+            guard let parsed = DogfoodCaptureFileName.parse(name) else { return nil }
+            return Entry(
+                fileName: name,
+                url: directoryURL.appendingPathComponent(name, isDirectory: false),
+                capturedAt: parsed.capturedAt,
+                flagged: parsed.flagged
+            )
+        }
+        .sorted { $0.capturedAt > $1.capturedAt }
+    }
+
+    /// Applies the retention rules. Flagged records are never removed.
+    func prune() throws {
+        let records = try listRecords()
+        let cutoff = now().addingTimeInterval(-retention.maximumUnflaggedAge)
+
+        // `records` is newest-first, so this is a POSITION, not a survivor
+        // count: the first `maximumUnflaggedRecords` unflagged records are the
+        // ones kept, and everything past that position goes regardless of how
+        // many of the earlier ones the age rule already removed.
+        var unflaggedSeen = 0
+        for record in records where !record.flagged {
+            unflaggedSeen += 1
+            let tooOld = record.capturedAt < cutoff
+            let beyondCount = unflaggedSeen > retention.maximumUnflaggedRecords
+            guard tooOld || beyondCount else { continue }
+            do {
+                try directoryIO.remove(at: record.url)
+            } catch {
+                // Loud, per the repo's rule about silent failure paths: a prune
+                // that decided to delete and then could not is why a capture
+                // directory grows without explanation.
+                Log.diagnostics.notice(
+                    "Dogfood capture: prune failed for \(record.fileName, privacy: .public): \(error.localizedDescription, privacy: .public)"
+                )
+            }
+        }
+    }
+}
+
+/// Capture file naming. The timestamp and the flag both live in the name so a
+/// retention pass never has to open a record.
+enum DogfoodCaptureFileName {
+    static let prefix = "dictation-"
+    static let flaggedSuffix = ".flagged.json"
+    static let plainSuffix = ".json"
+
+    static func name(for record: DogfoodCaptureRecord, flagged: Bool) -> String {
+        let stamp = makeStampFormatter().string(from: record.capturedAt)
+        let shortID = String(record.id.prefix(8))
+        return "\(prefix)\(stamp)-\(shortID)\(flagged ? flaggedSuffix : plainSuffix)"
+    }
+
+    static func parse(_ name: String) -> (capturedAt: Date, flagged: Bool)? {
+        guard name.hasPrefix(prefix) else { return nil }
+        let flagged = name.hasSuffix(flaggedSuffix)
+        guard flagged || name.hasSuffix(plainSuffix) else { return nil }
+
+        let body = name.dropFirst(prefix.count)
+            .dropLast((flagged ? flaggedSuffix : plainSuffix).count)
+        // `<stamp>-<shortID>`; the stamp itself contains no hyphen.
+        guard let separator = body.firstIndex(of: "-") else { return nil }
+        let stamp = String(body[body.startIndex..<separator])
+        guard let capturedAt = makeStampFormatter().date(from: stamp) else { return nil }
+        return (capturedAt, flagged)
+    }
+
+    /// Compact, sortable, hyphen-free (the name uses `-` as its separator), and
+    /// fixed to UTC so records sort the same way regardless of where the Mac was
+    /// when they were written.
+    ///
+    /// Millisecond resolution, not seconds: the write path replaces by
+    /// `rename(2)`, so two records that produced the same name would leave only
+    /// the later one, silently. Seconds plus eight UUID characters makes that
+    /// vanishingly unlikely in the field but perfectly reachable from a test
+    /// with a frozen injected clock.
+    ///
+    /// A factory rather than a shared instance, matching `DiagnosticsExporter`:
+    /// `DateFormatter` is not `Sendable`, and a stored one would either need an
+    /// unsafe opt-out or pin this type to an actor it has no reason to be on.
+    static func makeStampFormatter() -> DateFormatter {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyyMMdd'T'HHmmss.SSS'Z'"
+        formatter.timeZone = TimeZone(secondsFromGMT: 0)
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        return formatter
+    }
+}
+
+/// Scrubs token-shaped runs out of a record before it reaches disk.
+///
+/// The remote-enrollment token is 43 base64url characters with no prefix, and
+/// dogfooding the remote integration means running the enrollment command in a
+/// terminal — which is precisely the screen this build captures. The registry
+/// stores only hashes, so redaction cannot match a known plaintext; it matches
+/// the shape instead.
+///
+/// It errs in BOTH directions, deliberately, and it is worth being precise
+/// about which:
+///
+/// * It over-matches any isolated 43-character base64url run that is not a
+///   token. Rare in prose and code, and the cost is one masked line of a
+///   dev-only record.
+/// * It under-matches a token GLUED to other base64url characters — inside a
+///   longer path segment, or concatenated with an identifier — because that
+///   forms a run longer than 43. It also misses a token that lost or gained a
+///   character in transcription.
+///
+/// Widening it to "any long base64-ish thing" would shred the hashes, blobs,
+/// and identifiers a review needs to read, so the exact-length rule stays. This
+/// is a backstop for a dev-only artifact, not a guarantee — the guarantee is
+/// that the file never leaves the machine.
+enum DogfoodCaptureRedaction {
+    static let tokenLength = 43
+
+    /// Redacts in place, returning how many runs were replaced.
+    static func redact(_ record: inout DogfoodCaptureRecord) -> Int {
+        var count = 0
+
+        func scrub(_ text: inout String) {
+            let redacted = redacting(text, count: &count)
+            text = redacted
+        }
+        func scrubOptional(_ text: inout String?) {
+            guard let value = text else { return }
+            text = redacting(value, count: &count)
+        }
+
+        scrub(&record.text.rawTranscript)
+        scrub(&record.text.workingText)
+        scrub(&record.text.groundedText)
+        scrubOptional(&record.text.systemPrompt)
+        scrubOptional(&record.text.polishedOutput)
+        scrubOptional(&record.text.committedText)
+        record.text.userPrompts = record.text.userPrompts.map { redacting($0, count: &count) }
+
+        if var screen = record.screen {
+            scrubOptional(&screen.sanitizedText)
+            record.screen = screen
+        }
+
+        // Every string a source carries, not just the obviously bulky ones. A
+        // proposal's `term` comes out of the harvest and its `heard` spans come
+        // out of the transcript, so a token the collector walked into — or one
+        // the user read aloud — reaches disk through an entry just as easily as
+        // through the harvest itself.
+        func scrubEntries(_ entries: inout [DogfoodCaptureRecord.Source.Entry]) {
+            for index in entries.indices {
+                entries[index].term = redacting(entries[index].term, count: &count)
+                entries[index].heard = entries[index].heard.map {
+                    redacting($0, count: &count)
+                }
+            }
+        }
+
+        for index in record.sources.indices {
+            record.sources[index].harvest = record.sources[index].harvest.map {
+                redacting($0, count: &count)
+            }
+            scrubOptional(&record.sources[index].renderedExcerpt)
+            scrubEntries(&record.sources[index].entries)
+            scrubEntries(&record.sources[index].phoneticEntries)
+            scrubEntries(&record.sources[index].verificationEntries)
+        }
+
+        return count
+    }
+
+    /// Replaces every maximal base64url run of exactly `tokenLength`
+    /// characters. Runs of any other length are left alone: a token is fixed
+    /// width, and matching "long base64-ish thing" would shred hashes and blobs
+    /// the review needs to read.
+    static func redacting(_ text: String, count: inout Int) -> String {
+        guard text.count >= tokenLength else { return text }
+
+        var output = ""
+        output.reserveCapacity(text.count)
+        var run = ""
+
+        func flush() {
+            if run.count == tokenLength {
+                output += ClaudeRemoteTokenRedaction.placeholder
+                count += 1
+            } else {
+                output += run
+            }
+            run.removeAll(keepingCapacity: true)
+        }
+
+        for character in text {
+            if isBase64URL(character) {
+                run.append(character)
+            } else {
+                flush()
+                output.append(character)
+            }
+        }
+        flush()
+        return output
+    }
+
+    private static func isBase64URL(_ character: Character) -> Bool {
+        character.isLetter && character.isASCII
+            || character.isNumber && character.isASCII
+            || character == "-"
+            || character == "_"
+    }
+}
+
+#endif

--- a/Sources/localvoxtral/SettingsStore.swift
+++ b/Sources/localvoxtral/SettingsStore.swift
@@ -285,6 +285,12 @@ final class SettingsStore {
         /// Note the `debug.` prefix (not `settings.`): this is not a
         /// user-facing preference and must never surface in the settings UI.
         static let debugLogRealtimeDeltas = "debug.log_realtime_deltas"
+        #if LOCALVOXTRAL_DOGFOOD
+        /// The runtime half of the dogfooding gate. `debug.` prefixed like the
+        /// flag above: it exists only in an instrumented build and is not a
+        /// product preference.
+        static let dogfoodCaptureEnabled = "debug.dogfood_capture_enabled"
+        #endif
         static let modifierOnlyHotKeyEnabled = "settings.modifier_only_hotkey_enabled"
         static let modifierOnlyHotKeyModifier = "settings.modifier_only_hotkey_modifier"
         static let modifierOnlyHoldDelay = "settings.modifier_only_hold_delay"
@@ -601,6 +607,28 @@ final class SettingsStore {
         didSet { defaults.set(debugLogRealtimeDeltas, forKey: Keys.debugLogRealtimeDeltas) }
     }
 
+    #if LOCALVOXTRAL_DOGFOOD
+    /// Arms the dogfooding context capture. Default false, and it exists at all
+    /// only in a build compiled with `LOCALVOXTRAL_DOGFOOD` (see `Package.swift`
+    /// for why that gate is a compile flag rather than this toggle alone).
+    ///
+    /// While armed, every polished dictation writes a record containing the raw
+    /// transcript, the harvested context, the rendered prompts, and the model's
+    /// reply to `~/Library/Application Support/localvoxtral/dogfood`. That is
+    /// content the shipped app deliberately never writes anywhere, which is why
+    /// arming it is a deliberate act rather than a side effect of running an
+    /// instrumented build.
+    ///
+    /// No UI yet — like `debugLogRealtimeDeltas`, and toggled the same way:
+    ///   `defaults write com.localvoxtral.app debug.dogfood_capture_enabled -bool true`
+    /// A Settings row and a status-item indicator belong with the flag-this-
+    /// dictation affordance; until they exist, an armed build is only
+    /// discoverable from this default and the capture directory.
+    var dogfoodCaptureEnabled: Bool {
+        didSet { defaults.set(dogfoodCaptureEnabled, forKey: Keys.dogfoodCaptureEnabled) }
+    }
+    #endif
+
     var modifierOnlyHotKeyEnabled: Bool {
         didSet { defaults.set(modifierOnlyHotKeyEnabled, forKey: Keys.modifierOnlyHotKeyEnabled) }
     }
@@ -826,6 +854,10 @@ final class SettingsStore {
             defaults: defaults, key: Keys.polishContextTrustedEndpointEnabled, fallback: false)
         debugLogRealtimeDeltas = Self.loadBool(
             defaults: defaults, key: Keys.debugLogRealtimeDeltas, fallback: false)
+        #if LOCALVOXTRAL_DOGFOOD
+        dogfoodCaptureEnabled = Self.loadBool(
+            defaults: defaults, key: Keys.dogfoodCaptureEnabled, fallback: false)
+        #endif
         modifierOnlyHotKeyEnabled = Self.loadBool(
             defaults: defaults, key: Keys.modifierOnlyHotKeyEnabled, fallback: false)
         if let storedModifier = defaults.string(forKey: Keys.modifierOnlyHotKeyModifier),

--- a/Tests/localvoxtralTests/DogfoodCaptureStoreTests.swift
+++ b/Tests/localvoxtralTests/DogfoodCaptureStoreTests.swift
@@ -1,0 +1,381 @@
+#if LOCALVOXTRAL_DOGFOOD
+
+import Foundation
+import Synchronization
+import XCTest
+@testable import localvoxtral
+
+/// In-memory disk for the capture store, mirroring `MemoryStoreIO` in the
+/// registry tests: the retention rules and the naming contract are the parts
+/// worth asserting, and neither needs a real directory. The hardened write path
+/// itself is `ClaudeRemoteHostFileStoreIO`'s, already covered by its own tests.
+private final class MemoryCaptureIO: ClaudeRemoteHostStoreIO, DogfoodCaptureDirectoryIO {
+    private let files = Mutex<[String: Data]>([:])
+
+    // ClaudeRemoteHostStoreIO
+    func read(from url: URL) throws -> Data? {
+        files.withLock { $0[url.path] }
+    }
+
+    func write(_ data: Data, to url: URL) throws {
+        files.withLock { $0[url.path] = data }
+    }
+
+    // DogfoodCaptureDirectoryIO
+    func contents(of url: URL) throws -> [String]? {
+        let prefix = url.path.hasSuffix("/") ? url.path : url.path + "/"
+        return files.withLock { store in
+            store.keys
+                .filter { $0.hasPrefix(prefix) }
+                .map { String($0.dropFirst(prefix.count)) }
+        }
+    }
+
+    func remove(at url: URL) throws {
+        files.withLock { $0[url.path] = nil }
+    }
+
+    func seed(_ data: Data, at url: URL) {
+        files.withLock { $0[url.path] = data }
+    }
+
+    var fileNames: [String] {
+        files.withLock { Array($0.keys.map { URL(fileURLWithPath: $0).lastPathComponent }) }
+    }
+}
+
+private final class CaptureTestClock: Sendable {
+    private let value = Mutex(Date(timeIntervalSince1970: 1_800_000_000))
+
+    func now() -> Date { value.withLock { $0 } }
+    func advance(_ seconds: TimeInterval) { value.withLock { $0 = $0.addingTimeInterval(seconds) } }
+    func set(_ date: Date) { value.withLock { $0 = date } }
+}
+
+final class DogfoodCaptureStoreTests: XCTestCase {
+    private let directory = URL(fileURLWithPath: "/tmp/lvx-dogfood-test")
+    private var io: MemoryCaptureIO!
+    private let clock = CaptureTestClock()
+
+    override func setUp() {
+        super.setUp()
+        io = MemoryCaptureIO()
+        clock.set(Date(timeIntervalSince1970: 1_800_000_000))
+    }
+
+    private func makeStore(
+        retention: DogfoodCaptureStore.Retention = .default
+    ) -> DogfoodCaptureStore {
+        let clock = self.clock
+        return DogfoodCaptureStore(
+            directoryURL: directory,
+            io: io,
+            directoryIO: io,
+            retention: retention,
+            now: { clock.now() }
+        )
+    }
+
+    private func makeRecord(
+        id: String = UUID().uuidString,
+        capturedAt: Date? = nil,
+        rawTranscript: String = "run the tests",
+        screenText: String? = nil
+    ) -> DogfoodCaptureRecord {
+        DogfoodCaptureRecord(
+            id: id,
+            capturedAt: capturedAt ?? clock.now(),
+            session: .init(
+                targetBundleID: "com.mitchellh.ghostty",
+                targetKind: "terminal",
+                outputMode: "overlayBuffer",
+                promptProfile: "agent",
+                endpointClass: "loopback",
+                polishModel: "qwen35-4b"
+            ),
+            join: nil,
+            screen: screenText.map {
+                DogfoodCaptureRecord.Screen(
+                    route: "herdrPaneRead",
+                    decision: "render",
+                    cause: nil,
+                    sanitizedCharacterCount: $0.count,
+                    sanitizedText: $0
+                )
+            },
+            allocation: [],
+            sources: [],
+            text: .init(
+                rawTranscript: rawTranscript,
+                workingText: rawTranscript,
+                groundedText: rawTranscript,
+                systemPrompt: nil,
+                userPrompts: [],
+                polishedOutput: nil,
+                committedText: nil
+            ),
+            timings: .init()
+        )
+    }
+
+    // MARK: - Writing and round-tripping
+
+    func testWriteProducesAParseableNameAndRoundTripsTheRecord() throws {
+        let store = makeStore()
+        let record = makeRecord(rawTranscript: "check DictationViewModel plus Session")
+
+        let url = try store.write(record)
+
+        let parsed = try XCTUnwrap(DogfoodCaptureFileName.parse(url.lastPathComponent))
+        XCTAssertEqual(parsed.capturedAt.timeIntervalSince1970,
+                       record.capturedAt.timeIntervalSince1970,
+                       accuracy: 0.001)
+        XCTAssertFalse(parsed.flagged)
+
+        let data = try XCTUnwrap(io.read(from: url))
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        let decoded = try decoder.decode(DogfoodCaptureRecord.self, from: data)
+        XCTAssertEqual(decoded.text.rawTranscript, "check DictationViewModel plus Session")
+        XCTAssertEqual(decoded.schemaVersion, DogfoodCaptureRecord.currentSchemaVersion)
+    }
+
+    // MARK: - Retention
+
+    func testCountRetentionRemovesOldestUnflaggedRecordsFirst() throws {
+        let store = makeStore(
+            retention: .init(maximumUnflaggedRecords: 2, maximumUnflaggedAge: .greatestFiniteMagnitude)
+        )
+
+        let oldest = try store.write(makeRecord(id: "aaaaaaaa-oldest"))
+        clock.advance(60)
+        let middle = try store.write(makeRecord(id: "bbbbbbbb-middle"))
+        clock.advance(60)
+        let newest = try store.write(makeRecord(id: "cccccccc-newest"))
+
+        XCTAssertNil(try io.read(from: oldest), "oldest unflagged record should be pruned")
+        XCTAssertNotNil(try io.read(from: middle))
+        XCTAssertNotNil(try io.read(from: newest))
+    }
+
+    func testAgeRetentionRemovesRecordsPastTheWindow() throws {
+        let store = makeStore(
+            retention: .init(maximumUnflaggedRecords: .max, maximumUnflaggedAge: 3600)
+        )
+
+        let stale = try store.write(makeRecord(id: "aaaaaaaa-stale"))
+        clock.advance(7200)
+        let fresh = try store.write(makeRecord(id: "bbbbbbbb-fresh"))
+
+        XCTAssertNil(try io.read(from: stale))
+        XCTAssertNotNil(try io.read(from: fresh))
+    }
+
+    /// The whole point of flagging: a flagged record is a corpus candidate, and
+    /// retention silently eating one would lose exactly the case the dogfooding
+    /// cycle exists to find.
+    func testFlaggedRecordsSurviveBothRetentionRules() throws {
+        let store = makeStore(
+            retention: .init(maximumUnflaggedRecords: 1, maximumUnflaggedAge: 3600)
+        )
+
+        try store.write(makeRecord(id: "aaaaaaaa-keepme"))
+        let flagged = try XCTUnwrap(try store.flagMostRecentRecord())
+
+        clock.advance(7200)
+        try store.write(makeRecord(id: "bbbbbbbb-newer"))
+        clock.advance(7200)
+        try store.write(makeRecord(id: "cccccccc-newest"))
+
+        XCTAssertNotNil(try io.read(from: flagged),
+                        "a flagged record must survive both the count and the age rule")
+    }
+
+    func testPruneIgnoresFilesItCannotParse() throws {
+        let store = makeStore(
+            retention: .init(maximumUnflaggedRecords: 0, maximumUnflaggedAge: 0)
+        )
+        let foreign = directory.appendingPathComponent("notes.txt", isDirectory: false)
+        try io.write(Data("owner's own file".utf8), to: foreign)
+
+        try store.write(makeRecord())
+        try store.prune()
+
+        XCTAssertNotNil(try io.read(from: foreign),
+                        "pruning must not delete files it did not write")
+    }
+
+    // MARK: - Flagging
+
+    func testFlaggingRenamesTheFileAndSetsTheFlagInsideIt() throws {
+        let store = makeStore()
+        let original = try store.write(makeRecord(id: "aaaaaaaa-flagme"))
+
+        let flagged = try XCTUnwrap(try store.flagMostRecentRecord())
+
+        XCTAssertNil(try io.read(from: original), "the unflagged file should be gone")
+        XCTAssertTrue(flagged.lastPathComponent.hasSuffix(DogfoodCaptureFileName.flaggedSuffix))
+
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        let decoded = try decoder.decode(
+            DogfoodCaptureRecord.self,
+            from: try XCTUnwrap(io.read(from: flagged))
+        )
+        XCTAssertTrue(decoded.flagged, "the record must report its own flagged state")
+    }
+
+    func testFlaggingTwiceIsANoOp() throws {
+        let store = makeStore()
+        try store.write(makeRecord(id: "aaaaaaaa-flagme"))
+
+        let first = try XCTUnwrap(try store.flagMostRecentRecord())
+        let second = try XCTUnwrap(try store.flagMostRecentRecord())
+
+        XCTAssertEqual(first, second)
+        XCTAssertEqual(io.fileNames.count, 1)
+    }
+
+    func testFlaggingWithNoRecordsReturnsNil() throws {
+        XCTAssertNil(try makeStore().flagMostRecentRecord())
+    }
+
+    /// Refusing beats renaming. A flagged NAME over unflagged CONTENT is a
+    /// contradiction that never resolves: the next `listRecords` believes the
+    /// name, so a second flag call no-ops, and retention's flagged exemption is
+    /// silently disarmed on a record the owner asked to keep.
+    func testFlaggingRefusesWhenTheRecordCannotBeDecoded() throws {
+        let store = makeStore()
+        let name = "dictation-20260724T191408.000Z-deadbeef.json"
+        let url = directory.appendingPathComponent(name, isDirectory: false)
+        io.seed(Data("{ not a record }".utf8), at: url)
+
+        XCTAssertThrowsError(try store.flagMostRecentRecord()) { error in
+            guard case DogfoodCaptureStore.StoreError.unreadableRecord = error else {
+                return XCTFail("expected unreadableRecord, got \(error)")
+            }
+        }
+        XCTAssertNotNil(try io.read(from: url), "the original must be left untouched")
+        XCTAssertEqual(io.fileNames, [name], "no flagged twin may be created")
+    }
+
+    // MARK: - Naming
+
+    func testFileNameParsingRejectsForeignNames() {
+        XCTAssertNil(DogfoodCaptureFileName.parse("notes.txt"))
+        XCTAssertNil(DogfoodCaptureFileName.parse("dictation-nonsense-abc.json"))
+        XCTAssertNil(DogfoodCaptureFileName.parse("dictation-20260724T191408.000Z-abc123.txt"))
+        XCTAssertNotNil(DogfoodCaptureFileName.parse("dictation-20260724T191408.000Z-abc123.json"))
+        XCTAssertEqual(
+            DogfoodCaptureFileName.parse(
+                "dictation-20260724T191408.000Z-abc123.flagged.json"
+            )?.flagged,
+            true
+        )
+    }
+
+    /// Two records in the same clock second must not collide: the write path
+    /// replaces by `rename(2)`, so a collision would silently keep only the
+    /// later one.
+    func testSameSecondRecordsGetDistinctNames() throws {
+        let store = makeStore()
+        let first = try store.write(makeRecord(id: "aaaaaaaa-first"))
+        clock.advance(0.010)
+        let second = try store.write(makeRecord(id: "bbbbbbbb-second"))
+
+        XCTAssertNotEqual(first, second)
+        XCTAssertNotNil(try io.read(from: first))
+        XCTAssertNotNil(try io.read(from: second))
+    }
+}
+
+/// Token-shaped redaction. Enrollment tokens are 43 base64url characters with no
+/// prefix and the registry keeps only hashes, so shape is the only thing
+/// redaction can match — and dogfooding the remote integration means the
+/// enrollment command is on the very screen this build captures.
+final class DogfoodCaptureRedactionTests: XCTestCase {
+    private func token(length: Int) -> String {
+        String(repeating: "a", count: length)
+    }
+
+    func testRedactsATokenLengthBase64URLRun() {
+        var count = 0
+        let secret = token(length: 43)
+        let result = DogfoodCaptureRedaction.redacting(
+            "export TOKEN=\(secret) && claude plugin install",
+            count: &count
+        )
+
+        XCTAssertEqual(count, 1)
+        XCTAssertFalse(result.contains(secret))
+        XCTAssertTrue(result.contains(ClaudeRemoteTokenRedaction.placeholder))
+        XCTAssertTrue(result.contains("claude plugin install"), "surrounding text is preserved")
+    }
+
+    /// A token is fixed width. Matching "long base64-ish thing" instead would
+    /// shred the hashes, identifiers, and blobs a review needs to read.
+    func testLeavesRunsOfOtherLengthsAlone() {
+        for length in [42, 44, 64] {
+            var count = 0
+            let text = "value=\(token(length: length))"
+            XCTAssertEqual(DogfoodCaptureRedaction.redacting(text, count: &count), text)
+            XCTAssertEqual(count, 0, "length \(length) must not be treated as a token")
+        }
+    }
+
+    func testRedactsAcrossEveryContentBearingFieldOfARecord() {
+        let secret = token(length: 43)
+        var record = DogfoodCaptureRecord(
+            id: "aaaaaaaa-0000",
+            capturedAt: Date(timeIntervalSince1970: 1_800_000_000),
+            session: .init(outputMode: "overlayBuffer"),
+            screen: .init(
+                decision: "render",
+                sanitizedCharacterCount: "token \(secret) on screen".count,
+                sanitizedText: "token \(secret) on screen"
+            ),
+            allocation: [],
+            sources: [
+                .init(
+                    source: "repository",
+                    harvest: ["\(secret)", "DictationViewModel.swift"],
+                    harvestCount: 2,
+                    // A proposal's term comes out of the harvest and its heard
+                    // spans out of the transcript, so both can carry a token
+                    // that the harvest itself already leaked into.
+                    entries: [.init(term: secret, heard: ["heard \(secret)"])],
+                    phoneticEntries: [
+                        .init(term: "PolishContextGrounding", heard: [secret])
+                    ],
+                    verificationEntries: [.init(term: secret, heard: ["spoken"])],
+                    isFallbackOnly: false,
+                    renderedExcerpt: "excerpt with \(secret)"
+                )
+            ],
+            text: .init(
+                rawTranscript: "raw \(secret)",
+                workingText: "working \(secret)",
+                groundedText: "grounded \(secret)",
+                systemPrompt: "system \(secret)",
+                userPrompts: ["prompt \(secret)"],
+                polishedOutput: "polished \(secret)",
+                committedText: "committed \(secret)"
+            ),
+            timings: .init()
+        )
+
+        let redactions = DogfoodCaptureRedaction.redact(&record)
+
+        // Seven text stages, the screen text, one harvest term, the rendered
+        // excerpt, and four across the three entry arrays (entry term + heard,
+        // phonetic heard, verification term).
+        XCTAssertEqual(redactions, 14)
+        let encoded = String(
+            data: try! JSONEncoder().encode(record),
+            encoding: .utf8
+        ) ?? ""
+        XCTAssertFalse(encoded.contains(secret), "no field may carry the token to disk")
+    }
+}
+
+#endif

--- a/scripts/package_app.sh
+++ b/scripts/package_app.sh
@@ -324,6 +324,20 @@ ${DOGFOOD_PLIST_ENTRY}
 </plist>
 PLIST
 
+# Verify the stamp in the artifact agrees with the predicate above — the loud
+# "Dogfood capture" line must describe the Info.plist that actually shipped,
+# not just the branch this script took.
+DOGFOOD_STAMP="$(/usr/libexec/PlistBuddy -c 'Print :LVXDogfoodCapture' "$APP_DIR/Contents/Info.plist" 2>/dev/null || echo absent)"
+if [[ -n "$DOGFOOD_PLIST_ENTRY" && "$DOGFOOD_STAMP" != "true" ]]; then
+  echo "Dogfood capture was enabled but LVXDogfoodCapture is not stamped in Info.plist (got: $DOGFOOD_STAMP)"
+  exit 1
+fi
+if [[ -z "$DOGFOOD_PLIST_ENTRY" && "$DOGFOOD_STAMP" != "absent" ]]; then
+  echo "Dogfood capture is disabled but Info.plist carries LVXDogfoodCapture=$DOGFOOD_STAMP"
+  exit 1
+fi
+echo "Info.plist LVXDogfoodCapture stamp: $DOGFOOD_STAMP"
+
 # --- Bundled polishing helper (localvoxtral-polishd, PolishHelper/) --------
 # MUST build with xcodebuild: SwiftPM CLI cannot compile mlx-swift's Metal
 # kernels (mlx-swift README), producing a binary that fails at runtime with

--- a/scripts/package_app.sh
+++ b/scripts/package_app.sh
@@ -119,6 +119,29 @@ patch_shortcutrecorder_bundle_lookup
 # regenerates DerivedSources every build) and shipped launch-broken artifacts
 # for days (#87). Never patch DerivedSources; only dependency checkouts (the
 # ShortcutRecorder patch above) persist across builds.
+# Dogfooding capture is a COMPILE gate (see Package.swift): the released
+# artifact must not contain the code that writes context to disk. `swift build`
+# inherits this environment, so exporting it here is all the threading needed —
+# but the artifact must also be identifiable at runtime, because "which binary
+# is the owner actually running" has already cost an hour of field debugging
+# once (AGENTS.md). The bundle identifier deliberately does NOT change: a
+# different one would be a different app to TCC and would throw away the
+# Accessibility grant this build exists to exercise.
+#
+# Enablement matches Package.swift exactly: the env var OR the gitignored
+# marker file (which is how it crosses the build gate — see remote-build.sh).
+# Recomputing the same predicate here is deliberate: the loud line and the
+# plist stamp must describe what was actually compiled, not what the caller
+# thought they asked for.
+DOGFOOD_PLIST_ENTRY=""
+if [[ "${LOCALVOXTRAL_DOGFOOD:-}" == "1" || -f "$ROOT_DIR/.dogfood-capture-enable" ]]; then
+  echo "Dogfood capture: ENABLED — this artifact can write context records to disk"
+  DOGFOOD_PLIST_ENTRY="  <key>LVXDogfoodCapture</key>
+  <true/>"
+else
+  echo "Dogfood capture: disabled (set LOCALVOXTRAL_DOGFOOD=1 to build an instrumented artifact)"
+fi
+
 swift build -c "$CONFIGURATION" --product localvoxtral -Xswiftc -g
 
 BINARY_PATH="$(find "$ROOT_DIR/.build" -type f -path "*/${CONFIGURATION}/localvoxtral" | head -n 1)"
@@ -296,6 +319,7 @@ cat > "$APP_DIR/Contents/Info.plist" <<PLIST
   <string>localvoxtral reads project files from Claude Code sessions when project context is enabled.</string>
   <key>NSRemovableVolumesUsageDescription</key>
   <string>localvoxtral reads project files from Claude Code sessions when project context is enabled.</string>
+${DOGFOOD_PLIST_ENTRY}
 </dict>
 </plist>
 PLIST

--- a/scripts/remote-build.sh
+++ b/scripts/remote-build.sh
@@ -6,7 +6,7 @@ set -euo pipefail
 # tree (no commit needed) and runs the toolchain remotely over SSH.
 #
 # Usage:
-#   ./scripts/remote-build.sh [build|test|integration|integration-polishd|integration-speechd|speechd-bench|eval-llm|eval-e2e|package|exec|diag|applog|voxlog|svc-status|disk|gc] [extra args...]
+#   ./scripts/remote-build.sh [build|test|integration|integration-polishd|integration-speechd|speechd-bench|eval-llm|eval-e2e|dogfood|dogfood-package|package|exec|diag|applog|voxlog|svc-status|disk|gc] [extra args...]
 #     build        swift build
 #     test         swift build + unit tests (default; skips live-backend suites)
 #     integration  realtime pipeline tests against the live speechd STT service
@@ -34,6 +34,13 @@ set -euo pipefail
 #                  path, scored against EvalCorpus/agent-dictation (run
 #                  `package` first; optional arg = a complete recording-set
 #                  directory made by scripts/record-agent-eval.sh)
+#     dogfood      build the instrumented (LOCALVOXTRAL_DOGFOOD) tree and run
+#                  the context-capture suite; the capture is a compile gate, so
+#                  no other lane ever builds it
+#     dogfood-package
+#                  package an instrumented .app for hand-dogfooding (same
+#                  bundle id, so the Accessibility grant survives; the artifact
+#                  is identifiable by LVXDogfoodCapture in its Info.plist)
 #     package      ./scripts/package_app.sh release
 #     exec         run the extra args verbatim in the remote work dir
 #     diag         build-host diagnostic summary (gate v2 required)
@@ -430,6 +437,28 @@ case "$CMD" in
     fi
     REMOTE_CMD=(swift test --filter LLMPolishPromptEvalTests)
     ;;
+  dogfood|dogfood-package)
+    # The dogfooding capture is a COMPILE gate (Package.swift), and the build
+    # gate allowlists exact payloads, so enablement travels as the same kind of
+    # gitignored marker the eval lanes use rather than an env prefix.
+    #
+    # `dogfood`         — build + run the capture suite in an instrumented tree.
+    # `dogfood-package` — package an instrumented .app for hand-dogfooding.
+    #                     The bundle identifier is unchanged (the TCC grant is
+    #                     part of what is being exercised); the artifact
+    #                     identifies itself through Info.plist's
+    #                     LVXDogfoodCapture, which Settings > About reports.
+    DOGFOOD_MARKER="$ROOT_DIR/.dogfood-capture-enable"
+    # Registered before the marker exists, so no kill window can leave an
+    # instrumented tree behind — locally or in the remote work dir.
+    trap 'cleanup_transient_marker "$DOGFOOD_MARKER"' EXIT
+    printf 'dogfood capture build marker; removed automatically\n' >"$DOGFOOD_MARKER"
+    if [[ "$CMD" == "dogfood-package" ]]; then
+      REMOTE_CMD=(./scripts/package_app.sh release "$@")
+    else
+      REMOTE_CMD=(swift test --filter Dogfood "$@")
+    fi
+    ;;
   package) REMOTE_CMD=(./scripts/package_app.sh release "$@") ;;
   exec)
     if [[ $# -eq 0 ]]; then
@@ -439,7 +468,7 @@ case "$CMD" in
     REMOTE_CMD=("$@")
     ;;
   *)
-    echo "Usage: $0 [build|test|integration|integration-polishd|integration-speechd|speechd-bench|eval-llm|eval-e2e|package|exec|diag|applog|voxlog|svc-status] [extra args...]" >&2
+    echo "Usage: $0 [build|test|integration|integration-polishd|integration-speechd|speechd-bench|eval-llm|eval-e2e|dogfood|dogfood-package|package|exec|diag|applog|voxlog|svc-status] [extra args...]" >&2
     exit 1
     ;;
 esac


### PR DESCRIPTION
## What

First step of the dogfooding instrumentation: a record of the whole polish
context pipeline for one dictation, and the store that writes it. **Nothing
calls it yet** — wiring the commit path is the next PR.

The app logs context COUNTS only, on purpose. That policy is what makes the
privacy claims true, and it is also why a technical term that came out wrong is
unattributable after the fact: by commit time every intermediate the answer
depends on has been reduced to an integer.

A miss is lost by exactly one of four stages, and the fix differs completely
between them:

1. **retrieval** — the term never entered the harvest (collector, screen read,
   or `pane.read` never surfaced it)
2. **matcher** — in the harvest, but no tier matched the heard span
3. **conflict** — a tier matched, but the cross-source merge abstained/demoted
4. **budget** — survived the merge, but the render allocation cut the excerpt
   carrying its evidence

Every field in `DogfoodCaptureRecord` exists to make that four-way question
answerable from the record alone, without re-running the dictation. This is the
measurement layer for the retrieval work the 2026-07-21 ablation pointed at
(4B + exact-evidence oracle: +37 cases; 27B over that: +1).

### Gating — two locks, and the outer one is not a checkbox

- **Compile flag** `LOCALVOXTRAL_DOGFOOD` (`Package.swift`), so a shipped
  release does not contain the capture code at all rather than containing it
  behind a default. Enablement also travels as a gitignored
  `.dogfood-capture-enable` marker, because the Mac build gate allowlists exact
  `swift test …` payloads and cannot pass env vars — the same pattern
  `eval-llm` and `integration-polishd` already use. `package_app.sh` recomputes
  the same predicate independently so the loud build line and the
  `LVXDogfoodCapture` Info.plist stamp describe what was actually compiled.
- **Runtime opt-in**, default off, no UI yet (matching the existing `debug.`
  flag convention):
  `defaults write com.localvoxtral.app debug.dogfood_capture_enabled -bool true`

Records are local files under Application Support. **There is no uploader and
must never be one** — the compile gate is what makes "this build cannot
exfiltrate your context" a property of the artifact instead of a promise about
a setting.

### Notes on the implementation

- The hardened write is `ClaudeRemoteHostFileStoreIO`'s, **reused rather than
  reimplemented**: 0700 directory validation, `O_CREAT|O_EXCL|O_NOFOLLOW` at
  0600, fsync, `rename(2)`. These records hold repo contents and screen text
  and deserve the token store's handling.
- **The flag lives in the file name**, not the JSON, so retention is a
  directory listing rather than reading every captured prompt back off disk.
  Flagged records are exempt from both retention rules.
- Redaction matches the enrollment token by **shape** (43 base64url chars),
  since the registry keeps only hashes and there is no plaintext to match — and
  dogfooding the remote integration puts the enrollment command on the very
  screen this build captures. It errs both ways (over-matches isolated
  non-token runs, under-matches a token glued to other base64url characters);
  the doc comment states which, and the count is logged rather than silent.
- The bundle identifier is unchanged for `dogfood-package`: a different one
  would be a different app to TCC and would throw away the Accessibility grant
  this build exists to exercise.

`./scripts/remote-build.sh dogfood` builds the instrumented tree and runs the
suite; `dogfood-package` produces a hand-testable instrumented `.app`.

## Proof

All run 2026-07-25 against the Mac build host (previously unreachable — this PR
opened as a draft with no proof; see history).

- [x] **Capture suite green** — `./scripts/remote-build.sh dogfood`:

  ```
  Test Suite 'DogfoodCaptureStoreTests' passed at 2026-07-25 17:50:58.961.
       Executed 11 tests, with 0 failures (0 unexpected) in 0.009 (0.009) seconds
  Test Suite 'localvoxtralPackageTests.xctest' passed at 2026-07-25 17:50:58.961.
       Executed 14 tests, with 0 failures (0 unexpected) in 0.010 (0.011) seconds
  ```

- [x] **Unit suite green in the SHIPPING configuration** —
  `./scripts/remote-build.sh test` (flag off; proves the `#if` leaves a
  compiling shape):

  ```
  Test Suite 'localvoxtralPackageTests.xctest' passed at 2026-07-25 17:50:38.214.
       Executed 1995 tests, with 2 tests skipped and 0 failures (0 unexpected) in 68.884 (68.973) seconds
  ```

- [x] **Instrumented package builds and stamps** —
  `./scripts/remote-build.sh dogfood-package`:

  ```
  Dogfood capture: ENABLED — this artifact can write context records to disk
  Info.plist LVXDogfoodCapture stamp: true
  ```

  and a plain `./scripts/remote-build.sh package` immediately after does NOT
  stamp:

  ```
  Dogfood capture: disabled (set LOCALVOXTRAL_DOGFOOD=1 to build an instrumented artifact)
  Info.plist LVXDogfoodCapture stamp: absent
  ```

  The stamp lines are new in this PR: `package_app.sh` now reads
  `LVXDogfoodCapture` back out of the written Info.plist with PlistBuddy and
  fails the package if it disagrees with the predicate in either direction, so
  the build log proves the artifact rather than the script branch. Launching
  the instrumented app by hand (dictate → confirm a record lands under
  Application Support) is the owner's dogfooding step and stays open — nothing
  in this PR calls the capture yet, so there is no record to observe until the
  wiring PR.

- [x] **CI's self-hosted `Dogfood capture suite` step green** — [run
  30164792836](https://github.com/T0mSIlver/localvoxtral/actions/runs/30164792836/job/89695851283)
  passed in 5m1s with `Dogfood capture suite (instrumented build)`, `Package
  app bundle` (which now asserts the stamp is ABSENT in the shipping bundle),
  and the launch smoke all green. The one prior CI run failed only on
  `BackendProcessSupervisorTests.testCrashRestartsWithBackoffThenRunsWhenReady`
  (`WaitTimeout`, the known supervisor timing flake under host load — not a
  dogfood path; it passed in this run and in the local `test` run above).

No behavior change ships to users in this PR: with the flag off (every existing
lane, every release artifact) none of this code exists.

### Review

Reviewed by opencode (GLM-5.2, read-only) before opening. It found two blockers,
both fixed here with tests:

- **Redaction skipped each source's `entries` / `phoneticEntries` /
  `verificationEntries`.** A proposal's `term` comes out of the harvest and its
  `heard` spans out of the transcript, so a token the collector walked into (a
  committed `.env`) or that ASR picked up because someone read it aloud reached
  disk verbatim. The test was complicit — named "every content-bearing field"
  while populating 10 of them; it now covers the entry arrays and expects 14.
- **The flagging fallback produced a file whose name disagreed with its
  contents.** On a decode failure it fell through to a plain rename, so the name
  said flagged and the JSON said `flagged: false`. That never resolves: the next
  `listRecords` believes the name, a second flag call no-ops, and retention's
  flagged exemption is silently disarmed on exactly the record you asked to
  keep. It now refuses with `unreadableRecord` and leaves the original
  untouched, which removed `move` from the directory protocol entirely.

Also applied from that review: suffix-anchored flag rename, millisecond
timestamps so two same-second records cannot silently overwrite each other
through `rename(2)`, loud logging on prune failures, and a corrected redaction
comment.

That review was read-only against the working tree, so its compile-correctness
verdicts are careful reading, **not a build**.


