### PR TITLE
ASR pin: make the qhead checkpoint the single model reference

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -406,7 +406,7 @@ jobs:
         if: runner.environment == 'self-hosted' && steps.ci_scope.outputs.docs_only != 'true'
         env:
           VLLM_REALTIME_TEST_ENABLE: "1"
-          VLLM_REALTIME_TEST_MODEL: T0mSIlver/Voxtral-Mini-4B-Realtime-2602-MLX-4bit
+          VLLM_REALTIME_TEST_MODEL: T0mSIlver/Voxtral-Mini-4B-Realtime-2602-4bit-qhead
         # --enable-code-coverage matches the unit step's build flags exactly:
         # without it SwiftPM treats the coverage-instrumented products as
         # stale and recompiles the whole app+test module a second time

--- a/.github/workflows/eval-e2e.yml
+++ b/.github/workflows/eval-e2e.yml
@@ -111,7 +111,7 @@ jobs:
         env:
           LV_AGENT_EVAL_E2E_ENABLE: "1"
           LV_AGENT_EVAL_E2E_HELPER_PATH: PolishHelper/.build/xcode/Build/Products/Release/localvoxtral-polishd
-          LV_AGENT_EVAL_E2E_ASR_MODEL: T0mSIlver/Voxtral-Mini-4B-Realtime-2602-MLX-4bit
+          LV_AGENT_EVAL_E2E_ASR_MODEL: T0mSIlver/Voxtral-Mini-4B-Realtime-2602-4bit-qhead
         run: |
           mkdir -p logs
           set -o pipefail

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -109,7 +109,7 @@ jobs:
       - name: Gate — live integration (STT service)
         env:
           VLLM_REALTIME_TEST_ENABLE: "1"
-          VLLM_REALTIME_TEST_MODEL: T0mSIlver/Voxtral-Mini-4B-Realtime-2602-MLX-4bit
+          VLLM_REALTIME_TEST_MODEL: T0mSIlver/Voxtral-Mini-4B-Realtime-2602-4bit-qhead
         run: swift test --filter RealtimeAPIVLLMIntegrationTests
 
       - name: Gate — package app bundle

