### PR TITLE
Enrollment sheet: confirm and report inside the section that asked

### DIFF
--- a/.github/workflows/mac-crashlog.yml
+++ b/.github/workflows/mac-crashlog.yml
@@ -113,6 +113,25 @@ jobs:
           probe_model "polishd" "$polish_repo" "$polish_revision"
           exit 0
 
+      - name: Claude remote ssh config state (markers only)
+        run: |
+          # Field-debugging the enrollment insertion: report only what proves
+          # or disproves that the app's marked block is present. Never print
+          # the config's content — Host aliases and hostnames are private and
+          # this log is public. Marker lines carry only the random host id.
+          cfg="$HOME/.ssh/config"
+          echo "--- lstat ~/.ssh and ~/.ssh/config:"
+          /usr/bin/stat -f '%N: type=%HT perms=%Mp%Lp owner=%Su mtime=%Sm size=%z' \
+            "$HOME/.ssh" "$cfg" 2>&1 | sed "s|$HOME|~|g"
+          echo "--- localvoxtral marker lines (line number + marker only):"
+          grep -n '^# \(BEGIN\|END\) localvoxtral claude context' "$cfg" 2>/dev/null \
+            || echo "<no localvoxtral markers>"
+          echo "--- RemoteForward 8473 present:"
+          grep -c 'RemoteForward 8473' "$cfg" 2>/dev/null || echo "0"
+          echo "--- leftover atomic-write temp files:"
+          ls "$HOME/.ssh/".config.localvoxtral.* 2>/dev/null | sed "s|$HOME|~|g" \
+            || echo "<none>"
+
       - name: List running localvoxtral instances
         run: |
           pids=$(pgrep -x localvoxtral || true)

--- a/.github/workflows/mac-crashlog.yml
+++ b/.github/workflows/mac-crashlog.yml
@@ -116,21 +116,42 @@ jobs:
       - name: Claude remote ssh config state (markers only)
         run: |
           # Field-debugging the enrollment insertion: report only what proves
-          # or disproves that the app's marked block is present. Never print
-          # the config's content — Host aliases and hostnames are private and
-          # this log is public. Marker lines carry only the random host id.
+          # or disproves that the app's marked block is present. This log is
+          # PUBLIC: never print config content, filenames, aliases, hostnames,
+          # or account names. Markers print only when they match the app's
+          # exact grammar (grep -o keeps the matched text alone, so a
+          # marker-like line carrying extra private text is counted, never
+          # shown). A diagnostic must not go red on the states it exists to
+          # characterize (missing file, symlink), hence set +e.
+          set +e
           cfg="$HOME/.ssh/config"
-          echo "--- lstat ~/.ssh and ~/.ssh/config:"
-          /usr/bin/stat -f '%N: type=%HT perms=%Mp%Lp owner=%Su mtime=%Sm size=%z' \
-            "$HOME/.ssh" "$cfg" 2>&1 | sed "s|$HOME|~|g"
-          echo "--- localvoxtral marker lines (line number + marker only):"
-          grep -n '^# \(BEGIN\|END\) localvoxtral claude context' "$cfg" 2>/dev/null \
-            || echo "<no localvoxtral markers>"
-          echo "--- RemoteForward 8473 present:"
-          grep -c 'RemoteForward 8473' "$cfg" 2>/dev/null || echo "0"
-          echo "--- leftover atomic-write temp files:"
-          ls "$HOME/.ssh/".config.localvoxtral.* 2>/dev/null | sed "s|$HOME|~|g" \
-            || echo "<none>"
+          marker_grammar='^# \(BEGIN\|END\) localvoxtral claude context ([a-z0-9]\{1,32\})$'
+          echo "--- ~/.ssh and config state:"
+          for path in "$HOME/.ssh" "$cfg"; do
+            if [ -e "$path" ] || [ -L "$path" ]; then
+              /usr/bin/stat -f '%N: type=%HT perms=%Mp%Lp mtime=%Sm size=%z' "$path" 2>&1 \
+                | sed "s|$HOME|~|g"
+            else
+              echo "$path: <absent>" | sed "s|$HOME|~|g"
+            fi
+          done
+          if [ "$(/usr/bin/stat -f %u "$HOME/.ssh" 2>/dev/null)" = "$(id -u)" ]; then
+            echo "ssh dir owned by current user: yes"
+          else
+            echo "ssh dir owned by current user: NO"
+          fi
+          echo "--- localvoxtral marker lines (strict grammar only):"
+          grep -no "$marker_grammar" "$cfg" 2>/dev/null \
+            || echo "<no well-formed localvoxtral markers>"
+          marker_like="$(grep -c '^# \(BEGIN\|END\) localvoxtral claude context' "$cfg" 2>/dev/null)"
+          well_formed="$(grep -c "$marker_grammar" "$cfg" 2>/dev/null)"
+          echo "marker-like lines: ${marker_like:-0} (well-formed: ${well_formed:-0})"
+          echo "--- RemoteForward 8473 count:"
+          grep -c 'RemoteForward 8473' "$cfg" 2>/dev/null
+          [ -f "$cfg" ] || echo "<no config file>"
+          echo "--- leftover atomic-write temp files (count only):"
+          /usr/bin/find "$HOME/.ssh" -maxdepth 1 -name '.config.localvoxtral.*' 2>/dev/null \
+            | wc -l | tr -d ' '
 
       - name: List running localvoxtral instances
         run: |

