### PR TITLE
Live Auto-Paste: don't type the space that dismisses a TUI autocomplete popup

### DIFF
--- a/Sources/localvoxtral/TUIAutocompleteTrailingSpace.swift
+++ b/Sources/localvoxtral/TUIAutocompleteTrailingSpace.swift
@@ -23,10 +23,17 @@ import Foundation
 ///   command names are ASCII by construction in every agent TUI we target, so
 ///   a non-ASCII token (`/compacté`) abstains rather than guessing.
 /// - **Trailing mention**: the last whitespace-separated token is `@` plus a
-///   run of filename characters (`@Sources/Foo.swift`, `@README`). A bare `@`
-///   proposes nothing and `a@b` is an email address, not a mention: neither
-///   opens a picker, so neither is touched. A token carrying trailing
-///   punctuation (`@file,`) is prose, and abstains too.
+///   run of filename characters holding at least one name character. A bare
+///   `@` proposes nothing and `a@b` is an email address, not a mention:
+///   neither opens a picker, so neither is touched. A token carrying trailing
+///   punctuation (`@file,`) is prose, and abstains too. The name-character
+///   floor rejects degenerate punctuation-only tokens (`@.`, `@/`, `@~/`) that
+///   name no file and would otherwise pass the filename-character test.
+///
+/// LEADING whitespace is ignored when recognizing a shape and preserved in the
+/// result, so `"  /compact "` is recognized and returns `"  /compact"`. That is
+/// deliberate: only the tail is ever cut, and the shape of the line the TUI
+/// sees does not change with indentation the ASR happened to emit.
 ///
 /// Nothing else is ever modified, and no character the user dictated is ever
 /// removed.
@@ -41,6 +48,13 @@ enum TUIAutocompleteTrailingSpace {
     /// paths and extensions qualify while prose punctuation does not.
     private static let mentionNameCharacters = Set(
         "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_-./~"
+    )
+
+    /// The subset a mention name must contain at least one of. Without this
+    /// floor, punctuation-only tokens like `@.` or `@/` — which name no file
+    /// and open no picker — would satisfy the filename-character test.
+    private static let mentionRequiredCharacters = Set(
+        "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_-"
     )
 
     /// Returns `text` with its trailing whitespace removed when the text is one
@@ -73,7 +87,9 @@ enum TUIAutocompleteTrailingSpace {
         guard let token = text.split(whereSeparator: \.isWhitespace).last else { return false }
         guard token.first == "@" else { return false }
         let name = token.dropFirst()
-        guard !name.isEmpty else { return false }
+        guard name.contains(where: { mentionRequiredCharacters.contains($0) }) else {
+            return false
+        }
         return name.allSatisfy { mentionNameCharacters.contains($0) }
     }
 }

--- a/Sources/localvoxtral/TUIAutocompleteTrailingSpace.swift
+++ b/Sources/localvoxtral/TUIAutocompleteTrailingSpace.swift
@@ -1,0 +1,79 @@
+import Foundation
+
+/// Trailing-whitespace policy for text dictated into a coding-agent TUI.
+///
+/// Terminal agents (Claude Code, Codex CLI, …) open a slash-command
+/// autocomplete popup while the prompt line is a bare `/token`, and a file
+/// picker while the line ends in an `@token`. In both, a SPACE after the token
+/// confirms or dismisses that popup — so an invisible trailing space decides
+/// what the user's next keystroke does.
+///
+/// Dictation adds exactly that space without the user ever speaking it: ASR
+/// segments carry token-trailing spaces, so "slash compact" reaches the field
+/// as `/compact ` and the popup is gone before the user can pick anything.
+///
+/// The policy is deliberately narrow — the repo's abstain-over-guess rule. It
+/// removes only whitespace, only from the end, and only for two shapes:
+///
+/// - **Lone slash command**: the whole text is `/` followed by one run of
+///   `[A-Za-z0-9_-]`. A token holding a SECOND `/` is a filesystem path
+///   (`/usr/bin`, `/tmp/x`), never a slash command, and is left alone — as is
+///   any text with other words in it (`fix /compact please`), where the popup
+///   is already closed and the trailing space is dictated content. Slash
+///   command names are ASCII by construction in every agent TUI we target, so
+///   a non-ASCII token (`/compacté`) abstains rather than guessing.
+/// - **Trailing mention**: the last whitespace-separated token is `@` plus a
+///   run of filename characters (`@Sources/Foo.swift`, `@README`). A bare `@`
+///   proposes nothing and `a@b` is an email address, not a mention: neither
+///   opens a picker, so neither is touched. A token carrying trailing
+///   punctuation (`@file,`) is prose, and abstains too.
+///
+/// Nothing else is ever modified, and no character the user dictated is ever
+/// removed.
+enum TUIAutocompleteTrailingSpace {
+    /// Characters a slash-command NAME may contain. `/` is deliberately absent:
+    /// that is what separates `/compact` from the path `/usr/bin`.
+    private static let slashCommandNameCharacters = Set(
+        "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_-"
+    )
+
+    /// Characters a mention token may contain after its `@` — filename-ish, so
+    /// paths and extensions qualify while prose punctuation does not.
+    private static let mentionNameCharacters = Set(
+        "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_-./~"
+    )
+
+    /// Returns `text` with its trailing whitespace removed when the text is one
+    /// of the two autocomplete shapes above; otherwise returns `text` unchanged.
+    static func stripped(_ text: String) -> String {
+        var body = text
+        while let last = body.last, last.isWhitespace {
+            body.removeLast()
+        }
+        // Nothing to strip: never rewrite text that has no trailing whitespace.
+        guard body.count != text.count else { return text }
+
+        // Leading whitespace belongs to neither shape's recognition (and is
+        // preserved either way — only the tail is ever cut).
+        let candidate = body.drop(while: \.isWhitespace)
+        guard isLoneSlashCommand(candidate) || endsWithMentionToken(candidate) else {
+            return text
+        }
+        return body
+    }
+
+    private static func isLoneSlashCommand(_ text: Substring) -> Bool {
+        guard text.first == "/" else { return false }
+        let name = text.dropFirst()
+        guard !name.isEmpty else { return false }
+        return name.allSatisfy { slashCommandNameCharacters.contains($0) }
+    }
+
+    private static func endsWithMentionToken(_ text: Substring) -> Bool {
+        guard let token = text.split(whereSeparator: \.isWhitespace).last else { return false }
+        guard token.first == "@" else { return false }
+        let name = token.dropFirst()
+        guard !name.isEmpty else { return false }
+        return name.allSatisfy { mentionNameCharacters.contains($0) }
+    }
+}

