### PR TITLE
Dogfood capture: record whether the user immediately erased the insertion

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -126,7 +126,18 @@ Learned the hard way (2026-07-04) — use these instead of manual steps:
   the join outcome, the screen decision and its cause, each source's harvest and
   proposals, budget demands vs. grants, the rendered prompts, and the model's
   reply, so a wrong term can be blamed on exactly one of four stages
-  (retrieval / matcher / conflict / budget). It is behind a COMPILE flag
+  (retrieval / matcher / conflict / budget). Records also carry a content-free
+  behavioral signal (`DogfoodEditSignalWatcher`): a bounded post-commit window
+  — 2 s for 1–5 words up to 15 s for very long transcripts — watching for the
+  user immediately erasing what was inserted (Backspace or ⌘A). Only the
+  gesture, a bucketed delay, the word-count bucket, and the output mode are
+  recorded; no key content and no other key at all. It is a GLOBAL `NSEvent`
+  keyDown observer (no new permission — the same Accessibility trust insertion
+  already needs), installed only while a window is open and torn down the
+  instant it closes, and the record is patched in place afterwards rather than
+  held back for the window (a held record is lost to any quit). The `clean` and
+  `superseded` outcomes are recorded too: without the negative there is no
+  denominator. It is behind a COMPILE flag
   (`LOCALVOXTRAL_DOGFOOD`, or the gitignored `.dogfood-capture-enable` marker
   that crosses the build gate) plus a runtime opt-in
   (`defaults write com.localvoxtral.app debug.dogfood_capture_enabled -bool true`).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -129,8 +129,8 @@ Learned the hard way (2026-07-04) — use these instead of manual steps:
   (retrieval / matcher / conflict / budget). Records also carry a content-free
   behavioral signal (`DogfoodEditSignalWatcher`): a bounded post-commit window
   — 2 s for 1–5 words up to 15 s for very long transcripts — watching for the
-  user immediately erasing what was inserted (Backspace or ⌘A). Only the
-  gesture, a bucketed delay, the word-count bucket, and the output mode are
+  user immediately erasing what was inserted (Backspace, forward delete, or ⌘A).
+  Only the gesture, a bucketed delay, the word-count bucket, and the output mode are
   recorded; no key content and no other key at all. It is a GLOBAL `NSEvent`
   keyDown observer (no new permission — the same Accessibility trust insertion
   already needs), installed only while a window is open and torn down the

