### PR TITLE
One-command dogfood install: opt-in CI artifact + try-pr --dogfood

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -15,7 +15,9 @@ Opt-in dogfood artifact: with the literal marker `[dogfood-package]` in the
 PR body / head commit message, or a `workflow_dispatch` with `dogfood=true`,
 the job packages a second, `LOCALVOXTRAL_DOGFOOD`-instrumented bundle after
 the launch smoke and uploads it as `localvoxtral-app-dogfood` (7-day
-retention). Fetch and launch it with `scripts/try-pr.sh <pr|main> --dogfood`,
+retention) plus `localvoxtral-dsym-dogfood` (30-day — the instrumented
+binary's UUID differs from the clean dSYM's). Fetch and launch it with
+`scripts/try-pr.sh <pr|main> --dogfood`,
 which also arms the runtime capture default. On manual dispatch the
 conditional live-model lanes (polishd/speechd) skip — the dispatched ref's
 own push/PR run already decided them.

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -11,6 +11,15 @@ with `scripts/try-pr.sh`), and a `localvoxtral-dsym` artifact (30-day
 retention) for symbolicating field crashes. Same-repo branches run on the
 self-hosted Mac runner; fork PRs run on GitHub-hosted macOS.
 
+Opt-in dogfood artifact: with the literal marker `[dogfood-package]` in the
+PR body / head commit message, or a `workflow_dispatch` with `dogfood=true`,
+the job packages a second, `LOCALVOXTRAL_DOGFOOD`-instrumented bundle after
+the launch smoke and uploads it as `localvoxtral-app-dogfood` (7-day
+retention). Fetch and launch it with `scripts/try-pr.sh <pr|main> --dogfood`,
+which also arms the runtime capture default. On manual dispatch the
+conditional live-model lanes (polishd/speechd) skip — the dispatched ref's
+own push/PR run already decided them.
+
 The same `build-test` check takes a docs/scripts-only fast path when every
 changed file passes `scripts/ci/docs-only-filter.sh`; it then skips all Swift,
 helper, packaging, artifact, smoke, warm, and integration steps. The filter

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,16 @@ on:
   pull_request:
   push:
     branches: [main]
+  # Manual dispatch exists to produce artifacts on demand — today that means
+  # the opt-in dogfood build (scripts/try-pr.sh --dogfood offers to trigger
+  # one). The dispatched ref already had its own push/PR run, so the
+  # conditional live-model lanes skip on dispatch (see the lane decide steps).
+  workflow_dispatch:
+    inputs:
+      dogfood:
+        description: "Also package the dogfood-instrumented app (artifact: localvoxtral-app-dogfood)"
+        type: boolean
+        default: false
 
 concurrency:
   group: ci-${{ github.ref }}
@@ -99,7 +109,8 @@ jobs:
           # filter can decide otherwise.
           MARKER_TEXT="${PR_BODY}"$'\n'"${PUSH_HEAD_MESSAGE}"
           if grep -qF '[run-llm-eval]' <<<"$MARKER_TEXT" \
-              || grep -qF '[run-speechd-integration]' <<<"$MARKER_TEXT"; then
+              || grep -qF '[run-speechd-integration]' <<<"$MARKER_TEXT" \
+              || grep -qF '[dogfood-package]' <<<"$MARKER_TEXT"; then
             full_run "explicit lane marker present in PR body / head commit"
           fi
 
@@ -206,6 +217,15 @@ jobs:
           BASE_REF: ${{ github.base_ref }}
         run: |
           set -euo pipefail
+          if [[ "$GITHUB_EVENT_NAME" == "workflow_dispatch" ]]; then
+            # Manual dispatch exists to (re)produce artifacts (try-pr.sh
+            # --dogfood). The dispatched ref's own push/PR run already made
+            # this lane's diff-based decision; don't reload 4B weights here.
+            echo "run=false" >> "$GITHUB_OUTPUT"
+            echo "LLM eval lane: SKIPPED (manual dispatch — decided by the ref's own push/PR run)" \
+              | tee -a "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
           FILES="$RUNNER_TEMP/llm-lane-changed-files.txt"
           MARKER_TEXT="$RUNNER_TEMP/llm-lane-marker-text.txt"
 
@@ -262,6 +282,14 @@ jobs:
           BASE_REF: ${{ github.base_ref }}
         run: |
           set -euo pipefail
