### PR TITLE
Broker replies say accepted: close the opencode focus-race residual (stacked on #209)

### DIFF
--- a/Sources/ClaudeContextWire/ClaudeMarkerSequence.swift
+++ b/Sources/ClaudeContextWire/ClaudeMarkerSequence.swift
@@ -11,15 +11,24 @@ public struct ClaudeBrokerResponse: Sendable, Equatable, Codable {
     /// Marker for the session this record belongs to. Nil when the broker
     /// accepted the record but has no marker to publish (e.g. it was rejected).
     public var marker: String?
+    /// Whether the record was actually committed to the registry. Nil means
+    /// the reply came from a pre-`accepted`-era broker, which consumers must
+    /// treat exactly as they always did — as success. Deliberately NOT a
+    /// version bump: synthesized Codable omits the key when nil and ignores
+    /// unknown keys on decode, so both directions of a version skew (old
+    /// publisher/new broker, new publisher/old broker) decode cleanly.
+    public var accepted: Bool?
 
-    public init(version: Int = ClaudeHookWire.version, marker: String?) {
+    public init(version: Int = ClaudeHookWire.version, marker: String?, accepted: Bool? = nil) {
         self.version = version
         self.marker = marker
+        self.accepted = accepted
     }
 
     enum CodingKeys: String, CodingKey {
         case version = "v"
         case marker
+        case accepted
     }
 
     public static func encodeLine(_ response: ClaudeBrokerResponse) -> Data? {

--- a/Sources/localvoxtral/ClaudeContext/ClaudeContextBroker.swift
+++ b/Sources/localvoxtral/ClaudeContext/ClaudeContextBroker.swift
@@ -515,6 +515,7 @@ public final class ClaudeContextBroker: Sendable {
                 reply(
                     to: fd,
                     marker: handled.marker,
+                    accepted: handled.accepted,
                     isHerdrHosted: handled.isHerdrHosted,
                     version: handled.replyVersion
                 )
@@ -583,6 +584,7 @@ public final class ClaudeContextBroker: Sendable {
     private func reply(
         to fd: Int32,
         marker: ClaudeSessionMarker?,
+        accepted: Bool,
         isHerdrHosted: Bool,
         version: Int
     ) {
@@ -592,7 +594,9 @@ public final class ClaudeContextBroker: Sendable {
             // v1 publisher rejects any reply that does not say v1, so replying
             // with the broker's own version would silently kill the marker
             // channel for every stale plugin install until it updated.
-            ClaudeBrokerResponse(version: version, marker: responseMarker)
+            // `accepted` rides along in every reply shape — old decoders
+            // ignore the unknown key (synthesized Codable), so no bump.
+            ClaudeBrokerResponse(version: version, marker: responseMarker, accepted: accepted)
         ) else { return }
         _ = line.withUnsafeBytes { raw -> Int in
             guard let base = raw.baseAddress else { return 0 }
@@ -609,15 +613,30 @@ public final class ClaudeContextBroker: Sendable {
     }
 
     /// - Returns: the marker for the session this record belongs to, whether
-    ///   herdr must intercept title changes, and the wire version to shape the
-    ///   reply as (the request's own — see `reply`), or nil marker metadata
-    ///   when the record was rejected.
+    ///   the record was committed to the registry (`accepted` — carried back
+    ///   in the reply so a publisher can distinguish "read" from "took
+    ///   effect"), whether herdr must intercept title changes, and the wire
+    ///   version to shape the reply as (the request's own — see `reply`).
+    ///
+    /// `accepted` is truthful for every layer that still produces a reply. A
+    /// reply is per complete LINE, so exactly three rejection layers can
+    /// answer `false`:
+    ///   1. wire-shape rejection of a complete line (`decodeLine` throws —
+    ///      malformed JSON, unsupported version, over-limit fields);
+    ///   2. the opencode peer-pid cross-check below;
+    ///   3. the registry refusing the record (`ingest` returns nil: focus
+    ///      declarations/clears for sessions it has never seen, origin or
+    ///      agent mismatch, `SessionEnd` for an unknown session, and the
+    ///      namespace-prefix aliasing drop).
+    /// Connection-level rejections (foreign uid, unterminated over-cap line,
+    /// too many records, read deadline) drop the connection WITHOUT a reply,
+    /// unchanged — publishers observe those as an error/close, not a verdict.
     @discardableResult
     private func handle(
         line: Data,
         origin: ClaudeTransportOrigin,
         peerPID: pid_t?
-    ) -> (marker: ClaudeSessionMarker?, isHerdrHosted: Bool, replyVersion: Int) {
+    ) -> (marker: ClaudeSessionMarker?, accepted: Bool, isHerdrHosted: Bool, replyVersion: Int) {
         do {
             let record = try ClaudeHookWireCodec.decodeLine(line, limits: limits.wire)
             // Per-agent pid cross-check against the KERNEL's answer. The
@@ -639,13 +658,18 @@ public final class ClaudeContextBroker: Sendable {
                     #if DEBUG
                     debugNotify(.failure(.malformed))
                     #endif
-                    return (nil, false, record.version)
+                    return (nil, false, false, record.version)
                 }
             }
             let snapshot = registry.ingest(record, origin: origin)
+            let accepted = snapshot != nil
             // Content is never logged — only its shape. A hook record carries
             // the user's prompt and their file paths.
-            Log.claudeContext.debug("Ingested \(record.event.rawValue, privacy: .public)")
+            if accepted {
+                Log.claudeContext.debug("Ingested \(record.event.rawValue, privacy: .public)")
+            } else {
+                Log.claudeContext.debug("Registry refused \(record.event.rawValue, privacy: .public)")
+            }
             #if DEBUG
             debugNotify(.success(record))
             #endif
@@ -657,21 +681,21 @@ public final class ClaudeContextBroker: Sendable {
             // never writes to the terminal at all. Allocation is unchanged —
             // the registry marker remains every join's liveness handle.
             let marker = snapshot?.agent == .claude ? snapshot?.marker : nil
-            return (marker, record.process?.herdrPaneID != nil, record.version)
+            return (marker, accepted, record.process?.herdrPaneID != nil, record.version)
         } catch let error as ClaudeHookWireError {
             Log.claudeContext.error("Rejected record: \(String(describing: error), privacy: .public)")
             #if DEBUG
             debugNotify(.failure(error))
             #endif
-            // A rejected record carries no marker, so its reply shape is
-            // inert; the current version is as good as any guess.
-            return (nil, false, ClaudeHookWire.version)
+            // A rejected record carries no marker; the current version is as
+            // good as any guess for the reply shape.
+            return (nil, false, false, ClaudeHookWire.version)
         } catch {
             Log.claudeContext.error("Rejected record: undecodable")
             #if DEBUG
             debugNotify(.failure(.malformed))
             #endif
-            return (nil, false, ClaudeHookWire.version)
+            return (nil, false, false, ClaudeHookWire.version)
         }
     }
 }

--- a/Tests/localvoxtralTests/ClaudeContextBrokerTests.swift
+++ b/Tests/localvoxtralTests/ClaudeContextBrokerTests.swift
@@ -293,6 +293,7 @@ final class ClaudeContextBrokerIntegrationTests: XCTestCase {
         }
         let response = try XCTUnwrap(ClaudeBrokerResponse.decodeLine(try XCTUnwrap(reply)))
         XCTAssertNil(response.marker)
+        XCTAssertEqual(response.accepted, false, "the pid cross-check is a rejection and must say so")
         XCTAssertNil(
             registry.snapshot(sessionID: "opencode:ses_forged"),
             "a pid-forged opencode record must never reach the registry"
@@ -301,7 +302,7 @@ final class ClaudeContextBrokerIntegrationTests: XCTestCase {
 
     func testRejectedRecordRepliesWithNoMarker() throws {
         // A reply still comes back so the publisher is not left waiting, but it
-        // carries nothing to put in a title.
+        // carries nothing to put in a title — and says the record was refused.
         try broker.start()
         let result = UnixSocketPublisher(timeout: 2.0)
             .publishAndReadReply(line: Data("{not json}\n".utf8), to: socketPath)
@@ -310,6 +311,78 @@ final class ClaudeContextBrokerIntegrationTests: XCTestCase {
         }
         let response = try XCTUnwrap(ClaudeBrokerResponse.decodeLine(try XCTUnwrap(reply)))
         XCTAssertNil(response.marker)
+        XCTAssertEqual(response.accepted, false)
+    }
+
+    // MARK: Acceptance verdict — the reply says what actually happened
+
+    func testRegistryRejectedFocusDeclarationRepliesNotAccepted() throws {
+        // The gap #209 documented as residual: a FocusChanged for a session
+        // the registry has never seen is refused by the registry, but the
+        // reply used to be shape-identical to success — the opencode plugin
+        // advanced its focus state and heartbeat-suppressed the retry for
+        // 20s, so a fresh session could dictate with the PREVIOUS session's
+        // context. The reply now carries the verdict.
+        try broker.start()
+        let declaration = ClaudeHookRecord(
+            event: .focusChanged,
+            agent: .opencode,
+            sessionID: "ses_unseen",
+            timestamp: 1,
+            process: ClaudeHookProcessInfo(hookPID: 4242, claudePID: getpid(), tty: "/dev/ttys004")
+        )
+        let result = UnixSocketPublisher(timeout: 2.0).publishAndReadReply(
+            line: try XCTUnwrap(ClaudeHookWireCodec.encodeLine(declaration)),
+            to: socketPath
+        )
+        guard case .success(let reply) = result else {
+            return XCTFail("publish failed: \(result)")
+        }
+        let response = try XCTUnwrap(ClaudeBrokerResponse.decodeLine(try XCTUnwrap(reply)))
+        XCTAssertEqual(
+            response.accepted, false,
+            "a registry-refused declaration must not read as delivered"
+        )
+    }
+
+    func testCommittedRecordAndValidFocusDeclarationReplyAccepted() throws {
+        try broker.start()
+        // A committed regular record replies accepted — the positive pin.
+        let start = ClaudeHookRecord(
+            event: .sessionStart,
+            agent: .opencode,
+            sessionID: "ses_focus",
+            timestamp: 1,
+            rawCwd: "/repo",
+            process: ClaudeHookProcessInfo(hookPID: 4242, claudePID: getpid())
+        )
+        let startResult = UnixSocketPublisher(timeout: 2.0).publishAndReadReply(
+            line: try XCTUnwrap(ClaudeHookWireCodec.encodeLine(start)),
+            to: socketPath
+        )
+        guard case .success(let startReply) = startResult else {
+            return XCTFail("publish failed: \(startResult)")
+        }
+        let startResponse = try XCTUnwrap(ClaudeBrokerResponse.decodeLine(try XCTUnwrap(startReply)))
+        XCTAssertEqual(startResponse.accepted, true, "a committed record must read as accepted")
+
+        // And a declaration for a session the registry KNOWS is accepted too.
+        let declaration = ClaudeHookRecord(
+            event: .focusChanged,
+            agent: .opencode,
+            sessionID: "ses_focus",
+            timestamp: 2,
+            process: ClaudeHookProcessInfo(hookPID: 4242, claudePID: getpid(), tty: "/dev/ttys004")
+        )
+        let result = UnixSocketPublisher(timeout: 2.0).publishAndReadReply(
+            line: try XCTUnwrap(ClaudeHookWireCodec.encodeLine(declaration)),
+            to: socketPath
+        )
+        guard case .success(let reply) = result else {
+            return XCTFail("publish failed: \(result)")
+        }
+        let response = try XCTUnwrap(ClaudeBrokerResponse.decodeLine(try XCTUnwrap(reply)))
+        XCTAssertEqual(response.accepted, true)
     }
 
     func testPublisherEmitsMarkerOutputWhenLocalTitleFallbackIsEnabled() throws {

--- a/Tests/localvoxtralTests/ClaudeMarkerSequenceTests.swift
+++ b/Tests/localvoxtralTests/ClaudeMarkerSequenceTests.swift
@@ -21,6 +21,38 @@ final class ClaudeBrokerResponseTests: XCTestCase {
         XCTAssertNil(decoded.marker)
     }
 
+    func testRoundTripsTheAcceptanceVerdict() throws {
+        for accepted in [true, false] {
+            let line = try XCTUnwrap(
+                ClaudeBrokerResponse.encodeLine(ClaudeBrokerResponse(marker: nil, accepted: accepted))
+            )
+            let decoded = try XCTUnwrap(ClaudeBrokerResponse.decodeLine(line.dropLast()))
+            XCTAssertEqual(decoded.accepted, accepted)
+        }
+    }
+
+    func testNilAcceptanceEncodesNoKeyAndDecodesBackAsNil() throws {
+        let line = try XCTUnwrap(ClaudeBrokerResponse.encodeLine(ClaudeBrokerResponse(marker: nil)))
+        XCTAssertFalse(
+            String(decoding: line, as: UTF8.self).contains("accepted"),
+            "nil must keep the key off the wire — its absence IS the pre-accepted-era shape"
+        )
+        let decoded = try XCTUnwrap(ClaudeBrokerResponse.decodeLine(line.dropLast()))
+        XCTAssertNil(decoded.accepted)
+    }
+
+    func testPreAcceptedEraReplyStillDecodesWithNilAcceptance() throws {
+        // A reply from a broker built before the field existed. It must keep
+        // decoding, with `accepted == nil` — the compat promise the plugin's
+        // settle-true fallback rests on. No version bump guards this; the
+        // shape itself is the guarantee.
+        let json = #"{"v":1,"marker":"lvx-abcd1234"}"#
+        let decoded = try XCTUnwrap(ClaudeBrokerResponse.decodeLine(Data(json.utf8)))
+        XCTAssertEqual(decoded.version, 1)
+        XCTAssertEqual(decoded.marker, "lvx-abcd1234")
+        XCTAssertNil(decoded.accepted)
+    }
+
     func testRejectsForeignVersion() {
         let json = #"{"v":99,"marker":"lvx-abcd1234"}"#
         XCTAssertNil(ClaudeBrokerResponse.decodeLine(Data(json.utf8)))

--- a/Tests/localvoxtralTests/OpencodePluginContractTests.swift
+++ b/Tests/localvoxtralTests/OpencodePluginContractTests.swift
@@ -214,17 +214,29 @@ final class OpencodePluginContractTests: XCTestCase {
 
     /// Deliver one broker reply line on the most recently created socket —
     /// the shape `ClaudeContextBroker.reply` sends for an opencode record.
-    private func deliverBrokerReply() {
+    /// `accepted: nil` produces a reply with no `accepted` key at all: the
+    /// pre-accepted-era broker shape, which must settle callbacks true.
+    private func deliverBrokerReply(accepted: Bool? = nil) {
         let line = String(
-            decoding: ClaudeBrokerResponse.encodeLine(ClaudeBrokerResponse(marker: nil))!,
+            decoding: ClaudeBrokerResponse.encodeLine(
+                ClaudeBrokerResponse(marker: nil, accepted: accepted)
+            )!,
             as: UTF8.self
         ).replacingOccurrences(of: "\n", with: "\\n")
-        run(#"""
-        (() => {
-          const socket = globalThis.__sockets[globalThis.__sockets.length - 1];
-          socket.handlers.data('\#(line)');
-        })();
-        """#)
+        deliverRawReplyChunks([line])
+    }
+
+    /// Deliver raw bytes on the most recently created socket, one data event
+    /// per chunk — for unparseable replies and chunk-boundary splits.
+    private func deliverRawReplyChunks(_ chunks: [String]) {
+        for chunk in chunks {
+            run(#"""
+            (() => {
+              const socket = globalThis.__sockets[globalThis.__sockets.length - 1];
+              socket.handlers.data('\#(chunk)');
+            })();
+            """#)
+        }
     }
 
     /// Fail the most recently created socket the way a dead broker does:
@@ -287,6 +299,9 @@ final class OpencodePluginContractTests: XCTestCase {
     }
 
     func testFocusStateAdvancesOnReplyAndHeartbeatSuppressesResends() throws {
+        // Doubles as the old-broker compat pin: this reply carries no
+        // `accepted` field (a pre-accepted-era broker never sends one), and
+        // it must settle true — an old broker must not cause retry storms.
         try startTUI()
         setRoute(sessionID: "sesA")
         sample()
@@ -296,6 +311,66 @@ final class OpencodePluginContractTests: XCTestCase {
         XCTAssertEqual(
             try records(event: "FocusChanged", session: "sesA").count, 1,
             "an acknowledged declaration must be heartbeat-suppressed, not resent every sample"
+        )
+    }
+
+    func testRegistryRejectedFocusDeclarationIsRetriedUntilAccepted() throws {
+        // The declaration-before-session race #209 documented as residual,
+        // now closed: the broker replies `accepted:false` when the registry
+        // refused the declaration (it only honors declarations for sessions
+        // it knows), and the plugin must treat that as NOT delivered — retry
+        // at the next 500ms sample instead of letting the 20s heartbeat
+        // suppress the repair while dictation grounds on the previous
+        // session's context.
+        try startTUI()
+        setRoute(sessionID: "sesB")
+        sample()
+        XCTAssertEqual(try records(event: "FocusChanged", session: "sesB").count, 1)
+
+        deliverBrokerReply(accepted: false)
+        sample()
+        XCTAssertEqual(
+            try records(event: "FocusChanged", session: "sesB").count, 2,
+            "a registry-rejected declaration must be retried at the next sample"
+        )
+
+        deliverBrokerReply(accepted: true)
+        sample()
+        sample()
+        XCTAssertEqual(
+            try records(event: "FocusChanged", session: "sesB").count, 2,
+            "once the reply says accepted, the heartbeat takes over"
+        )
+    }
+
+    func testUnparseableReplyLineSettlesTrueLikeAPreAcceptedEraBroker() throws {
+        // The tolerant end of the new contract: a reply line the plugin
+        // cannot parse must behave exactly like one with no `accepted` field
+        // — settle true. Anything else turns an odd-but-live broker into a
+        // permanent retry storm inside the user's agent process.
+        try startTUI()
+        setRoute(sessionID: "sesA")
+        sample()
+        deliverRawReplyChunks(["this is not json\\n"])
+        sample()
+        sample()
+        XCTAssertEqual(
+            try records(event: "FocusChanged", session: "sesA").count, 1,
+            "an unparseable reply must settle true, exactly the pre-accepted behavior"
+        )
+    }
+
+    func testAcceptedFalseIsParsedAcrossChunkBoundaries() throws {
+        // Reply bytes arrive on whatever read boundaries the runtime picked;
+        // the verdict must survive a line split mid-key.
+        try startTUI()
+        setRoute(sessionID: "sesA")
+        sample()
+        deliverRawReplyChunks([#"{"accep"#, #"ted":false,"v":2}\n"#])
+        sample()
+        XCTAssertEqual(
+            try records(event: "FocusChanged", session: "sesA").count, 2,
+            "a rejection split across data events must still be read as one line"
         )
     }
 

--- a/integrations/opencode/localvoxtral.js
+++ b/integrations/opencode/localvoxtral.js
@@ -14,9 +14,9 @@
 // is the worst possible failure. Hence the hard rules below:
 //
 //   * No network-shaped waiting inside hooks. One lazily (re)connected
-//     socket, unref()ed, fire-and-forget writes. Broker reply lines are only
-//     ever COUNTED (one reply per record, in order) to settle callbacks —
-//     never parsed for content, never surfaced anywhere.
+//     socket, unref()ed, fire-and-forget writes. Broker reply lines settle
+//     callbacks (one reply per record, in order); each is read only for the
+//     broker's `accepted` verdict and never surfaced anywhere.
 //   * Every handler body is wrapped in try/catch and swallows everything.
 //   * Nothing is ever written to the terminal: no stdout, no stderr, no
 //     logging. opencode's TUI owns those descriptors.
@@ -117,14 +117,15 @@ function socketPath() {
 // blocks a hook on the dial.
 //
 // The socket is request/response: the broker writes exactly one reply line
-// per record it reads, in order (ClaudeBrokerResponse). publish() exploits
-// only that SHAPE — replies are counted, never parsed: this plugin has no
-// title channel and must never surface a byte anywhere a terminal could see
-// it. A caller that passes an onReply callback gets it settled exactly once,
-// with true when this record's reply line arrived (the broker read the
-// record) or false when the connection failed, was reset, or closed first.
-// A reply does NOT mean the registry accepted the record — see the focus
-// declaration notes in the TUI half for what that leaves unguaranteed.
+// per record it reads, in order (ClaudeBrokerResponse). A caller that passes
+// an onReply callback gets it settled exactly once: false when the reply says
+// `accepted:false` (the broker read the record but the registry refused it —
+// e.g. a focus declaration racing ahead of its session record) or when the
+// connection failed, was reset, or closed first; true otherwise. A reply
+// with no `accepted` field, or one that does not parse, settles TRUE — that
+// is a pre-`accepted`-era broker, and an old broker must look like the old
+// contract, not like a rejection storm. Reply content is never surfaced
+// anywhere a terminal could see it; this plugin has no title channel.
 
 let socket;
 
@@ -143,15 +144,31 @@ function connectSocket(path) {
       } catch {}
     }
   };
+  // Partial reply line carried between data events. Real replies are tiny,
+  // so the buffer is capped: past the cap the line stops accumulating and
+  // will not parse, which settles true (the tolerant fallback below).
+  let replyLine = "";
   created.on("data", (chunk) => {
     try {
       if (!chunk) return;
       for (let index = 0; index < chunk.length; index += 1) {
         const byte = typeof chunk === "string" ? chunk.charCodeAt(index) : chunk[index];
-        if (byte !== 10) continue; // count newline-terminated reply lines only
+        if (byte !== 10) {
+          if (replyLine.length < 512) replyLine += String.fromCharCode(byte);
+          continue;
+        }
+        const line = replyLine;
+        replyLine = "";
+        // `accepted === false` is the ONLY rejecting shape. A missing field
+        // or an unparseable line is a pre-`accepted`-era broker and settles
+        // true — exactly the old contract.
+        let verdict = true;
+        try {
+          verdict = JSON.parse(line).accepted !== false;
+        } catch {}
         const settle = pending.shift();
         try {
-          if (settle) settle(true);
+          if (settle) settle(verdict);
         } catch {}
       }
     } catch {}
@@ -458,12 +475,12 @@ const TuiHalf = async (api) => {
   // (reply, connection error, or close — the broker's own deadline bounds
   // the quiet case) re-enables sampling.
   //
-  // What a reply still cannot promise on this wire: REGISTRY acceptance. A
-  // rejected record earns the same nil-marker reply line as an accepted one
-  // (ClaudeContextBroker.handle), so a FocusChanged racing ahead of its
-  // session record — the registry refuses declarations for sessions it does
-  // not know — is indistinguishable from success here. That residual window
-  // is bounded by the 20s heartbeat re-declaration and by every route change.
+  // The reply also carries the REGISTRY's verdict (`accepted`, broker-side
+  // ClaudeContextBroker.handle): a FocusChanged racing ahead of its session
+  // record — the registry refuses declarations for sessions it does not
+  // know — settles false like any lost write, so the next sample retries
+  // instead of the 20s heartbeat suppressing the repair while dictation
+  // grounds on the previous session. Old brokers omit the field: settle true.
   let lastSession;
   let lastSentAt = 0;
   let inflight = false;


### PR DESCRIPTION
## What

Closes the residual documented in #209 (owner-approved follow-through on its wire proposal): the broker's reply was shape-identical for accepted and rejected records, so a `FocusChanged` racing ahead of its session record earned a normal-looking reply and the opencode plugin pinned dictation to the *previous* session's context for up to one 20 s heartbeat.

**Stacked on #209** — review only the delta.

- **Wire**: `ClaudeBrokerResponse` gains optional `accepted: Bool?`. Omitted when nil, missing decodes as nil, no version bump — backward compatible by construction. The installed Claude shim's decoder is the synthesized Codable `init(from:)` (`ClaudeHookPublisher.swift:117` → `decodeLine`), which ignores unknown keys, so old shim binaries are unaffected.
- **Broker**: every reply now states truthfully whether the record was committed (`registry.ingest != nil`), including v1-echoed replies; the registry-refused case now logs "Registry refused" instead of "Ingested". Which cases reply is UNCHANGED — the rejection layers that reply (wire-shape decode failure, opencode peer-pid check, registry refusal) are enumerated in `handle()`'s doc comment; connection-level drops still never reply.
- **Plugin**: reply lines are now buffered across chunks (512-char cap) and parsed in try/catch. Only `accepted === false` settles the reply callback false — routing into #209's retry-at-next-500ms-sample machinery, so a rejected focus declaration converges as soon as the session record lands (window shrinks from ≤20 s to ~one sample). `true`, a *missing* field (old broker), or an unparseable line settle true — exactly the prior behavior, so no retry storms against old brokers. Size 24,427 of the manifest's 24,576-byte bound; zero-`await`/no-terminal-output invariants pinned and green.

## Proof

- [x] Broker red → green:
  ```
  XCTAssertEqual failed: ("nil") is not equal to ("Optional(false)") - a registry-refused declaration must not read as delivered
  after: ClaudeContextBrokerIntegrationTests — Executed 29 tests, with 0 failures
  ```
- [x] Plugin red → green (JSC contract harness):
  ```
  XCTAssertEqual failed: ("1") is not equal to ("2") - a registry-rejected declaration must be retried at the next sample
  after: OpencodePluginContractTests 14/14 + OpencodePluginManifestTests 17/17 — Executed 31 tests, with 0 failures
  ```
  Compat pins (reply with no `accepted` field; unparseable reply) pass before AND after — old-broker behavior is unchanged by construction, not by luck.
- [x] Wire: `ClaudeBrokerResponseTests` 8/8 — round-trips, nil-omits-key, and a pre-accepted-era `{"v":1,"marker":…}` line decoding with `accepted == nil`.
- [x] Full unit suite: `Executed 2133 tests, with 2 tests skipped and 0 failures`, 0 warnings.
- [x] Tier-1 realtime integration (fresh gate): 7 tests, 0 failures, speechd word accuracy 0.759.
- [x] LLM lane: paths match the filter, so the lane runs; the change alters reply metadata on the context transport, not what reaches the model.
