### PR TITLE
Runner node re-sign agent: TCC grants that survive runner auto-updates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -154,6 +154,7 @@ jobs:
           ./scripts/ci/test-remote-build-gc.sh
           ./scripts/ci/test-run-supervised-command.sh
           ./scripts/ci/test-ui-smoke-guard.sh
+          ./scripts/ci/test-runner-node-resign.sh
           ./scripts/ci/test-ac-power-guard.sh
           ./scripts/ci/test-clean-stale-outputs.sh
 
@@ -179,6 +180,7 @@ jobs:
           ./scripts/ci/test-remote-build-reap.sh
           ./scripts/ci/test-remote-build-gc.sh
           ./scripts/ci/test-run-supervised-command.sh
+          ./scripts/ci/test-runner-node-resign.sh
 
       - name: Decide LLM eval lane (path filter + [run-llm-eval] marker)
         # CI must not pay ~8 min of 4B weight-loading + live inference on

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -84,6 +84,11 @@ Learned the hard way (2026-07-04) — use these instead of manual steps:
   System Settings → Accessibility). First codesign with a new key needs one
   GUI "Always Allow" keychain prompt — trigger it with a local
   `package_app.sh` run before relying on CI, or the runner job hangs.
+  The same identity-vs-hash rule protects the tier-2 lanes' TCC grants: the
+  `com.localvoxtral.runner-node-resign` LaunchAgent re-signs the runner's
+  bundled `externals/node*` with `localvoxtral-dev` after every runner
+  auto-update so the Accessibility/Screen Recording grants survive
+  (`scripts/mac/runner-node-resign.sh`, owner runbook `scripts/mac/README.md`).
 - **macOS 26 launch stall**: first launch of a *downloaded* ad-hoc-signed
   bundle stalls forever at `_dyld_start` (Gatekeeper first-exec scan);
   `xattr -cr` does NOT fix it, a LOCAL `codesign --force --deep --sign -`