+          if [[ "$GITHUB_EVENT_NAME" == "workflow_dispatch" ]]; then
+            # Same rationale as the LLM lane above: dispatch produces
+            # artifacts; the ref's own push/PR run decided this lane.
+            echo "run=false" >> "$GITHUB_OUTPUT"
+            echo "Speechd integration lane: SKIPPED (manual dispatch — decided by the ref's own push/PR run)" \
+              | tee -a "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
           FILES="$RUNNER_TEMP/speechd-lane-changed-files.txt"
           MARKER_TEXT="$RUNNER_TEMP/speechd-lane-marker-text.txt"
 
@@ -293,6 +321,57 @@ jobs:
             echo "Speechd integration lane: RUNNING ($REASON)" | tee -a "$GITHUB_STEP_SUMMARY"
           else
             echo "Speechd integration lane: SKIPPED ($REASON)" | tee -a "$GITHUB_STEP_SUMMARY"
+          fi
+
+      - name: Decide dogfood artifact lane ([dogfood-package] marker / dispatch input)
+        # The instrumented (LOCALVOXTRAL_DOGFOOD) app is packaged and uploaded
+        # only on explicit opt-in: the literal marker [dogfood-package] in the
+        # PR body / head commit message, or the workflow_dispatch `dogfood`
+        # input (which is what scripts/try-pr.sh --dogfood offers to trigger).
+        # Opt-in because the second packaging pass recompiles the root app
+        # under the extra define — and flips the incremental cache, so the
+        # NEXT clean run recompiles it back. No path filter: dogfooding is a
+        # human decision, not a diff property.
+        id: dogfood_lane
+        if: runner.environment == 'self-hosted' && steps.ci_scope.outputs.docs_only != 'true'
+        env:
+          # env indirection, not inline ${{ }} in the script body: PR bodies
+          # and commit messages are attacker-shaped strings.
+          PR_BODY: ${{ github.event.pull_request.body }}
+          PUSH_HEAD_MESSAGE: ${{ github.event.head_commit.message }}
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          DISPATCH_DOGFOOD: ${{ inputs.dogfood }}
+        run: |
+          set -euo pipefail
+          RUN=false
+          if [[ "$GITHUB_EVENT_NAME" == "workflow_dispatch" ]]; then
+            if [[ "$DISPATCH_DOGFOOD" == "true" ]]; then
+              RUN=true; REASON="workflow_dispatch with dogfood=true"
+            else
+              REASON="workflow_dispatch without dogfood=true"
+            fi
+          else
+            # Marker sources mirror the LLM lane: PR body + PR head commit
+            # message (HEAD is the synthetic merge commit on PRs), or the
+            # head commit message on push.
+            MARKER_TEXT="$RUNNER_TEMP/dogfood-lane-marker-text.txt"
+            printf '%s\n' "$PR_BODY" > "$MARKER_TEXT"
+            if [[ "$GITHUB_EVENT_NAME" == "pull_request" ]]; then
+              git log -1 --format=%B "$PR_HEAD_SHA" >> "$MARKER_TEXT" || true
+            else
+              printf '%s\n' "$PUSH_HEAD_MESSAGE" >> "$MARKER_TEXT"
+            fi
+            if grep -qF '[dogfood-package]' "$MARKER_TEXT"; then
+              RUN=true; REASON="[dogfood-package] marker present"
+            else
+              REASON="no [dogfood-package] marker in PR body / head commit message"
+            fi
+          fi
+          echo "run=$RUN" >> "$GITHUB_OUTPUT"
+          if [[ "$RUN" == "true" ]]; then
+            echo "Dogfood artifact lane: RUNNING ($REASON)" | tee -a "$GITHUB_STEP_SUMMARY"
+          else
+            echo "Dogfood artifact lane: SKIPPED ($REASON)" | tee -a "$GITHUB_STEP_SUMMARY"
           fi
 
       - name: Setup Swift
@@ -598,6 +677,40 @@ jobs:
             process.kill()
             process.wait(timeout=5)
           PY