--- a/Sources/localvoxtral/TextInsertionService.swift
+++ b/Sources/localvoxtral/TextInsertionService.swift
@@ -118,6 +118,18 @@ final class TextInsertionService {
     /// failed; retried as-is and never re-ingested into the stream.
     @ObservationIgnored
     private var pendingHoldBackReleasedText = ""
+    /// Whether this live session's target is terminal-like. TUI autocomplete
+    /// popups only exist there, so the trailing-space policy is scoped to it
+    /// (`TUIAutocompleteTrailingSpace`).
+    @ObservationIgnored
+    private var liveTargetIsTerminalLike = false
+    /// Everything the hold-back stream released AND successfully handed to the
+    /// field this session. The trailing-space policy judges the WHOLE
+    /// utterance ("is this only a slash command?"), so the stop flush needs
+    /// what came before it. Read-only by construction: typed text is in the
+    /// user's app and can never be recalled.
+    @ObservationIgnored
+    private var liveTypedTextForSession = ""
 
 #if DEBUG
     @ObservationIgnored
@@ -326,6 +338,8 @@ final class TextInsertionService {
     ) {
         liveHoldBackStream = nil
         pendingHoldBackReleasedText = ""
+        liveTargetIsTerminalLike = isTerminalLikeTarget
+        liveTypedTextForSession = ""
 
         let entryCount = dictionary?.entries.count ?? 0
         let ruleCount = dictionary.map { LiveReplacementCorrector(dictionary: $0).ruleCount } ?? 0
@@ -414,11 +428,15 @@ final class TextInsertionService {
         }
         liveHoldBackStream = stream
 
+        if releaseRemainder, liveTargetIsTerminalLike {
+            releasedText = withholdingTUIAutocompleteTrailingSpace(releasedText)
+        }
+
         guard !releasedText.isEmpty else { return }
 
         switch insertTextPrioritizingKeyboard(releasedText) {
         case .insertedByAccessibility, .insertedByKeyboardFallback:
-            break
+            liveTypedTextForSession += releasedText
         case .failed:
             // Keep the released text verbatim for the retry task; it must
             // never be re-ingested into the stream.
@@ -427,6 +445,34 @@ final class TextInsertionService {
                 "corrector holdback release failed chars=\(releasedText.count, privacy: .public) queued_for_retry=1"
             )
         }
+    }
+
+    /// Stop-flush trailing-space policy for terminal targets: a lone slash
+    /// command (or an utterance ending on an `@mention`) must reach the agent
+    /// TUI without the space that would confirm/dismiss its autocomplete popup
+    /// (`TUIAutocompleteTrailingSpace`).
+    ///
+    /// The stop flush is the complete choke point for a terminal session: with
+    /// newline sanitization on, `LiveHoldBackReplacementStream` buffers every
+    /// trailing space run until the next non-whitespace character, so no
+    /// mid-session release can ever END in whitespace — the only trailing space
+    /// a terminal ever sees is the one emitted here.
+    ///
+    /// The verdict is taken on the whole session's text, but only the
+    /// not-yet-typed tail may be cut (`min` below). That is the same
+    /// never-un-type invariant the hold-back stream enforces: text already
+    /// handed to the field is in the user's app and there are no backspaces in
+    /// the insertion path.
+    private func withholdingTUIAutocompleteTrailingSpace(_ releasedText: String) -> String {
+        let sessionText = liveTypedTextForSession + releasedText
+        let stripped = TUIAutocompleteTrailingSpace.stripped(sessionText)
+        let dropCount = min(sessionText.count - stripped.count, releasedText.count)
+        guard dropCount > 0 else { return releasedText }
+
+        Log.corrector.notice(
+            "tui autocomplete: withheld \(dropCount, privacy: .public) trailing whitespace char(s) at stop"
+        )
+        return String(releasedText.dropLast(dropCount))
     }
 
     private func tryAccessibilityInsertion(

--- a/Tests/localvoxtralTests/LiveHoldBackReplacementStreamTests.swift
+++ b/Tests/localvoxtralTests/LiveHoldBackReplacementStreamTests.swift
@@ -327,6 +327,59 @@ final class LiveHoldBackReplacementStreamTests: XCTestCase {
         XCTAssertEqual(stream.flushRemainder(), " ")
     }
 
+    // MARK: - Mid-session releases never end in whitespace (sanitize ON)
+
+    // Load-bearing invariant, not an incidental property: because the
+    // sanitizer buffers every trailing whitespace run until the next
+    // non-whitespace character, NO `ingest` output can end in whitespace when
+    // sanitization is on. That makes `flushRemainder()` the single point where
+    // a terminal can ever receive a trailing space — which is exactly what
+    // `TextInsertionService`'s TUI-autocomplete trailing-space policy relies on
+    // to strip that space without ever needing to un-type text
+    // (`TUIAutocompleteTrailingSpace`). Reordering the whitespace flush would
+    // silently reintroduce the dismissed-popup bug, so pin it here.
+    func testSanitizingIngestNeverReturnsTextEndingInWhitespace() {
+        let chunkSequences: [[String]] = [
+            ["/compact "],
+            ["/comp", "act "],
+            ["hello world "],
+            ["hello\n"],
+            ["hello\t"],
+            ["hello \n\n "],
+            ["a\r\n"],
+            ["run the tests   "],
+            ["look at @Sources/Foo.swift "],
+            ["voxtral "],
+            ["voxtral\nrocks "],
+            ["one ", "two ", "three "],
+            ["trailing", " ", " ", " "],
+            ["\n\nleading "],
+            [" "],
+            ["\t\n "],
+        ]
+
+        for chunks in chunkSequences {
+            var stream = makeStream(entries: [voxtralEntry], sanitizesNewlines: true)
+            for chunk in chunks {
+                let released = stream.ingest(chunk)
+                XCTAssertFalse(
+                    released.last?.isWhitespace ?? false,
+                    "mid-session release \(released.debugDescription) ends in whitespace "
+                        + "for chunks \(chunks) — flushRemainder() must stay the only "
+                        + "path that emits a trailing space to a terminal"
+                )
+            }
+        }
+    }
+
+    // The same invariant does NOT hold with sanitization off — that path
+    // releases whitespace as it arrives, which is why the trailing-space policy
+    // is scoped to terminal-like targets only.
+    func testNonSanitizingIngestCanReturnTextEndingInWhitespace() {
+        var stream = makeStream(entries: [], sanitizesNewlines: false)
+        XCTAssertEqual(stream.ingest("/compact "), "/compact ")
+    }
+
     // MARK: - Rule chaining (a correction rewrites held text into rule-key words)
 
     /// PR #100 review finding, exact repro: rules `"x y" -> "bar"` and

--- a/Tests/localvoxtralTests/TUIAutocompleteTrailingSpaceTests.swift
+++ b/Tests/localvoxtralTests/TUIAutocompleteTrailingSpaceTests.swift
@@ -1,0 +1,287 @@
+import XCTest
+@testable import localvoxtral
+
+#if DEBUG
+/// A coding-agent TUI (Claude Code, Codex CLI, …) opens its slash-command
+/// autocomplete popup while the prompt line is a bare `/token`, and its file
+/// picker while the line ends in an `@token`. In both, a SPACE after the token
+/// confirms/dismisses the popup — so an invisible trailing space decides what
+/// the user's next keystroke does.
+///
+/// These tests pin where such a space can reach the focused app.
+@MainActor
+final class TUIAutocompleteTrailingSpaceTests: XCTestCase {
+    // MARK: - The pure policy
+
+    func testLoneSlashCommandLosesItsTrailingWhitespace() {
+        XCTAssertEqual(TUIAutocompleteTrailingSpace.stripped("/compact "), "/compact")
+        XCTAssertEqual(TUIAutocompleteTrailingSpace.stripped("/compact  "), "/compact")
+        XCTAssertEqual(TUIAutocompleteTrailingSpace.stripped("/compact\n"), "/compact")
+        XCTAssertEqual(TUIAutocompleteTrailingSpace.stripped("/compact \n "), "/compact")
+        XCTAssertEqual(TUIAutocompleteTrailingSpace.stripped("/review\t"), "/review")
+        XCTAssertEqual(TUIAutocompleteTrailingSpace.stripped("/init "), "/init")
+        XCTAssertEqual(TUIAutocompleteTrailingSpace.stripped("/agent-eval "), "/agent-eval")
+        XCTAssertEqual(TUIAutocompleteTrailingSpace.stripped("/run_2 "), "/run_2")
+    }
+
+    func testLoneSlashCommandWithoutTrailingWhitespaceIsUntouched() {
+        XCTAssertEqual(TUIAutocompleteTrailingSpace.stripped("/compact"), "/compact")
+    }
+
+    /// Leading whitespace is not part of either shape and survives — only the
+    /// tail is ever cut.
+    func testLeadingWhitespaceIsPreserved() {
+        XCTAssertEqual(TUIAutocompleteTrailingSpace.stripped(" /compact "), " /compact")
+    }
+
+    /// A token holding a second `/` is a filesystem path, not a slash command.
+    func testPathsAreNotSlashCommands() {
+        XCTAssertEqual(TUIAutocompleteTrailingSpace.stripped("/usr/bin "), "/usr/bin ")
+        XCTAssertEqual(TUIAutocompleteTrailingSpace.stripped("/tmp/x "), "/tmp/x ")
+        XCTAssertEqual(TUIAutocompleteTrailingSpace.stripped("/ "), "/ ")
+    }
+
+    func testMultiWordTextIsUntouched() {
+        XCTAssertEqual(
+            TUIAutocompleteTrailingSpace.stripped(" /cmd extra words "),
+            " /cmd extra words "
+        )
+        XCTAssertEqual(
+            TUIAutocompleteTrailingSpace.stripped("run /compact "),
+            "run /compact "
+        )
+        XCTAssertEqual(
+            TUIAutocompleteTrailingSpace.stripped("read Sources/App.swift then stop "),
+            "read Sources/App.swift then stop "
+        )
+    }
+
+    func testFrenchProseIsUntouched() {
+        XCTAssertEqual(
+            TUIAutocompleteTrailingSpace.stripped("Relis le fichier et corrige la faute. "),
+            "Relis le fichier et corrige la faute. "
+        )
+        // Slash-command names are ASCII in every agent TUI we target: abstain
+        // rather than guess on an accented token.
+        XCTAssertEqual(TUIAutocompleteTrailingSpace.stripped("/compacté "), "/compacté ")
+    }
+
+    func testEmptyAndWhitespaceOnlyTextIsUntouched() {
+        XCTAssertEqual(TUIAutocompleteTrailingSpace.stripped(""), "")
+        XCTAssertEqual(TUIAutocompleteTrailingSpace.stripped("   "), "   ")
+        XCTAssertEqual(TUIAutocompleteTrailingSpace.stripped("\n"), "\n")
+    }
+
+    func testTrailingMentionLosesItsTrailingWhitespace() {
+        XCTAssertEqual(
+            TUIAutocompleteTrailingSpace.stripped("@Sources/Foo.swift "),
+            "@Sources/Foo.swift"
+        )
+        XCTAssertEqual(TUIAutocompleteTrailingSpace.stripped("@filename "), "@filename")
+        XCTAssertEqual(
+            TUIAutocompleteTrailingSpace.stripped("look at @Sources/Foo.swift "),
+            "look at @Sources/Foo.swift"
+        )
+        XCTAssertEqual(
+            TUIAutocompleteTrailingSpace.stripped("regarde @src/main.rs\n"),
+            "regarde @src/main.rs"
+        )
+    }
+
+    /// A bare `@` proposes nothing; `a@b` is an email address, not a mention;
+    /// a token carrying prose punctuation is prose.
+    func testNonMentionAtSignsAreUntouched() {
+        XCTAssertEqual(TUIAutocompleteTrailingSpace.stripped("@ "), "@ ")
+        XCTAssertEqual(TUIAutocompleteTrailingSpace.stripped("a@b "), "a@b ")
+        XCTAssertEqual(
+            TUIAutocompleteTrailingSpace.stripped("mail him at dev@example.com "),
+            "mail him at dev@example.com "
+        )
+        XCTAssertEqual(TUIAutocompleteTrailingSpace.stripped("check @file, "), "check @file, ")
+    }
+
+    /// A mention that is not the LAST token had its picker closed by the words
+    /// that followed it.
+    func testMentionInTheMiddleIsUntouched() {
+        XCTAssertEqual(
+            TUIAutocompleteTrailingSpace.stripped("@Sources/Foo.swift needs a test "),
+            "@Sources/Foo.swift needs a test "
+        )
+    }
+
+    // MARK: - Overlay Buffer commit path (characterization)
+
+    /// The overlay stop-commit path has never had the bug: every commit goes
+    /// through `insertionText(from:)`, which trims both edges before the text
+    /// reaches `TextInsertionService`. Locked in here so a future change to the
+    /// assembler cannot reintroduce it silently.
+    func testOverlayCommitTextNeverCarriesTrailingWhitespace() {
+        XCTAssertEqual(OverlayBufferTextAssembler.insertionText(from: "/compact "), "/compact")
+        XCTAssertEqual(OverlayBufferTextAssembler.insertionText(from: "/compact\n"), "/compact")
+        XCTAssertEqual(
+            OverlayBufferTextAssembler.insertionText(from: "look at @Sources/Foo.swift "),
+            "look at @Sources/Foo.swift"
+        )
+    }
+
+    // MARK: - Live Auto-Paste path (the regression)
+
+    /// Field shape: "slash compact" into a terminal in Live Auto-Paste. The ASR
+    /// segment carries a trailing space, the terminal stream buffers it, and the
+    /// stop flush types it — dismissing the popup the user opened.
+    func testTerminalLoneSlashCommandDoesNotTypeTrailingSpace() {
+        let typed = Box<[String]>([])
+        let service = makeService(capturing: typed)
+        service.beginLiveReplacementSession(
+            dictionary: nil,
+            preferredAppPID: nil,
+            isTerminalLikeTarget: true
+        )
+
+        service.enqueueRealtimeInsertion("/compact ")
+        service.flushFinalLiveReplacementCorrections()
+
+        XCTAssertEqual(
+            typed.value.joined(), "/compact",
+            "a lone slash command must reach the TUI without the space that dismisses its popup"
+        )
+        service.endLiveReplacementSession()
+    }
+
+    /// Same shape when the trailing space only arrives as its own delta.
+    func testTerminalLoneSlashCommandWithSeparateSpaceDeltaDoesNotTypeTrailingSpace() {
+        let typed = Box<[String]>([])
+        let service = makeService(capturing: typed)
+        service.beginLiveReplacementSession(
+            dictionary: nil,
+            preferredAppPID: nil,
+            isTerminalLikeTarget: true
+        )
+
+        service.enqueueRealtimeInsertion("/rev")
+        service.enqueueRealtimeInsertion("iew")
+        service.enqueueRealtimeInsertion(" ")
+        service.flushFinalLiveReplacementCorrections()
+
+        XCTAssertEqual(typed.value.joined(), "/review")
+        service.endLiveReplacementSession()
+    }
+
+    /// An utterance ending on an `@file` mention: the file picker is open and
+    /// the trailing space would accept whatever it has highlighted.
+    func testTerminalTrailingMentionDoesNotTypeTrailingSpace() {
+        let typed = Box<[String]>([])
+        let service = makeService(capturing: typed)
+        service.beginLiveReplacementSession(
+            dictionary: nil,
+            preferredAppPID: nil,
+            isTerminalLikeTarget: true
+        )
+
+        service.enqueueRealtimeInsertion("look at @Sources/Foo.swift ")
+        service.flushFinalLiveReplacementCorrections()
+
+        XCTAssertEqual(typed.value.joined(), "look at @Sources/Foo.swift")
+        service.endLiveReplacementSession()
+    }
+
+    // MARK: - Live Auto-Paste path (what must NOT change)
+
+    /// `/usr/bin` is a filesystem path, not a slash command — its trailing
+    /// space is dictated content and stays.
+    func testTerminalPathLikeTokenKeepsItsTrailingSpace() {
+        let typed = Box<[String]>([])
+        let service = makeService(capturing: typed)
+        service.beginLiveReplacementSession(
+            dictionary: nil,
+            preferredAppPID: nil,
+            isTerminalLikeTarget: true
+        )
+
+        service.enqueueRealtimeInsertion("/usr/bin ")
+        service.flushFinalLiveReplacementCorrections()
+
+        XCTAssertEqual(typed.value.joined(), "/usr/bin ")
+        service.endLiveReplacementSession()
+    }
+
+    /// Ordinary prose keeps every character the user dictated.
+    func testTerminalSentenceKeepsItsTrailingSpace() {
+        let typed = Box<[String]>([])
+        let service = makeService(capturing: typed)
+        service.beginLiveReplacementSession(
+            dictionary: nil,
+            preferredAppPID: nil,
+            isTerminalLikeTarget: true
+        )
+
+        service.enqueueRealtimeInsertion("run the tests and fix /compact ")
+        service.flushFinalLiveReplacementCorrections()
+
+        XCTAssertEqual(typed.value.joined(), "run the tests and fix /compact ")
+        service.endLiveReplacementSession()
+    }
+
+    /// The space between a slash command and the words that follow it is
+    /// dictated content and must be typed as the session goes.
+    func testTerminalSlashCommandFollowedByWordsKeepsTheInteriorSpace() {
+        let typed = Box<[String]>([])
+        let service = makeService(capturing: typed)
+        service.beginLiveReplacementSession(
+            dictionary: nil,
+            preferredAppPID: nil,
+            isTerminalLikeTarget: true
+        )
+
+        service.enqueueRealtimeInsertion("/compact ")
+        service.enqueueRealtimeInsertion("now")
+        service.flushFinalLiveReplacementCorrections()
+
+        XCTAssertEqual(typed.value.joined(), "/compact now")
+        service.endLiveReplacementSession()
+    }
+
+    /// No autocomplete popup exists outside a terminal, so a regular editor
+    /// keeps exactly what was dictated.
+    func testNonTerminalTargetKeepsTheTrailingSpace() {
+        let typed = Box<[String]>([])
+        let service = makeService(capturing: typed)
+        service.beginLiveReplacementSession(
+            dictionary: ReplacementDictionary(entries: [
+                ReplacementEntry(replaceWith: "localvoxtral", matches: ["voxtral"]),
+            ]),
+            preferredAppPID: nil,
+            isTerminalLikeTarget: false
+        )
+
+        service.enqueueRealtimeInsertion("/compact ")
+        service.flushFinalLiveReplacementCorrections()
+
+        XCTAssertEqual(typed.value.joined(), "/compact ")
+        service.endLiveReplacementSession()
+    }
+
+    // MARK: - Harness
+
+    private func makeService(capturing typed: Box<[String]>) -> TextInsertionService {
+        let service = TextInsertionService()
+        service.debugConfigureInsertionHooks(
+            unicodePoster: { chunk in
+                typed.value.append(chunk)
+                return true
+            },
+            modifierStateReader: { false },
+            accessibilityInserter: { _, _ in false }
+        )
+        return service
+    }
+}
+
+private final class Box<Value> {
+    var value: Value
+
+    init(_ value: Value) {
+        self.value = value
+    }
+}
+#endif

--- a/Tests/localvoxtralTests/TUIAutocompleteTrailingSpaceTests.swift
+++ b/Tests/localvoxtralTests/TUIAutocompleteTrailingSpaceTests.swift
@@ -28,10 +28,17 @@ final class TUIAutocompleteTrailingSpaceTests: XCTestCase {
         XCTAssertEqual(TUIAutocompleteTrailingSpace.stripped("/compact"), "/compact")
     }
 
-    /// Leading whitespace is not part of either shape and survives — only the
-    /// tail is ever cut.
+    /// Deliberate (documented on the type): leading whitespace is ignored when
+    /// recognizing a shape and preserved in the result — only the tail is ever
+    /// cut, and indentation the ASR happened to emit does not change the shape
+    /// of the line the TUI sees.
     func testLeadingWhitespaceIsPreserved() {
         XCTAssertEqual(TUIAutocompleteTrailingSpace.stripped(" /compact "), " /compact")
+        XCTAssertEqual(TUIAutocompleteTrailingSpace.stripped("  /compact "), "  /compact")
+        XCTAssertEqual(
+            TUIAutocompleteTrailingSpace.stripped(" @Sources/Foo.swift "),
+            " @Sources/Foo.swift"
+        )
     }
 
     /// A token holding a second `/` is a filesystem path, not a slash command.
@@ -100,6 +107,19 @@ final class TUIAutocompleteTrailingSpaceTests: XCTestCase {
         XCTAssertEqual(TUIAutocompleteTrailingSpace.stripped("check @file, "), "check @file, ")
     }
 
+    /// A mention name must hold at least one name character: `.` and `/` are
+    /// allowed so paths qualify, but a token made only of them names no file
+    /// and opens no picker.
+    func testPunctuationOnlyMentionNamesAreUntouched() {
+        XCTAssertEqual(TUIAutocompleteTrailingSpace.stripped("@. "), "@. ")
+        XCTAssertEqual(TUIAutocompleteTrailingSpace.stripped("@/ "), "@/ ")
+        XCTAssertEqual(TUIAutocompleteTrailingSpace.stripped("@~/ "), "@~/ ")
+        XCTAssertEqual(TUIAutocompleteTrailingSpace.stripped("@... "), "@... ")
+        // A real path keeps working.
+        XCTAssertEqual(TUIAutocompleteTrailingSpace.stripped("@~/notes.md "), "@~/notes.md")
+        XCTAssertEqual(TUIAutocompleteTrailingSpace.stripped("@./Package.swift "), "@./Package.swift")
+    }
+
     /// A mention that is not the LAST token had its picker closed by the words
     /// that followed it.
     func testMentionInTheMiddleIsUntouched() {
@@ -164,6 +184,39 @@ final class TUIAutocompleteTrailingSpaceTests: XCTestCase {
         service.flushFinalLiveReplacementCorrections()
 
         XCTAssertEqual(typed.value.joined(), "/review")
+        service.endLiveReplacementSession()
+    }
+
+    /// The subtlest interaction: the slash command is assembled across SEVERAL
+    /// releases, so the stop flush can only recognize it by consulting
+    /// `liveTypedTextForSession` — the text already handed to the field. The
+    /// tail space is withheld and every earlier release is left exactly as it
+    /// was typed (there are no backspaces in the insertion path).
+    func testTerminalSlashCommandAssembledAcrossFlushesWithholdsOnlyTheTailSpace() {
+        let typed = Box<[String]>([])
+        let service = makeService(capturing: typed)
+        service.beginLiveReplacementSession(
+            dictionary: nil,
+            preferredAppPID: nil,
+            isTerminalLikeTarget: true
+        )
+
+        service.enqueueRealtimeInsertion("/comp")
+        XCTAssertEqual(typed.value, ["/comp"], "the first release reaches the field immediately")
+        service.enqueueRealtimeInsertion("act ")
+        XCTAssertEqual(
+            typed.value, ["/comp", "act"],
+            "the second release types the word; its trailing space is buffered"
+        )
+
+        service.flushFinalLiveReplacementCorrections()
+
+        XCTAssertEqual(
+            typed.value, ["/comp", "act"],
+            "the stop flush must add nothing: already-typed releases are untouched "
+                + "and the buffered tail space is withheld"
+        )
+        XCTAssertEqual(typed.value.joined(), "/compact")
         service.endLiveReplacementSession()
     }
 


### PR DESCRIPTION
## What

Dictating exactly one slash-command token into a coding-agent TUI — "slash compact" → `/compact ` — typed an invisible trailing space that **confirms/dismisses Claude Code's slash-command autocomplete popup** before the user can pick anything. Same for an utterance ending on an `@file` mention while the file picker is open. The space is never spoken: ASR segments carry token-trailing spaces. This is invisible in testing and sits on our core use case (dictation into Claude Code).

### Investigation: where a trailing space can reach the focused app

| Stage | Verdict |
|---|---|
| ASR transcript / merge | `resolvedFinalizedSegment` and `TextMergingAlgorithms.livePasteExtensionSuffix` both `.trimmed` their input, and `FirstChunkPreprocessor` trims only the LEADING edge. But the raw **partial deltas** are handed to `enqueueRealtimeInsertion` verbatim, trailing space and all. |
| **Overlay Buffer stop-commit** (`DictationViewModel+Session.swift`) | **Never affected.** Post-polish text lands in `currentDictationEventText` → `refreshOverlayBufferSession()` → `commitBufferText`, and `commitIfNeeded` inserts `OverlayBufferTextAssembler.insertionText(from:)`, which is `.trimmed` — both edges, after polish. So a polish model returning `"/compact "` or `"/compact\n"` already commits `/compact`. Nothing to fix; locked in with a characterization test so a future assembler change can't reintroduce it silently. **`DictationViewModel+Session.swift` is not touched by this PR.** |
| **Live Auto-Paste** | **The bug.** In a terminal session the hold-back stream is always armed with newline sanitization, and `sanitizingNewlines` buffers every trailing space run (`pendingPlainSpaces`) until the next non-whitespace character. So no mid-session release can ever *end* in whitespace — the only trailing space a terminal ever sees is the one `flushRemainder()` emits at stop. That makes the stop flush a **complete choke point**, and it is where the space was typed. |

Traced end to end for `/compact `: partial delta `"/compact "` → stream releases `"/compact"`, buffers `" "` → final transcript `"/compact"` is not a prefix-extension of the live-typed text, so `livePasteExtensionSuffix` returns nil → stop → `flushRemainder()` emits the buffered `" "` → popup dismissed.

### Fix

New shared pure policy `TUIAutocompleteTrailingSpace.stripped(_:)` (`Sources/localvoxtral/TUIAutocompleteTrailingSpace.swift`), deliberately narrow per the repo's abstain-over-guess rule. It removes only whitespace, only from the end, and only for two shapes:

- **Lone slash command** — the whole text is `/` + one run of `[A-Za-z0-9_-]`. A token holding a **second `/` is a filesystem path** (`/usr/bin`, `/tmp/x`), never a slash command, and is left alone — as is any text with other words in it (`fix /compact please`), where the popup is already closed and the trailing space is dictated content. Slash-command names are ASCII in every agent TUI we target, so `/compacté` abstains.
- **Trailing mention** — the last whitespace-separated token is `@` + filename characters (`@Sources/Foo.swift`, `@README`). A bare `@` proposes nothing, `a@b` is an email address, and `@file,` is prose: none are touched.

Applied at the Live Auto-Paste stop flush (`TextInsertionService.flushLiveHoldBackStream(releaseRemainder: true)`), gated on the **existing** session terminal-like verdict already threaded into `beginLiveReplacementSession(isTerminalLikeTarget:)` — autocomplete popups only exist there, so no new heuristic and no window-title guessing was invented. The verdict is taken on the whole session's text (it has to be: "is this *only* a slash command?"), but `min(dropCount, releasedText.count)` means only the not-yet-typed tail can ever be cut — the same never-un-type invariant the hold-back stream enforces.

No settings toggle: this is a deterministic correctness fix for a well-defined shape.

### CI lane filters

`scripts/ci/llm-lane-filter.sh` does **not** match this diff (checked, output below) and neither does the speechd filter. Correct: the change is purely insertion-side, downstream of polish, and alters nothing that reaches the model. `DictationViewModel+Session.swift` (which *is* in the filter) is untouched.

```
$ bash scripts/ci/llm-lane-filter.sh <changed-files>
run=false
reason=no LLM-relevant changes; add [run-llm-eval] to the PR body or commit message and push to opt in

$ bash scripts/ci/speechd-lane-filter.sh <changed-files>
run=false
reason=no speechd-relevant changes; ...

$ bash scripts/ci/docs-only-filter.sh <changed-files>
docs_only=false
count=1
reason=Swift source/test/helper path: Sources/localvoxtral/TextInsertionService.swift
```

## Proof

- [x] **Bug fix: regression test added — failing run before the fix and passing run after**

**BEFORE the fix** — `./scripts/remote-build.sh test --filter TUIAutocompleteTrailingSpaceTests` (probe tests only, source unchanged). The three pipeline probes fail exactly where predicted; the five must-not-change cases (overlay characterization, `/usr/bin `, prose, non-terminal target) already pass:

```
Test Suite 'TUIAutocompleteTrailingSpaceTests' started at 2026-07-28 00:00:57.269.
Test Case '...testNonTerminalTargetKeepsTheTrailingSpace]' passed (0.004 seconds).
Test Case '...testOverlayCommitTextNeverCarriesTrailingWhitespace]' passed (0.000 seconds).
Test Case '...testTerminalLoneSlashCommandDoesNotTypeTrailingSpace]' started.
TUIAutocompleteTrailingSpaceTests.swift:46: error: -[...testTerminalLoneSlashCommandDoesNotTypeTrailingSpace] : XCTAssertEqual failed: ("/compact ") is not equal to ("/compact") - a lone slash command must reach the TUI without the space that dismisses its popup
Test Case '...testTerminalLoneSlashCommandDoesNotTypeTrailingSpace]' failed (0.149 seconds).
Test Case '...testTerminalLoneSlashCommandWithSeparateSpaceDeltaDoesNotTypeTrailingSpace]' started.
TUIAutocompleteTrailingSpaceTests.swift:68: error: -[...testTerminalLoneSlashCommandWithSeparateSpaceDeltaDoesNotTypeTrailingSpace] : XCTAssertEqual failed: ("/review ") is not equal to ("/review")
Test Case '...testTerminalLoneSlashCommandWithSeparateSpaceDeltaDoesNotTypeTrailingSpace]' failed (0.000 seconds).
Test Case '...testTerminalPathLikeTokenKeepsItsTrailingSpace]' passed (0.000 seconds).
Test Case '...testTerminalSentenceKeepsItsTrailingSpace]' passed (0.000 seconds).
Test Case '...testTerminalSlashCommandFollowedByWordsKeepsTheInteriorSpace]' passed (0.000 seconds).
Test Case '...testTerminalTrailingMentionDoesNotTypeTrailingSpace]' started.
TUIAutocompleteTrailingSpaceTests.swift:86: error: -[...testTerminalTrailingMentionDoesNotTypeTrailingSpace] : XCTAssertEqual failed: ("look at @Sources/Foo.swift ") is not equal to ("look at @Sources/Foo.swift")
Test Case '...testTerminalTrailingMentionDoesNotTypeTrailingSpace]' failed (0.000 seconds).
Test Suite 'TUIAutocompleteTrailingSpaceTests' failed at 2026-07-28 00:00:57.423.
	 Executed 8 tests, with 3 failures (0 unexpected) in 0.154 (0.154) seconds
```

**AFTER the fix** — same command, now with the exhaustive pure-policy cases added (lone `/cmd`, `/cmd `, `/cmd  `, `/cmd\n`, `/cmd\t`, multi-word sentences containing slashes, `/usr/bin `, ` /cmd extra words `, French prose + `/compacté `, empty string, whitespace-only, `@file ` endings, `@ ` alone, `a@b `, `dev@example.com `, mid-sentence mention):

```
Test Suite 'TUIAutocompleteTrailingSpaceTests' started at 2026-07-28 00:02:36.006.
Test Case '...testEmptyAndWhitespaceOnlyTextIsUntouched]' passed (0.001 seconds).
Test Case '...testFrenchProseIsUntouched]' passed (0.000 seconds).
Test Case '...testLeadingWhitespaceIsPreserved]' passed (0.000 seconds).
Test Case '...testLoneSlashCommandLosesItsTrailingWhitespace]' passed (0.000 seconds).
Test Case '...testLoneSlashCommandWithoutTrailingWhitespaceIsUntouched]' passed (0.000 seconds).
Test Case '...testMentionInTheMiddleIsUntouched]' passed (0.000 seconds).
Test Case '...testMultiWordTextIsUntouched]' passed (0.000 seconds).
Test Case '...testNonMentionAtSignsAreUntouched]' passed (0.000 seconds).
Test Case '...testNonTerminalTargetKeepsTheTrailingSpace]' passed (0.003 seconds).
Test Case '...testOverlayCommitTextNeverCarriesTrailingWhitespace]' passed (0.000 seconds).
Test Case '...testPathsAreNotSlashCommands]' passed (0.000 seconds).
Test Case '...testTerminalLoneSlashCommandDoesNotTypeTrailingSpace]' passed (0.000 seconds).
Test Case '...testTerminalLoneSlashCommandWithSeparateSpaceDeltaDoesNotTypeTrailingSpace]' passed (0.000 seconds).
Test Case '...testTerminalPathLikeTokenKeepsItsTrailingSpace]' passed (0.000 seconds).
Test Case '...testTerminalSentenceKeepsItsTrailingSpace]' passed (0.000 seconds).
Test Case '...testTerminalSlashCommandFollowedByWordsKeepsTheInteriorSpace]' passed (0.000 seconds).
Test Case '...testTerminalTrailingMentionDoesNotTypeTrailingSpace]' passed (0.000 seconds).
Test Case '...testTrailingMentionLosesItsTrailingWhitespace]' passed (0.000 seconds).
Test Suite 'TUIAutocompleteTrailingSpaceTests' passed at 2026-07-28 00:02:36.012.
	 Executed 18 tests, with 0 failures (0 unexpected) in 0.006 (0.006) seconds
```

- [x] **Unit suite green** — `./scripts/remote-build.sh` (build + full tier-0 suite), zero warnings:

```
Test Suite 'localvoxtralPackageTests.xctest' passed at 2026-07-28 00:03:58.751.
	 Executed 2033 tests, with 2 tests skipped and 0 failures (0 unexpected) in 73.798 (73.906) seconds
Test Suite 'Selected tests' passed at 2026-07-28 00:03:58.752.
	 Executed 2033 tests, with 2 tests skipped and 0 failures (0 unexpected) in 73.798 (73.907) seconds

$ grep -c "warning:" .build/last-remote.log
0
```

No existing test was weakened. The neighbouring `TextInsertionServiceLiveStrategyTests` — including `testTerminalLikeSessionWithoutDictionaryStillSanitizesNewlines` (`"git status\n"` → `"git status "`, a terminal flush that legitimately emits a trailing space) and `testFailedHoldBackReleaseIsRetriedWithoutDuplication` — pass unchanged, which is the direct evidence that the policy does not fire on ordinary text.

- [x] **LLM lanes**: skipped, justified — insertion-side only, downstream of polish, nothing that reaches the model changes; the path filter agrees (output above) and `DictationViewModel+Session.swift` is untouched.
- [x] **eval-e2e**: skipped, justified — same reason; no model, prompt, or feature-pipeline input changes.
- [ ] UI change: none.

### Not in this PR

The `@mention` case is handled (the terminal gate already existed and is per-session, so no fragile window-title heuristic was needed). Two live paths are deliberately left alone because they have no autocomplete popup to protect and no safe choke point: a **non-terminal** target with a dictionary (releases trailing spaces mid-stream, un-typable) and a non-terminal target with no rules (types deltas directly).


---

## Review hardening (commit `411e20e`)

Independent review came back LGTM-with-nits, no correctness bugs. Addressed on the same branch, no force-push.

**N1 — pin the invariant the fix rests on.** The policy works because `flushRemainder()` is the *only* point where a terminal can receive a trailing space, which in turn rests on "no mid-session `ingest()` release ends in whitespace when `sanitizesNewlines == true`". True today, asserted nowhere. `LiveHoldBackReplacementStreamTests.testSanitizingIngestNeverReturnsTextEndingInWhitespace` now pins it over 16 chunk shapes (space / newline / tab / CR endings, multi-chunk sequences, replacement-rewriting chunks, whitespace-only chunks), with a sanitize-OFF counterpart documenting why the policy is scoped to terminal-like targets.

The pin is load-bearing, not decorative — with the whitespace flush reordered (plain spaces appended to `output` immediately instead of buffered in `pendingPlainSpaces`), it fails on 10 shapes:

```
LiveHoldBackReplacementStreamTests.swift:365: error: -[...testSanitizingIngestNeverReturnsTextEndingInWhitespace] : XCTAssertFalse failed - mid-session release "/compact " ends in whitespace for chunks ["/compact "] — flushRemainder() must stay the only path that emits a trailing space to a terminal
LiveHoldBackReplacementStreamTests.swift:365: error: ... mid-session release "/compact " ends in whitespace for chunks ["/comp", "act "] ...
LiveHoldBackReplacementStreamTests.swift:365: error: ... mid-session release "hello world " ends in whitespace for chunks ["hello world "] ...
LiveHoldBackReplacementStreamTests.swift:365: error: ... mid-session release "hello " ends in whitespace for chunks ["hello \n\n "] ...
LiveHoldBackReplacementStreamTests.swift:365: error: ... mid-session release "run the tests   " ends in whitespace for chunks ["run the tests   "] ...
LiveHoldBackReplacementStreamTests.swift:365: error: ... mid-session release "look at @Sources/Foo.swift " ends in whitespace for chunks ["look at @Sources/Foo.swift "] ...
LiveHoldBackReplacementStreamTests.swift:365: error: ... mid-session release "localvoxtral " ends in whitespace for chunks ["voxtral "] ...
LiveHoldBackReplacementStreamTests.swift:365: error: ... mid-session release "localvoxtral rocks " ends in whitespace for chunks ["voxtral\nrocks "] ...
LiveHoldBackReplacementStreamTests.swift:365: error: ... mid-session release "one " ends in whitespace for chunks ["one ", "two ", "three "] ...
```

That counterfactual edit was reverted; `LiveHoldBackReplacementStream.swift` is unchanged by this PR.

**N2 — slash command assembled across flushes.** The subtlest interaction: only `liveTypedTextForSession` can recognize the shape at stop. `testTerminalSlashCommandAssembledAcrossFlushesWithholdsOnlyTheTailSpace` enqueues `"/comp"` then `"act "` in a terminal session and asserts **per release**, so it also proves no already-typed chunk is disturbed:

```swift
service.enqueueRealtimeInsertion("/comp")      // typed == ["/comp"]
service.enqueueRealtimeInsertion("act ")       // typed == ["/comp", "act"]  (space buffered)
service.flushFinalLiveReplacementCorrections() // typed == ["/comp", "act"]  (flush adds nothing)
// joined == "/compact"
```

**N3 — degenerate mention names.** A mention name must now hold at least one `[A-Za-z0-9_-]` character. `.` and `/` remain legal so paths still qualify (`@~/notes.md`, `@./Package.swift`), but `@.`, `@/`, `@~/` and `@...` name no file, open no picker, and no longer match — covered by `testPunctuationOnlyMentionNamesAreUntouched`. Leading-whitespace candidates (`"  /compact "`) are **kept**, and the choice is now documented on the type and in `testLeadingWhitespaceIsPreserved`: leading whitespace is ignored when recognizing a shape and preserved in the result, because only the tail is ever cut and indentation the ASR happened to emit does not change the shape of the line the TUI sees.

**N4** — skipped as agreed; the overlay characterization test is adequate.

### Hardening test runs

```
$ ./scripts/remote-build.sh test --filter TUIAutocompleteTrailingSpaceTests
Test Suite 'TUIAutocompleteTrailingSpaceTests' passed at 2026-07-28 00:25:10.824.
	 Executed 20 tests, with 0 failures (0 unexpected) in 0.007 (0.008) seconds

$ ./scripts/remote-build.sh test --filter LiveHoldBackReplacementStreamTests
Test Suite 'LiveHoldBackReplacementStreamTests' passed at 2026-07-28 00:25:20.767.
	 Executed 55 tests, with 0 failures (0 unexpected) in 2.529 (2.531) seconds

$ ./scripts/remote-build.sh          # full tier-0, after hardening
Test Suite 'localvoxtralPackageTests.xctest' passed at 2026-07-28 00:27:16.798.
	 Executed 2037 tests, with 2 tests skipped and 0 failures (0 unexpected) in 71.806 (71.904) seconds

$ grep -c "warning:" .build/last-remote.log
0
```

Lane filters re-checked over the whole branch diff after the hardening commit — `llm-lane-filter.sh` and `speechd-lane-filter.sh` both still `run=false`, and `DictationViewModel+Session.swift` is still untouched.
