### PR TITLE
Runbook: repin speechd test service to the qhead catalog default

### DIFF
--- a/Tests/localvoxtralTests/MacTestServerRunbookPinTests.swift
+++ b/Tests/localvoxtralTests/MacTestServerRunbookPinTests.swift
@@ -1,0 +1,74 @@
+import Foundation
+import XCTest
+@testable import localvoxtral
+
+/// `scripts/mac/README.md` is the owner runbook for the on-demand test
+/// services, and it embeds complete launchd plists plus `hf download` commands
+/// with model pins. Its own rule — "keep these pins in sync with
+/// `SpeechModelCatalog.defaultOption` and `PolishModelCatalog.defaultOption`" —
+/// drifted almost immediately: #186 moved the speech default to the qhead
+/// repo while the runbook kept the retired mlx-community pin, so anyone
+/// installing from the runbook verbatim would silently reintroduce the old
+/// model and tier-1 would measure a backend production no longer ships.
+/// Prose sync rules drift; these assertions do not.
+final class MacTestServerRunbookPinTests: XCTestCase {
+    private func runbook() throws -> String {
+        let root = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent() // localvoxtralTests
+            .deletingLastPathComponent() // Tests
+            .deletingLastPathComponent() // repo root
+        return try String(
+            contentsOf: root.appendingPathComponent("scripts/mac/README.md"),
+            encoding: .utf8
+        )
+    }
+
+    /// Values from runbook plist lines shaped
+    /// `<string>FLAG</string><string>VALUE</string>`.
+    private func plistValues(after flag: String, in text: String) -> [String] {
+        text.split(separator: "\n").compactMap { line in
+            guard let flagRange = line.range(of: "<string>\(flag)</string><string>") else {
+                return nil
+            }
+            let tail = line[flagRange.upperBound...]
+            guard let end = tail.range(of: "</string>") else { return nil }
+            return String(tail[..<end.lowerBound])
+        }
+    }
+
+    func testEveryRunbookPlistModelPinIsACurrentCatalogDefault() throws {
+        // Set equality both ways: a stale pin fails (it is not a default), and
+        // a missing service section fails (a default is not pinned anywhere).
+        let text = try runbook()
+        XCTAssertEqual(
+            Set(plistValues(after: "--model", in: text)),
+            [SpeechModelCatalog.defaultOption.repoID, PolishModelCatalog.defaultOption.repoID],
+            "every plist --model in the runbook must be a current catalog default"
+        )
+        XCTAssertEqual(
+            Set(plistValues(after: "--model-revision", in: text)),
+            [SpeechModelCatalog.defaultOption.revision, PolishModelCatalog.defaultOption.revision],
+            "every plist --model-revision in the runbook must be a current catalog pin"
+        )
+    }
+
+    func testRunbookDownloadCommandsMatchTheCatalogDefaults() throws {
+        // The pre-download step is what puts weights where launchd's services
+        // can load them; a stale repo here makes the service relaunch-loop on
+        // a missing model with nothing in the runbook to explain it.
+        let text = try runbook()
+        for option in [
+            (SpeechModelCatalog.defaultOption.repoID, SpeechModelCatalog.defaultOption.revision),
+            (PolishModelCatalog.defaultOption.repoID, PolishModelCatalog.defaultOption.revision),
+        ] {
+            XCTAssertTrue(
+                text.contains("hf download \(option.0)"),
+                "the runbook must pre-download \(option.0)"
+            )
+            XCTAssertTrue(
+                text.contains("--revision \(option.1)"),
+                "the runbook must pin \(option.0) to revision \(option.1)"
+            )
+        }
+    }
+}

--- a/Tests/localvoxtralTests/MacTestServerRunbookPinTests.swift
+++ b/Tests/localvoxtralTests/MacTestServerRunbookPinTests.swift
@@ -6,12 +6,38 @@ import XCTest
 /// services, and it embeds complete launchd plists plus `hf download` commands
 /// with model pins. Its own rule — "keep these pins in sync with
 /// `SpeechModelCatalog.defaultOption` and `PolishModelCatalog.defaultOption`" —
-/// drifted almost immediately: #186 moved the speech default to the qhead
-/// repo while the runbook kept the retired mlx-community pin, so anyone
+/// drifted almost immediately: #169 moved the speech default to the qhead
+/// repo while the runbook kept the pin #176 had installed, so anyone
 /// installing from the runbook verbatim would silently reintroduce the old
 /// model and tier-1 would measure a backend production no longer ships.
 /// Prose sync rules drift; these assertions do not.