+
+      - name: Package dogfood app bundle (opt-in instrumented artifact)
+        # Second packaging pass with the dogfood capture COMPILE flag. Fetch
+        # and launch with `scripts/try-pr.sh <pr|main> --dogfood`.
+        # - Enablement is the step env, NEVER the .dogfood-capture-enable
+        #   marker file: this workspace is persistent (clean: false), and a
+        #   marker file surviving a cancelled run would silently instrument
+        #   every later build. A step env cannot leak.
+        # - Runs AFTER the launch smoke so the smoke exercises the artifact
+        #   end users get, and the clean dist/localvoxtral.app is already
+        #   zipped and uploaded before this pass overwrites dist/. The helper
+        #   xcodebuild lanes are incremental no-ops; only the root app
+        #   recompiles under the define.
+        # - Same bundle id and signing identity as the clean build, so the
+        #   designated requirement — and the owner's Accessibility (TCC)
+        #   grant — is identical when switching between the two.
+        # - package_app.sh self-verifies the LVXDogfoodCapture Info.plist
+        #   stamp and fails loudly on mismatch; no re-check needed here.
+        if: runner.environment == 'self-hosted' && steps.ci_scope.outputs.docs_only != 'true' && steps.dogfood_lane.outputs.run == 'true'
+        env:
+          LOCALVOXTRAL_CODESIGN_IDENTITY: localvoxtral-dev
+          LOCALVOXTRAL_REQUIRE_CODESIGN_IDENTITY: "1"
+          LOCALVOXTRAL_DOGFOOD: "1"
+        run: |
+          ./scripts/package_app.sh release
+          ditto -c -k --sequesterRsrc --keepParent dist/localvoxtral.app dist/localvoxtral-app-dogfood.zip
+
+      - name: Upload dogfood app artifact
+        if: runner.environment == 'self-hosted' && steps.ci_scope.outputs.docs_only != 'true' && steps.dogfood_lane.outputs.run == 'true'
+        uses: actions/upload-artifact@v4
+        with:
+          name: localvoxtral-app-dogfood
+          path: dist/localvoxtral-app-dogfood.zip
+          retention-days: 7
 
       - name: Process leak check (informational)
         # ~15% of runs spend ~105 s in the runner's post-job "Cleaning up

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,6 +56,7 @@ jobs:
           # the lane-decide steps below).
           PR_BODY: ${{ github.event.pull_request.body }}
           PUSH_HEAD_MESSAGE: ${{ github.event.head_commit.message }}
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
           set -uo pipefail
           FILES="$RUNNER_TEMP/ci-fast-path-changed-files.txt"
@@ -108,6 +109,15 @@ jobs:
           # diff itself is docs-only, so they force the full path BEFORE the
           # filter can decide otherwise.
           MARKER_TEXT="${PR_BODY}"$'\n'"${PUSH_HEAD_MESSAGE}"
+          if [[ "$GITHUB_EVENT_NAME" == "pull_request" && -n "$PR_HEAD_SHA" ]]; then
+            # On PRs, head_commit.message is empty and HEAD is the synthetic
+            # merge commit. The marker contract includes the PR's real head
+            # commit message (the lane decide steps below read it), so this
+            # fast-path escape hatch must read it too — otherwise a marker
+            # carried only by the head commit of a docs-only diff would be
+            # skipped straight past the lane it asked for.
+            MARKER_TEXT+=$'\n'"$(git log -1 --format=%B "$PR_HEAD_SHA" 2>/dev/null || true)"
+          fi
           if grep -qF '[run-llm-eval]' <<<"$MARKER_TEXT" \
               || grep -qF '[run-speechd-integration]' <<<"$MARKER_TEXT" \
               || grep -qF '[dogfood-package]' <<<"$MARKER_TEXT"; then
@@ -703,6 +713,12 @@ jobs:
         run: |
           ./scripts/package_app.sh release
           ditto -c -k --sequesterRsrc --keepParent dist/localvoxtral.app dist/localvoxtral-app-dogfood.zip
+          # The instrumented root binary has its own UUID, so the clean
+          # localvoxtral-dsym artifact can't symbolicate a crash that happens
+          # while hand-dogfooding — ship this pass's dSYM too. The helper
+          # dSYMs are unchanged by this pass (incremental xcodebuild no-ops)
+          # and already ship in localvoxtral-dsym.
+          ditto -c -k --keepParent dist/localvoxtral.dSYM dist/localvoxtral-dsym-dogfood.zip
 
       - name: Upload dogfood app artifact
         if: runner.environment == 'self-hosted' && steps.ci_scope.outputs.docs_only != 'true' && steps.dogfood_lane.outputs.run == 'true'
@@ -711,6 +727,16 @@ jobs:
           name: localvoxtral-app-dogfood
           path: dist/localvoxtral-app-dogfood.zip
           retention-days: 7
