### PR TITLE
opencode integration: dual-realm plugin, broker marker gating, contract tests

### DIFF
--- a/Sources/ClaudeContextWire/ClaudeHookWire.swift
+++ b/Sources/ClaudeContextWire/ClaudeHookWire.swift
@@ -12,7 +12,59 @@ import Foundation
 /// dropped, never partially trusted.
 public enum ClaudeHookWire {
     /// Current wire version. Bump on any incompatible field change.
-    public static let version = 1
+    ///
+    /// v2 added the `agent` field (absent = `.claude`) and the `FocusChanged`
+    /// event for the opencode integration.
+    public static let version = 2
+
+    /// Versions this build still reads. v1 is the pre-agent wire: every v1
+    /// record is, by definition, a Claude Code record, so v1 lines decode with
+    /// `agent == .claude` rather than being dropped — the publisher binary and
+    /// the app usually ship together, but a stale installed plugin pointing at
+    /// an old publisher must not silently lose all context after an update.
+    public static let readableVersions: Set<Int> = [1, 2]
+}
+
+/// Which coding agent published a record. Content, not trust: trust stays a
+/// property of the transport (`ClaudeTransportOrigin`), and every local agent
+/// publishes over the same peer-authenticated socket. What the agent tag
+/// decides is session-id namespacing (`ClaudeAgentSessionScope`) and
+/// per-agent channel rules — e.g. the broker never returns a title marker to
+/// an opencode session, because opencode owns its window title the way herdr
+/// owns its pane titles.
+///
+/// Decoding an unknown agent name is a drop, mirroring unknown events: a
+/// newer plugin talking to an older app degrades to "ignored", and an agent
+/// whose channel rules we do not know must not inherit another's.
+public enum ClaudeHookAgent: String, Sendable, Equatable, CaseIterable, Codable {
+    case claude
+    case opencode
+}
+
+/// Namespacing for per-agent session ids, mirroring `ClaudeRemoteSessionScope`.
+///
+/// Two agents pick their own session ids and cannot coordinate — Claude Code
+/// uses bare UUIDs, opencode uses `ses_…` — so a bare id is a claim, not a
+/// key. Scoping opencode ids under a prefix no Claude-published UUID can carry
+/// makes cross-agent collision structurally impossible. Applied by the
+/// RECEIVER (`ClaudeSessionRegistry.ingest`), never trusted from the wire, so
+/// a publisher cannot pre-scope itself into another namespace being honest or
+/// otherwise — the registry recomputes the key from the agent tag every time.
+/// (A local peer lying about its agent tag is a same-UID process and already
+/// outside the threat model, same as the remote scope's note on host ids.)
+public enum ClaudeAgentSessionScope {
+    /// Distinct from `ClaudeRemoteSessionScope.prefix` ("remote:") — the two
+    /// namespaces must never alias.
+    public static let opencodePrefix = "opencode:"
+
+    public static func scopedSessionID(agent: ClaudeHookAgent, sessionID: String) -> String {
+        switch agent {
+        case .claude:
+            return sessionID
+        case .opencode:
+            return opencodePrefix + sessionID
+        }
+    }
 }
 
 /// Hook events the plugin publishes. Cases map 1:1 to Claude Code hook names.
@@ -36,6 +88,13 @@ public enum ClaudeHookEvent: String, Sendable, Equatable, CaseIterable, Codable 
     case fileChanged = "FileChanged"
     case stop = "Stop"
     case sessionEnd = "SessionEnd"
+    /// Published by the opencode plugin's TUI half only (v2): "the pane on
+    /// this TTY currently displays this session". One opencode process hosts
+    /// several sessions on one terminal, so per-session TTY claims cannot
+    /// disambiguate them — an explicit, freshness-bounded focus declaration
+    /// can. Claude Code never sends this; nothing in its hook set knows what a
+    /// pane displays.
+    case focusChanged = "FocusChanged"
 }
 
 /// Hard bounds applied at BOTH ends of the wire.