--- a/scripts/ci/test-runner-node-resign.sh
+++ b/scripts/ci/test-runner-node-resign.sh
@@ -1,0 +1,178 @@
+#!/usr/bin/env bash
+# Regression tests for runner-node-resign.sh's `run` verb: signing decisions,
+# service stop/start ordering, busy-worker refusal, dry-run inertness, and
+# the restart-even-on-sign-failure guarantee. codesign/pgrep are PATH stubs
+# and svc.sh is a recording fake — no real signing or launchd, runs anywhere.
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "$0")/../.." && pwd -P)"
+SCRIPT="$ROOT_DIR/scripts/mac/runner-node-resign.sh"
+
+TMP_DIR="$(mktemp -d "${TMPDIR:-/tmp}/lv-runner-node-resign-test.XXXXXX")"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+fail() {
+  printf 'FAIL: %s\n' "$*" >&2
+  [[ -f "$TMP_DIR/calls.log" ]] && sed 's/^/  calls: /' "$TMP_DIR/calls.log" >&2
+  exit 1
+}
+
+STUB_BIN="$TMP_DIR/bin"
+mkdir -p "$STUB_BIN"
+
+# codesign stub: display mode reports our identity iff a "<file>.oursig"
+# marker exists; sign mode creates the marker (or fails under
+# STUB_CODESIGN_FAIL). Every invocation is recorded.
+cat >"$STUB_BIN/codesign" <<'STUB'
+#!/usr/bin/env bash
+printf 'codesign %s\n' "$*" >>"$CALLS_LOG"
+case "$1" in
+  -dvv)
+    target="$2"
+    if [[ -f "$target.oursig" ]]; then
+      cat "$target.oursig"
+    else
+      printf 'Identifier=node\nSignature=adhoc\n'
+    fi
+    ;;
+  --force)
+    if [[ -n "${STUB_CODESIGN_FAIL:-}" ]]; then exit 1; fi
+    target="${!#}"
+    # Record what a real signature would answer for the display probe.
+    # argv: --force --sign <identity> --identifier <identifier> <file>
+    printf 'Identifier=%s\nAuthority=%s\n' "$5" "$3" >"$target.oursig"
+    ;;
+  *)
+    exit 64
+    ;;
+esac
+STUB
+chmod +x "$STUB_BIN/codesign"
+
+# pgrep stub: "busy" (exit 0) for the first $STUB_PGREP_BUSY_COUNT calls,
+# then idle (exit 1). Call count persists in a file across invocations.
+cat >"$STUB_BIN/pgrep" <<'STUB'
+#!/usr/bin/env bash
+printf 'pgrep %s\n' "$*" >>"$CALLS_LOG"
+count_file="$CALLS_LOG.pgrep-count"
+n="$(cat "$count_file" 2>/dev/null || echo 0)"
+n=$((n + 1))
+printf '%s\n' "$n" >"$count_file"
+if [[ -n "${STUB_PGREP_BUSY_COUNT:-}" ]] && [[ "$n" -le "$STUB_PGREP_BUSY_COUNT" ]]; then
+  echo 12345
+  exit 0
+fi
+exit 1
+STUB
+chmod +x "$STUB_BIN/pgrep"
+
+make_runner() {
+  local dir="$TMP_DIR/runner"
+  rm -rf "$dir"
+  mkdir -p "$dir/externals/node20/bin" "$dir/externals/node24/bin" "$dir/bin"
+  printf 'fake-node\n' >"$dir/externals/node20/bin/node"
+  printf 'fake-node\n' >"$dir/externals/node24/bin/node"
+  cat >"$dir/svc.sh" <<'SVC'
+#!/usr/bin/env bash
+printf 'svc.sh %s\n' "$*" >>"$CALLS_LOG"
+if [[ -n "${STUB_SVC_FAIL_START:-}" && "$1" == "start" ]]; then exit 1; fi
+exit 0
+SVC
+  chmod +x "$dir/svc.sh"
+  : >"$TMP_DIR/calls.log"
+  rm -f "$TMP_DIR/calls.log.pgrep-count"
+  printf '%s\n' "$dir"
+}
+
+# run_script <expected-exit> [args/env...] — env pairs (VAR=val) then args.
+run_script() {
+  local expected="$1"
+  shift
+  local envs=() args=()
+  local a
+  for a in "$@"; do
+    case "$a" in
+      *=*) envs+=("$a") ;;
+      *) args+=("$a") ;;
+    esac
+  done
+  local status=0
+  env CALLS_LOG="$TMP_DIR/calls.log" \
+    PATH="$STUB_BIN:$PATH" \
+    LV_RUNNER_DIR="$RUNNER" \
+    LV_RESIGN_IDLE_POLL_SECS=0 \
+    LV_RESIGN_IDLE_TIMEOUT_SECS=3 \
+    LV_RESIGN_SETTLE_SECS=0 \
+    ${envs[@]+"${envs[@]}"} \
+    "$SCRIPT" run ${args[@]+"${args[@]}"} >"$TMP_DIR/out.log" 2>&1 \
+    || status=$?
+  [[ "$status" -eq "$expected" ]] \
+    || { cat "$TMP_DIR/out.log" >&2; fail "expected exit $expected, got $status"; }
+}
+
+calls() { cat "$TMP_DIR/calls.log"; }
+
+# --- fresh runner: both nodes unsigned -> stop, sign both, start ----------
+RUNNER="$(make_runner)"
+run_script 0
+calls | grep -q 'svc.sh stop' || fail "unsigned pass: service was not stopped"
+[[ "$(calls | grep -c -- '--force --sign localvoxtral-dev --identifier com.localvoxtral.runner-node')" -eq 2 ]] \
+  || fail "unsigned pass: expected exactly 2 sign invocations with identity+identifier"
+calls | grep -q 'svc.sh start' || fail "unsigned pass: service was not restarted"
+stop_line="$(calls | grep -n 'svc.sh stop' | cut -d: -f1 | head -1)"
+first_sign="$(calls | grep -n -- '--force' | cut -d: -f1 | head -1)"
+start_line="$(calls | grep -n 'svc.sh start' | cut -d: -f1 | head -1)"
+[[ "$stop_line" -lt "$first_sign" && "$first_sign" -lt "$start_line" ]] \
+  || fail "unsigned pass: expected stop < sign < start ordering"
+echo "PASS: unsigned nodes are signed between a service stop and start"
+
+# --- second pass: everything signed -> pure no-op -------------------------
+: >"$TMP_DIR/calls.log"
+run_script 0
+calls | grep -q 'svc.sh' && fail "signed pass: touched the service"
+calls | grep -q -- '--force' && fail "signed pass: re-signed a signed node"
+grep -q 'nothing to do' "$TMP_DIR/out.log" || fail "signed pass: missing no-op message"
+echo "PASS: fully-signed state is a no-op"
+
+# --- partial: only the unsigned node gets signed --------------------------
+rm "$RUNNER/externals/node24/bin/node.oursig"
+: >"$TMP_DIR/calls.log"
+run_script 0
+[[ "$(calls | grep -c -- '--force')" -eq 1 ]] || fail "partial pass: expected exactly 1 sign"
+calls | grep -- '--force' | grep -q 'node24' || fail "partial pass: signed the wrong node"
+echo "PASS: partial invalidation signs only the unsigned node"
+
+# --- dry-run: reports, changes nothing ------------------------------------
+RUNNER="$(make_runner)"
+run_script 0 --dry-run
+calls | grep -qE 'svc.sh|--force' && fail "dry-run: performed real actions"
+grep -q 'would sign' "$TMP_DIR/out.log" || fail "dry-run: missing would-sign report"
+echo "PASS: dry-run is inert"
+
+# --- busy worker: refuse to touch anything, nonzero exit ------------------
+RUNNER="$(make_runner)"
+run_script 1 STUB_PGREP_BUSY_COUNT=999
+calls | grep -qE 'svc.sh|--force' && fail "busy: touched service or signed under a live job"
+grep -q 'still busy' "$TMP_DIR/out.log" || fail "busy: missing busy-timeout message"
+echo "PASS: live runner job blocks the pass without side effects"
+
+# --- busy then idle: waits, then proceeds ---------------------------------
+RUNNER="$(make_runner)"
+run_script 0 STUB_PGREP_BUSY_COUNT=2
+[[ "$(calls | grep -c -- '--force')" -eq 2 ]] || fail "busy-then-idle: did not sign after wait"
+echo "PASS: pass proceeds once the worker drains"
+
+# --- sign failure: service still restarted, nonzero exit ------------------
+RUNNER="$(make_runner)"
+run_script 1 STUB_CODESIGN_FAIL=1
+calls | grep -q 'svc.sh start' || fail "sign failure: service left stopped"
+grep -q 'failed to sign' "$TMP_DIR/out.log" || fail "sign failure: missing failure message"
+echo "PASS: sign failure never leaves the runner service down"
+
+# --- missing runner dir: clear error --------------------------------------
+RUNNER="$TMP_DIR/nonexistent"
+run_script 1
+grep -q 'externals dir not found' "$TMP_DIR/out.log" || fail "missing dir: unclear error"
+echo "PASS: missing runner dir fails loudly"
+
+echo "runner-node-resign tests passed"