+
+      - name: Upload dogfood dSYM artifact
+        # Same longer retention rationale as localvoxtral-dsym: field crashes
+        # surface days after the build that produced them.
+        if: runner.environment == 'self-hosted' && steps.ci_scope.outputs.docs_only != 'true' && steps.dogfood_lane.outputs.run == 'true'
+        uses: actions/upload-artifact@v4
+        with:
+          name: localvoxtral-dsym-dogfood
+          path: dist/localvoxtral-dsym-dogfood.zip
+          retention-days: 30
 
       - name: Process leak check (informational)
         # ~15% of runs spend ~105 s in the runner's post-job "Cleaning up

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -73,6 +73,13 @@ Learned the hard way (2026-07-04) — use these instead of manual steps:
 - **Trying a PR build on the Mac**: `./scripts/try-pr.sh <pr-number|main>`
   downloads the exact CI-built artifact and launches it. No checkout, no
   build. Push → CI (~1.5 min) → try-pr.sh is the whole owner iteration loop.
+  `--dogfood` fetches the instrumented `localvoxtral-app-dogfood` artifact
+  instead, verifies its `LVXDogfoodCapture` stamp, arms the runtime capture
+  default, and launches — the one-command dogfood install. That artifact is
+  opt-in in CI (`[dogfood-package]` in the PR body / head commit message, or
+  a `workflow_dispatch` with `dogfood=true`); when the target run lacks it,
+  the script offers to trigger a dispatch build and shows the latest run
+  that has one.
 - **Code signing (why TCC used to reset)**: `package_app.sh` signs with
   `$LOCALVOXTRAL_CODESIGN_IDENTITY` when set, else ad-hoc. The owner's Mac
   has a self-signed code-signing cert `localvoxtral-dev`; the identity env
@@ -142,10 +149,12 @@ Learned the hard way (2026-07-04) — use these instead of manual steps:
   that crosses the build gate) plus a runtime opt-in
   (`defaults write com.localvoxtral.app debug.dogfood_capture_enabled -bool true`).
   Shipped releases do not contain it, and there is deliberately no uploader —
-  records are local files under Application Support. Use `dogfood-package` for a
-  hand-testable build; it keeps the bundle id so the TCC grant survives and
-  stamps `LVXDogfoodCapture` into Info.plist so you can tell which binary you
-  are running.
+  records are local files under Application Support. Fastest install:
+  `./scripts/try-pr.sh main --dogfood` (CI-built opt-in artifact, stamp
+  verified, capture default armed automatically). `dogfood-package` remains
+  the local-build equivalent; both keep the bundle id so the TCC grant
+  survives and stamp `LVXDogfoodCapture` into Info.plist so you can tell
+  which binary you are running.
 - **Pipes from child processes**: never read with
   `FileHandle.availableData` — it raises an uncatchable ObjC exception on
   descriptor errors and aborts the app (field crash, PR #60). Use
@@ -319,7 +328,8 @@ rather than silently treating it as a model failure.
   documentation, presentation, or operational-script path per the conservative
   allowlist in `scripts/ci/docs-only-filter.sh`. Unknown/ambiguous diffs,
   packaging inputs (`assets/icons/**`), lane-filter-relevant paths, the
-  `[run-llm-eval]`/`[run-speechd-integration]` markers, and changes to the
+  `[run-llm-eval]`/`[run-speechd-integration]`/`[dogfood-package]` markers,
+  and changes to the
   filter or other `scripts/ci/**` paths all fail open to the full run. Release
   and all other workflows remain fully gated.
 - Watch a PR's checks with `./scripts/watch-checks.sh <n>` (or `--run

--- a/scripts/try-pr.sh
+++ b/scripts/try-pr.sh
@@ -6,8 +6,16 @@ set -euo pipefail
 # artifact is the exact bundle CI built and smoke-tested for that revision.
 #
 # Usage:
-#   ./scripts/try-pr.sh <pr-number>   # e.g. ./scripts/try-pr.sh 30
-#   ./scripts/try-pr.sh main          # latest green build of main
+#   ./scripts/try-pr.sh <pr-number>            # e.g. ./scripts/try-pr.sh 30
+#   ./scripts/try-pr.sh main                   # latest green build of main
+#   ./scripts/try-pr.sh main --dogfood         # instrumented dogfood build
+#
+# --dogfood fetches the LOCALVOXTRAL_DOGFOOD-instrumented artifact
+# (localvoxtral-app-dogfood), verifies its Info.plist stamp, arms the runtime
+# capture opt-in default, and launches it. The dogfood artifact is OPT-IN in
+# CI ([dogfood-package] marker or a manual dispatch with dogfood=true), so if
+# the target's run doesn't carry one, this script offers to trigger a build
+# and shows the latest run that does have one.
 #
 # Requires: gh (authenticated). Artifacts exist for CI runs made after the
 # artifact-upload step landed; use "gh run rerun <run-id>" on older PRs.
@@ -17,13 +25,45 @@ if [[ "$(uname)" != "Darwin" ]]; then
   exit 1
 fi
 
-TARGET="${1:?usage: $0 <pr-number|main>}"
+TARGET=""
+DOGFOOD=0
+for arg in "$@"; do
+  case "$arg" in
+    --dogfood) DOGFOOD=1 ;;
+    -*)
+      echo "unknown flag: $arg" >&2
+      echo "usage: $0 <pr-number|main> [--dogfood]" >&2
+      exit 1
+      ;;
+    *)
+      if [[ -n "$TARGET" ]]; then
+        echo "usage: $0 <pr-number|main> [--dogfood]" >&2
+        exit 1
+      fi
+      TARGET="$arg"
+      ;;
+  esac
+done
+if [[ -z "$TARGET" ]]; then
+  echo "usage: $0 <pr-number|main> [--dogfood]" >&2
+  exit 1
+fi
 
