### PR TITLE
Remote setup: resolve claude under sshd's minimal PATH, drop setup forwarding

### DIFF
--- a/Sources/localvoxtral/ClaudeContext/ClaudeRemoteEnrollmentService.swift
+++ b/Sources/localvoxtral/ClaudeContext/ClaudeRemoteEnrollmentService.swift
@@ -286,6 +286,10 @@ public struct ClaudeRemoteEnrollmentService: Sendable {
             "A second concurrent SSH session to the same host will fail to bind \(port) on the "
                 + "remote and — because ExitOnForwardFailure is `no` — will connect anyway with no "
                 + "tunnel. The first session keeps the forward.",
+            "One-click setup connects with forwarding disabled (the tunnel belongs to your real "
+                + "sessions, not setup) and first resolves `claude` from common install locations — "
+                + "non-interactive SSH shells often lack the user-local PATH entries an interactive "
+                + "login has.",
         ]
     }
 
@@ -410,7 +414,8 @@ public struct ClaudeRemoteEnrollmentService: Sendable {
     ///
     /// Throws `.executionNotConfigured` when no runner was supplied. Each plan
     /// command is sent to `/bin/sh -s` over SSH stdin. The only spawned argv is
-    /// `ssh -o BatchMode=yes <alias> /bin/sh -s`, which contains no token.
+    /// `ssh -o BatchMode=yes -o ClearAllForwardings=yes <alias> /bin/sh -s`,
+    /// which contains no token.
     ///
     /// - Parameter token: the plaintext, used ONLY to redact it back out of any
     ///   failure. Nothing here logs or stores it.
@@ -448,7 +453,15 @@ public struct ClaudeRemoteEnrollmentService: Sendable {
                 throw failure
             }
             let invocation = Invocation(
-                argv: ["ssh", "-o", "BatchMode=yes", sshHostAlias, "/bin/sh", "-s"],
+                // ClearAllForwardings: the setup connection has no use for the
+                // 8473 tunnel, and with the user's own session usually holding
+                // it, attempting the forward here only produced a scary
+                // "remote port forwarding failed" warning inside setup errors
+                // (field report 2026-07-26).
+                argv: [
+                    "ssh", "-o", "BatchMode=yes", "-o", "ClearAllForwardings=yes",
+                    sshHostAlias, "/bin/sh", "-s",
+                ],
                 standardInput: Self.remoteScript(command: command),
                 timeout: remaining
             )
@@ -516,7 +529,36 @@ public struct ClaudeRemoteEnrollmentService: Sendable {
         return completed
     }
 
+    /// PATH resolution for `claude` under `ssh <host> /bin/sh -s`.
+    ///
+    /// Non-interactive SSH shells run with sshd's minimal PATH (no login rc),
+    /// which usually lacks the user-local directories claude installs into —
+    /// the field failure was dash's bare `claude: not found` on a host where
+    /// claude worked fine interactively. Probe the same locations the local
+    /// installer does (`ClaudePluginInstallService.claudeCLICandidates`), plus
+    /// nvm-style node bins, and fail with an actionable message instead of
+    /// dash's. POSIX sh only — the remote /bin/sh is dash on Debian-family
+    /// hosts. Token-free by construction, like the `set -eu` line: the
+    /// confirmation shows the commands the user authorizes; this is part of
+    /// how they run.
+    static let claudePathResolverPreamble = """
+        if ! command -v claude >/dev/null 2>&1; then
+          for lv_dir in "$HOME/.claude/local" "$HOME/.local/bin" "$HOME/bin" /opt/homebrew/bin /usr/local/bin "$HOME"/.nvm/versions/node/*/bin; do
+            if [ -x "$lv_dir/claude" ]; then PATH="$lv_dir:$PATH"; break; fi
+          done
+        fi
+        if ! command -v claude >/dev/null 2>&1; then
+          echo "localvoxtral: 'claude' was not found on this host's non-interactive PATH, nor in ~/.claude/local, ~/.local/bin, ~/bin, /opt/homebrew/bin, /usr/local/bin, or ~/.nvm/versions/node/*/bin. Run 'command -v claude' in a normal shell on this host, then rerun setup — or add that directory to PATH for non-interactive SSH shells." >&2
+          exit 127
+        fi
+
+        """
+
     static func remoteScript(command: String) -> Data {
-        Data("set -eu\n\(command)\n".utf8)
+        // The resolver only guards commands that actually invoke claude, so a
+        // future non-claude step cannot be failed by a missing CLI it never
+        // needed.
+        let preamble = command.contains("claude") ? claudePathResolverPreamble : ""
+        return Data("set -eu\n\(preamble)\(command)\n".utf8)
     }
 }