--- a/scripts/mac/README.md
+++ b/scripts/mac/README.md
@@ -340,6 +340,57 @@ reference, so expect equal-or-better numbers). Both are OWNER-verified: the
 repo-side changes are compatible with either generation behind the ports, but
 only a live run on the swapped host proves accuracy parity.
 
+## Runner node re-sign agent — TCC grants that survive runner auto-updates
+
+`runner-node-resign.sh` keeps the self-hosted runner's bundled node binaries
+(`~/actions-runner/externals/node*/bin/node` — BOTH of them, node20 and
+node24) signed with the owner's stable `localvoxtral-dev` identity and a
+fixed identifier. macOS keys a TCC grant for an unsigned binary to its
+content hash, so every runner auto-update used to silently invalidate the
+Accessibility + Screen Recording grants the tier-2 GUI lanes need (field
+incidents 2026-07-24/25: red ui-smoke, real TCC prompts on the GUI session).
+With a stable signature the grant is keyed to identity+identifier and
+survives updates untouched. Auto-update stays ON — there is no monthly
+manual-update ritual with this in place.
+
+A LaunchAgent (`com.localvoxtral.runner-node-resign`) re-signs automatically:
+`WatchPaths` on `externals/` fires when an update swaps node (plus an hourly
+`StartInterval` sweep as backstop), waits for any in-flight CI job to drain
+(never stops the service under a live `Runner.Worker`), then
+`svc.sh stop` → `codesign --force` → `svc.sh start`. Sign failures still
+restart the service — a broken grant is recoverable, a dead runner is not.
+Log: `~/Library/Logs/localvoxtral-runner-node-resign.log`.
+
+### One-time install (owner GUI session on the Mac)
+
+```bash
+# 1. Install + bootstrap the agent (copies the script to a stable path under
+#    ~/Library/Application Support/localvoxtral/bin — the repo checkout may
+#    be a garbage-collected rsync dir, the agent must not point into it):
+scripts/mac/runner-node-resign.sh install-agent
+
+# 2. FIRST signed pass BY HAND, so the keychain "Always Allow" prompt for the
+#    signing key lands on you, not on the silent agent:
+"$HOME/Library/Application Support/localvoxtral/bin/runner-node-resign.sh" run
+
+# 3. System Settings > Privacy & Security: in BOTH Accessibility and Screen
+#    Recording, REMOVE the existing node rows and re-add BOTH
+#    ~/actions-runner/externals/node*/bin/node binaries (4 entries total).
+#    The old rows are keyed to the pre-signing hashes and never match again.
+#    This is the LAST manual TCC action; later updates re-sign automatically.
+
+# 4. Verify:
+scripts/mac/runner-node-resign.sh status     # expect: signed x2, agent loaded
+gh workflow run ui-smoke.yml --ref main      # TCC preflight = the live probe
+```
+
+Caveats: there is a sub-minute window between an auto-update landing and the
+agent re-signing + restarting — a tier-2 run in that window fails its TCC
+preflight once and self-heals. If the `localvoxtral-dev` certificate is ever
+rotated or deleted, all four grants die with it (redo step 3 after signing
+with the new identity). Regression tests: `scripts/ci/test-runner-node-resign.sh`
+(stubbed codesign/pgrep/svc.sh, runs in CI on every push).
+
 ## `localvoxtral-build-gate.sh` — SSH build gate (v4)
 
 Forced command for the Linux dev box's build key on the Mac build host. It