+ARTIFACT="localvoxtral-app"
+(( DOGFOOD )) && ARTIFACT="localvoxtral-app-dogfood"
+
+# BRANCH is what a workflow_dispatch would target; empty when dispatch is
+# impossible (cross-repo fork PRs have no branch in this repo to dispatch on).
+BRANCH=""
 if [[ "$TARGET" == "main" ]]; then
+  BRANCH="main"
   RUN_ID="$(gh run list --workflow CI --branch main --status success --limit 1 \
     --json databaseId --jq '.[0].databaseId')"
 else
-  HEAD_SHA="$(gh pr view "$TARGET" --json headRefOid --jq .headRefOid)"
+  IFS=$'\t' read -r HEAD_SHA PR_BRANCH PR_CROSS_REPO < <(gh pr view "$TARGET" \
+    --json headRefOid,headRefName,isCrossRepository \
+    --jq '[.headRefOid, .headRefName, (.isCrossRepository|tostring)] | @tsv')
+  [[ "$PR_CROSS_REPO" == "true" ]] || BRANCH="$PR_BRANCH"
   RUN_ID="$(gh run list --workflow CI --commit "$HEAD_SHA" --status success --limit 1 \
     --json databaseId --jq '.[0].databaseId')"
 fi
@@ -34,11 +74,111 @@ if [[ -z "$RUN_ID" || "$RUN_ID" == "null" ]]; then
   exit 1
 fi
 