--- a/Sources/localvoxtral/ClaudeContext/ClaudeRemoteEnrollmentService.swift
+++ b/Sources/localvoxtral/ClaudeContext/ClaudeRemoteEnrollmentService.swift
@@ -239,16 +239,26 @@ public struct ClaudeRemoteEnrollmentService: Sendable {
         ]
     }
 
+    /// The comments are part of the deliverable: these commands are run by a
+    /// person, and the field failure was a person reading healthy output as
+    /// broken — a forward "failure" that just means another session already
+    /// holds the tunnel, and a 401 that is the success signal. Say so in the
+    /// output they are pasting, not in a note they have scrolled past.
     static func verifyCommands(sshHostAlias: String, port: UInt16) -> [String] {
         [
-            // Does the forward actually exist? -v prints the remote forwarding
-            // request and the remote's answer, which is the only place a failed
-            // RemoteForward is visible when ExitOnForwardFailure is `no`.
+            // -v because a failed RemoteForward is otherwise invisible when
+            // ExitOnForwardFailure is `no`.
+            "# Forward check — 'remote forward success' means this probe owns the",
+            "# tunnel. A failure here is EXPECTED while another live session to",
+            "# this host holds it; the port check below is the truth either way.",
             "ssh -v \(sshHostAlias) true 2>&1 | grep -i 'remote forward'",
-            "ssh \(sshHostAlias) 'claude plugin list'",
-            // From the remote side, through the tunnel: 401 proves the tunnel is
-            // up and the listener is answering. A connection error means the
-            // forward did not take.
+            "# Non-interactive SSH skips your shell rc, so claude can be off PATH",
+            "# here even though it runs fine when you are logged in.",
+            "ssh \(sshHostAlias) 'PATH=\"$HOME/.claude/local:$HOME/.local/bin:$HOME/bin"
+                + ":/opt/homebrew/bin:/usr/local/bin:$PATH\" claude plugin list'",
+            "# 401 = SUCCESS: the tunnel is up and localvoxtral answered (an",
+            "# unauthenticated probe must be refused). A connection error means",
+            "# no live session holds the forward right now.",
             "ssh \(sshHostAlias) 'curl -s -o /dev/null -w \"%{http_code}\\n\" -X POST "
                 + "-H \"Content-Type: application/json\" -d \"{}\" http://127.0.0.1:\(port)/v1/hook/SessionStart'",
         ]

--- a/Tests/localvoxtralTests/ClaudeRemoteEnrollmentServiceTests.swift
+++ b/Tests/localvoxtralTests/ClaudeRemoteEnrollmentServiceTests.swift
@@ -315,6 +315,21 @@ final class ClaudeRemoteEnrollmentServiceTests: XCTestCase {
         for command in commands {
             XCTAssertFalse(command.contains(token), "a preflight must not print the credential")
         }
+        // Field report 2026-07-26: the owner read healthy verify output as
+        // broken. The commands themselves must say what their output means and
+        // survive a login shell that skips rc files.
+        XCTAssertTrue(
+            joined.contains("EXPECTED while another live session"),
+            "the forward-failure line needs its interpretation next to it"
+        )
+        XCTAssertTrue(
+            joined.contains("401 = SUCCESS"),
+            "401 is the pass signal and must be labeled as such"
+        )
+        XCTAssertTrue(
+            joined.contains("PATH=\"$HOME/.claude/local:$HOME/.local/bin"),
+            "plugin list must not depend on the remote shell's rc-file PATH"
+        )
     }
 
     // MARK: Notes

--- a/Tests/localvoxtralTests/ClaudeRemoteEnrollmentServiceTests.swift
+++ b/Tests/localvoxtralTests/ClaudeRemoteEnrollmentServiceTests.swift
@@ -524,16 +524,58 @@ final class ClaudeRemoteEnrollmentServiceTests: XCTestCase {
         let recorded = calls.withLock { $0 }
         XCTAssertEqual(recorded.count, 2)
         for invocation in recorded {
+            // ClearAllForwardings: setup must not compete for the 8473 tunnel
+            // a real session already holds (field report 2026-07-26).
             XCTAssertEqual(
                 invocation.argv,
-                ["ssh", "-o", "BatchMode=yes", "builder", "/bin/sh", "-s"]
+                [
+                    "ssh", "-o", "BatchMode=yes", "-o", "ClearAllForwardings=yes",
+                    "builder", "/bin/sh", "-s",
+                ]
             )
             XCTAssertFalse(invocation.argv.joined(separator: " ").contains(token))
         }
         XCTAssertEqual(
             recorded.map { String(decoding: $0.standardInput, as: UTF8.self) },
-            try plan().remoteCommands.map { "set -eu\n\($0)\n" }
+            try plan().remoteCommands.map {
+                "set -eu\n\(ClaudeRemoteEnrollmentService.claudePathResolverPreamble)\($0)\n"
+            }
         )
+    }
+
+    /// Field failure 2026-07-26: `ssh <host> /bin/sh -s` runs under sshd's
+    /// minimal PATH, so a host where `claude` works interactively still died
+    /// with dash's bare "claude: not found". The script must resolve claude
+    /// from the known install locations before running, and fail with an
+    /// actionable message when it truly is absent.
+    func testRemoteScriptResolvesClaudeFromUserLocalInstallLocations() {
+        let script = String(
+            decoding: ClaudeRemoteEnrollmentService.remoteScript(
+                command: "claude plugin list"
+            ),
+            as: UTF8.self
+        )
+        XCTAssertTrue(script.hasPrefix("set -eu\n"))
+        XCTAssertTrue(script.contains("command -v claude"))
+        for location in [".claude/local", ".local/bin", "/opt/homebrew/bin", ".nvm/versions/node"] {
+            XCTAssertTrue(script.contains(location), "missing probe location \(location)")
+        }
+        XCTAssertTrue(script.contains("exit 127"), "a missing claude must fail loudly, not run on")
+        XCTAssertTrue(
+            script.contains("Run 'command -v claude' in a normal shell"),
+            "the failure message must tell the user what to actually do"
+        )
+        XCTAssertTrue(script.hasSuffix("claude plugin list\n"))
+    }
+
+    func testRemoteScriptLeavesNonClaudeCommandsUnguarded() {
+        let script = String(
+            decoding: ClaudeRemoteEnrollmentService.remoteScript(command: "uname -a"),
+            as: UTF8.self
+        )
+        // A future non-claude step must not be failed by a missing CLI it
+        // never needed.
+        XCTAssertEqual(script, "set -eu\nuname -a\n")
     }
 
     func testRemoteSetupKeepsTokenInStdinAndOutOfEveryArgv() throws {


### PR DESCRIPTION
## What

Field report (owner, 2026-07-26, second round of hand-testing): "Run on SSH host" failed with `/bin/sh: 2: claude: not found` although claude is installed on the host, plus a scary `Warning: remote port forwarding failed for listen port 8473` in the error output.

Diagnosis: the error format is **dash's** (Debian-family `/bin/sh`), and `ssh <alias> /bin/sh -s` runs under sshd's minimal PATH with no login rc — so user-local install dirs (`~/.local/bin`, where claude actually lives on the reporting host) are absent. The forwarding warning was noise: setup's own ssh connection tried the 8473 RemoteForward from the inserted config block while the user's real session already held it — setup never needed the tunnel at all.

- `remoteScript` now prepends a POSIX resolver for claude-invoking commands: probes `~/.claude/local`, `~/.local/bin`, `~/bin`, `/opt/homebrew/bin`, `/usr/local/bin`, `~/.nvm/versions/node/*/bin` (mirroring `ClaudePluginInstallService.claudeCLICandidates`), then fails with an actionable message + exit 127 instead of dash's bare one. Token-free by construction, same class as the already-injected `set -eu`; a plan note discloses it.
- Setup connections pass `-o ClearAllForwardings=yes` — no tunnel competition with the user's live session, no misleading warning inside setup errors.
- Non-claude commands stay unguarded (`testRemoteScriptLeavesNonClaudeCommandsUnguarded`).

## Proof

- [x] Unit suite green — `./scripts/remote-build.sh test`:
  ```
  Executed 2009 tests, with 2 tests skipped and 0 failures (0 unexpected) in 70.853 (70.956) seconds
  ```
- [x] Regression tests added — `testRemoteScriptResolvesClaudeFromUserLocalInstallLocations` + `testRemoteScriptLeavesNonClaudeCommandsUnguarded`; existing argv/stdin equality tests updated to pin the new invocation. (The "failing before" state is the field error itself: the old script was literally `set -eu\n<command>` with no resolution.)
- [x] Resolver verified under real dash (Debian `/bin/sh -> dash`) with `PATH=/usr/bin:/bin`:
  ```
  === claude in ~/.local/bin:  FAKE-CLAUDE plugin list / exit=0
  === claude absent:           localvoxtral: 'claude' was not found ... / exit=127
  ```
  and on the reporting host with the real binary under `env -i HOME=$HOME PATH=/usr/bin:/bin dash -s`:
  ```
  2.1.220 (Claude Code)
  exit=0
  ```
- [ ] Hand-verify: `./scripts/try-pr.sh <this PR#>` → enroll/rotate → "Run on SSH host" against the real host should now pass step 1 (or fail with the actionable message, never dash's).

LLM lanes: skipped — remote-enrollment execution path only; nothing on `llm-lane-filter.sh` paths, nothing reaches the model.