+///
+/// Pins are checked as PER-SERVICE (repo, revision) PAIRS, never as
+/// independent sets: independent sets would accept the two services'
+/// revisions swapped — a runbook state where `hf download` rejects both
+/// commands and both services relaunch-loop on a missing snapshot.
 final class MacTestServerRunbookPinTests: XCTestCase {
+    private struct ServicePin {
+        let binary: String
+        let repoID: String
+        let revision: String
+    }
+
+    private var expectedPins: [ServicePin] {
+        [
+            ServicePin(
+                binary: "localvoxtral-speechd",
+                repoID: SpeechModelCatalog.defaultOption.repoID,
+                revision: SpeechModelCatalog.defaultOption.revision
+            ),
+            ServicePin(
+                binary: "localvoxtral-polishd",
+                repoID: PolishModelCatalog.defaultOption.repoID,
+                revision: PolishModelCatalog.defaultOption.revision
+            ),
+        ]
+    }
+
     private func runbook() throws -> String {
         let root = URL(fileURLWithPath: #filePath)
             .deletingLastPathComponent() // localvoxtralTests
@@ -23,52 +49,87 @@ final class MacTestServerRunbookPinTests: XCTestCase {
         )
     }
 
-    /// Values from runbook plist lines shaped
-    /// `<string>FLAG</string><string>VALUE</string>`.
-    private func plistValues(after flag: String, in text: String) -> [String] {
-        text.split(separator: "\n").compactMap { line in
-            guard let flagRange = line.range(of: "<string>\(flag)</string><string>") else {
-                return nil
-            }
-            let tail = line[flagRange.upperBound...]
-            guard let end = tail.range(of: "</string>") else { return nil }
-            return String(tail[..<end.lowerBound])
+    /// The plist window for one service: from its binary path to the close of
+    /// that `ProgramArguments` array. Scoping the search here is what makes a
+    /// stray mention elsewhere in the doc (prose, comments, another snippet)
+    /// unable to satisfy the assertion.
+    private func serviceWindow(binary: String, in text: String) throws -> String {
+        let anchor = try XCTUnwrap(
+            text.range(of: "/\(binary)</string>"),
+            "the runbook must embed a plist running \(binary)"
+        )
+        let tail = text[anchor.upperBound...]
+        let end = try XCTUnwrap(
+            tail.range(of: "</array>"),
+            "\(binary)'s ProgramArguments array never closes"
+        )
+        return String(tail[..<end.lowerBound])
+    }
+
+    /// The single value of `<string>FLAG</string> <string>VALUE</string>`
+    /// inside `window`, tolerant of the value landing on the next line.
+    /// Exactly one occurrence — zero means the pin is gone, two means the
+    /// window boundary or the plist grew ambiguous; both must fail loudly.
+    private func plistValue(
+        after flag: String, inWindow window: String, service: String
+    ) throws -> String {
+        let pattern = "<string>\(NSRegularExpression.escapedPattern(for: flag))</string>"
+            + "\\s*<string>([^<]+)</string>"
+        let expression = try NSRegularExpression(pattern: pattern)
+        let matches = expression.matches(
+            in: window, range: NSRange(window.startIndex..., in: window)
+        )
+        XCTAssertEqual(
+            matches.count, 1,
+            "\(service): expected exactly one \(flag) in its plist block, found \(matches.count)"
+        )
+        let match = try XCTUnwrap(matches.first)
+        let valueRange = try XCTUnwrap(Range(match.range(at: 1), in: window))
+        return String(window[valueRange])
+    }
+
+    func testEachServicePlistPinsItsOwnCatalogDefault() throws {
+        // Pairing, per service: speechd's block must carry speechd's repo AND
+        // revision, polishd's block polishd's. A swapped pair, a stale value,
+        // and a missing service section each fail on their own line.
+        let text = try runbook()
+        for pin in expectedPins {
+            let window = try serviceWindow(binary: pin.binary, in: text)
+            XCTAssertEqual(
+                try plistValue(after: "--model", inWindow: window, service: pin.binary),
+                pin.repoID,
+                "\(pin.binary) plist must run the current catalog default repo"
+            )
+            XCTAssertEqual(
+                try plistValue(after: "--model-revision", inWindow: window, service: pin.binary),
+                pin.revision,
+                "\(pin.binary) plist must pin the current catalog revision"
+            )
         }
     }
 
-    func testEveryRunbookPlistModelPinIsACurrentCatalogDefault() throws {
-        // Set equality both ways: a stale pin fails (it is not a default), and
-        // a missing service section fails (a default is not pinned anywhere).
-        let text = try runbook()
-        XCTAssertEqual(
-            Set(plistValues(after: "--model", in: text)),
-            [SpeechModelCatalog.defaultOption.repoID, PolishModelCatalog.defaultOption.repoID],
-            "every plist --model in the runbook must be a current catalog default"
-        )
-        XCTAssertEqual(
-            Set(plistValues(after: "--model-revision", in: text)),
-            [SpeechModelCatalog.defaultOption.revision, PolishModelCatalog.defaultOption.revision],
-            "every plist --model-revision in the runbook must be a current catalog pin"
-        )
-    }
-
-    func testRunbookDownloadCommandsMatchTheCatalogDefaults() throws {
+    func testEveryDownloadCommandIsACatalogDefaultPair() throws {
         // The pre-download step is what puts weights where launchd's services
-        // can load them; a stale repo here makes the service relaunch-loop on
-        // a missing model with nothing in the runbook to explain it.
+        // can load them; a stale or cross-wired pair makes a service
+        // relaunch-loop on a missing snapshot with nothing in the runbook to
+        // explain it. Repo and revision are matched as one command-level pair
+        // (the `\` continuation puts --revision on the following line), and
+        // the complete mapping must equal the catalog defaults — a swapped,
+        // extra, or missing pair all fail.
         let text = try runbook()
-        for option in [
-            (SpeechModelCatalog.defaultOption.repoID, SpeechModelCatalog.defaultOption.revision),
-            (PolishModelCatalog.defaultOption.repoID, PolishModelCatalog.defaultOption.revision),
-        ] {
-            XCTAssertTrue(
-                text.contains("hf download \(option.0)"),
-                "the runbook must pre-download \(option.0)"
-            )
-            XCTAssertTrue(
-                text.contains("--revision \(option.1)"),
-                "the runbook must pin \(option.0) to revision \(option.1)"
-            )
+        let pattern = "hf download (\\S+) \\\\\\s*--revision ([0-9a-f]{40})"
+        let expression = try NSRegularExpression(pattern: pattern)
+        let matches = expression.matches(in: text, range: NSRange(text.startIndex..., in: text))
+        var downloaded: [String: String] = [:]
+        for match in matches {
+            let repoRange = try XCTUnwrap(Range(match.range(at: 1), in: text))
+            let revisionRange = try XCTUnwrap(Range(match.range(at: 2), in: text))
+            downloaded[String(text[repoRange])] = String(text[revisionRange])
         }
+        XCTAssertEqual(
+            downloaded,
+            Dictionary(uniqueKeysWithValues: expectedPins.map { ($0.repoID, $0.revision) }),
+            "the runbook's hf download pairs must be exactly the catalog defaults"
+        )
     }
 }


### PR DESCRIPTION
## What

The owner runbook (`scripts/mac/README.md`) still pinned speechd's test service to the retired `mlx-community/Voxtral-Mini-4B-Realtime-2602-4bit @ fdebf7b2` in both the `hf download` step and the embedded launchd plist — but #169 moved `SpeechModelCatalog.defaultOption` to `T0mSIlver/Voxtral-Mini-4B-Realtime-2602-4bit-qhead @ 247f2eec`. Anyone installing from the runbook verbatim (as the runbook's own "keep these pins in sync" rule warns) would silently reintroduce the old model, and tier-1 would measure a backend production no longer ships. Flagged during the 2026-07-27/28 test-services migration (the live service was installed with the correct qhead pin; only the doc drifted).

Both pins updated, and — since the prose sync rule drifted within days of being written — `MacTestServerRunbookPinTests` now pins the runbook to the catalogs: every plist `--model`/`--model-revision` in the doc must equal a current `SpeechModelCatalog`/`PolishModelCatalog` default (set equality, so a stale pin AND a missing service section both fail), and the `hf download` commands must name the same repo+revision.

## Proof

- [x] Regression test added — failing before the fix (stale runbook, new tests):
  ```
  MacTestServerRunbookPinTests.swift:43: XCTAssertEqual failed: ("["mlx-community/Voxtral-Mini-4B-Realtime-2602-4bit", …]") is not equal to ("["T0mSIlver/Voxtral-Mini-4B-Realtime-2602-4bit-qhead", …]")
       Executed 2 tests, with 4 failures (0 unexpected) in 0.200 (0.200) seconds
  ```
  Passing after:
  ```
  Test Suite 'MacTestServerRunbookPinTests' passed at 2026-07-28 11:29:08.081.
  ```
- [x] Tier-1 against the live migrated testspeechd (new gate, Swift helper, qhead model), run from the Linux box via the gate's `ensure`:
  ```
  Executed 7 tests, with 2 tests skipped and 0 failures (0 unexpected) in 19.090 (19.091) seconds
  speechd integration: word accuracy 0.759
  ```
- [x] LLM lanes: not required — docs + a doc-pinning test; nothing that reaches a model changed.