+run_has_artifact() {
+  gh api "repos/{owner}/{repo}/actions/runs/$1/artifacts" \
+    --jq '.artifacts[].name' | grep -qxF "$ARTIFACT"
+}
+
+if (( DOGFOOD )) && ! run_has_artifact "$RUN_ID"; then
+  echo "No dogfood artifact on CI run $RUN_ID for '$TARGET' — the dogfood lane is opt-in"
+  echo "([dogfood-package] in the PR body / head commit message, or a manual dispatch)."
+  echo
+
+  # Newest non-expired dogfood artifact anywhere in the repo, so there is
+  # always a concrete "latest build that HAS one" to point at (or use).
+  LATEST="$(gh api "repos/{owner}/{repo}/actions/artifacts?name=localvoxtral-app-dogfood&per_page=50" \
+    --jq '[.artifacts[] | select(.expired | not)][0]
+          | if . == null then ""
+            else "\(.workflow_run.id)\t\(.workflow_run.head_branch)\t\(.workflow_run.head_sha[0:7])\t\(.created_at)"
+            end')"
+  LATEST_RUN=""
+  if [[ -n "$LATEST" ]]; then
+    IFS=$'\t' read -r LATEST_RUN LATEST_BRANCH LATEST_SHA LATEST_DATE <<<"$LATEST"
+    echo "Latest existing dogfood build: $LATEST_BRANCH @ $LATEST_SHA (run $LATEST_RUN, created $LATEST_DATE)"
+  else
+    echo "No dogfood artifact exists anywhere yet (or all have expired — 7-day retention)."
+  fi
+
+  if [[ ! -t 0 ]]; then
+    echo >&2
+    echo "stdin is not a TTY — rerun interactively, or trigger a build yourself:" >&2
+    if [[ -n "$BRANCH" ]]; then
+      echo "  gh workflow run CI --ref $BRANCH -f dogfood=true" >&2
+    else
+      echo "  (cross-repo fork PR: push the [dogfood-package] marker instead)" >&2
+    fi
+    exit 1
+  fi
+
+  echo
+  [[ -n "$BRANCH" ]] && echo "  [t] trigger a fresh dogfood CI build of '$TARGET' and wait for it"
+  [[ -n "$LATEST_RUN" ]] && echo "  [l] use that latest existing dogfood build instead"
+  echo "  [q] quit"
+  read -r -p "Choice: " CHOICE
+  case "$CHOICE" in
+    t|T)
+      if [[ -z "$BRANCH" ]]; then
+        echo "Can't dispatch for a cross-repo fork PR — push the [dogfood-package] marker instead." >&2
+        exit 1
+      fi
+      # gh workflow run doesn't return the run id; detect the new run by
+      # comparing against the newest dispatch run that existed beforehand.
+      PREV_DISPATCH="$(gh run list --workflow CI --event workflow_dispatch --branch "$BRANCH" \
+        --limit 1 --json databaseId --jq '.[0].databaseId // empty')"
+      gh workflow run CI --ref "$BRANCH" -f dogfood=true
+      echo "Dispatched. Waiting for the run to register..."
+      NEW_RUN=""
+      for _ in $(seq 1 24); do
+        sleep 5
+        CAND="$(gh run list --workflow CI --event workflow_dispatch --branch "$BRANCH" \
+          --limit 1 --json databaseId --jq '.[0].databaseId // empty')"
+        if [[ -n "$CAND" && "$CAND" != "$PREV_DISPATCH" ]]; then
+          NEW_RUN="$CAND"
+          break
+        fi
+      done
+      if [[ -z "$NEW_RUN" ]]; then
+        echo "Dispatched run never appeared — check: gh run list --workflow CI --event workflow_dispatch" >&2
+        exit 1
+      fi
+      echo "Watching run $NEW_RUN (full CI + dogfood packaging; ~a few minutes on a warm runner)..."
+      if ! gh run watch "$NEW_RUN" --exit-status; then
+        echo "CI run failed — see: gh run view $NEW_RUN" >&2
+        exit 1
+      fi
+      RUN_ID="$NEW_RUN"
+      ;;
+    l|L)
+      if [[ -z "$LATEST_RUN" ]]; then
+        echo "No existing dogfood build to use." >&2
+        exit 1
+      fi
+      RUN_ID="$LATEST_RUN"
+      ;;
+    *)
+      exit 0
+      ;;
+  esac
+fi
+
 DEST="$(mktemp -d /tmp/localvoxtral-try.XXXXXX)"
-gh run download "$RUN_ID" -n localvoxtral-app -D "$DEST"
-ditto -x -k "$DEST/localvoxtral-app.zip" "$DEST/extracted"
+gh run download "$RUN_ID" -n "$ARTIFACT" -D "$DEST"
+ditto -x -k "$DEST/${ARTIFACT}.zip" "$DEST/extracted"
 APP="$DEST/extracted/localvoxtral.app"
 xattr -cr "$APP" 2>/dev/null || true
+
+# Which binary is this? The Info.plist stamp is the ground truth (AGENTS.md:
+# "confirm WHICH binary the user is actually running" has cost an hour once).
+STAMP="$(/usr/libexec/PlistBuddy -c 'Print :LVXDogfoodCapture' "$APP/Contents/Info.plist" 2>/dev/null || echo absent)"
+echo "Dogfood capture stamp: $STAMP"
+if (( DOGFOOD )) && [[ "$STAMP" != "true" ]]; then
+  echo "FATAL: --dogfood requested but the downloaded bundle is not stamped (LVXDogfoodCapture: $STAMP)." >&2
+  echo "Refusing to launch a build that can't capture — this is exactly the wrong-binary confusion." >&2
+  exit 1
+fi
+if (( ! DOGFOOD )) && [[ "$STAMP" != "absent" ]]; then
+  echo "WARNING: this 'clean' artifact is stamped LVXDogfoodCapture=$STAMP — it can capture if armed."
+fi
 
 # Detect whether the downloaded bundle is ad-hoc. The reliable marker is the
 # 'Signature=adhoc' line — and it MUST be read at -dvv (verbose>=2): at -dv the
@@ -67,7 +207,22 @@ if pgrep -x localvoxtral >/dev/null 2>&1; then
   echo "NOTE: another localvoxtral instance is running — quit it first to avoid"
   echo "      two menu bar icons / hotkey conflicts."
 fi
