### PR TITLE
Publish allowlisted Claude Code hook env/context values to the app (remote headers + local wire)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Off-screen Claude Code session context for the localvoxtral dictation app. Add this marketplace from a REMOTE host, where there is no app bundle to register a local directory from: claude plugin marketplace add T0mSIlver/localvoxtral",
-    "version": "1.2.0"
+    "version": "1.3.0"
   },
   "plugins": [
     {

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -407,7 +407,16 @@ Key subsystems:
     hooks running the bundled POSIX-sh shim `hooks/post.sh`, which curls the
     event JSON to `127.0.0.1:8473/v1/hook/<Event>` through an OpenSSH
     `RemoteForward` — no localvoxtral binary and no `jq`/`nc`/Node on that
-    host, but it does need `sh` and `curl` (fail-open when absent). After a
+    host, but it does need `sh` and `curl` (fail-open when absent). The body
+    stays Claude's verbatim JSON (no `jq` to rewrite it with), so the
+    allowlisted env enrichment — herdr/cmux/tmux/bridge handles, `SSH_TTY`,
+    the shim's `$PPID` — rides as `X-Lvx-Env-*` HEADERS, written into the same
+    0600 header file as the token and charset-whitelisted
+    (`[A-Za-z0-9._:/@+,=%-]`, ≤200 bytes) before a byte is written so CR/LF
+    injection is impossible by construction; the listener re-validates and
+    stores them as `ClaudeRemoteSessionEnvironment`, NEVER in
+    `ClaudeSessionSnapshot.process` — see the remote-opacity tradeoff below.
+    After a
     transport-level failure the shim backs off for 5 minutes (epoch stamp
     under `$XDG_RUNTIME_DIR`/`~/.cache`) for every event except
     `UserPromptSubmit`: each dial against a live forward with no app behind
@@ -575,7 +584,15 @@ Key subsystems:
   or git calls. Sessions are namespaced by the host id whose token authenticated
   them, so hosts cannot collide or forge each other's sessions. Bounded,
   sanitized remote prompt/file/tool excerpts may feed the same context budget,
-  but there is no remote repository collector.
+  but there is no remote repository collector. The same rule governs the
+  `X-Lvx-Env-*` enrichment: those values live in
+  `ClaudeSessionSnapshot.remoteEnvironment`, never in `.process`, so they
+  cannot reach `resolve(tty:)`, `resolve(herdrPaneID:)`, or
+  `liveLocalHerdrSocketPaths()` — the local-only arms all read `process`. A
+  remote `HERDR_SOCKET_PATH` is a label, not a socket `HerdrSocketClient` may
+  dial (its guard still requires a local socket owned by `getuid()`), and
+  `hookParentPID` is a String on purpose: a pid in another host's namespace is
+  not a number this process may probe.
 - **Remote enrollment execution is opt-in, preview-first, and keeps the token
   out of process arguments.** `ClaudeRemoteEnrollmentService` generates a
   copyable plan (idempotent ssh config block, `claude plugin` commands,

--- a/Sources/ClaudeContextWire/ClaudeHookWire.swift
+++ b/Sources/ClaudeContextWire/ClaudeHookWire.swift
@@ -166,6 +166,17 @@ public struct ClaudeHookProcessInfo: Sendable, Equatable, Codable {
     public var herdrPaneID: String?
     /// The herdr JSON API socket path herdr injected into the pane environment.
     public var herdrSocketPath: String?
+    /// cmux surface identity, published only when the hook ran inside a cmux
+    /// surface. Same shape and same trust as the herdr pair: a LOCAL session's
+    /// values, vouched for by the AF_UNIX peer-UID check, naming things on this
+    /// machine. A remote session's equivalents never land here — they arrive as
+    /// request headers and stay in `ClaudeRemoteSessionEnvironment`.
+    public var cmuxSurfaceID: String?
+    /// The cmux control socket path from the surface environment.
+    public var cmuxSocketPath: String?
+    /// `$CLAUDE_CODE_BRIDGE_SESSION_ID` — the browser-side session handle a
+    /// Remote Control bridge injects, when this session is driven by one.
+    public var bridgeSessionID: String?
 
     public init(
         hookPID: Int32,
@@ -173,7 +184,10 @@ public struct ClaudeHookProcessInfo: Sendable, Equatable, Codable {
         tty: String? = nil,
         termProgram: String? = nil,
         herdrPaneID: String? = nil,
-        herdrSocketPath: String? = nil
+        herdrSocketPath: String? = nil,
+        cmuxSurfaceID: String? = nil,
+        cmuxSocketPath: String? = nil,
+        bridgeSessionID: String? = nil
     ) {
         self.hookPID = hookPID
         self.claudePID = claudePID
@@ -181,6 +195,9 @@ public struct ClaudeHookProcessInfo: Sendable, Equatable, Codable {
         self.termProgram = termProgram
         self.herdrPaneID = herdrPaneID
         self.herdrSocketPath = herdrSocketPath
+        self.cmuxSurfaceID = cmuxSurfaceID
+        self.cmuxSocketPath = cmuxSocketPath
+        self.bridgeSessionID = bridgeSessionID
     }
 
     enum CodingKeys: String, CodingKey {
@@ -190,6 +207,9 @@ public struct ClaudeHookProcessInfo: Sendable, Equatable, Codable {
         case termProgram = "term_program"
         case herdrPaneID = "herdr_pane_id"
         case herdrSocketPath = "herdr_socket_path"
+        case cmuxSurfaceID = "cmux_surface_id"
+        case cmuxSocketPath = "cmux_socket_path"
+        case bridgeSessionID = "bridge_session_id"
     }
 }
 
@@ -449,6 +469,15 @@ public enum ClaudeHookWireCodec {
                 truncate($0, toUTF8Bytes: limits.maxPathBytes)
             }
             process.herdrSocketPath = process.herdrSocketPath.map {
+                truncate($0, toUTF8Bytes: limits.maxPathBytes)
+            }
+            process.cmuxSurfaceID = process.cmuxSurfaceID.map {
+                truncate($0, toUTF8Bytes: limits.maxPathBytes)
+            }
+            process.cmuxSocketPath = process.cmuxSocketPath.map {
+                truncate($0, toUTF8Bytes: limits.maxPathBytes)
+            }
+            process.bridgeSessionID = process.bridgeSessionID.map {
                 truncate($0, toUTF8Bytes: limits.maxPathBytes)
             }
             clamped.process = process

--- a/Sources/ClaudeContextWire/ClaudeRemoteHTTP.swift
+++ b/Sources/ClaudeContextWire/ClaudeRemoteHTTP.swift
@@ -162,10 +162,8 @@ public enum ClaudeRemoteHTTPCodec {
                 // will not reassemble.
                 throw ClaudeRemoteHTTPError.malformed
             }
-            let name = line[line.startIndex..<colon]
-                .trimmingCharacters(in: .whitespaces)
-                .lowercased()
-            let value = line[line.index(after: colon)...].trimmingCharacters(in: .whitespaces)
+            let name = trimmingOWS(line[line.startIndex..<colon]).lowercased()
+            let value = trimmingOWS(line[line.index(after: colon)...])
             guard !name.isEmpty else { throw ClaudeRemoteHTTPError.malformed }
             // Duplicates are rejected rather than last-wins. Two Content-Lengths
             // or two Authorizations mean the sender and we would have to agree on
@@ -203,6 +201,34 @@ public enum ClaudeRemoteHTTPCodec {
             bearerToken: bearerToken(in: headers["authorization"], limits: limits)
         )
         return (request, terminator.upperBound - buffer.startIndex)
+    }
+
+    /// Strip HTTP optional whitespace — ASCII SP and HTAB, and nothing else.
+    ///
+    /// NOT `trimmingCharacters(in: .whitespaces)`, which is a UNICODE set: it
+    /// eats U+00A0 NBSP, U+2007, U+3000 and friends. Two bugs follow from that,
+    /// and only the second is obvious:
+    ///
+    /// 1. It rewrites the field NAME. `Content-Length<NBSP>: 5` would trim to
+    ///    `content-length` here while a conforming proxy reads a different (or
+    ///    invalid) header — the parsers-disagree shape this file exists to
+    ///    avoid.
+    /// 2. It launders a field VALUE past a byte-level validator. The env
+    ///    enrichment rejects any non-ASCII byte, but `pane-7<NBSP>` was being
+    ///    trimmed to `pane-7` BEFORE that check ever ran, so a malformed wire
+    ///    value was accepted as a well-formed one.
+    ///
+    /// RFC 9110 defines OWS as `*( SP / HTAB )`. Trimming exactly that means a
+    /// value's bytes reach a validator as the peer actually wrote them.
+    static func trimmingOWS(_ value: Substring) -> String {
+        var slice = value
+        while let first = slice.first, first == " " || first == "\t" {
+            slice = slice.dropFirst()
+        }
+        while let last = slice.last, last == " " || last == "\t" {
+            slice = slice.dropLast()
+        }
+        return String(slice)
     }
 
     /// The `Bearer` credential, or nil for any other scheme/shape.

--- a/Sources/ClaudeContextWire/ClaudeRemoteSessionEnvironment.swift
+++ b/Sources/ClaudeContextWire/ClaudeRemoteSessionEnvironment.swift
@@ -228,6 +228,14 @@ public enum ClaudeRemoteEnvironmentCodec {
 
     /// Whether a single value is acceptable: non-empty, within the byte cap,
     /// and entirely inside the charset above.
+    ///
+    /// Applied to the value as the PEER WROTE IT, minus HTTP's own OWS. That
+    /// ordering is load-bearing: while the head parser trimmed with Foundation's
+    /// Unicode whitespace set, `pane-7<NBSP>` reached here already trimmed to
+    /// `pane-7` and passed — a malformed wire value laundered into a
+    /// well-formed one before the byte check could see it. The parser now trims
+    /// SP/HTAB only (`ClaudeRemoteHTTPCodec.trimmingOWS`), so a non-ASCII byte
+    /// anywhere in the value arrives intact and is rejected here.
     public static func isAcceptableValue(
         _ value: String,
         limits: ClaudeRemoteEnvironmentLimits = .default

--- a/Sources/ClaudeContextWire/ClaudeRemoteSessionEnvironment.swift
+++ b/Sources/ClaudeContextWire/ClaudeRemoteSessionEnvironment.swift
@@ -1,0 +1,269 @@
+import Foundation
+
+/// One allowlisted environment value a REMOTE Claude Code hook may report.
+///
+/// The remote shim has no `jq` and must leave the event body byte-identical to
+/// what Claude Code handed it, so the enrichment rides as request HEADERS. This
+/// enum is the single source of truth for that mapping: the shim writes
+/// `headerName`, the listener reads `lowercasedHeaderName`, and the plugin
+/// manifest tests assert both against `shellSource` so the two sides can never
+/// drift into a silent no-op.
+///
+/// Everything here names WHERE a session runs on another machine — a pane id, a
+/// socket path, a multiplexer handle. None of it is content, and none of it is
+/// ever trusted: see `ClaudeRemoteSessionEnvironment`.
+public enum ClaudeRemoteEnvironmentField: String, CaseIterable, Sendable {
+    case herdrPaneID
+    case herdrSocketPath
+    case herdrSession
+    case cmuxSurfaceID
+    case cmuxSocketPath
+    case bridgeSessionID
+    case tmux
+    case tmuxPane
+    case sshTTY
+    case hookParentPID
+
+    /// The header the shim writes, in its canonical spelling.
+    ///
+    /// No underscores by construction: some proxies and CGI-shaped readers fold
+    /// `-` and `_` together, and a name that survives that folding unchanged is
+    /// one fewer thing to reason about.
+    public var headerName: String {
+        switch self {
+        case .herdrPaneID: return "X-Lvx-Env-Herdr-Pane-Id"
+        case .herdrSocketPath: return "X-Lvx-Env-Herdr-Socket-Path"
+        case .herdrSession: return "X-Lvx-Env-Herdr-Session"
+        case .cmuxSurfaceID: return "X-Lvx-Env-Cmux-Surface-Id"
+        case .cmuxSocketPath: return "X-Lvx-Env-Cmux-Socket-Path"
+        case .bridgeSessionID: return "X-Lvx-Env-Bridge-Session-Id"
+        case .tmux: return "X-Lvx-Env-Tmux"
+        case .tmuxPane: return "X-Lvx-Env-Tmux-Pane"
+        case .sshTTY: return "X-Lvx-Env-Ssh-Tty"
+        case .hookParentPID: return "X-Lvx-Env-Hook-Parent-Pid"
+        }
+    }
+
+    /// How the parser keys it — `ClaudeRemoteHTTPCodec` lowercases field names.
+    public var lowercasedHeaderName: String { headerName.lowercased() }
+
+    /// The shell expansion the shim reads this value from. `$PPID` is the one
+    /// that is not an environment variable: it is the shim's own parent, i.e. a
+    /// best-effort handle on the Claude Code process on the remote host.
+    public var shellSource: String {
+        switch self {
+        case .herdrPaneID: return "$HERDR_PANE_ID"
+        case .herdrSocketPath: return "$HERDR_SOCKET_PATH"
+        case .herdrSession: return "$HERDR_SESSION"
+        case .cmuxSurfaceID: return "$CMUX_SURFACE_ID"
+        case .cmuxSocketPath: return "$CMUX_SOCKET_PATH"
+        case .bridgeSessionID: return "$CLAUDE_CODE_BRIDGE_SESSION_ID"
+        case .tmux: return "$TMUX"
+        case .tmuxPane: return "$TMUX_PANE"
+        case .sshTTY: return "$SSH_TTY"
+        case .hookParentPID: return "$PPID"
+        }
+    }
+}
+
+/// Hard bounds on the env-header enrichment, applied on the receiving side and
+/// mirrored by the shim.
+///
+/// The shim validates before it writes, and this re-validates on arrival and
+/// never trusts that it did — the same posture `ClaudeHookLimits` takes toward
+/// the local publisher.
+public struct ClaudeRemoteEnvironmentLimits: Sendable, Equatable {
+    /// Max UTF-8 bytes of any single value. A pane id or socket path that
+    /// approaches this is not one.
+    public var maxValueBytes: Int
+    /// Max values retained from one request. The allowlist is smaller than this
+    /// today, which is the point: the cap is a belt that survives someone
+    /// growing the allowlist without revisiting the budget.
+    public var maxFieldCount: Int
+    /// Max total UTF-8 bytes across all retained values.
+    public var maxTotalBytes: Int
+
+    public init(
+        maxValueBytes: Int = 200,
+        maxFieldCount: Int = 12,
+        maxTotalBytes: Int = 1024
+    ) {
+        self.maxValueBytes = maxValueBytes
+        self.maxFieldCount = maxFieldCount
+        self.maxTotalBytes = maxTotalBytes
+    }
+
+    public static let `default` = ClaudeRemoteEnvironmentLimits()
+}
+
+/// Allowlisted environment values reported by a REMOTE session's hooks.
+///
+/// **Every field here is an opaque, untrusted LABEL about another machine.**
+/// That is not a caveat, it is the type's reason to exist as a separate type
+/// rather than more fields on `ClaudeHookProcessInfo`:
+///
+/// * It is never merged into `ClaudeSessionSnapshot.process`, which the local
+///   arms read — `resolve(tty:)`, `resolve(herdrPaneID:)`, and
+///   `liveLocalHerdrSocketPaths()` all filter on `origin.isLocalAuthenticated`
+///   AND read `process`, so a remote value has no route into any of them.
+/// * `herdrSocketPath`/`cmuxSocketPath` name a socket in ANOTHER host's
+///   filesystem. Nothing here may be dialed, `stat`ed, or handed to
+///   `FileManager`; `HerdrSocketClient` requires a local socket owned by
+///   `getuid()` and that guard is what makes this safe by construction.
+/// * `hookParentPID` is a String, deliberately. It is a pid in another host's
+///   namespace, so it is not a number this process may ever `kill(pid, 0)` —
+///   keeping it un-numeric keeps it out of every liveness probe by type.
+///
+/// What it IS good for: a future remote-herdr / cmux / bridge join arm can ask
+/// "does the surface the user is looking at report the same pane id this remote
+/// session did", which is an equality test between two labels and needs no
+/// trust at all.
+public struct ClaudeRemoteSessionEnvironment: Sendable, Equatable {
+    public var herdrPaneID: String?
+    public var herdrSocketPath: String?
+    public var herdrSession: String?
+    public var cmuxSurfaceID: String?
+    public var cmuxSocketPath: String?
+    public var bridgeSessionID: String?
+    public var tmux: String?
+    public var tmuxPane: String?
+    public var sshTTY: String?
+    /// The remote shim's `$PPID` — Claude Code's pid ON THAT HOST. Diagnostics
+    /// and cross-checks against another remote report only; never a local pid.
+    public var hookParentPID: String?
+
+    public init(
+        herdrPaneID: String? = nil,
+        herdrSocketPath: String? = nil,
+        herdrSession: String? = nil,
+        cmuxSurfaceID: String? = nil,
+        cmuxSocketPath: String? = nil,
+        bridgeSessionID: String? = nil,
+        tmux: String? = nil,
+        tmuxPane: String? = nil,
+        sshTTY: String? = nil,
+        hookParentPID: String? = nil
+    ) {
+        self.herdrPaneID = herdrPaneID
+        self.herdrSocketPath = herdrSocketPath
+        self.herdrSession = herdrSession
+        self.cmuxSurfaceID = cmuxSurfaceID
+        self.cmuxSocketPath = cmuxSocketPath
+        self.bridgeSessionID = bridgeSessionID
+        self.tmux = tmux
+        self.tmuxPane = tmuxPane
+        self.sshTTY = sshTTY
+        self.hookParentPID = hookParentPID
+    }
+
+    public var isEmpty: Bool {
+        ClaudeRemoteEnvironmentField.allCases.allSatisfy { self[$0] == nil }
+    }
+
+    /// Field-keyed access, so callers (and tests) can iterate the allowlist
+    /// instead of restating it.
+    public subscript(field: ClaudeRemoteEnvironmentField) -> String? {
+        get {
+            switch field {
+            case .herdrPaneID: return herdrPaneID
+            case .herdrSocketPath: return herdrSocketPath
+            case .herdrSession: return herdrSession
+            case .cmuxSurfaceID: return cmuxSurfaceID
+            case .cmuxSocketPath: return cmuxSocketPath
+            case .bridgeSessionID: return bridgeSessionID
+            case .tmux: return tmux
+            case .tmuxPane: return tmuxPane
+            case .sshTTY: return sshTTY
+            case .hookParentPID: return hookParentPID
+            }
+        }
+        set {
+            switch field {
+            case .herdrPaneID: herdrPaneID = newValue
+            case .herdrSocketPath: herdrSocketPath = newValue
+            case .herdrSession: herdrSession = newValue
+            case .cmuxSurfaceID: cmuxSurfaceID = newValue
+            case .cmuxSocketPath: cmuxSocketPath = newValue
+            case .bridgeSessionID: bridgeSessionID = newValue
+            case .tmux: tmux = newValue
+            case .tmuxPane: tmuxPane = newValue
+            case .sshTTY: sshTTY = newValue
+            case .hookParentPID: hookParentPID = newValue
+            }
+        }
+    }
+}
+
+/// Reads the allowlisted env headers off a parsed request head.
+public enum ClaudeRemoteEnvironmentCodec {
+    /// The charset a value may consist of: ASCII alphanumerics plus
+    /// `. _ : / @ + , = % -`.
+    ///
+    /// `%` is in the set for one concrete reason: a tmux pane id IS `%3`. It
+    /// was left out of the first draft and the hand-run of the shim showed
+    /// `TMUX_PANE` silently never arriving — exactly the failure mode this
+    /// whole plugin is prone to.
+    ///
+    /// This is the whole header-injection defence, and it is a whitelist for
+    /// that reason: CR, LF, NUL, every other C0 byte, space, tab, and every
+    /// non-ASCII byte are outside it, so a value that passes CANNOT terminate a
+    /// header line or start a new one. The shim applies the identical set in a
+    /// `case` pattern before it writes the file; this is the half that does not
+    /// depend on the remote host having done so.
+    static func isAllowedByte(_ byte: UInt8) -> Bool {
+        switch byte {
+        case UInt8(ascii: "A")...UInt8(ascii: "Z"),
+             UInt8(ascii: "a")...UInt8(ascii: "z"),
+             UInt8(ascii: "0")...UInt8(ascii: "9"):
+            return true
+        case UInt8(ascii: "."), UInt8(ascii: "_"), UInt8(ascii: ":"),
+             UInt8(ascii: "/"), UInt8(ascii: "@"), UInt8(ascii: "+"),
+             UInt8(ascii: ","), UInt8(ascii: "="), UInt8(ascii: "%"),
+             UInt8(ascii: "-"):
+            return true
+        default:
+            return false
+        }
+    }
+
+    /// Whether a single value is acceptable: non-empty, within the byte cap,
+    /// and entirely inside the charset above.
+    public static func isAcceptableValue(
+        _ value: String,
+        limits: ClaudeRemoteEnvironmentLimits = .default
+    ) -> Bool {
+        let bytes = Array(value.utf8)
+        guard !bytes.isEmpty, bytes.count <= limits.maxValueBytes else { return false }
+        return bytes.allSatisfy(isAllowedByte)
+    }
+
+    /// Collect the allowlisted env values from already-parsed request headers.
+    ///
+    /// Returns nil when nothing survived, so "no enrichment" and "an empty
+    /// enrichment" are the same value downstream.
+    ///
+    /// A value that fails validation is DROPPED — the request is not rejected.
+    /// Delivery of the hook itself is the thing that must not become brittle:
+    /// the body is the payload, and an enrichment header is a bonus. Caps are
+    /// applied walking `allCases` in declaration order, so a truncated result is
+    /// deterministic rather than dictionary-order noise.
+    public static func environment(
+        in headers: [String: String],
+        limits: ClaudeRemoteEnvironmentLimits = .default
+    ) -> ClaudeRemoteSessionEnvironment? {
+        var environment = ClaudeRemoteSessionEnvironment()
+        var count = 0
+        var totalBytes = 0
+        for field in ClaudeRemoteEnvironmentField.allCases {
+            guard count < limits.maxFieldCount else { break }
+            guard let value = headers[field.lowercasedHeaderName] else { continue }
+            guard isAcceptableValue(value, limits: limits) else { continue }
+            let size = value.utf8.count
+            guard totalBytes + size <= limits.maxTotalBytes else { continue }
+            environment[field] = value
+            count += 1
+            totalBytes += size
+        }
+        return environment.isEmpty ? nil : environment
+    }
+}

--- a/Sources/ClaudeHookPublisherCore/ClaudeHookPublisher.swift
+++ b/Sources/ClaudeHookPublisherCore/ClaudeHookPublisher.swift
@@ -126,8 +126,14 @@ public struct ClaudeHookPublisher: Sendable {
     }
 
     /// Safe metadata only: identity and location of the terminal, never its
-    /// contents and never argv/env beyond `$TERM_PROGRAM`,
-    /// `$HERDR_PANE_ID`, and `$HERDR_SOCKET_PATH`.
+    /// contents and never argv/env beyond an ALLOWLIST — `$TERM_PROGRAM` plus
+    /// the multiplexer/bridge handles below.
+    ///
+    /// Every one of these names WHERE the session runs (a pane, a surface, a
+    /// socket, a browser-side session handle) on THIS machine, which is what
+    /// makes a later join arm able to ask "is the thing the user is looking at
+    /// the thing this session lives in". None of them is content, and the list
+    /// grows only for values that answer that question.
     func processInfo() -> ClaudeHookProcessInfo {
         // ONE ppid resolution feeds both fields: the published claudePID and
         // the tty's process-table fallback must describe the same process.
@@ -136,12 +142,22 @@ public struct ClaudeHookPublisher: Sendable {
             hookPID: environment.pid(),
             claudePID: claudePID,
             tty: environment.ttyName(claudePID),
-            termProgram: environment.variables["TERM_PROGRAM"].flatMap { $0.isEmpty ? nil : $0 },
-            herdrPaneID: environment.variables["HERDR_PANE_ID"].flatMap { $0.isEmpty ? nil : $0 },
-            herdrSocketPath: environment.variables["HERDR_SOCKET_PATH"].flatMap {
-                $0.isEmpty ? nil : $0
-            }
+            termProgram: nonEmptyVariable("TERM_PROGRAM"),
+            herdrPaneID: nonEmptyVariable("HERDR_PANE_ID"),
+            herdrSocketPath: nonEmptyVariable("HERDR_SOCKET_PATH"),
+            cmuxSurfaceID: nonEmptyVariable("CMUX_SURFACE_ID"),
+            cmuxSocketPath: nonEmptyVariable("CMUX_SOCKET_PATH"),
+            bridgeSessionID: nonEmptyVariable("CLAUDE_CODE_BRIDGE_SESSION_ID")
         )
+    }
+
+    /// An environment variable's value, treating empty as absent.
+    ///
+    /// An exported-but-empty variable is how a shell says "not in one of
+    /// these", and publishing `""` would make a later join arm compare two
+    /// empty strings and call it a match.
+    private func nonEmptyVariable(_ name: String) -> String? {
+        environment.variables[name].flatMap { $0.isEmpty ? nil : $0 }
     }
 
     /// Environment variable the shim uses to hand us the real Claude Code pid.

--- a/Sources/localvoxtral/ClaudeContext/ClaudeRemoteContextListener.swift
+++ b/Sources/localvoxtral/ClaudeContext/ClaudeRemoteContextListener.swift
@@ -19,6 +19,9 @@ public struct ClaudeRemoteListenerLimits: Sendable, Equatable {
     public var http: ClaudeRemoteHTTPLimits
     public var wire: ClaudeHookLimits
     public var snippets: ClaudeSnippetLimits
+    /// Caps on the allowlisted env headers the shim adds. Re-applied here on
+    /// arrival: the shim validating first is a courtesy, not a guarantee.
+    public var environment: ClaudeRemoteEnvironmentLimits
 
     public init(
         port: UInt16 = 8473,
@@ -27,7 +30,8 @@ public struct ClaudeRemoteListenerLimits: Sendable, Equatable {
         connectionTimeout: TimeInterval = 3.0,
         http: ClaudeRemoteHTTPLimits = .default,
         wire: ClaudeHookLimits = .default,
-        snippets: ClaudeSnippetLimits = .default
+        snippets: ClaudeSnippetLimits = .default,
+        environment: ClaudeRemoteEnvironmentLimits = .default
     ) {
         self.port = port
         self.maxConcurrentConnections = maxConcurrentConnections
@@ -36,6 +40,7 @@ public struct ClaudeRemoteListenerLimits: Sendable, Equatable {
         self.http = http
         self.wire = wire
         self.snippets = snippets
+        self.environment = environment
     }
 
     public static let `default` = ClaudeRemoteListenerLimits()
@@ -491,6 +496,7 @@ public final class ClaudeRemoteContextListener: Sendable {
     private struct PreparedIngest {
         let record: ClaudeHookRecord
         let snippets: [ClaudeContentSnippet]
+        let environment: ClaudeRemoteSessionEnvironment?
         let hostID: String
     }
 
@@ -528,7 +534,36 @@ public final class ClaudeRemoteContextListener: Sendable {
             hostID: host.id,
             sessionID: record.sessionID
         )
-        return PreparedIngest(record: record, snippets: payload.snippets, hostID: host.id)
+
+        // Enrichment rides as HEADERS, not in the body: the shim has no jq and
+        // must hand Claude Code's event JSON on byte-for-byte, so there is
+        // nowhere in the body to put this without parsing and re-serializing it
+        // on a host where we cannot count on a JSON tool existing.
+        //
+        // The header VALUES stay what they were on the wire — opaque labels
+        // about another machine — and they land in their own snapshot field,
+        // never in `process`. Re-validated here against the same charset and
+        // caps the shim applies; the shim's own validation is a courtesy from a
+        // machine we do not control.
+        let environment = ClaudeRemoteEnvironmentCodec.environment(
+            in: request.headers, limits: limits.environment
+        )
+        // Count only. The values name panes, sockets and TTYs on the user's
+        // other machine; the log is not the place for them, and a count is what
+        // makes "the shim is on an old version" diagnosable.
+        if let environment {
+            let count = ClaudeRemoteEnvironmentField.allCases.filter { environment[$0] != nil }.count
+            Log.claudeContext.debug(
+                "Remote record carried \(count, privacy: .public) allowlisted env labels"
+            )
+        }
+
+        return PreparedIngest(
+            record: record,
+            snippets: payload.snippets,
+            environment: environment,
+            hostID: host.id
+        )
     }
 
     /// The session-registry half of ingest. Runs under the host-registry lock
@@ -542,7 +577,10 @@ public final class ClaudeRemoteContextListener: Sendable {
             channel: ClaudeRemoteSessionScope.channel(hostID: prepared.hostID)
         )
         let snapshot = registry.ingest(
-            prepared.record, origin: origin, snippets: prepared.snippets
+            prepared.record,
+            origin: origin,
+            snippets: prepared.snippets,
+            environment: prepared.environment
         )
         // Shape only. A remote record carries the user's prompt and excerpts of
         // their code; a log is the wrong place for either.

--- a/Sources/localvoxtral/ClaudeContext/ClaudeSessionRegistry.swift
+++ b/Sources/localvoxtral/ClaudeContext/ClaudeSessionRegistry.swift
@@ -137,12 +137,18 @@ public final class ClaudeSessionRegistry: Sendable {
     ///     field to consult.
     ///   - snippets: sanitized excerpts the transport extracted. Always empty
     ///     from the local NDJSON wire, which has no field for them.
+    ///   - environment: allowlisted env labels the REMOTE listener read off the
+    ///     request headers, likewise absent from the local wire. Untrusted
+    ///     labels about another machine: the reducer stores them only for a
+    ///     `.remote` origin and NEVER in `process`, which is what the
+    ///     local-only arms below read.
     /// - Returns: the resulting snapshot, or nil if the record was dropped.
     @discardableResult
     public func ingest(
         _ record: ClaudeHookRecord,
         origin: ClaudeTransportOrigin,
-        snippets: [ClaudeContentSnippet] = []
+        snippets: [ClaudeContentSnippet] = [],
+        environment: ClaudeRemoteSessionEnvironment? = nil
     ) -> ClaudeSessionSnapshot? {
         let timestamp = now()
         // A LOCAL Claude record whose raw id spells another namespace's prefix
@@ -236,6 +242,7 @@ public final class ClaudeSessionRegistry: Sendable {
                 record: record,
                 origin: snapshot.origin,
                 snippets: snippets,
+                environment: environment,
                 now: timestamp
             )
 

--- a/Sources/localvoxtral/ClaudeContext/ClaudeSessionState.swift
+++ b/Sources/localvoxtral/ClaudeContext/ClaudeSessionState.swift
@@ -81,6 +81,19 @@ public struct ClaudeSessionSnapshot: Sendable, Equatable {
     public var recentSnippets: [ClaudeContentSnippet]
     public var activity: ClaudeSessionActivity
     public var process: ClaudeHookProcessInfo?
+    /// Allowlisted environment labels a REMOTE session's hooks reported.
+    ///
+    /// Deliberately NOT folded into `process`: that block is what the local
+    /// join arms read, and every one of them (`resolve(tty:)`,
+    /// `resolve(herdrPaneID:)`, `liveLocalHerdrSocketPaths()`) pairs an
+    /// `origin.isLocalAuthenticated` filter with a `process` field. Keeping the
+    /// remote labels in their own field means a remote host cannot reach those
+    /// arms even if a future edit forgot the origin filter — there is nothing
+    /// of its in the field they read.
+    ///
+    /// Only ever populated for a `.remote` origin (`ClaudeSessionReducer`), and
+    /// `remoteSessionEnvironment` re-states that at the read side.
+    public var remoteEnvironment: ClaudeRemoteSessionEnvironment?
     public var firstSeen: Date
     public var lastActivity: Date
 
@@ -105,6 +118,18 @@ public struct ClaudeSessionSnapshot: Sendable, Equatable {
         return recentFiles
     }
 
+    /// The remote env labels, and nil for any local session — the mirror image
+    /// of `localWorkspacePath`.
+    ///
+    /// A local session's pane identity arrives inside `process`, vouched for by
+    /// peer-UID authentication on the AF_UNIX socket. Anything reading this
+    /// accessor is by definition reasoning about another machine, and the gate
+    /// makes that impossible to forget.
+    public var remoteSessionEnvironment: ClaudeRemoteSessionEnvironment? {
+        guard case .remote = origin else { return nil }
+        return remoteEnvironment
+    }
+
     init(
         sessionID: String,
         origin: ClaudeTransportOrigin,
@@ -123,6 +148,7 @@ public struct ClaudeSessionSnapshot: Sendable, Equatable {
         self.recentSnippets = []
         self.activity = .idle
         self.process = nil
+        self.remoteEnvironment = nil
         self.firstSeen = firstSeen
         self.lastActivity = firstSeen
     }
@@ -148,11 +174,17 @@ public enum ClaudeSessionReducer {
     /// - Parameter snippets: sanitized excerpts, supplied by the transport that
     ///   parsed them. The local NDJSON wire has no field for these, so in
     ///   practice only the remote HTTP listener ever passes a non-empty array.
+    /// - Parameter environment: allowlisted env labels the REMOTE listener read
+    ///   off the request headers. Applied only for a `.remote` origin — a local
+    ///   caller passing one is ignored rather than trusted, so the remote-only
+    ///   property of `ClaudeSessionSnapshot.remoteEnvironment` holds at the one
+    ///   place that writes it.
     public static func reduce(
         _ snapshot: inout ClaudeSessionSnapshot,
         record: ClaudeHookRecord,
         origin: ClaudeTransportOrigin,
         snippets: [ClaudeContentSnippet] = [],
+        environment: ClaudeRemoteSessionEnvironment? = nil,
         now: Date
     ) {
         snapshot.lastActivity = now
@@ -170,6 +202,15 @@ public enum ClaudeSessionReducer {
         if let process = record.process,
            record.event != .focusChanged, record.event != .focusCleared {
             snapshot.process = process
+        }
+        // Remote only, and replace-whole rather than merge-per-field: the shim
+        // publishes everything it can see on every event, so the newest report
+        // is the honest one — a merge would keep resurrecting a pane the user
+        // has since left. Skipped for focus records for the same reason the
+        // process block is: they describe a pane, not the session.
+        if case .remote = origin, let environment, !environment.isEmpty,
+           record.event != .focusChanged, record.event != .focusCleared {
+            snapshot.remoteEnvironment = environment
         }
 
         switch record.event {

--- a/Tests/localvoxtralTests/ClaudeHookPublisherTests.swift
+++ b/Tests/localvoxtralTests/ClaudeHookPublisherTests.swift
@@ -88,6 +88,73 @@ final class ClaudeHookPublisherTests: XCTestCase {
         XCTAssertNil(info.herdrSocketPath)
     }
 
+    func testCmuxAndBridgeEnvironmentValuesArePublished() {
+        // Same class as the herdr pair and the same reason: they name WHERE a
+        // LOCAL session runs, which is the only question a join arm asks. Their
+        // trust is the AF_UNIX peer-UID check, so they may sit in `process`
+        // beside the rest — the remote equivalents deliberately may not.
+        let info = publisher(variables: [
+            "HOME": "/h",
+            "CMUX_SURFACE_ID": "surface-3",
+            "CMUX_SOCKET_PATH": "/tmp/cmux.sock",
+            "CLAUDE_CODE_BRIDGE_SESSION_ID": "bridge-abc",
+        ]).processInfo()
+        XCTAssertEqual(info.cmuxSurfaceID, "surface-3")
+        XCTAssertEqual(info.cmuxSocketPath, "/tmp/cmux.sock")
+        XCTAssertEqual(info.bridgeSessionID, "bridge-abc")
+    }
+
+    func testCmuxAndBridgeEnvironmentValuesArePublishedIndependently() {
+        let surfaceOnly = publisher(variables: ["CMUX_SURFACE_ID": "surface-3"]).processInfo()
+        XCTAssertEqual(surfaceOnly.cmuxSurfaceID, "surface-3")
+        XCTAssertNil(surfaceOnly.cmuxSocketPath)
+        XCTAssertNil(surfaceOnly.bridgeSessionID)
+
+        let bridgeOnly = publisher(
+            variables: ["CLAUDE_CODE_BRIDGE_SESSION_ID": "bridge-abc"]
+        ).processInfo()
+        XCTAssertEqual(bridgeOnly.bridgeSessionID, "bridge-abc")
+        XCTAssertNil(bridgeOnly.cmuxSurfaceID)
+    }
+
+    func testEmptyOrAbsentCmuxAndBridgeValuesAreTreatedAsAbsent() {
+        // An exported-but-empty variable is how a shell says "not in one of
+        // these". Publishing `""` would let a later join arm match two empty
+        // strings and call it the same surface.
+        let empty = publisher(variables: [
+            "CMUX_SURFACE_ID": "",
+            "CMUX_SOCKET_PATH": "",
+            "CLAUDE_CODE_BRIDGE_SESSION_ID": "",
+        ]).processInfo()
+        XCTAssertNil(empty.cmuxSurfaceID)
+        XCTAssertNil(empty.cmuxSocketPath)
+        XCTAssertNil(empty.bridgeSessionID)
+
+        let absent = publisher(variables: ["HOME": "/h"]).processInfo()
+        XCTAssertNil(absent.cmuxSurfaceID)
+        XCTAssertNil(absent.cmuxSocketPath)
+        XCTAssertNil(absent.bridgeSessionID)
+    }
+
+    func testNoEnvironmentVariableOutsideTheAllowlistIsEverPublished() throws {
+        // The publisher reads the environment, so "it only takes the allowlist"
+        // is a property worth asserting against the ENCODED line rather than
+        // field by field: a secret picked up by a future edit would show up
+        // here as a value on the wire.
+        let info = publisher(variables: [
+            "HOME": "/h",
+            "AWS_SECRET_ACCESS_KEY": "super-secret",
+            "GITHUB_TOKEN": "ghp_secret",
+            "PATH": "/usr/bin",
+            "TERM_PROGRAM": "ghostty",
+        ]).processInfo()
+        let encoded = String(decoding: try JSONEncoder().encode(info), as: UTF8.self)
+        for secret in ["super-secret", "ghp_secret", "/usr/bin"] {
+            XCTAssertFalse(encoded.contains(secret), "\(secret) must never be published")
+        }
+        XCTAssertTrue(encoded.contains("ghostty"))
+    }
+
     // The published claudePID and the tty resolution consume the SAME pid,
     // from one `ppid()` call: the tty seam receives the pid the ppid seam
     // yielded, so the two fields can never describe different processes (the

--- a/Tests/localvoxtralTests/ClaudeHookWireTests.swift
+++ b/Tests/localvoxtralTests/ClaudeHookWireTests.swift
@@ -90,6 +90,73 @@ final class ClaudeHookWireCodecTests: XCTestCase {
         XCTAssertEqual(clamped.process?.herdrSocketPath, "sssss")
     }
 
+    func testCmuxAndBridgeProcessFieldsUseGoldenWireNamesAndDecode() throws {
+        let record = ClaudeHookRecord(
+            event: .sessionStart,
+            sessionID: "sess-cmux",
+            timestamp: 1.5,
+            process: ClaudeHookProcessInfo(
+                hookPID: 42,
+                claudePID: 41,
+                cmuxSurfaceID: "surface-3",
+                cmuxSocketPath: "cmux.sock",
+                bridgeSessionID: "bridge-abc"
+            )
+        )
+
+        let encoded = try XCTUnwrap(ClaudeHookWireCodec.encodeLine(record))
+        XCTAssertEqual(
+            String(decoding: encoded, as: UTF8.self),
+            #"{"event":"SessionStart","files":[],"process":{"bridge_session_id":"bridge-abc","claude_pid":41,"cmux_socket_path":"cmux.sock","cmux_surface_id":"surface-3","hook_pid":42},"session_id":"sess-cmux","ts":1.5,"v":2}"# + "\n"
+        )
+        let decoded = try ClaudeHookWireCodec.decodeLine(encoded)
+        XCTAssertEqual(decoded.process?.cmuxSurfaceID, "surface-3")
+        XCTAssertEqual(decoded.process?.cmuxSocketPath, "cmux.sock")
+        XCTAssertEqual(decoded.process?.bridgeSessionID, "bridge-abc")
+    }
+
+    func testClampTruncatesTheCmuxAndBridgeProcessFields() {
+        let record = ClaudeHookRecord(
+            event: .sessionStart,
+            sessionID: "s",
+            timestamp: 1,
+            process: ClaudeHookProcessInfo(
+                hookPID: 2,
+                claudePID: 1,
+                cmuxSurfaceID: String(repeating: "u", count: 20),
+                cmuxSocketPath: String(repeating: "k", count: 20),
+                bridgeSessionID: String(repeating: "b", count: 20)
+            )
+        )
+
+        let clamped = ClaudeHookWireCodec.clamp(record, limits: ClaudeHookLimits(maxPathBytes: 5))
+        XCTAssertEqual(clamped.process?.cmuxSurfaceID, "uuuuu")
+        XCTAssertEqual(clamped.process?.cmuxSocketPath, "kkkkk")
+        XCTAssertEqual(clamped.process?.bridgeSessionID, "bbbbb")
+    }
+
+    func testAWireLineWithoutTheCmuxAndBridgeFieldsIsUnchangedByThem() throws {
+        // The compatibility property: an install running an older publisher
+        // still sends lines with no such keys, and re-encoding one must not
+        // invent them — a broker/publisher version skew is the normal state
+        // during an update, not an edge case.
+        let oldLine = line(
+            #"{"event":"SessionStart","process":{"claude_pid":1,"herdr_pane_id":"pane-7","hook_pid":2},"session_id":"old","ts":1,"v":2}"#
+        )
+        let record = try ClaudeHookWireCodec.decodeLine(oldLine)
+        XCTAssertEqual(record.process?.herdrPaneID, "pane-7")
+        XCTAssertNil(record.process?.cmuxSurfaceID)
+        XCTAssertNil(record.process?.cmuxSocketPath)
+        XCTAssertNil(record.process?.bridgeSessionID)
+
+        let reencoded = String(
+            decoding: try XCTUnwrap(ClaudeHookWireCodec.encodeLine(record)), as: UTF8.self
+        )
+        for key in ["cmux_surface_id", "cmux_socket_path", "bridge_session_id"] {
+            XCTAssertFalse(reencoded.contains(key), "an absent field must stay absent")
+        }
+    }
+
     func testAbsentHerdrProcessFieldsDecodeAsNil() throws {
         let json = validJSON(
             event: "SessionStart",

--- a/Tests/localvoxtralTests/ClaudeRemoteContextListenerTests.swift
+++ b/Tests/localvoxtralTests/ClaudeRemoteContextListenerTests.swift
@@ -294,6 +294,21 @@ final class ClaudeRemoteContextListenerTests: XCTestCase {
         XCTAssertEqual(environment.sshTTY, "/dev/pts/3", "the good neighbour still arrives")
     }
 
+    func testAnEnvValuePaddedWithUnicodeWhitespaceIsRejectedOverTheRealSocket() throws {
+        // Review finding, end to end: `pane-7<NBSP>` used to be trimmed by the
+        // head parser (Foundation's Unicode whitespace set) into a value the
+        // byte-level charset check then accepted. The hook itself must still
+        // succeed — a bad enrichment value never costs delivery.
+        try startListener()
+        let response = try XCTUnwrap(try send(hookRequest(token: token, extraHeaders: [
+            "X-Lvx-Env-Herdr-Pane-Id: pane-7\u{A0}",
+        ])))
+        XCTAssertEqual(response.status, 200)
+        let snapshot = try XCTUnwrap(sessions.liveSessions().first)
+        XCTAssertNil(snapshot.remoteSessionEnvironment)
+        XCTAssertEqual(sessions.resolve(herdrPaneID: "pane-7"), .unknown)
+    }
+
     func testARequestWithNoEnvHeadersCarriesNoEnvironment() throws {
         try startListener()
         _ = try send(hookRequest(token: token))

--- a/Tests/localvoxtralTests/ClaudeRemoteContextListenerTests.swift
+++ b/Tests/localvoxtralTests/ClaudeRemoteContextListenerTests.swift
@@ -220,6 +220,87 @@ final class ClaudeRemoteContextListenerTests: XCTestCase {
         XCTAssertEqual(snapshot.workspace, .remoteOpaque(label: "service"))
     }
 
+    func testAllowlistedEnvHeadersReachTheSnapshotWithoutTouchingProcessIdentity() throws {
+        // The enrichment rides as headers because the body must stay Claude
+        // Code's JSON byte-for-byte (no jq on the remote host). It must arrive —
+        // and it must arrive in `remoteEnvironment`, never in `process`, which
+        // is what the local join arms read.
+        try startListener()
+        let response = try XCTUnwrap(try send(hookRequest(token: token, extraHeaders: [
+            "X-Lvx-Env-Herdr-Pane-Id: pane-7",
+            "X-Lvx-Env-Herdr-Socket-Path: /run/user/1000/herdr/default.sock",
+            "X-Lvx-Env-Cmux-Surface-Id: surface-3",
+            "X-Lvx-Env-Bridge-Session-Id: bridge-abc",
+            "X-Lvx-Env-Tmux-Pane: %3",
+            "X-Lvx-Env-Ssh-Tty: /dev/pts/3",
+            "X-Lvx-Env-Hook-Parent-Pid: 4242",
+        ])))
+        XCTAssertEqual(response.status, 200)
+
+        let snapshot = try XCTUnwrap(sessions.liveSessions().first)
+        let environment = try XCTUnwrap(snapshot.remoteSessionEnvironment)
+        XCTAssertEqual(environment.herdrPaneID, "pane-7")
+        XCTAssertEqual(environment.herdrSocketPath, "/run/user/1000/herdr/default.sock")
+        XCTAssertEqual(environment.cmuxSurfaceID, "surface-3")
+        XCTAssertEqual(environment.bridgeSessionID, "bridge-abc")
+        XCTAssertEqual(environment.tmuxPane, "%3")
+        XCTAssertEqual(environment.sshTTY, "/dev/pts/3")
+        XCTAssertEqual(environment.hookParentPID, "4242")
+        XCTAssertNil(snapshot.process, "headers must never become process identity")
+        // And the local arms stay blind to all of it.
+        XCTAssertEqual(sessions.resolve(herdrPaneID: "pane-7"), .unknown)
+        XCTAssertEqual(sessions.resolve(tty: "/dev/pts/3"), .unknown)
+        XCTAssertTrue(sessions.liveLocalHerdrSocketPaths().isEmpty)
+    }
+
+    func testAProcessBlockInARemoteBodyIsIgnoredEvenWhenTheHeadersAreHonest() throws {
+        // The other half of the same invariant, from the body side: a remote
+        // payload can WRITE a `process` object, and the parser's allowlist has
+        // no field for it. Nothing about `process` is reachable from remote.
+        try startListener()
+        _ = try send(hookRequest(token: token, payload: [
+            "session_id": "s-1",
+            "cwd": "/srv/app",
+            "process": [
+                "hook_pid": 1,
+                "claude_pid": 9001,
+                "tty": "/dev/ttys004",
+                "herdr_pane_id": "pane-7",
+                "herdr_socket_path": "/tmp/herdr.sock",
+            ],
+        ], extraHeaders: ["X-Lvx-Env-Herdr-Pane-Id: pane-7"]))
+        let snapshot = try XCTUnwrap(sessions.liveSessions().first)
+        XCTAssertNil(snapshot.process)
+        XCTAssertEqual(sessions.resolve(herdrPaneID: "pane-7"), .unknown)
+        XCTAssertEqual(sessions.resolve(tty: "/dev/ttys004"), .unknown)
+    }
+
+    func testHostileEnvHeaderValuesAreDroppedWithoutFailingTheHook() throws {
+        // A value the shim would never have written (its charset check happens
+        // before it writes) — so this is the receiving side refusing to trust
+        // that the shim ran at all. The hook itself must still succeed: the
+        // body is the payload and the enrichment is a bonus.
+        try startListener()
+        let response = try XCTUnwrap(try send(hookRequest(token: token, extraHeaders: [
+            "X-Lvx-Env-Herdr-Pane-Id: pane 7 with spaces",
+            "X-Lvx-Env-Cmux-Surface-Id: " + String(repeating: "a", count: 400),
+            "X-Lvx-Env-Ssh-Tty: /dev/pts/3",
+        ])))
+        XCTAssertEqual(response.status, 200, "a bad enrichment value must not fail the hook")
+        let snapshot = try XCTUnwrap(sessions.liveSessions().first)
+        let environment = try XCTUnwrap(snapshot.remoteSessionEnvironment)
+        XCTAssertNil(environment.herdrPaneID, "whitespace is outside the charset")
+        XCTAssertNil(environment.cmuxSurfaceID, "over the per-value byte cap")
+        XCTAssertEqual(environment.sshTTY, "/dev/pts/3", "the good neighbour still arrives")
+    }
+
+    func testARequestWithNoEnvHeadersCarriesNoEnvironment() throws {
+        try startListener()
+        _ = try send(hookRequest(token: token))
+        let snapshot = try XCTUnwrap(sessions.liveSessions().first)
+        XCTAssertNil(snapshot.remoteSessionEnvironment)
+    }
+
     func testTheEventPathSuppliesTheEventWhenThePayloadOmitsIt() throws {
         try startListener()
         _ = try send(hookRequest(event: "UserPromptSubmit", token: token, payload: [

--- a/Tests/localvoxtralTests/ClaudeRemoteHTTPTests.swift
+++ b/Tests/localvoxtralTests/ClaudeRemoteHTTPTests.swift
@@ -164,6 +164,38 @@ final class ClaudeRemoteHTTPTests: XCTestCase {
         XCTAssertEqual(parsed.bearerToken, "abc123abc123abc123")
     }
 
+    func testOnlyASCIIOWSIsTrimmedFromNamesAndValues() throws {
+        // Review finding: `trimmingCharacters(in: .whitespaces)` is a UNICODE
+        // set. It ate U+00A0 and friends, which laundered a malformed wire
+        // value into a well-formed one before any byte-level validator could
+        // see it — and, worse, rewrote the field NAME, so `Content-Length<NBSP>`
+        // parsed as a Content-Length here while a conforming proxy would read
+        // something else. RFC 9110 OWS is `*( SP / HTAB )` and nothing more.
+        let padded = Data(
+            "POST /v1/hook/Stop HTTP/1.1\r\nX-Thing: pane-7\u{A0}\r\nContent-Length: 2\r\n\r\n{}".utf8
+        )
+        let (parsed, _) = try ClaudeRemoteHTTPCodec.parseRequestHead(padded)
+        XCTAssertEqual(
+            parsed.headers["x-thing"], "pane-7\u{A0}",
+            "a non-ASCII pad is part of the value, not whitespace to discard"
+        )
+
+        // Tab is OWS and still goes.
+        let tabbed = Data(
+            "POST /v1/hook/Stop HTTP/1.1\r\nX-Thing:\tvalue\t\r\nContent-Length: 2\r\n\r\n{}".utf8
+        )
+        XCTAssertEqual(try ClaudeRemoteHTTPCodec.parseRequestHead(tabbed).request.headers["x-thing"], "value")
+
+        // And the name is no longer rewritten: a NBSP-suffixed Content-Length
+        // is a different header, so the required one is simply absent.
+        let paddedName = Data(
+            "POST /v1/hook/Stop HTTP/1.1\r\nContent-Length\u{A0}: 2\r\n\r\n{}".utf8
+        )
+        XCTAssertThrowsError(try ClaudeRemoteHTTPCodec.parseRequestHead(paddedName)) { error in
+            XCTAssertEqual(error as? ClaudeRemoteHTTPError, .lengthRequired)
+        }
+    }
+
     func testHeaderFoldingIsRejected() {
         let raw = Data(
             "POST /v1/hook/Stop HTTP/1.1\r\nX-Thing: a\r\n  continued\r\nContent-Length: 2\r\n\r\n{}".utf8

--- a/Tests/localvoxtralTests/ClaudeRemotePluginManifestTests.swift
+++ b/Tests/localvoxtralTests/ClaudeRemotePluginManifestTests.swift
@@ -657,6 +657,77 @@ final class ClaudeRemotePluginManifestTests: XCTestCase {
         }
     }
 
+    func testShimDropsMultibyteValuesUnderAUTF8Locale() throws {
+        // Review finding: a bracket RANGE (`[A-Za-z]`) follows the active
+        // COLLATION, so under a UTF-8 locale `[a-z]` can match `é` — and
+        // `${#var}` counts CHARACTERS, so 200 accented characters would have
+        // become a ~400-byte header line while passing a "200 byte" cap. The
+        // shim now enumerates the charset (no ranges to collate) and runs the
+        // checks under `LC_ALL=C`.
+        //
+        // The locale is set for the shim process. On a host without
+        // `en_US.UTF-8` the shell falls back to C and the value is rejected for
+        // the plain reason instead — the assertion holds either way, and on the
+        // macOS runner (where the locale exists) it exercises the real path.
+        let cases: [(String, String)] = [
+            ("one accented character", "pan\u{c9}7"),
+            ("200 accented characters, ~400 bytes", String(repeating: "\u{c9}", count: 200)),
+        ]
+        for (name, value) in cases {
+            let captured = try capturedRequestHeaders(environment: [
+                "LANG": "en_US.UTF-8",
+                "LC_ALL": "en_US.UTF-8",
+                "HERDR_PANE_ID": value,
+                "SSH_TTY": "/dev/pts/3",
+            ])
+            XCTAssertFalse(
+                captured.contains("X-Lvx-Env-Herdr-Pane-Id"),
+                "\(name): a multibyte value must be dropped in every locale"
+            )
+            XCTAssertTrue(
+                captured.utf8.allSatisfy { $0 < 0x80 },
+                "\(name): no non-ASCII byte may reach the header file"
+            )
+            // Fail-open is unchanged: the neighbour and the token still go.
+            XCTAssertTrue(captured.contains("X-Lvx-Env-Ssh-Tty: /dev/pts/3"), name)
+            let request = try parseCapturedHeaders(captured)
+            XCTAssertEqual(request.bearerToken, "unit-test-token", name)
+        }
+    }
+
+    func testShimValidationIsWrittenToBeLocaleIndependent() throws {
+        // Source-level, because the behavioural test above cannot fail on a
+        // runner whose locale data is missing. These two properties are what
+        // make the check locale-independent, and both are easy to undo by
+        // "simplifying" the pattern back to ranges.
+        let source = try shimSource()
+        XCTAssertTrue(
+            source.contains("abcdefghijklmnopqrstuvwxyz0123456789"),
+            "the charset must be ENUMERATED; a bracket range follows collation"
+        )
+        // Scoped to the env-validation function's own body: the comment above
+        // it necessarily quotes the range syntax it warns against, and the
+        // unrelated backoff code legitimately digit-checks an epoch stamp.
+        let body = try XCTUnwrap(
+            source.range(of: "lvx_env_header() {").map { start in
+                let rest = source[start.upperBound...]
+                let end = rest.range(of: "\n}")?.lowerBound ?? rest.endIndex
+                return String(rest[..<end])
+            },
+            "the env-validation function must still be called lvx_env_header"
+        )
+        for range in ["A-Za-z", "a-z]", "0-9]"] {
+            XCTAssertFalse(
+                body.contains(range),
+                "no collation-sensitive range may validate an env value: \(range)"
+            )
+        }
+        XCTAssertTrue(
+            source.contains("LC_ALL=C"),
+            "the validation must run under LC_ALL=C so ${#var} is a byte count"
+        )
+    }
+
     func testShimSendsAValueExactlyAtTheLengthCap() throws {
         // The other side of the cap: a real herdr socket path is long, and an
         // off-by-one here would silently drop every one of them.

--- a/Tests/localvoxtralTests/ClaudeRemotePluginManifestTests.swift
+++ b/Tests/localvoxtralTests/ClaudeRemotePluginManifestTests.swift
@@ -363,6 +363,12 @@ final class ClaudeRemotePluginManifestTests: XCTestCase {
         process.arguments = [shimURL.path, event]
         var processEnvironment = ProcessInfo.processInfo.environment
         processEnvironment.removeValue(forKey: "CLAUDE_PLUGIN_OPTION_TOKEN")
+        // The enrichment allowlist is cleared unless a test sets it: a runner
+        // that happens to be inside tmux (or herdr) would otherwise leak its own
+        // pane into every "nothing is set" assertion.
+        for field in ClaudeRemoteEnvironmentField.allCases {
+            processEnvironment.removeValue(forKey: String(field.shellSource.dropFirst()))
+        }
         processEnvironment["XDG_RUNTIME_DIR"] = isolatedState.path
         processEnvironment.merge(environment) { _, new in new }
         process.environment = processEnvironment
@@ -495,6 +501,11 @@ final class ClaudeRemotePluginManifestTests: XCTestCase {
         previous=""
         for argument in "$@"; do
           [ "$previous" = "--output" ] && out="$argument"
+          if [ "$previous" = "--header" ] && [ -n "${FAKE_CURL_HEADER_DUMP:-}" ]; then
+            case "$argument" in
+            @*) cat "${argument#@}" >>"$FAKE_CURL_HEADER_DUMP" 2>/dev/null ;;
+            esac
+          fi
           previous="$argument"
         done
         cat >/dev/null
@@ -514,6 +525,182 @@ final class ClaudeRemotePluginManifestTests: XCTestCase {
         ]
         environment.merge(extraEnvironment) { _, new in new }
         return try runShim(event: event, environment: environment)
+    }
+
+    // MARK: Shim environment enrichment
+    //
+    // The shim adds an allowlisted set of env values as `X-Lvx-Env-*` headers
+    // (the body must stay Claude Code's event JSON byte-for-byte — there is no
+    // jq on the remote host to merge anything into it). Two properties are
+    // tested by RUNNING the shim against the stub curl and reading the header
+    // file it actually wrote: the values arrive in the exact spelling the
+    // listener's parser reads, and a hostile value cannot forge a header line.
+
+    /// Runs the shim with the given extra environment and returns the header
+    /// file curl was handed, verbatim. This is the real artifact — not the
+    /// shim's source, and not a reconstruction.
+    private func capturedRequestHeaders(
+        environment: [String: String], event: String = "Stop"
+    ) throws -> String {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("shim-headers-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let dump = directory.appendingPathComponent("headers")
+        var extra = environment
+        extra["FAKE_CURL_HEADER_DUMP"] = dump.path
+        let result = try runShimWithStubCurl(
+            event: event,
+            status: "200",
+            body: ClaudeRemoteHTTPCodec.markerResponseBody(marker: nil),
+            extraEnvironment: extra
+        )
+        XCTAssertEqual(result.exitCode, 0)
+        XCTAssertEqual(result.stderr, "", "enrichment must not make the shim noisy")
+        return (try? String(contentsOf: dump, encoding: .utf8)) ?? ""
+    }
+
+    /// The captured header block, re-parsed by the REAL request-head parser and
+    /// read by the REAL env codec — the two sides of the contract meeting on
+    /// bytes the shim produced.
+    private func parseCapturedHeaders(_ captured: String) throws -> ClaudeRemoteHTTPRequest {
+        let lines = captured.split(separator: "\n").map(String.init)
+        var head = "POST /v1/hook/Stop HTTP/1.1\r\nHost: 127.0.0.1\r\n"
+        for line in lines { head += line + "\r\n" }
+        head += "Content-Length: 2\r\n\r\n{}"
+        return try ClaudeRemoteHTTPCodec.parseRequestHead(Data(head.utf8)).request
+    }
+
+    func testShimSendsEveryAllowlistedEnvValueUnderTheHeaderTheListenerReads() throws {
+        // One distinct value per variable, so a copy-pasted header name shows
+        // up as a swap rather than as a test that still passes.
+        var environment: [String: String] = [:]
+        var expected = ClaudeRemoteSessionEnvironment()
+        for field in ClaudeRemoteEnvironmentField.allCases where field != .hookParentPID {
+            let variable = String(field.shellSource.dropFirst())
+            environment[variable] = "value-\(field.rawValue)"
+            expected[field] = "value-\(field.rawValue)"
+        }
+        let captured = try capturedRequestHeaders(environment: environment)
+        let request = try parseCapturedHeaders(captured)
+        let parsed = try XCTUnwrap(ClaudeRemoteEnvironmentCodec.environment(in: request.headers))
+
+        for field in ClaudeRemoteEnvironmentField.allCases where field != .hookParentPID {
+            XCTAssertEqual(
+                parsed[field], expected[field],
+                "\(field.shellSource) did not arrive as \(field.headerName)"
+            )
+        }
+        // `$PPID` is the shell's own, so it cannot be injected — assert its
+        // SHAPE instead. Without it, a later arm would have no handle at all on
+        // the Claude Code process on the remote host.
+        let parentPID = try XCTUnwrap(parsed.hookParentPID, "the shim must report its parent pid")
+        XCTAssertFalse(parentPID.isEmpty)
+        XCTAssertTrue(parentPID.allSatisfy(\.isNumber), "a pid is digits: \(parentPID)")
+        // The token header is still the first thing in the file and untouched.
+        XCTAssertEqual(request.bearerToken, "unit-test-token")
+    }
+
+    func testShimSendsNoEnvHeadersWhenNoneOfTheVariablesAreSet() throws {
+        // Everything unset (the stub environment inherits the runner's, which
+        // has none of these) leaves only Authorization and the always-present
+        // parent pid: a plain host must not pay for a feature it is not using.
+        let captured = try capturedRequestHeaders(environment: [:])
+        let request = try parseCapturedHeaders(captured)
+        let parsed = ClaudeRemoteEnvironmentCodec.environment(in: request.headers)
+        for field in ClaudeRemoteEnvironmentField.allCases where field != .hookParentPID {
+            XCTAssertNil(parsed?[field], "\(field.headerName) must not be sent when unset")
+        }
+    }
+
+    func testShimTreatsAnExportedButEmptyVariableAsAbsent() throws {
+        let captured = try capturedRequestHeaders(environment: [
+            "HERDR_PANE_ID": "", "CMUX_SURFACE_ID": "",
+        ])
+        XCTAssertFalse(captured.contains("X-Lvx-Env-Herdr-Pane-Id"))
+        XCTAssertFalse(captured.contains("X-Lvx-Env-Cmux-Surface-Id"))
+    }
+
+    func testShimRefusesToWriteAnEnvValueThatCouldForgeAHeaderLine() throws {
+        // The header-injection cases. Each of these, written unvalidated, would
+        // let the remote host add headers of its own — including a second
+        // Authorization, which the listener's duplicate rejection would then
+        // turn into a hard 400 on every hook. The charset whitelist makes it
+        // impossible before a byte is written.
+        let hostile: [(String, String)] = [
+            ("CRLF", "pane\r\nAuthorization: Bearer stolen"),
+            ("bare LF", "pane\nX-Evil: 1"),
+            ("bare CR", "pane\rX-Evil: 1"),
+            ("space", "pane 7"),
+            ("tab", "pane\tX-Evil: 1"),
+            ("quote", "pane\"7"),
+            ("backslash", "pane\\7"),
+            ("command substitution", "pane$(id)"),
+            ("backtick", "pane`id`"),
+            ("non-ASCII", "pane-\u{e9}"),
+            ("over the length cap", String(repeating: "a", count: 201)),
+        ]
+        for (name, value) in hostile {
+            let captured = try capturedRequestHeaders(environment: ["HERDR_PANE_ID": value])
+            XCTAssertFalse(
+                captured.contains("X-Lvx-Env-Herdr-Pane-Id"),
+                "\(name): the value must be dropped, not escaped"
+            )
+            XCTAssertFalse(captured.contains("X-Evil"), "\(name): forged a header")
+            XCTAssertFalse(
+                captured.contains("Bearer stolen"), "\(name): forged an Authorization"
+            )
+            // The request still parses, and still carries exactly one token —
+            // fail-open means a bad env value costs a hint, never the hook.
+            let request = try parseCapturedHeaders(captured)
+            XCTAssertEqual(request.bearerToken, "unit-test-token", "\(name)")
+        }
+    }
+
+    func testShimSendsAValueExactlyAtTheLengthCap() throws {
+        // The other side of the cap: a real herdr socket path is long, and an
+        // off-by-one here would silently drop every one of them.
+        let atCap = String(repeating: "a", count: 200)
+        let captured = try capturedRequestHeaders(environment: ["HERDR_PANE_ID": atCap])
+        let request = try parseCapturedHeaders(captured)
+        XCTAssertEqual(
+            ClaudeRemoteEnvironmentCodec.environment(in: request.headers)?.herdrPaneID, atCap
+        )
+    }
+
+    func testShimSourceCoversTheWholeAllowlistWithNoDrift() throws {
+        // Source-level, because a variable the shim never reads is invisible to
+        // every behavioural test above: it simply never appears. This is the
+        // assertion that fails when the Swift allowlist grows and the shim does
+        // not, which would otherwise ship as a join arm that never joins.
+        let source = try shimSource()
+        for field in ClaudeRemoteEnvironmentField.allCases {
+            let expected = field == .hookParentPID
+                ? "'\(field.headerName)' \"${PPID:-}\""
+                : "'\(field.headerName)' \"${\(field.shellSource.dropFirst()):-}\""
+            XCTAssertTrue(
+                source.contains(expected),
+                "the shim must publish \(field.shellSource) as \(field.headerName): \(expected)"
+            )
+        }
+    }
+
+    func testShimKeepsTheEnvHeadersOutOfArgvAndInThePrivateHeaderFile() throws {
+        // Same rule as the token, for the same reason: /proc/<pid>/cmdline is
+        // world-readable. It also keeps the curl invocation itself untouched.
+        let source = try shimSource()
+        for field in ClaudeRemoteEnvironmentField.allCases {
+            for line in source.split(separator: "\n") where line.contains("curl") {
+                XCTAssertFalse(
+                    line.contains(field.headerName),
+                    "no curl argument may carry \(field.headerName): \(line)"
+                )
+            }
+        }
+        XCTAssertTrue(
+            source.contains(">>\"$WORK/header\""),
+            "env headers must be appended to the same private header file as the token"
+        )
     }
 
     // MARK: Shim transport backoff

--- a/Tests/localvoxtralTests/ClaudeRemoteSessionEnvironmentTests.swift
+++ b/Tests/localvoxtralTests/ClaudeRemoteSessionEnvironmentTests.swift
@@ -1,0 +1,351 @@
+import ClaudeContextWire
+import Foundation
+import XCTest
+@testable import localvoxtral
+
+/// The allowlisted env enrichment a REMOTE hook sends as `X-Lvx-Env-*` headers.
+///
+/// Two things are being pinned here and they pull in opposite directions:
+/// the values must ARRIVE (a join arm that never sees a pane id is a feature
+/// that silently does not exist), and they must stay INERT — labels about
+/// another machine that no local arm, filesystem call, or liveness probe can
+/// ever consume.
+final class ClaudeRemoteSessionEnvironmentCodecTests: XCTestCase {
+    private func headers(_ pairs: [ClaudeRemoteEnvironmentField: String]) -> [String: String] {
+        var result: [String: String] = ["authorization": "Bearer t", "content-length": "2"]
+        for (field, value) in pairs { result[field.lowercasedHeaderName] = value }
+        return result
+    }
+
+    // MARK: Allowlist mapping
+
+    func testEveryFieldHasADistinctUnderscoreFreeHeaderNameUnderOneNamespace() {
+        var seen: Set<String> = []
+        for field in ClaudeRemoteEnvironmentField.allCases {
+            XCTAssertTrue(
+                field.headerName.hasPrefix("X-Lvx-Env-"),
+                "\(field) must live under the one namespace the shim and parser agree on"
+            )
+            XCTAssertFalse(
+                field.headerName.contains("_"),
+                "\(field): underscores fold into hyphens in some readers; do not rely on the difference"
+            )
+            XCTAssertTrue(
+                seen.insert(field.lowercasedHeaderName).inserted,
+                "\(field) collides with another field's header name"
+            )
+        }
+        // The allowlist itself: it grows only deliberately, so a silent addition
+        // (or removal, which would break a join arm) fails here first.
+        XCTAssertEqual(ClaudeRemoteEnvironmentField.allCases.count, 10)
+    }
+
+    func testEachFieldRoundTripsThroughItsOwnHeader() throws {
+        // One value per field, all distinct, so a mis-wired subscript or a
+        // copy-pasted header name shows up as a swapped value rather than as a
+        // test that still passes.
+        var expected = ClaudeRemoteSessionEnvironment()
+        var raw: [ClaudeRemoteEnvironmentField: String] = [:]
+        for (index, field) in ClaudeRemoteEnvironmentField.allCases.enumerated() {
+            let value = "value-\(index)"
+            expected[field] = value
+            raw[field] = value
+        }
+        let parsed = try XCTUnwrap(ClaudeRemoteEnvironmentCodec.environment(in: headers(raw)))
+        XCTAssertEqual(parsed, expected)
+        XCTAssertFalse(parsed.isEmpty)
+    }
+
+    func testNoEnvHeadersMeansNoEnvironmentRatherThanAnEmptyOne() {
+        XCTAssertNil(ClaudeRemoteEnvironmentCodec.environment(in: headers([:])))
+    }
+
+    func testHeadersOutsideTheAllowlistAreIgnored() {
+        var raw = headers([.herdrPaneID: "pane-7"])
+        raw["x-lvx-env-anything-else"] = "surprise"
+        raw["x-forwarded-for"] = "10.0.0.1"
+        let parsed = ClaudeRemoteEnvironmentCodec.environment(in: raw)
+        XCTAssertEqual(parsed, ClaudeRemoteSessionEnvironment(herdrPaneID: "pane-7"))
+    }
+
+    // MARK: Charset — the header-injection defence
+
+    func testValuesCarryingAnythingOutsideTheCharsetAreDropped() {
+        // Every one of these is a value the shim's `case` pattern also refuses.
+        // The CR/LF cases are the reason the charset is a whitelist: a value
+        // that could carry them would be a header-injection primitive, and this
+        // side must not depend on the remote host having checked first.
+        let hostile: [(String, String)] = [
+            ("CRLF header injection", "pane\r\nX-Evil: 1"),
+            ("bare LF", "pane\nX-Evil: 1"),
+            ("bare CR", "pane\rX-Evil: 1"),
+            ("NUL", "pane\u{0}x"),
+            ("other C0 control", "pane\u{7}x"),
+            ("ESC", "pane\u{1B}]2;lvx-forged\u{7}"),
+            ("space", "pane 7"),
+            ("tab", "pane\tsource"),
+            ("quote", "pane\"7"),
+            ("backslash", "pane\\7"),
+            ("dollar", "pane$(id)"),
+            ("semicolon", "pane;id"),
+            ("non-ASCII", "pane-\u{e9}"),
+            ("empty", ""),
+        ]
+        for (name, value) in hostile {
+            XCTAssertFalse(
+                ClaudeRemoteEnvironmentCodec.isAcceptableValue(value),
+                "\(name) must not be an acceptable value"
+            )
+            XCTAssertNil(
+                ClaudeRemoteEnvironmentCodec.environment(in: headers([.herdrPaneID: value])),
+                "\(name) must be dropped, leaving no environment at all"
+            )
+        }
+    }
+
+    func testTheCharsetAcceptsTheShapesRealValuesActuallyTake() {
+        // Real examples, so a future tightening that would silently break a
+        // join arm fails here instead of in the field.
+        let realistic = [
+            "%3",                                  // tmux pane
+            "/tmp/tmux-1000/default,3721,0",       // $TMUX
+            "/dev/pts/3",                          // SSH_TTY
+            "/run/user/1000/herdr/default.sock",   // herdr socket
+            "pane-7", "srv-01:default", "a1b2c3d4-e5f6-4a7b-8c9d-0e1f2a3b4c5d",
+            "user@host", "v1.2.3+build", "12345",
+        ]
+        for value in realistic {
+            XCTAssertTrue(
+                ClaudeRemoteEnvironmentCodec.isAcceptableValue(value),
+                "\(value) is a shape these variables really take"
+            )
+        }
+    }
+
+    // MARK: Caps
+
+    func testAnOversizedValueIsDroppedWhileItsNeighboursSurvive() throws {
+        let limits = ClaudeRemoteEnvironmentLimits.default
+        let tooLong = String(repeating: "a", count: limits.maxValueBytes + 1)
+        let exactlyAtCap = String(repeating: "b", count: limits.maxValueBytes)
+        let parsed = try XCTUnwrap(ClaudeRemoteEnvironmentCodec.environment(
+            in: headers([.herdrSocketPath: tooLong, .herdrPaneID: exactlyAtCap])
+        ))
+        XCTAssertNil(parsed.herdrSocketPath, "over the cap")
+        XCTAssertEqual(parsed.herdrPaneID, exactlyAtCap, "the cap is inclusive")
+    }
+
+    func testTheTotalByteBudgetIsEnforcedAcrossFields() throws {
+        // Four values that each pass alone but cannot all fit. The walk is in
+        // `allCases` order, so what survives is deterministic rather than
+        // dictionary-order noise — that determinism is the assertion.
+        let limits = ClaudeRemoteEnvironmentLimits(
+            maxValueBytes: 200, maxFieldCount: 12, maxTotalBytes: 300
+        )
+        let chunk = String(repeating: "c", count: 200)
+        let parsed = try XCTUnwrap(ClaudeRemoteEnvironmentCodec.environment(
+            in: headers([
+                .herdrPaneID: chunk, .herdrSocketPath: chunk,
+                .cmuxSurfaceID: chunk, .sshTTY: "/dev/pts/9",
+            ]),
+            limits: limits
+        ))
+        XCTAssertEqual(parsed.herdrPaneID, chunk, "first in allCases order")
+        XCTAssertNil(parsed.herdrSocketPath, "would exceed the total budget")
+        XCTAssertNil(parsed.cmuxSurfaceID)
+        // A later SMALL value still fits: the budget skips what does not fit
+        // rather than stopping the walk, so one fat value cannot starve the
+        // cheap ones behind it.
+        XCTAssertEqual(parsed.sshTTY, "/dev/pts/9")
+    }
+
+    func testTheFieldCountCapStopsTheWalk() throws {
+        let limits = ClaudeRemoteEnvironmentLimits(maxFieldCount: 2)
+        var raw: [ClaudeRemoteEnvironmentField: String] = [:]
+        for field in ClaudeRemoteEnvironmentField.allCases { raw[field] = "v" }
+        let parsed = try XCTUnwrap(
+            ClaudeRemoteEnvironmentCodec.environment(in: headers(raw), limits: limits)
+        )
+        let kept = ClaudeRemoteEnvironmentField.allCases.filter { parsed[$0] != nil }
+        XCTAssertEqual(kept, [.herdrPaneID, .herdrSocketPath])
+    }
+
+    // MARK: Agreement with the real HTTP head parser
+
+    func testEnvHeadersSurviveTheRealHeadParserAsWrittenOnTheWire() throws {
+        // Not a hand-built dictionary: the exact bytes a shim writes, through
+        // `parseRequestHead`, which lowercases names — the one place the two
+        // spellings have to agree.
+        var head = "POST /v1/hook/SessionStart HTTP/1.1\r\nHost: 127.0.0.1\r\n"
+        head += "Authorization: Bearer token\r\n"
+        for field in ClaudeRemoteEnvironmentField.allCases {
+            head += "\(field.headerName): \(field.rawValue)\r\n"
+        }
+        head += "Content-Length: 2\r\n\r\n{}"
+        let (request, _) = try ClaudeRemoteHTTPCodec.parseRequestHead(Data(head.utf8))
+        let parsed = try XCTUnwrap(ClaudeRemoteEnvironmentCodec.environment(in: request.headers))
+        for field in ClaudeRemoteEnvironmentField.allCases {
+            XCTAssertEqual(parsed[field], field.rawValue, "\(field.headerName) did not survive")
+        }
+    }
+}
+
+/// The invariant the whole PR exists to keep: remote env labels never become
+/// local identity.
+final class ClaudeRemoteEnvironmentIsolationTests: XCTestCase {
+    private let epoch = Date(timeIntervalSince1970: 3_000_000)
+    private let local = ClaudeTransportOrigin.localAuthenticated(peerUID: 501)
+    private let remote = ClaudeTransportOrigin.remote(channel: "ssh:host-1")
+
+    private func makeRegistry() -> ClaudeSessionRegistry {
+        let epoch = epoch
+        return ClaudeSessionRegistry(
+            now: { epoch },
+            isProcessAlive: { _ in true },
+            allocateMarkerValue: { "lvx-\(UUID().uuidString.prefix(8).lowercased())" }
+        )
+    }
+
+    private func record(
+        _ event: ClaudeHookEvent = .sessionStart,
+        session: String = "remote:host-1:s1",
+        process: ClaudeHookProcessInfo? = nil
+    ) -> ClaudeHookRecord {
+        ClaudeHookRecord(
+            event: event,
+            sessionID: session,
+            timestamp: 0,
+            rawCwd: "/srv/app",
+            process: process
+        )
+    }
+
+    /// A remote host reporting a herdr pane/socket that really does exist on
+    /// the Mac. Nothing about the wire distinguishes it from an honest report —
+    /// the isolation has to come from where the value is STORED.
+    private let collidingEnvironment = ClaudeRemoteSessionEnvironment(
+        herdrPaneID: "pane-7",
+        herdrSocketPath: "/tmp/herdr-local.sock",
+        cmuxSurfaceID: "surface-3",
+        hookParentPID: "9001"
+    )
+
+    func testRemoteEnvironmentIsStoredAndReadableAsRemoteOnly() throws {
+        let registry = makeRegistry()
+        let snapshot = try XCTUnwrap(
+            registry.ingest(record(), origin: remote, environment: collidingEnvironment)
+        )
+        XCTAssertEqual(snapshot.remoteEnvironment, collidingEnvironment)
+        XCTAssertEqual(snapshot.remoteSessionEnvironment, collidingEnvironment)
+    }
+
+    func testRemoteEnvironmentNeverPopulatesTheProcessBlock() throws {
+        // `process` is what every local arm reads. A remote report must leave
+        // it exactly as it was — nil, because the remote body parser has no
+        // process field at all.
+        let registry = makeRegistry()
+        let snapshot = try XCTUnwrap(
+            registry.ingest(record(), origin: remote, environment: collidingEnvironment)
+        )
+        XCTAssertNil(snapshot.process, "remote env values must not become process identity")
+    }
+
+    func testALocalSessionNeverAbsorbsAnEnvironmentEvenWhenOneIsHandedIn() throws {
+        // Defence in depth against a future caller: the reducer decides on the
+        // ORIGIN, not on whether an argument was supplied.
+        let registry = makeRegistry()
+        let snapshot = try XCTUnwrap(registry.ingest(
+            record(session: "s-local"), origin: local, environment: collidingEnvironment
+        ))
+        XCTAssertNil(snapshot.remoteEnvironment)
+        XCTAssertNil(snapshot.remoteSessionEnvironment)
+    }
+
+    func testTheHerdrArmCannotResolveARemoteSessionThroughItsEnvPaneID() {
+        // THE test. A remote host says it is in `pane-7`; the Mac genuinely has
+        // a `pane-7`. The local herdr arm must not see the remote session at
+        // all — not as a match, not as an ambiguity, not even as stale.
+        let registry = makeRegistry()
+        registry.ingest(record(), origin: remote, environment: collidingEnvironment)
+        XCTAssertEqual(
+            registry.resolve(herdrPaneID: "pane-7"), .unknown,
+            "a remote env pane id must be invisible to the local herdr arm"
+        )
+    }
+
+    func testARemoteEnvPaneIDCannotTurnALocalMatchIntoAnAmbiguity() throws {
+        // The subtler failure: not claiming the pane, but poisoning it. If the
+        // remote session were merely origin-filtered out of the winner set but
+        // still counted, the honest local session would abstain forever.
+        let registry = makeRegistry()
+        registry.ingest(
+            ClaudeHookRecord(
+                event: .sessionStart,
+                sessionID: "s-local",
+                timestamp: 0,
+                process: ClaudeHookProcessInfo(
+                    hookPID: 1, claudePID: 9001, herdrPaneID: "pane-7"
+                )
+            ),
+            origin: local
+        )
+        registry.ingest(record(), origin: remote, environment: collidingEnvironment)
+        guard case .resolved(let snapshot) = registry.resolve(herdrPaneID: "pane-7") else {
+            return XCTFail("the local session in that pane must still resolve")
+        }
+        XCTAssertEqual(snapshot.sessionID, "s-local")
+    }
+
+    func testARemoteEnvSocketPathNeverEntersTheLocalHerdrDialSet() {
+        // `liveLocalHerdrSocketPaths()` feeds `HerdrSocketClient`, which dials
+        // what it is given. A remote-supplied path reaching this set would be
+        // the app connecting to a socket named by another machine.
+        let registry = makeRegistry()
+        registry.ingest(record(), origin: remote, environment: collidingEnvironment)
+        XCTAssertTrue(
+            registry.liveLocalHerdrSocketPaths().isEmpty,
+            "a remote env socket path must never be dialable"
+        )
+    }
+
+    func testARemoteSessionEnvironmentDoesNotSurviveIntoTheTTYArm() {
+        // `SSH_TTY` on the remote host names a device in ITS /dev. The tty arm
+        // reads `process.tty`, which a remote record can never populate.
+        let registry = makeRegistry()
+        registry.ingest(
+            record(),
+            origin: remote,
+            environment: ClaudeRemoteSessionEnvironment(sshTTY: "/dev/ttys004")
+        )
+        XCTAssertEqual(registry.resolve(tty: "/dev/ttys004"), .unknown)
+    }
+
+    func testAnEnvironmentWithNothingUsableLeavesTheSnapshotUntouched() throws {
+        let registry = makeRegistry()
+        registry.ingest(record(), origin: remote, environment: collidingEnvironment)
+        let snapshot = try XCTUnwrap(
+            registry.ingest(record(.stop), origin: remote, environment: ClaudeRemoteSessionEnvironment())
+        )
+        XCTAssertEqual(
+            snapshot.remoteEnvironment, collidingEnvironment,
+            "an empty report is not a retraction"
+        )
+    }
+
+    func testTheNewestReportReplacesTheOldOneWholesale() throws {
+        // The shim publishes everything it can see on every event, so a field
+        // that stopped being reported means the user left that pane. Merging
+        // would resurrect it.
+        let registry = makeRegistry()
+        registry.ingest(record(), origin: remote, environment: collidingEnvironment)
+        let snapshot = try XCTUnwrap(registry.ingest(
+            record(.stop),
+            origin: remote,
+            environment: ClaudeRemoteSessionEnvironment(cmuxSurfaceID: "surface-9")
+        ))
+        // Read through the origin-gated accessor: the assertion is about what a
+        // consumer can see, not about the stored field.
+        XCTAssertEqual(snapshot.remoteSessionEnvironment?.cmuxSurfaceID, "surface-9")
+        XCTAssertNil(snapshot.remoteEnvironment?.herdrPaneID, "a stale pane must not linger")
+    }
+}

--- a/Tests/localvoxtralTests/ClaudeRemoteSessionEnvironmentTests.swift
+++ b/Tests/localvoxtralTests/ClaudeRemoteSessionEnvironmentTests.swift
@@ -170,6 +170,37 @@ final class ClaudeRemoteSessionEnvironmentCodecTests: XCTestCase {
         XCTAssertEqual(kept, [.herdrPaneID, .herdrSocketPath])
     }
 
+    func testUnicodeWhitespacePaddingIsRejectedRatherThanTrimmedIntoAcceptance() throws {
+        // Review finding: the head parser used to trim with Foundation's
+        // UNICODE whitespace set, so `pane-7<NBSP>` arrived here already
+        // trimmed to `pane-7` and passed the byte check — a malformed wire
+        // value laundered into a well-formed one. Asserted end to end, through
+        // the real parser, because the bug lived in the seam between the two.
+        let padding = ["\u{A0}", "\u{2007}", "\u{3000}", "\u{200B}"]
+        for pad in padding {
+            XCTAssertFalse(
+                ClaudeRemoteEnvironmentCodec.isAcceptableValue("pane-7" + pad),
+                "U+\(String(pad.unicodeScalars.first!.value, radix: 16)) is not ASCII and not whitespace to us"
+            )
+            var head = "POST /v1/hook/Stop HTTP/1.1\r\nAuthorization: Bearer token\r\n"
+            head += "X-Lvx-Env-Herdr-Pane-Id: pane-7\(pad)\r\n"
+            head += "Content-Length: 2\r\n\r\n{}"
+            let (request, _) = try ClaudeRemoteHTTPCodec.parseRequestHead(Data(head.utf8))
+            XCTAssertNil(
+                ClaudeRemoteEnvironmentCodec.environment(in: request.headers),
+                "a non-ASCII pad must reach the validator and be rejected"
+            )
+        }
+        // The legal ASCII pad is still tolerated — this is OWS, not an attack.
+        var head = "POST /v1/hook/Stop HTTP/1.1\r\nAuthorization: Bearer token\r\n"
+        head += "X-Lvx-Env-Herdr-Pane-Id:  pane-7 \r\n"
+        head += "Content-Length: 2\r\n\r\n{}"
+        let (request, _) = try ClaudeRemoteHTTPCodec.parseRequestHead(Data(head.utf8))
+        XCTAssertEqual(
+            ClaudeRemoteEnvironmentCodec.environment(in: request.headers)?.herdrPaneID, "pane-7"
+        )
+    }
+
     // MARK: Agreement with the real HTTP head parser
 
     func testEnvHeadersSurviveTheRealHeadParserAsWrittenOnTheWire() throws {

--- a/integrations/claude-code/README.md
+++ b/integrations/claude-code/README.md
@@ -154,7 +154,11 @@ An allowlist, not a filter:
 * the event name, session id, timestamp, and cwd
 * your prompt text (`UserPromptSubmit` only)
 * absolute file paths from the tools above
-* safe process metadata: pid, ppid, controlling TTY, `$TERM_PROGRAM`
+* safe process metadata: pid, ppid, controlling TTY, `$TERM_PROGRAM`, and the
+  multiplexer/bridge handles that say which pane the session lives in —
+  `$HERDR_PANE_ID`, `$HERDR_SOCKET_PATH`, `$CMUX_SURFACE_ID`,
+  `$CMUX_SOCKET_PATH`, `$CLAUDE_CODE_BRIDGE_SESSION_ID`. Never the rest of the
+  environment.
 
 What never crosses, by construction:
 
@@ -422,10 +426,22 @@ with no enrolled host, the app binds no port at all.
 
 ## What crosses the tunnel
 
-The same allowlist as the local plugin, plus one addition:
+The same allowlist as the local plugin, plus two additions:
 
 * bounded, sanitized excerpts of `Read`/`Edit`/`Write` tool input and output
   (≤512 bytes each, ≤8 kept per session)
+* an allowlisted set of environment values, sent as `X-Lvx-Env-*` request
+  headers rather than in the body (the body stays Claude Code's event JSON
+  byte-for-byte, because the host is not assumed to have `jq`):
+  `HERDR_PANE_ID`, `HERDR_SOCKET_PATH`, `HERDR_SESSION`, `CMUX_SURFACE_ID`,
+  `CMUX_SOCKET_PATH`, `CLAUDE_CODE_BRIDGE_SESSION_ID`, `TMUX`, `TMUX_PANE`,
+  `SSH_TTY`, and the shim's own parent pid. Each is sent only if it is
+  non-empty, at most 200 characters, and made purely of ASCII alphanumerics
+  plus `._:/@+,=%-`; anything else is dropped rather than escaped. They tell the
+  app WHERE the session runs so it can tell whether the pane you are dictating
+  into is this one — never what it contains. The rest of the environment is not
+  read, and these values are labels on the Mac: they can never become a local
+  path, a socket the app dials, or a process it probes.
 
 These exist only for remote sessions. A local session's files are on your Mac
 and the app reads them properly; a remote session's are on a machine the app has

--- a/integrations/claude-code/plugins/localvoxtral-remote/.claude-plugin/plugin.json
+++ b/integrations/claude-code/plugins/localvoxtral-remote/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "localvoxtral-remote",
   "description": "Publishes Claude Code session context from a REMOTE host to localvoxtral on your Mac, over an SSH RemoteForward tunnel. Command hooks running a bundled POSIX-sh shim that POSTs via curl — needs only sh and curl on the remote host, and fails open silently when either is missing.",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "author": {
     "name": "localvoxtral"
   },

--- a/integrations/claude-code/plugins/localvoxtral-remote/hooks/post.sh
+++ b/integrations/claude-code/plugins/localvoxtral-remote/hooks/post.sh
@@ -110,6 +110,56 @@ cat 2>/dev/null >"$WORK/header" <<EOF || fail_open
 Authorization: Bearer $TOKEN
 EOF
 
+# --- Allowlisted environment enrichment --------------------------------------
+# A handful of values naming WHERE this session runs — a herdr pane, a cmux
+# surface, a tmux pane, the SSH tty, the browser-side bridge session — so the
+# Mac can later tell whether the surface the user is dictating into is the one
+# this session lives in. Never content, never argv, never the whole environment.
+#
+# They ride as HEADERS because the body must stay Claude Code's event JSON
+# BYTE-FOR-BYTE: the remote host is not assumed to have jq (or any JSON tool),
+# so there is no way to merge a field into the body here. They go into the same
+# 0600 header file as the token, which also keeps them out of every argv and
+# leaves the curl invocation below untouched.
+#
+# Validation is a WHITELIST, applied before a byte is written: ASCII
+# alphanumerics plus `._:/@+,=%-` only (`%` is in because a tmux pane id IS
+# `%3`, and dropping it would silently disable the tmux arm). CR, LF, NUL,
+# every other control byte,
+# space and tab are all outside it, so a value that passes cannot terminate this
+# header line or forge a new one — header injection is impossible by
+# construction rather than by escaping. Anything failing validation, or longer
+# than 200 characters, is silently DROPPED: this is enrichment, and losing a
+# hint is nothing next to delivering the hook itself. The app re-applies the
+# identical charset and caps on arrival and trusts none of this.
+lvx_env_header() {
+  _lvx_name="$1"
+  _lvx_value="${2:-}"
+  [ -n "$_lvx_value" ] || return 0
+  case "$_lvx_value" in
+  *[!A-Za-z0-9._:/@+,=%-]*) return 0 ;;
+  esac
+  # Charset-checked first, so every remaining character is one ASCII byte and
+  # this length is also the byte length.
+  [ "${#_lvx_value}" -le 200 ] || return 0
+  cat 2>/dev/null >>"$WORK/header" <<EOF || return 0
+$_lvx_name: $_lvx_value
+EOF
+}
+
+lvx_env_header 'X-Lvx-Env-Herdr-Pane-Id' "${HERDR_PANE_ID:-}"
+lvx_env_header 'X-Lvx-Env-Herdr-Socket-Path' "${HERDR_SOCKET_PATH:-}"
+lvx_env_header 'X-Lvx-Env-Herdr-Session' "${HERDR_SESSION:-}"
+lvx_env_header 'X-Lvx-Env-Cmux-Surface-Id' "${CMUX_SURFACE_ID:-}"
+lvx_env_header 'X-Lvx-Env-Cmux-Socket-Path' "${CMUX_SOCKET_PATH:-}"
+lvx_env_header 'X-Lvx-Env-Bridge-Session-Id' "${CLAUDE_CODE_BRIDGE_SESSION_ID:-}"
+lvx_env_header 'X-Lvx-Env-Tmux' "${TMUX:-}"
+lvx_env_header 'X-Lvx-Env-Tmux-Pane' "${TMUX_PANE:-}"
+lvx_env_header 'X-Lvx-Env-Ssh-Tty' "${SSH_TTY:-}"
+# Best effort: the shim's parent is the Claude Code process on THIS host. It is
+# a pid in this machine's namespace and the Mac treats it as a label only.
+lvx_env_header 'X-Lvx-Env-Hook-Parent-Pid' "${PPID:-}"
+
 # --max-time 1 mirrors the old http hooks' one-second fail-open ceiling: a
 # host whose forward silently failed must not stall every turn. --max-filesize
 # (recognized since curl 7.10.8) belts the body the stdout gate below already

--- a/integrations/claude-code/plugins/localvoxtral-remote/hooks/post.sh
+++ b/integrations/claude-code/plugins/localvoxtral-remote/hooks/post.sh
@@ -132,12 +132,26 @@ EOF
 # than 200 characters, is silently DROPPED: this is enrichment, and losing a
 # hint is nothing next to delivering the hook itself. The app re-applies the
 # identical charset and caps on arrival and trusts none of this.
+#
+# The charset is ENUMERATED, not written as `[A-Za-z0-9…]` ranges. A bracket
+# RANGE follows the active collation (POSIX leaves range expressions
+# locale-dependent, and bash documents exactly this), so under a UTF-8 locale
+# `[a-z]` can match `é` — which would have let a multibyte value through and,
+# because `${#var}` counts CHARACTERS rather than bytes, let 200 such
+# characters become a ~400-byte header line. An enumerated set has no collation
+# to follow and matches the same bytes in every locale. The `LC_ALL=C` around
+# the calls is the belt to that braces: with it, `${#var}` is a byte count too,
+# so the cap means what it says even on a shell that resolves the enumeration
+# oddly. It is scoped to a subshell — one fork, and the stdout gate below keeps
+# the locale it was tested under.
 lvx_env_header() {
   _lvx_name="$1"
   _lvx_value="${2:-}"
   [ -n "$_lvx_value" ] || return 0
   case "$_lvx_value" in
-  *[!A-Za-z0-9._:/@+,=%-]*) return 0 ;;
+  *[!ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789._:/@+,=%-]*)
+    return 0
+    ;;
   esac
   # Charset-checked first, so every remaining character is one ASCII byte and
   # this length is also the byte length.
@@ -147,18 +161,22 @@ $_lvx_name: $_lvx_value
 EOF
 }
 
-lvx_env_header 'X-Lvx-Env-Herdr-Pane-Id' "${HERDR_PANE_ID:-}"
-lvx_env_header 'X-Lvx-Env-Herdr-Socket-Path' "${HERDR_SOCKET_PATH:-}"
-lvx_env_header 'X-Lvx-Env-Herdr-Session' "${HERDR_SESSION:-}"
-lvx_env_header 'X-Lvx-Env-Cmux-Surface-Id' "${CMUX_SURFACE_ID:-}"
-lvx_env_header 'X-Lvx-Env-Cmux-Socket-Path' "${CMUX_SOCKET_PATH:-}"
-lvx_env_header 'X-Lvx-Env-Bridge-Session-Id' "${CLAUDE_CODE_BRIDGE_SESSION_ID:-}"
-lvx_env_header 'X-Lvx-Env-Tmux' "${TMUX:-}"
-lvx_env_header 'X-Lvx-Env-Tmux-Pane' "${TMUX_PANE:-}"
-lvx_env_header 'X-Lvx-Env-Ssh-Tty' "${SSH_TTY:-}"
-# Best effort: the shim's parent is the Claude Code process on THIS host. It is
-# a pid in this machine's namespace and the Mac treats it as a label only.
-lvx_env_header 'X-Lvx-Env-Hook-Parent-Pid' "${PPID:-}"
+(
+  LC_ALL=C
+  export LC_ALL
+  lvx_env_header 'X-Lvx-Env-Herdr-Pane-Id' "${HERDR_PANE_ID:-}"
+  lvx_env_header 'X-Lvx-Env-Herdr-Socket-Path' "${HERDR_SOCKET_PATH:-}"
+  lvx_env_header 'X-Lvx-Env-Herdr-Session' "${HERDR_SESSION:-}"
+  lvx_env_header 'X-Lvx-Env-Cmux-Surface-Id' "${CMUX_SURFACE_ID:-}"
+  lvx_env_header 'X-Lvx-Env-Cmux-Socket-Path' "${CMUX_SOCKET_PATH:-}"
+  lvx_env_header 'X-Lvx-Env-Bridge-Session-Id' "${CLAUDE_CODE_BRIDGE_SESSION_ID:-}"
+  lvx_env_header 'X-Lvx-Env-Tmux' "${TMUX:-}"
+  lvx_env_header 'X-Lvx-Env-Tmux-Pane' "${TMUX_PANE:-}"
+  lvx_env_header 'X-Lvx-Env-Ssh-Tty' "${SSH_TTY:-}"
+  # Best effort: the shim's parent is the Claude Code process on THIS host. It
+  # is a pid in this machine's namespace and the Mac treats it as a label only.
+  lvx_env_header 'X-Lvx-Env-Hook-Parent-Pid' "${PPID:-}"
+) 2>/dev/null || :
 
 # --max-time 1 mirrors the old http hooks' one-second fail-open ceiling: a
 # host whose forward silently failed must not stall every turn. --max-filesize


### PR DESCRIPTION
## What

Publishes an allowlisted set of environment/context values from Claude Code hook
processes to the app, on **both** the remote and local paths. This is foundation
only — no consumer ships here. Three follow-up join arms (remote herdr pane, cmux
surface, claude.ai Remote Control browser tab) need this data to exist before
they can be written.

**Remote path.** `post.sh` now sends ten allowlisted values as `X-Lvx-Env-*`
request headers. Headers, not body: the body must stay Claude Code's event JSON
**byte-for-byte**, and the remote host is not assumed to have `jq` (or any JSON
tool) to merge a field into it. They are appended to the same 0600 header file
the token already uses, which keeps them out of every argv *and* leaves the
`curl` invocation itself completely untouched (deliberate — a parallel PR edits
that line).

Validation is a whitelist applied **before a byte is written**: ASCII
alphanumerics plus `._:/@+,=%-`, non-empty, ≤200 characters. CR, LF, NUL, every
other control byte, space and tab are outside the set, so a value that passes
cannot terminate a header line or forge a new one — header injection is
impossible by construction rather than by escaping. Anything failing validation
is silently dropped: the body is the payload and the enrichment is a bonus, so a
bad value must never cost the hook.

`ClaudeRemoteContextListener` re-validates on arrival against the identical
charset and caps (≤12 fields, ≤1024 total bytes) and stores the result as a new
`ClaudeRemoteSessionEnvironment` on `ClaudeSessionSnapshot.remoteEnvironment`.

**The invariant this PR is really about.** Remote-supplied values never populate
`ClaudeSessionSnapshot.process` and can never become resolvable through the
local-only arms. That is why they get their own field rather than more members on
`ClaudeHookProcessInfo`: `resolve(tty:)`, `resolve(herdrPaneID:)` and
`liveLocalHerdrSocketPaths()` each pair an `origin.isLocalAuthenticated` filter
with a `process` read, so a remote value has **nothing in the field they read**
even if a future edit lost the origin filter. `hookParentPID` is a `String` on
purpose — a pid in another host's namespace is not a number this process may ever
probe. A remote `HERDR_SOCKET_PATH` is a label, never something
`HerdrSocketClient` may dial; its local-socket/`getuid()` guard is untouched.

**Local path.** `ClaudeHookPublisher` additionally publishes `CMUX_SURFACE_ID`,
`CMUX_SOCKET_PATH` and `CLAUDE_CODE_BRIDGE_SESSION_ID` alongside the existing
`HERDR_*` pair, flowing through the existing wire/process types. Local trust is
transport-derived (AF_UNIX + peer UID), so these legitimately live in `process`.

Also: remote plugin `1.2.0 → 1.3.0`, marketplace metadata version likewise (the
marketplace's content changed; the local plugin's own manifest is untouched),
minimal AGENTS.md + `integrations/claude-code/README.md` updates.

**LLM lanes:** not required. This PR changes join machinery only — nothing here
reaches the model: no prompt, no model pin, no request shape, no context
attachment or rendering. Per `scripts/ci/llm-lane-filter.sh` the touched paths
are outside the list, and no follow-up consumer exists yet.

## Proof

- [x] **Unit suite green** — `./scripts/remote-build.sh` on the exact pushed tree:

```
Test Suite 'localvoxtralPackageTests.xctest' passed at 2026-08-04 01:19:36.392.
	 Executed 2208 tests, with 2 tests skipped and 0 failures (0 unexpected) in 82.995 (83.117) seconds
```

Zero compiler warnings (`grep -c 'warning:' .build/last-remote.log` → `0`).

New/extended suites in that run:

```
Test Suite 'ClaudeRemoteSessionEnvironmentCodecTests' passed — Executed 10 tests, 0 failures
Test Suite 'ClaudeRemoteEnvironmentIsolationTests'   passed — Executed  9 tests, 0 failures
Test Suite 'ClaudeRemoteContextListenerTests'        passed — Executed 39 tests, 0 failures (was 35)
Test Suite 'ClaudeRemotePluginManifestTests'         passed — Executed 43 tests, 0 failures (was 36)
Test Suite 'ClaudeHookPublisherTests'                passed — Executed 22 tests, 0 failures (was 18)
Test Suite 'ClaudeHookWireCodecTests'                passed — Executed 31 tests, 0 failures (was 28)
```

### The tests have teeth — three red runs

Not a bug fix, so there is no pre-existing failure to show. Instead, each guard
was deliberately broken and the suite re-run, to prove the assertions bite rather
than merely pass.

**Red 1 — the reducer merges the remote env into `process`** (the exact mistake
the design prevents), `./scripts/remote-build.sh test --filter ClaudeRemoteEnvironmentIsolationTests`:

```
ClaudeRemoteSessionEnvironmentTests.swift:250: error: testRemoteEnvironmentNeverPopulatesTheProcessBlock :
  XCTAssertNil failed: "ClaudeHookProcessInfo(hookPID: 0, claudePID: 0, tty: nil, termProgram: nil,
  herdrPaneID: Optional("pane-7"), herdrSocketPath: Optional("/tmp/herdr-local.sock"), …)"
  - remote env values must not become process identity
	 Executed 9 tests, with 1 failure (0 unexpected)
```

Only **one** test failed, which is itself the finding worth recording: the origin
filters on the join arms still held, so a single-layer mistake does not leak. The
arm tests bite when *both* layers are gone —

**Red 2 — red 1 plus the `origin.isLocalAuthenticated` filters removed from
`resolve(tty:)`, `resolve(herdrPaneID:)` and `liveLocalHerdrSocketPaths()`**:

```
testARemoteEnvPaneIDCannotTurnALocalMatchIntoAnAmbiguity  failed
testARemoteEnvSocketPathNeverEntersTheLocalHerdrDialSet   failed - a remote env socket path must never be dialable
testARemoteSessionEnvironmentDoesNotSurviveIntoTheTTYArm  failed - resolved(…) is not equal to unknown
testRemoteEnvironmentNeverPopulatesTheProcessBlock        failed
testTheHerdrArmCannotResolveARemoteSessionThroughItsEnvPaneID failed - a remote env pane id must be invisible to the local herdr arm
	 Executed 9 tests, with 5 failures (0 unexpected)
```

Both mutations reverted; the final green run above is the reverted tree.

**Red 3 — the shim's charset `case` guard disabled**,
`./scripts/remote-build.sh test --filter ClaudeRemotePluginManifestTests`:

```
ClaudeRemotePluginManifestTests.swift:645: error: testShimRefusesToWriteAnEnvValueThatCouldForgeAHeaderLine :
  XCTAssertFalse failed - CRLF: the value must be dropped, not escaped
ClaudeRemotePluginManifestTests.swift:650: error: … - CRLF: forged an Authorization
ClaudeRemoteHTTP.swift:173: error: … failed: caught error: "malformed"
	 Executed 43 tests, with 3 failures (1 unexpected)
```

The third line is the point: without the charset guard, a `HERDR_PANE_ID`
containing CRLF really does write a second `Authorization: Bearer stolen` line,
which the real head parser then rejects as `malformed` — i.e. the injection is
live and the whitelist is what stops it.

### Shim hand-verification (real transcript)

The shim is also exercised by executing tests (`ClaudeRemotePluginManifestTests`
runs `/bin/sh post.sh` against a stub `curl` and reads back the header file curl
was actually handed, then re-parses it with the real
`ClaudeRemoteHTTPCodec.parseRequestHead` + `ClaudeRemoteEnvironmentCodec`). It
was additionally hand-run on a Linux host against a stub curl that dumps the
header file:

```
=== honest values ===
shim exit=0
Authorization: Bearer tok-123$
X-Lvx-Env-Herdr-Pane-Id: pane-7$
X-Lvx-Env-Herdr-Socket-Path: /run/user/1000/herdr/default.sock$
X-Lvx-Env-Herdr-Session: default$
X-Lvx-Env-Cmux-Surface-Id: surface-3$
X-Lvx-Env-Cmux-Socket-Path: /tmp/cmux.sock$
X-Lvx-Env-Bridge-Session-Id: bridge-abc$
X-Lvx-Env-Tmux: /tmp/tmux-1000/default,3721,0$
X-Lvx-Env-Tmux-Pane: %3$
X-Lvx-Env-Ssh-Tty: /dev/pts/3$
X-Lvx-Env-Hook-Parent-Pid: 322985$

=== CRLF injection attempt (HERDR_PANE_ID="pane\nAuthorization: Bearer stolen") ===
shim exit=0
Authorization: Bearer tok-123$
X-Lvx-Env-Ssh-Tty: /dev/pts/3$
X-Lvx-Env-Hook-Parent-Pid: 322985$

=== space / command substitution / 201-char value ===
shim exit=0
Authorization: Bearer tok-123$
X-Lvx-Env-Ssh-Tty: /dev/pts/3$
X-Lvx-Env-Hook-Parent-Pid: 322985$

=== nothing set ===
shim exit=0
Authorization: Bearer tok-123$
X-Lvx-Env-Hook-Parent-Pid: 322985$
```

(`cat -A`, so `$` is end-of-line — the point being that nothing hostile produced
one.) Note the hostile cases drop only the bad value: `SSH_TTY` and the token
survive, and the shim still exits 0.

**This hand-run found a real bug before it shipped.** The first draft's charset
omitted `%`, and a tmux pane id *is* `%3` — `TMUX_PANE` was silently never sent,
which is precisely this plugin's characteristic failure mode. `%` was added to
the shim, the Swift codec, and the docs; `testTheCharsetAcceptsTheShapesRealValuesActuallyTake`
now pins `%3` along with the other real-world shapes (`$TMUX`, `/dev/pts/3`,
herdr socket paths).

### Notes

- No wall-clock in any new test: the registry tests inject a fixed clock, the
  shim tests are process-synchronous, and `runShim` now clears the enrichment
  allowlist from the inherited environment so a runner that happens to be inside
  tmux/herdr cannot leak its own pane into a "nothing is set" assertion.
- No test was weakened, skipped, or had a threshold moved.
- UI: unchanged, nothing to verify by hand.

---

## Review round 2 — both codex findings fixed (`b5d425f`)

Two reviewers: **opencode** MERGEABLE with zero findings; **codex** MERGEABLE with
two edge cases. Both are fixed, each pinned by a test shown red against the
pre-fix code.

### Finding 1 (minor) — the shim's validation was locale-dependent

`[A-Za-z0-9…]` is a bracket **range**, and POSIX leaves range expressions
locale-dependent (bash documents it): under a UTF-8 collation `[a-z]` can match
`é`. And `${#var}` counts **characters**, so 200 accented characters would have
passed a "≤200 byte" check and produced a ~400-byte header line. The listener
rejected it server-side, so it was never exploitable — but the shim's byte bound
was not true.

Fixed two ways, the first structural:

- The charset is now **enumerated** (`[!ABC…XYZabc…xyz0123456789._:/@+,=%-]`).
  A set with no ranges has no collation to follow and matches the same bytes in
  every locale. This also makes the length check byte-accurate *by construction*:
  the two halves of the finding are coupled, because a multibyte character can
  only reach `${#var}` if the charset check let it through first.
- The ten calls now run in one subshell with `LC_ALL=C` exported (one fork), so
  `${#var}` is a byte count even on a shell that resolves the enumeration oddly.
  Scoped deliberately: the stdout gate below keeps the locale it was tested under.

### Finding 2 (nit) — the server validated *after* a Unicode-wide trim

`ClaudeRemoteHTTP.swift` trimmed header names and values with
`trimmingCharacters(in: .whitespaces)`, a **Unicode** set. `pane-7<NBSP>` was
therefore trimmed to `pane-7` *before* the byte-level charset check ran — a
malformed wire value laundered into a well-formed one.

Fixed at the root: `ClaudeRemoteHTTPCodec.trimmingOWS` strips ASCII SP/HTAB only,
which is what RFC 9110 actually defines OWS to be. Non-ASCII bytes now reach the
env validator intact and are rejected. This also closes a second, quieter case
the same trim had: `Content-Length<NBSP>` was being rewritten into a valid
`content-length` here while a conforming proxy would read a different header —
the parsers-disagree shape this file's comments exist to avoid.

### New tests

| Test | File | Pins |
|---|---|---|
| `testShimDropsMultibyteValuesUnderAUTF8Locale` | `ClaudeRemotePluginManifestTests` | shim run under `LC_ALL=en_US.UTF-8` with `panÉ7` and 200×`É` — dropped, no byte ≥ 0x80 in the header file, neighbour + token unaffected |
| `testShimValidationIsWrittenToBeLocaleIndependent` | `ClaudeRemotePluginManifestTests` | the enumeration and `LC_ALL=C` are present, and no collation range appears in `lvx_env_header`'s body |
| `testOnlyASCIIOWSIsTrimmedFromNamesAndValues` | `ClaudeRemoteHTTPTests` | NBSP kept in a value, tab still trimmed, `Content-Length<NBSP>` no longer read as Content-Length |
| `testUnicodeWhitespacePaddingIsRejectedRatherThanTrimmedIntoAcceptance` | `ClaudeRemoteSessionEnvironmentTests` | U+00A0/2007/3000/200B padding rejected through the real head parser; ASCII OWS still tolerated |
| `testAnEnvValuePaddedWithUnicodeWhitespaceIsRejectedOverTheRealSocket` | `ClaudeRemoteContextListenerTests` | same, end to end over the socket, hook still 200 |

### Proof

Suite, on the pushed tree — **2213 tests, 0 failures** (was 2208; +5), 0 warnings:

```
Executed 2213 tests, with 2 tests skipped and 0 failures (0 unexpected) in 81.597 (81.695) seconds
```

**Red for finding 2** — Unicode trim restored, `--filter ClaudeRemoteHTTPTests`
and `--filter ClaudeRemoteSessionEnvironmentCodecTests`:

```
ClaudeRemoteHTTPTests.swift:178: error: testOnlyASCIIOWSIsTrimmedFromNamesAndValues :
  XCTAssertEqual failed: ("Optional("pane-7")") is not equal to ("Optional("pane-7 ")")
  - a non-ASCII pad is part of the value, not whitespace to discard
ClaudeRemoteHTTPTests.swift:194: error: … XCTAssertThrowsError failed: did not throw an error
	 Executed 29 tests, with 2 failures

ClaudeRemoteSessionEnvironmentTests.swift:189: error: testUnicodeWhitespacePaddingIsRejectedRatherThanTrimmedIntoAcceptance :
  XCTAssertNil failed: "ClaudeRemoteSessionEnvironment(herdrPaneID: Optional("pane-7"), …)"
  - a non-ASCII pad must reach the validator and be rejected
```

That is the finding reproduced exactly: `pane-7<NBSP>` arriving as an accepted
`pane-7`. (U+200B is not in `.whitespaces`, so it was already rejected — the test
carries a mix on purpose.)

**Red for finding 1** — ranges restored and `LC_ALL=C` removed,
`--filter ClaudeRemotePluginManifestTests`:

```
ClaudeRemotePluginManifestTests.swift:704: error: testShimValidationIsWrittenToBeLocaleIndependent :
  XCTAssertTrue failed - the charset must be ENUMERATED; a bracket range follows collation
ClaudeRemotePluginManifestTests.swift:720: error: … - no collation-sensitive range may validate an env value: A-Za-z
	 Executed 45 tests, with 2 failures
```

**Honest limit on that red:** only the source-level assertion fired. The
behavioural test still passed against the pre-fix shim, because macOS `/bin/sh`
(bash 3.2) under `en_US.UTF-8` did **not** match `É` with `[a-z]`, and neither
does dash (it compares bytes). The collation behaviour is a glibc-locale
property — i.e. it bites on exactly the remote Linux hosts this plugin targets,
which is where CI cannot observe it. So: the fix is structural and preventive,
the behavioural test asserts the invariant on whatever locale the runner
provides, and the source assertion is what actually holds the line. The
character-vs-byte half *is* reproducible and was confirmed on Linux directly —
bash reports `${#v}` as `5` for the 6-byte `panÉ7` under a UTF-8 locale, and `6`
under `LC_ALL=C`.

Both mutations were reverted; the 2213-green run above is the reverted tree.

**Scope note (deliberately not changed):** `authorizationShape` still trims its
credential with `.whitespaces`, so an NBSP-padded token would authenticate. It is
benign — an attacker holding the token does not need the padding — and it is
outside the two findings, so it is left for a follow-up rather than folded in
here.