--- a/Sources/localvoxtral/ClaudeContext/ClaudeIntegrationSettingsModel.swift
+++ b/Sources/localvoxtral/ClaudeContext/ClaudeIntegrationSettingsModel.swift
@@ -193,6 +193,11 @@ public final class ClaudeIntegrationSettingsModel {
     public private(set) var presentedPlan: EnrollmentPresentation?
     public private(set) var enrollmentConfirmation: EnrollmentConfirmation?
     public private(set) var enrollmentStepStatuses: [EnrollmentStepStatus] = []
+    /// Which action produced `enrollmentStepStatuses`. The sheet renders each
+    /// outcome inside the section whose button the user actually clicked; a
+    /// pooled results area below step 2 is how a step-1 success went unseen
+    /// and got re-confirmed (field report 2026-07-26).
+    public private(set) var enrollmentResultsAction: EnrollmentAction?
     public private(set) var isPerformingEnrollmentAction = false
     public var alert: DetailAlert?
 
@@ -485,11 +490,13 @@ public final class ClaudeIntegrationSettingsModel {
         presentedPlan = nil
         enrollmentConfirmation = nil
         enrollmentStepStatuses = []
+        enrollmentResultsAction = nil
     }
 
     public func requestSSHConfigInsertion() {
         guard let presentation = presentedPlan, !isPerformingEnrollmentAction else { return }
         enrollmentStepStatuses = []
+        enrollmentResultsAction = nil
         enrollmentConfirmation = EnrollmentConfirmation(
             action: .insertSSHConfig,
             title: "Insert this exact block into ~/.ssh/config?",
@@ -502,6 +509,7 @@ public final class ClaudeIntegrationSettingsModel {
     public func requestRemoteSetup() {
         guard let presentation = presentedPlan, !isPerformingEnrollmentAction else { return }
         enrollmentStepStatuses = []
+        enrollmentResultsAction = nil
         enrollmentConfirmation = EnrollmentConfirmation(
             action: .runRemoteSetup,
             title: "Run these commands on the SSH host?",
@@ -523,6 +531,7 @@ public final class ClaudeIntegrationSettingsModel {
         enrollmentConfirmation = nil
         isPerformingEnrollmentAction = true
         enrollmentStepStatuses = []
+        enrollmentResultsAction = nil
         defer { isPerformingEnrollmentAction = false }
 
         let service = enrollmentService
@@ -550,6 +559,7 @@ public final class ClaudeIntegrationSettingsModel {
                 failure,
                 action: confirmation.action
             )
+            enrollmentResultsAction = confirmation.action
             alert = DetailAlert(
                 title: "Remote Claude Code setup",
                 detail: Self.enrollmentFailureDetail(failure)
@@ -564,7 +574,7 @@ public final class ClaudeIntegrationSettingsModel {
         case .insertSSHConfig:
             enrollmentStepStatuses = [
                 EnrollmentStepStatus(
-                    id: 0, text: "SSH config updated.", succeeded: true, detail: ""
+                    id: 0, text: "Inserted this host's block into ~/.ssh/config.", succeeded: true, detail: ""
                 )
             ]
         case .runRemoteSetup:
@@ -577,6 +587,7 @@ public final class ClaudeIntegrationSettingsModel {
                 )
             }
         }
+        enrollmentResultsAction = confirmation.action
     }
 
     public static func redactedRemoteCommands(for presentation: EnrollmentPresentation) -> String {

--- a/Sources/localvoxtral/ClaudeContext/ClaudeIntegrationSettingsModel.swift
+++ b/Sources/localvoxtral/ClaudeContext/ClaudeIntegrationSettingsModel.swift
@@ -399,6 +399,7 @@ public final class ClaudeIntegrationSettingsModel {
             // dismissPlan() cleared them.
             enrollmentConfirmation = nil
             enrollmentStepStatuses = []
+            enrollmentResultsAction = nil
             presentedPlan = EnrollmentPresentation(
                 host: enrollment.host,
                 token: enrollment.token,
@@ -433,6 +434,7 @@ public final class ClaudeIntegrationSettingsModel {
             )
             enrollmentConfirmation = nil
             enrollmentStepStatuses = []
+            enrollmentResultsAction = nil
             presentedPlan = EnrollmentPresentation(
                 host: enrollment.host,
                 token: enrollment.token,
@@ -551,8 +553,11 @@ public final class ClaudeIntegrationSettingsModel {
 
         // The sheet may have been dismissed (window close) and even replaced
         // while the detached work ran; a late result must not surface under a
-        // different host's sheet.
-        guard presentedPlan?.host.id == presentation.host.id else { return }
+        // different sheet. The whole presentation must match, not just the
+        // host id — rotation REUSES the host id, and an id-only guard let an
+        // old-token outcome render beneath the new token's commands. Rotation
+        // mints a fresh token, so value equality distinguishes generations.
+        guard presentedPlan == presentation else { return }
 
         if let failure = attempt.failure {
             enrollmentStepStatuses = Self.failureStatuses(

--- a/Sources/localvoxtral/SettingsView.swift
+++ b/Sources/localvoxtral/SettingsView.swift
@@ -1125,6 +1125,7 @@ private struct ClaudeRemoteEnrollmentSheet: View {
                         body: plan.sshConfigSnippet,
                         note: "Insertion replaces only this host's marked block and writes the file atomically.",
                         actionTitle: "Insert into ~/.ssh/config",
+                        enrollmentAction: .insertSSHConfig,
                         action: { model.requestSSHConfigInsertion() }
                     )
                     section(
@@ -1133,10 +1134,9 @@ private struct ClaudeRemoteEnrollmentSheet: View {
                         displayedBody: ClaudeIntegrationSettingsModel.redactedRemoteCommands(for: presentation),
                         note: "One-click execution sends the token through SSH stdin, never process arguments.",
                         actionTitle: "Run on SSH host",
+                        enrollmentAction: .runRemoteSetup,
                         action: { model.requestRemoteSetup() }
                     )
-                    confirmationView
-                    enrollmentResults
                     section("Verify", body: plan.verifyCommands.joined(separator: "\n"), note: nil)
                     section("Uninstall", body: plan.uninstallCommands.joined(separator: "\n"), note: nil)
 
@@ -1163,31 +1163,12 @@ private struct ClaudeRemoteEnrollmentSheet: View {
         .frame(width: 560, height: 520)
     }
 
+    /// One step's outcome, rendered inside the section whose button ran it.
+    /// A pooled results area below step 2 is how a step-1 success went unseen
+    /// in the field and got re-confirmed.
     @ViewBuilder
-    private var confirmationView: some View {
-        if let confirmation = model.enrollmentConfirmation {
-            VStack(alignment: .leading, spacing: 6) {
-                Text(confirmation.title).font(.subheadline).bold()
-                Text(confirmation.preview)
-                    .font(.system(.caption, design: .monospaced))
-                    .textSelection(.enabled)
-                    .frame(maxWidth: .infinity, alignment: .leading)
-                    .padding(6)
-                    .background(Color.orange.opacity(0.10), in: RoundedRectangle(cornerRadius: 4))
-                HStack {
-                    Button("Cancel") { model.cancelEnrollmentActionConfirmation() }
-                    Button(confirmation.confirmButtonTitle) {
-                        Task { await model.confirmEnrollmentAction() }
-                    }
-                    .buttonStyle(.borderedProminent)
-                }
-            }
-        }
-    }
-
-    @ViewBuilder
-    private var enrollmentResults: some View {
-        if !model.enrollmentStepStatuses.isEmpty {
+    private func sectionResults(for enrollmentAction: ClaudeIntegrationSettingsModel.EnrollmentAction) -> some View {
+        if model.enrollmentResultsAction == enrollmentAction, !model.enrollmentStepStatuses.isEmpty {
             VStack(alignment: .leading, spacing: 4) {
                 ForEach(model.enrollmentStepStatuses) { step in
                     Text("\(step.succeeded ? "✓" : "✗") \(step.text)")
@@ -1220,9 +1201,19 @@ private struct ClaudeRemoteEnrollmentSheet: View {
         displayedBody: String? = nil,
         note: String?,
         actionTitle: String? = nil,
+        enrollmentAction: ClaudeIntegrationSettingsModel.EnrollmentAction? = nil,
         action: (() -> Void)? = nil
     ) -> some View {
-        VStack(alignment: .leading, spacing: 4) {
+        // The confirmation lives in the section whose button requested it, so
+        // "Confirm" is always next to the thing it confirms. The displayed body
+        // above the buttons IS the confirmation preview (the plan's exact
+        // snippet for step 1, the redacted commands for step 2) — highlighted
+        // while the question is pending, so the second explicit confirmation
+        // still repeats the exact text it authorizes.
+        let pendingConfirmation = model.enrollmentConfirmation.flatMap { confirmation in
+            confirmation.action == enrollmentAction ? confirmation : nil
+        }
+        return VStack(alignment: .leading, spacing: 4) {
             HStack {
                 Text(title).font(.subheadline).bold()
                 Spacer()
@@ -1239,14 +1230,31 @@ private struct ClaudeRemoteEnrollmentSheet: View {
                 .textSelection(.enabled)
                 .frame(maxWidth: .infinity, alignment: .leading)
                 .padding(6)
-                .background(Color.secondary.opacity(0.08), in: RoundedRectangle(cornerRadius: 4))
+                .background(
+                    pendingConfirmation != nil
+                        ? Color.orange.opacity(0.10) : Color.secondary.opacity(0.08),
+                    in: RoundedRectangle(cornerRadius: 4)
+                )
             if let note {
                 Text(note).font(.caption2).foregroundStyle(.secondary)
             }
-            if let actionTitle, let action {
+            if let confirmation = pendingConfirmation {
+                Text(confirmation.title).font(.caption).bold()
+                HStack {
+                    Button("Cancel") { model.cancelEnrollmentActionConfirmation() }
+                    Button(confirmation.confirmButtonTitle) {
+                        Task { await model.confirmEnrollmentAction() }
+                    }
+                    .buttonStyle(.borderedProminent)
+                }
+                .controlSize(.small)
+            } else if let actionTitle, let action {
                 Button(actionTitle, action: action)
                     .controlSize(.small)
                     .disabled(model.isPerformingEnrollmentAction)
+            }
+            if let enrollmentAction {
+                sectionResults(for: enrollmentAction)
             }
         }
     }

--- a/Tests/localvoxtralTests/ClaudeIntegrationSettingsModelTests.swift
+++ b/Tests/localvoxtralTests/ClaudeIntegrationSettingsModelTests.swift
@@ -496,6 +496,75 @@ final class ClaudeIntegrationSettingsModelTests: XCTestCase {
         XCTAssertEqual(model.enrollmentStepStatuses.first?.succeeded, false)
     }
 
+    /// Review finding (PR #194): the late-result guard compared only
+    /// `host.id`, which token rotation REUSES — a setup still in flight when
+    /// the sheet went away could publish its old-token outcome underneath the
+    /// rotation sheet that replaced it. The guard now requires the whole
+    /// presentation to match; rotation mints a new token, so equality
+    /// distinguishes the generations.
+    func testALateResultFromBeforeARotationNeverSurfacesUnderTheNewToken() async throws {
+        let registry = try makeRegistry()
+        let (gate, releaseGate) = AsyncStream.makeStream(of: Void.self)
+        let service = ClaudeRemoteEnrollmentService(runner: { _ in
+            .init(exitCode: 0, message: "ok")
+        })
+        let model = ClaudeIntegrationSettingsModel(
+            registry: registry,
+            listener: StubListener(hosts: registry),
+            pluginService: { StubPluginService() },
+            enrollmentService: service,
+            performAsync: { body in
+                do {
+                    try body()
+                    return nil
+                } catch {
+                    return ClaudePluginActionFailure(error)
+                }
+            },
+            performEnrollmentAsync: { body in
+                // Park until the test releases the gate, so the "sheet went
+                // away and the user rotated while ssh was still running"
+                // interleaving is deterministic — cooperative yields only, no
+                // wall-clock.
+                var latch = gate.makeAsyncIterator()
+                _ = await latch.next()
+                do {
+                    return ClaudeEnrollmentActionAttempt(steps: try body(), failure: nil)
+                } catch {
+                    return ClaudeEnrollmentActionAttempt(
+                        steps: [],
+                        failure: ClaudeEnrollmentActionFailure(error)
+                    )
+                }
+            }
+        )
+        model.enrollLabel = "buildhost"
+        model.enrollSSHAlias = "builder"
+        await model.enroll()
+        let hostID = try XCTUnwrap(model.presentedPlan).host.id
+
+        model.requestRemoteSetup()
+        let inFlight = Task { await model.confirmEnrollmentAction() }
+        while !model.isPerformingEnrollmentAction { await Task.yield() }
+
+        model.dismissPlan()
+        await model.rotate(hostID: hostID)
+        XCTAssertEqual(
+            model.presentedPlan?.host.id, hostID,
+            "rotation reuses the host id — that reuse is the trap"
+        )
+
+        releaseGate.yield(())
+        releaseGate.finish()
+        await inFlight.value
+
+        XCTAssertTrue(
+            model.enrollmentStepStatuses.isEmpty,
+            "an old-token result must not render under the rotation sheet"
+        )
+        XCTAssertNil(model.enrollmentResultsAction)
+    }
+
     func testRemoteSetupTimeoutHasShortStepStatusAndClearDetail() async throws {
         let registry = try makeRegistry()
         let service = ClaudeRemoteEnrollmentService(runner: { _ in

--- a/Tests/localvoxtralTests/ClaudeIntegrationSettingsModelTests.swift
+++ b/Tests/localvoxtralTests/ClaudeIntegrationSettingsModelTests.swift
@@ -423,6 +423,7 @@ final class ClaudeIntegrationSettingsModelTests: XCTestCase {
         XCTAssertNotNil(model.presentedPlan)
         XCTAssertTrue(model.enrollmentStepStatuses.isEmpty)
         XCTAssertNil(model.enrollmentConfirmation)
+        XCTAssertNil(model.enrollmentResultsAction)
     }
 
     func testSSHConfigInsertionDoesNotTouchFilesystemBeforeExplicitConfirmation() async throws {
@@ -451,7 +452,48 @@ final class ClaudeIntegrationSettingsModelTests: XCTestCase {
 
         XCTAssertEqual(fileSystem.readCount, 1)
         XCTAssertEqual(fileSystem.writeCount, 1)
-        XCTAssertEqual(model.enrollmentStepStatuses.first?.text, "SSH config updated.")
+        XCTAssertEqual(
+            model.enrollmentStepStatuses.first?.text,
+            "Inserted this host's block into ~/.ssh/config."
+        )
+        XCTAssertEqual(model.enrollmentResultsAction, .insertSSHConfig)
+    }
+
+    /// Field report 2026-07-26: the step-1 success rendered in a pooled results
+    /// area below step 2, the owner never saw it, and confirmed the insertion
+    /// twice believing it had done nothing. The sheet now renders each outcome
+    /// inside the section that ran it, which needs the model to say WHICH
+    /// action the statuses belong to — and to clear that tag the moment a new
+    /// confirmation starts, so step 1's stale result can never render while
+    /// step 2 is the one being confirmed.
+    func testStepResultsAreTaggedWithTheActionThatProducedThem() async throws {
+        let registry = try makeRegistry()
+        let fileSystem = RecordingSSHConfigFileSystem()
+        let service = ClaudeRemoteEnrollmentService(
+            runner: { _ in .init(exitCode: 1, message: "remote said no") },
+            sshConfigFileSystem: fileSystem
+        )
+        let model = makeModel(
+            registry: registry,
+            listener: StubListener(hosts: registry),
+            enrollmentService: service
+        )
+        model.enrollLabel = "buildhost"
+        model.enrollSSHAlias = "builder"
+        await model.enroll()
+        XCTAssertNil(model.enrollmentResultsAction)
+
+        model.requestSSHConfigInsertion()
+        await model.confirmEnrollmentAction()
+        XCTAssertEqual(model.enrollmentResultsAction, .insertSSHConfig)
+
+        model.requestRemoteSetup()
+        XCTAssertNil(model.enrollmentResultsAction, "a pending confirmation must not show stale results")
+        XCTAssertTrue(model.enrollmentStepStatuses.isEmpty)
+
+        await model.confirmEnrollmentAction()
+        XCTAssertEqual(model.enrollmentResultsAction, .runRemoteSetup)
+        XCTAssertEqual(model.enrollmentStepStatuses.first?.succeeded, false)
     }
 
     func testRemoteSetupTimeoutHasShortStepStatusAndClearDetail() async throws {


### PR DESCRIPTION
## What

Field report (owner, 2026-07-26): tried the ssh enrollment flow, confirmed the insert, and believed nothing was written to `~/.ssh/config`. Two things were actually true:

1. **The insertion worked.** Diagnosed via `mac-crashlog.yml` first (per the runbook): the app log shows `Claude remote ssh config insertion completed` at 20:18:18 **and** 20:19:17 — the owner confirmed twice because there was no visible feedback. A new redacted ssh-config probe (added to `mac-crashlog.yml` in this PR) then proved the block on disk: markers `# BEGIN/END localvoxtral claude context (h9b61d528)` at lines 105–115 of `~/.ssh/config`, `RemoteForward 8473` present, file mtime `Jul 26 20:19:17` = the second insertion. The block lands at the END of a long config, and the sole feedback was a small caption pooled below step 2 — invisible in practice.
2. **The confirmation UX was misplaced by design.** Both confirmations and all step results rendered under step 2 regardless of which section's button requested them.

Changes:

- The confirmation now renders inside the section whose button requested it: the action button swaps to `Cancel` / `Confirm Insert` (or `Confirm Run`) right where the user clicked, with the exact text highlighted. The second-explicit-confirmation invariant holds — the displayed body IS the confirmation preview (plan snippet for step 1, token-redacted commands for step 2; asserted equal by existing tests).
- Step results render inside the same section. The model tags results with the action that produced them (`enrollmentResultsAction`), cleared when a new confirmation starts, so a stale step-1 result can never render while step 2 is being confirmed.
- Success copy names the file: `Inserted this host's block into ~/.ssh/config.`
- `mac-crashlog.yml`: new "Claude remote ssh config state" step — lstat + marker line numbers + `RemoteForward 8473` count + leftover atomic-write temp files. Never prints config content; Host aliases/hostnames stay private (public Actions log).

## Proof

- [x] Unit suite green — `./scripts/remote-build.sh test`:
  ```
  Executed 1998 tests, with 2 tests skipped and 0 failures (0 unexpected) in 74.461 (74.556) seconds
  ```
- [x] Regression test added — `testStepResultsAreTaggedWithTheActionThatProducedThem` plus tagging assertions in the three existing enrollment tests. A literal failing-before run is impossible for the model half (the test exercises `enrollmentResultsAction`, which did not exist — it fails by compile error against the old model); the field evidence above is the failing "before": two confirmed insertions with the outcome rendered where the owner never saw it.
  ```
  Test Case 'testStepResultsAreTaggedWithTheActionThatProducedThem' passed (0.000 seconds).
  Test Suite 'ClaudeIntegrationSettingsModelTests' passed — Executed 24 tests, with 0 failures
  ```
- [x] Diagnostic probe verified live — dispatched `mac-crashlog.yml` from this branch (run 30214904868):
  ```
  ~/.ssh/config: type=Regular File perms=0644 owner=tom mtime=Jul 26 20:19:17 2026 size=2689
  105:# BEGIN localvoxtral claude context (h9b61d528)
  115:# END localvoxtral claude context (h9b61d528)
  --- RemoteForward 8473 present: 1
  ```
- [ ] UI change: hand-verification pending — I have no GUI access; owner loop is `./scripts/try-pr.sh <this PR#>` → Settings → Claude → enroll a host → click "Insert into ~/.ssh/config": Cancel/Confirm should appear under step 1 with the snippet highlighted, and the result line should appear there too (same for step 2's "Run on SSH host").

LLM lanes: skipped — settings-sheet UI + model state tagging + a diagnostic workflow; nothing on the `llm-lane-filter.sh` paths, nothing that reaches the model input.