--- a/Sources/localvoxtral/DictationViewModel.swift
+++ b/Sources/localvoxtral/DictationViewModel.swift
@@ -317,6 +317,11 @@ final class DictationViewModel {
     /// temp directory. Production uses the Application Support default.
     @ObservationIgnored
     var dogfoodCaptureStore = DogfoodCaptureStore()
+    /// Watches the seconds after a commit for an immediate erase, and patches
+    /// that dictation's record with what it saw. `var` for the same reason as
+    /// the store: tests inject the clock and the event source.
+    @ObservationIgnored
+    var dogfoodEditSignalWatcher = DogfoodEditSignalWatcher()
     #endif
     /// Warms the managed polishing helper's prompt-prefix cache on every
     /// helper launch (see `PolishPromptWarmupCoordinator`). Created only when
@@ -1879,6 +1884,10 @@ final class DictationViewModel {
         // A fresh dictation gets fresh tap slots: an abandoned pipeline's late
         // note from the PREVIOUS session must not describe this one.
         DogfoodCaptureTap.shared.beginSession()
+        // Same rule for the post-commit edit watch: the previous dictation's
+        // window closes here rather than reading this session's keys. It still
+        // flushes its own record, as `superseded`.
+        dogfoodEditSignalWatcher.supersede()
         #endif
         guard let endpointURL = settings.llmPolishingConfiguration?.endpointURL else {
             terminalScreenStartCapture = nil

--- a/Sources/localvoxtral/DictationViewModel.swift
+++ b/Sources/localvoxtral/DictationViewModel.swift
@@ -811,6 +811,13 @@ final class DictationViewModel {
                 if self.isDictating {
                     self.stopDictation(reason: "app terminating", finalizeRemainingAudio: false)
                 }
+                #if LOCALVOXTRAL_DOGFOOD
+                // Last chance for a still-open post-commit watch to patch its
+                // record: after this the process is gone and the dictation
+                // would keep no behavior block at all. Written inline — a Task
+                // spawned at terminate is not guaranteed to run.
+                self.dogfoodEditSignalWatcher.flushForTermination()
+                #endif
                 await self.backendManager.stopAll()
             }
         }

--- a/Sources/localvoxtral/Dogfood/DictationViewModel+DogfoodCapture.swift
+++ b/Sources/localvoxtral/Dogfood/DictationViewModel+DogfoodCapture.swift
@@ -29,6 +29,16 @@ extension DictationViewModel {
         let store = dogfoodCaptureStore
         let started = ContinuousClock.now
 
+        // BEFORE assembly, not after the write: the watch window measures from
+        // the commit, and assembly re-derives every harvest off-actor. A user
+        // reaching for Backspace during those milliseconds is the strongest
+        // signal there is, and arming after the write would be exactly the
+        // window that misses it.
+        dogfoodEditSignalWatcher.arm(
+            committedText: inputs.text.committedText ?? inputs.text.groundedText,
+            outputMode: inputs.session.outputMode
+        )
+
         // Assembly walks complete retained buffers (harvest re-derivation);
         // `build` is nonisolated, so this await hops off the main actor the
         // same way the preparations it mirrors do.
@@ -36,7 +46,13 @@ extension DictationViewModel {
         let elapsed = (ContinuousClock.now - started).components
         record.timings.captureMilliseconds =
             Double(elapsed.seconds) * 1000 + Double(elapsed.attoseconds) / 1e15
-        await DogfoodCaptureWriter.write(record, store: store)
+        // The watch is already open; this only tells it which record to patch.
+        // A failed write leaves it open until its window closes, where it finds
+        // no record and flushes nothing — the signal costs the record, never
+        // the other way around.
+        if let url = await DogfoodCaptureWriter.write(record, store: store) {
+            dogfoodEditSignalWatcher.attachRecord(url: url, store: store)
+        }
     }
 
     private nonisolated static func assembleDogfoodRecord(

--- a/Sources/localvoxtral/Dogfood/DictationViewModel+DogfoodCapture.swift
+++ b/Sources/localvoxtral/Dogfood/DictationViewModel+DogfoodCapture.swift
@@ -34,7 +34,12 @@ extension DictationViewModel {
         // reaching for Backspace during those milliseconds is the strongest
         // signal there is, and arming after the write would be exactly the
         // window that misses it.
-        dogfoodEditSignalWatcher.arm(
+        //
+        // The token names THIS dictation's watch. It has to be carried across
+        // the write below, because that write is awaited and the next dictation
+        // can arm in the meantime — an untokened attach would hand this
+        // record's URL to that session's window.
+        let watchToken = dogfoodEditSignalWatcher.arm(
             committedText: inputs.text.committedText ?? inputs.text.groundedText,
             outputMode: inputs.session.outputMode
         )
@@ -50,8 +55,9 @@ extension DictationViewModel {
         // A failed write leaves it open until its window closes, where it finds
         // no record and flushes nothing — the signal costs the record, never
         // the other way around.
-        if let url = await DogfoodCaptureWriter.write(record, store: store) {
-            dogfoodEditSignalWatcher.attachRecord(url: url, store: store)
+        let url = await DogfoodCaptureWriter.write(record, store: store)
+        if let url, let watchToken {
+            dogfoodEditSignalWatcher.attachRecord(url: url, store: store, token: watchToken)
         }
     }
 

--- a/Sources/localvoxtral/Dogfood/DogfoodCapturePipeline.swift
+++ b/Sources/localvoxtral/Dogfood/DogfoodCapturePipeline.swift
@@ -442,20 +442,45 @@ extension DogfoodCaptureBuilder {
 /// the commit. The write itself is synchronous file IO on the generic executor
 /// — the user's text was already committed before the capture is assembled.
 enum DogfoodCaptureWriter {
+    /// Where the record landed, or nil when the write failed (loudly).
+    @discardableResult
     nonisolated static func write(
         _ record: DogfoodCaptureRecord,
         store: DogfoodCaptureStore
-    ) async {
+    ) async -> URL? {
         do {
             let url = try store.write(record)
             Log.polishing.info(
                 "Dogfood capture written: \(url.lastPathComponent, privacy: .public)"
             )
+            return url
         } catch {
             // Loud by convention (AGENTS.md): a silent failure path here means
             // dogfooding quietly collects nothing.
             Log.polishing.error(
                 "Dogfood capture write failed: \(error.localizedDescription, privacy: .public)"
+            )
+            return nil
+        }
+    }
+
+    /// Patches one already-written record with the post-commit behavior signal.
+    /// Off the commit path entirely — by the time this runs the dictation has
+    /// been finished for seconds — and, like `write`, it can only ever cost the
+    /// record.
+    nonisolated static func attach(
+        _ behavior: DogfoodCaptureRecord.Behavior,
+        toRecordAt url: URL,
+        store: DogfoodCaptureStore
+    ) async {
+        do {
+            try store.attachBehavior(behavior, toRecordAt: url)
+            Log.polishing.info(
+                "Dogfood capture behavior: \(behavior.outcome.rawValue, privacy: .public) (\(behavior.signal?.rawValue ?? "none", privacy: .public), window \(behavior.watchWindowSeconds, privacy: .public)s) -> \(url.lastPathComponent, privacy: .public)"
+            )
+        } catch {
+            Log.polishing.error(
+                "Dogfood capture behavior patch failed: \(error.localizedDescription, privacy: .public)"
             )
         }
     }

--- a/Sources/localvoxtral/Dogfood/DogfoodCapturePipeline.swift
+++ b/Sources/localvoxtral/Dogfood/DogfoodCapturePipeline.swift
@@ -473,6 +473,18 @@ enum DogfoodCaptureWriter {
         toRecordAt url: URL,
         store: DogfoodCaptureStore
     ) async {
+        attachSynchronously(behavior, toRecordAt: url, store: store)
+    }
+
+    /// The same patch, without the hop. Used at app termination, where a `Task`
+    /// is not guaranteed to run — see
+    /// `DogfoodEditSignalWatcher.flushForTermination`. The work is one small
+    /// JSON rewrite either way; only the caller's urgency differs.
+    nonisolated static func attachSynchronously(
+        _ behavior: DogfoodCaptureRecord.Behavior,
+        toRecordAt url: URL,
+        store: DogfoodCaptureStore
+    ) {
         do {
             try store.attachBehavior(behavior, toRecordAt: url)
             Log.polishing.info(

--- a/Sources/localvoxtral/Dogfood/DogfoodCaptureRecord.swift
+++ b/Sources/localvoxtral/Dogfood/DogfoodCaptureRecord.swift
@@ -58,6 +58,17 @@ struct DogfoodCaptureRecord: Codable, Equatable, Sendable {
     var text: Text
     var timings: Timings
 
+    /// What the user DID with the insertion, patched in after the commit — see
+    /// `Behavior` and `DogfoodEditSignalWatcher`. Absent on records written
+    /// before the field existed, on a dictation whose watch could not install a
+    /// monitor, and on one whose patch write failed; in none of those is it safe
+    /// to read the absence as "the user kept the text".
+    ///
+    /// Additive and optional, so `currentSchemaVersion` stays where it is: the
+    /// version exists to stop a reader MISREADING an older shape, and no field
+    /// above changed meaning. An older record decodes unchanged.
+    var behavior: Behavior?
+
     struct Session: Codable, Equatable, Sendable {
         /// Bundle identifier of the app the text was inserted into.
         var targetBundleID: String?
@@ -178,6 +189,36 @@ struct DogfoodCaptureRecord: Codable, Equatable, Sendable {
         var polishedOutput: String?
         /// What was actually committed to the focused app.
         var committedText: String?
+    }
+
+    /// Did the user immediately take the insertion back?
+    ///
+    /// Every other field in this record describes what the pipeline DID; none of
+    /// them says whether the answer was good. A record whose retrieval, budget,
+    /// and prompt all look correct reads identically to one the owner erased
+    /// half a second later, and the second is the one worth reviewing.
+    ///
+    /// Content-free by construction: two recognized gestures, everything else
+    /// bucketed, nothing about any other key. The four-way attribution above
+    /// says WHERE a term was lost; this says whether anything was lost at all.
+    struct Behavior: Codable, Equatable, Sendable {
+        /// `edited`, `clean`, or `superseded`. `clean` is recorded on purpose —
+        /// without the negative there is no denominator for an edit rate.
+        var outcome: DogfoodEditSignalOutcome
+        /// Which gesture ended the window. Nil unless `outcome == .edited`.
+        var signal: DogfoodEditSignal?
+        /// Bucketed delay from commit to gesture (`0-1`, `1-2`, `2-5`, `5-15`).
+        /// Nil unless `outcome == .edited`.
+        var secondsSinceCommitBucket: String?
+        /// Transcript length as a bucket (`1-5`, `6-15`, `16-40`, `41+`) — the
+        /// same ladder step that chose the window.
+        var wordCountBucket: String
+        /// The window this dictation actually got, so a review can tell a clean
+        /// 2 s from a clean 15 s.
+        var watchWindowSeconds: Double
+        /// Overlay Buffer vs Live Auto-Paste, duplicated from `Session` so the
+        /// behavior block reads on its own in an aggregate.
+        var outputMode: String
     }
 
     struct Timings: Codable, Equatable, Sendable {

--- a/Sources/localvoxtral/Dogfood/DogfoodCaptureStore.swift
+++ b/Sources/localvoxtral/Dogfood/DogfoodCaptureStore.swift
@@ -1,6 +1,7 @@
 #if LOCALVOXTRAL_DOGFOOD
 
 import Foundation
+import Synchronization
 
 /// Directory operations the store needs beyond writing one file. Split out as a
 /// protocol for the same reason the registry splits its own IO: the pruning
@@ -76,6 +77,25 @@ struct DogfoodCaptureStore: Sendable {
         case unreadableRecord(path: String)
     }
 
+    /// Serializes every read-modify-write over a record file.
+    ///
+    /// The store is a value type and its two mutating paths run on different
+    /// isolation domains — flagging from the menu on the main actor, the
+    /// behavior patch from a detached task — over the same file. Their
+    /// interleaving is not theoretical: flagging RENAMES (write flagged, remove
+    /// plain), so a patch that read the plain file, lost the race, and then
+    /// wrote it back would resurrect the unflagged copy ALONGSIDE the flagged
+    /// one. Two records for one dictation, one of them stale and exempt from
+    /// nothing, is exactly the contradiction `flagMostRecentRecord` refuses to
+    /// create for itself.
+    ///
+    /// Process-wide (`static`) rather than per-instance because the identity
+    /// that matters is the directory, and every store in a process points at the
+    /// same one. Held across locate/read/encode/write only — never across an
+    /// `await`, and never re-entered: the locked paths call the private
+    /// unlocked bodies, not each other.
+    private static let recordMutationLock = Mutex(0)
+
     private let directoryURL: URL
     private let io: ClaudeRemoteHostStoreIO
     private let directoryIO: DogfoodCaptureDirectoryIO
@@ -116,6 +136,10 @@ struct DogfoodCaptureStore: Sendable {
     /// Writes `record` and prunes. Returns the file it wrote.
     @discardableResult
     func write(_ record: DogfoodCaptureRecord) throws -> URL {
+        try Self.recordMutationLock.withLock { _ in try writeLocked(record) }
+    }
+
+    private func writeLocked(_ record: DogfoodCaptureRecord) throws -> URL {
         var redacted = record
         let redactions = DogfoodCaptureRedaction.redact(&redacted)
         if redactions > 0 {
@@ -135,7 +159,7 @@ struct DogfoodCaptureStore: Sendable {
             isDirectory: false
         )
         try io.write(data, to: url)
-        try? prune()
+        try? pruneLocked()
         return url
     }
 
@@ -164,8 +188,20 @@ struct DogfoodCaptureStore: Sendable {
         _ behavior: DogfoodCaptureRecord.Behavior,
         toRecordAt url: URL
     ) throws -> URL {
+        try Self.recordMutationLock.withLock { _ in
+            try attachBehaviorLocked(behavior, toRecordAt: url)
+        }
+    }
+
+    private func attachBehaviorLocked(
+        _ behavior: DogfoodCaptureRecord.Behavior,
+        toRecordAt url: URL
+    ) throws -> URL {
         // Flagging renames; a record flagged during the watch window is still
-        // this dictation's record and must still receive its signal.
+        // this dictation's record and must still receive its signal. The
+        // locate/read/write below is one critical section, so a concurrent
+        // flag either completes before the locate (and is followed) or after
+        // the write (and carries the behavior with it).
         let target = try locateRecord(writtenAt: url)
         guard
             let data = try directoryIO.read(from: target),
@@ -219,6 +255,10 @@ struct DogfoodCaptureStore: Sendable {
     /// record the owner explicitly asked to keep. Better to fail loudly.
     @discardableResult
     func flagMostRecentRecord() throws -> URL? {
+        try Self.recordMutationLock.withLock { _ in try flagMostRecentRecordLocked() }
+    }
+
+    private func flagMostRecentRecordLocked() throws -> URL? {
         guard let latest = try listRecords().first else { return nil }
         guard !latest.flagged else { return latest.url }
 
@@ -289,6 +329,12 @@ struct DogfoodCaptureStore: Sendable {
 
     /// Applies the retention rules. Flagged records are never removed.
     func prune() throws {
+        try Self.recordMutationLock.withLock { _ in try pruneLocked() }
+    }
+
+    /// The retention body, without the lock. Callers already inside the
+    /// critical section use this — `Mutex` is not recursive.
+    private func pruneLocked() throws {
         let records = try listRecords()
         let cutoff = now().addingTimeInterval(-retention.maximumUnflaggedAge)
 

--- a/Sources/localvoxtral/Dogfood/DogfoodCaptureStore.swift
+++ b/Sources/localvoxtral/Dogfood/DogfoodCaptureStore.swift
@@ -139,6 +139,70 @@ struct DogfoodCaptureStore: Sendable {
         return url
     }
 
+    // MARK: - Patching
+
+    /// Attaches the post-commit behavior signal to an already-written record,
+    /// returning where it landed.
+    ///
+    /// A patch rather than a delayed write: the record is what the commit path
+    /// knew AT commit, and holding it back for up to fifteen seconds to wait for
+    /// a signal would lose every record to a quit, a crash, or a cancelled task
+    /// — including the ones whose commit went wrong, which are exactly the ones
+    /// worth having.
+    ///
+    /// Read-modify-write of the SAME file, never `write(_:)`: that recomputes
+    /// the file name from the record, and `capturedAt` has lost its milliseconds
+    /// to the ISO-8601 round trip by the time it is decoded again, so a
+    /// rewritten record would land beside the original as a duplicate rather
+    /// than on top of it. Following `flagMostRecentRecord`, the name on disk is
+    /// authoritative and is preserved.
+    ///
+    /// The behavior block is fixed slugs and numbers, so no re-redaction is
+    /// needed (and the rest of the record was redacted on its way in).
+    @discardableResult
+    func attachBehavior(
+        _ behavior: DogfoodCaptureRecord.Behavior,
+        toRecordAt url: URL
+    ) throws -> URL {
+        // Flagging renames; a record flagged during the watch window is still
+        // this dictation's record and must still receive its signal.
+        let target = try locateRecord(writtenAt: url)
+        guard
+            let data = try directoryIO.read(from: target),
+            var record = try? makeDecoder().decode(DogfoodCaptureRecord.self, from: data)
+        else {
+            throw StoreError.unreadableRecord(path: target.path)
+        }
+
+        record.behavior = behavior
+        guard let encoded = try? makeEncoder().encode(record) else {
+            throw StoreError.encodingFailed
+        }
+        try io.write(encoded, to: target)
+        return target
+    }
+
+    /// The record's current location: where it was written, or its flagged
+    /// rename. Throws when neither exists — a pruned or hand-deleted record is
+    /// not something to recreate.
+    private func locateRecord(writtenAt url: URL) throws -> URL {
+        if (try? directoryIO.read(from: url)) ?? nil != nil { return url }
+
+        let name = url.lastPathComponent
+        guard name.hasSuffix(DogfoodCaptureFileName.plainSuffix) else {
+            throw StoreError.unreadableRecord(path: url.path)
+        }
+        let base = String(name.dropLast(DogfoodCaptureFileName.plainSuffix.count))
+        let flagged = url.deletingLastPathComponent().appendingPathComponent(
+            base + DogfoodCaptureFileName.flaggedSuffix,
+            isDirectory: false
+        )
+        guard (try? directoryIO.read(from: flagged)) ?? nil != nil else {
+            throw StoreError.unreadableRecord(path: url.path)
+        }
+        return flagged
+    }
+
     // MARK: - Flagging
 
     /// Marks the most recently captured record for review, returning its new

--- a/Sources/localvoxtral/Dogfood/DogfoodEditSignalWatcher.swift
+++ b/Sources/localvoxtral/Dogfood/DogfoodEditSignalWatcher.swift
@@ -10,9 +10,10 @@ import Foundation
 /// Everything else in a record describes what the pipeline DID. None of it says
 /// whether the answer was any good — a record whose grounding, budget, and
 /// prompt all look perfect is indistinguishable from one the owner erased half a
-/// second later. Reaching for Backspace or ⌘A within a couple of seconds of a
-/// commit is the cheapest honest label available: the user just told us the
-/// transcription or the polish was wrong, without being asked.
+/// second later. Reaching for Backspace (or forward delete) or ⌘A within a
+/// couple of seconds of a commit is the cheapest honest label available: the
+/// user just told us the transcription or the polish was wrong, without being
+/// asked.
 ///
 /// It is deliberately NOT a keylogger, and the shape of the record is what
 /// guarantees that: the enum has two cases, and the only other things recorded
@@ -56,8 +57,9 @@ enum DogfoodEditSignal: String, Codable, Equatable, Sendable {
 enum DogfoodEditSignalOutcome: String, Codable, Equatable, Sendable {
     case edited
     case clean
-    /// A new dictation began before the window closed. Reported rather than
-    /// folded into `clean`: the user moved on, which is not evidence either way.
+    /// The window was cut short — a new dictation began, or the app quit.
+    /// Reported rather than folded into `clean`: the user moved on, which is
+    /// not evidence either way.
     case superseded
 }
 
@@ -126,9 +128,14 @@ enum DogfoodEditSignalPolicy {
 /// Accessibility grant.
 @MainActor
 protocol DogfoodEditKeyMonitoring: AnyObject {
-    /// Begins delivering recognized signals. Called at most once per watch;
-    /// `stop()` always follows, including when the window closed unobserved.
-    func start(_ handler: @escaping @MainActor (DogfoodEditSignal) -> Void)
+    /// Begins delivering recognized signals, reporting whether an observer
+    /// actually went up. Called at most once per watch; `stop()` always follows
+    /// a `true`, including when the window closed unobserved.
+    ///
+    /// A `false` is not a failure to handle — it is the answer "this dictation
+    /// was never observed", and the watcher refuses to arm on it rather than
+    /// reporting an unwatched window as clean.
+    func start(_ handler: @escaping @MainActor (DogfoodEditSignal) -> Void) -> Bool
     func stop()
 }
 
@@ -148,13 +155,14 @@ protocol DogfoodEditKeyMonitoring: AnyObject {
 ///   production signature for a capture that shipped builds do not compile —
 ///   the same trade `DogfoodCaptureTap` documents, decided the same way.
 /// * **No new permission.** Global `NSEvent` monitors need the Accessibility
-///   trust the app already holds for insertion; without it, this simply never
-///   installs and the watch reports `clean`.
+///   trust the app already holds for insertion; without it, this reports
+///   `false` and the dictation gets NO behavior block at all — see
+///   `DogfoodEditSignalWatcher.arm`.
 @MainActor
 final class DogfoodEditKeyNSEventMonitor: DogfoodEditKeyMonitoring {
     private var monitor: Any?
 
-    func start(_ handler: @escaping @MainActor (DogfoodEditSignal) -> Void) {
+    func start(_ handler: @escaping @MainActor (DogfoodEditSignal) -> Void) -> Bool {
         stop()
 
         #if DEBUG
@@ -163,7 +171,7 @@ final class DogfoodEditKeyNSEventMonitor: DogfoodEditKeyMonitoring {
         // monitor here would read the HOST's keyboard while the suite runs, and
         // an unattended CI machine is not a test fixture. The watcher's own
         // tests inject a fake monitor.
-        if TerminalTargetDetector.isRunningUnderXCTest { return }
+        if TerminalTargetDetector.isRunningUnderXCTest { return false }
         #endif
 
         guard AXIsProcessTrusted() else {
@@ -173,7 +181,7 @@ final class DogfoodEditKeyNSEventMonitor: DogfoodEditKeyMonitoring {
             Log.diagnostics.notice(
                 "Dogfood edit signal: Accessibility not trusted; no watch installed"
             )
-            return
+            return false
         }
 
         monitor = NSEvent.addGlobalMonitorForEvents(matching: .keyDown) { event in
@@ -188,11 +196,13 @@ final class DogfoodEditKeyNSEventMonitor: DogfoodEditKeyMonitoring {
             Task { @MainActor in handler(signal) }
         }
 
-        if monitor == nil {
+        guard monitor != nil else {
             Log.diagnostics.notice(
                 "Dogfood edit signal: keyDown monitor installation failed; no watch"
             )
+            return false
         }
+        return true
     }
 
     func stop() {
@@ -214,8 +224,15 @@ final class DogfoodEditKeyNSEventMonitor: DogfoodEditKeyMonitoring {
 /// 2. `attachRecord` — the record finished being written and now has a location
 ///    to patch. Assembly runs off-actor, so this can arrive after the window
 ///    already closed; both orders end in one patch, never two.
-/// 3. The window closes — a recognized key, the elapsed window, or a new
-///    dictation. The monitor is torn down at that instant, not at flush.
+/// 3. The window closes — a recognized key, the elapsed window, a new
+///    dictation, or the app terminating (`supersede`, wired to
+///    `willTerminateNotification`, so a window still open at quit patches its
+///    record instead of silently losing it). The monitor is torn down at that
+///    instant, not at flush.
+///
+/// A quit that beats even that — a crash, a force-quit — leaves the record with
+/// no behavior block. That is the same "never observed" answer an untrusted
+/// process gets, and it is deliberately NOT `clean`.
 ///
 /// Cross-session contamination is impossible by construction rather than by
 /// timing: a watch patches the ONE record URL it was handed, and arming a new
@@ -267,6 +284,14 @@ final class DogfoodEditSignalWatcher {
         self.sleepFor = sleepFor
     }
 
+    /// A watcher that goes away with a window still open must not leave a live
+    /// keyboard observer behind it. `isolated deinit` (SE-0371) so the teardown
+    /// runs on the actor the monitor requires; `ModifierOnlyHotKeyManager`
+    /// predates it and drives teardown from its owner instead.
+    isolated deinit {
+        monitor.stop()
+    }
+
     /// True while a window is open. Tests assert the monitor is not left
     /// installed; production never branches on it.
     var isWatching: Bool {
@@ -274,19 +299,47 @@ final class DogfoodEditSignalWatcher {
         return watch.result == nil
     }
 
-    /// Opens the window for the dictation that just committed.
+    /// Identifies ONE watch. The caller holds it across the record write and
+    /// hands it back to `attachRecord`, which is what makes a stale attach
+    /// rejectable: the token names the dictation the URL belongs to, and a
+    /// watcher that has moved on refuses it.
+    ///
+    /// Not an `Int` and not `Equatable` by accident — it exists to be compared
+    /// against the watcher's own state and nothing else.
+    struct WatchToken: Equatable, Sendable {
+        fileprivate let generation: UInt64
+    }
+
+    /// Opens the window for the dictation that just committed, returning the
+    /// token to hand back with the record. Nil when nothing is being watched —
+    /// an empty commit, or an observer that could not be installed (no
+    /// Accessibility trust). A nil token means the dictation gets NO behavior
+    /// block, which is the honest answer: "never observed" must not be
+    /// recordable as "the user kept the text".
     ///
     /// `committedText` is measured, never stored: only its word-count bucket
     /// reaches the record.
-    func arm(committedText: String, outputMode: String) {
+    @discardableResult
+    func arm(committedText: String, outputMode: String) -> WatchToken? {
         supersede()
 
         let wordCount = DogfoodEditSignalPolicy.wordCount(of: committedText)
-        guard wordCount > 0 else { return }
+        guard wordCount > 0 else { return nil }
 
         generation &+= 1
         let generation = generation
         let windowSeconds = DogfoodEditSignalPolicy.windowSeconds(wordCount: wordCount)
+
+        // Install BEFORE the watch exists, so an observer that never went up
+        // leaves no watch behind to flush a misleading `clean`.
+        let installed = monitor.start { [weak self] signal in
+            self?.handle(signal: signal, generation: generation)
+        }
+        guard installed else {
+            watch = nil
+            return nil
+        }
+
         watch = Watch(
             generation: generation,
             armedAt: now(),
@@ -295,22 +348,25 @@ final class DogfoodEditSignalWatcher {
             outputMode: outputMode
         )
 
-        monitor.start { [weak self] signal in
-            self?.handle(signal: signal, generation: generation)
-        }
-
         windowTask = Task { [weak self] in
             guard let self else { return }
             await self.sleepFor(.seconds(windowSeconds))
             guard !Task.isCancelled else { return }
             self.closeWindow(outcome: .clean, signal: nil, generation: generation)
         }
+
+        return WatchToken(generation: generation)
     }
 
-    /// Hands the open (or already-closed) watch the record it belongs to. The
-    /// record is written after the commit, so this always follows `arm`.
-    func attachRecord(url: URL, store: DogfoodCaptureStore) {
-        guard var watch, watch.generation == generation else { return }
+    /// Hands the open (or already-closed) watch the record it belongs to.
+    ///
+    /// `token` is the one `arm` returned for THIS dictation. Comparing it
+    /// against the watch's own generation is the whole contamination guard: the
+    /// record write is `await`ed, so a second dictation can arm in between, and
+    /// without the token this call would hand session A's record to session B's
+    /// open window — which would then patch A's record with B's behavior.
+    func attachRecord(url: URL, store: DogfoodCaptureStore, token: WatchToken) {
+        guard var watch, watch.generation == token.generation else { return }
         watch.recordURL = url
         watch.store = store
         self.watch = watch
@@ -324,6 +380,21 @@ final class DogfoodEditSignalWatcher {
         closeWindow(outcome: .superseded, signal: nil, generation: watch.generation)
     }
 
+    /// Closes an open window because the app is terminating, writing the patch
+    /// INLINE rather than from a `Task`.
+    ///
+    /// `willTerminateNotification` observers run synchronously and the process
+    /// is gone shortly after; a Task enqueued there is not guaranteed to run at
+    /// all (the backend shutdown next to it is best-effort for the same
+    /// reason). One small JSON rewrite on the main actor is cheap enough to pay
+    /// at quit, and the alternative is losing the window's answer entirely.
+    func flushForTermination() {
+        guard let watch, watch.result == nil else { return }
+        closeWindow(
+            outcome: .superseded, signal: nil, generation: watch.generation, inline: true
+        )
+    }
+
     private func handle(signal: DogfoodEditSignal, generation: UInt64) {
         closeWindow(outcome: .edited, signal: signal, generation: generation)
     }
@@ -331,7 +402,8 @@ final class DogfoodEditSignalWatcher {
     private func closeWindow(
         outcome: DogfoodEditSignalOutcome,
         signal: DogfoodEditSignal?,
-        generation: UInt64
+        generation: UInt64,
+        inline: Bool = false
     ) {
         guard var watch, watch.generation == generation, watch.result == nil else { return }
 
@@ -344,12 +416,12 @@ final class DogfoodEditSignalWatcher {
         let elapsed = max(0, now().timeIntervalSince(watch.armedAt))
         watch.result = (outcome, signal, elapsed)
         self.watch = watch
-        flushIfReady()
+        flushIfReady(inline: inline)
     }
 
     /// Patches the record once both halves are known: the window's verdict and
     /// where the record landed. Whichever arrives second triggers the write.
-    private func flushIfReady() {
+    private func flushIfReady(inline: Bool = false) {
         guard let watch,
               let result = watch.result,
               let url = watch.recordURL,
@@ -367,6 +439,10 @@ final class DogfoodEditSignalWatcher {
         )
         self.watch = nil
 
+        guard !inline else {
+            DogfoodCaptureWriter.attachSynchronously(behavior, toRecordAt: url, store: store)
+            return
+        }
         flushTask = Task {
             await DogfoodCaptureWriter.attach(behavior, toRecordAt: url, store: store)
         }

--- a/Sources/localvoxtral/Dogfood/DogfoodEditSignalWatcher.swift
+++ b/Sources/localvoxtral/Dogfood/DogfoodEditSignalWatcher.swift
@@ -1,0 +1,376 @@
+#if LOCALVOXTRAL_DOGFOOD
+
+import AppKit
+import Carbon.HIToolbox
+import Foundation
+
+/// The one behavioral quality signal a capture record cannot derive from its own
+/// contents: did the user immediately take the insertion back?
+///
+/// Everything else in a record describes what the pipeline DID. None of it says
+/// whether the answer was any good — a record whose grounding, budget, and
+/// prompt all look perfect is indistinguishable from one the owner erased half a
+/// second later. Reaching for Backspace or ⌘A within a couple of seconds of a
+/// commit is the cheapest honest label available: the user just told us the
+/// transcription or the polish was wrong, without being asked.
+///
+/// It is deliberately NOT a keylogger, and the shape of the record is what
+/// guarantees that: the enum has two cases, and the only other things recorded
+/// are bucketed. No key content, no text, no timestamps finer than a bucket, and
+/// nothing at all about keys that are neither of these two.
+enum DogfoodEditSignal: String, Codable, Equatable, Sendable {
+    /// Backspace / forward delete: the user is erasing what we inserted.
+    case backspace
+    /// ⌘A: almost always the first half of select-all-then-retype or
+    /// select-all-then-delete.
+    case selectAll
+
+    /// The ONLY mapping from a key event to a signal. Pure and total: anything
+    /// that is not one of the two gestures returns nil and is forgotten
+    /// immediately — the monitor never retains, forwards, or counts it.
+    ///
+    /// ⌘A only with Command held and no other command-class modifier: ⌥⌘A /
+    /// ⌃⌘A are app shortcuts, not select-all, and counting them would inflate
+    /// the signal with ordinary navigation.
+    static func from(keyCode: UInt16, modifiers: NSEvent.ModifierFlags) -> DogfoodEditSignal? {
+        let relevant = modifiers.intersection(.deviceIndependentFlagsMask)
+        switch Int(keyCode) {
+        case kVK_Delete, kVK_ForwardDelete:
+            // A modifier'd delete (⌥⌫ deletes a word, ⌘⌫ a line) is still the
+            // user erasing what we inserted, so no modifier condition here.
+            return .backspace
+        case kVK_ANSI_A where relevant.contains(.command)
+            && !relevant.contains(.option)
+            && !relevant.contains(.control):
+            return .selectAll
+        default:
+            return nil
+        }
+    }
+}
+
+/// How a watch window ended. Every armed watch reaches exactly one of these and
+/// patches its record with it, including the negative — without the "clean"
+/// denominator an edit rate is not computable, and "no behavior block" would be
+/// indistinguishable from "the watch never armed".
+enum DogfoodEditSignalOutcome: String, Codable, Equatable, Sendable {
+    case edited
+    case clean
+    /// A new dictation began before the window closed. Reported rather than
+    /// folded into `clean`: the user moved on, which is not evidence either way.
+    case superseded
+}
+
+/// The window ladder and the buckets. Pure, so the boundaries are testable
+/// without a clock, a monitor, or a record.
+enum DogfoodEditSignalPolicy {
+    /// How long to watch after a commit, by transcript length.
+    ///
+    /// The ladder scales with how long the insertion takes to READ: a five-word
+    /// command is judged before the user's hand leaves the key, while a
+    /// paragraph has to be scanned first. Deliberately a small stepped ladder
+    /// rather than a formula — the buckets are what the review reads, and a
+    /// continuous function would only add false precision to a signal whose
+    /// whole claim is "roughly immediately".
+    ///
+    /// | words | window |
+    /// |---|---|
+    /// | 1–5 | 2 s |
+    /// | 6–15 | 4 s |
+    /// | 16–40 | 8 s |
+    /// | 41+ | 15 s |
+    static func windowSeconds(wordCount: Int) -> Double {
+        switch wordCount {
+        case ..<6: return 2
+        case ..<16: return 4
+        case ..<41: return 8
+        default: return 15
+        }
+    }
+
+    /// Transcript length as a bucket, never the count. The count is one query
+    /// away from the transcript itself, and the record already carries the text
+    /// stages under the same gate — but the behavior block is meant to stay
+    /// readable as an aggregate, and a bucket is what an aggregate wants.
+    static func wordCountBucket(_ wordCount: Int) -> String {
+        switch wordCount {
+        case ..<6: return "1-5"
+        case ..<16: return "6-15"
+        case ..<41: return "16-40"
+        default: return "41+"
+        }
+    }
+
+    /// Seconds since the commit, bucketed. The top bucket is open-ended only in
+    /// name: nothing past the longest window can be reported.
+    static func secondsSinceCommitBucket(_ seconds: Double) -> String {
+        switch seconds {
+        case ..<1: return "0-1"
+        case ..<2: return "1-2"
+        case ..<5: return "2-5"
+        default: return "5-15"
+        }
+    }
+
+    /// Words, by whitespace. The count never leaves this type unbucketed.
+    static func wordCount(of text: String) -> Int {
+        text.split(whereSeparator: { $0.isWhitespace }).count
+    }
+}
+
+/// Installs a key observer for the duration of one watch window.
+///
+/// A protocol for the usual reason (`OverlayBufferSessionCoordinator`'s clock
+/// seams): the watcher's arming, bucketing, and teardown rules are the part
+/// worth testing, and none of them should need a real event stream or a real
+/// Accessibility grant.
+@MainActor
+protocol DogfoodEditKeyMonitoring: AnyObject {
+    /// Begins delivering recognized signals. Called at most once per watch;
+    /// `stop()` always follows, including when the window closed unobserved.
+    func start(_ handler: @escaping @MainActor (DogfoodEditSignal) -> Void)
+    func stop()
+}
+
+/// The production observer: one GLOBAL `NSEvent` keyDown monitor, installed when
+/// a watch window opens and removed the moment it closes.
+///
+/// Design decisions worth keeping:
+///
+/// * **Global only, never local.** A local monitor sees keys typed into
+///   localvoxtral's OWN windows (Settings, the shortcut recorder), which is not
+///   the user reacting to an insertion. The insertion lands in another app, so
+///   the reaction does too.
+/// * **A new monitor rather than a tap on `ModifierOnlyHotKeyManager`'s.** That
+///   manager already holds a keyDown monitor, but only while the modifier-only
+///   hotkey mode is active, and its handler deliberately discards the event
+///   (it needs "a key happened", not which). Widening its callback would fork a
+///   production signature for a capture that shipped builds do not compile —
+///   the same trade `DogfoodCaptureTap` documents, decided the same way.
+/// * **No new permission.** Global `NSEvent` monitors need the Accessibility
+///   trust the app already holds for insertion; without it, this simply never
+///   installs and the watch reports `clean`.
+@MainActor
+final class DogfoodEditKeyNSEventMonitor: DogfoodEditKeyMonitoring {
+    private var monitor: Any?
+
+    func start(_ handler: @escaping @MainActor (DogfoodEditSignal) -> Void) {
+        stop()
+
+        #if DEBUG
+        // Never install a real monitor under XCTest. Same rule (and the same
+        // 2026-07-24 incident) as `ModifierOnlyHotKeyManager.start`: a live
+        // monitor here would read the HOST's keyboard while the suite runs, and
+        // an unattended CI machine is not a test fixture. The watcher's own
+        // tests inject a fake monitor.
+        if TerminalTargetDetector.isRunningUnderXCTest { return }
+        #endif
+
+        guard AXIsProcessTrusted() else {
+            // Loud, per the repo's rule about silent failure paths: a dogfood
+            // build that quietly never observes an edit would read as "the
+            // owner never edits".
+            Log.diagnostics.notice(
+                "Dogfood edit signal: Accessibility not trusted; no watch installed"
+            )
+            return
+        }
+
+        monitor = NSEvent.addGlobalMonitorForEvents(matching: .keyDown) { event in
+            // Nothing about the event survives this closure except the verdict:
+            // an unrecognized key is not retained, forwarded, or counted.
+            let keyCode = event.keyCode
+            let rawFlags = event.modifierFlags.rawValue
+            guard let signal = DogfoodEditSignal.from(
+                keyCode: keyCode,
+                modifiers: NSEvent.ModifierFlags(rawValue: rawFlags)
+            ) else { return }
+            Task { @MainActor in handler(signal) }
+        }
+
+        if monitor == nil {
+            Log.diagnostics.notice(
+                "Dogfood edit signal: keyDown monitor installation failed; no watch"
+            )
+        }
+    }
+
+    func stop() {
+        if let monitor {
+            NSEvent.removeMonitor(monitor)
+        }
+        monitor = nil
+    }
+}
+
+/// Opens a bounded post-commit watch window, and patches that dictation's record
+/// with what the window saw.
+///
+/// Lifecycle of one watch:
+///
+/// 1. `arm` — the commit just landed. Installs the monitor and starts the
+///    window. Called only after `writeDogfoodCaptureIfArmed` cleared the runtime
+///    opt-in, so a build that is not armed never observes anything.
+/// 2. `attachRecord` — the record finished being written and now has a location
+///    to patch. Assembly runs off-actor, so this can arrive after the window
+///    already closed; both orders end in one patch, never two.
+/// 3. The window closes — a recognized key, the elapsed window, or a new
+///    dictation. The monitor is torn down at that instant, not at flush.
+///
+/// Cross-session contamination is impossible by construction rather than by
+/// timing: a watch patches the ONE record URL it was handed, and arming a new
+/// watch supersedes the old one (which still flushes its own record, with
+/// `superseded`). This is the same discipline as `DogfoodCaptureTap`'s
+/// generation, arrived at the same way — a late producer must not describe a
+/// session that has ended.
+@MainActor
+final class DogfoodEditSignalWatcher {
+    typealias DateProvider = () -> Date
+    typealias SleepClosure = (Duration) async -> Void
+
+    private struct Watch {
+        let generation: UInt64
+        let armedAt: Date
+        let windowSeconds: Double
+        let wordCount: Int
+        let outputMode: String
+
+        var store: DogfoodCaptureStore?
+        var recordURL: URL?
+        /// Set when the window closed; nil while it is still open.
+        var result: (outcome: DogfoodEditSignalOutcome, signal: DogfoodEditSignal?, elapsed: Double)?
+    }
+
+    private let monitor: any DogfoodEditKeyMonitoring
+    // Injected for the same reason the overlay coordinator injects them: window
+    // timing and elapsed-time bucketing must be assertable without wall-clock.
+    private let now: DateProvider
+    private let sleepFor: SleepClosure
+
+    private var watch: Watch?
+    private var generation: UInt64 = 0
+    /// The open window's timer, and the in-flight record patch. Retained so
+    /// tests can await them the way they await `polishAndCommitTask`; nothing in
+    /// production reads either.
+    private(set) var windowTask: Task<Void, Never>?
+    private(set) var flushTask: Task<Void, Never>?
+
+    init(
+        monitor: any DogfoodEditKeyMonitoring = DogfoodEditKeyNSEventMonitor(),
+        now: @escaping DateProvider = Date.init,
+        sleepFor: @escaping SleepClosure = { duration in
+            try? await Task.sleep(for: duration)
+        }
+    ) {
+        self.monitor = monitor
+        self.now = now
+        self.sleepFor = sleepFor
+    }
+
+    /// True while a window is open. Tests assert the monitor is not left
+    /// installed; production never branches on it.
+    var isWatching: Bool {
+        guard let watch else { return false }
+        return watch.result == nil
+    }
+
+    /// Opens the window for the dictation that just committed.
+    ///
+    /// `committedText` is measured, never stored: only its word-count bucket
+    /// reaches the record.
+    func arm(committedText: String, outputMode: String) {
+        supersede()
+
+        let wordCount = DogfoodEditSignalPolicy.wordCount(of: committedText)
+        guard wordCount > 0 else { return }
+
+        generation &+= 1
+        let generation = generation
+        let windowSeconds = DogfoodEditSignalPolicy.windowSeconds(wordCount: wordCount)
+        watch = Watch(
+            generation: generation,
+            armedAt: now(),
+            windowSeconds: windowSeconds,
+            wordCount: wordCount,
+            outputMode: outputMode
+        )
+
+        monitor.start { [weak self] signal in
+            self?.handle(signal: signal, generation: generation)
+        }
+
+        windowTask = Task { [weak self] in
+            guard let self else { return }
+            await self.sleepFor(.seconds(windowSeconds))
+            guard !Task.isCancelled else { return }
+            self.closeWindow(outcome: .clean, signal: nil, generation: generation)
+        }
+    }
+
+    /// Hands the open (or already-closed) watch the record it belongs to. The
+    /// record is written after the commit, so this always follows `arm`.
+    func attachRecord(url: URL, store: DogfoodCaptureStore) {
+        guard var watch, watch.generation == generation else { return }
+        watch.recordURL = url
+        watch.store = store
+        self.watch = watch
+        flushIfReady()
+    }
+
+    /// Closes an open window because a new dictation began. Safe to call with
+    /// nothing armed.
+    func supersede() {
+        guard let watch, watch.result == nil else { return }
+        closeWindow(outcome: .superseded, signal: nil, generation: watch.generation)
+    }
+
+    private func handle(signal: DogfoodEditSignal, generation: UInt64) {
+        closeWindow(outcome: .edited, signal: signal, generation: generation)
+    }
+
+    private func closeWindow(
+        outcome: DogfoodEditSignalOutcome,
+        signal: DogfoodEditSignal?,
+        generation: UInt64
+    ) {
+        guard var watch, watch.generation == generation, watch.result == nil else { return }
+
+        // The monitor comes down at the instant the window closes, not when the
+        // patch lands: the observer must not outlive the question it answers.
+        monitor.stop()
+        windowTask?.cancel()
+        windowTask = nil
+
+        let elapsed = max(0, now().timeIntervalSince(watch.armedAt))
+        watch.result = (outcome, signal, elapsed)
+        self.watch = watch
+        flushIfReady()
+    }
+
+    /// Patches the record once both halves are known: the window's verdict and
+    /// where the record landed. Whichever arrives second triggers the write.
+    private func flushIfReady() {
+        guard let watch,
+              let result = watch.result,
+              let url = watch.recordURL,
+              let store = watch.store
+        else { return }
+
+        let behavior = DogfoodCaptureRecord.Behavior(
+            outcome: result.outcome,
+            signal: result.signal,
+            secondsSinceCommitBucket: result.outcome == .edited
+                ? DogfoodEditSignalPolicy.secondsSinceCommitBucket(result.elapsed) : nil,
+            wordCountBucket: DogfoodEditSignalPolicy.wordCountBucket(watch.wordCount),
+            watchWindowSeconds: watch.windowSeconds,
+            outputMode: watch.outputMode
+        )
+        self.watch = nil
+
+        flushTask = Task {
+            await DogfoodCaptureWriter.attach(behavior, toRecordAt: url, store: store)
+        }
+    }
+}
+
+#endif

--- a/Tests/localvoxtralTests/DogfoodCaptureWiringTests.swift
+++ b/Tests/localvoxtralTests/DogfoodCaptureWiringTests.swift
@@ -273,6 +273,87 @@ final class DogfoodCaptureWiringTests: XCTestCase {
         XCTAssertEqual(try recordsOnDisk(in: harness.captureDirectory).count, 0)
     }
 
+    // MARK: - Post-commit edit signal
+
+    /// The commit path arms the watch and hands it the record it just wrote: a
+    /// Backspace inside the window patches THAT record, in place.
+    func testCommitArmsTheEditWatchAndPatchesItsOwnRecord() async throws {
+        let signals = EditSignalHarness()
+        let harness = try makeHarness(dogfoodArmed: true, editSignal: signals)
+
+        harness.viewModel.finishStoppedSession(promotePendingSegment: false)
+        await harness.viewModel.polishAndCommitTask?.value
+
+        XCTAssertEqual(signals.monitor.startCount, 1, "the commit opened a window")
+        // "polished output text" is three words: the 1–5 rung of the ladder.
+        await signals.sleeper.waitForSleepRequest()
+        XCTAssertEqual(signals.sleeper.requestedDurations, [.seconds(2.0)])
+
+        signals.clock.advance(0.5)
+        signals.monitor.send(.backspace)
+        await signals.watcher.flushTask?.value
+
+        let records = try recordsOnDisk(in: harness.captureDirectory)
+        XCTAssertEqual(records.count, 1, "the signal patches the record, never adds one")
+        let behavior = try XCTUnwrap(records[0].behavior)
+        XCTAssertEqual(behavior.outcome, .edited)
+        XCTAssertEqual(behavior.signal, .backspace)
+        XCTAssertEqual(behavior.secondsSinceCommitBucket, "0-1")
+        XCTAssertEqual(behavior.wordCountBucket, "1-5")
+        XCTAssertEqual(behavior.outputMode, DictationOutputMode.overlayBuffer.rawValue)
+
+        // The rest of the record is untouched by the patch.
+        XCTAssertEqual(records[0].text.committedText, "polished output text")
+        XCTAssertNotNil(records[0].timings.captureMilliseconds)
+    }
+
+    /// A window that closes unobserved still patches its record: the clean
+    /// outcome is the denominator an edit rate needs.
+    func testUneventfulWindowPatchesTheCleanOutcome() async throws {
+        let signals = EditSignalHarness()
+        let harness = try makeHarness(dogfoodArmed: true, editSignal: signals)
+
+        harness.viewModel.finishStoppedSession(promotePendingSegment: false)
+        await harness.viewModel.polishAndCommitTask?.value
+
+        let windowTask = signals.watcher.windowTask
+        signals.clock.advance(2)
+        signals.sleeper.fireAll()
+        await windowTask?.value
+        await signals.watcher.flushTask?.value
+
+        let record = try XCTUnwrap(recordsOnDisk(in: harness.captureDirectory).last)
+        XCTAssertEqual(record.behavior?.outcome, .clean)
+        XCTAssertNil(record.behavior?.signal)
+    }
+
+    /// The compile flag alone must not watch either: with the runtime opt-in
+    /// off, no observer is ever installed.
+    func testDisarmedRuntimeFlagNeverInstallsAnObserver() async throws {
+        let signals = EditSignalHarness()
+        let harness = try makeHarness(dogfoodArmed: false, editSignal: signals)
+
+        harness.viewModel.finishStoppedSession(promotePendingSegment: false)
+        await harness.viewModel.polishAndCommitTask?.value
+
+        XCTAssertEqual(signals.monitor.startCount, 0)
+        XCTAssertFalse(signals.watcher.isWatching)
+        XCTAssertTrue(signals.sleeper.requestedDurations.isEmpty)
+    }
+
+    /// A stopped-with-no-speech session has nothing to attribute and nothing to
+    /// watch — the guard that skips the record skips the observer too.
+    func testEmptyDictationNeverInstallsAnObserver() async throws {
+        let signals = EditSignalHarness()
+        let harness = try makeHarness(dogfoodArmed: true, editSignal: signals)
+        harness.viewModel.currentDictationEventText = "   "
+
+        harness.viewModel.finishStoppedSession(promotePendingSegment: false)
+        await harness.viewModel.polishAndCommitTask?.value
+
+        XCTAssertEqual(signals.monitor.startCount, 0)
+    }
+
     // MARK: - Builder
 
     func testEndpointClassBuckets() {
@@ -401,9 +482,31 @@ final class DogfoodCaptureWiringTests: XCTestCase {
         let captureDirectory: URL
     }
 
+    /// The injected seams of the post-commit edit watch, bundled so a test can
+    /// drive the window without wall-clock.
+    @MainActor
+    private struct EditSignalHarness {
+        let monitor = DogfoodEditSignalTestMonitor()
+        let sleeper = DogfoodManualSleeper()
+        let clock = DogfoodTestClock()
+        let watcher: DogfoodEditSignalWatcher
+
+        init() {
+            let monitor = self.monitor
+            let sleeper = self.sleeper
+            let clock = self.clock
+            watcher = DogfoodEditSignalWatcher(
+                monitor: monitor,
+                now: { clock.now() },
+                sleepFor: { await sleeper.sleep($0) }
+            )
+        }
+    }
+
     private func makeHarness(
         dogfoodArmed: Bool,
-        blockCaptureDirectory: Bool = false
+        blockCaptureDirectory: Bool = false,
+        editSignal: EditSignalHarness? = nil
     ) throws -> Harness {
         let settings = makeSettings()
         settings.llmPolishingEnabled = true
@@ -432,6 +535,17 @@ final class DogfoodCaptureWiringTests: XCTestCase {
         viewModel.appConfigStore = WiringMockAppConfigStore()
         viewModel.llmPolishingService = SucceedingPolishingService()
         viewModel.dogfoodCaptureStore = DogfoodCaptureStore(directoryURL: captureDirectory)
+        // Always injected, even for the tests that ignore it: the production
+        // watcher would arm a REAL 2 s timer on a process-retained view model,
+        // and this suite does not add wall-clock timers (AGENTS.md).
+        let signals = editSignal ?? EditSignalHarness()
+        viewModel.dogfoodEditSignalWatcher = signals.watcher
+        let sleeper = signals.sleeper
+        addTeardownBlock {
+            // Release a window the test never closed, so no continuation is
+            // left unresumed behind it.
+            sleeper.fireAll()
+        }
         viewModel.isShowingConnectionFailureAlert = true
         Self.retainedViewModels.append(viewModel)
 

--- a/Tests/localvoxtralTests/DogfoodEditSignalTests.swift
+++ b/Tests/localvoxtralTests/DogfoodEditSignalTests.swift
@@ -1,0 +1,475 @@
+#if LOCALVOXTRAL_DOGFOOD
+
+import AppKit
+import Carbon.HIToolbox
+import Foundation
+import Synchronization
+import XCTest
+@testable import localvoxtral
+
+// MARK: - Shared doubles (also used by DogfoodCaptureWiringTests)
+
+/// A key source the watcher can be driven from without an event stream, an
+/// Accessibility grant, or the host's keyboard.
+///
+/// `stop()` deliberately KEEPS the handler: the watcher's own generation/result
+/// guard is what must reject a late signal, and a double that forgot the handler
+/// would pass those tests without the guard existing.
+@MainActor
+final class DogfoodEditSignalTestMonitor: DogfoodEditKeyMonitoring {
+    private(set) var startCount = 0
+    private(set) var stopCount = 0
+    private(set) var isInstalled = false
+    private var handler: (@MainActor (DogfoodEditSignal) -> Void)?
+
+    func start(_ handler: @escaping @MainActor (DogfoodEditSignal) -> Void) {
+        startCount += 1
+        isInstalled = true
+        self.handler = handler
+    }
+
+    func stop() {
+        stopCount += 1
+        isInstalled = false
+    }
+
+    func send(_ signal: DogfoodEditSignal) {
+        handler?(signal)
+    }
+}
+
+/// A `sleepFor` seam the test decides the duration of. No wall-clock: the window
+/// elapses when `fireAll()` says it does (AGENTS.md forbids real sleeps here).
+///
+/// `fireAll()` LATCHES. The watcher starts its window inside a `Task`, which
+/// does not necessarily reach the sleep before the test's next statement runs —
+/// an un-latched fire would resume nobody and the window would then wait
+/// forever, hanging the suite rather than failing it.
+final class DogfoodManualSleeper: Sendable {
+    private struct State {
+        var requested: [Duration] = []
+        var waiters: [CheckedContinuation<Void, Never>] = []
+        var arrivalWaiters: [CheckedContinuation<Void, Never>] = []
+        var fired = false
+    }
+
+    private let state = Mutex(State())
+
+    /// Returns once a window has actually reached the sleep.
+    ///
+    /// `Task.yield()` is NOT enough: the window runs in a `Task` the main actor
+    /// is free to schedule after the test's next statement, which made asserting
+    /// the requested duration flaky (observed on the build host, 2026-07-27).
+    func waitForSleepRequest() async {
+        await withCheckedContinuation { continuation in
+            let resumeNow = state.withLock { current -> Bool in
+                guard current.requested.isEmpty else { return true }
+                current.arrivalWaiters.append(continuation)
+                return false
+            }
+            if resumeNow { continuation.resume() }
+        }
+    }
+
+    func sleep(_ duration: Duration) async {
+        let (alreadyFired, arrivals) = state.withLock { current -> (Bool, [CheckedContinuation<Void, Never>]) in
+            current.requested.append(duration)
+            let arrivals = current.arrivalWaiters
+            current.arrivalWaiters = []
+            return (current.fired, arrivals)
+        }
+        for arrival in arrivals { arrival.resume() }
+        guard !alreadyFired else { return }
+        await withCheckedContinuation { continuation in
+            let resumeNow = state.withLock { current -> Bool in
+                guard !current.fired else { return true }
+                current.waiters.append(continuation)
+                return false
+            }
+            if resumeNow { continuation.resume() }
+        }
+    }
+
+    var requestedDurations: [Duration] { state.withLock { $0.requested } }
+
+    func fireAll() {
+        let waiters = state.withLock { current -> [CheckedContinuation<Void, Never>] in
+            current.fired = true
+            let waiters = current.waiters + current.arrivalWaiters
+            current.waiters = []
+            current.arrivalWaiters = []
+            return waiters
+        }
+        for waiter in waiters { waiter.resume() }
+    }
+}
+
+/// Injected clock, mirroring `CaptureTestClock` in the store suite.
+final class DogfoodTestClock: Sendable {
+    private let value = Mutex(Date(timeIntervalSince1970: 1_800_000_000))
+
+    func now() -> Date { value.withLock { $0 } }
+    func advance(_ seconds: TimeInterval) {
+        value.withLock { $0 = $0.addingTimeInterval(seconds) }
+    }
+}
+
+// MARK: - Tests
+
+/// The post-commit behavioral signal: the ladder, the key mapping, and the
+/// watch window's lifecycle.
+@MainActor
+final class DogfoodEditSignalTests: XCTestCase {
+    // MARK: Policy
+
+    func testWindowLadderBoundaries() {
+        let cases: [(Int, Double)] = [
+            (1, 2), (5, 2),
+            (6, 4), (15, 4),
+            (16, 8), (40, 8),
+            (41, 15), (400, 15),
+        ]
+        for (words, expected) in cases {
+            XCTAssertEqual(
+                DogfoodEditSignalPolicy.windowSeconds(wordCount: words), expected,
+                "\(words) words"
+            )
+        }
+    }
+
+    func testWordCountBucketBoundaries() {
+        let cases: [(Int, String)] = [
+            (1, "1-5"), (5, "1-5"),
+            (6, "6-15"), (15, "6-15"),
+            (16, "16-40"), (40, "16-40"),
+            (41, "41+"), (400, "41+"),
+        ]
+        for (words, expected) in cases {
+            XCTAssertEqual(
+                DogfoodEditSignalPolicy.wordCountBucket(words), expected, "\(words) words"
+            )
+        }
+    }
+
+    func testSecondsSinceCommitBucketBoundaries() {
+        let cases: [(Double, String)] = [
+            (0, "0-1"), (0.99, "0-1"),
+            (1, "1-2"), (1.99, "1-2"),
+            (2, "2-5"), (4.99, "2-5"),
+            (5, "5-15"), (14.9, "5-15"),
+        ]
+        for (seconds, expected) in cases {
+            XCTAssertEqual(
+                DogfoodEditSignalPolicy.secondsSinceCommitBucket(seconds), expected,
+                "\(seconds)s"
+            )
+        }
+    }
+
+    func testWordCountIgnoresWhitespaceRuns() {
+        XCTAssertEqual(DogfoodEditSignalPolicy.wordCount(of: "  run   the tests\n"), 3)
+        XCTAssertEqual(DogfoodEditSignalPolicy.wordCount(of: "   "), 0)
+    }
+
+    // MARK: Key mapping
+
+    /// The whole recognized alphabet. Everything else must be forgotten — this
+    /// is the property that keeps the watch from being a keylogger.
+    func testOnlyTwoGesturesAreRecognized() {
+        XCTAssertEqual(
+            DogfoodEditSignal.from(keyCode: UInt16(kVK_Delete), modifiers: []), .backspace
+        )
+        XCTAssertEqual(
+            DogfoodEditSignal.from(keyCode: UInt16(kVK_ForwardDelete), modifiers: []), .backspace
+        )
+        // A word/line delete is still the user erasing the insertion.
+        XCTAssertEqual(
+            DogfoodEditSignal.from(keyCode: UInt16(kVK_Delete), modifiers: [.option]), .backspace
+        )
+        XCTAssertEqual(
+            DogfoodEditSignal.from(keyCode: UInt16(kVK_ANSI_A), modifiers: [.command]), .selectAll
+        )
+
+        // Plain "a" is typing, not selecting.
+        XCTAssertNil(DogfoodEditSignal.from(keyCode: UInt16(kVK_ANSI_A), modifiers: []))
+        // ⌥⌘A / ⌃⌘A are app shortcuts, not select-all.
+        XCTAssertNil(
+            DogfoodEditSignal.from(keyCode: UInt16(kVK_ANSI_A), modifiers: [.command, .option])
+        )
+        XCTAssertNil(
+            DogfoodEditSignal.from(keyCode: UInt16(kVK_ANSI_A), modifiers: [.command, .control])
+        )
+        // Every other key, modified or not.
+        XCTAssertNil(DogfoodEditSignal.from(keyCode: UInt16(kVK_ANSI_B), modifiers: [.command]))
+        XCTAssertNil(DogfoodEditSignal.from(keyCode: UInt16(kVK_Return), modifiers: []))
+        XCTAssertNil(DogfoodEditSignal.from(keyCode: UInt16(kVK_Escape), modifiers: []))
+    }
+
+    // MARK: Watch window
+
+    /// A gesture inside the window is recorded with the buckets that describe
+    /// it, and the observer comes down at that instant.
+    func testSignalInsideWindowIsRecordedWithBuckets() async throws {
+        let harness = makeWatcher()
+
+        harness.watcher.arm(committedText: "run the tests", outputMode: "overlay_buffer")
+        XCTAssertTrue(harness.watcher.isWatching)
+        XCTAssertEqual(harness.monitor.startCount, 1)
+        await harness.sleeper.waitForSleepRequest()
+        XCTAssertEqual(harness.sleeper.requestedDurations, [.seconds(2.0)], "3 words -> 2s window")
+
+        harness.watcher.attachRecord(url: harness.recordURL, store: harness.store)
+        harness.clock.advance(1.5)
+        harness.monitor.send(.backspace)
+        await harness.watcher.flushTask?.value
+
+        let behavior = try XCTUnwrap(harness.readBack()?.behavior)
+        XCTAssertEqual(behavior.outcome, .edited)
+        XCTAssertEqual(behavior.signal, .backspace)
+        XCTAssertEqual(behavior.secondsSinceCommitBucket, "1-2")
+        XCTAssertEqual(behavior.wordCountBucket, "1-5")
+        XCTAssertEqual(behavior.watchWindowSeconds, 2)
+        XCTAssertEqual(behavior.outputMode, "overlay_buffer")
+
+        XCTAssertFalse(harness.watcher.isWatching)
+        XCTAssertFalse(harness.monitor.isInstalled, "the observer must not outlive its window")
+        XCTAssertEqual(harness.monitor.stopCount, 1)
+    }
+
+    /// ⌘A, and the far end of the ladder: a long transcript gets the long
+    /// window and a late gesture still lands inside it.
+    func testSelectAllLateInALongWindowIsRecorded() async throws {
+        let harness = makeWatcher()
+        let longText = (0..<60).map { "word\($0)" }.joined(separator: " ")
+
+        harness.watcher.arm(committedText: longText, outputMode: "overlay_buffer")
+        await harness.sleeper.waitForSleepRequest()
+        XCTAssertEqual(harness.sleeper.requestedDurations, [.seconds(15.0)])
+        harness.watcher.attachRecord(url: harness.recordURL, store: harness.store)
+
+        harness.clock.advance(9)
+        harness.monitor.send(.selectAll)
+        await harness.watcher.flushTask?.value
+
+        let behavior = try XCTUnwrap(harness.readBack()?.behavior)
+        XCTAssertEqual(behavior.outcome, .edited)
+        XCTAssertEqual(behavior.signal, .selectAll)
+        XCTAssertEqual(behavior.secondsSinceCommitBucket, "5-15")
+        XCTAssertEqual(behavior.wordCountBucket, "41+")
+        XCTAssertEqual(behavior.watchWindowSeconds, 15)
+    }
+
+    /// The negative is recorded too — without it there is no denominator — and
+    /// a gesture arriving after the window closed must not rewrite it.
+    func testSignalAfterWindowIsNotRecorded() async throws {
+        let harness = makeWatcher()
+
+        harness.watcher.arm(committedText: "run the tests", outputMode: "overlay_buffer")
+        harness.watcher.attachRecord(url: harness.recordURL, store: harness.store)
+
+        let windowTask = harness.watcher.windowTask
+        harness.clock.advance(2)
+        harness.sleeper.fireAll()
+        await windowTask?.value
+        await harness.watcher.flushTask?.value
+
+        let clean = try XCTUnwrap(harness.readBack()?.behavior)
+        XCTAssertEqual(clean.outcome, .clean)
+        XCTAssertNil(clean.signal)
+        XCTAssertNil(clean.secondsSinceCommitBucket)
+        XCTAssertEqual(clean.wordCountBucket, "1-5")
+        XCTAssertFalse(harness.monitor.isInstalled)
+
+        // A key that arrives after the window (the monitor double keeps its
+        // handler on purpose) must be ignored, not re-flush the record.
+        harness.clock.advance(1)
+        harness.monitor.send(.backspace)
+        await harness.watcher.flushTask?.value
+        XCTAssertEqual(harness.readBack()?.behavior?.outcome, .clean)
+        XCTAssertEqual(harness.monitor.stopCount, 1, "a closed window closes exactly once")
+    }
+
+    /// Live Auto-Paste rides the same watch; the mode is recorded as given.
+    func testLiveModeOutputModeIsRecorded() async throws {
+        let harness = makeWatcher()
+
+        harness.watcher.arm(
+            committedText: "insert this live",
+            outputMode: DictationOutputMode.liveAutoPaste.rawValue
+        )
+        harness.watcher.attachRecord(url: harness.recordURL, store: harness.store)
+        harness.clock.advance(0.4)
+        harness.monitor.send(.backspace)
+        await harness.watcher.flushTask?.value
+
+        let behavior = try XCTUnwrap(harness.readBack()?.behavior)
+        XCTAssertEqual(behavior.outputMode, DictationOutputMode.liveAutoPaste.rawValue)
+        XCTAssertEqual(behavior.secondsSinceCommitBucket, "0-1")
+    }
+
+    /// A new dictation closes the previous window. The old record still gets its
+    /// own verdict — `superseded`, which is neither evidence of an edit nor of a
+    /// clean commit — and the new watch starts fresh.
+    func testNewDictationSupersedesTheOpenWindow() async throws {
+        let harness = makeWatcher()
+
+        harness.watcher.arm(committedText: "first dictation text", outputMode: "overlay_buffer")
+        harness.watcher.attachRecord(url: harness.recordURL, store: harness.store)
+
+        harness.watcher.arm(committedText: "second dictation text", outputMode: "overlay_buffer")
+        await harness.watcher.flushTask?.value
+
+        XCTAssertEqual(harness.readBack()?.behavior?.outcome, .superseded)
+        XCTAssertEqual(harness.monitor.startCount, 2)
+        XCTAssertEqual(
+            harness.monitor.stopCount, 1,
+            "the old window's observer came down before the new one went up"
+        )
+        XCTAssertTrue(harness.watcher.isWatching, "the new dictation's window is open")
+    }
+
+    /// The superseded record must not then be overwritten by the NEW window's
+    /// verdict: a watch patches only the record it was handed.
+    func testSupersededRecordIsNotRewrittenByTheNextWatch() async throws {
+        let harness = makeWatcher()
+
+        harness.watcher.arm(committedText: "first dictation text", outputMode: "overlay_buffer")
+        harness.watcher.attachRecord(url: harness.recordURL, store: harness.store)
+        harness.watcher.arm(committedText: "second dictation text", outputMode: "overlay_buffer")
+        await harness.watcher.flushTask?.value
+
+        // The second dictation never attached a record (its write is still in
+        // flight), so its gesture has nowhere to land — and must not land on
+        // the first dictation's record.
+        harness.monitor.send(.backspace)
+        await harness.watcher.flushTask?.value
+        XCTAssertEqual(harness.readBack()?.behavior?.outcome, .superseded)
+    }
+
+    /// Nothing to measure, nothing to watch: an empty commit never installs an
+    /// observer.
+    func testEmptyCommitNeverArms() {
+        let harness = makeWatcher()
+        harness.watcher.arm(committedText: "   \n", outputMode: "overlay_buffer")
+        XCTAssertFalse(harness.watcher.isWatching)
+        XCTAssertEqual(harness.monitor.startCount, 0)
+    }
+
+    /// A record that vanished (pruned, or a write that never landed) costs the
+    /// signal, never anything else.
+    func testMissingRecordFailsQuietly() async throws {
+        let harness = makeWatcher(writeRecord: false)
+
+        harness.watcher.arm(committedText: "run the tests", outputMode: "overlay_buffer")
+        harness.watcher.attachRecord(url: harness.recordURL, store: harness.store)
+        harness.monitor.send(.backspace)
+        await harness.watcher.flushTask?.value
+
+        XCTAssertNil(harness.readBack())
+    }
+
+    /// Flagging renames the file; a record flagged during the watch window
+    /// still receives its signal.
+    func testBehaviorPatchFollowsAFlagRename() async throws {
+        let harness = makeWatcher()
+
+        harness.watcher.arm(committedText: "run the tests", outputMode: "overlay_buffer")
+        harness.watcher.attachRecord(url: harness.recordURL, store: harness.store)
+
+        let flaggedURL = try XCTUnwrap(harness.store.flagMostRecentRecord())
+        harness.monitor.send(.backspace)
+        await harness.watcher.flushTask?.value
+
+        let record = try XCTUnwrap(harness.readBack(at: flaggedURL))
+        XCTAssertTrue(record.flagged, "flagging must survive the patch")
+        XCTAssertEqual(record.behavior?.outcome, .edited)
+        XCTAssertNil(harness.readBack(), "the patch must not resurrect the unflagged name")
+    }
+
+    // MARK: Harness
+
+    private struct WatcherHarness {
+        let watcher: DogfoodEditSignalWatcher
+        let monitor: DogfoodEditSignalTestMonitor
+        let sleeper: DogfoodManualSleeper
+        let clock: DogfoodTestClock
+        let store: DogfoodCaptureStore
+        let directory: URL
+        let recordURL: URL
+
+        func readBack(at url: URL? = nil) -> DogfoodCaptureRecord? {
+            let target = url ?? recordURL
+            guard let data = try? Data(contentsOf: target) else { return nil }
+            let decoder = JSONDecoder()
+            decoder.dateDecodingStrategy = .iso8601
+            return try? decoder.decode(DogfoodCaptureRecord.self, from: data)
+        }
+    }
+
+    private func makeWatcher(writeRecord: Bool = true) -> WatcherHarness {
+        let monitor = DogfoodEditSignalTestMonitor()
+        let sleeper = DogfoodManualSleeper()
+        let clock = DogfoodTestClock()
+        let watcher = DogfoodEditSignalWatcher(
+            monitor: monitor,
+            now: { clock.now() },
+            sleepFor: { await sleeper.sleep($0) }
+        )
+
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("dogfood-edit-signal-\(UUID().uuidString)", isDirectory: true)
+        addTeardownBlock {
+            // Release any window still parked on the sleeper, so a test that
+            // ended before its window did leaves no unresumed continuation.
+            sleeper.fireAll()
+            try? FileManager.default.removeItem(at: directory)
+        }
+        let store = DogfoodCaptureStore(directoryURL: directory, now: { clock.now() })
+
+        var recordURL = directory.appendingPathComponent("missing.json", isDirectory: false)
+        if writeRecord {
+            recordURL = (try? store.write(makeRecord(capturedAt: clock.now()))) ?? recordURL
+        }
+
+        return WatcherHarness(
+            watcher: watcher,
+            monitor: monitor,
+            sleeper: sleeper,
+            clock: clock,
+            store: store,
+            directory: directory,
+            recordURL: recordURL
+        )
+    }
+
+    private func makeRecord(capturedAt: Date) -> DogfoodCaptureRecord {
+        DogfoodCaptureRecord(
+            id: UUID().uuidString,
+            capturedAt: capturedAt,
+            session: .init(
+                targetBundleID: "com.mitchellh.ghostty",
+                targetKind: "terminal-like",
+                outputMode: "overlay_buffer",
+                promptProfile: "agent",
+                endpointClass: "loopback",
+                polishModel: "qwen35-4b"
+            ),
+            join: nil,
+            screen: nil,
+            allocation: [],
+            sources: [],
+            text: .init(
+                rawTranscript: "run the tests",
+                workingText: "run the tests",
+                groundedText: "run the tests",
+                systemPrompt: nil,
+                userPrompts: [],
+                polishedOutput: nil,
+                committedText: nil
+            ),
+            timings: .init()
+        )
+    }
+}
+
+#endif

--- a/Tests/localvoxtralTests/DogfoodEditSignalTests.swift
+++ b/Tests/localvoxtralTests/DogfoodEditSignalTests.swift
@@ -20,12 +20,17 @@ final class DogfoodEditSignalTestMonitor: DogfoodEditKeyMonitoring {
     private(set) var startCount = 0
     private(set) var stopCount = 0
     private(set) var isInstalled = false
+    /// Set false to stand in for the untrusted-Accessibility case, where the
+    /// real monitor never goes up.
+    var canInstall = true
     private var handler: (@MainActor (DogfoodEditSignal) -> Void)?
 
-    func start(_ handler: @escaping @MainActor (DogfoodEditSignal) -> Void) {
+    func start(_ handler: @escaping @MainActor (DogfoodEditSignal) -> Void) -> Bool {
         startCount += 1
+        guard canInstall else { return false }
         isInstalled = true
         self.handler = handler
+        return true
     }
 
     func stop() {
@@ -212,13 +217,15 @@ final class DogfoodEditSignalTests: XCTestCase {
     func testSignalInsideWindowIsRecordedWithBuckets() async throws {
         let harness = makeWatcher()
 
-        harness.watcher.arm(committedText: "run the tests", outputMode: "overlay_buffer")
+        let token = try XCTUnwrap(
+            harness.watcher.arm(committedText: "run the tests", outputMode: "overlay_buffer")
+        )
         XCTAssertTrue(harness.watcher.isWatching)
         XCTAssertEqual(harness.monitor.startCount, 1)
         await harness.sleeper.waitForSleepRequest()
         XCTAssertEqual(harness.sleeper.requestedDurations, [.seconds(2.0)], "3 words -> 2s window")
 
-        harness.watcher.attachRecord(url: harness.recordURL, store: harness.store)
+        harness.watcher.attachRecord(url: harness.recordURL, store: harness.store, token: token)
         harness.clock.advance(1.5)
         harness.monitor.send(.backspace)
         await harness.watcher.flushTask?.value
@@ -242,10 +249,12 @@ final class DogfoodEditSignalTests: XCTestCase {
         let harness = makeWatcher()
         let longText = (0..<60).map { "word\($0)" }.joined(separator: " ")
 
-        harness.watcher.arm(committedText: longText, outputMode: "overlay_buffer")
+        let token = try XCTUnwrap(
+            harness.watcher.arm(committedText: longText, outputMode: "overlay_buffer")
+        )
         await harness.sleeper.waitForSleepRequest()
         XCTAssertEqual(harness.sleeper.requestedDurations, [.seconds(15.0)])
-        harness.watcher.attachRecord(url: harness.recordURL, store: harness.store)
+        harness.watcher.attachRecord(url: harness.recordURL, store: harness.store, token: token)
 
         harness.clock.advance(9)
         harness.monitor.send(.selectAll)
@@ -264,8 +273,10 @@ final class DogfoodEditSignalTests: XCTestCase {
     func testSignalAfterWindowIsNotRecorded() async throws {
         let harness = makeWatcher()
 
-        harness.watcher.arm(committedText: "run the tests", outputMode: "overlay_buffer")
-        harness.watcher.attachRecord(url: harness.recordURL, store: harness.store)
+        let token = try XCTUnwrap(
+            harness.watcher.arm(committedText: "run the tests", outputMode: "overlay_buffer")
+        )
+        harness.watcher.attachRecord(url: harness.recordURL, store: harness.store, token: token)
 
         let windowTask = harness.watcher.windowTask
         harness.clock.advance(2)
@@ -293,11 +304,11 @@ final class DogfoodEditSignalTests: XCTestCase {
     func testLiveModeOutputModeIsRecorded() async throws {
         let harness = makeWatcher()
 
-        harness.watcher.arm(
+        let token = try XCTUnwrap(harness.watcher.arm(
             committedText: "insert this live",
             outputMode: DictationOutputMode.liveAutoPaste.rawValue
-        )
-        harness.watcher.attachRecord(url: harness.recordURL, store: harness.store)
+        ))
+        harness.watcher.attachRecord(url: harness.recordURL, store: harness.store, token: token)
         harness.clock.advance(0.4)
         harness.monitor.send(.backspace)
         await harness.watcher.flushTask?.value
@@ -313,8 +324,10 @@ final class DogfoodEditSignalTests: XCTestCase {
     func testNewDictationSupersedesTheOpenWindow() async throws {
         let harness = makeWatcher()
 
-        harness.watcher.arm(committedText: "first dictation text", outputMode: "overlay_buffer")
-        harness.watcher.attachRecord(url: harness.recordURL, store: harness.store)
+        let token = try XCTUnwrap(
+            harness.watcher.arm(committedText: "first dictation text", outputMode: "overlay_buffer")
+        )
+        harness.watcher.attachRecord(url: harness.recordURL, store: harness.store, token: token)
 
         harness.watcher.arm(committedText: "second dictation text", outputMode: "overlay_buffer")
         await harness.watcher.flushTask?.value
@@ -333,8 +346,10 @@ final class DogfoodEditSignalTests: XCTestCase {
     func testSupersededRecordIsNotRewrittenByTheNextWatch() async throws {
         let harness = makeWatcher()
 
-        harness.watcher.arm(committedText: "first dictation text", outputMode: "overlay_buffer")
-        harness.watcher.attachRecord(url: harness.recordURL, store: harness.store)
+        let token = try XCTUnwrap(
+            harness.watcher.arm(committedText: "first dictation text", outputMode: "overlay_buffer")
+        )
+        harness.watcher.attachRecord(url: harness.recordURL, store: harness.store, token: token)
         harness.watcher.arm(committedText: "second dictation text", outputMode: "overlay_buffer")
         await harness.watcher.flushTask?.value
 
@@ -360,8 +375,10 @@ final class DogfoodEditSignalTests: XCTestCase {
     func testMissingRecordFailsQuietly() async throws {
         let harness = makeWatcher(writeRecord: false)
 
-        harness.watcher.arm(committedText: "run the tests", outputMode: "overlay_buffer")
-        harness.watcher.attachRecord(url: harness.recordURL, store: harness.store)
+        let token = try XCTUnwrap(
+            harness.watcher.arm(committedText: "run the tests", outputMode: "overlay_buffer")
+        )
+        harness.watcher.attachRecord(url: harness.recordURL, store: harness.store, token: token)
         harness.monitor.send(.backspace)
         await harness.watcher.flushTask?.value
 
@@ -373,8 +390,10 @@ final class DogfoodEditSignalTests: XCTestCase {
     func testBehaviorPatchFollowsAFlagRename() async throws {
         let harness = makeWatcher()
 
-        harness.watcher.arm(committedText: "run the tests", outputMode: "overlay_buffer")
-        harness.watcher.attachRecord(url: harness.recordURL, store: harness.store)
+        let token = try XCTUnwrap(
+            harness.watcher.arm(committedText: "run the tests", outputMode: "overlay_buffer")
+        )
+        harness.watcher.attachRecord(url: harness.recordURL, store: harness.store, token: token)
 
         let flaggedURL = try XCTUnwrap(harness.store.flagMostRecentRecord())
         harness.monitor.send(.backspace)
@@ -384,6 +403,158 @@ final class DogfoodEditSignalTests: XCTestCase {
         XCTAssertTrue(record.flagged, "flagging must survive the patch")
         XCTAssertEqual(record.behavior?.outcome, .edited)
         XCTAssertNil(harness.readBack(), "the patch must not resurrect the unflagged name")
+        XCTAssertEqual(
+            try harness.store.listRecords().count, 1,
+            "one dictation keeps exactly one record file"
+        )
+    }
+
+    /// The other order: the patch lands first and flagging follows. The flagged
+    /// copy must carry the behavior, and the plain name must be gone — the
+    /// review-queue file is the one with the whole story in it.
+    func testFlagAfterBehaviorPatchKeepsBothFacts() async throws {
+        let harness = makeWatcher()
+
+        let token = try XCTUnwrap(
+            harness.watcher.arm(committedText: "run the tests", outputMode: "overlay_buffer")
+        )
+        harness.watcher.attachRecord(url: harness.recordURL, store: harness.store, token: token)
+        harness.monitor.send(.backspace)
+        await harness.watcher.flushTask?.value
+
+        let flaggedURL = try XCTUnwrap(harness.store.flagMostRecentRecord())
+        let record = try XCTUnwrap(harness.readBack(at: flaggedURL))
+        XCTAssertTrue(record.flagged)
+        XCTAssertEqual(record.behavior?.outcome, .edited)
+        XCTAssertNil(harness.readBack(), "the plain name must not survive the flag")
+        XCTAssertEqual(try harness.store.listRecords().count, 1)
+    }
+
+    /// The race itself, run for real: a flag and a behavior patch issued
+    /// concurrently over the SAME record.
+    ///
+    /// Flagging renames (write flagged, remove plain), so an unserialized patch
+    /// that read the plain file and lost the race would write it back and leave
+    /// TWO files for one dictation — a stale unflagged copy beside the flagged
+    /// one. The store's single-flight lock is what makes both orders end in one
+    /// file that carries both facts.
+    func testConcurrentFlagAndPatchLeaveExactlyOneRecord() async throws {
+        let harness = makeWatcher()
+        let store = harness.store
+        let behavior = DogfoodCaptureRecord.Behavior(
+            outcome: .edited,
+            signal: .backspace,
+            secondsSinceCommitBucket: "0-1",
+            wordCountBucket: "1-5",
+            watchWindowSeconds: 2,
+            outputMode: "overlay_buffer"
+        )
+        let recordURL = harness.recordURL
+
+        // Both are running before either is awaited — the interleaving is real,
+        // not simulated.
+        let flagging = Task.detached { _ = try? store.flagMostRecentRecord() }
+        let patching = Task.detached {
+            _ = try? store.attachBehavior(behavior, toRecordAt: recordURL)
+        }
+        await flagging.value
+        await patching.value
+
+        let records = try store.listRecords()
+        XCTAssertEqual(
+            records.count, 1,
+            "a lost race must never resurrect the pre-rename copy: \(records.map(\.fileName))"
+        )
+        XCTAssertTrue(records[0].flagged, "the flag is the user's, and it wins either way")
+        let record = try XCTUnwrap(harness.readBack(at: records[0].url))
+        XCTAssertTrue(record.flagged, "the name and the JSON must agree")
+        XCTAssertEqual(
+            record.behavior?.outcome, .edited,
+            "whichever order ran, the behavior belongs in the surviving record"
+        )
+    }
+
+    /// FINDING 1's regression, in the LOSING order: a stale watch's attach must
+    /// be rejected by the token, not by timing.
+    ///
+    /// The record write is awaited, so a second dictation can arm while the
+    /// first is still being written. Without the token, the late
+    /// `attachRecord` would hand session A's record to session B's OPEN window
+    /// — and B's gesture would then be written into A's record.
+    func testStaleAttachIsRejectedByTheToken() async throws {
+        let harness = makeWatcher()
+
+        // Session A arms and commits; its record write is still in flight.
+        let staleToken = try XCTUnwrap(
+            harness.watcher.arm(committedText: "first dictation text", outputMode: "overlay_buffer")
+        )
+        // Session B arms before A's write returns. A's window closes as
+        // superseded, with no record attached — nothing is written for it.
+        harness.watcher.arm(committedText: "second dictation text", outputMode: "overlay_buffer")
+        await harness.watcher.flushTask?.value
+
+        // A's write finally returns and tries to attach its record — with A's
+        // (now stale) token.
+        let sessionARecord = try harness.writeExtraRecord()
+        harness.watcher.attachRecord(
+            url: sessionARecord, store: harness.store, token: staleToken
+        )
+
+        // B's window is open and now sees the gesture. If the stale attach had
+        // been accepted, B's `edited` would be sitting in that record.
+        harness.clock.advance(0.5)
+        harness.monitor.send(.backspace)
+        await harness.watcher.flushTask?.value
+
+        XCTAssertNil(
+            harness.readBack(at: sessionARecord)?.behavior,
+            "a stale token must not connect one session's record to another's window"
+        )
+    }
+
+    /// FINDING 5: no Accessibility trust means the observer never goes up, and
+    /// an unobserved dictation must record NOTHING rather than a clean window.
+    /// "Never watched" and "the user kept the text" are different facts and a
+    /// review has to be able to tell them apart from the records alone.
+    func testUnobservableDictationLeavesNoBehaviorBlock() async throws {
+        let harness = makeWatcher()
+        harness.monitor.canInstall = false
+
+        XCTAssertNil(
+            harness.watcher.arm(committedText: "run the tests", outputMode: "overlay_buffer"),
+            "no observer, no token"
+        )
+        XCTAssertFalse(harness.watcher.isWatching)
+        XCTAssertEqual(harness.monitor.startCount, 1, "it did try")
+        XCTAssertTrue(harness.sleeper.requestedDurations.isEmpty, "no window was opened")
+
+        await harness.watcher.flushTask?.value
+        XCTAssertNil(
+            harness.readBack()?.behavior,
+            "an unobserved dictation must not be recorded as clean"
+        )
+    }
+
+    /// FINDING 3: a window still open at quit patches its record INLINE. A Task
+    /// enqueued during `willTerminate` is not guaranteed to run, so the assert
+    /// deliberately does not await anything.
+    func testTerminationFlushesTheOpenWindowInline() throws {
+        let harness = makeWatcher()
+
+        let token = try XCTUnwrap(
+            harness.watcher.arm(committedText: "run the tests", outputMode: "overlay_buffer")
+        )
+        harness.watcher.attachRecord(url: harness.recordURL, store: harness.store, token: token)
+        harness.clock.advance(0.5)
+
+        harness.watcher.flushForTermination()
+
+        XCTAssertEqual(
+            harness.readBack()?.behavior?.outcome, .superseded,
+            "the patch must be on disk before the call returns"
+        )
+        XCTAssertFalse(harness.watcher.isWatching)
+        XCTAssertFalse(harness.monitor.isInstalled)
     }
 
     // MARK: Harness
@@ -396,6 +567,13 @@ final class DogfoodEditSignalTests: XCTestCase {
         let store: DogfoodCaptureStore
         let directory: URL
         let recordURL: URL
+
+        /// A second record in the same store, for the tests that need two.
+        func writeExtraRecord() throws -> URL {
+            try store.write(
+                DogfoodEditSignalTests.makeRecord(capturedAt: clock.now().addingTimeInterval(1))
+            )
+        }
 
         func readBack(at url: URL? = nil) -> DogfoodCaptureRecord? {
             let target = url ?? recordURL
@@ -428,7 +606,7 @@ final class DogfoodEditSignalTests: XCTestCase {
 
         var recordURL = directory.appendingPathComponent("missing.json", isDirectory: false)
         if writeRecord {
-            recordURL = (try? store.write(makeRecord(capturedAt: clock.now()))) ?? recordURL
+            recordURL = (try? store.write(Self.makeRecord(capturedAt: clock.now()))) ?? recordURL
         }
 
         return WatcherHarness(
@@ -442,7 +620,9 @@ final class DogfoodEditSignalTests: XCTestCase {
         )
     }
 
-    private func makeRecord(capturedAt: Date) -> DogfoodCaptureRecord {
+    /// `nonisolated`: a pure factory, and the harness that writes a second
+    /// record is a plain struct off the test class's actor.
+    nonisolated fileprivate static func makeRecord(capturedAt: Date) -> DogfoodCaptureRecord {
         DogfoodCaptureRecord(
             id: UUID().uuidString,
             capturedAt: capturedAt,


### PR DESCRIPTION
## What

The dogfood capture records what the pipeline DID (retrieval / matcher / conflict / budget); nothing in a record says whether the answer was any *good*. A record whose grounding, allocation, and prompt all look correct reads identically to one the owner erased half a second later — and the second is the one worth reviewing.

This adds one content-free behavioral signal to those records: **did the user immediately take the insertion back?**

- After a commit, a bounded window watches for Backspace / forward-delete or ⌘A. The window scales with how long the insertion takes to read: **2 s for 1–5 words, 4 s to 15, 8 s to 40, 15 s beyond** (a stepped ladder on purpose — the buckets are what a review reads, and a formula would only add false precision to a signal whose whole claim is "roughly immediately").
- Recorded: the gesture, a bucketed delay (`0-1`/`1-2`/`2-5`/`5-15`), the word-count bucket, the window length, the output mode. **Not** recorded: key content, text, timestamps, or anything at all about any other key — `DogfoodEditSignal.from(keyCode:modifiers:)` is a two-case total function and the monitor drops everything it returns nil for, inside the closure.
- `clean` and `superseded` outcomes are written too. Without the negative there is no denominator for an edit rate, and "no behavior block" would be indistinguishable from "the watch never armed".

### Design decisions

**Event mechanism — one GLOBAL `NSEvent` keyDown monitor, open only for the window.**
- *Global only, never local*: a local monitor sees keys typed into localvoxtral's own Settings/shortcut-recorder windows, which is not the user reacting to an insertion. The insertion lands in another app, so the reaction does too.
- *No new permission*: global `NSEvent` monitors ride the Accessibility trust insertion already needs. Without it nothing installs (logged) and the window reports `clean`.
- *Not a tap on `ModifierOnlyHotKeyManager`'s existing keyDown monitor*: that one exists only while modifier-only hotkey mode is active, and its handler deliberately discards the event (it needs "a key happened", not which). Widening its callback would fork a production signature for a capture shipped builds do not compile — the same trade `DogfoodCaptureTap` documents, decided the same way.
- Real installation is skipped under XCTest, same rule (and same 2026-07-24 incident) as `ModifierOnlyHotKeyManager.start`; the tests inject a fake monitor.

**Patch, don't delay.** The record is written at commit as before and patched in place when the window closes. Holding a record back for up to 15 s would lose every one of them to a quit, a crash, or a cancelled task — including exactly the dictations whose commit went wrong. `attachBehavior` is a read-modify-write of the *same file*, never `write(_:)`: that recomputes the name from the record, and `capturedAt` has lost its milliseconds to the ISO-8601 round trip by then, so a rewrite would land beside the original as a duplicate. It follows a flag rename (a record flagged during the window still gets its signal).

**Cross-session contamination is structural, not timed.** A watch patches only the one record URL it was handed; a new dictation supersedes the open window (`supersede()` next to `DogfoodCaptureTap.beginSession()` in `captureTerminalScreenContextForSession`), and the superseded watch flushes its *own* record. Same discipline as the tap's generation fix.

**Schema.** `behavior` is additive and optional, so `currentSchemaVersion` stays at 1 — the version exists to stop a reader misreading an older shape, and no existing field changed meaning. Documented in the type that its absence is not "the user kept the text".

**Timing is injected** (`now:` / `sleepFor:`, the `OverlayBufferSessionCoordinator` pattern). No wall-clock anywhere in the logic or the tests. The wiring suite now injects the watcher in *every* harness, so no test in it arms a real 2 s timer on a process-retained view model.

Live vs Overlay: the mode is a parameter the watcher records as given (covered both ways in tests). Today the only arming site is the polish commit path, which is overlay-only — the watcher does not assume it.

## Proof

- [x] Dogfood capture suite green (the lane that compiles this code) — `LV_BUILD_DIR=work/localvoxtral-edit-signal ./scripts/remote-build.sh dogfood`

```
Executed 47 tests, with 0 failures (0 unexpected) in 0.077 (0.079) seconds
```

Per-suite, from `.build/last-remote.log`:

```
Test Suite 'DogfoodEditSignalTests'   Executed 14 tests, with 0 failures (0 unexpected)
Test Suite 'DogfoodCaptureWiringTests' Executed 19 tests, with 0 failures (0 unexpected)
Test Suite 'DogfoodCaptureStoreTests'  Executed 11 tests, with 0 failures (0 unexpected)
```

New tests demonstrating the behavior:

| Test | What it locks |
|---|---|
| `testSignalInsideWindowIsRecordedWithBuckets` | Backspace inside the window → `edited` + `1-2` delay bucket + `1-5` word bucket + 2 s window; observer torn down at close |
| `testSelectAllLateInALongWindowIsRecorded` | ⌘A at 9 s inside a 60-word 15 s window → `5-15` / `41+` |
| `testSignalAfterWindowIsNotRecorded` | Window elapses → `clean`; a gesture after it does not rewrite the record and does not re-close the window |
| `testLiveModeOutputModeIsRecorded` | Live Auto-Paste mode rides through as given |
| `testNewDictationSupersedesTheOpenWindow` / `testSupersededRecordIsNotRewrittenByTheNextWatch` | The old record gets `superseded`; the new watch cannot land on it |
| `testEmptyCommitNeverArms`, `testMissingRecordFailsQuietly`, `testBehaviorPatchFollowsAFlagRename` | No observer without text; a vanished record costs only the signal; a flag rename is followed |
| `testWindowLadderBoundaries`, `testWordCountBucketBoundaries`, `testSecondsSinceCommitBucketBoundaries` | Every ladder/bucket boundary (1/5/6/15/16/40/41, 0.99/1/1.99/2/4.99/5) |
| `testOnlyTwoGesturesAreRecognized` | The whole recognized alphabet: ⌥⌘A/⌃⌘A/plain-a/B/Return/Escape all map to nil — the property that keeps this from being a keylogger |
| `testCommitArmsTheEditWatchAndPatchesItsOwnRecord`, `testUneventfulWindowPatchesTheCleanOutcome` | End-to-end through the REAL `finishStoppedSession` polish/commit path: the commit opens the window, asks for the 2 s ladder rung, and the signal patches that record (still exactly one record on disk) |
| `testDisarmedRuntimeFlagNeverInstallsAnObserver`, `testEmptyDictationNeverInstallsAnObserver` | Compile flag alone never watches: no runtime opt-in → no observer, no window |

- [x] Full unit suite green (shipping shape, flag off — proves it all compiles away) — `LV_BUILD_DIR=work/localvoxtral-edit-signal ./scripts/remote-build.sh`

```
Executed 2015 tests, with 2 tests skipped and 0 failures (0 unexpected) in 71.108 (71.199) seconds
```

No new warnings in either build (the only warnings in the log are pre-existing: `ClaudePluginInstallService.swift:226`, `ClaudeHookPublisherTests.swift:297/321`).

- [ ] **Hand-verification of the live monitor is deferred to the owner's dogfood build.** The real `NSEvent` global monitor cannot be exercised from the unit tier (it is XCTest-pinned off, exactly like `ModifierOnlyHotKeyManager`'s), so what has NOT been verified by hand is: the global monitor actually delivering Backspace/⌘A from another app under the app's Accessibility grant, and the patch landing on a real record in Application Support. `./scripts/remote-build.sh dogfood-package`, arm `defaults write com.localvoxtral.app debug.dogfood_capture_enabled -bool true`, dictate, erase, then check `behavior` in the newest file under `~/Library/Application Support/localvoxtral/dogfood/`.

- [x] CI green end to end — run [30310562086](https://github.com/T0mSIlver/localvoxtral/actions/runs/30310562086), every lane `success`:

```
Test (unit suite)                                   success
Integration tests (live STT service)                success
Polishing helper unit tests (PolishHelper)          success
Speech helper unit tests (SpeechHelper)             success
Dogfood capture suite (instrumented build)          success   Executed 47 tests, with 0 failures
Polishing helper integration (live model + eval)    success   Executed  6 tests, with 0 failures in 82.404s
Smoke test packaged app launch                      success
```

- LLM lanes: the path filter matches (`Sources/localvoxtral/DictationViewModel.swift`), so CI's polishd live-model lane RAN and passed (`LLM eval lane: RUNNING (matched Sources/localvoxtral/DictationViewModel.swift)`, 6/6 green above). Nothing here changes what reaches the model — the arm call sits after the commit inside `#if LOCALVOXTRAL_DOGFOOD`, which the shipping-shape lanes do not compile at all; prompts, grounding, budget, and the request shape are untouched.

## Review round (ab0fc83)

Independent review found one real bug and five hardening items. All addressed on this branch.

**1 (required) — the `attachRecord` generation guard was a no-op.** It compared the current watch's generation against the watcher's own, which are equal by construction, so the contamination prevention this PR claimed was not delivered. `arm` now returns a `WatchToken` naming that dictation; the commit path carries it across the awaited record write and `attachRecord` compares against it.

Regression test in the LOSING order (`testStaleAttachIsRejectedByTheToken`): A arms, B arms while A's write is still in flight, A's late attach must be rejected. Against the pre-fix guard, restored temporarily:

```
DogfoodEditSignalTests.swift:509: error: -[DogfoodEditSignalTests testStaleAttachIsRejectedByTheToken] :
XCTAssertNil failed: "Behavior(outcome: edited, signal: Optional(backspace), secondsSinceCommitBucket:
Optional("0-1"), wordCountBucket: "1-5", watchWindowSeconds: 2.0, outputMode: "overlay_buffer")"
- a stale token must not connect one session's record to another's window
	 Executed 52 tests, with 1 failure (0 unexpected) in 0.284 (0.287) seconds
```

— i.e. exactly the reported contamination: session B's gesture written into session A's record. With the token guard: **52 tests, 0 failures**.

**2 — `attachBehavior` raced `flagMostRecentRecord`'s rename.** A patch that read the plain file and lost the race would write it back beside the flagged one: two records for one dictation, the stale one exempt from nothing. Both mutating paths (plus `write`/`prune`) now run under one process-wide single-flight lock, with unlocked private bodies so the non-recursive `Mutex` is never re-entered.

Three tests: `testBehaviorPatchFollowsAFlagRename` (flag wins — extended to assert exactly one file), `testFlagAfterBehaviorPatchKeepsBothFacts` (patch wins), and `testConcurrentFlagAndPatchLeaveExactlyOneRecord` (both issued concurrently). The concurrent one fails with the lock removed, on the first run:

```
DogfoodEditSignalTests.swift:471: error: -[DogfoodEditSignalTests testConcurrentFlagAndPatchLeaveExactlyOneRecord] :
XCTAssertEqual failed: ("nil") is not equal to ("Optional(edited)")
- whichever order ran, the behavior belongs in the surviving record
	 Executed 52 tests, with 1 failure (0 unexpected) in 0.308 (0.311) seconds
```

**3 — quit path.** A window still open at quit now patches its record from `willTerminateNotification`, written INLINE: a `Task` enqueued at terminate is not guaranteed to run (the backend shutdown beside it is best-effort for the same reason), so `flushForTermination` does the one small JSON rewrite on the main actor. `superseded` is documented as covering both causes, and the class doc states what a crash still loses. Test: `testTerminationFlushesTheOpenWindowInline` deliberately awaits nothing before asserting the patch is on disk.

**4 — prose.** Docs said "Backspace or ⌘A" while the code also matches forward delete. Fixed in the AGENTS.md paragraph and the type doc, so the privacy claim matches the mapping.

**5 — honest "never observed".** With Accessibility untrusted the observer never goes up, and the window used to report `clean` — indistinguishable from the user keeping the text. `start` now reports whether it installed, `arm` refuses on `false` and returns no token, and the dictation gets **no behavior block at all**. Test: `testUnobservableDictationLeavesNoBehaviorBlock`.

**6 — `isolated deinit { monitor.stop() }`** (SE-0371), so a watcher that goes away mid-window leaves no live keyboard observer behind.

### Proof after the review round

- Dogfood lane — `LV_BUILD_DIR=work/localvoxtral-edit-signal ./scripts/remote-build.sh dogfood`

```
Test Suite 'DogfoodEditSignalTests'    Executed 19 tests, with 0 failures (0 unexpected)
Test Suite 'DogfoodCaptureWiringTests' Executed 19 tests, with 0 failures (0 unexpected)
Test Suite 'DogfoodCaptureStoreTests'  Executed 11 tests, with 0 failures (0 unexpected)
                                       Executed 52 tests, with 0 failures (0 unexpected) in 0.094s
```

- Full shipping-shape suite (flag off) — `LV_BUILD_DIR=work/localvoxtral-edit-signal ./scripts/remote-build.sh`

```
Executed 2015 tests, with 2 tests skipped and 0 failures (0 unexpected) in 74.929 (75.028) seconds
```

Still zero new warnings (the only one in the build is pre-existing `ClaudePluginInstallService.swift:226`).

- CI green on `ab0fc83` — run [30312344206](https://github.com/T0mSIlver/localvoxtral/actions/runs/30312344206), every lane `success`:

```
Test (unit suite)                                   success   Executed 2024 tests, 11 skipped, 0 failures
Integration tests (live STT service)                success
Polishing helper unit tests (PolishHelper)          success
Speech helper unit tests (SpeechHelper)             success
Dogfood capture suite (instrumented build)          success   Executed 52 tests, with 0 failures
Polishing helper integration (live model + eval)    success
Smoke test packaged app launch                      success
```

## Notes

- One flake found and fixed while writing the tests, worth knowing for the next dogfood suite: the window runs in a `Task`, and `Task.yield()` does **not** reliably let it reach the injected sleep before the test's next statement. The manual sleeper now latches its fire and exposes `waitForSleepRequest()`; an unlatched fire hung the suite outright rather than failing it.