--- a/scripts/mac/runner-node-resign.sh
+++ b/scripts/mac/runner-node-resign.sh
@@ -1,0 +1,249 @@
+#!/usr/bin/env bash
+# runner-node-resign.sh — keep the self-hosted runner's bundled node binaries
+# signed with the owner's stable code-signing identity so their TCC grants
+# (Accessibility + Screen Recording, needed by the tier-2 GUI lanes) survive
+# runner auto-updates.
+#
+# Why: macOS keys a TCC grant to the client binary's code signature. An
+# UNSIGNED binary is keyed by content hash, so the runner's auto-update —
+# which replaces every externals/node*/bin/node — silently kills the grants
+# on each update (field incidents 2026-07-24/25: red tier-2 lanes plus real
+# TCC prompts on the runner's GUI session). Signing node with a stable
+# identity + identifier records the grant against the signature's designated
+# requirement instead; re-signing a NEW node with the SAME identity and
+# identifier keeps the existing grant valid with no Settings visit.
+#
+# Verbs:
+#   run [--dry-run]  resign pass (default; what the LaunchAgent invokes)
+#   install-agent    copy this script to a stable path and bootstrap the
+#                    WatchPaths + hourly LaunchAgent (owner GUI session, once)
+#   status           per-node signing state + agent state
+#
+# One-time, after the FIRST signed pass only: remove and re-add the four TCC
+# rows (node20 + node24 x Accessibility + Screen Recording) — the old rows
+# are keyed to the pre-signing content hashes and never match again. The
+# first manual `run` may pop one keychain "Always Allow" prompt for the
+# signing key — trigger that by hand in a GUI terminal; never let the agent
+# be the first signer or it hangs on the prompt (same gotcha as CI signing,
+# AGENTS.md).
+#
+# The agent double-fires benignly: our own codesign writes touch WatchPaths,
+# so launchd runs one extra pass that finds everything signed and exits.
+#
+# Test seams (scripts/ci/test-runner-node-resign.sh): external commands
+# (codesign, pgrep) resolve via PATH; locations and timings via LV_* env.
+# No seam default changes production behavior.
+set -euo pipefail
+
+RUNNER_DIR="${LV_RUNNER_DIR:-$HOME/actions-runner}"
+IDENTITY="${LV_RESIGN_IDENTITY:-localvoxtral-dev}"
+IDENTIFIER="${LV_RESIGN_IDENTIFIER:-com.localvoxtral.runner-node}"
+IDLE_TIMEOUT_SECS="${LV_RESIGN_IDLE_TIMEOUT_SECS:-1800}"
+IDLE_POLL_SECS="${LV_RESIGN_IDLE_POLL_SECS:-20}"
+# The LaunchAgent sets this to 60: WatchPaths fires mid-auto-update, and the
+# scan must not race the runner still unpacking its new externals tree.
+SETTLE_SECS="${LV_RESIGN_SETTLE_SECS:-0}"
+
+LABEL="com.localvoxtral.runner-node-resign"
+AGENT_PLIST="$HOME/Library/LaunchAgents/$LABEL.plist"
+INSTALL_BIN_DIR="$HOME/Library/Application Support/localvoxtral/bin"
+INSTALLED_SCRIPT="$INSTALL_BIN_DIR/runner-node-resign.sh"
+LOG_FILE="$HOME/Library/Logs/localvoxtral-runner-node-resign.log"
+
+log() { printf '%s %s\n' "$(date '+%Y-%m-%dT%H:%M:%S%z')" "$*"; }
+die() {
+  log "ERROR: $*" >&2
+  exit 1
+}
+
+list_nodes() {
+  local n
+  for n in "$RUNNER_DIR"/externals/node*/bin/node; do
+    [[ -f "$n" ]] && printf '%s\n' "$n"
+  done
+  return 0
+}
+
+# True when the binary already carries our identity AND identifier. Display
+# flags only — never let a probe re-sign anything (PR #82 forensics).
+node_is_ours() {
+  local node="$1" info
+  info="$(codesign -dvv "$node" 2>&1 || true)"
+  [[ "$info" == *"Identifier=$IDENTIFIER"* && "$info" == *"Authority=$IDENTITY"* ]]
+}
+
+worker_active() {
+  pgrep -f "$RUNNER_DIR/bin/Runner.Worker" >/dev/null 2>&1
+}
+
+# Never stop the service under a live job: a Runner.Worker process means a
+# CI run is in flight. Timeout leaves everything untouched — the hourly
+# StartInterval pass retries.
+wait_for_idle() {
+  local waited=0 step="$IDLE_POLL_SECS"
+  [[ "$step" -ge 1 ]] || step=1
+  while worker_active; do
+    if [[ "$waited" -ge "$IDLE_TIMEOUT_SECS" ]]; then
+      return 1
+    fi
+    log "a runner job is in flight — waiting (${waited}s/${IDLE_TIMEOUT_SECS}s)"
+    sleep "$IDLE_POLL_SECS"
+    waited=$((waited + step))
+  done
+  return 0
+}
+
+cmd_run() {
+  local dry_run="${1:-}"
+  [[ -d "$RUNNER_DIR/externals" ]] \
+    || die "runner externals dir not found: $RUNNER_DIR/externals (set LV_RUNNER_DIR)"
+  if [[ "$SETTLE_SECS" -gt 0 ]]; then
+    sleep "$SETTLE_SECS"
+  fi
+
+  local nodes total=0 n unsigned
+  unsigned=()
+  nodes="$(list_nodes)"
+  [[ -n "$nodes" ]] || die "no externals/node*/bin/node binaries under $RUNNER_DIR"
+  while IFS= read -r n; do
+    total=$((total + 1))
+    node_is_ours "$n" || unsigned+=("$n")
+  done <<<"$nodes"
+
+  if [[ ${#unsigned[@]} -eq 0 ]]; then
+    log "all $total node binaries already carry $IDENTITY/$IDENTIFIER — nothing to do"
+    return 0
+  fi
+
+  if [[ "$dry_run" == "--dry-run" ]]; then
+    for n in ${unsigned[@]+"${unsigned[@]}"}; do
+      log "dry-run: would sign $n"
+    done
+    log "dry-run: would stop the runner service, sign ${#unsigned[@]} of $total binaries, restart it"
+    return 0
+  fi
+
+  wait_for_idle \
+    || die "runner worker still busy after ${IDLE_TIMEOUT_SECS}s — leaving the service untouched (hourly pass retries)"
+
+  log "signing ${#unsigned[@]} of $total node binaries with identity '$IDENTITY' (identifier $IDENTIFIER)"
+  local svc_stopped=0 failures=0
+  if [[ -x "$RUNNER_DIR/svc.sh" ]]; then
+    log "stopping runner service"
+    (cd "$RUNNER_DIR" && ./svc.sh stop) || log "WARN: svc.sh stop reported nonzero (continuing)"
+    svc_stopped=1
+  else
+    # Signing a binary the running service has mapped can get its process
+    # killed by the kernel's signature revalidation — warn loudly.
+    log "WARN: $RUNNER_DIR/svc.sh not found/executable — signing WITHOUT a service stop"
+  fi
+
+  for n in ${unsigned[@]+"${unsigned[@]}"}; do
+    if codesign --force --sign "$IDENTITY" --identifier "$IDENTIFIER" "$n"; then
+      log "signed: $n"
+    else
+      log "ERROR: codesign failed for $n"
+      failures=$((failures + 1))
+    fi
+  done
+
+  # Restart even after sign failures: a broken grant is recoverable, a
+  # stopped runner service silently kills all CI.
+  if [[ "$svc_stopped" -eq 1 ]]; then
+    log "starting runner service"
+    (cd "$RUNNER_DIR" && ./svc.sh start) \
+      || die "svc.sh start failed — the runner service may be DOWN, intervene now"
+  fi
+
+  [[ "$failures" -eq 0 ]] \
+    || die "$failures binaries failed to sign — their TCC grants stay broken until a clean pass"
+  log "done — TCC grants keyed to $IDENTITY/$IDENTIFIER remain valid across this update"
+}
+
+cmd_status() {
+  local n found=0
+  while IFS= read -r n; do
+    [[ -n "$n" ]] || continue
+    found=1
+    if node_is_ours "$n"; then
+      printf 'signed   %s\n' "$n"
+    else
+      printf 'UNSIGNED %s\n' "$n"
+    fi
+  done <<<"$(list_nodes)"
+  [[ "$found" -eq 1 ]] || printf 'no node binaries under %s/externals\n' "$RUNNER_DIR"
+  if launchctl print "gui/$(id -u)/$LABEL" >/dev/null 2>&1; then
+    printf 'agent    %s loaded\n' "$LABEL"
+  else
+    printf 'agent    %s NOT loaded (run install-agent)\n' "$LABEL"
+  fi
+}
+
+cmd_install_agent() {
+  [[ -d "$RUNNER_DIR/externals" ]] \
+    || die "runner externals dir not found: $RUNNER_DIR/externals (set LV_RUNNER_DIR)"
+  command -v codesign >/dev/null 2>&1 || die "codesign not found"
+
+  mkdir -p "$INSTALL_BIN_DIR" "$(dirname "$AGENT_PLIST")" "$(dirname "$LOG_FILE")"
+  install -m 0755 "${BASH_SOURCE[0]}" "$INSTALLED_SCRIPT"
+
+  cat >"$AGENT_PLIST" <<PLIST
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key><string>$LABEL</string>
+  <key>ProgramArguments</key>
+  <array>
+    <string>/bin/bash</string>
+    <string>$INSTALLED_SCRIPT</string>
+    <string>run</string>
+  </array>
+  <key>EnvironmentVariables</key>
+  <dict>
+    <key>LV_RESIGN_SETTLE_SECS</key><string>60</string>
+  </dict>
+  <key>WatchPaths</key>
+  <array><string>$RUNNER_DIR/externals</string></array>
+  <key>StartInterval</key><integer>3600</integer>
+  <key>RunAtLoad</key><true/>
+  <key>ThrottleInterval</key><integer>30</integer>
+  <key>StandardOutPath</key><string>$LOG_FILE</string>
+  <key>StandardErrorPath</key><string>$LOG_FILE</string>
+</dict>
+</plist>
+PLIST
+
+  launchctl bootout "gui/$(id -u)" "$AGENT_PLIST" 2>/dev/null || true
+  launchctl bootstrap "gui/$(id -u)" "$AGENT_PLIST"
+
+  log "agent installed: $AGENT_PLIST (script: $INSTALLED_SCRIPT, log: $LOG_FILE)"
+  cat <<'NEXT'
+Next steps (once):
+  1. Run the first pass BY HAND in this GUI terminal so the keychain
+     "Always Allow" prompt for the signing key lands on you, not the agent:
+       "$HOME/Library/Application Support/localvoxtral/bin/runner-node-resign.sh" run
+  2. System Settings > Privacy & Security: in BOTH Accessibility and
+     Screen Recording, REMOVE the existing node rows and re-add BOTH
+     ~/actions-runner/externals/node*/bin/node binaries (4 entries total).
+     The old rows are keyed to the pre-signing hashes and never match again.
+  3. Verify: dispatch ui-smoke.yml — its TCC preflight is the live probe.
+NEXT
+}
+
+case "${1:-run}" in
+  run)
+    shift || true
+    cmd_run "${1:-}"
+    ;;
+  install-agent)
+    cmd_install_agent
+    ;;
+  status)
+    cmd_status
+    ;;
+  *)
+    echo "Usage: $0 [run [--dry-run]|install-agent|status]" >&2
+    exit 1
+    ;;
+esac


