### PR TITLE
opencode plugin follow-up: reply-gated focus state, fail-closed sessions, lane filter (codex review of #204)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -156,6 +156,7 @@ jobs:
           ./scripts/ci/test-ui-smoke-guard.sh
           ./scripts/ci/test-runner-node-resign.sh
           ./scripts/ci/test-ac-power-guard.sh
+          ./scripts/ci/test-llm-lane-filter.sh
           ./scripts/ci/test-clean-stale-outputs.sh
 
       - name: Clean abandoned test processes in this workspace
@@ -181,6 +182,7 @@ jobs:
           ./scripts/ci/test-remote-build-gc.sh
           ./scripts/ci/test-run-supervised-command.sh
           ./scripts/ci/test-runner-node-resign.sh
+          ./scripts/ci/test-llm-lane-filter.sh
 
       - name: Decide LLM eval lane (path filter + [run-llm-eval] marker)
         # CI must not pay ~8 min of 4B weight-loading + live inference on

--- a/Tests/localvoxtralTests/OpencodePluginContractTests.swift
+++ b/Tests/localvoxtralTests/OpencodePluginContractTests.swift
@@ -1,0 +1,452 @@
+import Foundation
+import JavaScriptCore
+import XCTest
+@testable import ClaudeContextWire
+@testable import localvoxtral
+
+/// Behavior-level contract tests for the opencode plugin
+/// (`integrations/opencode/localvoxtral.js`), complementing the artifact pins
+/// in `OpencodePluginManifestTests`: the plugin is evaluated under
+/// JavaScriptCore with Node built-ins stubbed, its handlers are driven
+/// directly, and every line it writes to the fake broker socket is captured
+/// and decoded.
+///
+/// Two invariants earned their tests in review (PR #204 follow-up):
+///
+/// 1. Focus-declaration state must advance ONLY after a broker reply arrives
+///    for that write. `socket.write()` succeeding proves nothing — the runtime
+///    buffers writes while connecting, and the broker serves short
+///    connections (8 records / 2s deadline), so a written record is routinely
+///    lost to a reset. A declaration or retraction the broker never read must
+///    be retried at the next sample, not suppressed for the 20s heartbeat.
+///
+/// 2. Session filtering must fail CLOSED. The server half publishes a
+///    session's activity only while its id is in the bounded allowlist of
+///    known top-level (parentless) sessions — an evicted child, a deleted
+///    session, or an id never seen created is dropped, never published as if
+///    it were the session the user is typing into.
+///
+/// Harness note: the manifest suite enforces zero `await` tokens in the
+/// plugin, so stripping the `async ` keyword is semantics-preserving here —
+/// handlers become synchronous and no microtask draining is needed.
+final class OpencodePluginContractTests: XCTestCase {
+    private var context: JSContext!
+    private var failure: Box<String?>!
+
+    private final class Box<Value>: @unchecked Sendable {
+        var value: Value
+        init(_ value: Value) { self.value = value }
+    }
+
+    // MARK: Harness
+
+    /// Node built-ins the plugin imports, stubbed for a bare JSContext. The
+    /// fake socket records every write into `__writes`, keeps its event
+    /// handlers reachable so tests can deliver broker replies or fail the
+    /// connection, and exposes the created sockets as `__sockets`.
+    private static let prelude = #"""
+    globalThis.__writes = [];
+    globalThis.__sockets = [];
+    globalThis.__intervals = [];
+
+    function __utf8Bytes(value) {
+      const out = [];
+      for (const ch of String(value)) {
+        const cp = ch.codePointAt(0);
+        if (cp < 0x80) out.push(cp);
+        else if (cp < 0x800) out.push(0xc0 | (cp >> 6), 0x80 | (cp & 0x3f));
+        else if (cp < 0x10000) {
+          out.push(0xe0 | (cp >> 12), 0x80 | ((cp >> 6) & 0x3f), 0x80 | (cp & 0x3f));
+        } else {
+          out.push(
+            0xf0 | (cp >> 18), 0x80 | ((cp >> 12) & 0x3f),
+            0x80 | ((cp >> 6) & 0x3f), 0x80 | (cp & 0x3f)
+          );
+        }
+      }
+      return out;
+    }
+    function __wrapBytes(bytes) {
+      bytes.subarray = (from, to) => __wrapBytes(bytes.slice(from, to));
+      bytes.toString = () => {
+        // ASCII round-trip is all the tests need; payloads stay under limits.
+        let text = "";
+        for (const byte of bytes) text += String.fromCharCode(byte);
+        return text;
+      };
+      return bytes;
+    }
+    globalThis.Buffer = {
+      byteLength: (value) => __utf8Bytes(value).length,
+      from: (value) => __wrapBytes(__utf8Bytes(value)),
+    };
+
+    globalThis.process = {
+      pid: 4242,
+      platform: "linux",
+      env: {
+        HOME: "/home/tester",
+        LOCALVOXTRAL_CLAUDE_SOCKET: "/tmp/lvx-contract-test.sock",
+        TERM_PROGRAM: "ghostty",
+      },
+    };
+
+    globalThis.setInterval = (fn) => {
+      globalThis.__intervals.push(fn);
+      return { unref() {} };
+    };
+    globalThis.clearInterval = () => {};
+
+    globalThis.net = {
+      createConnection(path) {
+        const socket = {
+          destroyed: false,
+          writableLength: 0,
+          handlers: {},
+          unref() {},
+          on(name, fn) { this.handlers[name] = fn; },
+          write(line) {
+            globalThis.__writes.push(line);
+            return true;
+          },
+          destroy() {
+            if (this.destroyed) return;
+            this.destroyed = true;
+            if (this.handlers.close) this.handlers.close();
+          },
+          end() { this.destroy(); },
+        };
+        globalThis.__sockets.push(socket);
+        return socket;
+      },
+    };
+    globalThis.fs = {
+      readlinkSync: () => "/dev/pts/7",
+    };
+    globalThis.isatty = () => true;
+    """#
+
+    private func loadPlugin(isMainThread: Bool) throws {
+        let pluginURL = try XCTUnwrap(ClaudePluginAssets.developmentOpencodePluginURL())
+        var text = try String(contentsOf: pluginURL, encoding: .utf8)
+        text = text
+            .split(separator: "\n", omittingEmptySubsequences: false)
+            .map { line in line.hasPrefix("import ") ? "" : String(line) }
+            .joined(separator: "\n")
+            .replacingOccurrences(of: "export default", with: "globalThis.__module =")
+            // Zero `await` tokens is a pinned invariant, so the async keyword
+            // is inert: dropping it makes handlers return their values
+            // synchronously instead of via an immediately-resolved promise.
+            .replacingOccurrences(of: "async ", with: "")
+
+        context = try XCTUnwrap(JSContext())
+        failure = Box(nil)
+        let box = failure!
+        context.exceptionHandler = { _, exception in
+            box.value = exception?.toString()
+        }
+        context.evaluateScript("const isMainThread = \(isMainThread);")
+        context.evaluateScript(Self.prelude)
+        context.evaluateScript(text)
+        if let message = failure.value {
+            XCTFail("plugin failed to evaluate: \(message)")
+        }
+    }
+
+    @discardableResult
+    private func run(_ script: String, file: StaticString = #filePath, line: UInt = #line) -> JSValue? {
+        let value = context.evaluateScript(script)
+        if let message = failure.value {
+            XCTFail("script raised: \(message)\nscript: \(script)", file: file, line: line)
+            failure.value = nil
+        }
+        return value
+    }
+
+    /// Every record written to any socket so far, decoded, oldest first.
+    private func writtenRecords() throws -> [[String: Any]] {
+        let json = try XCTUnwrap(run("JSON.stringify(globalThis.__writes)")?.toString())
+        let lines = try XCTUnwrap(
+            JSONSerialization.jsonObject(with: Data(json.utf8)) as? [String]
+        )
+        return try lines.map { line in
+            try XCTUnwrap(
+                JSONSerialization.jsonObject(with: Data(line.utf8)) as? [String: Any],
+                "unparseable record line: \(line)"
+            )
+        }
+    }
+
+    private func records(event: String, session: String? = nil) throws -> [[String: Any]] {
+        try writtenRecords().filter { record in
+            record["event"] as? String == event
+                && (session == nil || record["session_id"] as? String == session)
+        }
+    }
+
+    // MARK: TUI-half helpers
+
+    private func startTUI() throws {
+        try loadPlugin(isMainThread: true)
+        run(#"""
+        globalThis.__api = {
+          route: { current: undefined },
+          event: { on: (type, fn) => (() => {}) },
+          lifecycle: { onDispose: (fn) => { globalThis.__dispose = fn; } },
+        };
+        globalThis.__module.tui(globalThis.__api);
+        """#)
+        let sampler = try XCTUnwrap(run("globalThis.__intervals.length")?.toInt32())
+        XCTAssertEqual(sampler, 1, "the TUI half must register exactly one sampling interval")
+    }
+
+    private func setRoute(sessionID: String?) {
+        if let sessionID {
+            run(#"__api.route.current = { name: "session", params: { sessionID: "\#(sessionID)" } };"#)
+        } else {
+            run("__api.route.current = undefined;")
+        }
+    }
+
+    private func sample() {
+        run("globalThis.__intervals[0]();")
+    }
+
+    /// Deliver one broker reply line on the most recently created socket —
+    /// the shape `ClaudeContextBroker.reply` sends for an opencode record.
+    private func deliverBrokerReply() {
+        let line = String(
+            decoding: ClaudeBrokerResponse.encodeLine(ClaudeBrokerResponse(marker: nil))!,
+            as: UTF8.self
+        ).replacingOccurrences(of: "\n", with: "\\n")
+        run(#"""
+        (() => {
+          const socket = globalThis.__sockets[globalThis.__sockets.length - 1];
+          socket.handlers.data('\#(line)');
+        })();
+        """#)
+    }
+
+    /// Fail the most recently created socket the way a dead broker does:
+    /// an error event, then close. No reply is ever delivered.
+    private func failConnection() {
+        run(#"""
+        (() => {
+          const socket = globalThis.__sockets[globalThis.__sockets.length - 1];
+          if (socket.handlers.error) socket.handlers.error(new Error("connection lost"));
+          socket.destroy();
+        })();
+        """#)
+    }
+
+    // MARK: Finding 1 — focus state advances only after a broker reply
+
+    func testFocusDeclarationIsRetriedWhenTheConnectionFailsBeforeAnyReply() throws {
+        try startTUI()
+        setRoute(sessionID: "sesA")
+        sample()
+        XCTAssertEqual(
+            try records(event: "FocusChanged", session: "sesA").count, 1,
+            "first sample must declare the focused session"
+        )
+
+        // The write reached the socket but the broker never replied — the
+        // connection dies (routine: the broker closes after 8 records or 2s).
+        failConnection()
+
+        sample()
+        XCTAssertEqual(
+            try records(event: "FocusChanged", session: "sesA").count, 2,
+            "an unacknowledged declaration must be retried at the next sample, "
+                + "not suppressed for the 20s heartbeat"
+        )
+        let declaration = try XCTUnwrap(try records(event: "FocusChanged").last)
+        let process = try XCTUnwrap(declaration["process"] as? [String: Any])
+        XCTAssertEqual(process["tty"] as? String, "/dev/pts/7")
+    }
+
+    func testFocusRetractionIsRetriedWhenTheConnectionFailsBeforeAnyReply() throws {
+        try startTUI()
+        setRoute(sessionID: "sesA")
+        sample()
+        deliverBrokerReply() // declaration acknowledged: sesA is now declared
+
+        setRoute(sessionID: nil)
+        sample()
+        XCTAssertEqual(try records(event: "FocusCleared", session: "sesA").count, 1)
+
+        // Retraction written, never read by the broker.
+        failConnection()
+
+        sample()
+        XCTAssertEqual(
+            try records(event: "FocusCleared", session: "sesA").count, 2,
+            "a lost retraction must be retried — clearing local state on an "
+                + "unacknowledged write silently leaves the registry declaring sesA"
+        )
+    }
+
+    func testFocusStateAdvancesOnReplyAndHeartbeatSuppressesResends() throws {
+        try startTUI()
+        setRoute(sessionID: "sesA")
+        sample()
+        deliverBrokerReply()
+        sample()
+        sample()
+        XCTAssertEqual(
+            try records(event: "FocusChanged", session: "sesA").count, 1,
+            "an acknowledged declaration must be heartbeat-suppressed, not resent every sample"
+        )
+    }
+
+    func testOnlyOneFocusRecordIsInFlightAtATime() throws {
+        try startTUI()
+        setRoute(sessionID: "sesA")
+        sample()
+        sample() // no reply yet — must not stack a second declaration
+        XCTAssertEqual(
+            try records(event: "FocusChanged", session: "sesA").count, 1,
+            "sampling while a declaration is unacknowledged must not spam the broker"
+        )
+        deliverBrokerReply()
+        setRoute(sessionID: "sesB")
+        sample()
+        XCTAssertEqual(
+            try records(event: "FocusChanged", session: "sesB").count, 1,
+            "a session switch after the reply must declare immediately"
+        )
+    }
+
+    func testDisposeRetractsTheDeclaredFocusBestEffort() throws {
+        try startTUI()
+        setRoute(sessionID: "sesA")
+        sample()
+        deliverBrokerReply()
+        run("globalThis.__dispose();")
+        XCTAssertEqual(
+            try records(event: "FocusCleared", session: "sesA").count, 1,
+            "dispose must retract the declared focus (fire-and-forget is fine here)"
+        )
+    }
+
+    // MARK: Finding 3 — session filtering fails closed
+
+    private func startServer() throws {
+        try loadPlugin(isMainThread: false)
+        run("globalThis.__hooks = globalThis.__module.server();")
+        let kind = try XCTUnwrap(run("typeof globalThis.__hooks")?.toString())
+        XCTAssertEqual(kind, "object", "ServerHalf must return its hooks object")
+    }
+
+    private func createSession(id: String, parentID: String? = nil, directory: String? = nil) {
+        let parent = parentID.map { #", parentID: "\#($0)""# } ?? ""
+        let dir = directory.map { #", directory: "\#($0)""# } ?? ""
+        run(#"""
+        __hooks.event({ event: { type: "session.created", properties: {
+          info: { id: "\#(id)"\#(parent)\#(dir) } } } });
+        """#)
+    }
+
+    private func sendChatMessage(sessionID: String, text: String = "hello") {
+        run(#"""
+        __hooks["chat.message"](
+          { sessionID: "\#(sessionID)" },
+          { parts: [{ type: "text", text: "\#(text)" }] }
+        );
+        """#)
+    }
+
+    func testTopLevelSessionLifecyclePublishes() throws {
+        try startServer()
+        createSession(id: "parent", directory: "/repo/p")
+        XCTAssertEqual(try records(event: "SessionStart", session: "parent").count, 1)
+
+        sendChatMessage(sessionID: "parent", text: "hello world")
+        let prompt = try XCTUnwrap(try records(event: "UserPromptSubmit", session: "parent").first)
+        XCTAssertEqual(prompt["prompt"] as? String, "hello world")
+        XCTAssertEqual(prompt["cwd"] as? String, "/repo/p")
+
+        run(#"__hooks.event({ event: { type: "session.idle", properties: { sessionID: "parent" } } });"#)
+        XCTAssertEqual(try records(event: "Stop", session: "parent").count, 1)
+
+        run(#"__hooks.event({ event: { type: "session.deleted", properties: { info: { id: "parent" } } } });"#)
+        XCTAssertEqual(try records(event: "SessionEnd", session: "parent").count, 1)
+    }
+
+    func testChildSessionLifecycleIsNeverPublished() throws {
+        try startServer()
+        createSession(id: "parent", directory: "/repo/p")
+        createSession(id: "child", parentID: "parent")
+        sendChatMessage(sessionID: "child")
+        run(#"__hooks.event({ event: { type: "session.deleted", properties: { info: { id: "child" } } } });"#)
+        let childRecords = try writtenRecords().filter { $0["session_id"] as? String == "child" }
+        XCTAssertTrue(
+            childRecords.isEmpty,
+            "a task-tool child session must never publish; got \(childRecords)"
+        )
+    }
+
+    func testEvictedChildSessionActivityIsNotPublished() throws {
+        try startServer()
+        createSession(id: "parent", directory: "/repo/p")
+        createSession(id: "child-0", parentID: "parent")
+        // Push child-0 out of any bounded tracking structure.
+        run(#"""
+        for (let index = 1; index <= 64; index += 1) {
+          __hooks.event({ event: { type: "session.created", properties: {
+            info: { id: "child-" + index, parentID: "parent" } } } });
+        }
+        """#)
+        sendChatMessage(sessionID: "child-0")
+        run(#"""
+        __hooks["tool.execute.after"]({
+          sessionID: "child-0", tool: "read", args: { filePath: "/repo/p/file.txt" },
+        });
+        """#)
+        run(#"__hooks.event({ event: { type: "session.idle", properties: { sessionID: "child-0" } } });"#)
+        let escaped = try writtenRecords().filter { $0["session_id"] as? String == "child-0" }
+        XCTAssertTrue(
+            escaped.isEmpty,
+            "an evicted child's later activity must fail closed, not publish as top-level; got \(escaped)"
+        )
+    }
+
+    func testSessionNeverSeenCreatedIsNotPublished() throws {
+        try startServer()
+        sendChatMessage(sessionID: "ghost")
+        run(#"__hooks.event({ event: { type: "session.idle", properties: { sessionID: "ghost" } } });"#)
+        run(#"__hooks.event({ event: { type: "session.deleted", properties: { info: { id: "ghost" } } } });"#)
+        let ghost = try writtenRecords().filter { $0["session_id"] as? String == "ghost" }
+        XCTAssertTrue(
+            ghost.isEmpty,
+            "an id with unknown parentage must be dropped — only known top-level sessions publish; got \(ghost)"
+        )
+    }
+
+    func testDeletedSessionsLateActivityIsNotPublished() throws {
+        try startServer()
+        createSession(id: "parent", directory: "/repo/p")
+        run(#"__hooks.event({ event: { type: "session.deleted", properties: { info: { id: "parent" } } } });"#)
+        sendChatMessage(sessionID: "parent")
+        XCTAssertEqual(
+            try records(event: "UserPromptSubmit", session: "parent").count, 0,
+            "activity after SessionEnd must be dropped, not resurrect the session"
+        )
+    }
+
+    func testEvictedTopLevelSessionFailsClosed() throws {
+        try startServer()
+        createSession(id: "top-0", directory: "/repo/0")
+        run(#"""
+        for (let index = 1; index <= 64; index += 1) {
+          __hooks.event({ event: { type: "session.created", properties: {
+            info: { id: "top-" + index, directory: "/repo/x" } } } });
+        }
+        """#)
+        sendChatMessage(sessionID: "top-0")
+        XCTAssertEqual(
+            try records(event: "UserPromptSubmit", session: "top-0").count, 0,
+            "past the tracking bound the oldest top-level session drops out fail-closed"
+        )
+    }
+}

--- a/Tests/localvoxtralTests/OpencodePluginManifestTests.swift
+++ b/Tests/localvoxtralTests/OpencodePluginManifestTests.swift
@@ -100,6 +100,18 @@ final class OpencodePluginManifestTests: XCTestCase {
         )
     }
 
+    func testPendingBrokerRepliesAreBoundedByAReset() throws {
+        // The reply-callback queue must be bounded the same way queued bytes
+        // are: a peer that reads but never answers must reset the connection,
+        // not grow a callback queue inside the agent process.
+        let text = try source()
+        XCTAssertTrue(text.contains("const MAX_PENDING_REPLIES = 16;"))
+        XCTAssertTrue(
+            text.contains("pendingReplies.length >= MAX_PENDING_REPLIES"),
+            "the pending-reply watermark must gate every write"
+        )
+    }
+
     // MARK: Wire contract — pinned to the Swift constants, not to copies
 
     func testWireVersionAndAgentMatchTheSwiftWire() throws {

--- a/integrations/opencode/README.md
+++ b/integrations/opencode/README.md
@@ -68,8 +68,11 @@ and remove the line from `~/.config/opencode/tui.json`.
 - **No title markers.** opencode owns and rewrites its window title mid-turn,
   so the title channel Claude Code uses cannot work here; localvoxtral never
   sends this plugin one.
-- **Subagent sessions are filtered.** Child (task-tool) sessions never
-  masquerade as the session you are typing into.
+- **Subagent sessions are filtered, fail-closed.** The plugin publishes a
+  session's activity only while it is in a bounded allowlist of known
+  top-level sessions, so a child (task-tool) session — or any session whose
+  parentage it never observed — never masquerades as the session you are
+  typing into.
 - **herdr panes keep working.** The plugin forwards the herdr pane identity
   it inherited from the environment, so localvoxtral's existing herdr join
   applies to opencode panes unchanged.

--- a/integrations/opencode/localvoxtral.js
+++ b/integrations/opencode/localvoxtral.js
@@ -14,7 +14,9 @@
 // is the worst possible failure. Hence the hard rules below:
 //
 //   * No network-shaped waiting inside hooks. One lazily (re)connected
-//     socket, unref()ed, fire-and-forget writes, broker replies discarded.
+//     socket, unref()ed, fire-and-forget writes. Broker reply lines are only
+//     ever COUNTED (one reply per record, in order) to settle callbacks —
+//     never parsed for content, never surfaced anywhere.
 //   * Every handler body is wrapped in try/catch and swallows everything.
 //   * Nothing is ever written to the terminal: no stdout, no stderr, no
 //     logging. opencode's TUI owns those descriptors.
@@ -78,8 +80,17 @@ const MAX_TRACKED_SESSIONS = 64;
 // Hard cap on bytes queued in the socket before the runtime flushed them. A
 // broker that stops reading must never grow this process's memory: past the
 // cap the connection is reset and records are DROPPED — context is a
-// nice-to-have, the user's agent process is not.
+// nice-to-have, the user's agent process is not. (Soft by one record: the
+// check runs before each write, so the queue can exceed the cap by at most
+// one MAX_LINE_BYTES record before the reset triggers.)
 const MAX_QUEUED_BYTES = 64 * 1024;
+
+// Cap on reply callbacks outstanding on one connection. The real broker
+// answers every record it reads and closes a connection after 8 records or
+// a 2s read deadline (ClaudeContextBroker limits), so a queue anywhere near
+// this deep means the peer is not behaving like the broker: reset the
+// connection (settling every pending callback as failed) rather than grow.
+const MAX_PENDING_REPLIES = 16;
 
 // ---------------------------------------------------------------------------
 // Socket path — mirrors ClaudeHookSocketPath.swift exactly.
@@ -97,21 +108,75 @@ function socketPath() {
 }
 
 // ---------------------------------------------------------------------------
-// Publisher — lazy connection, fire and forget, replies discarded.
+// Publisher — lazy connection, fire and forget, replies settle callbacks.
 //
 // The broker serves short connections (whole-connection read deadline, a
 // per-connection record cap), so the socket naturally closes between bursts;
 // the next publish reconnects. Writes issued right after createConnection are
 // buffered by the runtime until the connect completes — nothing here ever
 // blocks a hook on the dial.
+//
+// The socket is request/response: the broker writes exactly one reply line
+// per record it reads, in order (ClaudeBrokerResponse). publish() exploits
+// only that SHAPE — replies are counted, never parsed: this plugin has no
+// title channel and must never surface a byte anywhere a terminal could see
+// it. A caller that passes an onReply callback gets it settled exactly once,
+// with true when this record's reply line arrived (the broker read the
+// record) or false when the connection failed, was reset, or closed first.
+// A reply does NOT mean the registry accepted the record — see the focus
+// declaration notes in the TUI half for what that leaves unguaranteed.
 
 let socket;
 
-/// Returns true only when the line was actually handed to a healthy socket —
-/// callers that track publish state (the focus declarations) must not advance
-/// on a dropped write, or a lost switch would go unrepaired until the next
-/// heartbeat.
-function publish(record) {
+function connectSocket(path) {
+  const created = net.createConnection(path);
+  created.unref();
+  // Reply callbacks for records written on THIS connection, oldest first —
+  // per-connection state, so a reset can never settle a successor's writes.
+  const pending = [];
+  created.pendingReplies = pending;
+  const settleAllFailed = () => {
+    while (pending.length > 0) {
+      const settle = pending.shift();
+      try {
+        if (settle) settle(false);
+      } catch {}
+    }
+  };
+  created.on("data", (chunk) => {
+    try {
+      if (!chunk) return;
+      for (let index = 0; index < chunk.length; index += 1) {
+        const byte = typeof chunk === "string" ? chunk.charCodeAt(index) : chunk[index];
+        if (byte !== 10) continue; // count newline-terminated reply lines only
+        const settle = pending.shift();
+        try {
+          if (settle) settle(true);
+        } catch {}
+      }
+    } catch {}
+  });
+  created.on("error", () => {
+    try {
+      created.destroy();
+    } catch {}
+    settleAllFailed();
+  });
+  // Fires after destroy() and after a broker-side FIN (the broker closes
+  // every connection within seconds by design). Unreplied records on this
+  // connection are lost for good at that point; settle them as failed so
+  // their callers can retry. Idempotent with the error path above.
+  created.on("close", settleAllFailed);
+  return created;
+}
+
+/// Fire-and-forget publish. Returns true only when the line was actually
+/// handed to a healthy socket. `onReply`, when given, is settled exactly once
+/// per the connection contract above — callers that track publish state (the
+/// focus declarations) must advance ONLY in a `true` settlement: a write the
+/// runtime buffered while connecting, or one the broker never read, would
+/// otherwise mark a lost switch as delivered until the next heartbeat.
+function publish(record, onReply) {
   try {
     if (!record) return false;
     const line = JSON.stringify(record) + "\n";
@@ -119,29 +184,23 @@ function publish(record) {
     if (!socket || socket.destroyed) {
       const path = socketPath();
       if (!path) return false;
-      socket = net.createConnection(path);
-      socket.unref();
-      // Broker replies (marker lines for Claude publishers) are read and
-      // dropped: this plugin has no title channel and must never surface a
-      // byte anywhere a terminal could see it.
-      socket.on("data", () => {});
-      socket.on("error", () => {
-        try {
-          socket.destroy();
-        } catch {}
-      });
+      socket = connectSocket(path);
     }
-    // Backpressure is a drop, never a wait: if the broker stopped draining,
-    // reset the connection (the next publish lazily reconnects) and lose
-    // this record rather than queue unboundedly inside the agent process.
-    if (socket.writableLength > MAX_QUEUED_BYTES) {
-      try {
-        socket.destroy();
-      } catch {}
+    // Backpressure is a drop, never a wait: if the broker stopped draining
+    // (queued bytes) or stopped answering (pending replies), reset the
+    // connection (the next publish lazily reconnects) and lose this record
+    // rather than queue unboundedly inside the agent process. The reset
+    // settles every pending reply callback as failed via the close event.
+    if (socket.writableLength > MAX_QUEUED_BYTES || socket.pendingReplies.length >= MAX_PENDING_REPLIES) {
+      const stale = socket;
       socket = undefined;
+      try {
+        stale.destroy();
+      } catch {}
       return false;
     }
     socket.write(line);
+    socket.pendingReplies.push(typeof onReply === "function" ? onReply : undefined);
     return true;
   } catch {
     return false;
@@ -237,15 +296,25 @@ const ServerHalf = async () => {
   // When the directory is unknown the record goes out WITHOUT a cwd — fail
   // closed on the field, not the record.
   const directoryBySession = new Map();
-  // Subagent (task tool) sessions carry parentID; their lifecycle must not
-  // masquerade as user-facing sessions (same rule herdr's plugin applies).
-  const childSessions = new Set();
+  // The bounded ALLOWLIST of known top-level sessions. Parentage is only
+  // observable on session.created (info.parentID marks a subagent / task-tool
+  // child; nothing after that event carries it), so a session publishes only
+  // while its id is in here: children are never added, and an id this half
+  // never saw created — or one evicted by the bound — fails CLOSED, dropped.
+  // The previous shape (a bounded blocklist of child ids) failed OPEN after
+  // eviction: an evicted child's later activity looked top-level and was
+  // published as the session the user is typing into. The deliberate cost of
+  // the inversion: a top-level session predating this plugin's load (or past
+  // the bound) stops publishing entirely — dictation abstains for it instead
+  // of risking a child session's content grounding someone's prompt.
+  const topLevelSessions = new Set();
 
-  function remember(map, key, value) {
-    map.set(key, value);
-    if (map.size > MAX_TRACKED_SESSIONS) {
-      const oldest = map.keys().next().value;
-      map.delete(oldest);
+  function rememberTopLevel(sessionID) {
+    topLevelSessions.add(sessionID);
+    if (topLevelSessions.size > MAX_TRACKED_SESSIONS) {
+      const oldest = topLevelSessions.values().next().value;
+      topLevelSessions.delete(oldest);
+      directoryBySession.delete(oldest);
     }
   }
 
@@ -261,15 +330,10 @@ const ServerHalf = async () => {
         if (type === "session.created") {
           const info = properties.info || {};
           if (!info.id) return;
-          if (info.parentID) {
-            childSessions.add(info.id);
-            if (childSessions.size > MAX_TRACKED_SESSIONS) {
-              childSessions.delete(childSessions.values().next().value);
-            }
-            return;
-          }
+          if (info.parentID) return; // child: never enters the allowlist
+          rememberTopLevel(info.id);
           if (typeof info.directory === "string" && info.directory) {
-            remember(directoryBySession, info.id, info.directory);
+            directoryBySession.set(info.id, info.directory);
           }
           publish(record("SessionStart", info.id, { cwd: directoryFor(info.id) }));
           return;
@@ -277,14 +341,14 @@ const ServerHalf = async () => {
         if (type === "session.deleted") {
           const info = properties.info || {};
           if (!info.id) return;
-          if (childSessions.delete(info.id)) return;
+          if (!topLevelSessions.delete(info.id)) return;
           publish(record("SessionEnd", info.id, { cwd: directoryFor(info.id) }));
           directoryBySession.delete(info.id);
           return;
         }
         if (type === "session.idle") {
           const sessionID = properties.sessionID;
-          if (!sessionID || childSessions.has(sessionID)) return;
+          if (!sessionID || !topLevelSessions.has(sessionID)) return;
           publish(record("Stop", sessionID, { cwd: directoryFor(sessionID) }));
         }
       } catch {}
@@ -295,7 +359,7 @@ const ServerHalf = async () => {
     "chat.message": async (input, output) => {
       try {
         const sessionID = input && input.sessionID;
-        if (!sessionID || childSessions.has(sessionID)) return;
+        if (!sessionID || !topLevelSessions.has(sessionID)) return;
         const parts = (output && output.parts) || [];
         const prompt = parts
           .filter((part) => part && part.type === "text" && typeof part.text === "string")
@@ -314,7 +378,7 @@ const ServerHalf = async () => {
       try {
         const sessionID = input && input.sessionID;
         const tool = input && input.tool;
-        if (!sessionID || childSessions.has(sessionID)) return;
+        if (!sessionID || !topLevelSessions.has(sessionID)) return;
         // File-bearing tools only, mirroring the Claude plugin's
         // Read|Edit|Write matcher. Everything else (bash, grep, glob) carries
         // command strings, not file touches.
@@ -380,10 +444,29 @@ const TuiHalf = async (api) => {
   // triggers an immediate resample so switches that coincide with session
   // activity are caught event-fast. Leaving the session view publishes an
   // explicit retraction (FocusCleared) instead of waiting for the registry's
-  // TTL. Publish state only advances when the write was actually accepted, so
-  // a lost declaration or retraction is retried at the next sample.
+  // TTL.
+  //
+  // Publish state advances ONLY when the broker's reply line for that exact
+  // record arrives (publish's onReply contract — one reply per record, in
+  // order). A bare successful write proves nothing: the runtime buffers
+  // writes while the dial is still in flight, and the broker resets
+  // connections routinely (8 records / 2s deadline), so advancing on the
+  // write would mark a lost declaration as delivered — and a lost RETRACTION
+  // as retracted — and heartbeat-suppress the repair for 20 seconds. On any
+  // failed settlement the local state is left alone, so the next sample
+  // simply retries. One focus record is in flight at a time; its settlement
+  // (reply, connection error, or close — the broker's own deadline bounds
+  // the quiet case) re-enables sampling.
+  //
+  // What a reply still cannot promise on this wire: REGISTRY acceptance. A
+  // rejected record earns the same nil-marker reply line as an accepted one
+  // (ClaudeContextBroker.handle), so a FocusChanged racing ahead of its
+  // session record — the registry refuses declarations for sessions it does
+  // not know — is indistinguishable from success here. That residual window
+  // is bounded by the 20s heartbeat re-declaration and by every route change.
   let lastSession;
   let lastSentAt = 0;
+  let inflight = false;
 
   function sample() {
     try {
@@ -392,19 +475,28 @@ const TuiHalf = async (api) => {
         route && route.name === "session" && route.params && typeof route.params.sessionID === "string"
           ? route.params.sessionID
           : undefined;
+      if (inflight) return;
       const nowMillis = Date.now();
       if (!sessionID) {
-        if (lastSession && publish(record("FocusCleared", lastSession, undefined, tty))) {
-          lastSession = undefined;
-          lastSentAt = 0;
-        }
+        if (!lastSession) return;
+        const cleared = lastSession;
+        inflight = publish(record("FocusCleared", cleared, undefined, tty), (replied) => {
+          inflight = false;
+          if (replied && lastSession === cleared) {
+            lastSession = undefined;
+            lastSentAt = 0;
+          }
+        });
         return;
       }
       if (sessionID === lastSession && nowMillis - lastSentAt < FOCUS_HEARTBEAT_MS) return;
-      if (publish(record("FocusChanged", sessionID, undefined, tty))) {
-        lastSession = sessionID;
-        lastSentAt = nowMillis;
-      }
+      inflight = publish(record("FocusChanged", sessionID, undefined, tty), (replied) => {
+        inflight = false;
+        if (replied) {
+          lastSession = sessionID;
+          lastSentAt = nowMillis;
+        }
+      });
     } catch {}
   }
 

--- a/scripts/ci/llm-lane-filter.sh
+++ b/scripts/ci/llm-lane-filter.sh
@@ -67,6 +67,7 @@ PATTERNS=(
   '*ClaudeHookInputParser*'                          # which hook fields become session state
   '*ClaudeHookPublisher*'                            # the identity metadata (tty/pid/herdr pane) joins key on
   'integrations/claude-code/*'                       # the plugin that publishes those hooks
+  'integrations/opencode/*'                          # the opencode publisher: prompt extraction, cwd, file grounding
   '*TerminalScreenContext*'                          # screen context source/policy feeding the prompt
   '*TerminalScreenAXReader*'                         # screen text sanitization/compaction: the excerpt's exact bytes
   '*TerminalScreenAppleScriptReader*'                # iTerm2/Terminal.app focused-pane contents: the excerpt's exact bytes

--- a/scripts/ci/test-llm-lane-filter.sh
+++ b/scripts/ci/test-llm-lane-filter.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+# Regression test for llm-lane-filter.sh's path decisions and marker opt-in.
+# Pure shell, no git or network — changed-file lists are written to temp
+# files, so it runs anywhere (hosted fork PRs included).
+#
+# Not a mirror of the whole pattern list: it pins the decisions that were
+# bugs or near-misses — model-input integrations (the opencode plugin
+# shipped without a pattern, PR #204 review), the marker path, and the
+# run=false side that keeps UI/doc-only diffs off the live-model lane.
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "$0")/../.." && pwd -P)"
+FILTER="$ROOT_DIR/scripts/ci/llm-lane-filter.sh"
+
+TMP_DIR="$(mktemp -d "${TMPDIR:-/tmp}/lv-llm-lane-filter-test.XXXXXX")"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+fail() {
+  printf 'FAIL: %s\n' "$*" >&2
+  exit 1
+}
+
+# expect <true|false> <description> <changed-path>... [--marker <text>]
+expect() {
+  local expected="$1" description="$2"
+  shift 2
+  local changed="$TMP_DIR/changed" marker_file=""
+  : >"$changed"
+  while [[ $# -gt 0 ]]; do
+    if [[ "$1" == "--marker" ]]; then
+      marker_file="$TMP_DIR/marker"
+      printf '%s\n' "$2" >"$marker_file"
+      shift 2
+      continue
+    fi
+    printf '%s\n' "$1" >>"$changed"
+    shift
+  done
+  local output
+  if [[ -n "$marker_file" ]]; then
+    output="$("$FILTER" "$changed" "$marker_file")" || fail "$description: filter exited non-zero"
+  else
+    output="$("$FILTER" "$changed")" || fail "$description: filter exited non-zero"
+  fi
+  local run reason
+  run="$(sed -n 's/^run=//p' <<<"$output")"
+  reason="$(sed -n 's/^reason=//p' <<<"$output")"
+  [[ "$run" == "$expected" ]] \
+    || fail "$description: expected run=$expected, got run=$run ($reason)"
+  [[ -n "$reason" ]] || fail "$description: reason line is missing"
+  printf 'PASS: %s (%s)\n' "$description" "$reason"
+}
+
+# --- Model-input integrations ---------------------------------------------
+# Both agent plugins shape what reaches the polish model (prompt extraction,
+# cwd, file grounding); a plugin-only diff must run the lane.
+
+expect true "opencode plugin change runs the lane" \
+  integrations/opencode/localvoxtral.js
+expect true "opencode integration docs stay lane-relevant (claude-code parity)" \
+  integrations/opencode/README.md
+expect true "claude-code plugin change runs the lane" \
+  integrations/claude-code/plugins/localvoxtral/hooks/hooks.json
+
+# --- Marker opt-in ----------------------------------------------------------
+
+expect true "[run-llm-eval] marker forces the lane on any diff" \
+  README.md --marker 'judgment call, opting in [run-llm-eval]'
+expect false "unrelated marker text does not trigger" \
+  README.md --marker 'no opt-in here'
+
+# --- run=false side ---------------------------------------------------------
+
+expect false "top-level docs do not run the lane" \
+  README.md AGENTS.md
+expect false "UI-only Swift change does not run the lane" \
+  Sources/localvoxtral/SettingsView.swift
+expect false "empty changed-file list decides run=false (caller owns fail-open)" \
+  ""
+
+printf 'OK: llm-lane-filter tests passed\n'


### PR DESCRIPTION
## What

Follow-up to #204 (merged before its codex/GPT-5.6 review landed); fixes the review's three findings on main.

1. **High — focus-declaration state advanced without any acknowledgement.** `publish()` returned true straight off `socket.write()` (runtime-buffered even mid-dial), and the broker deliberately serves short connections (8 records / 2s deadline), so lost writes are routine — a lost `FocusCleared` cleared local state permanently, and a suppressed retry window meant dictation could resolve to the previous session's context for up to 20 s. The plugin now keeps a per-connection FIFO of reply callbacks (the broker answers exactly one `ClaudeBrokerResponse` line per record, in order; the handler counts lines, never parses content), advances focus state only when the declaration's reply arrives, holds one focus record in flight, and retries both declarations and retractions on any failed settlement at the next 500 ms sample. New `MAX_PENDING_REPLIES = 16` bound, manifest-pinned. Zero `await`, zero terminal output — all invariants preserved (one manifest test added, none weakened).

   **Documented residual (in the plugin comment):** the broker's reply is shape-identical for accepted and rejected records, so a `FocusChanged` that races ahead of its session record still earns a reply and can pin the wrong context for one heartbeat. Closing it needs a wire change — an optional `accepted: Bool` on `ClaudeBrokerResponse` (backward compatible: existing decoders ignore unknown keys; the plugin would treat a missing field as today's behavior). Proposed, deliberately not implemented here — owner call.

2. **Medium — `integrations/opencode/**` was missing from the LLM lane filter.** The plugin shapes model inputs (prompt extraction, cwd, grounding), so plugin-only changes must run the lane. Added beside the `integrations/claude-code/*` precedent, plus `scripts/ci/test-llm-lane-filter.sh` in the existing `test-*.sh` family, wired into both ci.yml shell-test lists.

3. **Low — evicted child sessions failed open.** The bounded child *blocklist* let an evicted child's late event publish as top-level. Inverted to a bounded allowlist of known top-level sessions (bound preserved at 64): children never enter; unknown, evicted, and post-SessionEnd ids drop. Deliberate cost documented in plugin + README: a session whose creation predates plugin load abstains rather than risking child content grounding a prompt.

## Proof

- [x] New `OpencodePluginContractTests` (JSC harness driving the real plugin file): 6 regressions red on main → green, e.g.
  ```
  testFocusDeclarationIsRetriedWhenTheConnectionFailsBeforeAnyReply: ("1") is not equal to ("2")
    - an unacknowledged declaration must be retried at the next sample, not suppressed for the 20s heartbeat
  testEvictedChildSessionActivityIsNotPublished   # main published the evicted child's UserPromptSubmit
  ```
  plus 5 pins (reply-advance, single-in-flight, dispose retraction, never-seen and deleted sessions fail closed).
- [x] Filter demo, run directly: `integrations/opencode/localvoxtral.js` → before `run=false / no LLM-relevant changes`, after `run=true / matched (integrations/opencode/*)`; `test-llm-lane-filter.sh` 8/8 PASS (opencode case FAILed pre-pattern).
- [x] Full unit suite: `Executed 2125 tests, with 2 tests skipped and 0 failures` (pre-existing env-gated skips).
- [x] LLM lanes: this PR itself touches the filter and the plugin — the lane runs by its own new rule.
