### PR TITLE
TUI trailing-space follow-up: path abstention, NBSP buffering, documented tradeoff (codex review of #198)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -430,6 +430,17 @@ Key subsystems:
 
 ## Known tradeoffs — deliberate, not bugs
 
+- **The TUI trailing-space policy judges this dictation's text only.** The
+  terminal stop-flush verdict (`TUIAutocompleteTrailingSpace`, applied in
+  `TextInsertionService`) cannot see text the field already held before
+  dictation started, so dictating a lone command shape (`/compact `) into a
+  prompt line pre-populated by hand withholds a trailing space no popup
+  consumed. Accepted: the insertion path has no field-read capability and no
+  popup-state signal exists, mid-line command-shaped dictation is rare, and
+  the dismissed-popup case the policy exists for is the common one (pinned by
+  `testPrePopulatedFieldTextCannotRescueTheTrailingSpace`). Single-component
+  tokens naming an EXISTING absolute path (`/tmp `) abstain via a
+  filesystem-existence seam; non-existing ones (`/compact`) stay commands.
 - **Live Auto-Paste holds back the tail of the transcript.** Replacements are
   applied before typing (nothing is ever un-typed — there are no backspaces in
   the insertion path, and terminals can't support them: field bug 2026-07-06),

--- a/Sources/localvoxtral/LiveHoldBackReplacementStream.swift
+++ b/Sources/localvoxtral/LiveHoldBackReplacementStream.swift
@@ -44,13 +44,18 @@ import Foundation
 /// and submit a prompt mid-dictation, and a typed Tab can trigger shell
 /// completion UI — both mutate terminal state. When `sanitizesNewlines` is
 /// on, every whitespace run containing a newline or tab — including all
-/// adjacent spaces/tabs on BOTH sides of it — collapses to exactly one
+/// adjacent whitespace on BOTH sides of it — collapses to exactly one
 /// space, even when the run spans release boundaries or ends in the flushed
-/// remainder. To decide a run's fate, trailing spaces/tabs are buffered
-/// until the next non-whitespace character (or the remainder flush); plain
-/// space runs are then re-emitted verbatim, so no dictated text is ever
-/// dropped. Collapse runs at the very start of the session produce no
-/// leading space.
+/// remainder. To decide a run's fate, EVERY trailing whitespace character —
+/// not just ASCII space, but also the NBSP/narrow-NBSP French typography
+/// puts before `?!:;` — is buffered until the next non-whitespace character
+/// (or the remainder flush); runs without a newline or tab are then
+/// re-emitted verbatim, so no dictated text is ever dropped or rewritten.
+/// Buffering the full whitespace set is load-bearing: it is what makes
+/// `flushRemainder()` the only path that can emit a trailing whitespace
+/// character to a terminal, which the TUI-autocomplete trailing-space policy
+/// relies on (`TUIAutocompleteTrailingSpace`). Collapse runs at the very
+/// start of the session produce no leading space.
 struct LiveHoldBackReplacementStream {
     /// How much text `safeReleaseLimit()` may release mid-session, chosen
     /// once per rule set (see the type doc's caveats, most conservative
@@ -83,11 +88,12 @@ struct LiveHoldBackReplacementStream {
     // Newline/tab sanitization state, persisted across releases so whitespace
     // runs spanning chunk boundaries still collapse to a single space.
     // Starts "as if a space was emitted" so leading collapse runs are
-    // dropped. `pendingPlainSpaces` buffers spaces whose run fate (verbatim
-    // vs collapsed) is not yet known; `pendingRunNeedsCollapse` marks the
-    // current whitespace run as containing a newline or tab.
+    // dropped. `pendingPlainWhitespace` buffers whitespace (space, NBSP, …)
+    // whose run fate (verbatim vs collapsed) is not yet known;
+    // `pendingRunNeedsCollapse` marks the current whitespace run as
+    // containing a newline or tab.
     private var lastEmittedCharacterWasSpace = true
-    private var pendingPlainSpaces = ""
+    private var pendingPlainWhitespace = ""
     private var pendingRunNeedsCollapse = false
 
     init(dictionary: ReplacementDictionary, sanitizesNewlines: Bool) {
@@ -279,11 +285,13 @@ struct LiveHoldBackReplacementStream {
     }
 
     /// Collapses every whitespace run containing a newline or tab — with all
-    /// adjacent spaces/tabs on both sides — into a single space, without ever
-    /// producing double spaces. Trailing spaces are buffered (not emitted)
-    /// until the next non-whitespace character or the remainder flush decides
-    /// whether the run stays verbatim or collapses; state persists across
-    /// release boundaries.
+    /// adjacent whitespace on both sides — into a single space, without ever
+    /// producing double spaces. Every trailing whitespace character (the full
+    /// `Character.isWhitespace` set — ASCII space, NBSP, narrow NBSP, …) is
+    /// buffered (not emitted) until the next non-whitespace character or the
+    /// remainder flush decides whether the run stays verbatim or collapses;
+    /// state persists across release boundaries. Verbatim re-emission
+    /// preserves the exact characters, so French NBSP spacing survives.
     private mutating func sanitizingNewlines(in text: String) -> String {
         var output = ""
         output.reserveCapacity(text.count)
@@ -291,12 +299,12 @@ struct LiveHoldBackReplacementStream {
         for character in text {
             if character.isNewline || character == "\t" {
                 pendingRunNeedsCollapse = true
-                pendingPlainSpaces = ""
+                pendingPlainWhitespace = ""
                 continue
             }
-            if character == " " {
+            if character.isWhitespace {
                 if !pendingRunNeedsCollapse {
-                    pendingPlainSpaces.append(" ")
+                    pendingPlainWhitespace.append(character)
                 }
                 continue
             }
@@ -314,11 +322,11 @@ struct LiveHoldBackReplacementStream {
                 output.append(" ")
                 lastEmittedCharacterWasSpace = true
             }
-        } else if !pendingPlainSpaces.isEmpty {
-            output.append(pendingPlainSpaces)
+        } else if !pendingPlainWhitespace.isEmpty {
+            output.append(pendingPlainWhitespace)
             lastEmittedCharacterWasSpace = true
         }
-        pendingPlainSpaces = ""
+        pendingPlainWhitespace = ""
         pendingRunNeedsCollapse = false
     }
 }

--- a/Sources/localvoxtral/TUIAutocompleteTrailingSpace.swift
+++ b/Sources/localvoxtral/TUIAutocompleteTrailingSpace.swift
@@ -19,7 +19,13 @@ import Foundation
 ///   `[A-Za-z0-9_-]`. A token holding a SECOND `/` is a filesystem path
 ///   (`/usr/bin`, `/tmp/x`), never a slash command, and is left alone — as is
 ///   any text with other words in it (`fix /compact please`), where the popup
-///   is already closed and the trailing space is dictated content. Slash
+///   is already closed and the trailing space is dictated content. A
+///   single-component token satisfies the same syntax, so a token naming an
+///   EXISTING absolute path (`/tmp`, `/Applications`) abstains too: no agent
+///   TUI ships a command that collides with a root-level entry on the same
+///   machine, so existence is decisive, and a NON-existing token stays a
+///   command — dictating a path to a file that is not there is far rarer than
+///   dictating the command whose popup is open. Slash
 ///   command names are ASCII by construction in every agent TUI we target, so
 ///   a non-ASCII token (`/compacté`) abstains rather than guessing.
 /// - **Trailing mention**: the last whitespace-separated token is `@` plus a
@@ -59,7 +65,15 @@ enum TUIAutocompleteTrailingSpace {
 
     /// Returns `text` with its trailing whitespace removed when the text is one
     /// of the two autocomplete shapes above; otherwise returns `text` unchanged.
-    static func stripped(_ text: String) -> String {
+    ///
+    /// `isExistingAbsolutePath` is the filesystem-existence seam for the
+    /// single-component-path abstention (tests inject a fixed set so they do
+    /// not depend on the host filesystem); production uses the default, one
+    /// `FileManager` stat on the stop flush.
+    static func stripped(
+        _ text: String,
+        isExistingAbsolutePath: (String) -> Bool = { FileManager.default.fileExists(atPath: $0) }
+    ) -> String {
         var body = text
         while let last = body.last, last.isWhitespace {
             body.removeLast()
@@ -70,7 +84,12 @@ enum TUIAutocompleteTrailingSpace {
         // Leading whitespace belongs to neither shape's recognition (and is
         // preserved either way — only the tail is ever cut).
         let candidate = body.drop(while: \.isWhitespace)
-        guard isLoneSlashCommand(candidate) || endsWithMentionToken(candidate) else {
+        if isLoneSlashCommand(candidate) {
+            // `/tmp` passes the syntax test but names a root-level entry: it
+            // is the path the user dictated, not a command (see the type doc).
+            return isExistingAbsolutePath(String(candidate)) ? text : body
+        }
+        guard endsWithMentionToken(candidate) else {
             return text
         }
         return body

--- a/Sources/localvoxtral/TextInsertionService.swift
+++ b/Sources/localvoxtral/TextInsertionService.swift
@@ -454,15 +454,28 @@ final class TextInsertionService {
     ///
     /// The stop flush is the complete choke point for a terminal session: with
     /// newline sanitization on, `LiveHoldBackReplacementStream` buffers every
-    /// trailing space run until the next non-whitespace character, so no
-    /// mid-session release can ever END in whitespace — the only trailing space
-    /// a terminal ever sees is the one emitted here.
+    /// trailing whitespace run — the full `Character.isWhitespace` set, NBSP
+    /// included — until the next non-whitespace character, so no mid-session
+    /// release can ever END in whitespace — the only trailing space a terminal
+    /// ever sees is the one emitted here.
     ///
     /// The verdict is taken on the whole session's text, but only the
     /// not-yet-typed tail may be cut (`min` below). That is the same
     /// never-un-type invariant the hold-back stream enforces: text already
     /// handed to the field is in the user's app and there are no backspaces in
     /// the insertion path.
+    ///
+    /// ACCEPTED LIMITATION (codex review of #198): "the whole session's text"
+    /// is exactly that — text the FIELD already held before dictation started
+    /// is invisible here. The insertion path cannot read field content and no
+    /// popup-state signal exists, so dictating a command-shaped utterance
+    /// (`/compact `) after a hand-typed `fix ` prefix withholds a space no
+    /// popup consumed, and the user's next keystroke glues to `/compact`.
+    /// Accepted deliberately: mid-line command-shaped dictation into a
+    /// pre-populated prompt is rare, while the dismissed-popup case this
+    /// policy exists for — a genuinely lone command — is the common one.
+    /// Pinned by `testPrePopulatedFieldTextCannotRescueTheTrailingSpace`;
+    /// changing that behavior is a policy revision, not a refactor.
     private func withholdingTUIAutocompleteTrailingSpace(_ releasedText: String) -> String {
         let sessionText = liveTypedTextForSession + releasedText
         let stripped = TUIAutocompleteTrailingSpace.stripped(sessionText)

--- a/Tests/localvoxtralTests/LiveHoldBackReplacementStreamTests.swift
+++ b/Tests/localvoxtralTests/LiveHoldBackReplacementStreamTests.swift
@@ -288,6 +288,25 @@ final class LiveHoldBackReplacementStreamTests: XCTestCase {
         XCTAssertEqual(stream.flushRemainder(), " ")
     }
 
+    /// French typography: the NBSP before `?` is dictated content. It is
+    /// buffered like a plain space (so no release ends in whitespace) and
+    /// re-emitted VERBATIM — sanitization must not rewrite it to an ASCII
+    /// space, which would change the user's French spacing.
+    func testNonBreakingSpaceIsBufferedAndReemittedVerbatim() {
+        var stream = makeStream(entries: [voxtralEntry], sanitizesNewlines: true)
+        XCTAssertEqual(stream.ingest("oui\u{00A0}"), "oui")
+        XCTAssertEqual(stream.ingest("? "), "\u{00A0}?")
+        XCTAssertEqual(stream.flushRemainder(), " ")
+    }
+
+    /// An NBSP adjacent to a newline joins the run: the whole run collapses
+    /// to exactly one ASCII space, same as adjacent plain spaces.
+    func testNonBreakingSpaceAdjacentToNewlineCollapsesWithTheRun() {
+        var stream = makeStream(entries: [voxtralEntry], sanitizesNewlines: true)
+        XCTAssertEqual(stream.ingest("a\u{00A0}\nb "), "a b")
+        XCTAssertEqual(stream.flushRemainder(), " ")
+    }
+
     func testFlushedRemainderIsSanitized() {
         var stream = makeStream(
             entries: [ReplacementEntry(replaceWith: "X", matches: ["run something"])],
@@ -356,6 +375,15 @@ final class LiveHoldBackReplacementStreamTests: XCTestCase {
             ["\n\nleading "],
             [" "],
             ["\t\n "],
+            // Non-ASCII whitespace (codex review of #198, finding 3): French
+            // typography puts NBSP (U+00A0) / narrow NBSP (U+202F) before
+            // `?!:;`, and the ASR path never normalizes them away — they are
+            // whitespace and must be buffered exactly like a plain space,
+            // never emitted at the tail of a mid-session release.
+            ["mot\u{00A0}"],
+            ["/compact\u{00A0}"],
+            ["continuer\u{202F}"],
+            ["oui\u{00A0}", "? "],
         ]
 
         for chunks in chunkSequences {

--- a/Tests/localvoxtralTests/TUIAutocompleteTrailingSpaceTests.swift
+++ b/Tests/localvoxtralTests/TUIAutocompleteTrailingSpaceTests.swift
@@ -48,6 +48,44 @@ final class TUIAutocompleteTrailingSpaceTests: XCTestCase {
         XCTAssertEqual(TUIAutocompleteTrailingSpace.stripped("/ "), "/ ")
     }
 
+    /// A SINGLE-component token satisfies the slash-command syntax too, but
+    /// `/tmp` or `/Applications` is a filesystem path the user dictated, not a
+    /// command (codex review of #198, finding 2). The default existence seam
+    /// is the real filesystem: `/tmp` and `/Applications` exist on every macOS
+    /// host this suite runs on, so their trailing space must stay.
+    func testSingleComponentExistingAbsolutePathKeepsItsTrailingSpace() {
+        XCTAssertEqual(TUIAutocompleteTrailingSpace.stripped("/tmp "), "/tmp ")
+        XCTAssertEqual(TUIAutocompleteTrailingSpace.stripped("/bin "), "/bin ")
+        XCTAssertEqual(
+            TUIAutocompleteTrailingSpace.stripped("/Applications "),
+            "/Applications "
+        )
+    }
+
+    /// Same rule, host-independent via the injected existence seam: existence
+    /// is decisive in BOTH directions — an existing path abstains, and a
+    /// non-existing token (a real command like `/compact`, or nonsense like
+    /// `/frobnicate`) is still treated as the command whose popup is open.
+    func testExistenceSeamDecidesSingleComponentTokens() {
+        let exists: (String) -> Bool = { ["/tmp", "/Applications"].contains($0) }
+        XCTAssertEqual(
+            TUIAutocompleteTrailingSpace.stripped("/tmp ", isExistingAbsolutePath: exists),
+            "/tmp "
+        )
+        XCTAssertEqual(
+            TUIAutocompleteTrailingSpace.stripped(" /Applications ", isExistingAbsolutePath: exists),
+            " /Applications "
+        )
+        XCTAssertEqual(
+            TUIAutocompleteTrailingSpace.stripped("/compact ", isExistingAbsolutePath: exists),
+            "/compact"
+        )
+        XCTAssertEqual(
+            TUIAutocompleteTrailingSpace.stripped("/frobnicate ", isExistingAbsolutePath: exists),
+            "/frobnicate"
+        )
+    }
+
     func testMultiWordTextIsUntouched() {
         XCTAssertEqual(
             TUIAutocompleteTrailingSpace.stripped(" /cmd extra words "),
@@ -291,6 +329,38 @@ final class TUIAutocompleteTrailingSpaceTests: XCTestCase {
         service.flushFinalLiveReplacementCorrections()
 
         XCTAssertEqual(typed.value.joined(), "/compact now")
+        service.endLiveReplacementSession()
+    }
+
+    /// ACCEPTED LIMITATION, pinned (codex review of #198, finding 1): the
+    /// stop-flush verdict sees only THIS session's text. Here the focused
+    /// field already holds a hand-typed "fix " before dictation starts — the
+    /// real prompt line is "fix /compact", mid-line, no popup open — but the
+    /// insertion path cannot read field content and no popup-state signal
+    /// exists, so the dictated "/compact " still looks like a lone slash
+    /// command and its trailing space is withheld. Accepted because mid-line
+    /// command-shaped dictation into a pre-populated prompt is rare and the
+    /// dismissed-popup case the policy exists for is the common one. If this
+    /// test starts failing, someone changed that judgment — make sure it was
+    /// a conscious decision, not a refactor side effect.
+    func testPrePopulatedFieldTextCannotRescueTheTrailingSpace() {
+        let typed = Box<[String]>([])
+        let service = makeService(capturing: typed)
+        // Nothing models the pre-existing "fix " on purpose: there is no seam
+        // through which the service could ever observe it.
+        service.beginLiveReplacementSession(
+            dictionary: nil,
+            preferredAppPID: nil,
+            isTerminalLikeTarget: true
+        )
+
+        service.enqueueRealtimeInsertion("/compact ")
+        service.flushFinalLiveReplacementCorrections()
+
+        XCTAssertEqual(
+            typed.value.joined(), "/compact",
+            "the session-local verdict must strip: field content is invisible by design"
+        )
         service.endLiveReplacementSession()
     }
 


### PR DESCRIPTION
## What

Follow-up to #198 (merged before its codex/GPT-5.6 review landed); fixes the review's three findings on main.

1. **Single-component absolute paths lost their trailing space (Medium).** `isLoneSlashCommand` accepted any `/token`, so dictating `/tmp `, `/bin `, or `/Applications ` into any terminal glued the next typed word. The predicate now abstains when the lone token names an **existing absolute path** — one `stat` on the stop flush, injected as a seam (`isExistingAbsolutePath`, default `FileManager.default.fileExists`) so tests are host-independent. `/compact ` still strips (no such root path).
2. **The "no ingest output ends in whitespace" invariant was silently false for French (Low).** The sanitizer buffered only ASCII space/tab/newline; NBSP passed straight through — and production never normalizes NBSP (`normalizeTranscriptionFormatting` is not in the live path), so French ASR's NBSP-before-`?!:;` could reach a terminal mid-session, breaking the choke point the TUI policy depends on. The buffered set is now all of `Character.isWhitespace`; newline/tab remain the only collapse triggers, and buffered runs re-emit **verbatim**, so French NBSP spacing survives (pinned by test). Word bookkeeping (`LiveReplacementCorrector`) was already whitespace-general — only the emit path lagged.
3. **Pre-populated field text is invisible to the policy (High — documented, not changed).** Dictating `/compact ` after a pre-existing `fix ` strips a space no popup consumed. There is no popup-state or field-read signal in the insertion path (an AX read of a terminal grid can't separate prompt line from scrollback), so this is now an explicit Known-tradeoffs entry in AGENTS.md, stated in the policy's doc comment, and pinned by a characterization test so any future change to it is a conscious decision.

## Proof

- [x] Finding 2 red → green:
  ```
  XCTAssertEqual failed: ("/tmp") is not equal to ("/tmp ")   # before, new test on main
  TUIAutocompleteTrailingSpaceTests: Executed 23 tests, with 0 failures   # after
  ```
- [x] Finding 3 red → green: the invariant test failed all 4 new NBSP/U+202F corpus rows before (`mid-session release "mot " ends in whitespace`); after:
  ```
  LiveHoldBackReplacementStreamTests: Executed 57 tests, with 0 failures
  ```
- [x] Finding 1: characterization pin `testPrePopulatedFieldTextCannotRescueTheTrailingSpace` (passes before and after by design — it pins accepted behavior).
- [x] Full unit suite:
  ```
  Executed 2118 tests, with 2 tests skipped and 0 failures (0 unexpected) in 73.945s
  ```
- [x] LLM lanes: not required — downstream insertion policy only; no model input changes.
