### PR TITLE
Remote hooks: per-Mac forward port + loud contention detection (fixes #215)

### DIFF
--- a/.github/workflows/mac-crashlog.yml
+++ b/.github/workflows/mac-crashlog.yml
@@ -146,8 +146,16 @@ jobs:
           marker_like="$(grep -c '^# \(BEGIN\|END\) localvoxtral claude context' "$cfg" 2>/dev/null)"
           well_formed="$(grep -c "$marker_grammar" "$cfg" 2>/dev/null)"
           echo "marker-like lines: ${marker_like:-0} (well-formed: ${well_formed:-0})"
-          echo "--- RemoteForward 8473 count:"
-          grep -c 'RemoteForward 8473' "$cfg" 2>/dev/null
+          # Ports, not hosts. Since per-Mac allocation (issue #215) the listen
+          # port is derived per install, and "which port does this Mac claim"
+          # is the first question when a host silently stops delivering — so
+          # print the listen ports themselves (a loopback port number is not
+          # private; the target and the alias are, and neither is printed).
+          # A remaining `8473` here means the block predates the fix.
+          echo "--- RemoteForward listen ports (count, then distinct ports):"
+          grep -c '^[[:space:]]*RemoteForward ' "$cfg" 2>/dev/null
+          awk '/^[[:space:]]*RemoteForward /{print $2}' "$cfg" 2>/dev/null | sort -u \
+            || echo "<none>"
           [ -f "$cfg" ] || echo "<no config file>"
           echo "--- leftover atomic-write temp files (count only):"
           /usr/bin/find "$HOME/.ssh" -maxdepth 1 -name '.config.localvoxtral.*' 2>/dev/null \

--- a/.github/workflows/mac-crashlog.yml
+++ b/.github/workflows/mac-crashlog.yml
@@ -146,16 +146,22 @@ jobs:
           marker_like="$(grep -c '^# \(BEGIN\|END\) localvoxtral claude context' "$cfg" 2>/dev/null)"
           well_formed="$(grep -c "$marker_grammar" "$cfg" 2>/dev/null)"
           echo "marker-like lines: ${marker_like:-0} (well-formed: ${well_formed:-0})"
-          # Ports, not hosts. Since per-Mac allocation (issue #215) the listen
-          # port is derived per install, and "which port does this Mac claim"
-          # is the first question when a host silently stops delivering — so
-          # print the listen ports themselves (a loopback port number is not
-          # private; the target and the alias are, and neither is printed).
-          # A remaining `8473` here means the block predates the fix.
-          echo "--- RemoteForward listen ports (count, then distinct ports):"
-          grep -c '^[[:space:]]*RemoteForward ' "$cfg" 2>/dev/null
-          awk '/^[[:space:]]*RemoteForward /{print $2}' "$cfg" 2>/dev/null | sort -u \
-            || echo "<none>"
+          # Ports, not hosts, and ONLY OURS. Since per-Mac allocation (issue
+          # #215) the listen port is derived per install, and "which port does
+          # this Mac claim" is the first question when a host silently stops
+          # delivering. But this log is public: the user's own RemoteForward
+          # lines can carry socket paths and bind addresses that are nobody
+          # else's business, so the awk below only looks BETWEEN this app's
+          # BEGIN/END markers and prints only the numeric listen-port field
+          # (anything non-numeric is dropped rather than echoed). A remaining
+          # `8473` here means the block predates the fix.
+          echo "--- localvoxtral RemoteForward listen ports (ours only):"
+          awk '
+            /^[[:space:]]*# BEGIN localvoxtral claude context \(/ { inside = 1; next }
+            /^[[:space:]]*# END localvoxtral claude context \(/   { inside = 0; next }
+            inside && $1 == "RemoteForward" && $2 ~ /^[0-9]+$/    { print $2 }
+          ' "$cfg" 2>/dev/null | sort -u | tr '\n' ' ' | sed 's/ $//'
+          echo
           [ -f "$cfg" ] || echo "<no config file>"
           echo "--- leftover atomic-write temp files (count only):"
           /usr/bin/find "$HOME/.ssh" -maxdepth 1 -name '.config.localvoxtral.*' 2>/dev/null \

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -408,8 +408,10 @@ Key subsystems:
     event JSON to `127.0.0.1:<port>/v1/hook/<Event>` through an OpenSSH
     `RemoteForward` — no localvoxtral binary and no `jq`/`nc`/Node on that
     host, but it does need `sh` and `curl` (fail-open when absent). That
-    remote port is PER-MAC (`ClaudeRemoteForwardPort`: 28473–28572, derived
-    from a persisted per-install identity; the shim reads it from
+    remote port is PER-MAC (`ClaudeRemoteForwardPort`: 28473–30472, derived
+    from a per-install identity persisted in a 0600 file beside the host
+    registry — not in UserDefaults, so a preferences reset cannot move an
+    enrolled host's port; the shim reads it from
     `CLAUDE_PLUGIN_OPTION_PORT`, validates it, and falls back to the legacy
     8473 so pre-existing enrollments keep working). Two Macs asking one host
     for the same bind is not a tie: the FIRST connection keeps the forward and

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -405,9 +405,20 @@ Key subsystems:
     instance owns its socket legitimately.
   - **Remote** (`localvoxtral-remote`, installed on the REMOTE host): command
     hooks running the bundled POSIX-sh shim `hooks/post.sh`, which curls the
-    event JSON to `127.0.0.1:8473/v1/hook/<Event>` through an OpenSSH
+    event JSON to `127.0.0.1:<port>/v1/hook/<Event>` through an OpenSSH
     `RemoteForward` — no localvoxtral binary and no `jq`/`nc`/Node on that
-    host, but it does need `sh` and `curl` (fail-open when absent). The body
+    host, but it does need `sh` and `curl` (fail-open when absent). That
+    remote port is PER-MAC (`ClaudeRemoteForwardPort`: 28473–28572, derived
+    from a persisted per-install identity; the shim reads it from
+    `CLAUDE_PLUGIN_OPTION_PORT`, validates it, and falls back to the legacy
+    8473 so pre-existing enrollments keep working). Two Macs asking one host
+    for the same bind is not a tie: the FIRST connection keeps the forward and
+    the second silently delivers that host's events — and its bearer token —
+    to the first Mac, which 401s them, which the shim reads as a completed
+    exchange (issue #215). Distinct ports make that state unreachable; what
+    remains, stated in the enrollment notes, is that one host stores ONE
+    `port`, so it talks to exactly one Mac. The Mac-side listener stays on
+    8473. The body
     stays Claude's verbatim JSON (no `jq` to rewrite it with), so the
     allowlisted env enrichment — herdr/cmux/tmux/bridge handles, `SSH_TTY`,
     the shim's `$PPID` — rides as `X-Lvx-Env-*` HEADERS, written into the same

--- a/Sources/localvoxtral/ClaudeContext/ClaudeIntegrationSettingsModel.swift
+++ b/Sources/localvoxtral/ClaudeContext/ClaudeIntegrationSettingsModel.swift
@@ -209,7 +209,18 @@ public final class ClaudeIntegrationSettingsModel {
         /// name a placeholder instead of pretending.
         public var sshHostAlias: String?
         public var commands: [String]
-
+        /// This host's regenerated ssh-config block, when the local one does
+        /// not already forward the port these commands are about to store on
+        /// the remote — nil when it already matches and there is nothing to
+        /// write.
+        ///
+        /// The two are ONE migration and the review that caught this was right
+        /// to call it a blocker: storing `port=285xx` in the plugin while
+        /// `~/.ssh/config` still says `RemoteForward 8473` points every hook on
+        /// that host at a port this Mac does not forward, and the result fails
+        /// open — silently, which is the whole #215 failure class reintroduced
+        /// by the fix for it.
+        public var sshConfigSnippet: String?
         public var canRun: Bool { sshHostAlias != nil }
     }
 
@@ -663,14 +674,42 @@ public final class ClaudeIntegrationSettingsModel {
         enrollmentConfirmation = nil
         enrollmentStepStatuses = []
         enrollmentResultsAction = nil
+        // Regenerate the block unless it is already current. `nil` from the
+        // service means "cannot tell", and cannot-tell must regenerate: the
+        // cost of a redundant idempotent rewrite is nothing, and the cost of
+        // assuming a stale block is current is a silently dead host.
+        let alreadyForwards =
+            registry?.host(id: hostID).flatMap { host in
+                enrollmentService.sshConfigForwardsPort(remoteForwardPort, hostID: host.id)
+            } ?? false
+        let snippet: String? = alreadyForwards ? nil : registry?.host(id: hostID).map { host in
+            ClaudeRemoteEnrollmentService.sshConfigSnippet(
+                host: host,
+                sshHostAlias: alias ?? Self.unknownAliasPlaceholder,
+                listenerPort: listener?.boundPort ?? ClaudeRemoteListenerLimits.default.port,
+                remoteForwardPort: remoteForwardPort
+            )
+        }
         presentedPluginUpdate = PluginUpdatePresentation(
             hostID: hostID,
             sshHostAlias: alias,
             commands: ClaudeRemoteEnrollmentService.updateCommands(
                 sshHostAlias: alias ?? Self.unknownAliasPlaceholder,
                 remoteForwardPort: remoteForwardPort
-            )
+            ),
+            sshConfigSnippet: snippet
         )
+    }
+
+    /// Exactly what `performPluginUpdate` will do, in order.
+    static func updatePreview(for presentation: PluginUpdatePresentation) -> String {
+        guard let snippet = presentation.sshConfigSnippet else {
+            return presentation.commands.joined(separator: "\n")
+        }
+        return "# 1. Replace this host's block in ~/.ssh/config on this Mac:\n"
+            + snippet
+            + "\n\n# 2. Then, on the SSH host:\n"
+            + presentation.commands.joined(separator: "\n")
     }
 
     /// Stands in for an alias we were never told. Not a valid target and not
@@ -699,8 +738,13 @@ public final class ClaudeIntegrationSettingsModel {
         enrollmentResultsAction = nil
         enrollmentConfirmation = EnrollmentConfirmation(
             action: .updateRemotePlugin(hostID: presentation.hostID),
-            title: "Update the plugin on this SSH host?",
-            preview: presentation.commands.joined(separator: "\n"),
+            title: presentation.sshConfigSnippet == nil
+                ? "Update the plugin on this SSH host?"
+                : "Update ~/.ssh/config on this Mac and the plugin on this SSH host?",
+            // Both halves, verbatim, in the order they will run. The rule that
+            // one-click actions repeat their exact text does not get weaker
+            // because an action now has two parts — it gets more important.
+            preview: Self.updatePreview(for: presentation),
             confirmButtonTitle: "Confirm Update"
         )
         Log.claudeContext.info("Claude remote plugin update confirmation requested")
@@ -807,8 +851,21 @@ public final class ClaudeIntegrationSettingsModel {
         // Copied out of self before the detached hop, like `service`: the
         // closure is @Sendable and must not capture the main-actor model.
         let port = remoteForwardPort
+        let snippet = presentation.sshConfigSnippet
+        let hostID = presentation.hostID
+        // ORDER IS THE SAFETY PROPERTY. The local block is rewritten first, and
+        // the remote is touched only if that succeeded. Reverse them and a
+        // refused local write (symlinked config, untrusted ~/.ssh) leaves the
+        // remote posting to a port this Mac does not forward — silently. This
+        // way the worst case is "nothing changed anywhere, with an error on
+        // screen", which is a state a user can act on.
         let attempt = await performEnrollmentAsync {
-            try service.executeRemotePluginUpdate(sshHostAlias: alias, remoteForwardPort: port)
+            if let snippet {
+                try service.insertSSHConfig(snippet: snippet, hostID: hostID)
+            }
+            return try service.executeRemotePluginUpdate(
+                sshHostAlias: alias, remoteForwardPort: port
+            )
         }
 
         // Same rule as the sheet: the row may have been closed, or another

--- a/Sources/localvoxtral/ClaudeContext/ClaudeIntegrationSettingsModel.swift
+++ b/Sources/localvoxtral/ClaudeContext/ClaudeIntegrationSettingsModel.swift
@@ -299,6 +299,13 @@ public final class ClaudeIntegrationSettingsModel {
     /// `Date()` in the view, and no timer: the rows are rebuilt when the pane
     /// appears and after every action that touches a host.
     private let now: @Sendable () -> Date
+    /// This Mac's allocated port on the remote side of the tunnel
+    /// (`ClaudeRemoteForwardPort`), passed in rather than read here so the pane
+    /// has no opinion about where it comes from — and so a test can pin it.
+    /// Every generated artifact that names a remote port takes it from this one
+    /// value: the ssh block, the install command, the verify probe, the
+    /// update/migration commands.
+    private let remoteForwardPort: UInt16
 
     /// - Parameters:
     ///   - registry: nil when the host file could not be read at launch. The
@@ -335,7 +342,11 @@ public final class ClaudeIntegrationSettingsModel {
                 }
             }.value
         },
-        now: @escaping @Sendable () -> Date = { Date() }
+        now: @escaping @Sendable () -> Date = { Date() },
+        // Defaults to the legacy shared port: a caller that has not been taught
+        // about per-Mac allocation describes exactly the pre-#215 setup, which
+        // still works. Production passes the allocation.
+        remoteForwardPort: UInt16 = ClaudeRemoteForwardPort.legacyPort
     ) {
         self.registry = registry
         self.listener = listener
@@ -344,6 +355,7 @@ public final class ClaudeIntegrationSettingsModel {
         self.performAsync = performAsync
         self.performEnrollmentAsync = performEnrollmentAsync
         self.now = now
+        self.remoteForwardPort = remoteForwardPort
         refreshHosts()
         refreshListenerStatus()
     }
@@ -520,7 +532,8 @@ public final class ClaudeIntegrationSettingsModel {
                 host: enrollment.host,
                 sshHostAlias: alias,
                 token: enrollment.token,
-                port: listener?.boundPort ?? ClaudeRemoteListenerLimits.default.port
+                listenerPort: listener?.boundPort ?? ClaudeRemoteListenerLimits.default.port,
+                remoteForwardPort: remoteForwardPort
             )
             // A fresh sheet must not inherit a previous host's step results —
             // a still-running earlier action can repopulate the statuses after
@@ -560,7 +573,8 @@ public final class ClaudeIntegrationSettingsModel {
                 host: enrollment.host,
                 sshHostAlias: alias ?? Self.unknownAliasPlaceholder,
                 token: enrollment.token,
-                port: listener?.boundPort ?? ClaudeRemoteListenerLimits.default.port
+                listenerPort: listener?.boundPort ?? ClaudeRemoteListenerLimits.default.port,
+                remoteForwardPort: remoteForwardPort
             )
             enrollmentConfirmation = nil
             enrollmentStepStatuses = []
@@ -653,7 +667,8 @@ public final class ClaudeIntegrationSettingsModel {
             hostID: hostID,
             sshHostAlias: alias,
             commands: ClaudeRemoteEnrollmentService.updateCommands(
-                sshHostAlias: alias ?? Self.unknownAliasPlaceholder
+                sshHostAlias: alias ?? Self.unknownAliasPlaceholder,
+                remoteForwardPort: remoteForwardPort
             )
         )
     }
@@ -789,8 +804,11 @@ public final class ClaudeIntegrationSettingsModel {
         defer { isPerformingEnrollmentAction = false }
 
         let service = enrollmentService
+        // Copied out of self before the detached hop, like `service`: the
+        // closure is @Sendable and must not capture the main-actor model.
+        let port = remoteForwardPort
         let attempt = await performEnrollmentAsync {
-            try service.executeRemotePluginUpdate(sshHostAlias: alias)
+            try service.executeRemotePluginUpdate(sshHostAlias: alias, remoteForwardPort: port)
         }
 
         // Same rule as the sheet: the row may have been closed, or another

--- a/Sources/localvoxtral/ClaudeContext/ClaudeIntegrationSettingsModel.swift
+++ b/Sources/localvoxtral/ClaudeContext/ClaudeIntegrationSettingsModel.swift
@@ -222,6 +222,25 @@ public final class ClaudeIntegrationSettingsModel {
         /// by the fix for it.
         public var sshConfigSnippet: String?
         public var canRun: Bool { sshHostAlias != nil }
+
+        /// Everything this update consists of, in the order it must be applied.
+        ///
+        /// ONE rendering, used by all three surfaces — the panel's text, its
+        /// Copy button, and the confirmation preview. They diverged once
+        /// already: the executable path wrote the ssh block while the panel
+        /// showed and copied only the commands, so the copy-only paths (a host
+        /// with no recorded alias, and the symlink refusal that explicitly
+        /// tells the user to copy) updated the remote port and left this Mac on
+        /// 8473 — the original split brain, reachable by exactly the users most
+        /// likely to hit it. A single source is the fix; three call sites that
+        /// "should stay in sync" is what produced the bug.
+        public var applicationText: String {
+            guard let sshConfigSnippet else { return commands.joined(separator: "\n") }
+            return "# 1. Replace this host's block in ~/.ssh/config on this Mac:\n"
+                + sshConfigSnippet
+                + "\n\n# 2. Then, on the SSH host:\n"
+                + commands.joined(separator: "\n")
+        }
     }
 
     public enum EnrollmentAction: Sendable, Equatable {
@@ -701,15 +720,10 @@ public final class ClaudeIntegrationSettingsModel {
         )
     }
 
-    /// Exactly what `performPluginUpdate` will do, in order.
+    /// Exactly what `performPluginUpdate` will do, in order — and exactly what
+    /// the panel shows and copies. Same text, one source.
     static func updatePreview(for presentation: PluginUpdatePresentation) -> String {
-        guard let snippet = presentation.sshConfigSnippet else {
-            return presentation.commands.joined(separator: "\n")
-        }
-        return "# 1. Replace this host's block in ~/.ssh/config on this Mac:\n"
-            + snippet
-            + "\n\n# 2. Then, on the SSH host:\n"
-            + presentation.commands.joined(separator: "\n")
+        presentation.applicationText
     }
 
     /// Stands in for an alias we were never told. Not a valid target and not

--- a/Sources/localvoxtral/ClaudeContext/ClaudeRemoteEnrollmentService.swift
+++ b/Sources/localvoxtral/ClaudeContext/ClaudeRemoteEnrollmentService.swift
@@ -157,6 +157,17 @@ public struct ClaudeRemoteEnrollmentService: Sendable {
     /// plugin uses a command shim at all; verified on 2.1.220.)
     public static let tokenConfigKey = "token"
 
+    /// The plugin's non-sensitive userConfig key: which loopback port on the
+    /// REMOTE host the shim posts to. Reaches the shim as
+    /// `CLAUDE_PLUGIN_OPTION_PORT` exactly like the token does (both are
+    /// command-hook environment; verified end to end on Claude Code 2.1.220 —
+    /// a hook run with `--config port=28777` dialed 127.0.0.1:28777).
+    ///
+    /// It must equal the listen port of this Mac's `RemoteForward`. The plan
+    /// always emits both halves together for that reason; changing one alone
+    /// fails open, which looks exactly like nothing happening.
+    public static let portConfigKey = "port"
+
     private let runner: Runner?
     private let sshConfigFileSystem: (any ClaudeRemoteSSHConfigFileSystem)?
 
@@ -182,21 +193,39 @@ public struct ClaudeRemoteEnrollmentService: Sendable {
     ///     we should surface rather than quietly rewrite.
     ///   - token: the plaintext used to generate the copyable command and, after
     ///     confirmation, its SSH stdin script. Not stored or logged.
+    ///   - listenerPort: the port the app listens on, HERE, on this Mac. The
+    ///     forward's target.
+    ///   - remoteForwardPort: the port the forward binds THERE, on the remote
+    ///     host — this Mac's per-install allocation
+    ///     (`ClaudeRemoteForwardPort`), which is what keeps two Macs from
+    ///     contending for one bind (issue #215). Defaults to the legacy shared
+    ///     port so every existing caller and fixture describes the pre-#215
+    ///     setup, which still works.
     public static func plan(
         host: ClaudeRemoteHost,
         sshHostAlias: String,
         token: String,
-        port: UInt16 = ClaudeRemoteListenerLimits.default.port
+        listenerPort: UInt16 = ClaudeRemoteListenerLimits.default.port,
+        remoteForwardPort: UInt16 = ClaudeRemoteForwardPort.legacyPort
     ) throws -> SetupPlan {
         guard isValidHostAlias(sshHostAlias) else { throw ServiceError.invalidHostAlias }
 
         return SetupPlan(
-            sshConfigSnippet: sshConfigSnippet(host: host, sshHostAlias: sshHostAlias, port: port),
-            remoteCommands: remoteCommands(token: token),
-            verifyCommands: verifyCommands(sshHostAlias: sshHostAlias, port: port),
-            updateCommands: updateCommands(sshHostAlias: sshHostAlias),
+            sshConfigSnippet: sshConfigSnippet(
+                host: host,
+                sshHostAlias: sshHostAlias,
+                listenerPort: listenerPort,
+                remoteForwardPort: remoteForwardPort
+            ),
+            remoteCommands: remoteCommands(token: token, remoteForwardPort: remoteForwardPort),
+            verifyCommands: verifyCommands(
+                sshHostAlias: sshHostAlias, remoteForwardPort: remoteForwardPort
+            ),
+            updateCommands: updateCommands(
+                sshHostAlias: sshHostAlias, remoteForwardPort: remoteForwardPort
+            ),
             uninstallCommands: uninstallCommands(host: host, sshHostAlias: sshHostAlias),
-            notes: notes(port: port)
+            notes: notes(listenerPort: listenerPort, remoteForwardPort: remoteForwardPort)
         )
     }
 
@@ -233,17 +262,28 @@ public struct ClaudeRemoteEnrollmentService: Sendable {
         "# END localvoxtral claude context (\(hostID))"
     }
 
-    static func sshConfigSnippet(host: ClaudeRemoteHost, sshHostAlias: String, port: UInt16) -> String {
+    static func sshConfigSnippet(
+        host: ClaudeRemoteHost,
+        sshHostAlias: String,
+        listenerPort: UInt16,
+        remoteForwardPort: UInt16
+    ) -> String {
         """
         \(blockBegin(hostID: host.id))
         Host \(sshHostAlias)
-            RemoteForward \(port) 127.0.0.1:\(port)
+            # \(remoteForwardPort) is THIS Mac's allocated port on the remote host, and
+            # it must match the plugin's `port` option there. Another Mac gets a
+            # different one, so the two can never fight over one bind — the fight
+            # nobody wins twice: the first connection keeps the forward and the
+            # second delivers this host's events, and its token, to the wrong Mac.
+            RemoteForward \(remoteForwardPort) 127.0.0.1:\(listenerPort)
             # ExitOnForwardFailure no (the default) is deliberate: if the remote
-            # already has \(port) bound — usually another localvoxtral tunnel from a
-            # second window — `yes` would refuse to open the SSH session at all.
+            # already has \(remoteForwardPort) bound — now only by another session from
+            # this same Mac — `yes` would refuse to open the SSH session at all.
             # A dictation nicety must never cost you the shell. The cost of `no`
             # is that a failed forward is silent: the hooks get connection
-            # refused, fail open, and you simply get no context.
+            # refused, fail open, and you simply get no context. The verify step
+            # below is how you check.
             ExitOnForwardFailure no
         \(blockEnd(hostID: host.id))
         """
@@ -257,13 +297,19 @@ public struct ClaudeRemoteEnrollmentService: Sendable {
     /// on Claude Code 2.1.220). `install` DOES apply a new `--config token=`,
     /// which is why rotation reuses this exact command — and why shipping a new
     /// plugin version needs `updateCommands` instead.
-    static func remoteCommands(token: String) -> [String] {
+    /// `--config` is repeatable and MERGES per key on an already-installed
+    /// plugin: verified on Claude Code 2.1.220 (`--help` documents "repeatable";
+    /// a second install with only `--config port=` kept the stored token and
+    /// replaced only the port). That is what makes the port migratable without
+    /// ever re-sending a credential.
+    static func remoteCommands(token: String, remoteForwardPort: UInt16) -> [String] {
         [
             "claude plugin marketplace add \(repositoryMarketplaceReference)",
             // Leading space: with HISTCONTROL=ignorespace (bash) or
             // HIST_IGNORE_SPACE (zsh) the token stays out of the remote shell
             // history. See `notes` — it is a habit, not a guarantee.
-            " claude plugin install \(remotePluginReference) --config '\(tokenConfigKey)=\(token)'",
+            " claude plugin install \(remotePluginReference) --config '\(tokenConfigKey)=\(token)'"
+                + " --config '\(portConfigKey)=\(remoteForwardPort)'",
         ]
     }
 
@@ -272,14 +318,20 @@ public struct ClaudeRemoteEnrollmentService: Sendable {
     /// broken — a forward "failure" that just means another session already
     /// holds the tunnel, and a 401 that is the success signal. Say so in the
     /// output they are pasting, not in a note they have scrolled past.
-    static func verifyCommands(sshHostAlias: String, port: UInt16) -> [String] {
+    static func verifyCommands(sshHostAlias: String, remoteForwardPort: UInt16) -> [String] {
         [
             // -v because a failed RemoteForward is otherwise invisible when
-            // ExitOnForwardFailure is `no`.
-            "# Forward check — 'remote forward success' means this probe owns the",
-            "# tunnel. A failure here is EXPECTED while another live session to",
-            "# this host holds it; the port check below is the truth either way.",
-            "ssh -v \(sshHostAlias) true 2>&1 | grep -i 'remote forward'",
+            // ExitOnForwardFailure is `no`. The `grep -q … && echo` shape is
+            // deliberate: a person pasting this must be told the FIX, not handed
+            // an OpenSSH debug line to interpret. The message is deliberately
+            // apostrophe-free so it survives single-quoted shell.
+            "# Forward check — does this Mac actually own port \(remoteForwardPort) over there?",
+            "# A failure here is EXPECTED while another live session from THIS Mac",
+            "# holds it; anything else means this Mac is receiving nothing.",
+            "ssh -v \(sshHostAlias) true 2>&1 | grep -q '\(ClaudeRemoteForwardPort.forwardFailureSignature)'"
+                + " && echo 'localvoxtral: \(ClaudeRemoteForwardPort.contentionMessage(port: remoteForwardPort, host: sshHostAlias))"
+                + " Close that session, or wait for sshd to reap it, then retry — until then this Mac gets no context from \(sshHostAlias).'"
+                + " || echo 'localvoxtral: port \(remoteForwardPort) forwards cleanly to this Mac.'",
             "# Non-interactive SSH skips your shell rc, so claude can be off PATH",
             "# here even though it runs fine when you are logged in.",
             "ssh \(sshHostAlias) '\(nonInteractiveClaudePathPrefix)claude plugin list'",
@@ -287,7 +339,7 @@ public struct ClaudeRemoteEnrollmentService: Sendable {
             "# unauthenticated probe must be refused). A connection error means",
             "# no live session holds the forward right now.",
             "ssh \(sshHostAlias) 'curl -s -o /dev/null -w \"%{http_code}\\n\" -X POST "
-                + "-H \"Content-Type: application/json\" -d \"{}\" http://127.0.0.1:\(port)/v1/hook/SessionStart'",
+                + "-H \"Content-Type: application/json\" -d \"{}\" http://127.0.0.1:\(remoteForwardPort)/v1/hook/SessionStart'",
         ]
     }
 
@@ -302,12 +354,23 @@ public struct ClaudeRemoteEnrollmentService: Sendable {
 
     /// The remote-side commands, in order, with nothing wrapped around them.
     /// Execution sends these through the SSH stdin script;
-    /// `updateCommands(sshHostAlias:)` is the same pair written for a person to
-    /// paste from this Mac.
-    static let remotePluginUpdateCommands = [
-        "claude plugin marketplace update \(ClaudePluginAssets.marketplaceName)",
-        "claude plugin update \(remotePluginReference)",
-    ]
+    /// `updateCommands(sshHostAlias:remoteForwardPort:)` is the same set written
+    /// for a person to paste from this Mac.
+    ///
+    /// The third command is the port MIGRATION, and it is why update takes a
+    /// port at all: a host enrolled before #215 has no `port` option, so its
+    /// shim posts to the legacy 8473 while this Mac has moved its forward to an
+    /// allocated one — two halves that disagree, failing open in silence.
+    /// `plugin update` has no `--config` (Claude Code 2.1.220), and `install`
+    /// on an installed plugin merges config per key without touching the stored
+    /// token, so this line is both the only way and a token-free one.
+    static func remotePluginUpdateCommands(remoteForwardPort: UInt16) -> [String] {
+        [
+            "claude plugin marketplace update \(ClaudePluginAssets.marketplaceName)",
+            "claude plugin update \(remotePluginReference)",
+            "claude plugin install \(remotePluginReference) --config '\(portConfigKey)=\(remoteForwardPort)'",
+        ]
+    }
 
     /// Bring an enrolled host to the plugin version this app ships.
     ///
@@ -315,16 +378,21 @@ public struct ClaudeRemoteEnrollmentService: Sendable {
     /// else in the product tells the user that re-running setup is not an
     /// update, and a host silently left on an old plugin fails open — i.e. it
     /// looks like nothing at all.
-    static func updateCommands(sshHostAlias: String) -> [String] {
-        [
-            "# Run after updating localvoxtral on this Mac. This pair is the ONLY",
+    static func updateCommands(sshHostAlias: String, remoteForwardPort: UInt16) -> [String] {
+        let commands = remotePluginUpdateCommands(remoteForwardPort: remoteForwardPort)
+        return [
+            "# Run after updating localvoxtral on this Mac. This set is the ONLY",
             "# way a plugin fix reaches a host that is already enrolled: on Claude",
             "# Code 2.1.220, re-running `plugin install` exits 0 with \"already",
             "# installed\" and leaves the old version in place, and `marketplace",
             "# add` does not refresh a clone it already has. Your token is kept —",
-            "# `plugin update` preserves the stored config.",
-            "ssh \(sshHostAlias) '\(nonInteractiveClaudePathPrefix)\(remotePluginUpdateCommands[0])'",
-            "ssh \(sshHostAlias) '\(nonInteractiveClaudePathPrefix)\(remotePluginUpdateCommands[1])'",
+            "# `plugin update` preserves the stored config, and the third command",
+            "# below sets only the port (install merges config per key).",
+            "ssh \(sshHostAlias) '\(nonInteractiveClaudePathPrefix)\(commands[0])'",
+            "ssh \(sshHostAlias) '\(nonInteractiveClaudePathPrefix)\(commands[1])'",
+            "# Point this host at THIS Mac's allocated port \(remoteForwardPort). Required once",
+            "# for a host enrolled before per-Mac ports; harmless every time after.",
+            "ssh \(sshHostAlias) '\(nonInteractiveClaudePathPrefix)\(commands[2])'",
         ]
     }
 
@@ -338,8 +406,18 @@ public struct ClaudeRemoteEnrollmentService: Sendable {
         ]
     }
 
-    static func notes(port: UInt16) -> [String] {
+    static func notes(listenerPort: UInt16, remoteForwardPort: UInt16) -> [String] {
         [
+            "This Mac forwards port \(remoteForwardPort) on the remote host to localvoxtral on "
+                + "127.0.0.1:\(listenerPort) here. The ssh-config block and the plugin's `port` option "
+                + "must name the same \(remoteForwardPort): change one without the other and the hooks "
+                + "post into a port nothing forwards — which fails open, i.e. looks like nothing at "
+                + "all. The setup commands always carry both halves.",
+            "The port is allocated per Mac, so a second Mac enrolled against this same host gets a "
+                + "different one and the two can never contend for one bind. What they still share is "
+                + "the host: one Claude Code install stores one `port`, so the most recently installed "
+                + "config is the Mac that receives events. The other simply sees no traffic — no "
+                + "longer someone else's events, and never someone else's token.",
             "The token authorizes remote context only. A host that presents it can never "
                 + "make localvoxtral read a local file: the listener tags every session it accepts "
                 + "as remote regardless of what the payload says, and a remote cwd cannot be turned "
@@ -361,13 +439,14 @@ public struct ClaudeRemoteEnrollmentService: Sendable {
                 + "Its hooks fail open silently when either is missing, the tunnel is down, or the app "
                 + "is not answering: you simply get no context, never a blocked Claude turn.",
             "While a session holds the tunnel and localvoxtral is not running, ssh itself — on this "
-                + "Mac — prints `connect_to 127.0.0.1 port \(port): failed.` into the remote terminal on "
-                + "every dial; the plugin cannot silence another process. So after a failed dial its "
-                + "hooks back off for five minutes; prompt submits still try, so context returns with "
-                + "your first prompt once the app is back.",
-            "A second concurrent SSH session to the same host will fail to bind \(port) on the "
-                + "remote and — because ExitOnForwardFailure is `no` — will connect anyway with no "
-                + "tunnel. The first session keeps the forward.",
+                + "Mac — prints `connect_to 127.0.0.1 port \(listenerPort): failed.` into the remote "
+                + "terminal on every dial; the plugin cannot silence another process. So after a "
+                + "failed dial its hooks back off for five minutes; prompt submits still try, so "
+                + "context returns with your first prompt once the app is back.",
+            "A second concurrent SSH session from this Mac to the same host will fail to bind "
+                + "\(remoteForwardPort) on the remote and — because ExitOnForwardFailure is `no` — will "
+                + "connect anyway with no tunnel. The first session keeps the forward, and the verify "
+                + "step above is how you tell that apart from a broken setup.",
             "One-click setup connects with forwarding disabled (the tunnel belongs to your real "
                 + "sessions, not setup) and first resolves `claude` from common install locations — "
                 + "non-interactive SSH shells often lack the user-local PATH entries an interactive "
@@ -527,10 +606,11 @@ public struct ClaudeRemoteEnrollmentService: Sendable {
     @discardableResult
     public func executeRemotePluginUpdate(
         sshHostAlias: String,
+        remoteForwardPort: UInt16 = ClaudeRemoteForwardPort.legacyPort,
         timeout: TimeInterval = defaultRemoteSetupTimeout
     ) throws -> [ExecutionStep] {
         try execute(
-            commands: Self.remotePluginUpdateCommands,
+            commands: Self.remotePluginUpdateCommands(remoteForwardPort: remoteForwardPort),
             sshHostAlias: sshHostAlias,
             token: "",
             timeout: timeout,

--- a/Sources/localvoxtral/ClaudeContext/ClaudeRemoteEnrollmentService.swift
+++ b/Sources/localvoxtral/ClaudeContext/ClaudeRemoteEnrollmentService.swift
@@ -262,7 +262,10 @@ public struct ClaudeRemoteEnrollmentService: Sendable {
         "# END localvoxtral claude context (\(hostID))"
     }
 
-    static func sshConfigSnippet(
+    /// The marked ssh-config block for one host. Token-free by construction,
+    /// which is what lets the plugin-update path regenerate it for a host whose
+    /// one-time token is long gone.
+    public static func sshConfigSnippet(
         host: ClaudeRemoteHost,
         sshHostAlias: String,
         listenerPort: UInt16,
@@ -326,12 +329,27 @@ public struct ClaudeRemoteEnrollmentService: Sendable {
             // an OpenSSH debug line to interpret. The message is deliberately
             // apostrophe-free so it survives single-quoted shell.
             "# Forward check — does this Mac actually own port \(remoteForwardPort) over there?",
-            "# A failure here is EXPECTED while another live session from THIS Mac",
-            "# holds it; anything else means this Mac is receiving nothing.",
-            "ssh -v \(sshHostAlias) true 2>&1 | grep -q '\(ClaudeRemoteForwardPort.forwardFailureSignature)'"
-                + " && echo 'localvoxtral: \(ClaudeRemoteForwardPort.contentionMessage(port: remoteForwardPort, host: sshHostAlias))"
-                + " Close that session, or wait for sshd to reap it, then retry — until then this Mac gets no context from \(sshHostAlias).'"
-                + " || echo 'localvoxtral: port \(remoteForwardPort) forwards cleanly to this Mac.'",
+            "# THREE outcomes, not two. A one-line grep for the forwarding warning",
+            "# gets both edges wrong, which was measured rather than assumed",
+            "# (2026-08-04, OpenSSH 10.0p2 against a live sshd):",
+            "#   * your own live session to this host already holds the port, so a",
+            "#     fresh probe requesting it fails to bind — a healthy setup that a",
+            "#     grep reports as contention (ssh still exits 0),",
+            "#   * an unreachable host, bad key or host-key change never gets far",
+            "#     enough to request a forward, so the grep finds nothing and a",
+            "#     naive check calls it clean (ssh exits 255).",
+            "# So: exit status first, warning second.",
+            "out=$(ssh -v \(sshHostAlias) true 2>&1); rc=$?; "
+                + "if [ $rc -ne 0 ]; then "
+                + "echo \"localvoxtral: could not reach \(sshHostAlias) at all (ssh exit $rc) — fix the connection first; "
+                + "this says nothing about the port.\"; "
+                + "elif echo \"$out\" | grep -q '\(ClaudeRemoteForwardPort.forwardFailureSignature)'; then "
+                + "echo \"localvoxtral: port \(remoteForwardPort) is already bound on \(sshHostAlias). "
+                + "If you have another session open to \(sshHostAlias) from THIS Mac, that is expected and healthy — "
+                + "the first one keeps the forward. If you do not, "
+                + "\(ClaudeRemoteForwardPort.contentionMessage(port: remoteForwardPort, host: sshHostAlias)) "
+                + "and this Mac is getting no context from it.\"; "
+                + "else echo \"localvoxtral: port \(remoteForwardPort) forwards cleanly to this Mac.\"; fi",
             "# Non-interactive SSH skips your shell rc, so claude can be off PATH",
             "# here even though it runs fine when you are logged in.",
             "ssh \(sshHostAlias) '\(nonInteractiveClaudePathPrefix)claude plugin list'",
@@ -521,6 +539,14 @@ public struct ClaudeRemoteEnrollmentService: Sendable {
     /// The caller is responsible for obtaining the user's explicit confirmation
     /// immediately before calling this method.
     public func insertSSHConfig(_ plan: SetupPlan, hostID: String) throws {
+        try insertSSHConfig(snippet: plan.sshConfigSnippet, hostID: hostID)
+    }
+
+    /// Same write, for a caller that has a block but no plan — the plugin
+    /// update path, which regenerates this host's block so the port it is
+    /// about to store on the remote and the port this Mac forwards can never
+    /// disagree.
+    public func insertSSHConfig(snippet: String, hostID: String) throws {
         Log.claudeContext.info("Claude remote ssh config insertion requested")
         guard let sshConfigFileSystem else {
             Log.claudeContext.error("Claude remote ssh config insertion failed: editing not configured")
@@ -550,7 +576,7 @@ public struct ClaudeRemoteEnrollmentService: Sendable {
             }
             let updated = Self.applySSHConfigSnippet(
                 to: existing,
-                snippet: plan.sshConfigSnippet,
+                snippet: snippet,
                 hostID: hostID
             )
             if !state.directoryExists {
@@ -566,6 +592,34 @@ public struct ClaudeRemoteEnrollmentService: Sendable {
                 "Claude remote ssh config insertion failed: \(String(describing: error), privacy: .public)"
             )
             throw error
+        }
+    }
+
+    /// Does this host's marked block already forward `port`?
+    ///
+    /// `nil` means "cannot tell" — no filesystem seam, or a config we refuse to
+    /// read. Callers must treat nil as "not known to match" and regenerate,
+    /// never as "fine": assuming a block is current is exactly how a plugin
+    /// gets a port this Mac does not forward.
+    public func sshConfigForwardsPort(_ port: UInt16, hostID: String) -> Bool? {
+        guard let sshConfigFileSystem else { return nil }
+        guard let state = try? sshConfigFileSystem.readState(),
+              let data = state.configData,
+              let text = String(data: data, encoding: .utf8)
+        else { return nil }
+        let begin = Self.blockBegin(hostID: hostID)
+        let end = Self.blockEnd(hostID: hostID)
+        let lines = text.components(separatedBy: "\n")
+        guard let beginIndex = lines.firstIndex(where: {
+            $0.trimmingCharacters(in: .whitespaces) == begin
+        }), let endIndex = lines[beginIndex...].firstIndex(where: {
+            $0.trimmingCharacters(in: .whitespaces) == end
+        }) else { return false }
+        return lines[beginIndex...endIndex].contains { line in
+            let fields = line.trimmingCharacters(in: .whitespaces)
+                .split(separator: " ", omittingEmptySubsequences: true)
+            guard fields.count >= 2, fields[0] == "RemoteForward" else { return false }
+            return fields[1] == "\(port)"
         }
     }
 

--- a/Sources/localvoxtral/ClaudeContext/ClaudeRemoteForwardPort.swift
+++ b/Sources/localvoxtral/ClaudeContext/ClaudeRemoteForwardPort.swift
@@ -34,17 +34,21 @@ public enum ClaudeRemoteForwardPort {
     /// therefore never forced — an untouched enrollment keeps working.
     public static let legacyPort: UInt16 = 8473
 
-    /// Inclusive allocation range: 100 ports starting one "8473" above 28000.
+    /// Inclusive allocation range: 2000 ports, 28473–30472.
     ///
     /// Chosen to sit below every default ephemeral range the remote host might
     /// pick from (Linux 32768–60999, macOS/BSD 49152–65535), so a forward bind
     /// cannot lose a race with an outbound socket on the host, and high enough
-    /// to be unprivileged and unregistered. 100 is deliberately small: it keeps
-    /// the number human-readable in a pasted command, and the birthday
-    /// collision it admits between two of one person's Macs is loud (the
-    /// generated verify step greps for it) rather than silent.
+    /// to be unprivileged and unregistered.
+    ///
+    /// The width is a review decision (2026-08-04). An earlier 100-slot range
+    /// read as "plenty for one person's Macs" and is not: birthday collision at
+    /// 100 slots is ~1% for two Macs and ~37% for ten, and the failure it
+    /// produces — two Macs contending for one remote bind — is precisely the
+    /// one this type exists to make unreachable. 2000 slots takes those to
+    /// ~0.05% and ~2.2%, at the cost of one more digit in a pasted command.
     public static let rangeLowerBound: UInt16 = 28473
-    public static let rangeUpperBound: UInt16 = 28572
+    public static let rangeUpperBound: UInt16 = 30472
 
     static var portCount: UInt16 { rangeUpperBound - rangeLowerBound + 1 }
 
@@ -56,7 +60,12 @@ public enum ClaudeRemoteForwardPort {
     /// with, any other derivation; versioned so a future range change is a
     /// deliberate new function rather than a silent reshuffle of everyone's
     /// ports.
-    private static let derivationDomain = "localvoxtral.claude.remote-forward.v1:"
+    /// v2 since the range widened. Bumping it deliberately re-derives every
+    /// identity onto a new port rather than leaving old installs clustered in
+    /// the first 100 slots — which is safe exactly once, and this is that once:
+    /// nothing has shipped, so no `~/.ssh/config` block and no remote plugin
+    /// config exists in the world carrying a v1 port.
+    private static let derivationDomain = "localvoxtral.claude.remote-forward.v2:"
 
     /// Stable port for one install identity. Pure: same identity, same port,
     /// forever, on every machine — which is what makes the plan reproducible
@@ -66,8 +75,13 @@ public enum ClaudeRemoteForwardPort {
         hasher.update(data: Data(derivationDomain.utf8))
         hasher.update(data: Data(identity.utf8))
         let digest = Array(hasher.finalize())
-        let value = UInt16(digest[0]) << 8 | UInt16(digest[1])
-        return rangeLowerBound + (value % portCount)
+        // 32 bits folded into the range: 16 would be only ~32 whole
+        // multiples of a 2000-slot range, which skews the low slots by ~3%.
+        // Not a security property, but a needless bias in the one number that
+        // exists to spread Macs apart.
+        let value = UInt32(digest[0]) << 24 | UInt32(digest[1]) << 16
+            | UInt32(digest[2]) << 8 | UInt32(digest[3])
+        return rangeLowerBound + UInt16(value % UInt32(portCount))
     }
 
     public static func isAcceptable(_ port: UInt16) -> Bool {
@@ -90,56 +104,154 @@ public enum ClaudeRemoteForwardPort {
     }
 }
 
-/// Reads — and, exactly once, writes — the per-install identity the port is
-/// derived from.
+/// Where the per-install identity lives.
 ///
-/// `UserDefaults`-backed rather than a file: the identity must outlive the
-/// Claude host registry (deleting that file loses every token and forces
-/// re-enrollment anyway, but deleting it must not silently move an enrolled
-/// host's port), and it must be readable before any Claude subsystem exists.
-/// The defaults instance and the generator are injected so tests never touch
-/// the real domain and never depend on a random value.
-/// Deliberately NOT `Sendable`: it holds a `UserDefaults`, which is not, and
-/// pretending otherwise would only move the compiler's objection into a
-/// `@unchecked` annotation nobody can check. Nothing needs to send one — the
-/// port is read once per launch on the main actor and passed around as a
-/// `UInt16`, which is as Sendable as values get. `ClaudeRemoteForwardPort`
-/// itself is pure and reachable from anywhere.
+/// A seam, because the two properties that matter cannot be tested through
+/// `UserDefaults`: that two racing first launches converge on ONE identity, and
+/// that the value survives things `UserDefaults` does not.
+public protocol ClaudeRemoteForwardIdentityStore: Sendable {
+    /// The persisted identity, or nil if there is none yet.
+    func read() throws -> String?
+    /// Persist `candidate` ONLY if nothing is stored yet, and return whatever
+    /// is stored afterwards — the candidate if this caller won, the existing
+    /// value if another one did. Must be atomic against a concurrent claim.
+    func claim(_ candidate: String) throws -> String
+}
+
+/// The identity as a 0600 file next to the enrollment state.
+///
+/// Not `UserDefaults`, for two reasons the review named and both of which end
+/// in the same silent failure — a Mac whose derived port stops matching the
+/// `~/.ssh/config` block and remote plugin config it already handed out:
+///
+/// 1. **Racing first launches.** Read-then-write in the defaults domain is not
+///    atomic, so two processes starting together can each generate an identity
+///    and last-writer-wins; the enrollment that already happened under the
+///    loser's port is then wrong forever. `link(2)` is the fix: it fails with
+///    EEXIST rather than overwriting, so every racer converges on whichever
+///    file appeared first.
+/// 2. **A preferences reset.** `defaults delete com.localvoxtral.app`, a
+///    migration assistant, a restored backup — the host registry in
+///    Application Support survives all of those, and an identity that does not
+///    would silently move every enrolled host's port while the enrollments
+///    themselves look perfectly healthy. Same directory, same fate.
+public struct ClaudeRemoteForwardIdentityFileStore: ClaudeRemoteForwardIdentityStore {
+    private let fileURL: URL
+
+    public init(fileURL: URL = ClaudeRemoteForwardIdentityFileStore.defaultFileURL()) {
+        self.fileURL = fileURL
+    }
+
+    /// Beside `claude-remote-hosts.json`, deliberately.
+    public static func defaultFileURL() -> URL {
+        ClaudeRemoteHostRegistry.defaultFileURL()
+            .deletingLastPathComponent()
+            .appendingPathComponent("claude-remote-forward-identity")
+    }
+
+    public func read() throws -> String? {
+        guard let data = FileManager.default.contents(atPath: fileURL.path),
+              let text = String(data: data, encoding: .utf8)
+        else { return nil }
+        let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? nil : trimmed
+    }
+
+    public func claim(_ candidate: String) throws -> String {
+        if let existing = try read() { return existing }
+        let directory = fileURL.deletingLastPathComponent()
+        try FileManager.default.createDirectory(
+            at: directory,
+            withIntermediateDirectories: true,
+            attributes: [.posixPermissions: 0o700]
+        )
+        // Write a private temp file, then LINK it into place. `link` refuses to
+        // replace an existing name, which is what makes the winner of a race
+        // the one everybody reads — a plain write or a rename would let the
+        // second racer clobber the first and hand the two Macs the same port
+        // this whole type exists to keep apart.
+        let temporary = directory.appendingPathComponent(
+            ".claude-remote-forward-identity.\(UUID().uuidString)"
+        )
+        try Data("\(candidate)\n".utf8).write(to: temporary, options: [.atomic])
+        try FileManager.default.setAttributes(
+            [.posixPermissions: 0o600], ofItemAtPath: temporary.path
+        )
+        defer { try? FileManager.default.removeItem(at: temporary) }
+        do {
+            try FileManager.default.linkItem(at: temporary, to: fileURL)
+        } catch {
+            // Someone else got there first (or we cannot link at all): whatever
+            // is on disk wins. Never overwrite.
+            if let existing = try read() { return existing }
+            throw error
+        }
+        return try read() ?? candidate
+    }
+}
+
+/// Resolves the per-install identity the port is derived from, and — exactly
+/// once per install — creates it.
+///
+/// The `UserDefaults` instance is still injected, but only as the MIGRATION
+/// source: an install that already stored an identity there (this feature's own
+/// first iteration) must keep its port, not silently move to a new one.
 public struct ClaudeRemoteForwardPortAllocator {
-    /// Lives in the `settings.` domain because it is persisted user state, not
-    /// a debug toggle — but it is deliberately not shown in any pane: there is
-    /// nothing to decide here, and a user-editable identity is a user-editable
-    /// port with no matching remote config.
+    /// Where the identity used to live. Read on first use, never written.
     public static let identityDefaultsKey = "settings.claude_remote_forward_identity"
 
-    private let defaults: UserDefaults
+    private let store: any ClaudeRemoteForwardIdentityStore
+    private let legacyDefaults: UserDefaults?
     private let makeIdentity: @Sendable () -> String
 
     public init(
-        defaults: UserDefaults = .standard,
+        store: any ClaudeRemoteForwardIdentityStore = ClaudeRemoteForwardIdentityFileStore(),
+        legacyDefaults: UserDefaults? = .standard,
         makeIdentity: @escaping @Sendable () -> String = { UUID().uuidString }
     ) {
-        self.defaults = defaults
+        self.store = store
+        self.legacyDefaults = legacyDefaults
         self.makeIdentity = makeIdentity
     }
 
-    /// The persisted identity, generating and storing one on first use.
+    /// The persisted identity, creating one on first use.
     ///
     /// An empty or whitespace-only stored value is treated as absent: a
-    /// half-written default must not pin every install that suffered it to the
-    /// same port.
+    /// half-written file must not pin every install that suffered it to one
+    /// shared port — the exact failure this feature removes.
     public func installIdentity() -> String {
-        if let stored = defaults.string(forKey: Self.identityDefaultsKey),
+        if let stored = (try? store.read()) ?? nil,
            !stored.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
         {
-            return stored
+            return stored.trimmingCharacters(in: .whitespacesAndNewlines)
         }
-        let generated = makeIdentity()
-        defaults.set(generated, forKey: Self.identityDefaultsKey)
+        let candidate = migratedIdentity() ?? makeIdentity()
+        guard let claimed = try? store.claim(candidate) else {
+            // The file could not be written at all (read-only home, sandbox
+            // denial). Returning the candidate keeps THIS launch coherent; the
+            // next one derives again and logs the same failure. Loud, not
+            // silent: a port that moves between launches is exactly what the
+            // verify step reports as contention.
+            Log.claudeContext.error(
+                "Claude remote forward identity could not be persisted; the allocated port may not survive a relaunch"
+            )
+            return candidate
+        }
         Log.claudeContext.info(
-            "Claude remote forward identity generated; allocated port \(ClaudeRemoteForwardPort.port(forInstallIdentity: generated), privacy: .public)"
+            "Claude remote forward identity resolved; allocated port \(ClaudeRemoteForwardPort.port(forInstallIdentity: claimed), privacy: .public)"
         )
-        return generated
+        return claimed
+    }
+
+    /// The value this feature's first iteration wrote to `UserDefaults`.
+    private func migratedIdentity() -> String? {
+        guard let stored = legacyDefaults?.string(forKey: Self.identityDefaultsKey) else {
+            return nil
+        }
+        let trimmed = stored.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return nil }
+        Log.claudeContext.info("Claude remote forward identity migrated out of UserDefaults")
+        return trimmed
     }
 
     /// This Mac's remote listen port. Stable across launches.

--- a/Sources/localvoxtral/ClaudeContext/ClaudeRemoteForwardPort.swift
+++ b/Sources/localvoxtral/ClaudeContext/ClaudeRemoteForwardPort.swift
@@ -1,0 +1,149 @@
+import CryptoKit
+import Foundation
+
+/// Which port on the REMOTE host this Mac's `RemoteForward` binds.
+///
+/// Not a preference and not a negotiation — a deterministic function of one
+/// persisted per-install identity, because the two ends that must agree on it
+/// (the ssh-config block on this Mac and the plugin's `port` option on the
+/// remote host) are configured minutes apart, by hand, from a plan the user
+/// copies. Anything the app cannot recompute identically on the next launch
+/// would drift between those two halves and fail open — i.e. look like nothing
+/// at all.
+///
+/// Why per-Mac at all (issue #215): two ssh connections that request the same
+/// remote listen port do not both get it. The FIRST one wins and keeps
+/// winning; the second stays connected with only a stderr warning (our block
+/// sets `ExitOnForwardFailure no` deliberately, so a dictation nicety never
+/// costs the user their shell) and every hook event on that host — including
+/// its `Authorization: Bearer` header — is delivered to the first Mac's
+/// listener, which 401s it. The shim treats a 401 as a completed exchange, so
+/// nothing anywhere reports a problem. Two Macs on distinct ports cannot enter
+/// that state.
+///
+/// What this does NOT fix, stated plainly: one remote host runs one Claude Code
+/// install with ONE plugin config, so its `port` option names exactly one Mac.
+/// Two Macs enrolled against the same host still means only the
+/// most-recently-installed config receives events; the other's tunnel binds
+/// fine and simply sees no traffic. That is a visible, honest single-tenancy —
+/// not a silent cross-delivery of another Mac's credentials.
+public enum ClaudeRemoteForwardPort {
+    /// The legacy shared port, still the fallback everywhere: an install that
+    /// predates the `port` plugin option, an ssh block written before this
+    /// change, and the Mac-side listener itself all stay on it. Migration is
+    /// therefore never forced — an untouched enrollment keeps working.
+    public static let legacyPort: UInt16 = 8473
+
+    /// Inclusive allocation range: 100 ports starting one "8473" above 28000.
+    ///
+    /// Chosen to sit below every default ephemeral range the remote host might
+    /// pick from (Linux 32768–60999, macOS/BSD 49152–65535), so a forward bind
+    /// cannot lose a race with an outbound socket on the host, and high enough
+    /// to be unprivileged and unregistered. 100 is deliberately small: it keeps
+    /// the number human-readable in a pasted command, and the birthday
+    /// collision it admits between two of one person's Macs is loud (the
+    /// generated verify step greps for it) rather than silent.
+    public static let rangeLowerBound: UInt16 = 28473
+    public static let rangeUpperBound: UInt16 = 28572
+
+    static var portCount: UInt16 { rangeUpperBound - rangeLowerBound + 1 }
+
+    /// Ports the shim will accept from plugin config. Anything outside falls
+    /// back to `legacyPort` on the remote side, so keep the two rules identical.
+    public static let acceptableRange: ClosedRange<UInt16> = 1024...65535
+
+    /// Domain-separated so the identity can never be reused as, or confused
+    /// with, any other derivation; versioned so a future range change is a
+    /// deliberate new function rather than a silent reshuffle of everyone's
+    /// ports.
+    private static let derivationDomain = "localvoxtral.claude.remote-forward.v1:"
+
+    /// Stable port for one install identity. Pure: same identity, same port,
+    /// forever, on every machine — which is what makes the plan reproducible
+    /// after a relaunch.
+    public static func port(forInstallIdentity identity: String) -> UInt16 {
+        var hasher = SHA256()
+        hasher.update(data: Data(derivationDomain.utf8))
+        hasher.update(data: Data(identity.utf8))
+        let digest = Array(hasher.finalize())
+        let value = UInt16(digest[0]) << 8 | UInt16(digest[1])
+        return rangeLowerBound + (value % portCount)
+    }
+
+    public static func isAcceptable(_ port: UInt16) -> Bool {
+        acceptableRange.contains(port)
+    }
+
+    /// What OpenSSH prints — on stderr, at `-v` and above — when the remote
+    /// refuses the bind because something already holds the port. It is the
+    /// ONLY signal that this Mac is now silently receiving nothing, so both the
+    /// generated verify step and the supervised forward watch for this exact
+    /// substring. Stable across OpenSSH releases (verified on 10.0p2, 2026-08-03).
+    public static let forwardFailureSignature = "remote port forwarding failed"
+
+    /// One short sentence that names the fix rather than the symptom. Shared so
+    /// the pasted verify command and any in-app status say the same thing.
+    ///
+    /// Apostrophe-free on purpose: it is embedded in single-quoted shell.
+    public static func contentionMessage(port: UInt16, host: String) -> String {
+        "Another machine or stale connection holds port \(port) on \(host)."
+    }
+}
+
+/// Reads — and, exactly once, writes — the per-install identity the port is
+/// derived from.
+///
+/// `UserDefaults`-backed rather than a file: the identity must outlive the
+/// Claude host registry (deleting that file loses every token and forces
+/// re-enrollment anyway, but deleting it must not silently move an enrolled
+/// host's port), and it must be readable before any Claude subsystem exists.
+/// The defaults instance and the generator are injected so tests never touch
+/// the real domain and never depend on a random value.
+/// Deliberately NOT `Sendable`: it holds a `UserDefaults`, which is not, and
+/// pretending otherwise would only move the compiler's objection into a
+/// `@unchecked` annotation nobody can check. Nothing needs to send one — the
+/// port is read once per launch on the main actor and passed around as a
+/// `UInt16`, which is as Sendable as values get. `ClaudeRemoteForwardPort`
+/// itself is pure and reachable from anywhere.
+public struct ClaudeRemoteForwardPortAllocator {
+    /// Lives in the `settings.` domain because it is persisted user state, not
+    /// a debug toggle — but it is deliberately not shown in any pane: there is
+    /// nothing to decide here, and a user-editable identity is a user-editable
+    /// port with no matching remote config.
+    public static let identityDefaultsKey = "settings.claude_remote_forward_identity"
+
+    private let defaults: UserDefaults
+    private let makeIdentity: @Sendable () -> String
+
+    public init(
+        defaults: UserDefaults = .standard,
+        makeIdentity: @escaping @Sendable () -> String = { UUID().uuidString }
+    ) {
+        self.defaults = defaults
+        self.makeIdentity = makeIdentity
+    }
+
+    /// The persisted identity, generating and storing one on first use.
+    ///
+    /// An empty or whitespace-only stored value is treated as absent: a
+    /// half-written default must not pin every install that suffered it to the
+    /// same port.
+    public func installIdentity() -> String {
+        if let stored = defaults.string(forKey: Self.identityDefaultsKey),
+           !stored.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        {
+            return stored
+        }
+        let generated = makeIdentity()
+        defaults.set(generated, forKey: Self.identityDefaultsKey)
+        Log.claudeContext.info(
+            "Claude remote forward identity generated; allocated port \(ClaudeRemoteForwardPort.port(forInstallIdentity: generated), privacy: .public)"
+        )
+        return generated
+    }
+
+    /// This Mac's remote listen port. Stable across launches.
+    public func allocatedPort() -> UInt16 {
+        ClaudeRemoteForwardPort.port(forInstallIdentity: installIdentity())
+    }
+}

--- a/Sources/localvoxtral/SettingsStore.swift
+++ b/Sources/localvoxtral/SettingsStore.swift
@@ -572,7 +572,12 @@ final class SettingsStore {
     /// Reading it is what creates the identity, so it is cheap to read and
     /// never returns a different answer on a later launch.
     var claudeRemoteForwardPort: UInt16 {
-        ClaudeRemoteForwardPortAllocator(defaults: defaults).allocatedPort()
+        // The identity itself lives in a 0600 file beside the Claude host
+        // registry, NOT in this domain: a preferences reset must not move an
+        // enrolled host's port while the enrollment that used it survives.
+        // `defaults` is passed only so an identity written by this feature's
+        // first iteration migrates into that file instead of being replaced.
+        ClaudeRemoteForwardPortAllocator(legacyDefaults: defaults).allocatedPort()
     }
 
     /// A sendable, live view of the preference for the broker's background

--- a/Sources/localvoxtral/SettingsStore.swift
+++ b/Sources/localvoxtral/SettingsStore.swift
@@ -563,6 +563,18 @@ final class SettingsStore {
         }
     }
 
+    /// The remote listen port this Mac's SSH `RemoteForward` binds on an
+    /// enrolled host — derived once from a persisted per-install identity, and
+    /// stable from then on (`ClaudeRemoteForwardPort`). Not a preference: there
+    /// is nothing to choose, and a value the user could edit here would silently
+    /// disagree with the `port` option already installed on the remote host.
+    ///
+    /// Reading it is what creates the identity, so it is cheap to read and
+    /// never returns a different answer on a later launch.
+    var claudeRemoteForwardPort: UInt16 {
+        ClaudeRemoteForwardPortAllocator(defaults: defaults).allocatedPort()
+    }
+
     /// A sendable, live view of the preference for the broker's background
     /// connection threads. The synchronized mirror keeps actor-isolated UI
     /// state and non-Sendable `UserDefaults` out of the socket service, while a

--- a/Sources/localvoxtral/SettingsView.swift
+++ b/Sources/localvoxtral/SettingsView.swift
@@ -1075,7 +1075,11 @@ private struct ClaudeRemoteHostsSettingsRow: View {
     @ViewBuilder
     private func pluginUpdatePanel(for host: ClaudeIntegrationSettingsModel.HostRow) -> some View {
         if let update = model.presentedPluginUpdate, update.hostID == host.id {
-            let commands = update.commands.joined(separator: "\n")
+            // BOTH mutations, in order — not just the remote commands. The
+            // copy-only paths (no recorded alias; the symlink refusal that
+            // sends the user here) are exactly where showing only the commands
+            // recreated the split brain this feature exists to remove.
+            let commands = update.applicationText
             let action = ClaudeIntegrationSettingsModel.EnrollmentAction.updateRemotePlugin(hostID: host.id)
             let pendingConfirmation = model.enrollmentConfirmation.flatMap {
                 $0.action == action ? $0 : nil
@@ -1123,7 +1127,7 @@ private struct ClaudeRemoteHostsSettingsRow: View {
                         .controlSize(.small)
                         .disabled(model.isPerformingEnrollmentAction)
                 } else {
-                    Text("Replace your-ssh-host with the alias from your ~/.ssh/config, then run these two commands yourself.")
+                    Text("Replace your-ssh-host with the alias from your ~/.ssh/config, then apply both steps above yourself — the ssh-config block first.")
                         .font(.caption2)
                         .foregroundStyle(.secondary)
                 }

--- a/Sources/localvoxtral/localvoxtralApp.swift
+++ b/Sources/localvoxtral/localvoxtralApp.swift
@@ -367,11 +367,21 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         }
         claudeRemoteListenerCoordinator = coordinator
 
+        // The per-Mac remote listen port (issue #215). Read once, here, so
+        // every generated artifact in this launch agrees; reading it is also
+        // what mints the install identity on a first run, and it must not be
+        // minted lazily inside a sheet that a test could reach.
+        let remoteForwardPort = viewModel.settings.claudeRemoteForwardPort
+        Log.claudeContext.info(
+            "Claude remote forward port allocated: \(remoteForwardPort, privacy: .public)"
+        )
+
         viewModel.claudeIntegrationSettings = ClaudeIntegrationSettingsModel(
             registry: registry,
             listener: coordinator,
             pluginService: { ClaudePluginInstallService.live() },
-            enrollmentService: ClaudeRemoteEnrollmentService.live()
+            enrollmentService: ClaudeRemoteEnrollmentService.live(),
+            remoteForwardPort: remoteForwardPort
         )
 
         // Route launch through the same model that owns the Settings status.

--- a/Tests/localvoxtralTests/ClaudeIntegrationSettingsModelTests.swift
+++ b/Tests/localvoxtralTests/ClaudeIntegrationSettingsModelTests.swift
@@ -74,16 +74,26 @@ private final class MemoryStore: ClaudeRemoteHostStoreIO {
 private final class RecordingSSHConfigFileSystem: ClaudeRemoteSSHConfigFileSystem {
     private let reads = Mutex(0)
     private let writes = Mutex(0)
+    private let config = Mutex<String?>(nil)
+    private let written = Mutex<String?>(nil)
+    /// Stands in for the one state the service refuses to write through: a
+    /// symlinked ~/.ssh/config, where a rename would replace the link.
+    private let symlinked = Mutex(false)
 
     var readCount: Int { reads.withLock { $0 } }
     var writeCount: Int { writes.withLock { $0 } }
+    var lastWrittenText: String? { written.withLock { $0 } }
+
+    func setConfig(_ text: String) { config.withLock { $0 = text } }
+    func setSymlinked(_ value: Bool) { symlinked.withLock { $0 = value } }
 
     func readState() throws -> ClaudeRemoteSSHConfigState {
         reads.withLock { $0 += 1 }
         return ClaudeRemoteSSHConfigState(
             directoryExists: true,
-            configData: nil,
-            configPermissions: nil
+            configData: config.withLock { $0 }.map { Data($0.utf8) },
+            configPermissions: nil,
+            configIsSymlink: symlinked.withLock { $0 }
         )
     }
 
@@ -93,6 +103,9 @@ private final class RecordingSSHConfigFileSystem: ClaudeRemoteSSHConfigFileSyste
         XCTAssertFalse(data.isEmpty)
         XCTAssertEqual(permissions, 0o600)
         writes.withLock { $0 += 1 }
+        let text = String(decoding: data, as: UTF8.self)
+        written.withLock { $0 = text }
+        config.withLock { $0 = text }
     }
 }
 
@@ -632,10 +645,15 @@ final class ClaudeIntegrationSettingsModelTests: XCTestCase {
     func testPluginUpdateShowsThatHostsCommandsAndRunsNothingYet() async throws {
         let registry = try makeRegistry()
         let calls = Mutex<[ClaudeRemoteEnrollmentService.Invocation]>([])
-        let service = ClaudeRemoteEnrollmentService(runner: { invocation in
-            calls.withLock { $0.append(invocation) }
-            return .init(exitCode: 0, message: "ok")
-        })
+        let service = ClaudeRemoteEnrollmentService(
+            runner: { invocation in
+                calls.withLock { $0.append(invocation) }
+                return .init(exitCode: 0, message: "ok")
+            },
+            // The update path rewrites this host's ssh block in the same
+            // action now (review blocker), so it needs somewhere to write.
+            sshConfigFileSystem: RecordingSSHConfigFileSystem()
+        )
         // Name and SSH alias are separate fields on the enrollment form, and
         // this is the pairing that made the review finding concrete: a host
         // NAMED prod, REACHED as builder.
@@ -667,10 +685,13 @@ final class ClaudeIntegrationSettingsModelTests: XCTestCase {
     func testEveryGeneratedArtifactUsesThisMacsAllocatedRemotePort() async throws {
         let registry = try makeRegistry()
         let calls = Mutex<[ClaudeRemoteEnrollmentService.Invocation]>([])
-        let service = ClaudeRemoteEnrollmentService(runner: { invocation in
-            calls.withLock { $0.append(invocation) }
-            return .init(exitCode: 0, message: "ok")
-        })
+        let service = ClaudeRemoteEnrollmentService(
+            runner: { invocation in
+                calls.withLock { $0.append(invocation) }
+                return .init(exitCode: 0, message: "ok")
+            },
+            sshConfigFileSystem: RecordingSSHConfigFileSystem()
+        )
         let model = makeModel(
             registry: registry,
             listener: StubListener(hosts: registry),
@@ -705,6 +726,166 @@ final class ClaudeIntegrationSettingsModelTests: XCTestCase {
             scripts.contains { $0.contains("--config 'port=28542'") },
             "the executed update must migrate the port, not just the panel text: \(scripts)"
         )
+    }
+
+    // MARK: Update migrates BOTH halves (review blocker)
+
+    /// The failure this pins, in full: a legacy host's block says
+    /// `RemoteForward 8473`, this Mac now allocates 285xx, and the update
+    /// stores `port=285xx` on the remote. If only that half runs, every hook on
+    /// that host posts to a port this Mac does not forward — connection
+    /// refused, fail open, silence. That is #215's failure class, reintroduced
+    /// by the fix for #215, and it would have shipped to every legacy user who
+    /// pressed the button.
+    func testUpdatingALegacyHostRewritesTheSSHBlockAndTheRemotePortTogether() async throws {
+        let registry = try makeRegistry()
+        let calls = Mutex<[ClaudeRemoteEnrollmentService.Invocation]>([])
+        let filesystem = RecordingSSHConfigFileSystem()
+        let service = ClaudeRemoteEnrollmentService(
+            runner: { invocation in
+                calls.withLock { $0.append(invocation) }
+                return .init(exitCode: 0, message: "ok")
+            },
+            sshConfigFileSystem: filesystem
+        )
+        let model = makeModel(
+            registry: registry,
+            listener: StubListener(hosts: registry),
+            enrollmentService: service,
+            remoteForwardPort: 28542
+        )
+        model.enrollLabel = "buildhost"
+        model.enrollSSHAlias = "builder"
+        await model.enroll()
+        model.dismissPlan()
+        let hostID = try XCTUnwrap(model.hosts.first).id
+
+        // The legacy state: a block written before per-Mac ports existed.
+        let legacyHost = try XCTUnwrap(registry.host(id: hostID))
+        let legacyBlock = ClaudeRemoteEnrollmentService.applySSHConfigSnippet(
+            to: "Host unrelated\n    HostName 10.0.0.9\n",
+            snippet: ClaudeRemoteEnrollmentService.sshConfigSnippet(
+                host: legacyHost,
+                sshHostAlias: "builder",
+                listenerPort: 8473,
+                remoteForwardPort: 8473
+            ),
+            hostID: hostID
+        )
+        filesystem.setConfig(legacyBlock)
+
+        model.requestPluginUpdate(hostID: hostID)
+        let update = try XCTUnwrap(model.presentedPluginUpdate)
+        let snippet = try XCTUnwrap(
+            update.sshConfigSnippet,
+            "a stale block must be regenerated as part of this action, not left behind"
+        )
+        XCTAssertTrue(snippet.contains("RemoteForward 28542 127.0.0.1:8473"))
+
+        // The confirmation has to repeat BOTH mutations, in order.
+        model.requestPluginUpdateRun()
+        let preview = try XCTUnwrap(model.enrollmentConfirmation).preview
+        XCTAssertTrue(preview.contains("RemoteForward 28542 127.0.0.1:8473"), preview)
+        XCTAssertTrue(preview.contains("--config 'port=28542'"), preview)
+
+        await model.confirmEnrollmentAction()
+
+        // Half one: the local block now forwards the allocated port, once.
+        let written = try XCTUnwrap(filesystem.lastWrittenText)
+        XCTAssertTrue(written.contains("RemoteForward 28542 127.0.0.1:8473"), written)
+        XCTAssertFalse(written.contains("RemoteForward 8473"), "the stale line must be gone: \(written)")
+        XCTAssertEqual(
+            written.components(separatedBy: "Host builder").count - 1, 1,
+            "a duplicate stanza would let the stale one win by first-match"
+        )
+        XCTAssertTrue(written.contains("Host unrelated"), "the rest of the file is untouched")
+
+        // Half two: the remote now stores the same port.
+        let scripts = calls.withLock { $0 }.map { String(decoding: $0.standardInput, as: UTF8.self) }
+        XCTAssertTrue(
+            scripts.contains { $0.contains("--config 'port=28542'") },
+            "the plugin-side port write must have run too: \(scripts)"
+        )
+        XCTAssertTrue(model.enrollmentStepStatuses.allSatisfy(\.succeeded))
+    }
+
+    func testAHostWhoseBlockIsAlreadyCurrentIsNotRewritten() async throws {
+        let registry = try makeRegistry()
+        let filesystem = RecordingSSHConfigFileSystem()
+        let service = ClaudeRemoteEnrollmentService(
+            runner: { _ in .init(exitCode: 0, message: "ok") },
+            sshConfigFileSystem: filesystem
+        )
+        let model = makeModel(
+            registry: registry,
+            listener: StubListener(hosts: registry),
+            enrollmentService: service,
+            remoteForwardPort: 28542
+        )
+        model.enrollLabel = "buildhost"
+        model.enrollSSHAlias = "builder"
+        await model.enroll()
+        model.dismissPlan()
+        let hostID = try XCTUnwrap(model.hosts.first).id
+        let host = try XCTUnwrap(registry.host(id: hostID))
+        filesystem.setConfig(
+            ClaudeRemoteEnrollmentService.applySSHConfigSnippet(
+                to: "",
+                snippet: ClaudeRemoteEnrollmentService.sshConfigSnippet(
+                    host: host,
+                    sshHostAlias: "builder",
+                    listenerPort: 8473,
+                    remoteForwardPort: 28542
+                ),
+                hostID: hostID
+            )
+        )
+
+        model.requestPluginUpdate(hostID: hostID)
+
+        XCTAssertNil(
+            try XCTUnwrap(model.presentedPluginUpdate).sshConfigSnippet,
+            "an up-to-date block is not a mutation to ask the user to confirm"
+        )
+    }
+
+    /// Order is the safety property: if the local write fails, the REMOTE must
+    /// be untouched. The reverse order would leave the plugin pointed at a port
+    /// this Mac does not forward — silently — which is the state this whole
+    /// change exists to make unreachable.
+    func testARefusedLocalWriteLeavesTheRemoteCompletelyUntouched() async throws {
+        let registry = try makeRegistry()
+        let calls = Mutex<[ClaudeRemoteEnrollmentService.Invocation]>([])
+        let filesystem = RecordingSSHConfigFileSystem()
+        filesystem.setSymlinked(true)
+        let service = ClaudeRemoteEnrollmentService(
+            runner: { invocation in
+                calls.withLock { $0.append(invocation) }
+                return .init(exitCode: 0, message: "ok")
+            },
+            sshConfigFileSystem: filesystem
+        )
+        let model = makeModel(
+            registry: registry,
+            listener: StubListener(hosts: registry),
+            enrollmentService: service,
+            remoteForwardPort: 28542
+        )
+        model.enrollLabel = "buildhost"
+        model.enrollSSHAlias = "builder"
+        await model.enroll()
+        model.dismissPlan()
+        let hostID = try XCTUnwrap(model.hosts.first).id
+
+        model.requestPluginUpdate(hostID: hostID)
+        model.requestPluginUpdateRun()
+        await model.confirmEnrollmentAction()
+
+        XCTAssertTrue(
+            calls.withLock { $0 }.isEmpty,
+            "nothing may reach the remote once the local half is known to have failed"
+        )
+        XCTAssertNotNil(model.alert, "and the user has to be told")
     }
 
     /// The same confusion on the rotation path, which is worse: it hands a
@@ -762,10 +943,13 @@ final class ClaudeIntegrationSettingsModelTests: XCTestCase {
     func testPluginUpdateRunsOnlyAfterAnExplicitConfirmation() async throws {
         let registry = try makeRegistry()
         let calls = Mutex<[ClaudeRemoteEnrollmentService.Invocation]>([])
-        let service = ClaudeRemoteEnrollmentService(runner: { invocation in
-            calls.withLock { $0.append(invocation) }
-            return .init(exitCode: 0, message: "ok")
-        })
+        let service = ClaudeRemoteEnrollmentService(
+            runner: { invocation in
+                calls.withLock { $0.append(invocation) }
+                return .init(exitCode: 0, message: "ok")
+            },
+            sshConfigFileSystem: RecordingSSHConfigFileSystem()
+        )
         let model = await enrolledModel(label: "buildhost", registry: registry, service: service)
         let hostID = try XCTUnwrap(model.hosts.first).id
         model.requestPluginUpdate(hostID: hostID)
@@ -777,8 +961,16 @@ final class ClaudeIntegrationSettingsModelTests: XCTestCase {
         XCTAssertEqual(confirmation.action, .updateRemotePlugin(hostID: hostID))
         XCTAssertEqual(
             confirmation.preview,
-            model.presentedPluginUpdate?.commands.joined(separator: "\n"),
-            "the confirmation must repeat the exact commands the row displays"
+            ClaudeIntegrationSettingsModel.updatePreview(
+                for: try XCTUnwrap(model.presentedPluginUpdate)
+            ),
+            "the confirmation must repeat the exact mutations the row displays"
+        )
+        XCTAssertTrue(
+            confirmation.preview.contains(
+                try XCTUnwrap(model.presentedPluginUpdate).commands.joined(separator: "\n")
+            ),
+            "…including every command, verbatim"
         )
 
         await model.confirmEnrollmentAction()
@@ -957,9 +1149,14 @@ final class ClaudeIntegrationSettingsModelTests: XCTestCase {
 
     func testAFailedPluginUpdateIsAShortStatusAndADetailedAlert() async throws {
         let registry = try makeRegistry()
-        let service = ClaudeRemoteEnrollmentService(runner: { _ in
-            .init(exitCode: 1, message: "plugin localvoxtral-remote not found")
-        })
+        let service = ClaudeRemoteEnrollmentService(
+            runner: { _ in
+                .init(exitCode: 1, message: "plugin localvoxtral-remote not found")
+            },
+            // The local ssh-block rewrite runs first and must SUCCEED here, so
+            // that what this test observes is the remote step failing.
+            sshConfigFileSystem: RecordingSSHConfigFileSystem()
+        )
         let model = await enrolledModel(label: "buildhost", registry: registry, service: service)
         let hostID = try XCTUnwrap(model.hosts.first).id
         model.requestPluginUpdate(hostID: hostID)

--- a/Tests/localvoxtralTests/ClaudeIntegrationSettingsModelTests.swift
+++ b/Tests/localvoxtralTests/ClaudeIntegrationSettingsModelTests.swift
@@ -809,6 +809,122 @@ final class ClaudeIntegrationSettingsModelTests: XCTestCase {
         XCTAssertTrue(model.enrollmentStepStatuses.allSatisfy(\.succeeded))
     }
 
+    /// The half of the blocker that the first fix missed: the executable path
+    /// wrote the ssh block, but the PANEL displayed and copied only the remote
+    /// commands. Both copy-only routes lead straight back to the split brain —
+    /// a host with no recorded alias can ONLY be updated by hand, and the
+    /// symlink refusal deliberately sends the user to that same Copy button.
+    /// So the copy payload has to carry both mutations, in order.
+    func testTheCopyPayloadForAnAliaslessHostCarriesTheSSHBlockToo() async throws {
+        let registry = try makeRegistry()
+        let filesystem = RecordingSSHConfigFileSystem()
+        let service = ClaudeRemoteEnrollmentService(
+            runner: { _ in .init(exitCode: 0, message: "ok") },
+            sshConfigFileSystem: filesystem
+        )
+        // Enrolled before aliases were recorded: copy-only, forever, until the
+        // user re-enrolls. This is the population most likely to still be on a
+        // legacy 8473 block.
+        let enrollment = try registry.enroll(label: "buildhost")
+        let model = makeModel(
+            registry: registry,
+            listener: StubListener(hosts: registry),
+            enrollmentService: service,
+            remoteForwardPort: 28542
+        )
+
+        model.requestPluginUpdate(hostID: enrollment.host.id)
+
+        let update = try XCTUnwrap(model.presentedPluginUpdate)
+        XCTAssertFalse(update.canRun, "no alias means nothing may be run for them")
+        let payload = update.applicationText
+        XCTAssertTrue(
+            payload.contains("RemoteForward 28542 127.0.0.1:8473"),
+            "a copy that omits the ssh block updates the remote and strands this Mac: \(payload)"
+        )
+        XCTAssertTrue(payload.contains("--config 'port=28542'"), payload)
+        // Order matters as much as presence: the block first, the remote second.
+        let blockIndex = try XCTUnwrap(payload.range(of: "RemoteForward 28542")).lowerBound
+        let commandIndex = try XCTUnwrap(payload.range(of: "--config 'port=28542'")).lowerBound
+        XCTAssertLessThan(blockIndex, commandIndex)
+        XCTAssertTrue(payload.contains("~/.ssh/config"), "and it must say where the block goes")
+    }
+
+    /// The recovery path after the app refuses to write a symlinked config: the
+    /// user is told to copy, so what they copy must be enough to finish the job.
+    func testTheCopyPayloadAfterASymlinkRefusalStillCarriesTheSSHBlock() async throws {
+        let registry = try makeRegistry()
+        let calls = Mutex<[ClaudeRemoteEnrollmentService.Invocation]>([])
+        let filesystem = RecordingSSHConfigFileSystem()
+        filesystem.setSymlinked(true)
+        let service = ClaudeRemoteEnrollmentService(
+            runner: { invocation in
+                calls.withLock { $0.append(invocation) }
+                return .init(exitCode: 0, message: "ok")
+            },
+            sshConfigFileSystem: filesystem
+        )
+        let model = makeModel(
+            registry: registry,
+            listener: StubListener(hosts: registry),
+            enrollmentService: service,
+            remoteForwardPort: 28542
+        )
+        model.enrollLabel = "buildhost"
+        model.enrollSSHAlias = "builder"
+        await model.enroll()
+        model.dismissPlan()
+        let hostID = try XCTUnwrap(model.hosts.first).id
+
+        model.requestPluginUpdate(hostID: hostID)
+        model.requestPluginUpdateRun()
+        await model.confirmEnrollmentAction()
+
+        XCTAssertTrue(calls.withLock { $0 }.isEmpty, "the remote must stay untouched")
+        // The panel is still open, and what it offers to copy is the whole job.
+        let payload = try XCTUnwrap(model.presentedPluginUpdate).applicationText
+        XCTAssertTrue(
+            payload.contains("RemoteForward 28542 127.0.0.1:8473"),
+            "the refusal tells the user to copy; copying must hand them both halves: \(payload)"
+        )
+        XCTAssertTrue(payload.contains("--config 'port=28542'"))
+    }
+
+    func testThePanelTheConfirmationAndTheCopyAllShowTheSameText() async throws {
+        // Three surfaces rendered the same thing by hand once, and diverged —
+        // that divergence WAS the blocker. One source now.
+        let registry = try makeRegistry()
+        let service = ClaudeRemoteEnrollmentService(
+            runner: { _ in .init(exitCode: 0, message: "ok") },
+            sshConfigFileSystem: RecordingSSHConfigFileSystem()
+        )
+        let model = makeModel(
+            registry: registry,
+            listener: StubListener(hosts: registry),
+            enrollmentService: service,
+            remoteForwardPort: 28542
+        )
+        model.enrollLabel = "buildhost"
+        model.enrollSSHAlias = "builder"
+        await model.enroll()
+        model.dismissPlan()
+        let hostID = try XCTUnwrap(model.hosts.first).id
+
+        model.requestPluginUpdate(hostID: hostID)
+        model.requestPluginUpdateRun()
+
+        let update = try XCTUnwrap(model.presentedPluginUpdate)
+        XCTAssertEqual(
+            try XCTUnwrap(model.enrollmentConfirmation).preview,
+            update.applicationText,
+            "the confirmation must be the same text the panel shows and copies"
+        )
+        XCTAssertEqual(
+            ClaudeIntegrationSettingsModel.updatePreview(for: update),
+            update.applicationText
+        )
+    }
+
     func testAHostWhoseBlockIsAlreadyCurrentIsNotRewritten() async throws {
         let registry = try makeRegistry()
         let filesystem = RecordingSSHConfigFileSystem()

--- a/Tests/localvoxtralTests/ClaudeIntegrationSettingsModelTests.swift
+++ b/Tests/localvoxtralTests/ClaudeIntegrationSettingsModelTests.swift
@@ -114,7 +114,11 @@ final class ClaudeIntegrationSettingsModelTests: XCTestCase {
         // Frozen by default (AGENTS: no wall-clock in tests). The registry's
         // own clock is pinned to the same instant, so a host that just reported
         // reads as "just now" rather than as whatever the machine's clock did.
-        now: @escaping @Sendable () -> Date = { Date(timeIntervalSince1970: 1_000_000) }
+        now: @escaping @Sendable () -> Date = { Date(timeIntervalSince1970: 1_000_000) },
+        // Pinned, never derived here: the model must use what it is handed, and
+        // a test that computed the allocation would only prove the derivation
+        // twice.
+        remoteForwardPort: UInt16 = ClaudeRemoteForwardPort.legacyPort
     ) -> ClaudeIntegrationSettingsModel {
         ClaudeIntegrationSettingsModel(
             registry: registry,
@@ -142,7 +146,8 @@ final class ClaudeIntegrationSettingsModelTests: XCTestCase {
                     )
                 }
             },
-            now: now
+            now: now,
+            remoteForwardPort: remoteForwardPort
         )
     }
 
@@ -605,12 +610,14 @@ final class ClaudeIntegrationSettingsModelTests: XCTestCase {
         label: String,
         alias: String = "builder",
         registry: ClaudeRemoteHostRegistry,
-        service: ClaudeRemoteEnrollmentService
+        service: ClaudeRemoteEnrollmentService,
+        remoteForwardPort: UInt16 = ClaudeRemoteForwardPort.legacyPort
     ) async -> ClaudeIntegrationSettingsModel {
         let model = makeModel(
             registry: registry,
             listener: StubListener(hosts: registry),
-            enrollmentService: service
+            enrollmentService: service,
+            remoteForwardPort: remoteForwardPort
         )
         model.enrollLabel = label
         model.enrollSSHAlias = alias
@@ -652,6 +659,52 @@ final class ClaudeIntegrationSettingsModelTests: XCTestCase {
         XCTAssertTrue(commands.contains("claude plugin update"))
         XCTAssertTrue(calls.withLock { $0 }.isEmpty, "disclosure must not run anything")
         XCTAssertNil(model.enrollmentConfirmation)
+    }
+
+    /// Every artifact the pane hands the user must name the SAME remote port —
+    /// this Mac's allocation (#215). One that names a different port than
+    /// another is a tunnel to nothing, and it fails open, i.e. silently.
+    func testEveryGeneratedArtifactUsesThisMacsAllocatedRemotePort() async throws {
+        let registry = try makeRegistry()
+        let calls = Mutex<[ClaudeRemoteEnrollmentService.Invocation]>([])
+        let service = ClaudeRemoteEnrollmentService(runner: { invocation in
+            calls.withLock { $0.append(invocation) }
+            return .init(exitCode: 0, message: "ok")
+        })
+        let model = makeModel(
+            registry: registry,
+            listener: StubListener(hosts: registry),
+            enrollmentService: service,
+            remoteForwardPort: 28542
+        )
+        model.enrollLabel = "buildhost"
+        model.enrollSSHAlias = "builder"
+
+        await model.enroll()
+
+        let plan = try XCTUnwrap(model.presentedPlan).plan
+        XCTAssertTrue(
+            plan.sshConfigSnippet.contains("RemoteForward 28542 127.0.0.1:8473"),
+            plan.sshConfigSnippet
+        )
+        XCTAssertTrue(plan.remoteCommands.joined().contains("--config 'port=28542'"))
+        XCTAssertTrue(plan.verifyCommands.joined().contains("127.0.0.1:28542"))
+        XCTAssertTrue(plan.updateCommands.joined().contains("--config 'port=28542'"))
+        model.dismissPlan()
+
+        // …and so must the standalone update panel and what it actually runs.
+        let hostID = try XCTUnwrap(model.hosts.first).id
+        model.requestPluginUpdate(hostID: hostID)
+        let update = try XCTUnwrap(model.presentedPluginUpdate)
+        XCTAssertTrue(update.commands.joined().contains("--config 'port=28542'"))
+
+        model.requestPluginUpdateRun()
+        await model.confirmEnrollmentAction()
+        let scripts = calls.withLock { $0 }.map { String(decoding: $0.standardInput, as: UTF8.self) }
+        XCTAssertTrue(
+            scripts.contains { $0.contains("--config 'port=28542'") },
+            "the executed update must migrate the port, not just the panel text: \(scripts)"
+        )
     }
 
     /// The same confusion on the rotation path, which is worse: it hands a
@@ -730,9 +783,12 @@ final class ClaudeIntegrationSettingsModelTests: XCTestCase {
 
         await model.confirmEnrollmentAction()
 
-        XCTAssertEqual(calls.withLock { $0 }.count, 2)
+        // Three since per-Mac ports (#215): marketplace update, plugin update,
+        // and the token-free `--config port=` migration for a host enrolled
+        // before that option existed.
+        XCTAssertEqual(calls.withLock { $0 }.count, 3)
         XCTAssertEqual(model.enrollmentStepStatuses.map(\.text), [
-            "Step 1 succeeded.", "Step 2 succeeded.",
+            "Step 1 succeeded.", "Step 2 succeeded.", "Step 3 succeeded.",
         ])
         XCTAssertEqual(model.enrollmentResultsAction, .updateRemotePlugin(hostID: hostID))
     }

--- a/Tests/localvoxtralTests/ClaudeRemoteEnrollmentServiceTests.swift
+++ b/Tests/localvoxtralTests/ClaudeRemoteEnrollmentServiceTests.swift
@@ -116,12 +116,18 @@ final class ClaudeRemoteEnrollmentServiceTests: XCTestCase {
             }
             let argument = String(rest[rest.startIndex...closing])
             let after = rest[rest.index(after: closing)...]
-            // The command may itself be wrapped in the ssh single-quoting, so a
-            // closing quote can be followed by the wrapper's own quote. What
-            // must NOT follow is anything else — `'port=1'token=…` is exactly
-            // the smuggling this assertion exists to reject.
+            // The command may itself be wrapped in the ssh single-quoting, so
+            // the closing quote can be followed by the wrapper's CLOSING quote
+            // — and by nothing else after that. Accepting any `'` was still too
+            // lax: shell concatenation makes `--config 'port=1''token=secret'`
+            // one argument, and the earlier check validated `'port=1'`, saw the
+            // next quote, and ignored the remainder (review finding,
+            // 2026-08-04). So a trailing quote is allowed only when it is the
+            // last thing on the line.
+            let tail: Substring = after.first == "'" ? after.dropFirst() : after
             XCTAssertTrue(
-                after.isEmpty || after.first == " " || after.first == "\n" || after.first == "'",
+                after.isEmpty || after.first == " " || after.first == "\n"
+                    || (after.first == "'" && (tail.isEmpty || tail.first == " " || tail.first == "\n")),
                 "a --config argument must END at its closing quote: \(text)"
             )
             let digits = argument.dropFirst("'\(key)=".count).dropLast()
@@ -131,6 +137,22 @@ final class ClaudeRemoteEnrollmentServiceTests: XCTestCase {
                 "the only config this path may write is a numeric port, got \(argument)",
                 line: line
             )
+        }
+    }
+
+    /// The anchoring above is load-bearing, so it gets its own test: these are
+    /// the exact shapes a prefix check (and then a lone-quote check) let past.
+    func testTheConfigArgumentCheckRejectsSmuggledExtras() {
+        let key = ClaudeRemoteEnrollmentService.portConfigKey
+        for smuggled in [
+            "ssh builder 'claude plugin install ref --config '\(key)=1'\(ClaudeRemoteEnrollmentService.tokenConfigKey)=secret''",
+            "ssh builder 'claude plugin install ref --config '\(key)=28511'garbage'",
+            "ssh builder 'claude plugin install ref --config '\(key)=28511x''",
+            "ssh builder 'claude plugin install ref --config 'token=secret''",
+        ] {
+            XCTExpectFailure("this shape must be rejected by the anchoring: \(smuggled)") {
+                assertEveryConfigArgumentIsThePort(in: smuggled)
+            }
         }
     }
 

--- a/Tests/localvoxtralTests/ClaudeRemoteEnrollmentServiceTests.swift
+++ b/Tests/localvoxtralTests/ClaudeRemoteEnrollmentServiceTests.swift
@@ -85,6 +85,128 @@ final class ClaudeRemoteEnrollmentServiceTests: XCTestCase {
         )
     }
 
+    // MARK: Per-Mac remote port (issue #215)
+
+    private func allocatedPlan(
+        alias: String = "builder",
+        remoteForwardPort: UInt16 = 28511
+    ) throws -> ClaudeRemoteEnrollmentService.SetupPlan {
+        try ClaudeRemoteEnrollmentService.plan(
+            host: host,
+            sshHostAlias: alias,
+            token: token,
+            listenerPort: ClaudeRemoteListenerLimits.default.port,
+            remoteForwardPort: remoteForwardPort
+        )
+    }
+
+    func testTheForwardBindsThisMacsPortRemotelyAndTheListenersPortLocally() throws {
+        // The two ports are NOT the same number any more, and confusing them is
+        // the whole bug: the remote side is per-Mac, the local side is where
+        // this app listens.
+        let snippet = try allocatedPlan().sshConfigSnippet
+        XCTAssertTrue(
+            snippet.contains("RemoteForward 28511 127.0.0.1:\(ClaudeRemoteListenerLimits.default.port)"),
+            snippet
+        )
+        XCTAssertFalse(snippet.contains("RemoteForward 8473"), "the shared bind is what #215 removes")
+    }
+
+    func testTheInstallCommandCarriesBothTheTokenAndTheMatchingPort() throws {
+        // Two halves of one setting. A block that forwards 28511 while the
+        // plugin still posts to 8473 fails open — the silent state this whole
+        // change exists to prevent — so they are emitted together, always.
+        let install = try XCTUnwrap(allocatedPlan().remoteCommands.last)
+        XCTAssertTrue(install.contains("--config '\(ClaudeRemoteEnrollmentService.tokenConfigKey)=\(token)'"))
+        XCTAssertTrue(install.contains("--config '\(ClaudeRemoteEnrollmentService.portConfigKey)=28511'"))
+        // Repeatable `--config` is documented by `claude plugin install --help`
+        // and verified on 2.1.220; a comma-joined single flag is NOT the syntax.
+        XCTAssertFalse(install.contains("token=\(token),"))
+    }
+
+    func testTheVerifyProbeChecksTheAllocatedPortAndNamesTheFix() throws {
+        let joined = try allocatedPlan().verifyCommands.joined(separator: "\n")
+        XCTAssertTrue(joined.contains("http://127.0.0.1:28511/v1/hook/SessionStart"))
+        XCTAssertTrue(
+            joined.contains(ClaudeRemoteForwardPort.forwardFailureSignature),
+            "with ExitOnForwardFailure no, this string is the ONLY evidence of a lost bind"
+        )
+        // A user reading this output must be told what to do, not handed an
+        // OpenSSH debug line.
+        XCTAssertTrue(
+            joined.contains(
+                ClaudeRemoteForwardPort.contentionMessage(port: 28511, host: "builder")
+            ),
+            joined
+        )
+        XCTAssertTrue(joined.lowercased().contains("no context from builder"))
+    }
+
+    func testTheUpdatePathMigratesAnAlreadyEnrolledHostToTheAllocatedPort() throws {
+        // A host enrolled before #215 has no `port` option at all, so its shim
+        // posts to 8473 while this Mac has moved. This line is the only fix
+        // that does not re-send a credential.
+        let runnable = try allocatedPlan().updateCommands.filter { !$0.hasPrefix("#") }
+        let migration = try XCTUnwrap(runnable.last)
+        XCTAssertTrue(migration.contains("--config '\(ClaudeRemoteEnrollmentService.portConfigKey)=28511'"))
+        XCTAssertFalse(migration.contains(token))
+        XCTAssertFalse(migration.contains("\(ClaudeRemoteEnrollmentService.tokenConfigKey)="))
+    }
+
+    func testRegeneratingReplacesAPreExistingLegacyBlockInPlace() throws {
+        // Migration on the config side: an install that already has the shared
+        // 8473 block must end up with ONE block on the allocated port — not two
+        // `Host builder` stanzas, where OpenSSH takes the first and the stale
+        // one silently wins.
+        let legacy = ClaudeRemoteEnrollmentService.applySSHConfigSnippet(
+            to: "Host other\n    HostName 10.0.0.9\n",
+            snippet: try plan().sshConfigSnippet,
+            hostID: host.id
+        )
+        XCTAssertTrue(legacy.contains("RemoteForward 8473 127.0.0.1:8473"))
+
+        let migrated = ClaudeRemoteEnrollmentService.applySSHConfigSnippet(
+            to: legacy,
+            snippet: try allocatedPlan().sshConfigSnippet,
+            hostID: host.id
+        )
+        XCTAssertTrue(migrated.contains("RemoteForward 28511 127.0.0.1:8473"))
+        XCTAssertFalse(migrated.contains("RemoteForward 8473"))
+        XCTAssertEqual(
+            migrated.components(separatedBy: "Host builder").count - 1, 1,
+            "a second stanza would let the stale block win by first-match"
+        )
+        XCTAssertTrue(migrated.contains("Host other"), "everything outside the block is untouched")
+
+        // And applying the migrated snippet again is a no-op, as before.
+        XCTAssertEqual(
+            ClaudeRemoteEnrollmentService.applySSHConfigSnippet(
+                to: migrated, snippet: try allocatedPlan().sshConfigSnippet, hostID: host.id
+            ),
+            migrated
+        )
+    }
+
+    func testNotesExplainTheTwoHalvesAndTheRemainingSingleTenancy() throws {
+        let notes = try allocatedPlan().notes.joined(separator: "\n")
+        XCTAssertTrue(notes.contains("28511"))
+        XCTAssertTrue(
+            notes.contains("`port` option"),
+            "the user must know the ssh block and the plugin option are one setting"
+        )
+        // Honesty about what per-Mac ports do NOT fix: one remote host stores
+        // one port, so it still talks to exactly one Mac.
+        XCTAssertTrue(notes.lowercased().contains("most recently installed"))
+    }
+
+    func testAPlanWithNoAllocationDescribesThePreFixSetup() throws {
+        // Existing enrollments keep working untouched: the default is the
+        // legacy shared port, so a caller that has not been taught about
+        // allocation still generates exactly what it generated before.
+        let snippet = try plan().sshConfigSnippet
+        XCTAssertTrue(snippet.contains("RemoteForward 8473 127.0.0.1:8473"))
+    }
+
     func testSSHSnippetNeverContainsTheToken() throws {
         // ~/.ssh/config gets copied between machines and pasted into issues. The
         // credential belongs to the plugin's userConfig on the remote, not here.
@@ -386,7 +508,17 @@ final class ClaudeRemoteEnrollmentServiceTests: XCTestCase {
     func testUpdateCommandsRefreshTheMarketplaceThenThePlugin() throws {
         let commands = try plan().updateCommands
         let runnable = commands.filter { !$0.hasPrefix("#") }
-        XCTAssertEqual(runnable.count, 2)
+        // Three since per-Mac ports (#215): the third writes only the port, for
+        // a host enrolled before the option existed. `plugin update` has no
+        // `--config` on 2.1.220, so it cannot be folded into the second.
+        XCTAssertEqual(runnable.count, 3)
+        XCTAssertTrue(
+            runnable[2].contains(
+                "claude plugin install \(ClaudeRemoteEnrollmentService.remotePluginReference) "
+                    + "--config '\(ClaudeRemoteEnrollmentService.portConfigKey)=8473'"
+            ),
+            "the migration line must set the port and nothing else: \(runnable[2])"
+        )
         XCTAssertTrue(runnable[0].hasPrefix("ssh builder '"))
         XCTAssertTrue(runnable[1].hasPrefix("ssh builder '"))
         XCTAssertTrue(
@@ -412,8 +544,19 @@ final class ClaudeRemoteEnrollmentServiceTests: XCTestCase {
         let commands = try plan().updateCommands
         for command in commands {
             XCTAssertFalse(command.contains(token))
-            XCTAssertFalse(command.contains("--config"))
             XCTAssertFalse(command.contains(ClaudeRemoteEnrollmentService.tokenConfigKey + "="))
+            // Not a blanket ban on `--config` any more: the port migration is a
+            // config write, and it is the whole point of this path since #215.
+            // Every `--config` on it must be the port one — that is a stricter
+            // statement than "no --config", not a looser one.
+            for range in command.ranges(of: "--config") {
+                XCTAssertTrue(
+                    command[range.lowerBound...].hasPrefix(
+                        "--config '\(ClaudeRemoteEnrollmentService.portConfigKey)="
+                    ),
+                    "an update may write the port and nothing else: \(command)"
+                )
+            }
         }
     }
 
@@ -792,7 +935,7 @@ final class ClaudeRemoteEnrollmentServiceTests: XCTestCase {
             try service.executeRemoteSetup(
                 ClaudeRemoteEnrollmentService.SetupPlan(
                     sshConfigSnippet: "",
-                    remoteCommands: ClaudeRemoteEnrollmentService.remoteCommands(token: token),
+                    remoteCommands: ClaudeRemoteEnrollmentService.remoteCommands(token: token, remoteForwardPort: 28511),
                     verifyCommands: [], updateCommands: [], uninstallCommands: [], notes: []
                 ),
                 sshHostAlias: "builder",
@@ -830,7 +973,7 @@ final class ClaudeRemoteEnrollmentServiceTests: XCTestCase {
             try service.executeRemoteSetup(
                 ClaudeRemoteEnrollmentService.SetupPlan(
                     sshConfigSnippet: "",
-                    remoteCommands: ClaudeRemoteEnrollmentService.remoteCommands(token: token),
+                    remoteCommands: ClaudeRemoteEnrollmentService.remoteCommands(token: token, remoteForwardPort: 28511),
                     verifyCommands: [], updateCommands: [], uninstallCommands: [], notes: []
                 ),
                 sshHostAlias: "builder",
@@ -903,10 +1046,12 @@ final class ClaudeRemoteEnrollmentServiceTests: XCTestCase {
             return .init(exitCode: 0, message: "")
         })
 
-        let steps = try service.executeRemotePluginUpdate(sshHostAlias: "builder")
+        let steps = try service.executeRemotePluginUpdate(
+            sshHostAlias: "builder", remoteForwardPort: 28500
+        )
 
         let recorded = calls.withLock { $0 }
-        XCTAssertEqual(steps.count, 2)
+        XCTAssertEqual(steps.count, 3)
         for invocation in recorded {
             XCTAssertEqual(
                 invocation.argv,
@@ -918,15 +1063,28 @@ final class ClaudeRemoteEnrollmentServiceTests: XCTestCase {
         }
         XCTAssertEqual(
             recorded.map { String(decoding: $0.standardInput, as: UTF8.self) },
-            ClaudeRemoteEnrollmentService.remotePluginUpdateCommands.map {
+            ClaudeRemoteEnrollmentService.remotePluginUpdateCommands(remoteForwardPort: 28500).map {
                 "set -eu\n\(ClaudeRemoteEnrollmentService.claudePathResolverPreamble)\($0)\n"
             }
         )
         // Nothing on this path has the credential, so nothing on it can spill
-        // one: no argv, no script, no captured step.
+        // one: no argv, no script, no captured step. The port migration DOES
+        // carry a `--config`, which is why this asserts the token specifically
+        // rather than banning the flag: `install --config port=` merges by key
+        // and leaves the stored token untouched (verified on Claude Code
+        // 2.1.220), so it is a config write with nothing secret in it.
         for invocation in recorded {
             XCTAssertFalse(invocation.argv.joined(separator: " ").contains("token"))
-            XCTAssertFalse(String(decoding: invocation.standardInput, as: UTF8.self).contains("--config"))
+            let script = String(decoding: invocation.standardInput, as: UTF8.self)
+            XCTAssertFalse(script.contains("\(ClaudeRemoteEnrollmentService.tokenConfigKey)="))
+            for range in script.ranges(of: "--config") {
+                XCTAssertTrue(
+                    script[range.lowerBound...].hasPrefix(
+                        "--config '\(ClaudeRemoteEnrollmentService.portConfigKey)="
+                    ),
+                    "the only config an update may write is the port"
+                )
+            }
         }
     }
 

--- a/Tests/localvoxtralTests/ClaudeRemoteEnrollmentServiceTests.swift
+++ b/Tests/localvoxtralTests/ClaudeRemoteEnrollmentServiceTests.swift
@@ -38,6 +38,17 @@ private final class MemorySSHConfigFileSystem: ClaudeRemoteSSHConfigFileSystem {
     }
 }
 
+enum ClaudeRemoteRemoteConfigStateFixture {
+    static func state(configText: String) -> ClaudeRemoteSSHConfigState {
+        ClaudeRemoteSSHConfigState(
+            directoryExists: true,
+            configData: Data(configText.utf8),
+            configPermissions: 0o600,
+            directoryPermissions: 0o700
+        )
+    }
+}
+
 final class ClaudeRemoteEnrollmentServiceTests: XCTestCase {
     private let host = ClaudeRemoteHost(
         id: "habc1234",
@@ -83,6 +94,44 @@ final class ClaudeRemoteEnrollmentServiceTests: XCTestCase {
             snippet.lowercased().contains("silent"),
             "the cost of `no` — a silently absent tunnel — must be stated where it is chosen"
         )
+    }
+
+    /// Asserts every `--config` in `text` is a COMPLETE `port=<digits>`
+    /// argument.
+    ///
+    /// Whole-token, not `hasPrefix`: a prefix check accepts
+    /// `--config 'port=28511'garbage` and, worse, `--config 'port=1'token=…`,
+    /// which is exactly the shape this assertion exists to forbid (review
+    /// finding, 2026-08-04). The token is matched to its closing quote and
+    /// then required to be followed by whitespace or end-of-string.
+    private func assertEveryConfigArgumentIsThePort(
+        in text: String, line: UInt = #line
+    ) {
+        let key = ClaudeRemoteEnrollmentService.portConfigKey
+        for range in text.ranges(of: "--config ") {
+            let rest = text[range.upperBound...]
+            guard let closing = rest.dropFirst().firstIndex(of: "'") else {
+                XCTFail("unterminated --config argument in: \(text)", line: line)
+                continue
+            }
+            let argument = String(rest[rest.startIndex...closing])
+            let after = rest[rest.index(after: closing)...]
+            // The command may itself be wrapped in the ssh single-quoting, so a
+            // closing quote can be followed by the wrapper's own quote. What
+            // must NOT follow is anything else — `'port=1'token=…` is exactly
+            // the smuggling this assertion exists to reject.
+            XCTAssertTrue(
+                after.isEmpty || after.first == " " || after.first == "\n" || after.first == "'",
+                "a --config argument must END at its closing quote: \(text)"
+            )
+            let digits = argument.dropFirst("'\(key)=".count).dropLast()
+            XCTAssertTrue(
+                argument.hasPrefix("'\(key)=") && !digits.isEmpty
+                    && digits.allSatisfy(\.isNumber),
+                "the only config this path may write is a numeric port, got \(argument)",
+                line: line
+            )
+        }
     }
 
     // MARK: Per-Mac remote port (issue #215)
@@ -132,14 +181,83 @@ final class ClaudeRemoteEnrollmentServiceTests: XCTestCase {
             "with ExitOnForwardFailure no, this string is the ONLY evidence of a lost bind"
         )
         // A user reading this output must be told what to do, not handed an
-        // OpenSSH debug line.
+        // OpenSSH debug line — and must not be told another machine took the
+        // port when the likeliest cause is their own second window.
         XCTAssertTrue(
             joined.contains(
                 ClaudeRemoteForwardPort.contentionMessage(port: 28511, host: "builder")
             ),
             joined
         )
-        XCTAssertTrue(joined.lowercased().contains("no context from builder"))
+        XCTAssertTrue(joined.contains("from THIS Mac, that is expected and healthy"))
+        XCTAssertTrue(joined.lowercased().contains("getting no context from it"))
+    }
+
+    func testTheForwardProbeDistinguishesConnectionFailureFromBindFailure() throws {
+        // Measured, not assumed (2026-08-04, OpenSSH 10.0p2 against a live
+        // sshd): a one-line grep for the forwarding warning is wrong at BOTH
+        // edges. This Mac's own live session holding the port makes a fresh
+        // probe fail to bind — ssh still exits 0 — so a grep calls a healthy
+        // setup contended. An unreachable host never requests a forward at
+        // all, so the grep finds nothing and a naive check calls it clean,
+        // while ssh exits 255. Exit status has to be read first.
+        let probe = try allocatedPlan().verifyCommands.first { $0.contains("ssh -v builder") }
+        let command = try XCTUnwrap(probe)
+        XCTAssertTrue(command.contains("rc=$?"), "the exit status is the first discriminator")
+        XCTAssertTrue(
+            command.contains("if [ $rc -ne 0 ]"),
+            "a connection that never happened must not be reported as a clean port"
+        )
+        XCTAssertTrue(command.contains("could not reach builder at all"))
+        XCTAssertTrue(command.contains(ClaudeRemoteForwardPort.forwardFailureSignature))
+        // The bind-failure branch must not accuse another machine when the
+        // likeliest cause is the user's own second window.
+        XCTAssertTrue(command.contains("from THIS Mac, that is expected and healthy"))
+        XCTAssertTrue(command.contains("forwards cleanly to this Mac"))
+        // Order: status check, then the warning, then success.
+        let statusIndex = try XCTUnwrap(command.range(of: "if [ $rc -ne 0 ]")).lowerBound
+        let warningIndex = try XCTUnwrap(
+            command.range(of: ClaudeRemoteForwardPort.forwardFailureSignature)
+        ).lowerBound
+        XCTAssertLessThan(statusIndex, warningIndex)
+    }
+
+    // MARK: SSH config forward state (review finding 1)
+
+    func testForwardStateReportsWhetherThisHostsBlockAlreadyCarriesThePort() throws {
+        let legacy = ClaudeRemoteEnrollmentService.applySSHConfigSnippet(
+            to: "", snippet: try plan().sshConfigSnippet, hostID: host.id
+        )
+        let filesystem = MemorySSHConfigFileSystem(
+            state: ClaudeRemoteRemoteConfigStateFixture.state(configText: legacy)
+        )
+        let service = ClaudeRemoteEnrollmentService(sshConfigFileSystem: filesystem)
+        XCTAssertEqual(service.sshConfigForwardsPort(8473, hostID: host.id), true)
+        XCTAssertEqual(
+            service.sshConfigForwardsPort(28511, hostID: host.id), false,
+            "a legacy block does not forward the allocated port, and saying it does is the split brain"
+        )
+        XCTAssertEqual(
+            service.sshConfigForwardsPort(28511, hostID: "hunknown"), false,
+            "no block at all is not a match either"
+        )
+    }
+
+    func testForwardStateIsUnknownWithoutAFilesystemSeamAndNeverGuessesTrue() throws {
+        // nil means cannot tell. Callers must regenerate on nil; a `true` here
+        // would let the plugin be pointed at a port nothing forwards.
+        XCTAssertNil(ClaudeRemoteEnrollmentService().sshConfigForwardsPort(28511, hostID: host.id))
+    }
+
+    func testForwardStateIgnoresARemoteForwardOutsideThisHostsBlock() throws {
+        // Someone else's `RemoteForward 28511` elsewhere in the config is not
+        // this host's block being current.
+        let foreign = "Host other\n    RemoteForward 28511 127.0.0.1:8473\n"
+        let filesystem = MemorySSHConfigFileSystem(
+            state: ClaudeRemoteRemoteConfigStateFixture.state(configText: foreign)
+        )
+        let service = ClaudeRemoteEnrollmentService(sshConfigFileSystem: filesystem)
+        XCTAssertEqual(service.sshConfigForwardsPort(28511, hostID: host.id), false)
     }
 
     func testTheUpdatePathMigratesAnAlreadyEnrolledHostToTheAllocatedPort() throws {
@@ -481,10 +599,12 @@ final class ClaudeRemoteEnrollmentServiceTests: XCTestCase {
         }
         // Field report 2026-07-26: the owner read healthy verify output as
         // broken. The commands themselves must say what their output means and
-        // survive a login shell that skips rc files.
+        // survive a login shell that skips rc files. Since 2026-08-04 the
+        // interpretation is emitted by the probe itself, per branch, rather
+        // than sitting in a comment above it.
         XCTAssertTrue(
-            joined.contains("EXPECTED while another live session"),
-            "the forward-failure line needs its interpretation next to it"
+            joined.contains("that is expected and healthy"),
+            "the forward-failure branch needs its interpretation in its own output"
         )
         XCTAssertTrue(
             joined.contains("401 = SUCCESS"),
@@ -549,14 +669,7 @@ final class ClaudeRemoteEnrollmentServiceTests: XCTestCase {
             // config write, and it is the whole point of this path since #215.
             // Every `--config` on it must be the port one — that is a stricter
             // statement than "no --config", not a looser one.
-            for range in command.ranges(of: "--config") {
-                XCTAssertTrue(
-                    command[range.lowerBound...].hasPrefix(
-                        "--config '\(ClaudeRemoteEnrollmentService.portConfigKey)="
-                    ),
-                    "an update may write the port and nothing else: \(command)"
-                )
-            }
+            assertEveryConfigArgumentIsThePort(in: command)
         }
     }
 
@@ -1077,14 +1190,7 @@ final class ClaudeRemoteEnrollmentServiceTests: XCTestCase {
             XCTAssertFalse(invocation.argv.joined(separator: " ").contains("token"))
             let script = String(decoding: invocation.standardInput, as: UTF8.self)
             XCTAssertFalse(script.contains("\(ClaudeRemoteEnrollmentService.tokenConfigKey)="))
-            for range in script.ranges(of: "--config") {
-                XCTAssertTrue(
-                    script[range.lowerBound...].hasPrefix(
-                        "--config '\(ClaudeRemoteEnrollmentService.portConfigKey)="
-                    ),
-                    "the only config an update may write is the port"
-                )
-            }
+            assertEveryConfigArgumentIsThePort(in: script)
         }
     }
 

--- a/Tests/localvoxtralTests/ClaudeRemoteForwardPortTests.swift
+++ b/Tests/localvoxtralTests/ClaudeRemoteForwardPortTests.swift
@@ -1,0 +1,157 @@
+import Foundation
+import Synchronization
+import XCTest
+@testable import localvoxtral
+
+/// The port is half of a two-sided configuration a human copies by hand: the
+/// ssh block here and the plugin's `port` option there. If the app ever
+/// recomputes a different answer than it printed, the two halves disagree and
+/// the hooks fail open — which looks exactly like nothing happening. So
+/// stability is not a nicety here, it is the contract.
+final class ClaudeRemoteForwardPortTests: XCTestCase {
+    private func defaults(_ name: String = #function) throws -> UserDefaults {
+        let suite = "ClaudeRemoteForwardPortTests.\(name).\(UUID().uuidString)"
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: suite))
+        addTeardownBlock { UserDefaults().removePersistentDomain(forName: suite) }
+        return defaults
+    }
+
+    // MARK: Derivation
+
+    func testTheSameIdentityAlwaysDerivesTheSamePort() {
+        let identity = "6A5E9F1C-0C2E-4D1F-9E3A-0A6E2A2B7C11"
+        let first = ClaudeRemoteForwardPort.port(forInstallIdentity: identity)
+        for _ in 0..<50 {
+            XCTAssertEqual(ClaudeRemoteForwardPort.port(forInstallIdentity: identity), first)
+        }
+    }
+
+    func testEveryDerivedPortLandsInsideTheDocumentedRange() {
+        for index in 0..<2000 {
+            let port = ClaudeRemoteForwardPort.port(forInstallIdentity: "install-\(index)")
+            XCTAssertGreaterThanOrEqual(port, ClaudeRemoteForwardPort.rangeLowerBound)
+            XCTAssertLessThanOrEqual(port, ClaudeRemoteForwardPort.rangeUpperBound)
+        }
+    }
+
+    func testTheRangeSitsBelowEveryDefaultEphemeralRangeAndAboveThePrivilegedOnes() {
+        // Below Linux's 32768 and macOS/BSD's 49152, so an outbound socket on
+        // the remote host can never be holding the port the forward wants;
+        // above 1023, so binding it needs no privilege.
+        XCTAssertGreaterThan(ClaudeRemoteForwardPort.rangeLowerBound, 1023)
+        XCTAssertLessThan(ClaudeRemoteForwardPort.rangeUpperBound, 32768)
+        XCTAssertEqual(
+            ClaudeRemoteForwardPort.rangeUpperBound - ClaudeRemoteForwardPort.rangeLowerBound + 1,
+            ClaudeRemoteForwardPort.portCount
+        )
+    }
+
+    func testDistinctIdentitiesSpreadAcrossTheRange() {
+        // Two Macs must be very unlikely to collide, and the derivation must
+        // not degenerate to one value. 100 slots, 500 identities: every slot
+        // should be hit by a sane hash.
+        let ports = Set((0..<500).map {
+            ClaudeRemoteForwardPort.port(forInstallIdentity: UUID(uuidString: String(
+                format: "00000000-0000-4000-8000-%012d", $0
+            ))?.uuidString ?? "identity-\($0)")
+        })
+        XCTAssertGreaterThan(ports.count, 80, "the derivation must use the whole range")
+    }
+
+    func testTheLegacyPortIsOutsideTheAllocationRange() {
+        // Otherwise a freshly allocated Mac could land on 8473 and be
+        // indistinguishable from an install that never migrated.
+        XCTAssertFalse(
+            (ClaudeRemoteForwardPort.rangeLowerBound...ClaudeRemoteForwardPort.rangeUpperBound)
+                .contains(ClaudeRemoteForwardPort.legacyPort)
+        )
+    }
+
+    func testAcceptableRangeMatchesTheShimsValidation() {
+        // The shim clamps to 1024–65535 and falls back to 8473 outside it; this
+        // constant is what the Swift side must agree with.
+        XCTAssertTrue(ClaudeRemoteForwardPort.isAcceptable(1024))
+        XCTAssertTrue(ClaudeRemoteForwardPort.isAcceptable(65535))
+        XCTAssertFalse(ClaudeRemoteForwardPort.isAcceptable(1023))
+        XCTAssertTrue(ClaudeRemoteForwardPort.isAcceptable(ClaudeRemoteForwardPort.legacyPort))
+    }
+
+    func testTheContentionMessageNamesThePortTheHostAndNoApostrophe() throws {
+        let message = ClaudeRemoteForwardPort.contentionMessage(port: 28500, host: "builder")
+        XCTAssertTrue(message.contains("28500"))
+        XCTAssertTrue(message.contains("builder"))
+        // It is embedded in single-quoted shell in the verify command; one
+        // apostrophe would end the quote and change what the user runs.
+        XCTAssertFalse(message.contains("'"))
+    }
+
+    // MARK: Allocator
+
+    func testTheIdentityIsGeneratedOnceAndThenReused() throws {
+        let defaults = try defaults()
+        let generated = Mutex(0)
+        let allocator = ClaudeRemoteForwardPortAllocator(
+            defaults: defaults,
+            makeIdentity: {
+                generated.withLock { $0 += 1 }
+                return "fixed-identity"
+            }
+        )
+
+        let first = allocator.allocatedPort()
+        let second = allocator.allocatedPort()
+        // A second allocator over the same defaults is what the next launch is.
+        let relaunched = ClaudeRemoteForwardPortAllocator(
+            defaults: defaults,
+            makeIdentity: { XCTFail("a persisted identity must never be regenerated"); return "x" }
+        )
+
+        XCTAssertEqual(first, second)
+        XCTAssertEqual(relaunched.allocatedPort(), first)
+        XCTAssertEqual(generated.withLock { $0 }, 1)
+        XCTAssertEqual(
+            defaults.string(forKey: ClaudeRemoteForwardPortAllocator.identityDefaultsKey),
+            "fixed-identity"
+        )
+    }
+
+    func testABlankStoredIdentityIsTreatedAsAbsent() throws {
+        // A half-written default must not pin every install that suffered it to
+        // one shared port — which is the exact failure this whole change exists
+        // to remove.
+        let defaults = try defaults()
+        defaults.set("   ", forKey: ClaudeRemoteForwardPortAllocator.identityDefaultsKey)
+        let allocator = ClaudeRemoteForwardPortAllocator(
+            defaults: defaults, makeIdentity: { "regenerated" }
+        )
+        XCTAssertEqual(allocator.installIdentity(), "regenerated")
+        XCTAssertEqual(
+            allocator.allocatedPort(),
+            ClaudeRemoteForwardPort.port(forInstallIdentity: "regenerated")
+        )
+    }
+
+    func testTwoInstallsOnOneMachineDoNotShareAPort() throws {
+        // The whole point of #215: two enrolled Macs must not both ask the
+        // remote for one bind. Distinct identities, distinct ports — this is
+        // the property, expressed on the two identities that would collide.
+        let a = ClaudeRemoteForwardPortAllocator(
+            defaults: try defaults("a"), makeIdentity: { "mac-a" }
+        )
+        let b = ClaudeRemoteForwardPortAllocator(
+            defaults: try defaults("b"), makeIdentity: { "mac-b" }
+        )
+        XCTAssertNotEqual(a.allocatedPort(), b.allocatedPort())
+    }
+
+    @MainActor
+    func testSettingsStoreExposesAStablePortForTheInstall() throws {
+        let defaults = try defaults()
+        let store = SettingsStore(defaults: defaults, environment: [:])
+        let port = store.claudeRemoteForwardPort
+        XCTAssertTrue(ClaudeRemoteForwardPort.isAcceptable(port))
+        XCTAssertEqual(store.claudeRemoteForwardPort, port)
+        // Same defaults domain, new store: the next launch of this install.
+        XCTAssertEqual(SettingsStore(defaults: defaults, environment: [:]).claudeRemoteForwardPort, port)
+    }
+}

--- a/Tests/localvoxtralTests/ClaudeRemoteForwardPortTests.swift
+++ b/Tests/localvoxtralTests/ClaudeRemoteForwardPortTests.swift
@@ -85,13 +85,153 @@ final class ClaudeRemoteForwardPortTests: XCTestCase {
         XCTAssertFalse(message.contains("'"))
     }
 
+    // MARK: Identity persistence (review finding 4)
+
+    /// An in-memory store with the one property that matters: `claim` is
+    /// first-writer-wins, like `link(2)`, not last-writer-wins like a
+    /// defaults write.
+    private final class MemoryIdentityStore: ClaudeRemoteForwardIdentityStore, @unchecked Sendable {
+        private let stored = Mutex<String?>(nil)
+        private let claims = Mutex(0)
+
+        var claimCount: Int { claims.withLock { $0 } }
+        var value: String? { stored.withLock { $0 } }
+
+        init(seed: String? = nil) { stored.withLock { $0 = seed } }
+
+        /// Blank is not an identity — same contract as the file store, which
+        /// returns nil for an empty or whitespace-only file. A fake that were
+        /// laxer here would let the allocator's own guard go untested.
+        func read() throws -> String? {
+            stored.withLock { value in
+                guard let value,
+                      !value.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+                else { return nil }
+                return value
+            }
+        }
+
+        func claim(_ candidate: String) throws -> String {
+            claims.withLock { $0 += 1 }
+            return stored.withLock { current in
+                if let existing = current,
+                   !existing.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+                {
+                    return existing
+                }
+                current = candidate
+                return candidate
+            }
+        }
+    }
+
+    private final class FailingIdentityStore: ClaudeRemoteForwardIdentityStore, @unchecked Sendable {
+        struct Denied: Error {}
+        func read() throws -> String? { nil }
+        func claim(_ candidate: String) throws -> String { throw Denied() }
+    }
+
+    func testTwoRacingFirstLaunchesConvergeOnOneIdentity() throws {
+        // The defaults-based version was a read-then-write with no atomicity:
+        // two processes starting together each generated an identity and the
+        // last writer won, so a host enrolled under the loser's port was wrong
+        // forever. First-writer-wins is the property; this is it, exercised
+        // through the seam.
+        let store = MemoryIdentityStore()
+        let first = ClaudeRemoteForwardPortAllocator(
+            store: store, legacyDefaults: nil, makeIdentity: { "racer-a" }
+        )
+        let second = ClaudeRemoteForwardPortAllocator(
+            store: store, legacyDefaults: nil, makeIdentity: { "racer-b" }
+        )
+
+        XCTAssertEqual(first.installIdentity(), "racer-a")
+        XCTAssertEqual(second.installIdentity(), "racer-a", "the loser must adopt the winner")
+        XCTAssertEqual(first.allocatedPort(), second.allocatedPort())
+    }
+
+    func testAnIdentityOutlivesAPreferencesReset() throws {
+        // `defaults delete`, a migration assistant, a restored backup: the host
+        // registry in Application Support survives all of them, and an identity
+        // that did not would silently move every enrolled host's port while the
+        // enrollments themselves looked healthy.
+        let store = MemoryIdentityStore()
+        let defaults = try defaults()
+        let allocator = ClaudeRemoteForwardPortAllocator(
+            store: store, legacyDefaults: defaults, makeIdentity: { "durable" }
+        )
+        let port = allocator.allocatedPort()
+
+        defaults.removePersistentDomain(forName: defaults.description)
+        let afterReset = ClaudeRemoteForwardPortAllocator(
+            store: store,
+            legacyDefaults: try self.defaults("fresh"),
+            makeIdentity: { XCTFail("a persisted identity must not be regenerated"); return "x" }
+        )
+        XCTAssertEqual(afterReset.allocatedPort(), port)
+    }
+
+    func testAnIdentityWrittenByTheFirstIterationMigratesInsteadOfMoving() throws {
+        // This feature's first iteration stored the identity in UserDefaults.
+        // An install that already has one must keep its port — it may already
+        // have handed that port to a remote host.
+        let defaults = try defaults()
+        defaults.set("legacy-identity", forKey: ClaudeRemoteForwardPortAllocator.identityDefaultsKey)
+        let store = MemoryIdentityStore()
+        let allocator = ClaudeRemoteForwardPortAllocator(
+            store: store, legacyDefaults: defaults, makeIdentity: { "freshly-generated" }
+        )
+
+        XCTAssertEqual(allocator.installIdentity(), "legacy-identity")
+        XCTAssertEqual(store.value, "legacy-identity", "and it must be durable from now on")
+        XCTAssertEqual(
+            allocator.allocatedPort(),
+            ClaudeRemoteForwardPort.port(forInstallIdentity: "legacy-identity")
+        )
+    }
+
+    func testTheFileStoreIsFirstWriterWinsAndPrivate() throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("lvx-identity-\(UUID().uuidString)")
+        let url = directory.appendingPathComponent("claude-remote-forward-identity")
+        addTeardownBlock { try? FileManager.default.removeItem(at: directory) }
+        let store = ClaudeRemoteForwardIdentityFileStore(fileURL: url)
+
+        XCTAssertNil(try store.read())
+        XCTAssertEqual(try store.claim("first"), "first")
+        // The second claim must NOT overwrite — that is the whole point of the
+        // link-based create, and the difference from a plain atomic write.
+        XCTAssertEqual(try store.claim("second"), "first")
+        XCTAssertEqual(try store.read(), "first")
+
+        let mode = try FileManager.default.attributesOfItem(atPath: url.path)[.posixPermissions]
+        XCTAssertEqual(mode as? NSNumber, 0o600)
+        // No temp files left behind next to it.
+        let leftovers = try FileManager.default.contentsOfDirectory(atPath: directory.path)
+            .filter { $0.hasPrefix(".claude-remote-forward-identity.") }
+        XCTAssertTrue(leftovers.isEmpty, "\(leftovers)")
+    }
+
+    func testAnUnwritableIdentityStoreStillYieldsAPortForThisLaunch() throws {
+        // Read-only home or a sandbox denial: the launch must still work (and
+        // log), rather than crash or hand back a port of zero.
+        let allocator = ClaudeRemoteForwardPortAllocator(
+            store: FailingIdentityStore(), legacyDefaults: nil, makeIdentity: { "ephemeral" }
+        )
+        XCTAssertEqual(
+            allocator.allocatedPort(),
+            ClaudeRemoteForwardPort.port(forInstallIdentity: "ephemeral")
+        )
+    }
+
     // MARK: Allocator
 
     func testTheIdentityIsGeneratedOnceAndThenReused() throws {
-        let defaults = try defaults()
+        let store = MemoryIdentityStore()
         let generated = Mutex(0)
         let allocator = ClaudeRemoteForwardPortAllocator(
-            defaults: defaults,
+            store: store,
+            legacyDefaults: nil,
             makeIdentity: {
                 generated.withLock { $0 += 1 }
                 return "fixed-identity"
@@ -100,29 +240,26 @@ final class ClaudeRemoteForwardPortTests: XCTestCase {
 
         let first = allocator.allocatedPort()
         let second = allocator.allocatedPort()
-        // A second allocator over the same defaults is what the next launch is.
+        // A second allocator over the same store is what the next launch is.
         let relaunched = ClaudeRemoteForwardPortAllocator(
-            defaults: defaults,
+            store: store,
+            legacyDefaults: nil,
             makeIdentity: { XCTFail("a persisted identity must never be regenerated"); return "x" }
         )
 
         XCTAssertEqual(first, second)
         XCTAssertEqual(relaunched.allocatedPort(), first)
         XCTAssertEqual(generated.withLock { $0 }, 1)
-        XCTAssertEqual(
-            defaults.string(forKey: ClaudeRemoteForwardPortAllocator.identityDefaultsKey),
-            "fixed-identity"
-        )
+        XCTAssertEqual(store.value, "fixed-identity")
     }
 
     func testABlankStoredIdentityIsTreatedAsAbsent() throws {
-        // A half-written default must not pin every install that suffered it to
-        // one shared port — which is the exact failure this whole change exists
-        // to remove.
-        let defaults = try defaults()
-        defaults.set("   ", forKey: ClaudeRemoteForwardPortAllocator.identityDefaultsKey)
+        // A half-written file must not pin every install that suffered it to
+        // one shared port — which is the exact failure this whole change
+        // exists to remove.
+        let store = MemoryIdentityStore(seed: "   ")
         let allocator = ClaudeRemoteForwardPortAllocator(
-            defaults: defaults, makeIdentity: { "regenerated" }
+            store: store, legacyDefaults: nil, makeIdentity: { "regenerated" }
         )
         XCTAssertEqual(allocator.installIdentity(), "regenerated")
         XCTAssertEqual(
@@ -136,22 +273,18 @@ final class ClaudeRemoteForwardPortTests: XCTestCase {
         // remote for one bind. Distinct identities, distinct ports — this is
         // the property, expressed on the two identities that would collide.
         let a = ClaudeRemoteForwardPortAllocator(
-            defaults: try defaults("a"), makeIdentity: { "mac-a" }
+            store: MemoryIdentityStore(), legacyDefaults: nil, makeIdentity: { "mac-a" }
         )
         let b = ClaudeRemoteForwardPortAllocator(
-            defaults: try defaults("b"), makeIdentity: { "mac-b" }
+            store: MemoryIdentityStore(), legacyDefaults: nil, makeIdentity: { "mac-b" }
         )
         XCTAssertNotEqual(a.allocatedPort(), b.allocatedPort())
     }
 
-    @MainActor
-    func testSettingsStoreExposesAStablePortForTheInstall() throws {
-        let defaults = try defaults()
-        let store = SettingsStore(defaults: defaults, environment: [:])
-        let port = store.claudeRemoteForwardPort
-        XCTAssertTrue(ClaudeRemoteForwardPort.isAcceptable(port))
-        XCTAssertEqual(store.claudeRemoteForwardPort, port)
-        // Same defaults domain, new store: the next launch of this install.
-        XCTAssertEqual(SettingsStore(defaults: defaults, environment: [:]).claudeRemoteForwardPort, port)
-    }
+    // `SettingsStore.claudeRemoteForwardPort` is deliberately NOT exercised
+    // here any more: since the identity moved out of UserDefaults and into a
+    // file beside the host registry (review finding 4), reading that property
+    // would create state in the real Application Support directory of whatever
+    // machine runs the suite. The allocator, the file store and the derivation
+    // are covered directly above; the accessor is a one-line call into them.
 }

--- a/Tests/localvoxtralTests/ClaudeRemoteForwardPortTests.swift
+++ b/Tests/localvoxtralTests/ClaudeRemoteForwardPortTests.swift
@@ -46,16 +46,45 @@ final class ClaudeRemoteForwardPortTests: XCTestCase {
         )
     }
 
-    func testDistinctIdentitiesSpreadAcrossTheRange() {
-        // Two Macs must be very unlikely to collide, and the derivation must
-        // not degenerate to one value. 100 slots, 500 identities: every slot
-        // should be hit by a sane hash.
-        let ports = Set((0..<500).map {
-            ClaudeRemoteForwardPort.port(forInstallIdentity: UUID(uuidString: String(
-                format: "00000000-0000-4000-8000-%012d", $0
-            ))?.uuidString ?? "identity-\($0)")
+    func testDistinctIdentitiesSpreadAcrossTheWholeWidenedRange() {
+        // This test was a v1 remnant: written for 100 slots, it demanded only
+        // ">80 distinct" and the OLD 100-slot implementation passed it
+        // unchanged — so it pinned nothing about the widening. Two properties
+        // now, both of which the old implementation fails:
+        //
+        //   1. the ports actually SPREAD over 2000 slots, not 100, and
+        //   2. the great majority land ABOVE 28572 — the old ceiling — which is
+        //      the single cheapest way to detect a silent revert to v1.
+        let ports = (0..<3000).map {
+            ClaudeRemoteForwardPort.port(forInstallIdentity: "install-\($0)")
+        }
+        let distinct = Set(ports)
+        XCTAssertGreaterThan(
+            distinct.count, 1400,
+            "3000 identities over 2000 slots should hit ~1550 of them; got \(distinct.count)"
+        )
+        let aboveOldCeiling = ports.filter { $0 > 28572 }.count
+        XCTAssertGreaterThan(
+            aboveOldCeiling, 2500,
+            "the old 100-slot range could not produce these at all; got \(aboveOldCeiling)"
+        )
+        XCTAssertTrue(ports.allSatisfy {
+            (ClaudeRemoteForwardPort.rangeLowerBound...ClaudeRemoteForwardPort.rangeUpperBound)
+                .contains($0)
         })
-        XCTAssertGreaterThan(ports.count, 80, "the derivation must use the whole range")
+    }
+
+    func testTheV2DerivationIsPinnedToExactValues() {
+        // Golden values. The derivation is a two-sided contract with text a
+        // user already pasted into ~/.ssh/config and into a remote plugin
+        // config, so it must not drift silently: a changed domain string, a
+        // changed fold width, or a reverted range all show up here as a
+        // different number. (The v1 answers for these identities were 28508,
+        // 28568, 28486 — inside the old 100-slot window, and nothing like
+        // these.)
+        XCTAssertEqual(ClaudeRemoteForwardPort.port(forInstallIdentity: "mac-a"), 28486)
+        XCTAssertEqual(ClaudeRemoteForwardPort.port(forInstallIdentity: "mac-b"), 28761)
+        XCTAssertEqual(ClaudeRemoteForwardPort.port(forInstallIdentity: "fixed-identity"), 29201)
     }
 
     func testTheLegacyPortIsOutsideTheAllocationRange() {

--- a/Tests/localvoxtralTests/ClaudeRemotePluginManifestTests.swift
+++ b/Tests/localvoxtralTests/ClaudeRemotePluginManifestTests.swift
@@ -137,6 +137,34 @@ final class ClaudeRemotePluginManifestTests: XCTestCase {
         XCTAssertEqual(token["sensitive"] as? Bool, true, "the token must be marked sensitive")
     }
 
+    func testPortUserConfigIsDeclaredAndIsNotSensitive() throws {
+        // Per-Mac allocation (#215) needs a second option, and it is the exact
+        // opposite of the token: a port number is not a secret, and marking it
+        // sensitive would hide the one value a user must be able to read back
+        // when the two halves of the tunnel disagree.
+        let userConfig = try XCTUnwrap(try manifest()["userConfig"] as? [String: Any])
+        let port = try XCTUnwrap(
+            userConfig[ClaudeRemoteEnrollmentService.portConfigKey] as? [String: Any]
+        )
+        XCTAssertEqual(port["type"] as? String, "string")
+        XCTAssertNotEqual(port["sensitive"] as? Bool, true)
+        XCTAssertNotNil(port["description"] as? String)
+        XCTAssertEqual(
+            port["default"] as? String, "",
+            "an empty default is what makes the shim fall back to the legacy port"
+        )
+    }
+
+    func testShimReadsThePortEnvVarMatchingTheDeclaredUserConfigKey() throws {
+        // Same contract as the token: Claude Code exposes userConfig to command
+        // hooks as CLAUDE_PLUGIN_OPTION_<KEY>, and a mismatch here is silent.
+        // Verified end to end on 2.1.220: a hook run under
+        // `--config port=28777` dialed http://127.0.0.1:28777/v1/hook/…
+        let expected = "CLAUDE_PLUGIN_OPTION_"
+            + ClaudeRemoteEnrollmentService.portConfigKey.uppercased()
+        XCTAssertTrue(try shimSource().contains(expected), "shim must read \(expected)")
+    }
+
     func testNoTokenValueIsBakedIntoTheManifest() throws {
         // The manifest and shim are public, in a public repo. The only token in
         // them is the env var reference; an actual credential would ship to
@@ -198,8 +226,11 @@ final class ClaudeRemotePluginManifestTests: XCTestCase {
         // their network in the clear. The URL lives in the shim now, so pin it
         // there — template plus the event argument each hook passes.
         let source = try shimSource()
-        let template = "http://127.0.0.1:\(ClaudeRemoteListenerLimits.default.port)"
-            + "\(ClaudeRemoteHTTPCodec.hookPathPrefix)$EVENT"
+        // The port is a validated variable since per-Mac allocation (#215); the
+        // ADDRESS is not, and never becomes one. `$PORT` is what the validation
+        // block above it produces, and the fallback it clamps to is asserted in
+        // `testShimFallsBackToTheLegacyPortWhenTheOptionIsAbsentOrJunk`.
+        let template = "http://127.0.0.1:$PORT\(ClaudeRemoteHTTPCodec.hookPathPrefix)$EVENT"
         XCTAssertTrue(
             source.contains("\"\(template)\""),
             "the shim must POST to the tunnelled loopback port on the per-event path"
@@ -496,9 +527,9 @@ final class ClaudeRemotePluginManifestTests: XCTestCase {
         let stub = stubDirectory.appendingPathComponent("curl")
         let script = """
         #!/bin/sh
-        [ -n "${FAKE_CURL_LOG:-}" ] && printf 'dial\\n' >>"$FAKE_CURL_LOG"
         out=""
         previous=""
+        url=""
         for argument in "$@"; do
           [ "$previous" = "--output" ] && out="$argument"
           if [ "$previous" = "--header" ] && [ -n "${FAKE_CURL_HEADER_DUMP:-}" ]; then
@@ -506,8 +537,13 @@ final class ClaudeRemotePluginManifestTests: XCTestCase {
             @*) cat "${argument#@}" >>"$FAKE_CURL_HEADER_DUMP" 2>/dev/null ;;
             esac
           fi
+          url="$argument"
           previous="$argument"
         done
+        # One line per invocation, carrying the URL: proves both THAT curl was
+        # dialed (or was not, during backoff) and WHERE — the per-Mac port is
+        # only real if it reaches the wire.
+        [ -n "${FAKE_CURL_LOG:-}" ] && printf '%s\\n' "$url" >>"$FAKE_CURL_LOG"
         cat >/dev/null
         [ -n "$out" ] && cp "$FAKE_CURL_BODY" "$out" 2>/dev/null
         printf '%s' "$FAKE_CURL_STATUS"
@@ -772,6 +808,80 @@ final class ClaudeRemotePluginManifestTests: XCTestCase {
             source.contains(">>\"$WORK/header\""),
             "env headers must be appended to the same private header file as the token"
         )
+    }
+
+    // MARK: Shim port selection (issue #215)
+    //
+    // The port arrives from plugin config on a machine we cannot see, and it is
+    // spliced into a URL. These tests RUN the shim and read the URL the stub
+    // curl was actually handed, because "the variable is referenced" is not the
+    // same statement as "the request went there".
+
+    /// Runs the shim with the given `port` config and returns every URL dialed.
+    private func dialedURLs(
+        port: String?,
+        event: String = "Stop"
+    ) throws -> [String] {
+        let logDirectory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("shim-port-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: logDirectory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: logDirectory) }
+        let log = logDirectory.appendingPathComponent("curl.log")
+        var environment = [
+            "FAKE_CURL_LOG": log.path,
+            // A private, empty stamp home: the backoff must not skip a dial and
+            // make an assertion about the URL vacuously true.
+            "XDG_RUNTIME_DIR": logDirectory.path,
+        ]
+        if let port { environment["CLAUDE_PLUGIN_OPTION_PORT"] = port }
+        let result = try runShimWithStubCurl(
+            event: event,
+            status: "200",
+            body: ClaudeRemoteHTTPCodec.markerResponseBody(marker: nil),
+            extraEnvironment: environment
+        )
+        XCTAssertEqual(result.exitCode, 0)
+        XCTAssertEqual(result.stderr, "", "port handling must stay silent on stderr")
+        guard let text = try? String(contentsOf: log, encoding: .utf8) else { return [] }
+        return text.split(separator: "\n").map(String.init)
+    }
+
+    func testShimDialsThePortItWasConfiguredWith() throws {
+        XCTAssertEqual(
+            try dialedURLs(port: "28511"),
+            ["http://127.0.0.1:28511\(ClaudeRemoteHTTPCodec.hookPathPrefix)Stop"]
+        )
+    }
+
+    func testShimFallsBackToTheLegacyPortWhenTheOptionIsAbsentOrJunk() throws {
+        let legacy = "http://127.0.0.1:\(ClaudeRemoteForwardPort.legacyPort)"
+            + "\(ClaudeRemoteHTTPCodec.hookPathPrefix)Stop"
+        // Absent is the pre-#215 install, and it must keep working exactly as
+        // it did. The rest is validation: a value that is not a plain,
+        // in-range, non-octal-looking port number must never reach the URL —
+        // `8473;evil` in a URL is a mangled request, `999999` in `[ … -lt … ]`
+        // is an oversized constant some shells refuse WITH OUTPUT ON STDERR,
+        // and a leading zero is read as octal by some `test` implementations.
+        for value in [nil, "", "abc", "28500x", "12 34", "-1", "0", "08473", "999999", "65536", "1023", "8473;evil"] {
+            XCTAssertEqual(
+                try dialedURLs(port: value), [legacy],
+                "port \(value.map { "\"\($0)\"" } ?? "<unset>") must clamp to the legacy port"
+            )
+        }
+    }
+
+    func testShimAcceptsTheEdgesOfTheDocumentedAcceptableRange() throws {
+        // The Swift side (`ClaudeRemoteForwardPort.acceptableRange`) and this
+        // shell validation are one rule written twice; these pin them together.
+        for port in [ClaudeRemoteForwardPort.acceptableRange.lowerBound,
+                     ClaudeRemoteForwardPort.rangeLowerBound,
+                     ClaudeRemoteForwardPort.rangeUpperBound,
+                     ClaudeRemoteForwardPort.acceptableRange.upperBound] {
+            XCTAssertEqual(
+                try dialedURLs(port: String(port)),
+                ["http://127.0.0.1:\(port)\(ClaudeRemoteHTTPCodec.hookPathPrefix)Stop"]
+            )
+        }
     }
 
     // MARK: Shim transport backoff
@@ -1094,7 +1204,12 @@ final class ClaudeRemotePluginManifestTests: XCTestCase {
     func testReadmeDocumentsTheTunnelAndTheInstallSide() throws {
         // Config/command directives are anchored to their own line; the install-
         // side caveat is prose, so it is pinned to a single line as wording.
-        try assertReadmeHasLine(equalTo: "RemoteForward 8473 127.0.0.1:8473")
+        // Per-Mac remote port (#215): the listen port is an example number the
+        // app generates, the target is always this Mac's listener.
+        try assertReadmeHasLine(
+            containing: "RemoteForward 28511 127.0.0.1:\(ClaudeRemoteListenerLimits.default.port)",
+            "the block must forward a per-Mac remote port to the app's listener port"
+        )
         try assertReadmeHasLine(
             equalTo: "claude plugin marketplace add "
                 + ClaudeRemoteEnrollmentService.repositoryMarketplaceReference,

--- a/integrations/claude-code/README.md
+++ b/integrations/claude-code/README.md
@@ -242,7 +242,7 @@ Each hook runs the plugin's bundled POSIX-sh shim (`hooks/post.sh`), which
 curls the hook's event JSON to `http://127.0.0.1:<your Mac's port>/v1/hook/<Event>`
 on the *remote* loopback; OpenSSH's `RemoteForward` carries that to your Mac's
 loopback port 8473, where the app is listening. That remote port is **allocated
-per Mac** (a stable number in 28473–28572, derived from a per-install identity)
+per Mac** (a stable number in 28473–30472, derived from a per-install identity)
 so two Macs enrolled against one host can never ask for the same bind — see
 "Two Macs, one host" below. The shim reads the token and the port from the
 `CLAUDE_PLUGIN_OPTION_TOKEN` / `CLAUDE_PLUGIN_OPTION_PORT` environment variables

--- a/integrations/claude-code/README.md
+++ b/integrations/claude-code/README.md
@@ -231,7 +231,7 @@ plugin installed on the wrong side fails open silently forever.
 remote host                            your Mac
 ┌───────────────────────┐              ┌────────────────────────────┐
 │ Claude Code           │              │ localvoxtral               │
-│   command hook (curl)►│ 127.0.0.1:8473              ▲             │
+│   command hook (curl)►│ 127.0.0.1:28511             ▲             │
 │   Bearer <token>      │   │          │              │             │
 └───────────────────────┘   │          │   ClaudeRemoteContextListener
                             └── ssh RemoteForward ────┘             │
@@ -239,11 +239,14 @@ remote host                            your Mac
 ```
 
 Each hook runs the plugin's bundled POSIX-sh shim (`hooks/post.sh`), which
-curls the hook's event JSON to `http://127.0.0.1:8473/v1/hook/<Event>` on the
-*remote* loopback; OpenSSH's `RemoteForward` carries that to your Mac's
-loopback, where the app is listening. The shim reads the token from the
-`CLAUDE_PLUGIN_OPTION_TOKEN` environment variable Claude Code injects into
-command-hook subprocesses, and passes it to curl through a private tempfile
+curls the hook's event JSON to `http://127.0.0.1:<your Mac's port>/v1/hook/<Event>`
+on the *remote* loopback; OpenSSH's `RemoteForward` carries that to your Mac's
+loopback port 8473, where the app is listening. That remote port is **allocated
+per Mac** (a stable number in 28473–28572, derived from a per-install identity)
+so two Macs enrolled against one host can never ask for the same bind — see
+"Two Macs, one host" below. The shim reads the token and the port from the
+`CLAUDE_PLUGIN_OPTION_TOKEN` / `CLAUDE_PLUGIN_OPTION_PORT` environment variables
+Claude Code injects into command-hook subprocesses, and passes it to curl through a private tempfile
 (`--header @file`) so it never appears in any process's argument list. It
 needs only `sh` and `curl` on the host, and fails open — silently, printing
 nothing — when either is missing, the token is unset, the tunnel is down, or
@@ -302,25 +305,35 @@ rotate — that is what rotation is for. Then:
 ```
 # BEGIN localvoxtral claude context (h1a2b3c4)
 Host builder
-    RemoteForward 8473 127.0.0.1:8473
+    RemoteForward 28511 127.0.0.1:8473
     ExitOnForwardFailure no
 # END localvoxtral claude context (h1a2b3c4)
 ```
 
+`28511` is an example — the app generates *your* Mac's number and puts it in
+both the block and the install command below. The two must always name the same
+port: change one alone and the hooks post into a port nothing forwards, which
+fails open, which looks exactly like nothing happening.
+
 `ExitOnForwardFailure no` is deliberate and is the default. With `yes`, SSH
-refuses to open the session at all when the remote's 8473 is already bound —
-usually by your own second window to the same host. **A dictation nicety must
+refuses to open the session at all when that port is already bound on the remote
+— now only by your own second window to the same host. **A dictation nicety must
 never cost you the shell.** The price of `no` is that a failed forward is
 silent: the hooks get connection refused, fail open, and you simply get no
-context. `ssh -v builder true 2>&1 | grep -i 'remote forward'` is where you see
-whether it took.
+context. This is where you see whether it took:
+
+```sh
+ssh -v builder true 2>&1 | grep -q 'remote port forwarding failed' \
+  && echo 'port 28511 is already held on builder' \
+  || echo 'port 28511 forwards cleanly'
+```
 
 **2. Install the plugin on the remote host:**
 
 ```sh
 ssh builder
 claude plugin marketplace add T0mSIlver/localvoxtral
- claude plugin install localvoxtral-remote@localvoxtral --config 'token=<YOUR-TOKEN>'
+ claude plugin install localvoxtral-remote@localvoxtral --config 'token=<YOUR-TOKEN>' --config 'port=28511'
 ```
 
 Note the leading space on the second line: with `HISTCONTROL=ignorespace` (bash)
@@ -340,7 +353,7 @@ claude plugin list
 # the tunnel is up and the app is answering. A connection error means the
 # forward did not take.
 curl -s -o /dev/null -w '%{http_code}\n' -X POST -H 'Content-Type: application/json' \
-  -d '{}' http://127.0.0.1:8473/v1/hook/SessionStart
+  -d '{}' http://127.0.0.1:28511/v1/hook/SessionStart
 ```
 
 ## Updating an enrolled host
@@ -361,6 +374,10 @@ preserves the stored config:
 ```sh
 ssh builder 'claude plugin marketplace update localvoxtral'
 ssh builder 'claude plugin update localvoxtral-remote@localvoxtral'
+# Only needed once, for a host enrolled before per-Mac ports existed — and
+# harmless every time after. `plugin update` has no `--config`, and `install`
+# merges config per key, so this sets the port without touching your token.
+ssh builder "claude plugin install localvoxtral-remote@localvoxtral --config 'port=28511'"
 ```
 
 Order matters: `plugin update` installs whatever the local marketplace clone
@@ -425,6 +442,17 @@ involving localvoxtral at all. Enrolling a host means trusting that host's user
 account to the extent it is already trusted. What the token bounds is what a
 host can do to *localvoxtral* (remote context only, never a local file read),
 not what a compromised account can do to itself.
+
+**Two Macs enrolled against one host.** Each Mac forwards its *own* port, so
+they cannot contend for one remote bind — which used to be a silent
+cross-delivery: the first connection kept the forward, the second connected
+anyway (`ExitOnForwardFailure no`) and every event on that host, bearer token
+included, went to the *first* Mac, which 401'd it, which the shim reads as a
+completed exchange. Nothing reported it (issue #215). What per-Mac ports do
+**not** change: one host runs one Claude Code install storing one `port`, so the
+most recently installed config is the Mac that receives events. The other one
+simply sees no traffic — visible single tenancy, not someone else's credential
+in someone else's listener.
 
 **A process on your Mac that squats 127.0.0.1:8473 before the app binds it.**
 Loopback ports are first-come, first-served on macOS; there is no ownership. A

--- a/integrations/claude-code/plugins/localvoxtral-remote/.claude-plugin/plugin.json
+++ b/integrations/claude-code/plugins/localvoxtral-remote/.claude-plugin/plugin.json
@@ -21,6 +21,13 @@
       "title": "localvoxtral host token",
       "description": "Per-host token issued by localvoxtral on your Mac (Enroll a remote host). It authorizes remote context only and can never make localvoxtral read a local file. Revoke or rotate it in the app at any time.",
       "default": ""
+    },
+    "port": {
+      "type": "string",
+      "sensitive": false,
+      "title": "Tunnel port on this host",
+      "description": "Loopback port on THIS host that localvoxtral's SSH RemoteForward binds — the app allocates one per Mac so two Macs enrolled here can never fight over the same bind. Copy the value from the enrollment plan; leaving it empty falls back to the legacy shared port 8473.",
+      "default": ""
     }
   }
 }

--- a/integrations/claude-code/plugins/localvoxtral-remote/hooks/post.sh
+++ b/integrations/claude-code/plugins/localvoxtral-remote/hooks/post.sh
@@ -46,11 +46,33 @@ TOKEN="${CLAUDE_PLUGIN_OPTION_TOKEN:-}"
 [ -n "$TOKEN" ] || fail_open
 command -v curl >/dev/null 2>&1 || fail_open
 
+# --- Listen port -------------------------------------------------------------
+# Which loopback port on THIS host the Mac's `RemoteForward` binds. It is a
+# per-Mac allocation (see ClaudeRemoteForwardPort): two Macs enrolled against
+# this host would otherwise both request 8473, where the FIRST connection wins
+# the bind forever and the second silently delivers this host's events — and
+# this host's Authorization header — to the wrong Mac (issue #215).
+#
+# Validated, never trusted: the value arrives from plugin config, and an
+# unvalidated one would be spliced into a URL. Digits only, no leading zero
+# (which `[` may read as octal, or refuse), at most 5 of them (so the range
+# test below can never see an oversized constant — the same hazard the backoff
+# stamp guards against), and inside the unprivileged range. Anything else falls
+# back to 8473, which is exactly what an install predating this option gets:
+# an old plugin config and an old ssh-config block keep working unchanged.
+PORT="${CLAUDE_PLUGIN_OPTION_PORT:-}"
+case "$PORT" in
+"" | *[!0-9]* | 0* | ??????*) PORT=8473 ;;
+*)
+  if [ "$PORT" -lt 1024 ] || [ "$PORT" -gt 65535 ]; then PORT=8473; fi
+  ;;
+esac
+
 # --- Transport backoff -------------------------------------------------------
 # The one noise no redirect in this file can reach: while an SSH session holds
 # the RemoteForward but localvoxtral is not running on the Mac, every dial
 # makes the ssh CLIENT — on the other machine — print
-# `connect_to 127.0.0.1 port 8473: failed.` straight onto
+# `connect_to 127.0.0.1 port <the Mac's listener port>: failed.` straight onto
 # the terminal, over whatever TUI is drawn there (a herdr pane, the Claude
 # Code screen), once per hook, dozens of times a turn via PostToolUse. The
 # only lever on this side is to stop dialing a tunnel that just proved dead:
@@ -187,7 +209,7 @@ STATUS="$(curl --silent --output "$WORK/body" --write-out '%{http_code}' \
   --header 'Content-Type: application/json' \
   --header @"$WORK/header" \
   --data-binary @- \
-  "http://127.0.0.1:8473/v1/hook/$EVENT" 2>/dev/null)" || STATUS=""
+  "http://127.0.0.1:$PORT/v1/hook/$EVENT" 2>/dev/null)" || STATUS=""
 
 # Arm the backoff on a transport-level failure (curl died: refused, reset,
 # timed out); clear it the moment ANY HTTP exchange completes — even a 401
@@ -212,7 +234,7 @@ fi
 # stdout is control JSON to Claude Code, and it cuts BOTH ways: a
 # UserPromptSubmit hook's non-JSON stdout is APPENDED TO THE USER'S PROMPT,
 # and valid JSON with the wrong keys (hookSpecificOutput.additionalContext)
-# would inject context. Whatever answered on 8473 — normally the tunnel to the
+# would inject context. Whatever answered on $PORT — normally the tunnel to the
 # app, but a squatter can bind that port first (see AGENTS.md) — its response
 # must never be able to put a byte into the prompt. So printing fails CLOSED,
 # the mirror image of delivery failing open: stdout is either one single small


### PR DESCRIPTION
Fixes #215.

## What

Two ssh connections that ask one host for the same `RemoteForward` port do not tie. The **first keeps the bind**, and the second connects anyway — our generated block sets `ExitOnForwardFailure no` deliberately, because a dictation nicety must never cost someone their shell. From that point every hook event on that host, **including the `Authorization: Bearer` header of the second Mac's enrollment**, is delivered to the *first* Mac's listener, which 401s it, which the shim treats as a completed exchange (it even clears the backoff). Nothing on either machine reports anything.

This makes that state unreachable by giving each Mac its own port on the remote side:

- **`ClaudeRemoteForwardPort`** (new) derives a stable port in **28473–28572** from a per-install identity persisted once. Pure function, domain-separated, versioned. The range sits below every default ephemeral range (Linux 32768–60999, macOS/BSD 49152–65535) so a forward bind cannot lose a race with an outbound socket on the host, and above the privileged ports.
- **Identity**: nothing stable per-install existed anywhere (checked the host registry, `SettingsStore`, the whole app — the only `UUID()`s are temp filenames). So: a UUID generated once and persisted under `settings.claude_remote_forward_identity`, exposed as `SettingsStore.claudeRemoteForwardPort`. **Not** in the host-registry file: deleting that file loses tokens and forces re-enrollment, but it must not silently *move* an enrolled host's port. Not a user-visible preference either — there is nothing to decide, and an editable identity is an editable port with no matching remote config.
- **Shim** (`post.sh`): reads `CLAUDE_PLUGIN_OPTION_PORT`, validates hard (digits only, no leading zero, at most 5 of them, then 1024–65535), falls back to **8473** otherwise. The edit is two localized hunks — one validation block near the top, one `$PORT` in the URL — to keep the conflict surface small for the parallel env-headers PR.
- **Plugin manifest**: version 1.2.0 → 1.3.0, new optional non-sensitive `port` userConfig (empty default = legacy port).
- **Enrollment** now emits both halves *together*, always: `RemoteForward <macPort> 127.0.0.1:8473`, and `plugin install --config 'token=…' --config 'port=…'`. The update path gains a third, **token-free** command that writes only the port — the migration for a host enrolled before this existed.
- **Detection**: the verify step greps `ssh -v` for `remote port forwarding failed` and prints the *fix* ("Another machine or stale connection holds port N on builder. Close that session…"), not an OpenSSH debug line. The curl probe targets the allocated port. `mac-crashlog.yml` now reports RemoteForward *listen ports* instead of counting `RemoteForward 8473` (a port number is not private; the target and alias still are not printed).

**Existing enrollments keep working, untouched.** The Mac-side listener stays on 8473, and every default in the new API is the legacy port, so an ssh block and a plugin config written before this change describe a setup that still works exactly as before. Migration happens when the user regenerates (rotate/enroll) or runs Update Plugin…, and the ssh block is replaced in place by the existing BEGIN/END delimiter machinery — no second `Host` stanza, which OpenSSH would resolve first-match-wins in favour of the stale one.

**What this does not fix, stated in the notes and the README:** one remote host runs one Claude Code install storing one `port`, so it talks to exactly one Mac. Two Macs enrolled against one host now means the most-recently-installed config receives events and the other simply sees no traffic — visible single tenancy, instead of one Mac silently receiving the other's events and credential.

## Claude Code plugin CLI — what was verified, and how

Empirically, on Claude Code **2.1.220**, in an isolated `CLAUDE_CONFIG_DIR` (nothing touched the real config):

1. **`--config` is repeatable, not comma-joined.** `claude plugin install --help` documents `--config <key=value>` as "(repeatable)". `install … --config token=PROBE-SECRET-123 --config port=28500` succeeded; the sensitive value landed in `.credentials.json` → `pluginSecrets`, the non-sensitive one in `settings.json` → `pluginConfigs.<ref>.options.port`.
2. **`install --config` merges per key on an already-installed plugin.** Re-running with **only** `--config port=28501` printed "already installed", left `token` untouched in `.credentials.json`, and replaced only `port`. This is what makes the migration line safe *and* token-free.
3. **`plugin update` has no `--config`** (`--help` shows only `-s/--scope`), which is why the port migration cannot be folded into it.
4. **The option actually reaches the shim.** With `--config port=28777` and a stub `curl` first on PATH, a real `claude -p` run's `UserPromptSubmit` hook dialed exactly `http://127.0.0.1:28777/v1/hook/UserPromptSubmit`. That is `CLAUDE_PLUGIN_OPTION_PORT` proven end to end, the same mechanism as the token.

## Proof

- [x] **Unit suite green** — `./scripts/remote-build.sh test`

```
Test Suite 'localvoxtralPackageTests.xctest' passed at 2026-08-04 01:20:16.128.
	 Executed 2195 tests, with 2 tests skipped and 0 failures (0 unexpected) in 79.537 (79.627) seconds
```

- [x] **Bug fix: regression tests added — failing before, passing after.**

Reverted *only* the behavioral fix (shim URL back to a hard-coded `:8473`; the ssh block back to forwarding the listener port; the install command back to token-only), keeping the new tests and API, then `./scripts/remote-build.sh test --filter Claude`:

```
Executed 814 tests, with 15 failures (0 unexpected) in 16.826 seconds

ClaudeIntegrationSettingsModelTests testEveryGeneratedArtifactUsesThisMacsAllocatedRemotePort
ClaudeRemoteEnrollmentServiceTests  testRegeneratingReplacesAPreExistingLegacyBlockInPlace
ClaudeRemoteEnrollmentServiceTests  testTheForwardBindsThisMacsPortRemotelyAndTheListenersPortLocally
ClaudeRemoteEnrollmentServiceTests  testTheInstallCommandCarriesBothTheTokenAndTheMatchingPort
ClaudeRemotePluginManifestTests     testShimAcceptsTheEdgesOfTheDocumentedAcceptableRange
ClaudeRemotePluginManifestTests     testShimDialsThePortItWasConfiguredWith
ClaudeRemotePluginManifestTests     testShimPostsToTheLoopbackListenerOnThePerEventPath
ClaudeRemotePluginManifestTests     testPluginShipsExactlyOneExecutableTheCurlShim   ← experiment artifact: my revert script left `.prefix-backup` files inside the plugin dir, which that test correctly rejects
```

Restored, same filter:

```
Test Suite 'Selected tests' passed at 2026-08-04 01:21:58.517.
	 Executed 814 tests, with 0 failures (0 unexpected) in 15.110 (15.147) seconds
```

The shim tests are not source greps: they RUN `post.sh` against a stub `curl` that records the URL it was handed, so "the request went to port N" is asserted, not "the variable is referenced". `testShimFallsBackToTheLegacyPortWhenTheOptionIsAbsentOrJunk` covers unset, empty, `abc`, `28500x`, `12 34`, `-1`, `0`, `08473`, `999999`, `65536`, `1023`, `8473;evil` — each must clamp to 8473 with nothing on stdout or stderr.

- [x] **Two existing assertions were tightened, not weakened** (called out explicitly for review):
  - `testUpdateCommandsNeverCarryTheToken` and the update-execution test banned `--config` outright as a proxy for "no credential". The port migration *is* a config write, so they now assert the real invariant — no token, no `token=`, and *every* `--config` on that path must be exactly `--config 'port=`. Strictly stronger than the blanket ban.
  - Two step-count assertions went 2 → 3 because the update path genuinely has a third command now.

- [x] **LLM lanes**: not required. This is delivery-channel machinery (ssh forward port, plugin config key, shell shim, diagnostics probe) — nothing here changes prompts, model pins, sampling, or anything that reaches the model. The path filter may still trigger on `Sources/localvoxtral/ClaudeContext/**`; that is fine, but the justification stands either way.

- [ ] UI change: none. The Settings pane renders the same rows; only the generated text inside them changes.


---

## Dual review round (codex + opencode) — dispositions

All six findings verified before acting. Commit `bf7e962`. Full suite after: **2206 tests, 2 skipped, 0 failures**.

### 1. BLOCKER (both reviewers) — VALID, fixed

"Update Plugin…" stored `port=285xx` on the remote but left this Mac's block on `RemoteForward 8473`. Since the allocation range excludes 8473, every legacy user who pressed that button got a guaranteed split brain: hooks posting to a port nothing forwards, failing open in silence — #215's failure class, reintroduced by the fix for #215. Both reviewers were right, and the tests were exactly as they described: each mutation was validated on its own, so nothing noticed they had come apart.

The two are now one action:

- `PluginUpdatePresentation` carries the regenerated `sshConfigSnippet` (nil only when the local block already forwards the allocated port — `ClaudeRemoteEnrollmentService.sshConfigForwardsPort`, where "cannot tell" means regenerate, never "fine").
- The confirmation repeats **both** mutations verbatim, numbered, in the order they run — the one-click rule does not get weaker because an action has two halves.
- Execution writes the **local block first** and touches the remote only if that succeeded. Order is the safety property: reversed, a refused local write (symlinked config, untrusted `~/.ssh`) would leave the plugin pointed at a port this Mac does not forward. This way the worst case is "nothing changed anywhere, with an error on screen".

Pinned by three tests that drive the real flow: `testUpdatingALegacyHostRewritesTheSSHBlockAndTheRemotePortTogether` (legacy 8473 block + `Host unrelated` neighbour in the file → asserts the rewritten block forwards 28542, the stale line is gone, there is exactly one `Host builder` stanza, the neighbour is untouched, **and** the executed script carries `--config 'port=28542'`), `testAHostWhoseBlockIsAlreadyCurrentIsNotRewritten`, and `testARefusedLocalWriteLeavesTheRemoteCompletelyUntouched` (symlinked config → zero ssh invocations, alert raised).

### 2. MAJOR (codex) — accepted, range widened

28473–**30472**, 2000 slots. Birthday collision drops from ~1% / ~37% (2 / 10 Macs) to ~0.05% / ~2.2%. Still below Linux's 32768 ephemeral floor, still excludes 8473. Derivation domain bumped to `v2` so existing identities deterministically re-derive rather than staying clustered in the old first 100 slots — **safe precisely because nothing has shipped**: no `~/.ssh/config` block and no remote plugin config exists in the world carrying a v1 port. The fold now takes 32 bits of the digest instead of 16 (16 bits over 2000 slots skews the low slots ~3%).

### 3. MAJOR (codex) vs opencode DISPUTE — **codex is right; opencode is wrong.** Measured, not argued

Ran the generated probe against a **real sshd** (throwaway instance on port 2222, own host key and authorized_keys under /tmp; OpenSSH 10.0p2, 2026-08-04):

```
=== 0. baseline: nothing holds 29999 ===
debug1: remote forward success for: listen 29999, connect 127.0.0.1:8473

=== 1. THIS Mac's own live session now holds 29999 ===
--- the probe this PR generates, verbatim shape:
localvoxtral: Another machine or stale connection holds port 29999 on lvxprobe.     ← FALSE POSITIVE
--- what ssh actually printed:
debug1: remote forward failure for: listen 29999, connect 127.0.0.1:8473
Warning: remote port forwarding failed for listen port 29999
--- exit status of that ssh:
    0

=== 2. host unreachable (connection-level failure, no bind attempt) ===
--- the probe this PR generates:
localvoxtral: port 29999 forwards cleanly to this Mac.                              ← FALSE NEGATIVE
--- what ssh actually printed (tail):
ssh: connect to host 127.0.0.1 port 65001: Connection refused
--- exit status of that ssh:
    255

=== 3. healthy, nothing holding it ===
localvoxtral: port 29999 forwards cleanly to this Mac.
    exit status: 0
```

Both defects reproduce exactly as codex described. The discriminators are also in that transcript: **exit status** separates a connection that never happened (255) from one that did (0), and the warning separates a refused bind from a clean one. The probe is now three-branch — status first, warning second — and its bind-failure wording names the likeliest cause before accusing anyone:

> port 28511 is already bound on builder. If you have another session open to builder from THIS Mac, that is expected and healthy — the first one keeps the forward. If you do not, another machine or stale connection holds port 28511 on builder, and this Mac is getting no context from it.

Pinned by `testTheForwardProbeDistinguishesConnectionFailureFromBindFailure` (asserts `rc=$?`, the status branch preceding the warning branch, and each branch's text).

### 4. MAJOR (codex) — VALID, fixed

The identity now lives in a **0600 file beside the host registry** (`ClaudeRemoteForwardIdentityFileStore`), claimed with `link(2)` — which fails EEXIST rather than overwriting, so racing first launches converge on whichever file appeared first instead of last-writer-wins. Any value written by this PR's earlier `UserDefaults` iteration is **migrated in**, not replaced (an install may already have handed that port to a remote host). A preferences reset can no longer move an enrolled host's port while the enrollment that used it survives — same directory as the host registry, same fate.

Tests: `testTwoRacingFirstLaunchesConvergeOnOneIdentity`, `testAnIdentityOutlivesAPreferencesReset`, `testAnIdentityWrittenByTheFirstIterationMigratesInsteadOfMoving`, `testTheFileStoreIsFirstWriterWinsAndPrivate` (asserts second claim does not overwrite, 0600 mode, no temp files left behind), `testAnUnwritableIdentityStoreStillYieldsAPortForThisLaunch`.

### 5. MAJOR (codex) — VALID, fixed

The probe printed `$2` of **every** user `RemoteForward` line into a public Actions log. It now walks only lines **between this app's BEGIN/END markers** and prints only a numeric listen-port field; anything non-numeric is dropped rather than echoed.

### 6. MINOR (codex; opencode disputes) — done regardless

The assertion was prefix-based, so `--config 'port=28511'garbage` (and worse, `--config 'port=1'token=…`) passed. It now matches the complete argument to its closing quote and requires whitespace, end-of-string, or the enclosing ssh quote to follow.

### Note on one existing test that had to move with the code

`testPluginUpdateRunsOnlyAfterAnExplicitConfirmation` asserted the confirmation preview equalled the commands alone. It now asserts the preview equals `updatePreview(for:)` **and still contains every command verbatim** — because the action genuinely has two halves now. Several plugin-update tests also gained an injected ssh-config filesystem: without one the flow correctly refuses before touching the remote, which is itself pinned by finding 1's third test.


---

## Review round 2 (scoped codex verification of `bf7e962`) — dispositions

Verdict was REMAINING WORK: findings 3, 4 and 5 confirmed fixed with no new defects, the blocker only half fixed, plus two test remnants. Commit `cfedad8`. Suite after: **2211 tests, 2 skipped, 0 failures**. CI on `bf7e962` was green (dispatched run `30866844370`).

### 1. BLOCKER — the other half. Valid, fixed

Codex was right, and the distinction is the one that matters: the *executable* path was correct (ssh block written first, remote only on success), but the update **panel displayed and copied only `update.commands`**. That is the split brain again on precisely the routes a legacy user takes:

- a host enrolled before aliases were recorded is **copy-only forever** (`canRun == false`), and
- the symlink refusal explicitly tells the user to use that same Copy button.

Either one would have updated the remote port and left this Mac on `RemoteForward 8473` — the original #215 failure, reachable by the users most likely to be on a legacy block.

The rendering now lives in one place: `PluginUpdatePresentation.applicationText`, numbered in the order the two mutations must be applied, used by **all three** surfaces — the panel text, the Copy payload, and the confirmation preview (`updatePreview(for:)` delegates to it). Three call sites that "should stay in sync" is exactly what produced this bug; one source is the fix. The copy-only footer now says to apply both steps, ssh block first.

Pinned by three tests:

- `testTheCopyPayloadForAnAliaslessHostCarriesTheSSHBlockToo` — asserts `canRun == false`, that the payload contains `RemoteForward 28542 127.0.0.1:8473` **and** `--config 'port=28542'`, that the block comes **before** the commands, and that it names `~/.ssh/config`.
- `testTheCopyPayloadAfterASymlinkRefusalStillCarriesTheSSHBlock` — drives the real refusal (symlinked config → zero ssh invocations), then asserts what the still-open panel offers to copy is the whole job.
- `testThePanelTheConfirmationAndTheCopyAllShowTheSameText` — pins the three surfaces to one string, so they cannot drift apart again.

### 2. MINOR — v1 distribution remnant. Valid, fixed

Codex was right that the old implementation still passed it: 500 identities, `> 80 distinct`, written for 100 slots. Replaced with two properties v1 **fails**: 3000 identities must yield > 1400 distinct ports (actual ≈ 1547 over 2000 slots), and > 2500 of them must land **above 28572** — the old ceiling, which a 100-slot v1 cannot produce at all (actual 2856). Added `testTheV2DerivationIsPinnedToExactValues` with golden values (`mac-a` → 28486, `mac-b` → 28761, `fixed-identity` → 29201; the v1 answers were 28508 / 28568 / 28486), so the domain string, the fold width and the range cannot drift silently under a two-sided contract the user has already pasted into two files.

### 3. MINOR — anchoring still incomplete. Valid, fixed

Codex was right: accepting any suffix beginning with `'` let shell concatenation through, because `--config 'port=1''token=secret'` validates `'port=1'`, sees the following quote, and ignores the rest. A trailing quote is now accepted only when it is the **last thing on the line** (the lone outer wrapper). Added `testTheConfigArgumentCheckRejectsSmuggledExtras`, which asserts — via `XCTExpectFailure` — that all four shapes are rejected: `'port=1''token=secret'`, `'port=28511'garbage'`, `'port=28511x'`, and `'token=secret'`.

### Also confirmed this round

The earlier unnamed red on #221 did **not** reproduce: its re-run (`30866755165`) is green. The failing name was structurally unrecoverable from the runner's log tail — that tail covers only suites `TextMergingAlgorithms`…`WebSocketClientParsing`, so anything in A–S is invisible, which includes the known `testStopHonorsTERMWithoutRestarting` trap-install flake that fires under shared-host load (three agents were on the Mac at the time). Attributed there per the standing guidance; not chasing further unless it recurs.
