### PR TITLE
Remote plugin: an update path for hosts that are already enrolled

### DIFF
--- a/Sources/localvoxtral/ClaudeContext/ClaudeIntegrationSettingsModel.swift
+++ b/Sources/localvoxtral/ClaudeContext/ClaudeIntegrationSettingsModel.swift
@@ -154,9 +154,33 @@ public final class ClaudeIntegrationSettingsModel {
         public var isRotation: Bool
     }
 
+    /// The two commands that bring one enrolled host to the plugin version this
+    /// app ships, plus the host they belong to.
+    ///
+    /// Carries no token — `claude plugin update` keeps the config the install
+    /// stored — so unlike `EnrollmentPresentation` this can be shown at any
+    /// time, which is the point: the user needs it long after the one-time
+    /// token is gone.
+    public struct PluginUpdatePresentation: Identifiable, Equatable, Sendable {
+        public var id: String { hostID }
+        public var hostID: String
+        /// The alias one-click execution would use, or nil when the host's
+        /// label is not a usable one. The alias belongs to the user's ssh
+        /// config and is never persisted, so the label is the only guess
+        /// available; when it does not qualify the commands are copy-only and
+        /// name a placeholder instead of pretending.
+        public var sshHostAlias: String?
+        public var commands: [String]
+
+        public var canRun: Bool { sshHostAlias != nil }
+    }
+
     public enum EnrollmentAction: Sendable, Equatable {
         case insertSSHConfig
         case runRemoteSetup
+        /// Per-host, because the pane shows one row per host and the outcome
+        /// has to render in the row whose button ran it.
+        case updateRemotePlugin(hostID: String)
     }
 
     public struct EnrollmentConfirmation: Identifiable, Equatable, Sendable {
@@ -191,6 +215,8 @@ public final class ClaudeIntegrationSettingsModel {
     public private(set) var pluginResult: String?
     public private(set) var isPerformingPluginAction = false
     public private(set) var presentedPlan: EnrollmentPresentation?
+    /// The update commands the user asked to see, for one host at a time.
+    public private(set) var presentedPluginUpdate: PluginUpdatePresentation?
     public private(set) var enrollmentConfirmation: EnrollmentConfirmation?
     public private(set) var enrollmentStepStatuses: [EnrollmentStepStatus] = []
     /// Which action produced `enrollmentStepStatuses`. The sheet renders each
@@ -467,6 +493,8 @@ public final class ClaudeIntegrationSettingsModel {
         guard let registry else { return }
         do {
             try registry.remove(hostID: hostID)
+            // The row is going away; its open update panel must not outlive it.
+            if presentedPluginUpdate?.hostID == hostID { dismissPluginUpdate() }
             refreshHosts()
             reconcileListener()
         } catch {
@@ -493,6 +521,59 @@ public final class ClaudeIntegrationSettingsModel {
         enrollmentConfirmation = nil
         enrollmentStepStatuses = []
         enrollmentResultsAction = nil
+    }
+
+    /// Show one host's plugin-update commands in its row.
+    ///
+    /// Needed because `claude plugin install` is not an update: on an installed
+    /// plugin it exits 0 and leaves the old version in place (Claude Code
+    /// 2.1.220), so re-running enrollment does nothing and a host stays on a
+    /// plugin the app has since fixed — silently, because the hooks fail open.
+    public func requestPluginUpdate(hostID: String) {
+        guard !isPerformingEnrollmentAction, hosts.contains(where: { $0.id == hostID }) else { return }
+        let alias = hosts.first { $0.id == hostID }
+            .map(\.label)
+            .flatMap { ClaudeRemoteEnrollmentService.isValidHostAlias($0) ? $0 : nil }
+        // A fresh panel must not inherit another action's results, for the same
+        // reason a fresh enrollment sheet must not (field report 2026-07-26).
+        enrollmentConfirmation = nil
+        enrollmentStepStatuses = []
+        enrollmentResultsAction = nil
+        presentedPluginUpdate = PluginUpdatePresentation(
+            hostID: hostID,
+            sshHostAlias: alias,
+            commands: ClaudeRemoteEnrollmentService.updateCommands(
+                sshHostAlias: alias ?? "your-ssh-host"
+            )
+        )
+    }
+
+    public func dismissPluginUpdate() {
+        if case .updateRemotePlugin? = enrollmentResultsAction {
+            enrollmentStepStatuses = []
+            enrollmentResultsAction = nil
+        }
+        if case .updateRemotePlugin? = enrollmentConfirmation?.action {
+            enrollmentConfirmation = nil
+        }
+        presentedPluginUpdate = nil
+    }
+
+    /// Ask before running the update commands, repeating the exact pair.
+    public func requestPluginUpdateRun() {
+        guard let presentation = presentedPluginUpdate,
+              presentation.canRun,
+              !isPerformingEnrollmentAction
+        else { return }
+        enrollmentStepStatuses = []
+        enrollmentResultsAction = nil
+        enrollmentConfirmation = EnrollmentConfirmation(
+            action: .updateRemotePlugin(hostID: presentation.hostID),
+            title: "Update the plugin on this SSH host?",
+            preview: presentation.commands.joined(separator: "\n"),
+            confirmButtonTitle: "Confirm Update"
+        )
+        Log.claudeContext.info("Claude remote plugin update confirmation requested")
     }
 
     public func requestSSHConfigInsertion() {
@@ -526,30 +607,45 @@ public final class ClaudeIntegrationSettingsModel {
     }
 
     public func confirmEnrollmentAction() async {
-        guard let confirmation = enrollmentConfirmation,
-              let presentation = presentedPlan,
-              !isPerformingEnrollmentAction
-        else { return }
+        guard let confirmation = enrollmentConfirmation, !isPerformingEnrollmentAction else { return }
+        switch confirmation.action {
+        case .insertSSHConfig, .runRemoteSetup:
+            await performPlanAction(confirmation)
+        case .updateRemotePlugin:
+            await performPluginUpdate(confirmation)
+        }
+    }
+
+    private func performPlanAction(_ confirmation: EnrollmentConfirmation) async {
+        guard let presentation = presentedPlan else { return }
+        let service = enrollmentService
+        let work: @Sendable () throws -> [ClaudeRemoteEnrollmentService.ExecutionStep]
+        switch confirmation.action {
+        case .insertSSHConfig:
+            work = {
+                try service.insertSSHConfig(presentation.plan, hostID: presentation.host.id)
+                return []
+            }
+        case .runRemoteSetup:
+            work = {
+                try service.executeRemoteSetup(
+                    presentation.plan,
+                    sshHostAlias: presentation.sshHostAlias,
+                    token: presentation.token
+                )
+            }
+        case .updateRemotePlugin:
+            // Routed to performPluginUpdate: that action belongs to a host row,
+            // has no plan and no token, and must not run against one.
+            return
+        }
         enrollmentConfirmation = nil
         isPerformingEnrollmentAction = true
         enrollmentStepStatuses = []
         enrollmentResultsAction = nil
         defer { isPerformingEnrollmentAction = false }
 
-        let service = enrollmentService
-        let attempt = await performEnrollmentAsync {
-            switch confirmation.action {
-            case .insertSSHConfig:
-                try service.insertSSHConfig(presentation.plan, hostID: presentation.host.id)
-                return []
-            case .runRemoteSetup:
-                return try service.executeRemoteSetup(
-                    presentation.plan,
-                    sshHostAlias: presentation.sshHostAlias,
-                    token: presentation.token
-                )
-            }
-        }
+        let attempt = await performEnrollmentAsync(work)
 
         // The sheet may have been dismissed (window close) and even replaced
         // while the detached work ran; a late result must not surface under a
@@ -559,14 +655,39 @@ public final class ClaudeIntegrationSettingsModel {
         // mints a fresh token, so value equality distinguishes generations.
         guard presentedPlan == presentation else { return }
 
+        publish(attempt, action: confirmation.action)
+    }
+
+    private func performPluginUpdate(_ confirmation: EnrollmentConfirmation) async {
+        guard let presentation = presentedPluginUpdate,
+              let alias = presentation.sshHostAlias
+        else { return }
+        enrollmentConfirmation = nil
+        isPerformingEnrollmentAction = true
+        enrollmentStepStatuses = []
+        enrollmentResultsAction = nil
+        defer { isPerformingEnrollmentAction = false }
+
+        let service = enrollmentService
+        let attempt = await performEnrollmentAsync {
+            try service.executeRemotePluginUpdate(sshHostAlias: alias)
+        }
+
+        // Same rule as the sheet: the row may have been closed, or another
+        // host's opened, while ssh was still running — one host's outcome must
+        // never render under another host's commands.
+        guard presentedPluginUpdate == presentation else { return }
+
+        publish(attempt, action: confirmation.action)
+    }
+
+    /// Turn one finished attempt into the statuses its section renders.
+    private func publish(_ attempt: ClaudeEnrollmentActionAttempt, action: EnrollmentAction) {
         if let failure = attempt.failure {
-            enrollmentStepStatuses = Self.failureStatuses(
-                failure,
-                action: confirmation.action
-            )
-            enrollmentResultsAction = confirmation.action
+            enrollmentStepStatuses = Self.failureStatuses(failure, action: action)
+            enrollmentResultsAction = action
             alert = DetailAlert(
-                title: "Remote Claude Code setup",
+                title: Self.failureAlertTitle(for: action),
                 detail: Self.enrollmentFailureDetail(failure)
             )
             Log.claudeContext.error(
@@ -575,14 +696,14 @@ public final class ClaudeIntegrationSettingsModel {
             return
         }
 
-        switch confirmation.action {
+        switch action {
         case .insertSSHConfig:
             enrollmentStepStatuses = [
                 EnrollmentStepStatus(
                     id: 0, text: "Inserted this host's block into ~/.ssh/config.", succeeded: true, detail: ""
                 )
             ]
-        case .runRemoteSetup:
+        case .runRemoteSetup, .updateRemotePlugin:
             enrollmentStepStatuses = attempt.steps.map {
                 EnrollmentStepStatus(
                     id: $0.index,
@@ -592,7 +713,14 @@ public final class ClaudeIntegrationSettingsModel {
                 )
             }
         }
-        enrollmentResultsAction = confirmation.action
+        enrollmentResultsAction = action
+    }
+
+    static func failureAlertTitle(for action: EnrollmentAction) -> String {
+        switch action {
+        case .insertSSHConfig, .runRemoteSetup: return "Remote Claude Code setup"
+        case .updateRemotePlugin: return "Remote Claude Code plugin"
+        }
     }
 
     public static func redactedRemoteCommands(for presentation: EnrollmentPresentation) -> String {
@@ -605,7 +733,7 @@ public final class ClaudeIntegrationSettingsModel {
         _ failure: ClaudeEnrollmentActionFailure,
         action: EnrollmentAction
     ) -> [EnrollmentStepStatus] {
-        guard action == .runRemoteSetup else {
+        guard action != .insertSSHConfig else {
             return [EnrollmentStepStatus(id: 0, text: "SSH config update failed.", succeeded: false, detail: failure.describedError)]
         }
 
@@ -622,7 +750,9 @@ public final class ClaudeIntegrationSettingsModel {
             failedStep = step
             detail = message
         default:
-            return [EnrollmentStepStatus(id: 0, text: "Remote setup failed.", succeeded: false, detail: failure.describedError)]
+            var text = "Remote setup failed."
+            if case .updateRemotePlugin = action { text = "Plugin update failed." }
+            return [EnrollmentStepStatus(id: 0, text: text, succeeded: false, detail: failure.describedError)]
         }
         let succeeded = (0..<failedStep).map {
             EnrollmentStepStatus(id: $0, text: "Step \($0 + 1) succeeded.", succeeded: true, detail: "")

--- a/Sources/localvoxtral/ClaudeContext/ClaudeIntegrationSettingsModel.swift
+++ b/Sources/localvoxtral/ClaudeContext/ClaudeIntegrationSettingsModel.swift
@@ -78,6 +78,11 @@ public final class ClaudeIntegrationSettingsModel {
     public struct HostRow: Identifiable, Equatable, Sendable {
         public var id: String
         public var label: String
+        /// Nil for hosts enrolled before the alias was persisted. Never
+        /// substituted with `label`: they are different fields on the form, so
+        /// guessing one from the other can ssh to a machine the user did not
+        /// pick.
+        public var sshHostAlias: String?
         public var isRevoked: Bool
         public var lastSeenAt: Date?
 
@@ -152,6 +157,12 @@ public final class ClaudeIntegrationSettingsModel {
         /// Rotation reuses this sheet; the copy differs because the user's
         /// situation does (their remote is currently broken, on purpose).
         public var isRotation: Bool
+        /// False when `sshHostAlias` is the sheet's placeholder rather than an
+        /// alias the user gave us — a legacy host rotated before the alias was
+        /// persisted. The commands are still copyable; what is withheld is
+        /// one-click execution, which would otherwise hand a fresh token to
+        /// whichever machine happened to answer to a guessed name.
+        public var canRunRemoteSetup: Bool = true
     }
 
     /// The two commands that bring one enrolled host to the plugin version this
@@ -376,7 +387,13 @@ public final class ClaudeIntegrationSettingsModel {
 
     public func refreshHosts() {
         hosts = (registry?.hosts() ?? []).map {
-            HostRow(id: $0.id, label: $0.label, isRevoked: $0.isRevoked, lastSeenAt: $0.lastSeenAt)
+            HostRow(
+                id: $0.id,
+                label: $0.label,
+                sshHostAlias: $0.sshHostAlias,
+                isRevoked: $0.isRevoked,
+                lastSeenAt: $0.lastSeenAt
+            )
         }
     }
 
@@ -413,7 +430,7 @@ public final class ClaudeIntegrationSettingsModel {
             return
         }
         do {
-            let enrollment = try registry.enroll(label: label)
+            let enrollment = try registry.enroll(label: label, sshHostAlias: alias)
             let plan = try ClaudeRemoteEnrollmentService.plan(
                 host: enrollment.host,
                 sshHostAlias: alias,
@@ -447,14 +464,16 @@ public final class ClaudeIntegrationSettingsModel {
         guard let registry else { return }
         do {
             let enrollment = try registry.rotateToken(hostID: hostID)
+            // The alias the user enrolled with, or nothing. The label is NOT a
+            // fallback: name and alias are separate fields, so `prod` named
+            // over alias `builder` would have sent the new token to whatever
+            // answers to `prod` (review finding, PR #197). A host enrolled
+            // before the alias was persisted gets the placeholder and copy-only
+            // commands, which is honest about what we know.
+            let alias = enrollment.host.sshHostAlias
             let plan = try ClaudeRemoteEnrollmentService.plan(
                 host: enrollment.host,
-                // The alias is not persisted — it is the user's ssh config, not
-                // ours — so the label is the best guess we have, and the sheet
-                // says so rather than pretending.
-                sshHostAlias: ClaudeRemoteEnrollmentService.isValidHostAlias(enrollment.host.label)
-                    ? enrollment.host.label
-                    : "your-ssh-host",
+                sshHostAlias: alias ?? Self.unknownAliasPlaceholder,
                 token: enrollment.token,
                 port: listener?.boundPort ?? ClaudeRemoteListenerLimits.default.port
             )
@@ -464,11 +483,10 @@ public final class ClaudeIntegrationSettingsModel {
             presentedPlan = EnrollmentPresentation(
                 host: enrollment.host,
                 token: enrollment.token,
-                sshHostAlias: ClaudeRemoteEnrollmentService.isValidHostAlias(enrollment.host.label)
-                    ? enrollment.host.label
-                    : "your-ssh-host",
+                sshHostAlias: alias ?? Self.unknownAliasPlaceholder,
                 plan: plan,
-                isRotation: true
+                isRotation: true,
+                canRunRemoteSetup: alias != nil
             )
             refreshHosts()
             // Rotation reinstates a revoked host, so it can be a 0→1 transition.
@@ -530,10 +548,17 @@ public final class ClaudeIntegrationSettingsModel {
     /// 2.1.220), so re-running enrollment does nothing and a host stays on a
     /// plugin the app has since fixed — silently, because the hooks fail open.
     public func requestPluginUpdate(hostID: String) {
-        guard !isPerformingEnrollmentAction, hosts.contains(where: { $0.id == hostID }) else { return }
-        let alias = hosts.first { $0.id == hostID }
-            .map(\.label)
-            .flatMap { ClaudeRemoteEnrollmentService.isValidHostAlias($0) ? $0 : nil }
+        guard !isPerformingEnrollmentAction,
+              let host = hosts.first(where: { $0.id == hostID })
+        else { return }
+        // The ENROLLED alias, never the label: a host named `prod` may be
+        // reached over alias `builder`, and `ssh prod …` would then update
+        // whatever machine answers to that name (review finding, PR #197).
+        // Hosts enrolled before the alias was persisted have none, and get
+        // copy-only commands rather than a guess.
+        let alias = host.sshHostAlias.flatMap {
+            ClaudeRemoteEnrollmentService.isValidHostAlias($0) ? $0 : nil
+        }
         // A fresh panel must not inherit another action's results, for the same
         // reason a fresh enrollment sheet must not (field report 2026-07-26).
         enrollmentConfirmation = nil
@@ -543,10 +568,15 @@ public final class ClaudeIntegrationSettingsModel {
             hostID: hostID,
             sshHostAlias: alias,
             commands: ClaudeRemoteEnrollmentService.updateCommands(
-                sshHostAlias: alias ?? "your-ssh-host"
+                sshHostAlias: alias ?? Self.unknownAliasPlaceholder
             )
         )
     }
+
+    /// Stands in for an alias we were never told. Not a valid target and not
+    /// meant to be one — it is there so the copyable commands read correctly
+    /// with an obvious blank to fill in.
+    static let unknownAliasPlaceholder = "your-ssh-host"
 
     public func dismissPluginUpdate() {
         if case .updateRemotePlugin? = enrollmentResultsAction {
@@ -590,7 +620,12 @@ public final class ClaudeIntegrationSettingsModel {
     }
 
     public func requestRemoteSetup() {
-        guard let presentation = presentedPlan, !isPerformingEnrollmentAction else { return }
+        guard let presentation = presentedPlan,
+              // A placeholder alias must not reach ssh: one-click would hand
+              // the new token to whatever answers to a name we invented.
+              presentation.canRunRemoteSetup,
+              !isPerformingEnrollmentAction
+        else { return }
         enrollmentStepStatuses = []
         enrollmentResultsAction = nil
         enrollmentConfirmation = EnrollmentConfirmation(
@@ -688,7 +723,7 @@ public final class ClaudeIntegrationSettingsModel {
             enrollmentResultsAction = action
             alert = DetailAlert(
                 title: Self.failureAlertTitle(for: action),
-                detail: Self.enrollmentFailureDetail(failure)
+                detail: Self.enrollmentFailureDetail(failure, action: action)
             )
             Log.claudeContext.error(
                 "Claude remote enrollment action failed: \(failure.describedError, privacy: .public)"
@@ -767,15 +802,23 @@ public final class ClaudeIntegrationSettingsModel {
         ]
     }
 
-    static func enrollmentFailureDetail(_ failure: ClaudeEnrollmentActionFailure) -> String {
+    /// The alert body. `action` names the work in the user's terms — an alert
+    /// that says "SSH setup" after they pressed Update Plugin reads as a
+    /// different failure than the one they are looking at.
+    static func enrollmentFailureDetail(
+        _ failure: ClaudeEnrollmentActionFailure,
+        action: EnrollmentAction
+    ) -> String {
+        var subject = "SSH setup"
+        if case .updateRemotePlugin = action { subject = "Plugin update" }
         switch failure.serviceError {
         case .commandTimedOut(_, _, let seconds, let message):
             let output = message.isEmpty ? "" : "\n\n\(message)"
-            return "SSH setup did not finish within \(Int(seconds))s and was stopped.\(output)"
+            return "\(subject) did not finish within \(Int(seconds))s and was stopped.\(output)"
         case .commandFailed(_, _, let exitCode, let message):
-            return "SSH setup exited with code \(exitCode).\n\n\(message)"
+            return "\(subject) exited with code \(exitCode).\n\n\(message)"
         case .runnerFailed(_, _, let message):
-            return "SSH setup could not run.\n\n\(message)"
+            return "\(subject) could not run.\n\n\(message)"
         case .invalidSSHConfigEncoding:
             return "~/.ssh/config is not valid UTF-8, so localvoxtral left it unchanged."
         case .sshConfigIsSymlink:
@@ -789,7 +832,7 @@ public final class ClaudeIntegrationSettingsModel {
         case .sshConfigEditingNotConfigured:
             return "Editing ~/.ssh/config is not available in this build."
         case .executionNotConfigured:
-            return "Running SSH setup is not available in this build."
+            return "Running commands over SSH is not available in this build."
         case .invalidHostAlias:
             return "The SSH host alias is invalid."
         case .none:

--- a/Sources/localvoxtral/ClaudeContext/ClaudeRemoteEnrollmentService.swift
+++ b/Sources/localvoxtral/ClaudeContext/ClaudeRemoteEnrollmentService.swift
@@ -52,6 +52,10 @@ public struct ClaudeRemoteEnrollmentService: Sendable {
         public var remoteCommands: [String]
         /// Run to check the setup without changing it.
         public var verifyCommands: [String]
+        /// Bring an already-enrolled host to the plugin version this app ships.
+        /// Carries no token: `claude plugin update` keeps the config the install
+        /// already stored.
+        public var updateCommands: [String]
         /// Undo, in order: remote first, then local revocation.
         public var uninstallCommands: [String]
         /// Caveats worth reading before the first surprise.
@@ -190,6 +194,7 @@ public struct ClaudeRemoteEnrollmentService: Sendable {
             sshConfigSnippet: sshConfigSnippet(host: host, sshHostAlias: sshHostAlias, port: port),
             remoteCommands: remoteCommands(token: token),
             verifyCommands: verifyCommands(sshHostAlias: sshHostAlias, port: port),
+            updateCommands: updateCommands(sshHostAlias: sshHostAlias),
             uninstallCommands: uninstallCommands(host: host, sshHostAlias: sshHostAlias),
             notes: notes(port: port)
         )
@@ -232,6 +237,14 @@ public struct ClaudeRemoteEnrollmentService: Sendable {
         """
     }
 
+    /// The first-time setup pair.
+    ///
+    /// Both are idempotent, but only in the weak sense: on a host that already
+    /// has them, `marketplace add` exits 0 without refreshing the clone and
+    /// `plugin install` exits 0 without changing the installed version (verified
+    /// on Claude Code 2.1.220). `install` DOES apply a new `--config token=`,
+    /// which is why rotation reuses this exact command — and why shipping a new
+    /// plugin version needs `updateCommands` instead.
     static func remoteCommands(token: String) -> [String] {
         [
             "claude plugin marketplace add \(repositoryMarketplaceReference)",
@@ -257,13 +270,49 @@ public struct ClaudeRemoteEnrollmentService: Sendable {
             "ssh -v \(sshHostAlias) true 2>&1 | grep -i 'remote forward'",
             "# Non-interactive SSH skips your shell rc, so claude can be off PATH",
             "# here even though it runs fine when you are logged in.",
-            "ssh \(sshHostAlias) 'PATH=\"$HOME/.claude/local:$HOME/.local/bin:$HOME/bin"
-                + ":/opt/homebrew/bin:/usr/local/bin:$PATH\" claude plugin list'",
+            "ssh \(sshHostAlias) '\(nonInteractiveClaudePathPrefix)claude plugin list'",
             "# 401 = SUCCESS: the tunnel is up and localvoxtral answered (an",
             "# unauthenticated probe must be refused). A connection error means",
             "# no live session holds the forward right now.",
             "ssh \(sshHostAlias) 'curl -s -o /dev/null -w \"%{http_code}\\n\" -X POST "
                 + "-H \"Content-Type: application/json\" -d \"{}\" http://127.0.0.1:\(port)/v1/hook/SessionStart'",
+        ]
+    }
+
+    /// PATH prefix for a `claude` invocation inside `ssh <host> '<command>'`.
+    ///
+    /// Non-interactive SSH skips the login rc, so `claude` is routinely off PATH
+    /// there on a host where it works fine interactively. The stdin script has
+    /// its own resolver (`claudePathResolverPreamble`); this is the one-liner
+    /// equivalent for the commands a person pastes.
+    static let nonInteractiveClaudePathPrefix =
+        "PATH=\"$HOME/.claude/local:$HOME/.local/bin:$HOME/bin:/opt/homebrew/bin:/usr/local/bin:$PATH\" "
+
+    /// The remote-side commands, in order, with nothing wrapped around them.
+    /// Execution sends these through the SSH stdin script;
+    /// `updateCommands(sshHostAlias:)` is the same pair written for a person to
+    /// paste from this Mac.
+    static let remotePluginUpdateCommands = [
+        "claude plugin marketplace update \(ClaudePluginAssets.marketplaceName)",
+        "claude plugin update \(remotePluginReference)",
+    ]
+
+    /// Bring an enrolled host to the plugin version this app ships.
+    ///
+    /// The comments are part of the deliverable, as in `verifyCommands`: nothing
+    /// else in the product tells the user that re-running setup is not an
+    /// update, and a host silently left on an old plugin fails open — i.e. it
+    /// looks like nothing at all.
+    static func updateCommands(sshHostAlias: String) -> [String] {
+        [
+            "# Run after updating localvoxtral on this Mac. This pair is the ONLY",
+            "# way a plugin fix reaches a host that is already enrolled: on Claude",
+            "# Code 2.1.220, re-running `plugin install` exits 0 with \"already",
+            "# installed\" and leaves the old version in place, and `marketplace",
+            "# add` does not refresh a clone it already has. Your token is kept —",
+            "# `plugin update` preserves the stored config.",
+            "ssh \(sshHostAlias) '\(nonInteractiveClaudePathPrefix)\(remotePluginUpdateCommands[0])'",
+            "ssh \(sshHostAlias) '\(nonInteractiveClaudePathPrefix)\(remotePluginUpdateCommands[1])'",
         ]
     }
 
@@ -442,18 +491,59 @@ public struct ClaudeRemoteEnrollmentService: Sendable {
         token: String,
         timeout: TimeInterval = defaultRemoteSetupTimeout
     ) throws -> [ExecutionStep] {
-        Log.claudeContext.info("Claude remote setup execution requested")
+        try execute(
+            commands: plan.remoteCommands,
+            sshHostAlias: sshHostAlias,
+            token: token,
+            timeout: timeout,
+            label: "setup"
+        )
+    }
+
+    /// Update the remote plugin on an already-enrolled host.
+    ///
+    /// Token-free by construction: `claude plugin update` preserves the config
+    /// the install stored, so this path never has the credential to leak. It is
+    /// a separate entry point rather than a plan step because the user runs it
+    /// long after enrollment — when the app ships a new plugin version — and by
+    /// then the one-time token is gone.
+    @discardableResult
+    public func executeRemotePluginUpdate(
+        sshHostAlias: String,
+        timeout: TimeInterval = defaultRemoteSetupTimeout
+    ) throws -> [ExecutionStep] {
+        try execute(
+            commands: Self.remotePluginUpdateCommands,
+            sshHostAlias: sshHostAlias,
+            token: "",
+            timeout: timeout,
+            label: "plugin update"
+        )
+    }
+
+    private func execute(
+        commands: [String],
+        sshHostAlias: String,
+        token: String,
+        timeout: TimeInterval,
+        label: String
+    ) throws -> [ExecutionStep] {
+        Log.claudeContext.info("Claude remote \(label, privacy: .public) execution requested")
         guard let runner else {
-            Log.claudeContext.error("Claude remote setup execution failed: runner not configured")
+            Log.claudeContext.error(
+                "Claude remote \(label, privacy: .public) execution failed: runner not configured"
+            )
             throw ServiceError.executionNotConfigured
         }
         guard Self.isValidHostAlias(sshHostAlias) else {
-            Log.claudeContext.error("Claude remote setup execution failed: invalid host alias")
+            Log.claudeContext.error(
+                "Claude remote \(label, privacy: .public) execution failed: invalid host alias"
+            )
             throw ServiceError.invalidHostAlias
         }
         let deadline = Date().addingTimeInterval(max(timeout, 0))
         var completed: [ExecutionStep] = []
-        for (index, command) in plan.remoteCommands.enumerated() {
+        for (index, command) in commands.enumerated() {
             let displayCommand = ClaudeRemoteTokenRedaction.redact(
                 command.trimmingCharacters(in: .whitespaces),
                 token: token
@@ -464,12 +554,12 @@ public struct ClaudeRemoteEnrollmentService: Sendable {
                     step: index, command: displayCommand, seconds: timeout, message: ""
                 )
                 Log.claudeContext.error(
-                    "Claude remote setup step \(index + 1, privacy: .public) failed: \(String(describing: failure), privacy: .public)"
+                    "Claude remote \(label, privacy: .public) step \(index + 1, privacy: .public) failed: \(String(describing: failure), privacy: .public)"
                 )
                 throw failure
             }
             let invocation = Invocation(
-                // ClearAllForwardings: the setup connection has no use for the
+                // ClearAllForwardings: this connection has no use for the
                 // 8473 tunnel, and with the user's own session usually holding
                 // it, attempting the forward here only produced a scary
                 // "remote port forwarding failed" warning inside setup errors
@@ -482,7 +572,7 @@ public struct ClaudeRemoteEnrollmentService: Sendable {
                 timeout: remaining
             )
             Log.claudeContext.info(
-                "Claude remote setup step \(index + 1, privacy: .public) requested"
+                "Claude remote \(label, privacy: .public) step \(index + 1, privacy: .public) requested"
             )
             let result: RunResult
             do {
@@ -505,7 +595,7 @@ public struct ClaudeRemoteEnrollmentService: Sendable {
                     )
                 }
                 Log.claudeContext.error(
-                    "Claude remote setup step \(index + 1, privacy: .public) failed: \(String(describing: error), privacy: .public)"
+                    "Claude remote \(label, privacy: .public) step \(index + 1, privacy: .public) failed: \(String(describing: error), privacy: .public)"
                 )
                 throw error
             } catch {
@@ -514,7 +604,7 @@ public struct ClaudeRemoteEnrollmentService: Sendable {
                     step: index, command: displayCommand, message: redacted
                 )
                 Log.claudeContext.error(
-                    "Claude remote setup step \(index + 1, privacy: .public) failed: \(String(describing: failure), privacy: .public)"
+                    "Claude remote \(label, privacy: .public) step \(index + 1, privacy: .public) failed: \(String(describing: failure), privacy: .public)"
                 )
                 throw failure
             }
@@ -526,7 +616,7 @@ public struct ClaudeRemoteEnrollmentService: Sendable {
                     message: ClaudeRemoteTokenRedaction.redact(result.message, token: token)
                 )
                 Log.claudeContext.error(
-                    "Claude remote setup step \(index + 1, privacy: .public) failed: \(String(describing: failure), privacy: .public)"
+                    "Claude remote \(label, privacy: .public) step \(index + 1, privacy: .public) failed: \(String(describing: failure), privacy: .public)"
                 )
                 throw failure
             }
@@ -538,10 +628,10 @@ public struct ClaudeRemoteEnrollmentService: Sendable {
                 )
             )
             Log.claudeContext.info(
-                "Claude remote setup step \(index + 1, privacy: .public) completed"
+                "Claude remote \(label, privacy: .public) step \(index + 1, privacy: .public) completed"
             )
         }
-        Log.claudeContext.info("Claude remote setup execution completed")
+        Log.claudeContext.info("Claude remote \(label, privacy: .public) execution completed")
         return completed
     }
 

--- a/Sources/localvoxtral/ClaudeContext/ClaudeRemoteEnrollmentService.swift
+++ b/Sources/localvoxtral/ClaudeContext/ClaudeRemoteEnrollmentService.swift
@@ -207,8 +207,20 @@ public struct ClaudeRemoteEnrollmentService: Sendable {
     /// block), no quotes. This is the only user-supplied string that reaches the
     /// generated config, so it is checked rather than escaped — an alias that
     /// needs escaping is not an alias.
+    ///
+    /// A leading `-` is refused separately from the charset, because `-` is
+    /// legal INSIDE a hostname and fatal in front of one: an alias of `-V`
+    /// reaches `ssh`'s argv as an option, and OpenSSH then prints its version
+    /// and exits 0 without connecting — every step reports success while
+    /// nothing ran on any host (review finding, PR #197). Argv termination in
+    /// `execute` is the second layer; this is the first, and it is the one that
+    /// also covers the commands the user pastes by hand.
     public static func isValidHostAlias(_ alias: String) -> Bool {
         guard !alias.isEmpty, alias.count <= 128 else { return false }
+        guard !alias.hasPrefix("-") else { return false }
+        // "." and ".." would name a directory, not a host, and an all-dot alias
+        // resolves to nothing anyone meant.
+        guard alias.contains(where: { $0 != "." }) else { return false }
         let allowed = Set("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789.-_")
         return alias.allSatisfy { allowed.contains($0) }
     }
@@ -564,8 +576,12 @@ public struct ClaudeRemoteEnrollmentService: Sendable {
                 // it, attempting the forward here only produced a scary
                 // "remote port forwarding failed" warning inside setup errors
                 // (field report 2026-07-26).
+                // `--` ends OpenSSH's option parsing: the alias is validated
+                // above and cannot start with `-`, and this makes an alias that
+                // somehow did reach here a failed connection rather than a
+                // silently successful option.
                 argv: [
-                    "ssh", "-o", "BatchMode=yes", "-o", "ClearAllForwardings=yes",
+                    "ssh", "-o", "BatchMode=yes", "-o", "ClearAllForwardings=yes", "--",
                     sshHostAlias, "/bin/sh", "-s",
                 ],
                 standardInput: Self.remoteScript(command: command),

--- a/Sources/localvoxtral/ClaudeContext/ClaudeRemoteHostRegistry.swift
+++ b/Sources/localvoxtral/ClaudeContext/ClaudeRemoteHostRegistry.swift
@@ -18,6 +18,15 @@ public struct ClaudeRemoteHost: Sendable, Equatable, Identifiable {
     public let id: String
     /// User-facing name (typically the SSH host alias). Sanitized on enroll.
     public var label: String
+    /// The alias the user enrolled with, when it is still a valid one.
+    ///
+    /// Nil for hosts enrolled before this was persisted. The label is NOT a
+    /// usable substitute: the two are separate fields on the enrollment form,
+    /// so a host named `prod` can have alias `builder`, and running setup
+    /// against the name would act on a machine the user never chose (review
+    /// finding, PR #197). Anything that would ssh somewhere therefore needs
+    /// this, and treats nil as "ask, or copy only".
+    public var sshHostAlias: String?
     public var createdAt: Date
     public var lastSeenAt: Date?
     public var revokedAt: Date?
@@ -315,11 +324,17 @@ public final class ClaudeRemoteHostRegistry: Sendable {
         /// Absent means the legacy unframed SHA-256 construction. New and
         /// rotated credentials are HMAC v2; legacy hosts migrate on rotation.
         var hashVersion: Int? = nil
+        /// Absent for hosts enrolled before the alias was persisted. Optional
+        /// rather than a new file version: an older build reading this file
+        /// ignores the key, and a newer build reading an older file gets nil
+        /// and degrades to copy-only — neither loses a host.
+        var sshHostAlias: String? = nil
 
         var publicView: ClaudeRemoteHost {
             ClaudeRemoteHost(
                 id: id,
                 label: label,
+                sshHostAlias: sshHostAlias,
                 createdAt: createdAt,
                 lastSeenAt: lastSeenAt,
                 revokedAt: revokedAt
@@ -509,9 +524,15 @@ public final class ClaudeRemoteHostRegistry: Sendable {
     ///
     /// - Returns: the host and its plaintext token. This is the only time the
     ///   token is knowable; show it, then let it go.
-    public func enroll(label: String) throws -> ClaudeRemoteEnrollment {
+    /// - Parameter sshHostAlias: the alias the user typed. Stored only when it
+    ///   is a valid alias — a stored value is later allowed to reach `ssh`'s
+    ///   argv, so it is checked here rather than trusted from a caller.
+    public func enroll(label: String, sshHostAlias: String? = nil) throws -> ClaudeRemoteEnrollment {
         let cleanLabel = Self.sanitizeLabel(label)
         guard !cleanLabel.isEmpty else { throw StoreError.invalidLabel }
+        let cleanAlias = sshHostAlias.flatMap {
+            ClaudeRemoteEnrollmentService.isValidHostAlias($0) ? $0 : nil
+        }
         let token = makeToken()
         let salt = makeToken()
         let timestamp = now()
@@ -533,7 +554,8 @@ public final class ClaudeRemoteHostRegistry: Sendable {
                 revokedAt: nil,
                 tokenSalt: salt,
                 tokenHash: ClaudeRemoteTokenDigest.hash(token: token, salt: salt),
-                hashVersion: Self.currentHashVersion
+                hashVersion: Self.currentHashVersion,
+                sshHostAlias: cleanAlias
             )
             hosts.append(host)
             return host

--- a/Sources/localvoxtral/SettingsView.swift
+++ b/Sources/localvoxtral/SettingsView.swift
@@ -1052,6 +1052,10 @@ private struct ClaudeRemoteHostsSettingsRow: View {
                         }
                         Button("Remove") { Task { await model.remove(hostID: host.id) } }
                             .controlSize(.small)
+                            // Removing the row an action is reporting into is
+                            // handled (the late-result guard drops the outcome),
+                            // but offering it mid-run is still offering a race.
+                            .disabled(model.isPerformingEnrollmentAction)
                     }
                     pluginUpdatePanel(for: host)
                 }
@@ -1238,14 +1242,19 @@ private struct ClaudeRemoteEnrollmentSheet: View {
                         enrollmentAction: .insertSSHConfig,
                         action: { model.requestSSHConfigInsertion() }
                     )
+                    // No Run button when the alias is the placeholder: this host
+                    // was enrolled before the alias was persisted, so we do not
+                    // know where to send a token. Copy still works.
                     section(
                         "2. Run on the remote host",
                         body: plan.remoteCommands.joined(separator: "\n"),
                         displayedBody: ClaudeIntegrationSettingsModel.redactedRemoteCommands(for: presentation),
-                        note: "One-click execution sends the token through SSH stdin, never process arguments.",
-                        actionTitle: "Run on SSH host",
+                        note: presentation.canRunRemoteSetup
+                            ? "One-click execution sends the token through SSH stdin, never process arguments."
+                            : "Replace \(ClaudeIntegrationSettingsModel.unknownAliasPlaceholder) with the alias from your ~/.ssh/config and run these yourself — this host was enrolled before localvoxtral recorded its alias.",
+                        actionTitle: presentation.canRunRemoteSetup ? "Run on SSH host" : nil,
                         enrollmentAction: .runRemoteSetup,
-                        action: { model.requestRemoteSetup() }
+                        action: presentation.canRunRemoteSetup ? { model.requestRemoteSetup() } : nil
                     )
                     section("Verify", body: plan.verifyCommands.joined(separator: "\n"), note: nil)
                     section(

--- a/Sources/localvoxtral/SettingsView.swift
+++ b/Sources/localvoxtral/SettingsView.swift
@@ -1041,6 +1041,9 @@ private struct ClaudeRemoteHostsSettingsRow: View {
                             .foregroundStyle(.secondary)
                         }
                         Spacer()
+                        Button("Update Plugin…") { model.requestPluginUpdate(hostID: host.id) }
+                            .controlSize(.small)
+                            .disabled(model.isPerformingEnrollmentAction)
                         Button("Rotate Token") { Task { await model.rotate(hostID: host.id) } }
                             .controlSize(.small)
                         if !host.isRevoked {
@@ -1050,8 +1053,78 @@ private struct ClaudeRemoteHostsSettingsRow: View {
                         Button("Remove") { Task { await model.remove(hostID: host.id) } }
                             .controlSize(.small)
                     }
+                    pluginUpdatePanel(for: host)
                 }
             }
+        }
+    }
+
+    /// One host's plugin-update commands, disclosed in that host's row.
+    ///
+    /// In the row rather than a new group, and confirmed and reported where the
+    /// button is (PR #194): a result the user has to go looking for is a result
+    /// they conclude never happened.
+    @ViewBuilder
+    private func pluginUpdatePanel(for host: ClaudeIntegrationSettingsModel.HostRow) -> some View {
+        if let update = model.presentedPluginUpdate, update.hostID == host.id {
+            let commands = update.commands.joined(separator: "\n")
+            let action = ClaudeIntegrationSettingsModel.EnrollmentAction.updateRemotePlugin(hostID: host.id)
+            let pendingConfirmation = model.enrollmentConfirmation.flatMap {
+                $0.action == action ? $0 : nil
+            }
+            VStack(alignment: .leading, spacing: 4) {
+                HStack {
+                    Text("Update the plugin on \(host.label)").font(.caption).bold()
+                    Spacer()
+                    Button("Copy") {
+                        // No token here — the update keeps the stored one — but
+                        // concealed anyway, so a Settings copy cannot ride into
+                        // the next polish prompt's clipboard context.
+                        ConcealedPasteboardWriter.write(commands)
+                    }
+                    .controlSize(.small)
+                    Button("Close") { model.dismissPluginUpdate() }
+                        .controlSize(.small)
+                        .disabled(model.isPerformingEnrollmentAction)
+                }
+                // The displayed block IS the confirmation preview, highlighted
+                // while the question is pending, so confirming still repeats the
+                // exact commands it authorizes.
+                Text(commands)
+                    .font(.system(.caption2, design: .monospaced))
+                    .textSelection(.enabled)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .padding(6)
+                    .background(
+                        pendingConfirmation != nil
+                            ? Color.orange.opacity(0.10) : Color.secondary.opacity(0.08),
+                        in: RoundedRectangle(cornerRadius: 4)
+                    )
+                if let confirmation = pendingConfirmation {
+                    Text(confirmation.title).font(.caption).bold()
+                    HStack {
+                        Button("Cancel") { model.cancelEnrollmentActionConfirmation() }
+                        Button(confirmation.confirmButtonTitle) {
+                            Task { await model.confirmEnrollmentAction() }
+                        }
+                        .buttonStyle(.borderedProminent)
+                    }
+                    .controlSize(.small)
+                } else if update.canRun {
+                    Button("Run on SSH host") { model.requestPluginUpdateRun() }
+                        .controlSize(.small)
+                        .disabled(model.isPerformingEnrollmentAction)
+                } else {
+                    Text("Replace your-ssh-host with the alias from your ~/.ssh/config, then run these two commands yourself.")
+                        .font(.caption2)
+                        .foregroundStyle(.secondary)
+                }
+                if model.enrollmentResultsAction == action {
+                    ClaudeEnrollmentStepResults(statuses: model.enrollmentStepStatuses)
+                }
+            }
+            .padding(.leading, 8)
+            .padding(.bottom, 4)
         }
     }
 
@@ -1085,6 +1158,43 @@ private struct ClaudeRemoteHostsSettingsRow: View {
                 .font(.caption)
                 .foregroundStyle(.secondary)
                 .lineLimit(3)
+        }
+    }
+}
+
+/// One action's outcome, rendered inside the section whose button ran it.
+///
+/// A pooled results area below step 2 is how a step-1 success went unseen in the
+/// field and got re-confirmed — so the caller places this, and the model's
+/// `enrollmentResultsAction` decides which caller gets to.
+private struct ClaudeEnrollmentStepResults: View {
+    let statuses: [ClaudeIntegrationSettingsModel.EnrollmentStepStatus]
+
+    var body: some View {
+        if !statuses.isEmpty {
+            VStack(alignment: .leading, spacing: 4) {
+                ForEach(statuses) { step in
+                    Text("\(step.succeeded ? "✓" : "✗") \(step.text)")
+                        .font(.caption)
+                        .foregroundStyle(step.succeeded ? AnyShapeStyle(.secondary) : AnyShapeStyle(.orange))
+                        .lineLimit(1)
+                }
+                let details = statuses
+                    .map(\.detail)
+                    .filter { !$0.isEmpty }
+                    .joined(separator: "\n\n")
+                if !details.isEmpty {
+                    ScrollView {
+                        Text(details)
+                            .font(.system(.caption2, design: .monospaced))
+                            .textSelection(.enabled)
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                    }
+                    .frame(maxHeight: 90)
+                    .padding(6)
+                    .background(Color.secondary.opacity(0.08), in: RoundedRectangle(cornerRadius: 4))
+                }
+            }
         }
     }
 }
@@ -1138,6 +1248,11 @@ private struct ClaudeRemoteEnrollmentSheet: View {
                         action: { model.requestRemoteSetup() }
                     )
                     section("Verify", body: plan.verifyCommands.joined(separator: "\n"), note: nil)
+                    section(
+                        "Update later",
+                        body: plan.updateCommands.joined(separator: "\n"),
+                        note: "Also available per host in Settings, once localvoxtral ships a newer plugin."
+                    )
                     section("Uninstall", body: plan.uninstallCommands.joined(separator: "\n"), note: nil)
 
                     VStack(alignment: .leading, spacing: 4) {
@@ -1163,35 +1278,10 @@ private struct ClaudeRemoteEnrollmentSheet: View {
         .frame(width: 560, height: 520)
     }
 
-    /// One step's outcome, rendered inside the section whose button ran it.
-    /// A pooled results area below step 2 is how a step-1 success went unseen
-    /// in the field and got re-confirmed.
     @ViewBuilder
     private func sectionResults(for enrollmentAction: ClaudeIntegrationSettingsModel.EnrollmentAction) -> some View {
-        if model.enrollmentResultsAction == enrollmentAction, !model.enrollmentStepStatuses.isEmpty {
-            VStack(alignment: .leading, spacing: 4) {
-                ForEach(model.enrollmentStepStatuses) { step in
-                    Text("\(step.succeeded ? "✓" : "✗") \(step.text)")
-                        .font(.caption)
-                        .foregroundStyle(step.succeeded ? AnyShapeStyle(.secondary) : AnyShapeStyle(.orange))
-                        .lineLimit(1)
-                }
-                let details = model.enrollmentStepStatuses
-                    .map(\.detail)
-                    .filter { !$0.isEmpty }
-                    .joined(separator: "\n\n")
-                if !details.isEmpty {
-                    ScrollView {
-                        Text(details)
-                            .font(.system(.caption2, design: .monospaced))
-                            .textSelection(.enabled)
-                            .frame(maxWidth: .infinity, alignment: .leading)
-                    }
-                    .frame(maxHeight: 90)
-                    .padding(6)
-                    .background(Color.secondary.opacity(0.08), in: RoundedRectangle(cornerRadius: 4))
-                }
-            }
+        if model.enrollmentResultsAction == enrollmentAction {
+            ClaudeEnrollmentStepResults(statuses: model.enrollmentStepStatuses)
         }
     }
 

--- a/Tests/localvoxtralTests/ClaudeIntegrationSettingsModelTests.swift
+++ b/Tests/localvoxtralTests/ClaudeIntegrationSettingsModelTests.swift
@@ -590,6 +590,189 @@ final class ClaudeIntegrationSettingsModelTests: XCTestCase {
         XCTAssertTrue(model.alert?.detail.contains("connection stalled") ?? false)
     }
 
+    // MARK: Remote plugin update
+
+    private func enrolledModel(
+        label: String,
+        registry: ClaudeRemoteHostRegistry,
+        service: ClaudeRemoteEnrollmentService
+    ) async -> ClaudeIntegrationSettingsModel {
+        let model = makeModel(
+            registry: registry,
+            listener: StubListener(hosts: registry),
+            enrollmentService: service
+        )
+        model.enrollLabel = label
+        model.enrollSSHAlias = "builder"
+        await model.enroll()
+        model.dismissPlan()
+        return model
+    }
+
+    /// `claude plugin install` is not an update — on Claude Code 2.1.220 it
+    /// exits 0 on an installed plugin and leaves the old version in place — so
+    /// an enrolled host has no way to receive a plugin fix without this action.
+    func testPluginUpdateShowsThatHostsCommandsAndRunsNothingYet() async throws {
+        let registry = try makeRegistry()
+        let calls = Mutex<[ClaudeRemoteEnrollmentService.Invocation]>([])
+        let service = ClaudeRemoteEnrollmentService(runner: { invocation in
+            calls.withLock { $0.append(invocation) }
+            return .init(exitCode: 0, message: "ok")
+        })
+        let model = await enrolledModel(label: "buildhost", registry: registry, service: service)
+        let hostID = try XCTUnwrap(model.hosts.first).id
+
+        model.requestPluginUpdate(hostID: hostID)
+
+        let update = try XCTUnwrap(model.presentedPluginUpdate)
+        XCTAssertEqual(update.hostID, hostID)
+        XCTAssertEqual(update.sshHostAlias, "buildhost")
+        XCTAssertTrue(update.canRun)
+        XCTAssertTrue(update.commands.joined(separator: "\n").contains("claude plugin update"))
+        XCTAssertTrue(calls.withLock { $0 }.isEmpty, "disclosure must not run anything")
+        XCTAssertNil(model.enrollmentConfirmation)
+    }
+
+    func testPluginUpdateRunsOnlyAfterAnExplicitConfirmation() async throws {
+        let registry = try makeRegistry()
+        let calls = Mutex<[ClaudeRemoteEnrollmentService.Invocation]>([])
+        let service = ClaudeRemoteEnrollmentService(runner: { invocation in
+            calls.withLock { $0.append(invocation) }
+            return .init(exitCode: 0, message: "ok")
+        })
+        let model = await enrolledModel(label: "buildhost", registry: registry, service: service)
+        let hostID = try XCTUnwrap(model.hosts.first).id
+        model.requestPluginUpdate(hostID: hostID)
+
+        model.requestPluginUpdateRun()
+
+        XCTAssertTrue(calls.withLock { $0 }.isEmpty)
+        let confirmation = try XCTUnwrap(model.enrollmentConfirmation)
+        XCTAssertEqual(confirmation.action, .updateRemotePlugin(hostID: hostID))
+        XCTAssertEqual(
+            confirmation.preview,
+            model.presentedPluginUpdate?.commands.joined(separator: "\n"),
+            "the confirmation must repeat the exact commands the row displays"
+        )
+
+        await model.confirmEnrollmentAction()
+
+        XCTAssertEqual(calls.withLock { $0 }.count, 2)
+        XCTAssertEqual(model.enrollmentStepStatuses.map(\.text), [
+            "Step 1 succeeded.", "Step 2 succeeded.",
+        ])
+        XCTAssertEqual(model.enrollmentResultsAction, .updateRemotePlugin(hostID: hostID))
+    }
+
+    func testCancellingThePluginUpdateConfirmationRunsNothing() async throws {
+        let registry = try makeRegistry()
+        let calls = Mutex<[ClaudeRemoteEnrollmentService.Invocation]>([])
+        let service = ClaudeRemoteEnrollmentService(runner: { invocation in
+            calls.withLock { $0.append(invocation) }
+            return .init(exitCode: 0, message: "ok")
+        })
+        let model = await enrolledModel(label: "buildhost", registry: registry, service: service)
+        let hostID = try XCTUnwrap(model.hosts.first).id
+        model.requestPluginUpdate(hostID: hostID)
+        model.requestPluginUpdateRun()
+
+        model.cancelEnrollmentActionConfirmation()
+        await model.confirmEnrollmentAction()
+
+        XCTAssertNil(model.enrollmentConfirmation)
+        XCTAssertTrue(calls.withLock { $0 }.isEmpty)
+        XCTAssertTrue(model.enrollmentStepStatuses.isEmpty)
+    }
+
+    /// The results render in the row whose button ran them (PR #194), so the
+    /// tag has to name the HOST as well as the action — and opening another
+    /// host's panel must not leave the first host's outcome sitting under it.
+    func testAnotherHostsPanelDoesNotInheritThePreviousResults() async throws {
+        let registry = try makeRegistry()
+        let service = ClaudeRemoteEnrollmentService(runner: { _ in .init(exitCode: 0, message: "ok") })
+        let model = await enrolledModel(label: "buildhost", registry: registry, service: service)
+        model.enrollLabel = "laptop"
+        model.enrollSSHAlias = "laptop"
+        await model.enroll()
+        model.dismissPlan()
+        let firstID = try XCTUnwrap(model.hosts.first).id
+        let secondID = try XCTUnwrap(model.hosts.last).id
+        XCTAssertNotEqual(firstID, secondID)
+
+        model.requestPluginUpdate(hostID: firstID)
+        model.requestPluginUpdateRun()
+        await model.confirmEnrollmentAction()
+        XCTAssertEqual(model.enrollmentResultsAction, .updateRemotePlugin(hostID: firstID))
+
+        model.requestPluginUpdate(hostID: secondID)
+
+        XCTAssertEqual(model.presentedPluginUpdate?.hostID, secondID)
+        XCTAssertTrue(model.enrollmentStepStatuses.isEmpty)
+        XCTAssertNil(model.enrollmentResultsAction)
+        XCTAssertNil(model.enrollmentConfirmation)
+    }
+
+    func testPluginUpdateIsCopyOnlyWhenTheLabelIsNotAnSSHAlias() async throws {
+        // The ssh alias is the user's config and is never persisted, so the
+        // label is the only guess available. When it cannot be one, the row
+        // says so instead of running ssh against a name that does not exist.
+        let registry = try makeRegistry()
+        let calls = Mutex(0)
+        let service = ClaudeRemoteEnrollmentService(runner: { _ in
+            calls.withLock { $0 += 1 }
+            return .init(exitCode: 0, message: "ok")
+        })
+        let model = await enrolledModel(label: "build host", registry: registry, service: service)
+        let hostID = try XCTUnwrap(model.hosts.first).id
+
+        model.requestPluginUpdate(hostID: hostID)
+
+        let update = try XCTUnwrap(model.presentedPluginUpdate)
+        XCTAssertNil(update.sshHostAlias)
+        XCTAssertFalse(update.canRun)
+        XCTAssertTrue(update.commands.joined(separator: "\n").contains("your-ssh-host"))
+
+        model.requestPluginUpdateRun()
+        await model.confirmEnrollmentAction()
+
+        XCTAssertNil(model.enrollmentConfirmation)
+        XCTAssertEqual(calls.withLock { $0 }, 0, "a placeholder alias must never reach ssh")
+    }
+
+    func testRemovingAHostClosesItsOpenUpdatePanel() async throws {
+        let registry = try makeRegistry()
+        let service = ClaudeRemoteEnrollmentService(runner: { _ in .init(exitCode: 0, message: "ok") })
+        let model = await enrolledModel(label: "buildhost", registry: registry, service: service)
+        let hostID = try XCTUnwrap(model.hosts.first).id
+        model.requestPluginUpdate(hostID: hostID)
+        model.requestPluginUpdateRun()
+        await model.confirmEnrollmentAction()
+
+        await model.remove(hostID: hostID)
+
+        XCTAssertNil(model.presentedPluginUpdate, "the row is gone; its panel must not outlive it")
+        XCTAssertTrue(model.enrollmentStepStatuses.isEmpty)
+        XCTAssertNil(model.enrollmentResultsAction)
+    }
+
+    func testAFailedPluginUpdateIsAShortStatusAndADetailedAlert() async throws {
+        let registry = try makeRegistry()
+        let service = ClaudeRemoteEnrollmentService(runner: { _ in
+            .init(exitCode: 1, message: "plugin localvoxtral-remote not found")
+        })
+        let model = await enrolledModel(label: "buildhost", registry: registry, service: service)
+        let hostID = try XCTUnwrap(model.hosts.first).id
+        model.requestPluginUpdate(hostID: hostID)
+        model.requestPluginUpdateRun()
+
+        await model.confirmEnrollmentAction()
+
+        XCTAssertEqual(model.enrollmentStepStatuses.map(\.text), ["Step 1 failed."])
+        XCTAssertEqual(model.enrollmentResultsAction, .updateRemotePlugin(hostID: hostID))
+        XCTAssertEqual(model.alert?.title, "Remote Claude Code plugin")
+        XCTAssertTrue(model.alert?.detail.contains("plugin localvoxtral-remote not found") ?? false)
+    }
+
     // MARK: Validation and failures
 
     func testEnrollIsRefusedUntilBothFieldsAreUsable() {

--- a/Tests/localvoxtralTests/ClaudeIntegrationSettingsModelTests.swift
+++ b/Tests/localvoxtralTests/ClaudeIntegrationSettingsModelTests.swift
@@ -594,6 +594,7 @@ final class ClaudeIntegrationSettingsModelTests: XCTestCase {
 
     private func enrolledModel(
         label: String,
+        alias: String = "builder",
         registry: ClaudeRemoteHostRegistry,
         service: ClaudeRemoteEnrollmentService
     ) async -> ClaudeIntegrationSettingsModel {
@@ -603,7 +604,7 @@ final class ClaudeIntegrationSettingsModelTests: XCTestCase {
             enrollmentService: service
         )
         model.enrollLabel = label
-        model.enrollSSHAlias = "builder"
+        model.enrollSSHAlias = alias
         await model.enroll()
         model.dismissPlan()
         return model
@@ -619,18 +620,81 @@ final class ClaudeIntegrationSettingsModelTests: XCTestCase {
             calls.withLock { $0.append(invocation) }
             return .init(exitCode: 0, message: "ok")
         })
-        let model = await enrolledModel(label: "buildhost", registry: registry, service: service)
+        // Name and SSH alias are separate fields on the enrollment form, and
+        // this is the pairing that made the review finding concrete: a host
+        // NAMED prod, REACHED as builder.
+        let model = await enrolledModel(
+            label: "prod", alias: "builder", registry: registry, service: service
+        )
         let hostID = try XCTUnwrap(model.hosts.first).id
 
         model.requestPluginUpdate(hostID: hostID)
 
         let update = try XCTUnwrap(model.presentedPluginUpdate)
         XCTAssertEqual(update.hostID, hostID)
-        XCTAssertEqual(update.sshHostAlias, "buildhost")
+        XCTAssertEqual(
+            update.sshHostAlias, "builder",
+            "the update must target the enrolled alias, never the display name"
+        )
         XCTAssertTrue(update.canRun)
-        XCTAssertTrue(update.commands.joined(separator: "\n").contains("claude plugin update"))
+        let commands = update.commands.joined(separator: "\n")
+        XCTAssertTrue(commands.contains("ssh builder "))
+        XCTAssertFalse(commands.contains("ssh prod "), "updating the wrong host is the whole risk")
+        XCTAssertTrue(commands.contains("claude plugin update"))
         XCTAssertTrue(calls.withLock { $0 }.isEmpty, "disclosure must not run anything")
         XCTAssertNil(model.enrollmentConfirmation)
+    }
+
+    /// The same confusion on the rotation path, which is worse: it hands a
+    /// FRESH token to whatever answers to the guessed name.
+    func testRotationTargetsTheEnrolledAliasNotTheDisplayName() async throws {
+        let registry = try makeRegistry()
+        let service = ClaudeRemoteEnrollmentService(runner: { _ in .init(exitCode: 0, message: "ok") })
+        let model = await enrolledModel(
+            label: "prod", alias: "builder", registry: registry, service: service
+        )
+        let hostID = try XCTUnwrap(model.hosts.first).id
+
+        await model.rotate(hostID: hostID)
+
+        let presentation = try XCTUnwrap(model.presentedPlan)
+        XCTAssertEqual(presentation.sshHostAlias, "builder")
+        XCTAssertTrue(presentation.canRunRemoteSetup)
+        XCTAssertTrue(presentation.plan.verifyCommands.joined().contains("ssh builder"))
+        XCTAssertFalse(presentation.plan.updateCommands.joined().contains("ssh prod"))
+    }
+
+    func testRotatingAHostEnrolledBeforeAliasesWereRecordedIsCopyOnly() async throws {
+        // No alias on file means we do not know where to send the new token,
+        // and a guess is exactly what this PR removed. Copy still works.
+        let registry = try makeRegistry()
+        let calls = Mutex(0)
+        let service = ClaudeRemoteEnrollmentService(runner: { _ in
+            calls.withLock { $0 += 1 }
+            return .init(exitCode: 0, message: "ok")
+        })
+        let enrollment = try registry.enroll(label: "buildhost")
+        let model = makeModel(
+            registry: registry,
+            listener: StubListener(hosts: registry),
+            enrollmentService: service
+        )
+
+        await model.rotate(hostID: enrollment.host.id)
+
+        let presentation = try XCTUnwrap(model.presentedPlan)
+        XCTAssertFalse(presentation.canRunRemoteSetup)
+        XCTAssertEqual(
+            presentation.sshHostAlias,
+            ClaudeIntegrationSettingsModel.unknownAliasPlaceholder,
+            "the label is not a stand-in for an alias we were never told"
+        )
+
+        model.requestRemoteSetup()
+        await model.confirmEnrollmentAction()
+
+        XCTAssertNil(model.enrollmentConfirmation)
+        XCTAssertEqual(calls.withLock { $0 }, 0, "a placeholder alias must never reach ssh")
     }
 
     func testPluginUpdateRunsOnlyAfterAnExplicitConfirmation() async throws {
@@ -712,31 +776,102 @@ final class ClaudeIntegrationSettingsModelTests: XCTestCase {
         XCTAssertNil(model.enrollmentConfirmation)
     }
 
-    func testPluginUpdateIsCopyOnlyWhenTheLabelIsNotAnSSHAlias() async throws {
-        // The ssh alias is the user's config and is never persisted, so the
-        // label is the only guess available. When it cannot be one, the row
-        // says so instead of running ssh against a name that does not exist.
+    func testPluginUpdateIsCopyOnlyForAHostWithNoRecordedAlias() async throws {
+        // Hosts enrolled before the alias was persisted. The row says what it
+        // does not know instead of ssh-ing at a name it made up.
         let registry = try makeRegistry()
         let calls = Mutex(0)
         let service = ClaudeRemoteEnrollmentService(runner: { _ in
             calls.withLock { $0 += 1 }
             return .init(exitCode: 0, message: "ok")
         })
-        let model = await enrolledModel(label: "build host", registry: registry, service: service)
-        let hostID = try XCTUnwrap(model.hosts.first).id
+        let enrollment = try registry.enroll(label: "buildhost")
+        let model = makeModel(
+            registry: registry,
+            listener: StubListener(hosts: registry),
+            enrollmentService: service
+        )
 
-        model.requestPluginUpdate(hostID: hostID)
+        model.requestPluginUpdate(hostID: enrollment.host.id)
 
         let update = try XCTUnwrap(model.presentedPluginUpdate)
         XCTAssertNil(update.sshHostAlias)
         XCTAssertFalse(update.canRun)
-        XCTAssertTrue(update.commands.joined(separator: "\n").contains("your-ssh-host"))
+        XCTAssertTrue(
+            update.commands.joined(separator: "\n")
+                .contains(ClaudeIntegrationSettingsModel.unknownAliasPlaceholder)
+        )
 
         model.requestPluginUpdateRun()
         await model.confirmEnrollmentAction()
 
         XCTAssertNil(model.enrollmentConfirmation)
         XCTAssertEqual(calls.withLock { $0 }, 0, "a placeholder alias must never reach ssh")
+    }
+
+    /// Review finding (PR #197): the removal test below waits for the update to
+    /// FINISH, so it never exercised the late-result guard. This is the
+    /// interleaving that guard exists for — the row goes away while ssh is
+    /// still running — and it is asserted the same way rotation's is: a gate
+    /// the test releases, no wall-clock.
+    func testAResultFromAHostRemovedMidUpdateNeverSurfaces() async throws {
+        let registry = try makeRegistry()
+        let (gate, releaseGate) = AsyncStream.makeStream(of: Void.self)
+        // Failing, so a leaked result would be loud: statuses AND an alert.
+        let service = ClaudeRemoteEnrollmentService(runner: { _ in
+            .init(exitCode: 1, message: "remote said no")
+        })
+        let model = ClaudeIntegrationSettingsModel(
+            registry: registry,
+            listener: StubListener(hosts: registry),
+            pluginService: { StubPluginService() },
+            enrollmentService: service,
+            performAsync: { body in
+                do {
+                    try body()
+                    return nil
+                } catch {
+                    return ClaudePluginActionFailure(error)
+                }
+            },
+            performEnrollmentAsync: { body in
+                var latch = gate.makeAsyncIterator()
+                _ = await latch.next()
+                do {
+                    return ClaudeEnrollmentActionAttempt(steps: try body(), failure: nil)
+                } catch {
+                    return ClaudeEnrollmentActionAttempt(
+                        steps: [],
+                        failure: ClaudeEnrollmentActionFailure(error)
+                    )
+                }
+            }
+        )
+        model.enrollLabel = "buildhost"
+        model.enrollSSHAlias = "builder"
+        await model.enroll()
+        model.dismissPlan()
+        let hostID = try XCTUnwrap(model.hosts.first).id
+
+        model.requestPluginUpdate(hostID: hostID)
+        model.requestPluginUpdateRun()
+        let inFlight = Task { await model.confirmEnrollmentAction() }
+        while !model.isPerformingEnrollmentAction { await Task.yield() }
+
+        await model.remove(hostID: hostID)
+
+        releaseGate.yield(())
+        releaseGate.finish()
+        await inFlight.value
+
+        XCTAssertTrue(model.hosts.isEmpty)
+        XCTAssertNil(model.presentedPluginUpdate)
+        XCTAssertTrue(
+            model.enrollmentStepStatuses.isEmpty,
+            "a removed host's outcome has no row to render in"
+        )
+        XCTAssertNil(model.enrollmentResultsAction)
+        XCTAssertNil(model.alert, "and no alert about a host that is gone")
     }
 
     func testRemovingAHostClosesItsOpenUpdatePanel() async throws {
@@ -770,7 +905,12 @@ final class ClaudeIntegrationSettingsModelTests: XCTestCase {
         XCTAssertEqual(model.enrollmentStepStatuses.map(\.text), ["Step 1 failed."])
         XCTAssertEqual(model.enrollmentResultsAction, .updateRemotePlugin(hostID: hostID))
         XCTAssertEqual(model.alert?.title, "Remote Claude Code plugin")
-        XCTAssertTrue(model.alert?.detail.contains("plugin localvoxtral-remote not found") ?? false)
+        let detail = try XCTUnwrap(model.alert?.detail)
+        XCTAssertTrue(detail.contains("plugin localvoxtral-remote not found"))
+        // The body has to name what the user pressed. "SSH setup exited with
+        // code 1" under an Update Plugin button reads as a different failure.
+        XCTAssertTrue(detail.hasPrefix("Plugin update exited with code 1."))
+        XCTAssertFalse(detail.contains("SSH setup"))
     }
 
     // MARK: Validation and failures

--- a/Tests/localvoxtralTests/ClaudeRemoteEnrollmentServiceTests.swift
+++ b/Tests/localvoxtralTests/ClaudeRemoteEnrollmentServiceTests.swift
@@ -333,6 +333,79 @@ final class ClaudeRemoteEnrollmentServiceTests: XCTestCase {
         )
     }
 
+    // MARK: Update
+
+    /// Verified on Claude Code 2.1.220: re-running the enrollment pair on an
+    /// enrolled host exits 0 and changes nothing — `marketplace add` says
+    /// "already on disk" without refreshing the clone, and `plugin install`
+    /// says "already installed" without touching the version. `marketplace
+    /// update` + `plugin update` is the only pair that delivers a plugin fix,
+    /// and the order matters: `plugin update` installs whatever the local
+    /// marketplace clone currently offers.
+    func testUpdateCommandsRefreshTheMarketplaceThenThePlugin() throws {
+        let commands = try plan().updateCommands
+        let runnable = commands.filter { !$0.hasPrefix("#") }
+        XCTAssertEqual(runnable.count, 2)
+        XCTAssertTrue(runnable[0].hasPrefix("ssh builder '"))
+        XCTAssertTrue(runnable[1].hasPrefix("ssh builder '"))
+        XCTAssertTrue(
+            runnable[0].contains(
+                "claude plugin marketplace update \(ClaudePluginAssets.marketplaceName)"
+            )
+        )
+        XCTAssertTrue(runnable[1].contains("claude plugin update localvoxtral-remote@localvoxtral"))
+        XCTAssertTrue(
+            runnable[1].contains(ClaudeRemoteEnrollmentService.remotePluginReference),
+            "the reference must come from the shared constants, not a second literal"
+        )
+        XCTAssertFalse(
+            runnable[1].contains(" \(ClaudePluginAssets.pluginName)@"),
+            "the local plugin is not what a remote host runs"
+        )
+    }
+
+    func testUpdateCommandsNeverCarryTheToken() throws {
+        // `plugin update` preserves the stored config, so this path has no
+        // reason to hold the credential — and a command with no token in it
+        // cannot leak one into a log, a screenshot, or shell history.
+        let commands = try plan().updateCommands
+        for command in commands {
+            XCTAssertFalse(command.contains(token))
+            XCTAssertFalse(command.contains("--config"))
+            XCTAssertFalse(command.contains(ClaudeRemoteEnrollmentService.tokenConfigKey + "="))
+        }
+    }
+
+    func testUpdateCommandsSurviveANonInteractiveSSHPath() throws {
+        // Same failure the verify probe hit: `ssh host 'claude …'` skips the
+        // login rc, so claude is routinely off PATH there.
+        let runnable = try plan().updateCommands.filter { !$0.hasPrefix("#") }
+        for command in runnable {
+            XCTAssertTrue(
+                command.contains("PATH=\"$HOME/.claude/local:$HOME/.local/bin"),
+                "an update must not depend on the remote shell's rc-file PATH"
+            )
+            XCTAssertTrue(
+                command.contains(ClaudeRemoteEnrollmentService.nonInteractiveClaudePathPrefix),
+                "the prefix is shared with the verify commands, not re-spelled"
+            )
+        }
+    }
+
+    func testUpdateCommandsSayWhyReinstallingIsNotAnUpdate() throws {
+        // These are pasted by a person who has already run the install command
+        // once and seen it exit 0. Without this, "I re-ran setup" reads as "I
+        // updated", and the host silently stays on the old plugin.
+        let joined = try plan().updateCommands.joined(separator: "\n")
+        XCTAssertTrue(joined.contains("plugin install"))
+        XCTAssertTrue(joined.contains("already"))
+        XCTAssertTrue(joined.contains("2.1.220"), "the behavior is version-specific and dated as such")
+        XCTAssertTrue(
+            joined.lowercased().contains("token is kept"),
+            "the first question is whether updating costs the user their token"
+        )
+    }
+
     // MARK: Notes
 
     func testNotesCoverTheCaveatsThatBiteFirst() throws {
@@ -673,7 +746,7 @@ final class ClaudeRemoteEnrollmentServiceTests: XCTestCase {
                 ClaudeRemoteEnrollmentService.SetupPlan(
                     sshConfigSnippet: "",
                     remoteCommands: ClaudeRemoteEnrollmentService.remoteCommands(token: token),
-                    verifyCommands: [], uninstallCommands: [], notes: []
+                    verifyCommands: [], updateCommands: [], uninstallCommands: [], notes: []
                 ),
                 sshHostAlias: "builder",
                 token: token
@@ -711,7 +784,7 @@ final class ClaudeRemoteEnrollmentServiceTests: XCTestCase {
                 ClaudeRemoteEnrollmentService.SetupPlan(
                     sshConfigSnippet: "",
                     remoteCommands: ClaudeRemoteEnrollmentService.remoteCommands(token: token),
-                    verifyCommands: [], uninstallCommands: [], notes: []
+                    verifyCommands: [], updateCommands: [], uninstallCommands: [], notes: []
                 ),
                 sshHostAlias: "builder",
                 token: token
@@ -756,12 +829,93 @@ final class ClaudeRemoteEnrollmentServiceTests: XCTestCase {
             try service.executeRemoteSetup(
                 ClaudeRemoteEnrollmentService.SetupPlan(
                     sshConfigSnippet: "", remoteCommands: ["echo hi"], verifyCommands: [],
-                    uninstallCommands: [], notes: []
+                    updateCommands: [], uninstallCommands: [], notes: []
                 ),
                 sshHostAlias: "a b",
                 token: token
             )
         )
+    }
+
+    // MARK: Update execution
+
+    func testPluginUpdateExecutionIsRefusedWithoutAnInjectedRunner() throws {
+        let service = ClaudeRemoteEnrollmentService()
+        XCTAssertThrowsError(try service.executeRemotePluginUpdate(sshHostAlias: "builder")) { error in
+            XCTAssertEqual(
+                error as? ClaudeRemoteEnrollmentService.ServiceError,
+                .executionNotConfigured
+            )
+        }
+    }
+
+    func testPluginUpdateRunsExactlyTheTwoClaudeCommandsOverSSH() throws {
+        let calls = Mutex<[ClaudeRemoteEnrollmentService.Invocation]>([])
+        let service = ClaudeRemoteEnrollmentService(runner: { invocation in
+            calls.withLock { $0.append(invocation) }
+            return .init(exitCode: 0, message: "")
+        })
+
+        let steps = try service.executeRemotePluginUpdate(sshHostAlias: "builder")
+
+        let recorded = calls.withLock { $0 }
+        XCTAssertEqual(steps.count, 2)
+        for invocation in recorded {
+            XCTAssertEqual(
+                invocation.argv,
+                [
+                    "ssh", "-o", "BatchMode=yes", "-o", "ClearAllForwardings=yes",
+                    "builder", "/bin/sh", "-s",
+                ]
+            )
+        }
+        XCTAssertEqual(
+            recorded.map { String(decoding: $0.standardInput, as: UTF8.self) },
+            ClaudeRemoteEnrollmentService.remotePluginUpdateCommands.map {
+                "set -eu\n\(ClaudeRemoteEnrollmentService.claudePathResolverPreamble)\($0)\n"
+            }
+        )
+        // Nothing on this path has the credential, so nothing on it can spill
+        // one: no argv, no script, no captured step.
+        for invocation in recorded {
+            XCTAssertFalse(invocation.argv.joined(separator: " ").contains("token"))
+            XCTAssertFalse(String(decoding: invocation.standardInput, as: UTF8.self).contains("--config"))
+        }
+    }
+
+    func testPluginUpdateStopsAtTheFirstFailure() throws {
+        // A `plugin update` against a marketplace clone that failed to refresh
+        // would "succeed" onto the version the host already has.
+        let calls = Mutex(0)
+        let service = ClaudeRemoteEnrollmentService(runner: { _ in
+            calls.withLock { $0 += 1 }
+            return .init(exitCode: 1, message: "marketplace not found")
+        })
+        XCTAssertThrowsError(try service.executeRemotePluginUpdate(sshHostAlias: "builder")) { error in
+            guard case .commandFailed(let step, let command, let exitCode, let message)? =
+                error as? ClaudeRemoteEnrollmentService.ServiceError
+            else {
+                return XCTFail("expected commandFailed, got \(error)")
+            }
+            XCTAssertEqual(step, 0)
+            XCTAssertEqual(exitCode, 1)
+            XCTAssertEqual(message, "marketplace not found")
+            XCTAssertTrue(command.contains("marketplace update"))
+        }
+        XCTAssertEqual(calls.withLock { $0 }, 1)
+    }
+
+    func testPluginUpdateRefusesAnInvalidAlias() {
+        let service = ClaudeRemoteEnrollmentService(runner: { _ in
+            XCTFail("the runner must never be reached with an invalid alias")
+            return .init(exitCode: 0, message: "")
+        })
+        XCTAssertThrowsError(try service.executeRemotePluginUpdate(sshHostAlias: "a b")) { error in
+            XCTAssertEqual(
+                error as? ClaudeRemoteEnrollmentService.ServiceError,
+                .invalidHostAlias
+            )
+        }
     }
 
     func testExecutionNeverTouchesTheSSHConfig() throws {

--- a/Tests/localvoxtralTests/ClaudeRemoteEnrollmentServiceTests.swift
+++ b/Tests/localvoxtralTests/ClaudeRemoteEnrollmentServiceTests.swift
@@ -118,6 +118,47 @@ final class ClaudeRemoteEnrollmentServiceTests: XCTestCase {
         }
     }
 
+    /// Review finding (PR #197): the charset allowed `-` anywhere, so `-V`
+    /// passed validation and reached `ssh`'s argv as an OPTION. OpenSSH then
+    /// prints its version and exits 0 without connecting — every step reports
+    /// success while nothing ran on any host, which is the worst possible
+    /// failure for a setup tool. Reachable on the pre-existing setup path too,
+    /// not only on the update path this PR adds.
+    func testAnAliasCanNeverBeMistakenForAnSSHOption() {
+        for alias in ["-V", "-v", "-oProxyCommand", "--", "-", "-F", ".", "..", "..."] {
+            XCTAssertFalse(
+                ClaudeRemoteEnrollmentService.isValidHostAlias(alias),
+                "'\(alias)' must not be accepted as an alias"
+            )
+        }
+        // Hyphens and dots INSIDE a name stay legal — they are ordinary in real
+        // host aliases, and rejecting them would push users off the one-click
+        // path for no gain.
+        for alias in ["build-host", "build.host.local", "a-1.b_2", "x"] {
+            XCTAssertTrue(
+                ClaudeRemoteEnrollmentService.isValidHostAlias(alias),
+                "'\(alias)' is an ordinary alias"
+            )
+        }
+    }
+
+    func testTheSpawnedArgvTerminatesOptionParsingBeforeTheAlias() throws {
+        // Second layer under the validator: whatever reaches argv is positional.
+        let calls = Mutex<[ClaudeRemoteEnrollmentService.Invocation]>([])
+        let service = ClaudeRemoteEnrollmentService(runner: { invocation in
+            calls.withLock { $0.append(invocation) }
+            return .init(exitCode: 0, message: "")
+        })
+        try service.executeRemoteSetup(try plan(), sshHostAlias: "builder", token: token)
+        try service.executeRemotePluginUpdate(sshHostAlias: "builder")
+
+        for invocation in calls.withLock({ $0 }) {
+            let terminator = try XCTUnwrap(invocation.argv.firstIndex(of: "--"))
+            let alias = try XCTUnwrap(invocation.argv.firstIndex(of: "builder"))
+            XCTAssertLessThan(terminator, alias, "the alias must sit after `--`")
+        }
+    }
+
     func testPlanRefusesAnInvalidAlias() {
         XCTAssertThrowsError(try plan(alias: "host\nRemoteForward 22 evil:22")) { error in
             XCTAssertEqual(
@@ -622,7 +663,7 @@ final class ClaudeRemoteEnrollmentServiceTests: XCTestCase {
             XCTAssertEqual(
                 invocation.argv,
                 [
-                    "ssh", "-o", "BatchMode=yes", "-o", "ClearAllForwardings=yes",
+                    "ssh", "-o", "BatchMode=yes", "-o", "ClearAllForwardings=yes", "--",
                     "builder", "/bin/sh", "-s",
                 ]
             )
@@ -864,7 +905,7 @@ final class ClaudeRemoteEnrollmentServiceTests: XCTestCase {
             XCTAssertEqual(
                 invocation.argv,
                 [
-                    "ssh", "-o", "BatchMode=yes", "-o", "ClearAllForwardings=yes",
+                    "ssh", "-o", "BatchMode=yes", "-o", "ClearAllForwardings=yes", "--",
                     "builder", "/bin/sh", "-s",
                 ]
             )

--- a/Tests/localvoxtralTests/ClaudeRemoteHostRegistryTests.swift
+++ b/Tests/localvoxtralTests/ClaudeRemoteHostRegistryTests.swift
@@ -144,6 +144,61 @@ final class ClaudeRemoteHostRegistryTests: XCTestCase {
         XCTAssertEqual(persisted.hosts.first?.hashVersion, ClaudeRemoteHostRegistry.currentHashVersion)
     }
 
+    /// Review finding (PR #197): the update/rotate paths had to guess the ssh
+    /// alias from the display name, so a host NAMED `prod` and REACHED over
+    /// alias `builder` would have been acted on as `prod` — a different
+    /// machine. The alias the user enrolled with is persisted for exactly this,
+    /// and survives the relaunch that separates enrollment from an update.
+    func testTheEnrolledSSHAliasIsPersistedSeparatelyFromTheLabel() throws {
+        let first = try makeRegistry()
+        let enrollment = try first.enroll(label: "prod", sshHostAlias: "builder")
+        XCTAssertEqual(enrollment.host.label, "prod")
+        XCTAssertEqual(enrollment.host.sshHostAlias, "builder")
+
+        let second = try makeRegistry()
+        XCTAssertEqual(second.hosts().first?.sshHostAlias, "builder")
+    }
+
+    func testAnUnusableSSHAliasIsNotStoredAtAll() throws {
+        // A stored alias is later allowed to reach ssh's argv, so the registry
+        // stores only what the validator accepts — nil, never a repaired value
+        // that some caller would then trust.
+        let registry = try makeRegistry()
+        for alias in ["-V", "two words", "host#comment", ""] {
+            let enrollment = try registry.enroll(label: "host", sshHostAlias: alias)
+            XCTAssertNil(enrollment.host.sshHostAlias, "'\(alias)' must not be stored")
+        }
+    }
+
+    func testAHostStoredBeforeAliasesWereRecordedLoadsWithoutOne() throws {
+        // The key is absent in files written by earlier builds. That must read
+        // back as "no alias" — not as a decode failure, which would report the
+        // whole store unreadable and strand every enrolled host.
+        let storedHost = ClaudeRemoteHostRegistry.StoredHost(
+            id: "hlegacy02",
+            label: "legacy",
+            createdAt: clock.now(),
+            lastSeenAt: nil,
+            revokedAt: nil,
+            tokenSalt: "legacySalt_1234567890",
+            tokenHash: "abc",
+            hashVersion: nil
+        )
+        let storedFile = ClaudeRemoteHostRegistry.StoredFile(
+            version: ClaudeRemoteHostRegistry.fileVersion,
+            hosts: [storedHost]
+        )
+        let json = try XCTUnwrap(
+            String(data: try JSONEncoder.claudeRemote.encode(storedFile), encoding: .utf8)
+        )
+        XCTAssertFalse(json.contains("sshHostAlias"), "an absent alias must not be written as null")
+        io.seed(Data(json.utf8), at: fileURL)
+
+        let registry = try makeRegistry()
+        XCTAssertEqual(registry.hosts().map(\.id), ["hlegacy02"])
+        XCTAssertNil(registry.hosts().first?.sshHostAlias)
+    }
+
     func testLabelIsSanitized() throws {
         let registry = try makeRegistry()
         // Anything that could act is dropped, not escaped. There is no host
@@ -206,8 +261,15 @@ final class ClaudeRemoteHostRegistryTests: XCTestCase {
         // The public type is what a UI, a log line, and a diagnostics export all
         // see. Reflection over it is the check that no secret property was added
         // later by someone who only meant to make debugging easier.
+        // `sshHostAlias` joined this allowlist deliberately (PR #197): it is
+        // the name of a host in the user's own ssh config, not a credential,
+        // and the alternative — guessing it from the label — acted on the wrong
+        // machine.
         let properties = Mirror(reflecting: enrollment.host).children.compactMap(\.label)
-        XCTAssertEqual(Set(properties), ["id", "label", "createdAt", "lastSeenAt", "revokedAt"])
+        XCTAssertEqual(
+            Set(properties),
+            ["id", "label", "sshHostAlias", "createdAt", "lastSeenAt", "revokedAt"]
+        )
         let described = String(describing: enrollment.host)
         XCTAssertFalse(described.contains(enrollment.token))
     }

--- a/integrations/claude-code/README.md
+++ b/integrations/claude-code/README.md
@@ -233,8 +233,8 @@ In **Settings → Text Processing → Polishing → "Remote Claude Code over SSH
 type a name and your SSH host alias and press **Enroll…**. The app issues a
 token, shows it once alongside every command below with a Copy button on each,
 and binds the listener immediately — there is no relaunch step. The list in that
-row shows each enrolled host, when it was last seen, and gives you **Rotate
-Token**, **Revoke** and **Remove**.
+row shows each enrolled host, when it was last seen, and gives you **Update
+Plugin…**, **Rotate Token**, **Revoke** and **Remove**.
 
 The app hands you every command as copyable text, and can also do the two
 steps for you — **only after showing you exactly what will happen and asking
@@ -294,6 +294,35 @@ claude plugin list
 curl -s -o /dev/null -w '%{http_code}\n' -X POST -H 'Content-Type: application/json' \
   -d '{}' http://127.0.0.1:8473/v1/hook/SessionStart
 ```
+
+## Updating an enrolled host
+
+When localvoxtral ships a newer version of this plugin, an already-enrolled host
+does **not** pick it up by re-running the setup commands. Verified on Claude Code
+2.1.220:
+
+- `claude plugin marketplace add …` on a marketplace it already has exits 0,
+  says it is already on disk, and does **not** refresh the clone.
+- `claude plugin install …` on an installed plugin exits 0, says it is already
+  installed, and does **not** change the version. (It *does* apply a new
+  `--config token=…`, which is why rotating a token reuses that same command.)
+
+So the update is its own pair, and it keeps your token — `plugin update`
+preserves the stored config:
+
+```sh
+ssh builder 'claude plugin marketplace update localvoxtral'
+ssh builder 'claude plugin update localvoxtral-remote@localvoxtral'
+```
+
+Order matters: `plugin update` installs whatever the local marketplace clone
+currently offers, so refreshing the clone first is what makes it an update at
+all. In the app, each row in **Remote Claude Code over SSH** has an **Update
+Plugin…** button that shows these two commands with a Copy button, and can run
+them over SSH after you confirm. Non-interactive SSH skips your login shell's
+rc, so the app's version of these commands sets `PATH` to the usual `claude`
+install locations first; add that yourself if `claude` is off the PATH a plain
+`ssh host 'claude …'` sees.
 
 ## Uninstall and revoke
 

--- a/integrations/claude-code/README.md
+++ b/integrations/claude-code/README.md
@@ -319,7 +319,12 @@ Order matters: `plugin update` installs whatever the local marketplace clone
 currently offers, so refreshing the clone first is what makes it an update at
 all. In the app, each row in **Remote Claude Code over SSH** has an **Update
 Plugin…** button that shows these two commands with a Copy button, and can run
-them over SSH after you confirm. Non-interactive SSH skips your login shell's
+them over SSH after you confirm. One-click runs against the **SSH alias you
+enrolled with**, which is recorded with the host — the display name is never
+used as a substitute, since the two are separate fields and can name different
+machines. A host enrolled before localvoxtral recorded aliases has none on file:
+its commands are copy-only (and so is its rotation sheet) until you re-enroll it.
+Non-interactive SSH skips your login shell's
 rc, so the app's version of these commands sets `PATH` to the usual `claude`
 install locations first; add that yourself if `claude` is off the PATH a plain
 `ssh host 'claude …'` sees.


### PR DESCRIPTION
## Stack

Stacked on **#197** (`remote-plugin-update-path` — per-host Update Plugin action) and targets that branch, not `main`. Merge #197 first; do not delete the base branch while this is open.

## What

Field evidence, tonight: the Mac app's unified log carried an hours-long stream of one line, once every few minutes —

```
[com.localvoxtral:ClaudeContext] Rejected unauthenticated connection to the remote listener
```

The cause turned out to be long-running remote Claude Code sessions still running the pre-1.1.0 plugin, whose http hooks sent `Authorization: Bearer ` (empty credential). But that log line cannot distinguish an EMPTY token from a WRONG one (stale after rotation), and the app's UI said nothing at all — remote dictation just silently had no context. Diagnosing it needed a workflow-dispatched log collection plus manual probing. This PR makes the same failure self-describing.

Three parts, all diagnostics — the auth path itself does not move.

**1. The rejection is classified on the way out.** `ClaudeRemoteHTTPCodec.authorizationShape(in:)` keeps the answer `bearerToken(in:)` used to collapse to `nil`, and `ClaudeRemoteRejectionCategory` turns it into one of three lines:

| case | log line |
|---|---|
| missing / empty bearer | `Rejected remote connection: no bearer token — a pre-1.1.0 plugin or misconfigured hook; update the plugin on the host` |
| well-formed, unrecognized | `Rejected remote connection: no enrolled host matches — rotated token or revoked host; re-run enrollment install with the current token` |
| malformed `Authorization` | `Rejected remote connection: malformed Authorization header` |

Each line is a CONSTANT — no token, no header contents, no lengths, nothing derived from the credential, so `ClaudeRemoteTokenRedaction` has nothing to redact here by construction. `bearerToken` is now implemented in terms of the classifier, so the two can never disagree about which strings are credentials (there is a test that walks every case through both).

The existing `Rejected remote record: unparseable payload` line now names its event — narrowed through `ClaudeHookEvent(rawValue:)` first, so peer-supplied path text can never reach the log (`unknown` otherwise).

**2. Per-host "last heard" in Settings.** `ClaudeRemoteHostRegistry` ALREADY tracked this: `noteActivity(hostID:)` stamps `lastSeenAt` after every authenticated request (in memory; persisted on the next mutation, deliberately, to avoid a disk write per hook event). Nothing was added to the registry. What changed is the surfacing: the row previously read `"Last seen"` + a self-ticking `Text(_:style:.relative)`; it now reads `Last context: 2 min ago` / `Last context: never` / `Revoked`, rendered by `ClaudeIntegrationSettingsModel` against an **injected clock** (`now:` seam, frozen in tests) and refreshed by the existing `refreshHosts()` — which the pane already calls on `.onAppear` and after every host action. No timer, no `Date()` in the view.

Known and accepted: because `lastSeenAt` persists only on the next registry mutation, a host that was active before a relaunch reads `never` until its next hook event. That is the pre-existing write-amplification trade, not new behaviour.

**3. Stale-signal hint.** `ClaudeRemoteRejectionTally` (Mutex, `Sendable`) counts rejections since launch by category. It is owned by `ClaudeRemoteListenerCoordinator`, not by a listener — `reconcile()` builds a NEW listener on every 0→1 transition, so a tally inside the listener would forget a night of rejections the moment the user enrolled another host. When nonzero, the hosts section shows ONE short `SettingsInlineMessage`:

> Rejected connections detected — a host may have an outdated plugin — use Update Plugin.
> Rejected connections detected — a host may have a stale token — rotate it and re-run setup.
> Rejected connections detected — a host may have an outdated plugin or a stale token.

Count-free on purpose (a busy session produces one every few minutes; the KIND is the diagnosis), and asserted under 110 characters — owner rule, no long text in a pane.

**Invariants deliberately unchanged:** auth still runs on the head alone before a byte of body is read; the constant-time compare and the registry's no-early-exit loop are untouched; the 401 is still silent on the wire (`testTheDiagnosisNeverLeavesTheMachine`) — the diagnosis is for the local log and the local UI only. `post.sh`/`hooks.json` are not touched.

## Proof

- [x] Unit suite green — `./scripts/remote-build.sh`

```
Executed 2049 tests, with 2 tests skipped and 0 failures (0 unexpected) in 71.545 (71.638) seconds
```

- [x] Focused lane — `./scripts/remote-build.sh test --filter ClaudeRemote`

```
Executed 253 tests, with 0 failures (0 unexpected) in 4.391 (4.401) seconds
```

- [x] The new tests FAIL against the old undifferentiated behaviour. Collapsing the classification back to one category (`let category = .unknownToken` in place of the shape mapping) and re-running the listener suite:

```
Executed 35 tests, with 6 failures (0 unexpected) in 0.443 (0.446) seconds

testAnEmptyBearerCredentialIsDiagnosedAsAPluginProblem
testAnAbsentAuthorizationHeaderCountsAsAMissingToken
testANonBearerSchemeIsItsOwnCategory
testTheThreeCategoriesAccumulateIndependently
  XCTAssertEqual failed: ("Snapshot(missingToken: 0, unknownToken: 4, malformedAuthorization: 0)")
                     is not equal to ("Snapshot(missingToken: 2, unknownToken: 1, malformedAuthorization: 1)")
```

Reverting the collapse returns the suite to the 253/0 line above.

New coverage (all through the existing raw-POSIX-socket client, real bytes on a real loopback port):

* `ClaudeRemoteContextListenerTests` — empty `Bearer `, absent header, unrecognized token, rotated token, non-Bearer scheme, the three counters accumulating independently, a 200 counting as nothing, the 401 body staying empty in every category, the shape→category mapping, the log lines being one short actionable sentence each, and `knownEventLabel` refusing peer text.
* `ClaudeRemoteHTTPTests` — `authorizationShape` cases, and `bearerToken`/`authorizationShape` agreeing on every input.
* `ClaudeRemoteListenerCoordinatorTests` — the tally survives a revoke→rebind and is the same instance across listeners.
* `ClaudeIntegrationSettingsModelTests` — relative formatting against an injected clock (never / just now / minutes / hours / days / a backwards clock step), `Revoked` beating the age, the row built from the registry's activity, and the hint's visibility, wording, kind-selection, count-freeness and length bound.

No test was weakened; no threshold, assertion, skip or tolerance changed. Two test stubs gained the protocol's new `rejectionSnapshot` member and the coordinator factory's second parameter. Zero new compiler warnings (the three in `.build/last-remote.log` are pre-existing, in `ClaudePluginInstallService.swift` and `ClaudeHookPublisherTests.swift`, both untouched here).

- [ ] **UI rows flagged for owner hand-test** — no automated UI tier yet. Two things to eyeball in Settings → Claude Code: (a) each enrolled host row now reads `Last context: …` on one line where it used to read `Last seen` plus a live-ticking relative date (the value now refreshes when the pane appears rather than ticking on its own), and (b) after any rejected connection, one orange sentence appears between the host list and the enroll form. Both are strings the model renders and unit-tests assert; what needs eyes is layout in the row.

**LLM lane:** `Sources/localvoxtral/ClaudeContext/**` is in `scripts/ci/llm-lane-filter.sh`, so the polishd live-model lane will run. Nothing here changes what reaches the model — no prompt, context attachment, vocabulary, budget or request-shape path is touched; the diff is a log line, a status string, and a counter.

---

## Review round 1 — fixes (commit `0b4d3c8`)

Two independent reviews (opencode/GLM, codex/GPT-5.6). All four findings fixed on this branch.

**1. The executable alias was guessed from the display name (correctness/safety).** Name and
SSH alias are separate fields on the enrollment form, so a host named `prod` reached over alias
`builder` would have been updated as `ssh prod …` — a different machine. **Rotation shared the
flaw with worse consequences**: it hands a *fresh token* to whatever answers to the guessed name.
Fixed by persisting the enrolled alias (chosen over asking again in the panel: the app already
knows the answer, and a second place to type it is a second place to get it wrong). New optional
`StoredHost.sshHostAlias`, no file-version bump — an older build ignores the key, a newer build
reading an older file gets nil. The registry stores only what `isValidHostAlias` accepts, since a
stored alias later reaches ssh's argv. Hosts with no alias on file are copy-only (update panel
*and* rotation sheet), never a guess.

Red (alias re-derived from the label), then green after:

```
ClaudeIntegrationSettingsModelTests.swift:635: error: -[… testPluginUpdateShowsThatHostsCommandsAndRunsNothingYet] : XCTAssertEqual failed: ("Optional("prod")") is not equal to ("Optional("builder")") - the update must target the enrolled alias, never the display name
ClaudeIntegrationSettingsModelTests.swift:642: error: -[… testPluginUpdateShowsThatHostsCommandsAndRunsNothingYet] : XCTAssertFalse failed - updating the wrong host is the whole risk
ClaudeIntegrationSettingsModelTests.swift:798: error: -[… testPluginUpdateIsCopyOnlyForAHostWithNoRecordedAlias] : XCTAssertNil failed: "buildhost"
ClaudeIntegrationSettingsModelTests.swift:809: error: -[… testPluginUpdateIsCopyOnlyForAHostWithNoRecordedAlias] : XCTAssertEqual failed: ("2") is not equal to ("0") - a placeholder alias must never reach ssh
```

New tests: `testTheEnrolledSSHAliasIsPersistedSeparatelyFromTheLabel`,
`testAnUnusableSSHAliasIsNotStoredAtAll`, `testAHostStoredBeforeAliasesWereRecordedLoadsWithoutOne`
(registry); `testRotationTargetsTheEnrolledAliasNotTheDisplayName`,
`testRotatingAHostEnrolledBeforeAliasesWereRecordedIsCopyOnly`,
`testPluginUpdateIsCopyOnlyForAHostWithNoRecordedAlias` (model).
`testThePublicHostViewExposesNoSecretMaterial`'s reflection allowlist gained `sshHostAlias` — an
ssh-config name, not a credential; the allowlist is exhaustive by design, so it is updated, not relaxed.

**2. `isValidHostAlias` allowed a leading `-` (security).** `-V` reached ssh's argv as an option:
OpenSSH prints its version, exits 0, connects to nothing, and every step reports success. **This
was reachable on the pre-existing setup path too** (`executeRemoteSetup` has always taken the
enrolled alias through the same validator) — not only on the update path this PR adds. Leading
hyphens and all-dot aliases are now rejected, and the spawned argv terminates option parsing with
`--` before the alias. The displayed/copyable commands are left idiomatic (`ssh builder '…'`):
the validator is what guarantees them, and the user sees the alias they typed.

Red (hyphen rule and `--` both removed), then green after:

```
ClaudeRemoteEnrollmentServiceTests.swift:129: error: -[… testAnAliasCanNeverBeMistakenForAnSSHOption] : XCTAssertFalse failed - '-V' must not be accepted as an alias
ClaudeRemoteEnrollmentServiceTests.swift:129: error: -[… testAnAliasCanNeverBeMistakenForAnSSHOption] : XCTAssertFalse failed - '-oProxyCommand' must not be accepted as an alias
ClaudeRemoteEnrollmentServiceTests.swift:129: error: -[… testAnAliasCanNeverBeMistakenForAnSSHOption] : XCTAssertFalse failed - '.' must not be accepted as an alias
ClaudeRemoteEnrollmentServiceTests.swift:156: error: -[… testTheSpawnedArgvTerminatesOptionParsingBeforeTheAlias] : XCTUnwrap failed: expected non-nil value of type "Int"
	 Executed 51 tests, with 14 failures (0 unexpected) in 0.181 (0.183) seconds
```

The same test asserts ordinary aliases (`build-host`, `build.host.local`, `a-1.b_2`) still pass.

**3. The late-result guard was untested.** New
`testAResultFromAHostRemovedMidUpdateNeverSurfaces` parks the injected `performEnrollmentAsync`
on an `AsyncStream` gate (no wall-clock), removes the host mid-run, releases, and asserts no
statuses, no result action, **and no alert** — with a *failing* runner, so a leak would be loud.
Red with the guard deleted, then green after:

```
ClaudeIntegrationSettingsModelTests.swift:869: error: -[… testAResultFromAHostRemovedMidUpdateNeverSurfaces] : XCTAssertTrue failed - a removed host's outcome has no row to render in
ClaudeIntegrationSettingsModelTests.swift:873: error: -[… testAResultFromAHostRemovedMidUpdateNeverSurfaces] : XCTAssertNil failed: "updateRemotePlugin(hostID: "hcaaed3bd")"
ClaudeIntegrationSettingsModelTests.swift:874: error: -[… testAResultFromAHostRemovedMidUpdateNeverSurfaces] : XCTAssertNil failed: "DetailAlert(… title: "Remote Claude Code plugin", detail: "Plugin update exited with code 1.…")" - and no alert about a host that is gone
```

Remove also gained `.disabled(model.isPerformingEnrollmentAction)`, matching Close/Update.

**4. The failure alert said "SSH setup" for a plugin update.** `enrollmentFailureDetail` now takes
the action and names it ("Plugin update exited with code 1."), and
`testAFailedPluginUpdateIsAShortStatusAndADetailedAlert` asserts the detail's prefix and that it
does **not** contain "SSH setup".

Suites after the fixes:

```
$ ./scripts/remote-build.sh test --filter ClaudeRemote
	 Executed 245 tests, with 0 failures (0 unexpected) in 3.395 (3.403) seconds

$ ./scripts/remote-build.sh test --filter ClaudeIntegrationSettingsModelTests
	 Executed 35 tests, with 0 failures (0 unexpected) in 0.016 (0.018) seconds

$ ./scripts/remote-build.sh          # full build + unit, zero warnings
	 Executed 2038 tests, with 2 tests skipped and 0 failures (0 unexpected) in 71.459 (71.563) seconds
```

Hand-test note for the owner is unchanged, plus one addition: hosts enrolled with a build before
this PR show copy-only commands (no Run button) in both the update panel and the rotation sheet.