-echo "Launching build of '$TARGET' (CI run $RUN_ID, ${SIGNER}): $APP"
+
+if (( DOGFOOD )); then
+  # Arm the runtime opt-in BEFORE launch so the first session already
+  # captures. Same bundle id as the clean build, so this is the app's normal
+  # defaults domain — and harmless to leave armed: release binaries don't
+  # contain the capture code at all (compile gate), so a later clean try-pr
+  # ignores the key.
+  defaults write com.localvoxtral.app debug.dogfood_capture_enabled -bool true
+  echo "Dogfood capture ARMED (debug.dogfood_capture_enabled = true)."
+  echo "  records: ~/Library/Application Support/localvoxtral/dogfood"
+  echo "  disarm:  defaults write com.localvoxtral.app debug.dogfood_capture_enabled -bool false"
+fi
+
+LAUNCH_LABEL="$SIGNER"
+(( DOGFOOD )) && LAUNCH_LABEL="$LAUNCH_LABEL, dogfood"
+echo "Launching build of '$TARGET' (CI run $RUN_ID, ${LAUNCH_LABEL}): $APP"
 # The designated requirement is what TCC keys the Accessibility grant on.
 # Compare this block between two try-pr runs: identical DR => the grant
 # survives; a DR that changes every run (ad-hoc pins the per-build cdhash) is

--- a/scripts/try-pr.sh
+++ b/scripts/try-pr.sh
@@ -75,8 +75,18 @@ if [[ -z "$RUN_ID" || "$RUN_ID" == "null" ]]; then
 fi
 
 run_has_artifact() {
-  gh api "repos/{owner}/{repo}/actions/runs/$1/artifacts" \
-    --jq '.artifacts[].name' | grep -qxF "$ARTIFACT"
+  # Capture first, grep second: `gh | grep -q` under pipefail can turn an
+  # early grep exit into a spurious SIGPIPE "failure", and a gh error must
+  # abort loudly rather than read as "artifact missing".
+  local names
+  # Expired artifacts keep their listing row but download as 410 Gone, so
+  # they must not count as present.
+  if ! names="$(gh api "repos/{owner}/{repo}/actions/runs/$1/artifacts" \
+      --jq '.artifacts[] | select(.expired | not) | .name')"; then
+    echo "Failed to list artifacts for run $1 (gh api error)." >&2
+    exit 1
+  fi
+  grep -qxF "$ARTIFACT" <<<"$names"
 }
 
 if (( DOGFOOD )) && ! run_has_artifact "$RUN_ID"; then
@@ -86,8 +96,10 @@ if (( DOGFOOD )) && ! run_has_artifact "$RUN_ID"; then
 
   # Newest non-expired dogfood artifact anywhere in the repo, so there is
   # always a concrete "latest build that HAS one" to point at (or use).
-  LATEST="$(gh api "repos/{owner}/{repo}/actions/artifacts?name=localvoxtral-app-dogfood&per_page=50" \
-    --jq '[.artifacts[] | select(.expired | not)][0]
+  # sort_by(.created_at) because the REST endpoint documents no response
+  # ordering; 7-day retention keeps the population well inside one page.
+  LATEST="$(gh api "repos/{owner}/{repo}/actions/artifacts?name=localvoxtral-app-dogfood&per_page=100" \
+    --jq '[.artifacts[] | select(.expired | not)] | sort_by(.created_at) | last
           | if . == null then ""
             else "\(.workflow_run.id)\t\(.workflow_run.head_branch)\t\(.workflow_run.head_sha[0:7])\t\(.created_at)"
             end')"
@@ -105,7 +117,8 @@ if (( DOGFOOD )) && ! run_has_artifact "$RUN_ID"; then
     if [[ -n "$BRANCH" ]]; then
       echo "  gh workflow run CI --ref $BRANCH -f dogfood=true" >&2
     else
-      echo "  (cross-repo fork PR: push the [dogfood-package] marker instead)" >&2
+      echo "  (cross-repo fork PR: fork PRs run on GitHub-hosted runners and never build" >&2
+      echo "   dogfood artifacts — push the branch to this repo instead)" >&2
     fi
     exit 1
   fi
@@ -118,7 +131,9 @@ if (( DOGFOOD )) && ! run_has_artifact "$RUN_ID"; then
   case "$CHOICE" in
     t|T)
       if [[ -z "$BRANCH" ]]; then
-        echo "Can't dispatch for a cross-repo fork PR — push the [dogfood-package] marker instead." >&2
+        echo "Can't dispatch for a cross-repo fork PR — and fork PRs run on GitHub-hosted" >&2
+        echo "runners, which never build dogfood artifacts (the lane is self-hosted-only)." >&2
+        echo "Push the branch to this repo instead." >&2
         exit 1
       fi
       # gh workflow run doesn't return the run id; detect the new run by
