### PR TITLE
Profile-aware polish prompt warmup: prime the agent prefix too

### DIFF
--- a/Sources/localvoxtral/PolishPromptWarmup.swift
+++ b/Sources/localvoxtral/PolishPromptWarmup.swift
@@ -5,15 +5,16 @@ import Foundation
 /// not pay the full static-prefix prefill (with the 4B default that prefill
 /// is the dominant share of first-polish latency).
 ///
-/// Why app-side: `localvoxtral-polishd` keeps a single KV-state checkpoint of
-/// the templated stable prefix — every message except the last — keyed by the
-/// exact prefix tokens plus chat-template kwargs (`MLXPolishModel`). The app,
-/// not the helper, knows the prompt templates, and every production polish
-/// request shares the same `[system, static user prefix]` head (the rendered
-/// user prompt is split at its first placeholder — `LLMPromptTemplates
-/// .renderedUserPrompts`). One request through the production request path
-/// with that head and a throwaway tail therefore checkpoints exactly the
-/// state real requests reuse.
+/// Why app-side: `localvoxtral-polishd` keeps KV-state checkpoints of the
+/// templated stable prefix — every message except the last — keyed by the
+/// exact prefix tokens plus chat-template kwargs, one LRU slot per prompt
+/// profile (`MLXPolishModel` / `PromptPrefixSlotStore`). The app, not the
+/// helper, knows the prompt templates, and every production polish request
+/// of a given profile shares that profile's `[system, static user prefix]`
+/// head (the rendered user prompt is split at its first placeholder —
+/// `LLMPromptTemplates.renderedUserPrompts`). One request per profile
+/// through the production request path with that head and a throwaway tail
+/// therefore checkpoints exactly the state real requests reuse.
 enum PolishPromptWarmup {
     /// Throwaway final-message content. Its text never matters for cache
     /// reuse — only the preceding messages are checkpointed — it just has to
@@ -23,10 +24,6 @@ enum PolishPromptWarmup {
     /// The warmup request: identical prefix messages to a production polish
     /// request (same system prompt, same static user prefix, dictionary slot
     /// rides the dynamic tail), minimal tail, and a 1-token generation cap.
-    ///
-    /// TODO(profile-aware warmup): once the agent polish profile ships, warm
-    /// the profile the next commit will actually use instead of assuming the
-    /// standard one.
     static func request(templates: LLMPromptTemplates) -> LLMPolishingRequest {
         LLMPolishingRequest(
             inputText: warmupInputText,
@@ -39,21 +36,49 @@ enum PolishPromptWarmup {
         )
     }
 
-    /// The warmup to run for the current settings, or nil when warmup must
+    /// The warmups to run for the current settings, or nil when warmup must
     /// not run: polishing disabled, or the polishing backend is an external
     /// URL (never warm someone else's server — and its cache keying is
     /// unknown anyway).
+    ///
+    /// One request per prompt profile a commit could use: the standard
+    /// profile always, plus the agent profile when its toggle is on — the
+    /// helper keeps one prefix-checkpoint slot per profile
+    /// (`--prompt-cache-slots`, default 2), so warming both keeps the first
+    /// polish fast whichever app the user dictates into. When the agent
+    /// prompt files fall back to the standard templates (corrupt/missing —
+    /// see `loadLLMPromptTemplates(profile:)`), the prefixes are identical
+    /// and the duplicate request is dropped.
     @MainActor
     static func plan(
         settings: SettingsStore,
         appConfigStore: any AppConfigServing
-    ) -> (request: LLMPolishingRequest, configuration: LLMPolishingConfiguration)? {
+    ) -> (requests: [ProfiledRequest], configuration: LLMPolishingConfiguration)? {
         guard settings.polishingBackendMode == .managedLocal,
             let configuration = settings.llmPolishingConfiguration
         else {
             return nil
         }
-        return (request(templates: appConfigStore.loadLLMPromptTemplates()), configuration)
+        let standardTemplates = appConfigStore.loadLLMPromptTemplates()
+        var requests: [ProfiledRequest] = [
+            ProfiledRequest(profile: .standard, request: request(templates: standardTemplates))
+        ]
+        if settings.agentPolishProfileEnabled {
+            let agentTemplates = appConfigStore.loadLLMPromptTemplates(profile: .agent)
+            if agentTemplates != standardTemplates {
+                requests.append(
+                    ProfiledRequest(profile: .agent, request: request(templates: agentTemplates))
+                )
+            }
+        }
+        return (requests, configuration)
+    }
+
+    /// A warmup request labeled with the profile it primes, so per-request
+    /// log lines can attribute a slow or failed warmup to the right prefix.
+    struct ProfiledRequest {
+        let profile: PolishPromptProfile
+        let request: LLMPolishingRequest
     }
 }
 
@@ -66,14 +91,20 @@ enum PolishPromptWarmup {
 ///
 /// The warmup task is fire-and-forget: nothing in the session path ever
 /// awaits it, so it cannot delay a real polish request app-side. Helper-side
-/// the two requests serialize on the model container; with `max_tokens: 1`
-/// the warmup's tail work past the (wanted) prefix prefill is a few tail
-/// tokens plus one generated token. Failures are logged to `Log.backends`
-/// and swallowed — warmup is never user-visible.
+/// warmup and real requests serialize on the model container; with
+/// `max_tokens: 1` each warmup's tail work past the (wanted) prefix prefill
+/// is a few tail tokens plus one generated token. The plan's per-profile
+/// requests run sequentially in one task (the container would serialize them
+/// anyway), a non-cancellation failure on one profile still warms the rest,
+/// and failures are logged to `Log.backends` and swallowed — warmup is never
+/// user-visible.
 @MainActor
 final class PolishPromptWarmupCoordinator {
     typealias PlanProvider =
-        @MainActor () -> (request: LLMPolishingRequest, configuration: LLMPolishingConfiguration)?
+        @MainActor () -> (
+            requests: [PolishPromptWarmup.ProfiledRequest],
+            configuration: LLMPolishingConfiguration
+        )?
     typealias ServiceProvider = @MainActor () -> any LLMPolishingServicing
 
     private let serviceProvider: ServiceProvider
@@ -131,32 +162,38 @@ final class PolishPromptWarmupCoordinator {
             return
         }
         warmupTask?.cancel()
+        let profiles = plan.requests.map(\.profile.rawValue).joined(separator: "+")
         Log.backends.info(
-            "polish prompt warmup started for model \(plan.configuration.model, privacy: .public)"
+            "polish prompt warmup started for model \(plan.configuration.model, privacy: .public) profiles \(profiles, privacy: .public)"
         )
         let service = serviceProvider()
         warmupTask = Task { @MainActor in
-            do {
-                let result = try await service.polish(
-                    request: plan.request,
-                    configuration: plan.configuration
-                )
-                Log.backends.info(
-                    "polish prompt warmup completed in \(String(format: "%.2f", result.durationSeconds), privacy: .public)s"
-                )
-            } catch is CancellationError {
-                Log.backends.info("polish prompt warmup cancelled")
-            } catch {
-                guard !Task.isCancelled else {
+            for profiledRequest in plan.requests {
+                let profile = profiledRequest.profile.rawValue
+                do {
+                    let result = try await service.polish(
+                        request: profiledRequest.request,
+                        configuration: plan.configuration
+                    )
+                    Log.backends.info(
+                        "polish prompt warmup (\(profile, privacy: .public)) completed in \(String(format: "%.2f", result.durationSeconds), privacy: .public)s"
+                    )
+                } catch is CancellationError {
                     Log.backends.info("polish prompt warmup cancelled")
                     return
+                } catch {
+                    guard !Task.isCancelled else {
+                        Log.backends.info("polish prompt warmup cancelled")
+                        return
+                    }
+                    // Log-only by design: the helper may still have prefilled
+                    // the prefix (e.g. a client-side timeout), and the next
+                    // real request works either way — it just pays full
+                    // prefill. The remaining profiles still get their warmup.
+                    Log.backends.error(
+                        "polish prompt warmup (\(profile, privacy: .public)) failed (log-only): \(error.localizedDescription, privacy: .public)"
+                    )
                 }
-                // Log-only by design: the helper may still have prefilled the
-                // prefix (e.g. a client-side timeout), and the next real
-                // request works either way — it just pays full prefill.
-                Log.backends.error(
-                    "polish prompt warmup failed (log-only): \(error.localizedDescription, privacy: .public)"
-                )
             }
         }
     }

--- a/Sources/localvoxtral/PolishPromptWarmup.swift
+++ b/Sources/localvoxtral/PolishPromptWarmup.swift
@@ -59,19 +59,33 @@ enum PolishPromptWarmup {
         else {
             return nil
         }
-        let standardTemplates = appConfigStore.loadLLMPromptTemplates()
+        let standardRequest = request(templates: appConfigStore.loadLLMPromptTemplates())
         var requests: [ProfiledRequest] = [
-            ProfiledRequest(profile: .standard, request: request(templates: standardTemplates))
+            ProfiledRequest(profile: .standard, request: standardRequest)
         ]
         if settings.agentPolishProfileEnabled {
-            let agentTemplates = appConfigStore.loadLLMPromptTemplates(profile: .agent)
-            if agentTemplates != standardTemplates {
-                requests.append(
-                    ProfiledRequest(profile: .agent, request: request(templates: agentTemplates))
-                )
+            let agentRequest = request(
+                templates: appConfigStore.loadLLMPromptTemplates(profile: .agent)
+            )
+            if !sharesCheckpointedPrefix(agentRequest, standardRequest) {
+                requests.append(ProfiledRequest(profile: .agent, request: agentRequest))
             }
         }
         return (requests, configuration)
+    }
+
+    /// Whether two warmup requests would prime the same helper checkpoint.
+    /// The helper's cache key is the templated NON-FINAL messages (system +
+    /// all user prompts but the last), so the comparison mirrors exactly
+    /// that — templates that differ only past the first placeholder (or an
+    /// agent fallback to the standard files) share one checkpoint, and the
+    /// duplicate request would be wasted helper work.
+    private static func sharesCheckpointedPrefix(
+        _ lhs: LLMPolishingRequest,
+        _ rhs: LLMPolishingRequest
+    ) -> Bool {
+        lhs.systemPrompt == rhs.systemPrompt
+            && lhs.userPrompts.dropLast() == rhs.userPrompts.dropLast()
     }
 
     /// A warmup request labeled with the profile it primes, so per-request
@@ -169,6 +183,14 @@ final class PolishPromptWarmupCoordinator {
         let service = serviceProvider()
         warmupTask = Task { @MainActor in
             for profiledRequest in plan.requests {
+                // Checked per iteration, not only on the error path: a helper
+                // stop can race a SUCCESSFUL response, and the next profile's
+                // request must not land on the stopped (or replacement)
+                // helper.
+                guard !Task.isCancelled else {
+                    Log.backends.info("polish prompt warmup cancelled")
+                    return
+                }
                 let profile = profiledRequest.profile.rawValue
                 do {
                     let result = try await service.polish(

--- a/Tests/localvoxtralTests/PolishHelperIntegrationTests.swift
+++ b/Tests/localvoxtralTests/PolishHelperIntegrationTests.swift
@@ -676,9 +676,10 @@ final class PolishHelperIntegrationTests: XCTestCase {
         // timeout and failed the scoreboard with "request timed out" — a
         // latency artifact, not a quality regression (CI, 2026-07-11). Pay
         // the profile's prefill up front with the production warmup request
-        // shape, result ignored — exactly what the planned profile-aware
-        // warmup will do in production (TODO in `PolishPromptWarmup
-        // .request`). Bounded: an attempt that times out client-side still
+        // shape, result ignored — exactly what the production profile-aware
+        // warmup does per launch (`PolishPromptWarmup.plan` warms the agent
+        // prefix alongside the standard one). Bounded: an attempt that times
+        // out client-side still
         // leaves the helper prefilling, so the next attempt (and the
         // scoreboard) hits the warm checkpoint.
         let service = LLMPolishingService()

--- a/Tests/localvoxtralTests/PolishPromptWarmupTests.swift
+++ b/Tests/localvoxtralTests/PolishPromptWarmupTests.swift
@@ -104,16 +104,24 @@ final class PolishPromptWarmupTests: XCTestCase {
 
     // MARK: - Helpers
 
-    private func makePlan() -> (
-        request: LLMPolishingRequest, configuration: LLMPolishingConfiguration
+    private func makePlan(
+        profiles: [PolishPromptProfile] = [.standard]
+    ) -> (
+        requests: [PolishPromptWarmup.ProfiledRequest],
+        configuration: LLMPolishingConfiguration
     ) {
         (
-            request: LLMPolishingRequest(
-                inputText: "warm",
-                systemPrompt: "system",
-                userPrompts: ["static prefix", "tail"],
-                maxTokens: 1
-            ),
+            requests: profiles.map { profile in
+                PolishPromptWarmup.ProfiledRequest(
+                    profile: profile,
+                    request: LLMPolishingRequest(
+                        inputText: "warm",
+                        systemPrompt: "system \(profile.rawValue)",
+                        userPrompts: ["static prefix \(profile.rawValue)", "tail"],
+                        maxTokens: 1
+                    )
+                )
+            },
             configuration: LLMPolishingConfiguration(
                 endpointURL: URL(string: "http://127.0.0.1:9/v1/chat/completions")!,
                 apiKey: "",
@@ -156,6 +164,41 @@ final class PolishPromptWarmupTests: XCTestCase {
         coordinator.handleStatusUpdate(update(BackendCatalog.polishd, .ready))
         await awaitWarmup(coordinator)
         XCTAssertEqual(service.requests.count, 1, "duplicate ready must not re-fire warmup")
+    }
+
+    func testTwoProfilePlanWarmsBothPrefixesPerReadyEdge() async {
+        let service = RecordingPolishService()
+        let coordinator = PolishPromptWarmupCoordinator(
+            serviceProvider: { service },
+            planProvider: { [plan = makePlan(profiles: [.standard, .agent])] in plan }
+        )
+
+        coordinator.handleStatusUpdate(update(BackendCatalog.polishd, .ready))
+        await awaitWarmup(coordinator)
+        XCTAssertEqual(
+            service.requests.map(\.systemPrompt),
+            ["system standard", "system agent"],
+            "one ready edge must warm every profile's prefix, standard first"
+        )
+
+        coordinator.handleStatusUpdate(update(BackendCatalog.polishd, .ready))
+        await awaitWarmup(coordinator)
+        XCTAssertEqual(service.requests.count, 2, "duplicate ready must not re-fire warmup")
+    }
+
+    func testFirstProfileFailureStillWarmsRemainingProfiles() async {
+        // A non-cancellation failure is log-only per profile: the agent
+        // request must still be sent when the standard one failed.
+        let service = RecordingPolishService()
+        service.setFailure(LLMPolishingError.networkError("connection refused"))
+        let coordinator = PolishPromptWarmupCoordinator(
+            serviceProvider: { service },
+            planProvider: { [plan = makePlan(profiles: [.standard, .agent])] in plan }
+        )
+
+        coordinator.handleStatusUpdate(update(BackendCatalog.polishd, .ready))
+        await awaitWarmup(coordinator)
+        XCTAssertEqual(service.requests.count, 2)
     }
 
     func testWarmupFiresAgainAfterHelperRestart() async {
@@ -298,6 +341,32 @@ final class PolishPromptWarmupTests: XCTestCase {
         )
     }
 
+    /// Same invariant for the agent profile's bundled templates: an agent
+    /// commit reuses the checkpoint only if the warmup's non-final messages
+    /// are byte-identical to an agent production request's.
+    func testWarmupRequestSharesAllNonFinalMessagesWithAgentProductionRequests() throws {
+        let (templates, cleanup) = try LLMPolishEvalSupport.agentPromptTemplates()
+        defer { cleanup() }
+
+        let warmup = PolishPromptWarmup.request(templates: templates)
+        let production = LLMPolishingRequest(
+            inputText: "run cargo test dash dash release",
+            systemPrompt: templates.systemContent,
+            userPrompts: templates.renderedUserPrompts(
+                inputText: "run cargo test dash dash release",
+                replacementDictionary: ""
+            )
+        )
+
+        XCTAssertEqual(warmup.systemPrompt, production.systemPrompt)
+        XCTAssertEqual(warmup.userPrompts.count, production.userPrompts.count)
+        XCTAssertEqual(
+            Array(warmup.userPrompts.dropLast()),
+            Array(production.userPrompts.dropLast()),
+            "warmup must prime the exact prefix messages agent production requests reuse"
+        )
+    }
+
     /// A custom user template with no static text before its first
     /// placeholder renders as a single user message; the shared prefix is
     /// then just the system message, and warmup must mirror that shape.
@@ -343,6 +412,9 @@ final class PolishPromptWarmupPlanTests: XCTestCase {
         SettingsStore(defaults: defaults, environment: [:])
     }
 
+    /// Implements only the zero-arg loader, so the protocol's default
+    /// conformance answers every profile with the standard templates —
+    /// exactly the agent-file-fallback shape of the real store.
     private var configStore: some AppConfigServing {
         struct Fixed: AppConfigServing {
             func configDirectoryURL() -> URL { URL(fileURLWithPath: "/dev/null") }
@@ -357,6 +429,33 @@ final class PolishPromptWarmupPlanTests: XCTestCase {
         return Fixed()
     }
 
+    /// Distinct templates per profile, like the real store with healthy
+    /// agent prompt files.
+    private var profileAwareConfigStore: some AppConfigServing {
+        struct ProfileAware: AppConfigServing {
+            func configDirectoryURL() -> URL { URL(fileURLWithPath: "/dev/null") }
+            func loadReplacementDictionary() -> ReplacementDictionary {
+                ReplacementDictionary(entries: [])
+            }
+            func loadLLMPromptTemplates() -> LLMPromptTemplates {
+                LLMPromptTemplates(systemContent: "system", userContent: "prefix {{input_text}}")
+            }
+            func loadLLMPromptTemplates(profile: PolishPromptProfile) -> LLMPromptTemplates {
+                switch profile {
+                case .standard:
+                    return loadLLMPromptTemplates()
+                case .agent:
+                    return LLMPromptTemplates(
+                        systemContent: "agent system",
+                        userContent: "agent prefix {{input_text}}"
+                    )
+                }
+            }
+            func loadTerminalAppBundleIDs() -> [String] { [] }
+        }
+        return ProfileAware()
+    }
+
     func testPlanWarmsManagedEndpointWhenPolishingEnabled() throws {
         let store = makeStore()
         store.llmPolishingEnabled = true
@@ -369,7 +468,55 @@ final class PolishPromptWarmupPlanTests: XCTestCase {
             plan.configuration.endpointURL.absoluteString,
             ManagedBackendEndpoints.polishingURLString
         )
-        XCTAssertEqual(plan.request.maxTokens, 1)
+        XCTAssertEqual(plan.requests.first?.request.maxTokens, 1)
+    }
+
+    /// Regression (first agent-profile polish paid full cold prefill): with
+    /// the agent profile enabled and healthy agent prompt files, the plan
+    /// must warm the AGENT prefix too — the helper keeps one checkpoint slot
+    /// per profile, and a standard-only warmup leaves the terminal-dictation
+    /// first polish cold.
+    func testPlanWarmsAgentPrefixWhenAgentProfileEnabled() throws {
+        let store = makeStore()
+        store.llmPolishingEnabled = true
+        store.agentPolishProfileEnabled = true
+
+        let plan = try XCTUnwrap(
+            PolishPromptWarmup.plan(settings: store, appConfigStore: profileAwareConfigStore)
+        )
+
+        XCTAssertEqual(plan.requests.map(\.profile), [.standard, .agent])
+        let agentRequest = try XCTUnwrap(plan.requests.last?.request)
+        XCTAssertEqual(agentRequest.systemPrompt, "agent system")
+        XCTAssertEqual(agentRequest.userPrompts.first, "agent prefix ")
+        XCTAssertEqual(agentRequest.maxTokens, 1)
+    }
+
+    func testPlanSkipsAgentPrefixWhenProfileDisabled() throws {
+        let store = makeStore()
+        store.llmPolishingEnabled = true
+        store.agentPolishProfileEnabled = false
+
+        let plan = try XCTUnwrap(
+            PolishPromptWarmup.plan(settings: store, appConfigStore: profileAwareConfigStore)
+        )
+
+        XCTAssertEqual(plan.requests.map(\.profile), [.standard])
+    }
+
+    func testPlanDropsDuplicateAgentRequestOnTemplateFallback() throws {
+        // Agent prompt files corrupt/missing → the loader answers with the
+        // standard templates; warming the identical prefix twice is wasted
+        // helper work, so the plan de-duplicates it.
+        let store = makeStore()
+        store.llmPolishingEnabled = true
+        store.agentPolishProfileEnabled = true
+
+        let plan = try XCTUnwrap(
+            PolishPromptWarmup.plan(settings: store, appConfigStore: configStore)
+        )
+
+        XCTAssertEqual(plan.requests.map(\.profile), [.standard])
     }
 
     func testPlanIsNilWhenPolishingDisabled() {

--- a/Tests/localvoxtralTests/PolishPromptWarmupTests.swift
+++ b/Tests/localvoxtralTests/PolishPromptWarmupTests.swift
@@ -102,6 +102,53 @@ final class PolishPromptWarmupTests: XCTestCase {
         }
     }
 
+    /// First polish call suspends, and resolves SUCCESSFULLY when the
+    /// surrounding task is cancelled — models a helper response that wins
+    /// the race against cancellation. Later calls answer immediately.
+    private final class SucceedOnCancelPolishService: LLMPolishingServicing, @unchecked Sendable {
+        private let lock = NSLock()
+        private var continuation: CheckedContinuation<Void, Never>?
+        private var recordedRequests: [LLMPolishingRequest] = []
+        let started = XCTestExpectation(description: "first polish request reached the service")
+
+        var requests: [LLMPolishingRequest] {
+            lock.lock()
+            defer { lock.unlock() }
+            return recordedRequests
+        }
+
+        func polish(
+            request: LLMPolishingRequest,
+            configuration: LLMPolishingConfiguration
+        ) async throws -> LLMPolishingResult {
+            let isFirst: Bool = lock.withLock {
+                recordedRequests.append(request)
+                return recordedRequests.count == 1
+            }
+            if isFirst {
+                started.fulfill()
+                await withTaskCancellationHandler {
+                    await withCheckedContinuation { continuation in
+                        lock.lock()
+                        self.continuation = continuation
+                        lock.unlock()
+                    }
+                } onCancel: {
+                    lock.lock()
+                    let continuation = self.continuation
+                    self.continuation = nil
+                    lock.unlock()
+                    continuation?.resume()
+                }
+            }
+            return LLMPolishingResult(
+                rawText: request.inputText,
+                polishedText: request.inputText,
+                durationSeconds: 0
+            )
+        }
+    }
+
     // MARK: - Helpers
 
     private func makePlan(
@@ -199,6 +246,26 @@ final class PolishPromptWarmupTests: XCTestCase {
         coordinator.handleStatusUpdate(update(BackendCatalog.polishd, .ready))
         await awaitWarmup(coordinator)
         XCTAssertEqual(service.requests.count, 2)
+    }
+
+    func testHelperStopAfterSuccessfulFirstProfileSkipsRemainingProfiles() async {
+        // Codex review finding: cancellation was only observed on the error
+        // path, so a helper stop racing a SUCCESSFUL standard response let
+        // the agent request land on the stopped (or replacement) helper.
+        let service = SucceedOnCancelPolishService()
+        let coordinator = PolishPromptWarmupCoordinator(
+            serviceProvider: { service },
+            planProvider: { [plan = makePlan(profiles: [.standard, .agent])] in plan }
+        )
+
+        coordinator.handleStatusUpdate(update(BackendCatalog.polishd, .ready))
+        await fulfillment(of: [service.started], timeout: 5)
+        coordinator.handleStatusUpdate(update(BackendCatalog.polishd, .stopped))
+        await awaitWarmup(coordinator)
+        XCTAssertEqual(
+            service.requests.count, 1,
+            "a cancelled warmup must not start the next profile's request"
+        )
     }
 
     func testWarmupFiresAgainAfterHelperRestart() async {
@@ -514,6 +581,44 @@ final class PolishPromptWarmupPlanTests: XCTestCase {
 
         let plan = try XCTUnwrap(
             PolishPromptWarmup.plan(settings: store, appConfigStore: configStore)
+        )
+
+        XCTAssertEqual(plan.requests.map(\.profile), [.standard])
+    }
+
+    func testPlanDropsAgentRequestWhenOnlyTailsDiffer() throws {
+        // Codex review finding: the helper's cache key is the NON-FINAL
+        // messages only, so agent templates that differ from standard only
+        // past the first placeholder prime the same checkpoint — a second
+        // request would be wasted helper work.
+        struct TailOnlyDiff: AppConfigServing {
+            func configDirectoryURL() -> URL { URL(fileURLWithPath: "/dev/null") }
+            func loadReplacementDictionary() -> ReplacementDictionary {
+                ReplacementDictionary(entries: [])
+            }
+            func loadLLMPromptTemplates() -> LLMPromptTemplates {
+                LLMPromptTemplates(systemContent: "system", userContent: "prefix {{input_text}}")
+            }
+            func loadLLMPromptTemplates(profile: PolishPromptProfile) -> LLMPromptTemplates {
+                switch profile {
+                case .standard:
+                    return loadLLMPromptTemplates()
+                case .agent:
+                    return LLMPromptTemplates(
+                        systemContent: "system",
+                        userContent: "prefix {{input_text}} agent-only tail"
+                    )
+                }
+            }
+            func loadTerminalAppBundleIDs() -> [String] { [] }
+        }
+
+        let store = makeStore()
+        store.llmPolishingEnabled = true
+        store.agentPolishProfileEnabled = true
+
+        let plan = try XCTUnwrap(
+            PolishPromptWarmup.plan(settings: store, appConfigStore: TailOnlyDiff())
         )
 
         XCTAssertEqual(plan.requests.map(\.profile), [.standard])


### PR DESCRIPTION
## What

The per-launch polish prompt warmup only ever primed the **standard** profile's prompt prefix (`PolishPromptWarmup.plan` called the no-profile template loader — the `TODO(profile-aware warmup)` left when the agent profile shipped). The commit path selects a profile per target app: `.agent` (default-enabled) whenever the focused app is a terminal, whose system prompt is a different, ~2x larger text. The helper's prefix cache is keyed on exact prefix tokens, so the first dictation into a terminal paid the full cold prefill of the largest prompt in the app — the dominant share of first-polish latency on the 4B default (field report: ~10x slower first polish). Helper-side nothing was missing: `PromptPrefixSlotStore` already has one LRU slot per profile (default 2) precisely so both prefixes can stay warm.

Fix, all app-side in `PolishPromptWarmup.swift`:

- `plan` now returns one profile-labeled request per prompt profile a commit could use: standard always, agent when `agentPolishProfileEnabled` — dropped when the agent prefix is identical to the standard one (agent-file fallback, or templates differing only past the first placeholder; the comparison mirrors exactly the helper's cache key, the templated non-final messages).
- The coordinator fires the requests sequentially inside the one warmup task (the helper's model container would serialize them anyway). Cancellation is checked before every profile's request; a non-cancellation failure on one profile still warms the rest. Per-profile log lines attribute slow/failed warmups.
- Trigger semantics unchanged: one warmup per polishd ready edge, never per dictation.

Also updates the stale comment in `PolishHelperIntegrationTests` that referenced the TODO.

**Pre-PR review** (codex `gpt-5.6-sol`, adversarial pass over the diff): initial verdict "fix first" with two findings, both fixed in the second commit with their own fail-first regression tests — (1) should-fix: cancellation was only observed on the error path, so a helper stop racing a *successful* first-profile response let the next profile's request land on the stopped helper; (2) nit: the dedup compared full templates, broader than the helper's cache key. Cache-hit invariant, test quality, and strict concurrency: no findings.

## Proof

- [x] Unit suite green — `./scripts/remote-build.sh test`

  ```
  Executed 2005 tests, with 2 tests skipped and 0 failures (0 unexpected) in 67.055 (67.152) seconds
  ```

- [x] Bug fix: regression tests added — failing run before the fix and passing run after.

  Main regression (`testPlanWarmsAgentPrefixWhenAgentProfileEnabled`) needs the new list-shaped `plan` API to compile, so the "before" run is the full change with only the behavior chunk (the agent-append in `plan`) reverted — the API refactor alone still warms standard-only:

  ```
  Tests/localvoxtralTests/PolishPromptWarmupTests.swift:488: error: -[localvoxtralTests.PolishPromptWarmupPlanTests testPlanWarmsAgentPrefixWhenAgentProfileEnabled] : XCTAssertEqual failed: ("[localvoxtral.PolishPromptProfile.standard]") is not equal to ("[localvoxtral.PolishPromptProfile.standard, localvoxtral.PolishPromptProfile.agent]")
  Test Case '-[localvoxtralTests.PolishPromptWarmupPlanTests testPlanWarmsAgentPrefixWhenAgentProfileEnabled]' failed (0.166 seconds).
  ```

  Review-finding regression (`testHelperStopAfterSuccessfulFirstProfileSkipsRemainingProfiles`), run with the per-iteration cancellation guard reverted:

  ```
  Tests/localvoxtralTests/PolishPromptWarmupTests.swift:265: error: -[localvoxtralTests.PolishPromptWarmupTests testHelperStopAfterSuccessfulFirstProfileSkipsRemainingProfiles] : XCTAssertEqual failed: ("2") is not equal to ("1") - a cancelled warmup must not start the next profile's request
  Test Case '-[localvoxtralTests.PolishPromptWarmupTests testHelperStopAfterSuccessfulFirstProfileSkipsRemainingProfiles]' failed (0.157 seconds).
  ```

  With both fixes in place (`./scripts/remote-build.sh test --filter PolishPromptWarmup`):

  ```
  Test Suite 'PolishPromptWarmupPlanTests' passed at 2026-07-26 20:05:27.256.
  Test Suite 'PolishPromptWarmupTests' passed at 2026-07-26 20:05:27.264.
  ```

  New coverage beyond the two regressions: two-profile plans warm both prefixes per ready edge (standard first) and still never re-fire on duplicate `.ready`; a failed standard warmup still warms the agent prefix; the agent request is dropped when the profile toggle is off, when the agent templates fell back to standard, and when they differ only past the first placeholder; the warmup request's non-final messages are byte-identical to an agent production request's for the bundled agent templates (the cache-hit invariant, mirroring the existing standard-profile test).

- LLM lanes: this PR touches `*PolishPromptWarmup*`, which is in `scripts/ci/llm-lane-filter.sh`, so the polishd live-model lane runs on this PR. No prompt text, model pin, or commit-path request-shape change reaches the model — the change only adds a second warmup request whose prefix is byte-identical to a production agent request's — so no eval-e2e rerun beyond the lane CI runs.
