### PR TITLE
Dogfood edit signal follow-up: verdict parking, outcome-gated arming, inline quit flush (codex review of #202)

### DIFF
--- a/Sources/localvoxtral/DictationViewModel+Session.swift
+++ b/Sources/localvoxtral/DictationViewModel+Session.swift
@@ -1394,7 +1394,8 @@ extension DictationViewModel {
                     // can only ever land on the tail of this task, never on the
                     // user's paste. `writeDogfoodCaptureIfArmed` checks the
                     // runtime opt-in before doing any work.
-                    await self.writeDogfoodCaptureIfArmed(DogfoodCaptureInputs(
+                    await self.writeDogfoodCaptureIfArmed(
+                        DogfoodCaptureInputs(
                         session: DogfoodCaptureRecord.Session(
                             targetBundleID: capturedTargetBundleID,
                             targetKind: self.sessionTargetIsTerminalLike
@@ -1463,7 +1464,16 @@ extension DictationViewModel {
                             committedText: dogfoodCommittedText
                         ),
                         polishSeconds: polishingDuration
-                    ))
+                        ),
+                        commitOutcome: overlayCommitOutcome,
+                        // Substituted for MEASUREMENT only (the watch window
+                        // scales with what was inserted); the record keeps the
+                        // placeholder-bearing text above.
+                        committedTextForWatch: self.clipboardPayloadSubstituted(
+                            dogfoodCommittedText ?? groundedWorkingText,
+                            payload: clipboardPayload
+                        )
+                    )
                     #endif
 
                     if let llmConnectionFailure {

--- a/Sources/localvoxtral/DictationViewModel.swift
+++ b/Sources/localvoxtral/DictationViewModel.swift
@@ -787,7 +787,20 @@ final class DictationViewModel {
     // MARK: - Lifecycle Observers
 
     private func registerLifecycleObservers() {
-        let nc = NotificationCenter.default
+        registerLifecycleObservers(on: .default)
+    }
+
+    #if DEBUG
+    /// Test seam: registers the REAL lifecycle observers on a private center,
+    /// so a suite can post `willTerminateNotification` through the actual
+    /// wiring without broadcasting to every retained view model in the
+    /// process.
+    func debugRegisterLifecycleObservers(on center: NotificationCenter) {
+        registerLifecycleObservers(on: center)
+    }
+    #endif
+
+    private func registerLifecycleObservers(on nc: NotificationCenter) {
 
         let sleepObserver = nc.addObserver(
             forName: NSWorkspace.willSleepNotification,
@@ -805,20 +818,29 @@ final class DictationViewModel {
             object: nil,
             queue: .main
         ) { [weak self] _ in
-            Task { @MainActor [weak self] in
+            // `willTerminate` is posted on the main thread and a `.main`-queue
+            // observer runs synchronously in it — this closure is the last
+            // execution the process guarantees. Anything that must survive
+            // quit happens inline HERE, before the Task below, which is
+            // best-effort only (a Task spawned at terminate is not guaranteed
+            // to run).
+            MainActor.assumeIsolated {
                 guard let self else { return }
-                self.cancelManagedStartupTask()
-                if self.isDictating {
-                    self.stopDictation(reason: "app terminating", finalizeRemainingAudio: false)
-                }
                 #if LOCALVOXTRAL_DOGFOOD
                 // Last chance for a still-open post-commit watch to patch its
                 // record: after this the process is gone and the dictation
-                // would keep no behavior block at all. Written inline — a Task
-                // spawned at terminate is not guaranteed to run.
+                // would keep no behavior block at all.
                 self.dogfoodEditSignalWatcher.flushForTermination()
                 #endif
-                await self.backendManager.stopAll()
+                Task {
+                    self.cancelManagedStartupTask()
+                    if self.isDictating {
+                        self.stopDictation(
+                            reason: "app terminating", finalizeRemainingAudio: false
+                        )
+                    }
+                    await self.backendManager.stopAll()
+                }
             }
         }
 

--- a/Sources/localvoxtral/Dogfood/DictationViewModel+DogfoodCapture.swift
+++ b/Sources/localvoxtral/Dogfood/DictationViewModel+DogfoodCapture.swift
@@ -13,7 +13,24 @@ extension DictationViewModel {
     ///
     /// The tap is consumed EVEN when disarmed — its slots must not carry one
     /// session's facts into a later, armed session's record.
-    func writeDogfoodCaptureIfArmed(_ inputs: DogfoodCaptureInputs) async {
+    ///
+    /// `commitOutcome` gates the edit watch: only `.succeeded` put text in
+    /// front of the user, so only `.succeeded` is watchable. `.failed` and
+    /// `.copiedToClipboard` left nothing in the target app — a Backspace
+    /// there would be recorded as erasing an insertion that never happened,
+    /// and an uneventful window would pad the `clean` denominator.
+    ///
+    /// `committedTextForWatch` is the payload-SUBSTITUTED commit copy,
+    /// measured and discarded (the watcher keeps only its word-count bucket):
+    /// the window must scale with what was actually inserted — a 100-word
+    /// paste takes far longer to judge than its one-token placeholder — while
+    /// the record itself keeps only placeholder-bearing text. The clipboard
+    /// payload must not enter the record through this parameter.
+    func writeDogfoodCaptureIfArmed(
+        _ inputs: DogfoodCaptureInputs,
+        commitOutcome: OverlayBufferCommitOutcome,
+        committedTextForWatch: String
+    ) async {
         let abstentions = DogfoodCaptureTap.shared.consumeJoinAbstentions()
         let repoVocabularyHarvest = DogfoodCaptureTap.shared.consumeRepoVocabularyHarvest()
         guard settings.dogfoodCaptureEnabled else { return }
@@ -39,10 +56,17 @@ extension DictationViewModel {
         // the write below, because that write is awaited and the next dictation
         // can arm in the meantime — an untokened attach would hand this
         // record's URL to that session's window.
-        let watchToken = dogfoodEditSignalWatcher.arm(
-            committedText: inputs.text.committedText ?? inputs.text.groundedText,
-            outputMode: inputs.session.outputMode
-        )
+        let watchToken: DogfoodEditSignalWatcher.WatchToken?
+        if case .succeeded = commitOutcome {
+            watchToken = dogfoodEditSignalWatcher.arm(
+                committedText: committedTextForWatch,
+                outputMode: inputs.session.outputMode
+            )
+        } else {
+            // Unwatchable commit: the record is still written (the pipeline
+            // stages happened and stay attributable), with no behavior block.
+            watchToken = nil
+        }
 
         // Assembly walks complete retained buffers (harvest re-derivation);
         // `build` is nonisolated, so this await hops off the main actor the

--- a/Sources/localvoxtral/Dogfood/DogfoodEditSignalWatcher.swift
+++ b/Sources/localvoxtral/Dogfood/DogfoodEditSignalWatcher.swift
@@ -31,8 +31,8 @@ enum DogfoodEditSignal: String, Codable, Equatable, Sendable {
     /// immediately — the monitor never retains, forwards, or counts it.
     ///
     /// ⌘A only with Command held and no other command-class modifier: ⌥⌘A /
-    /// ⌃⌘A are app shortcuts, not select-all, and counting them would inflate
-    /// the signal with ordinary navigation.
+    /// ⌃⌘A / ⇧⌘A are app shortcuts, not select-all, and counting them would
+    /// inflate the signal with ordinary navigation.
     static func from(keyCode: UInt16, modifiers: NSEvent.ModifierFlags) -> DogfoodEditSignal? {
         let relevant = modifiers.intersection(.deviceIndependentFlagsMask)
         switch Int(keyCode) {
@@ -42,7 +42,8 @@ enum DogfoodEditSignal: String, Codable, Equatable, Sendable {
             return .backspace
         case kVK_ANSI_A where relevant.contains(.command)
             && !relevant.contains(.option)
-            && !relevant.contains(.control):
+            && !relevant.contains(.control)
+            && !relevant.contains(.shift):
             return .selectAll
         default:
             return nil
@@ -265,6 +266,15 @@ final class DogfoodEditSignalWatcher {
     private let sleepFor: SleepClosure
 
     private var watch: Watch?
+    /// Closed watches whose `attachRecord` has not arrived yet, keyed by
+    /// generation. The record write is awaited, so the next dictation's arm
+    /// can beat the attach — and the closed watch's verdict must survive
+    /// until its record shows up, or the record becomes indistinguishable
+    /// from "never observed". Bounded: an entry lives only while one record
+    /// write is in flight, so growth past the cap means the writes are
+    /// failing; the oldest generation is evicted first.
+    private var parkedWatches: [UInt64: Watch] = [:]
+    private static let parkedWatchCap = 8
     private var generation: UInt64 = 0
     /// The open window's timer, and the in-flight record patch. Retained so
     /// tests can await them the way they await `polishAndCommitTask`; nothing in
@@ -322,6 +332,7 @@ final class DogfoodEditSignalWatcher {
     @discardableResult
     func arm(committedText: String, outputMode: String) -> WatchToken? {
         supersede()
+        parkClosedWatchAwaitingAttach()
 
         let wordCount = DogfoodEditSignalPolicy.wordCount(of: committedText)
         guard wordCount > 0 else { return nil }
@@ -348,14 +359,31 @@ final class DogfoodEditSignalWatcher {
             outputMode: outputMode
         )
 
-        windowTask = Task { [weak self] in
-            guard let self else { return }
-            await self.sleepFor(.seconds(windowSeconds))
+        // `sleepFor` is captured by value so the sleep holds NO reference to
+        // the watcher: a strong `self` promoted before the await would retain
+        // it for the whole window and `isolated deinit` could never run
+        // mid-window. Promotion happens only after the sleep resumes.
+        windowTask = Task { [weak self, sleepFor] in
+            await sleepFor(.seconds(windowSeconds))
             guard !Task.isCancelled else { return }
-            self.closeWindow(outcome: .clean, signal: nil, generation: generation)
+            self?.closeWindow(outcome: .clean, signal: nil, generation: generation)
         }
 
         return WatchToken(generation: generation)
+    }
+
+    /// Moves a closed watch that is still waiting for its record out of the
+    /// active slot, so the next `arm` cannot erase its pending verdict. Runs
+    /// after `supersede()`, which guarantees any remaining watch is closed —
+    /// a closed AND attached watch has already flushed and left the slot nil.
+    private func parkClosedWatchAwaitingAttach() {
+        guard let watch else { return }
+        parkedWatches[watch.generation] = watch
+        self.watch = nil
+        if parkedWatches.count > Self.parkedWatchCap,
+           let oldest = parkedWatches.keys.min() {
+            parkedWatches.removeValue(forKey: oldest)
+        }
     }
 
     /// Hands the open (or already-closed) watch the record it belongs to.
@@ -366,11 +394,21 @@ final class DogfoodEditSignalWatcher {
     /// without the token this call would hand session A's record to session B's
     /// open window — which would then patch A's record with B's behavior.
     func attachRecord(url: URL, store: DogfoodCaptureStore, token: WatchToken) {
-        guard var watch, watch.generation == token.generation else { return }
-        watch.recordURL = url
-        watch.store = store
-        self.watch = watch
-        flushIfReady()
+        if var watch, watch.generation == token.generation {
+            watch.recordURL = url
+            watch.store = store
+            self.watch = watch
+            flushIfReady()
+            return
+        }
+        // A parked watch: its window closed (superseded by the next dictation,
+        // or a gesture landed) before the record write returned. The token
+        // still names it exactly; any other generation attaches to nothing.
+        if var parked = parkedWatches.removeValue(forKey: token.generation) {
+            parked.recordURL = url
+            parked.store = store
+            flush(parked)
+        }
     }
 
     /// Closes an open window because a new dictation began. Safe to call with
@@ -423,7 +461,18 @@ final class DogfoodEditSignalWatcher {
     /// where the record landed. Whichever arrives second triggers the write.
     private func flushIfReady(inline: Bool = false) {
         guard let watch,
-              let result = watch.result,
+              watch.result != nil,
+              watch.recordURL != nil,
+              watch.store != nil
+        else { return }
+        self.watch = nil
+        flush(watch, inline: inline)
+    }
+
+    /// The write itself, for a watch that has both halves — the active one, or
+    /// a parked one whose late attach just delivered its record.
+    private func flush(_ watch: Watch, inline: Bool = false) {
+        guard let result = watch.result,
               let url = watch.recordURL,
               let store = watch.store
         else { return }
@@ -437,7 +486,6 @@ final class DogfoodEditSignalWatcher {
             watchWindowSeconds: watch.windowSeconds,
             outputMode: watch.outputMode
         )
-        self.watch = nil
 
         guard !inline else {
             DogfoodCaptureWriter.attachSynchronously(behavior, toRecordAt: url, store: store)

--- a/Tests/localvoxtralTests/DogfoodCaptureWiringTests.swift
+++ b/Tests/localvoxtralTests/DogfoodCaptureWiringTests.swift
@@ -354,6 +354,116 @@ final class DogfoodCaptureWiringTests: XCTestCase {
         XCTAssertEqual(signals.monitor.startCount, 0)
     }
 
+    /// A commit that never landed must not be watched: `.failed` leaves nothing
+    /// in the target app to erase, so a Backspace typed there would be recorded
+    /// as erasing an insertion that never happened — and an uneventful window
+    /// would pad the `clean` denominator with unwatchable dictations. The
+    /// record itself is still written; it just carries no behavior block.
+    func testFailedCommitNeverArmsTheWatch() async throws {
+        let signals = EditSignalHarness()
+        let harness = try makeHarness(
+            dogfoodArmed: true,
+            editSignal: signals,
+            commitOutcome: .failed(message: "insertion failed")
+        )
+
+        harness.viewModel.finishStoppedSession(promotePendingSegment: false)
+        await harness.viewModel.polishAndCommitTask?.value
+
+        XCTAssertEqual(signals.monitor.startCount, 0, "nothing was inserted; nothing to watch")
+        XCTAssertFalse(signals.watcher.isWatching)
+        let record = try XCTUnwrap(recordsOnDisk(in: harness.captureDirectory).last)
+        XCTAssertNil(record.behavior, "an unwatched dictation keeps no behavior block")
+    }
+
+    /// Same rule for the Secure Keyboard Entry fallback: the text went to the
+    /// clipboard, not the target app, so post-commit keys say nothing about it.
+    func testClipboardFallbackCommitNeverArmsTheWatch() async throws {
+        let signals = EditSignalHarness()
+        let harness = try makeHarness(
+            dogfoodArmed: true,
+            editSignal: signals,
+            commitOutcome: .copiedToClipboard(message: "Copied to clipboard")
+        )
+
+        harness.viewModel.finishStoppedSession(promotePendingSegment: false)
+        await harness.viewModel.polishAndCommitTask?.value
+
+        XCTAssertEqual(signals.monitor.startCount, 0)
+        XCTAssertFalse(signals.watcher.isWatching)
+        let record = try XCTUnwrap(recordsOnDisk(in: harness.captureDirectory).last)
+        XCTAssertNil(record.behavior)
+    }
+
+    /// The watch window must scale with what was actually inserted. A
+    /// clipboard-payload commit inserts the substituted payload, not the
+    /// placeholder — a 100-word paste takes far longer to judge than one
+    /// placeholder token, so it gets the 15 s rung, not 2 s. The payload
+    /// itself must still never reach the record: only the window length (and
+    /// the bucket it implies) may reflect it.
+    func testClipboardPayloadWindowScalesWithTheInsertedPayload() async throws {
+        let signals = EditSignalHarness()
+        let harness = try makeHarness(dogfoodArmed: true, editSignal: signals)
+        harness.viewModel.settings.clipboardPayloadMacroEnabled = true
+        let payload = (0..<100).map { "word\($0)" }.joined(separator: " ")
+        harness.viewModel.debugClipboardPayloadPasteboardReaderOverride = {
+            WiringPasteboardStub(text: payload)
+        }
+        // The polish stub returns text without the placeholder, so the
+        // placeholder-count guard discards the polish and commits the
+        // placeholder-bearing grounded text — payload-substituted at commit.
+        harness.viewModel.currentDictationEventText = "paste clipboard"
+
+        harness.viewModel.finishStoppedSession(promotePendingSegment: false)
+        await harness.viewModel.polishAndCommitTask?.value
+
+        await signals.sleeper.waitForSleepRequest()
+        XCTAssertEqual(
+            signals.sleeper.requestedDurations, [.seconds(15.0)],
+            "the window measures the substituted commit, not its placeholder"
+        )
+
+        let record = try XCTUnwrap(recordsOnDisk(in: harness.captureDirectory).last)
+        XCTAssertEqual(
+            record.text.committedText, ClipboardPayloadMacro.placeholder,
+            "measuring the payload must not persist it"
+        )
+
+        signals.clock.advance(1)
+        signals.monitor.send(.backspace)
+        await signals.watcher.flushTask?.value
+        let behavior = try XCTUnwrap(recordsOnDisk(in: harness.captureDirectory).last?.behavior)
+        XCTAssertEqual(behavior.wordCountBucket, "41+", "buckets follow the inserted length")
+        XCTAssertEqual(behavior.watchWindowSeconds, 15)
+    }
+
+    /// FINDING 3, at the notification wiring: the flush must run INLINE in the
+    /// `willTerminateNotification` observer. The observer's synchronous return
+    /// is the last execution the process guarantees — a Task spawned there is
+    /// not guaranteed to run — so the record must already be patched when
+    /// `post` returns, with deliberately no await in between. A private
+    /// notification center keeps the post from reaching every other retained
+    /// view model in the suite.
+    func testWillTerminateNotificationFlushesTheOpenWatchInline() async throws {
+        let signals = EditSignalHarness()
+        let harness = try makeHarness(dogfoodArmed: true, editSignal: signals)
+        let center = NotificationCenter()
+        harness.viewModel.debugRegisterLifecycleObservers(on: center)
+
+        harness.viewModel.finishStoppedSession(promotePendingSegment: false)
+        await harness.viewModel.polishAndCommitTask?.value
+        XCTAssertTrue(signals.watcher.isWatching, "the commit opened a window")
+
+        center.post(name: NSApplication.willTerminateNotification, object: nil)
+
+        let record = try XCTUnwrap(recordsOnDisk(in: harness.captureDirectory).last)
+        XCTAssertEqual(
+            record.behavior?.outcome, .superseded,
+            "the patch must be on disk when the observer returns"
+        )
+        XCTAssertFalse(signals.watcher.isWatching)
+    }
+
     // MARK: - Builder
 
     func testEndpointClassBuckets() {
@@ -506,7 +616,8 @@ final class DogfoodCaptureWiringTests: XCTestCase {
     private func makeHarness(
         dogfoodArmed: Bool,
         blockCaptureDirectory: Bool = false,
-        editSignal: EditSignalHarness? = nil
+        editSignal: EditSignalHarness? = nil,
+        commitOutcome: OverlayBufferCommitOutcome = .succeeded
     ) throws -> Harness {
         let settings = makeSettings()
         settings.llmPolishingEnabled = true
@@ -527,9 +638,11 @@ final class DogfoodCaptureWiringTests: XCTestCase {
             try? FileManager.default.removeItem(at: base)
         }
 
+        let overlayCoordinator = WiringMockOverlayCoordinator()
+        overlayCoordinator.commitOutcome = commitOutcome
         let viewModel = DictationViewModel(
             settings: settings,
-            overlayBufferCoordinator: WiringMockOverlayCoordinator(),
+            overlayBufferCoordinator: overlayCoordinator,
             startRuntimeServices: false
         )
         viewModel.appConfigStore = WiringMockAppConfigStore()
@@ -624,6 +737,9 @@ private final class WiringMockAppConfigStore: AppConfigServing {
 @MainActor
 private final class WiringMockOverlayCoordinator: OverlayBufferSessionCoordinating {
     var commitTargetAppPID: pid_t? = nil
+    /// What `commitIfNeeded` reports — the seam for the failed / clipboard-
+    /// fallback arming tests.
+    var commitOutcome: OverlayBufferCommitOutcome = .succeeded
 
     func resolveAnchorNow() -> OverlayAnchor {
         OverlayAnchor(
@@ -640,7 +756,7 @@ private final class WiringMockOverlayCoordinator: OverlayBufferSessionCoordinati
         using _: OverlayTextCommitting,
         autoCopyEnabled _: Bool
     ) -> OverlayBufferCommitOutcome {
-        .succeeded
+        commitOutcome
     }
 
     func dismissAfterHold(minimumVisibility _: TimeInterval) {}

--- a/Tests/localvoxtralTests/DogfoodEditSignalTests.swift
+++ b/Tests/localvoxtralTests/DogfoodEditSignalTests.swift
@@ -197,12 +197,15 @@ final class DogfoodEditSignalTests: XCTestCase {
 
         // Plain "a" is typing, not selecting.
         XCTAssertNil(DogfoodEditSignal.from(keyCode: UInt16(kVK_ANSI_A), modifiers: []))
-        // ⌥⌘A / ⌃⌘A are app shortcuts, not select-all.
+        // ⌥⌘A / ⌃⌘A / ⇧⌘A are app shortcuts, not select-all.
         XCTAssertNil(
             DogfoodEditSignal.from(keyCode: UInt16(kVK_ANSI_A), modifiers: [.command, .option])
         )
         XCTAssertNil(
             DogfoodEditSignal.from(keyCode: UInt16(kVK_ANSI_A), modifiers: [.command, .control])
+        )
+        XCTAssertNil(
+            DogfoodEditSignal.from(keyCode: UInt16(kVK_ANSI_A), modifiers: [.command, .shift])
         )
         // Every other key, modified or not.
         XCTAssertNil(DogfoodEditSignal.from(keyCode: UInt16(kVK_ANSI_B), modifiers: [.command]))
@@ -474,41 +477,107 @@ final class DogfoodEditSignalTests: XCTestCase {
         )
     }
 
-    /// FINDING 1's regression, in the LOSING order: a stale watch's attach must
-    /// be rejected by the token, not by timing.
+    /// The supersede-before-attach race: a second dictation arms while the
+    /// first's record write is still in flight. The first watch's verdict must
+    /// SURVIVE the supersede (parked, keyed by its token) and land in its own
+    /// record when the late attach arrives — and the second watch's gesture
+    /// must still not land there.
     ///
-    /// The record write is awaited, so a second dictation can arm while the
-    /// first is still being written. Without the token, the late
-    /// `attachRecord` would hand session A's record to session B's OPEN window
-    /// — and B's gesture would then be written into A's record.
-    func testStaleAttachIsRejectedByTheToken() async throws {
+    /// An earlier version of this test pinned the opposite expectation: it
+    /// asserted A's behavior was LOST ("nothing is written for it"). That
+    /// pinned a bug, not a contract — a supersede that beats the attach left
+    /// A's record indistinguishable from "never observed", which is exactly
+    /// the distinction the behavior block exists to make. Rewriting it is a
+    /// correction, not a weakening: the contamination assertion it existed
+    /// for (B's gesture must not reach A's record) is still here, strictly
+    /// stronger — A's record now holds a verdict that B's close must not
+    /// overwrite.
+    func testSupersededVerdictSurvivesAnAttachThatArrivesAfterTheNextArm() async throws {
         let harness = makeWatcher()
 
         // Session A arms and commits; its record write is still in flight.
-        let staleToken = try XCTUnwrap(
+        let tokenA = try XCTUnwrap(
             harness.watcher.arm(committedText: "first dictation text", outputMode: "overlay_buffer")
         )
         // Session B arms before A's write returns. A's window closes as
-        // superseded, with no record attached — nothing is written for it.
+        // superseded and is parked awaiting its record.
         harness.watcher.arm(committedText: "second dictation text", outputMode: "overlay_buffer")
         await harness.watcher.flushTask?.value
 
-        // A's write finally returns and tries to attach its record — with A's
-        // (now stale) token.
+        // A's write finally returns and attaches its record — with A's token.
         let sessionARecord = try harness.writeExtraRecord()
         harness.watcher.attachRecord(
-            url: sessionARecord, store: harness.store, token: staleToken
+            url: sessionARecord, store: harness.store, token: tokenA
+        )
+        await harness.watcher.flushTask?.value
+
+        XCTAssertEqual(
+            harness.readBack(at: sessionARecord)?.behavior?.outcome, .superseded,
+            "a supersede that beats the attach must not erase A's verdict"
         )
 
-        // B's window is open and now sees the gesture. If the stale attach had
-        // been accepted, B's `edited` would be sitting in that record.
+        // B's window is open and now sees a gesture. It has no record of its
+        // own; it must not land in A's.
         harness.clock.advance(0.5)
         harness.monitor.send(.backspace)
         await harness.watcher.flushTask?.value
 
+        XCTAssertEqual(
+            harness.readBack(at: sessionARecord)?.behavior?.outcome, .superseded,
+            "a stale token must not connect one session's record to another's window"
+        )
+    }
+
+    /// The same race with a REAL verdict in it: a gesture closed A's window
+    /// before the supersede, so the parked watch carries `edited` and its
+    /// buckets — and the late attach must deliver them, not a blank.
+    func testEditedVerdictSurvivesAnAttachThatArrivesAfterTheNextArm() async throws {
+        let harness = makeWatcher()
+
+        let tokenA = try XCTUnwrap(
+            harness.watcher.arm(committedText: "first dictation text", outputMode: "overlay_buffer")
+        )
+        harness.clock.advance(1.2)
+        harness.monitor.send(.backspace)
+        // The next dictation arms while A's record write is still in flight.
+        harness.watcher.arm(committedText: "second dictation text", outputMode: "overlay_buffer")
+
+        let sessionARecord = try harness.writeExtraRecord()
+        harness.watcher.attachRecord(
+            url: sessionARecord, store: harness.store, token: tokenA
+        )
+        await harness.watcher.flushTask?.value
+
+        let behavior = try XCTUnwrap(harness.readBack(at: sessionARecord)?.behavior)
+        XCTAssertEqual(behavior.outcome, .edited)
+        XCTAssertEqual(behavior.signal, .backspace)
+        XCTAssertEqual(behavior.secondsSinceCommitBucket, "1-2")
+    }
+
+    /// Parked watches must not leak when their attach never arrives (a failed
+    /// record write leaves the token holder with no URL to hand over). The
+    /// dictionary is capped; the oldest generation is evicted first and its
+    /// late attach then lands nowhere.
+    func testParkedWatchesAreBoundedAndEvictOldestFirst() async throws {
+        let harness = makeWatcher()
+
+        let tokenA = try XCTUnwrap(
+            harness.watcher.arm(committedText: "first dictation text", outputMode: "overlay_buffer")
+        )
+        // Enough later dictations, none attaching, to push A past the cap.
+        for _ in 0..<12 {
+            harness.watcher.arm(committedText: "later dictation text", outputMode: "overlay_buffer")
+        }
+
+        let sessionARecord = try harness.writeExtraRecord()
+        harness.watcher.attachRecord(
+            url: sessionARecord, store: harness.store, token: tokenA
+        )
+        await harness.watcher.flushTask?.value
+
         XCTAssertNil(
             harness.readBack(at: sessionARecord)?.behavior,
-            "a stale token must not connect one session's record to another's window"
+            "an evicted watch attaches to nothing"
         )
     }
 
@@ -555,6 +624,42 @@ final class DogfoodEditSignalTests: XCTestCase {
         )
         XCTAssertFalse(harness.watcher.isWatching)
         XCTAssertFalse(harness.monitor.isInstalled)
+    }
+
+    /// FINDING 5: the window timer must not retain the watcher across its
+    /// sleep — a strong `self` held for up to 15 s is what the `isolated
+    /// deinit` cleanup claim says cannot happen. Releasing the last owner
+    /// mid-window must deallocate the watcher and tear the monitor down.
+    func testReleasingTheWatcherMidWindowTearsDownTheMonitor() async throws {
+        let monitor = DogfoodEditSignalTestMonitor()
+        let sleeper = DogfoodManualSleeper()
+        let clock = DogfoodTestClock()
+        var watcher: DogfoodEditSignalWatcher? = DogfoodEditSignalWatcher(
+            monitor: monitor,
+            now: { clock.now() },
+            sleepFor: { await sleeper.sleep($0) }
+        )
+        weak var released = watcher
+        addTeardownBlock { sleeper.fireAll() }
+
+        _ = watcher?.arm(committedText: "run the tests", outputMode: "overlay_buffer")
+        // The window is parked on its (un-fired) sleep: mid-window, by
+        // construction, with no wall-clock.
+        await sleeper.waitForSleepRequest()
+        XCTAssertTrue(monitor.isInstalled)
+
+        watcher = nil
+
+        // `isolated deinit` runs on the main actor; give it a beat without
+        // resuming the sleep (the sleeper stays un-fired, so a strong capture
+        // in the timer would still be holding the watcher here).
+        await Task.yield()
+        XCTAssertNil(
+            released, "the window timer must not retain the watcher across its sleep"
+        )
+        XCTAssertFalse(
+            monitor.isInstalled, "deinit must tear down the monitor mid-window"
+        )
     }
 
     // MARK: Harness


### PR DESCRIPTION
## What

Follow-up to #202 (merged before its codex/GPT-5.6 review landed); fixes all six review findings on main. The feature is dogfood-only instrumentation, but every one of these corrupted the measurement it exists to produce.

1. **High — a superseded watch lost its verdict when its record write was still pending.** Arming B replaced the single watch slot, so A's late `attachRecord` was rejected and A read as "never observed". Closed-but-unattached watches now park keyed by generation (cap 8, oldest evicted) until their attach arrives. The old test at the previous line 491 *pinned this bug* — it was rewritten to assert the survival, with a comment saying exactly that (this is correcting a bug-pinning expectation, not weakening).
2. **High — the watcher armed on `.failed` and `.copiedToClipboard` commits**, so Backspace in the target app recorded erasing an insertion that never happened, and phantom `clean`s inflated the denominator. The commit outcome is now passed through; the watch arms only on `.succeeded` (the record still writes, honestly behavior-free).
3. **High — the quit flush ran inside a `Task` spawned at terminate** — the exact non-guarantee its own comment warned about. `flushForTermination()` now runs inline in the main-queue notification callback (`MainActor.assumeIsolated`); only backend shutdown stays async. New seam (`debugRegisterLifecycleObservers(on:)`) lets the test post the real notification and assert the patch is on disk when the observer returns, with no await after `post`.
4. **Medium — clipboard payloads were sized by the placeholder**, giving a 100-word paste a 2s window instead of 15s. The substituted text now feeds the window ladder for measurement only; the persisted record keeps the placeholder (asserted — clipboard content must not leak into dogfood records through this fix).
5. **Medium — the window timer promoted weak self to strong before its sleep**, retaining the watcher for the whole window and defeating the `isolated deinit` cleanup. Promotion now happens after the sleep; a release test nils the last owner mid-window and asserts dealloc + monitor teardown.
6. **Low — ⇧⌘A was classified as select-all.** `.shift` excluded; the two-gestures test extended.

## Proof

- [x] Regression tests added, failing before / passing after (both runs via `remote-build.sh dogfood`, the instrumented lane — these suites are `#if LOCALVOXTRAL_DOGFOOD` and compile out of the plain test lane):
  ```
  before: Executed 59 tests, with 15 failures (0 unexpected)   # every finding reproduced
  after:  Executed 59 tests, with 0 failures (0 unexpected)
  ```
  Representative red lines per finding are in the commit message; e.g. finding 3: `the patch must be on disk when the observer returns`, finding 5: `the window timer must not retain the watcher across its sleep`.
- [x] Full non-instrumented unit suite green on the pre-rebase base: `Executed 2015 tests, with 2 tests skipped and 0 failures`; instrumented suite re-run green after rebasing onto current main (post-#200): `Executed 59 tests, with 0 failures`.
- [x] LLM lanes: `DictationViewModel+Session.swift` is on the filter path list, so the lane will run; the change passes a new parameter on the capture call and does not alter what reaches the model.
- [ ] Not machine-verifiable: OS-level quit ordering on a real GUI session — the notification-path test pins the wiring; a hand-quit during a dogfood window on the next dogfood build is the remaining eyeball.
