### PR TITLE
Wire v2: agent-tagged records, per-agent session namespacing, pane focus declarations

### DIFF
--- a/Sources/ClaudeContextWire/ClaudeHookWire.swift
+++ b/Sources/ClaudeContextWire/ClaudeHookWire.swift
@@ -12,7 +12,59 @@ import Foundation
 /// dropped, never partially trusted.
 public enum ClaudeHookWire {
     /// Current wire version. Bump on any incompatible field change.
-    public static let version = 1
+    ///
+    /// v2 added the `agent` field (absent = `.claude`) and the `FocusChanged`
+    /// event for the opencode integration.
+    public static let version = 2
+
+    /// Versions this build still reads. v1 is the pre-agent wire: every v1
+    /// record is, by definition, a Claude Code record, so v1 lines decode with
+    /// `agent == .claude` rather than being dropped — the publisher binary and
+    /// the app usually ship together, but a stale installed plugin pointing at
+    /// an old publisher must not silently lose all context after an update.
+    public static let readableVersions: Set<Int> = [1, 2]
+}
+
+/// Which coding agent published a record. Content, not trust: trust stays a
+/// property of the transport (`ClaudeTransportOrigin`), and every local agent
+/// publishes over the same peer-authenticated socket. What the agent tag
+/// decides is session-id namespacing (`ClaudeAgentSessionScope`) and
+/// per-agent channel rules — e.g. the broker never returns a title marker to
+/// an opencode session, because opencode owns its window title the way herdr
+/// owns its pane titles.
+///
+/// Decoding an unknown agent name is a drop, mirroring unknown events: a
+/// newer plugin talking to an older app degrades to "ignored", and an agent
+/// whose channel rules we do not know must not inherit another's.
+public enum ClaudeHookAgent: String, Sendable, Equatable, CaseIterable, Codable {
+    case claude
+    case opencode
+}
+
+/// Namespacing for per-agent session ids, mirroring `ClaudeRemoteSessionScope`.
+///
+/// Two agents pick their own session ids and cannot coordinate — Claude Code
+/// uses bare UUIDs, opencode uses `ses_…` — so a bare id is a claim, not a
+/// key. Scoping opencode ids under a prefix no Claude-published UUID can carry
+/// makes cross-agent collision structurally impossible. Applied by the
+/// RECEIVER (`ClaudeSessionRegistry.ingest`), never trusted from the wire, so
+/// a publisher cannot pre-scope itself into another namespace being honest or
+/// otherwise — the registry recomputes the key from the agent tag every time.
+/// (A local peer lying about its agent tag is a same-UID process and already
+/// outside the threat model, same as the remote scope's note on host ids.)
+public enum ClaudeAgentSessionScope {
+    /// Distinct from `ClaudeRemoteSessionScope.prefix` ("remote:") — the two
+    /// namespaces must never alias.
+    public static let opencodePrefix = "opencode:"
+
+    public static func scopedSessionID(agent: ClaudeHookAgent, sessionID: String) -> String {
+        switch agent {
+        case .claude:
+            return sessionID
+        case .opencode:
+            return opencodePrefix + sessionID
+        }
+    }
 }
 
 /// Hook events the plugin publishes. Cases map 1:1 to Claude Code hook names.
@@ -36,6 +88,13 @@ public enum ClaudeHookEvent: String, Sendable, Equatable, CaseIterable, Codable 
     case fileChanged = "FileChanged"
     case stop = "Stop"
     case sessionEnd = "SessionEnd"
+    /// Published by the opencode plugin's TUI half only (v2): "the pane on
+    /// this TTY currently displays this session". One opencode process hosts
+    /// several sessions on one terminal, so per-session TTY claims cannot
+    /// disambiguate them — an explicit, freshness-bounded focus declaration
+    /// can. Claude Code never sends this; nothing in its hook set knows what a
+    /// pane displays.
+    case focusChanged = "FocusChanged"
 }
 
 /// Hard bounds applied at BOTH ends of the wire.