@@ -155,6 +214,10 @@ public struct ClaudeFileTouch: Sendable, Equatable, Codable {
 public struct ClaudeHookRecord: Sendable, Equatable {
     public var version: Int
     public var event: ClaudeHookEvent
+    /// Which coding agent published this. Encoded only when it is not the
+    /// default `.claude`, so v1 readers' "absent field" and v2's default agree
+    /// byte-for-byte on every Claude record.
+    public var agent: ClaudeHookAgent
     public var sessionID: String
     /// Seconds since the UNIX epoch, as stamped by the publisher.
     public var timestamp: Double
@@ -170,6 +233,7 @@ public struct ClaudeHookRecord: Sendable, Equatable {
     public init(
         version: Int = ClaudeHookWire.version,
         event: ClaudeHookEvent,
+        agent: ClaudeHookAgent = .claude,
         sessionID: String,
         timestamp: Double,
         rawCwd: String? = nil,
@@ -180,6 +244,7 @@ public struct ClaudeHookRecord: Sendable, Equatable {
     ) {
         self.version = version
         self.event = event
+        self.agent = agent
         self.sessionID = sessionID
         self.timestamp = timestamp
         self.rawCwd = rawCwd
@@ -194,6 +259,7 @@ extension ClaudeHookRecord: Codable {
     enum CodingKeys: String, CodingKey {
         case version = "v"
         case event
+        case agent
         case sessionID = "session_id"
         case timestamp = "ts"
         case rawCwd = "cwd"
@@ -207,6 +273,11 @@ extension ClaudeHookRecord: Codable {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         version = try container.decode(Int.self, forKey: .version)
         event = try container.decode(ClaudeHookEvent.self, forKey: .event)
+        // Absent means the default agent — that is what makes every v1 line
+        // (which predates the field) a Claude record by construction. An
+        // unknown agent NAME never reaches this decoder: `decodeLine` probes
+        // and rejects it first, the same way it handles unknown events.
+        agent = try container.decodeIfPresent(ClaudeHookAgent.self, forKey: .agent) ?? .claude
         sessionID = try container.decode(String.self, forKey: .sessionID)
         timestamp = try container.decode(Double.self, forKey: .timestamp)
         rawCwd = try container.decodeIfPresent(String.self, forKey: .rawCwd)
@@ -216,6 +287,24 @@ extension ClaudeHookRecord: Codable {
         process = try container.decodeIfPresent(ClaudeHookProcessInfo.self, forKey: .process)
         // Any other key on the wire — notably an `origin`-shaped one — is
         // silently discarded here. That is the point: trust is not a field.
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(version, forKey: .version)
+        try container.encode(event, forKey: .event)
+        // Omitted when `.claude`: absence IS the default, so a Claude record's
+        // bytes carry no agent key — the exact shape a v1 reader expects.
+        if agent != .claude {
+            try container.encode(agent, forKey: .agent)
+        }
+        try container.encode(sessionID, forKey: .sessionID)
+        try container.encode(timestamp, forKey: .timestamp)
+        try container.encodeIfPresent(rawCwd, forKey: .rawCwd)
+        try container.encodeIfPresent(prompt, forKey: .prompt)
+        try container.encodeIfPresent(toolName, forKey: .toolName)
+        try container.encode(files, forKey: .files)
+        try container.encodeIfPresent(process, forKey: .process)
     }
 }
 
@@ -227,6 +316,11 @@ public enum ClaudeHookWireError: Error, Equatable {
     case unsupportedVersion(Int?)
     /// Event name we do not know (e.g. from a newer plugin).
     case unknownEvent(String?)
+    /// Agent name we do not know. Dropped for the same reason as an unknown
+    /// event — and additionally because per-agent channel rules (marker
+    /// emission, session namespacing) cannot be applied to an agent this build
+    /// has never heard of.
+    case unknownAgent(String?)
     /// Malformed JSON, or a required field missing.
     case malformed
     /// `session_id` was empty — the record cannot be attributed.
@@ -275,12 +369,21 @@ public enum ClaudeHookWireCodec {
             throw ClaudeHookWireError.malformed
         }
         let claimedVersion = dictionary["v"] as? Int
-        guard claimedVersion == ClaudeHookWire.version else {
+        guard let claimedVersion, ClaudeHookWire.readableVersions.contains(claimedVersion) else {
             throw ClaudeHookWireError.unsupportedVersion(claimedVersion)
         }
         let eventName = dictionary["event"] as? String
         guard let eventName, ClaudeHookEvent(rawValue: eventName) != nil else {
             throw ClaudeHookWireError.unknownEvent(eventName)
+        }
+        // Probed like the event: an unknown agent must be a precise "ignored",
+        // not a generic decode failure — and never a fallthrough to `.claude`,
+        // which would hand a future agent Claude's channel rules.
+        if let agentValue = dictionary["agent"] {
+            let agentName = agentValue as? String
+            guard let agentName, ClaudeHookAgent(rawValue: agentName) != nil else {
+                throw ClaudeHookWireError.unknownAgent(agentName)
+            }
         }
 
         guard let record = try? JSONDecoder().decode(ClaudeHookRecord.self, from: trimmed) else {

--- a/Sources/ClaudeContextWire/ClaudeHookWire.swift
+++ b/Sources/ClaudeContextWire/ClaudeHookWire.swift
@@ -95,6 +95,14 @@ public enum ClaudeHookEvent: String, Sendable, Equatable, CaseIterable, Codable 
     /// can. Claude Code never sends this; nothing in its hook set knows what a
     /// pane displays.
     case focusChanged = "FocusChanged"
+    /// The pane left its session view (v2, opencode TUI half only): "this TTY
+    /// no longer displays the named session". Retracts the pane's focus
+    /// declaration immediately instead of letting it linger until TTL — a
+    /// user who navigated home is not dictating into the session they left.
+    /// The named session is the one being retracted; the registry clears the
+    /// TTY's declaration regardless, because a clear can only ever widen
+    /// abstention.
+    case focusCleared = "FocusCleared"
 }
 
 /// Hard bounds applied at BOTH ends of the wire.
@@ -380,6 +388,13 @@ public enum ClaudeHookWireCodec {
         // not a generic decode failure — and never a fallthrough to `.claude`,
         // which would hand a future agent Claude's channel rules.
         if let agentValue = dictionary["agent"] {
+            // No v1 writer ever emitted this key — v1 predates it, and
+            // "absent = claude" is the entire v1 compatibility contract. A v1
+            // line that carries it anyway is not an old publisher; it is a
+            // malformed or hand-crafted record, and it is dropped as such.
+            guard claimedVersion >= 2 else {
+                throw ClaudeHookWireError.malformed
+            }
             let agentName = agentValue as? String
             guard let agentName, ClaudeHookAgent(rawValue: agentName) != nil else {
                 throw ClaudeHookWireError.unknownAgent(agentName)

--- a/Sources/ClaudeContextWire/ClaudeMarkerSequence.swift
+++ b/Sources/ClaudeContextWire/ClaudeMarkerSequence.swift
@@ -37,7 +37,10 @@ public struct ClaudeBrokerResponse: Sendable, Equatable, Codable {
         guard let response = try? JSONDecoder().decode(ClaudeBrokerResponse.self, from: line) else {
             return nil
         }
-        guard response.version == ClaudeHookWire.version else { return nil }
+        // Any readable wire version, not just the current one: a publisher one
+        // release ahead of or behind the app must degrade to "no marker", not
+        // lose the marker channel entirely until both halves are updated.
+        guard ClaudeHookWire.readableVersions.contains(response.version) else { return nil }
         return response
     }
 }

--- a/Sources/localvoxtral/ClaudeContext/ClaudeContextBroker.swift
+++ b/Sources/localvoxtral/ClaudeContext/ClaudeContextBroker.swift
@@ -607,7 +607,15 @@ public final class ClaudeContextBroker: Sendable {
             #if DEBUG
             debugNotify(.success(record))
             #endif
-            return (snapshot?.marker, record.process?.herdrPaneID != nil)
+            // Only Claude Code has a writable title channel, so only Claude
+            // sessions ever receive their marker back — the herdr rule,
+            // generalized per agent: opencode rewrites its own OSC titles
+            // mid-turn (and clears them on exit), so a marker sent there could
+            // never survive to identify a pane, and its plugin deliberately
+            // never writes to the terminal at all. Allocation is unchanged —
+            // the registry marker remains every join's liveness handle.
+            let marker = snapshot?.agent == .claude ? snapshot?.marker : nil
+            return (marker, record.process?.herdrPaneID != nil)
         } catch let error as ClaudeHookWireError {
             Log.claudeContext.error("Rejected record: \(String(describing: error), privacy: .public)")
             #if DEBUG

--- a/Sources/localvoxtral/ClaudeContext/ClaudeContextBroker.swift
+++ b/Sources/localvoxtral/ClaudeContext/ClaudeContextBroker.swift
@@ -474,6 +474,10 @@ public final class ClaudeContextBroker: Sendable {
             return
         }
         let origin = ClaudeTransportOrigin.localAuthenticated(peerUID: peerUID)
+        // Kernel-verified peer pid, read once per connection. Used only for
+        // the per-agent pid cross-check in `handle` — see peerPID's doc for
+        // why it applies to opencode records and cannot apply to Claude's.
+        let peerPID = ClaudeSocketGuard.peerPID(ofDescriptor: fd)
 
         var noSigPipe: Int32 = 1
         setsockopt(fd, SOL_SOCKET, SO_NOSIGPIPE, &noSigPipe, socklen_t(MemoryLayout<Int32>.size))
@@ -507,8 +511,13 @@ public final class ClaudeContextBroker: Sendable {
                     Log.claudeContext.error("Dropping connection: too many records")
                     return
                 }
-                let handled = handle(line: line, origin: origin)
-                reply(to: fd, marker: handled.marker, isHerdrHosted: handled.isHerdrHosted)
+                let handled = handle(line: line, origin: origin, peerPID: peerPID)
+                reply(
+                    to: fd,
+                    marker: handled.marker,
+                    isHerdrHosted: handled.isHerdrHosted,
+                    version: handled.replyVersion
+                )
             }
         }
     }
@@ -571,10 +580,19 @@ public final class ClaudeContextBroker: Sendable {
     ///
     /// Best-effort by design — a publisher that has already exited is normal,
     /// not an error.
-    private func reply(to fd: Int32, marker: ClaudeSessionMarker?, isHerdrHosted: Bool) {
+    private func reply(
+        to fd: Int32,
+        marker: ClaudeSessionMarker?,
+        isHerdrHosted: Bool,
+        version: Int
+    ) {
         let responseMarker = shouldEmitLocalTitleMarker() && !isHerdrHosted ? marker?.value : nil
         guard let line = ClaudeBrokerResponse.encodeLine(
-            ClaudeBrokerResponse(marker: responseMarker)
+            // Echo the REQUEST's wire version (review C4): an already-installed
+            // v1 publisher rejects any reply that does not say v1, so replying
+            // with the broker's own version would silently kill the marker
+            // channel for every stale plugin install until it updated.
+            ClaudeBrokerResponse(version: version, marker: responseMarker)
         ) else { return }
         _ = line.withUnsafeBytes { raw -> Int in
             guard let base = raw.baseAddress else { return 0 }
@@ -590,16 +608,40 @@ public final class ClaudeContextBroker: Sendable {
         }
     }
 
-    /// - Returns: the marker for the session this record belongs to and whether
-    ///   herdr must intercept title changes, or nil marker metadata when the
-    ///   record was rejected.
+    /// - Returns: the marker for the session this record belongs to, whether
+    ///   herdr must intercept title changes, and the wire version to shape the
+    ///   reply as (the request's own — see `reply`), or nil marker metadata
+    ///   when the record was rejected.
     @discardableResult
     private func handle(
         line: Data,
-        origin: ClaudeTransportOrigin
-    ) -> (marker: ClaudeSessionMarker?, isHerdrHosted: Bool) {
+        origin: ClaudeTransportOrigin,
+        peerPID: pid_t?
+    ) -> (marker: ClaudeSessionMarker?, isHerdrHosted: Bool, replyVersion: Int) {
         do {
             let record = try ClaudeHookWireCodec.decodeLine(line, limits: limits.wire)
+            // Per-agent pid cross-check against the KERNEL's answer. The
+            // opencode plugin runs inside the agent process and dials this
+            // socket from it, so the pid its records claim must be the pid on
+            // the other end of the connection — a same-user process forging
+            // opencode records for a pid it does not own is cut off here.
+            // Claude records cannot be held to this: their publisher is a
+            // transient child of the session, never the session process
+            // itself, which is exactly why the claude pid rides in the record
+            // (see ClaudeSocketGuard.peerPID). The residual same-user threat
+            // for THAT path is accepted and documented in AGENTS.md — trust
+            // is transport-derived, and every local peer shares this uid.
+            if record.agent == .opencode {
+                guard let peerPID, record.process?.claudePID == peerPID else {
+                    Log.claudeContext.error(
+                        "Rejected opencode record: claimed pid does not match socket peer"
+                    )
+                    #if DEBUG
+                    debugNotify(.failure(.malformed))
+                    #endif
+                    return (nil, false, record.version)
+                }
+            }
             let snapshot = registry.ingest(record, origin: origin)
             // Content is never logged — only its shape. A hook record carries
             // the user's prompt and their file paths.
@@ -615,19 +657,21 @@ public final class ClaudeContextBroker: Sendable {
             // never writes to the terminal at all. Allocation is unchanged —
             // the registry marker remains every join's liveness handle.
             let marker = snapshot?.agent == .claude ? snapshot?.marker : nil
-            return (marker, record.process?.herdrPaneID != nil)
+            return (marker, record.process?.herdrPaneID != nil, record.version)
         } catch let error as ClaudeHookWireError {
             Log.claudeContext.error("Rejected record: \(String(describing: error), privacy: .public)")
             #if DEBUG
             debugNotify(.failure(error))
             #endif
-            return (nil, false)
+            // A rejected record carries no marker, so its reply shape is
+            // inert; the current version is as good as any guess.
+            return (nil, false, ClaudeHookWire.version)
         } catch {
             Log.claudeContext.error("Rejected record: undecodable")
             #if DEBUG
             debugNotify(.failure(.malformed))
             #endif
-            return (nil, false)
+            return (nil, false, ClaudeHookWire.version)
         }
     }
 }

--- a/Sources/localvoxtral/ClaudeContext/ClaudePluginAssets.swift
+++ b/Sources/localvoxtral/ClaudeContext/ClaudePluginAssets.swift
@@ -96,6 +96,24 @@ public enum ClaudePluginAssets {
             .deletingLastPathComponent() // repo root
     }
 
+    // MARK: opencode
+
+    /// Repo-relative home of the opencode integration: one dependency-free JS
+    /// file plus its README. Not packaged into the app bundle yet — install
+    /// is manual (copy + a tui.json line) until the Settings row lands.
+    public static let opencodeRepositoryRelativePath = "integrations/opencode"
+    public static let opencodePluginFileName = "localvoxtral.js"
+
+    /// Repo checkout location of the opencode plugin file, for the contract
+    /// tests that pin it to the Swift wire constants.
+    static func developmentOpencodePluginURL(
+        sourceFile: String = ClaudePluginAssets.assetsSourceFile
+    ) -> URL? {
+        repositoryRootURL(sourceFile: sourceFile)?
+            .appendingPathComponent(opencodeRepositoryRelativePath)
+            .appendingPathComponent(opencodePluginFileName)
+    }
+
     /// Name of the publisher binary, as packaged and as the shim looks for it.
     public static let publisherExecutableName = "localvoxtral-claude-hook"
 

--- a/Sources/localvoxtral/ClaudeContext/ClaudeSessionRegistry.swift
+++ b/Sources/localvoxtral/ClaudeContext/ClaudeSessionRegistry.swift
@@ -32,12 +32,14 @@ public struct ClaudeRegistryLimits: Sendable, Equatable {
     /// while leaving most of the global registry available to other origins.
     public static let defaultMaxSessionsPerOrigin = 8
     /// How long a focus declaration stays credible. The opencode TUI half
-    /// heartbeats its focused session roughly every 20 seconds, so two minutes
-    /// tolerates a few lost beats while bounding how long a pane that stopped
-    /// declaring anything (TUI quit, machine slept) can keep steering the TTY
-    /// join. Stale focus is treated as ABSENT information, never as "probably
-    /// still the same one".
-    public static let defaultFocusDeclarationTTL: TimeInterval = 2 * 60
+    /// re-declares on every displayed-session change AND retracts explicitly
+    /// (`FocusCleared`) when the pane leaves its session view, so this bound
+    /// only defends against lost writes and a silently dead TUI: at a
+    /// 20-second heartbeat, 45 seconds tolerates one lost beat plus jitter
+    /// while keeping a pane that stopped declaring from steering the TTY join
+    /// for long. Stale focus is treated as ABSENT information, never as
+    /// "probably still the same one".
+    public static let defaultFocusDeclarationTTL: TimeInterval = 45
     /// Focus declarations are keyed by TTY device, one live entry per pane.
     /// Matches the session cap: there is no reason to remember more panes than
     /// we would remember sessions.
@@ -143,6 +145,18 @@ public final class ClaudeSessionRegistry: Sendable {
         snippets: [ClaudeContentSnippet] = []
     ) -> ClaudeSessionSnapshot? {
         let timestamp = now()
+        // A LOCAL Claude record whose raw id spells another namespace's prefix
+        // is spelling a key that can never be its own: Claude Code ids are
+        // bare UUIDs, opencode ids get the prefix added HERE, and remote ids
+        // are minted by the remote listener (which passes them in pre-scoped,
+        // over a remote origin — that path is exempt below). Dropping these
+        // outright closes the aliasing hole where a crafted `claude` record
+        // literally named "opencode:X" would collide with opencode's raw "X".
+        if origin.isLocalAuthenticated, record.agent == .claude,
+           record.sessionID.hasPrefix(ClaudeAgentSessionScope.opencodePrefix)
+               || record.sessionID.hasPrefix(ClaudeRemoteSessionScope.prefix) {
+            return nil
+        }
         // Receiver-side namespacing, recomputed on EVERY ingest from the agent
         // tag — mirroring how the remote listener scopes ids under the host
         // that authenticated them. The registry keys, the focus table, and
@@ -154,15 +168,33 @@ public final class ClaudeSessionRegistry: Sendable {
         return state.withLock { state -> ClaudeSessionSnapshot? in
             pruneLocked(&state, now: timestamp)
 
-            if record.event == .focusChanged {
-                // Focus is pane state, not session state: record the TTY→session
-                // binding, bump the named session if we know it, but NEVER mint
-                // a session from a focus record — a pane can display a session
-                // whose own records were lost, and inventing an empty snapshot
-                // for it would let the focus join "resolve" to a session we know
-                // nothing about.
-                recordFocusLocked(&state, record: record, origin: origin, now: timestamp)
+            // Focus records are pane state, not session state, and they are an
+            // opencode-only mechanism (Claude Code has no way to know what a
+            // pane displays — a `.claude` focus record is an inconsistency to
+            // refuse, not to honor). Everything is validated BEFORE any focus
+            // state is touched: an invalid declaration must not be able to
+            // suppress an existing per-session TTY claim for the focus TTL —
+            // that ordering bug is exactly what review C2b caught.
+            switch record.event {
+            case .focusChanged:
+                guard isValidFocusDeclarationLocked(state, record: record, origin: origin) else {
+                    return nil
+                }
+                recordFocusLocked(&state, record: record, now: timestamp)
+                // Falls through: the target exists (validated), so the reduce
+                // below bumps its activity.
+            case .focusCleared:
+                guard record.agent == .opencode, origin.isLocalAuthenticated,
+                      let tty = record.process?.tty, !tty.isEmpty
+                else { return nil }
+                // Unconditional removal by TTY, no pid cross-check: a clear
+                // can only ever WIDEN abstention, and requiring the declaring
+                // pid to match would let a restarted TUI's retraction bounce
+                // off its predecessor's lingering entry.
+                state.focusByTTY.removeValue(forKey: tty)
                 guard state.sessions[record.sessionID] != nil else { return nil }
+            default:
+                break
             }
 
             var snapshot: ClaudeSessionSnapshot
@@ -335,6 +367,14 @@ public final class ClaudeSessionRegistry: Sendable {
     /// remote host's pane ids live in another machine's herdr and could collide
     /// with (or deliberately mirror) a local pane's id; matching them here would
     /// let an SSH host claim a local pane by echoing its pane id.
+    ///
+    /// Every opencode session in one TUI shares the pane id AND the pid, so
+    /// with two sessions this used to hit `.ambiguous` before focus could
+    /// participate — the herdr arm silently stopped joining opencode panes
+    /// (review C3). Fresh focus declarations now arbitrate multi-candidate
+    /// panes the same way they arbitrate a TTY: a verified declaration
+    /// (fresh, pid-matched) naming EXACTLY ONE of the pane's candidates
+    /// resolves to it; anything else stays `.ambiguous`.
     public func resolve(herdrPaneID: String) -> ClaudeMarkerResolution {
         let timestamp = now()
         return state.withLock { state in
@@ -352,7 +392,22 @@ public final class ClaudeSessionRegistry: Sendable {
             case 1:
                 return .resolved(matches[0])
             default:
-                return .ambiguous
+                // Focus declarations are keyed by the pane's inner TTY, which
+                // the outer herdr surface cannot know — so scan all fresh,
+                // pid-verified declarations for ones naming a candidate of
+                // THIS pane. Exactly one distinct session may win; zero or
+                // several (two TUIs somehow claiming siblings) abstain.
+                let focused = Set(state.focusByTTY.values.compactMap { focus -> String? in
+                    guard timestamp.timeIntervalSince(focus.declaredAt) <= limits.focusDeclarationTTL,
+                          let candidate = matches.first(where: { $0.sessionID == focus.sessionID }),
+                          candidate.process?.claudePID == focus.declaredPID
+                    else { return nil }
+                    return focus.sessionID
+                })
+                guard focused.count == 1, let winner = focused.first,
+                      let snapshot = matches.first(where: { $0.sessionID == winner })
+                else { return .ambiguous }
+                return .resolved(snapshot)
             }
         }
     }
@@ -479,21 +534,45 @@ public final class ClaudeSessionRegistry: Sendable {
         }
     }
 
-    /// Record one pane's declared focus. LOCAL transport only — a remote
-    /// host's TTY names a device on another machine, exactly the reason
-    /// `resolve(tty:)` refuses remote candidates — and only when the record
-    /// carries the declaring pane's device; a focus claim with no TTY binds
-    /// nothing.
+    /// Every condition a focus declaration must meet BEFORE any focus state is
+    /// mutated (review C2b: writing first let an invalid declaration suppress
+    /// a live per-session TTY claim for the focus TTL even though ingest
+    /// rejected the record):
+    ///
+    /// * opencode-only — focus is that agent's mechanism, and a `.claude`
+    ///   focus record is an inconsistency to refuse (review hardening);
+    /// * LOCAL transport only — a remote host's TTY names a device on another
+    ///   machine, exactly the reason `resolve(tty:)` refuses remote candidates;
+    /// * carries the declaring pane's device — a claim with no TTY binds
+    ///   nothing;
+    /// * names a session the registry KNOWS, of the same agent, itself locally
+    ///   authenticated, registered to the declaring process. A declaration
+    ///   that could never resolve must not exist — and a session the pane
+    ///   displays but whose records were lost self-heals at the next
+    ///   heartbeat, once its own records arrive.
+    private func isValidFocusDeclarationLocked(
+        _ state: State,
+        record: ClaudeHookRecord,
+        origin: ClaudeTransportOrigin
+    ) -> Bool {
+        guard record.agent == .opencode,
+              origin.isLocalAuthenticated,
+              let process = record.process,
+              let tty = process.tty, !tty.isEmpty,
+              let target = state.sessions[record.sessionID],
+              target.agent == record.agent,
+              target.origin.isLocalAuthenticated,
+              target.process?.claudePID == process.claudePID
+        else { return false }
+        return true
+    }
+
     private func recordFocusLocked(
         _ state: inout State,
         record: ClaudeHookRecord,
-        origin: ClaudeTransportOrigin,
         now: Date
     ) {
-        guard origin.isLocalAuthenticated,
-              let process = record.process,
-              let tty = process.tty, !tty.isEmpty
-        else { return }
+        guard let process = record.process, let tty = process.tty else { return }
         state.focusByTTY[tty] = FocusDeclaration(
             sessionID: record.sessionID,
             declaredPID: process.claudePID,

--- a/Sources/localvoxtral/ClaudeContext/ClaudeSessionRegistry.swift
+++ b/Sources/localvoxtral/ClaudeContext/ClaudeSessionRegistry.swift
@@ -31,6 +31,17 @@ public struct ClaudeRegistryLimits: Sendable, Equatable {
     /// than this many sessions. Eight covers a generous set of terminal tabs
     /// while leaving most of the global registry available to other origins.
     public static let defaultMaxSessionsPerOrigin = 8
+    /// How long a focus declaration stays credible. The opencode TUI half
+    /// heartbeats its focused session roughly every 20 seconds, so two minutes
+    /// tolerates a few lost beats while bounding how long a pane that stopped
+    /// declaring anything (TUI quit, machine slept) can keep steering the TTY
+    /// join. Stale focus is treated as ABSENT information, never as "probably
+    /// still the same one".
+    public static let defaultFocusDeclarationTTL: TimeInterval = 2 * 60
+    /// Focus declarations are keyed by TTY device, one live entry per pane.
+    /// Matches the session cap: there is no reason to remember more panes than
+    /// we would remember sessions.
+    public static let defaultMaxFocusDeclarations = 32
 
     /// Hard cap on retained sessions. Beyond this, the least-recently-active is
     /// evicted — a user with hundreds of stale sessions must not grow the app.
@@ -44,17 +55,23 @@ public struct ClaudeRegistryLimits: Sendable, Equatable {
     /// PID liveness — not SessionEnd alone — is what keeps the registry honest.
     public var sessionTTL: TimeInterval
     public var pidlessLocalSessionTTL: TimeInterval
+    public var focusDeclarationTTL: TimeInterval
+    public var maxFocusDeclarations: Int
 
     public init(
         maxSessions: Int = 32,
         maxSessionsPerOrigin: Int = Self.defaultMaxSessionsPerOrigin,
         sessionTTL: TimeInterval = 4 * 60 * 60,
-        pidlessLocalSessionTTL: TimeInterval = Self.defaultPIDLessLocalSessionTTL
+        pidlessLocalSessionTTL: TimeInterval = Self.defaultPIDLessLocalSessionTTL,
+        focusDeclarationTTL: TimeInterval = Self.defaultFocusDeclarationTTL,
+        maxFocusDeclarations: Int = Self.defaultMaxFocusDeclarations
     ) {
         self.maxSessions = maxSessions
         self.maxSessionsPerOrigin = maxSessionsPerOrigin
         self.sessionTTL = sessionTTL
         self.pidlessLocalSessionTTL = pidlessLocalSessionTTL
+        self.focusDeclarationTTL = focusDeclarationTTL
+        self.maxFocusDeclarations = maxFocusDeclarations
     }
 
     public static let `default` = ClaudeRegistryLimits()
@@ -65,9 +82,23 @@ public struct ClaudeRegistryLimits: Sendable, Equatable {
 /// `Mutex` + `Sendable` per repo convention (no custom actors): the broker's
 /// accept thread writes, the main actor reads, and neither should await.
 public final class ClaudeSessionRegistry: Sendable {
+    /// One pane's declared focus: "the TTY this is keyed by currently displays
+    /// this session", as published by an agent that can actually see its own
+    /// pane (the opencode TUI half). Held per TTY, not per session — focus is
+    /// a property of the pane.
+    private struct FocusDeclaration {
+        var sessionID: String
+        /// The declaring process's pid. Cross-checked against the focused
+        /// session's registered pid at resolution: a declaration that outlived
+        /// its process must not steer a recycled TTY.
+        var declaredPID: Int32
+        var declaredAt: Date
+    }
+
     private struct State {
         var sessions: [String: ClaudeSessionSnapshot] = [:]
         var markerIndex: [String: String] = [:] // marker value -> session id
+        var focusByTTY: [String: FocusDeclaration] = [:]
     }
 
     private let state = Mutex(State())
@@ -112,8 +143,27 @@ public final class ClaudeSessionRegistry: Sendable {
         snippets: [ClaudeContentSnippet] = []
     ) -> ClaudeSessionSnapshot? {
         let timestamp = now()
+        // Receiver-side namespacing, recomputed on EVERY ingest from the agent
+        // tag — mirroring how the remote listener scopes ids under the host
+        // that authenticated them. The registry keys, the focus table, and
+        // every snapshot all speak scoped ids from here on.
+        var record = record
+        record.sessionID = ClaudeAgentSessionScope.scopedSessionID(
+            agent: record.agent, sessionID: record.sessionID
+        )
         return state.withLock { state -> ClaudeSessionSnapshot? in
             pruneLocked(&state, now: timestamp)
+
+            if record.event == .focusChanged {
+                // Focus is pane state, not session state: record the TTY→session
+                // binding, bump the named session if we know it, but NEVER mint
+                // a session from a focus record — a pane can display a session
+                // whose own records were lost, and inventing an empty snapshot
+                // for it would let the focus join "resolve" to a session we know
+                // nothing about.
+                recordFocusLocked(&state, record: record, origin: origin, now: timestamp)
+                guard state.sessions[record.sessionID] != nil else { return nil }
+            }
 
             var snapshot: ClaudeSessionSnapshot
             if let existing = state.sessions[record.sessionID] {
@@ -130,12 +180,19 @@ public final class ClaudeSessionRegistry: Sendable {
                 // transport naming the same id is, by construction, someone
                 // spelling an id that is not theirs.
                 if snapshot.origin != origin { return nil }
+                // The agent is likewise fixed at first sight. Agent scoping
+                // makes an honest collision impossible (the scoped keys
+                // differ), so a mismatch here is a record spelling another
+                // agent's scoped id — drop it rather than let one agent's
+                // records mutate another's session.
+                if snapshot.agent != record.agent { return nil }
             } else {
                 if record.event == .sessionEnd { return nil } // nothing to start
                 let marker = ClaudeSessionMarker(value: allocateUniqueMarkerLocked(&state))
                 snapshot = ClaudeSessionSnapshot(
                     sessionID: record.sessionID,
                     origin: origin,
+                    agent: record.agent,
                     marker: marker,
                     firstSeen: timestamp
                 )
@@ -209,9 +266,28 @@ public final class ClaudeSessionRegistry: Sendable {
     /// Only LOCAL sessions are candidates: a remote session's TTY names a
     /// device on another machine, where it can collide with an unrelated local
     /// pane — matching it here would let an SSH host claim a local pane by
-    /// publishing that pane's TTY. Abstains `.ambiguous` when two live local
-    /// sessions claim one TTY (a suspended Claude beneath a new one in the same
-    /// pane); the caller's marker fallback may still disambiguate.
+    /// publishing that pane's TTY.
+    ///
+    /// Two kinds of evidence can bind a TTY to a session, and they must agree:
+    ///
+    /// * **Per-session claims** (Claude Code): each hook record carries the
+    ///   session's controlling TTY, so a device usually maps to one session.
+    ///   Two live claims on one TTY (a suspended Claude beneath a new one in
+    ///   the same pane) abstain `.ambiguous`; the caller's marker fallback may
+    ///   still disambiguate.
+    /// * **Focus declarations** (opencode): one opencode process hosts many
+    ///   sessions on one TTY and its TUI shows one at a time, so its sessions
+    ///   carry no TTY at all — the TUI half instead declares which session the
+    ///   pane DISPLAYS (`FocusChanged`, freshness-bounded). A fresh declaration
+    ///   resolves the TTY to that session iff the session is live and its
+    ///   registered pid matches the declarer's; a declaration whose session is
+    ///   gone or unverifiable abstains rather than falling back to guesswork,
+    ///   and a stale declaration is ABSENT information, not a hint.
+    ///
+    /// When both kinds of evidence exist for one TTY and disagree — a live
+    /// per-session claim next to a fresh focus declaration naming a different
+    /// session — that is two agents each positively claiming the same pane,
+    /// and the only safe answer is `.ambiguous`.
     public func resolve(tty: String) -> ClaudeMarkerResolution {
         let timestamp = now()
         return state.withLock { state in
@@ -220,6 +296,27 @@ public final class ClaudeSessionRegistry: Sendable {
                     && snapshot.process?.tty == tty
                     && isFresh(snapshot, now: timestamp)
             }
+
+            if let focus = state.focusByTTY[tty],
+               timestamp.timeIntervalSince(focus.declaredAt) <= limits.focusDeclarationTTL {
+                guard let focused = state.sessions[focus.sessionID],
+                      focused.origin.isLocalAuthenticated,
+                      isFresh(focused, now: timestamp),
+                      focused.process?.claudePID == focus.declaredPID
+                else {
+                    // A fresh declaration for a session that is dead, unknown,
+                    // or from a different process than the declarer. The pane
+                    // positively told us what it displays and we cannot verify
+                    // it — trusting any OTHER candidate now would contradict
+                    // the freshest evidence we have, so abstain outright.
+                    return .stale
+                }
+                if matches.isEmpty || matches.contains(where: { $0.sessionID == focus.sessionID }) {
+                    return .resolved(focused)
+                }
+                return .ambiguous
+            }
+
             switch matches.count {
             case 0:
                 let hadStale = state.sessions.values.contains {
@@ -342,6 +439,7 @@ public final class ClaudeSessionRegistry: Sendable {
         state.withLock { state in
             state.sessions.removeAll()
             state.markerIndex.removeAll()
+            state.focusByTTY.removeAll()
         }
     }
 
@@ -372,6 +470,42 @@ public final class ClaudeSessionRegistry: Sendable {
     private func pruneLocked(_ state: inout State, now: Date) {
         for (sessionID, snapshot) in state.sessions where !isFresh(snapshot, now: now) {
             removeLocked(&state, sessionID: sessionID)
+        }
+        // Expired focus declarations are dead weight: resolution already treats
+        // them as absent, this just keeps the table from accumulating panes.
+        for (tty, focus) in state.focusByTTY
+        where now.timeIntervalSince(focus.declaredAt) > limits.focusDeclarationTTL {
+            state.focusByTTY.removeValue(forKey: tty)
+        }
+    }
+
+    /// Record one pane's declared focus. LOCAL transport only — a remote
+    /// host's TTY names a device on another machine, exactly the reason
+    /// `resolve(tty:)` refuses remote candidates — and only when the record
+    /// carries the declaring pane's device; a focus claim with no TTY binds
+    /// nothing.
+    private func recordFocusLocked(
+        _ state: inout State,
+        record: ClaudeHookRecord,
+        origin: ClaudeTransportOrigin,
+        now: Date
+    ) {
+        guard origin.isLocalAuthenticated,
+              let process = record.process,
+              let tty = process.tty, !tty.isEmpty
+        else { return }
+        state.focusByTTY[tty] = FocusDeclaration(
+            sessionID: record.sessionID,
+            declaredPID: process.claudePID,
+            declaredAt: now
+        )
+        // Bounded like everything else a peer can grow: beyond the cap the
+        // oldest declaration goes — it is the one closest to expiring anyway.
+        while state.focusByTTY.count > limits.maxFocusDeclarations {
+            guard let oldest = state.focusByTTY.min(by: {
+                ($0.value.declaredAt, $0.key) < ($1.value.declaredAt, $1.key)
+            }) else { break }
+            state.focusByTTY.removeValue(forKey: oldest.key)
         }
     }
 

--- a/Sources/localvoxtral/ClaudeContext/ClaudeSessionState.swift
+++ b/Sources/localvoxtral/ClaudeContext/ClaudeSessionState.swift
@@ -57,6 +57,12 @@ public struct ClaudeSessionSnapshot: Sendable, Equatable {
     public var sessionID: String
     /// Assigned by the broker from peer credentials. Never from the record.
     public var origin: ClaudeTransportOrigin
+    /// Which coding agent this session belongs to, fixed at first sight like
+    /// `origin`. Decides per-agent channel rules — most importantly, the
+    /// broker never returns a title marker to a non-Claude session, because
+    /// only Claude Code has a writable title channel (opencode rewrites its
+    /// own OSC titles mid-turn, like herdr does inside its panes).
+    public var agent: ClaudeHookAgent
     public var marker: ClaudeSessionMarker
     /// Local path or opaque remote label — the type enforces which.
     public var workspace: ClaudeWorkspaceReference?
@@ -102,11 +108,13 @@ public struct ClaudeSessionSnapshot: Sendable, Equatable {
     init(
         sessionID: String,
         origin: ClaudeTransportOrigin,
+        agent: ClaudeHookAgent = .claude,
         marker: ClaudeSessionMarker,
         firstSeen: Date
     ) {
         self.sessionID = sessionID
         self.origin = origin
+        self.agent = agent
         self.marker = marker
         self.workspace = nil
         self.latestPriorUserPrompt = nil
@@ -152,7 +160,13 @@ public enum ClaudeSessionReducer {
         if let workspace = ClaudeWorkspaceReference.make(rawCwd: record.rawCwd, origin: origin) {
             snapshot.workspace = workspace
         }
-        if let process = record.process {
+        // Never absorbed from a focus record: its process block describes the
+        // PANE (the declarer's tty and pid), not the session. Folding it in
+        // would hand the session a per-session TTY claim its publisher
+        // deliberately never makes — the opencode server half publishes no tty
+        // precisely because it cannot prove it owns a pane — and would let a
+        // focus record overwrite the pid that liveness probes.
+        if let process = record.process, record.event != .focusChanged {
             snapshot.process = process
         }
 
@@ -179,6 +193,13 @@ public enum ClaudeSessionReducer {
             snapshot.activity = .working
         case .stop:
             snapshot.activity = .idle
+        case .focusChanged:
+            // Focus is registry-level state (a TTY→session binding, held in
+            // `ClaudeSessionRegistry`'s focus table) — a pane DISPLAYING a
+            // session says nothing about whether its model is working, so the
+            // per-session state here changes only by the lastActivity bump
+            // applied above.
+            break
         case .sessionEnd:
             snapshot.activity = .ended
         }

--- a/Sources/localvoxtral/ClaudeContext/ClaudeSessionState.swift
+++ b/Sources/localvoxtral/ClaudeContext/ClaudeSessionState.swift
@@ -160,13 +160,15 @@ public enum ClaudeSessionReducer {
         if let workspace = ClaudeWorkspaceReference.make(rawCwd: record.rawCwd, origin: origin) {
             snapshot.workspace = workspace
         }
-        // Never absorbed from a focus record: its process block describes the
-        // PANE (the declarer's tty and pid), not the session. Folding it in
-        // would hand the session a per-session TTY claim its publisher
-        // deliberately never makes — the opencode server half publishes no tty
-        // precisely because it cannot prove it owns a pane — and would let a
-        // focus record overwrite the pid that liveness probes.
-        if let process = record.process, record.event != .focusChanged {
+        // Never absorbed from a focus record (declaration or retraction): its
+        // process block describes the PANE (the declarer's tty and pid), not
+        // the session. Folding it in would hand the session a per-session TTY
+        // claim its publisher deliberately never makes — the opencode server
+        // half publishes no tty precisely because it cannot prove it owns a
+        // pane — and would let a focus record overwrite the pid that liveness
+        // probes.
+        if let process = record.process,
+           record.event != .focusChanged, record.event != .focusCleared {
             snapshot.process = process
         }
 
@@ -193,12 +195,12 @@ public enum ClaudeSessionReducer {
             snapshot.activity = .working
         case .stop:
             snapshot.activity = .idle
-        case .focusChanged:
+        case .focusChanged, .focusCleared:
             // Focus is registry-level state (a TTY→session binding, held in
-            // `ClaudeSessionRegistry`'s focus table) — a pane DISPLAYING a
-            // session says nothing about whether its model is working, so the
-            // per-session state here changes only by the lastActivity bump
-            // applied above.
+            // `ClaudeSessionRegistry`'s focus table) — a pane DISPLAYING or
+            // leaving a session says nothing about whether its model is
+            // working, so the per-session state here changes only by the
+            // lastActivity bump applied above.
             break
         case .sessionEnd:
             snapshot.activity = .ended

--- a/Sources/localvoxtral/ClaudeContext/ClaudeSocketGuard.swift
+++ b/Sources/localvoxtral/ClaudeContext/ClaudeSocketGuard.swift
@@ -131,5 +131,29 @@ public enum ClaudeSocketGuard {
         guard getpeereid(fd, &uid, &gid) == 0 else { return nil }
         return UInt32(uid)
     }
+
+    /// The pid of the process on the other end of a connected AF_UNIX socket,
+    /// as the kernel recorded it at connect time (`LOCAL_PEERPID`,
+    /// `<sys/un.h>`). Same trust class as `peerUID`: transport evidence a
+    /// sender cannot forge.
+    ///
+    /// This exists for the opencode records' pid cross-check: that plugin runs
+    /// INSIDE the agent process and connects from it directly, so its claimed
+    /// pid must equal the kernel's answer. The Claude hook path can make no
+    /// such promise — its publisher is a transient child of the session, so
+    /// its peer pid is never the Claude pid. That asymmetry is why this check
+    /// is applied per agent, not universally.
+    public static func peerPID(ofDescriptor fd: Int32) -> pid_t? {
+        // Spelled numerically: the Darwin overlay does not export these two
+        // <sys/un.h> constants. SOL_LOCAL is 0; LOCAL_PEERPID is 0x002.
+        let solLocal: Int32 = 0
+        let localPeerPID: Int32 = 0x002
+        var pid: pid_t = 0
+        var length = socklen_t(MemoryLayout<pid_t>.size)
+        guard getsockopt(fd, solLocal, localPeerPID, &pid, &length) == 0, pid > 0 else {
+            return nil
+        }
+        return pid
+    }
     #endif
 }

--- a/Sources/localvoxtral/ClaudeContext/TerminalScreenClaudeJoin.swift
+++ b/Sources/localvoxtral/ClaudeContext/TerminalScreenClaudeJoin.swift
@@ -270,7 +270,17 @@ struct ClaudeSessionJoinResolver {
             return nil
         }
 
-        if let claimed = pane.claimedClaudeSessionID, claimed != snapshot.sessionID {
+        // herdr reports the agent's RAW session id; the registry speaks
+        // agent-scoped ids (`ClaudeAgentSessionScope`). Scope the claim by the
+        // resolved session's own agent before comparing — for Claude that is
+        // the identity function, for opencode it adds the same prefix ingest
+        // did. Scoping by the snapshot's agent (not by anything herdr says)
+        // keeps this a pure cross-check: a claim can only ever CONFIRM the
+        // pane-id join, never redirect it.
+        if let claimed = pane.claimedClaudeSessionID,
+           ClaudeAgentSessionScope.scopedSessionID(
+               agent: snapshot.agent, sessionID: claimed
+           ) != snapshot.sessionID {
             Self.abstainedHerdrJoin(outcome: "pane session claim disagrees")
             return nil
         }

--- a/Sources/localvoxtral/ClaudeContext/TerminalScreenClaudeJoin.swift
+++ b/Sources/localvoxtral/ClaudeContext/TerminalScreenClaudeJoin.swift
@@ -294,7 +294,7 @@ struct ClaudeSessionJoinResolver {
             Self.abstainedHerdrJoin(outcome: "foreground process detection unavailable")
             return nil
         }
-        guard Self.registeredClaudeIsForeground(
+        guard Self.registeredAgentIsForeground(
             snapshot: snapshot, foregroundPIDs: foregroundPIDs
         ) else { return nil }
 
@@ -334,7 +334,10 @@ struct ClaudeSessionJoinResolver {
     /// Pure pid cross-check kept visible to tests because a snapshot with no
     /// process cannot be produced by a successful pane-id registry lookup, but
     /// the resolver must still fail closed if that invariant ever changes.
-    static func registeredClaudeIsForeground(
+    /// Agent-neutral (review F3): the pane may host Claude Code or opencode,
+    /// and the registered pid is whichever agent process the session's records
+    /// named — the abstention wording must not claim Claude for both.
+    static func registeredAgentIsForeground(
         snapshot: ClaudeSessionSnapshot,
         foregroundPIDs: [Int32]
     ) -> Bool {
@@ -343,7 +346,9 @@ struct ClaudeSessionJoinResolver {
             return false
         }
         guard foregroundPIDs.contains(process.claudePID) else {
-            abstainedHerdrJoin(outcome: "registered Claude process is not foreground")
+            abstainedHerdrJoin(
+                outcome: "registered \(snapshot.agent.rawValue) process is not foreground"
+            )
             return false
         }
         return true

--- a/Tests/localvoxtralTests/ClaudeContextBrokerTests.swift
+++ b/Tests/localvoxtralTests/ClaudeContextBrokerTests.swift
@@ -201,6 +201,37 @@ final class ClaudeContextBrokerIntegrationTests: XCTestCase {
         )
     }
 
+    func testBrokerWithholdsTheMarkerForAnOpencodeRecord() throws {
+        // The herdr rule, per agent: opencode rewrites its own OSC titles
+        // mid-turn (and clears them on exit), so a marker sent there could
+        // never survive in a title — and the plugin never writes to the
+        // terminal anyway. Allocation is unchanged; only emission is gated.
+        try broker.start()
+        let record = ClaudeHookRecord(
+            event: .sessionStart,
+            agent: .opencode,
+            sessionID: "ses_1",
+            timestamp: 1,
+            rawCwd: "/repo",
+            process: ClaudeHookProcessInfo(hookPID: 4242, claudePID: getpid())
+        )
+        let result = UnixSocketPublisher(timeout: 2.0).publishAndReadReply(
+            line: try XCTUnwrap(ClaudeHookWireCodec.encodeLine(record)),
+            to: socketPath
+        )
+        guard case .success(let reply) = result else {
+            return XCTFail("publish failed: \(result)")
+        }
+
+        let response = try XCTUnwrap(ClaudeBrokerResponse.decodeLine(try XCTUnwrap(reply)))
+        XCTAssertNil(response.marker)
+        XCTAssertEqual(
+            registry.snapshot(sessionID: "opencode:ses_1")?.marker,
+            ClaudeSessionMarker(value: "lvx-deadbeef"),
+            "agent gating changes reply emission only; the scoped session keeps its registry marker"
+        )
+    }
+
     func testRejectedRecordRepliesWithNoMarker() throws {
         // A reply still comes back so the publisher is not left waiting, but it
         // carries nothing to put in a title.

--- a/Tests/localvoxtralTests/ClaudeContextBrokerTests.swift
+++ b/Tests/localvoxtralTests/ClaudeContextBrokerTests.swift
@@ -232,6 +232,73 @@ final class ClaudeContextBrokerIntegrationTests: XCTestCase {
         )
     }
 
+    func testBrokerEchoesAV1RequestsVersionSoAStalePublisherKeepsItsMarker() throws {
+        // Mixed-version end-to-end (review C4): a machine can run an OLD
+        // installed plugin (v1 publisher binary) against a NEW app. The old
+        // publisher rejects any reply that does not say v1, so the broker must
+        // shape each reply as the REQUEST's version — or every stale install
+        // silently loses the marker channel until it updates.
+        try broker.start()
+        let v1Line = Data(
+            (#"{"v":1,"event":"SessionStart","session_id":"old-publisher","ts":1,"cwd":"/repo"}"# + "\n").utf8
+        )
+        let result = UnixSocketPublisher(timeout: 2.0)
+            .publishAndReadReply(line: v1Line, to: socketPath)
+        guard case .success(let reply) = result else {
+            return XCTFail("publish failed: \(result)")
+        }
+        let raw = try XCTUnwrap(reply)
+        XCTAssertTrue(
+            String(decoding: raw, as: UTF8.self).contains(#""v":1"#),
+            "the reply must be v1-shaped for a v1 request"
+        )
+        // And it still round-trips through the response codec with the marker.
+        let response = try XCTUnwrap(ClaudeBrokerResponse.decodeLine(raw))
+        XCTAssertEqual(response.version, 1)
+        XCTAssertEqual(response.marker, "lvx-deadbeef")
+
+        // A v2 request gets a v2-shaped reply.
+        let v2Record = ClaudeHookRecord(event: .stop, sessionID: "old-publisher", timestamp: 2)
+        let v2Result = UnixSocketPublisher(timeout: 2.0).publishAndReadReply(
+            line: try XCTUnwrap(ClaudeHookWireCodec.encodeLine(v2Record)),
+            to: socketPath
+        )
+        guard case .success(let v2Reply) = v2Result else {
+            return XCTFail("publish failed: \(v2Result)")
+        }
+        let v2Response = try XCTUnwrap(ClaudeBrokerResponse.decodeLine(try XCTUnwrap(v2Reply)))
+        XCTAssertEqual(v2Response.version, 2)
+    }
+
+    func testOpencodeRecordClaimingAForeignPidIsRejectedByThePeerPidCheck() throws {
+        // The opencode plugin runs inside the agent process and dials the
+        // socket from it, so the kernel's peer pid must equal the record's
+        // claimed pid. This connection comes from the TEST process, so a
+        // claim of pid 1 is a forgery and must not reach the registry.
+        try broker.start()
+        let forged = ClaudeHookRecord(
+            event: .sessionStart,
+            agent: .opencode,
+            sessionID: "ses_forged",
+            timestamp: 1,
+            rawCwd: "/repo",
+            process: ClaudeHookProcessInfo(hookPID: 1, claudePID: 1)
+        )
+        let result = UnixSocketPublisher(timeout: 2.0).publishAndReadReply(
+            line: try XCTUnwrap(ClaudeHookWireCodec.encodeLine(forged)),
+            to: socketPath
+        )
+        guard case .success(let reply) = result else {
+            return XCTFail("publish failed: \(result)")
+        }
+        let response = try XCTUnwrap(ClaudeBrokerResponse.decodeLine(try XCTUnwrap(reply)))
+        XCTAssertNil(response.marker)
+        XCTAssertNil(
+            registry.snapshot(sessionID: "opencode:ses_forged"),
+            "a pid-forged opencode record must never reach the registry"
+        )
+    }
+
     func testRejectedRecordRepliesWithNoMarker() throws {
         // A reply still comes back so the publisher is not left waiting, but it
         // carries nothing to put in a title.

--- a/Tests/localvoxtralTests/ClaudeHookWireTests.swift
+++ b/Tests/localvoxtralTests/ClaudeHookWireTests.swift
@@ -185,6 +185,28 @@ final class ClaudeHookWireCodecTests: XCTestCase {
         }
     }
 
+    func testV1LineCarryingAnExplicitAgentKeyIsMalformed() {
+        // No v1 writer ever emitted the key — "absent = claude" IS the v1
+        // contract. A v1 line carrying it is hand-crafted, not old.
+        XCTAssertThrowsError(
+            try ClaudeHookWireCodec.decodeLine(
+                line(validJSON(version: 1, extra: #","agent":"claude""#))
+            )
+        ) { error in
+            XCTAssertEqual(error as? ClaudeHookWireError, .malformed)
+        }
+    }
+
+    func testFocusClearedEventDecodes() throws {
+        let json = validJSON(
+            event: "FocusCleared",
+            extra: #","agent":"opencode","process":{"hook_pid":9,"claude_pid":9,"tty":"/dev/ttys004"}"#
+        )
+        let record = try ClaudeHookWireCodec.decodeLine(line(json))
+        XCTAssertEqual(record.event, .focusCleared)
+        XCTAssertEqual(record.agent, .opencode)
+    }
+
     func testFocusChangedEventDecodes() throws {
         let json = validJSON(
             event: "FocusChanged",

--- a/Tests/localvoxtralTests/ClaudeHookWireTests.swift
+++ b/Tests/localvoxtralTests/ClaudeHookWireTests.swift
@@ -10,7 +10,7 @@ final class ClaudeHookWireCodecTests: XCTestCase {
     }
 
     private func validJSON(
-        version: Int = 1,
+        version: Int = 2,
         event: String = "UserPromptSubmit",
         sessionID: String = "sess-1",
         extra: String = ""
@@ -62,7 +62,7 @@ final class ClaudeHookWireCodecTests: XCTestCase {
         let encoded = try XCTUnwrap(ClaudeHookWireCodec.encodeLine(record))
         XCTAssertEqual(
             String(decoding: encoded, as: UTF8.self),
-            #"{"event":"SessionStart","files":[],"process":{"claude_pid":41,"herdr_pane_id":"pane-7","herdr_socket_path":"herdr.sock","hook_pid":42},"session_id":"sess-herdr","ts":1.5,"v":1}"# + "\n"
+            #"{"event":"SessionStart","files":[],"process":{"claude_pid":41,"herdr_pane_id":"pane-7","herdr_socket_path":"herdr.sock","hook_pid":42},"session_id":"sess-herdr","ts":1.5,"v":2}"# + "\n"
         )
         let decoded = try ClaudeHookWireCodec.decodeLine(encoded)
         XCTAssertEqual(decoded.process?.herdrPaneID, "pane-7")
@@ -118,8 +118,8 @@ final class ClaudeHookWireCodecTests: XCTestCase {
     // MARK: Version gating
 
     func testRejectsFutureVersion() {
-        XCTAssertThrowsError(try ClaudeHookWireCodec.decodeLine(line(validJSON(version: 2)))) { error in
-            XCTAssertEqual(error as? ClaudeHookWireError, .unsupportedVersion(2))
+        XCTAssertThrowsError(try ClaudeHookWireCodec.decodeLine(line(validJSON(version: 3)))) { error in
+            XCTAssertEqual(error as? ClaudeHookWireError, .unsupportedVersion(3))
         }
     }
 
@@ -128,6 +128,87 @@ final class ClaudeHookWireCodecTests: XCTestCase {
         XCTAssertThrowsError(try ClaudeHookWireCodec.decodeLine(line(json))) { error in
             XCTAssertEqual(error as? ClaudeHookWireError, .unsupportedVersion(nil))
         }
+    }
+
+    // MARK: v1 compatibility and the agent field (wire v2)
+
+    func testV1LineStillDecodesAndIsAClaudeRecordByConstruction() throws {
+        // Every v1 record predates the agent field, and every v1 publisher was
+        // the Claude Code hook — so v1 must keep decoding, as Claude.
+        let record = try ClaudeHookWireCodec.decodeLine(line(validJSON(version: 1)))
+        XCTAssertEqual(record.version, 1)
+        XCTAssertEqual(record.agent, .claude)
+    }
+
+    func testV2LineWithoutAgentFieldDefaultsToClaude() throws {
+        let record = try ClaudeHookWireCodec.decodeLine(line(validJSON()))
+        XCTAssertEqual(record.agent, .claude)
+    }
+
+    func testOpencodeAgentRoundTripsWithGoldenWireShape() throws {
+        let record = ClaudeHookRecord(
+            event: .userPromptSubmit,
+            agent: .opencode,
+            sessionID: "ses_0123",
+            timestamp: 9.5,
+            prompt: "rename the flag"
+        )
+        let encoded = try XCTUnwrap(ClaudeHookWireCodec.encodeLine(record))
+        XCTAssertEqual(
+            String(decoding: encoded, as: UTF8.self),
+            #"{"agent":"opencode","event":"UserPromptSubmit","files":[],"prompt":"rename the flag","session_id":"ses_0123","ts":9.5,"v":2}"# + "\n"
+        )
+        XCTAssertEqual(try ClaudeHookWireCodec.decodeLine(encoded), record)
+    }
+
+    func testClaudeAgentIsOmittedFromTheWireSoV1ReadersStayCompatible() throws {
+        let record = ClaudeHookRecord(event: .stop, sessionID: "s", timestamp: 1)
+        let encoded = try XCTUnwrap(ClaudeHookWireCodec.encodeLine(record))
+        XCTAssertFalse(
+            String(decoding: encoded, as: UTF8.self).contains("agent"),
+            "absence is the default: a Claude record must not grow an agent key"
+        )
+    }
+
+    func testRejectsUnknownAgentPreciselyRatherThanDefaultingToClaude() {
+        // Defaulting would hand a future agent Claude's channel rules (title
+        // markers, bare session-id namespace). Ignored, precisely.
+        XCTAssertThrowsError(
+            try ClaudeHookWireCodec.decodeLine(line(validJSON(extra: #","agent":"aider""#)))
+        ) { error in
+            XCTAssertEqual(error as? ClaudeHookWireError, .unknownAgent("aider"))
+        }
+        XCTAssertThrowsError(
+            try ClaudeHookWireCodec.decodeLine(line(validJSON(extra: #","agent":7"#)))
+        ) { error in
+            XCTAssertEqual(error as? ClaudeHookWireError, .unknownAgent(nil))
+        }
+    }
+
+    func testFocusChangedEventDecodes() throws {
+        let json = validJSON(
+            event: "FocusChanged",
+            extra: #","agent":"opencode","process":{"hook_pid":9,"claude_pid":9,"tty":"/dev/ttys004"}"#
+        )
+        let record = try ClaudeHookWireCodec.decodeLine(line(json))
+        XCTAssertEqual(record.event, .focusChanged)
+        XCTAssertEqual(record.agent, .opencode)
+        XCTAssertEqual(record.process?.tty, "/dev/ttys004")
+    }
+
+    // MARK: Session-id namespacing per agent
+
+    func testOpencodeSessionIDsAreScopedAndClaudeIDsStayBare() {
+        XCTAssertEqual(
+            ClaudeAgentSessionScope.scopedSessionID(agent: .opencode, sessionID: "ses_1"),
+            "opencode:ses_1"
+        )
+        XCTAssertEqual(
+            ClaudeAgentSessionScope.scopedSessionID(agent: .claude, sessionID: "b81c2a"),
+            "b81c2a"
+        )
+        // The two receiver-side namespaces must never alias each other.
+        XCTAssertNotEqual(ClaudeAgentSessionScope.opencodePrefix, "remote:")
     }
 
     func testRejectsUnknownEventRatherThanThrowingGenericError() {

--- a/Tests/localvoxtralTests/ClaudeSessionFocusResolutionTests.swift
+++ b/Tests/localvoxtralTests/ClaudeSessionFocusResolutionTests.swift
@@ -1,0 +1,391 @@
+import ClaudeContextWire
+import Foundation
+import Synchronization
+import XCTest
+@testable import localvoxtral
+
+// Focused coverage for the wire-v2 additions to the registry: per-agent
+// session-id namespacing and the pane focus declarations that make the TTY
+// join answer for opencode, where one process (one TTY) hosts several
+// sessions and the TUI shows exactly one.
+//
+// Helpers mirror `ClaudeSessionRegistryTests` (they are file-private there).
+// Same capture rules apply: closures capture `[self]`, never the `Mutex`.
+
+private final class TestClock: Sendable {
+    private let value: Mutex<Date>
+
+    init(_ start: Date) { value = Mutex(start) }
+
+    var now: @Sendable () -> Date { { [self] in value.withLock { $0 } } }
+
+    func advance(_ interval: TimeInterval) {
+        value.withLock { $0 = $0.addingTimeInterval(interval) }
+    }
+}
+
+private final class TestLiveness: Sendable {
+    private let dead: Mutex<Set<Int32>> = Mutex([])
+
+    var probe: @Sendable (Int32) -> Bool { { [self] pid in dead.withLock { !$0.contains(pid) } } }
+
+    func kill(_ pid: Int32) { dead.withLock { _ = $0.insert(pid) } }
+}
+
+final class ClaudeSessionFocusResolutionTests: XCTestCase {
+    private let epoch = Date(timeIntervalSince1970: 3_000_000)
+    private let local = ClaudeTransportOrigin.localAuthenticated(peerUID: 501)
+    private let tty = "/dev/ttys004"
+    /// The opencode process pid — shared by every session it hosts AND by its
+    /// focus declarations, because the plugin runs inside that one process.
+    private let opencodePID: Int32 = 4242
+
+    /// Endless distinct markers — these tests create many sessions and never
+    /// care which marker each one got.
+    private final class SequentialMarkers: Sendable {
+        private let counter = Mutex(0)
+
+        var allocate: @Sendable () -> String {
+            { [self] in
+                counter.withLock { value in
+                    value += 1
+                    return "lvx-" + String(format: "%08x", value)
+                }
+            }
+        }
+    }
+
+    private func makeRegistry(
+        limits: ClaudeRegistryLimits = .default,
+        clock: TestClock? = nil,
+        liveness: TestLiveness? = nil
+    ) -> ClaudeSessionRegistry {
+        ClaudeSessionRegistry(
+            limits: limits,
+            now: (clock ?? TestClock(epoch)).now,
+            isProcessAlive: (liveness ?? TestLiveness()).probe,
+            allocateMarkerValue: SequentialMarkers().allocate
+        )
+    }
+
+    /// An opencode session record as the plugin's server half publishes it:
+    /// agent-tagged, pid = the opencode process, and NO tty — the server half
+    /// cannot prove it owns a pane, so it never claims one.
+    private func opencodeRecord(
+        _ event: ClaudeHookEvent,
+        session: String,
+        cwd: String? = "/repo",
+        prompt: String? = nil,
+        files: [ClaudeFileTouch] = []
+    ) -> ClaudeHookRecord {
+        ClaudeHookRecord(
+            event: event,
+            agent: .opencode,
+            sessionID: session,
+            timestamp: 0,
+            rawCwd: cwd,
+            prompt: prompt,
+            files: files,
+            process: ClaudeHookProcessInfo(hookPID: opencodePID, claudePID: opencodePID)
+        )
+    }
+
+    /// A focus declaration as the plugin's TUI half publishes it: the pane's
+    /// own TTY plus the session it currently displays.
+    private func focusRecord(
+        session: String,
+        agent: ClaudeHookAgent = .opencode,
+        pid: Int32? = nil,
+        tty: String? = nil
+    ) -> ClaudeHookRecord {
+        ClaudeHookRecord(
+            event: .focusChanged,
+            agent: agent,
+            sessionID: session,
+            timestamp: 0,
+            process: ClaudeHookProcessInfo(
+                hookPID: pid ?? opencodePID,
+                claudePID: pid ?? opencodePID,
+                tty: tty ?? self.tty
+            )
+        )
+    }
+
+    /// A Claude Code record claiming a TTY per-session, the pre-v2 shape.
+    private func claudeRecord(
+        _ event: ClaudeHookEvent,
+        session: String,
+        claudePID: Int32,
+        tty: String? = nil
+    ) -> ClaudeHookRecord {
+        ClaudeHookRecord(
+            event: event,
+            sessionID: session,
+            timestamp: 0,
+            rawCwd: "/repo",
+            process: ClaudeHookProcessInfo(hookPID: 999, claudePID: claudePID, tty: tty)
+        )
+    }
+
+    private func resolvedSessionID(_ resolution: ClaudeMarkerResolution) -> String? {
+        if case .resolved(let snapshot) = resolution { return snapshot.sessionID }
+        return nil
+    }
+
+    // MARK: - Per-agent session-id namespacing
+
+    func testOpencodeSessionIDsAreScopedOnIngestAndClaudeIDsStayBare() throws {
+        let registry = makeRegistry()
+        let opencode = try XCTUnwrap(
+            registry.ingest(opencodeRecord(.sessionStart, session: "ses_1"), origin: local)
+        )
+        XCTAssertEqual(opencode.sessionID, "opencode:ses_1")
+        XCTAssertEqual(opencode.agent, .opencode)
+
+        let claude = try XCTUnwrap(
+            registry.ingest(claudeRecord(.sessionStart, session: "ses_1", claudePID: 7), origin: local)
+        )
+        XCTAssertEqual(claude.sessionID, "ses_1", "Claude ids stay bare — v1 behavior is unchanged")
+        XCTAssertEqual(claude.agent, .claude)
+
+        // Same raw id, two agents, two sessions: the namespace IS the
+        // collision prevention.
+        XCTAssertNotNil(registry.snapshot(sessionID: "opencode:ses_1"))
+        XCTAssertNotNil(registry.snapshot(sessionID: "ses_1"))
+    }
+
+    func testARecordSpellingAnotherAgentsScopedIDIsDropped() throws {
+        // Scoping makes honest collision impossible, so a Claude record whose
+        // session id literally reads "opencode:ses_1" is spelling a key that
+        // is not its own. It must not mutate the opencode session.
+        let registry = makeRegistry()
+        registry.ingest(opencodeRecord(.sessionStart, session: "ses_1", cwd: "/real"), origin: local)
+
+        let forged = registry.ingest(
+            claudeRecord(.cwdChanged, session: "opencode:ses_1", claudePID: 7), origin: local
+        )
+        XCTAssertNil(forged, "cross-agent key spelling is dropped whole")
+        let snapshot = try XCTUnwrap(registry.snapshot(sessionID: "opencode:ses_1"))
+        XCTAssertEqual(snapshot.localWorkspacePath?.path, "/real")
+    }
+
+    func testFocusRecordNeverMintsASession() {
+        let registry = makeRegistry()
+        let result = registry.ingest(focusRecord(session: "ses_ghost"), origin: local)
+        XCTAssertNil(result, "a pane can display a session whose records were lost; inventing an empty snapshot for it would let the join resolve to nothing")
+        XCTAssertNil(registry.snapshot(sessionID: "opencode:ses_ghost"))
+        XCTAssertTrue(registry.liveSessions().isEmpty)
+    }
+
+    // MARK: - Focus truth table for resolve(tty:)
+
+    func testSingleSessionWithFreshFocusResolves() {
+        let registry = makeRegistry()
+        registry.ingest(opencodeRecord(.sessionStart, session: "ses_a"), origin: local)
+        registry.ingest(focusRecord(session: "ses_a"), origin: local)
+
+        XCTAssertEqual(resolvedSessionID(registry.resolve(tty: tty)), "opencode:ses_a")
+    }
+
+    func testSingleOpencodeSessionWithoutFocusAbstains() {
+        // Positive evidence or nothing: the server half never claims a TTY, so
+        // an opencode session with no focus declaration is unjoinable — there
+        // is deliberately no sole-session fallback.
+        let registry = makeRegistry()
+        registry.ingest(opencodeRecord(.sessionStart, session: "ses_a"), origin: local)
+
+        XCTAssertEqual(registry.resolve(tty: tty), .unknown)
+    }
+
+    func testMultipleSessionsWithFreshFocusResolveToTheDeclaredOne() {
+        let registry = makeRegistry()
+        registry.ingest(opencodeRecord(.sessionStart, session: "ses_a"), origin: local)
+        registry.ingest(opencodeRecord(.sessionStart, session: "ses_b"), origin: local)
+        registry.ingest(focusRecord(session: "ses_b"), origin: local)
+
+        XCTAssertEqual(resolvedSessionID(registry.resolve(tty: tty)), "opencode:ses_b")
+
+        // A session switch re-declares; the newest declaration wins.
+        registry.ingest(focusRecord(session: "ses_a"), origin: local)
+        XCTAssertEqual(resolvedSessionID(registry.resolve(tty: tty)), "opencode:ses_a")
+    }
+
+    func testStaleFocusIsAbsentInformationSoMultipleSessionsAbstain() {
+        let clock = TestClock(epoch)
+        let registry = makeRegistry(clock: clock)
+        registry.ingest(opencodeRecord(.sessionStart, session: "ses_a"), origin: local)
+        registry.ingest(opencodeRecord(.sessionStart, session: "ses_b"), origin: local)
+        registry.ingest(focusRecord(session: "ses_b"), origin: local)
+
+        clock.advance(ClaudeRegistryLimits.defaultFocusDeclarationTTL - 1)
+        XCTAssertEqual(
+            resolvedSessionID(registry.resolve(tty: tty)), "opencode:ses_b",
+            "inside the bound the declaration still answers"
+        )
+
+        clock.advance(2)
+        XCTAssertEqual(
+            registry.resolve(tty: tty), .unknown,
+            "past the bound the declaration is not a hint — nothing claims this TTY anymore"
+        )
+    }
+
+    func testMultipleSessionsWithNoFocusEverAbstain() {
+        let registry = makeRegistry()
+        registry.ingest(opencodeRecord(.sessionStart, session: "ses_a"), origin: local)
+        registry.ingest(opencodeRecord(.sessionStart, session: "ses_b"), origin: local)
+
+        XCTAssertEqual(registry.resolve(tty: tty), .unknown)
+    }
+
+    func testFreshFocusForADeadSessionAbstainsOutright() {
+        let registry = makeRegistry()
+        registry.ingest(opencodeRecord(.sessionStart, session: "ses_a"), origin: local)
+        registry.ingest(opencodeRecord(.sessionStart, session: "ses_b"), origin: local)
+        registry.ingest(focusRecord(session: "ses_b"), origin: local)
+        // The displayed session ends (session.deleted); the pane has not
+        // re-declared yet.
+        registry.ingest(opencodeRecord(.sessionEnd, session: "ses_b"), origin: local)
+
+        XCTAssertEqual(
+            registry.resolve(tty: tty), .stale,
+            "the pane said it displays ses_b; ses_b is gone; resolving to the surviving sibling would contradict the freshest evidence"
+        )
+    }
+
+    func testFocusForASessionWhoseProcessDiedAbstains() {
+        let liveness = TestLiveness()
+        let registry = makeRegistry(liveness: liveness)
+        registry.ingest(opencodeRecord(.sessionStart, session: "ses_a"), origin: local)
+        registry.ingest(focusRecord(session: "ses_a"), origin: local)
+        liveness.kill(opencodePID)
+
+        XCTAssertEqual(registry.resolve(tty: tty), .stale)
+    }
+
+    func testFocusDeclaredByADifferentProcessThanTheSessionAbstains() {
+        // A declaration that outlived its process must not steer a recycled
+        // TTY: the declarer's pid and the focused session's registered pid
+        // must be the same process.
+        let registry = makeRegistry()
+        registry.ingest(opencodeRecord(.sessionStart, session: "ses_a"), origin: local)
+        registry.ingest(focusRecord(session: "ses_a", pid: 5555), origin: local)
+
+        XCTAssertEqual(registry.resolve(tty: tty), .stale)
+    }
+
+    func testFocusDisambiguatesCompetingPerSessionTTYClaims() {
+        // The generic form of "multiple + focus fresh": two live sessions each
+        // claim the same device per-session (the suspended-agent-under-a-new-
+        // one shape), and a fresh declaration picks the displayed one.
+        let registry = makeRegistry()
+        registry.ingest(claudeRecord(.sessionStart, session: "old", claudePID: 71, tty: tty), origin: local)
+        registry.ingest(claudeRecord(.sessionStart, session: "new", claudePID: 72, tty: tty), origin: local)
+        XCTAssertEqual(registry.resolve(tty: tty), .ambiguous, "without focus this abstains today")
+
+        registry.ingest(focusRecord(session: "new", agent: .claude, pid: 72), origin: local)
+        XCTAssertEqual(resolvedSessionID(registry.resolve(tty: tty)), "new")
+    }
+
+    func testConflictBetweenATTYClaimAndAFocusDeclarationAbstains() {
+        // A live Claude session claims the device per-session while a fresh
+        // opencode declaration names a different live session: two agents each
+        // positively claiming one pane. Nobody wins.
+        let registry = makeRegistry()
+        registry.ingest(claudeRecord(.sessionStart, session: "cl", claudePID: 71, tty: tty), origin: local)
+        registry.ingest(opencodeRecord(.sessionStart, session: "ses_a"), origin: local)
+        registry.ingest(focusRecord(session: "ses_a"), origin: local)
+
+        XCTAssertEqual(registry.resolve(tty: tty), .ambiguous)
+    }
+
+    func testSingleClaudeTTYClaimStillResolvesWithoutAnyFocus() {
+        // The pre-v2 join, byte-for-byte: no focus table entry, one live local
+        // claim, resolved. Claude behavior must be unchanged by all of this.
+        let registry = makeRegistry()
+        registry.ingest(claudeRecord(.sessionStart, session: "cl", claudePID: 71, tty: tty), origin: local)
+
+        XCTAssertEqual(resolvedSessionID(registry.resolve(tty: tty)), "cl")
+    }
+
+    func testRemoteFocusDeclarationsAreIgnored() {
+        // A remote host declaring focus for a local TTY device is exactly the
+        // "SSH host claims a local pane" attack the TTY join refuses; the
+        // focus table must refuse it at the door too.
+        let registry = makeRegistry()
+        registry.ingest(opencodeRecord(.sessionStart, session: "ses_a"), origin: local)
+        registry.ingest(
+            focusRecord(session: "ses_a"), origin: .remote(channel: "ssh:host")
+        )
+
+        XCTAssertEqual(registry.resolve(tty: tty), .unknown)
+    }
+
+    func testFocusRecordForALiveSessionBumpsItsActivity() throws {
+        let clock = TestClock(epoch)
+        let registry = makeRegistry(clock: clock)
+        registry.ingest(opencodeRecord(.sessionStart, session: "ses_a"), origin: local)
+        clock.advance(100)
+        let bumped = try XCTUnwrap(registry.ingest(focusRecord(session: "ses_a"), origin: local))
+        XCTAssertEqual(bumped.lastActivity, epoch.addingTimeInterval(100))
+        XCTAssertEqual(bumped.activity, .idle, "displaying a session says nothing about its turn state")
+    }
+
+    func testFocusTableIsBounded() {
+        let clock = TestClock(epoch)
+        let registry = makeRegistry(
+            limits: ClaudeRegistryLimits(maxFocusDeclarations: 2), clock: clock
+        )
+        registry.ingest(opencodeRecord(.sessionStart, session: "ses_a"), origin: local)
+        for index in 0..<5 {
+            clock.advance(1)
+            registry.ingest(
+                focusRecord(session: "ses_a", tty: "/dev/ttys00\(index)"), origin: local
+            )
+        }
+        // The newest declaration must have survived the cap.
+        XCTAssertEqual(resolvedSessionID(registry.resolve(tty: "/dev/ttys004")), "opencode:ses_a")
+        // The oldest ones are gone: their TTYs resolve as if never declared.
+        XCTAssertEqual(registry.resolve(tty: "/dev/ttys000"), .unknown)
+        XCTAssertEqual(registry.resolve(tty: "/dev/ttys001"), .unknown)
+    }
+
+    // MARK: - Opencode event shapes through the reducer
+
+    func testOpencodeLifecycleReducesLikeAnyLocalSession() throws {
+        // The verified plugin payload mapping: chat.message → UserPromptSubmit,
+        // tool.execute.after → PostToolUse, session.idle → Stop,
+        // session.deleted → SessionEnd. Everything downstream (blocks, repo
+        // collection, budget) reads the same snapshot fields as Claude's.
+        let registry = makeRegistry()
+        let prompt = try XCTUnwrap(registry.ingest(
+            opencodeRecord(
+                .userPromptSubmit, session: "ses_a", cwd: "/repo", prompt: "add a --json flag"
+            ),
+            origin: local
+        ))
+        XCTAssertEqual(prompt.latestPriorUserPrompt, "add a --json flag")
+        XCTAssertEqual(prompt.activity, .working)
+        XCTAssertEqual(prompt.localWorkspacePath?.path, "/repo")
+
+        let touched = try XCTUnwrap(registry.ingest(
+            opencodeRecord(
+                .postToolUse, session: "ses_a",
+                files: [ClaudeFileTouch(path: "/repo/src/cli.ts", kind: .edited)]
+            ),
+            origin: local
+        ))
+        XCTAssertEqual(touched.recentFiles.map(\.path), ["/repo/src/cli.ts"])
+
+        let idle = try XCTUnwrap(
+            registry.ingest(opencodeRecord(.stop, session: "ses_a"), origin: local)
+        )
+        XCTAssertEqual(idle.activity, .idle)
+
+        let ended = try XCTUnwrap(
+            registry.ingest(opencodeRecord(.sessionEnd, session: "ses_a"), origin: local)
+        )
+        XCTAssertEqual(ended.activity, .ended)
+        XCTAssertNil(registry.snapshot(sessionID: "opencode:ses_a"), "SessionEnd evicts")
+    }
+}

--- a/Tests/localvoxtralTests/ClaudeSessionFocusResolutionTests.swift
+++ b/Tests/localvoxtralTests/ClaudeSessionFocusResolutionTests.swift
@@ -76,7 +76,8 @@ final class ClaudeSessionFocusResolutionTests: XCTestCase {
         session: String,
         cwd: String? = "/repo",
         prompt: String? = nil,
-        files: [ClaudeFileTouch] = []
+        files: [ClaudeFileTouch] = [],
+        herdrPaneID: String? = nil
     ) -> ClaudeHookRecord {
         ClaudeHookRecord(
             event: event,
@@ -86,7 +87,9 @@ final class ClaudeSessionFocusResolutionTests: XCTestCase {
             rawCwd: cwd,
             prompt: prompt,
             files: files,
-            process: ClaudeHookProcessInfo(hookPID: opencodePID, claudePID: opencodePID)
+            process: ClaudeHookProcessInfo(
+                hookPID: opencodePID, claudePID: opencodePID, herdrPaneID: herdrPaneID
+            )
         )
     }
 
@@ -154,10 +157,11 @@ final class ClaudeSessionFocusResolutionTests: XCTestCase {
         XCTAssertNotNil(registry.snapshot(sessionID: "ses_1"))
     }
 
-    func testARecordSpellingAnotherAgentsScopedIDIsDropped() throws {
-        // Scoping makes honest collision impossible, so a Claude record whose
-        // session id literally reads "opencode:ses_1" is spelling a key that
-        // is not its own. It must not mutate the opencode session.
+    func testALocalClaudeRecordSpellingAReservedPrefixIsDroppedOutright() throws {
+        // Review C2a: prefix concatenation would otherwise let a literal
+        // Claude id "opencode:ses_1" alias opencode's raw "ses_1". A LOCAL
+        // Claude record with a reserved prefix is dropped at the door — it
+        // neither mutates the aliased session nor mints one of its own.
         let registry = makeRegistry()
         registry.ingest(opencodeRecord(.sessionStart, session: "ses_1", cwd: "/real"), origin: local)
 
@@ -167,6 +171,24 @@ final class ClaudeSessionFocusResolutionTests: XCTestCase {
         XCTAssertNil(forged, "cross-agent key spelling is dropped whole")
         let snapshot = try XCTUnwrap(registry.snapshot(sessionID: "opencode:ses_1"))
         XCTAssertEqual(snapshot.localWorkspacePath?.path, "/real")
+        XCTAssertEqual(snapshot.agent, .opencode)
+
+        // Without a session to collide with, the reserved spelling still never
+        // becomes a key.
+        XCTAssertNil(
+            registry.ingest(
+                claudeRecord(.sessionStart, session: "opencode:ses_9", claudePID: 7), origin: local
+            )
+        )
+        XCTAssertNil(registry.snapshot(sessionID: "opencode:ses_9"))
+        // Same rule for the remote namespace: only the remote LISTENER may
+        // spell "remote:" ids, and it arrives over a remote origin.
+        XCTAssertNil(
+            registry.ingest(
+                claudeRecord(.sessionStart, session: "remote:host:x", claudePID: 7), origin: local
+            )
+        )
+        XCTAssertNil(registry.snapshot(sessionID: "remote:host:x"))
     }
 
     func testFocusRecordNeverMintsASession() {
@@ -263,28 +285,105 @@ final class ClaudeSessionFocusResolutionTests: XCTestCase {
         XCTAssertEqual(registry.resolve(tty: tty), .stale)
     }
 
-    func testFocusDeclaredByADifferentProcessThanTheSessionAbstains() {
-        // A declaration that outlived its process must not steer a recycled
-        // TTY: the declarer's pid and the focused session's registered pid
-        // must be the same process.
+    func testFocusDeclaredByADifferentProcessThanTheSessionIsRefusedAtIngest() {
+        // A declaration whose pid does not match the focused session's
+        // registered process could never resolve — it is refused before any
+        // focus state is written, so it cannot suppress anything either.
         let registry = makeRegistry()
         registry.ingest(opencodeRecord(.sessionStart, session: "ses_a"), origin: local)
-        registry.ingest(focusRecord(session: "ses_a", pid: 5555), origin: local)
+        XCTAssertNil(registry.ingest(focusRecord(session: "ses_a", pid: 5555), origin: local))
+
+        XCTAssertEqual(
+            registry.resolve(tty: tty), .unknown,
+            "a refused declaration leaves the TTY exactly as undeclared as before"
+        )
+    }
+
+    func testDeclarationWhoseSessionPidChangedAfterwardsAbstainsAtResolve() {
+        // The resolve-time pid cross-check still matters after a valid ingest:
+        // if the session's registered process changes underneath a standing
+        // declaration (a new opencode process reusing the session id), the
+        // stale declaration must stop steering the TTY.
+        let registry = makeRegistry()
+        registry.ingest(opencodeRecord(.sessionStart, session: "ses_a"), origin: local)
+        registry.ingest(focusRecord(session: "ses_a"), origin: local)
+        XCTAssertEqual(resolvedSessionID(registry.resolve(tty: tty)), "opencode:ses_a")
+
+        var restarted = opencodeRecord(.userPromptSubmit, session: "ses_a", prompt: "hi")
+        restarted.process = ClaudeHookProcessInfo(hookPID: 9999, claudePID: 9999)
+        registry.ingest(restarted, origin: local)
 
         XCTAssertEqual(registry.resolve(tty: tty), .stale)
     }
 
-    func testFocusDisambiguatesCompetingPerSessionTTYClaims() {
-        // The generic form of "multiple + focus fresh": two live sessions each
-        // claim the same device per-session (the suspended-agent-under-a-new-
-        // one shape), and a fresh declaration picks the displayed one.
+    func testClaudeAgentFocusRecordsAreRefused() {
+        // Focus is an opencode-only mechanism: nothing in Claude Code's hook
+        // set knows what a pane displays, so a `.claude` focus record is an
+        // inconsistency to refuse — it must not create, refresh, or clear any
+        // declaration.
         let registry = makeRegistry()
         registry.ingest(claudeRecord(.sessionStart, session: "old", claudePID: 71, tty: tty), origin: local)
         registry.ingest(claudeRecord(.sessionStart, session: "new", claudePID: 72, tty: tty), origin: local)
-        XCTAssertEqual(registry.resolve(tty: tty), .ambiguous, "without focus this abstains today")
 
-        registry.ingest(focusRecord(session: "new", agent: .claude, pid: 72), origin: local)
-        XCTAssertEqual(resolvedSessionID(registry.resolve(tty: tty)), "new")
+        XCTAssertNil(registry.ingest(focusRecord(session: "new", agent: .claude, pid: 72), origin: local))
+        XCTAssertEqual(
+            registry.resolve(tty: tty), .ambiguous,
+            "competing per-session claims stay ambiguous; a refused declaration decides nothing"
+        )
+    }
+
+    func testInvalidFocusRecordCannotSuppressAClaudeTTYClaim() {
+        // Review C2b regression: focus state used to be written BEFORE the
+        // record was validated, so a declaration naming an unknown session
+        // poisoned the TTY into `.stale` for the whole focus TTL — silently
+        // unjoining a perfectly live Claude session on that device.
+        let registry = makeRegistry()
+        registry.ingest(claudeRecord(.sessionStart, session: "cl", claudePID: 71, tty: tty), origin: local)
+
+        XCTAssertNil(registry.ingest(focusRecord(session: "ses_ghost"), origin: local))
+        XCTAssertEqual(
+            resolvedSessionID(registry.resolve(tty: tty)), "cl",
+            "an invalid declaration must leave the per-session TTY claim untouched"
+        )
+    }
+
+    func testFocusClearedRetractsTheDeclarationImmediately() {
+        let registry = makeRegistry()
+        registry.ingest(opencodeRecord(.sessionStart, session: "ses_a"), origin: local)
+        registry.ingest(focusRecord(session: "ses_a"), origin: local)
+        XCTAssertEqual(resolvedSessionID(registry.resolve(tty: tty)), "opencode:ses_a")
+
+        var clear = focusRecord(session: "ses_a")
+        clear.event = .focusCleared
+        registry.ingest(clear, origin: local)
+
+        XCTAssertEqual(
+            registry.resolve(tty: tty), .unknown,
+            "leaving the session view must stop the join NOW, not at TTL expiry"
+        )
+        XCTAssertNotNil(
+            registry.snapshot(sessionID: "opencode:ses_a"),
+            "retraction clears the pane binding, never the session"
+        )
+    }
+
+    func testFocusClearedFromClaudeAgentOrRemoteTransportIsRefused() {
+        let registry = makeRegistry()
+        registry.ingest(opencodeRecord(.sessionStart, session: "ses_a"), origin: local)
+        registry.ingest(focusRecord(session: "ses_a"), origin: local)
+
+        var claudeClear = focusRecord(session: "ses_a", agent: .claude)
+        claudeClear.event = .focusCleared
+        XCTAssertNil(registry.ingest(claudeClear, origin: local))
+
+        var remoteClear = focusRecord(session: "ses_a")
+        remoteClear.event = .focusCleared
+        XCTAssertNil(registry.ingest(remoteClear, origin: .remote(channel: "ssh:host")))
+
+        XCTAssertEqual(
+            resolvedSessionID(registry.resolve(tty: tty)), "opencode:ses_a",
+            "a refused retraction leaves the declaration standing"
+        )
     }
 
     func testConflictBetweenATTYClaimAndAFocusDeclarationAbstains() {
@@ -348,6 +447,67 @@ final class ClaudeSessionFocusResolutionTests: XCTestCase {
         // The oldest ones are gone: their TTYs resolve as if never declared.
         XCTAssertEqual(registry.resolve(tty: "/dev/ttys000"), .unknown)
         XCTAssertEqual(registry.resolve(tty: "/dev/ttys001"), .unknown)
+    }
+
+    // MARK: - Focus participation in the herdr pane join (review C3)
+
+    func testHerdrPaneWithTwoOpencodeSessionsResolvesThroughFreshFocus() {
+        // Every opencode session in one TUI shares the pane id AND the pid, so
+        // without focus participation a second session made the herdr arm
+        // permanently `.ambiguous` — the join silently died for opencode
+        // panes. A verified fresh declaration picks the displayed session.
+        let registry = makeRegistry()
+        registry.ingest(
+            opencodeRecord(.sessionStart, session: "ses_a", herdrPaneID: "w1:p1"), origin: local
+        )
+        registry.ingest(
+            opencodeRecord(.sessionStart, session: "ses_b", herdrPaneID: "w1:p1"), origin: local
+        )
+        XCTAssertEqual(registry.resolve(herdrPaneID: "w1:p1"), .ambiguous, "no focus, no winner")
+
+        registry.ingest(focusRecord(session: "ses_b"), origin: local)
+        XCTAssertEqual(
+            resolvedSessionID(registry.resolve(herdrPaneID: "w1:p1")), "opencode:ses_b"
+        )
+
+        // Retraction restores the abstention immediately.
+        var clear = focusRecord(session: "ses_b")
+        clear.event = .focusCleared
+        registry.ingest(clear, origin: local)
+        XCTAssertEqual(registry.resolve(herdrPaneID: "w1:p1"), .ambiguous)
+    }
+
+    func testHerdrPaneFocusGoesStaleWithTheDeclaration() {
+        let clock = TestClock(epoch)
+        let registry = makeRegistry(clock: clock)
+        registry.ingest(
+            opencodeRecord(.sessionStart, session: "ses_a", herdrPaneID: "w1:p1"), origin: local
+        )
+        registry.ingest(
+            opencodeRecord(.sessionStart, session: "ses_b", herdrPaneID: "w1:p1"), origin: local
+        )
+        registry.ingest(focusRecord(session: "ses_b"), origin: local)
+        XCTAssertEqual(
+            resolvedSessionID(registry.resolve(herdrPaneID: "w1:p1")), "opencode:ses_b"
+        )
+
+        clock.advance(ClaudeRegistryLimits.defaultFocusDeclarationTTL + 1)
+        XCTAssertEqual(
+            registry.resolve(herdrPaneID: "w1:p1"), .ambiguous,
+            "an expired declaration is absent information for the pane join too"
+        )
+    }
+
+    func testHerdrPaneWithSingleSessionStillResolvesWithoutFocus() {
+        // The pre-existing single-candidate behavior is untouched: focus only
+        // arbitrates multi-candidate panes.
+        let registry = makeRegistry()
+        registry.ingest(
+            opencodeRecord(.sessionStart, session: "ses_a", herdrPaneID: "w1:p1"), origin: local
+        )
+        XCTAssertEqual(
+            resolvedSessionID(registry.resolve(herdrPaneID: "w1:p1")), "opencode:ses_a"
+        )
     }
 
     // MARK: - Opencode event shapes through the reducer

--- a/Tests/localvoxtralTests/OpencodePluginManifestTests.swift
+++ b/Tests/localvoxtralTests/OpencodePluginManifestTests.swift
@@ -54,6 +54,10 @@ final class OpencodePluginManifestTests: XCTestCase {
             "console.", // any logging corrupts the TUI or the turn
             "process.stdout",
             "process.stderr",
+            // The blocklist above misses raw descriptor writes (review C6):
+            // fs.writeSync(1, …) reaches the terminal without ever naming
+            // stdout. No form of writeSync has a legitimate use here.
+            "writeSync",
             "child_process",
             "Bun.spawn",
             "fetch(",
@@ -66,8 +70,34 @@ final class OpencodePluginManifestTests: XCTestCase {
         }
     }
 
+    func testServerHalfSpanNeverMentionsATTY() throws {
+        // The server half must be UNABLE to publish a TTY (invariant 1: under
+        // `opencode serve` an isatty answer names a pane that does not display
+        // the session). record()'s tty parameter is only reachable from the
+        // TUI half; pin that mechanically by asserting the server half's whole
+        // span never contains the token at all (review C6 / opencode F2).
+        let text = try source()
+        let start = try XCTUnwrap(text.range(of: "const ServerHalf"))
+        let end = try XCTUnwrap(text.range(of: "// TUI half"))
+        XCTAssertLessThan(start.lowerBound, end.lowerBound, "server half must precede the TUI half")
+        let span = text[start.lowerBound..<end.lowerBound].lowercased()
+        XCTAssertFalse(span.contains("tty"), "the server half may never touch a TTY, even lexically")
+    }
+
     func testSocketIsUnrefedSoThePluginCannotKeepOpencodeAlive() throws {
         XCTAssertTrue(try source().contains(".unref()"))
+    }
+
+    func testBackpressureIsBoundedByADropNeverAWait() throws {
+        // Review C5: socket.write with the broker not draining must never
+        // queue unboundedly inside the agent process. The plugin checks the
+        // queued-byte watermark and resets the connection past the cap.
+        let text = try source()
+        XCTAssertTrue(text.contains("const MAX_QUEUED_BYTES = 64 * 1024;"))
+        XCTAssertTrue(
+            text.contains("writableLength > MAX_QUEUED_BYTES"),
+            "the queued-bytes watermark must gate every write"
+        )
     }
 
     // MARK: Wire contract — pinned to the Swift constants, not to copies
@@ -96,7 +126,10 @@ final class OpencodePluginManifestTests: XCTestCase {
 
     func testEveryPublishedEventNameIsAKnownWireEvent() throws {
         let text = try source()
-        let published = ["SessionStart", "UserPromptSubmit", "PostToolUse", "Stop", "SessionEnd", "FocusChanged"]
+        let published = [
+            "SessionStart", "UserPromptSubmit", "PostToolUse", "Stop", "SessionEnd",
+            "FocusChanged", "FocusCleared",
+        ]
         for event in published {
             XCTAssertTrue(text.contains("\"\(event)\""), "plugin should publish \(event)")
             XCTAssertNotNil(
@@ -121,12 +154,17 @@ final class OpencodePluginManifestTests: XCTestCase {
         }
     }
 
-    func testFocusHeartbeatStaysComfortablyInsideTheRegistryTTL() throws {
-        XCTAssertTrue(try source().contains("const FOCUS_HEARTBEAT_MS = 20000;"))
-        // Three lost heartbeats must still leave a live declaration.
+    func testFocusHeartbeatAndSampleCadenceFitTheRegistryTTL() throws {
+        let text = try source()
+        XCTAssertTrue(text.contains("const FOCUS_HEARTBEAT_MS = 20000;"))
+        // The half-second sample is what bounds switch latency (no
+        // route-change event exists in opencode 1.17.x's TUI plugin API).
+        XCTAssertTrue(text.contains("const FOCUS_POLL_MS = 500;"))
+        // One lost 20s heartbeat plus sampling jitter must still leave a live
+        // declaration; more than that and the pane has gone silent for real.
         XCTAssertGreaterThanOrEqual(
-            ClaudeRegistryLimits.defaultFocusDeclarationTTL, 4 * 20,
-            "registry focus TTL must cover several lost 20s heartbeats"
+            ClaudeRegistryLimits.defaultFocusDeclarationTTL, 2 * 20 + 5,
+            "registry focus TTL must cover one lost 20s heartbeat plus jitter"
         )
     }
 

--- a/Tests/localvoxtralTests/OpencodePluginManifestTests.swift
+++ b/Tests/localvoxtralTests/OpencodePluginManifestTests.swift
@@ -1,0 +1,216 @@
+import Foundation
+import JavaScriptCore
+import XCTest
+@testable import ClaudeContextWire
+@testable import localvoxtral
+
+/// Validates the opencode plugin (`integrations/opencode/localvoxtral.js`) as
+/// an artifact, the way `ClaudeRemotePluginManifestTests` pins the remote
+/// shim: the file runs inside the user's agent process on a machine where
+/// nothing of ours is watching, so every drift below would fail open and
+/// silently — wrong socket path, wrong wire constants, an event name the
+/// broker drops, or a stray write that corrupts the user's TUI.
+///
+/// What is mechanically checkable is pinned here; actually loading under
+/// opencode's two plugin loaders is proven by the scripted TUI run in the
+/// PR's Proof section (opencode is not installed on CI machines).
+final class OpencodePluginManifestTests: XCTestCase {
+    private var pluginURL: URL!
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        pluginURL = try XCTUnwrap(ClaudePluginAssets.developmentOpencodePluginURL())
+    }
+
+    private func source() throws -> String {
+        try String(contentsOf: pluginURL, encoding: .utf8)
+    }
+
+    private var readmeURL: URL {
+        pluginURL.deletingLastPathComponent().appendingPathComponent("README.md")
+    }
+
+    // MARK: Blast radius — the plugin runs inside the user's agent process
+
+    func testPluginExistsAndStaysSmall() throws {
+        let bytes = try Data(contentsOf: pluginURL).count
+        XCTAssertGreaterThan(bytes, 0)
+        // One dependency-free file is the premise; a bundle would mean the
+        // premise is gone.
+        XCTAssertLessThan(bytes, 24 * 1024, "the plugin must stay one small auditable file")
+    }
+
+    func testNoAwaitAnywhereSoNoHookCanStallTheUsersTurn() throws {
+        // The hard blast-radius rule: handlers are fire-and-forget. Zero
+        // occurrences of the keyword anywhere (code or comments) keeps this
+        // trivially checkable — a legitimate future use must restructure, not
+        // relax.
+        XCTAssertFalse(try source().contains("await"), "no handler may suspend on anything")
+    }
+
+    func testNeverTouchesTheTerminalOrSpawnsAnything() throws {
+        let text = try source()
+        for forbidden in [
+            "console.", // any logging corrupts the TUI or the turn
+            "process.stdout",
+            "process.stderr",
+            "child_process",
+            "Bun.spawn",
+            "fetch(",
+            "require(",
+            "\\x1b", // no escape sequences: this plugin has no title channel
+            "\\u001b",
+            "]2;",
+        ] {
+            XCTAssertFalse(text.contains(forbidden), "forbidden pattern in plugin: \(forbidden)")
+        }
+    }
+
+    func testSocketIsUnrefedSoThePluginCannotKeepOpencodeAlive() throws {
+        XCTAssertTrue(try source().contains(".unref()"))
+    }
+
+    // MARK: Wire contract — pinned to the Swift constants, not to copies
+
+    func testWireVersionAndAgentMatchTheSwiftWire() throws {
+        let text = try source()
+        XCTAssertTrue(
+            text.contains("const WIRE_VERSION = \(ClaudeHookWire.version);"),
+            "plugin wire version must equal ClaudeHookWire.version"
+        )
+        XCTAssertTrue(
+            text.contains("const AGENT = \"\(ClaudeHookAgent.opencode.rawValue)\";"),
+            "plugin agent tag must equal ClaudeHookAgent.opencode"
+        )
+    }
+
+    func testSocketPathResolutionMirrorsClaudeHookSocketPath() throws {
+        let text = try source()
+        XCTAssertTrue(text.contains(ClaudeHookSocketPath.environmentKey))
+        // The darwin default, assembled from the same components the Swift
+        // resolver uses — a drifted directory name would fail open forever.
+        let darwin = "/Library/Application Support/localvoxtral/"
+            + ClaudeHookSocketPath.runDirectoryName + "/" + ClaudeHookSocketPath.socketFileName
+        XCTAssertTrue(text.contains(darwin), "darwin socket path must match ClaudeHookSocketPath")
+    }
+
+    func testEveryPublishedEventNameIsAKnownWireEvent() throws {
+        let text = try source()
+        let published = ["SessionStart", "UserPromptSubmit", "PostToolUse", "Stop", "SessionEnd", "FocusChanged"]
+        for event in published {
+            XCTAssertTrue(text.contains("\"\(event)\""), "plugin should publish \(event)")
+            XCTAssertNotNil(
+                ClaudeHookEvent(rawValue: event),
+                "\(event) is not a wire event; the broker would drop every record"
+            )
+        }
+    }
+
+    func testBoundsMirrorClaudeHookLimits() throws {
+        let text = try source()
+        let pins: [(String, Int)] = [
+            ("const MAX_LINE_BYTES = 64 * 1024;", ClaudeHookLimits.default.maxLineBytes),
+            ("const MAX_PROMPT_BYTES = 8 * 1024;", ClaudeHookLimits.default.maxPromptBytes),
+            ("const MAX_PATH_BYTES = 4 * 1024;", ClaudeHookLimits.default.maxPathBytes),
+            ("const MAX_FILES_PER_RECORD = 16;", ClaudeHookLimits.default.maxFilePathsPerRecord),
+        ]
+        let values = [64 * 1024, 8 * 1024, 4 * 1024, 16]
+        for (index, (line, swiftValue)) in pins.enumerated() {
+            XCTAssertTrue(text.contains(line), "missing bound pin: \(line)")
+            XCTAssertEqual(swiftValue, values[index], "Swift limit drifted from the plugin's pin")
+        }
+    }
+
+    func testFocusHeartbeatStaysComfortablyInsideTheRegistryTTL() throws {
+        XCTAssertTrue(try source().contains("const FOCUS_HEARTBEAT_MS = 20000;"))
+        // Three lost heartbeats must still leave a live declaration.
+        XCTAssertGreaterThanOrEqual(
+            ClaudeRegistryLimits.defaultFocusDeclarationTTL, 4 * 20,
+            "registry focus TTL must cover several lost 20s heartbeats"
+        )
+    }
+
+    func testHerdrPaneIdentityIsForwarded() throws {
+        let text = try source()
+        XCTAssertTrue(text.contains("HERDR_PANE_ID"))
+        XCTAssertTrue(text.contains("HERDR_SOCKET_PATH"))
+    }
+
+    // MARK: Realm split — evaluate the file and check both export shapes
+    //
+    // JavaScriptCore is the same engine Bun embeds, so a syntax error here is
+    // a syntax error there. ESM statements are rewritten (imports stripped,
+    // `export default` captured) because JSC's evaluateScript is not a module
+    // loader; only `isMainThread` needs stubbing for top-level evaluation.
+
+    private func evaluateDefaultExport(isMainThread: Bool) throws -> JSValue {
+        var text = try source()
+        text = text
+            .split(separator: "\n", omittingEmptySubsequences: false)
+            .map { line in line.hasPrefix("import ") ? "" : String(line) }
+            .joined(separator: "\n")
+            .replacingOccurrences(of: "export default", with: "globalThis.__defaultExport =")
+
+        let context = try XCTUnwrap(JSContext())
+        let failure = Box<String?>(nil)
+        context.exceptionHandler = { _, exception in
+            failure.value = exception?.toString()
+        }
+        context.evaluateScript("const isMainThread = \(isMainThread);")
+        context.evaluateScript(text)
+        if let message = failure.value {
+            XCTFail("plugin failed to evaluate: \(message)")
+        }
+        return try XCTUnwrap(context.evaluateScript("globalThis.__defaultExport"))
+    }
+
+    private final class Box<Value>: @unchecked Sendable {
+        var value: Value
+        init(_ value: Value) { self.value = value }
+    }
+
+    func testMainRealmExportsTheTuiHalfOnly() throws {
+        // opencode's loaders reject a default export carrying both server()
+        // and tui() (plugin/shared.ts, readV1Plugin), and the local TUI runs
+        // its server in a Worker realm — so the export must be exactly one
+        // half per realm, chosen by isMainThread.
+        let module = try evaluateDefaultExport(isMainThread: true)
+        XCTAssertEqual(module.forProperty("id").toString(), "localvoxtral")
+        XCTAssertTrue(module.forProperty("tui").isObject, "main realm must export tui()")
+        XCTAssertTrue(module.forProperty("server").isUndefined, "main realm must not export server()")
+    }
+
+    func testWorkerRealmExportsTheServerHalfOnly() throws {
+        let module = try evaluateDefaultExport(isMainThread: false)
+        XCTAssertEqual(module.forProperty("id").toString(), "localvoxtral")
+        XCTAssertTrue(module.forProperty("server").isObject, "worker realm must export server()")
+        XCTAssertTrue(module.forProperty("tui").isUndefined, "worker realm must not export tui()")
+    }
+
+    // MARK: README — the only install instructions a user gets
+
+    private func readmeLines() throws -> [String] {
+        try String(contentsOf: readmeURL, encoding: .utf8)
+            .split(separator: "\n", omittingEmptySubsequences: false)
+            .map { $0.trimmingCharacters(in: .whitespaces) }
+    }
+
+    func testReadmeDocumentsBothInstallStepsAndUninstall() throws {
+        let lines = try readmeLines()
+        XCTAssertTrue(lines.contains("cp localvoxtral.js ~/.config/opencode/plugins/"))
+        // The tui.json step is the one users will skip; it must be present and
+        // must explain the cost of skipping it.
+        XCTAssertTrue(lines.contains(#""plugin": ["./plugins/localvoxtral.js"]"#))
+        XCTAssertTrue(lines.contains { $0.contains("vocabulary-only") })
+        XCTAssertTrue(lines.contains("rm ~/.config/opencode/plugins/localvoxtral.js"))
+    }
+
+    func testReadmeIsHonestAboutHeadlessModes() throws {
+        // `opencode run`/`serve` publishing nothing is deliberate; undocumented
+        // it reads as a bug and invites a "fix" that would publish a
+        // mis-joining TTY from a serve process.
+        let lines = try readmeLines()
+        XCTAssertTrue(lines.contains { $0.contains("`opencode run` and `opencode serve`") })
+        XCTAssertTrue(lines.contains { $0.contains("never") && $0.contains("TTY") })
+    }
+}

--- a/Tests/localvoxtralTests/TerminalScreenClaudeJoinTests.swift
+++ b/Tests/localvoxtralTests/TerminalScreenClaudeJoinTests.swift
@@ -668,7 +668,7 @@ final class TerminalScreenClaudeJoinTests: XCTestCase {
         )
         XCTAssertNil(snapshot.process, "precondition")
         XCTAssertFalse(
-            ClaudeSessionJoinResolver.registeredClaudeIsForeground(
+            ClaudeSessionJoinResolver.registeredAgentIsForeground(
                 snapshot: snapshot, foregroundPIDs: [9001]
             )
         )

--- a/integrations/opencode/README.md
+++ b/integrations/opencode/README.md
@@ -55,9 +55,12 @@ and remove the line from `~/.config/opencode/tui.json`.
   mis-joins. The server half therefore never claims a TTY; the TUI half —
   which only loads in the realm that renders your pane — declares
   `FocusChanged` records ("this TTY currently displays session X"),
-  freshness-bounded and heartbeat-refreshed. localvoxtral resolves a pane to
-  a session only through a fresh declaration, cross-checked against the
-  declaring process's pid, and abstains on anything ambiguous or stale.
+  freshness-bounded, heartbeat-refreshed, and explicitly retracted
+  (`FocusCleared`) the moment the pane leaves its session view. localvoxtral
+  resolves a pane to a session only through a fresh declaration,
+  cross-checked against the declaring process's pid (and, at the broker,
+  against the kernel-verified pid of the connecting process), and abstains
+  on anything ambiguous or stale.
 - **Blast radius zero.** The plugin runs inside your agent process. It never
   blocks a hook on IO: one lazily reconnected, `unref()`ed socket,
   fire-and-forget writes, every handler wrapped in try/catch, all fields

--- a/integrations/opencode/README.md
+++ b/integrations/opencode/README.md
@@ -1,0 +1,83 @@
+# localvoxtral opencode plugin
+
+Off-screen dictation context for [opencode](https://github.com/sst/opencode)
+sessions, the same way the Claude Code plugin provides it for Claude Code:
+when you dictate into an opencode pane, localvoxtral can ground transcription
+on the session's prior prompt, working directory, and recently touched files —
+without reading your screen.
+
+Everything is local: the plugin publishes bounded records over localvoxtral's
+private, peer-authenticated UNIX socket on this machine. No network, no
+telemetry, and when the app is not running every write silently does nothing.
+
+## Install (manual, two steps)
+
+1. Copy `localvoxtral.js` into opencode's global plugin directory:
+
+```sh
+mkdir -p ~/.config/opencode/plugins
+cp localvoxtral.js ~/.config/opencode/plugins/
+```
+
+2. List it in `~/.config/opencode/tui.json` (create the file if it does not
+   exist; merge the `plugin` entry if it does):
+
+```json
+{
+  "plugin": ["./plugins/localvoxtral.js"]
+}
+```
+
+Restart opencode. Nothing else: no dependencies, no tokens, no daemons.
+
+Why two steps: opencode auto-discovers `plugins/*.js` for its **server**
+plugin loader, but its **TUI** plugin loader only loads plugins explicitly
+listed in `tui.json` (verified on opencode 1.17.12). This plugin is one file
+with both halves — the server half publishes session content, the TUI half
+publishes which session your pane currently displays. Skipping step 2 keeps
+session content flowing but leaves panes undeclared, so dictation cannot join
+your terminal to a session and stays vocabulary-only.
+
+## Uninstall
+
+```sh
+rm ~/.config/opencode/plugins/localvoxtral.js
+```
+
+and remove the line from `~/.config/opencode/tui.json`.
+
+## Design invariants (why it is built this way)
+
+- **The TTY is published only by the half that owns a pane.** One opencode
+  process can host many sessions on one terminal while the TUI displays one
+  at a time — and under `opencode serve` the process owns no pane at all, so
+  a naive "am I attached to a TTY" check would publish a device that
+  mis-joins. The server half therefore never claims a TTY; the TUI half —
+  which only loads in the realm that renders your pane — declares
+  `FocusChanged` records ("this TTY currently displays session X"),
+  freshness-bounded and heartbeat-refreshed. localvoxtral resolves a pane to
+  a session only through a fresh declaration, cross-checked against the
+  declaring process's pid, and abstains on anything ambiguous or stale.
+- **Blast radius zero.** The plugin runs inside your agent process. It never
+  blocks a hook on IO: one lazily reconnected, `unref()`ed socket,
+  fire-and-forget writes, every handler wrapped in try/catch, all fields
+  bounded before they cross the wire. It never writes to the terminal.
+- **No title markers.** opencode owns and rewrites its window title mid-turn,
+  so the title channel Claude Code uses cannot work here; localvoxtral never
+  sends this plugin one.
+- **Subagent sessions are filtered.** Child (task-tool) sessions never
+  masquerade as the session you are typing into.
+- **herdr panes keep working.** The plugin forwards the herdr pane identity
+  it inherited from the environment, so localvoxtral's existing herdr join
+  applies to opencode panes unchanged.
+
+## What does not publish (deliberate)
+
+- `opencode run` and `opencode serve`: their main-realm server finds the TUI
+  module shape and skips the plugin (a line in opencode's log, nothing else).
+  There is no pane to dictate into in `run`, and a serve process must never
+  publish a TTY. Sessions viewed through `opencode attach` get focus
+  declarations from the attach TUI, but their content lives in the serve
+  process and is not published — those panes stay vocabulary-only.
+- Session transcripts, model output, file contents: never sent. The wire
+  carries the prior prompt (bounded), the cwd, and touched file paths only.

--- a/integrations/opencode/localvoxtral.js
+++ b/integrations/opencode/localvoxtral.js
@@ -1,0 +1,385 @@
+// localvoxtral opencode plugin — dictation context for opencode sessions.
+//
+// Install (see README.md beside this file): copy this ONE file into
+// ~/.config/opencode/plugins/ (the server half auto-discovers from there),
+// and list it in ~/.config/opencode/tui.json (the TUI half loads only
+// explicitly listed plugins — verified on opencode 1.17.12). Uninstall:
+// delete the file and the tui.json line. No dependencies.
+//
+// It publishes bounded NDJSON records (wire v2, `agent: "opencode"`) over the
+// localvoxtral app's private AF_UNIX socket — the same wire the Claude Code
+// hook publisher speaks (Sources/ClaudeContextWire/ClaudeHookWire.swift).
+// When the app is not running, every write fails silently: this plugin runs
+// INSIDE the user's agent process, and a hang or throw that stalls their turn
+// is the worst possible failure. Hence the hard rules below:
+//
+//   * No network-shaped waiting inside hooks. One lazily (re)connected
+//     socket, unref()ed, fire-and-forget writes, broker replies discarded.
+//   * Every handler body is wrapped in try/catch and swallows everything.
+//   * Nothing is ever written to the terminal: no stdout, no stderr, no
+//     logging. opencode's TUI owns those descriptors.
+//   * Bounded everything: prompts, paths, per-record file lists, line bytes,
+//     session caches.
+//
+// TWO HALVES, ONE FILE, chosen per JS realm. opencode's local TUI runs its
+// server in a Bun Worker thread (opencode source: packages/opencode/src/cli/
+// cmd/tui.ts, `new Worker(file)`), so the server plugin loader executes in
+// the worker realm and the TUI plugin loader executes in the main realm — and
+// a module may default-export either `server()` or `tui()`, never both
+// (packages/opencode/src/plugin/shared.ts, readV1Plugin). The realm split is
+// exactly the gate we need:
+//
+//   * Worker realm (never a TUI) -> the server half. It publishes session
+//     content and NEVER a TTY: under `opencode serve` a naive isatty answer
+//     would name a device whose pane does not display the session — the
+//     mis-join the whole design exists to prevent. Positive evidence or
+//     abstain, like the app's HerdrClientTTYProbe.
+//   * Main realm -> the TUI half. Only a realm that renders a pane loads it,
+//     and only it publishes the pane's TTY — inside FocusChanged records that
+//     declare which session the pane currently displays. One opencode process
+//     hosts many sessions on one TTY; the focus declaration is what lets the
+//     app's registry resolve that TTY to exactly one of them, or abstain.
+//
+// Headless realms (`opencode serve` / `opencode run` main thread) find a
+// `tui` module where the server loader wants `server()` and skip this plugin
+// with a log entry. Deliberate: `run` has no pane to dictate into, and a
+// serve process must not publish TTYs. See README.md ("What does not
+// publish") before "fixing" this.
+
+import net from "node:net";
+import fs from "node:fs";
+import { isatty } from "node:tty";
+import { isMainThread } from "node:worker_threads";
+
+// Wire constants — must mirror ClaudeHookWire.swift / ClaudeHookLimits. The
+// repo's OpencodePluginManifestTests pin these against the Swift constants.
+const WIRE_VERSION = 2;
+const AGENT = "opencode";
+const MAX_LINE_BYTES = 64 * 1024;
+const MAX_PROMPT_BYTES = 8 * 1024;
+const MAX_PATH_BYTES = 4 * 1024;
+const MAX_FILES_PER_RECORD = 16;
+
+// The registry treats a focus declaration as stale after two minutes
+// (ClaudeRegistryLimits.defaultFocusDeclarationTTL); a 20-second heartbeat
+// keeps a steadily displayed session comfortably fresh across lost writes.
+const FOCUS_POLL_MS = 2000;
+const FOCUS_HEARTBEAT_MS = 20000;
+
+// Bounds on in-process caches, so a very long-lived opencode cannot grow.
+const MAX_TRACKED_SESSIONS = 64;
+
+// ---------------------------------------------------------------------------
+// Socket path — mirrors ClaudeHookSocketPath.swift exactly.
+
+function socketPath() {
+  const override = process.env.LOCALVOXTRAL_CLAUDE_SOCKET;
+  if (override) return override;
+  const home = process.env.HOME;
+  if (!home) return undefined;
+  if (process.platform === "darwin") {
+    return home + "/Library/Application Support/localvoxtral/run/claude-context.sock";
+  }
+  const base = process.env.XDG_RUNTIME_DIR || home + "/.local/state";
+  return base + "/localvoxtral/claude-context.sock";
+}
+
+// ---------------------------------------------------------------------------
+// Publisher — lazy connection, fire and forget, replies discarded.
+//
+// The broker serves short connections (whole-connection read deadline, a
+// per-connection record cap), so the socket naturally closes between bursts;
+// the next publish reconnects. Writes issued right after createConnection are
+// buffered by the runtime until the connect completes — nothing here ever
+// blocks a hook on the dial.
+
+let socket;
+
+function publish(record) {
+  try {
+    if (!record) return;
+    const line = JSON.stringify(record) + "\n";
+    if (Buffer.byteLength(line, "utf8") > MAX_LINE_BYTES) return;
+    if (!socket || socket.destroyed) {
+      const path = socketPath();
+      if (!path) return;
+      socket = net.createConnection(path);
+      socket.unref();
+      // Broker replies (marker lines for Claude publishers) are read and
+      // dropped: this plugin has no title channel and must never surface a
+      // byte anywhere a terminal could see it.
+      socket.on("data", () => {});
+      socket.on("error", () => {
+        try {
+          socket.destroy();
+        } catch {}
+      });
+    }
+    socket.write(line);
+  } catch {}
+}
+
+function closeSocket() {
+  try {
+    if (socket && !socket.destroyed) socket.destroy();
+  } catch {}
+  socket = undefined;
+}
+
+// ---------------------------------------------------------------------------
+// Record shaping. The broker re-applies every bound on decode; truncating
+// here as well keeps oversized payloads from ever crossing the wire.
+
+function truncateBytes(value, limit) {
+  if (typeof value !== "string" || value.length === 0) return undefined;
+  if (Buffer.byteLength(value, "utf8") <= limit) return value;
+  const bytes = Buffer.from(value, "utf8").subarray(0, limit);
+  let end = bytes.length;
+  // Never cut inside a UTF-8 sequence: drop continuation bytes, then a
+  // dangling lead byte.
+  while (end > 0 && (bytes[end - 1] & 0b11000000) === 0b10000000) end -= 1;
+  if (end > 0 && (bytes[end - 1] & 0b11000000) === 0b11000000) end -= 1;
+  return bytes.subarray(0, end).toString("utf8");
+}
+
+/// Safe process metadata only — identity and (for the TUI half) location of
+/// the pane, mirroring what the Claude hook publisher sends. The plugin runs
+/// inside the agent process, so `process.pid` IS the liveness pid the app
+/// probes; there is no shim ancestry to unwind here.
+function processBlock(tty) {
+  const block = {
+    hook_pid: process.pid,
+    claude_pid: process.pid,
+  };
+  if (typeof tty === "string" && tty) block.tty = tty;
+  const term = process.env.TERM_PROGRAM;
+  if (term) block.term_program = term;
+  // Inherited herdr pane identity keeps the app's existing herdr join arm
+  // working for opencode panes, unchanged.
+  const herdrPane = process.env.HERDR_PANE_ID;
+  const herdrSocket = process.env.HERDR_SOCKET_PATH;
+  if (herdrPane) block.herdr_pane_id = truncateBytes(herdrPane, MAX_PATH_BYTES);
+  if (herdrSocket) block.herdr_socket_path = truncateBytes(herdrSocket, MAX_PATH_BYTES);
+  return block;
+}
+
+function record(event, sessionID, fields, tty) {
+  const scopedID = truncateBytes(sessionID, MAX_PATH_BYTES);
+  if (!scopedID) return undefined;
+  const result = {
+    v: WIRE_VERSION,
+    event,
+    agent: AGENT,
+    session_id: scopedID,
+    ts: Date.now() / 1000,
+    process: processBlock(tty),
+  };
+  if (fields && typeof fields.cwd === "string" && fields.cwd) {
+    result.cwd = truncateBytes(fields.cwd, MAX_PATH_BYTES);
+  }
+  if (fields && typeof fields.prompt === "string" && fields.prompt) {
+    result.prompt = truncateBytes(fields.prompt, MAX_PROMPT_BYTES);
+  }
+  if (fields && typeof fields.toolName === "string" && fields.toolName) {
+    result.tool_name = truncateBytes(fields.toolName, MAX_PATH_BYTES);
+  }
+  if (fields && Array.isArray(fields.files) && fields.files.length > 0) {
+    result.files = fields.files.slice(0, MAX_FILES_PER_RECORD).map((file) => ({
+      path: truncateBytes(file.path, MAX_PATH_BYTES),
+      kind: file.kind,
+    }));
+  }
+  return result;
+}
+
+// ---------------------------------------------------------------------------
+// Server half (worker realm): session content, never a TTY.
+
+const ServerHalf = async (input) => {
+  // session id -> directory, learned from session.created (the session's cwd
+  // is not on chat.message). The plugin-load directory is the only fallback;
+  // when neither is known the record goes out WITHOUT a cwd — fail closed on
+  // the field, not the record.
+  const directoryBySession = new Map();
+  // Subagent (task tool) sessions carry parentID; their lifecycle must not
+  // masquerade as user-facing sessions (same rule herdr's plugin applies).
+  const childSessions = new Set();
+  const fallbackDirectory =
+    input && typeof input.directory === "string" && input.directory ? input.directory : undefined;
+
+  function remember(map, key, value) {
+    map.set(key, value);
+    if (map.size > MAX_TRACKED_SESSIONS) {
+      const oldest = map.keys().next().value;
+      map.delete(oldest);
+    }
+  }
+
+  function directoryFor(sessionID) {
+    return directoryBySession.get(sessionID) || fallbackDirectory;
+  }
+
+  return {
+    event: async ({ event }) => {
+      try {
+        const type = event && event.type;
+        const properties = (event && event.properties) || {};
+        if (type === "session.created") {
+          const info = properties.info || {};
+          if (!info.id) return;
+          if (info.parentID) {
+            childSessions.add(info.id);
+            if (childSessions.size > MAX_TRACKED_SESSIONS) {
+              childSessions.delete(childSessions.values().next().value);
+            }
+            return;
+          }
+          if (typeof info.directory === "string" && info.directory) {
+            remember(directoryBySession, info.id, info.directory);
+          }
+          publish(record("SessionStart", info.id, { cwd: directoryFor(info.id) }));
+          return;
+        }
+        if (type === "session.deleted") {
+          const info = properties.info || {};
+          if (!info.id) return;
+          if (childSessions.delete(info.id)) return;
+          publish(record("SessionEnd", info.id, { cwd: directoryFor(info.id) }));
+          directoryBySession.delete(info.id);
+          return;
+        }
+        if (type === "session.idle") {
+          const sessionID = properties.sessionID;
+          if (!sessionID || childSessions.has(sessionID)) return;
+          publish(record("Stop", sessionID, { cwd: directoryFor(sessionID) }));
+        }
+      } catch {}
+    },
+
+    // Fires in createUserMessage AFTER @-mention resolution and BEFORE the
+    // model call; the prompt text is the join of the text parts.
+    "chat.message": async (input, output) => {
+      try {
+        const sessionID = input && input.sessionID;
+        if (!sessionID || childSessions.has(sessionID)) return;
+        const parts = (output && output.parts) || [];
+        const prompt = parts
+          .filter((part) => part && part.type === "text" && typeof part.text === "string")
+          .map((part) => part.text)
+          .join("\n");
+        publish(
+          record("UserPromptSubmit", sessionID, {
+            prompt,
+            cwd: directoryFor(sessionID),
+          })
+        );
+      } catch {}
+    },
+
+    "tool.execute.after": async (input) => {
+      try {
+        const sessionID = input && input.sessionID;
+        const tool = input && input.tool;
+        if (!sessionID || childSessions.has(sessionID)) return;
+        // File-bearing tools only, mirroring the Claude plugin's
+        // Read|Edit|Write matcher. Everything else (bash, grep, glob) carries
+        // command strings, not file touches.
+        const kinds = { read: "read", edit: "edited", write: "edited" };
+        const kind = kinds[tool];
+        if (!kind) return;
+        const filePath = input.args && typeof input.args.filePath === "string" ? input.args.filePath : undefined;
+        if (!filePath) return;
+        publish(
+          record("PostToolUse", sessionID, {
+            toolName: tool,
+            files: [{ path: filePath, kind }],
+            cwd: directoryFor(sessionID),
+          })
+        );
+      } catch {}
+    },
+
+    dispose: async () => {
+      try {
+        closeSocket();
+      } catch {}
+    },
+  };
+};
+
+// ---------------------------------------------------------------------------
+// TUI half (main realm): the pane's TTY plus which session it displays.
+
+/// This process's controlling terminal, read child-free from fd 0 — the TUI
+/// realm owns the pane by construction (it renders into it). Positive
+/// verification or abstain: on macOS the candidate device's rdev must match
+/// fd 0's before it is ever published.
+function ownTTY() {
+  try {
+    if (!isatty(0)) return undefined;
+    if (process.platform === "linux") {
+      const link = fs.readlinkSync("/proc/self/fd/0");
+      return link.startsWith("/dev/") ? link : undefined;
+    }
+    if (process.platform === "darwin") {
+      const stat = fs.fstatSync(0);
+      if (!stat.isCharacterDevice()) return undefined;
+      // macOS device numbers: minor is the low 24 bits; pseudo-terminals are
+      // named /dev/ttysNNN, zero-padded to three digits.
+      const minor = stat.rdev & 0xffffff;
+      const candidate = "/dev/ttys" + String(minor).padStart(3, "0");
+      return fs.statSync(candidate).rdev === stat.rdev ? candidate : undefined;
+    }
+  } catch {}
+  return undefined;
+}
+
+const TuiHalf = async (api) => {
+  const tty = ownTTY();
+  if (!tty) return; // No pane evidence, nothing to declare. Ever.
+
+  // opencode's TUI exposes the displayed session as api.route.current
+  // (@opencode-ai/plugin/tui: TuiRouteCurrent) and publishes no route-change
+  // event on any bus, so the getter is sampled on an unref()ed timer — a pure
+  // in-memory read, no IO. A change publishes immediately; a heartbeat keeps
+  // the declaration fresh; leaving the session view (home) simply stops the
+  // heartbeat and the app's registry expires the declaration.
+  let lastSession;
+  let lastSentAt = 0;
+  const timer = setInterval(() => {
+    try {
+      const route = api.route && api.route.current;
+      const sessionID =
+        route && route.name === "session" && route.params && typeof route.params.sessionID === "string"
+          ? route.params.sessionID
+          : undefined;
+      if (!sessionID) {
+        lastSession = undefined;
+        return;
+      }
+      const nowMillis = Date.now();
+      if (sessionID === lastSession && nowMillis - lastSentAt < FOCUS_HEARTBEAT_MS) return;
+      lastSession = sessionID;
+      lastSentAt = nowMillis;
+      publish(record("FocusChanged", sessionID, undefined, tty));
+    } catch {}
+  }, FOCUS_POLL_MS);
+  if (timer && typeof timer.unref === "function") timer.unref();
+
+  if (api.lifecycle && typeof api.lifecycle.onDispose === "function") {
+    api.lifecycle.onDispose(() => {
+      try {
+        clearInterval(timer);
+        closeSocket();
+      } catch {}
+    });
+  }
+};
+
+// ---------------------------------------------------------------------------
+// One default export per realm — see the header for why this split is the
+// TUI-ownership gate, not a convenience.
+
+export default isMainThread
+  ? { id: "localvoxtral", tui: TuiHalf }
+  : { id: "localvoxtral", server: ServerHalf };

--- a/integrations/opencode/localvoxtral.js
+++ b/integrations/opencode/localvoxtral.js
@@ -60,14 +60,26 @@ const MAX_PROMPT_BYTES = 8 * 1024;
 const MAX_PATH_BYTES = 4 * 1024;
 const MAX_FILES_PER_RECORD = 16;
 
-// The registry treats a focus declaration as stale after two minutes
+// The registry treats a focus declaration as stale after 45 seconds
 // (ClaudeRegistryLimits.defaultFocusDeclarationTTL); a 20-second heartbeat
-// keeps a steadily displayed session comfortably fresh across lost writes.
-const FOCUS_POLL_MS = 2000;
+// keeps a steadily displayed session fresh across one lost write, and the
+// half-second sample keeps a session SWITCH visible almost immediately —
+// opencode's TUI plugin API exposes the displayed session only as the
+// `api.route.current` getter (no route-change event exists on any bus in
+// 1.17.x), so sampling cadence is the switch latency. Bus events additionally
+// trigger an immediate resample, so any switch that coincides with session
+// activity is caught event-fast.
+const FOCUS_POLL_MS = 500;
 const FOCUS_HEARTBEAT_MS = 20000;
 
 // Bounds on in-process caches, so a very long-lived opencode cannot grow.
 const MAX_TRACKED_SESSIONS = 64;
+
+// Hard cap on bytes queued in the socket before the runtime flushed them. A
+// broker that stops reading must never grow this process's memory: past the
+// cap the connection is reset and records are DROPPED — context is a
+// nice-to-have, the user's agent process is not.
+const MAX_QUEUED_BYTES = 64 * 1024;
 
 // ---------------------------------------------------------------------------
 // Socket path — mirrors ClaudeHookSocketPath.swift exactly.
@@ -95,14 +107,18 @@ function socketPath() {
 
 let socket;
 
+/// Returns true only when the line was actually handed to a healthy socket —
+/// callers that track publish state (the focus declarations) must not advance
+/// on a dropped write, or a lost switch would go unrepaired until the next
+/// heartbeat.
 function publish(record) {
   try {
-    if (!record) return;
+    if (!record) return false;
     const line = JSON.stringify(record) + "\n";
-    if (Buffer.byteLength(line, "utf8") > MAX_LINE_BYTES) return;
+    if (Buffer.byteLength(line, "utf8") > MAX_LINE_BYTES) return false;
     if (!socket || socket.destroyed) {
       const path = socketPath();
-      if (!path) return;
+      if (!path) return false;
       socket = net.createConnection(path);
       socket.unref();
       // Broker replies (marker lines for Claude publishers) are read and
@@ -115,13 +131,29 @@ function publish(record) {
         } catch {}
       });
     }
+    // Backpressure is a drop, never a wait: if the broker stopped draining,
+    // reset the connection (the next publish lazily reconnects) and lose
+    // this record rather than queue unboundedly inside the agent process.
+    if (socket.writableLength > MAX_QUEUED_BYTES) {
+      try {
+        socket.destroy();
+      } catch {}
+      socket = undefined;
+      return false;
+    }
     socket.write(line);
-  } catch {}
+    return true;
+  } catch {
+    return false;
+  }
 }
 
 function closeSocket() {
   try {
-    if (socket && !socket.destroyed) socket.destroy();
+    // end(), not destroy(): a final retraction may still be in the buffer,
+    // and end() flushes before FIN while an unref()ed socket cannot keep the
+    // process alive anyway.
+    if (socket && !socket.destroyed) socket.end();
   } catch {}
   socket = undefined;
 }
@@ -164,13 +196,15 @@ function processBlock(tty) {
 }
 
 function record(event, sessionID, fields, tty) {
-  const scopedID = truncateBytes(sessionID, MAX_PATH_BYTES);
-  if (!scopedID) return undefined;
+  // Bounded, not scoped: namespacing ("opencode:…") is applied by the
+  // RECEIVER from the agent tag, by design. The plugin sends raw ids.
+  const boundedID = truncateBytes(sessionID, MAX_PATH_BYTES);
+  if (!boundedID) return undefined;
   const result = {
     v: WIRE_VERSION,
     event,
     agent: AGENT,
-    session_id: scopedID,
+    session_id: boundedID,
     ts: Date.now() / 1000,
     process: processBlock(tty),
   };
@@ -195,17 +229,17 @@ function record(event, sessionID, fields, tty) {
 // ---------------------------------------------------------------------------
 // Server half (worker realm): session content, never a TTY.
 
-const ServerHalf = async (input) => {
+const ServerHalf = async () => {
   // session id -> directory, learned from session.created (the session's cwd
-  // is not on chat.message). The plugin-load directory is the only fallback;
-  // when neither is known the record goes out WITHOUT a cwd — fail closed on
-  // the field, not the record.
+  // is not on chat.message). There is deliberately NO fallback — not even the
+  // plugin-load directory: an instance-less server hosts sessions from many
+  // directories, and a wrong cwd would ground dictation on the wrong repo.
+  // When the directory is unknown the record goes out WITHOUT a cwd — fail
+  // closed on the field, not the record.
   const directoryBySession = new Map();
   // Subagent (task tool) sessions carry parentID; their lifecycle must not
   // masquerade as user-facing sessions (same rule herdr's plugin applies).
   const childSessions = new Set();
-  const fallbackDirectory =
-    input && typeof input.directory === "string" && input.directory ? input.directory : undefined;
 
   function remember(map, key, value) {
     map.set(key, value);
@@ -216,7 +250,7 @@ const ServerHalf = async (input) => {
   }
 
   function directoryFor(sessionID) {
-    return directoryBySession.get(sessionID) || fallbackDirectory;
+    return directoryBySession.get(sessionID);
   }
 
   return {
@@ -338,38 +372,75 @@ const TuiHalf = async (api) => {
   const tty = ownTTY();
   if (!tty) return; // No pane evidence, nothing to declare. Ever.
 
-  // opencode's TUI exposes the displayed session as api.route.current
-  // (@opencode-ai/plugin/tui: TuiRouteCurrent) and publishes no route-change
-  // event on any bus, so the getter is sampled on an unref()ed timer — a pure
-  // in-memory read, no IO. A change publishes immediately; a heartbeat keeps
-  // the declaration fresh; leaving the session view (home) simply stops the
-  // heartbeat and the app's registry expires the declaration.
+  // opencode's TUI exposes the displayed session only as the
+  // `api.route.current` getter (@opencode-ai/plugin/tui: TuiRouteCurrent) —
+  // no route-change event exists on any bus in 1.17.x, so event-driven focus
+  // is approximated from both ends: a half-second sample of the getter (pure
+  // in-memory read, no IO) bounds switch latency, and every bus event
+  // triggers an immediate resample so switches that coincide with session
+  // activity are caught event-fast. Leaving the session view publishes an
+  // explicit retraction (FocusCleared) instead of waiting for the registry's
+  // TTL. Publish state only advances when the write was actually accepted, so
+  // a lost declaration or retraction is retried at the next sample.
   let lastSession;
   let lastSentAt = 0;
-  const timer = setInterval(() => {
+
+  function sample() {
     try {
       const route = api.route && api.route.current;
       const sessionID =
         route && route.name === "session" && route.params && typeof route.params.sessionID === "string"
           ? route.params.sessionID
           : undefined;
+      const nowMillis = Date.now();
       if (!sessionID) {
-        lastSession = undefined;
+        if (lastSession && publish(record("FocusCleared", lastSession, undefined, tty))) {
+          lastSession = undefined;
+          lastSentAt = 0;
+        }
         return;
       }
-      const nowMillis = Date.now();
       if (sessionID === lastSession && nowMillis - lastSentAt < FOCUS_HEARTBEAT_MS) return;
-      lastSession = sessionID;
-      lastSentAt = nowMillis;
-      publish(record("FocusChanged", sessionID, undefined, tty));
+      if (publish(record("FocusChanged", sessionID, undefined, tty))) {
+        lastSession = sessionID;
+        lastSentAt = nowMillis;
+      }
     } catch {}
-  }, FOCUS_POLL_MS);
+  }
+
+  const timer = setInterval(sample, FOCUS_POLL_MS);
   if (timer && typeof timer.unref === "function") timer.unref();
+
+  const unsubscribes = [];
+  if (api.event && typeof api.event.on === "function") {
+    // Resample-on-event: TuiEventBus.on requires a concrete type per
+    // subscription, so cover the events a session switch tends to ride on.
+    for (const type of [
+      "session.created",
+      "session.deleted",
+      "session.status",
+      "session.idle",
+      "message.updated",
+    ]) {
+      try {
+        unsubscribes.push(api.event.on(type, sample));
+      } catch {}
+    }
+  }
 
   if (api.lifecycle && typeof api.lifecycle.onDispose === "function") {
     api.lifecycle.onDispose(() => {
       try {
         clearInterval(timer);
+        for (const unsubscribe of unsubscribes) {
+          try {
+            unsubscribe();
+          } catch {}
+        }
+        if (lastSession) {
+          publish(record("FocusCleared", lastSession, undefined, tty));
+          lastSession = undefined;
+        }
         closeSocket();
       } catch {}
     });


### PR DESCRIPTION
## What

The opencode plugin itself, stacked on the wire/registry generalization (parent PR). One dependency-free JS file, `integrations/opencode/localvoxtral.js`, carrying BOTH plugin halves, plus README, broker marker gating, and contract tests.

**Why the file exports one half per JS realm.** opencode's loaders reject a default export that carries both `server()` and `tui()` (`packages/opencode/src/plugin/shared.ts`, `readV1Plugin` — verified against the v1.17.12 source), and the local TUI runs its server in a Bun **Worker thread** (`cli/cmd/tui.ts`, `new Worker(file)`): the server loader executes in the worker realm, the TUI loader in the main realm, same process, different module graphs. So a cross-realm in-process flag is impossible — and unnecessary: `isMainThread` IS the pane-ownership gate. The worker realm (never a TUI) exports the server half; the main realm exports the TUI half; headless main realms (`opencode serve`/`run`) find the wrong shape and load nothing (log-only), which is the safe outcome — a serve process must never publish a TTY.

- **Server half**: `session.created/deleted/idle` + `chat.message` + `tool.execute.after` → `SessionStart/SessionEnd/Stop/UserPromptSubmit/PostToolUse`, agent-tagged, cwd cached from `session.created` (`chat.message` carries none; missing cwd drops the FIELD, not the record), subagent (parentID) sessions filtered, herdr pane env forwarded so the existing herdr arm applies unchanged. Never a TTY.
- **TUI half**: reads its own TTY child-free (fd 0; on macOS the `/dev/ttysNNN` candidate's `rdev` must equal fd 0's or it abstains; `/proc/self/fd/0` on Linux) and declares the displayed session (`FocusChanged`) by sampling `api.route.current` on an `unref()`ed **500 ms** timer plus an immediate resample on every TuiEventBus event (opencode 1.17.x publishes no route-change event — checked the TUI event bus types and runtime source), with an explicit `FocusCleared` retraction on leaving the session view and on dispose, a 20 s heartbeat, and publish state that advances only on an accepted write — against the registry's 45 s focus TTL. (Post-review shape; see the review-response comment.)
- **Blast radius** (the plugin lives inside the user's agent process): zero `await`s, one lazily reconnected `unref()`ed AF_UNIX socket, fire-and-forget writes, replies read and discarded, every handler try/caught, every field bounded to the Swift wire limits before encoding, zero terminal output.
- **Broker**: marker emission gated per agent — an opencode session never receives a title marker (opencode rewrites its own OSC titles mid-turn; the herdr rule generalized). Allocation unchanged: the registry marker stays every join's liveness handle.
- **Install** is manual for now (Settings row is a follow-up): copy the file into `~/.config/opencode/plugins/` AND list it in `~/.config/opencode/tui.json`. Empirically the TUI loader has **no** plugin auto-discovery on 1.17.x — only the server loader scans `plugins/*.js` — so the research premise "no config edit needed" held for the server half only. The README explains the cost of skipping the tui.json step (vocabulary-only).

## Proof

- [x] Unit suite green — `./scripts/remote-build.sh`:

```
Executed 2055 tests, with 2 tests skipped and 0 failures (0 unexpected) in 76.654 (76.746) seconds
```

  including the new `OpencodePluginManifestTests` (14 tests: wire-constant pins against `ClaudeHookWire`/`ClaudeHookLimits`/`ClaudeHookSocketPath`, forbidden-pattern gates incl. zero `await`s and zero terminal writes, and a JavaScriptCore evaluation — Bun's own engine — asserting the per-realm export shapes) and the broker gating test (`testBrokerWithholdsTheMarkerForAnOpencodeRecord`).

- [x] **Empirical plugin transcript** (strongest proof available off-Mac): on the Linux dev box, opencode 1.17.12, ISOLATED config (`XDG_CONFIG_HOME` scratch dir — the real `~/.config/opencode` untouched), `LOCALVOXTRAL_CLAUDE_SOCKET` pointed at a fake AF_UNIX broker that logs lines and replies `{"marker":null,"v":2}`. Drove the real TUI in a pty (typed a prompt, real GLM-5.2 turn, read tool ran). Everything the plugin published (cwd paths shortened to `…/oc-test/proj` for width; otherwise verbatim):

```
{"v":2,"event":"SessionStart","agent":"opencode","session_id":"ses_05a3d3459ffeFtEYWjY8GxWRYU","ts":1785192434.603,"process":{"hook_pid":2621112,"claude_pid":2621112,"herdr_pane_id":"w3:p2","herdr_socket_path":"/home/dev/.config/herdr/herdr.sock"},"cwd":"…/oc-test/proj"}
{"v":2,"event":"UserPromptSubmit","agent":"opencode","session_id":"ses_05a3d3459ffeFtEYWjY8GxWRYU","ts":1785192434.617,"process":{…same…},"cwd":"…/oc-test/proj","prompt":"Read notes.txt and tell me the demo word."}
{"v":2,"event":"FocusChanged","agent":"opencode","session_id":"ses_05a3d3459ffeFtEYWjY8GxWRYU","ts":1785192435.38,"process":{"hook_pid":2621112,"claude_pid":2621112,"tty":"/dev/pts/4","herdr_pane_id":"w3:p2","herdr_socket_path":"/home/dev/.config/herdr/herdr.sock"}}
{"v":2,"event":"PostToolUse","agent":"opencode","session_id":"ses_05a3d3459ffeFtEYWjY8GxWRYU","ts":1785192437.799,"process":{…same, no tty…},"cwd":"…/oc-test/proj","tool_name":"read","files":[{"path":"…/oc-test/proj/notes.txt","kind":"read"}]}
{"v":2,"event":"Stop","agent":"opencode","session_id":"ses_05a3d3459ffeFtEYWjY8GxWRYU","ts":1785192439.586,"process":{…same, no tty…},"cwd":"…/oc-test/proj"}
{"v":2,"event":"FocusChanged", …ts":1785192455.395, "tty":"/dev/pts/4" …}   <- 20 s heartbeat
{"v":2,"event":"FocusChanged", …ts":1785192475.416, "tty":"/dev/pts/4" …}   <- 20 s heartbeat
```

  Note the invariants visible in the bytes: **only** `FocusChanged` carries `tty`; session records never do; `hook_pid == claude_pid ==` the one opencode process in both realms (so the registry's pid cross-check binds focus to sessions); herdr pane identity forwarded (this run really was inside a herdr pane, `w3:p2`).

- [x] **Negative proof — headless publishes nothing**: same isolated config, `opencode run "Say the word hello and nothing else."` completed a real model turn (`hello`) and the fake broker received **zero** records (no log file created). Exactly the design: no pane, no TTY, no records.

- [x] An instrumented debug run (scratch copy only) confirmed both halves load in ONE process, two realms: `module eval isMainThread=false … worker.js` → ServerHalf; `module eval isMainThread=true … index.js` (same pid) → TuiHalf, `ownTTY=/dev/pts/4`, route polls `{"name":"home"}` → `{"name":"session","params":{"sessionID":…}}` on submit.

LLM lanes: paths under `Sources/localvoxtral/ClaudeContext` are lane-relevant and the lane will run. Context-attachment semantics for CLAUDE sessions are unchanged; opencode sessions only add grounding inputs through the existing pipeline — no prompt, model, or request-shape change.

## Deferred

- Settings row / bundled install service (parallel Settings redesign in flight).
- Remote/SSH phase for opencode.
- `opencode serve`+`attach` session content (attach panes get focus declarations, but serve publishes nothing — documented in the README).

