### PR TITLE
Remote shim: back off after transport failures so ssh stops spraying connect_to noise over the terminal

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -394,7 +394,13 @@ Key subsystems:
     hooks running the bundled POSIX-sh shim `hooks/post.sh`, which curls the
     event JSON to `127.0.0.1:8473/v1/hook/<Event>` through an OpenSSH
     `RemoteForward` — no localvoxtral binary and no `jq`/`nc`/Node on that
-    host, but it does need `sh` and `curl` (fail-open when absent). It was
+    host, but it does need `sh` and `curl` (fail-open when absent). After a
+    transport-level failure the shim backs off for 5 minutes (epoch stamp
+    under `$XDG_RUNTIME_DIR`/`~/.cache`) for every event except
+    `UserPromptSubmit`: each dial against a live forward with no app behind
+    it makes the Mac-side ssh client print `connect_to …: failed.` onto the
+    user's terminal — stderr the remote side can never redirect — and any
+    completed HTTP exchange (even a 401) clears the backoff. It was
     `type: "http"` hooks until 2026-07-27: Claude Code expands http-hook
     header `${VAR}`s from the process environment only and never injects
     plugin userConfig options there (verified on 2.1.220), so every hook

--- a/Sources/localvoxtral/ClaudeContext/ClaudeRemoteEnrollmentService.swift
+++ b/Sources/localvoxtral/ClaudeContext/ClaudeRemoteEnrollmentService.swift
@@ -360,6 +360,11 @@ public struct ClaudeRemoteEnrollmentService: Sendable {
             "The plugin needs only POSIX `sh` and `curl` on the remote host — no localvoxtral binary. "
                 + "Its hooks fail open silently when either is missing, the tunnel is down, or the app "
                 + "is not answering: you simply get no context, never a blocked Claude turn.",
+            "While a session holds the tunnel and localvoxtral is not running, ssh itself — on this "
+                + "Mac — prints `connect_to 127.0.0.1 port \(port): failed.` into the remote terminal on "
+                + "every dial; the plugin cannot silence another process. So after a failed dial its "
+                + "hooks back off for five minutes; prompt submits still try, so context returns with "
+                + "your first prompt once the app is back.",
             "A second concurrent SSH session to the same host will fail to bind \(port) on the "
                 + "remote and — because ExitOnForwardFailure is `no` — will connect anyway with no "
                 + "tunnel. The first session keeps the forward.",

--- a/Tests/localvoxtralTests/ClaudeRemoteEnrollmentServiceTests.swift
+++ b/Tests/localvoxtralTests/ClaudeRemoteEnrollmentServiceTests.swift
@@ -465,6 +465,12 @@ final class ClaudeRemoteEnrollmentServiceTests: XCTestCase {
             notes.contains("curl") && notes.contains("fail open"),
             "the host dependency (sh + curl) and its fail-open behavior must be stated honestly"
         )
+        XCTAssertTrue(
+            notes.contains("connect_to") && notes.contains("back off"),
+            "the app-down ssh noise (`connect_to … failed`, printed by ssh on this Mac, not by "
+                + "the plugin) and the shim's backoff must be stated — the symptom reads as a "
+                + "plugin bug and the user must learn whose stderr it is"
+        )
     }
 
     func testNotesStateThatARemoteTokenCannotReachLocalFiles() throws {

--- a/Tests/localvoxtralTests/ClaudeRemotePluginManifestTests.swift
+++ b/Tests/localvoxtralTests/ClaudeRemotePluginManifestTests.swift
@@ -675,6 +675,71 @@ final class ClaudeRemotePluginManifestTests: XCTestCase {
         }
     }
 
