### PR TITLE
Settings > About: Build row shows dogfood variant + capture armed state

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -154,7 +154,9 @@ Learned the hard way (2026-07-04) — use these instead of manual steps:
   verified, capture default armed automatically). `dogfood-package` remains
   the local-build equivalent; both keep the bundle id so the TCC grant
   survives and stamp `LVXDogfoodCapture` into Info.plist so you can tell
-  which binary you are running.
+  which binary you are running — as does Settings > About's constant "Build"
+  row (`DogfoodBuildStatus`), which also shows whether capture is armed in
+  this process.
 - **Pipes from child processes**: never read with
   `FileHandle.availableData` — it raises an uncatchable ObjC exception on
   descriptor errors and aborts the app (field crash, PR #60). Use

--- a/Sources/localvoxtral/Dogfood/DogfoodBuildStatus.swift
+++ b/Sources/localvoxtral/Dogfood/DogfoodBuildStatus.swift
@@ -1,0 +1,34 @@
+import Foundation
+
+/// Content of the About pane's "Build" row: is this binary a dogfood build,
+/// and is the capture armed?
+///
+/// Deliberately NOT wrapped in `#if LOCALVOXTRAL_DOGFOOD` like the rest of
+/// this directory: the row exists in every build variant (a constant group
+/// structure is the settings-pane rule), and keeping the strings pure lets the
+/// tier-0 suite pin them without the compile flag. Only `isDogfoodBuild`
+/// consults the flag — it is the in-binary ground truth that
+/// `package_app.sh` mirrors into Info.plist as `LVXDogfoodCapture`.
+enum DogfoodBuildStatus {
+    static var isDogfoodBuild: Bool {
+        #if LOCALVOXTRAL_DOGFOOD
+        true
+        #else
+        false
+        #endif
+    }
+
+    static func label(isDogfoodBuild: Bool, captureArmed: Bool) -> String {
+        guard isDogfoodBuild else { return "Standard" }
+        return captureArmed ? "Dogfood — capture armed" : "Dogfood — capture disarmed"
+    }
+
+    /// One short reference line under the label; nil for standard builds,
+    /// which have nothing to say (and must not advertise dogfood plumbing).
+    static func detail(isDogfoodBuild: Bool, captureArmed: Bool) -> String? {
+        guard isDogfoodBuild else { return nil }
+        return captureArmed
+            ? "Records: ~/Library/Application Support/localvoxtral/dogfood"
+            : "Arm: defaults write com.localvoxtral.app debug.dogfood_capture_enabled -bool true (relaunch)"
+    }
+}

--- a/Sources/localvoxtral/SettingsView.swift
+++ b/Sources/localvoxtral/SettingsView.swift
@@ -120,7 +120,7 @@ struct SettingsView: View {
             }
             .tag(SettingsTab.textProcessing)
 
-            AboutSettingsPane(viewModel: viewModel)
+            AboutSettingsPane(settings: settings, viewModel: viewModel)
                 .tabItem {
                     Label("About", systemImage: "info.circle")
                 }
@@ -1364,11 +1364,24 @@ private struct ClaudeRemoteEnrollmentSheet: View {
 }
 
 private struct AboutSettingsPane: View {
+    let settings: SettingsStore
     let viewModel: DictationViewModel
 
     private var appName: String {
         Bundle.main.object(forInfoDictionaryKey: "CFBundleName") as? String
             ?? "localvoxtral"
+    }
+
+    /// Shows the in-memory value the capture pipeline actually consults
+    /// (DictationViewModel+DogfoodCapture), not a live defaults read — a
+    /// `defaults write` while the app runs takes effect on relaunch, and the
+    /// row must describe what THIS process is doing.
+    private var dogfoodCaptureArmed: Bool {
+        #if LOCALVOXTRAL_DOGFOOD
+        settings.dogfoodCaptureEnabled
+        #else
+        false
+        #endif
     }
 
     private var appVersion: String {
@@ -1390,6 +1403,29 @@ private struct AboutSettingsPane: View {
 
                 SettingsFieldRow(title: "Version") {
                     Text("\(appVersion) (build \(appBuild))")
+                }
+
+                // Constant row, variant-dependent content: "which binary am I
+                // running" is exactly the question that has cost field-debug
+                // time before (AGENTS.md), and version alone can't answer it —
+                // dogfood builds keep the same version and bundle id.
+                SettingsFieldRow(title: "Build") {
+                    VStack(alignment: .leading, spacing: 6) {
+                        Text(
+                            DogfoodBuildStatus.label(
+                                isDogfoodBuild: DogfoodBuildStatus.isDogfoodBuild,
+                                captureArmed: dogfoodCaptureArmed
+                            )
+                        )
+                        .foregroundStyle(DogfoodBuildStatus.isDogfoodBuild ? Color.orange : Color.primary)
+
+                        if let detail = DogfoodBuildStatus.detail(
+                            isDogfoodBuild: DogfoodBuildStatus.isDogfoodBuild,
+                            captureArmed: dogfoodCaptureArmed
+                        ) {
+                            SettingsHelpText(detail)
+                        }
+                    }
                 }
 
                 SettingsFieldRow(title: "Project") {

--- a/Tests/localvoxtralTests/DogfoodBuildStatusTests.swift
+++ b/Tests/localvoxtralTests/DogfoodBuildStatusTests.swift
@@ -1,0 +1,58 @@
+import XCTest
+
+@testable import localvoxtral
+
+/// Pins the About pane's "Build" row strings. Runs in BOTH build variants:
+/// the tier-0 suite compiles without LOCALVOXTRAL_DOGFOOD and the CI dogfood
+/// capture suite (`swift test --filter Dogfood`) compiles with it — the pure
+/// functions must behave identically in both, which is why they take the
+/// build variant as a parameter instead of consulting the flag themselves.
+final class DogfoodBuildStatusTests: XCTestCase {
+    func testStandardBuildLabelSaysStandardRegardlessOfArmedState() {
+        XCTAssertEqual(
+            DogfoodBuildStatus.label(isDogfoodBuild: false, captureArmed: false), "Standard")
+        // Armed can't be true in a standard build (the setting doesn't exist
+        // there), but the pure function must not invent a dogfood claim even
+        // when handed the impossible combination.
+        XCTAssertEqual(
+            DogfoodBuildStatus.label(isDogfoodBuild: false, captureArmed: true), "Standard")
+    }
+
+    func testDogfoodBuildLabelReportsArmedState() {
+        XCTAssertEqual(
+            DogfoodBuildStatus.label(isDogfoodBuild: true, captureArmed: true),
+            "Dogfood — capture armed")
+        XCTAssertEqual(
+            DogfoodBuildStatus.label(isDogfoodBuild: true, captureArmed: false),
+            "Dogfood — capture disarmed")
+    }
+
+    func testStandardBuildHasNoDetailLine() {
+        // Standard builds must not advertise dogfood plumbing.
+        XCTAssertNil(DogfoodBuildStatus.detail(isDogfoodBuild: false, captureArmed: false))
+        XCTAssertNil(DogfoodBuildStatus.detail(isDogfoodBuild: false, captureArmed: true))
+    }
+
+    func testDogfoodDetailPointsAtRecordsWhenArmedAndArmCommandWhenNot() {
+        let armed = DogfoodBuildStatus.detail(isDogfoodBuild: true, captureArmed: true)
+        XCTAssertEqual(
+            armed, "Records: ~/Library/Application Support/localvoxtral/dogfood",
+            "armed detail must name the capture directory (DogfoodCaptureStore.defaultDirectoryURL)")
+
+        let disarmed = DogfoodBuildStatus.detail(isDogfoodBuild: true, captureArmed: false)
+        XCTAssertEqual(
+            disarmed,
+            "Arm: defaults write com.localvoxtral.app debug.dogfood_capture_enabled -bool true (relaunch)",
+            "disarmed detail must quote the exact arm command (SettingsStore.Keys.dogfoodCaptureEnabled)")
+    }
+
+    func testInBinaryFlagMatchesCompileVariant() {
+        // Meaningful because this suite runs under both variants in CI: the
+        // tier-0 lane must see false and the dogfood capture lane true.
+        #if LOCALVOXTRAL_DOGFOOD
+        XCTAssertTrue(DogfoodBuildStatus.isDogfoodBuild)
+        #else
+        XCTAssertFalse(DogfoodBuildStatus.isDogfoodBuild)
+        #endif
+    }
+}


### PR DESCRIPTION
## What

Settings > About gains a constant **Build** row answering "is the running app a dogfood build?" in-app — version and bundle id can't (dogfood builds keep both on purpose, for the TCC grant). Content per variant:

- Standard build: `Standard`, no detail line (standard builds don't advertise dogfood plumbing).
- Dogfood build: `Dogfood — capture armed|disarmed` in orange, with a detail line: the records directory when armed, the exact `defaults write … (relaunch)` arm command when disarmed. Armed state is the in-memory value the capture pipeline actually consults, so the row describes THIS process, not a later relaunch.

Strings live in a pure `DogfoodBuildStatus` (deliberately outside the `#if`, unlike the rest of `Dogfood/`), so the group structure stays constant (owner settings-pane rule) and both variants are unit-pinned. `SettingsStore.dogfoodCaptureEnabled`'s doc comment already named this row as planned work.

This PR body carries [dogfood-package] so the run uploads an instrumented artifact for eyeballing the row.

## Proof

- [x] Unit tests both variants, run pre-push on the build host:
  - tier-0 (no flag): `./scripts/remote-build.sh test --filter DogfoodBuildStatusTests` → `Test Suite 'DogfoodBuildStatusTests' passed … Executed 5 tests, with 0 failures`
  - instrumented: `./scripts/remote-build.sh dogfood` → `Executed 57 tests, with 0 failures` incl. `DogfoodBuildStatusTests` (the in-binary flag assertion has now passed as false in tier-0 and true here)
- [ ] UI change, verified by hand (owner): `./scripts/try-pr.sh <this-pr> --dogfood` → About shows orange "Dogfood — capture armed" + records path; a clean `try-pr.sh <this-pr>` → "Standard" with no detail line.

LLM lanes: not required — UI-only change, nothing that reaches the model.