--- a/Sources/localvoxtral/SettingsStore.swift
+++ b/Sources/localvoxtral/SettingsStore.swift
@@ -239,7 +239,11 @@ final class SettingsStore {
 
         var defaultEndpoint: String { "ws://127.0.0.1:8000/v1/realtime" }
 
-        var defaultModelName: String { "T0mSIlver/Voxtral-Mini-4B-Realtime-2602-MLX-4bit" }
+        /// Placeholder/default for External URL mode only (managed mode always
+        /// uses `SpeechModelCatalog.defaultOption`). The default endpoint above
+        /// is the local speechd test service, so this tracks the same checkpoint
+        /// the rest of the project pins.
+        var defaultModelName: String { "T0mSIlver/Voxtral-Mini-4B-Realtime-2602-4bit-qhead" }
     }
 
     private enum Keys {

--- a/SpeechHelper/Tests/SpeechEngineTextTests/SpeechdLaunchOptionsTests.swift
+++ b/SpeechHelper/Tests/SpeechEngineTextTests/SpeechdLaunchOptionsTests.swift
@@ -6,14 +6,14 @@ import XCTest
 final class SpeechdLaunchOptionsTests: XCTestCase {
     func testParsesPinnedModelRevisionAndSupervisorArguments() throws {
         let options = try SpeechdOptionParser.parse([
-            "--model", "mlx-community/Voxtral-Mini-4B-Realtime-2602-4bit",
+            "--model", "T0mSIlver/Voxtral-Mini-4B-Realtime-2602-4bit-qhead",
             "--model-revision", "0123456789abcdef0123456789abcdef01234567",
             "--port", "8471",
             "--parent-pid", "4321",
             "--step-ms", "240",
         ])
 
-        XCTAssertEqual(options.modelID, "mlx-community/Voxtral-Mini-4B-Realtime-2602-4bit")
+        XCTAssertEqual(options.modelID, "T0mSIlver/Voxtral-Mini-4B-Realtime-2602-4bit-qhead")
         XCTAssertEqual(options.modelRevision, "0123456789abcdef0123456789abcdef01234567")
         XCTAssertEqual(options.port, 8471)
         XCTAssertEqual(options.parentPID, 4321)
@@ -100,9 +100,9 @@ final class SpeechdLaunchOptionsTests: XCTestCase {
         let cacheRoot = FileManager.default.temporaryDirectory
             .appending(path: "speechd-hf-cache-\(UUID().uuidString)")
         defer { try? FileManager.default.removeItem(at: cacheRoot) }
-        let repoID = "mlx-community/Voxtral-Mini-4B-Realtime-2602-4bit"
+        let repoID = "T0mSIlver/Voxtral-Mini-4B-Realtime-2602-4bit-qhead"
         let snapshots = cacheRoot
-            .appending(path: "models--mlx-community--Voxtral-Mini-4B-Realtime-2602-4bit")
+            .appending(path: "models--T0mSIlver--Voxtral-Mini-4B-Realtime-2602-4bit-qhead")
             .appending(path: "snapshots")
         let pinned = snapshots.appending(path: "pinned")
         let main = snapshots.appending(path: "moved-main")

--- a/Tests/localvoxtralTests/AgentDictationE2EEvalSupport.swift
+++ b/Tests/localvoxtralTests/AgentDictationE2EEvalSupport.swift
@@ -33,7 +33,7 @@ enum AgentDictationE2EEvalSupport {
     static let defaultVoxmlxEndpoint = "ws://127.0.0.1:8000/v1/realtime"
     /// The realtime model the build host's speechd STT service serves (same pin
     /// as the tier-1 integration lane in `remote-build.sh integration`).
-    static let defaultASRModel = "T0mSIlver/Voxtral-Mini-4B-Realtime-2602-MLX-4bit"
+    static let defaultASRModel = "T0mSIlver/Voxtral-Mini-4B-Realtime-2602-4bit-qhead"
 
     struct MarkerConfig: Decodable, Equatable {
         let helperPath: String?

--- a/Tests/localvoxtralTests/SettingsStoreTests.swift
+++ b/Tests/localvoxtralTests/SettingsStoreTests.swift
@@ -351,9 +351,14 @@ final class SettingsStoreTests: XCTestCase {
             store.effectiveModelName,
             SpeechModelCatalog.defaultOption.repoID
         )
+        // The literal is deliberately spelled out rather than read from
+        // RealtimeProvider: this assertion exists to catch an accidental change
+        // to the External URL default. Updating it is a pin change (the qhead
+        // checkpoint replaced the stale MLX-4bit conversion), not a weakening —
+        // the assertion is exactly as strict as before.
         XCTAssertEqual(
             store.modelPlaceholder,
-            "T0mSIlver/Voxtral-Mini-4B-Realtime-2602-MLX-4bit",
+            "T0mSIlver/Voxtral-Mini-4B-Realtime-2602-4bit-qhead",
             "external endpoint placeholder remains independent from managed speechd"
         )
     }

--- a/scripts/mac/README.md
+++ b/scripts/mac/README.md
@@ -111,8 +111,8 @@ sudo install -d -m 0755 /Users/Shared/localvoxtral        # log dir, if absent
 #    clear message. Keep these pins in sync with SpeechModelCatalog.defaultOption
 #    and PolishModelCatalog.defaultOption in the app source.
 python3 -m pip install --user -U 'huggingface_hub[cli]'   # or: uv tool install huggingface_hub
-hf download mlx-community/Voxtral-Mini-4B-Realtime-2602-4bit \
-  --revision fdebf7b2af834a1db4b8a3c99ab7480b333adf9e     # speechd (STT, 8000)
+hf download T0mSIlver/Voxtral-Mini-4B-Realtime-2602-4bit-qhead \
+  --revision 247f2eeccf962fbcaf85e361731a5e75b2d8cac1     # speechd (STT, 8000)
 hf download mlx-community/Qwen3.5-4B-OptiQ-4bit \
   --revision 41eccc3316fd4bf4b27cedf4924fe23ce44e77d9     # polishd (polish, 8080)
 ```
@@ -181,8 +181,8 @@ cat > ~/Library/LaunchAgents/com.localvoxtral.testspeechd.plist <<'PLIST'
   <key>ProgramArguments</key>
   <array>
     <string>/Users/Shared/localvoxtral/testservers/localvoxtral.app/Contents/MacOS/localvoxtral-speechd</string>
-    <string>--model</string><string>mlx-community/Voxtral-Mini-4B-Realtime-2602-4bit</string>
-    <string>--model-revision</string><string>fdebf7b2af834a1db4b8a3c99ab7480b333adf9e</string>
+    <string>--model</string><string>T0mSIlver/Voxtral-Mini-4B-Realtime-2602-4bit-qhead</string>
+    <string>--model-revision</string><string>247f2eeccf962fbcaf85e361731a5e75b2d8cac1</string>
     <string>--port</string><string>8000</string>
     <string>--cache-limit-mb</string><string>4096</string>
   </array>

--- a/scripts/mac/convert-qhead-checkpoint.py
+++ b/scripts/mac/convert-qhead-checkpoint.py
@@ -40,7 +40,10 @@ import mlx.core as mx
 from huggingface_hub import snapshot_download
 
 SOURCE_REPO = "mlx-community/Voxtral-Mini-4B-Realtime-2602-4bit"
-SOURCE_REVISION = "fdebf7b2af834a1db4b8a3c99ab7480b333adf9e"  # SpeechModelCatalog pin
+# Frozen conversion-input snapshot of SOURCE_REPO. SpeechModelCatalog now pins the
+# qhead OUTPUT repo (T0mSIlver/...-4bit-qhead @ 247f2eec...), not this one — do not
+# sync these two. Changing this SHA re-derives qhead from a different source snapshot.
+SOURCE_REVISION = "fdebf7b2af834a1db4b8a3c99ab7480b333adf9e"
 EMBED_KEY = "decoder.tok_embeddings.weight"
 
 

--- a/scripts/mac/localvoxtral-build-gate.sh
+++ b/scripts/mac/localvoxtral-build-gate.sh
@@ -721,7 +721,7 @@ payload_starts_with_command() {
 
 allow_build_payload() {
   local payload="$1"
-  local integration_prefix="env VLLM_REALTIME_TEST_ENABLE=1 VLLM_REALTIME_TEST_MODEL=T0mSIlver/Voxtral-Mini-4B-Realtime-2602-MLX-4bit swift test --filter RealtimeAPIVLLMIntegrationTests"
+  local integration_prefix="env VLLM_REALTIME_TEST_ENABLE=1 VLLM_REALTIME_TEST_MODEL=T0mSIlver/Voxtral-Mini-4B-Realtime-2602-4bit-qhead swift test --filter RealtimeAPIVLLMIntegrationTests"
 
   payload_has_safe_chars "$payload" || return 1
 

--- a/scripts/remote-build.sh
+++ b/scripts/remote-build.sh
@@ -261,7 +261,7 @@ case "$CMD" in
   integration)
     ENSURE_SERVER="speechd"
     REMOTE_CMD=(env VLLM_REALTIME_TEST_ENABLE=1
-      VLLM_REALTIME_TEST_MODEL=T0mSIlver/Voxtral-Mini-4B-Realtime-2602-MLX-4bit
+      VLLM_REALTIME_TEST_MODEL=T0mSIlver/Voxtral-Mini-4B-Realtime-2602-4bit-qhead
       swift test --filter RealtimeAPIVLLMIntegrationTests "$@")
     ;;
   integration-polishd)
@@ -392,13 +392,13 @@ case "$CMD" in
     if [[ -n "$E2E_RECORDING_DIR" ]]; then
       printf '{"helperPath": "%s", "asrModel": "%s", "recordingDirectory": "%s"}\n' \
         "PolishHelper/.build/xcode/Build/Products/Release/localvoxtral-polishd" \
-        "T0mSIlver/Voxtral-Mini-4B-Realtime-2602-MLX-4bit" \
+        "T0mSIlver/Voxtral-Mini-4B-Realtime-2602-4bit-qhead" \
         "$E2E_RECORDING_DIR" \
         >"$E2E_MARKER"
     else
       printf '{"helperPath": "%s", "asrModel": "%s"}\n' \
         "PolishHelper/.build/xcode/Build/Products/Release/localvoxtral-polishd" \
-        "T0mSIlver/Voxtral-Mini-4B-Realtime-2602-MLX-4bit" \
+        "T0mSIlver/Voxtral-Mini-4B-Realtime-2602-4bit-qhead" \
         >"$E2E_MARKER"
     fi
     REMOTE_CMD=(swift test --filter AgentDictationE2EEvalTests)


### PR DESCRIPTION
## What

`SpeechModelCatalog.defaultOption` already pins
`T0mSIlver/Voxtral-Mini-4B-Realtime-2602-4bit-qhead`, but the test, eval, infra
and runbook references still named **two stale generations**:

- `T0mSIlver/Voxtral-Mini-4B-Realtime-2602-MLX-4bit` — the previous conversion
- `mlx-community/Voxtral-Mini-4B-Realtime-2602-4bit` — that conversion's source

This makes qhead the single ASR model reference for everything we control.

**Split by consequence** — the speechd wire protocol has **no model field**
(`SpeechHelper/Sources/SpeechEngineText/RealtimeProtocol.swift`; the server
loads its weights from the `--model`/`--model-revision` CLI args in
`RealtimeSpeechServer.load`). So a *client-side* model string never selects the
served model against the bundled helper — it only does against a real vLLM.

**Behavior:**

| File | Change |
|---|---|
| `scripts/mac/README.md` | speechd `hf download` + the `com.localvoxtral.testspeechd` plist `--model` — this decides what the tier-1 launchd test service actually serves |
| `scripts/remote-build.sh` (:395/:401) | the eval-e2e marker's `asrModel` for both branches |

The two README revision pins **had to follow** the repo change
(`fdebf7b2…` → `247f2eec…`, taken from `SpeechModelCatalog`); leaving them would
have made the download 404 and the plist unloadable. That is the only edit
beyond the literal audit list.

**Documentation-truth (no behavior change against the bundled helper):**

- `.github/workflows/ci.yml`, `.github/workflows/release.yml` — `VLLM_REALTIME_TEST_MODEL`
- `.github/workflows/eval-e2e.yml` — `LV_AGENT_EVAL_E2E_ASR_MODEL`
- `scripts/mac/localvoxtral-build-gate.sh` — the `integration_prefix` allowlist string
- `Tests/localvoxtralTests/AgentDictationE2EEvalSupport.swift` — `defaultASRModel`
- `Sources/localvoxtral/SettingsStore.swift` — `RealtimeProvider.defaultModelName`
  (External URL mode's default/placeholder; its default endpoint is
  `ws://127.0.0.1:8000/v1/realtime`, the local speechd test service, so qhead is
  the honest default) + the matching `SettingsStoreTests` literal
- `SpeechHelper/Tests/.../SpeechdLaunchOptionsTests.swift` — parser fixtures
  (values are arbitrary; stale repo names mislead), including the
  `models--T0mSIlver--…-qhead` HF-cache path derivation

### Consumption trace for `defaultASRModel` / `LV_AGENT_EVAL_E2E_ASR_MODEL`

It does **not** spawn or warm speechd. Two consumers only:

1. **Report/scoreboard labels** — `AgentDictationE2EEvalTests.swift:254`
   (scoreboard header) and `:267` (`Support.ReportHeader.asrModel`, rendered by
   `scripts/render-agent-eval-report.swift:395`).
2. **The realtime session config's `model` field** —
   `AgentDictationE2EEvalTests.swift:726`,
   `client.connect(configuration: .init(endpoint:apiKey:model:))`.

The server it connects to is the already-running launchd `testspeechd`, warmed
by `remote-build.sh`'s `ENSURE_SERVER="speechd"` → the gate's `ensure` verb,
which only touches the trigger file — the plist's own `--model` decides the
weights. **Consequence:** before this PR the eval scoreboards and HTML reports
*named the wrong checkpoint* for every run; the ASR they measured was whatever
the plist served. Nothing in `remote-build.sh` provisions weights (the helpers
never auto-download — `scripts/mac/README.md` step 3 is the only provisioning
path), so the audit's "pre-download reference" framing for :395/:401 is
corrected here to "eval marker `asrModel`".

### Sequencing (read before merging)

The build host still runs the **retired Python voxmlx** service; the owner's
migration to the bundled `localvoxtral-speechd` launchd services is pending.
Merging this **before** that migration is safe *and required* — the runbook this
PR updates is what the migration follows, so it installs qhead directly instead
of installing the stale pin and needing a second pass.

Two owner runbook steps this PR creates:

1. **Reinstall the build gate** on the Mac (`scripts/mac/localvoxtral-build-gate.sh`).
   The gate allowlists the integration payload by exact string; until it is
   reinstalled, `./scripts/remote-build.sh integration` from a dev box is
   rejected. CI is unaffected (it runs `swift test` directly, not through the gate).
2. **Pre-download qhead** into the owner's HF cache per the updated README step 3
   before bootstrapping `com.localvoxtral.testspeechd`.

Heads-up from `./scripts/mac-health.sh`: the build host is at **9 GiB free**
(98% used). The speechd integration lane self-provisions qhead weights, so a
`./scripts/remote-build.sh gc` may be wanted before the migration.

## Proof

- [x] **Unit suite green** — `./scripts/remote-build.sh`

```
Test Suite 'localvoxtralPackageTests.xctest' passed at 2026-07-28 09:25:02.548.
	 Executed 2015 tests, with 2 tests skipped and 0 failures (0 unexpected) in 71.709 (71.801) seconds
```

- [x] **SpeechHelper unit suite green** — `./scripts/remote-build.sh test --package-path SpeechHelper`

```
Test Suite 'SpeechHelperPackageTests.xctest' passed at 2026-07-28 09:28:05.929.
	 Executed 47 tests, with 0 failures (0 unexpected) in 0.010 (0.012) seconds
```

- [x] **The two repinned suites, focused:**

`./scripts/remote-build.sh test --package-path SpeechHelper --filter SpeechdLaunchOptionsTests`

```
Test Suite 'SpeechdLaunchOptionsTests' passed at 2026-07-28 09:28:34.487.
	 Executed 10 tests, with 0 failures (0 unexpected) in 0.004 (0.004) seconds
```

`./scripts/remote-build.sh test --filter SettingsStoreTests`

```
Test Suite 'SettingsStoreTests' passed at 2026-07-28 09:28:11.794.
	 Executed 75 tests, with 0 failures (0 unexpected) in 0.136 (0.139) seconds
```

- [x] **Shell syntax** — `bash -n scripts/remote-build.sh scripts/mac/localvoxtral-build-gate.sh` → OK

### Not a weakened test

`SettingsStoreTests.testEffectiveModelName_managedLocal_returnsSpeechdModelIgnoringExternalOverride`
asserts the External URL placeholder against a **spelled-out literal on
purpose** — so an accidental change to the default is caught. Updating the
literal alongside the source is a **pin change**: same assertion, same
strictness, one fewer stale name. A comment in the test now says so, so the next
reader doesn't have to re-derive it. No threshold moved, no assertion removed,
no skip added.

### LLM / speechd lane decisions

Both filters were run against this exact diff (`git diff --name-only origin/main`):

```
$ scripts/ci/speechd-lane-filter.sh changed.txt
run=true
reason=matched SpeechHelper/Tests/SpeechEngineTextTests/SpeechdLaunchOptionsTests.swift (SpeechHelper/*)

$ scripts/ci/llm-lane-filter.sh changed.txt
run=true
reason=matched Tests/localvoxtralTests/AgentDictationE2EEvalSupport.swift (*AgentDictationE2EEval*)

$ scripts/ci/docs-only-filter.sh changed.txt
docs_only=false
count=1
reason=workflow path: .github/workflows/ci.yml
```

**Both live-model lanes ran in CI on this PR and passed** —
[run 30338696613](https://github.com/T0mSIlver/localvoxtral/actions/runs/30338696613)
(`build-test` pass, 6m46s), and re-ran green on the current head after the review
nit — [run 30340673836](https://github.com/T0mSIlver/localvoxtral/actions/runs/30340673836)
@ `7b9876a`, `build-test` pass 6m31s, both lanes RUNNING, identical numbers
(unit 2024/0, tier-1 7/0 @ 0.804, speechd 4/0 @ 0.804, polishd 6/0).
Step summary decisions:

```
LLM eval lane: RUNNING (matched Tests/localvoxtralTests/AgentDictationE2EEvalSupport.swift (*AgentDictationE2EEval*))
Speechd integration lane: RUNNING (matched SpeechHelper/Tests/SpeechEngineTextTests/SpeechdLaunchOptionsTests.swift (SpeechHelper/*))
```

Results:

```
Test (unit suite)
  Executed 2024 tests, with 11 tests skipped and 0 failures (0 unexpected) in 71.109 s

Integration tests (live STT service)        # tier 1
  Executed 7 tests, with 2 tests skipped and 0 failures (0 unexpected) in 33.704 s
  speechd integration: word accuracy 0.804

Speech helper integration (real audio + live model)   # SpeechHelperIntegrationTests
  Executed 4 tests, with 0 failures (0 unexpected) in 24.810 s
  speechd integration: word accuracy 0.804

Polishing helper integration (live model + eval baseline)
  Executed 6 tests, with 0 failures (0 unexpected) in 80.676 s
  == required: 7/7, known-hard passing: 10/10 ==          (standard profile)
  == required: 1/1, known-hard passing: 7/8 ==            (agent profile)
```

`SpeechHelperIntegrationTests` reads `SpeechModelCatalog.defaultOption` (already
qhead, unchanged by this PR), so **0.804 word accuracy is a live re-confirmation
of the qhead checkpoint itself** — comfortably above the 0.759 the per-model gate
recorded when it was adopted (#232). The polishd lane is unaffected by an ASR
repin; it ran because `AgentDictationE2EEvalSupport.swift` is in the LLM filter,
and it stayed at baseline.

**Not re-run locally:** the multi-minute per-model quality gate
(`remote-build.sh integration-speechd T0mSIlver/…-qhead`) — CI's speechd lane
above covers exactly that ground with the same checkpoint, so re-running it by
hand would only repeat it. This PR changes no weights, only which name the
test/infra/doc layer prints and which one the runbook installs.

**eval-e2e not run:** this PR cannot change what the nightly eval measures — the
served ASR model is set by the launchd plist, and the polish side is untouched.
It only fixes the checkpoint name printed in that eval's own scoreboard header.

### Residual references — every remaining hit accounted for

`grep -rn "MLX-4bit"`:

- `Tests/localvoxtralTests/SettingsStoreTests.swift:357` — the word appears
  inside the new explanatory comment ("the qhead checkpoint replaced the stale
  MLX-4bit conversion"). Not a reference.

`grep -rn "mlx-community/Voxtral"`:

- `scripts/mac/convert-qhead-checkpoint.py:42` — `SOURCE_REPO`. **Correct as-is:**
  mlx-community is the *input* the qhead checkpoint is converted *from*.
  Its `SOURCE_REVISION` comment did say "SpeechModelCatalog pin", which was true
  before this PR and would now read as a sync invariant that no longer holds —
  the catalog pins the qhead **output** repo. Reworded to frozen-input framing
  (`7b9876a`) so nobody "fixes" the drift and silently re-derives qhead from a
  different source snapshot. Comment only; both values unchanged.

`grep -rn "mistralai/Voxtral-Mini-4B-Realtime-2602"` (deliberately untouched —
upstream full-precision model for CUDA/vLLM users):

- `README.md:22`, `:52`, `:150`, `:153` — user-facing vLLM example + model links
- `Tests/localvoxtralTests/RealtimeAPIVLLMIntegrationTests.swift:22`, `:33` —
  the vLLM-mode default/doc string
- `Sources/localvoxtral/Backends/SpeechModelCatalog.swift:14` — a comment naming
  the model qhead is a conversion of

`README.md:138` was already qhead. `mlx-community/Qwen3.5-4B-OptiQ-4bit` in the
mac runbook is the *polish* model — out of scope.