@@ -144,6 +159,14 @@ if (( DOGFOOD )) && ! run_has_artifact "$RUN_ID"; then
       echo "Watching run $NEW_RUN (full CI + dogfood packaging; ~a few minutes on a warm runner)..."
       if ! gh run watch "$NEW_RUN" --exit-status; then
         echo "CI run failed — see: gh run view $NEW_RUN" >&2
+        exit 1
+      fi
+      # The newest-dispatch heuristic above can pick up someone else's
+      # concurrent dispatch (possibly without dogfood=true); verify the
+      # watched run actually produced the artifact before downloading.
+      if ! run_has_artifact "$NEW_RUN"; then
+        echo "Run $NEW_RUN finished green but has no dogfood artifact — a concurrent" >&2
+        echo "dispatch may have been picked up instead of ours. Rerun this script." >&2
         exit 1
       fi
       RUN_ID="$NEW_RUN"


### PR DESCRIPTION
## What

Installing a dogfood build was all manual (build on the Mac via `dogfood-package`, ssh over, copy, launch, `defaults write` to arm capture). This makes it one command: `./scripts/try-pr.sh <pr|main> --dogfood`.

- **ci.yml — opt-in dogfood lane** (`[dogfood-package]` marker in PR body / head commit message, or `workflow_dispatch` with `dogfood=true`): a second packaging pass after the launch smoke with `LOCALVOXTRAL_DOGFOOD=1` in the *step env* (never the `.dogfood-capture-enable` marker file — the runner workspace is persistent (`clean: false`), and a leftover marker would silently instrument every later build). Uploads `localvoxtral-app-dogfood` (7-day retention) and `localvoxtral-dsym-dogfood` (30-day — the instrumented binary's UUID differs from the clean dSYM's). Same bundle id + `localvoxtral-dev` identity as the clean artifact, so the designated requirement — and the Accessibility grant — is unchanged when switching between the two.
- **try-pr.sh `--dogfood`**: downloads that artifact, prints and enforces the `LVXDogfoodCapture` Info.plist stamp (refuses to launch an unstamped bundle — wrong-binary confusion has cost an hour before), arms `debug.dogfood_capture_enabled` before `open`, and prints the records dir + disarm command. If the target run has no dogfood artifact, it names the latest run that does (explicit `sort_by(.created_at)`, expired artifacts excluded) and offers `[t]` trigger a dispatch build and wait (verifying the watched run actually produced the artifact), or `[l]` launch that latest existing one. Leaving the default armed is harmless for clean builds — release binaries don't compile the capture code.
- **Dispatch semantics**: the conditional live-model lanes (polishd/speechd) skip on `workflow_dispatch` — dispatch exists to produce artifacts; the dispatched ref's own push/PR run already made those diff-based decisions. The docs-only fast path treats `[dogfood-package]` like the other lane markers, and now reads the PR head commit message for all three markers (`head_commit` is push-only; a marker carried only by the head commit of a docs-only PR was previously invisible — pre-existing hole for the other two markers).

This PR body carries the marker so every run of this PR exercises the lane: [dogfood-package]

## Proof

- [x] Lane proof, first commit (f8b33c3): run 30856174155 — step summary "Dogfood artifact lane: RUNNING ([dogfood-package] marker present)"; steps `Package dogfood app bundle` / `Upload dogfood app artifact` succeeded; artifacts: `localvoxtral-app-dogfood` 46,675,068 bytes alongside `localvoxtral-app` 46,560,117 bytes (the ~115 KB delta is the compiled capture code). https://github.com/T0mSIlver/localvoxtral/actions/runs/30856174155
- [x] Reviewed by codex (gpt-5.6-sol, read-only) and opencode (GLM-5.2, read-only): 5 + 3 findings, overlap deduped, all fixed in 540b424 (marker visibility in the docs-only fast path, expired-artifact handling, explicit created_at sort, dispatch race verification, fork-PR guidance, dogfood dSYM upload). No findings waived.
- [x] `bash -n scripts/try-pr.sh` clean; ci.yml parses.
- [ ] Hand-verified on the Mac (owner, post-merge): `./scripts/try-pr.sh main --dogfood` → offers trigger (main's head run has no artifact) / after trigger: stamp `true`, capture default armed, stable designated requirement.

No Swift code changes; unit/integration suites unaffected (CI runs them as usual).