### PR DESCRIPTION
## What

Removes the last manual TCC chore on the runner: every runner auto-update replaces the unsigned `externals/node*/bin/node` binaries, and macOS keys an unsigned binary's TCC grant to its content hash — so the tier-2 lanes' Accessibility + Screen Recording grants died on each update (2026-07-24/25 incident chain; the 07-25 re-grant additionally showed BOTH node20 and node24 need entries). This PR keys the grants to a *stable signature* instead:

- `scripts/mac/runner-node-resign.sh` — signs all `externals/node*/bin/node` with the owner's `localvoxtral-dev` identity and the fixed identifier `com.localvoxtral.runner-node`. Verbs: `run [--dry-run]`, `install-agent`, `status`.
- A LaunchAgent (`com.localvoxtral.runner-node-resign`, written+bootstrapped by `install-agent`): `WatchPaths` on `externals/` (fires when an update swaps node) + hourly `StartInterval` backstop + `RunAtLoad`. 60 s settle delay so it never races the update mid-unpack. Because a re-signed binary satisfies the same designated requirement, the existing TCC rows stay valid — auto-update stays ON, no monthly manual-update ritual, no Settings visits after the one-time re-add.
- Safety invariants, both tested: the pass never stops the service while a `Runner.Worker` is alive (waits up to 30 min, then defers to the hourly retry), and it restarts the service even when codesign fails — a broken grant is recoverable, a dead runner silently kills all CI.
- Owner runbook section in `scripts/mac/README.md` (install steps, the one-time 4-row TCC re-add, keychain first-sign gotcha, caveats incl. the sub-minute self-healing race window); AGENTS.md pointer under the code-signing bullet.