@@ -155,6 +214,10 @@ public struct ClaudeFileTouch: Sendable, Equatable, Codable {
 public struct ClaudeHookRecord: Sendable, Equatable {
     public var version: Int
     public var event: ClaudeHookEvent
+    /// Which coding agent published this. Encoded only when it is not the
+    /// default `.claude`, so v1 readers' "absent field" and v2's default agree
+    /// byte-for-byte on every Claude record.
+    public var agent: ClaudeHookAgent
     public var sessionID: String
     /// Seconds since the UNIX epoch, as stamped by the publisher.
     public var timestamp: Double
@@ -170,6 +233,7 @@ public struct ClaudeHookRecord: Sendable, Equatable {
     public init(
         version: Int = ClaudeHookWire.version,
         event: ClaudeHookEvent,
+        agent: ClaudeHookAgent = .claude,
         sessionID: String,
         timestamp: Double,
         rawCwd: String? = nil,
@@ -180,6 +244,7 @@ public struct ClaudeHookRecord: Sendable, Equatable {
     ) {
         self.version = version
         self.event = event
+        self.agent = agent
         self.sessionID = sessionID
         self.timestamp = timestamp
         self.rawCwd = rawCwd
@@ -194,6 +259,7 @@ extension ClaudeHookRecord: Codable {
     enum CodingKeys: String, CodingKey {
         case version = "v"
         case event
+        case agent
         case sessionID = "session_id"
         case timestamp = "ts"
         case rawCwd = "cwd"
@@ -207,6 +273,11 @@ extension ClaudeHookRecord: Codable {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         version = try container.decode(Int.self, forKey: .version)
         event = try container.decode(ClaudeHookEvent.self, forKey: .event)
+        // Absent means the default agent — that is what makes every v1 line
+        // (which predates the field) a Claude record by construction. An
+        // unknown agent NAME never reaches this decoder: `decodeLine` probes
+        // and rejects it first, the same way it handles unknown events.
+        agent = try container.decodeIfPresent(ClaudeHookAgent.self, forKey: .agent) ?? .claude
         sessionID = try container.decode(String.self, forKey: .sessionID)
         timestamp = try container.decode(Double.self, forKey: .timestamp)
         rawCwd = try container.decodeIfPresent(String.self, forKey: .rawCwd)
@@ -216,6 +287,24 @@ extension ClaudeHookRecord: Codable {
         process = try container.decodeIfPresent(ClaudeHookProcessInfo.self, forKey: .process)
         // Any other key on the wire — notably an `origin`-shaped one — is
         // silently discarded here. That is the point: trust is not a field.
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(version, forKey: .version)
+        try container.encode(event, forKey: .event)
+        // Omitted when `.claude`: absence IS the default, so a Claude record's
+        // bytes carry no agent key — the exact shape a v1 reader expects.
+        if agent != .claude {
+            try container.encode(agent, forKey: .agent)
+        }
+        try container.encode(sessionID, forKey: .sessionID)
+        try container.encode(timestamp, forKey: .timestamp)
+        try container.encodeIfPresent(rawCwd, forKey: .rawCwd)
+        try container.encodeIfPresent(prompt, forKey: .prompt)
+        try container.encodeIfPresent(toolName, forKey: .toolName)
+        try container.encode(files, forKey: .files)
+        try container.encodeIfPresent(process, forKey: .process)
     }
 }
 
@@ -227,6 +316,11 @@ public enum ClaudeHookWireError: Error, Equatable {
     case unsupportedVersion(Int?)
     /// Event name we do not know (e.g. from a newer plugin).
     case unknownEvent(String?)
+    /// Agent name we do not know. Dropped for the same reason as an unknown
+    /// event — and additionally because per-agent channel rules (marker
+    /// emission, session namespacing) cannot be applied to an agent this build
+    /// has never heard of.
+    case unknownAgent(String?)
     /// Malformed JSON, or a required field missing.
     case malformed
     /// `session_id` was empty — the record cannot be attributed.
@@ -275,12 +369,21 @@ public enum ClaudeHookWireCodec {
             throw ClaudeHookWireError.malformed
         }
         let claimedVersion = dictionary["v"] as? Int
-        guard claimedVersion == ClaudeHookWire.version else {
+        guard let claimedVersion, ClaudeHookWire.readableVersions.contains(claimedVersion) else {
             throw ClaudeHookWireError.unsupportedVersion(claimedVersion)
         }
         let eventName = dictionary["event"] as? String
         guard let eventName, ClaudeHookEvent(rawValue: eventName) != nil else {
             throw ClaudeHookWireError.unknownEvent(eventName)
+        }
+        // Probed like the event: an unknown agent must be a precise "ignored",
+        // not a generic decode failure — and never a fallthrough to `.claude`,
+        // which would hand a future agent Claude's channel rules.
+        if let agentValue = dictionary["agent"] {
+            let agentName = agentValue as? String
+            guard let agentName, ClaudeHookAgent(rawValue: agentName) != nil else {
+                throw ClaudeHookWireError.unknownAgent(agentName)
+            }
         }
 
         guard let record = try? JSONDecoder().decode(ClaudeHookRecord.self, from: trimmed) else {

--- a/Sources/ClaudeContextWire/ClaudeHookWire.swift
+++ b/Sources/ClaudeContextWire/ClaudeHookWire.swift
@@ -95,6 +95,14 @@ public enum ClaudeHookEvent: String, Sendable, Equatable, CaseIterable, Codable 
     /// can. Claude Code never sends this; nothing in its hook set knows what a
     /// pane displays.
     case focusChanged = "FocusChanged"
+    /// The pane left its session view (v2, opencode TUI half only): "this TTY
+    /// no longer displays the named session". Retracts the pane's focus
+    /// declaration immediately instead of letting it linger until TTL — a
+    /// user who navigated home is not dictating into the session they left.
+    /// The named session is the one being retracted; the registry clears the
+    /// TTY's declaration regardless, because a clear can only ever widen
+    /// abstention.
+    case focusCleared = "FocusCleared"
 }
 
 /// Hard bounds applied at BOTH ends of the wire.
@@ -380,6 +388,13 @@ public enum ClaudeHookWireCodec {
         // not a generic decode failure — and never a fallthrough to `.claude`,
         // which would hand a future agent Claude's channel rules.
         if let agentValue = dictionary["agent"] {
+            // No v1 writer ever emitted this key — v1 predates it, and
+            // "absent = claude" is the entire v1 compatibility contract. A v1
+            // line that carries it anyway is not an old publisher; it is a
+            // malformed or hand-crafted record, and it is dropped as such.
+            guard claimedVersion >= 2 else {
+                throw ClaudeHookWireError.malformed
+            }
             let agentName = agentValue as? String
             guard let agentName, ClaudeHookAgent(rawValue: agentName) != nil else {
                 throw ClaudeHookWireError.unknownAgent(agentName)

--- a/Sources/ClaudeContextWire/ClaudeMarkerSequence.swift
+++ b/Sources/ClaudeContextWire/ClaudeMarkerSequence.swift
@@ -37,7 +37,10 @@ public struct ClaudeBrokerResponse: Sendable, Equatable, Codable {
         guard let response = try? JSONDecoder().decode(ClaudeBrokerResponse.self, from: line) else {
             return nil
         }
-        guard response.version == ClaudeHookWire.version else { return nil }
+        // Any readable wire version, not just the current one: a publisher one
+        // release ahead of or behind the app must degrade to "no marker", not
+        // lose the marker channel entirely until both halves are updated.
+        guard ClaudeHookWire.readableVersions.contains(response.version) else { return nil }
         return response
     }
 }

--- a/Sources/localvoxtral/ClaudeContext/ClaudeSessionRegistry.swift
+++ b/Sources/localvoxtral/ClaudeContext/ClaudeSessionRegistry.swift
@@ -32,12 +32,14 @@ public struct ClaudeRegistryLimits: Sendable, Equatable {
     /// while leaving most of the global registry available to other origins.
     public static let defaultMaxSessionsPerOrigin = 8
     /// How long a focus declaration stays credible. The opencode TUI half
-    /// heartbeats its focused session roughly every 20 seconds, so two minutes
-    /// tolerates a few lost beats while bounding how long a pane that stopped
-    /// declaring anything (TUI quit, machine slept) can keep steering the TTY
-    /// join. Stale focus is treated as ABSENT information, never as "probably
-    /// still the same one".
-    public static let defaultFocusDeclarationTTL: TimeInterval = 2 * 60
+    /// re-declares on every displayed-session change AND retracts explicitly
+    /// (`FocusCleared`) when the pane leaves its session view, so this bound
+    /// only defends against lost writes and a silently dead TUI: at a
+    /// 20-second heartbeat, 45 seconds tolerates one lost beat plus jitter
+    /// while keeping a pane that stopped declaring from steering the TTY join
+    /// for long. Stale focus is treated as ABSENT information, never as
+    /// "probably still the same one".
+    public static let defaultFocusDeclarationTTL: TimeInterval = 45
     /// Focus declarations are keyed by TTY device, one live entry per pane.
     /// Matches the session cap: there is no reason to remember more panes than
     /// we would remember sessions.
@@ -143,6 +145,18 @@ public final class ClaudeSessionRegistry: Sendable {
         snippets: [ClaudeContentSnippet] = []
     ) -> ClaudeSessionSnapshot? {
         let timestamp = now()
+        // A LOCAL Claude record whose raw id spells another namespace's prefix
+        // is spelling a key that can never be its own: Claude Code ids are
+        // bare UUIDs, opencode ids get the prefix added HERE, and remote ids
+        // are minted by the remote listener (which passes them in pre-scoped,
+        // over a remote origin — that path is exempt below). Dropping these
+        // outright closes the aliasing hole where a crafted `claude` record
+        // literally named "opencode:X" would collide with opencode's raw "X".
+        if origin.isLocalAuthenticated, record.agent == .claude,
+           record.sessionID.hasPrefix(ClaudeAgentSessionScope.opencodePrefix)
+               || record.sessionID.hasPrefix(ClaudeRemoteSessionScope.prefix) {
+            return nil
+        }
         // Receiver-side namespacing, recomputed on EVERY ingest from the agent
         // tag — mirroring how the remote listener scopes ids under the host
         // that authenticated them. The registry keys, the focus table, and
@@ -154,15 +168,33 @@ public final class ClaudeSessionRegistry: Sendable {
         return state.withLock { state -> ClaudeSessionSnapshot? in
             pruneLocked(&state, now: timestamp)
 
-            if record.event == .focusChanged {
-                // Focus is pane state, not session state: record the TTY→session
-                // binding, bump the named session if we know it, but NEVER mint
-                // a session from a focus record — a pane can display a session
-                // whose own records were lost, and inventing an empty snapshot
-                // for it would let the focus join "resolve" to a session we know
-                // nothing about.
-                recordFocusLocked(&state, record: record, origin: origin, now: timestamp)
+            // Focus records are pane state, not session state, and they are an
+            // opencode-only mechanism (Claude Code has no way to know what a
+            // pane displays — a `.claude` focus record is an inconsistency to
+            // refuse, not to honor). Everything is validated BEFORE any focus
+            // state is touched: an invalid declaration must not be able to
+            // suppress an existing per-session TTY claim for the focus TTL —
+            // that ordering bug is exactly what review C2b caught.
+            switch record.event {
+            case .focusChanged:
+                guard isValidFocusDeclarationLocked(state, record: record, origin: origin) else {
+                    return nil
+                }
+                recordFocusLocked(&state, record: record, now: timestamp)
+                // Falls through: the target exists (validated), so the reduce
+                // below bumps its activity.
+            case .focusCleared:
+                guard record.agent == .opencode, origin.isLocalAuthenticated,
+                      let tty = record.process?.tty, !tty.isEmpty
+                else { return nil }
+                // Unconditional removal by TTY, no pid cross-check: a clear
+                // can only ever WIDEN abstention, and requiring the declaring
+                // pid to match would let a restarted TUI's retraction bounce
+                // off its predecessor's lingering entry.
+                state.focusByTTY.removeValue(forKey: tty)
                 guard state.sessions[record.sessionID] != nil else { return nil }
+            default:
+                break
             }
 
             var snapshot: ClaudeSessionSnapshot
@@ -335,6 +367,14 @@ public final class ClaudeSessionRegistry: Sendable {
     /// remote host's pane ids live in another machine's herdr and could collide
     /// with (or deliberately mirror) a local pane's id; matching them here would
     /// let an SSH host claim a local pane by echoing its pane id.
+    ///
+    /// Every opencode session in one TUI shares the pane id AND the pid, so
+    /// with two sessions this used to hit `.ambiguous` before focus could
+    /// participate — the herdr arm silently stopped joining opencode panes
+    /// (review C3). Fresh focus declarations now arbitrate multi-candidate
+    /// panes the same way they arbitrate a TTY: a verified declaration
+    /// (fresh, pid-matched) naming EXACTLY ONE of the pane's candidates
+    /// resolves to it; anything else stays `.ambiguous`.
     public func resolve(herdrPaneID: String) -> ClaudeMarkerResolution {
         let timestamp = now()
         return state.withLock { state in
@@ -352,7 +392,22 @@ public final class ClaudeSessionRegistry: Sendable {
             case 1:
                 return .resolved(matches[0])
             default:
-                return .ambiguous
+                // Focus declarations are keyed by the pane's inner TTY, which
+                // the outer herdr surface cannot know — so scan all fresh,
+                // pid-verified declarations for ones naming a candidate of
+                // THIS pane. Exactly one distinct session may win; zero or
+                // several (two TUIs somehow claiming siblings) abstain.
+                let focused = Set(state.focusByTTY.values.compactMap { focus -> String? in
+                    guard timestamp.timeIntervalSince(focus.declaredAt) <= limits.focusDeclarationTTL,
+                          let candidate = matches.first(where: { $0.sessionID == focus.sessionID }),
+                          candidate.process?.claudePID == focus.declaredPID
+                    else { return nil }
+                    return focus.sessionID
+                })
+                guard focused.count == 1, let winner = focused.first,
+                      let snapshot = matches.first(where: { $0.sessionID == winner })
+                else { return .ambiguous }
+                return .resolved(snapshot)
             }
         }
     }
@@ -479,21 +534,45 @@ public final class ClaudeSessionRegistry: Sendable {
         }
     }
 
-    /// Record one pane's declared focus. LOCAL transport only — a remote
-    /// host's TTY names a device on another machine, exactly the reason
-    /// `resolve(tty:)` refuses remote candidates — and only when the record
-    /// carries the declaring pane's device; a focus claim with no TTY binds
-    /// nothing.
+    /// Every condition a focus declaration must meet BEFORE any focus state is
+    /// mutated (review C2b: writing first let an invalid declaration suppress
+    /// a live per-session TTY claim for the focus TTL even though ingest
+    /// rejected the record):
+    ///
+    /// * opencode-only — focus is that agent's mechanism, and a `.claude`
+    ///   focus record is an inconsistency to refuse (review hardening);
+    /// * LOCAL transport only — a remote host's TTY names a device on another
+    ///   machine, exactly the reason `resolve(tty:)` refuses remote candidates;
+    /// * carries the declaring pane's device — a claim with no TTY binds
+    ///   nothing;
+    /// * names a session the registry KNOWS, of the same agent, itself locally
+    ///   authenticated, registered to the declaring process. A declaration
+    ///   that could never resolve must not exist — and a session the pane
+    ///   displays but whose records were lost self-heals at the next
+    ///   heartbeat, once its own records arrive.
+    private func isValidFocusDeclarationLocked(
+        _ state: State,
+        record: ClaudeHookRecord,
+        origin: ClaudeTransportOrigin
+    ) -> Bool {
+        guard record.agent == .opencode,
+              origin.isLocalAuthenticated,
+              let process = record.process,
+              let tty = process.tty, !tty.isEmpty,
+              let target = state.sessions[record.sessionID],
+              target.agent == record.agent,
+              target.origin.isLocalAuthenticated,
+              target.process?.claudePID == process.claudePID
+        else { return false }
+        return true
+    }
+
     private func recordFocusLocked(
         _ state: inout State,
         record: ClaudeHookRecord,
-        origin: ClaudeTransportOrigin,
         now: Date
     ) {
-        guard origin.isLocalAuthenticated,
-              let process = record.process,
-              let tty = process.tty, !tty.isEmpty
-        else { return }
+        guard let process = record.process, let tty = process.tty else { return }
         state.focusByTTY[tty] = FocusDeclaration(
             sessionID: record.sessionID,
             declaredPID: process.claudePID,

--- a/Sources/localvoxtral/ClaudeContext/ClaudeSessionRegistry.swift
+++ b/Sources/localvoxtral/ClaudeContext/ClaudeSessionRegistry.swift
@@ -31,6 +31,17 @@ public struct ClaudeRegistryLimits: Sendable, Equatable {
     /// than this many sessions. Eight covers a generous set of terminal tabs
     /// while leaving most of the global registry available to other origins.
     public static let defaultMaxSessionsPerOrigin = 8
+    /// How long a focus declaration stays credible. The opencode TUI half
+    /// heartbeats its focused session roughly every 20 seconds, so two minutes
+    /// tolerates a few lost beats while bounding how long a pane that stopped
+    /// declaring anything (TUI quit, machine slept) can keep steering the TTY
+    /// join. Stale focus is treated as ABSENT information, never as "probably
+    /// still the same one".
+    public static let defaultFocusDeclarationTTL: TimeInterval = 2 * 60
+    /// Focus declarations are keyed by TTY device, one live entry per pane.
+    /// Matches the session cap: there is no reason to remember more panes than
+    /// we would remember sessions.
+    public static let defaultMaxFocusDeclarations = 32
 
     /// Hard cap on retained sessions. Beyond this, the least-recently-active is
     /// evicted — a user with hundreds of stale sessions must not grow the app.
@@ -44,17 +55,23 @@ public struct ClaudeRegistryLimits: Sendable, Equatable {
     /// PID liveness — not SessionEnd alone — is what keeps the registry honest.
     public var sessionTTL: TimeInterval
     public var pidlessLocalSessionTTL: TimeInterval
+    public var focusDeclarationTTL: TimeInterval
+    public var maxFocusDeclarations: Int
 
     public init(
         maxSessions: Int = 32,
         maxSessionsPerOrigin: Int = Self.defaultMaxSessionsPerOrigin,
         sessionTTL: TimeInterval = 4 * 60 * 60,
-        pidlessLocalSessionTTL: TimeInterval = Self.defaultPIDLessLocalSessionTTL
+        pidlessLocalSessionTTL: TimeInterval = Self.defaultPIDLessLocalSessionTTL,
+        focusDeclarationTTL: TimeInterval = Self.defaultFocusDeclarationTTL,
+        maxFocusDeclarations: Int = Self.defaultMaxFocusDeclarations
     ) {
         self.maxSessions = maxSessions
         self.maxSessionsPerOrigin = maxSessionsPerOrigin
         self.sessionTTL = sessionTTL
         self.pidlessLocalSessionTTL = pidlessLocalSessionTTL
+        self.focusDeclarationTTL = focusDeclarationTTL
+        self.maxFocusDeclarations = maxFocusDeclarations
     }
 
     public static let `default` = ClaudeRegistryLimits()
@@ -65,9 +82,23 @@ public struct ClaudeRegistryLimits: Sendable, Equatable {
 /// `Mutex` + `Sendable` per repo convention (no custom actors): the broker's
 /// accept thread writes, the main actor reads, and neither should await.
 public final class ClaudeSessionRegistry: Sendable {
+    /// One pane's declared focus: "the TTY this is keyed by currently displays
+    /// this session", as published by an agent that can actually see its own
+    /// pane (the opencode TUI half). Held per TTY, not per session — focus is
+    /// a property of the pane.
+    private struct FocusDeclaration {
+        var sessionID: String
+        /// The declaring process's pid. Cross-checked against the focused
+        /// session's registered pid at resolution: a declaration that outlived
+        /// its process must not steer a recycled TTY.
+        var declaredPID: Int32
+        var declaredAt: Date
+    }
+
     private struct State {
         var sessions: [String: ClaudeSessionSnapshot] = [:]
         var markerIndex: [String: String] = [:] // marker value -> session id
+        var focusByTTY: [String: FocusDeclaration] = [:]
     }
 
     private let state = Mutex(State())
@@ -112,8 +143,27 @@ public final class ClaudeSessionRegistry: Sendable {
         snippets: [ClaudeContentSnippet] = []
     ) -> ClaudeSessionSnapshot? {
         let timestamp = now()
+        // Receiver-side namespacing, recomputed on EVERY ingest from the agent
+        // tag — mirroring how the remote listener scopes ids under the host
+        // that authenticated them. The registry keys, the focus table, and
+        // every snapshot all speak scoped ids from here on.
+        var record = record
+        record.sessionID = ClaudeAgentSessionScope.scopedSessionID(
+            agent: record.agent, sessionID: record.sessionID
+        )
         return state.withLock { state -> ClaudeSessionSnapshot? in
             pruneLocked(&state, now: timestamp)
+
+            if record.event == .focusChanged {
+                // Focus is pane state, not session state: record the TTY→session
+                // binding, bump the named session if we know it, but NEVER mint
+                // a session from a focus record — a pane can display a session
+                // whose own records were lost, and inventing an empty snapshot
+                // for it would let the focus join "resolve" to a session we know
+                // nothing about.
+                recordFocusLocked(&state, record: record, origin: origin, now: timestamp)
+                guard state.sessions[record.sessionID] != nil else { return nil }
+            }
 
             var snapshot: ClaudeSessionSnapshot
             if let existing = state.sessions[record.sessionID] {
@@ -130,12 +180,19 @@ public final class ClaudeSessionRegistry: Sendable {
                 // transport naming the same id is, by construction, someone
                 // spelling an id that is not theirs.
                 if snapshot.origin != origin { return nil }
+                // The agent is likewise fixed at first sight. Agent scoping
+                // makes an honest collision impossible (the scoped keys
+                // differ), so a mismatch here is a record spelling another
+                // agent's scoped id — drop it rather than let one agent's
+                // records mutate another's session.
+                if snapshot.agent != record.agent { return nil }
             } else {
                 if record.event == .sessionEnd { return nil } // nothing to start
                 let marker = ClaudeSessionMarker(value: allocateUniqueMarkerLocked(&state))
                 snapshot = ClaudeSessionSnapshot(
                     sessionID: record.sessionID,
                     origin: origin,
+                    agent: record.agent,
                     marker: marker,
                     firstSeen: timestamp
                 )
@@ -209,9 +266,28 @@ public final class ClaudeSessionRegistry: Sendable {
     /// Only LOCAL sessions are candidates: a remote session's TTY names a
     /// device on another machine, where it can collide with an unrelated local
     /// pane — matching it here would let an SSH host claim a local pane by
-    /// publishing that pane's TTY. Abstains `.ambiguous` when two live local
-    /// sessions claim one TTY (a suspended Claude beneath a new one in the same
-    /// pane); the caller's marker fallback may still disambiguate.
+    /// publishing that pane's TTY.
+    ///
+    /// Two kinds of evidence can bind a TTY to a session, and they must agree:
+    ///
+    /// * **Per-session claims** (Claude Code): each hook record carries the
+    ///   session's controlling TTY, so a device usually maps to one session.
+    ///   Two live claims on one TTY (a suspended Claude beneath a new one in
+    ///   the same pane) abstain `.ambiguous`; the caller's marker fallback may
+    ///   still disambiguate.
+    /// * **Focus declarations** (opencode): one opencode process hosts many
+    ///   sessions on one TTY and its TUI shows one at a time, so its sessions
+    ///   carry no TTY at all — the TUI half instead declares which session the
+    ///   pane DISPLAYS (`FocusChanged`, freshness-bounded). A fresh declaration
+    ///   resolves the TTY to that session iff the session is live and its
+    ///   registered pid matches the declarer's; a declaration whose session is
+    ///   gone or unverifiable abstains rather than falling back to guesswork,
+    ///   and a stale declaration is ABSENT information, not a hint.
+    ///
+    /// When both kinds of evidence exist for one TTY and disagree — a live
+    /// per-session claim next to a fresh focus declaration naming a different
+    /// session — that is two agents each positively claiming the same pane,
+    /// and the only safe answer is `.ambiguous`.
     public func resolve(tty: String) -> ClaudeMarkerResolution {
         let timestamp = now()
         return state.withLock { state in
@@ -220,6 +296,27 @@ public final class ClaudeSessionRegistry: Sendable {
                     && snapshot.process?.tty == tty
                     && isFresh(snapshot, now: timestamp)
             }
+
+            if let focus = state.focusByTTY[tty],
+               timestamp.timeIntervalSince(focus.declaredAt) <= limits.focusDeclarationTTL {
+                guard let focused = state.sessions[focus.sessionID],
+                      focused.origin.isLocalAuthenticated,
+                      isFresh(focused, now: timestamp),
+                      focused.process?.claudePID == focus.declaredPID
+                else {
+                    // A fresh declaration for a session that is dead, unknown,
+                    // or from a different process than the declarer. The pane
+                    // positively told us what it displays and we cannot verify
+                    // it — trusting any OTHER candidate now would contradict
+                    // the freshest evidence we have, so abstain outright.
+                    return .stale
+                }
+                if matches.isEmpty || matches.contains(where: { $0.sessionID == focus.sessionID }) {
+                    return .resolved(focused)
+                }
+                return .ambiguous
+            }
+
             switch matches.count {
             case 0:
                 let hadStale = state.sessions.values.contains {
@@ -342,6 +439,7 @@ public final class ClaudeSessionRegistry: Sendable {
         state.withLock { state in
             state.sessions.removeAll()
             state.markerIndex.removeAll()
+            state.focusByTTY.removeAll()
         }
     }
 
@@ -372,6 +470,42 @@ public final class ClaudeSessionRegistry: Sendable {
     private func pruneLocked(_ state: inout State, now: Date) {
         for (sessionID, snapshot) in state.sessions where !isFresh(snapshot, now: now) {
             removeLocked(&state, sessionID: sessionID)
+        }
+        // Expired focus declarations are dead weight: resolution already treats
+        // them as absent, this just keeps the table from accumulating panes.
+        for (tty, focus) in state.focusByTTY
+        where now.timeIntervalSince(focus.declaredAt) > limits.focusDeclarationTTL {
+            state.focusByTTY.removeValue(forKey: tty)
+        }
+    }
+
+    /// Record one pane's declared focus. LOCAL transport only — a remote
+    /// host's TTY names a device on another machine, exactly the reason
+    /// `resolve(tty:)` refuses remote candidates — and only when the record
+    /// carries the declaring pane's device; a focus claim with no TTY binds
+    /// nothing.
+    private func recordFocusLocked(
+        _ state: inout State,
+        record: ClaudeHookRecord,
+        origin: ClaudeTransportOrigin,
+        now: Date
+    ) {
+        guard origin.isLocalAuthenticated,
+              let process = record.process,
+              let tty = process.tty, !tty.isEmpty
+        else { return }
+        state.focusByTTY[tty] = FocusDeclaration(
+            sessionID: record.sessionID,
+            declaredPID: process.claudePID,
+            declaredAt: now
+        )
+        // Bounded like everything else a peer can grow: beyond the cap the
+        // oldest declaration goes — it is the one closest to expiring anyway.
+        while state.focusByTTY.count > limits.maxFocusDeclarations {
+            guard let oldest = state.focusByTTY.min(by: {
+                ($0.value.declaredAt, $0.key) < ($1.value.declaredAt, $1.key)
+            }) else { break }
+            state.focusByTTY.removeValue(forKey: oldest.key)
         }
     }
 

--- a/Sources/localvoxtral/ClaudeContext/ClaudeSessionState.swift
+++ b/Sources/localvoxtral/ClaudeContext/ClaudeSessionState.swift
@@ -57,6 +57,12 @@ public struct ClaudeSessionSnapshot: Sendable, Equatable {
     public var sessionID: String
     /// Assigned by the broker from peer credentials. Never from the record.
     public var origin: ClaudeTransportOrigin
+    /// Which coding agent this session belongs to, fixed at first sight like
+    /// `origin`. Decides per-agent channel rules — most importantly, the
+    /// broker never returns a title marker to a non-Claude session, because
+    /// only Claude Code has a writable title channel (opencode rewrites its
+    /// own OSC titles mid-turn, like herdr does inside its panes).
+    public var agent: ClaudeHookAgent
     public var marker: ClaudeSessionMarker
     /// Local path or opaque remote label — the type enforces which.
     public var workspace: ClaudeWorkspaceReference?
@@ -102,11 +108,13 @@ public struct ClaudeSessionSnapshot: Sendable, Equatable {
     init(
         sessionID: String,
         origin: ClaudeTransportOrigin,
+        agent: ClaudeHookAgent = .claude,
         marker: ClaudeSessionMarker,
         firstSeen: Date
     ) {
         self.sessionID = sessionID
         self.origin = origin
+        self.agent = agent
         self.marker = marker
         self.workspace = nil
         self.latestPriorUserPrompt = nil
@@ -152,7 +160,13 @@ public enum ClaudeSessionReducer {
         if let workspace = ClaudeWorkspaceReference.make(rawCwd: record.rawCwd, origin: origin) {
             snapshot.workspace = workspace
         }
-        if let process = record.process {
+        // Never absorbed from a focus record: its process block describes the
+        // PANE (the declarer's tty and pid), not the session. Folding it in
+        // would hand the session a per-session TTY claim its publisher
+        // deliberately never makes — the opencode server half publishes no tty
+        // precisely because it cannot prove it owns a pane — and would let a
+        // focus record overwrite the pid that liveness probes.
+        if let process = record.process, record.event != .focusChanged {
             snapshot.process = process
         }
 
@@ -179,6 +193,13 @@ public enum ClaudeSessionReducer {
             snapshot.activity = .working
         case .stop:
             snapshot.activity = .idle
+        case .focusChanged:
+            // Focus is registry-level state (a TTY→session binding, held in
+            // `ClaudeSessionRegistry`'s focus table) — a pane DISPLAYING a
+            // session says nothing about whether its model is working, so the
+            // per-session state here changes only by the lastActivity bump
+            // applied above.
+            break
         case .sessionEnd:
             snapshot.activity = .ended
         }

--- a/Sources/localvoxtral/ClaudeContext/ClaudeSessionState.swift
+++ b/Sources/localvoxtral/ClaudeContext/ClaudeSessionState.swift
@@ -160,13 +160,15 @@ public enum ClaudeSessionReducer {
         if let workspace = ClaudeWorkspaceReference.make(rawCwd: record.rawCwd, origin: origin) {
             snapshot.workspace = workspace
         }
-        // Never absorbed from a focus record: its process block describes the
-        // PANE (the declarer's tty and pid), not the session. Folding it in
-        // would hand the session a per-session TTY claim its publisher
-        // deliberately never makes — the opencode server half publishes no tty
-        // precisely because it cannot prove it owns a pane — and would let a
-        // focus record overwrite the pid that liveness probes.
-        if let process = record.process, record.event != .focusChanged {
+        // Never absorbed from a focus record (declaration or retraction): its
+        // process block describes the PANE (the declarer's tty and pid), not
+        // the session. Folding it in would hand the session a per-session TTY
+        // claim its publisher deliberately never makes — the opencode server
+        // half publishes no tty precisely because it cannot prove it owns a
+        // pane — and would let a focus record overwrite the pid that liveness
+        // probes.
+        if let process = record.process,
+           record.event != .focusChanged, record.event != .focusCleared {
             snapshot.process = process
         }
 
@@ -193,12 +195,12 @@ public enum ClaudeSessionReducer {
             snapshot.activity = .working
         case .stop:
             snapshot.activity = .idle
-        case .focusChanged:
+        case .focusChanged, .focusCleared:
             // Focus is registry-level state (a TTY→session binding, held in
-            // `ClaudeSessionRegistry`'s focus table) — a pane DISPLAYING a
-            // session says nothing about whether its model is working, so the
-            // per-session state here changes only by the lastActivity bump
-            // applied above.
+            // `ClaudeSessionRegistry`'s focus table) — a pane DISPLAYING or
+            // leaving a session says nothing about whether its model is
+            // working, so the per-session state here changes only by the
+            // lastActivity bump applied above.
             break
         case .sessionEnd:
             snapshot.activity = .ended

--- a/Sources/localvoxtral/ClaudeContext/TerminalScreenClaudeJoin.swift
+++ b/Sources/localvoxtral/ClaudeContext/TerminalScreenClaudeJoin.swift
@@ -270,7 +270,17 @@ struct ClaudeSessionJoinResolver {
             return nil
         }
 
-        if let claimed = pane.claimedClaudeSessionID, claimed != snapshot.sessionID {
+        // herdr reports the agent's RAW session id; the registry speaks
+        // agent-scoped ids (`ClaudeAgentSessionScope`). Scope the claim by the
+        // resolved session's own agent before comparing — for Claude that is
+        // the identity function, for opencode it adds the same prefix ingest
+        // did. Scoping by the snapshot's agent (not by anything herdr says)
+        // keeps this a pure cross-check: a claim can only ever CONFIRM the
+        // pane-id join, never redirect it.
+        if let claimed = pane.claimedClaudeSessionID,
+           ClaudeAgentSessionScope.scopedSessionID(
+               agent: snapshot.agent, sessionID: claimed
+           ) != snapshot.sessionID {
             Self.abstainedHerdrJoin(outcome: "pane session claim disagrees")
             return nil
         }

--- a/Sources/localvoxtral/ClaudeContext/TerminalScreenClaudeJoin.swift
+++ b/Sources/localvoxtral/ClaudeContext/TerminalScreenClaudeJoin.swift
@@ -294,7 +294,7 @@ struct ClaudeSessionJoinResolver {
             Self.abstainedHerdrJoin(outcome: "foreground process detection unavailable")
             return nil
         }
-        guard Self.registeredClaudeIsForeground(
+        guard Self.registeredAgentIsForeground(
             snapshot: snapshot, foregroundPIDs: foregroundPIDs
         ) else { return nil }
 
@@ -334,7 +334,10 @@ struct ClaudeSessionJoinResolver {
     /// Pure pid cross-check kept visible to tests because a snapshot with no
     /// process cannot be produced by a successful pane-id registry lookup, but
     /// the resolver must still fail closed if that invariant ever changes.
-    static func registeredClaudeIsForeground(
+    /// Agent-neutral (review F3): the pane may host Claude Code or opencode,
+    /// and the registered pid is whichever agent process the session's records
+    /// named — the abstention wording must not claim Claude for both.
+    static func registeredAgentIsForeground(
         snapshot: ClaudeSessionSnapshot,
         foregroundPIDs: [Int32]
     ) -> Bool {
@@ -343,7 +346,9 @@ struct ClaudeSessionJoinResolver {
             return false
         }
         guard foregroundPIDs.contains(process.claudePID) else {
-            abstainedHerdrJoin(outcome: "registered Claude process is not foreground")
+            abstainedHerdrJoin(
+                outcome: "registered \(snapshot.agent.rawValue) process is not foreground"
+            )
             return false
         }
         return true

--- a/Tests/localvoxtralTests/ClaudeHookWireTests.swift
+++ b/Tests/localvoxtralTests/ClaudeHookWireTests.swift
@@ -185,6 +185,28 @@ final class ClaudeHookWireCodecTests: XCTestCase {
         }
     }
 
+    func testV1LineCarryingAnExplicitAgentKeyIsMalformed() {
+        // No v1 writer ever emitted the key — "absent = claude" IS the v1
+        // contract. A v1 line carrying it is hand-crafted, not old.
+        XCTAssertThrowsError(
+            try ClaudeHookWireCodec.decodeLine(
+                line(validJSON(version: 1, extra: #","agent":"claude""#))
+            )
+        ) { error in
+            XCTAssertEqual(error as? ClaudeHookWireError, .malformed)
+        }
+    }
+
+    func testFocusClearedEventDecodes() throws {
+        let json = validJSON(
+            event: "FocusCleared",
+            extra: #","agent":"opencode","process":{"hook_pid":9,"claude_pid":9,"tty":"/dev/ttys004"}"#
+        )
+        let record = try ClaudeHookWireCodec.decodeLine(line(json))
+        XCTAssertEqual(record.event, .focusCleared)
+        XCTAssertEqual(record.agent, .opencode)
+    }
+
     func testFocusChangedEventDecodes() throws {
         let json = validJSON(
             event: "FocusChanged",

--- a/Tests/localvoxtralTests/ClaudeHookWireTests.swift
+++ b/Tests/localvoxtralTests/ClaudeHookWireTests.swift
@@ -10,7 +10,7 @@ final class ClaudeHookWireCodecTests: XCTestCase {
     }
 
     private func validJSON(
-        version: Int = 1,
+        version: Int = 2,
         event: String = "UserPromptSubmit",
         sessionID: String = "sess-1",
         extra: String = ""
@@ -62,7 +62,7 @@ final class ClaudeHookWireCodecTests: XCTestCase {
         let encoded = try XCTUnwrap(ClaudeHookWireCodec.encodeLine(record))
         XCTAssertEqual(
             String(decoding: encoded, as: UTF8.self),
-            #"{"event":"SessionStart","files":[],"process":{"claude_pid":41,"herdr_pane_id":"pane-7","herdr_socket_path":"herdr.sock","hook_pid":42},"session_id":"sess-herdr","ts":1.5,"v":1}"# + "\n"
+            #"{"event":"SessionStart","files":[],"process":{"claude_pid":41,"herdr_pane_id":"pane-7","herdr_socket_path":"herdr.sock","hook_pid":42},"session_id":"sess-herdr","ts":1.5,"v":2}"# + "\n"
         )
         let decoded = try ClaudeHookWireCodec.decodeLine(encoded)
         XCTAssertEqual(decoded.process?.herdrPaneID, "pane-7")
@@ -118,8 +118,8 @@ final class ClaudeHookWireCodecTests: XCTestCase {
     // MARK: Version gating
 
     func testRejectsFutureVersion() {
-        XCTAssertThrowsError(try ClaudeHookWireCodec.decodeLine(line(validJSON(version: 2)))) { error in
-            XCTAssertEqual(error as? ClaudeHookWireError, .unsupportedVersion(2))
+        XCTAssertThrowsError(try ClaudeHookWireCodec.decodeLine(line(validJSON(version: 3)))) { error in
+            XCTAssertEqual(error as? ClaudeHookWireError, .unsupportedVersion(3))
         }
     }
 
@@ -128,6 +128,87 @@ final class ClaudeHookWireCodecTests: XCTestCase {
         XCTAssertThrowsError(try ClaudeHookWireCodec.decodeLine(line(json))) { error in
             XCTAssertEqual(error as? ClaudeHookWireError, .unsupportedVersion(nil))
         }
+    }
+
+    // MARK: v1 compatibility and the agent field (wire v2)
+
+    func testV1LineStillDecodesAndIsAClaudeRecordByConstruction() throws {
+        // Every v1 record predates the agent field, and every v1 publisher was
+        // the Claude Code hook — so v1 must keep decoding, as Claude.
+        let record = try ClaudeHookWireCodec.decodeLine(line(validJSON(version: 1)))
+        XCTAssertEqual(record.version, 1)
+        XCTAssertEqual(record.agent, .claude)
+    }
+
+    func testV2LineWithoutAgentFieldDefaultsToClaude() throws {
+        let record = try ClaudeHookWireCodec.decodeLine(line(validJSON()))
+        XCTAssertEqual(record.agent, .claude)
+    }
+
+    func testOpencodeAgentRoundTripsWithGoldenWireShape() throws {
+        let record = ClaudeHookRecord(
+            event: .userPromptSubmit,
+            agent: .opencode,
+            sessionID: "ses_0123",
+            timestamp: 9.5,
+            prompt: "rename the flag"
+        )
+        let encoded = try XCTUnwrap(ClaudeHookWireCodec.encodeLine(record))
+        XCTAssertEqual(
+            String(decoding: encoded, as: UTF8.self),
+            #"{"agent":"opencode","event":"UserPromptSubmit","files":[],"prompt":"rename the flag","session_id":"ses_0123","ts":9.5,"v":2}"# + "\n"
+        )
+        XCTAssertEqual(try ClaudeHookWireCodec.decodeLine(encoded), record)
+    }
+
+    func testClaudeAgentIsOmittedFromTheWireSoV1ReadersStayCompatible() throws {
+        let record = ClaudeHookRecord(event: .stop, sessionID: "s", timestamp: 1)
+        let encoded = try XCTUnwrap(ClaudeHookWireCodec.encodeLine(record))
+        XCTAssertFalse(
+            String(decoding: encoded, as: UTF8.self).contains("agent"),
+            "absence is the default: a Claude record must not grow an agent key"
+        )
+    }
+
+    func testRejectsUnknownAgentPreciselyRatherThanDefaultingToClaude() {
+        // Defaulting would hand a future agent Claude's channel rules (title
+        // markers, bare session-id namespace). Ignored, precisely.
+        XCTAssertThrowsError(
+            try ClaudeHookWireCodec.decodeLine(line(validJSON(extra: #","agent":"aider""#)))
+        ) { error in
+            XCTAssertEqual(error as? ClaudeHookWireError, .unknownAgent("aider"))
+        }
+        XCTAssertThrowsError(
+            try ClaudeHookWireCodec.decodeLine(line(validJSON(extra: #","agent":7"#)))
+        ) { error in
+            XCTAssertEqual(error as? ClaudeHookWireError, .unknownAgent(nil))
+        }
+    }
+
+    func testFocusChangedEventDecodes() throws {
+        let json = validJSON(
+            event: "FocusChanged",
+            extra: #","agent":"opencode","process":{"hook_pid":9,"claude_pid":9,"tty":"/dev/ttys004"}"#
+        )
+        let record = try ClaudeHookWireCodec.decodeLine(line(json))
+        XCTAssertEqual(record.event, .focusChanged)
+        XCTAssertEqual(record.agent, .opencode)
+        XCTAssertEqual(record.process?.tty, "/dev/ttys004")
+    }
+
+    // MARK: Session-id namespacing per agent
+
+    func testOpencodeSessionIDsAreScopedAndClaudeIDsStayBare() {
+        XCTAssertEqual(
+            ClaudeAgentSessionScope.scopedSessionID(agent: .opencode, sessionID: "ses_1"),
+            "opencode:ses_1"
+        )
+        XCTAssertEqual(
+            ClaudeAgentSessionScope.scopedSessionID(agent: .claude, sessionID: "b81c2a"),
+            "b81c2a"
+        )
+        // The two receiver-side namespaces must never alias each other.
+        XCTAssertNotEqual(ClaudeAgentSessionScope.opencodePrefix, "remote:")
     }
 
     func testRejectsUnknownEventRatherThanThrowingGenericError() {

--- a/Tests/localvoxtralTests/ClaudeSessionFocusResolutionTests.swift
+++ b/Tests/localvoxtralTests/ClaudeSessionFocusResolutionTests.swift
@@ -1,0 +1,391 @@
+import ClaudeContextWire
+import Foundation
+import Synchronization
+import XCTest
+@testable import localvoxtral
+
+// Focused coverage for the wire-v2 additions to the registry: per-agent
+// session-id namespacing and the pane focus declarations that make the TTY
+// join answer for opencode, where one process (one TTY) hosts several
+// sessions and the TUI shows exactly one.
+//
+// Helpers mirror `ClaudeSessionRegistryTests` (they are file-private there).
+// Same capture rules apply: closures capture `[self]`, never the `Mutex`.
+
+private final class TestClock: Sendable {
+    private let value: Mutex<Date>
+
+    init(_ start: Date) { value = Mutex(start) }
+
+    var now: @Sendable () -> Date { { [self] in value.withLock { $0 } } }
+
+    func advance(_ interval: TimeInterval) {
+        value.withLock { $0 = $0.addingTimeInterval(interval) }
+    }
+}
+
+private final class TestLiveness: Sendable {
+    private let dead: Mutex<Set<Int32>> = Mutex([])
+
+    var probe: @Sendable (Int32) -> Bool { { [self] pid in dead.withLock { !$0.contains(pid) } } }
+
+    func kill(_ pid: Int32) { dead.withLock { _ = $0.insert(pid) } }
+}
+
+final class ClaudeSessionFocusResolutionTests: XCTestCase {
+    private let epoch = Date(timeIntervalSince1970: 3_000_000)
+    private let local = ClaudeTransportOrigin.localAuthenticated(peerUID: 501)
+    private let tty = "/dev/ttys004"
+    /// The opencode process pid — shared by every session it hosts AND by its
+    /// focus declarations, because the plugin runs inside that one process.
+    private let opencodePID: Int32 = 4242
+
+    /// Endless distinct markers — these tests create many sessions and never
+    /// care which marker each one got.
+    private final class SequentialMarkers: Sendable {
+        private let counter = Mutex(0)
+
+        var allocate: @Sendable () -> String {
+            { [self] in
+                counter.withLock { value in
+                    value += 1
+                    return "lvx-" + String(format: "%08x", value)
+                }
+            }
+        }
+    }
+
+    private func makeRegistry(
+        limits: ClaudeRegistryLimits = .default,
+        clock: TestClock? = nil,
+        liveness: TestLiveness? = nil
+    ) -> ClaudeSessionRegistry {
+        ClaudeSessionRegistry(
+            limits: limits,
+            now: (clock ?? TestClock(epoch)).now,
+            isProcessAlive: (liveness ?? TestLiveness()).probe,
+            allocateMarkerValue: SequentialMarkers().allocate
+        )
+    }
+
+    /// An opencode session record as the plugin's server half publishes it:
+    /// agent-tagged, pid = the opencode process, and NO tty — the server half
+    /// cannot prove it owns a pane, so it never claims one.
+    private func opencodeRecord(
+        _ event: ClaudeHookEvent,
+        session: String,
+        cwd: String? = "/repo",
+        prompt: String? = nil,
+        files: [ClaudeFileTouch] = []
+    ) -> ClaudeHookRecord {
+        ClaudeHookRecord(
+            event: event,
+            agent: .opencode,
+            sessionID: session,
+            timestamp: 0,
+            rawCwd: cwd,
+            prompt: prompt,
+            files: files,
+            process: ClaudeHookProcessInfo(hookPID: opencodePID, claudePID: opencodePID)
+        )
+    }
+
+    /// A focus declaration as the plugin's TUI half publishes it: the pane's
+    /// own TTY plus the session it currently displays.
+    private func focusRecord(
+        session: String,
+        agent: ClaudeHookAgent = .opencode,
+        pid: Int32? = nil,
+        tty: String? = nil
+    ) -> ClaudeHookRecord {
+        ClaudeHookRecord(
+            event: .focusChanged,
+            agent: agent,
+            sessionID: session,
+            timestamp: 0,
+            process: ClaudeHookProcessInfo(
+                hookPID: pid ?? opencodePID,
+                claudePID: pid ?? opencodePID,
+                tty: tty ?? self.tty
+            )
+        )
+    }
+
+    /// A Claude Code record claiming a TTY per-session, the pre-v2 shape.
+    private func claudeRecord(
+        _ event: ClaudeHookEvent,
+        session: String,
+        claudePID: Int32,
+        tty: String? = nil
+    ) -> ClaudeHookRecord {
+        ClaudeHookRecord(
+            event: event,
+            sessionID: session,
+            timestamp: 0,
+            rawCwd: "/repo",
+            process: ClaudeHookProcessInfo(hookPID: 999, claudePID: claudePID, tty: tty)
+        )
+    }
+
+    private func resolvedSessionID(_ resolution: ClaudeMarkerResolution) -> String? {
+        if case .resolved(let snapshot) = resolution { return snapshot.sessionID }
+        return nil
+    }
+
+    // MARK: - Per-agent session-id namespacing
+
+    func testOpencodeSessionIDsAreScopedOnIngestAndClaudeIDsStayBare() throws {
+        let registry = makeRegistry()
+        let opencode = try XCTUnwrap(
+            registry.ingest(opencodeRecord(.sessionStart, session: "ses_1"), origin: local)
+        )
+        XCTAssertEqual(opencode.sessionID, "opencode:ses_1")
+        XCTAssertEqual(opencode.agent, .opencode)
+
+        let claude = try XCTUnwrap(
+            registry.ingest(claudeRecord(.sessionStart, session: "ses_1", claudePID: 7), origin: local)
+        )
+        XCTAssertEqual(claude.sessionID, "ses_1", "Claude ids stay bare — v1 behavior is unchanged")
+        XCTAssertEqual(claude.agent, .claude)
+
+        // Same raw id, two agents, two sessions: the namespace IS the
+        // collision prevention.
+        XCTAssertNotNil(registry.snapshot(sessionID: "opencode:ses_1"))
+        XCTAssertNotNil(registry.snapshot(sessionID: "ses_1"))
+    }
+
+    func testARecordSpellingAnotherAgentsScopedIDIsDropped() throws {
+        // Scoping makes honest collision impossible, so a Claude record whose
+        // session id literally reads "opencode:ses_1" is spelling a key that
+        // is not its own. It must not mutate the opencode session.
+        let registry = makeRegistry()
+        registry.ingest(opencodeRecord(.sessionStart, session: "ses_1", cwd: "/real"), origin: local)
+
+        let forged = registry.ingest(
+            claudeRecord(.cwdChanged, session: "opencode:ses_1", claudePID: 7), origin: local
+        )
+        XCTAssertNil(forged, "cross-agent key spelling is dropped whole")
+        let snapshot = try XCTUnwrap(registry.snapshot(sessionID: "opencode:ses_1"))
+        XCTAssertEqual(snapshot.localWorkspacePath?.path, "/real")
+    }
+
+    func testFocusRecordNeverMintsASession() {
+        let registry = makeRegistry()
+        let result = registry.ingest(focusRecord(session: "ses_ghost"), origin: local)
+        XCTAssertNil(result, "a pane can display a session whose records were lost; inventing an empty snapshot for it would let the join resolve to nothing")
+        XCTAssertNil(registry.snapshot(sessionID: "opencode:ses_ghost"))
+        XCTAssertTrue(registry.liveSessions().isEmpty)
+    }
+
+    // MARK: - Focus truth table for resolve(tty:)
+
+    func testSingleSessionWithFreshFocusResolves() {
+        let registry = makeRegistry()
+        registry.ingest(opencodeRecord(.sessionStart, session: "ses_a"), origin: local)
+        registry.ingest(focusRecord(session: "ses_a"), origin: local)
+
+        XCTAssertEqual(resolvedSessionID(registry.resolve(tty: tty)), "opencode:ses_a")
+    }
+
+    func testSingleOpencodeSessionWithoutFocusAbstains() {
+        // Positive evidence or nothing: the server half never claims a TTY, so
+        // an opencode session with no focus declaration is unjoinable — there
+        // is deliberately no sole-session fallback.
+        let registry = makeRegistry()
+        registry.ingest(opencodeRecord(.sessionStart, session: "ses_a"), origin: local)
+
+        XCTAssertEqual(registry.resolve(tty: tty), .unknown)
+    }
+
+    func testMultipleSessionsWithFreshFocusResolveToTheDeclaredOne() {
+        let registry = makeRegistry()
+        registry.ingest(opencodeRecord(.sessionStart, session: "ses_a"), origin: local)
+        registry.ingest(opencodeRecord(.sessionStart, session: "ses_b"), origin: local)
+        registry.ingest(focusRecord(session: "ses_b"), origin: local)
+
+        XCTAssertEqual(resolvedSessionID(registry.resolve(tty: tty)), "opencode:ses_b")
+
+        // A session switch re-declares; the newest declaration wins.
+        registry.ingest(focusRecord(session: "ses_a"), origin: local)
+        XCTAssertEqual(resolvedSessionID(registry.resolve(tty: tty)), "opencode:ses_a")
+    }
+
+    func testStaleFocusIsAbsentInformationSoMultipleSessionsAbstain() {
+        let clock = TestClock(epoch)
+        let registry = makeRegistry(clock: clock)
+        registry.ingest(opencodeRecord(.sessionStart, session: "ses_a"), origin: local)
+        registry.ingest(opencodeRecord(.sessionStart, session: "ses_b"), origin: local)
+        registry.ingest(focusRecord(session: "ses_b"), origin: local)
+
+        clock.advance(ClaudeRegistryLimits.defaultFocusDeclarationTTL - 1)
+        XCTAssertEqual(
+            resolvedSessionID(registry.resolve(tty: tty)), "opencode:ses_b",
+            "inside the bound the declaration still answers"
+        )
+
+        clock.advance(2)
+        XCTAssertEqual(
+            registry.resolve(tty: tty), .unknown,
+            "past the bound the declaration is not a hint — nothing claims this TTY anymore"
+        )
+    }
+
+    func testMultipleSessionsWithNoFocusEverAbstain() {
+        let registry = makeRegistry()
+        registry.ingest(opencodeRecord(.sessionStart, session: "ses_a"), origin: local)
+        registry.ingest(opencodeRecord(.sessionStart, session: "ses_b"), origin: local)
+
+        XCTAssertEqual(registry.resolve(tty: tty), .unknown)
+    }
+
+    func testFreshFocusForADeadSessionAbstainsOutright() {
+        let registry = makeRegistry()
+        registry.ingest(opencodeRecord(.sessionStart, session: "ses_a"), origin: local)
+        registry.ingest(opencodeRecord(.sessionStart, session: "ses_b"), origin: local)
+        registry.ingest(focusRecord(session: "ses_b"), origin: local)
+        // The displayed session ends (session.deleted); the pane has not
+        // re-declared yet.
+        registry.ingest(opencodeRecord(.sessionEnd, session: "ses_b"), origin: local)
+
+        XCTAssertEqual(
+            registry.resolve(tty: tty), .stale,
+            "the pane said it displays ses_b; ses_b is gone; resolving to the surviving sibling would contradict the freshest evidence"
+        )
+    }
+
+    func testFocusForASessionWhoseProcessDiedAbstains() {
+        let liveness = TestLiveness()
+        let registry = makeRegistry(liveness: liveness)
+        registry.ingest(opencodeRecord(.sessionStart, session: "ses_a"), origin: local)
+        registry.ingest(focusRecord(session: "ses_a"), origin: local)
+        liveness.kill(opencodePID)
+
+        XCTAssertEqual(registry.resolve(tty: tty), .stale)
+    }
+
+    func testFocusDeclaredByADifferentProcessThanTheSessionAbstains() {
+        // A declaration that outlived its process must not steer a recycled
+        // TTY: the declarer's pid and the focused session's registered pid
+        // must be the same process.
+        let registry = makeRegistry()
+        registry.ingest(opencodeRecord(.sessionStart, session: "ses_a"), origin: local)
+        registry.ingest(focusRecord(session: "ses_a", pid: 5555), origin: local)
+
+        XCTAssertEqual(registry.resolve(tty: tty), .stale)
+    }
+
+    func testFocusDisambiguatesCompetingPerSessionTTYClaims() {
+        // The generic form of "multiple + focus fresh": two live sessions each
+        // claim the same device per-session (the suspended-agent-under-a-new-
+        // one shape), and a fresh declaration picks the displayed one.
+        let registry = makeRegistry()
+        registry.ingest(claudeRecord(.sessionStart, session: "old", claudePID: 71, tty: tty), origin: local)
+        registry.ingest(claudeRecord(.sessionStart, session: "new", claudePID: 72, tty: tty), origin: local)
+        XCTAssertEqual(registry.resolve(tty: tty), .ambiguous, "without focus this abstains today")
+
+        registry.ingest(focusRecord(session: "new", agent: .claude, pid: 72), origin: local)
+        XCTAssertEqual(resolvedSessionID(registry.resolve(tty: tty)), "new")
+    }
+
+    func testConflictBetweenATTYClaimAndAFocusDeclarationAbstains() {
+        // A live Claude session claims the device per-session while a fresh
+        // opencode declaration names a different live session: two agents each
+        // positively claiming one pane. Nobody wins.
+        let registry = makeRegistry()
+        registry.ingest(claudeRecord(.sessionStart, session: "cl", claudePID: 71, tty: tty), origin: local)
+        registry.ingest(opencodeRecord(.sessionStart, session: "ses_a"), origin: local)
+        registry.ingest(focusRecord(session: "ses_a"), origin: local)
+
+        XCTAssertEqual(registry.resolve(tty: tty), .ambiguous)
+    }
+
+    func testSingleClaudeTTYClaimStillResolvesWithoutAnyFocus() {
+        // The pre-v2 join, byte-for-byte: no focus table entry, one live local
+        // claim, resolved. Claude behavior must be unchanged by all of this.
+        let registry = makeRegistry()
+        registry.ingest(claudeRecord(.sessionStart, session: "cl", claudePID: 71, tty: tty), origin: local)
+
+        XCTAssertEqual(resolvedSessionID(registry.resolve(tty: tty)), "cl")
+    }
+
+    func testRemoteFocusDeclarationsAreIgnored() {
+        // A remote host declaring focus for a local TTY device is exactly the
+        // "SSH host claims a local pane" attack the TTY join refuses; the
+        // focus table must refuse it at the door too.
+        let registry = makeRegistry()
+        registry.ingest(opencodeRecord(.sessionStart, session: "ses_a"), origin: local)
+        registry.ingest(
+            focusRecord(session: "ses_a"), origin: .remote(channel: "ssh:host")
+        )
+
+        XCTAssertEqual(registry.resolve(tty: tty), .unknown)
+    }
+
+    func testFocusRecordForALiveSessionBumpsItsActivity() throws {
+        let clock = TestClock(epoch)
+        let registry = makeRegistry(clock: clock)
+        registry.ingest(opencodeRecord(.sessionStart, session: "ses_a"), origin: local)
+        clock.advance(100)
+        let bumped = try XCTUnwrap(registry.ingest(focusRecord(session: "ses_a"), origin: local))
+        XCTAssertEqual(bumped.lastActivity, epoch.addingTimeInterval(100))
+        XCTAssertEqual(bumped.activity, .idle, "displaying a session says nothing about its turn state")
+    }
+
+    func testFocusTableIsBounded() {
+        let clock = TestClock(epoch)
+        let registry = makeRegistry(
+            limits: ClaudeRegistryLimits(maxFocusDeclarations: 2), clock: clock
+        )
+        registry.ingest(opencodeRecord(.sessionStart, session: "ses_a"), origin: local)
+        for index in 0..<5 {
+            clock.advance(1)
+            registry.ingest(
+                focusRecord(session: "ses_a", tty: "/dev/ttys00\(index)"), origin: local
+            )
+        }
+        // The newest declaration must have survived the cap.
+        XCTAssertEqual(resolvedSessionID(registry.resolve(tty: "/dev/ttys004")), "opencode:ses_a")
+        // The oldest ones are gone: their TTYs resolve as if never declared.
+        XCTAssertEqual(registry.resolve(tty: "/dev/ttys000"), .unknown)
+        XCTAssertEqual(registry.resolve(tty: "/dev/ttys001"), .unknown)
+    }
+
+    // MARK: - Opencode event shapes through the reducer
+
+    func testOpencodeLifecycleReducesLikeAnyLocalSession() throws {
+        // The verified plugin payload mapping: chat.message → UserPromptSubmit,
+        // tool.execute.after → PostToolUse, session.idle → Stop,
+        // session.deleted → SessionEnd. Everything downstream (blocks, repo
+        // collection, budget) reads the same snapshot fields as Claude's.
+        let registry = makeRegistry()
+        let prompt = try XCTUnwrap(registry.ingest(
+            opencodeRecord(
+                .userPromptSubmit, session: "ses_a", cwd: "/repo", prompt: "add a --json flag"
+            ),
+            origin: local
+        ))
+        XCTAssertEqual(prompt.latestPriorUserPrompt, "add a --json flag")
+        XCTAssertEqual(prompt.activity, .working)
+        XCTAssertEqual(prompt.localWorkspacePath?.path, "/repo")
+
+        let touched = try XCTUnwrap(registry.ingest(
+            opencodeRecord(
+                .postToolUse, session: "ses_a",
+                files: [ClaudeFileTouch(path: "/repo/src/cli.ts", kind: .edited)]
+            ),
+            origin: local
+        ))
+        XCTAssertEqual(touched.recentFiles.map(\.path), ["/repo/src/cli.ts"])
+
+        let idle = try XCTUnwrap(
+            registry.ingest(opencodeRecord(.stop, session: "ses_a"), origin: local)
+        )
+        XCTAssertEqual(idle.activity, .idle)
+
+        let ended = try XCTUnwrap(
+            registry.ingest(opencodeRecord(.sessionEnd, session: "ses_a"), origin: local)
+        )
+        XCTAssertEqual(ended.activity, .ended)
+        XCTAssertNil(registry.snapshot(sessionID: "opencode:ses_a"), "SessionEnd evicts")
+    }
+}

--- a/Tests/localvoxtralTests/ClaudeSessionFocusResolutionTests.swift
+++ b/Tests/localvoxtralTests/ClaudeSessionFocusResolutionTests.swift
@@ -76,7 +76,8 @@ final class ClaudeSessionFocusResolutionTests: XCTestCase {
         session: String,
         cwd: String? = "/repo",
         prompt: String? = nil,
-        files: [ClaudeFileTouch] = []
+        files: [ClaudeFileTouch] = [],
+        herdrPaneID: String? = nil
     ) -> ClaudeHookRecord {
         ClaudeHookRecord(
             event: event,
@@ -86,7 +87,9 @@ final class ClaudeSessionFocusResolutionTests: XCTestCase {
             rawCwd: cwd,
             prompt: prompt,
             files: files,
-            process: ClaudeHookProcessInfo(hookPID: opencodePID, claudePID: opencodePID)
+            process: ClaudeHookProcessInfo(
+                hookPID: opencodePID, claudePID: opencodePID, herdrPaneID: herdrPaneID
+            )
         )
     }
 
@@ -154,10 +157,11 @@ final class ClaudeSessionFocusResolutionTests: XCTestCase {
         XCTAssertNotNil(registry.snapshot(sessionID: "ses_1"))
     }
 
-    func testARecordSpellingAnotherAgentsScopedIDIsDropped() throws {
-        // Scoping makes honest collision impossible, so a Claude record whose
-        // session id literally reads "opencode:ses_1" is spelling a key that
-        // is not its own. It must not mutate the opencode session.
+    func testALocalClaudeRecordSpellingAReservedPrefixIsDroppedOutright() throws {
+        // Review C2a: prefix concatenation would otherwise let a literal
+        // Claude id "opencode:ses_1" alias opencode's raw "ses_1". A LOCAL
+        // Claude record with a reserved prefix is dropped at the door — it
+        // neither mutates the aliased session nor mints one of its own.
         let registry = makeRegistry()
         registry.ingest(opencodeRecord(.sessionStart, session: "ses_1", cwd: "/real"), origin: local)
 
@@ -167,6 +171,24 @@ final class ClaudeSessionFocusResolutionTests: XCTestCase {
         XCTAssertNil(forged, "cross-agent key spelling is dropped whole")
         let snapshot = try XCTUnwrap(registry.snapshot(sessionID: "opencode:ses_1"))
         XCTAssertEqual(snapshot.localWorkspacePath?.path, "/real")
+        XCTAssertEqual(snapshot.agent, .opencode)
+
+        // Without a session to collide with, the reserved spelling still never
+        // becomes a key.
+        XCTAssertNil(
+            registry.ingest(
+                claudeRecord(.sessionStart, session: "opencode:ses_9", claudePID: 7), origin: local
+            )
+        )
+        XCTAssertNil(registry.snapshot(sessionID: "opencode:ses_9"))
+        // Same rule for the remote namespace: only the remote LISTENER may
+        // spell "remote:" ids, and it arrives over a remote origin.
+        XCTAssertNil(
+            registry.ingest(
+                claudeRecord(.sessionStart, session: "remote:host:x", claudePID: 7), origin: local
+            )
+        )
+        XCTAssertNil(registry.snapshot(sessionID: "remote:host:x"))
     }
 
     func testFocusRecordNeverMintsASession() {
@@ -263,28 +285,105 @@ final class ClaudeSessionFocusResolutionTests: XCTestCase {
         XCTAssertEqual(registry.resolve(tty: tty), .stale)
     }
 
-    func testFocusDeclaredByADifferentProcessThanTheSessionAbstains() {
-        // A declaration that outlived its process must not steer a recycled
-        // TTY: the declarer's pid and the focused session's registered pid
-        // must be the same process.
+    func testFocusDeclaredByADifferentProcessThanTheSessionIsRefusedAtIngest() {
+        // A declaration whose pid does not match the focused session's
+        // registered process could never resolve — it is refused before any
+        // focus state is written, so it cannot suppress anything either.
         let registry = makeRegistry()
         registry.ingest(opencodeRecord(.sessionStart, session: "ses_a"), origin: local)
-        registry.ingest(focusRecord(session: "ses_a", pid: 5555), origin: local)
+        XCTAssertNil(registry.ingest(focusRecord(session: "ses_a", pid: 5555), origin: local))
+
+        XCTAssertEqual(
+            registry.resolve(tty: tty), .unknown,
+            "a refused declaration leaves the TTY exactly as undeclared as before"
+        )
+    }
+
+    func testDeclarationWhoseSessionPidChangedAfterwardsAbstainsAtResolve() {
+        // The resolve-time pid cross-check still matters after a valid ingest:
+        // if the session's registered process changes underneath a standing
+        // declaration (a new opencode process reusing the session id), the
+        // stale declaration must stop steering the TTY.
+        let registry = makeRegistry()
+        registry.ingest(opencodeRecord(.sessionStart, session: "ses_a"), origin: local)
+        registry.ingest(focusRecord(session: "ses_a"), origin: local)
+        XCTAssertEqual(resolvedSessionID(registry.resolve(tty: tty)), "opencode:ses_a")
+
+        var restarted = opencodeRecord(.userPromptSubmit, session: "ses_a", prompt: "hi")
+        restarted.process = ClaudeHookProcessInfo(hookPID: 9999, claudePID: 9999)
+        registry.ingest(restarted, origin: local)
 
         XCTAssertEqual(registry.resolve(tty: tty), .stale)
     }
 
-    func testFocusDisambiguatesCompetingPerSessionTTYClaims() {
-        // The generic form of "multiple + focus fresh": two live sessions each
-        // claim the same device per-session (the suspended-agent-under-a-new-
-        // one shape), and a fresh declaration picks the displayed one.
+    func testClaudeAgentFocusRecordsAreRefused() {
+        // Focus is an opencode-only mechanism: nothing in Claude Code's hook
+        // set knows what a pane displays, so a `.claude` focus record is an
+        // inconsistency to refuse — it must not create, refresh, or clear any
+        // declaration.
         let registry = makeRegistry()
         registry.ingest(claudeRecord(.sessionStart, session: "old", claudePID: 71, tty: tty), origin: local)
         registry.ingest(claudeRecord(.sessionStart, session: "new", claudePID: 72, tty: tty), origin: local)
-        XCTAssertEqual(registry.resolve(tty: tty), .ambiguous, "without focus this abstains today")
 
-        registry.ingest(focusRecord(session: "new", agent: .claude, pid: 72), origin: local)
-        XCTAssertEqual(resolvedSessionID(registry.resolve(tty: tty)), "new")
+        XCTAssertNil(registry.ingest(focusRecord(session: "new", agent: .claude, pid: 72), origin: local))
+        XCTAssertEqual(
+            registry.resolve(tty: tty), .ambiguous,
+            "competing per-session claims stay ambiguous; a refused declaration decides nothing"
+        )
+    }
+
+    func testInvalidFocusRecordCannotSuppressAClaudeTTYClaim() {
+        // Review C2b regression: focus state used to be written BEFORE the
+        // record was validated, so a declaration naming an unknown session
+        // poisoned the TTY into `.stale` for the whole focus TTL — silently
+        // unjoining a perfectly live Claude session on that device.
+        let registry = makeRegistry()
+        registry.ingest(claudeRecord(.sessionStart, session: "cl", claudePID: 71, tty: tty), origin: local)
+
+        XCTAssertNil(registry.ingest(focusRecord(session: "ses_ghost"), origin: local))
+        XCTAssertEqual(
+            resolvedSessionID(registry.resolve(tty: tty)), "cl",
+            "an invalid declaration must leave the per-session TTY claim untouched"
+        )
+    }
+
+    func testFocusClearedRetractsTheDeclarationImmediately() {
+        let registry = makeRegistry()
+        registry.ingest(opencodeRecord(.sessionStart, session: "ses_a"), origin: local)
+        registry.ingest(focusRecord(session: "ses_a"), origin: local)
+        XCTAssertEqual(resolvedSessionID(registry.resolve(tty: tty)), "opencode:ses_a")
+
+        var clear = focusRecord(session: "ses_a")
+        clear.event = .focusCleared
+        registry.ingest(clear, origin: local)
+
+        XCTAssertEqual(
+            registry.resolve(tty: tty), .unknown,
+            "leaving the session view must stop the join NOW, not at TTL expiry"
+        )
+        XCTAssertNotNil(
+            registry.snapshot(sessionID: "opencode:ses_a"),
+            "retraction clears the pane binding, never the session"
+        )
+    }
+
+    func testFocusClearedFromClaudeAgentOrRemoteTransportIsRefused() {
+        let registry = makeRegistry()
+        registry.ingest(opencodeRecord(.sessionStart, session: "ses_a"), origin: local)
+        registry.ingest(focusRecord(session: "ses_a"), origin: local)
+
+        var claudeClear = focusRecord(session: "ses_a", agent: .claude)
+        claudeClear.event = .focusCleared
+        XCTAssertNil(registry.ingest(claudeClear, origin: local))
+
+        var remoteClear = focusRecord(session: "ses_a")
+        remoteClear.event = .focusCleared
+        XCTAssertNil(registry.ingest(remoteClear, origin: .remote(channel: "ssh:host")))
+
+        XCTAssertEqual(
+            resolvedSessionID(registry.resolve(tty: tty)), "opencode:ses_a",
+            "a refused retraction leaves the declaration standing"
+        )
     }
 
     func testConflictBetweenATTYClaimAndAFocusDeclarationAbstains() {
@@ -348,6 +447,67 @@ final class ClaudeSessionFocusResolutionTests: XCTestCase {
         // The oldest ones are gone: their TTYs resolve as if never declared.
         XCTAssertEqual(registry.resolve(tty: "/dev/ttys000"), .unknown)
         XCTAssertEqual(registry.resolve(tty: "/dev/ttys001"), .unknown)
+    }
+
+    // MARK: - Focus participation in the herdr pane join (review C3)
+
+    func testHerdrPaneWithTwoOpencodeSessionsResolvesThroughFreshFocus() {
+        // Every opencode session in one TUI shares the pane id AND the pid, so
+        // without focus participation a second session made the herdr arm
+        // permanently `.ambiguous` — the join silently died for opencode
+        // panes. A verified fresh declaration picks the displayed session.
+        let registry = makeRegistry()
+        registry.ingest(
+            opencodeRecord(.sessionStart, session: "ses_a", herdrPaneID: "w1:p1"), origin: local
+        )
+        registry.ingest(
+            opencodeRecord(.sessionStart, session: "ses_b", herdrPaneID: "w1:p1"), origin: local
+        )
+        XCTAssertEqual(registry.resolve(herdrPaneID: "w1:p1"), .ambiguous, "no focus, no winner")
+
+        registry.ingest(focusRecord(session: "ses_b"), origin: local)
+        XCTAssertEqual(
+            resolvedSessionID(registry.resolve(herdrPaneID: "w1:p1")), "opencode:ses_b"
+        )
+
+        // Retraction restores the abstention immediately.
+        var clear = focusRecord(session: "ses_b")
+        clear.event = .focusCleared
+        registry.ingest(clear, origin: local)
+        XCTAssertEqual(registry.resolve(herdrPaneID: "w1:p1"), .ambiguous)
+    }
+
+    func testHerdrPaneFocusGoesStaleWithTheDeclaration() {
+        let clock = TestClock(epoch)
+        let registry = makeRegistry(clock: clock)
+        registry.ingest(
+            opencodeRecord(.sessionStart, session: "ses_a", herdrPaneID: "w1:p1"), origin: local
+        )
+        registry.ingest(
+            opencodeRecord(.sessionStart, session: "ses_b", herdrPaneID: "w1:p1"), origin: local
+        )
+        registry.ingest(focusRecord(session: "ses_b"), origin: local)
+        XCTAssertEqual(
+            resolvedSessionID(registry.resolve(herdrPaneID: "w1:p1")), "opencode:ses_b"
+        )
+
+        clock.advance(ClaudeRegistryLimits.defaultFocusDeclarationTTL + 1)
+        XCTAssertEqual(
+            registry.resolve(herdrPaneID: "w1:p1"), .ambiguous,
+            "an expired declaration is absent information for the pane join too"
+        )
+    }
+
+    func testHerdrPaneWithSingleSessionStillResolvesWithoutFocus() {
+        // The pre-existing single-candidate behavior is untouched: focus only
+        // arbitrates multi-candidate panes.
+        let registry = makeRegistry()
+        registry.ingest(
+            opencodeRecord(.sessionStart, session: "ses_a", herdrPaneID: "w1:p1"), origin: local
+        )
+        XCTAssertEqual(
+            resolvedSessionID(registry.resolve(herdrPaneID: "w1:p1")), "opencode:ses_a"
+        )
     }
 
     // MARK: - Opencode event shapes through the reducer

--- a/Tests/localvoxtralTests/TerminalScreenClaudeJoinTests.swift
+++ b/Tests/localvoxtralTests/TerminalScreenClaudeJoinTests.swift
@@ -668,7 +668,7 @@ final class TerminalScreenClaudeJoinTests: XCTestCase {
         )
         XCTAssertNil(snapshot.process, "precondition")
         XCTAssertFalse(
-            ClaudeSessionJoinResolver.registeredClaudeIsForeground(
+            ClaudeSessionJoinResolver.registeredAgentIsForeground(
                 snapshot: snapshot, foregroundPIDs: [9001]
             )
         )


### PR DESCRIPTION
## What

Groundwork for the opencode integration (localvoxtral's second coding agent): the wire and registry generalization, pure Swift, no plugin yet (that is the stacked child PR).

- **Wire v2** (`ClaudeHookWire.version = 2`): records gain an `agent` field (`claude` | `opencode`). It is omitted on the wire for `.claude`, so every Claude record keeps its v1 byte shape; v1 lines still decode and are Claude by construction (`readableVersions = {1, 2}`). Unknown agent names are dropped precisely (`.unknownAgent`), never defaulted — an agent this build has never heard of must not inherit Claude's channel rules (title markers, bare id namespace). `ClaudeBrokerResponse.decodeLine` accepts any readable version so a publisher one release apart from the app degrades to "no marker", not a dead channel.
- **Per-agent session namespacing** (`ClaudeAgentSessionScope`): opencode ids are scoped `opencode:ses_…` by the RECEIVER (`ClaudeSessionRegistry.ingest`), recomputed from the agent tag on every ingest — mirroring `ClaudeRemoteSessionScope`'s host namespacing. The agent is fixed at first sight like the origin; a record spelling another agent's scoped id is dropped whole.
- **`FocusChanged` (v2) + focus arbitration in `resolve(tty:)`**: one opencode process hosts several sessions on one TTY (the TUI shows one at a time), so per-session TTY claims structurally cannot disambiguate them. A pane may now declare which session it displays; the declaration is freshness-bounded (2 min TTL, table bounded and pruned), pid-cross-checked against the focused session's registered process, LOCAL transport only, and never mints a session. `resolve(tty:)` arbitrates: fresh focus resolves (and can disambiguate competing per-session claims); stale focus is ABSENT information; a fresh declaration for a dead/unknown/unverifiable session abstains outright; a live per-session claim conflicting with a fresh focus declaration abstains `.ambiguous`. Claude behavior with no focus entry is byte-for-byte the pre-v2 rules.
- The reducer never absorbs a focus record's process block into the session — pane state (the declarer's tty/pid) must not become a per-session TTY claim (caught by the new truth-table tests, fixed before first commit).
- herdr pane claim cross-check is agent-scoped (`scopedSessionID(agent:sessionID:)`) so the existing herdr arm keeps confirming — never redirecting — when the pane hosts opencode.

Downstream (join resolver arms, repo collector, context blocks, budget) is unchanged: opencode sessions flow through the same snapshot fields, and for CLAUDE sessions context-attachment semantics are untouched — every new code path only adds a second agent's records as grounding inputs through the existing pipeline.

## Proof

- [x] Unit suite green — `./scripts/remote-build.sh` (build + unit tests):

```
Executed 2040 tests, with 2 tests skipped and 0 failures (0 unexpected) in 71.840 (71.934) seconds
```

- [x] New focus truth-table coverage (`ClaudeSessionFocusResolutionTests`, 16 tests): single+focus resolved / single-no-focus abstain (no sole-session fallback) / multiple+fresh-focus resolved to declared / multiple+stale-focus abstain / multiple-no-focus abstain / focus-for-dead-session abstain / dead-declarer-pid abstain / pid-mismatch abstain / claim-vs-focus conflict abstain / claude single-claim unchanged / remote focus refused / bounded focus table / namespacing + cross-agent forgery drop / opencode lifecycle through the reducer.
- [x] Wire v1/v2 round-trips: v1 golden line still decodes as Claude; opencode golden line round-trips; unknown agent (`"aider"`, non-string) rejected precisely; `agent` key absent from Claude records (`ClaudeHookWireCodecTests`).
- [x] Regression shape called out: first test run caught the reducer absorbing focus-record process info into the session (3 truth-table failures — resolved-instead-of-abstain); fixed by excluding `.focusChanged` from process absorption, rerun green (`.build/last-remote.log` history in the PR discussion).

LLM lanes: these paths are in `scripts/ci/llm-lane-filter.sh` and the lane will run. Context-attachment semantics for Claude sessions are unchanged; opencode sessions only add grounding inputs through the existing pipeline (no prompt/model/request-shape change), so no eval scoreboard beyond the lane itself.