+    func testArmingReplacesAPrePlantedSymlinkInsteadOfWritingThroughIt() throws {
+        // The stamp write must be tempfile + mv: rename(2) replaces a symlink
+        // planted at the stamp path, where a direct `>` redirect would follow
+        // it and clobber whatever the link points at. Same-user scope, but the
+        // shim's own hygiene bar (mktemp, umask 077, 0600 header) demands it.
+        let state = try makeBackoffState()
+        defer { try? FileManager.default.removeItem(at: state.dir) }
+        let victim = state.dir.appendingPathComponent("victim")
+        let victimContents = "precious user data\n"
+        try victimContents.write(to: victim, atomically: true, encoding: .utf8)
+        try FileManager.default.createDirectory(
+            at: state.stamp.deletingLastPathComponent(), withIntermediateDirectories: true
+        )
+        try FileManager.default.createSymbolicLink(at: state.stamp, withDestinationURL: victim)
+
+        let result = try runShimWithStubCurl(
+            event: "Stop", status: "", body: nil, curlExitCode: 7,
+            extraEnvironment: state.environment
+        )
+        XCTAssertEqual(result.exitCode, 0)
+        XCTAssertEqual(result.stderr, "")
+        XCTAssertEqual(
+            try String(contentsOf: victim, encoding: .utf8), victimContents,
+            "arming the backoff must never write through a symlink at the stamp path"
+        )
+        let attributes = try FileManager.default.attributesOfItem(atPath: state.stamp.path)
+        XCTAssertEqual(
+            attributes[.type] as? FileAttributeType, .typeRegular,
+            "the symlink must have been replaced by a regular stamp file"
+        )
+        let stampText = try String(contentsOf: state.stamp, encoding: .utf8)
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        XCTAssertTrue(stampText.allSatisfy(\.isNumber), "the stamp must be epoch seconds: \(stampText)")
+    }
+
+    func testArmingTightensAPreExistingLooseStampDirectory() throws {
+        // `mkdir -p` leaves an existing directory's mode alone, so a stamp dir
+        // that pre-existed at 0777 (misconfig, prior tool) would let another
+        // local user replace the stamp or plant a symlink. Arming must chmod
+        // it to 0700.
+        let state = try makeBackoffState()
+        defer { try? FileManager.default.removeItem(at: state.dir) }
+        let stampDirectory = state.stamp.deletingLastPathComponent()
+        try FileManager.default.createDirectory(
+            at: stampDirectory, withIntermediateDirectories: true,
+            attributes: [.posixPermissions: 0o777]
+        )
+
+        let result = try runShimWithStubCurl(
+            event: "Stop", status: "", body: nil, curlExitCode: 7,
+            extraEnvironment: state.environment
+        )
+        XCTAssertEqual(result.exitCode, 0)
+        XCTAssertEqual(result.stderr, "")
+        let attributes = try FileManager.default.attributesOfItem(atPath: stampDirectory.path)
+        XCTAssertEqual(
+            (attributes[.posixPermissions] as? NSNumber)?.int16Value, 0o700,
+            "arming must tighten a pre-existing loose stamp directory to 0700"
+        )
+        XCTAssertTrue(
+            FileManager.default.fileExists(atPath: state.stamp.path),
+            "the stamp must still be armed after the chmod"
+        )
+    }
+
     func testPostToolUseMatchesOnlyFileBearingTools() throws {
         let matchers = try XCTUnwrap(try hooksByEvent()["PostToolUse"])
         let matcher = try XCTUnwrap(matchers.first?["matcher"] as? String)

--- a/Tests/localvoxtralTests/ClaudeRemotePluginManifestTests.swift
+++ b/Tests/localvoxtralTests/ClaudeRemotePluginManifestTests.swift
@@ -347,15 +347,23 @@ final class ClaudeRemotePluginManifestTests: XCTestCase {
 
     /// Runs the shim under `/bin/sh` with exactly the given extra environment
     /// (a nil-token run REMOVES the variable), a `{}` event body on stdin, and
-    /// captures everything.
+    /// captures everything. Unless the caller supplies its own state dir, the
+    /// backoff stamp is pointed at a throwaway `XDG_RUNTIME_DIR` so no test
+    /// run ever reads or writes real per-user state under `~/.cache`.
     private func runShim(
+        event: String = "Stop",
         environment: [String: String]
     ) throws -> (exitCode: Int32, stdout: String, stderr: String) {
+        let isolatedState = FileManager.default.temporaryDirectory
+            .appendingPathComponent("shim-state-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: isolatedState, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: isolatedState) }
         let process = Process()
         process.executableURL = URL(fileURLWithPath: "/bin/sh")
-        process.arguments = [shimURL.path, "Stop"]
+        process.arguments = [shimURL.path, event]
         var processEnvironment = ProcessInfo.processInfo.environment
         processEnvironment.removeValue(forKey: "CLAUDE_PLUGIN_OPTION_TOKEN")
+        processEnvironment["XDG_RUNTIME_DIR"] = isolatedState.path
         processEnvironment.merge(environment) { _, new in new }
         process.environment = processEnvironment
         let stdin = Pipe()
@@ -458,12 +466,20 @@ final class ClaudeRemotePluginManifestTests: XCTestCase {
 
     /// Runs the shim with a stub `curl` first on PATH that "answers" with the
     /// given status and body: it honors `--output <path>` the way the real curl
-    /// does, drains stdin, and prints the status as `--write-out` would. The
-    /// real system PATH stays behind it, so `grep`/`cat`/`wc` resolve normally.
-    /// A nil body means curl "succeeded" without ever writing the output file —
-    /// the shape a reset tunnel produces.
+    /// does, drains stdin, prints the status as `--write-out` would, and exits
+    /// with `curlExitCode` (nonzero = the transport-level failure a dead tunnel
+    /// produces; the shim then clears `STATUS`). The real system PATH stays
+    /// behind it, so `grep`/`cat`/`wc` resolve normally. A nil body means curl
+    /// "succeeded" without ever writing the output file — the shape a reset
+    /// tunnel produces. When `extraEnvironment` sets `FAKE_CURL_LOG`, the stub
+    /// appends one line per invocation, so a test can prove curl was — or was
+    /// NOT — dialed at all.
     private func runShimWithStubCurl(
-        status: String, body: Data?
+        event: String = "Stop",
+        status: String,
+        body: Data?,
+        curlExitCode: Int32 = 0,
+        extraEnvironment: [String: String] = [:]
     ) throws -> (exitCode: Int32, stdout: String, stderr: String) {
         let stubDirectory = FileManager.default.temporaryDirectory
             .appendingPathComponent("shim-stub-\(UUID().uuidString)")
@@ -474,6 +490,7 @@ final class ClaudeRemotePluginManifestTests: XCTestCase {
         let stub = stubDirectory.appendingPathComponent("curl")
         let script = """
         #!/bin/sh
+        [ -n "${FAKE_CURL_LOG:-}" ] && printf 'dial\\n' >>"$FAKE_CURL_LOG"
         out=""
         previous=""
         for argument in "$@"; do
@@ -483,16 +500,179 @@ final class ClaudeRemotePluginManifestTests: XCTestCase {
         cat >/dev/null
         [ -n "$out" ] && cp "$FAKE_CURL_BODY" "$out" 2>/dev/null
         printf '%s' "$FAKE_CURL_STATUS"
+        exit "${FAKE_CURL_EXIT:-0}"
         """
         try script.write(to: stub, atomically: true, encoding: .utf8)
         try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: stub.path)
         let systemPath = ProcessInfo.processInfo.environment["PATH"] ?? "/usr/bin:/bin"
-        return try runShim(environment: [
+        var environment = [
             "CLAUDE_PLUGIN_OPTION_TOKEN": "unit-test-token",
             "PATH": "\(stubDirectory.path):\(systemPath)",
             "FAKE_CURL_BODY": bodyFixture.path,
             "FAKE_CURL_STATUS": status,
-        ])
+            "FAKE_CURL_EXIT": String(curlExitCode),
+        ]
+        environment.merge(extraEnvironment) { _, new in new }
+        return try runShim(event: event, environment: environment)
+    }
+
+    // MARK: Shim transport backoff
+    //
+    // While an SSH session holds the RemoteForward but the app is not running,
+    // every dial makes the ssh client ON THE MAC print
+    // `connect_to 127.0.0.1 port 8473 failed` onto the user's terminal — over
+    // the herdr pane or the Claude Code TUI, once per hook. That stderr is
+    // another process on another machine; the shim's only lever is to stop
+    // dialing a tunnel that just proved dead. These tests RUN the shim against
+    // the stub curl and prove the contract: a transport failure arms a stamp,
+    // later events skip curl entirely, UserPromptSubmit always dials through,
+    // and any completed HTTP exchange clears the stamp. Every odd stamp state
+    // fails toward dialing — the pre-backoff behavior.
+
+    /// A throwaway backoff-state home shared across several shim runs, plus
+    /// the stamp path the shim derives from it.
+    private func makeBackoffState() throws -> (dir: URL, stamp: URL, environment: [String: String]) {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("shim-backoff-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        return (
+            dir,
+            dir.appendingPathComponent("localvoxtral/hook-backoff"),
+            ["XDG_RUNTIME_DIR": dir.path]
+        )
+    }
+
+    private func writeStamp(_ contents: String, at stamp: URL) throws {
+        try FileManager.default.createDirectory(
+            at: stamp.deletingLastPathComponent(), withIntermediateDirectories: true
+        )
+        try contents.write(to: stamp, atomically: true, encoding: .utf8)
+    }
+
+    private func freshEpochStamp(secondsAgo: Int = 0) -> String {
+        "\(Int(Date().timeIntervalSince1970) - secondsAgo)\n"
+    }
+
+    func testTransportFailureArmsTheBackoffAndLaterEventsSkipTheDialEntirely() throws {
+        let state = try makeBackoffState()
+        defer { try? FileManager.default.removeItem(at: state.dir) }
+
+        // A dead tunnel: curl exits 7, no status, no body. Silent as ever —
+        // and the stamp is now armed with epoch seconds.
+        let failure = try runShimWithStubCurl(
+            event: "Stop", status: "", body: nil, curlExitCode: 7,
+            extraEnvironment: state.environment
+        )
+        XCTAssertEqual(failure.exitCode, 0)
+        XCTAssertEqual(failure.stdout, "")
+        XCTAssertEqual(failure.stderr, "")
+        let stampText = try String(contentsOf: state.stamp, encoding: .utf8)
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        XCTAssertFalse(stampText.isEmpty, "a transport failure must arm the backoff stamp")
+        XCTAssertTrue(stampText.allSatisfy(\.isNumber), "the stamp must be epoch seconds: \(stampText)")
+
+        // Inside the window, an ordinary event must not invoke curl AT ALL —
+        // the dial itself is what makes ssh print. The stub would both log the
+        // invocation and answer a perfectly valid marker body; neither may
+        // happen.
+        let log = state.dir.appendingPathComponent("curl.log")
+        let backedOff = try runShimWithStubCurl(
+            event: "PostToolUse", status: "200",
+            body: ClaudeRemoteHTTPCodec.markerResponseBody(marker: nil),
+            extraEnvironment: state.environment.merging(["FAKE_CURL_LOG": log.path]) { _, new in new }
+        )
+        XCTAssertEqual(backedOff.exitCode, 0)
+        XCTAssertEqual(backedOff.stdout, "", "a backed-off event must print nothing")
+        XCTAssertEqual(backedOff.stderr, "")
+        XCTAssertFalse(
+            FileManager.default.fileExists(atPath: log.path),
+            "curl must not be dialed during the backoff window"
+        )
+    }
+
+    func testUserPromptSubmitDialsThroughAnArmedBackoffAndSuccessClearsIt() throws {
+        let state = try makeBackoffState()
+        defer { try? FileManager.default.removeItem(at: state.dir) }
+        try writeStamp(freshEpochStamp(), at: state.stamp)
+
+        // The prompt event is exempt: it must dial straight through the armed
+        // stamp, deliver the marker, and — having completed an exchange —
+        // clear the backoff.
+        let body = ClaudeRemoteHTTPCodec.markerResponseBody(marker: "lvx-441e1124")
+        let prompt = try runShimWithStubCurl(
+            event: "UserPromptSubmit", status: "200", body: body,
+            extraEnvironment: state.environment
+        )
+        XCTAssertEqual(prompt.exitCode, 0)
+        XCTAssertEqual(
+            Data(prompt.stdout.utf8), body,
+            "UserPromptSubmit must dial straight through an armed backoff"
+        )
+        XCTAssertFalse(
+            FileManager.default.fileExists(atPath: state.stamp.path),
+            "a completed exchange must clear the stamp"
+        )
+
+        // With the stamp gone, ordinary events dial again.
+        let log = state.dir.appendingPathComponent("curl.log")
+        let stop = try runShimWithStubCurl(
+            event: "Stop", status: "200", body: body,
+            extraEnvironment: state.environment.merging(["FAKE_CURL_LOG": log.path]) { _, new in new }
+        )
+        XCTAssertEqual(stop.exitCode, 0)
+        XCTAssertTrue(
+            FileManager.default.fileExists(atPath: log.path),
+            "Stop must dial again once the backoff is cleared"
+        )
+    }
+
+    func testEvenA401ClearsTheBackoffBecauseTheExchangeCompleted() throws {
+        // A 401 proves the tunnel terminates at a listener — nothing will make
+        // ssh complain — so it must clear the stamp exactly like a 200.
+        let state = try makeBackoffState()
+        defer { try? FileManager.default.removeItem(at: state.dir) }
+        try writeStamp(freshEpochStamp(), at: state.stamp)
+
+        let result = try runShimWithStubCurl(
+            event: "UserPromptSubmit", status: "401", body: nil,
+            extraEnvironment: state.environment
+        )
+        XCTAssertEqual(result.exitCode, 0)
+        XCTAssertEqual(result.stdout, "")
+        XCTAssertEqual(result.stderr, "")
+        XCTAssertFalse(
+            FileManager.default.fileExists(atPath: state.stamp.path),
+            "any completed HTTP exchange must clear the stamp"
+        )
+    }
+
+    func testExpiredCorruptAndFutureStampsAllFailTowardDialing() throws {
+        // Backoff must only ever SUBTRACT noise. An expired stamp, garbage
+        // content, or a clock that jumped backwards (stamp in the future) all
+        // mean the same thing: dial, exactly as before the backoff existed.
+        let stamps = [
+            ("expired", freshEpochStamp(secondsAgo: 3600)),
+            ("corrupt", "not-a-number\n"),
+            ("future", freshEpochStamp(secondsAgo: -100_000)),
+            ("oversized", "99999999999999999999999999\n"),
+        ]
+        for (name, contents) in stamps {
+            let state = try makeBackoffState()
+            defer { try? FileManager.default.removeItem(at: state.dir) }
+            try writeStamp(contents, at: state.stamp)
+            let log = state.dir.appendingPathComponent("curl.log")
+            let result = try runShimWithStubCurl(
+                event: "Stop", status: "200",
+                body: ClaudeRemoteHTTPCodec.markerResponseBody(marker: nil),
+                extraEnvironment: state.environment.merging(["FAKE_CURL_LOG": log.path]) { _, new in new }
+            )
+            XCTAssertEqual(result.exitCode, 0, "\(name): must still exit 0")
+            XCTAssertEqual(result.stderr, "", "\(name): must never print on stderr")
+            XCTAssertTrue(
+                FileManager.default.fileExists(atPath: log.path),
+                "\(name): a \(name) stamp must fail toward dialing"
+            )
+        }
     }
 
     func testPostToolUseMatchesOnlyFileBearingTools() throws {
@@ -622,6 +802,28 @@ final class ClaudeRemotePluginManifestTests: XCTestCase {
         try assertReadmeHasLine(
             containing: "silent",
             "the cost of `no` is a silently absent tunnel; a user who is not told will not look"
+        )
+    }
+
+    func testReadmeDocumentsTheAppDownSSHNoiseAndTheBackoff() throws {
+        // The failure mode reads as "the plugin is printing errors" when the
+        // printer is actually ssh on the Mac. Name the exact message a user
+        // will see, say the shim backs off rather than dialing, and keep the
+        // UserPromptSubmit exemption stated — it is the one residual line a
+        // user WILL still see per prompt while the app is down.
+        // OpenSSH's exact format string is `connect_to %.100s port %d: failed.`
+        // (channels.c) — quote it verbatim so a user can search for it.
+        try assertReadmeHasLine(
+            containing: "connect_to 127.0.0.1 port 8473: failed.",
+            "name the exact ssh message so a user can search for it"
+        )
+        try assertReadmeHasLine(
+            containing: "stops dialing",
+            "the fix is not dialing, and the doc must say so"
+        )
+        try assertReadmeHasLine(
+            containing: "`UserPromptSubmit` still dials every time",
+            "the residual one-line-per-prompt signal is deliberate and must be stated"
         )
     }
 

--- a/integrations/claude-code/.claude-plugin/marketplace.json
+++ b/integrations/claude-code/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Off-screen Claude Code session context for the localvoxtral dictation app.",
-    "version": "1.2.0"
+    "version": "1.3.0"
   },
   "plugins": [
     {

--- a/integrations/claude-code/README.md
+++ b/integrations/claude-code/README.md
@@ -227,6 +227,25 @@ Code writes to its terminal — so the marker rides the SSH PTY back into Ghostt
 and the pane identifies itself. Nothing else opens a port, and nothing is
 reachable from your LAN.
 
+## When the app is not running on your Mac
+
+The shim's own failures are always silent, but there is one message it cannot
+reach: while an SSH session holds the forward and localvoxtral is not running,
+each dial makes **ssh itself, on your Mac**, print
+`connect_to 127.0.0.1 port 8473: failed.`
+onto the terminal — over whatever is drawn there (a herdr pane, the Claude Code
+screen), once per hook. That stderr belongs to another process on another
+machine; no plugin-side redirect can touch it, and silencing it in ssh would
+take `LogLevel QUIET`, which also hides host-key warnings — not a trade this
+plugin will make for you.
+
+So the shim stops dialing instead: after a transport-level failure, every hook
+except `UserPromptSubmit` skips the tunnel for the next 5 minutes.
+`UserPromptSubmit` still dials every time — one line per submitted prompt while
+the app is down is the honest signal that context is off, and it means your
+first prompt after the app comes back is grounded immediately; that completed
+exchange (any HTTP status, even a 401) clears the backoff for everything else.
+
 ## Set it up
 
 In **Settings → Text Processing → Polishing → "Remote Claude Code over SSH"**,

--- a/integrations/claude-code/plugins/localvoxtral-remote/.claude-plugin/plugin.json
+++ b/integrations/claude-code/plugins/localvoxtral-remote/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "localvoxtral-remote",
   "description": "Publishes Claude Code session context from a REMOTE host to localvoxtral on your Mac, over an SSH RemoteForward tunnel. Command hooks running a bundled POSIX-sh shim that POSTs via curl — needs only sh and curl on the remote host, and fails open silently when either is missing.",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "author": {
     "name": "localvoxtral"
   },

--- a/integrations/claude-code/plugins/localvoxtral-remote/hooks/post.sh
+++ b/integrations/claude-code/plugins/localvoxtral-remote/hooks/post.sh
@@ -18,7 +18,12 @@
 # Everything here is fail-open. Missing curl, an unset/empty token, a tunnel
 # that is down, a Mac that is asleep, a timeout, a non-200 answer — all of it
 # exits 0 with NO stdout and NO stderr, so Claude Code never blocks, warns, or
-# fails a turn because dictation context is unavailable.
+# fails a turn because dictation context is unavailable. After a
+# transport-level failure the shim additionally BACKS OFF (see below): the ssh
+# client on the Mac prints a `connect_to …: failed.` line onto the user's
+# terminal for every dial against a live forward with no app behind it, and
+# that stderr is another process on another machine — un-redirectable from
+# here. Not dialing is the only silence we can buy.
 #
 # The token must never enter any process's argv: /proc/<pid>/cmdline is
 # world-readable on Linux, so `curl -H "Authorization: Bearer $TOKEN"` would
@@ -40,6 +45,54 @@ fail_open() {
 TOKEN="${CLAUDE_PLUGIN_OPTION_TOKEN:-}"
 [ -n "$TOKEN" ] || fail_open
 command -v curl >/dev/null 2>&1 || fail_open
+
+# --- Transport backoff -------------------------------------------------------
+# The one noise no redirect in this file can reach: while an SSH session holds
+# the RemoteForward but localvoxtral is not running on the Mac, every dial
+# makes the ssh CLIENT — on the other machine — print
+# `connect_to 127.0.0.1 port 8473: failed.` straight onto
+# the terminal, over whatever TUI is drawn there (a herdr pane, the Claude
+# Code screen), once per hook, dozens of times a turn via PostToolUse. The
+# only lever on this side is to stop dialing a tunnel that just proved dead:
+# after a transport-level failure, every event EXCEPT UserPromptSubmit skips
+# the dial for BACKOFF_SECONDS.
+#
+# UserPromptSubmit always dials, deliberately: it is user-paced (one ssh line
+# per submitted prompt while the app is down — an honest, bounded signal, not
+# a storm), it is the event that joins the session and carries the prompt, so
+# the first prompt after the app comes back is grounded immediately — and its
+# completed exchange clears the backoff for every other event.
+#
+# State is one epoch-seconds stamp in a private per-user dir. Anything odd —
+# no usable dir, no epoch from date, garbage content, a clock that jumped
+# backwards — disables the backoff and the shim simply dials: exactly the
+# pre-backoff behavior, fail-open as ever.
+BACKOFF_SECONDS=300
+if [ -n "${XDG_RUNTIME_DIR:-}" ]; then
+  STAMP_DIR="$XDG_RUNTIME_DIR/localvoxtral"
+elif [ -n "${HOME:-}" ]; then
+  STAMP_DIR="$HOME/.cache/localvoxtral"
+else
+  STAMP_DIR=""
+fi
+STAMP="$STAMP_DIR/hook-backoff"
+NOW="$(date +%s 2>/dev/null)" || NOW=""
+# Digits only, at most 12 of them (epoch seconds are 10 until year 2286): a
+# damaged value must never reach `[` or $(( )), where an oversized constant
+# aborts some shells — with output on stderr.
+case "$NOW" in *[!0-9]* | ?????????????*) NOW="" ;; esac
+if [ -n "$STAMP_DIR" ] && [ -n "$NOW" ] && [ "$EVENT" != "UserPromptSubmit" ] \
+  && [ -r "$STAMP" ]; then
+  LAST="$(cat "$STAMP" 2>/dev/null)" || LAST=""
+  case "$LAST" in
+  "" | *[!0-9]* | ?????????????*) ;;
+  *)
+    if [ "$LAST" -le "$NOW" ] && [ $((NOW - LAST)) -lt "$BACKOFF_SECONDS" ]; then
+      fail_open
+    fi
+    ;;
+  esac
+fi
 
 # 0700 directory / 0600 files for the header tempfile; removed on every exit.
 # Known, accepted leak: a SIGKILL (Claude Code escalating past the hook
@@ -67,6 +120,19 @@ STATUS="$(curl --silent --output "$WORK/body" --write-out '%{http_code}' \
   --header @"$WORK/header" \
   --data-binary @- \
   "http://127.0.0.1:8473/v1/hook/$EVENT" 2>/dev/null)" || STATUS=""
+
+# Arm the backoff on a transport-level failure (curl died: refused, reset,
+# timed out); clear it the moment ANY HTTP exchange completes — even a 401
+# proves the tunnel terminates at a listener instead of making ssh complain.
+# Both sides are best-effort and silent: failing to record state just means
+# the next event dials again.
+if [ -n "$STAMP_DIR" ] && [ -n "$NOW" ]; then
+  if [ -z "$STATUS" ] || [ "$STATUS" = "000" ]; then
+    { mkdir -p "$STAMP_DIR" && echo "$NOW" >"$STAMP"; } 2>/dev/null || :
+  else
+    rm -f "$STAMP" 2>/dev/null || :
+  fi
+fi
 
 # stdout is control JSON to Claude Code, and it cuts BOTH ways: a
 # UserPromptSubmit hook's non-JSON stdout is APPENDED TO THE USER'S PROMPT,

--- a/integrations/claude-code/plugins/localvoxtral-remote/hooks/post.sh
+++ b/integrations/claude-code/plugins/localvoxtral-remote/hooks/post.sh
@@ -125,10 +125,17 @@ STATUS="$(curl --silent --output "$WORK/body" --write-out '%{http_code}' \
 # timed out); clear it the moment ANY HTTP exchange completes — even a 401
 # proves the tunnel terminates at a listener instead of making ssh complain.
 # Both sides are best-effort and silent: failing to record state just means
-# the next event dials again.
+# the next event dials again. The stamp lands via a private tempfile + mv —
+# rename(2) replaces a pre-planted symlink at the stamp path instead of
+# writing through it, and a concurrent reader never sees a half-written
+# value. chmod tightens a stamp dir that pre-existed with looser modes;
+# if any step fails the arm is skipped, which just means dialing again.
 if [ -n "$STAMP_DIR" ] && [ -n "$NOW" ]; then
   if [ -z "$STATUS" ] || [ "$STATUS" = "000" ]; then
-    { mkdir -p "$STAMP_DIR" && echo "$NOW" >"$STAMP"; } 2>/dev/null || :
+    {
+      mkdir -p "$STAMP_DIR" && chmod 700 "$STAMP_DIR" \
+        && echo "$NOW" >"$STAMP.$$" && mv -f "$STAMP.$$" "$STAMP"
+    } 2>/dev/null || { rm -f "$STAMP.$$"; } 2>/dev/null || :
   else
     rm -f "$STAMP" 2>/dev/null || :
   fi


### PR DESCRIPTION
## What

When the `localvoxtral-remote` plugin runs in Claude Code over SSH while localvoxtral is **not** running on the Mac, the terminal fills with connection-failure noise — especially painful inside herdr panes.

The shim itself was already fully silent; the noise is **ssh on the Mac**: with the enrollment's `RemoteForward`, every hook curl makes sshd open a channel back to the Mac, the local ssh client fails to connect, and OpenSSH prints `connect_to 127.0.0.1 port 8473: failed.` (exact format string verified in OpenSSH channels.c) straight onto the PTY — once per hook, dozens of times per turn via `PostToolUse`. That stderr is another process on another machine: no plugin-side redirect can reach it, and `LogLevel QUIET` in the ssh config would also swallow host-key-changed warnings, which is not a trade the app should auto-insert.

So the shim stops dialing a tunnel it just proved dead:

- A transport-level curl failure arms a 5-minute epoch stamp (`$XDG_RUNTIME_DIR/localvoxtral/hook-backoff`, else `~/.cache/...`); while fresh, every event **except `UserPromptSubmit`** skips curl entirely — no dial, no ssh line.
- `UserPromptSubmit` always dials, deliberately: it is user-paced (one line per submitted prompt while the app is down — an honest, bounded signal), it carries the join marker and the prompt, so the **first prompt after the app comes back is grounded immediately** — and its completed exchange clears the backoff for everything else.
- Any completed HTTP exchange (even a 401) clears the stamp. Every odd stamp state — no usable dir, no `date`, garbage content, clock jumped backwards, oversized value — fails toward dialing, i.e. exactly the pre-backoff behavior. Fail-open is untouched.

Also: plugin `1.1.0 → 1.2.0` + marketplace metadata `1.2.0 → 1.3.0` (enrolled hosts pick this up via the existing `marketplace update` + `plugin update` pair); README section naming the exact ssh message, AGENTS.md, and a new enrollment-plan note (pinned by tests) so the symptom stops reading as a plugin bug.

`integrations/claude-code/*` is in `scripts/ci/llm-lane-filter.sh`, so the polishd lane runs on this PR by path match. Nothing here changes what reaches the model — the change is delivery-transport backoff plus docs.

## Proof

- [x] Full unit suite green — `./scripts/remote-build.sh` (build + unit):
  ```
  Executed 2164 tests, with 2 tests skipped and 0 failures (0 unexpected) in 73.778 (73.883) seconds
  ```
- [x] Regression tests added (4, they RUN the shim against the stub curl) — failing before the fix, passing after.

  **Red** (shim reverted to main, new tests in place, on the Mac):
  ```
  error: testTransportFailureArmsTheBackoffAndLaterEventsSkipTheDialEntirely : failed: caught error: "... hook-backoff couldn't be opened because there is no such file."
  error: testUserPromptSubmitDialsThroughAnArmedBackoffAndSuccessClearsIt : XCTAssertFalse failed - a completed exchange must clear the stamp
  error: testEvenA401ClearsTheBackoffBecauseTheExchangeCompleted : XCTAssertFalse failed - any completed HTTP exchange must clear the stamp
  Executed 34 tests, with 3 failures (1 unexpected)
  ```
  (`testExpiredCorruptAndFutureStampsAllFailTowardDialing` passes on main by design — it pins that odd stamp states behave exactly like the pre-backoff shim.)

  **Green** (this branch, on the Mac):
  ```
  Test Suite 'ClaudeRemotePluginManifestTests' passed
  Executed 34 tests, with 0 failures (0 unexpected) in 7.659 (7.666) seconds
  ```
  Plus `ClaudeRemoteEnrollmentServiceTests`: `Executed 51 tests, with 0 failures`.
- [x] POSIX-sh portability: the same scenarios replicated in a dash harness on Linux (macOS runs bash-as-sh; remote hosts are typically dash) — all 10 checks pass on the new shim; same harness on main's shim fails the 4 backoff checks and passes the 6 invariant ones.
- [x] Exact ssh message verified against OpenSSH: `strings /usr/bin/ssh | grep connect_to` → `connect_to %.100s port %d: failed.` — quoted verbatim in README/comments/notes so users can search for it.

Not run: `remote-build.sh integration` (no realtime/ASR path touched). The polishd lane runs in CI via the path filter.