Not covered, by design: the agent is owner-installed host state (like the test-server LaunchAgents) — CI tests the script's logic, not the bootstrap.

## Proof

- New regression suite `scripts/ci/test-runner-node-resign.sh` (stubbed `codesign`/`pgrep`/`svc.sh`, wired into both "Process-cleanup regression tests" CI steps), all 8 cases passing locally:
  ```
  PASS: unsigned nodes are signed between a service stop and start
  PASS: fully-signed state is a no-op
  PASS: partial invalidation signs only the unsigned node
  PASS: dry-run is inert
  PASS: live runner job blocks the pass without side effects
  PASS: pass proceeds once the worker drains
  PASS: sign failure never leaves the runner service down
  PASS: missing runner dir fails loudly
  runner-node-resign tests passed
  ```
- The signature-stability premise is this repo's own established behavior (AGENTS.md: identity-signed builds keep their TCC grant across rebuilds; ad-hoc/unsigned get invalidated) — the same mechanism, applied to the runner's node.
- End-to-end field proof happens at install time (owner action): after `install-agent` + first manual `run` + the one-time TCC re-add, `runner-node-resign.sh status` must show `signed` ×2 and a ui-smoke dispatch must pass its TCC preflight; the durable proof is the preflight staying green across the NEXT runner auto-update with zero Settings visits.
- LLM lane: skipped — operational scripts + docs only, nothing that reaches the model.
- UI change: none.
