### PR TITLE
Remote listener: say WHY a connection was rejected, in the log and in Settings

### DIFF
--- a/Sources/ClaudeContextWire/ClaudeRemoteHTTP.swift
+++ b/Sources/ClaudeContextWire/ClaudeRemoteHTTP.swift
@@ -49,6 +49,19 @@ public struct ClaudeRemoteHTTPLimits: Sendable, Equatable {
     public static let `default` = ClaudeRemoteHTTPLimits()
 }
 
+/// What a request's `Authorization` header turned out to be.
+///
+/// Carries the credential in `.bearer` and NOTHING derived from it in the other
+/// cases — no length, no prefix, no digest. A diagnostic that narrows a secret
+/// is not a diagnostic worth having.
+public enum ClaudeRemoteAuthorizationShape: Sendable, Equatable {
+    /// No `Authorization` header, or a `Bearer` scheme with an empty credential.
+    case missing
+    /// Present, but not a `Bearer` credential we are willing to read.
+    case malformed
+    case bearer(String)
+}
+
 /// A parsed request head. The body is deliberately NOT part of this type: the
 /// listener authenticates on the head alone and only then reads bytes.
 public struct ClaudeRemoteHTTPRequest: Sendable, Equatable {
@@ -197,11 +210,42 @@ public enum ClaudeRemoteHTTPCodec {
         in headerValue: String?,
         limits: ClaudeRemoteHTTPLimits = .default
     ) -> String? {
-        guard let headerValue, headerValue.utf8.count <= limits.maxTokenBytes else { return nil }
+        guard case .bearer(let token) = authorizationShape(in: headerValue, limits: limits) else {
+            return nil
+        }
+        return token
+    }
+
+    /// WHY an `Authorization` header did not yield a credential — the same walk
+    /// as `bearerToken`, keeping its answer instead of collapsing every failure
+    /// to nil.
+    ///
+    /// The distinction is not cosmetic. A remote host on a pre-1.1.0 plugin sends
+    /// `Authorization: Bearer ` with nothing after it (the http hook could never
+    /// present the token), and a host whose token was rotated sends a perfectly
+    /// well-formed one that no longer matches. Both used to log the same line, so
+    /// hours of rejections said nothing about which of the two fixes — update the
+    /// plugin, or re-run enrollment — the user actually needed.
+    ///
+    /// It classifies SHAPE only. The credential is returned for the caller to
+    /// authenticate; nothing here measures, hashes, or reports it.
+    public static func authorizationShape(
+        in headerValue: String?,
+        limits: ClaudeRemoteHTTPLimits = .default
+    ) -> ClaudeRemoteAuthorizationShape {
+        guard let headerValue else { return .missing }
+        // Oversized before anything else: a header this long is not a credential
+        // we failed to read, it is a header we refuse to read.
+        guard headerValue.utf8.count <= limits.maxTokenBytes else { return .malformed }
         let parts = headerValue.split(separator: " ", maxSplits: 1, omittingEmptySubsequences: true)
-        guard parts.count == 2, parts[0].lowercased() == "bearer" else { return nil }
+        guard let scheme = parts.first else { return .missing }
+        guard scheme.lowercased() == "bearer" else { return .malformed }
+        // `Bearer` with an empty credential — including the header parser's
+        // already-trimmed `Bearer ` — is the pre-1.1.0 plugin's exact shape, and
+        // is reported as a missing token rather than a malformed header.
+        guard parts.count == 2 else { return .missing }
         let token = parts[1].trimmingCharacters(in: .whitespaces)
-        return token.isEmpty ? nil : token
+        return token.isEmpty ? .missing : .bearer(token)
     }
 
     /// The event name a hook URL carries, e.g. `/v1/hook/SessionStart`.

--- a/Sources/localvoxtral/ClaudeContext/ClaudeIntegrationSettingsModel.swift
+++ b/Sources/localvoxtral/ClaudeContext/ClaudeIntegrationSettingsModel.swift
@@ -85,17 +85,37 @@ public final class ClaudeIntegrationSettingsModel {
         public var sshHostAlias: String?
         public var isRevoked: Bool
         public var lastSeenAt: Date?
-
-        /// The part of the status that is not a date.
+        /// The whole status, resolved against the model's injected clock when
+        /// the row was built.
         ///
-        /// A `RelativeDateTimeFormatter` cached in a `static let` here would be
-        /// non-Sendable global state — a Swift 6 error — and building one per
-        /// row per redraw is worse. The view renders `lastSeenAt` with
-        /// `Text(_:style:)`, which also keeps ticking on its own.
-        public var statusText: String {
-            if isRevoked { return "Revoked" }
-            return lastSeenAt == nil ? "Enrolled — not seen yet" : "Last seen"
-        }
+        /// Rendered rather than computed in the view for two reasons. A
+        /// `RelativeDateTimeFormatter` cached in a `static let` would be
+        /// non-Sendable global state (a Swift 6 error), and building one per row
+        /// per redraw is worse — but mostly, "when did this host last send
+        /// context" is the answer a user needs to tell a silent tunnel from a
+        /// working one, and an answer with a test beats an answer with a
+        /// formatter.
+        public var statusText: String
+    }
+
+    /// "Last context: 2 min ago", from a clock the caller supplies.
+    ///
+    /// Coarse on purpose: the question is "is this host still talking to me",
+    /// and a to-the-second answer would only invite the user to read precision
+    /// into a timestamp that is refreshed when the pane appears.
+    static func hostStatusText(isRevoked: Bool, lastSeenAt: Date?, now: Date) -> String {
+        if isRevoked { return "Revoked" }
+        guard let lastSeenAt else { return "Last context: never" }
+        let elapsed = now.timeIntervalSince(lastSeenAt)
+        // A clock that stepped backwards (NTP, a DST correction) must not print
+        // a negative age. "Just now" is the honest reading of "not in the past".
+        guard elapsed >= 60 else { return "Last context: just now" }
+        let minutes = Int(elapsed / 60)
+        if minutes < 60 { return "Last context: \(minutes) min ago" }
+        let hours = minutes / 60
+        if hours < 24 { return "Last context: \(hours) \(hours == 1 ? "hour" : "hours") ago" }
+        let days = hours / 24
+        return "Last context: \(days) \(days == 1 ? "day" : "days") ago"
     }
 
     /// What the pane says about the listener, in one short line.
@@ -221,6 +241,9 @@ public final class ClaudeIntegrationSettingsModel {
 
     public private(set) var hosts: [HostRow] = []
     public private(set) var listenerStatus: ListenerStatus = .idle
+    /// One short sentence when connections have been rejected since launch, nil
+    /// otherwise. See `rejectionHint(for:)`.
+    public private(set) var rejectionHint: String?
     /// Short result copy for the local plugin action, e.g. "Installed." Cleared
     /// when a new action starts.
     public private(set) var pluginResult: String?
@@ -265,6 +288,10 @@ public final class ClaudeIntegrationSettingsModel {
     private let performEnrollmentAsync:
         @Sendable (@escaping @Sendable () throws -> [ClaudeRemoteEnrollmentService.ExecutionStep]) async
             -> ClaudeEnrollmentActionAttempt
+    /// Injected wall clock, read once per refresh to age the host rows. No
+    /// `Date()` in the view, and no timer: the rows are rebuilt when the pane
+    /// appears and after every action that touches a host.
+    private let now: @Sendable () -> Date
 
     /// - Parameters:
     ///   - registry: nil when the host file could not be read at launch. The
@@ -300,7 +327,8 @@ public final class ClaudeIntegrationSettingsModel {
                     )
                 }
             }.value
-        }
+        },
+        now: @escaping @Sendable () -> Date = { Date() }
     ) {
         self.registry = registry
         self.listener = listener
@@ -308,6 +336,7 @@ public final class ClaudeIntegrationSettingsModel {
         self.enrollmentService = enrollmentService
         self.performAsync = performAsync
         self.performEnrollmentAsync = performEnrollmentAsync
+        self.now = now
         refreshHosts()
         refreshListenerStatus()
     }
@@ -386,15 +415,57 @@ public final class ClaudeIntegrationSettingsModel {
     // MARK: - Remote hosts
 
     public func refreshHosts() {
+        // One clock reading for the whole list, so two rows of the same age
+        // cannot disagree about what "now" was.
+        let timestamp = now()
         hosts = (registry?.hosts() ?? []).map {
             HostRow(
                 id: $0.id,
                 label: $0.label,
                 sshHostAlias: $0.sshHostAlias,
                 isRevoked: $0.isRevoked,
-                lastSeenAt: $0.lastSeenAt
+                lastSeenAt: $0.lastSeenAt,
+                statusText: Self.hostStatusText(
+                    isRevoked: $0.isRevoked, lastSeenAt: $0.lastSeenAt, now: timestamp
+                )
             )
         }
+        refreshRejectionHint()
+    }
+
+    /// Re-read the listener's rejection counters.
+    ///
+    /// Deliberately part of `refreshHosts` rather than a timer of its own: that
+    /// is what the pane already calls on appear and after every host action, and
+    /// a background timer redrawing Settings is a cost with no reader.
+    public func refreshRejectionHint() {
+        guard let listener else {
+            rejectionHint = nil
+            return
+        }
+        rejectionHint = Self.rejectionHint(for: listener.rejectionSnapshot)
+    }
+
+    /// One sentence naming the likely cause, or nil when nothing was rejected.
+    ///
+    /// Short by owner rule — a Settings row has the same "no long text" problem
+    /// the popover does — and count-free on purpose: the number of rejections is
+    /// noise (a busy session produces one every few minutes), while WHICH KIND
+    /// they were is the whole diagnosis. The detail stays in the log.
+    static func rejectionHint(for snapshot: ClaudeRemoteRejectionTally.Snapshot) -> String? {
+        guard !snapshot.isEmpty else { return nil }
+        let cause: String
+        switch (snapshot.missingToken > 0, snapshot.unknownToken > 0) {
+        case (true, true):
+            cause = "an outdated plugin or a stale token"
+        case (true, false):
+            cause = "an outdated plugin — use Update Plugin"
+        case (false, true):
+            cause = "a stale token — rotate it and re-run setup"
+        case (false, false):
+            cause = "a malformed authorization header"
+        }
+        return "Rejected connections detected — a host may have \(cause)."
     }
 
     public func refreshListenerStatus() {

--- a/Sources/localvoxtral/ClaudeContext/ClaudeIntegrationSettingsModel.swift
+++ b/Sources/localvoxtral/ClaudeContext/ClaudeIntegrationSettingsModel.swift
@@ -103,6 +103,13 @@ public final class ClaudeIntegrationSettingsModel {
     /// Coarse on purpose: the question is "is this host still talking to me",
     /// and a to-the-second answer would only invite the user to read precision
     /// into a timestamp that is refreshed when the pane appears.
+    ///
+    /// `lastSeenAt` is the registry's IN-MEMORY value, persisted only on the
+    /// next persisting mutation (see `ClaudeRemoteHostRegistry.noteActivity` —
+    /// a disk write per hook event would be steady write amplification for a
+    /// dictation nicety). So a host that was active before a relaunch reads
+    /// "never" until its next hook event. That is the existing trade, not a
+    /// missing write.
     static func hostStatusText(isRevoked: Bool, lastSeenAt: Date?, now: Date) -> String {
         if isRevoked { return "Revoked" }
         guard let lastSeenAt else { return "Last context: never" }
@@ -452,6 +459,13 @@ public final class ClaudeIntegrationSettingsModel {
     /// the popover does — and count-free on purpose: the number of rejections is
     /// noise (a busy session produces one every few minutes), while WHICH KIND
     /// they were is the whole diagnosis. The detail stays in the log.
+    ///
+    /// The hedge in "a host MAY have" is deliberate. The listener counts every
+    /// rejected connection, and an enrolled host is not the only thing that can
+    /// reach a loopback port: a probe or a curl with no `Authorization` header
+    /// lands in `.missingToken` exactly like a pre-1.1.0 plugin does. Naming a
+    /// cause with certainty would sometimes accuse a host of a fault it does
+    /// not have.
     static func rejectionHint(for snapshot: ClaudeRemoteRejectionTally.Snapshot) -> String? {
         guard !snapshot.isEmpty else { return nil }
         let cause: String

--- a/Sources/localvoxtral/ClaudeContext/ClaudeRemoteContextListener.swift
+++ b/Sources/localvoxtral/ClaudeContext/ClaudeRemoteContextListener.swift
@@ -93,6 +93,11 @@ public final class ClaudeRemoteContextListener: Sendable {
     private let limits: ClaudeRemoteListenerLimits
     private let now: @Sendable () -> Date
     private let uptimeNanos: @Sendable () -> UInt64
+    /// Rejections since launch, for the Settings hint. Injected (rather than
+    /// owned) so it OUTLIVES this listener: the coordinator builds a fresh
+    /// listener on every rebind, and evidence the user has not read yet must not
+    /// be erased by enrolling a second host.
+    private let rejections: ClaudeRemoteRejectionTally
 
     #if DEBUG
     private let debugPostAuthenticationHook = Mutex<(@Sendable () -> Void)?>(nil)
@@ -129,18 +134,22 @@ public final class ClaudeRemoteContextListener: Sendable {
         registry: ClaudeSessionRegistry,
         hosts: ClaudeRemoteHostRegistry,
         limits: ClaudeRemoteListenerLimits = .default,
+        rejections: ClaudeRemoteRejectionTally = ClaudeRemoteRejectionTally(),
         now: @escaping @Sendable () -> Date = { Date() },
         uptimeNanos: @escaping @Sendable () -> UInt64 = { DispatchTime.now().uptimeNanoseconds }
     ) {
         self.registry = registry
         self.hosts = hosts
         self.limits = limits
+        self.rejections = rejections
         self.now = now
         self.uptimeNanos = uptimeNanos
     }
 
     public var isRunning: Bool { state.withLock { $0.isRunning } }
     public var port: UInt16 { limits.port }
+    /// Rejections since the tally was created, by category.
+    public var rejectionSnapshot: ClaudeRemoteRejectionTally.Snapshot { rejections.snapshot() }
 
     /// Bind loopback and start accepting.
     ///
@@ -401,8 +410,23 @@ public final class ClaudeRemoteContextListener: Sendable {
         // attacker could not guess from the public plugin manifest — but "the
         // answer is currently harmless" is not a reason to answer. Nothing is
         // discriminated on until the token is known good.
-        guard let token = request.bearerToken, let host = hosts.authenticate(token: token) else {
-            Log.claudeContext.error("Rejected unauthenticated connection to the remote listener")
+        //
+        // The rejection is CLASSIFIED on the way out. One undifferentiated line
+        // is what made a night of "Rejected unauthenticated connection" say
+        // nothing about whether the remedy was updating a host's plugin or
+        // re-running its enrollment (field report, 2026-07-26). The category is
+        // derived from the header's shape and the authentication result only —
+        // no token material reaches the log, the tally, or the UI.
+        let shape = ClaudeRemoteHTTPCodec.authorizationShape(
+            in: request.headers["authorization"], limits: limits.http
+        )
+        let candidate = request.bearerToken
+        let authenticatedHost = candidate.flatMap { hosts.authenticate(token: $0) }
+        guard let token = candidate, let host = authenticatedHost else {
+            let category = ClaudeRemoteRejectionCategory.category(for: shape, authenticated: false)
+                ?? .unknownToken
+            rejections.record(category)
+            Log.claudeContext.error("\(category.logLine, privacy: .public)")
             respond(fd: fd, status: 401)
             return
         }
@@ -475,7 +499,15 @@ public final class ClaudeRemoteContextListener: Sendable {
             limits: limits.wire,
             snippetLimits: limits.snippets
         ) else {
-            Log.claudeContext.error("Rejected remote record: unparseable payload")
+            // With the event, which is the one thing that makes this actionable:
+            // "every SessionStart is unparseable" and "one PostToolUse was" are
+            // different bugs. Taken from the URL the plugin manifest chose and
+            // narrowed to a KNOWN event name — the path is bounded but still
+            // peer-supplied, and a log line is not the place to find that out.
+            let event = Self.knownEventLabel(inPath: request.path)
+            Log.claudeContext.error(
+                "Rejected remote record: unparseable payload (event \(event, privacy: .public))"
+            )
             return nil
         }
 
@@ -572,6 +604,19 @@ public final class ClaudeRemoteContextListener: Sendable {
         // were dropped mid-body.
         guard buffer.count <= Self.maxBufferedBytes(for: limits.http) else { return false }
         return true
+    }
+
+    /// The event a hook path names, when it names one this app knows.
+    ///
+    /// An unrecognized (or absent) event reads as `unknown` rather than as
+    /// whatever the peer wrote: the path reached us bounded by the head limit,
+    /// not by an allowlist, and echoing it into the log would put peer-chosen
+    /// text there.
+    static func knownEventLabel(inPath path: String) -> String {
+        guard let name = ClaudeRemoteHTTPCodec.eventName(inPath: path),
+              ClaudeHookEvent(rawValue: name) != nil
+        else { return "unknown" }
+        return name
     }
 
     /// The largest buffer a well-formed request can legitimately occupy.

--- a/Sources/localvoxtral/ClaudeContext/ClaudeRemoteContextListener.swift
+++ b/Sources/localvoxtral/ClaudeContext/ClaudeRemoteContextListener.swift
@@ -423,8 +423,16 @@ public final class ClaudeRemoteContextListener: Sendable {
         let candidate = request.bearerToken
         let authenticatedHost = candidate.flatMap { hosts.authenticate(token: $0) }
         guard let token = candidate, let host = authenticatedHost else {
-            let category = ClaudeRemoteRejectionCategory.category(for: shape, authenticated: false)
-                ?? .unknownToken
+            // The REAL authentication result, not a constant `false`: the
+            // mapping's contract includes "an accepted credential is not a
+            // rejection", and its only production caller should exercise that
+            // rather than assert it. Reaching the fallback would mean
+            // `bearerToken` and `authorizationShape` disagreed about one header
+            // — impossible while the former is implemented on the latter, and
+            // `unknownToken` is the conservative reading if it ever were not.
+            let category = ClaudeRemoteRejectionCategory.category(
+                for: shape, authenticated: authenticatedHost != nil
+            ) ?? .unknownToken
             rejections.record(category)
             Log.claudeContext.error("\(category.logLine, privacy: .public)")
             respond(fd: fd, status: 401)

--- a/Sources/localvoxtral/ClaudeContext/ClaudeRemoteListenerCoordinator.swift
+++ b/Sources/localvoxtral/ClaudeContext/ClaudeRemoteListenerCoordinator.swift
@@ -12,6 +12,10 @@ import Foundation
 public protocol ClaudeRemoteListenerControlling: AnyObject {
     var isListening: Bool { get }
     var boundPort: UInt16 { get }
+    /// Connections turned away since launch, by category. Settings turns a
+    /// nonzero count into one short, actionable line — the failure this
+    /// diagnoses used to be visible only in the unified log.
+    var rejectionSnapshot: ClaudeRemoteRejectionTally.Snapshot { get }
 
     /// Bring the listener AND the cached sessions in line with the registry:
     /// bind if a host is now enrolled, stop if the last one just went away, and
@@ -47,13 +51,22 @@ public protocol ClaudeRemoteListenerControlling: AnyObject {
 public final class ClaudeRemoteListenerCoordinator: ClaudeRemoteListenerControlling {
     private let hosts: ClaudeRemoteHostRegistry
     private let sessions: ClaudeSessionRegistry
-    private let makeListener: @MainActor (ClaudeRemoteHostRegistry) -> ClaudeRemoteContextListener
+    private let makeListener:
+        @MainActor (ClaudeRemoteHostRegistry, ClaudeRemoteRejectionTally) -> ClaudeRemoteContextListener
     private var listener: ClaudeRemoteContextListener?
+    /// Held HERE, not in the listener, because `reconcile` replaces the listener
+    /// object on every 0→1 transition. A tally that lived in the listener would
+    /// forget a night of rejections the moment the user enrolled another host.
+    private let rejections = ClaudeRemoteRejectionTally()
 
+    /// - Parameter makeListener: handed the tally as well as the registry, so
+    ///   every listener this coordinator builds reports into the SAME counters.
     public init(
         hosts: ClaudeRemoteHostRegistry,
         sessions: ClaudeSessionRegistry,
-        makeListener: @escaping @MainActor (ClaudeRemoteHostRegistry) -> ClaudeRemoteContextListener
+        makeListener: @escaping @MainActor (
+            ClaudeRemoteHostRegistry, ClaudeRemoteRejectionTally
+        ) -> ClaudeRemoteContextListener
     ) {
         self.hosts = hosts
         self.sessions = sessions
@@ -61,13 +74,14 @@ public final class ClaudeRemoteListenerCoordinator: ClaudeRemoteListenerControll
     }
 
     public convenience init(hosts: ClaudeRemoteHostRegistry, sessions: ClaudeSessionRegistry) {
-        self.init(hosts: hosts, sessions: sessions) { registry in
-            ClaudeRemoteContextListener(registry: sessions, hosts: registry)
+        self.init(hosts: hosts, sessions: sessions) { registry, rejections in
+            ClaudeRemoteContextListener(registry: sessions, hosts: registry, rejections: rejections)
         }
     }
 
     public var isListening: Bool { listener?.isRunning ?? false }
     public var boundPort: UInt16 { listener?.port ?? ClaudeRemoteListenerLimits.default.port }
+    public var rejectionSnapshot: ClaudeRemoteRejectionTally.Snapshot { rejections.snapshot() }
 
     public func reconcile() throws {
         // Before the listener, and unconditionally: a bind that throws must not
@@ -82,7 +96,7 @@ public final class ClaudeRemoteListenerCoordinator: ClaudeRemoteListenerControll
             // A listener that died on its own (a failed poll) reports
             // `isRunning == false` while `listener` is still non-nil, so this
             // deliberately builds a fresh one rather than restarting the corpse.
-            let listener = makeListener(hosts)
+            let listener = makeListener(hosts, rejections)
             try listener.start()
             self.listener = listener
         } else {

--- a/Sources/localvoxtral/ClaudeContext/ClaudeRemoteRejection.swift
+++ b/Sources/localvoxtral/ClaudeContext/ClaudeRemoteRejection.swift
@@ -1,0 +1,98 @@
+import ClaudeContextWire
+import Foundation
+import Synchronization
+
+/// Why the remote listener turned a connection away, in the only three shapes
+/// that have different fixes.
+///
+/// Field report, 2026-07-26: the app's unified log carried an hours-long stream
+/// of one line — "Rejected unauthenticated connection to the remote listener" —
+/// once every few minutes. The cause was long-running remote sessions still on
+/// the pre-1.1.0 plugin, whose http hooks sent `Authorization: Bearer ` with an
+/// empty credential. That line could not tell that apart from a token that had
+/// been rotated out, and the app's UI said nothing at all: remote dictation
+/// simply had no context. Diagnosing it took a dispatched log-collection
+/// workflow. The three cases below each name their own remedy instead.
+public enum ClaudeRemoteRejectionCategory: String, Sendable, Equatable, CaseIterable {
+    /// No bearer credential at all — the pre-1.1.0 plugin's exact signature.
+    case missingToken
+    /// A credential arrived and matched no enrolled host.
+    case unknownToken
+    /// The `Authorization` header was not a bearer credential we would read.
+    case malformedAuthorization
+
+    /// One line, and never any token material — not the header, not the
+    /// credential, not its length. What the user needs is which of three fixes
+    /// to apply, and that is decided by the SHAPE alone.
+    public var logLine: String {
+        switch self {
+        case .missingToken:
+            return "Rejected remote connection: no bearer token — a pre-1.1.0 plugin or misconfigured hook; "
+                + "update the plugin on the host"
+        case .unknownToken:
+            return "Rejected remote connection: no enrolled host matches — rotated token or revoked host; "
+                + "re-run enrollment install with the current token"
+        case .malformedAuthorization:
+            return "Rejected remote connection: malformed Authorization header"
+        }
+    }
+
+    /// The category a head's authorization shape implies, given whether the
+    /// credential it carried authenticated.
+    ///
+    /// Pure, so the mapping is assertable without binding a port — and so the
+    /// listener has exactly one place where a shape becomes a diagnosis.
+    public static func category(
+        for shape: ClaudeRemoteAuthorizationShape,
+        authenticated: Bool
+    ) -> ClaudeRemoteRejectionCategory? {
+        switch shape {
+        case .missing: return .missingToken
+        case .malformed: return .malformedAuthorization
+        case .bearer: return authenticated ? nil : .unknownToken
+        }
+    }
+}
+
+/// How many connections have been rejected since launch, by category.
+///
+/// In memory and never persisted: this answers "is something wrong RIGHT NOW",
+/// which a count that survived a relaunch would answer wrongly. It is owned by
+/// the listener coordinator rather than by a listener, so a rebind (enrolling a
+/// host, revoking one) does not reset the evidence the user has not read yet.
+///
+/// `Mutex` + `Sendable`, per repo convention: the listener's connection threads
+/// record while the main actor reads for Settings.
+public final class ClaudeRemoteRejectionTally: Sendable {
+    public struct Snapshot: Sendable, Equatable {
+        public var missingToken: Int
+        public var unknownToken: Int
+        public var malformedAuthorization: Int
+
+        public init(missingToken: Int = 0, unknownToken: Int = 0, malformedAuthorization: Int = 0) {
+            self.missingToken = missingToken
+            self.unknownToken = unknownToken
+            self.malformedAuthorization = malformedAuthorization
+        }
+
+        public var isEmpty: Bool {
+            missingToken == 0 && unknownToken == 0 && malformedAuthorization == 0
+        }
+    }
+
+    private let counts = Mutex(Snapshot())
+
+    public init() {}
+
+    public func record(_ category: ClaudeRemoteRejectionCategory) {
+        counts.withLock { counts in
+            switch category {
+            case .missingToken: counts.missingToken += 1
+            case .unknownToken: counts.unknownToken += 1
+            case .malformedAuthorization: counts.malformedAuthorization += 1
+            }
+        }
+    }
+
+    public func snapshot() -> Snapshot { counts.withLock { $0 } }
+}

--- a/Sources/localvoxtral/SettingsView.swift
+++ b/Sources/localvoxtral/SettingsView.swift
@@ -984,6 +984,12 @@ private struct ClaudeRemoteHostsSettingsRow: View {
                     )
                 } else {
                     hostList
+                    // The only place a rejected connection is visible without
+                    // the unified log. It is what an hours-long stream of
+                    // rejections looked like from the app: nothing at all.
+                    if let hint = model.rejectionHint {
+                        SettingsInlineMessage(hint, color: .orange)
+                    }
                     enrollmentForm
                     listenerStatus
                 }
@@ -1030,15 +1036,13 @@ private struct ClaudeRemoteHostsSettingsRow: View {
                     HStack(spacing: 8) {
                         VStack(alignment: .leading, spacing: 1) {
                             Text(host.label).font(.callout)
-                            HStack(spacing: 3) {
-                                Text(host.statusText)
-                                // Self-updating, and no formatter to cache.
-                                if let lastSeenAt = host.lastSeenAt, !host.isRevoked {
-                                    Text(lastSeenAt, style: .relative)
-                                }
-                            }
-                            .font(.caption)
-                            .foregroundStyle(.secondary)
+                            // Rendered by the model against its injected clock —
+                            // "Last context: 2 min ago" — and refreshed with the
+                            // rest of the section. A tunnel that quietly stopped
+                            // delivering context is otherwise invisible here.
+                            Text(host.statusText)
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
                         }
                         Spacer()
                         Button("Update Plugin…") { model.requestPluginUpdate(hostID: host.id) }

--- a/Tests/localvoxtralTests/ClaudeIntegrationSettingsModelTests.swift
+++ b/Tests/localvoxtralTests/ClaudeIntegrationSettingsModelTests.swift
@@ -45,6 +45,9 @@ private final class StubListener: ClaudeRemoteListenerControlling {
     var reconcileCount = 0
     /// Thrown on the next reconcile that would bind.
     var bindError: (any Error)?
+    /// What the real listener would have counted. Set by a test to stand in for
+    /// a night of rejected connections.
+    var rejectionSnapshot = ClaudeRemoteRejectionTally.Snapshot()
 
     init(hosts: ClaudeRemoteHostRegistry) {
         self.hosts = hosts
@@ -107,7 +110,11 @@ final class ClaudeIntegrationSettingsModelTests: XCTestCase {
         registry: ClaudeRemoteHostRegistry?,
         listener: (any ClaudeRemoteListenerControlling)?,
         plugin: StubPluginService = StubPluginService(),
-        enrollmentService: ClaudeRemoteEnrollmentService = ClaudeRemoteEnrollmentService()
+        enrollmentService: ClaudeRemoteEnrollmentService = ClaudeRemoteEnrollmentService(),
+        // Frozen by default (AGENTS: no wall-clock in tests). The registry's
+        // own clock is pinned to the same instant, so a host that just reported
+        // reads as "just now" rather than as whatever the machine's clock did.
+        now: @escaping @Sendable () -> Date = { Date(timeIntervalSince1970: 1_000_000) }
     ) -> ClaudeIntegrationSettingsModel {
         ClaudeIntegrationSettingsModel(
             registry: registry,
@@ -134,7 +141,8 @@ final class ClaudeIntegrationSettingsModelTests: XCTestCase {
                         failure: ClaudeEnrollmentActionFailure(error)
                     )
                 }
-            }
+            },
+            now: now
         )
     }
 
@@ -536,7 +544,8 @@ final class ClaudeIntegrationSettingsModelTests: XCTestCase {
                         failure: ClaudeEnrollmentActionFailure(error)
                     )
                 }
-            }
+            },
+            now: { Date(timeIntervalSince1970: 1_000_000) }
         )
         model.enrollLabel = "buildhost"
         model.enrollSSHAlias = "builder"
@@ -972,6 +981,122 @@ final class ClaudeIntegrationSettingsModelTests: XCTestCase {
 
         XCTAssertTrue(listener.isListening)
         XCTAssertEqual(model.listenerStatus, .listening(port: 8473))
+    }
+
+    // MARK: Last-heard and rejection diagnostics
+
+    /// The row has to answer "is this host still sending me context", because a
+    /// tunnel that quietly stopped looks exactly like one that works.
+    func testTheHostRowAgesLastContextAgainstTheInjectedClock() {
+        let seen = Date(timeIntervalSince1970: 1_000_000)
+        let format = { (offset: TimeInterval) in
+            ClaudeIntegrationSettingsModel.hostStatusText(
+                isRevoked: false, lastSeenAt: seen, now: seen.addingTimeInterval(offset)
+            )
+        }
+        XCTAssertEqual(format(0), "Last context: just now")
+        XCTAssertEqual(format(59), "Last context: just now")
+        XCTAssertEqual(format(60), "Last context: 1 min ago")
+        XCTAssertEqual(format(2 * 60 + 30), "Last context: 2 min ago")
+        XCTAssertEqual(format(59 * 60), "Last context: 59 min ago")
+        XCTAssertEqual(format(3600), "Last context: 1 hour ago")
+        XCTAssertEqual(format(5 * 3600), "Last context: 5 hours ago")
+        XCTAssertEqual(format(26 * 3600), "Last context: 1 day ago")
+        XCTAssertEqual(format(3 * 86_400), "Last context: 3 days ago")
+        // A clock that stepped backwards must not print a negative age.
+        XCTAssertEqual(format(-600), "Last context: just now")
+    }
+
+    func testAHostThatHasNeverReportedSaysSoAndARevokedOneSaysOnlyThat() {
+        XCTAssertEqual(
+            ClaudeIntegrationSettingsModel.hostStatusText(
+                isRevoked: false, lastSeenAt: nil, now: Date(timeIntervalSince1970: 1_000_000)
+            ),
+            "Last context: never"
+        )
+        XCTAssertEqual(
+            ClaudeIntegrationSettingsModel.hostStatusText(
+                isRevoked: true,
+                lastSeenAt: Date(timeIntervalSince1970: 999_000),
+                now: Date(timeIntervalSince1970: 1_000_000)
+            ),
+            "Revoked",
+            "a revoked host's age is not the fact the user needs"
+        )
+    }
+
+    func testRefreshBuildsTheRowStatusFromTheRegistrysActivity() async throws {
+        let registry = try makeRegistry()
+        let model = makeModel(
+            registry: registry,
+            listener: StubListener(hosts: registry),
+            // 10 minutes after the registry's frozen clock.
+            now: { Date(timeIntervalSince1970: 1_000_600) }
+        )
+        model.enrollLabel = "buildhost"
+        model.enrollSSHAlias = "builder"
+        await model.enroll()
+        XCTAssertEqual(model.hosts.first?.statusText, "Last context: never")
+
+        registry.noteActivity(hostID: try XCTUnwrap(model.hosts.first?.id))
+        model.refreshHosts()
+        XCTAssertEqual(model.hosts.first?.statusText, "Last context: 10 min ago")
+    }
+
+    /// Tonight's failure, made visible: the app knew connections were being
+    /// rejected and said nothing anywhere the user would look.
+    func testRejectedConnectionsSurfaceAsOneShortInlineMessage() throws {
+        let registry = try makeRegistry()
+        let listener = StubListener(hosts: registry)
+        let model = makeModel(registry: registry, listener: listener)
+        XCTAssertNil(model.rejectionHint, "nothing rejected, nothing to say")
+
+        listener.rejectionSnapshot = ClaudeRemoteRejectionTally.Snapshot(missingToken: 42)
+        model.refreshHosts()
+
+        let hint = try XCTUnwrap(model.rejectionHint)
+        XCTAssertTrue(hint.contains("outdated plugin"))
+        XCTAssertFalse(hint.contains("42"), "a count is noise; the KIND is the diagnosis")
+        // Owner rule: no long text in the pane.
+        XCTAssertLessThan(hint.count, 110)
+        XCTAssertFalse(hint.contains("\n"))
+    }
+
+    func testTheHintNamesWhichKindOfRejectionItWas() {
+        let hint = { (snapshot: ClaudeRemoteRejectionTally.Snapshot) in
+            ClaudeIntegrationSettingsModel.rejectionHint(for: snapshot)
+        }
+        XCTAssertNil(hint(ClaudeRemoteRejectionTally.Snapshot()))
+        XCTAssertEqual(
+            hint(ClaudeRemoteRejectionTally.Snapshot(missingToken: 1)),
+            "Rejected connections detected — a host may have an outdated plugin — use Update Plugin."
+        )
+        XCTAssertEqual(
+            hint(ClaudeRemoteRejectionTally.Snapshot(unknownToken: 1)),
+            "Rejected connections detected — a host may have a stale token — rotate it and re-run setup."
+        )
+        XCTAssertEqual(
+            hint(ClaudeRemoteRejectionTally.Snapshot(missingToken: 1, unknownToken: 1)),
+            "Rejected connections detected — a host may have an outdated plugin or a stale token."
+        )
+        XCTAssertEqual(
+            hint(ClaudeRemoteRejectionTally.Snapshot(malformedAuthorization: 1)),
+            "Rejected connections detected — a host may have a malformed authorization header."
+        )
+        for snapshot in [
+            ClaudeRemoteRejectionTally.Snapshot(missingToken: 1),
+            ClaudeRemoteRejectionTally.Snapshot(unknownToken: 1),
+            ClaudeRemoteRejectionTally.Snapshot(missingToken: 1, unknownToken: 1),
+            ClaudeRemoteRejectionTally.Snapshot(malformedAuthorization: 1),
+        ] {
+            XCTAssertLessThan(hint(snapshot)?.count ?? .max, 110)
+        }
+    }
+
+    func testAModelWithNoListenerNeverInventsAHint() {
+        let model = makeModel(registry: nil, listener: nil)
+        model.refreshRejectionHint()
+        XCTAssertNil(model.rejectionHint)
     }
 
     func testAnUnreadableRegistryDisablesTheRemoteSurfaceRatherThanFailingSilently() {

--- a/Tests/localvoxtralTests/ClaudeRemoteContextListenerTests.swift
+++ b/Tests/localvoxtralTests/ClaudeRemoteContextListenerTests.swift
@@ -138,16 +138,24 @@ final class ClaudeRemoteContextListenerTests: XCTestCase {
         return Response(status: status, body: body)
     }
 
+    /// - Parameter rawAuthorization: the `Authorization` value verbatim, for the
+    ///   shapes a token argument cannot express — an empty credential (what a
+    ///   pre-1.1.0 plugin sent) or another scheme entirely.
     private func hookRequest(
         event: String = "SessionStart",
         token: String?,
         payload: [String: Any] = ["session_id": "s-1", "cwd": "/srv/app"],
         contentLengthOverride: Int? = nil,
-        extraHeaders: [String] = []
+        extraHeaders: [String] = [],
+        rawAuthorization: String? = nil
     ) -> Data {
         var body = try! JSONSerialization.data(withJSONObject: payload)
         var text = "POST /v1/hook/\(event) HTTP/1.1\r\nHost: 127.0.0.1\r\n"
-        if let token { text += "Authorization: Bearer \(token)\r\n" }
+        if let rawAuthorization {
+            text += "Authorization: \(rawAuthorization)\r\n"
+        } else if let token {
+            text += "Authorization: Bearer \(token)\r\n"
+        }
         for header in extraHeaders { text += header + "\r\n" }
         text += "Content-Type: application/json\r\n"
         text += "Content-Length: \(contentLengthOverride ?? body.count)\r\n\r\n"
@@ -329,6 +337,136 @@ final class ClaudeRemoteContextListenerTests: XCTestCase {
             "a 400 here would mean the body was read before the token was checked"
         )
         XCTAssertTrue(sessions.liveSessions().isEmpty)
+    }
+
+    // MARK: - Rejection diagnosis
+
+    /// The field case (2026-07-26): hours of rejections from remote sessions
+    /// still running the pre-1.1.0 plugin, whose http hook sent `Bearer ` with
+    /// nothing after it. The old single log line could not tell that apart from
+    /// a rotated token, so the remedy was unknowable from the log.
+    func testAnEmptyBearerCredentialIsDiagnosedAsAPluginProblem() throws {
+        try startListener()
+        let response = try XCTUnwrap(try send(hookRequest(token: nil, rawAuthorization: "Bearer ")))
+        XCTAssertEqual(response.status, 401)
+
+        let tally = listener.rejectionSnapshot
+        XCTAssertEqual(tally.missingToken, 1)
+        XCTAssertEqual(tally.unknownToken, 0)
+        XCTAssertEqual(tally.malformedAuthorization, 0)
+    }
+
+    func testAnAbsentAuthorizationHeaderCountsAsAMissingToken() throws {
+        try startListener()
+        XCTAssertEqual(try send(hookRequest(token: nil))?.status, 401)
+        XCTAssertEqual(listener.rejectionSnapshot.missingToken, 1)
+    }
+
+    /// The other half of the same night's ambiguity: a credential that is a
+    /// perfectly good token and simply is not ours any more.
+    func testAnUnrecognizedTokenIsDiagnosedAsAStaleCredential() throws {
+        try startListener()
+        XCTAssertEqual(try send(hookRequest(token: ClaudeRemoteTokenDigest.makeToken()))?.status, 401)
+
+        let tally = listener.rejectionSnapshot
+        XCTAssertEqual(tally.unknownToken, 1)
+        XCTAssertEqual(tally.missingToken, 0, "a token DID arrive; blaming the plugin would misdirect")
+        XCTAssertEqual(tally.malformedAuthorization, 0)
+    }
+
+    func testARotatedTokenIsReportedAsUnknownRatherThanMissing() throws {
+        try startListener()
+        _ = try hosts.rotateToken(hostID: hostID)
+        XCTAssertEqual(try send(hookRequest(token: token))?.status, 401)
+        XCTAssertEqual(listener.rejectionSnapshot.unknownToken, 1)
+        XCTAssertEqual(listener.rejectionSnapshot.missingToken, 0)
+    }
+
+    func testANonBearerSchemeIsItsOwnCategory() throws {
+        try startListener()
+        let response = try XCTUnwrap(
+            try send(hookRequest(token: nil, rawAuthorization: "Basic ZGV2Omh1bnRlcjI="))
+        )
+        XCTAssertEqual(response.status, 401)
+
+        let tally = listener.rejectionSnapshot
+        XCTAssertEqual(tally.malformedAuthorization, 1)
+        XCTAssertEqual(tally.missingToken, 0)
+        XCTAssertEqual(tally.unknownToken, 0)
+    }
+
+    func testTheThreeCategoriesAccumulateIndependently() throws {
+        try startListener()
+        _ = try send(hookRequest(token: nil, rawAuthorization: "Bearer "))
+        _ = try send(hookRequest(token: nil, rawAuthorization: "Bearer "))
+        _ = try send(hookRequest(token: ClaudeRemoteTokenDigest.makeToken()))
+        _ = try send(hookRequest(token: nil, rawAuthorization: "Basic ZGV2"))
+        // A successful request must not be counted as anything.
+        XCTAssertEqual(try send(hookRequest(token: token))?.status, 200)
+
+        XCTAssertEqual(
+            listener.rejectionSnapshot,
+            ClaudeRemoteRejectionTally.Snapshot(
+                missingToken: 2, unknownToken: 1, malformedAuthorization: 1
+            )
+        )
+    }
+
+    /// Whatever the category, the response is still silent. A rejection that
+    /// explained itself on the wire would explain it to an attacker too; the
+    /// diagnosis is for the local log and the local UI.
+    func testTheDiagnosisNeverLeavesTheMachine() throws {
+        try startListener()
+        for authorization in ["Bearer ", "Basic ZGV2", "Bearer \(ClaudeRemoteTokenDigest.makeToken())"] {
+            let response = try XCTUnwrap(
+                try send(hookRequest(token: nil, rawAuthorization: authorization))
+            )
+            XCTAssertEqual(response.status, 401)
+            XCTAssertEqual(response.body, "", "a rejection must say nothing at all")
+        }
+    }
+
+    func testShapeAndAuthenticationResultDecideTheCategory() {
+        XCTAssertEqual(
+            ClaudeRemoteRejectionCategory.category(for: .missing, authenticated: false), .missingToken
+        )
+        XCTAssertEqual(
+            ClaudeRemoteRejectionCategory.category(for: .malformed, authenticated: false),
+            .malformedAuthorization
+        )
+        XCTAssertEqual(
+            ClaudeRemoteRejectionCategory.category(for: .bearer("t"), authenticated: false), .unknownToken
+        )
+        XCTAssertNil(
+            ClaudeRemoteRejectionCategory.category(for: .bearer("t"), authenticated: true),
+            "an accepted credential is not a rejection"
+        )
+    }
+
+    /// Each line names its own remedy, stays on one line, and — the rule that
+    /// matters — is a constant, so no token, header, or length can reach it.
+    func testEveryRejectionLineIsOneShortActionableSentence() {
+        for category in ClaudeRemoteRejectionCategory.allCases {
+            let line = category.logLine
+            XCTAssertFalse(line.contains("\n"), "\(category): one line")
+            XCTAssertLessThan(line.count, 180, "\(category): the detail belongs in the code, not the log")
+        }
+        XCTAssertTrue(ClaudeRemoteRejectionCategory.missingToken.logLine.contains("update the plugin"))
+        XCTAssertTrue(ClaudeRemoteRejectionCategory.unknownToken.logLine.contains("re-run enrollment"))
+    }
+
+    func testAnUnparseablePayloadNamesItsEventAndNothingElse() throws {
+        XCTAssertEqual(
+            ClaudeRemoteContextListener.knownEventLabel(inPath: "/v1/hook/PostToolUse"),
+            "PostToolUse"
+        )
+        // Peer-supplied text never reaches the log: an event this app does not
+        // know reads as `unknown`, not as whatever was in the URL.
+        XCTAssertEqual(
+            ClaudeRemoteContextListener.knownEventLabel(inPath: "/v1/hook/DROP TABLE hosts"),
+            "unknown"
+        )
+        XCTAssertEqual(ClaudeRemoteContextListener.knownEventLabel(inPath: "/admin"), "unknown")
     }
 
     // MARK: - Routing and bounds

--- a/Tests/localvoxtralTests/ClaudeRemoteHTTPTests.swift
+++ b/Tests/localvoxtralTests/ClaudeRemoteHTTPTests.swift
@@ -215,6 +215,45 @@ final class ClaudeRemoteHTTPTests: XCTestCase {
         )
     }
 
+    // MARK: Authorization shape
+
+    /// Why a header yielded no credential, which decides which of two fixes the
+    /// user needs: update the plugin, or re-run enrollment.
+    func testAuthorizationShapeSeparatesAMissingCredentialFromAMalformedHeader() {
+        XCTAssertEqual(ClaudeRemoteHTTPCodec.authorizationShape(in: nil), .missing)
+        // The pre-1.1.0 plugin's exact wire shape. The head parser trims the
+        // trailing space, so this arrives as a bare scheme.
+        XCTAssertEqual(ClaudeRemoteHTTPCodec.authorizationShape(in: "Bearer"), .missing)
+        XCTAssertEqual(ClaudeRemoteHTTPCodec.authorizationShape(in: "Bearer   "), .missing)
+        XCTAssertEqual(ClaudeRemoteHTTPCodec.authorizationShape(in: ""), .missing)
+        XCTAssertEqual(ClaudeRemoteHTTPCodec.authorizationShape(in: "Basic abc"), .malformed)
+        XCTAssertEqual(ClaudeRemoteHTTPCodec.authorizationShape(in: "abc"), .malformed)
+        XCTAssertEqual(
+            ClaudeRemoteHTTPCodec.authorizationShape(in: "Bearer " + String(repeating: "a", count: 4096)),
+            .malformed,
+            "an oversized header is refused, not classified as a credential we failed to read"
+        )
+        XCTAssertEqual(ClaudeRemoteHTTPCodec.authorizationShape(in: "bearer abc"), .bearer("abc"))
+    }
+
+    /// The classifier IS the bearer path, so the two can never disagree about
+    /// which strings are credentials.
+    func testBearerTokenAndShapeAgreeOnEveryCase() {
+        let cases: [String?] = [
+            nil, "", "Bearer", "Bearer ", "Bearer abc", "bearer abc", "Basic abc", "abc",
+            "Bearer a b", "Bearer " + String(repeating: "a", count: 4096),
+        ]
+        for value in cases {
+            let shape = ClaudeRemoteHTTPCodec.authorizationShape(in: value)
+            let token = ClaudeRemoteHTTPCodec.bearerToken(in: value)
+            if case .bearer(let credential) = shape {
+                XCTAssertEqual(token, credential, "disagreed on \(value ?? "nil")")
+            } else {
+                XCTAssertNil(token, "disagreed on \(value ?? "nil")")
+            }
+        }
+    }
+
     // MARK: Event path
 
     func testEventNameIsRecoveredFromThePath() {

--- a/Tests/localvoxtralTests/ClaudeRemoteListenerCoordinatorTests.swift
+++ b/Tests/localvoxtralTests/ClaudeRemoteListenerCoordinatorTests.swift
@@ -27,6 +27,14 @@ private final class CoordinatorMarkerQueue: Sendable {
     }
 }
 
+/// Every tally the coordinator handed a listener, in order. A local `var`
+/// cannot be captured by the escaping factory closure.
+@MainActor
+private final class TalliesHandedToListeners {
+    private(set) var all: [ClaudeRemoteRejectionTally] = []
+    func append(_ tally: ClaudeRemoteRejectionTally) { all.append(tally) }
+}
+
 @MainActor
 final class ClaudeRemoteListenerCoordinatorTests: XCTestCase {
     private let epoch = Date(timeIntervalSince1970: 3_000_000)
@@ -54,11 +62,12 @@ final class ClaudeRemoteListenerCoordinatorTests: XCTestCase {
         hosts: ClaudeRemoteHostRegistry,
         sessions: ClaudeSessionRegistry
     ) -> ClaudeRemoteListenerCoordinator {
-        ClaudeRemoteListenerCoordinator(hosts: hosts, sessions: sessions) { registry in
+        ClaudeRemoteListenerCoordinator(hosts: hosts, sessions: sessions) { registry, rejections in
             ClaudeRemoteContextListener(
                 registry: sessions,
                 hosts: registry,
-                limits: ClaudeRemoteListenerLimits(port: 0)
+                limits: ClaudeRemoteListenerLimits(port: 0),
+                rejections: rejections
             )
         }
     }
@@ -94,6 +103,45 @@ final class ClaudeRemoteListenerCoordinatorTests: XCTestCase {
         try hosts.revoke(hostID: enrollment.host.id)
         try coordinator.reconcile()
         XCTAssertFalse(coordinator.isListening)
+    }
+
+    /// The rejection counters belong to the coordinator, not to a listener.
+    /// `reconcile` builds a NEW listener on every 0→1 transition, so a tally
+    /// that lived in the listener would forget a night of rejected connections
+    /// the moment the user revoked and re-enrolled a host — losing exactly the
+    /// evidence the Settings hint exists to show.
+    func testRejectionCountersSurviveARebind() throws {
+        let hosts = try makeHosts()
+        let sessions = ClaudeSessionRegistry()
+        let handed = TalliesHandedToListeners()
+        let coordinator = ClaudeRemoteListenerCoordinator(
+            hosts: hosts, sessions: sessions
+        ) { registry, rejections in
+            handed.append(rejections)
+            return ClaudeRemoteContextListener(
+                registry: sessions,
+                hosts: registry,
+                limits: ClaudeRemoteListenerLimits(port: 0),
+                rejections: rejections
+            )
+        }
+        defer { coordinator.shutdown() }
+
+        let enrollment = try hosts.enroll(label: "builder")
+        try coordinator.reconcile()
+        handed.all.first?.record(.missingToken)
+
+        try hosts.revoke(hostID: enrollment.host.id)
+        try coordinator.reconcile()
+        _ = try hosts.rotateToken(hostID: enrollment.host.id)
+        try coordinator.reconcile()
+
+        XCTAssertEqual(handed.all.count, 2, "the rebind built a second listener")
+        XCTAssertTrue(handed.all[0] === handed.all[1], "and handed it the same counters")
+        XCTAssertEqual(
+            coordinator.rejectionSnapshot,
+            ClaudeRemoteRejectionTally.Snapshot(missingToken: 1)
+        )
     }
 
     func testRevokingAHostEvictsItsCachedSessionsAndMarkers() throws {


### PR DESCRIPTION
## Stack

Stacked on **#197** (`remote-plugin-update-path` — per-host Update Plugin action) and targets that branch, not `main`. Merge #197 first; do not delete the base branch while this is open.

## What

Field evidence, tonight: the Mac app's unified log carried an hours-long stream of one line, once every few minutes —

```
[com.localvoxtral:ClaudeContext] Rejected unauthenticated connection to the remote listener
```

The cause turned out to be long-running remote Claude Code sessions still running the pre-1.1.0 plugin, whose http hooks sent `Authorization: Bearer ` (empty credential). But that log line cannot distinguish an EMPTY token from a WRONG one (stale after rotation), and the app's UI said nothing at all — remote dictation just silently had no context. Diagnosing it needed a workflow-dispatched log collection plus manual probing. This PR makes the same failure self-describing.

Three parts, all diagnostics — the auth path itself does not move.

**1. The rejection is classified on the way out.** `ClaudeRemoteHTTPCodec.authorizationShape(in:)` keeps the answer `bearerToken(in:)` used to collapse to `nil`, and `ClaudeRemoteRejectionCategory` turns it into one of three lines:

| case | log line |
|---|---|
| missing / empty bearer | `Rejected remote connection: no bearer token — a pre-1.1.0 plugin or misconfigured hook; update the plugin on the host` |
| well-formed, unrecognized | `Rejected remote connection: no enrolled host matches — rotated token or revoked host; re-run enrollment install with the current token` |
| malformed `Authorization` | `Rejected remote connection: malformed Authorization header` |

Each line is a CONSTANT — no token, no header contents, no lengths, nothing derived from the credential, so `ClaudeRemoteTokenRedaction` has nothing to redact here by construction. `bearerToken` is now implemented in terms of the classifier, so the two can never disagree about which strings are credentials (there is a test that walks every case through both).

The existing `Rejected remote record: unparseable payload` line now names its event — narrowed through `ClaudeHookEvent(rawValue:)` first, so peer-supplied path text can never reach the log (`unknown` otherwise).

**2. Per-host "last heard" in Settings.** `ClaudeRemoteHostRegistry` ALREADY tracked this: `noteActivity(hostID:)` stamps `lastSeenAt` after every authenticated request (in memory; persisted on the next mutation, deliberately, to avoid a disk write per hook event). Nothing was added to the registry. What changed is the surfacing: the row previously read `"Last seen"` + a self-ticking `Text(_:style:.relative)`; it now reads `Last context: 2 min ago` / `Last context: never` / `Revoked`, rendered by `ClaudeIntegrationSettingsModel` against an **injected clock** (`now:` seam, frozen in tests) and refreshed by the existing `refreshHosts()` — which the pane already calls on `.onAppear` and after every host action. No timer, no `Date()` in the view.

Known and accepted: because `lastSeenAt` persists only on the next registry mutation, a host that was active before a relaunch reads `never` until its next hook event. That is the pre-existing write-amplification trade, not new behaviour.

**3. Stale-signal hint.** `ClaudeRemoteRejectionTally` (Mutex, `Sendable`) counts rejections since launch by category. It is owned by `ClaudeRemoteListenerCoordinator`, not by a listener — `reconcile()` builds a NEW listener on every 0→1 transition, so a tally inside the listener would forget a night of rejections the moment the user enrolled another host. When nonzero, the hosts section shows ONE short `SettingsInlineMessage`:

> Rejected connections detected — a host may have an outdated plugin — use Update Plugin.
> Rejected connections detected — a host may have a stale token — rotate it and re-run setup.
> Rejected connections detected — a host may have an outdated plugin or a stale token.

Count-free on purpose (a busy session produces one every few minutes; the KIND is the diagnosis), and asserted under 110 characters — owner rule, no long text in a pane.

**Invariants deliberately unchanged:** auth still runs on the head alone before a byte of body is read; the constant-time compare and the registry's no-early-exit loop are untouched; the 401 is still silent on the wire (`testTheDiagnosisNeverLeavesTheMachine`) — the diagnosis is for the local log and the local UI only. `post.sh`/`hooks.json` are not touched.

## Proof

- [x] Unit suite green — `./scripts/remote-build.sh`

```
Executed 2057 tests, with 2 tests skipped and 0 failures (0 unexpected) in 71.137 (71.231) seconds
```

(Rebased onto `remote-plugin-update-path`'s review-fix commit `0b4d3c8`, which added `HostRow.sshHostAlias`; the one conflict was that struct's initializer, and both fields are kept. The suite line above is the post-rebase run.)

- [x] Focused lane — `./scripts/remote-build.sh test --filter ClaudeRemote`

```
Executed 253 tests, with 0 failures (0 unexpected) in 4.391 (4.401) seconds
```

- [x] The new tests FAIL against the old undifferentiated behaviour. Collapsing the classification back to one category (`let category = .unknownToken` in place of the shape mapping) and re-running the listener suite:

```
Executed 35 tests, with 6 failures (0 unexpected) in 0.443 (0.446) seconds

testAnEmptyBearerCredentialIsDiagnosedAsAPluginProblem
testAnAbsentAuthorizationHeaderCountsAsAMissingToken
testANonBearerSchemeIsItsOwnCategory
testTheThreeCategoriesAccumulateIndependently
  XCTAssertEqual failed: ("Snapshot(missingToken: 0, unknownToken: 4, malformedAuthorization: 0)")
                     is not equal to ("Snapshot(missingToken: 2, unknownToken: 1, malformedAuthorization: 1)")
```

Reverting the collapse returns the suite to the 253/0 line above.

New coverage (all through the existing raw-POSIX-socket client, real bytes on a real loopback port):

* `ClaudeRemoteContextListenerTests` — empty `Bearer `, absent header, unrecognized token, rotated token, non-Bearer scheme, the three counters accumulating independently, a 200 counting as nothing, the 401 body staying empty in every category, the shape→category mapping, the log lines being one short actionable sentence each, and `knownEventLabel` refusing peer text.
* `ClaudeRemoteHTTPTests` — `authorizationShape` cases, and `bearerToken`/`authorizationShape` agreeing on every input.
* `ClaudeRemoteListenerCoordinatorTests` — the tally survives a revoke→rebind and is the same instance across listeners.
* `ClaudeIntegrationSettingsModelTests` — relative formatting against an injected clock (never / just now / minutes / hours / days / a backwards clock step), `Revoked` beating the age, the row built from the registry's activity, and the hint's visibility, wording, kind-selection, count-freeness and length bound.

No test was weakened; no threshold, assertion, skip or tolerance changed. Two test stubs gained the protocol's new `rejectionSnapshot` member and the coordinator factory's second parameter. Zero new compiler warnings (the three in `.build/last-remote.log` are pre-existing, in `ClaudePluginInstallService.swift` and `ClaudeHookPublisherTests.swift`, both untouched here).

- [ ] **UI rows flagged for owner hand-test** — no automated UI tier yet. Two things to eyeball in Settings → Claude Code: (a) each enrolled host row now reads `Last context: …` on one line where it used to read `Last seen` plus a live-ticking relative date (the value now refreshes when the pane appears rather than ticking on its own), and (b) after any rejected connection, one orange sentence appears between the host list and the enroll form. Both are strings the model renders and unit-tests assert; what needs eyes is layout in the row.

**LLM lane:** `Sources/localvoxtral/ClaudeContext/**` is in `scripts/ci/llm-lane-filter.sh`, so the polishd live-model lane RAN on this PR and passed (run 30310484213, step "Polishing helper integration (live model + eval baseline)": success; whole check `build-test` pass in 6m22s). Nothing here changes what reaches the model — no prompt, context attachment, vocabulary, budget or request-shape path is touched; the diff is a log line, a status string, and a counter.

---

## Review round 1 — fixes (commit `0b4d3c8`)

Two independent reviews (opencode/GLM, codex/GPT-5.6). All four findings fixed on this branch.

**1. The executable alias was guessed from the display name (correctness/safety).** Name and
SSH alias are separate fields on the enrollment form, so a host named `prod` reached over alias
`builder` would have been updated as `ssh prod …` — a different machine. **Rotation shared the
flaw with worse consequences**: it hands a *fresh token* to whatever answers to the guessed name.
Fixed by persisting the enrolled alias (chosen over asking again in the panel: the app already
knows the answer, and a second place to type it is a second place to get it wrong). New optional
`StoredHost.sshHostAlias`, no file-version bump — an older build ignores the key, a newer build
reading an older file gets nil. The registry stores only what `isValidHostAlias` accepts, since a
stored alias later reaches ssh's argv. Hosts with no alias on file are copy-only (update panel
*and* rotation sheet), never a guess.

Red (alias re-derived from the label), then green after:

```
ClaudeIntegrationSettingsModelTests.swift:635: error: -[… testPluginUpdateShowsThatHostsCommandsAndRunsNothingYet] : XCTAssertEqual failed: ("Optional("prod")") is not equal to ("Optional("builder")") - the update must target the enrolled alias, never the display name
ClaudeIntegrationSettingsModelTests.swift:642: error: -[… testPluginUpdateShowsThatHostsCommandsAndRunsNothingYet] : XCTAssertFalse failed - updating the wrong host is the whole risk
ClaudeIntegrationSettingsModelTests.swift:798: error: -[… testPluginUpdateIsCopyOnlyForAHostWithNoRecordedAlias] : XCTAssertNil failed: "buildhost"
ClaudeIntegrationSettingsModelTests.swift:809: error: -[… testPluginUpdateIsCopyOnlyForAHostWithNoRecordedAlias] : XCTAssertEqual failed: ("2") is not equal to ("0") - a placeholder alias must never reach ssh
```

New tests: `testTheEnrolledSSHAliasIsPersistedSeparatelyFromTheLabel`,
`testAnUnusableSSHAliasIsNotStoredAtAll`, `testAHostStoredBeforeAliasesWereRecordedLoadsWithoutOne`
(registry); `testRotationTargetsTheEnrolledAliasNotTheDisplayName`,
`testRotatingAHostEnrolledBeforeAliasesWereRecordedIsCopyOnly`,
`testPluginUpdateIsCopyOnlyForAHostWithNoRecordedAlias` (model).
`testThePublicHostViewExposesNoSecretMaterial`'s reflection allowlist gained `sshHostAlias` — an
ssh-config name, not a credential; the allowlist is exhaustive by design, so it is updated, not relaxed.

**2. `isValidHostAlias` allowed a leading `-` (security).** `-V` reached ssh's argv as an option:
OpenSSH prints its version, exits 0, connects to nothing, and every step reports success. **This
was reachable on the pre-existing setup path too** (`executeRemoteSetup` has always taken the
enrolled alias through the same validator) — not only on the update path this PR adds. Leading
hyphens and all-dot aliases are now rejected, and the spawned argv terminates option parsing with
`--` before the alias. The displayed/copyable commands are left idiomatic (`ssh builder '…'`):
the validator is what guarantees them, and the user sees the alias they typed.

Red (hyphen rule and `--` both removed), then green after:

```
ClaudeRemoteEnrollmentServiceTests.swift:129: error: -[… testAnAliasCanNeverBeMistakenForAnSSHOption] : XCTAssertFalse failed - '-V' must not be accepted as an alias
ClaudeRemoteEnrollmentServiceTests.swift:129: error: -[… testAnAliasCanNeverBeMistakenForAnSSHOption] : XCTAssertFalse failed - '-oProxyCommand' must not be accepted as an alias
ClaudeRemoteEnrollmentServiceTests.swift:129: error: -[… testAnAliasCanNeverBeMistakenForAnSSHOption] : XCTAssertFalse failed - '.' must not be accepted as an alias
ClaudeRemoteEnrollmentServiceTests.swift:156: error: -[… testTheSpawnedArgvTerminatesOptionParsingBeforeTheAlias] : XCTUnwrap failed: expected non-nil value of type "Int"
	 Executed 51 tests, with 14 failures (0 unexpected) in 0.181 (0.183) seconds
```

The same test asserts ordinary aliases (`build-host`, `build.host.local`, `a-1.b_2`) still pass.

**3. The late-result guard was untested.** New
`testAResultFromAHostRemovedMidUpdateNeverSurfaces` parks the injected `performEnrollmentAsync`
on an `AsyncStream` gate (no wall-clock), removes the host mid-run, releases, and asserts no
statuses, no result action, **and no alert** — with a *failing* runner, so a leak would be loud.
Red with the guard deleted, then green after:

```
ClaudeIntegrationSettingsModelTests.swift:869: error: -[… testAResultFromAHostRemovedMidUpdateNeverSurfaces] : XCTAssertTrue failed - a removed host's outcome has no row to render in
ClaudeIntegrationSettingsModelTests.swift:873: error: -[… testAResultFromAHostRemovedMidUpdateNeverSurfaces] : XCTAssertNil failed: "updateRemotePlugin(hostID: "hcaaed3bd")"
ClaudeIntegrationSettingsModelTests.swift:874: error: -[… testAResultFromAHostRemovedMidUpdateNeverSurfaces] : XCTAssertNil failed: "DetailAlert(… title: "Remote Claude Code plugin", detail: "Plugin update exited with code 1.…")" - and no alert about a host that is gone
```

Remove also gained `.disabled(model.isPerformingEnrollmentAction)`, matching Close/Update.

**4. The failure alert said "SSH setup" for a plugin update.** `enrollmentFailureDetail` now takes
the action and names it ("Plugin update exited with code 1."), and
`testAFailedPluginUpdateIsAShortStatusAndADetailedAlert` asserts the detail's prefix and that it
does **not** contain "SSH setup".

Suites after the fixes:

```
$ ./scripts/remote-build.sh test --filter ClaudeRemote
	 Executed 245 tests, with 0 failures (0 unexpected) in 3.395 (3.403) seconds

$ ./scripts/remote-build.sh test --filter ClaudeIntegrationSettingsModelTests
	 Executed 35 tests, with 0 failures (0 unexpected) in 0.016 (0.018) seconds

$ ./scripts/remote-build.sh          # full build + unit, zero warnings
	 Executed 2038 tests, with 2 tests skipped and 0 failures (0 unexpected) in 71.459 (71.563) seconds
```

Hand-test note for the owner is unchanged, plus one addition: hosts enrolled with a build before
this PR show copy-only commands (no Run button) in both the update panel and the rotation sheet.
