### PR TITLE
Dogfood capture: wire the polish commit path to write records

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,4 @@ DerivedData/
 # Compile gate for the dogfooding context capture (Package.swift reads it).
 # Never commit: its presence changes what the app is compiled to do.
 /.dogfood-capture-enable
+.fastcontext/

--- a/Sources/localvoxtral/ClaudeContext/TerminalScreenClaudeJoin.swift
+++ b/Sources/localvoxtral/ClaudeContext/TerminalScreenClaudeJoin.swift
@@ -233,6 +233,9 @@ struct ClaudeSessionJoinResolver {
         Log.claudeContext.info(
             "Focused-pane tty matched no session (\(outcome, privacy: .public)); trying title marker"
         )
+        #if LOCALVOXTRAL_DOGFOOD
+        DogfoodCaptureTap.shared.noteJoinAbstention("tty: \(outcome)")
+        #endif
     }
 
     private func resolveViaHerdr(target: TerminalScreenTarget) async -> ClaudeSessionJoin? {
@@ -342,6 +345,9 @@ struct ClaudeSessionJoinResolver {
         Log.claudeContext.info(
             "Herdr pane matched no session (\(outcome, privacy: .public)); Claude context withheld"
         )
+        #if LOCALVOXTRAL_DOGFOOD
+        DogfoodCaptureTap.shared.noteJoinAbstention("herdr: \(outcome)")
+        #endif
     }
 
     private func resolveViaMarker(target: TerminalScreenTarget) -> ClaudeSessionJoin? {
@@ -349,6 +355,9 @@ struct ClaudeSessionJoinResolver {
             // No marker on screen: this pane is not a joined Claude session, or
             // we cannot tell. Either way there is nothing to resolve.
             Log.claudeContext.info("Terminal pane carries no Claude session marker")
+            #if LOCALVOXTRAL_DOGFOOD
+            DogfoodCaptureTap.shared.noteJoinAbstention("marker: no marker in title")
+            #endif
             return nil
         }
 
@@ -368,6 +377,9 @@ struct ClaudeSessionJoinResolver {
             Log.claudeContext.info(
                 "Terminal pane not joined to a live Claude session; Claude context withheld"
             )
+            #if LOCALVOXTRAL_DOGFOOD
+            DogfoodCaptureTap.shared.noteJoinAbstention("marker: unknown/stale/ambiguous")
+            #endif
             return nil
         }
     }

--- a/Sources/localvoxtral/DictationViewModel+Session.swift
+++ b/Sources/localvoxtral/DictationViewModel+Session.swift
@@ -1870,7 +1870,7 @@ extension DictationViewModel {
     ) -> Task<RepoVocabularyMatcher.GroundingOutcome?, Never>? {
         #if DEBUG
         if let override = debugRepoVocabularyPipelineOverride {
-            return Task.detached(priority: .utility) { await override(transcript) }
+            return Self.detachedRepoVocabularyPipeline { await override(transcript) }
         }
         #endif
         guard let terminalApplicationPID = overlayBufferCoordinator.commitTargetAppPID else {
@@ -1894,24 +1894,7 @@ extension DictationViewModel {
             processFallbackPID = nil
         }
         let cache = repoVocabularyCache
-        #if LOCALVOXTRAL_DOGFOOD
-        // Read on the main actor, at task creation: the generation this
-        // pipeline works FOR. Task-locals do not cross `Task.detached`, so the
-        // binding happens inside the closure — see `DogfoodCaptureTap.noteGeneration`
-        // for why an abandoned pipeline's late note must be rejectable.
-        let dogfoodGeneration = DogfoodCaptureTap.shared.currentGeneration
-        return Task.detached(priority: .utility) {
-            await DogfoodCaptureTap.$noteGeneration.withValue(dogfoodGeneration) {
-                await RepoVocabularyService.entries(
-                    forWindowTitle: title,
-                    terminalApplicationPID: processFallbackPID,
-                    transcript: transcript,
-                    cache: cache
-                )
-            }
-        }
-        #else
-        return Task.detached(priority: .utility) {
+        return Self.detachedRepoVocabularyPipeline {
             await RepoVocabularyService.entries(
                 forWindowTitle: title,
                 terminalApplicationPID: processFallbackPID,
@@ -1919,6 +1902,29 @@ extension DictationViewModel {
                 cache: cache
             )
         }
+    }
+
+    /// The detached pipeline task, with the ONE dogfood obligation both the
+    /// live pipeline and the DEBUG override seam must share: in a dogfood
+    /// build, the body runs under the tap generation read at creation time
+    /// (synchronously, in the caller's main-actor context — ordered against
+    /// `beginSession`). Task-locals do not cross `Task.detached`, so the
+    /// binding happens inside the closure; see `DogfoodCaptureTap.noteGeneration`
+    /// for why an abandoned pipeline's late harvest note must be rejectable.
+    /// Routing the seam through here too is what makes the binding testable —
+    /// a pipeline path that skipped it would accept stale notes unchecked.
+    private static func detachedRepoVocabularyPipeline(
+        _ body: @escaping @Sendable () async -> RepoVocabularyMatcher.GroundingOutcome?
+    ) -> Task<RepoVocabularyMatcher.GroundingOutcome?, Never> {
+        #if LOCALVOXTRAL_DOGFOOD
+        let dogfoodGeneration = DogfoodCaptureTap.shared.currentGeneration
+        return Task.detached(priority: .utility) {
+            await DogfoodCaptureTap.$noteGeneration.withValue(dogfoodGeneration) {
+                await body()
+            }
+        }
+        #else
+        return Task.detached(priority: .utility) { await body() }
         #endif
     }
 

--- a/Sources/localvoxtral/DictationViewModel+Session.swift
+++ b/Sources/localvoxtral/DictationViewModel+Session.swift
@@ -1410,6 +1410,12 @@ extension DictationViewModel {
                         // Filled from the tap inside writeDogfoodCaptureIfArmed.
                         joinAbstentions: [],
                         screenDecision: screenDecision,
+                        // Value inequality is the swap signal: only the herdr
+                        // reconcile above ever reassigns `screenDecision`, and
+                        // a failed pane.read returns the fallback (equal). A
+                        // successful pane.read that happens to EQUAL the
+                        // fallback mislabels only the route — the decision and
+                        // cause still tell the true story. Intentional.
                         herdrSwapApplied: capturedHerdrPaneStart != nil
                             && screenDecision != capturedScreenDecision,
                         targetBundleID: capturedTargetBundleID,
@@ -1888,6 +1894,23 @@ extension DictationViewModel {
             processFallbackPID = nil
         }
         let cache = repoVocabularyCache
+        #if LOCALVOXTRAL_DOGFOOD
+        // Read on the main actor, at task creation: the generation this
+        // pipeline works FOR. Task-locals do not cross `Task.detached`, so the
+        // binding happens inside the closure — see `DogfoodCaptureTap.noteGeneration`
+        // for why an abandoned pipeline's late note must be rejectable.
+        let dogfoodGeneration = DogfoodCaptureTap.shared.currentGeneration
+        return Task.detached(priority: .utility) {
+            await DogfoodCaptureTap.$noteGeneration.withValue(dogfoodGeneration) {
+                await RepoVocabularyService.entries(
+                    forWindowTitle: title,
+                    terminalApplicationPID: processFallbackPID,
+                    transcript: transcript,
+                    cache: cache
+                )
+            }
+        }
+        #else
         return Task.detached(priority: .utility) {
             await RepoVocabularyService.entries(
                 forWindowTitle: title,
@@ -1896,6 +1919,7 @@ extension DictationViewModel {
                 cache: cache
             )
         }
+        #endif
     }
 
     private func resolveRepoVocabularyDeadlineSleep() -> @Sendable () async -> Void {

--- a/Sources/localvoxtral/DictationViewModel+Session.swift
+++ b/Sources/localvoxtral/DictationViewModel+Session.swift
@@ -1232,6 +1232,15 @@ extension DictationViewModel {
                     var polishingDuration: Double? = nil
                     var sessionStatus: DictationSessionStatus = .completed
                     var llmConnectionFailure: (message: String, technicalDetails: String?)?
+                    #if LOCALVOXTRAL_DOGFOOD
+                    // The model's raw reply and the (placeholder-bearing)
+                    // committed text, hoisted out of the do-block for the
+                    // capture record below. Placeholder-bearing on purpose: the
+                    // clipboard PAYLOAD follows the session-record rule and
+                    // never enters a persisted record.
+                    var dogfoodPolishedOutput: String?
+                    var dogfoodCommittedText: String?
+                    #endif
 
                     if let config = polishingConfig, !workingText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
                         do {
@@ -1278,6 +1287,10 @@ extension DictationViewModel {
                             // commit copy below.
                             processedTextForPersistence =
                                 committedText != originalText ? committedText : nil
+                            #if LOCALVOXTRAL_DOGFOOD
+                            dogfoodPolishedOutput = result.polishedText
+                            dogfoodCommittedText = committedText
+                            #endif
 
                             guard !Task.isCancelled else { return }
 
@@ -1375,6 +1388,77 @@ extension DictationViewModel {
                             }()
                         )
                     )
+
+                    #if LOCALVOXTRAL_DOGFOOD
+                    // AFTER the commit and the session record: capture latency
+                    // can only ever land on the tail of this task, never on the
+                    // user's paste. `writeDogfoodCaptureIfArmed` checks the
+                    // runtime opt-in before doing any work.
+                    await self.writeDogfoodCaptureIfArmed(DogfoodCaptureInputs(
+                        session: DogfoodCaptureRecord.Session(
+                            targetBundleID: capturedTargetBundleID,
+                            targetKind: self.sessionTargetIsTerminalLike
+                                ? "terminal-like" : "other",
+                            outputMode: capturedOutputMode,
+                            promptProfile: capturedPolishProfile,
+                            endpointClass: polishingConfig.map {
+                                DogfoodCaptureBuilder.endpointClass(of: $0.endpointURL)
+                            },
+                            polishModel: polishingConfig?.model
+                        ),
+                        join: capturedClaudeJoin,
+                        // Filled from the tap inside writeDogfoodCaptureIfArmed.
+                        joinAbstentions: [],
+                        screenDecision: screenDecision,
+                        herdrSwapApplied: capturedHerdrPaneStart != nil
+                            && screenDecision != capturedScreenDecision,
+                        targetBundleID: capturedTargetBundleID,
+                        demands: [
+                            .repository: repoRenderDemand,
+                            .terminal: screenRenderDemand,
+                            .claude: claudeSessionText.count,
+                            .clipboard: capturedClipboardContext?.retainedCharacterCount ?? 0,
+                        ],
+                        grants: allocation,
+                        rendered: [
+                            .repository: repoBlock != nil
+                                ? claudeRepoPreparation.excerpt.count : 0,
+                            .terminal: screenBlock != nil
+                                ? screenPreparation.excerpt.count : 0,
+                            .claude: claudeBlock != nil
+                                ? claudeSessionPreparation.excerpt.count : 0,
+                            .clipboard: clipboardBlock != nil
+                                ? clipboardPreparation.excerpt.count : 0,
+                        ],
+                        repoVocabularyHarvest: nil,
+                        repoVocabularyOutcome: repoVocabularyOutcome,
+                        claudeRepoSnapshot: claudeRepoSnapshot,
+                        claudeRepoOutcome: claudeRepoOutcome,
+                        claudeRepoRenderedExcerpt: repoBlock != nil
+                            ? claudeRepoPreparation.excerpt : nil,
+                        claudeSessionText: claudeSessionText.isEmpty ? nil : claudeSessionText,
+                        claudeSessionOutcome: claudeSessionOutcome,
+                        claudeSessionRenderedExcerpt: claudeBlock != nil
+                            ? claudeSessionPreparation.excerpt : nil,
+                        clipboardRetainedText: capturedClipboardContext?.retainedText,
+                        clipboardOutcome: clipboardVocabularyOutcome,
+                        clipboardRenderedExcerpt: clipboardBlock != nil
+                            ? clipboardPreparation.excerpt : nil,
+                        screenOutcome: screenVocabularyOutcome,
+                        screenRenderedExcerpt: screenBlock != nil
+                            ? screenPreparation.excerpt : nil,
+                        text: DogfoodCaptureRecord.Text(
+                            rawTranscript: originalText,
+                            workingText: workingText,
+                            groundedText: groundedWorkingText,
+                            systemPrompt: polishingRequest.systemPrompt,
+                            userPrompts: polishingRequest.userPrompts,
+                            polishedOutput: dogfoodPolishedOutput,
+                            committedText: dogfoodCommittedText
+                        ),
+                        polishSeconds: polishingDuration
+                    ))
+                    #endif
 
                     if let llmConnectionFailure {
                         self.handleLLMPolishingConnectionFailure(

--- a/Sources/localvoxtral/DictationViewModel.swift
+++ b/Sources/localvoxtral/DictationViewModel.swift
@@ -312,6 +312,12 @@ final class DictationViewModel {
     var llmPolishingService: any LLMPolishingServicing = LLMPolishingService()
     @ObservationIgnored
     var appConfigStore: any AppConfigServing = AppConfigStore()
+    #if LOCALVOXTRAL_DOGFOOD
+    /// `var` for the same reason `llmPolishingService` is: tests point it at a
+    /// temp directory. Production uses the Application Support default.
+    @ObservationIgnored
+    var dogfoodCaptureStore = DogfoodCaptureStore()
+    #endif
     /// Warms the managed polishing helper's prompt-prefix cache on every
     /// helper launch (see `PolishPromptWarmupCoordinator`). Created only when
     /// runtime services run — trigger logic is unit-tested on the coordinator
@@ -1869,6 +1875,11 @@ final class DictationViewModel {
     /// means the screen is never read. A nil polishing configuration also means
     /// no read: with no endpoint there is nothing to ground for.
     func captureTerminalScreenContextForSession() async {
+        #if LOCALVOXTRAL_DOGFOOD
+        // A fresh dictation gets fresh tap slots: an abandoned pipeline's late
+        // note from the PREVIOUS session must not describe this one.
+        DogfoodCaptureTap.shared.beginSession()
+        #endif
         guard let endpointURL = settings.llmPolishingConfiguration?.endpointURL else {
             terminalScreenStartCapture = nil
             claudeSessionJoin = nil
@@ -1910,12 +1921,14 @@ final class DictationViewModel {
     /// passive — it makes a live AX round trip for the window title. An opted-out
     /// user, a remote endpoint, or a revoked Accessibility grant means no read.
     private func resolveClaudeSessionJoin(endpointURL: URL) async -> ClaudeSessionJoin? {
-        guard let resolver = claudeSessionJoinResolver else { return nil }
+        guard let resolver = claudeSessionJoinResolver else {
+            return dogfoodUnresolvedJoin(cause: "gate: no resolver installed")
+        }
         // Either context feature can want a join: the screen needs it to
         // authorize a raw excerpt, the repo/session blocks ARE the join's
         // content. Neither being enabled means there is nothing to resolve for.
         guard settings.terminalScreenContextEnabled || settings.claudeRepoContextEnabled else {
-            return nil
+            return dogfoodUnresolvedJoin(cause: "gate: both context settings off")
         }
         // Permitted endpoints only (loopback, or any endpoint under the
         // explicit trusted-endpoint opt-in). Repository contents and a prior
@@ -1926,10 +1939,27 @@ final class DictationViewModel {
         guard PolishContextClipboardReader.isPermittedContextEndpoint(
             endpointURL,
             trustedEndpointEnabled: settings.polishContextTrustedEndpointEnabled
-        ) else { return nil }
-        guard textInsertion.isAccessibilityTrusted else { return nil }
-        guard let target = TerminalScreenContextSource.frontmostTarget() else { return nil }
+        ) else {
+            return dogfoodUnresolvedJoin(cause: "gate: endpoint not permitted")
+        }
+        guard textInsertion.isAccessibilityTrusted else {
+            return dogfoodUnresolvedJoin(cause: "gate: accessibility not trusted")
+        }
+        guard let target = TerminalScreenContextSource.frontmostTarget() else {
+            return dogfoodUnresolvedJoin(cause: "gate: no frontmost supported terminal")
+        }
         return await resolver.resolve(target: target)
+    }
+
+    /// Notes WHY the join never reached the resolver, so a dogfood record can
+    /// distinguish "gate refused" from "resolver abstained" — and always
+    /// returns nil, keeping the guard sites one-liners. Compiled to a bare nil
+    /// in a shipping build.
+    private func dogfoodUnresolvedJoin(cause: String) -> ClaudeSessionJoin? {
+        #if LOCALVOXTRAL_DOGFOOD
+        DogfoodCaptureTap.shared.noteJoinAbstention(cause)
+        #endif
+        return nil
     }
 
     /// Drops any retained screen capture. Idempotent, and safe to call on a

--- a/Sources/localvoxtral/Dogfood/DictationViewModel+DogfoodCapture.swift
+++ b/Sources/localvoxtral/Dogfood/DictationViewModel+DogfoodCapture.swift
@@ -17,6 +17,11 @@ extension DictationViewModel {
         let abstentions = DogfoodCaptureTap.shared.consumeJoinAbstentions()
         let repoVocabularyHarvest = DogfoodCaptureTap.shared.consumeRepoVocabularyHarvest()
         guard settings.dogfoodCaptureEnabled else { return }
+        // A stopped-with-no-speech session skipped the polish call and has
+        // nothing to attribute; a record of empty stages is retention noise.
+        guard !inputs.text.workingText
+            .trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        else { return }
 
         var inputs = inputs
         inputs.joinAbstentions = abstentions

--- a/Sources/localvoxtral/Dogfood/DictationViewModel+DogfoodCapture.swift
+++ b/Sources/localvoxtral/Dogfood/DictationViewModel+DogfoodCapture.swift
@@ -1,0 +1,48 @@
+#if LOCALVOXTRAL_DOGFOOD
+
+import Foundation
+
+extension DictationViewModel {
+    /// Writes this dictation's capture record, or does nothing at all.
+    ///
+    /// Called from the polish commit path AFTER the text was committed and the
+    /// session record saved — the capture can add latency only to the tail of
+    /// the task, never to the user's paste. The runtime opt-in is checked
+    /// first, before any harvest re-derivation, so an instrumented build that
+    /// is not armed does no extra work beyond this one Bool read.
+    ///
+    /// The tap is consumed EVEN when disarmed — its slots must not carry one
+    /// session's facts into a later, armed session's record.
+    func writeDogfoodCaptureIfArmed(_ inputs: DogfoodCaptureInputs) async {
+        let abstentions = DogfoodCaptureTap.shared.consumeJoinAbstentions()
+        let repoVocabularyHarvest = DogfoodCaptureTap.shared.consumeRepoVocabularyHarvest()
+        guard settings.dogfoodCaptureEnabled else { return }
+
+        var inputs = inputs
+        inputs.joinAbstentions = abstentions
+        inputs.repoVocabularyHarvest = repoVocabularyHarvest
+        let store = dogfoodCaptureStore
+        let started = ContinuousClock.now
+
+        // Assembly walks complete retained buffers (harvest re-derivation);
+        // `build` is nonisolated, so this await hops off the main actor the
+        // same way the preparations it mirrors do.
+        var record = await Self.assembleDogfoodRecord(inputs: inputs)
+        let elapsed = (ContinuousClock.now - started).components
+        record.timings.captureMilliseconds =
+            Double(elapsed.seconds) * 1000 + Double(elapsed.attoseconds) / 1e15
+        await DogfoodCaptureWriter.write(record, store: store)
+    }
+
+    private nonisolated static func assembleDogfoodRecord(
+        inputs: DogfoodCaptureInputs
+    ) async -> DogfoodCaptureRecord {
+        DogfoodCaptureBuilder.build(
+            id: UUID().uuidString,
+            capturedAt: Date(),
+            inputs: inputs
+        )
+    }
+}
+
+#endif

--- a/Sources/localvoxtral/Dogfood/DogfoodCapturePipeline.swift
+++ b/Sources/localvoxtral/Dogfood/DogfoodCapturePipeline.swift
@@ -1,0 +1,428 @@
+#if LOCALVOXTRAL_DOGFOOD
+
+import Foundation
+import Synchronization
+
+/// Side-channel for the two pipeline facts the commit path cannot see in its
+/// own return values: WHY a join abstained, and WHAT the terminal-cwd repo
+/// vocabulary harvested.
+///
+/// Both producers already reduce those facts to a log line before returning —
+/// the resolver returns `nil` for every abstention cause, and the vocabulary
+/// pipeline returns a `GroundingOutcome` that no longer carries its term pool.
+/// Threading them through the return types would fork the production signatures
+/// for a capture that shipped builds do not even compile, so a dogfood build
+/// taps them here instead: producers note, the commit path consumes.
+///
+/// One dictation at a time by design (the commit path is serialized on the main
+/// actor), so a single slot per fact is enough. `beginSession()` clears both
+/// slots at dictation start; a fact noted by an abandoned pipeline after its
+/// session's commit consumed the slot is cleared there rather than leaking into
+/// the next record.
+///
+/// `Mutex` rather than an actor because the producers are on different
+/// isolation domains: the resolver runs on the main actor, the repo-vocabulary
+/// pipeline in a detached utility task.
+final class DogfoodCaptureTap: Sendable {
+    static let shared = DogfoodCaptureTap()
+
+    private struct State {
+        var joinAbstentions: [String] = []
+        var repoVocabularyHarvest: [String]?
+    }
+
+    private let state = Mutex(State())
+
+    /// Clears both slots. Called at dictation start, before the join resolves.
+    func beginSession() {
+        state.withLock { $0 = State() }
+    }
+
+    /// One arm's abstention cause, e.g. `"tty: stale"`. Accumulated: a single
+    /// resolve can abstain on the tty arm and then again on the marker arm, and
+    /// the record wants the whole story, not the last chapter.
+    func noteJoinAbstention(_ cause: String) {
+        state.withLock { $0.joinAbstentions.append(cause) }
+    }
+
+    /// The exact term pool the terminal-cwd repo vocabulary matched against.
+    func noteRepoVocabularyHarvest(_ terms: [String]) {
+        state.withLock { $0.repoVocabularyHarvest = terms }
+    }
+
+    /// All abstention causes noted since `beginSession`, oldest first, and
+    /// clears them.
+    func consumeJoinAbstentions() -> [String] {
+        state.withLock {
+            let causes = $0.joinAbstentions
+            $0.joinAbstentions = []
+            return causes
+        }
+    }
+
+    /// The noted harvest, if any, and clears it.
+    func consumeRepoVocabularyHarvest() -> [String]? {
+        state.withLock {
+            let harvest = $0.repoVocabularyHarvest
+            $0.repoVocabularyHarvest = nil
+            return harvest
+        }
+    }
+}
+
+/// Assembles a `DogfoodCaptureRecord` from the values the commit path already
+/// holds, and derives the few record fields that are not literally one of them.
+///
+/// Pure and `nonisolated`: the harvest re-derivations walk complete retained
+/// buffers (a clipboard can retain 2M characters), and the commit path is
+/// `@MainActor` — so `build` is awaited off-actor exactly like the preparations
+/// whose inputs it mirrors.
+enum DogfoodCaptureBuilder {
+    /// Harvest lists are capped in the RECORD, never in matching (which already
+    /// ran). 500 terms is comfortably past where scanning a record stops being
+    /// how anyone reviews it; `harvestTruncated` says the cap fired so a review
+    /// never mistakes a truncated harvest for a retrieval miss.
+    static let harvestTermCap = 500
+
+    /// Screen text is capped at the AX reader's own retention cap; anything
+    /// past it was never in memory to begin with, so this only guards against
+    /// a future cap change silently growing records.
+    static let sanitizedScreenTextCap = 32_000
+
+    struct SourceInputs {
+        var source: PolishContextSource
+        var harvest: [String]
+        var outcome: RepoVocabularyMatcher.GroundingOutcome
+        var renderedExcerpt: String?
+    }
+
+    /// `host` class only, never the URL: `loopback`, `lan`, or `remote`.
+    /// Deliberately coarse — the record needs "was this the bundled helper, a
+    /// LAN box, or something else", not the user's network layout.
+    static func endpointClass(of url: URL) -> String {
+        if PolishContextClipboardReader.isLoopbackEndpoint(url) { return "loopback" }
+        guard let host = url.host?.lowercased() else { return "remote" }
+        if host.hasSuffix(".local") || host.hasPrefix("10.") || host.hasPrefix("192.168.") {
+            return "lan"
+        }
+        if host.hasPrefix("172."),
+           let second = host.split(separator: ".").dropFirst().first,
+           let octet = Int(second), (16...31).contains(octet)
+        {
+            return "lan"
+        }
+        return "remote"
+    }
+
+    static func join(
+        from join: ClaudeSessionJoin?,
+        abstentions: [String]
+    ) -> DogfoodCaptureRecord.Join {
+        guard let join else {
+            return DogfoodCaptureRecord.Join(
+                arm: "none",
+                abstentionReason: abstentions.isEmpty
+                    ? nil : abstentions.joined(separator: "; "),
+                origin: nil,
+                terminal: nil,
+                herdrBound: nil,
+                workspaceIsLocal: nil
+            )
+        }
+        let arm: String
+        switch join.mechanism {
+        case .ttyDevice: arm = "tty"
+        case .titleMarker: arm = "titleMarker"
+        case .herdrPane: arm = "herdrPane"
+        }
+        return DogfoodCaptureRecord.Join(
+            arm: arm,
+            // A resolved join can still have earlier arms' abstentions (tty
+            // abstained, marker answered) — kept, because "the tty arm never
+            // answers" is invisible in a record that only names the winner.
+            abstentionReason: abstentions.isEmpty
+                ? nil : abstentions.joined(separator: "; "),
+            origin: join.snapshot.origin.isLocalAuthenticated ? "local" : "remote",
+            terminal: join.target.bundleID,
+            herdrBound: join.herdrPane != nil,
+            workspaceIsLocal: join.snapshot.localWorkspacePath != nil
+        )
+    }
+
+    static func screen(
+        from decision: TerminalScreenContextDecision,
+        targetBundleID: String?,
+        herdrSwapApplied: Bool
+    ) -> DogfoodCaptureRecord.Screen {
+        let route: String?
+        if herdrSwapApplied {
+            route = "herdrPaneRead"
+        } else if let targetBundleID,
+                  TerminalScreenAllowlist.axCaptureBundleIDs.contains(targetBundleID)
+        {
+            route = "axGrid"
+        } else if let targetBundleID,
+                  TerminalScreenAllowlist.appleScriptCaptureBundleIDs.contains(targetBundleID)
+        {
+            route = "appleScriptContents"
+        } else {
+            route = nil
+        }
+
+        switch decision {
+        case let .render(excerpt, startText, elidedChurnLines):
+            return screenRecord(
+                route: route,
+                decision: "render",
+                cause: elidedChurnLines > 0 ? "elided-churn-lines:\(elidedChurnLines)" : nil,
+                sanitizedText: startText.isEmpty ? excerpt : startText
+            )
+        case let .vocabularyOnly(startText, cause):
+            return screenRecord(
+                route: route,
+                decision: "vocabularyOnly",
+                cause: cause.summarySlug,
+                sanitizedText: startText
+            )
+        case let .drop(reason):
+            return screenRecord(
+                route: route,
+                decision: "drop",
+                cause: reason.rawValue,
+                sanitizedText: nil
+            )
+        }
+    }
+
+    private static func screenRecord(
+        route: String?,
+        decision: String,
+        cause: String?,
+        sanitizedText: String?
+    ) -> DogfoodCaptureRecord.Screen {
+        let truncated = (sanitizedText?.count ?? 0) > sanitizedScreenTextCap
+        return DogfoodCaptureRecord.Screen(
+            route: route,
+            decision: decision,
+            cause: cause,
+            sanitizedCharacterCount: sanitizedText?.count ?? 0,
+            sanitizedText: truncated
+                ? sanitizedText.map { String($0.prefix(sanitizedScreenTextCap)) }
+                : sanitizedText,
+            sanitizedTextTruncated: truncated
+        )
+    }
+
+    static func source(_ inputs: SourceInputs) -> DogfoodCaptureRecord.Source {
+        let truncated = inputs.harvest.count > harvestTermCap
+        return DogfoodCaptureRecord.Source(
+            source: inputs.source.rawValue,
+            harvest: truncated
+                ? Array(inputs.harvest.prefix(harvestTermCap)) : inputs.harvest,
+            harvestCount: inputs.harvest.count,
+            harvestTruncated: truncated,
+            entries: entries(inputs.outcome.entries),
+            phoneticEntries: entries(inputs.outcome.phoneticEntries),
+            verificationEntries: entries(inputs.outcome.verificationCandidates),
+            isFallbackOnly: inputs.outcome.isFallbackOnly,
+            renderedExcerpt: inputs.renderedExcerpt.flatMap { $0.isEmpty ? nil : $0 }
+        )
+    }
+
+    private static func entries(
+        _ entries: [ReplacementEntry]
+    ) -> [DogfoodCaptureRecord.Source.Entry] {
+        entries.map { .init(term: $0.replaceWith, heard: $0.matches) }
+    }
+
+    static func allocations(
+        demands: [PolishContextSource: Int],
+        grants: [PolishContextSource: Int],
+        rendered: [PolishContextSource: Int]
+    ) -> [DogfoodCaptureRecord.Allocation] {
+        // Every source that DEMANDED, in allocation-rank order — a source
+        // granted zero is the whole of bucket 4 and it leaves no other trace.
+        PolishContextSource.allCases.compactMap { source in
+            let demand = demands[source] ?? 0
+            guard demand > 0 else { return nil }
+            let grant = grants[source] ?? 0
+            return DogfoodCaptureRecord.Allocation(
+                source: source.rawValue,
+                demandedCharacters: demand,
+                grantedCharacters: grant,
+                renderedCharacters: rendered[source] ?? 0,
+                excerptWasSelected: demand > grant
+            )
+        }
+    }
+
+    /// The candidate term pool for a flat text source — the same derivation
+    /// `ClipboardVocabulary.candidateOutcome` starts from, re-run here because
+    /// the outcome discards it. Runs off-actor (this whole type does); a
+    /// dogfood build pays this once per armed dictation and records the cost in
+    /// `Timings.captureMilliseconds`.
+    static func textSourceHarvest(_ text: String) -> [String] {
+        guard !text.isEmpty else { return [] }
+        return ClipboardVocabulary.entities(inExcerpt: text)
+    }
+
+    /// The joined-session repo's term pool — the exact list
+    /// `ClaudeRepoContextPreparation.prepare` matched against.
+    static func claudeRepoHarvest(_ snapshot: ClaudeRepoSnapshot?) -> [String] {
+        guard let snapshot else { return [] }
+        return ClaudeRepoContextPreparation.terms(
+            from: ClaudeRepoContextPreparation.groundingSources(snapshot: snapshot)
+        )
+    }
+}
+
+/// Everything the polish commit path knows that a record needs, captured by
+/// value so assembly can run off the main actor after the commit completed.
+///
+/// A nil text/snapshot means that source never ran this dictation and gets no
+/// `Source` row; an empty-but-present one ran and harvested nothing, which is
+/// exactly the retrieval evidence (bucket 1) the record exists to keep.
+struct DogfoodCaptureInputs: Sendable {
+    var session: DogfoodCaptureRecord.Session
+    var join: ClaudeSessionJoin?
+    var joinAbstentions: [String]
+    var screenDecision: TerminalScreenContextDecision
+    var herdrSwapApplied: Bool
+    var targetBundleID: String?
+
+    var demands: [PolishContextSource: Int]
+    var grants: [PolishContextSource: Int]
+    var rendered: [PolishContextSource: Int]
+
+    /// The terminal-cwd repo vocabulary's term pool from the tap, nil when the
+    /// pipeline never built a vocabulary.
+    var repoVocabularyHarvest: [String]?
+    var repoVocabularyOutcome: RepoVocabularyMatcher.GroundingOutcome
+    var claudeRepoSnapshot: ClaudeRepoSnapshot?
+    var claudeRepoOutcome: RepoVocabularyMatcher.GroundingOutcome
+    var claudeRepoRenderedExcerpt: String?
+    var claudeSessionText: String?
+    var claudeSessionOutcome: RepoVocabularyMatcher.GroundingOutcome
+    var claudeSessionRenderedExcerpt: String?
+    var clipboardRetainedText: String?
+    var clipboardOutcome: RepoVocabularyMatcher.GroundingOutcome
+    var clipboardRenderedExcerpt: String?
+    var screenOutcome: RepoVocabularyMatcher.GroundingOutcome
+    var screenRenderedExcerpt: String?
+
+    var text: DogfoodCaptureRecord.Text
+    var polishSeconds: Double?
+}
+
+extension DogfoodCaptureBuilder {
+    /// The full record, minus timings the caller measures around this call.
+    ///
+    /// Two `.repository` budget candidates exist (terminal-cwd vocabulary and
+    /// the joined session's repo), so `Source` rows carry their OWN names —
+    /// `repoVocabulary` / `claudeRepo` — while `Allocation` keeps the four
+    /// budget sources. Collapsing the two would make a repoVocabulary matcher
+    /// miss unattributable against a claudeRepo retrieval miss.
+    nonisolated static func build(
+        id: String,
+        capturedAt: Date,
+        inputs: DogfoodCaptureInputs
+    ) -> DogfoodCaptureRecord {
+        var sources: [DogfoodCaptureRecord.Source] = []
+
+        if inputs.repoVocabularyHarvest != nil || !inputs.repoVocabularyOutcome.entries.isEmpty {
+            var row = source(SourceInputs(
+                source: .repository,
+                harvest: inputs.repoVocabularyHarvest ?? [],
+                outcome: inputs.repoVocabularyOutcome,
+                renderedExcerpt: nil
+            ))
+            row.source = "repoVocabulary"
+            sources.append(row)
+        }
+        if inputs.claudeRepoSnapshot != nil {
+            var row = source(SourceInputs(
+                source: .repository,
+                harvest: claudeRepoHarvest(inputs.claudeRepoSnapshot),
+                outcome: inputs.claudeRepoOutcome,
+                renderedExcerpt: inputs.claudeRepoRenderedExcerpt
+            ))
+            row.source = "claudeRepo"
+            sources.append(row)
+        }
+        if let screenText = inputs.screenDecision.vocabularyGroundingText {
+            sources.append(source(SourceInputs(
+                source: .terminal,
+                harvest: textSourceHarvest(screenText),
+                outcome: inputs.screenOutcome,
+                renderedExcerpt: inputs.screenRenderedExcerpt
+            )))
+        }
+        if let claudeText = inputs.claudeSessionText, !claudeText.isEmpty {
+            sources.append(source(SourceInputs(
+                source: .claude,
+                harvest: textSourceHarvest(claudeText),
+                outcome: inputs.claudeSessionOutcome,
+                renderedExcerpt: inputs.claudeSessionRenderedExcerpt
+            )))
+        }
+        if let clipboardText = inputs.clipboardRetainedText {
+            sources.append(source(SourceInputs(
+                source: .clipboard,
+                harvest: textSourceHarvest(clipboardText),
+                outcome: inputs.clipboardOutcome,
+                renderedExcerpt: inputs.clipboardRenderedExcerpt
+            )))
+        }
+
+        return DogfoodCaptureRecord(
+            id: id,
+            capturedAt: capturedAt,
+            session: inputs.session,
+            join: join(from: inputs.join, abstentions: inputs.joinAbstentions),
+            screen: screen(
+                from: inputs.screenDecision,
+                targetBundleID: inputs.targetBundleID,
+                herdrSwapApplied: inputs.herdrSwapApplied
+            ),
+            allocation: allocations(
+                demands: inputs.demands,
+                grants: inputs.grants,
+                rendered: inputs.rendered
+            ),
+            sources: sources,
+            text: inputs.text,
+            timings: DogfoodCaptureRecord.Timings(
+                polishSeconds: inputs.polishSeconds,
+                captureMilliseconds: nil
+            )
+        )
+    }
+}
+
+/// Writes one record, off the commit path's actor, never throwing into it.
+///
+/// The capture must be unable to break a dictation: a full disk, a foreign
+/// directory owner, or an encoding surprise costs the RECORD (loudly), never
+/// the commit. The write itself is synchronous file IO on the generic executor
+/// — the user's text was already committed before the capture is assembled.
+enum DogfoodCaptureWriter {
+    nonisolated static func write(
+        _ record: DogfoodCaptureRecord,
+        store: DogfoodCaptureStore
+    ) async {
+        do {
+            let url = try store.write(record)
+            Log.polishing.info(
+                "Dogfood capture written: \(url.lastPathComponent, privacy: .public)"
+            )
+        } catch {
+            // Loud by convention (AGENTS.md): a silent failure path here means
+            // dogfooding quietly collects nothing.
+            Log.polishing.error(
+                "Dogfood capture write failed: \(error.localizedDescription, privacy: .public)"
+            )
+        }
+    }
+}
+
+#endif

--- a/Sources/localvoxtral/Dogfood/DogfoodCapturePipeline.swift
+++ b/Sources/localvoxtral/Dogfood/DogfoodCapturePipeline.swift
@@ -37,7 +37,8 @@ final class DogfoodCaptureTap: Sendable {
     private let state = Mutex(State())
 
     /// The generation a harvest note was created under. The repo-vocabulary
-    /// pipeline is a DETACHED task racing a 2 s deadline; when the deadline
+    /// pipeline is a DETACHED task racing `repoVocabularyPipelineDeadline`
+    /// (3 s at the time of writing); when the deadline
     /// wins, the pipeline is abandoned but keeps running, and its eventual
     /// harvest note can land after the owning session already consumed — which
     /// would put session A's repo terms into session B's record, the exact

--- a/Sources/localvoxtral/Dogfood/DogfoodCapturePipeline.swift
+++ b/Sources/localvoxtral/Dogfood/DogfoodCapturePipeline.swift
@@ -27,27 +27,62 @@ final class DogfoodCaptureTap: Sendable {
     static let shared = DogfoodCaptureTap()
 
     private struct State {
+        /// Which dictation the slots belong to. Bumped by `beginSession`, so a
+        /// note carrying an older generation can be recognized as stale.
+        var generation: UInt64 = 0
         var joinAbstentions: [String] = []
         var repoVocabularyHarvest: [String]?
     }
 
     private let state = Mutex(State())
 
-    /// Clears both slots. Called at dictation start, before the join resolves.
+    /// The generation a harvest note was created under. The repo-vocabulary
+    /// pipeline is a DETACHED task racing a 2 s deadline; when the deadline
+    /// wins, the pipeline is abandoned but keeps running, and its eventual
+    /// harvest note can land after the owning session already consumed — which
+    /// would put session A's repo terms into session B's record, the exact
+    /// bucket-1 misattribution the record exists to prevent (review, 2026-07-25).
+    /// The commit path binds this task-local around the pipeline body at task
+    /// creation (task-locals do not cross `Task.detached` on their own), and
+    /// `noteRepoVocabularyHarvest` rejects a note whose generation has passed.
+    /// Nil (an unbound caller, e.g. a direct unit test) is accepted as current.
+    @TaskLocal static var noteGeneration: UInt64?
+
+    /// Clears both slots and advances the generation. Called at dictation
+    /// start, before the join resolves.
     func beginSession() {
-        state.withLock { $0 = State() }
+        state.withLock {
+            $0.generation &+= 1
+            $0.joinAbstentions = []
+            $0.repoVocabularyHarvest = nil
+        }
+    }
+
+    var currentGeneration: UInt64 {
+        state.withLock { $0.generation }
     }
 
     /// One arm's abstention cause, e.g. `"tty: stale"`. Accumulated: a single
     /// resolve can abstain on the tty arm and then again on the marker arm, and
     /// the record wants the whole story, not the last chapter.
+    ///
+    /// No generation check, deliberately: abstentions are noted synchronously
+    /// on the main actor during session start, and overlapping session starts
+    /// are blocked upstream — there is no abandoned producer to guard against.
     func noteJoinAbstention(_ cause: String) {
         state.withLock { $0.joinAbstentions.append(cause) }
     }
 
     /// The exact term pool the terminal-cwd repo vocabulary matched against.
+    /// Dropped when `noteGeneration` says the note is from a session that has
+    /// already ended — see `noteGeneration`.
     func noteRepoVocabularyHarvest(_ terms: [String]) {
-        state.withLock { $0.repoVocabularyHarvest = terms }
+        state.withLock {
+            if let generation = Self.noteGeneration, generation != $0.generation {
+                return
+            }
+            $0.repoVocabularyHarvest = terms
+        }
     }
 
     /// All abstention causes noted since `beginSession`, oldest first, and

--- a/Sources/localvoxtral/RepoVocabulary.swift
+++ b/Sources/localvoxtral/RepoVocabulary.swift
@@ -991,6 +991,11 @@ enum RepoVocabularyService {
         ) else {
             return nil
         }
+        #if LOCALVOXTRAL_DOGFOOD
+        // The exact term pool matching runs against, which the returned
+        // outcome no longer carries — see `DogfoodCaptureTap`.
+        DogfoodCaptureTap.shared.noteRepoVocabularyHarvest(vocabulary.terms)
+        #endif
         // Carries provenance, not just entries: whether these came from the
         // exact / edit-distance-one tiers or from the bounded aligned fallback
         // decides who yields when another context source covers the same heard

--- a/Tests/localvoxtralTests/DogfoodCaptureWiringTests.swift
+++ b/Tests/localvoxtralTests/DogfoodCaptureWiringTests.swift
@@ -1,0 +1,375 @@
+#if LOCALVOXTRAL_DOGFOOD
+
+import Foundation
+import XCTest
+@testable import localvoxtral
+
+/// The wiring that turns one polished dictation into one on-disk capture
+/// record. Drives the REAL `finishStoppedSession` polish/commit path (the same
+/// harness as the polish-failure diagnostics suite) and reads the record back.
+@MainActor
+final class DogfoodCaptureWiringTests: XCTestCase {
+    // DictationViewModel owns app-lifetime services; retain test instances for
+    // the process lifetime (mirrors the token-guard suite).
+    private static var retainedViewModels: [DictationViewModel] = []
+
+    /// Armed build + armed runtime flag: a polished overlay commit writes
+    /// exactly one record whose text stages, session facts, join abstention,
+    /// and screen decision describe the dictation that just committed.
+    func testPolishedCommitWritesOneAttributableRecord() async throws {
+        let harness = try makeHarness(dogfoodArmed: true)
+
+        harness.viewModel.finishStoppedSession(promotePendingSegment: false)
+        await harness.viewModel.polishAndCommitTask?.value
+
+        let records = try recordsOnDisk(in: harness.captureDirectory)
+        XCTAssertEqual(records.count, 1, "one dictation writes exactly one record")
+        let record = records[0]
+
+        XCTAssertEqual(record.schemaVersion, DogfoodCaptureRecord.currentSchemaVersion)
+        XCTAssertFalse(record.flagged)
+
+        // Text stages, in pipeline order.
+        XCTAssertEqual(record.text.rawTranscript, "polish this text")
+        XCTAssertEqual(record.text.workingText, "polish this text")
+        XCTAssertEqual(record.text.groundedText, "polish this text")
+        XCTAssertEqual(record.text.polishedOutput, "polished output text")
+        XCTAssertEqual(record.text.committedText, "polished output text")
+        XCTAssertFalse(record.text.userPrompts.isEmpty, "the rendered prompt is the payload")
+        XCTAssertEqual(record.text.systemPrompt, "system")
+
+        // Session facts.
+        XCTAssertEqual(record.session.outputMode, DictationOutputMode.overlayBuffer.rawValue)
+        XCTAssertEqual(record.session.endpointClass, "loopback")
+        XCTAssertNotNil(record.session.promptProfile)
+        XCTAssertNotNil(record.session.polishModel)
+
+        // No session start ran, so no join was resolved: the record must say
+        // "none" rather than omitting the block.
+        XCTAssertEqual(record.join?.arm, "none")
+
+        // No start capture: the decision is drop(no-start-capture), and the
+        // record's screen block must carry that exact cause.
+        XCTAssertEqual(record.screen?.decision, "drop")
+        XCTAssertEqual(record.screen?.cause, "no-start-capture")
+
+        // Nothing demanded, so no allocation rows and no sources.
+        XCTAssertEqual(record.allocation, [])
+        XCTAssertEqual(record.sources, [])
+
+        // Timings: the polish duration came from the service; the capture
+        // measured itself.
+        XCTAssertEqual(record.timings.polishSeconds, 0.25)
+        XCTAssertNotNil(record.timings.captureMilliseconds)
+    }
+
+    /// The compile flag alone must not collect: with the runtime opt-in off,
+    /// the same commit writes nothing.
+    func testDisarmedRuntimeFlagWritesNothing() async throws {
+        let harness = try makeHarness(dogfoodArmed: false)
+
+        harness.viewModel.finishStoppedSession(promotePendingSegment: false)
+        await harness.viewModel.polishAndCommitTask?.value
+
+        XCTAssertFalse(
+            FileManager.default.fileExists(atPath: harness.captureDirectory.path),
+            "a disarmed build must not even create the capture directory"
+        )
+    }
+
+    /// A failing store must cost the record, never the commit: the dictation
+    /// still commits and the session completes.
+    func testCaptureWriteFailureDoesNotBreakTheCommit() async throws {
+        // A file where the capture DIRECTORY should be: every write fails.
+        let harness = try makeHarness(dogfoodArmed: true, blockCaptureDirectory: true)
+
+        harness.viewModel.finishStoppedSession(promotePendingSegment: false)
+        await harness.viewModel.polishAndCommitTask?.value
+
+        XCTAssertFalse(harness.viewModel.isCompletingStoppedSession)
+        XCTAssertEqual(
+            harness.viewModel.currentDictationEventText, "polished output text",
+            "the committed text must be unaffected by a capture-write failure"
+        )
+    }
+
+    /// A join abstention noted at (a would-be) session start is consumed into
+    /// the record; a second dictation does not inherit it.
+    func testJoinAbstentionRidesTheRecordOnceAndIsConsumed() async throws {
+        let harness = try makeHarness(dogfoodArmed: true)
+        DogfoodCaptureTap.shared.beginSession()
+        DogfoodCaptureTap.shared.noteJoinAbstention("tty: stale")
+        DogfoodCaptureTap.shared.noteJoinAbstention("marker: no marker in title")
+
+        harness.viewModel.finishStoppedSession(promotePendingSegment: false)
+        await harness.viewModel.polishAndCommitTask?.value
+
+        let first = try recordsOnDisk(in: harness.captureDirectory)
+        XCTAssertEqual(
+            first.last?.join?.abstentionReason,
+            "tty: stale; marker: no marker in title"
+        )
+
+        // A second commit on a fresh session must not repeat the reason.
+        let second = try makeHarness(dogfoodArmed: true)
+        second.viewModel.finishStoppedSession(promotePendingSegment: false)
+        await second.viewModel.polishAndCommitTask?.value
+        let records = try recordsOnDisk(in: second.captureDirectory)
+        XCTAssertNil(records.last?.join?.abstentionReason)
+    }
+
+    // MARK: - Builder
+
+    func testEndpointClassBuckets() {
+        let cases: [(String, String)] = [
+            ("http://127.0.0.1:8472/v1", "loopback"),
+            ("http://localhost:8080/v1", "loopback"),
+            ("http://[::1]:8080/v1", "loopback"),
+            ("http://192.168.1.183:8080/v1", "lan"),
+            ("http://10.0.0.7/v1", "lan"),
+            ("http://172.20.0.2/v1", "lan"),
+            ("http://mac-studio.local:8080/v1", "lan"),
+            ("http://172.15.0.2/v1", "remote"),
+            ("https://api.example.com/v1", "remote"),
+        ]
+        for (url, expected) in cases {
+            XCTAssertEqual(
+                DogfoodCaptureBuilder.endpointClass(of: URL(string: url)!),
+                expected, url
+            )
+        }
+    }
+
+    func testJoinBuilderMapsResolvedAndAbstainedJoins() {
+        let unresolved = DogfoodCaptureBuilder.join(
+            from: nil, abstentions: ["gate: accessibility not trusted"]
+        )
+        XCTAssertEqual(unresolved.arm, "none")
+        XCTAssertEqual(unresolved.abstentionReason, "gate: accessibility not trusted")
+        XCTAssertNil(unresolved.origin)
+
+        let empty = DogfoodCaptureBuilder.join(from: nil, abstentions: [])
+        XCTAssertEqual(empty.arm, "none")
+        XCTAssertNil(empty.abstentionReason)
+    }
+
+    func testScreenBuilderRouteAndCause() {
+        let vocabOnly = DogfoodCaptureBuilder.screen(
+            from: .vocabularyOnly(
+                startText: "screen text",
+                cause: .screenChanged(stopLength: 10, differingLines: 3, firstDifferingLine: 0)
+            ),
+            targetBundleID: TerminalScreenAllowlist.ghosttyBundleID,
+            herdrSwapApplied: false
+        )
+        XCTAssertEqual(vocabOnly.route, "axGrid")
+        XCTAssertEqual(vocabOnly.decision, "vocabularyOnly")
+        XCTAssertEqual(vocabOnly.cause, "screen-changed(stop:10ch lines:3 first:0)")
+        XCTAssertEqual(vocabOnly.sanitizedText, "screen text")
+        XCTAssertEqual(vocabOnly.sanitizedCharacterCount, "screen text".count)
+
+        let appleScript = DogfoodCaptureBuilder.screen(
+            from: .render(excerpt: "e", startText: "s", elidedChurnLines: 0),
+            targetBundleID: TerminalScreenAllowlist.iterm2BundleID,
+            herdrSwapApplied: false
+        )
+        XCTAssertEqual(appleScript.route, "appleScriptContents")
+        XCTAssertEqual(appleScript.decision, "render")
+
+        let herdr = DogfoodCaptureBuilder.screen(
+            from: .render(excerpt: "pane", startText: "pane", elidedChurnLines: 0),
+            targetBundleID: TerminalScreenAllowlist.ghosttyBundleID,
+            herdrSwapApplied: true
+        )
+        XCTAssertEqual(herdr.route, "herdrPaneRead")
+
+        let dropped = DogfoodCaptureBuilder.screen(
+            from: .drop(reason: .targetChanged),
+            targetBundleID: nil,
+            herdrSwapApplied: false
+        )
+        XCTAssertEqual(dropped.decision, "drop")
+        XCTAssertEqual(dropped.cause, "target-changed")
+        XCTAssertNil(dropped.route)
+        XCTAssertNil(dropped.sanitizedText)
+    }
+
+    func testAllocationsKeepZeroGrantsAndDropZeroDemands() {
+        let rows = DogfoodCaptureBuilder.allocations(
+            demands: [.repository: 9000, .terminal: 0, .clipboard: 200],
+            grants: [.repository: 0, .clipboard: 200],
+            rendered: [.clipboard: 180]
+        )
+        XCTAssertEqual(rows.count, 2, "zero-demand sources leave no row")
+
+        let repo = rows[0]
+        XCTAssertEqual(repo.source, "repository")
+        XCTAssertEqual(repo.demandedCharacters, 9000)
+        XCTAssertEqual(repo.grantedCharacters, 0)
+        XCTAssertTrue(
+            repo.excerptWasSelected,
+            "a starved source is exactly what bucket 4 needs recorded"
+        )
+
+        let clipboard = rows[1]
+        XCTAssertEqual(clipboard.source, "clipboard")
+        XCTAssertFalse(clipboard.excerptWasSelected)
+        XCTAssertEqual(clipboard.renderedCharacters, 180)
+    }
+
+    func testHarvestListIsCappedInTheRecordOnly() {
+        let harvest = (0..<(DogfoodCaptureBuilder.harvestTermCap + 7)).map { "term\($0)" }
+        let row = DogfoodCaptureBuilder.source(DogfoodCaptureBuilder.SourceInputs(
+            source: .clipboard,
+            harvest: harvest,
+            outcome: .empty,
+            renderedExcerpt: nil
+        ))
+        XCTAssertEqual(row.harvest.count, DogfoodCaptureBuilder.harvestTermCap)
+        XCTAssertEqual(row.harvestCount, harvest.count, "the true pool size survives the cap")
+        XCTAssertTrue(row.harvestTruncated)
+    }
+
+    func testTapBeginSessionClearsBothSlots() {
+        DogfoodCaptureTap.shared.beginSession()
+        DogfoodCaptureTap.shared.noteJoinAbstention("tty: stale")
+        DogfoodCaptureTap.shared.noteRepoVocabularyHarvest(["Term"])
+        DogfoodCaptureTap.shared.beginSession()
+        XCTAssertEqual(DogfoodCaptureTap.shared.consumeJoinAbstentions(), [])
+        XCTAssertNil(DogfoodCaptureTap.shared.consumeRepoVocabularyHarvest())
+    }
+
+    // MARK: - Harness (mirrors the polish-failure diagnostics suite)
+
+    private struct Harness {
+        let viewModel: DictationViewModel
+        let captureDirectory: URL
+    }
+
+    private func makeHarness(
+        dogfoodArmed: Bool,
+        blockCaptureDirectory: Bool = false
+    ) throws -> Harness {
+        let settings = makeSettings()
+        settings.llmPolishingEnabled = true
+        settings.polishingBackendMode = .managedLocal
+        settings.dogfoodCaptureEnabled = dogfoodArmed
+
+        let base = FileManager.default.temporaryDirectory
+            .appendingPathComponent("dogfood-wiring-\(UUID().uuidString)", isDirectory: true)
+        let captureDirectory = base.appendingPathComponent("captures", isDirectory: true)
+        try FileManager.default.createDirectory(at: base, withIntermediateDirectories: true)
+        if blockCaptureDirectory {
+            // A regular FILE at the directory path: every store write fails.
+            try Data("not a directory".utf8).write(
+                to: captureDirectory, options: []
+            )
+        }
+        addTeardownBlock {
+            try? FileManager.default.removeItem(at: base)
+        }
+
+        let viewModel = DictationViewModel(
+            settings: settings,
+            overlayBufferCoordinator: WiringMockOverlayCoordinator(),
+            startRuntimeServices: false
+        )
+        viewModel.appConfigStore = WiringMockAppConfigStore()
+        viewModel.llmPolishingService = SucceedingPolishingService()
+        viewModel.dogfoodCaptureStore = DogfoodCaptureStore(directoryURL: captureDirectory)
+        viewModel.isShowingConnectionFailureAlert = true
+        Self.retainedViewModels.append(viewModel)
+
+        viewModel.sessionOutputMode = .overlayBuffer
+        viewModel.isFinalizingStop = true
+        viewModel.currentDictationEventText = "polish this text"
+        return Harness(viewModel: viewModel, captureDirectory: captureDirectory)
+    }
+
+    /// Decoded records, oldest first.
+    private func recordsOnDisk(in directory: URL) throws -> [DogfoodCaptureRecord] {
+        guard FileManager.default.fileExists(atPath: directory.path) else { return [] }
+        let names = try FileManager.default
+            .contentsOfDirectory(atPath: directory.path).sorted()
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        return try names.map { name in
+            let data = try Data(contentsOf: directory.appendingPathComponent(name))
+            return try decoder.decode(DogfoodCaptureRecord.self, from: data)
+        }
+    }
+
+    private func makeSettings() -> SettingsStore {
+        let suiteName = "localvoxtral.DogfoodCaptureWiringTests.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defaults.removePersistentDomain(forName: suiteName)
+        addTeardownBlock {
+            defaults.removePersistentDomain(forName: suiteName)
+        }
+        let settings = SettingsStore(defaults: defaults, environment: [:])
+        settings.dictationOutputMode = .overlayBuffer
+        return settings
+    }
+}
+
+/// Always polishes successfully, without networking.
+private actor SucceedingPolishingService: LLMPolishingServicing {
+    func polish(
+        request: LLMPolishingRequest,
+        configuration _: LLMPolishingConfiguration
+    ) async throws -> LLMPolishingResult {
+        LLMPolishingResult(
+            rawText: request.inputText,
+            polishedText: "polished output text",
+            durationSeconds: 0.25
+        )
+    }
+}
+
+private final class WiringMockAppConfigStore: AppConfigServing {
+    func configDirectoryURL() -> URL {
+        FileManager.default.temporaryDirectory
+    }
+
+    func loadReplacementDictionary() -> ReplacementDictionary {
+        ReplacementDictionary(entries: [])
+    }
+
+    func loadLLMPromptTemplates() -> LLMPromptTemplates {
+        LLMPromptTemplates(systemContent: "system", userContent: "{{input_text}}")
+    }
+
+    func loadTerminalAppBundleIDs() -> [String] {
+        []
+    }
+}
+
+@MainActor
+private final class WiringMockOverlayCoordinator: OverlayBufferSessionCoordinating {
+    var commitTargetAppPID: pid_t? = nil
+
+    func resolveAnchorNow() -> OverlayAnchor {
+        OverlayAnchor(
+            targetRect: CGRect(x: 0, y: 0, width: 100, height: 24),
+            source: .windowCenter
+        )
+    }
+
+    func startSession(preResolvedAnchor _: OverlayAnchor?) {}
+    func beginFinalizing(displayBufferText _: String, commitBufferText _: String) {}
+    func refresh(displayBufferText _: String, commitBufferText _: String) {}
+
+    func commitIfNeeded(
+        using _: OverlayTextCommitting,
+        autoCopyEnabled _: Bool
+    ) -> OverlayBufferCommitOutcome {
+        .succeeded
+    }
+
+    func dismissAfterHold(minimumVisibility _: TimeInterval) {}
+    func reset() {}
+    func captureLiveCommitTargetAppPID() {}
+    func markPolished(_: Bool) {}
+}
+
+#endif

--- a/Tests/localvoxtralTests/DogfoodCaptureWiringTests.swift
+++ b/Tests/localvoxtralTests/DogfoodCaptureWiringTests.swift
@@ -1,5 +1,6 @@
 #if LOCALVOXTRAL_DOGFOOD
 
+import AppKit
 import Foundation
 import XCTest
 @testable import localvoxtral
@@ -116,6 +117,101 @@ final class DogfoodCaptureWiringTests: XCTestCase {
         await second.viewModel.polishAndCommitTask?.value
         let records = try recordsOnDisk(in: second.captureDirectory)
         XCTAssertNil(records.last?.join?.abstentionReason)
+    }
+
+    /// Populated sources ride the commit path into the record: a clipboard
+    /// context produces its allocation row and harvested source row, and a
+    /// repo-vocabulary outcome (with its tapped harvest) produces the
+    /// `repoVocabulary` row AND its pre-application shows in `groundedText`.
+    /// This is the end-to-end lock on the demand/grant/rendered extraction and
+    /// the tap→record path, which the builder unit tests alone cannot see
+    /// (review, 2026-07-25).
+    func testPopulatedSourcesProduceAllocationAndSourceRows() async throws {
+        let harness = try makeHarness(dogfoodArmed: true)
+        harness.viewModel.settings.polishClipboardContextEnabled = true
+        harness.viewModel.settings.repoVocabularyEnabled = true
+        harness.viewModel.debugPolishContextPasteboardReaderOverride = {
+            WiringPasteboardStub(text: "error in PolishContextBudget.swift line 40")
+        }
+        harness.viewModel.debugRepoVocabularyEntriesOverride = { _ in
+            RepoVocabularyMatcher.GroundingOutcome(
+                entries: [ReplacementEntry(replaceWith: "herdr", matches: ["herder"])],
+                isFallbackOnly: false
+            )
+        }
+        DogfoodCaptureTap.shared.beginSession()
+        DogfoodCaptureTap.shared.noteRepoVocabularyHarvest(["herdr", "pane.read"])
+        harness.viewModel.currentDictationEventText = "join the herder pane"
+
+        harness.viewModel.finishStoppedSession(promotePendingSegment: false)
+        await harness.viewModel.polishAndCommitTask?.value
+
+        let record = try XCTUnwrap(recordsOnDisk(in: harness.captureDirectory).last)
+
+        // Grounding pre-applied the repo entry before the model saw the text.
+        XCTAssertEqual(record.text.groundedText, "join the herdr pane")
+
+        // One allocation row: only the clipboard declared a render demand.
+        XCTAssertEqual(record.allocation.count, 1)
+        let allocation = record.allocation[0]
+        XCTAssertEqual(allocation.source, "clipboard")
+        XCTAssertGreaterThan(allocation.demandedCharacters, 0)
+        XCTAssertEqual(allocation.grantedCharacters, allocation.demandedCharacters)
+        XCTAssertEqual(allocation.renderedCharacters, allocation.demandedCharacters)
+        XCTAssertFalse(allocation.excerptWasSelected)
+
+        let sourceNames = record.sources.map(\.source)
+        XCTAssertEqual(sourceNames, ["repoVocabulary", "clipboard"])
+
+        let repoRow = record.sources[0]
+        XCTAssertEqual(repoRow.harvest, ["herdr", "pane.read"])
+        XCTAssertEqual(repoRow.entries, [.init(term: "herdr", heard: ["herder"])])
+
+        let clipboardRow = record.sources[1]
+        XCTAssertTrue(
+            clipboardRow.harvest.contains("PolishContextBudget.swift"),
+            "the clipboard's technical entities are the harvest: \(clipboardRow.harvest)"
+        )
+        XCTAssertEqual(
+            clipboardRow.renderedExcerpt,
+            "error in PolishContextBudget.swift line 40"
+        )
+    }
+
+    /// The MAJOR from the 2026-07-25 review: a deadline-abandoned repo
+    /// vocabulary pipeline finishing AFTER its session ended must not write its
+    /// harvest into the next session's slot. Notes carry the generation they
+    /// were created under; a stale one is dropped.
+    func testStaleGenerationHarvestNoteIsRejected() {
+        let tap = DogfoodCaptureTap.shared
+        tap.beginSession()
+        let staleGeneration = tap.currentGeneration
+        tap.beginSession() // the next dictation began; the old pipeline is stale
+
+        DogfoodCaptureTap.$noteGeneration.withValue(staleGeneration) {
+            tap.noteRepoVocabularyHarvest(["previous-session-term"])
+        }
+        XCTAssertNil(
+            tap.consumeRepoVocabularyHarvest(),
+            "a stale pipeline's harvest must not survive into the new session"
+        )
+
+        DogfoodCaptureTap.$noteGeneration.withValue(tap.currentGeneration) {
+            tap.noteRepoVocabularyHarvest(["current-session-term"])
+        }
+        XCTAssertEqual(tap.consumeRepoVocabularyHarvest(), ["current-session-term"])
+    }
+
+    /// A stopped-with-no-speech session writes nothing: there was no polish
+    /// call and there is nothing to attribute.
+    func testEmptyDictationWritesNoRecord() async throws {
+        let harness = try makeHarness(dogfoodArmed: true)
+        harness.viewModel.currentDictationEventText = "   "
+
+        harness.viewModel.finishStoppedSession(promotePendingSegment: false)
+        await harness.viewModel.polishAndCommitTask?.value
+
+        XCTAssertEqual(try recordsOnDisk(in: harness.captureDirectory).count, 0)
     }
 
     // MARK: - Builder
@@ -310,6 +406,14 @@ final class DogfoodCaptureWiringTests: XCTestCase {
         settings.dictationOutputMode = .overlayBuffer
         return settings
     }
+}
+
+/// A plain-text pasteboard with no concealed/transient markers.
+private final class WiringPasteboardStub: PasteboardReading {
+    private let text: String
+    init(text: String) { self.text = text }
+    func types() -> [NSPasteboard.PasteboardType]? { [.string] }
+    func string() -> String? { text }
 }
 
 /// Always polishes successfully, without networking.

--- a/Tests/localvoxtralTests/DogfoodCaptureWiringTests.swift
+++ b/Tests/localvoxtralTests/DogfoodCaptureWiringTests.swift
@@ -202,6 +202,65 @@ final class DogfoodCaptureWiringTests: XCTestCase {
         XCTAssertEqual(tap.consumeRepoVocabularyHarvest(), ["current-session-term"])
     }
 
+    /// The generation BINDING itself, through the real pipeline-task path: a
+    /// harvest noted from inside the detached pipeline (via the seam, which
+    /// shares `detachedRepoVocabularyPipeline` with production) carries the
+    /// creation-time generation and lands in the record. Deleting the
+    /// `withValue` binding would not fail this test — the next one exists for
+    /// that (verification review, 2026-07-25).
+    func testPipelineNotedHarvestRidesTheBindingIntoTheRecord() async throws {
+        let harness = try makeHarness(dogfoodArmed: true)
+        harness.viewModel.settings.polishClipboardContextEnabled = true
+        harness.viewModel.settings.repoVocabularyEnabled = true
+        harness.viewModel.debugPolishContextPasteboardReaderOverride = {
+            WiringPasteboardStub(text: "clipboard text")
+        }
+        harness.viewModel.debugRepoVocabularyPipelineOverride = { _ in
+            DogfoodCaptureTap.shared.noteRepoVocabularyHarvest(["pipeline-term"])
+            return .empty
+        }
+        DogfoodCaptureTap.shared.beginSession()
+
+        harness.viewModel.finishStoppedSession(promotePendingSegment: false)
+        await harness.viewModel.polishAndCommitTask?.value
+
+        let record = try XCTUnwrap(recordsOnDisk(in: harness.captureDirectory).last)
+        let repoRow = record.sources.first { $0.source == "repoVocabulary" }
+        XCTAssertEqual(repoRow?.harvest, ["pipeline-term"])
+    }
+
+    /// The MAJOR's end-to-end regression: a pipeline whose session has ended
+    /// (the next dictation's `beginSession` ran) must have its harvest note
+    /// REJECTED — because the detached task carries the creation-time
+    /// generation. This is the test that fails if the `withValue` binding is
+    /// removed from `detachedRepoVocabularyPipeline`: an unbound note fails
+    /// open and the stale harvest would land in the record.
+    func testAbandonedPipelineHarvestIsRejectedByTheBinding() async throws {
+        let harness = try makeHarness(dogfoodArmed: true)
+        harness.viewModel.settings.polishClipboardContextEnabled = true
+        harness.viewModel.settings.repoVocabularyEnabled = true
+        harness.viewModel.debugPolishContextPasteboardReaderOverride = {
+            WiringPasteboardStub(text: "clipboard text")
+        }
+        harness.viewModel.debugRepoVocabularyPipelineOverride = { _ in
+            // The next dictation begins while this pipeline is still running…
+            DogfoodCaptureTap.shared.beginSession()
+            // …so its late note is stale and must be dropped.
+            DogfoodCaptureTap.shared.noteRepoVocabularyHarvest(["stale-term"])
+            return .empty
+        }
+        DogfoodCaptureTap.shared.beginSession()
+
+        harness.viewModel.finishStoppedSession(promotePendingSegment: false)
+        await harness.viewModel.polishAndCommitTask?.value
+
+        let record = try XCTUnwrap(recordsOnDisk(in: harness.captureDirectory).last)
+        XCTAssertNil(
+            record.sources.first { $0.source == "repoVocabulary" },
+            "a stale pipeline's harvest must not reach any record"
+        )
+    }
+
     /// A stopped-with-no-speech session writes nothing: there was no polish
     /// call and there is nothing to attribute.
     func testEmptyDictationWritesNoRecord() async throws {


### PR DESCRIPTION
## What

Second half of the dogfooding instrumentation (#190 was the record + store;
this is the wiring). The polishing overlay commit path now assembles and
writes one `DogfoodCaptureRecord` per polished dictation — still behind BOTH
locks: the `LOCALVOXTRAL_DOGFOOD` compile gate (shipping builds contain none
of this) and the `debug.dogfood_capture_enabled` runtime opt-in.

With this merged, dogfooding can actually start: build with `dogfood-package`,
arm the default, dictate normally, and every polished dictation leaves a
record that answers the four-way question (retrieval / matcher / conflict /
budget) for any term that came out wrong.

### What gets recorded, and from where

- **Join** — the resolved arm (`tty`/`titleMarker`/`herdrPane`) with origin,
  terminal, herdr binding, and workspace locality from the dictation's single
  join; or `none` **with the exact abstention causes**, both the pre-resolver
  gates (settings off, endpoint not permitted, no AX trust, no supported
  terminal) and every resolver arm's refusal (`tty: stale; marker: no marker
  in title`). Producers only log these today, so a `DogfoodCaptureTap`
  (Mutex side-channel, gated) accumulates them for the commit to consume.
- **Screen** — decision + cause verbatim from the reconcile truth table
  (`render`/`vocabularyOnly`/`drop` with the `VocabularyOnlyCause`/`DropReason`
  slugs), the route (`axGrid`/`appleScriptContents`/`herdrPaneRead`), and the
  full sanitized start text — the retrieval evidence for "was the term on
  screen at all".
- **Sources** — five rows (`repoVocabulary`, `claudeRepo`, `terminal`,
  `claude`, `clipboard`): each source's complete harvest (the term pool
  matching ran against), its pre-merge proposals per tier
  (entries/phonetic/verification), and the excerpt it actually rendered.
  Text-source harvests re-run the same `ClipboardVocabulary.entities`
  derivation matching used; the joined repo's harvest reuses
  `ClaudeRepoContextPreparation.terms(from:groundingSources:)`; the
  terminal-cwd vocabulary's pool is tapped where the pipeline builds it.
- **Allocation** — every demanding source's demand vs grant vs rendered
  characters, straight from the `PolishContextBudget.allocate` call — a source
  granted zero is bucket 4 and previously left no trace.
- **Text stages** — raw transcript → working text → grounded text → the exact
  system/user prompts sent → the model's reply → the committed text
  (placeholder-bearing: the clipboard payload never enters a record, matching
  the session-record rule).

### Invariants kept

- **Zero shipping-build change.** Every addition is `#if LOCALVOXTRAL_DOGFOOD`;
  the one touched production path (`resolveClaudeSessionJoin`) keeps
  byte-identical nil-returning behavior through a helper that compiles to
  `return nil`.
- **The capture cannot break a dictation.** It runs after the commit and the
  session record (latency lands on the task tail, never the paste), checks the
  runtime opt-in before doing any work, and a store failure costs the record
  loudly (`Log.polishing.error`) — never the commit. Asserted by test.
- **No content in the unified log.** New log lines carry only filenames,
  counts, and fixed slugs.
- **Empty dictations write nothing** — no polish call, nothing to attribute.

## Proof

All run 2026-07-25 on the Mac build host.

- **Dogfood suite** — `./scripts/remote-build.sh dogfood`: **29 tests, 0
  failures** (13 new wiring tests: full `finishStoppedSession` drive with a
  record read back and every stage asserted; disarmed-runtime writes nothing;
  store failure does not break the commit; populated clipboard +
  repo-vocabulary sources produce the allocation/source rows end-to-end; tap
  generation, abstention consumption, builder mappings, harvest caps).
- **Shipping configuration** — `./scripts/remote-build.sh test`: **1997
  tests, 0 failures** (the `#if` leaves a compiling, behavior-identical shape
  with the flag off).
- **Packages** — `dogfood-package`: `Dogfood capture: ENABLED` +
  `Info.plist LVXDogfoodCapture stamp: true`; plain `package` right after:
  `disabled` + `stamp: absent` (the stamp verification added in #190's
  follow-up commit asserts both directions on every packaging run).
- **CI** — green on the first two commits ([run
  30166651032](https://github.com/T0mSIlver/localvoxtral/actions/runs/30166651032),
  6m13s, including the LLM lane — the diff touches
  `DictationViewModel+Session.swift`, which is on the lane's path filter).
  That run's FIRST attempt failed with the unit suite exceeding its 300s
  supervisor window 130 tests in, on a test this diff does not touch,
  seconds after the build host woke from sleep — the same suite passes
  locally in ~67s (twice) and passed on the rerun: the known
  wake-under-load host-state flake, not this change. The third commit's run
  is pending below.

## Review

Reviewed pre-push by opencode (GLM-5.2, read-only) against the wiring commit.
Verdict: ship-neutral, privacy-clean, attribution values correct — with one
MAJOR, fixed here in the second commit with a regression test:

- **A deadline-abandoned repo-vocabulary pipeline could contaminate the next
  session's record.** The pipeline is a detached task racing a 2 s deadline;
  abandoned-but-alive, it could note session A's term pool into the tap after
  A consumed, and session B would record A's repo harvest — the exact
  bucket-1 misattribution the record exists to prevent. Harvest notes now
  carry the tap generation they were created under (task-local bound inside
  the detached closure) and stale notes are dropped;
  `testStaleGenerationHarvestNoteIsRejected` locks it in.

Also applied from that review: the capture skips empty dictations, the
`herdrSwapApplied` equality corner is documented as intentional, and the
end-to-end populated-source test closes the coverage gap that had made the
MAJOR invisible to the suite.

A second opencode pass (GLM-5.2, read-only) then VERIFIED the final state:
no BLOCKER or MAJOR — it traced the generation fix through all three
abandonment interleavings (including the read-vs-bump ordering on the main
actor and task-local semantics across the detached body) and confirmed
shipping neutrality of the `#if` fork. Its one MINOR is fixed in the third
commit: no test exercised the `withValue` binding itself (both debug seams
bypassed it), so deleting the wrapper would have silently re-opened the
MAJOR — unbound notes fail open by design. Both pipeline paths now route
through one `detachedRepoVocabularyPipeline` helper that applies the
binding, and the new regression test was shown failing without it:

```
XCTAssertNil failed: "Source(source: "repoVocabulary", harvest: ["stale-term"], ...)"
- a stale pipeline's harvest must not reach any record
```

After the fix (and with the shipping refactor): dogfood 29/29, shipping
1997/1997.

## Dogfooding runbook (after merge)

```
./scripts/remote-build.sh dogfood-package     # instrumented .app, TCC-stable bundle id
defaults write com.localvoxtral.app debug.dogfood_capture_enabled -bool true
# dictate normally; records land in
#   ~/Library/Application Support/localvoxtral/dogfood/
```

Retention: newest 500 unflagged / 14 days; flagged records are exempt. There
is no uploader and must never be one.

