### PR TITLE
Join Claude Code sessions running inside a REMOTE herdr, over an app-managed ssh -L

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -564,8 +564,12 @@ Key subsystems:
     is herdr-or-nothing: no
     marker fallback, because a lingering title marker could only mis-join.
     The hook publishes `HERDR_PANE_ID`/`HERDR_SOCKET_PATH` from the pane env;
-    `HerdrSocketClient` (hand-written, read-only — herdr is AGPL, never vendor
-    its code) asks that one socket for the focused pane and the join is exact
+    `HerdrSocketClient` (hand-written and READ-ONLY — only `pane.current`,
+    `pane.process_info`, `pane.read` are ever sent. herdr was AGPL when this
+    was written and is Apache-2.0 since v0.8.0, repo `herdrdev/herdr`, so its
+    docs and source are freely readable; the client stays hand-written anyway,
+    because a vendored dependency would be a second implementation of the trust
+    rules) asks that one socket for the focused pane and the join is exact
     pane-id equality (`resolve(herdrPaneID:)`, local sessions only), guarded
     by two fail-closed cross-checks: herdr's own `agent_session` claim must
     not disagree, and the registered Claude pid must be in the pane's
@@ -578,8 +582,10 @@ Key subsystems:
     the joined pane (`SocketPaneScreenContext`, shared with cmux), fetched at
     start and stop
     behind the same consent gate and sanitize/cap pipeline as an AX read;
-    `pane.read` fires only after the herdrPane join resolved and never for
-    any other pane or mechanism. On any pane.read failure the session falls
+    `pane.read` fires only after a herdr join (local or remote) resolved, and
+    only ever for THAT join's pane — the request is keyed by the binding the
+    arm captured at resolution, so no other pane and no other mechanism can
+    reach a herdr socket through it. On any pane.read failure the session falls
     back to the pre-existing behavior — composite AX text, vocabulary-only,
     nothing attached.
   - cmux (github.com/manaflow-ai/cmux — a native Swift/AppKit terminal on
@@ -647,6 +653,128 @@ Key subsystems:
     cmux exposes no AX text at all, so the join never authorizes raw AX
     attachment and its screen context is `surface.read_text` through the same
     `SocketPaneScreenContext` gate as herdr's `pane.read`.
+  - A herdr running on an ENROLLED REMOTE host is its own arm
+    (`.remoteHerdrPane`), tried only after every local arm declined, and it
+    reaches that herdr over an app-managed, on-demand `ssh -L`
+    (`ClaudeRemoteHerdrForward`) opened at dictation start and closed when the
+    dictation is done with it. The bindings, ALL required, in cost order so an
+    ordinary ssh session never pays for a tunnel:
+    (1) the focused surface's own TTY hosts a FOREGROUND `ssh` session whose
+    destination is exactly one enrolled host's alias. `SSHDestinationTTYProbe`
+    is deliberately paranoid here, because every way an argv can name one host
+    while the connection goes elsewhere is a mis-join: it verifies the
+    EXECUTABLE against three EXACT absolute paths (`/usr/bin/ssh` and
+    Homebrew's two `bin/ssh`, via `proc_pidpath` — not `p_comm`, not argv[0],
+    and never by directory prefix, since `/opt/homebrew` and `/usr/local` are
+    user-writable and a prefix rule trusted `/opt/homebrew/tmp/ssh`; a symlink
+    target is accepted only when resolving a canonical path produces exactly
+    it, its basename is `ssh`, and it stays inside that canonical path's own
+    installation root — anyone who can repoint that symlink already controls
+    what the user's own `ssh` runs, so this is defense-in-depth, not a
+    privilege boundary), requires the
+    process to be in its terminal's foreground process group (so a stopped ssh,
+    a background one, or `scp`/`rsync`'s helper is not mistaken for the screen),
+    and ABSTAINS on `-o`/`-F`/`-O`/`-S`/`-N`/`-f`/`-M`/`-D`/`-W`/`-w` rather
+    than skipping them — `ssh -o HostName=other builder` must never answer
+    `builder`;
+    (2) THIS TERMINAL holds the ONLY ssh connection to that destination on the
+    machine (a `KERN_PROC_ALL` scan). Host-level binding alone was a mis-join:
+    with a plain shell to `builder` in one window and a herdr on `builder` in
+    another, both surfaces answer "ssh to builder" and every remaining check is
+    about the REMOTE side, so the plain shell would join the other window's
+    session. A remote command that IS herdr (first argv token, by basename) is
+    recorded as corroboration but NEVER substitutes for uniqueness — argv is
+    written by whoever launched the process, and treating it as sufficient let
+    `ssh host sh -lc 'printf herdr; exec claude'` claim to be a herdr
+    connection;
+    (3) that host has live remote sessions reporting a herdr pane, all from ONE
+    herdr socket (`liveRemoteHerdrSessions(hostID:)`, the mirror of the local
+    single-socket rule). The count that matters is SOCKETS, not sessions:
+    several live sessions on one herdr are expected and fine — panes are what a
+    multiplexer is for, and serving that workflow is the point of this arm — so
+    only two herdr SERVERS leave the surface ambiguous;
+    (4) over the forward, exactly ONE of those candidates claims that herdr's
+    FOCUSED pane id (two candidates claiming the same pane id abstain), and that
+    pane's captured `terminal_title` carries exactly that session's
+    broker-allocated marker;
+    (5) herdr's own `agent_session` claim for the pane does not disagree, and
+    the pane is running that session's agent.
+    Herdr-or-nothing begins at CONFIRMATION, not before: everything up to and
+    including step 4 falls THROUGH to the title marker on failure, and only
+    steps after it abstain. Registry candidates existing on the host is not a
+    binding for this connection — a detached herdr, or one whose sessions are
+    merely still inside their TTL, would otherwise cost a sole plain ssh session
+    the outer marker join it has always had. Once the pane id AND our own
+    broker-allocated marker both match, the connection IS displaying that
+    session, and from there a marker in the outer window could only describe
+    something else, so a later fail-closed refusal joins nothing at all. The
+    residual: while the arm has not confirmed, a marker left in the outer title
+    by a pre-herdr session on the same host can still win — exactly the behavior
+    that predates this arm.
+    Note WHY the marker works here and not locally: herdr captures an inner
+    pane's OSC 2 into `PaneInfo.terminal_title`, and the remote listener
+    already returns a marker to every remote session unconditionally — so the
+    marker is sitting in the joined pane's title, invisible to the outer
+    terminal. The `agent_session` cross-check is fail-closed exactly like the
+    local arm's and is what catches a REUSED pane (a session that died without
+    a SessionEnd leaves a live entry, its marker and its pane id behind).
+    The foreground check takes EITHER a `hookParentPID` (the shim's `$PPID`,
+    compared as a STRING — a remote pid is another machine's number) or a
+    process named for the agent; requiring both would fail closed forever on
+    two ordinary installs (Claude Code spawns hooks through a shell, so `$PPID`
+    is often that shell, and an npm install appears as `node`).
+    The tunnel is owned by `DictationViewModel`, never by the join value that
+    travels: the commit path CONSUMES the join, so an owner reaching the child
+    through `claudeSessionJoin` was nil at exactly the moments that mattered
+    (quit during polish, an aborted connect) and the ssh outlived the app.
+  - **The remote herdr forward is a trust inversion, and it is bounded by what
+    we SEND, not by what the socket allows.** herdr's JSON socket is
+    full-control: over that same forwarded stream one could create panes, write
+    keystrokes into them, kill them. We dial OUT to it and send only
+    `pane.current` / `pane.process_info` / `pane.read`, and that restraint —
+    plus the one client in the codebase being hand-written — is the whole
+    boundary. In exchange, `ClaudeRemoteSessionEnvironment.herdrSocketPath`
+    stays what PR #216 made it: a label that is NEVER handed to `FileManager`,
+    never `stat`ed, never dialed locally. Its one and only use is as an argv
+    token for `ssh`, resolved on the host that named it, after re-validation
+    (absolute, no `:` — that would re-split the `-L` spec — and PR #216's
+    header charset). The argv deliberately omits two options an earlier design
+    called for, both falsified against OpenSSH 10.0: `ClearAllForwardings=yes`
+    clears command-line forwardings too and deletes the very `-L` (measured: no
+    socket ever appears), and `ExitOnForwardFailure=yes` turns the enrolled
+    host's own `RemoteForward` — normally already held by the user's live
+    session — into a fatal error for this connection (measured: ssh exits).
+    Readiness is a bounded connect-poll of the local socket instead, on an
+    injected clock, with a ~2 s ceiling that is a dictation-start latency
+    budget as much as a correctness one. The RESIDUAL of dropping them: this
+    short-lived connection still requests whatever forwards the alias's own
+    `Host` block declares, including the enrollment `RemoteForward` — since
+    #217 that is this Mac's own port, so a collision with the user's live
+    session is a warning on a stderr we send to `/dev/null`, not a failure.
+    Three options ARE forced, because the alias's config would otherwise reach
+    into this child: `ControlPath=none` (so the forward belongs to our own
+    process and killing it IS the teardown, at the cost of one handshake per
+    dictation), `ForkAfterAuthentication=no` (a detached ssh is an orphan we
+    can neither observe nor kill), and `PermitLocalCommand=no` (a dictation
+    must not be able to trigger `LocalCommand` on this machine). Teardown
+    signals the process GROUP — the child is spawned as its own group leader
+    via `posix_spawn`'s `POSIX_SPAWN_SETPGROUP`, so `kill(-pgid)` can only ever
+    reach our own ssh and its descendants — and it ends with an UNCONDITIONAL
+    group SIGKILL. We observe only the leader, so its exit satisfies the
+    bounded wait while a descendant that ignored SIGTERM is still holding the
+    tunnel; gating that final kill on leader liveness (as the first version
+    did) suppressed exactly the signal that clears it. The pairing rule that
+    makes "unconditional" safe: the exit handler does NOT reap. A pid — and
+    with it the pgid — is reserved only while the child is unreaped, so the
+    zombie is what keeps `-pid` meaning OUR group; teardown signals first and
+    reaps last, and once reaped NOTHING may signal that group again (a tunnel
+    that exits by itself mid-dictation is closed at stop time seconds later,
+    which is exactly when a reused pid would be someone else's). Cost: one
+    zombie per open forward, for the life of one dictation.
+    A remote herdr join authorizes no more than a local one: never the raw AX
+    capture (that grid is the composite herdr TUI, on someone else's machine),
+    and never local repo collection — the origin is remote, so
+    `localWorkspacePath` is nil by type.
   - Screen capture is split by ROUTE (`TerminalScreenAllowlist`): raw AX grid
     capture remains Ghostty-only (its single-`AXTextArea` grid is verified;
     iTerm2's AX tree is ambiguous across splits, Terminal.app's unverified).
@@ -721,9 +849,13 @@ Key subsystems:
   cannot reach `resolve(tty:)`, `resolve(herdrPaneID:)`, or
   `liveLocalHerdrSocketPaths()` — the local-only arms all read `process`. A
   remote `HERDR_SOCKET_PATH` is a label, not a socket `HerdrSocketClient` may
-  dial (its guard still requires a local socket owned by `getuid()`), and
+  dial (its guard still requires a local socket owned by `getuid()`) — the
+  remote herdr arm reaches it only by handing it to `ssh -L` as a forward
+  target, so the path is resolved on the host that named it and the socket the
+  client actually dials is the LOCAL end our own child created. And
   `hookParentPID` is a String on purpose: a pid in another host's namespace is
-  not a number this process may probe.
+  not a number this process may probe, only a label to compare against another
+  label.
 - **Remote enrollment execution is opt-in, preview-first, and keeps the token
   out of process arguments.** `ClaudeRemoteEnrollmentService` generates a
   copyable plan (idempotent ssh config block, `claude plugin` commands,

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -659,8 +659,10 @@ Key subsystems:
     (`ClaudeRemoteHerdrForward`) opened at dictation start and closed when the
     dictation is done with it. The bindings, ALL required, in cost order so an
     ordinary ssh session never pays for a tunnel:
-    (1) the focused surface's own TTY hosts a FOREGROUND `ssh` session whose
-    destination is exactly one enrolled host's alias. `SSHDestinationTTYProbe`
+    (1) the focused surface's own TTY hosts EXACTLY ONE FOREGROUND `ssh`
+    session, whose destination is exactly one enrolled host's alias. One,
+    because several in a group cannot be told apart from here, and unioning
+    them let a plain connection borrow a sibling's herdr signal. `SSHDestinationTTYProbe`
     is deliberately paranoid here, because every way an argv can name one host
     while the connection goes elsewhere is a mis-join: it verifies the
     EXECUTABLE against three EXACT absolute paths (`/usr/bin/ssh` and
@@ -694,12 +696,17 @@ Key subsystems:
     socket schema and the 0.8.0 docs, the only `client.*` methods are
     `window_title.set`/`clear`, both MUTATIONS (so `no_foreground_client` is not
     an acceptable probe), and `session.snapshot` carries no attachment field.
-    The accepted cost, stated rather than hidden: the manual flow — `ssh host`,
-    then typing `herdr` — gets NO context at all, not even a marker fallback,
-    because herdr intercepts OSC 2 so the marker never reaches the outer
-    terminal. A wrong join is worse than no join. It also makes the arm free
-    for everyone else: a plain ssh to an enrolled host no longer spawns a
-    forward before falling through;
+    The accepted cost, stated accurately: the manual flow — `ssh host`, then
+    typing `herdr` — gets no HERDR join. It does NOT get "no context": the arm
+    returns `.notApplicable`, so the title-marker arm still runs, and a marker
+    an earlier session on that host left in the OUTER title can still win. That
+    residual is pre-existing (it is what remote sessions have always done) and
+    cannot be closed from here, because nothing on the surface reveals a remote
+    herdr running inside it — e.g. run Claude in a plain ssh so its marker sits
+    in the title, suspend it, then start herdr by hand: dictation joins the
+    suspended session. What this arm refuses is a wrong HERDR join. It also
+    makes the arm free for everyone else: a plain ssh to an enrolled host no
+    longer spawns a forward before falling through;
     (3) that host has live remote sessions reporting a herdr pane, all from ONE
     herdr socket (`liveRemoteHerdrSessions(hostID:)`, the mirror of the local
     single-socket rule). The count that matters is SOCKETS, not sessions:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -677,16 +677,29 @@ Key subsystems:
     and ABSTAINS on `-o`/`-F`/`-O`/`-S`/`-N`/`-f`/`-M`/`-D`/`-W`/`-w` rather
     than skipping them — `ssh -o HostName=other builder` must never answer
     `builder`;
-    (2) THIS TERMINAL holds the ONLY ssh connection to that destination on the
-    machine (a `KERN_PROC_ALL` scan). Host-level binding alone was a mis-join:
-    with a plain shell to `builder` in one window and a herdr on `builder` in
-    another, both surfaces answer "ssh to builder" and every remaining check is
-    about the REMOTE side, so the plain shell would join the other window's
-    session. A remote command that IS herdr (first argv token, by basename) is
-    recorded as corroboration but NEVER substitutes for uniqueness — argv is
-    written by whoever launched the process, and treating it as sufficient let
-    `ssh host sh -lc 'printf herdr; exec claude'` claim to be a herdr
-    connection;
+    (2) that ssh session IS herdr — its remote command's first argv token has
+    basename `herdr` — AND this terminal holds the ONLY ssh connection to that
+    destination on the machine (a `KERN_PROC_ALL` scan counting every other ssh
+    with a controlling terminal, including suspended ones on this same device).
+    BOTH, because each covers what the other cannot. Uniqueness alone does not
+    prove what the terminal DISPLAYS: a herdr whose client detached, or whose
+    pane still carries a marker and a running agent inside the registry TTL,
+    keeps answering `pane.current` with that pane, so a later sole `ssh builder`
+    would join a session the user cannot see. The argv signal alone is not
+    enough either — argv is written by whoever launched the process, which is
+    why it is matched on the FIRST command token only (`ssh host sh -lc 'printf
+    herdr; exec claude'` mentions herdr and is not it).
+    Requiring the argv signal is what the absence of a better one forces:
+    herdr exposes NO read-only attachment signal — verified against the 0.7.5
+    socket schema and the 0.8.0 docs, the only `client.*` methods are
+    `window_title.set`/`clear`, both MUTATIONS (so `no_foreground_client` is not
+    an acceptable probe), and `session.snapshot` carries no attachment field.
+    The accepted cost, stated rather than hidden: the manual flow — `ssh host`,
+    then typing `herdr` — gets NO context at all, not even a marker fallback,
+    because herdr intercepts OSC 2 so the marker never reaches the outer
+    terminal. A wrong join is worse than no join. It also makes the arm free
+    for everyone else: a plain ssh to an enrolled host no longer spawns a
+    forward before falling through;
     (3) that host has live remote sessions reporting a herdr pane, all from ONE
     herdr socket (`liveRemoteHerdrSessions(hostID:)`, the mirror of the local
     single-socket rule). The count that matters is SOCKETS, not sessions:
@@ -758,7 +771,9 @@ Key subsystems:
     can neither observe nor kill), and `PermitLocalCommand=no` (a dictation
     must not be able to trigger `LocalCommand` on this machine). Teardown
     signals the process GROUP — the child is spawned as its own group leader
-    via `posix_spawn`'s `POSIX_SPAWN_SETPGROUP`, so `kill(-pgid)` can only ever
+    via `posix_spawn`'s `POSIX_SPAWN_SETPGROUP` — whose return value is
+    CHECKED, since a silently failed one would leave the child in our own group
+    and turn every teardown into an orphan — so `kill(-pgid)` can only ever
     reach our own ssh and its descendants — and it ends with an UNCONDITIONAL
     group SIGKILL. We observe only the leader, so its exit satisfies the
     bounded wait while a descendant that ignored SIGTERM is still holding the
@@ -775,7 +790,11 @@ Key subsystems:
     collected, or `ECHILD`), retrying `EINTR` and leaving anything else
     unreaped for the next teardown. Claiming the reap before calling `waitpid`
     turned an interrupted collection into a permanent lie about a zombie that
-    was still there, i.e. one leaked per dictation without bound.
+    was still there, i.e. one leaked per dictation without bound. The collect
+    is also NON-BLOCKING first (`WNOHANG`, bounded poll, then handed to a
+    background queue): every caller is a user-visible path — stop, commit,
+    cancel, app quit, all on the main actor — and a child wedged in an
+    uninterruptible wait must cost a background thread, never the UI.
     A remote herdr join authorizes no more than a local one: never the raw AX
     capture (that grid is the composite herdr TUI, on someone else's machine),
     and never local repo collection — the origin is remote, so

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -770,7 +770,12 @@ Key subsystems:
     reaps last, and once reaped NOTHING may signal that group again (a tunnel
     that exits by itself mid-dictation is closed at stop time seconds later,
     which is exactly when a reused pid would be someone else's). Cost: one
-    zombie per open forward, for the life of one dictation.
+    zombie per open forward, for the life of one dictation — and that bound
+    only holds because the reap COMMITS only on a definitive answer (the child
+    collected, or `ECHILD`), retrying `EINTR` and leaving anything else
+    unreaped for the next teardown. Claiming the reap before calling `waitpid`
+    turned an interrupted collection into a permanent lie about a zombie that
+    was still there, i.e. one leaked per dictation without bound.
     A remote herdr join authorizes no more than a local one: never the raw AX
     capture (that grid is the composite herdr TUI, on someone else's machine),
     and never local repo collection — the origin is remote, so

--- a/Sources/localvoxtral/ClaudeContext/ClaudeRemoteHerdrForward.swift
+++ b/Sources/localvoxtral/ClaudeContext/ClaudeRemoteHerdrForward.swift
@@ -382,6 +382,9 @@ struct ClaudeRemoteHerdrForwardSpawner: ClaudeRemoteHerdrForwardSpawning {
     /// observe exhaustion without waiting out the production default.
     var reapPollAttempts = LiveHerdrForwardProcess.defaultReapPollAttempts
     var reapPollInterval = LiveHerdrForwardProcess.defaultReapPollInterval
+    /// Test seams, passed straight through. See `LiveHerdrForwardProcess`.
+    var reapEffortDidFinish: @Sendable () -> Void = {}
+    var willAttemptTeardownLock: @Sendable () -> Void = {}
 
     func spawn(argv: [String]) throws -> any ClaudeRemoteHerdrForwardProcess {
         guard !argv.isEmpty else { throw SpawnError.emptyArgv }
@@ -442,7 +445,9 @@ struct ClaudeRemoteHerdrForwardSpawner: ClaudeRemoteHerdrForwardSpawning {
             pid: pid,
             waitForChild: waitForChild,
             reapPollAttempts: reapPollAttempts,
-            reapPollInterval: reapPollInterval
+            reapPollInterval: reapPollInterval,
+            reapEffortDidFinish: reapEffortDidFinish,
+            willAttemptTeardownLock: willAttemptTeardownLock
         )
     }
 
@@ -493,6 +498,16 @@ final class LiveHerdrForwardProcess: ClaudeRemoteHerdrForwardProcess, @unchecked
     /// follows it, rather than asserting against a three-second default.
     private let reapPollAttempts: Int
     private let reapPollInterval: TimeInterval
+    /// Fires when the collection effort reaches a terminal state — collected,
+    /// definitively failed, or budget exhausted. Exists so a test can WAIT for
+    /// the end of the poll chain instead of sampling a counter and hoping
+    /// (review round 8b): sampling cannot tell "finished" from "descheduled".
+    private let reapEffortDidFinish: @Sendable () -> Void
+    /// Fires whenever a teardown is about to need the state mutex — on entry to
+    /// `terminate()`, and again before each group signal. That placement is the
+    /// point: it marks a teardown ARRIVING at the lock, which is what a race
+    /// test must establish before it starts timing anything (review round 8b).
+    private let willAttemptTeardownLock: @Sendable () -> Void
 
     init(
         pid: pid_t,
@@ -500,12 +515,16 @@ final class LiveHerdrForwardProcess: ClaudeRemoteHerdrForwardProcess, @unchecked
             waitpid($0, $1, $2)
         },
         reapPollAttempts: Int = LiveHerdrForwardProcess.defaultReapPollAttempts,
-        reapPollInterval: TimeInterval = LiveHerdrForwardProcess.defaultReapPollInterval
+        reapPollInterval: TimeInterval = LiveHerdrForwardProcess.defaultReapPollInterval,
+        reapEffortDidFinish: @escaping @Sendable () -> Void = {},
+        willAttemptTeardownLock: @escaping @Sendable () -> Void = {}
     ) {
         self.pid = pid
         self.waitForChild = waitForChild
         self.reapPollAttempts = reapPollAttempts
         self.reapPollInterval = reapPollInterval
+        self.reapEffortDidFinish = reapEffortDidFinish
+        self.willAttemptTeardownLock = willAttemptTeardownLock
         reapQueue = DispatchQueue(
             label: "com.localvoxtral.claude.herdr-forward-reap.\(pid)", qos: .utility
         )
@@ -557,6 +576,10 @@ final class LiveHerdrForwardProcess: ClaudeRemoteHerdrForwardProcess, @unchecked
     /// then reaps, and every later call is a no-op. Cost: one zombie per open
     /// forward, for the life of one dictation.
     func terminate() {
+        // Announced BEFORE the first thing that needs the mutex — the guard
+        // below is itself a lock acquisition, so this is where a teardown
+        // arrives at the door.
+        willAttemptTeardownLock()
         // Not gated on `isRunning`: the leader may be gone while its group is
         // not. It IS gated on not-yet-reaped, which is the only thing that
         // makes `-pid` still mean our group.
@@ -596,6 +619,7 @@ final class LiveHerdrForwardProcess: ClaudeRemoteHerdrForwardProcess, @unchecked
     /// established (review round 7). `kill` is non-blocking, so holding the
     /// mutex across it costs nothing.
     private func signalGroup(_ signal: Int32) {
+        willAttemptTeardownLock()
         state.withLock { current in
             guard !current.reaped else { return }
             current.groupSignalsSent += 1
@@ -709,9 +733,13 @@ final class LiveHerdrForwardProcess: ClaudeRemoteHerdrForwardProcess, @unchecked
     /// better than a thread parked forever, and the next `close()` (or deinit)
     /// tries again.
     private func reapWithoutBlocking() {
-        guard !state.withLock({ $0.reaped }) else { return }
+        guard !state.withLock({ $0.reaped }) else {
+            reapEffortDidFinish()
+            return
+        }
         switch collectOnce() {
         case .reaped, .failed:
+            reapEffortDidFinish()
             return
         case .pending:
             break
@@ -722,15 +750,20 @@ final class LiveHerdrForwardProcess: ClaudeRemoteHerdrForwardProcess, @unchecked
     }
 
     private func pollForCollection(attemptsLeft: Int) {
-        guard !state.withLock({ $0.reaped }) else { return }
+        guard !state.withLock({ $0.reaped }) else {
+            reapEffortDidFinish()
+            return
+        }
         switch collectOnce() {
         case .reaped, .failed:
+            reapEffortDidFinish()
             return
         case .pending:
             guard attemptsLeft > 1 else {
                 Log.claudeContext.error(
                     "Remote herdr forward never became collectable; leaving it unreaped rather than waiting on it"
                 )
+                reapEffortDidFinish()
                 return
             }
             reapQueue.asyncAfter(deadline: .now() + reapPollInterval) { [self] in

--- a/Sources/localvoxtral/ClaudeContext/ClaudeRemoteHerdrForward.swift
+++ b/Sources/localvoxtral/ClaudeContext/ClaudeRemoteHerdrForward.swift
@@ -1,0 +1,600 @@
+import ClaudeContextWire
+import Foundation
+
+#if canImport(Darwin)
+import Darwin
+import Synchronization
+
+/// A spawned, long-lived child process, reduced to what the forward needs of
+/// it.
+///
+/// Deliberately NOT `ClaudeRemoteEnrollmentService.Runner`: that seam is
+/// run-to-completion (argv in, exit code out), and an `ssh -N` that returns is
+/// an ssh that is no longer forwarding anything. This one is spawn/observe/kill.
+protocol ClaudeRemoteHerdrForwardProcess: AnyObject, Sendable {
+    var isRunning: Bool { get }
+    /// SIGTERM, then SIGKILL if it does not go. Idempotent.
+    func terminate()
+}
+
+/// Spawns the forward's child process. Injected everywhere, defaulted nowhere:
+/// a test that forgets it must not be able to dial a real host.
+protocol ClaudeRemoteHerdrForwardSpawning: Sendable {
+    func spawn(argv: [String]) throws -> any ClaudeRemoteHerdrForwardProcess
+}
+
+/// Where the forward's local socket lives: a freshly created, private
+/// directory, used once and removed.
+struct ClaudeRemoteHerdrForwardWorkspace: Sendable, Equatable {
+    var directoryPath: String
+    var socketPath: String
+
+    init(directoryPath: String, socketPath: String) {
+        self.directoryPath = directoryPath
+        self.socketPath = socketPath
+    }
+}
+
+protocol ClaudeRemoteHerdrWorkspaceProviding: Sendable {
+    /// A NEW directory every call. Never reuses a path: a socket path that
+    /// could already exist is a socket path someone else could have created.
+    func makeWorkspace() throws -> ClaudeRemoteHerdrForwardWorkspace
+    func remove(_ workspace: ClaudeRemoteHerdrForwardWorkspace)
+}
+
+/// An open `ssh -L` forward to one remote herdr socket.
+///
+/// Owned by the dictation that opened it and closed when that dictation is
+/// done with it — the stop-side `pane.read` needs the same tunnel the start
+/// side used, so the lifetime is the whole dictation and not one request.
+/// `close()` is idempotent and `deinit` calls it, so a join dropped on a path
+/// nobody thought about still takes the ssh child and the socket with it.
+final class ClaudeRemoteHerdrForwardHandle: Sendable, Equatable {
+    /// Identity, not value: two handles are the same forward only when they ARE
+    /// the same object. This exists so `ClaudeSessionJoin` can stay `Equatable`
+    /// while owning one.
+    static func == (lhs: ClaudeRemoteHerdrForwardHandle, rhs: ClaudeRemoteHerdrForwardHandle) -> Bool {
+        lhs === rhs
+    }
+
+    /// The LOCAL end of the forward — an AF_UNIX socket on this machine, owned
+    /// by this user, created by our own ssh child. That is what makes it
+    /// dialable by `HerdrSocketClient`'s unchanged local-socket guard.
+    let localSocketPath: String
+
+    private let workspace: ClaudeRemoteHerdrForwardWorkspace
+    private let process: any ClaudeRemoteHerdrForwardProcess
+    private let removeWorkspace: @Sendable (ClaudeRemoteHerdrForwardWorkspace) -> Void
+    private let closed = Mutex(false)
+
+    init(
+        workspace: ClaudeRemoteHerdrForwardWorkspace,
+        process: any ClaudeRemoteHerdrForwardProcess,
+        removeWorkspace: @escaping @Sendable (ClaudeRemoteHerdrForwardWorkspace) -> Void
+    ) {
+        self.localSocketPath = workspace.socketPath
+        self.workspace = workspace
+        self.process = process
+        self.removeWorkspace = removeWorkspace
+    }
+
+    var isRunning: Bool { process.isRunning }
+
+    func close() {
+        let alreadyClosed = closed.withLock { state -> Bool in
+            if state { return true }
+            state = true
+            return false
+        }
+        guard !alreadyClosed else { return }
+        process.terminate()
+        // The socket is ssh's to unlink on a clean exit, but a killed ssh
+        // leaves it behind — and the directory is ours either way.
+        removeWorkspace(workspace)
+        Log.claudeContext.info("Remote herdr forward closed")
+    }
+
+    deinit { close() }
+}
+
+/// Opens an on-demand `ssh -L` tunnel to a REMOTE herdr's JSON socket.
+///
+/// Why an app-managed forward at all: herdr's socket protocol is happy over a
+/// forwarded stream, but nothing on the user's machine forwards it — the
+/// enrollment tunnel is a RemoteForward carrying hook events the other way. So
+/// the join arm dials out for exactly as long as one dictation needs it.
+///
+/// Every live capability is a seam, and the two that matter most are the
+/// clock and the sleep: readiness is a poll, and a poll with a real clock in it
+/// is a test that sleeps.
+struct ClaudeRemoteHerdrForwardService: ClaudeRemoteHerdrForwarding {
+    /// How long a forward has to become dialable before it is abandoned.
+    ///
+    /// This is on the dictation-start path, so it is a latency ceiling as much
+    /// as a correctness one: a host that is asleep or unreachable must cost a
+    /// beat, not a stall. Two seconds is roughly four times a LAN ssh
+    /// handshake and still short enough to be invisible against the model
+    /// connect that follows.
+    static let defaultReadinessTimeout: TimeInterval = 2.0
+
+    private let spawner: any ClaudeRemoteHerdrForwardSpawning
+    private let workspaces: any ClaudeRemoteHerdrWorkspaceProviding
+    private let isSocketDialable: @Sendable (String) -> Bool
+    private let now: @Sendable () -> Date
+    private let sleepFor: @Sendable (TimeInterval) async -> Void
+    private let readinessTimeout: TimeInterval
+    private let pollInterval: TimeInterval
+
+    init(
+        spawner: any ClaudeRemoteHerdrForwardSpawning,
+        workspaces: any ClaudeRemoteHerdrWorkspaceProviding,
+        isSocketDialable: @escaping @Sendable (String) -> Bool = {
+            ClaudeRemoteHerdrForwardService.dial($0)
+        },
+        now: @escaping @Sendable () -> Date = { Date() },
+        sleepFor: @escaping @Sendable (TimeInterval) async -> Void = { seconds in
+            try? await Task.sleep(nanoseconds: UInt64(max(0, seconds) * 1_000_000_000))
+        },
+        readinessTimeout: TimeInterval = ClaudeRemoteHerdrForwardService.defaultReadinessTimeout,
+        pollInterval: TimeInterval = 0.025
+    ) {
+        self.spawner = spawner
+        self.workspaces = workspaces
+        self.isSocketDialable = isSocketDialable
+        self.now = now
+        self.sleepFor = sleepFor
+        self.readinessTimeout = readinessTimeout
+        self.pollInterval = pollInterval
+    }
+
+    /// Spawn the tunnel and wait for its local end to answer, or nil.
+    ///
+    /// Both inputs are validated HERE rather than at the call site, because
+    /// this is the last place before they become argv. `remoteSocketPath` in
+    /// particular arrived as an HTTP header from another machine
+    /// (`ClaudeRemoteSessionEnvironment.herdrSocketPath`) and is a LABEL: it is
+    /// never handed to `FileManager`, never `stat`ed, never opened — the only
+    /// thing that ever happens to it is being passed through to `ssh`, which
+    /// resolves it on the host that named it.
+    func open(alias: String, remoteSocketPath: String) async -> ClaudeRemoteHerdrForwardHandle? {
+        guard ClaudeRemoteEnrollmentService.isValidHostAlias(alias) else {
+            Log.claudeContext.info("Remote herdr forward refused: invalid host alias")
+            return nil
+        }
+        guard Self.isForwardableRemoteSocketPath(remoteSocketPath) else {
+            Log.claudeContext.info("Remote herdr forward refused: unusable remote socket path")
+            return nil
+        }
+
+        let workspace: ClaudeRemoteHerdrForwardWorkspace
+        do {
+            workspace = try workspaces.makeWorkspace()
+        } catch {
+            Log.claudeContext.error(
+                "Remote herdr forward failed: private socket directory unavailable (\(String(describing: error), privacy: .public))"
+            )
+            return nil
+        }
+        guard Self.isUsableLocalSocketPath(workspace.socketPath) else {
+            Log.claudeContext.error("Remote herdr forward failed: local socket path unusable")
+            workspaces.remove(workspace)
+            return nil
+        }
+
+        let process: any ClaudeRemoteHerdrForwardProcess
+        do {
+            process = try spawner.spawn(
+                argv: Self.argv(
+                    alias: alias,
+                    localSocketPath: workspace.socketPath,
+                    remoteSocketPath: remoteSocketPath
+                )
+            )
+        } catch {
+            Log.claudeContext.error(
+                "Remote herdr forward failed to spawn: \(String(describing: error), privacy: .public)"
+            )
+            workspaces.remove(workspace)
+            return nil
+        }
+
+        let handle = ClaudeRemoteHerdrForwardHandle(
+            workspace: workspace,
+            process: process,
+            removeWorkspace: { [workspaces] in workspaces.remove($0) }
+        )
+
+        let deadline = now().addingTimeInterval(max(0, readinessTimeout))
+        while now() < deadline {
+            // An ssh that has already exited will never open the socket, and
+            // its exit is the common failure (auth refused, host down,
+            // BatchMode with no key). Noticing it is what turns a 2 s stall
+            // into a prompt abstention.
+            guard handle.isRunning else {
+                Log.claudeContext.info("Remote herdr forward abstained: ssh exited before readiness")
+                handle.close()
+                return nil
+            }
+            if isSocketDialable(workspace.socketPath) {
+                Log.claudeContext.info("Remote herdr forward ready")
+                return handle
+            }
+            await sleepFor(pollInterval)
+        }
+        Log.claudeContext.info("Remote herdr forward abstained: readiness timeout")
+        handle.close()
+        return nil
+    }
+
+    /// The exact argv. Assembled in one static function so a test can assert
+    /// every token of it — this is a command line built partly from a remote
+    /// machine's strings, and "what exactly do we run" must be answerable
+    /// without reading the spawn path.
+    ///
+    /// Two options the design review asked for are deliberately ABSENT, both
+    /// falsified against OpenSSH 10.0 before this shipped:
+    ///
+    /// * `ClearAllForwardings=yes` clears forwardings "specified in the
+    ///   configuration files OR ON THE COMMAND LINE", and the clearing runs
+    ///   after all option parsing — so it deletes the very `-L` this exists
+    ///   for. Measured: with it, the local socket is never created; without
+    ///   it, it appears.
+    /// * `ExitOnForwardFailure=yes` would make the ENROLLED host's own
+    ///   `RemoteForward 8473` — which the user's live interactive session is
+    ///   normally already holding — a fatal error for this connection.
+    ///   Measured: with it, ssh exits ("Error: remote port forwarding failed");
+    ///   without it, the collision is a warning and the local forward stays up.
+    ///   That collision is not an edge case: it is the exact situation this
+    ///   feature runs in. Readiness is proven by dialing the socket instead,
+    ///   which is stronger than a flag anyway.
+    ///
+    /// `ControlPath=none` is present for lifetime hygiene: over a shared
+    /// master the forward would belong to the user's long-lived connection
+    /// rather than to our child, and killing our child would not be a
+    /// teardown. It costs one handshake per dictation.
+    static func argv(
+        alias: String,
+        localSocketPath: String,
+        remoteSocketPath: String
+    ) -> [String] {
+        [
+            "ssh", "-N",
+            "-o", "BatchMode=yes",
+            "-o", "ControlPath=none",
+            // The connection still inherits the ALIAS's own `Host` block, and
+            // two of its settings would break this child's containment
+            // (review finding 5), so both are overridden here rather than
+            // hoped about:
+            //   * ForkAfterAuthentication would detach ssh into a process this
+            //     Process object no longer tracks — a tunnel we could neither
+            //     observe nor kill, i.e. an orphan per dictation;
+            //   * PermitLocalCommand + LocalCommand would run a command on THIS
+            //     machine every time we open a tunnel, which is not something a
+            //     dictation should be able to trigger.
+            "-o", "ForkAfterAuthentication=no",
+            "-o", "PermitLocalCommand=no",
+            "-L", "\(localSocketPath):\(remoteSocketPath)",
+            // `--` ends option parsing; the alias is validated above and cannot
+            // begin with `-`, and this makes any alias that somehow did a
+            // failed connection rather than a silently accepted option.
+            "--", alias,
+        ]
+    }
+
+    /// Whether a remote socket path may be pasted into `-L`.
+    ///
+    /// The charset is PR #216's header allowlist, re-applied at the point of
+    /// use: the listener already dropped anything outside it, and this is the
+    /// half that does not depend on that having happened. On top of it:
+    ///
+    /// * absolute, because a relative herdr socket path is not a thing and a
+    ///   bare word could be read as a port;
+    /// * no `:`, because `-L` is a COLON-SEPARATED spec — a colon in the
+    ///   remote path would re-split the argument into a different forward;
+    /// * no leading `-` (implied by the absolute rule, asserted anyway) so it
+    ///   can never be read as an option.
+    static func isForwardableRemoteSocketPath(_ path: String) -> Bool {
+        guard path.hasPrefix("/"), !path.hasPrefix("-") else { return false }
+        guard !path.contains(":") else { return false }
+        return ClaudeRemoteEnvironmentCodec.isAcceptableValue(path)
+    }
+
+    /// `sun_path` is 104 bytes on Darwin including the terminator, and a path
+    /// that does not fit produces a socket nothing can dial — a failure worth
+    /// naming rather than discovering as a readiness timeout.
+    static let maxLocalSocketPathBytes = 100
+
+    static func isUsableLocalSocketPath(_ path: String) -> Bool {
+        path.hasPrefix("/") && !path.contains(":")
+            && !path.isEmpty && path.utf8.count <= maxLocalSocketPathBytes
+    }
+
+    /// Live readiness: can this AF_UNIX path be connected to right now?
+    ///
+    /// Existence is not enough. A killed ssh leaves the socket FILE behind, and
+    /// `-L` onto a path that cannot be bound leaves ssh running with no
+    /// listener at all — both look identical to `lstat`. A successful connect
+    /// proves only the LOCAL listener, which is the point: what is on the other
+    /// end is then re-proven by the herdr response itself.
+    static func dial(_ socketPath: String) -> Bool {
+        var address = sockaddr_un()
+        address.sun_family = sa_family_t(AF_UNIX)
+        address.sun_len = UInt8(MemoryLayout<sockaddr_un>.size)
+        let pathBytes = Array(socketPath.utf8)
+        let capacity = MemoryLayout.size(ofValue: address.sun_path)
+        guard pathBytes.count < capacity else { return false }
+        withUnsafeMutableBytes(of: &address.sun_path) { raw in
+            raw.copyBytes(from: pathBytes)
+            raw[pathBytes.count] = 0
+        }
+        let fd = socket(AF_UNIX, SOCK_STREAM, 0)
+        guard fd >= 0 else { return false }
+        defer { close(fd) }
+        let status = withUnsafePointer(to: &address) { pointer in
+            pointer.withMemoryRebound(to: sockaddr.self, capacity: 1) {
+                Darwin.connect(fd, $0, socklen_t(MemoryLayout<sockaddr_un>.size))
+            }
+        }
+        return status == 0
+    }
+}
+
+/// Protocol the resolver depends on, so the join arm can be tested without any
+/// notion of processes at all.
+protocol ClaudeRemoteHerdrForwarding: Sendable {
+    func open(alias: String, remoteSocketPath: String) async -> ClaudeRemoteHerdrForwardHandle?
+}
+
+// MARK: - Live implementations
+
+/// `posix_spawn`-backed spawn that puts the child in its OWN process group.
+///
+/// Not `Process`, and the reason is teardown: Foundation gives no way to set a
+/// process group, so `terminate()` could only ever signal the one pid it knows.
+/// ssh under some configurations leaves descendants behind (and re-execs
+/// itself), so a group leader plus `kill(-pgid)` is what makes "close the
+/// tunnel" mean the whole tunnel (review finding 5). The child is its own group
+/// leader, so the negative pid can only ever reach OUR ssh and its children.
+///
+/// stdout/stderr go to `/dev/null` on purpose: ssh is chatty on stderr
+/// (host-key notices, forwarding warnings) and reading a child's pipe is how
+/// this app crashed in the field once already (PR #60). Nothing here needs
+/// ssh's words — the socket either answers or it does not.
+struct ClaudeRemoteHerdrForwardSpawner: ClaudeRemoteHerdrForwardSpawning {
+    /// Absolute, exactly like the enrollment runner's: a PATH lookup for the
+    /// program we hand another machine's socket path to is not a lookup worth
+    /// having.
+    var executablePath = "/usr/bin/ssh"
+    /// Injected so a test can spawn something observable instead of ssh.
+    var environment: [String: String] = ProcessInfo.processInfo.environment
+
+    func spawn(argv: [String]) throws -> any ClaudeRemoteHerdrForwardProcess {
+        guard !argv.isEmpty else { throw SpawnError.emptyArgv }
+
+        var fileActions: posix_spawn_file_actions_t?
+        posix_spawn_file_actions_init(&fileActions)
+        defer { posix_spawn_file_actions_destroy(&fileActions) }
+        posix_spawn_file_actions_addopen(&fileActions, 0, "/dev/null", O_RDONLY, 0)
+        posix_spawn_file_actions_addopen(&fileActions, 1, "/dev/null", O_WRONLY, 0)
+        posix_spawn_file_actions_addopen(&fileActions, 2, "/dev/null", O_WRONLY, 0)
+
+        var attributes: posix_spawnattr_t?
+        posix_spawnattr_init(&attributes)
+        defer { posix_spawnattr_destroy(&attributes) }
+        // pgroup 0 with SETPGROUP: the child's process group id becomes its own
+        // pid, so it leads a group containing only itself and its descendants.
+        posix_spawnattr_setflags(&attributes, Int16(POSIX_SPAWN_SETPGROUP))
+        posix_spawnattr_setpgroup(&attributes, 0)
+
+        // The environment is passed explicitly rather than inherited through a
+        // global: ssh needs HOME to find the alias's config at all, and an
+        // empty envp would make every forward fail in a way that looks like a
+        // dead host.
+        let arguments = argv.map { strdup($0) } + [nil]
+        let environmentStrings = environment.map { strdup("\($0.key)=\($0.value)") } + [nil]
+        defer {
+            arguments.forEach { free($0) }
+            environmentStrings.forEach { free($0) }
+        }
+
+        var pid: pid_t = 0
+        let status = posix_spawn(
+            &pid, executablePath, &fileActions, &attributes, arguments, environmentStrings
+        )
+        guard status == 0, pid > 1 else { throw SpawnError.launchFailed(code: status) }
+        return LiveHerdrForwardProcess(pid: pid)
+    }
+
+    enum SpawnError: Error, Equatable {
+        case emptyArgv
+        case launchFailed(code: Int32)
+    }
+}
+
+/// A spawned forward, tracked by pid and torn down by process GROUP.
+final class LiveHerdrForwardProcess: ClaudeRemoteHerdrForwardProcess, @unchecked Sendable {
+    /// Short on purpose. This is our own `ssh -N`: it installs no SIGTERM
+    /// handler and dies at once, and the call runs on user-visible exit paths
+    /// (a cancelled dictation, app quit) where seconds of blocking would be
+    /// felt. SIGKILL to the group follows immediately after.
+    static let gracePeriod: TimeInterval = 0.25
+
+    /// Everything teardown has to agree about, in one lock.
+    private struct State {
+        /// The group leader has exited. Its zombie still reserves the pid.
+        var leaderExited = false
+        /// The child has been collected — from here `-pid` may name a stranger.
+        var reaped = false
+        /// Signals actually delivered to the group, so a test can prove none is
+        /// sent after the reap.
+        var groupSignalsSent = 0
+    }
+
+    private let pid: pid_t
+    private let exited = DispatchSemaphore(value: 0)
+    private let state = Mutex(State())
+    private let source: any DispatchSourceProcess
+
+    init(pid: pid_t) {
+        self.pid = pid
+        let source = DispatchSource.makeProcessSource(
+            identifier: pid, eventMask: .exit, queue: .global(qos: .utility)
+        )
+        self.source = source
+        source.setEventHandler { [weak self] in self?.noteExit() }
+        source.resume()
+    }
+
+    deinit {
+        source.cancel()
+    }
+
+    var isRunning: Bool { !state.withLock { $0.leaderExited } }
+
+    /// The group leader's pid. Exposed so the teardown test can kill the LEADER
+    /// alone and prove that a dead leader does not suppress the group SIGKILL —
+    /// the exact shape of the bug this guards.
+    var leaderPID: pid_t { pid }
+
+    /// Test seams for the reuse guard: how many signals reached the group, and
+    /// whether the child has been collected.
+    var groupSignalsSent: Int { state.withLock { $0.groupSignalsSent } }
+    var hasBeenReaped: Bool { state.withLock { $0.reaped } }
+
+    /// SIGTERM the group, wait a beat for the LEADER, SIGKILL the group
+    /// unconditionally — and only then reap.
+    ///
+    /// Two rules pull against each other here, and the reap order is what
+    /// satisfies both:
+    ///
+    /// * The final kill must NOT be gated on the leader being alive (review
+    ///   round 3). We observe only the leader, so its exit satisfies
+    ///   `waitForExit` while a descendant that ignored SIGTERM is still holding
+    ///   the tunnel; a liveness guard suppressed exactly the signal that clears
+    ///   it.
+    /// * We must NEVER signal a group we have already reaped (review round 4).
+    ///   A pid is reserved only while the child is unreaped; once reaped the
+    ///   kernel may hand that pid to a new process — as a new group leader with
+    ///   that pgid — and `kill(-pid)` would then hit a stranger. The window is
+    ///   real: a tunnel that exits by itself mid-dictation is reaped, and stop
+    ///   time calls `close()` seconds later.
+    ///
+    /// So the exit source does not reap; it only records and wakes the waiter.
+    /// The zombie it leaves is what RESERVES the pid (and with it the pgid) for
+    /// as long as we might still need to signal the group. Teardown signals,
+    /// then reaps, and every later call is a no-op. Cost: one zombie per open
+    /// forward, for the life of one dictation.
+    func terminate() {
+        // Not gated on `isRunning`: the leader may be gone while its group is
+        // not. It IS gated on not-yet-reaped, which is the only thing that
+        // makes `-pid` still mean our group.
+        guard signalGroupIsSafe else {
+            reapIfNeeded()
+            return
+        }
+        _ = ClaudePluginInstallService.terminateBounded(
+            gracePeriod: Self.gracePeriod,
+            // Negative pid = the whole process group. The child is its own
+            // group leader (POSIX_SPAWN_SETPGROUP), so this cannot reach
+            // anything we did not spawn.
+            terminate: { self.signalGroup(SIGTERM) },
+            kill: { self.signalGroup(SIGKILL) },
+            // The child's own exit event, not a poll: a spin would be a wall
+            // clock in production code as much as in a test.
+            waitForExit: { window in
+                self.exited.wait(timeout: .now() + max(window, 0)) == .success
+            }
+        )
+        // Unconditional within the un-reaped window: the leader going quietly
+        // says nothing about the rest of its group.
+        signalGroup(SIGKILL)
+        reapIfNeeded()
+    }
+
+    /// Whether `-pid` still names OUR process group.
+    private var signalGroupIsSafe: Bool { !state.withLock { $0.reaped } }
+
+    /// Signal the whole group, refusing once the pid could have been reused.
+    /// Counted so a test can prove no signal is sent after the reap.
+    private func signalGroup(_ signal: Int32) {
+        let sent = state.withLock { current -> Bool in
+            guard !current.reaped else { return false }
+            current.groupSignalsSent += 1
+            return true
+        }
+        guard sent else { return }
+        _ = Darwin.kill(-pid, signal)
+    }
+
+    /// Collect the child, once. After this the pid is the kernel's to reuse,
+    /// which is precisely why nothing may signal the group afterwards.
+    private func reapIfNeeded() {
+        let shouldReap = state.withLock { current -> Bool in
+            guard !current.reaped else { return false }
+            current.reaped = true
+            return true
+        }
+        guard shouldReap else { return }
+        var status: Int32 = 0
+        _ = waitpid(pid, &status, 0)
+        source.cancel()
+    }
+
+    /// Record the leader's exit and wake the waiter. Deliberately does NOT
+    /// reap: the zombie is what keeps `-pid` meaning our group until teardown
+    /// has finished signalling it.
+    private func noteExit() {
+        state.withLock { $0.leaderExited = true }
+        exited.signal()
+    }
+}
+
+/// Private per-forward directory under the user's own temporary directory.
+///
+/// Not Application Support: `sun_path` is 104 bytes, and
+/// `~/Library/Application Support/localvoxtral/...` plus a unique name is close
+/// enough to that ceiling that a long user name would break it. Not `/tmp`
+/// either — that is world-writable, and while the unpredictable name and the
+/// 0700 mode would carry it, the per-user temporary directory is 0700 by the
+/// OS and shorter. The directory is created fresh (never reused, never
+/// "repaired"), validated with the same lstat rules as the broker's run
+/// directory, and removed on close.
+struct ClaudeRemoteHerdrForwardWorkspaces: ClaudeRemoteHerdrWorkspaceProviding {
+    var base: String = NSTemporaryDirectory()
+    var makeName: @Sendable () -> String = { UUID().uuidString.prefix(8).lowercased() }
+
+    func makeWorkspace() throws -> ClaudeRemoteHerdrForwardWorkspace {
+        let directory = (base as NSString)
+            .appendingPathComponent("lvx-herdr-fwd-\(makeName())")
+        // withIntermediateDirectories: false — the create must FAIL if the path
+        // already exists, so an attacker-planted directory is an error rather
+        // than a socket we hand to ssh.
+        try FileManager.default.createDirectory(
+            atPath: directory,
+            withIntermediateDirectories: false,
+            attributes: [.posixPermissions: NSNumber(value: Int16(0o700))]
+        )
+        guard let metadata = ClaudeSocketGuard.metadata(ofPath: directory),
+              ClaudeSocketGuard.validateDirectory(
+                metadata, path: directory, expectedUID: UInt32(geteuid())
+              ) == nil
+        else {
+            try? FileManager.default.removeItem(atPath: directory)
+            throw WorkspaceError.directoryNotPrivate
+        }
+        return ClaudeRemoteHerdrForwardWorkspace(
+            directoryPath: directory,
+            socketPath: (directory as NSString).appendingPathComponent("h.sock")
+        )
+    }
+
+    func remove(_ workspace: ClaudeRemoteHerdrForwardWorkspace) {
+        unlink(workspace.socketPath)
+        try? FileManager.default.removeItem(atPath: workspace.directoryPath)
+    }
+
+    enum WorkspaceError: Error, Equatable {
+        case directoryNotPrivate
+    }
+}
+#endif

--- a/Sources/localvoxtral/ClaudeContext/ClaudeRemoteHerdrForward.swift
+++ b/Sources/localvoxtral/ClaudeContext/ClaudeRemoteHerdrForward.swift
@@ -376,20 +376,37 @@ struct ClaudeRemoteHerdrForwardSpawner: ClaudeRemoteHerdrForwardSpawning {
     func spawn(argv: [String]) throws -> any ClaudeRemoteHerdrForwardProcess {
         guard !argv.isEmpty else { throw SpawnError.emptyArgv }
 
+        // Every one of these is checked. A silently failed SETPGROUP is the
+        // dangerous one (review round 5b): the child would then share OUR
+        // process group, so the teardown's `kill(-pid)` would find nothing to
+        // signal and an orphan ssh would hold the tunnel open — a failure that
+        // looks exactly like success until someone counts processes. The
+        // redirections are checked in the same breath, since a child that
+        // inherited our stdio is not the child this code describes.
         var fileActions: posix_spawn_file_actions_t?
-        posix_spawn_file_actions_init(&fileActions)
+        guard posix_spawn_file_actions_init(&fileActions) == 0 else {
+            throw SpawnError.setupFailed(code: errno)
+        }
         defer { posix_spawn_file_actions_destroy(&fileActions) }
-        posix_spawn_file_actions_addopen(&fileActions, 0, "/dev/null", O_RDONLY, 0)
-        posix_spawn_file_actions_addopen(&fileActions, 1, "/dev/null", O_WRONLY, 0)
-        posix_spawn_file_actions_addopen(&fileActions, 2, "/dev/null", O_WRONLY, 0)
+        for (descriptor, flags) in [(0, O_RDONLY), (1, O_WRONLY), (2, O_WRONLY)] {
+            let status = posix_spawn_file_actions_addopen(
+                &fileActions, Int32(descriptor), "/dev/null", flags, 0
+            )
+            guard status == 0 else { throw SpawnError.setupFailed(code: status) }
+        }
 
         var attributes: posix_spawnattr_t?
-        posix_spawnattr_init(&attributes)
+        guard posix_spawnattr_init(&attributes) == 0 else {
+            throw SpawnError.setupFailed(code: errno)
+        }
         defer { posix_spawnattr_destroy(&attributes) }
         // pgroup 0 with SETPGROUP: the child's process group id becomes its own
         // pid, so it leads a group containing only itself and its descendants.
-        posix_spawnattr_setflags(&attributes, Int16(POSIX_SPAWN_SETPGROUP))
-        posix_spawnattr_setpgroup(&attributes, 0)
+        guard posix_spawnattr_setflags(&attributes, Int16(POSIX_SPAWN_SETPGROUP)) == 0,
+              posix_spawnattr_setpgroup(&attributes, 0) == 0
+        else {
+            throw SpawnError.processGroupUnavailable
+        }
 
         // The environment is passed explicitly rather than inherited through a
         // global: ssh needs HOME to find the alias's config at all, and an
@@ -413,6 +430,11 @@ struct ClaudeRemoteHerdrForwardSpawner: ClaudeRemoteHerdrForwardSpawning {
     enum SpawnError: Error, Equatable {
         case emptyArgv
         case launchFailed(code: Int32)
+        case setupFailed(code: Int32)
+        /// The child could not be made its own process-group leader, so
+        /// teardown could not guarantee taking its descendants with it. We do
+        /// not spawn a tunnel we cannot promise to close.
+        case processGroupUnavailable
     }
 }
 
@@ -551,33 +573,86 @@ final class LiveHerdrForwardProcess: ClaudeRemoteHerdrForwardProcess, @unchecked
     /// cancelled, every later teardown refused to signal or retry, and the
     /// documented "one zombie per open forward, for one dictation" became one
     /// per dictation forever.
+    /// How long the caller's own thread will poll before handing the wait off.
+    /// The child has been SIGKILLed by the time this runs, so the first attempt
+    /// almost always collects it; this bound exists for the case where it does
+    /// not.
+    private static let reapPollAttempts = 250
+    private static let reapQueue = DispatchQueue(
+        label: "com.localvoxtral.claude.herdr-forward-reap", qos: .utility
+    )
+
+    private enum CollectOutcome {
+        /// Definitively collected (or the kernel disowned the pid).
+        case reaped
+        /// Not yet collectable, or interrupted. Ask again.
+        case pending
+        /// A real error. Leave it UNREAPED so a later teardown retries.
+        case failed
+    }
+
+    private func collectOnce(options: Int32) -> CollectOutcome {
+        var status: Int32 = 0
+        let collected = waitForChild(pid, &status, options)
+        if collected > 0 {
+            markReaped()
+            return .reaped
+        }
+        // WNOHANG's "still running" answer, which sets no errno.
+        if collected == 0 { return .pending }
+        let failure = errno
+        // A caught signal is not an answer.
+        if failure == EINTR { return .pending }
+        if failure == ECHILD {
+            // Definitive: there is nothing left to collect, so the pid is no
+            // longer ours to signal either.
+            markReaped()
+            return .reaped
+        }
+        // Anything else stays UNREAPED on purpose: the zombie is still ours,
+        // `-pid` still names our group, and the next teardown (or the handle's
+        // deinit) will try again rather than leak it silently.
+        Log.claudeContext.error(
+            "Remote herdr forward could not be collected (errno \(failure, privacy: .public)); leaving it unreaped for a later attempt"
+        )
+        return .failed
+    }
+
+    /// Collect the child, once. After this the pid is the kernel's to reuse,
+    /// which is precisely why nothing may signal the group afterwards.
+    ///
+    /// `reaped` is committed only on a DEFINITIVE outcome — the child was
+    /// collected, or the kernel says there is no such child. Claiming it up
+    /// front (as the first version did) meant an interrupted `waitpid` left a
+    /// zombie behind while the state insisted it was gone: the source was
+    /// cancelled, every later teardown refused to signal or retry, and the
+    /// documented "one zombie per open forward, for one dictation" became one
+    /// per dictation forever.
+    ///
+    /// NON-BLOCKING first, because every caller is a user-visible path — stop,
+    /// commit, cancel, app quit, all on the main actor. A child wedged in an
+    /// uninterruptible wait must cost a background thread, never the UI, so the
+    /// bounded poll hands off rather than waiting it out (review round 5b).
     private func reapIfNeeded() {
         guard !state.withLock({ $0.reaped }) else { return }
-        var status: Int32 = 0
-        while true {
-            let collected = waitForChild(pid, &status, 0)
-            if collected > 0 {
-                markReaped()
+        for _ in 0..<Self.reapPollAttempts {
+            switch collectOnce(options: WNOHANG) {
+            case .reaped, .failed:
                 return
+            case .pending:
+                usleep(1000)
             }
-            let failure = errno
-            if collected == -1, failure == EINTR {
-                // A caught signal is not an answer. Ask again.
-                continue
+        }
+        Log.claudeContext.info(
+            "Remote herdr forward is not collectable yet; finishing the wait off the calling thread"
+        )
+        Self.reapQueue.async { [self] in
+            while true {
+                switch collectOnce(options: 0) {
+                case .reaped, .failed: return
+                case .pending: continue
+                }
             }
-            if collected == -1, failure == ECHILD {
-                // Definitive: there is nothing left to collect, so the pid is
-                // no longer ours to signal either.
-                markReaped()
-                return
-            }
-            // Anything else stays UNREAPED on purpose: the zombie is still
-            // ours, `-pid` still names our group, and the next teardown (or
-            // the handle's deinit) will try again rather than leak it silently.
-            Log.claudeContext.error(
-                "Remote herdr forward could not be collected (errno \(failure, privacy: .public)); leaving it unreaped for a later attempt"
-            )
-            return
         }
     }
 

--- a/Sources/localvoxtral/ClaudeContext/ClaudeRemoteHerdrForward.swift
+++ b/Sources/localvoxtral/ClaudeContext/ClaudeRemoteHerdrForward.swift
@@ -81,13 +81,19 @@ final class ClaudeRemoteHerdrForwardHandle: Sendable, Equatable {
     var isRunning: Bool { process.isRunning }
 
     func close() {
+        // ALWAYS, before the idempotence guard: `terminate()` is itself
+        // idempotent, and it is the production RETRY path for a collection that
+        // failed earlier. Gating it behind "already closed" meant a failed reap
+        // could only ever be retried by a test calling `terminate()` twice —
+        // deinit's `close()` was a no-op, so production had no second attempt
+        // at all (review round 7).
+        process.terminate()
         let alreadyClosed = closed.withLock { state -> Bool in
             if state { return true }
             state = true
             return false
         }
         guard !alreadyClosed else { return }
-        process.terminate()
         // The socket is ssh's to unlink on a clean exit, but a killed ssh
         // leaves it behind — and the directory is ours either way.
         removeWorkspace(workspace)
@@ -384,8 +390,11 @@ struct ClaudeRemoteHerdrForwardSpawner: ClaudeRemoteHerdrForwardSpawning {
         // redirections are checked in the same breath, since a child that
         // inherited our stdio is not the child this code describes.
         var fileActions: posix_spawn_file_actions_t?
-        guard posix_spawn_file_actions_init(&fileActions) == 0 else {
-            throw SpawnError.setupFailed(code: errno)
+        // The status IS the error number for these APIs; `errno` may hold
+        // something stale from an unrelated call (review round 7).
+        let fileActionsStatus = posix_spawn_file_actions_init(&fileActions)
+        guard fileActionsStatus == 0 else {
+            throw SpawnError.setupFailed(code: fileActionsStatus)
         }
         defer { posix_spawn_file_actions_destroy(&fileActions) }
         for (descriptor, flags) in [(0, O_RDONLY), (1, O_WRONLY), (2, O_WRONLY)] {
@@ -396,8 +405,9 @@ struct ClaudeRemoteHerdrForwardSpawner: ClaudeRemoteHerdrForwardSpawning {
         }
 
         var attributes: posix_spawnattr_t?
-        guard posix_spawnattr_init(&attributes) == 0 else {
-            throw SpawnError.setupFailed(code: errno)
+        let attributesStatus = posix_spawnattr_init(&attributes)
+        guard attributesStatus == 0 else {
+            throw SpawnError.setupFailed(code: attributesStatus)
         }
         defer { posix_spawnattr_destroy(&attributes) }
         // pgroup 0 with SETPGROUP: the child's process group id becomes its own
@@ -465,6 +475,11 @@ final class LiveHerdrForwardProcess: ClaudeRemoteHerdrForwardProcess, @unchecked
     /// without arranging real signal delivery. Same signature and same errno
     /// semantics as the real thing.
     private let waitForChild: @Sendable (pid_t, UnsafeMutablePointer<Int32>?, Int32) -> pid_t
+    /// PER HANDLE, never shared. One static serial queue meant a child that
+    /// never becomes collectable would block the single worker forever and
+    /// every later hand-off would queue behind it, retaining process objects
+    /// and leaving their children unreaped (review round 7).
+    private let reapQueue: DispatchQueue
 
     init(
         pid: pid_t,
@@ -474,6 +489,9 @@ final class LiveHerdrForwardProcess: ClaudeRemoteHerdrForwardProcess, @unchecked
     ) {
         self.pid = pid
         self.waitForChild = waitForChild
+        reapQueue = DispatchQueue(
+            label: "com.localvoxtral.claude.herdr-forward-reap.\(pid)", qos: .utility
+        )
         let source = DispatchSource.makeProcessSource(
             identifier: pid, eventMask: .exit, queue: .global(qos: .utility)
         )
@@ -526,7 +544,7 @@ final class LiveHerdrForwardProcess: ClaudeRemoteHerdrForwardProcess, @unchecked
         // not. It IS gated on not-yet-reaped, which is the only thing that
         // makes `-pid` still mean our group.
         guard signalGroupIsSafe else {
-            reapIfNeeded()
+            reapWithoutBlocking()
             return
         }
         _ = ClaudePluginInstallService.terminateBounded(
@@ -545,7 +563,7 @@ final class LiveHerdrForwardProcess: ClaudeRemoteHerdrForwardProcess, @unchecked
         // Unconditional within the un-reaped window: the leader going quietly
         // says nothing about the rest of its group.
         signalGroup(SIGKILL)
-        reapIfNeeded()
+        reapWithoutBlocking()
     }
 
     /// Whether `-pid` still names OUR process group.
@@ -553,14 +571,19 @@ final class LiveHerdrForwardProcess: ClaudeRemoteHerdrForwardProcess, @unchecked
 
     /// Signal the whole group, refusing once the pid could have been reused.
     /// Counted so a test can prove no signal is sent after the reap.
+    ///
+    /// The check and the signal happen under ONE lock acquisition. Releasing
+    /// between them left a window where a background collection could commit
+    /// `reaped` and a concurrent `terminate()` would then signal a pid the
+    /// kernel had already handed to someone else — the exact invariant round 4
+    /// established (review round 7). `kill` is non-blocking, so holding the
+    /// mutex across it costs nothing.
     private func signalGroup(_ signal: Int32) {
-        let sent = state.withLock { current -> Bool in
-            guard !current.reaped else { return false }
+        state.withLock { current in
+            guard !current.reaped else { return }
             current.groupSignalsSent += 1
-            return true
+            _ = Darwin.kill(-pid, signal)
         }
-        guard sent else { return }
-        _ = Darwin.kill(-pid, signal)
     }
 
     /// Collect the child, once. After this the pid is the kernel's to reuse,
@@ -573,27 +596,28 @@ final class LiveHerdrForwardProcess: ClaudeRemoteHerdrForwardProcess, @unchecked
     /// cancelled, every later teardown refused to signal or retry, and the
     /// documented "one zombie per open forward, for one dictation" became one
     /// per dictation forever.
-    /// How long the caller's own thread will poll before handing the wait off.
-    /// The child has been SIGKILLed by the time this runs, so the first attempt
-    /// almost always collects it; this bound exists for the case where it does
-    /// not.
-    private static let reapPollAttempts = 250
-    private static let reapQueue = DispatchQueue(
-        label: "com.localvoxtral.claude.herdr-forward-reap", qos: .utility
-    )
+    /// Total budget for collecting the child, in poll attempts of
+    /// `reapPollInterval` each. Generous, because the only cost of waiting is a
+    /// background timer; when it runs out we give up rather than block.
+    private static let reapPollAttempts = 600
+    private static let reapPollInterval: TimeInterval = 0.005
 
     private enum CollectOutcome {
         /// Definitively collected (or the kernel disowned the pid).
         case reaped
-        /// Not yet collectable, or interrupted. Ask again.
+        /// Not collectable yet, or interrupted. Ask again later.
         case pending
-        /// A real error. Leave it UNREAPED so a later teardown retries.
+        /// A real error. Leave it UNREAPED so a later attempt retries.
         case failed
     }
 
-    private func collectOnce(options: Int32) -> CollectOutcome {
+    /// One NON-BLOCKING collection attempt. `WNOHANG` everywhere, by design:
+    /// there is no `waitpid(…, 0)` left anywhere in this type, so no thread —
+    /// foreground or background — can ever be parked on a child that refuses to
+    /// die (review round 7).
+    private func collectOnce() -> CollectOutcome {
         var status: Int32 = 0
-        let collected = waitForChild(pid, &status, options)
+        let collected = waitForChild(pid, &status, WNOHANG)
         if collected > 0 {
             markReaped()
             return .reaped
@@ -610,48 +634,55 @@ final class LiveHerdrForwardProcess: ClaudeRemoteHerdrForwardProcess, @unchecked
             return .reaped
         }
         // Anything else stays UNREAPED on purpose: the zombie is still ours,
-        // `-pid` still names our group, and the next teardown (or the handle's
-        // deinit) will try again rather than leak it silently.
+        // `-pid` still names our group, and a later attempt will retry rather
+        // than leak it silently.
         Log.claudeContext.error(
             "Remote herdr forward could not be collected (errno \(failure, privacy: .public)); leaving it unreaped for a later attempt"
         )
         return .failed
     }
 
-    /// Collect the child, once. After this the pid is the kernel's to reuse,
-    /// which is precisely why nothing may signal the group afterwards.
+    /// Collect the child without ever blocking the caller.
     ///
-    /// `reaped` is committed only on a DEFINITIVE outcome — the child was
-    /// collected, or the kernel says there is no such child. Claiming it up
-    /// front (as the first version did) meant an interrupted `waitpid` left a
-    /// zombie behind while the state insisted it was gone: the source was
-    /// cancelled, every later teardown refused to signal or retry, and the
-    /// documented "one zombie per open forward, for one dictation" became one
-    /// per dictation forever.
+    /// `reaped` is committed only on a DEFINITIVE outcome — collected, or
+    /// `ECHILD`. Claiming it up front (as an earlier version did) meant an
+    /// interrupted `waitpid` left a zombie while the state insisted it was
+    /// gone, which turned the documented "one zombie per open forward, for one
+    /// dictation" into one per dictation forever.
     ///
-    /// NON-BLOCKING first, because every caller is a user-visible path — stop,
-    /// commit, cancel, app quit, all on the main actor. A child wedged in an
-    /// uninterruptible wait must cost a background thread, never the UI, so the
-    /// bounded poll hands off rather than waiting it out (review round 5b).
-    private func reapIfNeeded() {
+    /// One attempt runs on the caller's thread — after SIGKILL the child is
+    /// normally collectable immediately — and anything else goes to this
+    /// handle's own queue on a bounded budget. If the budget runs out the child
+    /// stays UNREAPED and says so loudly: a zombie we can still see is strictly
+    /// better than a thread parked forever, and the next `close()` (or deinit)
+    /// tries again.
+    private func reapWithoutBlocking() {
         guard !state.withLock({ $0.reaped }) else { return }
-        for _ in 0..<Self.reapPollAttempts {
-            switch collectOnce(options: WNOHANG) {
-            case .reaped, .failed:
-                return
-            case .pending:
-                usleep(1000)
-            }
+        switch collectOnce() {
+        case .reaped, .failed:
+            return
+        case .pending:
+            break
         }
-        Log.claudeContext.info(
-            "Remote herdr forward is not collectable yet; finishing the wait off the calling thread"
-        )
-        Self.reapQueue.async { [self] in
-            while true {
-                switch collectOnce(options: 0) {
-                case .reaped, .failed: return
-                case .pending: continue
-                }
+        reapQueue.asyncAfter(deadline: .now() + Self.reapPollInterval) { [self] in
+            pollForCollection(attemptsLeft: Self.reapPollAttempts)
+        }
+    }
+
+    private func pollForCollection(attemptsLeft: Int) {
+        guard !state.withLock({ $0.reaped }) else { return }
+        switch collectOnce() {
+        case .reaped, .failed:
+            return
+        case .pending:
+            guard attemptsLeft > 1 else {
+                Log.claudeContext.error(
+                    "Remote herdr forward never became collectable; leaving it unreaped rather than waiting on it"
+                )
+                return
+            }
+            reapQueue.asyncAfter(deadline: .now() + Self.reapPollInterval) { [self] in
+                pollForCollection(attemptsLeft: attemptsLeft - 1)
             }
         }
     }

--- a/Sources/localvoxtral/ClaudeContext/ClaudeRemoteHerdrForward.swift
+++ b/Sources/localvoxtral/ClaudeContext/ClaudeRemoteHerdrForward.swift
@@ -367,6 +367,11 @@ struct ClaudeRemoteHerdrForwardSpawner: ClaudeRemoteHerdrForwardSpawning {
     var executablePath = "/usr/bin/ssh"
     /// Injected so a test can spawn something observable instead of ssh.
     var environment: [String: String] = ProcessInfo.processInfo.environment
+    /// Passed through to the spawned process, so a test can drive the reap
+    /// path's failure handling against a REAL child in a real process group.
+    var waitForChild: @Sendable (pid_t, UnsafeMutablePointer<Int32>?, Int32) -> pid_t = {
+        waitpid($0, $1, $2)
+    }
 
     func spawn(argv: [String]) throws -> any ClaudeRemoteHerdrForwardProcess {
         guard !argv.isEmpty else { throw SpawnError.emptyArgv }
@@ -402,7 +407,7 @@ struct ClaudeRemoteHerdrForwardSpawner: ClaudeRemoteHerdrForwardSpawning {
             &pid, executablePath, &fileActions, &attributes, arguments, environmentStrings
         )
         guard status == 0, pid > 1 else { throw SpawnError.launchFailed(code: status) }
-        return LiveHerdrForwardProcess(pid: pid)
+        return LiveHerdrForwardProcess(pid: pid, waitForChild: waitForChild)
     }
 
     enum SpawnError: Error, Equatable {
@@ -434,9 +439,19 @@ final class LiveHerdrForwardProcess: ClaudeRemoteHerdrForwardProcess, @unchecked
     private let exited = DispatchSemaphore(value: 0)
     private let state = Mutex(State())
     private let source: any DispatchSourceProcess
+    /// `waitpid`, injected so the reap path's error handling is testable
+    /// without arranging real signal delivery. Same signature and same errno
+    /// semantics as the real thing.
+    private let waitForChild: @Sendable (pid_t, UnsafeMutablePointer<Int32>?, Int32) -> pid_t
 
-    init(pid: pid_t) {
+    init(
+        pid: pid_t,
+        waitForChild: @escaping @Sendable (pid_t, UnsafeMutablePointer<Int32>?, Int32) -> pid_t = {
+            waitpid($0, $1, $2)
+        }
+    ) {
         self.pid = pid
+        self.waitForChild = waitForChild
         let source = DispatchSource.makeProcessSource(
             identifier: pid, eventMask: .exit, queue: .global(qos: .utility)
         )
@@ -528,15 +543,46 @@ final class LiveHerdrForwardProcess: ClaudeRemoteHerdrForwardProcess, @unchecked
 
     /// Collect the child, once. After this the pid is the kernel's to reuse,
     /// which is precisely why nothing may signal the group afterwards.
+    ///
+    /// `reaped` is committed only on a DEFINITIVE outcome — the child was
+    /// collected, or the kernel says there is no such child. Claiming it up
+    /// front (as the first version did) meant an interrupted `waitpid` left a
+    /// zombie behind while the state insisted it was gone: the source was
+    /// cancelled, every later teardown refused to signal or retry, and the
+    /// documented "one zombie per open forward, for one dictation" became one
+    /// per dictation forever.
     private func reapIfNeeded() {
-        let shouldReap = state.withLock { current -> Bool in
-            guard !current.reaped else { return false }
-            current.reaped = true
-            return true
-        }
-        guard shouldReap else { return }
+        guard !state.withLock({ $0.reaped }) else { return }
         var status: Int32 = 0
-        _ = waitpid(pid, &status, 0)
+        while true {
+            let collected = waitForChild(pid, &status, 0)
+            if collected > 0 {
+                markReaped()
+                return
+            }
+            let failure = errno
+            if collected == -1, failure == EINTR {
+                // A caught signal is not an answer. Ask again.
+                continue
+            }
+            if collected == -1, failure == ECHILD {
+                // Definitive: there is nothing left to collect, so the pid is
+                // no longer ours to signal either.
+                markReaped()
+                return
+            }
+            // Anything else stays UNREAPED on purpose: the zombie is still
+            // ours, `-pid` still names our group, and the next teardown (or
+            // the handle's deinit) will try again rather than leak it silently.
+            Log.claudeContext.error(
+                "Remote herdr forward could not be collected (errno \(failure, privacy: .public)); leaving it unreaped for a later attempt"
+            )
+            return
+        }
+    }
+
+    private func markReaped() {
+        state.withLock { $0.reaped = true }
         source.cancel()
     }
 

--- a/Sources/localvoxtral/ClaudeContext/ClaudeRemoteHerdrForward.swift
+++ b/Sources/localvoxtral/ClaudeContext/ClaudeRemoteHerdrForward.swift
@@ -378,6 +378,10 @@ struct ClaudeRemoteHerdrForwardSpawner: ClaudeRemoteHerdrForwardSpawning {
     var waitForChild: @Sendable (pid_t, UnsafeMutablePointer<Int32>?, Int32) -> pid_t = {
         waitpid($0, $1, $2)
     }
+    /// Collection budget, passed through to the spawned process so a test can
+    /// observe exhaustion without waiting out the production default.
+    var reapPollAttempts = LiveHerdrForwardProcess.defaultReapPollAttempts
+    var reapPollInterval = LiveHerdrForwardProcess.defaultReapPollInterval
 
     func spawn(argv: [String]) throws -> any ClaudeRemoteHerdrForwardProcess {
         guard !argv.isEmpty else { throw SpawnError.emptyArgv }
@@ -434,7 +438,12 @@ struct ClaudeRemoteHerdrForwardSpawner: ClaudeRemoteHerdrForwardSpawning {
             &pid, executablePath, &fileActions, &attributes, arguments, environmentStrings
         )
         guard status == 0, pid > 1 else { throw SpawnError.launchFailed(code: status) }
-        return LiveHerdrForwardProcess(pid: pid, waitForChild: waitForChild)
+        return LiveHerdrForwardProcess(
+            pid: pid,
+            waitForChild: waitForChild,
+            reapPollAttempts: reapPollAttempts,
+            reapPollInterval: reapPollInterval
+        )
     }
 
     enum SpawnError: Error, Equatable {
@@ -480,15 +489,23 @@ final class LiveHerdrForwardProcess: ClaudeRemoteHerdrForwardProcess, @unchecked
     /// every later hand-off would queue behind it, retaining process objects
     /// and leaving their children unreaped (review round 7).
     private let reapQueue: DispatchQueue
+    /// Injected so a test can observe budget EXHAUSTION and the release that
+    /// follows it, rather than asserting against a three-second default.
+    private let reapPollAttempts: Int
+    private let reapPollInterval: TimeInterval
 
     init(
         pid: pid_t,
         waitForChild: @escaping @Sendable (pid_t, UnsafeMutablePointer<Int32>?, Int32) -> pid_t = {
             waitpid($0, $1, $2)
-        }
+        },
+        reapPollAttempts: Int = LiveHerdrForwardProcess.defaultReapPollAttempts,
+        reapPollInterval: TimeInterval = LiveHerdrForwardProcess.defaultReapPollInterval
     ) {
         self.pid = pid
         self.waitForChild = waitForChild
+        self.reapPollAttempts = reapPollAttempts
+        self.reapPollInterval = reapPollInterval
         reapQueue = DispatchQueue(
             label: "com.localvoxtral.claude.herdr-forward-reap.\(pid)", qos: .utility
         )
@@ -599,8 +616,8 @@ final class LiveHerdrForwardProcess: ClaudeRemoteHerdrForwardProcess, @unchecked
     /// Total budget for collecting the child, in poll attempts of
     /// `reapPollInterval` each. Generous, because the only cost of waiting is a
     /// background timer; when it runs out we give up rather than block.
-    private static let reapPollAttempts = 600
-    private static let reapPollInterval: TimeInterval = 0.005
+    static let defaultReapPollAttempts = 600
+    static let defaultReapPollInterval: TimeInterval = 0.005
 
     private enum CollectOutcome {
         /// Definitively collected (or the kernel disowned the pid).
@@ -611,35 +628,70 @@ final class LiveHerdrForwardProcess: ClaudeRemoteHerdrForwardProcess, @unchecked
         case failed
     }
 
-    /// One NON-BLOCKING collection attempt. `WNOHANG` everywhere, by design:
-    /// there is no `waitpid(…, 0)` left anywhere in this type, so no thread —
-    /// foreground or background — can ever be parked on a child that refuses to
-    /// die (review round 7).
+    /// One NON-BLOCKING collection attempt, performed UNDER THE SAME LOCK that
+    /// `signalGroup` consults.
+    ///
+    /// This is the whole PID-reuse invariant, and the earlier version only
+    /// looked like it held: the `waitpid` ran outside the mutex and the state
+    /// flip came after, so a background collection could release the pid while
+    /// a concurrent `terminate()` — holding the lock, still reading
+    /// `reaped == false` — went on to `kill(-pid)` a group the kernel had
+    /// already handed to someone else (review round 8). Two collectors could
+    /// also enter `waitpid` for the same pid in that gap.
+    ///
+    /// Serializing all three operations is trivially correct here BECAUSE of
+    /// the round-7 simplification: `waitpid(WNOHANG)` and `kill` are both
+    /// non-blocking syscalls, so the critical section has no wait in it and
+    /// needs no second lock or "collecting" state. (The injected
+    /// `waitForChild` is a syscall shim by contract — it must not re-enter this
+    /// object.)
+    ///
+    /// Logging and `source.cancel()` deliberately happen after the lock is
+    /// released: neither participates in the invariant.
     private func collectOnce() -> CollectOutcome {
-        var status: Int32 = 0
-        let collected = waitForChild(pid, &status, WNOHANG)
-        if collected > 0 {
-            markReaped()
-            return .reaped
+        enum LockedOutcome {
+            case reaped
+            case pending
+            case failed(Int32)
         }
-        // WNOHANG's "still running" answer, which sets no errno.
-        if collected == 0 { return .pending }
-        let failure = errno
-        // A caught signal is not an answer.
-        if failure == EINTR { return .pending }
-        if failure == ECHILD {
-            // Definitive: there is nothing left to collect, so the pid is no
-            // longer ours to signal either.
-            markReaped()
-            return .reaped
+        let outcome: LockedOutcome = state.withLock { current in
+            // Someone already collected it; the pid is not ours to touch.
+            guard !current.reaped else { return .reaped }
+            var status: Int32 = 0
+            let collected = waitForChild(pid, &status, WNOHANG)
+            if collected > 0 {
+                current.reaped = true
+                return .reaped
+            }
+            // WNOHANG's "still running" answer, which sets no errno.
+            if collected == 0 { return .pending }
+            let failure = errno
+            // A caught signal is not an answer.
+            if failure == EINTR { return .pending }
+            if failure == ECHILD {
+                // Definitive: there is nothing left to collect, so the pid is
+                // no longer ours to signal either.
+                current.reaped = true
+                return .reaped
+            }
+            return .failed(failure)
         }
-        // Anything else stays UNREAPED on purpose: the zombie is still ours,
-        // `-pid` still names our group, and a later attempt will retry rather
-        // than leak it silently.
-        Log.claudeContext.error(
-            "Remote herdr forward could not be collected (errno \(failure, privacy: .public)); leaving it unreaped for a later attempt"
-        )
-        return .failed
+
+        switch outcome {
+        case .reaped:
+            source.cancel()
+            return .reaped
+        case .pending:
+            return .pending
+        case .failed(let failure):
+            // Stays UNREAPED on purpose: the zombie is still ours, `-pid` still
+            // names our group, and a later attempt will retry rather than leak
+            // it silently.
+            Log.claudeContext.error(
+                "Remote herdr forward could not be collected (errno \(failure, privacy: .public)); leaving it unreaped for a later attempt"
+            )
+            return .failed
+        }
     }
 
     /// Collect the child without ever blocking the caller.
@@ -664,8 +716,8 @@ final class LiveHerdrForwardProcess: ClaudeRemoteHerdrForwardProcess, @unchecked
         case .pending:
             break
         }
-        reapQueue.asyncAfter(deadline: .now() + Self.reapPollInterval) { [self] in
-            pollForCollection(attemptsLeft: Self.reapPollAttempts)
+        reapQueue.asyncAfter(deadline: .now() + reapPollInterval) { [self] in
+            pollForCollection(attemptsLeft: reapPollAttempts)
         }
     }
 
@@ -681,15 +733,10 @@ final class LiveHerdrForwardProcess: ClaudeRemoteHerdrForwardProcess, @unchecked
                 )
                 return
             }
-            reapQueue.asyncAfter(deadline: .now() + Self.reapPollInterval) { [self] in
+            reapQueue.asyncAfter(deadline: .now() + reapPollInterval) { [self] in
                 pollForCollection(attemptsLeft: attemptsLeft - 1)
             }
         }
-    }
-
-    private func markReaped() {
-        state.withLock { $0.reaped = true }
-        source.cancel()
     }
 
     /// Record the leader's exit and wake the waiter. Deliberately does NOT

--- a/Sources/localvoxtral/ClaudeContext/ClaudeRemoteHostRegistry.swift
+++ b/Sources/localvoxtral/ClaudeContext/ClaudeRemoteHostRegistry.swift
@@ -457,6 +457,31 @@ public final class ClaudeRemoteHostRegistry: Sendable {
         state.withLock { $0.first { $0.id == id }?.publicView }
     }
 
+    /// Active hosts whose enrolled ssh alias IS this destination.
+    ///
+    /// The join side of the alias: the process table says the focused terminal
+    /// is an ssh client going to `builder`, and this answers "and is `builder`
+    /// a host the user enrolled?". Revoked hosts are not candidates — a
+    /// credential the user withdrew must not keep authorizing a context join.
+    ///
+    /// Compared case-insensitively, because a hostname is, and an ssh config
+    /// alias is used as one in practice. That makes the comparison WIDER, which
+    /// is safe only because a match is a precondition of the remote herdr arm
+    /// and never the join: the pane id, the marker, and the foreground process
+    /// all still have to agree afterwards.
+    ///
+    /// Returns the STORED alias, not the destination the user typed: that is
+    /// the string `ClaudeRemoteEnrollmentService.isValidHostAlias` vetted at
+    /// enrollment, and it is the one allowed to reach an argv.
+    public func hosts(matchingSSHDestination destination: String) -> [ClaudeRemoteHost] {
+        let needle = destination.lowercased()
+        guard !needle.isEmpty else { return [] }
+        return hosts().filter { host in
+            guard !host.isRevoked, let alias = host.sshHostAlias else { return false }
+            return alias.lowercased() == needle
+        }
+    }
+
     /// Whether binding the listener is worth doing at all.
     ///
     /// No enrolled host means no port is opened. A feature nobody has set up

--- a/Sources/localvoxtral/ClaudeContext/ClaudeSessionRegistry.swift
+++ b/Sources/localvoxtral/ClaudeContext/ClaudeSessionRegistry.swift
@@ -561,6 +561,42 @@ public final class ClaudeSessionRegistry: Sendable {
         }
     }
 
+    /// Live sessions from ONE enrolled remote host that reported both halves of
+    /// a herdr pane identity, most recently active first.
+    ///
+    /// The mirror image of `liveLocalHerdrSocketPaths()`, and deliberately its
+    /// opposite in every filter: `.remote` origin only, scoped to one host's
+    /// channel, reading `remoteSessionEnvironment` rather than `process`. Those
+    /// two fields never mix (PR #216), so this cannot see a local session's
+    /// pane and the local arms cannot see one of these.
+    ///
+    /// Nothing here is trusted. Both values are opaque labels naming things on
+    /// the host that reported them: this returns candidates, and the join arm
+    /// still has to prove — over the forwarded socket, against that host's own
+    /// herdr — that the focused pane is this session's.
+    ///
+    /// SEVERAL candidates is the expected shape, not an ambiguity: two Claude
+    /// sessions in two herdr panes is the ordinary multiplexer workflow. The
+    /// caller narrows by the herdr's own FOCUSED pane id and requires exactly
+    /// one match there; what it refuses is two candidates claiming the same
+    /// pane id, and two distinct herdr sockets on the host.
+    public func liveRemoteHerdrSessions(hostID: String) -> [ClaudeSessionSnapshot] {
+        let channel = ClaudeRemoteSessionScope.channel(hostID: hostID)
+        let timestamp = now()
+        return state.withLock { state in
+            state.sessions.values
+                .filter { snapshot in
+                    guard case .remote(let sessionChannel) = snapshot.origin,
+                          sessionChannel == channel,
+                          isFresh(snapshot, now: timestamp)
+                    else { return false }
+                    let environment = snapshot.remoteSessionEnvironment
+                    return environment?.herdrPaneID != nil && environment?.herdrSocketPath != nil
+                }
+                .sorted { $0.lastActivity > $1.lastActivity }
+        }
+    }
+
     public func snapshot(sessionID: String) -> ClaudeSessionSnapshot? {
         let timestamp = now()
         return state.withLock { state in

--- a/Sources/localvoxtral/ClaudeContext/HerdrClientTTYProbe.swift
+++ b/Sources/localvoxtral/ClaudeContext/HerdrClientTTYProbe.swift
@@ -33,42 +33,14 @@ enum HerdrClientTTYProbe {
         return names.contains("herdr")
     }
 
-    private static let liveDeviceID: @Sendable (String) -> dev_t? = { path in
-        // `lstat`, matching ClaudeSocketGuard: `Darwin.stat` resolves to the
-        // struct type, not the function, and a /dev node is never a symlink.
-        var metadata = stat()
-        guard lstat(path, &metadata) == 0 else { return nil }
-        return metadata.st_rdev
-    }
+    /// Both live reads are the SHARED walk (`TTYProcessTable`), so this probe
+    /// and the ssh-destination probe cannot drift apart on what "on this tty"
+    /// means. The injected-seam signatures above are unchanged: this one only
+    /// ever needs names, and says so by throwing the pids away here.
+    private static let liveDeviceID: @Sendable (String) -> dev_t? = TTYProcessTable.liveDeviceID
 
     private static let liveProcessNames: @Sendable (dev_t) -> [String]? = { device in
-        // dev_t is Int32 on Darwin, so this is an identity conversion today —
-        // but if the type ever widens, a device that does not fit must abstain,
-        // not trap mid-dictation.
-        guard let deviceMib = Int32(exactly: device) else { return nil }
-        var mib = [Int32(CTL_KERN), Int32(KERN_PROC), Int32(KERN_PROC_TTY), deviceMib]
-        var byteCount = 0
-        guard sysctl(&mib, u_int(mib.count), nil, &byteCount, nil, 0) == 0,
-              byteCount > 0
-        else { return nil }
-
-        let stride = MemoryLayout<kinfo_proc>.stride
-        var processes = [kinfo_proc](
-            repeating: kinfo_proc(), count: (byteCount + stride - 1) / stride
-        )
-        var fetchedBytes = processes.count * stride
-        let status = processes.withUnsafeMutableBytes { buffer in
-            sysctl(&mib, u_int(mib.count), buffer.baseAddress, &fetchedBytes, nil, 0)
-        }
-        guard status == 0 else { return nil }
-
-        return processes.prefix(fetchedBytes / stride).map { process in
-            // Bounded decode: `String(cString:)` would walk past the fixed-size
-            // p_comm tuple if a corrupted entry ever arrived without its NUL.
-            withUnsafeBytes(of: process.kp_proc.p_comm) { raw in
-                String(decoding: raw.prefix(while: { $0 != 0 }), as: UTF8.self)
-            }
-        }
+        TTYProcessTable.entries(onDevice: device)?.map(\.name)
     }
 }
 #endif

--- a/Sources/localvoxtral/ClaudeContext/HerdrSocketClient.swift
+++ b/Sources/localvoxtral/ClaudeContext/HerdrSocketClient.swift
@@ -9,13 +9,61 @@ struct HerdrFocusedPane: Sendable, Equatable {
     /// herdr's own Claude-session claim for the pane, when its integration is
     /// installed: (kind "id" → sessionID). nil when absent or kind == "path".
     var claimedClaudeSessionID: String?
+    /// The OSC 2 title of the INNER pane, as herdr captured it.
+    ///
+    /// herdr intercepts a pane's title writes rather than passing them out to
+    /// the surrounding terminal — which is why a title marker is useless for a
+    /// local herdr join, and precisely why it works for a REMOTE one: the
+    /// marker the remote listener hands back to every remote session rides the
+    /// SSH PTY into the inner pane and lands HERE, where the pane it describes
+    /// is the pane being reported. Untrusted text like any other wire field;
+    /// only the marker grammar is ever read out of it.
+    var terminalTitle: String?
+
+    init(paneID: String, claimedClaudeSessionID: String?, terminalTitle: String? = nil) {
+        self.paneID = paneID
+        self.claimedClaudeSessionID = claimedClaudeSessionID
+        self.terminalTitle = terminalTitle
+    }
+}
+
+/// One process herdr reports as foreground in a pane.
+struct HerdrForegroundProcess: Sendable, Equatable {
+    var pid: Int32
+    /// nil ⇒ herdr did not report a name for this process. Never inferred.
+    var name: String?
+
+    init(pid: Int32, name: String? = nil) {
+        self.pid = pid
+        self.name = name
+    }
 }
 
 struct HerdrPaneForegroundInfo: Sendable, Equatable {
     var shellPID: Int32?
     /// nil ⇒ the `foreground_processes` key was ABSENT (detection unavailable);
     /// distinct from [] which cannot occur on the wire.
-    var foregroundPIDs: [Int32]?
+    var foregroundProcesses: [HerdrForegroundProcess]?
+
+    /// The local arm's question: is the pid we registered running here? Derived
+    /// rather than stored, so a pid list and a process list can never disagree.
+    var foregroundPIDs: [Int32]? { foregroundProcesses?.map(\.pid) }
+
+    init(shellPID: Int32?, foregroundProcesses: [HerdrForegroundProcess]?) {
+        self.shellPID = shellPID
+        self.foregroundProcesses = foregroundProcesses
+    }
+
+    /// Pid-only convenience for the local arm and its tests, which have no
+    /// business knowing process names: a REMOTE session's pid means nothing
+    /// here (it is another machine's namespace), so that arm identifies the
+    /// agent by name instead and this init makes the asymmetry explicit.
+    init(shellPID: Int32?, foregroundPIDs: [Int32]?) {
+        self.init(
+            shellPID: shellPID,
+            foregroundProcesses: foregroundPIDs?.map { HerdrForegroundProcess(pid: $0) }
+        )
+    }
 }
 
 protocol HerdrPaneQuerying: Sendable {
@@ -76,7 +124,13 @@ struct HerdrSocketClient: HerdrPaneQuerying {
             }
             return HerdrFocusedPane(
                 paneID: result.pane.paneID,
-                claimedClaudeSessionID: claim
+                claimedClaudeSessionID: claim,
+                // A title longer than any title is not a title. Dropped rather
+                // than truncated: a cut string can only make marker parsing
+                // answer a question about bytes nobody sent.
+                terminalTitle: result.pane.terminalTitle.flatMap {
+                    $0.utf8.count <= Self.maxTerminalTitleBytes ? $0 : nil
+                }
             )
         }.value
     }
@@ -105,7 +159,9 @@ struct HerdrSocketClient: HerdrPaneQuerying {
             }
             return HerdrPaneForegroundInfo(
                 shellPID: result.processInfo.shellPID,
-                foregroundPIDs: result.processInfo.foregroundProcesses?.map(\.pid)
+                foregroundProcesses: result.processInfo.foregroundProcesses?.map {
+                    HerdrForegroundProcess(pid: $0.pid, name: $0.name)
+                }
             )
         }.value
     }
@@ -395,11 +451,13 @@ struct HerdrSocketClient: HerdrPaneQuerying {
         var paneID: String
         var focused: Bool
         var agentSession: AgentSession?
+        var terminalTitle: String?
 
         enum CodingKeys: String, CodingKey {
             case paneID = "pane_id"
             case focused
             case agentSession = "agent_session"
+            case terminalTitle = "terminal_title"
         }
 
         init(from decoder: Decoder) throws {
@@ -409,6 +467,9 @@ struct HerdrSocketClient: HerdrPaneQuerying {
             agentSession = container.contains(.agentSession)
                 ? try container.decode(AgentSession.self, forKey: .agentSession)
                 : nil
+            // Absent and null are the same thing for a title, unlike for
+            // `foreground_processes` below where presence is the signal.
+            terminalTitle = try container.decodeIfPresent(String.self, forKey: .terminalTitle)
         }
     }
 
@@ -453,7 +514,16 @@ struct HerdrSocketClient: HerdrPaneQuerying {
 
     private struct ForegroundProcess: Decodable {
         var pid: Int32
+        /// herdr's `name` for the process (`pane.process_info`). The REMOTE
+        /// herdr arm identifies the agent by this, because a remote pid is a
+        /// number in another machine's namespace.
+        var name: String?
     }
+
+    /// Ceiling on a retained `terminal_title`. A window title is a handful of
+    /// bytes; this is three orders of magnitude of headroom and still bounds
+    /// what marker parsing ever walks.
+    private static let maxTerminalTitleBytes = 1024
 
     /// `pane.read` success — herdr c234f221, `src/api/schema/response.rs`
     /// (`ResponseResult::PaneRead`, tag `pane_read`) wrapping

--- a/Sources/localvoxtral/ClaudeContext/SSHDestinationTTYProbe.swift
+++ b/Sources/localvoxtral/ClaudeContext/SSHDestinationTTYProbe.swift
@@ -1,0 +1,592 @@
+import Foundation
+
+#if canImport(Darwin)
+import Darwin
+
+/// The ssh connection a terminal surface is displaying, as far as the local
+/// process table can prove it.
+struct SSHSurfaceConnection: Sendable, Equatable {
+    /// Normalized destination host/alias.
+    var destination: String
+    /// No OTHER terminal on this machine hosts an ssh to the same destination.
+    ///
+    /// Without this the probe binds to a HOST rather than to a CONNECTION: with
+    /// one terminal on a plain shell to `builder` and another attached to herdr
+    /// on `builder`, both surfaces answer "ssh to builder", and the plain shell
+    /// would join the herdr terminal's session (review blocker 1).
+    var isOnlyConnectionToDestination: Bool
+    /// The argv positively names herdr as the remote command — the shape
+    /// `herdr --remote` spawns, or a hand-typed `ssh host herdr …`. This binds
+    /// the CONNECTION to herdr, which no amount of host-level reasoning can.
+    var indicatesHerdr: Bool
+
+    init(destination: String, isOnlyConnectionToDestination: Bool, indicatesHerdr: Bool) {
+        self.destination = destination
+        self.isOnlyConnectionToDestination = isOnlyConnectionToDestination
+        self.indicatesHerdr = indicatesHerdr
+    }
+}
+
+/// What the process table says about ssh clients on ONE terminal device.
+///
+/// Three answers, and the difference between the last two is the whole point:
+/// "there is no ssh session here" is a fact the resolver can act on (fall
+/// through to the arms that do not involve another machine), while "I could not
+/// tell" must stop the remote arm dead.
+enum SSHDestinationTTYProbeResult: Sendable, Equatable {
+    /// No foreground ssh session on this device.
+    case noSSHClient
+    case connection(SSHSurfaceConnection)
+    /// An ssh session is there and cannot be pinned down: argv unavailable, an
+    /// unverifiable executable, an option that can move the destination, a
+    /// grammar we do not recognize, or two of them going to different places.
+    case undeterminable
+}
+
+/// One ssh process as the probe sees it.
+struct SSHClientProcess: Sendable, Equatable {
+    var pid: Int32
+    /// Controlling terminal device, or nil when it has none. A process with no
+    /// terminal is not a surface anyone can be dictating into — our OWN
+    /// `ssh -L` forward is exactly that, which is why it must not count.
+    var ttyDevice: dev_t?
+    var processGroupID: Int32
+    /// The foreground process group of its controlling terminal.
+    var terminalForegroundGroupID: Int32
+    /// Resolved executable path (`proc_pidpath`), not argv[0] and not `p_comm`.
+    var executablePath: String?
+    var arguments: [String]?
+
+    init(
+        pid: Int32,
+        ttyDevice: dev_t?,
+        processGroupID: Int32,
+        terminalForegroundGroupID: Int32,
+        executablePath: String?,
+        arguments: [String]?
+    ) {
+        self.pid = pid
+        self.ttyDevice = ttyDevice
+        self.processGroupID = processGroupID
+        self.terminalForegroundGroupID = terminalForegroundGroupID
+        self.executablePath = executablePath
+        self.arguments = arguments
+    }
+
+    /// Is this process the one the terminal is currently giving input to?
+    var isForegroundOfItsTerminal: Bool {
+        ttyDevice != nil && processGroupID == terminalForegroundGroupID
+    }
+}
+
+/// Reads the local process table to answer "is the focused terminal surface an
+/// ssh session, to where, and is it the only one?".
+///
+/// This is the binding that makes a REMOTE herdr join safe. Without it, a live
+/// remote herdr whose focused pane hosts a Claude session would join whatever
+/// the user is looking at locally, because every other check in that arm is
+/// about the REMOTE side.
+///
+/// The posture is `HerdrClientTTYProbe`'s — same-user process table only,
+/// injected seams, every metadata failure abstains — with three additional
+/// refusals the review demanded, all of them ways an argv can name one host
+/// while the connection goes somewhere else:
+///
+/// * the EXECUTABLE is verified (`proc_pidpath`), not `p_comm` and not argv[0];
+/// * the process must be in its terminal's FOREGROUND process group, so a
+///   stopped ssh, a background one, or an ssh spawned by `scp`/`rsync` cannot
+///   be mistaken for the session on screen;
+/// * any option that can move the destination or means "this is not an
+///   interactive session" — `-o` (HostName/Port/User/ProxyJump/…), `-F`, `-O`,
+///   `-S`, `-N`, `-f`, `-M`, `-D`, `-W`, `-w` — ABSTAINS instead of being
+///   skipped.
+enum SSHDestinationTTYProbe {
+    /// The only executables we are willing to believe are OpenSSH: three exact
+    /// absolute paths, the system client plus Homebrew's on both architectures.
+    ///
+    /// PREFIXES were the earlier rule and they were forgeable: anything under
+    /// `/opt/homebrew/` or `/usr/local/` whose basename was `ssh` passed, so a
+    /// compiled `/opt/homebrew/tmp/ssh` with a crafted argv was trusted (review
+    /// round 3, blocker 2). Those directories are user-writable, which is the
+    /// whole problem — an exact path is a claim about ONE file.
+    static let canonicalSSHExecutablePaths = [
+        "/usr/bin/ssh",
+        "/opt/homebrew/bin/ssh",
+        "/usr/local/bin/ssh",
+    ]
+
+    /// Is this the executable of a process we will read a destination from?
+    ///
+    /// `proc_pidpath` reports the RESOLVED path, and Homebrew's `bin/ssh` is a
+    /// symlink into the Cellar — so a Cellar path is accepted only when it is
+    /// what resolving one of the canonical paths above actually produces. That
+    /// keeps the Homebrew case working without trusting the directory it lives
+    /// in: `/opt/homebrew/Cellar/openssh/9.9p1/bin/ssh` passes only while
+    /// `/opt/homebrew/bin/ssh` points at exactly it.
+    ///
+    /// - Parameter resolvedPath: injected so the Cellar rule is testable on a
+    ///   machine that has no Homebrew (and so a test can prove an impostor in
+    ///   the same tree is still refused).
+    static func isTrustedSSHExecutable(
+        _ path: String,
+        resolvedPath: (String) -> String? = { canonicalPath(of: $0) }
+    ) -> Bool {
+        guard path.hasPrefix("/") else { return false }
+        if canonicalSSHExecutablePaths.contains(path) { return true }
+        // The symlink-target rule, and every clause of it earns its place. The
+        // first version accepted ANYTHING a canonical path resolved to, so
+        // repointing `/opt/homebrew/bin/ssh` at a same-tree
+        // `…/bin/ssh-impostor` was trusted (review round 4, blocker 1).
+        //
+        // Honest about what this is: an attacker who can repoint that symlink
+        // already controls what the USER's own `ssh` runs, so this is
+        // defense-in-depth against a sloppy target, not a privilege boundary.
+        // It does make the accepted set describable — "the file Homebrew's
+        // `ssh` actually is" — instead of "whatever that name happens to point
+        // at today".
+        guard (path as NSString).lastPathComponent == "ssh" else { return false }
+        return canonicalSSHExecutablePaths.contains { canonical in
+            guard resolvedPath(canonical) == path else { return false }
+            // A resolved path must stay inside the tree its canonical name
+            // lives in: `/opt/homebrew/bin/ssh` may resolve into
+            // `/opt/homebrew/Cellar/…`, never into `/tmp`.
+            guard let root = installationRoot(ofCanonicalPath: canonical) else { return false }
+            return path.hasPrefix(root + "/")
+        }
+    }
+
+    /// `/opt/homebrew/bin/ssh` → `/opt/homebrew`; `/usr/bin/ssh` → `/usr`.
+    ///
+    /// The prefix is derived from the canonical path rather than listed, so a
+    /// new canonical entry cannot forget to bring its own boundary.
+    static func installationRoot(ofCanonicalPath canonical: String) -> String? {
+        let binDirectory = (canonical as NSString).deletingLastPathComponent
+        guard (binDirectory as NSString).lastPathComponent == "bin" else { return nil }
+        let root = (binDirectory as NSString).deletingLastPathComponent
+        return root.isEmpty || root == "/" ? nil : root
+    }
+
+    /// `realpath(3)`, or nil when the path does not resolve.
+    static func canonicalPath(of path: String) -> String? {
+        guard let resolved = realpath(path, nil) else { return nil }
+        defer { free(resolved) }
+        return String(cString: resolved)
+    }
+
+    static func connection(onTTYDevicePath path: String) -> SSHDestinationTTYProbeResult {
+        connection(
+            onTTYDevicePath: path,
+            deviceID: TTYProcessTable.liveDeviceID,
+            sshProcesses: liveSSHProcesses
+        )
+    }
+
+    /// Pure over the two live reads, so the whole truth table is unit-testable
+    /// without a real ssh on a real tty.
+    ///
+    /// - Parameter sshProcesses: EVERY ssh process on the machine, not just this
+    ///   device's — the uniqueness question is machine-wide by definition.
+    static func connection(
+        onTTYDevicePath path: String,
+        deviceID: @Sendable (String) -> dev_t?,
+        sshProcesses: @Sendable () -> [SSHClientProcess]?
+    ) -> SSHDestinationTTYProbeResult {
+        guard let device = deviceID(path), let processes = sshProcesses() else {
+            // A device we cannot resolve, or a process table we cannot read, is
+            // not evidence of absence.
+            return .undeterminable
+        }
+
+        // Only the foreground process group of THIS terminal can be what the
+        // user is looking at. A backgrounded or stopped ssh on the same device
+        // means the surface is showing the shell, not a remote session.
+        let onSurface = processes.filter {
+            $0.ttyDevice == device && $0.isForegroundOfItsTerminal
+        }
+        guard !onSurface.isEmpty else { return .noSSHClient }
+
+        var destinations = Set<String>()
+        var indicatesHerdr = false
+        for process in onSurface {
+            guard let parsed = verifiedInvocation(of: process) else { return .undeterminable }
+            destinations.insert(parsed.destination)
+            indicatesHerdr = indicatesHerdr || parsed.indicatesHerdr
+        }
+        guard destinations.count == 1, let destination = destinations.first else {
+            return .undeterminable
+        }
+
+        return .connection(
+            SSHSurfaceConnection(
+                destination: destination,
+                isOnlyConnectionToDestination: isOnlyConnection(
+                    to: destination, device: device, processes: processes
+                ),
+                indicatesHerdr: indicatesHerdr
+            )
+        )
+    }
+
+    /// Is this terminal's the only connection to that destination?
+    ///
+    /// Every OTHER terminal's ssh counts, foreground or not: a session the user
+    /// backgrounded a second ago is still a second connection to that host, and
+    /// the question here is "could another surface be the herdr one?", not
+    /// "which one is active". Processes with NO controlling terminal are
+    /// excluded — nobody can be dictating into one, and our own `ssh -L`
+    /// forward is exactly that.
+    private static func isOnlyConnection(
+        to destination: String,
+        device: dev_t,
+        processes: [SSHClientProcess]
+    ) -> Bool {
+        for process in processes where process.ttyDevice != nil && process.ttyDevice != device {
+            guard let parsed = verifiedInvocation(of: process) else {
+                // An ssh elsewhere we cannot read could be to this destination.
+                // Uniqueness is a claim, and an unreadable process cannot be
+                // part of one.
+                return false
+            }
+            if parsed.destination == destination { return false }
+        }
+        return true
+    }
+
+    private static func verifiedInvocation(of process: SSHClientProcess) -> ParsedInvocation? {
+        guard let executablePath = process.executablePath,
+              isTrustedSSHExecutable(executablePath),
+              let arguments = process.arguments
+        else { return nil }
+        return parse(arguments: arguments)
+    }
+
+    // MARK: - argv parsing
+
+    struct ParsedInvocation: Sendable, Equatable {
+        var destination: String
+        var indicatesHerdr: Bool
+    }
+
+    /// Options that take no argument, per ssh(1)'s synopsis
+    /// (`[-46AaCfGgKkMNnqsTtVvXxYy]`), minus the ones this probe refuses.
+    private static let flagOptions = Set("46AaCgKknqsTtVvXxYy")
+    /// Options that take one argument and cannot move the destination.
+    private static let argumentOptions = Set("BbcEeIiJLlmPpQR")
+    /// Options that ABSTAIN, either because they can change where the
+    /// connection actually goes (`-o HostName=…`, `-F other.conf`) or because
+    /// they mean this is not an interactive session on a terminal (`-N`, `-f`,
+    /// `-M`, `-O`, `-S`, `-D`, `-W`, `-w`).
+    ///
+    /// `-o` is refused wholesale rather than parsed: proving a specific option
+    /// inert means reimplementing OpenSSH's config semantics, and the cost of
+    /// refusing is one join that does not happen.
+    private static let refusedOptions = Set("oFOSNfMDWw")
+
+    /// The destination host and whether the remote command names herdr, or nil
+    /// when this argv cannot be interpreted with certainty.
+    ///
+    /// Deliberately NOT "the last non-option token": everything after the
+    /// destination is a remote COMMAND, and `ssh host ls /tmp` would then be
+    /// read as a destination of `/tmp`. The walk classifies options in order and
+    /// stops at the first operand, which is the destination by definition.
+    static func parse(arguments argv: [String]) -> ParsedInvocation? {
+        guard let executable = argv.first, isSSHArgumentZero(executable) else { return nil }
+
+        var index = 1
+        while index < argv.count {
+            let token = argv[index]
+            if token == "--" {
+                guard index + 1 < argv.count else { return nil }
+                return invocation(
+                    destinationOperand: argv[index + 1],
+                    remoteCommand: Array(argv.dropFirst(index + 2))
+                )
+            }
+            if token.hasPrefix("-"), token.count > 1 {
+                switch consumption(ofOptionToken: token) {
+                case .unrecognized, .refused:
+                    return nil
+                case .selfContained:
+                    index += 1
+                case .consumesNextArgument:
+                    index += 2
+                }
+                continue
+            }
+            return invocation(
+                destinationOperand: token,
+                remoteCommand: Array(argv.dropFirst(index + 1))
+            )
+        }
+        return nil
+    }
+
+    private static func invocation(
+        destinationOperand: String,
+        remoteCommand: [String]
+    ) -> ParsedInvocation? {
+        guard let destination = normalizedDestination(destinationOperand) else { return nil }
+        return ParsedInvocation(
+            destination: destination,
+            indicatesHerdr: commandNamesHerdr(remoteCommand)
+        )
+    }
+
+    /// Is the remote command herdr ITSELF?
+    ///
+    /// Exactly the first command token, by basename: `ssh host herdr attach`
+    /// and `ssh host /usr/local/bin/herdr attach` count; nothing else does.
+    ///
+    /// The earlier version scanned every token, split on whitespace and
+    /// semicolons, which made the signal forgeable by anything that merely
+    /// MENTIONED herdr — `ssh builder sh -lc 'printf herdr; exec claude'` set
+    /// it (review round 3, blocker 1a). A shell wrapper is refused for the same
+    /// reason it was the exploit: its first token is `sh`, and what it goes on
+    /// to run is not something an argv can promise.
+    ///
+    /// This is CORROBORATION ONLY. It never substitutes for the uniqueness
+    /// requirement, because argv is written by whoever launched the process and
+    /// a mis-join costs another session's pane text.
+    static func commandNamesHerdr(_ remoteCommand: [String]) -> Bool {
+        guard let command = remoteCommand.first, !command.isEmpty else { return false }
+        return (command as NSString).lastPathComponent == "herdr"
+    }
+
+    private static func isSSHArgumentZero(_ path: String) -> Bool {
+        (path as NSString).lastPathComponent == "ssh"
+    }
+
+    /// What one option token does to the walk.
+    enum OptionConsumption: Sendable, Equatable {
+        /// Pure flags (`-tt`), or an option whose argument is glued to it
+        /// (`-p22`).
+        case selfContained
+        /// The option's argument is the NEXT argv element (`-p 22`).
+        case consumesNextArgument
+        /// An option that can move the destination or marks a non-interactive
+        /// session. Abstain.
+        case refused
+        /// A letter this parser does not know. Never guessed: an unknown option
+        /// that takes an argument would make the walk read that argument as the
+        /// destination.
+        case unrecognized
+    }
+
+    static func consumption(ofOptionToken token: String) -> OptionConsumption {
+        let characters = Array(token.dropFirst())
+        for (index, character) in characters.enumerated() {
+            if refusedOptions.contains(character) { return .refused }
+            if flagOptions.contains(character) { continue }
+            guard argumentOptions.contains(character) else { return .unrecognized }
+            return index == characters.count - 1 ? .consumesNextArgument : .selfContained
+        }
+        // A cluster of pure flags (`-tt`, `-AC`).
+        return .selfContained
+    }
+
+    /// The host part of an ssh destination operand, lowercased, or nil when the
+    /// operand is a shape we refuse to interpret.
+    ///
+    /// Refused on purpose: the `ssh://` URI form (its host is followed by an
+    /// optional `:port`, and this is not the place to reimplement a URL parser)
+    /// and anything outside a hostname/alias charset.
+    ///
+    /// Lowercased because hostnames are case-insensitive and an ssh config alias
+    /// is matched the same way in practice. That makes the comparison WIDER,
+    /// which is only safe because a match is a precondition of the arm, never
+    /// the join: the pane id, the marker, herdr's own session claim, and the
+    /// foreground process all still have to agree afterwards.
+    static func normalizedDestination(_ operand: String) -> String? {
+        guard !operand.isEmpty, operand.utf8.count <= 253 else { return nil }
+        guard !operand.contains("://") else { return nil }
+        // `user@host`: split on the LAST `@`, so a username containing one does
+        // not steal the host.
+        let host: Substring
+        if let separator = operand.lastIndex(of: "@") {
+            host = operand[operand.index(after: separator)...]
+        } else {
+            host = operand[...]
+        }
+        guard !host.isEmpty else { return nil }
+        let allowed = host.allSatisfy { character in
+            character.isASCII
+                && (character.isLetter || character.isNumber
+                    || character == "." || character == "-" || character == "_")
+        }
+        guard allowed else { return nil }
+        return host.lowercased()
+    }
+
+    // MARK: - Live reads
+
+    /// EVERY ssh process on the machine (`KERN_PROC_ALL`), with the metadata the
+    /// rules above need. One scan answers both the surface question and the
+    /// uniqueness question.
+    static let liveSSHProcesses: @Sendable () -> [SSHClientProcess]? = {
+        guard let entries = TTYProcessTable.allProcesses() else { return nil }
+        return entries
+            .filter { $0.name == "ssh" }
+            .map { entry in
+                SSHClientProcess(
+                    pid: entry.pid,
+                    ttyDevice: entry.ttyDevice,
+                    processGroupID: entry.processGroupID,
+                    terminalForegroundGroupID: entry.terminalForegroundGroupID,
+                    executablePath: executablePath(pid: entry.pid),
+                    arguments: processArguments(pid: entry.pid)
+                )
+            }
+    }
+
+    /// The real executable behind a pid — which `p_comm` (16 bytes, and a name
+    /// the process chose) and argv[0] (chosen by whoever exec'd it) are not.
+    static func executablePath(pid: Int32) -> String? {
+        var buffer = [CChar](repeating: 0, count: Int(MAXPATHLEN) * 2)
+        let length = proc_pidpath(pid, &buffer, UInt32(buffer.count))
+        guard length > 0 else { return nil }
+        return String(
+            decoding: buffer.prefix(Int(length)).map { UInt8(bitPattern: $0) }, as: UTF8.self
+        )
+    }
+
+    /// argv of one process via `KERN_PROCARGS2`.
+    ///
+    /// Layout (`sysctl.h`, unchanged since 10.x): `int32 argc`, the exec path,
+    /// NUL padding, then exactly `argc` NUL-terminated argv strings, then the
+    /// environment — which this deliberately stops before. Another process's
+    /// environment is not ours to read, and nothing here needs it.
+    static func processArguments(pid: Int32) -> [String]? {
+        var argumentMax: Int32 = 0
+        var size = MemoryLayout<Int32>.size
+        var maxMIB = [Int32(CTL_KERN), Int32(KERN_ARGMAX)]
+        guard sysctl(&maxMIB, u_int(maxMIB.count), &argumentMax, &size, nil, 0) == 0,
+              argumentMax > 0
+        else { return nil }
+
+        var buffer = [UInt8](repeating: 0, count: Int(argumentMax))
+        var length = buffer.count
+        var mib = [Int32(CTL_KERN), Int32(KERN_PROCARGS2), pid]
+        let status = buffer.withUnsafeMutableBytes { raw in
+            sysctl(&mib, u_int(mib.count), raw.baseAddress, &length, nil, 0)
+        }
+        guard status == 0, length > MemoryLayout<Int32>.size else { return nil }
+
+        return parseProcessArguments(Array(buffer.prefix(length)))
+    }
+
+    /// Pure parser over a `KERN_PROCARGS2` buffer, so the layout handling is
+    /// testable without spawning processes.
+    static func parseProcessArguments(_ buffer: [UInt8]) -> [String]? {
+        let headerSize = MemoryLayout<Int32>.size
+        guard buffer.count > headerSize else { return nil }
+        var argumentCount: Int32 = 0
+        withUnsafeMutableBytes(of: &argumentCount) { destination in
+            destination.copyBytes(from: buffer[0..<headerSize])
+        }
+        guard argumentCount > 0, argumentCount < 4096 else { return nil }
+
+        var index = headerSize
+        // Exec path, then its NUL padding.
+        while index < buffer.count, buffer[index] != 0 { index += 1 }
+        while index < buffer.count, buffer[index] == 0 { index += 1 }
+
+        var arguments: [String] = []
+        while arguments.count < Int(argumentCount), index < buffer.count {
+            var end = index
+            while end < buffer.count, buffer[end] != 0 { end += 1 }
+            // The last string must be NUL-terminated inside the buffer; a
+            // truncated tail means the layout was not what we think it is.
+            guard end < buffer.count else { return nil }
+            arguments.append(String(decoding: buffer[index..<end], as: UTF8.self))
+            index = end + 1
+        }
+        guard arguments.count == Int(argumentCount) else { return nil }
+        return arguments
+    }
+}
+
+/// Shared same-user walks of the process table.
+///
+/// Extracted so the ssh probe and `HerdrClientTTYProbe` cannot drift apart on
+/// what "on this tty" means. The ssh probe needs more per process (controlling
+/// device, process groups) and needs a machine-wide scan for the uniqueness
+/// rule, so both shapes live here.
+enum TTYProcessTable {
+    struct Entry: Sendable, Equatable {
+        var pid: Int32
+        var name: String
+        var ttyDevice: dev_t?
+        var processGroupID: Int32
+        var terminalForegroundGroupID: Int32
+
+        init(
+            pid: Int32,
+            name: String,
+            ttyDevice: dev_t? = nil,
+            processGroupID: Int32 = 0,
+            terminalForegroundGroupID: Int32 = 0
+        ) {
+            self.pid = pid
+            self.name = name
+            self.ttyDevice = ttyDevice
+            self.processGroupID = processGroupID
+            self.terminalForegroundGroupID = terminalForegroundGroupID
+        }
+    }
+
+    static let liveDeviceID: @Sendable (String) -> dev_t? = { path in
+        // `lstat`, matching ClaudeSocketGuard: `Darwin.stat` resolves to the
+        // struct type, not the function, and a /dev node is never a symlink.
+        var metadata = stat()
+        guard lstat(path, &metadata) == 0 else { return nil }
+        return metadata.st_rdev
+    }
+
+    static func entries(onDevice device: dev_t) -> [Entry]? {
+        // dev_t is Int32 on Darwin, so this is an identity conversion today —
+        // but if the type ever widens, a device that does not fit must abstain,
+        // not trap mid-dictation.
+        guard let deviceMIB = Int32(exactly: device) else { return nil }
+        return scan(mib: [Int32(CTL_KERN), Int32(KERN_PROC), Int32(KERN_PROC_TTY), deviceMIB])
+    }
+
+    static func allProcesses() -> [Entry]? {
+        scan(mib: [Int32(CTL_KERN), Int32(KERN_PROC), Int32(KERN_PROC_ALL), 0])
+    }
+
+    private static func scan(mib: [Int32]) -> [Entry]? {
+        var mib = mib
+        var byteCount = 0
+        guard sysctl(&mib, u_int(mib.count), nil, &byteCount, nil, 0) == 0, byteCount > 0
+        else { return nil }
+
+        let stride = MemoryLayout<kinfo_proc>.stride
+        // Headroom: processes can appear between the sizing call and the fetch,
+        // and a short buffer makes the second sysctl fail with ENOMEM.
+        let capacity = (byteCount + stride - 1) / stride + 32
+        var processes = [kinfo_proc](repeating: kinfo_proc(), count: capacity)
+        var fetchedBytes = processes.count * stride
+        let status = processes.withUnsafeMutableBytes { buffer in
+            sysctl(&mib, u_int(mib.count), buffer.baseAddress, &fetchedBytes, nil, 0)
+        }
+        guard status == 0 else { return nil }
+
+        return processes.prefix(fetchedBytes / stride).map { process in
+            // Bounded decode: `String(cString:)` would walk past the fixed-size
+            // p_comm tuple if a corrupted entry ever arrived without its NUL.
+            let name = withUnsafeBytes(of: process.kp_proc.p_comm) { raw in
+                String(decoding: raw.prefix(while: { $0 != 0 }), as: UTF8.self)
+            }
+            let device = process.kp_eproc.e_tdev
+            return Entry(
+                pid: process.kp_proc.p_pid,
+                name: name,
+                // NODEV means no controlling terminal — not a surface.
+                ttyDevice: device == ~dev_t(0) ? nil : device,
+                processGroupID: process.kp_eproc.e_pgid,
+                terminalForegroundGroupID: process.kp_eproc.e_tpgid
+            )
+        }
+    }
+}
+#endif

--- a/Sources/localvoxtral/ClaudeContext/SSHDestinationTTYProbe.swift
+++ b/Sources/localvoxtral/ClaudeContext/SSHDestinationTTYProbe.swift
@@ -220,7 +220,9 @@ enum SSHDestinationTTYProbe {
             SSHSurfaceConnection(
                 destination: destination,
                 isOnlyConnectionToDestination: isOnlyConnection(
-                    to: destination, device: device, processes: processes
+                    to: destination,
+                    surfacePIDs: Set(onSurface.map(\.pid)),
+                    processes: processes
                 ),
                 indicatesHerdr: indicatesHerdr
             )
@@ -229,18 +231,27 @@ enum SSHDestinationTTYProbe {
 
     /// Is this terminal's the only connection to that destination?
     ///
-    /// Every OTHER terminal's ssh counts, foreground or not: a session the user
-    /// backgrounded a second ago is still a second connection to that host, and
-    /// the question here is "could another surface be the herdr one?", not
-    /// "which one is active". Processes with NO controlling terminal are
-    /// excluded — nobody can be dictating into one, and our own `ssh -L`
-    /// forward is exactly that.
+    /// Every OTHER ssh counts, foreground or not, and — this is the part the
+    /// first version got wrong (review round 5b) — including ones on THIS
+    /// device. Excluding same-device background processes let `ssh builder
+    /// herdr` be suspended with Ctrl+Z, its server side still attached and its
+    /// pane still focused, while a plain `ssh builder` in the foreground of the
+    /// same terminal claimed to be the only connection.
+    ///
+    /// "The surface shows the shell, not that ssh" is a fact about which
+    /// connection this terminal DISPLAYS — it belongs to destination
+    /// determination above, and says nothing about how many connections exist.
+    ///
+    /// Excluded: the surface's own foreground processes (they ARE this
+    /// connection), and anything with no controlling terminal — nobody can be
+    /// dictating into one, and our own `ssh -L` forward is exactly that.
     private static func isOnlyConnection(
         to destination: String,
-        device: dev_t,
+        surfacePIDs: Set<Int32>,
         processes: [SSHClientProcess]
     ) -> Bool {
-        for process in processes where process.ttyDevice != nil && process.ttyDevice != device {
+        for process in processes
+        where process.ttyDevice != nil && !surfacePIDs.contains(process.pid) {
             guard let parsed = verifiedInvocation(of: process) else {
                 // An ssh elsewhere we cannot read could be to this destination.
                 // Uniqueness is a claim, and an unreadable process cannot be

--- a/Sources/localvoxtral/ClaudeContext/SSHDestinationTTYProbe.swift
+++ b/Sources/localvoxtral/ClaudeContext/SSHDestinationTTYProbe.swift
@@ -205,26 +205,32 @@ enum SSHDestinationTTYProbe {
         }
         guard !onSurface.isEmpty else { return .noSSHClient }
 
-        var destinations = Set<String>()
-        var indicatesHerdr = false
-        for process in onSurface {
-            guard let parsed = verifiedInvocation(of: process) else { return .undeterminable }
-            destinations.insert(parsed.destination)
-            indicatesHerdr = indicatesHerdr || parsed.indicatesHerdr
+        // EXACTLY ONE foreground ssh, or nothing. The first version combined
+        // several — one destination set, `indicatesHerdr` OR-ed across them —
+        // and that union was itself a mis-join (review round 7): a foreground
+        // group holding both `ssh builder` and `ssh builder herdr` reported
+        // "unique" AND "is herdr", so the plain, visible connection joined the
+        // other process's herdr session. A pipeline or wrapper that launches
+        // several ssh children in one group is the same shape.
+        //
+        // There is no way to tell from here WHICH of them the user is looking
+        // at, and this arm's rule is to abstain rather than guess.
+        guard onSurface.count == 1, let surfaceProcess = onSurface.first else {
+            return .undeterminable
         }
-        guard destinations.count == 1, let destination = destinations.first else {
+        guard let parsed = verifiedInvocation(of: surfaceProcess) else {
             return .undeterminable
         }
 
         return .connection(
             SSHSurfaceConnection(
-                destination: destination,
+                destination: parsed.destination,
                 isOnlyConnectionToDestination: isOnlyConnection(
-                    to: destination,
-                    surfacePIDs: Set(onSurface.map(\.pid)),
+                    to: parsed.destination,
+                    surfacePID: surfaceProcess.pid,
                     processes: processes
                 ),
-                indicatesHerdr: indicatesHerdr
+                indicatesHerdr: parsed.indicatesHerdr
             )
         )
     }
@@ -242,16 +248,16 @@ enum SSHDestinationTTYProbe {
     /// connection this terminal DISPLAYS — it belongs to destination
     /// determination above, and says nothing about how many connections exist.
     ///
-    /// Excluded: the surface's own foreground processes (they ARE this
-    /// connection), and anything with no controlling terminal — nobody can be
-    /// dictating into one, and our own `ssh -L` forward is exactly that.
+    /// Excluded: the surface's own connection (the single foreground ssh this
+    /// answer is about), and anything with no controlling terminal — nobody can
+    /// be dictating into one, and our own `ssh -L` forward is exactly that.
     private static func isOnlyConnection(
         to destination: String,
-        surfacePIDs: Set<Int32>,
+        surfacePID: Int32,
         processes: [SSHClientProcess]
     ) -> Bool {
         for process in processes
-        where process.ttyDevice != nil && !surfacePIDs.contains(process.pid) {
+        where process.ttyDevice != nil && process.pid != surfacePID {
             guard let parsed = verifiedInvocation(of: process) else {
                 // An ssh elsewhere we cannot read could be to this destination.
                 // Uniqueness is a claim, and an unreadable process cannot be
@@ -355,9 +361,11 @@ enum SSHDestinationTTYProbe {
     /// reason it was the exploit: its first token is `sh`, and what it goes on
     /// to run is not something an argv can promise.
     ///
-    /// This is CORROBORATION ONLY. It never substitutes for the uniqueness
-    /// requirement, because argv is written by whoever launched the process and
-    /// a mis-join costs another session's pane text.
+    /// REQUIRED by the arm (review round 5b), not corroboration: herdr exposes
+    /// no read-only attachment signal, so the invocation is the only evidence
+    /// that this terminal is a herdr client at all. It never stands ALONE
+    /// either — uniqueness is required alongside it, because argv is written by
+    /// whoever launched the process.
     static func commandNamesHerdr(_ remoteCommand: [String]) -> Bool {
         guard let command = remoteCommand.first, !command.isEmpty else { return false }
         return (command as NSString).lastPathComponent == "herdr"

--- a/Sources/localvoxtral/ClaudeContext/SSHDestinationTTYProbe.swift
+++ b/Sources/localvoxtral/ClaudeContext/SSHDestinationTTYProbe.swift
@@ -39,7 +39,10 @@ enum SSHDestinationTTYProbeResult: Sendable, Equatable {
     case connection(SSHSurfaceConnection)
     /// An ssh session is there and cannot be pinned down: argv unavailable, an
     /// unverifiable executable, an option that can move the destination, a
-    /// grammar we do not recognize, or two of them going to different places.
+    /// grammar we do not recognize — or MORE THAN ONE foreground ssh on the
+    /// surface, whatever their destinations. Two to the same host abstain just
+    /// as two to different hosts do: nothing here says which one the user is
+    /// looking at, and unioning them let one borrow the other's herdr signal.
     case undeterminable
 }
 

--- a/Sources/localvoxtral/ClaudeContext/SocketPaneScreenContext.swift
+++ b/Sources/localvoxtral/ClaudeContext/SocketPaneScreenContext.swift
@@ -172,7 +172,11 @@ enum SocketPaneScreenContext {
         resolver: ClaudeSessionJoinResolver
     ) async -> String? {
         switch join.mechanism {
-        case .herdrPane:
+        case .herdrPane, .remoteHerdrPane:
+            // One route for both herdr arms: a remote herdr differs only in
+            // WHERE its socket is — the local end of an app-managed `ssh -L`,
+            // captured in the same binding — so the request, the sanitizing and
+            // the caps are identical.
             return await resolver.herdrPaneVisibleText(for: join)
         case .cmuxSurface:
             return await resolver.cmuxSurfaceVisibleText(for: join)

--- a/Sources/localvoxtral/ClaudeContext/TerminalScreenClaudeJoin.swift
+++ b/Sources/localvoxtral/ClaudeContext/TerminalScreenClaudeJoin.swift
@@ -554,16 +554,18 @@ struct ClaudeSessionJoinResolver {
     /// Bindings, all required, in cost order — the free local reads first, so an
     /// ordinary ssh session never pays for a forward:
     ///
-    /// 1. the focused surface's own TTY hosts a FOREGROUND ssh session whose
-    ///    destination is exactly one enrolled host's alias. This is the only
-    ///    step that says anything about what the user is looking at;
-    /// 2. that CONNECTION — not merely that host — is bound to herdr: either the
-    ///    ssh argv names herdr as its remote command, or this terminal holds the
-    ///    only ssh connection to that destination on the whole machine. Without
-    ///    this, a plain shell to `builder` in one window would join the session
-    ///    displayed in a herdr attached to `builder` in another (review blocker
-    ///    1): every remaining check is about the REMOTE side and cannot tell the
-    ///    two windows apart;
+    /// 1. the focused surface's TTY hosts EXACTLY ONE foreground ssh session,
+    ///    whose destination is exactly one enrolled host's alias. One, because
+    ///    several in a group cannot be told apart from here and unioning them
+    ///    let a plain connection borrow a sibling's herdr signal (round 7).
+    ///    This is the only step that says anything about what the user is
+    ///    looking at;
+    /// 2. that CONNECTION is bound to herdr, and it takes BOTH facts: the ssh
+    ///    argv names herdr as its remote command (first token), AND this
+    ///    terminal holds the only ssh connection to that destination on the
+    ///    machine. Neither alone is enough — uniqueness does not say what the
+    ///    terminal DISPLAYS (a detached herdr still answers `pane.current`),
+    ///    and argv is written by whoever launched the process;
     /// 3. that host has live sessions reporting a herdr pane, all from ONE herdr
     ///    socket. This counts SOCKETS, not sessions: several live sessions on
     ///    one herdr are expected and fine — panes are what a multiplexer is for
@@ -643,10 +645,14 @@ struct ClaudeSessionJoinResolver {
         // field. So the evidence has to come from the invocation itself, and
         // `indicatesHerdr` is promoted from corroboration to a REQUIREMENT.
         //
-        // The cost is stated rather than hidden: the manual flow — `ssh host`,
-        // then type `herdr` — gets NO context at all, not even a marker
-        // fallback, because herdr intercepts OSC 2 so the marker never reaches
-        // the outer terminal. A wrong join is worse than no join.
+        // The cost, stated accurately: the manual flow — `ssh host`, then type
+        // `herdr` — gets no HERDR join. It does not get "no context": this
+        // returns `.notApplicable`, so the title-marker arm still runs, and a
+        // marker left in the OUTER title by an earlier session on that host can
+        // still win. That residual is pre-existing (it is what a remote session
+        // has always done) and cannot be closed from here — nothing on the
+        // surface tells us a remote herdr is running inside it. A wrong HERDR
+        // join is what this refuses.
         //
         // Uniqueness stays REQUIRED alongside it: argv is written by whoever
         // launched the process, so it must never be the only thing standing

--- a/Sources/localvoxtral/ClaudeContext/TerminalScreenClaudeJoin.swift
+++ b/Sources/localvoxtral/ClaudeContext/TerminalScreenClaudeJoin.swift
@@ -26,11 +26,19 @@ enum ClaudeSessionJoinMechanism: Sendable, Equatable {
     /// session's environment. Local surfaces and `cmux ssh` remote shells both
     /// arrive here — see `ClaudeSessionJoinResolver.resolveViaCmux`.
     case cmuxSurface
+    /// A Claude Code session inside a herdr running on an ENROLLED REMOTE host,
+    /// reached over an app-managed `ssh -L` to that herdr's socket.
+    case remoteHerdrPane
 }
 
-/// The herdr pane a `.herdrPane` join resolved to. Captured at resolution so
-/// the pane-text fetch can only ever be keyed by the pane the join is ABOUT —
+/// The herdr pane a herdr join resolved to. Captured at resolution so the
+/// pane-text fetch can only ever be keyed by the pane the join is ABOUT —
 /// there is no other place a pane id enters that path.
+///
+/// `socketPath` is always a LOCAL socket this user owns: herdr's own socket for
+/// a `.herdrPane` join, and the local end of our `ssh -L` for a
+/// `.remoteHerdrPane` one. The remote host's own socket path never appears
+/// here; it exists only as an argv token inside the forward.
 struct ClaudeHerdrPaneBinding: Sendable, Equatable {
     let paneID: String
     let socketPath: String
@@ -69,8 +77,8 @@ struct ClaudeSessionJoin: Sendable, Equatable {
     /// pane join is useful for session/repository context but can never license
     /// a composite raw TUI capture.
     let mechanism: ClaudeSessionJoinMechanism
-    /// Non-nil exactly for `.herdrPane` joins: the pane whose clean, per-pane
-    /// text (`pane.read`) may stand in for the composite screen capture.
+    /// Non-nil exactly for herdr joins: the pane whose clean, per-pane text
+    /// (`pane.read`) may stand in for the composite screen capture.
     let herdrPane: ClaudeHerdrPaneBinding?
     /// Non-nil exactly for `.browserTab` joins: the bridge session id the tab
     /// URL and the session's hooks agreed on. Commit-time liveness re-checks it
@@ -80,6 +88,15 @@ struct ClaudeSessionJoin: Sendable, Equatable {
     /// Non-nil exactly for `.cmuxSurface` joins: the surface whose clean,
     /// per-surface text (`surface.read_text`) is the ONLY screen route cmux has.
     let cmuxSurface: ClaudeCmuxSurfaceBinding?
+    /// Non-nil exactly for `.remoteHerdrPane` joins: the `ssh -L` this join
+    /// runs over.
+    ///
+    /// Carried ON THE JOIN because its lifetime IS the join's: the stop-side
+    /// `pane.read` has to reach the same herdr the start-side one did, and the
+    /// join is the one object every consumer of that answer already holds.
+    /// Closing it is the holder's job (`close()` is idempotent, and the handle
+    /// closes itself on deinit as a backstop).
+    let remoteHerdrForward: ClaudeRemoteHerdrForwardHandle?
 
     init(
         target: TerminalScreenTarget,
@@ -89,7 +106,8 @@ struct ClaudeSessionJoin: Sendable, Equatable {
         mechanism: ClaudeSessionJoinMechanism,
         herdrPane: ClaudeHerdrPaneBinding? = nil,
         browserTab: ClaudeBrowserTabBinding? = nil,
-        cmuxSurface: ClaudeCmuxSurfaceBinding? = nil
+        cmuxSurface: ClaudeCmuxSurfaceBinding? = nil,
+        remoteHerdrForward: ClaudeRemoteHerdrForwardHandle? = nil
     ) {
         self.target = target
         self.marker = marker
@@ -99,6 +117,7 @@ struct ClaudeSessionJoin: Sendable, Equatable {
         self.herdrPane = herdrPane
         self.browserTab = browserTab
         self.cmuxSurface = cmuxSurface
+        self.remoteHerdrForward = remoteHerdrForward
     }
 
     /// The per-pane socket route this join owns, if any: the herdr pane id or
@@ -106,11 +125,18 @@ struct ClaudeSessionJoin: Sendable, Equatable {
     /// start/stop reconciliation without knowing which multiplexer answered.
     var socketPaneKey: String? {
         switch mechanism {
-        case .herdrPane: return herdrPane?.paneID
+        case .herdrPane, .remoteHerdrPane: return herdrPane?.paneID
         case .cmuxSurface: return cmuxSurface?.surfaceID
         case .ttyDevice, .titleMarker, .browserTab: return nil
         }
     }
+
+    // Deliberately NO `releaseResources()` here. The join VALUE travels — it is
+    // consumed by the commit path and captured into a Task — so a resource
+    // whose owner is "whoever currently holds the join" has no owner at all,
+    // which is how an aborted connect and a quit-during-polish each leaked an
+    // ssh child (review finding 4). `DictationViewModel` takes ownership of the
+    // handle when it assigns the join, and closes it from every exit.
 
     /// The workspace path, non-nil only for a locally authenticated session.
     /// The type is what keeps a remote session's cwd away from the filesystem;
@@ -163,6 +189,9 @@ struct ClaudeSessionJoinResolver {
     private let cmuxSurfaces: CmuxSurfaceQuerying?
     private let cmuxJoinEnabled: @MainActor () -> Bool
     private let reportCmuxStatus: @MainActor (CmuxSocketStatus) -> Void
+    private let sshDestinationProbe: @Sendable (String) -> SSHDestinationTTYProbeResult
+    private let enrolledHosts: @MainActor (String) -> [ClaudeRemoteHost]
+    private let remoteHerdrForwards: (any ClaudeRemoteHerdrForwarding)?
 
     /// - Parameters:
     ///   - markerInWindowTitle: reads the PID-pinned focused window title,
@@ -209,6 +238,18 @@ struct ClaudeSessionJoinResolver {
     ///     that socket.
     ///   - reportCmuxStatus: one short sentence for the Settings row when the
     ///     socket refuses us (details go to the log, never the popover).
+    ///   - sshDestinationProbe: reads the local process table for an ssh client
+    ///     on the focused surface's TTY and reports where it is going. Defaults
+    ///     to `.undeterminable`, which disables the remote herdr arm entirely
+    ///     — an un-injected resolver behaves exactly as it did before that arm
+    ///     existed.
+    ///   - enrolledHosts: the enrolled remote hosts whose ssh alias IS that
+    ///     destination. Defaults to none, for the same reason: no enrollment
+    ///     lookup, no remote arm. Passed as a closure rather than the registry
+    ///     because the host list is built later in launch than this resolver.
+    ///   - remoteHerdrForwards: opens the app-managed `ssh -L`. Nil means the
+    ///     arm can never spawn anything, which is what a test that forgets to
+    ///     inject must get.
     init(
         registry: ClaudeSessionRegistry,
         markerInWindowTitle: @escaping (pid_t) -> TerminalScreenAXReader.FocusedWindowMarkerRead? = {
@@ -223,7 +264,12 @@ struct ClaudeSessionJoinResolver {
         herdrPanes: HerdrPaneQuerying? = nil,
         cmuxSurfaces: CmuxSurfaceQuerying? = nil,
         cmuxJoinEnabled: @escaping @MainActor () -> Bool = { false },
-        reportCmuxStatus: @escaping @MainActor (CmuxSocketStatus) -> Void = { _ in }
+        reportCmuxStatus: @escaping @MainActor (CmuxSocketStatus) -> Void = { _ in },
+        sshDestinationProbe: @escaping @Sendable (String) -> SSHDestinationTTYProbeResult = { _ in
+            .undeterminable
+        },
+        enrolledHosts: @escaping @MainActor (String) -> [ClaudeRemoteHost] = { _ in [] },
+        remoteHerdrForwards: (any ClaudeRemoteHerdrForwarding)? = nil
     ) {
         self.registry = registry
         self.markerInWindowTitle = markerInWindowTitle
@@ -235,6 +281,9 @@ struct ClaudeSessionJoinResolver {
         self.cmuxSurfaces = cmuxSurfaces
         self.cmuxJoinEnabled = cmuxJoinEnabled
         self.reportCmuxStatus = reportCmuxStatus
+        self.sshDestinationProbe = sshDestinationProbe
+        self.enrolledHosts = enrolledHosts
+        self.remoteHerdrForwards = remoteHerdrForwards
     }
 
     /// The join for `target`, or nil on any abstention.
@@ -299,6 +348,21 @@ struct ClaudeSessionJoinResolver {
             // lingering marker there could only mis-join the pane now visible.
             if herdrClientProbe(tty) {
                 return await resolveViaHerdr(target: target)
+            }
+
+            // The surface is not a local herdr client. It may still be an ssh
+            // session into an enrolled host that is running one.
+            switch await resolveViaRemoteHerdr(target: target, tty: tty) {
+            case .joined(let join):
+                return join
+            case .abstained:
+                // Herdr-or-nothing, for the local arm's reason transposed: the
+                // remote pane's marker lives in herdr's captured pane title,
+                // and any marker in the OUTER window belongs to something else
+                // — most likely this same host BEFORE the user attached herdr.
+                return nil
+            case .notApplicable:
+                break
             }
         }
 
@@ -471,6 +535,352 @@ struct ClaudeSessionJoinResolver {
         )
     }
 
+    /// What the remote herdr arm concluded.
+    ///
+    /// `notApplicable` and `abstained` are NOT the same answer and the
+    /// difference is the whole safety argument: the arm falls through to the
+    /// title marker only while nothing has bound it to a remote herdr, and
+    /// stops the dictation's join dead once something has.
+    enum RemoteHerdrArmOutcome {
+        /// Nothing here is about a remote herdr; other arms may still answer.
+        case notApplicable
+        /// This surface IS an enrolled host's herdr and the join still failed.
+        case abstained
+        case joined(ClaudeSessionJoin)
+    }
+
+    /// A Claude Code session inside a herdr on an ENROLLED REMOTE host.
+    ///
+    /// Bindings, all required, in cost order — the free local reads first, so an
+    /// ordinary ssh session never pays for a forward:
+    ///
+    /// 1. the focused surface's own TTY hosts a FOREGROUND ssh session whose
+    ///    destination is exactly one enrolled host's alias. This is the only
+    ///    step that says anything about what the user is looking at;
+    /// 2. that CONNECTION — not merely that host — is bound to herdr: either the
+    ///    ssh argv names herdr as its remote command, or this terminal holds the
+    ///    only ssh connection to that destination on the whole machine. Without
+    ///    this, a plain shell to `builder` in one window would join the session
+    ///    displayed in a herdr attached to `builder` in another (review blocker
+    ///    1): every remaining check is about the REMOTE side and cannot tell the
+    ///    two windows apart;
+    /// 3. that host has live sessions reporting a herdr pane, all from ONE herdr
+    ///    socket. This counts SOCKETS, not sessions: several live sessions on
+    ///    one herdr are expected and fine — panes are what a multiplexer is for
+    ///    — and it is two herdr SERVERS that leave the surface ambiguous;
+    /// 4. over the forward, exactly ONE of those candidates claims that herdr's
+    ///    FOCUSED pane id (two claiming the same pane id abstain), and that
+    ///    pane's captured title carries exactly that session's broker-allocated
+    ///    marker;
+    /// 5. herdr's own session claim for the pane does not disagree, and the pane
+    ///    is running that session's agent.
+    ///
+    /// Every one of these can only ever CONFIRM. No step picks a session because
+    /// it is the only one, the most recent, or the one whose cwd looks right.
+    ///
+    /// The `notApplicable`/`abstained` split is exactly steps 1–3 vs 4–5: until
+    /// this terminal's connection is bound to a herdr that has candidates, a
+    /// non-answer must leave the title-marker arm alone — an unrelated herdr on
+    /// the host must not cost a plain remote session the join it has always had.
+    private func resolveViaRemoteHerdr(
+        target: TerminalScreenTarget,
+        tty: String
+    ) async -> RemoteHerdrArmOutcome {
+        let connection: SSHSurfaceConnection
+        switch sshDestinationProbe(tty) {
+        case .noSSHClient:
+            // The overwhelmingly common case: a local shell. Not logged — this
+            // is not an abstention, it is the arm not applying.
+            return .notApplicable
+        case .undeterminable:
+            Self.abstainedRemoteHerdrJoin(outcome: "ssh session undeterminable")
+            return .notApplicable
+        case .connection(let value):
+            connection = value
+        }
+
+        let hosts = enrolledHosts(connection.destination)
+        guard !hosts.isEmpty else {
+            // An ssh session to a host the user never enrolled. There is no
+            // context to join, and the title marker still deserves its chance:
+            // a plain remote session joins that way and always has.
+            return .notApplicable
+        }
+        guard hosts.count == 1, let host = hosts.first, let alias = host.sshHostAlias else {
+            Self.abstainedRemoteHerdrJoin(outcome: "ssh destination matches multiple enrolled hosts")
+            return .notApplicable
+        }
+
+        let candidates = registry.liveRemoteHerdrSessions(hostID: host.id)
+        guard !candidates.isEmpty else {
+            // Enrolled, but nothing on it reported a herdr pane — a plain
+            // remote Claude session. Marker arm, exactly as before.
+            return .notApplicable
+        }
+        let socketPaths = Set(candidates.compactMap { $0.remoteSessionEnvironment?.herdrSocketPath })
+        guard socketPaths.count == 1, let remoteSocketPath = socketPaths.first else {
+            // Mirror of the local single-socket rule: two herdr servers on one
+            // host, and no way to tell which one the surface is attached to.
+            Self.abstainedRemoteHerdrJoin(outcome: "multiple live herdr sockets on this host")
+            return .notApplicable
+        }
+
+        // The connection-level bind: this terminal must hold the ONLY ssh
+        // connection to that destination on the machine.
+        //
+        // `indicatesHerdr` deliberately does NOT substitute for this (review
+        // round 3, blocker 1a). argv is written by whoever launched the
+        // process, so treating it as sufficient let a forged remote command
+        // stand in for the one fact that is not forgeable — how many
+        // connections exist. It stays as corroboration, logged and nothing
+        // more.
+        guard connection.isOnlyConnectionToDestination else {
+            Self.abstainedRemoteHerdrJoin(
+                outcome: "another terminal holds an ssh session to this destination"
+            )
+            return .notApplicable
+        }
+        if connection.indicatesHerdr {
+            Log.claudeContext.info("Remote herdr arm: the ssh command is herdr itself")
+        }
+
+        // NOT yet herdr-or-nothing. Registry candidates existing on the host is
+        // not a binding for THIS connection — a detached herdr, or one whose
+        // sessions are merely still inside their TTL, would otherwise cost a
+        // sole plain ssh session the outer marker join it has always had
+        // (review round 3, blocker 1b). Everything up to and including the
+        // pane-id + marker confirmation therefore still falls through.
+        guard let remoteHerdrForwards else {
+            Self.abstainedRemoteHerdrJoin(outcome: "forward capability unavailable")
+            return .notApplicable
+        }
+        guard let herdrPanes else {
+            Self.abstainedRemoteHerdrJoin(outcome: "pane query capability unavailable")
+            return .notApplicable
+        }
+        guard let forward = await remoteHerdrForwards.open(
+            alias: alias, remoteSocketPath: remoteSocketPath
+        ) else {
+            Self.abstainedRemoteHerdrJoin(outcome: "forward unavailable")
+            return .notApplicable
+        }
+
+        switch await resolveRemoteHerdrPane(
+            target: target,
+            hostID: host.id,
+            candidates: candidates,
+            forward: forward,
+            herdrPanes: herdrPanes
+        ) {
+        case .joined(let join):
+            Log.claudeContext.info(
+                "Terminal pane joined to a live Claude session via remote herdr pane"
+            )
+            return .joined(join)
+        case .unconfirmed:
+            // The herdr on the other end never confirmed that THIS connection
+            // displays one of our sessions. Nothing was established, so the
+            // marker arm keeps its chance.
+            forward.close()
+            return .notApplicable
+        case .refusedAfterConfirmation:
+            // The focused pane IS this session's — pane id and the
+            // broker-allocated marker both said so — and a later fail-closed
+            // check refused it. NOW a marker in the outer window could only
+            // describe something else, so the dictation joins nothing.
+            forward.close()
+            return .abstained
+        }
+    }
+
+    /// What the over-the-forward half concluded.
+    ///
+    /// The `unconfirmed`/`refusedAfterConfirmation` split is where
+    /// herdr-or-nothing begins: only a pane id AND marker match prove this
+    /// connection is displaying one of our sessions.
+    private enum RemoteHerdrPaneOutcome {
+        case joined(ClaudeSessionJoin)
+        case unconfirmed
+        case refusedAfterConfirmation
+    }
+
+    /// The over-the-forward half: focused pane, marker, then the fail-closed
+    /// cross-checks. Split out so the failure paths have exactly one
+    /// `forward.close()` and one place deciding which side of the
+    /// herdr-or-nothing line each failure falls on.
+    private func resolveRemoteHerdrPane(
+        target: TerminalScreenTarget,
+        hostID: String,
+        candidates: [ClaudeSessionSnapshot],
+        forward: ClaudeRemoteHerdrForwardHandle,
+        herdrPanes: HerdrPaneQuerying
+    ) async -> RemoteHerdrPaneOutcome {
+        let socketPath = forward.localSocketPath
+        guard let pane = await herdrPanes.focusedPane(socketPath: socketPath) else {
+            Self.abstainedRemoteHerdrJoin(outcome: "focused pane unavailable")
+            return .unconfirmed
+        }
+        // The precondition, stated precisely because a loose reading of it drew
+        // a review finding: exactly one candidate for the FOCUSED PANE ID —
+        // NOT one candidate per socket. Several live sessions on one herdr are
+        // expected and fine; that is what a multiplexer is for, and it is the
+        // case this arm exists to serve. What abstains is two candidates
+        // claiming the SAME pane id, which is the only shape that would force a
+        // choice. Nothing here picks: the survivor still has to be confirmed by
+        // the marker, by herdr's own session claim, and by the foreground
+        // process below.
+        let matches = candidates.filter {
+            $0.remoteSessionEnvironment?.herdrPaneID == pane.paneID
+        }
+        guard matches.count == 1, let snapshot = matches.first else {
+            Self.abstainedRemoteHerdrJoin(
+                outcome: matches.isEmpty
+                    ? "focused pane has no live session"
+                    : "two live sessions claim the focused pane id"
+            )
+            return .unconfirmed
+        }
+
+        // The marker is the second, independent binding — pane id equality
+        // alone rests entirely on labels the host chose. This marker was
+        // ALLOCATED HERE, handed to that session over its own authenticated
+        // request, and written into the pane by Claude Code itself; a host
+        // cannot invent one, and a marker from another session cannot match.
+        guard let title = pane.terminalTitle else {
+            Self.abstainedRemoteHerdrJoin(outcome: "focused pane reported no title")
+            return .unconfirmed
+        }
+        guard let marker = ClaudeMarkerTitleParser.marker(inTitle: title) else {
+            // Zero markers (a plain title) or two (the parser abstains) —
+            // both are "this pane does not name one session".
+            Self.abstainedRemoteHerdrJoin(outcome: "focused pane title carries no single marker")
+            return .unconfirmed
+        }
+        guard marker == snapshot.marker else {
+            Self.abstainedRemoteHerdrJoin(outcome: "focused pane title marker names another session")
+            return .unconfirmed
+        }
+
+        // CONFIRMED: the focused pane of the herdr this connection reaches is
+        // this session's, proven by a pane id AND a marker we allocated
+        // ourselves. Failures from here are herdr-or-nothing.
+
+        // herdr's OWN claim about the pane, fail-closed exactly like the local
+        // arm's (`resolveViaHerdr`). This is the check that catches a reused
+        // pane: session A dies without a SessionEnd, leaving a fresh marker and
+        // pane id in the registry; session B starts in that same pane. Pane id
+        // and even a stale title can still name A, and herdr — which watches the
+        // pane — says B. A disagreement resolves to NEITHER (review finding 3).
+        //
+        // Scoped by the session's own host and agent before comparing, never by
+        // anything herdr says, so a claim can only ever CONFIRM the pane-id
+        // join and never redirect it.
+        if let claimed = pane.claimedClaudeSessionID,
+           Self.scopedRemoteSessionID(
+               claimed: claimed, hostID: hostID, agent: snapshot.agent
+           ) != snapshot.sessionID {
+            Self.abstainedRemoteHerdrJoin(outcome: "pane session claim disagrees")
+            return .refusedAfterConfirmation
+        }
+
+        guard let foreground = await herdrPanes.paneForegroundInfo(
+            socketPath: socketPath, paneID: pane.paneID
+        ) else {
+            Self.abstainedRemoteHerdrJoin(outcome: "foreground process query unavailable")
+            return .refusedAfterConfirmation
+        }
+        guard let processes = foreground.foregroundProcesses else {
+            Self.abstainedRemoteHerdrJoin(outcome: "foreground process detection unavailable")
+            return .refusedAfterConfirmation
+        }
+        guard Self.remoteAgentIsForeground(snapshot: snapshot, foregroundProcesses: processes) else {
+            return .refusedAfterConfirmation
+        }
+
+        return .joined(ClaudeSessionJoin(
+            target: target,
+            marker: snapshot.marker,
+            snapshot: snapshot,
+            windowID: focusedWindowID(target.pid),
+            mechanism: .remoteHerdrPane,
+            herdrPane: ClaudeHerdrPaneBinding(paneID: pane.paneID, socketPath: socketPath),
+            remoteHerdrForward: forward
+        ))
+    }
+
+    /// A raw session id as herdr reports it, in the registry's namespace.
+    ///
+    /// Two scopings apply to a remote session and both are recomputed here from
+    /// facts WE hold (the authenticating host, the snapshot's agent) rather than
+    /// from anything on the wire: the remote listener namespaces by host id, and
+    /// the registry then namespaces by agent. For Claude the second is the
+    /// identity function; for opencode it adds the same prefix ingest did.
+    static func scopedRemoteSessionID(
+        claimed: String,
+        hostID: String,
+        agent: ClaudeHookAgent
+    ) -> String {
+        ClaudeAgentSessionScope.scopedSessionID(
+            agent: agent,
+            sessionID: ClaudeRemoteSessionScope.scopedSessionID(
+                hostID: hostID, sessionID: claimed
+            )
+        )
+    }
+
+    /// Is the joined pane actually running that session's agent right now?
+    ///
+    /// The local arm answers this with a pid, which a remote pane cannot: its
+    /// numbers live in another machine's namespace. Two signals replace it, and
+    /// EITHER is sufficient while NEITHER is optional:
+    ///
+    /// * the session's reported `hookParentPID` (the remote shim's `$PPID`) is
+    ///   one of the pane's foreground pids — compared as STRINGS, because that
+    ///   value is a label and must never become a number this process could
+    ///   probe;
+    /// * a foreground process is NAMED for the session's agent.
+    ///
+    /// Requiring both, as first designed, would have failed closed forever on
+    /// two ordinary installs: `$PPID` is the shim's parent, which is the shell
+    /// Claude Code spawns hooks through rather than Claude Code itself, and an
+    /// npm-installed Claude Code appears in the process table as `node`. Either
+    /// signal alone still proves the pane is running the session — and neither
+    /// present (a suspended agent with the user back at the shell, the case
+    /// this check exists for) still abstains.
+    static func remoteAgentIsForeground(
+        snapshot: ClaudeSessionSnapshot,
+        foregroundProcesses: [HerdrForegroundProcess]
+    ) -> Bool {
+        if let hookParentPID = snapshot.remoteSessionEnvironment?.hookParentPID,
+           foregroundProcesses.contains(where: { String($0.pid) == hookParentPID }) {
+            return true
+        }
+        let agentName = snapshot.agent.rawValue
+        if foregroundProcesses.contains(where: { process in
+            guard let name = process.name else { return false }
+            return (name as NSString).lastPathComponent == agentName
+        }) {
+            return true
+        }
+        abstainedRemoteHerdrJoin(
+            outcome: "no foreground process matches the registered \(snapshot.agent.rawValue) session"
+        )
+        return false
+    }
+
+    /// Outcome only. Pane ids, socket paths, ssh destinations, and titles are
+    /// all live join material — and the destination additionally names the
+    /// user's infrastructure, which the unified log is emphatically not the
+    /// place for.
+    private static func abstainedRemoteHerdrJoin(outcome: String) {
+        Log.claudeContext.info(
+            "Remote herdr pane matched no session (\(outcome, privacy: .public)); Claude context withheld"
+        )
+        #if LOCALVOXTRAL_DOGFOOD
+        DogfoodCaptureTap.shared.noteJoinAbstention("remote-herdr: \(outcome)")
+        #endif
+    }
+
     /// The joined herdr pane's visible text, or nil on any refusal or failure.
     ///
     /// This is the ONLY path that issues a `pane.read`, and it can only read
@@ -480,7 +890,9 @@ struct ClaudeSessionJoinResolver {
     /// is RAW wire text; the caller owns sanitization, bounding, and every
     /// consent gate (see `SocketPaneScreenContext`).
     func herdrPaneVisibleText(for join: ClaudeSessionJoin) async -> String? {
-        guard join.mechanism == .herdrPane, let binding = join.herdrPane else {
+        guard join.mechanism == .herdrPane || join.mechanism == .remoteHerdrPane,
+              let binding = join.herdrPane
+        else {
             Log.claudeContext.info("Herdr pane read refused: join is not a herdr pane join")
             return nil
         }
@@ -913,7 +1325,7 @@ struct TerminalScreenClaudeJoinAuthorizer: TerminalScreenRawAttachmentAuthorizin
         switch join.mechanism {
         case .ttyDevice, .titleMarker:
             break
-        case .herdrPane, .cmuxSurface:
+        case .herdrPane, .cmuxSurface, .remoteHerdrPane:
             // AX sees herdr's composite TUI. Attaching it would let neighboring
             // panes — potentially other Claude sessions — ride into this
             // session's prompt, so a correct pane join still cannot authorize
@@ -926,6 +1338,10 @@ struct TerminalScreenClaudeJoinAuthorizer: TerminalScreenRawAttachmentAuthorizin
             // surface, it must not become attachable by default. Both
             // multiplexers' screen text arrives through their own per-pane
             // socket route instead (`SocketPaneScreenContext`).
+            //
+            // A REMOTE herdr join is refused for the first reason, doubled: the
+            // grid is not even this machine's — it is the local ssh client's
+            // window, showing whatever herdr drew, panes and all.
             Log.claudeContext.info(
                 "Socket-pane join cannot authorize raw AX screen attachment; withheld"
             )

--- a/Sources/localvoxtral/ClaudeContext/TerminalScreenClaudeJoin.swift
+++ b/Sources/localvoxtral/ClaudeContext/TerminalScreenClaudeJoin.swift
@@ -625,23 +625,43 @@ struct ClaudeSessionJoinResolver {
             return .notApplicable
         }
 
-        // The connection-level bind: this terminal must hold the ONLY ssh
-        // connection to that destination on the machine.
+        // The connection-level bind, and it takes BOTH facts.
         //
-        // `indicatesHerdr` deliberately does NOT substitute for this (review
-        // round 3, blocker 1a). argv is written by whoever launched the
-        // process, so treating it as sufficient let a forged remote command
-        // stand in for the one fact that is not forgeable — how many
-        // connections exist. It stays as corroboration, logged and nothing
-        // more.
+        // Uniqueness alone was a mis-join (review round 5b): it says nothing
+        // about what this terminal DISPLAYS. A herdr whose client detached —
+        // or whose pane still carries a marker and a running agent inside the
+        // registry TTL — keeps answering `pane.current` with that pane, so a
+        // later sole `ssh builder` passed the gate and every remaining check
+        // (pane id, marker, session claim, foreground) agreed about a session
+        // the user cannot see.
+        //
+        // The honest fix is to require positive evidence that THIS connection
+        // is a herdr client, and herdr does not expose one: verified against
+        // the 0.7.5 socket schema and the 0.8.0 docs, the only `client.*`
+        // methods are `window_title.set`/`clear` — both MUTATIONS, so neither
+        // is usable as a probe — and `session.snapshot` carries no attachment
+        // field. So the evidence has to come from the invocation itself, and
+        // `indicatesHerdr` is promoted from corroboration to a REQUIREMENT.
+        //
+        // The cost is stated rather than hidden: the manual flow — `ssh host`,
+        // then type `herdr` — gets NO context at all, not even a marker
+        // fallback, because herdr intercepts OSC 2 so the marker never reaches
+        // the outer terminal. A wrong join is worse than no join.
+        //
+        // Uniqueness stays REQUIRED alongside it: argv is written by whoever
+        // launched the process, so it must never be the only thing standing
+        // between two terminals and each other's sessions.
         guard connection.isOnlyConnectionToDestination else {
             Self.abstainedRemoteHerdrJoin(
                 outcome: "another terminal holds an ssh session to this destination"
             )
             return .notApplicable
         }
-        if connection.indicatesHerdr {
-            Log.claudeContext.info("Remote herdr arm: the ssh command is herdr itself")
+        guard connection.indicatesHerdr else {
+            Self.abstainedRemoteHerdrJoin(
+                outcome: "the ssh command on this terminal is not herdr itself"
+            )
+            return .notApplicable
         }
 
         // NOT yet herdr-or-nothing. Registry candidates existing on the host is

--- a/Sources/localvoxtral/DictationViewModel+Session.swift
+++ b/Sources/localvoxtral/DictationViewModel+Session.swift
@@ -693,10 +693,13 @@ extension DictationViewModel {
                     capturedSocketPaneStart = nil
                     // No endpoint: nothing to ground for, and neither the
                     // capture nor the join must survive into a later session's
-                    // reconciliation.
+                    // reconciliation. Nothing will read this join's remote
+                    // herdr tunnel either, so it goes now rather than at the
+                    // handle's deinit.
                     terminalScreenStartCapture = nil
                     claudeSessionJoin = nil
                     socketPaneStartCapture = nil
+                    closeRemoteHerdrForwards()
                 }
 
                 // Repo vocabulary rides in the `{{replacement_dictionary}}`
@@ -748,6 +751,13 @@ extension DictationViewModel {
                                 self.settings.polishContextTrustedEndpointEnabled
                         )
                     }
+                    // The stop-side pane read above was the LAST reader of a
+                    // remote herdr join's `ssh -L`; everything downstream works
+                    // from text already in hand. Closed through the view model,
+                    // which OWNS the handle — the join was consumed pre-Task,
+                    // so closing "the join's" tunnel here would leave the owner
+                    // holding a closed handle it still had to forget.
+                    self.closeRemoteHerdrForwards()
 
                     // The polish request is assembled HERE, inside the Task, so
                     // the opt-in repo-vocabulary indexing — whose git subprocess
@@ -2031,6 +2041,12 @@ extension DictationViewModel {
     }
 
     func abortConnectingSession(disconnectSocket: Bool = true) {
+        // An aborted connect never reaches stopped-session cleanup, so a remote
+        // herdr tunnel opened at start would otherwise stay up with nothing
+        // left to read from it (review finding 4). Every abort route — the
+        // connect timeout, a mic-start failure, a thrown connect, the escape
+        // cancel — funnels through here.
+        closeRemoteHerdrForwards()
         cancelConnectTimeout()
         finalizationWatchdogTask?.cancel()
         finalizationWatchdogTask = nil

--- a/Sources/localvoxtral/DictationViewModel.swift
+++ b/Sources/localvoxtral/DictationViewModel.swift
@@ -387,6 +387,10 @@ final class DictationViewModel {
     /// prompt. Cleared on every session exit, like the screen capture.
     @ObservationIgnored
     var claudeSessionJoin: ClaudeSessionJoin?
+    /// Remote herdr `ssh -L` children this process has open. See
+    /// `retainRemoteHerdrForward(of:)` for why they are owned here and not by
+    /// the join that travels.
+    private var liveRemoteHerdrForwards: [ClaudeRemoteHerdrForwardHandle] = []
 
     /// The JOINED pane's visible text at dictation start, read over its own
     /// multiplexer socket (herdr `pane.read` / cmux `surface.read_text`,
@@ -1910,10 +1914,17 @@ final class DictationViewModel {
             trustedEndpointEnabled: settings.polishContextTrustedEndpointEnabled
         )
         claudeSessionJoin = await resolveClaudeSessionJoin(endpointURL: endpointURL)
-        // Only a socket-routed pane join — herdr or cmux — produces a sample
-        // here (the function refuses everything else before any socket
-        // request), and it reads exactly the joined pane. Fetched at start for
-        // the same reason the AX screen is:
+        // Ownership of the join's `ssh -L` is taken HERE, at the one place a
+        // join is ever assigned, and never given back to whoever happens to
+        // hold the join later. The commit path CONSUMES the join, so an owner
+        // that reached the child only through `claudeSessionJoin` was nil at
+        // exactly the moments it mattered — quit during polish, an aborted
+        // connect — and the ssh outlived the app (review finding 4).
+        retainRemoteHerdrForward(of: claudeSessionJoin)
+        // Only a socket-routed pane join — herdr, remote herdr, or cmux —
+        // produces a sample here (the function refuses everything else before
+        // any socket request), and it reads exactly the joined pane. Fetched at
+        // start for the same reason the AX screen is:
         // this text is evidence of what the user could see while choosing
         // their words, and only a start sample can be that.
         socketPaneStartCapture = await SocketPaneScreenContext.captureAtStart(
@@ -2003,10 +2014,43 @@ final class DictationViewModel {
         // the session being abandoned, and a stale join surviving into the next
         // dictation is precisely how the wrong repo's context would get
         // attached to an unrelated sentence.
+        //
         claudeSessionJoin = nil
         // And the pane text with the join: it is that session's screen.
         socketPaneStartCapture = nil
+        // Every open `ssh -L`, not just this join's — the view model owns them
+        // all, so abandoning a dictation cannot leave one behind for a holder
+        // that no longer exists.
+        closeRemoteHerdrForwards()
     }
+
+    /// Takes ownership of a join's remote herdr tunnel, if it has one.
+    ///
+    /// One owner, deliberately: the join object travels (it is consumed by the
+    /// commit path and captured into a Task), and a resource whose owner is
+    /// "whoever currently holds the value" has no owner at all.
+    func retainRemoteHerdrForward(of join: ClaudeSessionJoin?) {
+        guard let forward = join?.remoteHerdrForward else { return }
+        liveRemoteHerdrForwards.append(forward)
+    }
+
+    /// Closes every open remote herdr tunnel. Idempotent, and safe from any
+    /// path — including ones that never knew a tunnel existed.
+    ///
+    /// Called from every dictation exit (`discardTerminalScreenCapture`, the
+    /// commit path once the stop-side pane read is done, `abortConnectingSession`)
+    /// and from `applicationWillTerminate`. Closing ALL of them rather than one
+    /// is what makes a leaked handle from some path nobody thought of
+    /// self-healing at the next exit.
+    func closeRemoteHerdrForwards() {
+        guard !liveRemoteHerdrForwards.isEmpty else { return }
+        let forwards = liveRemoteHerdrForwards
+        liveRemoteHerdrForwards = []
+        for forward in forwards { forward.close() }
+    }
+
+    /// Test seam: how many tunnels this view model is holding open.
+    var openRemoteHerdrForwardCount: Int { liveRemoteHerdrForwards.count }
 
     /// Reconciles the start capture against a stop-time re-read of the SAME
     /// PID/bundle and clears it. See `TerminalScreenContext.reconcile` for the

--- a/Sources/localvoxtral/Dogfood/DogfoodCapturePipeline.swift
+++ b/Sources/localvoxtral/Dogfood/DogfoodCapturePipeline.swift
@@ -172,6 +172,7 @@ enum DogfoodCaptureBuilder {
         case .herdrPane: arm = "herdrPane"
         case .browserTab: arm = "browserTab"
         case .cmuxSurface: arm = "cmuxSurface"
+        case .remoteHerdrPane: arm = "remoteHerdrPane"
         }
         return DogfoodCaptureRecord.Join(
             arm: arm,

--- a/Sources/localvoxtral/localvoxtralApp.swift
+++ b/Sources/localvoxtral/localvoxtralApp.swift
@@ -219,6 +219,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         // resolving joins against sessions nothing is feeding any more.
         viewModel.claudeSessionJoinResolver = nil
         viewModel.claudeSessionJoin = nil
+        // Quitting mid-dictation must take every remote herdr `ssh -L` with us.
+        // Asked of the view model, which OWNS them: during polish the join has
+        // already been consumed, so a quit that reached the child only through
+        // `claudeSessionJoin` found nil and left the ssh running past app exit
+        // (review finding 4).
+        viewModel.closeRemoteHerdrForwards()
     }
 
     /// Spin the run loop until every forward teardown has finished, or the
@@ -303,7 +309,22 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                 },
                 reportCmuxStatus: { [weak viewModel] status in
                     viewModel?.claudeIntegrationSettings?.cmuxStatus = status
-                }
+                },
+                sshDestinationProbe: {
+                    SSHDestinationTTYProbe.connection(onTTYDevicePath: $0)
+                },
+                // Read through the property rather than captured: the host
+                // registry is built later in launch than this resolver (and not
+                // at all for a user with no enrolled host), so the lookup has
+                // to be asked at dictation time, not wired at launch time. No
+                // registry ⇒ no candidates ⇒ the remote herdr arm never runs.
+                enrolledHosts: { [weak self] destination in
+                    self?.claudeRemoteHosts?.hosts(matchingSSHDestination: destination) ?? []
+                },
+                remoteHerdrForwards: ClaudeRemoteHerdrForwardService(
+                    spawner: ClaudeRemoteHerdrForwardSpawner(),
+                    workspaces: ClaudeRemoteHerdrForwardWorkspaces()
+                )
             )
             viewModel.claudeSessionJoinResolver = resolver
             // Pre-warm the Automation consent sheet OFF the dictation-start

--- a/Tests/localvoxtralTests/ClaudeRemoteHerdrForwardTests.swift
+++ b/Tests/localvoxtralTests/ClaudeRemoteHerdrForwardTests.swift
@@ -36,6 +36,21 @@ private final class ForwardTestClock: @unchecked Sendable {
     var sleepCount: Int { sleeps.withLock { $0.count } }
 }
 
+/// Counts injected `waitpid` calls across threads (the reap runs on whichever
+/// thread called teardown).
+private final class ReapCallCounter: @unchecked Sendable {
+    private let count = Mutex(0)
+
+    func next() -> Int {
+        count.withLock { current in
+            current += 1
+            return current
+        }
+    }
+
+    var value: Int { count.withLock { $0 } }
+}
+
 private final class ForwardTestProcess: ClaudeRemoteHerdrForwardProcess, @unchecked Sendable {
     private let running = Mutex(true)
     let terminations = Mutex(0)
@@ -633,6 +648,115 @@ final class ClaudeRemoteHerdrForwardTests: XCTestCase {
             process.groupSignalsSent, afterFirstTeardown,
             "a reaped pid must never be signalled again"
         )
+    }
+
+    // MARK: - The reap itself can fail (review round 4, medium)
+
+    /// Spawns a real `sh -c 'exit 0'` in its own process group, with an
+    /// injected `waitpid`. Real child, real group, scripted collection.
+    private func spawnExitingChild(
+        waitForChild: @escaping @Sendable (pid_t, UnsafeMutablePointer<Int32>?, Int32) -> pid_t,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) throws -> LiveHerdrForwardProcess {
+        let spawner = ClaudeRemoteHerdrForwardSpawner(
+            executablePath: "/bin/sh",
+            environment: ["PATH": "/usr/bin:/bin"],
+            waitForChild: waitForChild
+        )
+        let process = try XCTUnwrap(
+            try spawner.spawn(argv: ["sh", "-c", "exit 0"]) as? LiveHerdrForwardProcess,
+            "the live spawner returns a LiveHerdrForwardProcess", file: file, line: line
+        )
+        // Bounded wait for the exit event.
+        for _ in 0..<300 where process.isRunning { usleep(10_000) }
+        XCTAssertFalse(process.isRunning, "the child should have exited", file: file, line: line)
+        return process
+    }
+
+    func testAnInterruptedReapIsRetriedRatherThanClaimedAsDone() throws {
+        // `waitpid` returning EINTR is not an answer. The first version
+        // committed `reaped` BEFORE calling it and ignored the result, so a
+        // caught signal left a zombie while the state insisted it was gone —
+        // one leaked per dictation, forever.
+        let calls = ReapCallCounter()
+        let process = try spawnExitingChild(waitForChild: { pid, status, options in
+            if calls.next() <= 2 {
+                errno = EINTR
+                return -1
+            }
+            return waitpid(pid, status, options)
+        })
+
+        process.terminate()
+
+        XCTAssertTrue(process.hasBeenReaped)
+        XCTAssertGreaterThanOrEqual(calls.value, 3, "EINTR must be retried, not swallowed")
+        var isCollected = false
+        for _ in 0..<300 {
+            if kill(process.leaderPID, 0) != 0 {
+                isCollected = true
+                break
+            }
+            usleep(10_000)
+        }
+        XCTAssertTrue(isCollected, "the child must actually be collected")
+    }
+
+    func testAFailedReapLeavesTheChildForALaterAttempt() throws {
+        // A non-recoverable, non-ECHILD failure must NOT claim success: the
+        // zombie is still ours, `-pid` still names our group, and the next
+        // teardown has to be able to try again.
+        let calls = ReapCallCounter()
+        // Only the FIRST collection attempt fails, so the retry that every
+        // later exit path makes is the one that succeeds.
+        let process = try spawnExitingChild(waitForChild: { pid, status, options in
+            if calls.next() == 1 {
+                errno = EINVAL
+                return -1
+            }
+            return waitpid(pid, status, options)
+        })
+
+        process.terminate()
+
+        XCTAssertFalse(process.hasBeenReaped, "a failed collection is not a collection")
+        XCTAssertGreaterThan(
+            process.groupSignalsSent, 0, "an unreaped group is still ours to signal"
+        )
+        XCTAssertEqual(
+            kill(process.leaderPID, 0), 0, "the unreaped child still exists, holding its pid"
+        )
+
+        // The later attempt every exit path makes — and this one succeeds.
+        process.terminate()
+
+        XCTAssertTrue(process.hasBeenReaped)
+    }
+
+    func testAnAlreadyCollectedChildIsDefinitivelyReaped() throws {
+        // ECHILD is the kernel saying there is nothing left to collect. That IS
+        // definitive, so the state commits — and nothing may signal the group
+        // afterwards.
+        let process = try spawnExitingChild(waitForChild: { _, _, _ in
+            errno = ECHILD
+            return -1
+        })
+
+        process.terminate()
+        let signalsAtReap = process.groupSignalsSent
+
+        XCTAssertTrue(process.hasBeenReaped)
+        process.terminate()
+        XCTAssertEqual(
+            process.groupSignalsSent, signalsAtReap,
+            "a pid the kernel disowned must never be signalled again"
+        )
+
+        // The fake never collected it; do so now that the handle has stopped
+        // signalling, so the test process leaves no zombie behind.
+        var status: Int32 = 0
+        _ = waitpid(process.leaderPID, &status, 0)
     }
 
     func testTerminatingTwiceIsHarmless() throws {

--- a/Tests/localvoxtralTests/ClaudeRemoteHerdrForwardTests.swift
+++ b/Tests/localvoxtralTests/ClaudeRemoteHerdrForwardTests.swift
@@ -229,7 +229,11 @@ final class ClaudeRemoteHerdrForwardTests: XCTestCase {
         handle.close()
         handle.close()
 
-        XCTAssertEqual(spawner.process.terminations.withLock { $0 }, 1)
+        // `terminate()` is deliberately re-invoked by every close (it is the
+        // retry path for a failed collection) and is idempotent in EFFECT, so
+        // the contract is about what happened once: the workspace was removed
+        // exactly once, and the child was terminated at all.
+        XCTAssertGreaterThanOrEqual(spawner.process.terminations.withLock { $0 }, 1)
         XCTAssertEqual(workspaces.removed.withLock { $0.map(\.socketPath) }, [localSocketPath])
     }
 
@@ -244,7 +248,7 @@ final class ClaudeRemoteHerdrForwardTests: XCTestCase {
         let handle = await service.open(alias: "builder", remoteSocketPath: remoteSocketPath)
 
         XCTAssertNil(handle)
-        XCTAssertEqual(spawner.process.terminations.withLock { $0 }, 1)
+        XCTAssertGreaterThanOrEqual(spawner.process.terminations.withLock { $0 }, 1)
         XCTAssertEqual(workspaces.removeCount, 1)
         // Bounded: the poll loop cannot outlive the readiness budget. The count
         // is 2.0/0.025 give or take one — 0.025 is not exactly representable,
@@ -690,7 +694,17 @@ final class ClaudeRemoteHerdrForwardTests: XCTestCase {
 
         process.terminate()
 
-        XCTAssertTrue(process.hasBeenReaped)
+        // The retry happens on the handle's own queue — nothing blocks — so the
+        // collection lands asynchronously.
+        var collected = false
+        for _ in 0..<300 {
+            if process.hasBeenReaped {
+                collected = true
+                break
+            }
+            usleep(10_000)
+        }
+        XCTAssertTrue(collected)
         XCTAssertGreaterThanOrEqual(calls.value, 3, "EINTR must be retried, not swallowed")
         var isCollected = false
         for _ in 0..<300 {
@@ -757,6 +771,83 @@ final class ClaudeRemoteHerdrForwardTests: XCTestCase {
         // signalling, so the test process leaves no zombie behind.
         var status: Int32 = 0
         _ = waitpid(process.leaderPID, &status, 0)
+    }
+
+    // MARK: - The non-blocking collect and its hand-off (review round 7)
+
+    func testANeverCollectableChildDoesNotBlockTeardown() throws {
+        // The whole point of the simplification: there is no `waitpid(…, 0)`
+        // anywhere, so a child that never becomes collectable costs a bounded
+        // background poll and nothing else. If this regressed, the test would
+        // hang rather than fail.
+        let calls = ReapCallCounter()
+        let process = try spawnExitingChild(waitForChild: { _, _, _ in
+            _ = calls.next()
+            return 0 // WNOHANG: "still running", forever
+        })
+
+        process.terminate()
+
+        XCTAssertFalse(process.hasBeenReaped, "an uncollectable child is never claimed as reaped")
+        XCTAssertGreaterThan(process.groupSignalsSent, 0, "the group is still ours to signal")
+        // Collect it for real so the test process leaves nothing behind.
+        var status: Int32 = 0
+        _ = waitpid(process.leaderPID, &status, 0)
+    }
+
+    func testAChildThatIsNotReadyImmediatelyIsCollectedByTheHandOff() throws {
+        // The first attempt runs on the caller's thread; anything else goes to
+        // this handle's OWN queue. Nothing here is allowed to block, so the
+        // collection lands asynchronously.
+        let calls = ReapCallCounter()
+        let process = try spawnExitingChild(waitForChild: { pid, status, options in
+            if calls.next() <= 3 { return 0 }
+            return waitpid(pid, status, options)
+        })
+
+        process.terminate()
+
+        var collected = false
+        for _ in 0..<300 {
+            if process.hasBeenReaped {
+                collected = true
+                break
+            }
+            usleep(10_000)
+        }
+        XCTAssertTrue(collected, "the background poll must finish the collection")
+        XCTAssertGreaterThan(calls.value, 3)
+    }
+
+    func testClosingTheHandleAgainRetriesAFailedCollection() throws {
+        // Production's retry path. `close()` used to skip `terminate()` once the
+        // handle was already closed, so deinit could not retry and only a test
+        // calling `terminate()` twice ever recovered a failed reap.
+        let calls = ReapCallCounter()
+        let process = try spawnExitingChild(waitForChild: { pid, status, options in
+            if calls.next() == 1 {
+                errno = EINVAL
+                return -1
+            }
+            return waitpid(pid, status, options)
+        })
+        let workspace = ClaudeRemoteHerdrForwardWorkspace(
+            directoryPath: "/tmp/lvx-retry-test", socketPath: "/tmp/lvx-retry-test/h.sock"
+        )
+        let removals = ReapCallCounter()
+        let handle = ClaudeRemoteHerdrForwardHandle(
+            workspace: workspace,
+            process: process,
+            removeWorkspace: { _ in _ = removals.next() }
+        )
+
+        handle.close()
+        XCTAssertFalse(process.hasBeenReaped, "the first collection failed")
+
+        handle.close()
+
+        XCTAssertTrue(process.hasBeenReaped, "a later close must retry the collection")
+        XCTAssertEqual(removals.value, 1, "the workspace is still removed exactly once")
     }
 
     func testTerminatingTwiceIsHarmless() throws {

--- a/Tests/localvoxtralTests/ClaudeRemoteHerdrForwardTests.swift
+++ b/Tests/localvoxtralTests/ClaudeRemoteHerdrForwardTests.swift
@@ -1,0 +1,733 @@
+import ClaudeContextWire
+import Foundation
+import Synchronization
+import XCTest
+@testable import localvoxtral
+
+#if canImport(Darwin)
+import Darwin
+
+/// `XCTUnwrap` takes an autoclosure, which cannot contain `await`. This
+/// evaluates the value first and then unwraps it.
+private func unwrapAsync<T>(
+    _ value: T?, _ message: String = "", file: StaticString = #filePath, line: UInt = #line
+) throws -> T {
+    try XCTUnwrap(value, message, file: file, line: line)
+}
+
+/// Test clock whose SLEEP is what advances it — the OverlayBufferSessionCoordinator
+/// pattern (AGENTS: no wall clock in tests). A readiness poll driven by a real
+/// clock would be a test that actually waits two seconds.
+private final class ForwardTestClock: @unchecked Sendable {
+    private let state = Mutex(Date(timeIntervalSince1970: 1_700_000_000))
+    let sleeps = Mutex<[TimeInterval]>([])
+
+    var now: @Sendable () -> Date {
+        { [self] in state.withLock { $0 } }
+    }
+
+    var sleepFor: @Sendable (TimeInterval) async -> Void {
+        { [self] seconds in
+            sleeps.withLock { $0.append(seconds) }
+            state.withLock { $0 = $0.addingTimeInterval(seconds) }
+        }
+    }
+
+    var sleepCount: Int { sleeps.withLock { $0.count } }
+}
+
+private final class ForwardTestProcess: ClaudeRemoteHerdrForwardProcess, @unchecked Sendable {
+    private let running = Mutex(true)
+    let terminations = Mutex(0)
+
+    var isRunning: Bool { running.withLock { $0 } }
+    func exit() { running.withLock { $0 = false } }
+
+    func terminate() {
+        terminations.withLock { $0 += 1 }
+        running.withLock { $0 = false }
+    }
+}
+
+private final class ForwardTestSpawner: ClaudeRemoteHerdrForwardSpawning, @unchecked Sendable {
+    struct Failure: Error {}
+
+    let argv = Mutex<[[String]]>([])
+    let process = ForwardTestProcess()
+    private let fails: Bool
+
+    init(fails: Bool = false) { self.fails = fails }
+
+    func spawn(argv: [String]) throws -> any ClaudeRemoteHerdrForwardProcess {
+        self.argv.withLock { $0.append(argv) }
+        if fails { throw Failure() }
+        return process
+    }
+
+    var spawnCount: Int { argv.withLock { $0.count } }
+}
+
+private final class ForwardTestWorkspaces: ClaudeRemoteHerdrWorkspaceProviding, @unchecked Sendable {
+    struct Failure: Error {}
+
+    let made = Mutex(0)
+    let removed = Mutex<[ClaudeRemoteHerdrForwardWorkspace]>([])
+    private let socketPath: String
+    private let fails: Bool
+
+    init(socketPath: String = "/tmp/lvx-herdr-fwd-abcd1234/h.sock", fails: Bool = false) {
+        self.socketPath = socketPath
+        self.fails = fails
+    }
+
+    func makeWorkspace() throws -> ClaudeRemoteHerdrForwardWorkspace {
+        if fails { throw Failure() }
+        made.withLock { $0 += 1 }
+        return ClaudeRemoteHerdrForwardWorkspace(
+            directoryPath: (socketPath as NSString).deletingLastPathComponent,
+            socketPath: socketPath
+        )
+    }
+
+    func remove(_ workspace: ClaudeRemoteHerdrForwardWorkspace) {
+        removed.withLock { $0.append(workspace) }
+    }
+
+    var removeCount: Int { removed.withLock { $0.count } }
+}
+
+/// The app-managed `ssh -L` to a remote herdr socket.
+final class ClaudeRemoteHerdrForwardTests: XCTestCase {
+    private let remoteSocketPath = "/run/user/1000/herdr/default.sock"
+    private let localSocketPath = "/tmp/lvx-herdr-fwd-abcd1234/h.sock"
+
+    private func service(
+        spawner: ForwardTestSpawner,
+        workspaces: ForwardTestWorkspaces,
+        clock: ForwardTestClock,
+        dialable: @escaping @Sendable (String) -> Bool
+    ) -> ClaudeRemoteHerdrForwardService {
+        ClaudeRemoteHerdrForwardService(
+            spawner: spawner,
+            workspaces: workspaces,
+            isSocketDialable: dialable,
+            now: clock.now,
+            sleepFor: clock.sleepFor,
+            readinessTimeout: 2.0,
+            pollInterval: 0.025
+        )
+    }
+
+    // MARK: - argv
+
+    func testArgvIsExactlyWhatWeIntendToRun() {
+        XCTAssertEqual(
+            ClaudeRemoteHerdrForwardService.argv(
+                alias: "builder",
+                localSocketPath: localSocketPath,
+                remoteSocketPath: remoteSocketPath
+            ),
+            [
+                "ssh", "-N",
+                "-o", "BatchMode=yes",
+                "-o", "ControlPath=none",
+                "-o", "ForkAfterAuthentication=no",
+                "-o", "PermitLocalCommand=no",
+                "-L", "\(localSocketPath):\(remoteSocketPath)",
+                "--", "builder",
+            ]
+        )
+    }
+
+    func testArgvOverridesTheTwoAliasSettingsThatWouldBreakContainment() {
+        // The connection inherits the alias's own `Host` block (review finding
+        // 5): `ForkAfterAuthentication yes` would detach ssh into a process we
+        // no longer track — an orphan per dictation — and `LocalCommand` would
+        // run a command on THIS machine every time a tunnel opens.
+        let argv = ClaudeRemoteHerdrForwardService.argv(
+            alias: "builder", localSocketPath: localSocketPath, remoteSocketPath: remoteSocketPath
+        )
+        XCTAssertTrue(argv.contains("ForkAfterAuthentication=no"))
+        XCTAssertTrue(argv.contains("PermitLocalCommand=no"))
+    }
+
+    func testArgvOmitsTheTwoOptionsThatWouldBreakTheForward() {
+        // Both were in the original design and both were falsified against
+        // OpenSSH 10.0 before this shipped:
+        //   * ClearAllForwardings clears command-line forwardings too, so it
+        //     would delete this very -L (measured: no socket ever appears);
+        //   * ExitOnForwardFailure makes the enrolled host's own RemoteForward
+        //     8473 — normally already held by the user's live session — fatal
+        //     for this connection (measured: "Error: remote port forwarding
+        //     failed", ssh exits).
+        // Readiness is proven by dialing the socket instead.
+        let argv = ClaudeRemoteHerdrForwardService.argv(
+            alias: "builder", localSocketPath: localSocketPath, remoteSocketPath: remoteSocketPath
+        )
+        XCTAssertFalse(argv.contains { $0.contains("ClearAllForwardings") })
+        XCTAssertFalse(argv.contains { $0.contains("ExitOnForwardFailure") })
+    }
+
+    // MARK: - Lifecycle
+
+    func testOpenReturnsAHandleOnceTheSocketAnswers() async throws {
+        let spawner = ForwardTestSpawner()
+        let workspaces = ForwardTestWorkspaces()
+        let clock = ForwardTestClock()
+        let polls = Mutex(0)
+        let service = service(
+            spawner: spawner, workspaces: workspaces, clock: clock,
+            dialable: { _ in polls.withLock { $0 += 1; return $0 >= 3 } }
+        )
+
+        let handle = try unwrapAsync(
+            await service.open(alias: "builder", remoteSocketPath: remoteSocketPath)
+        )
+
+        XCTAssertEqual(handle.localSocketPath, localSocketPath)
+        XCTAssertEqual(
+            spawner.argv.withLock { $0 },
+            [
+                ClaudeRemoteHerdrForwardService.argv(
+                    alias: "builder",
+                    localSocketPath: localSocketPath,
+                    remoteSocketPath: remoteSocketPath
+                ),
+            ]
+        )
+        // Still open: the dictation is what closes it.
+        XCTAssertEqual(workspaces.removeCount, 0)
+        XCTAssertTrue(handle.isRunning)
+    }
+
+    func testCloseTerminatesTheChildAndRemovesTheWorkspaceExactlyOnce() async throws {
+        let spawner = ForwardTestSpawner()
+        let workspaces = ForwardTestWorkspaces()
+        let clock = ForwardTestClock()
+        let service = service(
+            spawner: spawner, workspaces: workspaces, clock: clock, dialable: { _ in true }
+        )
+        let handle = try unwrapAsync(
+            await service.open(alias: "builder", remoteSocketPath: remoteSocketPath)
+        )
+
+        handle.close()
+        handle.close()
+
+        XCTAssertEqual(spawner.process.terminations.withLock { $0 }, 1)
+        XCTAssertEqual(workspaces.removed.withLock { $0.map(\.socketPath) }, [localSocketPath])
+    }
+
+    func testReadinessTimeoutTearsEverythingDown() async throws {
+        let spawner = ForwardTestSpawner()
+        let workspaces = ForwardTestWorkspaces()
+        let clock = ForwardTestClock()
+        let service = service(
+            spawner: spawner, workspaces: workspaces, clock: clock, dialable: { _ in false }
+        )
+
+        let handle = await service.open(alias: "builder", remoteSocketPath: remoteSocketPath)
+
+        XCTAssertNil(handle)
+        XCTAssertEqual(spawner.process.terminations.withLock { $0 }, 1)
+        XCTAssertEqual(workspaces.removeCount, 1)
+        // Bounded: the poll loop cannot outlive the readiness budget. The count
+        // is 2.0/0.025 give or take one — 0.025 is not exactly representable,
+        // so eighty accumulated additions land just short of the deadline and
+        // buy one more iteration. What matters is that it is bounded at all.
+        XCTAssertEqual(clock.sleeps.withLock { $0.reduce(0, +) }, 2.0, accuracy: 0.05)
+        XCTAssertGreaterThanOrEqual(clock.sleepCount, 80)
+        XCTAssertLessThanOrEqual(clock.sleepCount, 82)
+    }
+
+    func testAnSSHThatExitsEarlyIsAbandonedWithoutWaitingOutTheTimeout() async throws {
+        let spawner = ForwardTestSpawner()
+        let workspaces = ForwardTestWorkspaces()
+        let clock = ForwardTestClock()
+        let polls = Mutex(0)
+        let service = service(
+            spawner: spawner, workspaces: workspaces, clock: clock,
+            dialable: { [spawner] _ in
+                let count = polls.withLock { $0 += 1; return $0 }
+                if count == 2 { spawner.process.exit() }
+                return false
+            }
+        )
+
+        let handle = await service.open(alias: "builder", remoteSocketPath: remoteSocketPath)
+
+        XCTAssertNil(handle)
+        XCTAssertLessThan(clock.sleepCount, 5)
+        XCTAssertEqual(workspaces.removeCount, 1)
+    }
+
+    func testSpawnFailureRemovesTheWorkspace() async throws {
+        let spawner = ForwardTestSpawner(fails: true)
+        let workspaces = ForwardTestWorkspaces()
+        let clock = ForwardTestClock()
+        let service = service(
+            spawner: spawner, workspaces: workspaces, clock: clock, dialable: { _ in true }
+        )
+
+        let handle = await service.open(alias: "builder", remoteSocketPath: remoteSocketPath)
+        XCTAssertNil(handle)
+        XCTAssertEqual(workspaces.removeCount, 1)
+        XCTAssertEqual(clock.sleepCount, 0)
+    }
+
+    func testAWorkspaceThatCannotBeCreatedNeverSpawns() async throws {
+        let spawner = ForwardTestSpawner()
+        let workspaces = ForwardTestWorkspaces(fails: true)
+        let clock = ForwardTestClock()
+        let service = service(
+            spawner: spawner, workspaces: workspaces, clock: clock, dialable: { _ in true }
+        )
+
+        let handle = await service.open(alias: "builder", remoteSocketPath: remoteSocketPath)
+        XCTAssertNil(handle)
+        XCTAssertEqual(spawner.spawnCount, 0)
+    }
+
+    func testAnOverlongLocalSocketPathIsRefusedBeforeSpawning() async throws {
+        // sun_path is 104 bytes; a socket nothing can dial is worth naming
+        // rather than discovering as a readiness timeout.
+        let spawner = ForwardTestSpawner()
+        let workspaces = ForwardTestWorkspaces(
+            socketPath: "/tmp/\(String(repeating: "d", count: 120))/h.sock"
+        )
+        let clock = ForwardTestClock()
+        let service = service(
+            spawner: spawner, workspaces: workspaces, clock: clock, dialable: { _ in true }
+        )
+
+        let handle = await service.open(alias: "builder", remoteSocketPath: remoteSocketPath)
+        XCTAssertNil(handle)
+        XCTAssertEqual(spawner.spawnCount, 0)
+        XCTAssertEqual(workspaces.removeCount, 1)
+    }
+
+    // MARK: - Validation of the two strings that reach argv
+
+    func testAnInvalidAliasNeverReachesArgv() async throws {
+        let spawner = ForwardTestSpawner()
+        let workspaces = ForwardTestWorkspaces()
+        let clock = ForwardTestClock()
+        let service = service(
+            spawner: spawner, workspaces: workspaces, clock: clock, dialable: { _ in true }
+        )
+
+        for alias in ["-oProxyCommand=touch /tmp/pwned", "build er", "host;rm -rf /", ""] {
+            let handle = await service.open(alias: alias, remoteSocketPath: remoteSocketPath)
+            XCTAssertNil(handle, "alias \(alias) must be refused")
+        }
+        XCTAssertEqual(spawner.spawnCount, 0)
+        XCTAssertEqual(workspaces.made.withLock { $0 }, 0)
+    }
+
+    func testAnUnusableRemoteSocketPathNeverReachesArgv() async throws {
+        let spawner = ForwardTestSpawner()
+        let workspaces = ForwardTestWorkspaces()
+        let clock = ForwardTestClock()
+        let service = service(
+            spawner: spawner, workspaces: workspaces, clock: clock, dialable: { _ in true }
+        )
+
+        for path in [
+            "relative/herdr.sock",
+            "-oProxyCommand=x",
+            "/run/herdr:1234",
+            "/run/herdr sock",
+            "/run/herdr\nsock",
+            "",
+        ] {
+            let handle = await service.open(alias: "builder", remoteSocketPath: path)
+            XCTAssertNil(handle, "remote socket path \(path) must be refused")
+        }
+        XCTAssertEqual(spawner.spawnCount, 0)
+    }
+
+    func testRemoteSocketPathValidationMatrix() {
+        let valid = [
+            "/run/user/1000/herdr/default.sock",
+            "/tmp/herdr-user.sock",
+            "/home/dev/.local/state/herdr/s-1.sock",
+        ]
+        for path in valid {
+            XCTAssertTrue(
+                ClaudeRemoteHerdrForwardService.isForwardableRemoteSocketPath(path), path
+            )
+        }
+        let invalid = [
+            "",                       // nothing
+            "herdr.sock",             // relative
+            "-L/tmp/x",               // option-shaped
+            "/tmp/a:b.sock",          // would re-split the -L spec
+            "/tmp/a b.sock",          // outside the header charset
+            "/tmp/a\r\nb.sock",       // outside the header charset
+            "/tmp/\u{1B}].sock",      // outside the header charset
+            "/tmp/" + String(repeating: "x", count: 300), // beyond the value cap
+        ]
+        for path in invalid {
+            XCTAssertFalse(
+                ClaudeRemoteHerdrForwardService.isForwardableRemoteSocketPath(path), path
+            )
+        }
+    }
+
+    // MARK: - The live workspace provider
+
+    func testLiveWorkspaceIsAFreshPrivateDirectoryAndIsRemovedOnClose() throws {
+        let base = NSTemporaryDirectory().appending("lvx-forward-tests-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(
+            atPath: base,
+            withIntermediateDirectories: true,
+            attributes: [.posixPermissions: NSNumber(value: Int16(0o700))]
+        )
+        defer { try? FileManager.default.removeItem(atPath: base) }
+
+        let provider = ClaudeRemoteHerdrForwardWorkspaces(base: base)
+        let first = try provider.makeWorkspace()
+        let second = try provider.makeWorkspace()
+
+        XCTAssertNotEqual(first.socketPath, second.socketPath, "a socket path is never reused")
+        XCTAssertTrue(first.socketPath.hasPrefix(first.directoryPath + "/"))
+        let metadata = try unwrapAsync(ClaudeSocketGuard.metadata(ofPath: first.directoryPath))
+        XCTAssertTrue(metadata.isDirectory)
+        XCTAssertEqual(metadata.mode, 0o700)
+        XCTAssertEqual(metadata.ownerUID, UInt32(geteuid()))
+
+        provider.remove(first)
+        XCTAssertNil(ClaudeSocketGuard.metadata(ofPath: first.directoryPath))
+        provider.remove(second)
+    }
+
+    func testTheProductionWorkspaceBaseProducesADialableSocketPath() throws {
+        // The DEFAULT base (the per-user temporary directory), because that is
+        // the one that has to fit in `sun_path`'s 104 bytes. Application
+        // Support was rejected for exactly this: a long user name would push a
+        // path past the ceiling and produce a socket nothing can dial.
+        let provider = ClaudeRemoteHerdrForwardWorkspaces()
+        let workspace = try provider.makeWorkspace()
+        defer { provider.remove(workspace) }
+
+        XCTAssertTrue(
+            ClaudeRemoteHerdrForwardService.isUsableLocalSocketPath(workspace.socketPath),
+            "production socket path is \(workspace.socketPath.utf8.count) bytes: \(workspace.socketPath)"
+        )
+    }
+
+    // MARK: - The live spawner tears down the whole process GROUP
+
+    /// Spawn a leader that forks a descendant which IGNORES SIGTERM, and hand
+    /// back the descendant's pid.
+    ///
+    /// The SIGTERM-ignoring part is the whole test (review round 3, new major):
+    /// with a descendant that dies on TERM, the leader's own exit satisfies
+    /// `waitForExit` and the bounded teardown returns before SIGKILL — so a
+    /// `sleep` descendant would pass even with the kill suppressed.
+    private func spawnLeaderWithStubbornDescendant(
+        file: StaticString = #filePath, line: UInt = #line
+    ) throws -> (process: LiveHerdrForwardProcess, descendant: pid_t, cleanup: () -> Void) {
+        let directory = NSTemporaryDirectory()
+            .appending("lvx-forward-group-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(
+            atPath: directory, withIntermediateDirectories: true
+        )
+        let pidFile = (directory as NSString).appendingPathComponent("child.pid")
+        let cleanup: () -> Void = { _ = try? FileManager.default.removeItem(atPath: directory) }
+
+        let spawner = ClaudeRemoteHerdrForwardSpawner(
+            executablePath: "/bin/sh", environment: ["PATH": "/usr/bin:/bin"]
+        )
+        let spawned = try spawner.spawn(argv: [
+            "sh", "-c",
+            "sh -c 'trap \"\" TERM; sleep 60' & echo $! > \(pidFile); wait",
+        ])
+        let process = try XCTUnwrap(
+            spawned as? LiveHerdrForwardProcess, "the live spawner returns a LiveHerdrForwardProcess",
+            file: file, line: line
+        )
+
+        // Bounded wait for the descendant to announce itself. A live-process
+        // test cannot inject a clock into the kernel; the bound is what keeps
+        // it from being a hang.
+        var descendantPID: pid_t?
+        for _ in 0..<300 {
+            if let text = try? String(contentsOfFile: pidFile, encoding: .utf8),
+               let pid = pid_t(text.trimmingCharacters(in: .whitespacesAndNewlines)) {
+                descendantPID = pid
+                break
+            }
+            usleep(10_000)
+        }
+        let descendant = try XCTUnwrap(
+            descendantPID, "the child never spawned a descendant", file: file, line: line
+        )
+        return (process, descendant, cleanup)
+    }
+
+    func testTerminatingTheLiveChildAlsoKillsADescendantThatIgnoresSIGTERM() throws {
+        // The orphan half of finding 5, tightened by round 3: ssh can leave
+        // descendants, and the leader exiting says NOTHING about them. Teardown
+        // therefore SIGKILLs the group unconditionally.
+        let (process, descendant, cleanup) = try spawnLeaderWithStubbornDescendant()
+        defer { cleanup() }
+        XCTAssertTrue(process.isRunning)
+        XCTAssertEqual(kill(descendant, 0), 0, "the descendant should be alive before teardown")
+
+        process.terminate()
+
+        var descendantIsGone = false
+        for _ in 0..<300 {
+            if kill(descendant, 0) != 0 {
+                descendantIsGone = true
+                break
+            }
+            usleep(10_000)
+        }
+        XCTAssertTrue(
+            descendantIsGone,
+            "terminate() must SIGKILL the whole group, even after the leader went quietly"
+        )
+        XCTAssertFalse(process.isRunning)
+    }
+
+    func testTerminatingAfterTheLeaderAlreadyExitedStillKillsTheGroup() throws {
+        // The exact shape the round-3 review described: by the time teardown
+        // runs, the leader is already gone and only the stubborn descendant is
+        // left. A liveness guard on the kill would skip it here.
+        let (process, descendant, cleanup) = try spawnLeaderWithStubbornDescendant()
+        defer { cleanup() }
+
+        // SIGTERM the leader ONLY (positive pid), and wait for it to go.
+        _ = kill(process.leaderPID, SIGTERM)
+        for _ in 0..<300 where process.isRunning { usleep(10_000) }
+        XCTAssertFalse(process.isRunning, "the leader should have exited on its own")
+        XCTAssertEqual(kill(descendant, 0), 0, "the descendant ignores SIGTERM and survives")
+
+        process.terminate()
+
+        var descendantIsGone = false
+        for _ in 0..<300 {
+            if kill(descendant, 0) != 0 {
+                descendantIsGone = true
+                break
+            }
+            usleep(10_000)
+        }
+        XCTAssertTrue(descendantIsGone, "a dead leader must not suppress the group SIGKILL")
+    }
+
+    func testTerminatingTheLiveChildAlsoKillsItsDescendants() throws {
+        // The plain case kept alongside the stubborn one: an ordinary
+        // descendant that does die on SIGTERM.
+        let directory = NSTemporaryDirectory()
+            .appending("lvx-forward-group-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(
+            atPath: directory, withIntermediateDirectories: true
+        )
+        defer { try? FileManager.default.removeItem(atPath: directory) }
+        let pidFile = (directory as NSString).appendingPathComponent("child.pid")
+
+        let spawner = ClaudeRemoteHerdrForwardSpawner(
+            executablePath: "/bin/sh",
+            environment: ["PATH": "/usr/bin:/bin"]
+        )
+        let process = try spawner.spawn(argv: [
+            "sh", "-c", "sleep 60 & echo $! > \(pidFile); wait",
+        ])
+        XCTAssertTrue(process.isRunning)
+
+        // Bounded wait for the grandchild to announce itself. A live-process
+        // test cannot inject a clock into the kernel; the bound is what keeps
+        // it from being a hang.
+        var grandchildPID: pid_t?
+        for _ in 0..<200 {
+            if let text = try? String(contentsOfFile: pidFile, encoding: .utf8),
+               let pid = pid_t(text.trimmingCharacters(in: .whitespacesAndNewlines)) {
+                grandchildPID = pid
+                break
+            }
+            usleep(10_000)
+        }
+        let grandchild = try XCTUnwrap(grandchildPID, "the child never spawned a grandchild")
+        XCTAssertEqual(kill(grandchild, 0), 0, "the grandchild should be alive before teardown")
+
+        process.terminate()
+
+        // The group signal reaches the grandchild too. Bounded poll again: the
+        // kernel delivers asynchronously.
+        var grandchildIsGone = false
+        for _ in 0..<200 {
+            if kill(grandchild, 0) != 0 {
+                grandchildIsGone = true
+                break
+            }
+            usleep(10_000)
+        }
+        XCTAssertTrue(grandchildIsGone, "terminate() must kill the whole process group")
+        XCTAssertFalse(process.isRunning)
+    }
+
+    // MARK: - Never signal a group after reaping it (review round 4)
+
+    func testAForwardThatExitsOnItsOwnIsNotReapedUntilTeardown() throws {
+        // The pid — and with it the process GROUP id — is reserved only while
+        // the child is unreaped. Reaping in the exit handler (as the round-3
+        // version did) opened a window where a later `close()` could
+        // `kill(-pid)` a stranger's group: a tunnel that exits by itself
+        // mid-dictation is reaped, and stop time closes it seconds later.
+        let spawner = ClaudeRemoteHerdrForwardSpawner(
+            executablePath: "/bin/sh", environment: ["PATH": "/usr/bin:/bin"]
+        )
+        let process = try unwrapAsync(
+            try spawner.spawn(argv: ["sh", "-c", "exit 0"]) as? LiveHerdrForwardProcess
+        )
+
+        // Wait for the exit event, bounded.
+        for _ in 0..<300 where process.isRunning { usleep(10_000) }
+        XCTAssertFalse(process.isRunning, "the leader should have exited on its own")
+
+        // Un-reaped: the zombie still holds the pid, which is what keeps
+        // `-pid` meaning OUR group.
+        XCTAssertFalse(process.hasBeenReaped)
+        XCTAssertEqual(
+            kill(process.leaderPID, 0), 0,
+            "an unreaped child still exists, reserving its pid"
+        )
+
+        process.terminate()
+
+        XCTAssertTrue(process.hasBeenReaped)
+        var isCollected = false
+        for _ in 0..<300 {
+            if kill(process.leaderPID, 0) != 0 {
+                isCollected = true
+                break
+            }
+            usleep(10_000)
+        }
+        XCTAssertTrue(isCollected, "teardown must collect the child")
+    }
+
+    func testNoGroupSignalIsSentAfterTheChildHasBeenReaped() throws {
+        let spawner = ClaudeRemoteHerdrForwardSpawner(
+            executablePath: "/bin/sh", environment: ["PATH": "/usr/bin:/bin"]
+        )
+        let process = try unwrapAsync(
+            try spawner.spawn(argv: ["sh", "-c", "exit 0"]) as? LiveHerdrForwardProcess
+        )
+        for _ in 0..<300 where process.isRunning { usleep(10_000) }
+
+        process.terminate()
+        let afterFirstTeardown = process.groupSignalsSent
+        XCTAssertTrue(process.hasBeenReaped)
+
+        // Every later close — and `close()` is called from several exit paths
+        // plus deinit — must send NOTHING, because the pid may now belong to
+        // someone else.
+        process.terminate()
+        process.terminate()
+
+        XCTAssertEqual(
+            process.groupSignalsSent, afterFirstTeardown,
+            "a reaped pid must never be signalled again"
+        )
+    }
+
+    func testTerminatingTwiceIsHarmless() throws {
+        let spawner = ClaudeRemoteHerdrForwardSpawner(
+            executablePath: "/bin/sh", environment: ["PATH": "/usr/bin:/bin"]
+        )
+        let process = try spawner.spawn(argv: ["sh", "-c", "sleep 60"])
+        process.terminate()
+        process.terminate()
+        XCTAssertFalse(process.isRunning)
+    }
+
+    func testSpawningAMissingExecutableThrows() {
+        let spawner = ClaudeRemoteHerdrForwardSpawner(
+            executablePath: "/nonexistent/lvx-ssh", environment: [:]
+        )
+        XCTAssertThrowsError(try spawner.spawn(argv: ["ssh", "-N", "--", "builder"]))
+    }
+
+    func testLiveWorkspaceRefusesToReuseAnExistingDirectory() throws {
+        let base = NSTemporaryDirectory().appending("lvx-forward-tests-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(
+            atPath: base, withIntermediateDirectories: true
+        )
+        defer { try? FileManager.default.removeItem(atPath: base) }
+
+        // A provider with a fixed name, so the second call collides with the
+        // first — standing in for a directory somebody else planted.
+        let provider = ClaudeRemoteHerdrForwardWorkspaces(base: base, makeName: { "fixed" })
+        _ = try provider.makeWorkspace()
+        XCTAssertThrowsError(try provider.makeWorkspace())
+    }
+}
+
+// MARK: - Alias → enrolled host
+
+private final class MemoryHostStore: ClaudeRemoteHostStoreIO, @unchecked Sendable {
+    private let files = Mutex<[String: Data]>([:])
+
+    func read(from url: URL) throws -> Data? {
+        files.withLock { $0[url.path] }
+    }
+
+    func write(_ data: Data, to url: URL) throws {
+        files.withLock { $0[url.path] = data }
+    }
+}
+
+final class ClaudeRemoteHostAliasMatchingTests: XCTestCase {
+    private func makeRegistry() throws -> ClaudeRemoteHostRegistry {
+        let ids = Mutex(["h11111111", "h22222222", "h33333333"])
+        return try ClaudeRemoteHostRegistry(
+            fileURL: URL(fileURLWithPath: "/lvx-tests/hosts.json"),
+            io: MemoryHostStore(),
+            now: { Date(timeIntervalSince1970: 1_700_000_000) },
+            makeToken: { String(repeating: "t", count: 32) },
+            makeHostID: { ids.withLock { $0.isEmpty ? "hzzzzzzz" : $0.removeFirst() } }
+        )
+    }
+
+    func testTheEnrolledAliasMatchesTheSSHDestinationCaseInsensitively() throws {
+        let registry = try makeRegistry()
+        _ = try registry.enroll(label: "build box", sshHostAlias: "Builder")
+
+        XCTAssertEqual(registry.hosts(matchingSSHDestination: "builder").count, 1)
+        XCTAssertEqual(registry.hosts(matchingSSHDestination: "BUILDER").count, 1)
+        // And the STORED spelling comes back — that is the vetted string, and
+        // the only one allowed to reach an argv.
+        XCTAssertEqual(registry.hosts(matchingSSHDestination: "builder").first?.sshHostAlias, "Builder")
+    }
+
+    func testAnotherDestinationMatchesNothing() throws {
+        let registry = try makeRegistry()
+        _ = try registry.enroll(label: "build box", sshHostAlias: "builder")
+
+        XCTAssertTrue(registry.hosts(matchingSSHDestination: "someone-elses-box").isEmpty)
+        XCTAssertTrue(registry.hosts(matchingSSHDestination: "").isEmpty)
+        // The label is not the alias, and never stands in for it.
+        XCTAssertTrue(registry.hosts(matchingSSHDestination: "build box").isEmpty)
+    }
+
+    func testARevokedHostStopsMatching() throws {
+        let registry = try makeRegistry()
+        let enrollment = try registry.enroll(label: "build box", sshHostAlias: "builder")
+        XCTAssertEqual(registry.hosts(matchingSSHDestination: "builder").count, 1)
+
+        try registry.revoke(hostID: enrollment.host.id)
+
+        XCTAssertTrue(registry.hosts(matchingSSHDestination: "builder").isEmpty)
+    }
+
+    func testAHostEnrolledWithoutAnAliasNeverMatches() throws {
+        let registry = try makeRegistry()
+        _ = try registry.enroll(label: "legacy", sshHostAlias: nil)
+        XCTAssertTrue(registry.hosts(matchingSSHDestination: "legacy").isEmpty)
+    }
+}
+#endif

--- a/Tests/localvoxtralTests/ClaudeRemoteHerdrForwardTests.swift
+++ b/Tests/localvoxtralTests/ClaudeRemoteHerdrForwardTests.swift
@@ -769,11 +769,135 @@ final class ClaudeRemoteHerdrForwardTests: XCTestCase {
 
         // The fake never collected it; do so now that the handle has stopped
         // signalling, so the test process leaves no zombie behind.
-        var status: Int32 = 0
-        _ = waitpid(process.leaderPID, &status, 0)
+        collectForTestCleanup(process.leaderPID)
     }
 
     // MARK: - The non-blocking collect and its hand-off (review round 7)
+
+    /// Collect a child the test's fake never collected, WITHOUT a blocking
+    /// wait: the child is already dead, so WNOHANG succeeds at once and the
+    /// bound is only there so a surprise cannot hang the suite.
+    private func collectForTestCleanup(_ pid: pid_t) {
+        var status: Int32 = 0
+        for _ in 0..<200 {
+            if waitpid(pid, &status, WNOHANG) != 0 { return }
+            usleep(10_000)
+        }
+        XCTFail("test child \(pid) was never collectable")
+    }
+
+    func testAGroupSignalCannotRunWhileTheCollectionIsInFlight() throws {
+        // The PID-reuse invariant, stated as a race rather than as a comment
+        // (review round 8). The collection's `waitpid` releases the pid; if a
+        // concurrent `terminate()` can take the lock and read `reaped == false`
+        // in that gap, it signals a pid the kernel may already have reissued.
+        //
+        // So: park a collection INSIDE `waitpid` and prove a concurrent
+        // teardown cannot get through. With the reap under the same lock as the
+        // `reaped` check, the second teardown blocks on the mutex; with the
+        // reap outside it (the earlier shape), it sails past and signals.
+        let insideWaitpid = DispatchSemaphore(value: 0)
+        let releaseWaitpid = DispatchSemaphore(value: 0)
+        let calls = ReapCallCounter()
+        let process = try spawnExitingChild(waitForChild: { pid, status, options in
+            if calls.next() == 1 {
+                insideWaitpid.signal()
+                // Held long enough that "B is still blocked" cannot be confused
+                // with "B is merely slow": a teardown that DOES get through
+                // costs at most two 0.25 s grace waits, well under the window
+                // sampled below. Bounded so a failure cannot hang the suite.
+                _ = releaseWaitpid.wait(timeout: .now() + 3)
+            }
+            return waitpid(pid, status, options)
+        })
+
+        // A: drives the collection and parks inside `waitpid`.
+        let firstTeardownReturned = DispatchSemaphore(value: 0)
+        DispatchQueue.global().async {
+            process.terminate()
+            firstTeardownReturned.signal()
+        }
+        XCTAssertEqual(
+            insideWaitpid.wait(timeout: .now() + 5), .success,
+            "the collection should have reached waitpid"
+        )
+
+        // B: a concurrent teardown, which must not be able to signal the group
+        // while A holds the collection open. Deliberately does NOT touch the
+        // mutex from this thread — progress is observed through B's own
+        // completion, not through a counter that would itself take the lock.
+        let secondTeardownReturned = DispatchSemaphore(value: 0)
+        DispatchQueue.global().async {
+            process.terminate()
+            secondTeardownReturned.signal()
+        }
+
+        // 1.2 s: longer than a teardown that gets through needs (≤0.5 s of
+        // grace waits), shorter than the 3 s the collection is parked for.
+        XCTAssertEqual(
+            secondTeardownReturned.wait(timeout: .now() + 1.2), .timedOut,
+            "a teardown must not proceed while a collection holds the lock"
+        )
+
+        releaseWaitpid.signal()
+        XCTAssertEqual(firstTeardownReturned.wait(timeout: .now() + 5), .success)
+        XCTAssertEqual(secondTeardownReturned.wait(timeout: .now() + 5), .success)
+        XCTAssertTrue(process.hasBeenReaped)
+    }
+
+    func testTheCollectionBudgetIsExhaustedAndThenReleased() throws {
+        // A genuine observation of the bound (review round 8): with a small
+        // injected budget, the poll must stop by itself — a fixed number of
+        // attempts, and then no further work at all.
+        let attempts = 5
+        let calls = ReapCallCounter()
+        let spawner = ClaudeRemoteHerdrForwardSpawner(
+            executablePath: "/bin/sh",
+            environment: ["PATH": "/usr/bin:/bin"],
+            waitForChild: { _, _, _ in
+                _ = calls.next()
+                return 0 // WNOHANG: "still running", forever
+            },
+            reapPollAttempts: attempts,
+            reapPollInterval: 0.002
+        )
+        let process = try XCTUnwrap(
+            try spawner.spawn(argv: ["sh", "-c", "exit 0"]) as? LiveHerdrForwardProcess
+        )
+        for _ in 0..<300 where process.isRunning { usleep(10_000) }
+
+        process.terminate()
+
+        // Wait, bounded, for the count to stop moving: that IS the release.
+        var settled = 0
+        var previous = -1
+        for _ in 0..<200 {
+            let current = calls.value
+            if current == previous {
+                settled += 1
+                if settled >= 3 { break }
+            } else {
+                settled = 0
+                previous = current
+            }
+            usleep(10_000)
+        }
+
+        let total = calls.value
+        // One attempt on the caller's thread, then at most `attempts` on the
+        // handle's queue. Never more, and never forever.
+        XCTAssertGreaterThan(total, 1, "the hand-off must have polled at all")
+        XCTAssertLessThanOrEqual(
+            total, attempts + 1, "the budget must bound the number of attempts"
+        )
+        XCTAssertFalse(process.hasBeenReaped, "an uncollectable child is never claimed as reaped")
+
+        // And nothing is left running: no further attempts after the budget.
+        usleep(50_000)
+        XCTAssertEqual(calls.value, total, "the poll chain must release itself")
+
+        collectForTestCleanup(process.leaderPID)
+    }
 
     func testANeverCollectableChildDoesNotBlockTeardown() throws {
         // The whole point of the simplification: there is no `waitpid(…, 0)`
@@ -791,8 +915,7 @@ final class ClaudeRemoteHerdrForwardTests: XCTestCase {
         XCTAssertFalse(process.hasBeenReaped, "an uncollectable child is never claimed as reaped")
         XCTAssertGreaterThan(process.groupSignalsSent, 0, "the group is still ours to signal")
         // Collect it for real so the test process leaves nothing behind.
-        var status: Int32 = 0
-        _ = waitpid(process.leaderPID, &status, 0)
+        collectForTestCleanup(process.leaderPID)
     }
 
     func testAChildThatIsNotReadyImmediatelyIsCollectedByTheHandOff() throws {

--- a/Tests/localvoxtralTests/ClaudeRemoteHerdrForwardTests.swift
+++ b/Tests/localvoxtralTests/ClaudeRemoteHerdrForwardTests.swift
@@ -799,17 +799,28 @@ final class ClaudeRemoteHerdrForwardTests: XCTestCase {
         let insideWaitpid = DispatchSemaphore(value: 0)
         let releaseWaitpid = DispatchSemaphore(value: 0)
         let calls = ReapCallCounter()
-        let process = try spawnExitingChild(waitForChild: { pid, status, options in
-            if calls.next() == 1 {
-                insideWaitpid.signal()
-                // Held long enough that "B is still blocked" cannot be confused
-                // with "B is merely slow": a teardown that DOES get through
-                // costs at most two 0.25 s grace waits, well under the window
-                // sampled below. Bounded so a failure cannot hang the suite.
-                _ = releaseWaitpid.wait(timeout: .now() + 3)
-            }
-            return waitpid(pid, status, options)
-        })
+        let signalAttempts = ReapCallCounter()
+        let spawner = ClaudeRemoteHerdrForwardSpawner(
+            executablePath: "/bin/sh",
+            environment: ["PATH": "/usr/bin:/bin"],
+            waitForChild: { pid, status, options in
+                if calls.next() == 1 {
+                    insideWaitpid.signal()
+                    // Held long enough that "B is still blocked" cannot be
+                    // confused with "B is merely slow": a teardown that DOES
+                    // get through costs at most two 0.25 s grace waits, well
+                    // under the window sampled below. Bounded so a failure
+                    // cannot hang the suite.
+                    _ = releaseWaitpid.wait(timeout: .now() + 3)
+                }
+                return waitpid(pid, status, options)
+            },
+            willAttemptTeardownLock: { _ = signalAttempts.next() }
+        )
+        let process = try XCTUnwrap(
+            try spawner.spawn(argv: ["sh", "-c", "exit 0"]) as? LiveHerdrForwardProcess
+        )
+        for _ in 0..<300 where process.isRunning { usleep(10_000) }
 
         // A: drives the collection and parks inside `waitpid`.
         let firstTeardownReturned = DispatchSemaphore(value: 0)
@@ -821,16 +832,34 @@ final class ClaudeRemoteHerdrForwardTests: XCTestCase {
             insideWaitpid.wait(timeout: .now() + 5), .success,
             "the collection should have reached waitpid"
         )
+        let attemptsBeforeB = signalAttempts.value
 
         // B: a concurrent teardown, which must not be able to signal the group
         // while A holds the collection open. Deliberately does NOT touch the
-        // mutex from this thread — progress is observed through B's own
-        // completion, not through a counter that would itself take the lock.
+        // state mutex from this thread — progress is observed through the
+        // signal-ATTEMPT seam (which fires before the lock is taken) and
+        // through B's own completion.
         let secondTeardownReturned = DispatchSemaphore(value: 0)
         DispatchQueue.global().async {
             process.terminate()
             secondTeardownReturned.signal()
         }
+
+        // BARRIER (review round 8b): prove B has actually reached the lock
+        // before timing anything. Without this, a starved global queue could
+        // leave B merely unscheduled and the interval below would "pass" even
+        // with the reap moved back outside the mutex. The seam fires on
+        // `terminate()` entry — the guard immediately after it IS a lock
+        // acquisition — so an increment means B is at the door.
+        var reachedTheLock = false
+        for _ in 0..<500 {
+            if signalAttempts.value > attemptsBeforeB {
+                reachedTheLock = true
+                break
+            }
+            usleep(10_000)
+        }
+        XCTAssertTrue(reachedTheLock, "the second teardown never reached the group signal")
 
         // 1.2 s: longer than a teardown that gets through needs (≤0.5 s of
         // grace waits), shorter than the 3 s the collection is parked for.
@@ -846,11 +875,17 @@ final class ClaudeRemoteHerdrForwardTests: XCTestCase {
     }
 
     func testTheCollectionBudgetIsExhaustedAndThenReleased() throws {
-        // A genuine observation of the bound (review round 8): with a small
-        // injected budget, the poll must stop by itself — a fixed number of
-        // attempts, and then no further work at all.
+        // A genuine observation of the bound (review round 8b). Sampling a
+        // counter could not distinguish "the chain finished" from "the queue is
+        // busy": one poll running, a delayed utility queue, and the old
+        // assertions passed with four polls still scheduled — and a regression
+        // that stopped after a single hand-off poll passed too.
+        //
+        // So the process announces the END of the collection effort, and this
+        // waits for that instead of guessing.
         let attempts = 5
         let calls = ReapCallCounter()
+        let effortFinished = DispatchSemaphore(value: 0)
         let spawner = ClaudeRemoteHerdrForwardSpawner(
             executablePath: "/bin/sh",
             environment: ["PATH": "/usr/bin:/bin"],
@@ -859,7 +894,8 @@ final class ClaudeRemoteHerdrForwardTests: XCTestCase {
                 return 0 // WNOHANG: "still running", forever
             },
             reapPollAttempts: attempts,
-            reapPollInterval: 0.002
+            reapPollInterval: 0.002,
+            reapEffortDidFinish: { effortFinished.signal() }
         )
         let process = try XCTUnwrap(
             try spawner.spawn(argv: ["sh", "-c", "exit 0"]) as? LiveHerdrForwardProcess
@@ -868,33 +904,21 @@ final class ClaudeRemoteHerdrForwardTests: XCTestCase {
 
         process.terminate()
 
-        // Wait, bounded, for the count to stop moving: that IS the release.
-        var settled = 0
-        var previous = -1
-        for _ in 0..<200 {
-            let current = calls.value
-            if current == previous {
-                settled += 1
-                if settled >= 3 { break }
-            } else {
-                settled = 0
-                previous = current
-            }
-            usleep(10_000)
-        }
-
-        let total = calls.value
-        // One attempt on the caller's thread, then at most `attempts` on the
-        // handle's queue. Never more, and never forever.
-        XCTAssertGreaterThan(total, 1, "the hand-off must have polled at all")
-        XCTAssertLessThanOrEqual(
-            total, attempts + 1, "the budget must bound the number of attempts"
+        XCTAssertEqual(
+            effortFinished.wait(timeout: .now() + 5), .success,
+            "the poll chain must reach a terminal state on its own"
         )
+
+        // EXACTLY one attempt on the caller's thread plus the full queued
+        // budget — no fewer (a chain that gave up early) and no more (a chain
+        // that outlived its budget).
+        XCTAssertEqual(calls.value, attempts + 1)
         XCTAssertFalse(process.hasBeenReaped, "an uncollectable child is never claimed as reaped")
 
-        // And nothing is left running: no further attempts after the budget.
+        // And nothing is left scheduled: no further attempts after the end.
+        let afterFinish = calls.value
         usleep(50_000)
-        XCTAssertEqual(calls.value, total, "the poll chain must release itself")
+        XCTAssertEqual(calls.value, afterFinish, "the poll chain must release itself")
 
         collectForTestCleanup(process.leaderPID)
     }

--- a/Tests/localvoxtralTests/RemoteHerdrJoinTests.swift
+++ b/Tests/localvoxtralTests/RemoteHerdrJoinTests.swift
@@ -862,8 +862,9 @@ final class RemoteHerdrJoinTests: XCTestCase {
     }
 
     func testAUniqueConnectionThatNamesHerdrJoins() async throws {
-        // Corroboration on top of uniqueness is still a join — the signal is
-        // not required, it just must not replace anything.
+        // The positive case for the pair of requirements: BOTH the herdr
+        // invocation and uniqueness, which is what a join takes since round 5b.
+        // (This comment used to say the signal was "not required" — it is.)
         let registry = makeRegistry(markers: [markerValue])
         ingestRemoteHerdrSession(into: registry)
         let forwards = RecordingForwards()

--- a/Tests/localvoxtralTests/RemoteHerdrJoinTests.swift
+++ b/Tests/localvoxtralTests/RemoteHerdrJoinTests.swift
@@ -277,7 +277,7 @@ final class RemoteHerdrJoinTests: XCTestCase {
         forwards: (any ClaudeRemoteHerdrForwarding)?,
         sshResult: SSHDestinationTTYProbeResult = .connection(
             SSHSurfaceConnection(
-                destination: "builder", isOnlyConnectionToDestination: true, indicatesHerdr: false
+                destination: "builder", isOnlyConnectionToDestination: true, indicatesHerdr: true
             )
         ),
         hosts: [ClaudeRemoteHost]? = nil,
@@ -408,7 +408,7 @@ final class RemoteHerdrJoinTests: XCTestCase {
                     SSHSurfaceConnection(
                         destination: "someone-elses-box",
                         isOnlyConnectionToDestination: true,
-                        indicatesHerdr: false
+                        indicatesHerdr: true
                     )
                 ),
                 title: markerValue
@@ -747,7 +747,7 @@ final class RemoteHerdrJoinTests: XCTestCase {
                     SSHSurfaceConnection(
                         destination: "builder",
                         isOnlyConnectionToDestination: false,
-                        indicatesHerdr: false
+                        indicatesHerdr: true
                     )
                 ),
                 title: markerValue
@@ -788,6 +788,73 @@ final class RemoteHerdrJoinTests: XCTestCase {
         XCTAssertEqual(join.mechanism, .titleMarker)
         XCTAssertEqual(forwards.openCount, 0)
         XCTAssertTrue(panes.requests.withLock { $0.isEmpty })
+    }
+
+    func testAPlainSSHSessionNeverReachesTheArmEvenAsTheSoleConnection() async throws {
+        // Review round 5b, major 1. Being the only connection says nothing
+        // about what this terminal DISPLAYS: a herdr whose client detached —
+        // or whose pane still carries a marker and a running agent inside the
+        // registry TTL — keeps answering `pane.current` with that pane, so a
+        // later plain `ssh builder` would join a session the user cannot see.
+        //
+        // herdr exposes no read-only attachment signal (verified against the
+        // 0.7.5 socket schema and the 0.8.0 docs: the only `client.*` methods
+        // are `window_title.set`/`clear`, both mutations), so the evidence has
+        // to be the invocation itself.
+        let registry = makeRegistry(markers: [markerValue])
+        ingestRemoteHerdrSession(into: registry)
+        let panes = RemoteJoinHerdrPanes(focused: focusedPane())
+        let forwards = RecordingForwards()
+
+        let join = try unwrapAsync(
+            await resolver(
+                registry: registry,
+                panes: panes,
+                forwards: forwards,
+                sshResult: .connection(
+                    SSHSurfaceConnection(
+                        destination: "builder",
+                        isOnlyConnectionToDestination: true,
+                        indicatesHerdr: false
+                    )
+                ),
+                title: markerValue
+            ).resolve(target: ghostty)
+        )
+
+        XCTAssertEqual(join.mechanism, .titleMarker)
+        // And it costs NOTHING: no tunnel spawned, no herdr dialled. This is
+        // also the answer to the round-5b UX finding — a plain sole ssh to an
+        // enrolled host no longer pays a forward before falling through.
+        XCTAssertEqual(forwards.openCount, 0)
+        XCTAssertTrue(panes.requests.withLock { $0.isEmpty })
+    }
+
+    func testTheManualHerdrFlowGetsNoContextAtAll() async throws {
+        // The documented, accepted limitation: `ssh host`, then typing `herdr`,
+        // leaves no trace in argv. herdr also intercepts OSC 2, so the pane's
+        // marker never reaches the outer terminal — meaning there is no marker
+        // to fall back to either. No join, and no pretending otherwise.
+        let registry = makeRegistry(markers: [markerValue])
+        ingestRemoteHerdrSession(into: registry)
+        let forwards = RecordingForwards()
+
+        let join = await resolver(
+            registry: registry,
+            panes: RemoteJoinHerdrPanes(focused: focusedPane()),
+            forwards: forwards,
+            sshResult: .connection(
+                SSHSurfaceConnection(
+                    destination: "builder",
+                    isOnlyConnectionToDestination: true,
+                    indicatesHerdr: false
+                )
+            )
+            // No outer title marker: herdr swallowed it.
+        ).resolve(target: ghostty)
+
+        XCTAssertNil(join)
+        XCTAssertEqual(forwards.openCount, 0)
     }
 
     func testAUniqueConnectionThatNamesHerdrJoins() async throws {

--- a/Tests/localvoxtralTests/RemoteHerdrJoinTests.swift
+++ b/Tests/localvoxtralTests/RemoteHerdrJoinTests.swift
@@ -1,0 +1,1393 @@
+import ClaudeContextWire
+import CoreGraphics
+import Foundation
+import Synchronization
+import XCTest
+@testable import localvoxtral
+
+#if canImport(Darwin)
+
+/// `XCTUnwrap` takes an autoclosure, which cannot contain `await`. This
+/// evaluates the value first and then unwraps it.
+private func unwrapAsync<T>(
+    _ value: T?, _ message: String = "", file: StaticString = #filePath, line: UInt = #line
+) throws -> T {
+    try XCTUnwrap(value, message, file: file, line: line)
+}
+
+// MARK: - Fakes
+
+/// Scripted herdr socket, recording every request so a test can prove which
+/// socket path and which pane the client was pointed at.
+private final class RemoteJoinHerdrPanes: HerdrPaneQuerying, @unchecked Sendable {
+    struct Request: Equatable {
+        var method: String
+        var socketPath: String
+        var paneID: String?
+    }
+
+    let requests = Mutex<[Request]>([])
+    private let focused: HerdrFocusedPane?
+    private let foreground: HerdrPaneForegroundInfo?
+    private let visibleTexts = Mutex<[String?]>([])
+
+    init(
+        focused: HerdrFocusedPane?,
+        foreground: HerdrPaneForegroundInfo? = HerdrPaneForegroundInfo(
+            shellPID: 8000, foregroundProcesses: [HerdrForegroundProcess(pid: 9001, name: "claude")]
+        ),
+        texts: [String?] = []
+    ) {
+        self.focused = focused
+        self.foreground = foreground
+        visibleTexts.withLock { $0 = texts }
+    }
+
+    func focusedPane(socketPath: String) async -> HerdrFocusedPane? {
+        requests.withLock {
+            $0.append(Request(method: "pane.current", socketPath: socketPath, paneID: nil))
+        }
+        return focused
+    }
+
+    func paneForegroundInfo(socketPath: String, paneID: String) async -> HerdrPaneForegroundInfo? {
+        requests.withLock {
+            $0.append(
+                Request(method: "pane.process_info", socketPath: socketPath, paneID: paneID)
+            )
+        }
+        return foreground
+    }
+
+    func paneVisibleText(socketPath: String, paneID: String) async -> String? {
+        requests.withLock {
+            $0.append(Request(method: "pane.read", socketPath: socketPath, paneID: paneID))
+        }
+        return visibleTexts.withLock { $0.isEmpty ? nil : $0.removeFirst() }
+    }
+}
+
+private final class FakeForwardProcess: ClaudeRemoteHerdrForwardProcess, @unchecked Sendable {
+    private let state = Mutex(true)
+    let terminations = Mutex(0)
+
+    init(running: Bool = true) {
+        state.withLock { $0 = running }
+    }
+
+    var isRunning: Bool { state.withLock { $0 } }
+
+    func exit() { state.withLock { $0 = false } }
+
+    func terminate() {
+        terminations.withLock { $0 += 1 }
+        state.withLock { $0 = false }
+    }
+}
+
+private final class RecordingSpawner: ClaudeRemoteHerdrForwardSpawning, @unchecked Sendable {
+    struct Failure: Error {}
+
+    let spawnedArgv = Mutex<[[String]]>([])
+    let process: FakeForwardProcess
+    private let shouldFail: Bool
+
+    init(process: FakeForwardProcess = FakeForwardProcess(), shouldFail: Bool = false) {
+        self.process = process
+        self.shouldFail = shouldFail
+    }
+
+    func spawn(argv: [String]) throws -> any ClaudeRemoteHerdrForwardProcess {
+        spawnedArgv.withLock { $0.append(argv) }
+        if shouldFail { throw Failure() }
+        return process
+    }
+}
+
+private final class RecordingWorkspaces: ClaudeRemoteHerdrWorkspaceProviding, @unchecked Sendable {
+    struct Failure: Error {}
+
+    let made = Mutex<[ClaudeRemoteHerdrForwardWorkspace]>([])
+    let removed = Mutex<[ClaudeRemoteHerdrForwardWorkspace]>([])
+    private let socketPath: String
+    private let shouldFail: Bool
+
+    init(socketPath: String = "/tmp/lvx-herdr-fwd-test/h.sock", shouldFail: Bool = false) {
+        self.socketPath = socketPath
+        self.shouldFail = shouldFail
+    }
+
+    func makeWorkspace() throws -> ClaudeRemoteHerdrForwardWorkspace {
+        if shouldFail { throw Failure() }
+        let workspace = ClaudeRemoteHerdrForwardWorkspace(
+            directoryPath: (socketPath as NSString).deletingLastPathComponent,
+            socketPath: socketPath
+        )
+        made.withLock { $0.append(workspace) }
+        return workspace
+    }
+
+    func remove(_ workspace: ClaudeRemoteHerdrForwardWorkspace) {
+        removed.withLock { $0.append(workspace) }
+    }
+}
+
+/// Stands in for the whole forward service in resolver tests, so the join arm
+/// can be exercised without any notion of processes.
+private final class RecordingForwards: ClaudeRemoteHerdrForwarding, @unchecked Sendable {
+    struct Opened: Equatable {
+        var alias: String
+        var remoteSocketPath: String
+    }
+
+    let opens = Mutex<[Opened]>([])
+    let localSocketPath: String
+    private let succeeds: Bool
+    let process = FakeForwardProcess()
+    let workspaces = RecordingWorkspaces()
+
+    init(succeeds: Bool = true, localSocketPath: String = "/tmp/lvx-herdr-fwd-test/h.sock") {
+        self.succeeds = succeeds
+        self.localSocketPath = localSocketPath
+    }
+
+    func open(alias: String, remoteSocketPath: String) async -> ClaudeRemoteHerdrForwardHandle? {
+        opens.withLock { $0.append(Opened(alias: alias, remoteSocketPath: remoteSocketPath)) }
+        guard succeeds else { return nil }
+        return ClaudeRemoteHerdrForwardHandle(
+            workspace: ClaudeRemoteHerdrForwardWorkspace(
+                directoryPath: (localSocketPath as NSString).deletingLastPathComponent,
+                socketPath: localSocketPath
+            ),
+            process: process,
+            removeWorkspace: { [workspaces] in workspaces.remove($0) }
+        )
+    }
+
+    var openCount: Int { opens.withLock { $0.count } }
+    var closeCount: Int { workspaces.removed.withLock { $0.count } }
+}
+
+private final class RemoteJoinTestLiveness: Sendable {
+    private let dead: Mutex<Set<Int32>> = Mutex([])
+    var probe: @Sendable (Int32) -> Bool { { [self] pid in dead.withLock { !$0.contains(pid) } } }
+    func kill(_ pid: Int32) { dead.withLock { _ = $0.insert(pid) } }
+}
+
+// MARK: - Resolver: the remote herdr arm
+
+/// A Claude Code session inside a herdr on an ENROLLED REMOTE host.
+///
+/// The arm's whole safety argument is that four independent bindings all have
+/// to agree, and that anything less abstains — so most of this file is the
+/// abstention matrix.
+@MainActor
+final class RemoteHerdrJoinTests: XCTestCase {
+    private let epoch = Date(timeIntervalSince1970: 1_700_000_000)
+    private let ghostty = TerminalScreenTarget(
+        pid: 4242, bundleID: TerminalScreenAllowlist.ghosttyBundleID
+    )
+    private let hostID = "h1a2b3c4"
+    private let surfaceTTY = "/dev/ttys-outer"
+    private let remotePaneID = "pane-remote-7"
+    private let remoteSocketPath = "/run/user/1000/herdr/default.sock"
+    private let markerValue = "lvx-abc123"
+
+    private var origin: ClaudeTransportOrigin {
+        .remote(channel: ClaudeRemoteSessionScope.channel(hostID: hostID))
+    }
+
+    private func makeRegistry(
+        markers: [String] = [],
+        liveness: RemoteJoinTestLiveness = RemoteJoinTestLiveness()
+    ) -> ClaudeSessionRegistry {
+        let queue = Mutex(markers)
+        return ClaudeSessionRegistry(
+            now: { [epoch] in epoch },
+            isProcessAlive: liveness.probe,
+            allocateMarkerValue: {
+                queue.withLock { queue in
+                    queue.isEmpty ? ClaudeSessionRegistry.defaultMarkerValue() : queue.removeFirst()
+                }
+            }
+        )
+    }
+
+    /// One live REMOTE session on `hostID`, reporting a herdr pane.
+    @discardableResult
+    private func ingestRemoteHerdrSession(
+        into registry: ClaudeSessionRegistry,
+        sessionID: String = "s-remote-1",
+        paneID: String? = nil,
+        socketPath: String? = nil,
+        hookParentPID: String? = "4711",
+        host: String? = nil
+    ) -> ClaudeSessionSnapshot? {
+        let hostID = host ?? self.hostID
+        let record = ClaudeHookRecord(
+            event: .sessionStart,
+            sessionID: ClaudeRemoteSessionScope.scopedSessionID(
+                hostID: hostID, sessionID: sessionID
+            ),
+            timestamp: epoch.timeIntervalSince1970,
+            rawCwd: "/home/dev/work/service",
+            process: ClaudeHookProcessInfo(hookPID: 11, claudePID: 12, tty: "/dev/pts/3")
+        )
+        return registry.ingest(
+            record,
+            origin: .remote(channel: ClaudeRemoteSessionScope.channel(hostID: hostID)),
+            environment: ClaudeRemoteSessionEnvironment(
+                herdrPaneID: paneID ?? remotePaneID,
+                herdrSocketPath: socketPath ?? remoteSocketPath,
+                hookParentPID: hookParentPID
+            )
+        )
+    }
+
+    private func enrolledHost(
+        id: String? = nil,
+        alias: String? = "Builder",
+        revoked: Bool = false
+    ) -> ClaudeRemoteHost {
+        ClaudeRemoteHost(
+            id: id ?? hostID,
+            label: "builder",
+            sshHostAlias: alias,
+            createdAt: epoch,
+            lastSeenAt: nil,
+            revokedAt: revoked ? epoch : nil
+        )
+    }
+
+    private func focusedPane(
+        paneID: String? = nil,
+        title: String? = nil,
+        claim: String? = nil
+    ) -> HerdrFocusedPane {
+        HerdrFocusedPane(
+            paneID: paneID ?? remotePaneID,
+            claimedClaudeSessionID: claim,
+            terminalTitle: title ?? markerValue
+        )
+    }
+
+    private func resolver(
+        registry: ClaudeSessionRegistry,
+        panes: HerdrPaneQuerying?,
+        forwards: (any ClaudeRemoteHerdrForwarding)?,
+        sshResult: SSHDestinationTTYProbeResult = .connection(
+            SSHSurfaceConnection(
+                destination: "builder", isOnlyConnectionToDestination: true, indicatesHerdr: false
+            )
+        ),
+        hosts: [ClaudeRemoteHost]? = nil,
+        title: String? = nil
+    ) -> ClaudeSessionJoinResolver {
+        let hostList = hosts ?? [enrolledHost()]
+        return ClaudeSessionJoinResolver(
+            registry: registry,
+            markerInWindowTitle: { _ in
+                guard let title, let marker = ClaudeMarkerTitleParser.marker(inTitle: title) else {
+                    return nil
+                }
+                return TerminalScreenAXReader.FocusedWindowMarkerRead(marker: marker, windowID: 101)
+            },
+            focusedTerminalTTY: { [surfaceTTY] _ in surfaceTTY },
+            focusedWindowID: { _ in 101 },
+            // The surface is NOT a local herdr client: that arm has to have
+            // declined before this one is even reached.
+            herdrClientProbe: { _ in false },
+            herdrPanes: panes,
+            sshDestinationProbe: { _ in sshResult },
+            enrolledHosts: { destination in
+                hostList.filter { host in
+                    guard !host.isRevoked, let alias = host.sshHostAlias else { return false }
+                    return alias.lowercased() == destination.lowercased()
+                }
+            },
+            remoteHerdrForwards: forwards
+        )
+    }
+
+    // MARK: Happy path
+
+    func testEveryBindingAgreeingResolvesARemoteHerdrJoin() async throws {
+        let registry = makeRegistry(markers: [markerValue])
+        ingestRemoteHerdrSession(into: registry)
+        let panes = RemoteJoinHerdrPanes(focused: focusedPane())
+        let forwards = RecordingForwards()
+
+        let join = try unwrapAsync(
+            await resolver(registry: registry, panes: panes, forwards: forwards)
+                .resolve(target: ghostty)
+        )
+
+        XCTAssertEqual(join.mechanism, .remoteHerdrPane)
+        XCTAssertEqual(join.herdrPane?.paneID, remotePaneID)
+        // The binding names the LOCAL end of the tunnel; the remote path never
+        // becomes something this machine dials.
+        XCTAssertEqual(join.herdrPane?.socketPath, forwards.localSocketPath)
+        XCTAssertEqual(join.marker.value, markerValue)
+        // The forward was asked for with the STORED alias (the vetted string),
+        // not the lowercased destination the process table reported.
+        XCTAssertEqual(
+            forwards.opens.withLock { $0 },
+            [RecordingForwards.Opened(alias: "Builder", remoteSocketPath: remoteSocketPath)]
+        )
+        // Every herdr request went to the forwarded socket, and pane queries
+        // named only the joined pane.
+        let requests = panes.requests.withLock { $0 }
+        XCTAssertEqual(requests.map(\.method), ["pane.current", "pane.process_info"])
+        XCTAssertTrue(requests.allSatisfy { $0.socketPath == forwards.localSocketPath })
+        XCTAssertEqual(requests.compactMap(\.paneID), [remotePaneID])
+    }
+
+    func testAJoinedRemoteSessionStaysJoinableByItsMarkerAtCommit() async throws {
+        let registry = makeRegistry(markers: [markerValue])
+        ingestRemoteHerdrSession(into: registry)
+        let resolver = resolver(
+            registry: registry,
+            panes: RemoteJoinHerdrPanes(focused: focusedPane()),
+            forwards: RecordingForwards()
+        )
+        let join = try unwrapAsync(await resolver.resolve(target: ghostty))
+        XCTAssertTrue(resolver.isStillLive(join))
+    }
+
+    // MARK: Fallthrough — the arm does not apply
+
+    func testNoSSHClientOnTheSurfaceFallsThroughToTheTitleMarker() async throws {
+        let registry = makeRegistry(markers: [markerValue])
+        ingestRemoteHerdrSession(into: registry)
+        let forwards = RecordingForwards()
+
+        let join = try unwrapAsync(
+            await resolver(
+                registry: registry,
+                panes: RemoteJoinHerdrPanes(focused: focusedPane()),
+                forwards: forwards,
+                sshResult: .noSSHClient,
+                title: markerValue
+            ).resolve(target: ghostty)
+        )
+
+        XCTAssertEqual(join.mechanism, .titleMarker)
+        XCTAssertEqual(forwards.openCount, 0)
+    }
+
+    func testUndeterminableSSHDestinationFallsThroughToTheTitleMarker() async throws {
+        let registry = makeRegistry(markers: [markerValue])
+        ingestRemoteHerdrSession(into: registry)
+        let forwards = RecordingForwards()
+
+        let join = try unwrapAsync(
+            await resolver(
+                registry: registry,
+                panes: RemoteJoinHerdrPanes(focused: focusedPane()),
+                forwards: forwards,
+                sshResult: .undeterminable,
+                title: markerValue
+            ).resolve(target: ghostty)
+        )
+
+        XCTAssertEqual(join.mechanism, .titleMarker)
+        XCTAssertEqual(forwards.openCount, 0)
+    }
+
+    func testSSHToAnUnenrolledHostFallsThroughToTheTitleMarker() async throws {
+        let registry = makeRegistry(markers: [markerValue])
+        ingestRemoteHerdrSession(into: registry)
+        let forwards = RecordingForwards()
+
+        let join = try unwrapAsync(
+            await resolver(
+                registry: registry,
+                panes: RemoteJoinHerdrPanes(focused: focusedPane()),
+                forwards: forwards,
+                sshResult: .connection(
+                    SSHSurfaceConnection(
+                        destination: "someone-elses-box",
+                        isOnlyConnectionToDestination: true,
+                        indicatesHerdr: false
+                    )
+                ),
+                title: markerValue
+            ).resolve(target: ghostty)
+        )
+
+        XCTAssertEqual(join.mechanism, .titleMarker)
+        XCTAssertEqual(forwards.openCount, 0)
+    }
+
+    func testARevokedHostIsNotAnEnrolledHost() async throws {
+        let registry = makeRegistry(markers: [markerValue])
+        ingestRemoteHerdrSession(into: registry)
+        let forwards = RecordingForwards()
+
+        let join = try unwrapAsync(
+            await resolver(
+                registry: registry,
+                panes: RemoteJoinHerdrPanes(focused: focusedPane()),
+                forwards: forwards,
+                hosts: [enrolledHost(revoked: true)],
+                title: markerValue
+            ).resolve(target: ghostty)
+        )
+
+        XCTAssertEqual(join.mechanism, .titleMarker)
+        XCTAssertEqual(forwards.openCount, 0)
+    }
+
+    func testEnrolledHostWithNoHerdrSessionsFallsThroughToTheTitleMarker() async throws {
+        // A plain remote Claude session on an enrolled host: it joined by
+        // marker before this feature existed and must keep doing so.
+        let registry = makeRegistry(markers: [markerValue])
+        let record = ClaudeHookRecord(
+            event: .sessionStart,
+            sessionID: ClaudeRemoteSessionScope.scopedSessionID(hostID: hostID, sessionID: "s-plain"),
+            timestamp: epoch.timeIntervalSince1970,
+            rawCwd: "/home/dev/work/service",
+            process: ClaudeHookProcessInfo(hookPID: 11, claudePID: 12)
+        )
+        registry.ingest(record, origin: origin)
+        let forwards = RecordingForwards()
+
+        let join = try unwrapAsync(
+            await resolver(
+                registry: registry,
+                panes: RemoteJoinHerdrPanes(focused: focusedPane()),
+                forwards: forwards,
+                title: markerValue
+            ).resolve(target: ghostty)
+        )
+
+        XCTAssertEqual(join.mechanism, .titleMarker)
+        XCTAssertEqual(forwards.openCount, 0)
+    }
+
+    func testALocalSessionOnTheSamePaneIDIsNeverARemoteCandidate() async throws {
+        // The local and remote pane identities live in different snapshot
+        // fields precisely so this cannot happen (PR #216).
+        let registry = makeRegistry(markers: [markerValue])
+        let record = ClaudeHookRecord(
+            event: .sessionStart,
+            sessionID: "s-local",
+            timestamp: epoch.timeIntervalSince1970,
+            rawCwd: "/home/dev/work/service",
+            process: ClaudeHookProcessInfo(
+                hookPID: 11,
+                claudePID: 9001,
+                tty: "/dev/ttys-inner",
+                herdrPaneID: remotePaneID,
+                herdrSocketPath: remoteSocketPath
+            )
+        )
+        registry.ingest(record, origin: .localAuthenticated(peerUID: 501))
+        let forwards = RecordingForwards()
+
+        let join = await resolver(
+            registry: registry,
+            panes: RemoteJoinHerdrPanes(focused: focusedPane()),
+            forwards: forwards
+        ).resolve(target: ghostty)
+
+        // No remote candidates ⇒ the arm never applies ⇒ marker arm, which has
+        // no title to read here.
+        XCTAssertNil(join)
+        XCTAssertEqual(forwards.openCount, 0)
+    }
+
+    // MARK: Abstention — bound to a remote herdr, and still no join
+
+    func testTwoEnrolledHostsSharingTheDestinationFallThroughToTheTitleMarker() async throws {
+        // Ambiguous enrollment says nothing about THIS terminal being a herdr
+        // surface, so it must not cost a plain remote session the marker join
+        // it has always had (review blocker 1c).
+        let registry = makeRegistry(markers: [markerValue])
+        ingestRemoteHerdrSession(into: registry)
+        let forwards = RecordingForwards()
+
+        let join = try unwrapAsync(
+            await resolver(
+                registry: registry,
+                panes: RemoteJoinHerdrPanes(focused: focusedPane()),
+                forwards: forwards,
+                hosts: [enrolledHost(), enrolledHost(id: "h9z9z9z9")],
+                title: markerValue
+            ).resolve(target: ghostty)
+        )
+
+        XCTAssertEqual(join.mechanism, .titleMarker)
+        XCTAssertEqual(forwards.openCount, 0)
+    }
+
+    func testTwoLiveHerdrSocketsOnTheHostFallThroughToTheTitleMarker() async throws {
+        let registry = makeRegistry(markers: [markerValue, "lvx-def456"])
+        ingestRemoteHerdrSession(into: registry, sessionID: "s-a")
+        ingestRemoteHerdrSession(
+            into: registry, sessionID: "s-b", paneID: "pane-other",
+            socketPath: "/run/user/1000/herdr/second.sock"
+        )
+        let forwards = RecordingForwards()
+
+        let join = try unwrapAsync(
+            await resolver(
+                registry: registry,
+                panes: RemoteJoinHerdrPanes(focused: focusedPane()),
+                forwards: forwards,
+                title: markerValue
+            ).resolve(target: ghostty)
+        )
+
+        XCTAssertEqual(join.mechanism, .titleMarker)
+        XCTAssertEqual(forwards.openCount, 0)
+    }
+
+    func testForwardSpawnFailureIssuesNoHerdrQueryAndKeepsTheMarkerJoin() async throws {
+        let registry = makeRegistry(markers: [markerValue])
+        ingestRemoteHerdrSession(into: registry)
+        let forwards = RecordingForwards(succeeds: false)
+        let panes = RemoteJoinHerdrPanes(focused: focusedPane())
+
+        let join = try unwrapAsync(
+            await resolver(
+                registry: registry, panes: panes, forwards: forwards, title: markerValue
+            ).resolve(target: ghostty)
+        )
+
+        // Nothing about this connection was ever confirmed, so the outer marker
+        // keeps its chance (review round 3, blocker 1b).
+        XCTAssertEqual(join.mechanism, .titleMarker)
+        XCTAssertEqual(forwards.openCount, 1)
+        XCTAssertTrue(panes.requests.withLock { $0.isEmpty })
+    }
+
+    func testMissingForwardCapabilityKeepsTheMarkerJoin() async throws {
+        let registry = makeRegistry(markers: [markerValue])
+        ingestRemoteHerdrSession(into: registry)
+
+        let join = try unwrapAsync(
+            await resolver(
+                registry: registry,
+                panes: RemoteJoinHerdrPanes(focused: focusedPane()),
+                forwards: nil,
+                title: markerValue
+            ).resolve(target: ghostty)
+        )
+
+        XCTAssertEqual(join.mechanism, .titleMarker)
+    }
+
+    func testMissingPaneQueryCapabilityOpensNoForwardAndKeepsTheMarkerJoin() async throws {
+        let registry = makeRegistry(markers: [markerValue])
+        ingestRemoteHerdrSession(into: registry)
+        let forwards = RecordingForwards()
+
+        let join = try unwrapAsync(
+            await resolver(
+                registry: registry, panes: nil, forwards: forwards, title: markerValue
+            ).resolve(target: ghostty)
+        )
+
+        XCTAssertEqual(join.mechanism, .titleMarker)
+        XCTAssertEqual(forwards.openCount, 0)
+    }
+
+    func testTwoSessionsClaimingTheFocusedPaneNeverJoinThatPane() async throws {
+        let registry = makeRegistry(markers: [markerValue, "lvx-def456"])
+        ingestRemoteHerdrSession(into: registry, sessionID: "s-a")
+        ingestRemoteHerdrSession(into: registry, sessionID: "s-b")
+        let forwards = RecordingForwards()
+
+        let join = try unwrapAsync(
+            await resolver(
+                registry: registry,
+                panes: RemoteJoinHerdrPanes(focused: focusedPane()),
+                forwards: forwards,
+                title: markerValue
+            ).resolve(target: ghostty)
+        )
+
+        // The pane could name either session, so it names neither — and since
+        // nothing was confirmed, the outer marker still answers.
+        XCTAssertNotEqual(join.mechanism, .remoteHerdrPane)
+        XCTAssertEqual(join.mechanism, .titleMarker)
+        XCTAssertEqual(forwards.closeCount, 1)
+    }
+
+    func testPaneWithNoTitleKeepsTheMarkerJoin() async throws {
+        let registry = makeRegistry(markers: [markerValue])
+        ingestRemoteHerdrSession(into: registry)
+        let forwards = RecordingForwards()
+
+        let join = await resolver(
+            registry: registry,
+            panes: RemoteJoinHerdrPanes(
+                focused: HerdrFocusedPane(
+                    paneID: remotePaneID, claimedClaudeSessionID: nil, terminalTitle: nil
+                )
+            ),
+            forwards: forwards,
+            title: markerValue
+        ).resolve(target: ghostty)
+
+        XCTAssertEqual(join?.mechanism, .titleMarker)
+        XCTAssertEqual(forwards.closeCount, 1)
+    }
+
+    func testPaneTitleWithoutAMarkerKeepsTheMarkerJoin() async throws {
+        let registry = makeRegistry(markers: [markerValue])
+        ingestRemoteHerdrSession(into: registry)
+        let forwards = RecordingForwards()
+
+        let join = await resolver(
+            registry: registry,
+            panes: RemoteJoinHerdrPanes(focused: focusedPane(title: "~/work/service — zsh")),
+            forwards: forwards,
+            title: markerValue
+        ).resolve(target: ghostty)
+
+        XCTAssertEqual(join?.mechanism, .titleMarker)
+        XCTAssertEqual(forwards.closeCount, 1)
+    }
+
+    func testPaneTitleWithTwoMarkersKeepsTheMarkerJoin() async throws {
+        let registry = makeRegistry(markers: [markerValue])
+        ingestRemoteHerdrSession(into: registry)
+        let forwards = RecordingForwards()
+
+        let join = await resolver(
+            registry: registry,
+            panes: RemoteJoinHerdrPanes(focused: focusedPane(title: "\(markerValue) lvx-def456")),
+            forwards: forwards,
+            title: markerValue
+        ).resolve(target: ghostty)
+
+        XCTAssertEqual(join?.mechanism, .titleMarker)
+        XCTAssertEqual(forwards.closeCount, 1)
+    }
+
+    func testForegroundQueryUnavailableAbstains() async throws {
+        let registry = makeRegistry(markers: [markerValue])
+        ingestRemoteHerdrSession(into: registry)
+        let forwards = RecordingForwards()
+
+        let join = await resolver(
+            registry: registry,
+            panes: RemoteJoinHerdrPanes(focused: focusedPane(), foreground: nil),
+            forwards: forwards,
+            title: markerValue
+        ).resolve(target: ghostty)
+
+        XCTAssertNil(join)
+        XCTAssertEqual(forwards.closeCount, 1)
+    }
+
+    func testForegroundDetectionUnavailableAbstains() async throws {
+        let registry = makeRegistry(markers: [markerValue])
+        ingestRemoteHerdrSession(into: registry)
+        let forwards = RecordingForwards()
+
+        let join = await resolver(
+            registry: registry,
+            panes: RemoteJoinHerdrPanes(
+                focused: focusedPane(),
+                foreground: HerdrPaneForegroundInfo(shellPID: 8000, foregroundProcesses: nil)
+            ),
+            forwards: forwards,
+            title: markerValue
+        ).resolve(target: ghostty)
+
+        XCTAssertNil(join)
+    }
+
+    func testAgentNotInTheForegroundAbstains() async throws {
+        // The user suspended Claude Code and is back at the shell: the pane is
+        // still "theirs", and its context is still not what they are dictating
+        // into.
+        let registry = makeRegistry(markers: [markerValue])
+        ingestRemoteHerdrSession(into: registry)
+        let forwards = RecordingForwards()
+
+        let join = await resolver(
+            registry: registry,
+            panes: RemoteJoinHerdrPanes(
+                focused: focusedPane(),
+                foreground: HerdrPaneForegroundInfo(
+                    shellPID: 8000,
+                    foregroundProcesses: [HerdrForegroundProcess(pid: 8000, name: "zsh")]
+                )
+            ),
+            forwards: forwards,
+            title: markerValue
+        ).resolve(target: ghostty)
+
+        XCTAssertNil(join)
+        XCTAssertEqual(forwards.closeCount, 1)
+    }
+
+    // MARK: The connection-level bind (review blocker 1)
+
+    func testASecondTerminalToTheSameHostStopsTheArmAndKeepsTheMarkerJoin() async throws {
+        // THE blocker: terminal A is a plain shell to `builder`, terminal B is
+        // attached to herdr on `builder`. Dictating in A must not query B's
+        // herdr, must not join B's session — and must not lose A's own
+        // title-marker join either.
+        let registry = makeRegistry(markers: [markerValue])
+        ingestRemoteHerdrSession(into: registry)
+        let panes = RemoteJoinHerdrPanes(focused: focusedPane())
+        let forwards = RecordingForwards()
+
+        let join = try unwrapAsync(
+            await resolver(
+                registry: registry,
+                panes: panes,
+                forwards: forwards,
+                sshResult: .connection(
+                    SSHSurfaceConnection(
+                        destination: "builder",
+                        isOnlyConnectionToDestination: false,
+                        indicatesHerdr: false
+                    )
+                ),
+                title: markerValue
+            ).resolve(target: ghostty)
+        )
+
+        XCTAssertEqual(join.mechanism, .titleMarker)
+        XCTAssertEqual(forwards.openCount, 0, "no tunnel may be opened for an unbound connection")
+        XCTAssertTrue(panes.requests.withLock { $0.isEmpty }, "no herdr query may be issued")
+    }
+
+    func testTheHerdrArgvSignalNeverSubstitutesForUniqueness() async throws {
+        // argv is written by whoever launched the process, so a remote command
+        // that claims to be herdr must not stand in for the one fact that is
+        // not forgeable — how many connections to that host exist (review
+        // round 3, blocker 1a).
+        let registry = makeRegistry(markers: [markerValue])
+        ingestRemoteHerdrSession(into: registry)
+        let panes = RemoteJoinHerdrPanes(focused: focusedPane())
+        let forwards = RecordingForwards()
+
+        let join = try unwrapAsync(
+            await resolver(
+                registry: registry,
+                panes: panes,
+                forwards: forwards,
+                sshResult: .connection(
+                    SSHSurfaceConnection(
+                        destination: "builder",
+                        isOnlyConnectionToDestination: false,
+                        indicatesHerdr: true
+                    )
+                ),
+                title: markerValue
+            ).resolve(target: ghostty)
+        )
+
+        XCTAssertEqual(join.mechanism, .titleMarker)
+        XCTAssertEqual(forwards.openCount, 0)
+        XCTAssertTrue(panes.requests.withLock { $0.isEmpty })
+    }
+
+    func testAUniqueConnectionThatNamesHerdrJoins() async throws {
+        // Corroboration on top of uniqueness is still a join — the signal is
+        // not required, it just must not replace anything.
+        let registry = makeRegistry(markers: [markerValue])
+        ingestRemoteHerdrSession(into: registry)
+        let forwards = RecordingForwards()
+
+        let join = try unwrapAsync(
+            await resolver(
+                registry: registry,
+                panes: RemoteJoinHerdrPanes(focused: focusedPane()),
+                forwards: forwards,
+                sshResult: .connection(
+                    SSHSurfaceConnection(
+                        destination: "builder",
+                        isOnlyConnectionToDestination: true,
+                        indicatesHerdr: true
+                    )
+                )
+            ).resolve(target: ghostty)
+        )
+
+        XCTAssertEqual(join.mechanism, .remoteHerdrPane)
+        XCTAssertEqual(forwards.openCount, 1)
+    }
+
+    // MARK: herdr-or-nothing starts at CONFIRMATION (review round 3, blocker 1b)
+
+    func testASolePlainSSHKeepsItsMarkerJoinWhenThePaneIsNotOurs() async throws {
+        // The regression this arm must never cause: a lone ssh session to an
+        // enrolled host that happens to run a detached herdr — or whose herdr
+        // sessions are merely still inside their TTL — must keep the outer
+        // title-marker join it has always had. Registry candidates existing is
+        // not a binding for THIS connection.
+        let registry = makeRegistry(markers: [markerValue])
+        ingestRemoteHerdrSession(into: registry)
+        let forwards = RecordingForwards()
+
+        let join = try unwrapAsync(
+            await resolver(
+                registry: registry,
+                // The herdr's focused pane belongs to something else entirely.
+                panes: RemoteJoinHerdrPanes(focused: focusedPane(paneID: "pane-someone-else")),
+                forwards: forwards,
+                title: markerValue
+            ).resolve(target: ghostty)
+        )
+
+        XCTAssertEqual(join.mechanism, .titleMarker)
+        // The tunnel was opened to ask, and closed once the answer was "not
+        // this connection".
+        XCTAssertEqual(forwards.openCount, 1)
+        XCTAssertEqual(forwards.closeCount, 1)
+    }
+
+    func testAnUnreachableHerdrKeepsTheMarkerJoin() async throws {
+        // Same rule, earlier failure: a detached herdr that answers nothing.
+        let registry = makeRegistry(markers: [markerValue])
+        ingestRemoteHerdrSession(into: registry)
+        let forwards = RecordingForwards()
+
+        let join = try unwrapAsync(
+            await resolver(
+                registry: registry,
+                panes: RemoteJoinHerdrPanes(focused: nil),
+                forwards: forwards,
+                title: markerValue
+            ).resolve(target: ghostty)
+        )
+
+        XCTAssertEqual(join.mechanism, .titleMarker)
+        XCTAssertEqual(forwards.closeCount, 1)
+    }
+
+    func testAFailedForwardKeepsTheMarkerJoin() async throws {
+        let registry = makeRegistry(markers: [markerValue])
+        ingestRemoteHerdrSession(into: registry)
+        let forwards = RecordingForwards(succeeds: false)
+
+        let join = try unwrapAsync(
+            await resolver(
+                registry: registry,
+                panes: RemoteJoinHerdrPanes(focused: focusedPane()),
+                forwards: forwards,
+                title: markerValue
+            ).resolve(target: ghostty)
+        )
+
+        XCTAssertEqual(join.mechanism, .titleMarker)
+    }
+
+    func testATitleMarkerNamingAnotherSessionKeepsTheMarkerJoin() async throws {
+        // The pane confirmed nothing about US, so the outer marker still gets
+        // its chance.
+        let registry = makeRegistry(markers: [markerValue])
+        ingestRemoteHerdrSession(into: registry)
+        let forwards = RecordingForwards()
+
+        let join = try unwrapAsync(
+            await resolver(
+                registry: registry,
+                panes: RemoteJoinHerdrPanes(focused: focusedPane(title: "lvx-999999")),
+                forwards: forwards,
+                title: markerValue
+            ).resolve(target: ghostty)
+        )
+
+        XCTAssertEqual(join.mechanism, .titleMarker)
+        XCTAssertEqual(forwards.closeCount, 1)
+    }
+
+    func testAConfirmedPaneThatFailsALaterCheckJoinsNOTHING() async throws {
+        // Past confirmation — pane id AND our own marker both matched — the
+        // outer title can only describe something else, so a later fail-closed
+        // check refuses the whole dictation rather than falling back.
+        let registry = makeRegistry(markers: [markerValue])
+        ingestRemoteHerdrSession(into: registry)
+        let forwards = RecordingForwards()
+
+        let join = await resolver(
+            registry: registry,
+            panes: RemoteJoinHerdrPanes(
+                focused: focusedPane(),
+                foreground: HerdrPaneForegroundInfo(
+                    shellPID: 8000,
+                    foregroundProcesses: [HerdrForegroundProcess(pid: 8000, name: "zsh")]
+                )
+            ),
+            forwards: forwards,
+            title: markerValue
+        ).resolve(target: ghostty)
+
+        XCTAssertNil(join)
+        XCTAssertEqual(forwards.closeCount, 1)
+    }
+
+    // MARK: herdr's own session claim (review finding 3)
+
+    func testAContradictoryPaneSessionClaimAbstains() async throws {
+        // Stale-session scenario: session A died without a SessionEnd, leaving
+        // a live registry entry, its marker, and its pane id; session B now
+        // runs in that reused pane. herdr — which watches the pane — says B.
+        // Pane id and a stale title still say A. That resolves to NEITHER.
+        let registry = makeRegistry(markers: [markerValue])
+        ingestRemoteHerdrSession(into: registry, sessionID: "s-stale-a")
+        let forwards = RecordingForwards()
+
+        let join = await resolver(
+            registry: registry,
+            panes: RemoteJoinHerdrPanes(focused: focusedPane(claim: "s-live-b")),
+            forwards: forwards,
+            title: markerValue
+        ).resolve(target: ghostty)
+
+        XCTAssertNil(join)
+        XCTAssertEqual(forwards.closeCount, 1)
+    }
+
+    func testAnAgreeingPaneSessionClaimJoins() async throws {
+        // The same check must CONFIRM when herdr agrees. The claim is herdr's
+        // RAW session id; the registry speaks host- and agent-scoped ids.
+        let registry = makeRegistry(markers: [markerValue])
+        ingestRemoteHerdrSession(into: registry, sessionID: "s-remote-1")
+
+        let join = try unwrapAsync(
+            await resolver(
+                registry: registry,
+                panes: RemoteJoinHerdrPanes(focused: focusedPane(claim: "s-remote-1")),
+                forwards: RecordingForwards()
+            ).resolve(target: ghostty)
+        )
+        XCTAssertEqual(join.mechanism, .remoteHerdrPane)
+    }
+
+    func testARemoteSessionClaimIsScopedByHostBeforeComparison() {
+        // A raw id from herdr can only match once it is put in the registry's
+        // namespace — a bare "s-1" must never equal the stored scoped id by
+        // accident, and a claim scoped to ANOTHER host must never match.
+        XCTAssertEqual(
+            ClaudeSessionJoinResolver.scopedRemoteSessionID(
+                claimed: "s-1", hostID: hostID, agent: .claude
+            ),
+            ClaudeRemoteSessionScope.scopedSessionID(hostID: hostID, sessionID: "s-1")
+        )
+        XCTAssertNotEqual(
+            ClaudeSessionJoinResolver.scopedRemoteSessionID(
+                claimed: "s-1", hostID: "h00000000", agent: .claude
+            ),
+            ClaudeRemoteSessionScope.scopedSessionID(hostID: hostID, sessionID: "s-1")
+        )
+    }
+
+    // MARK: Two labelled sessions on one socket
+
+    func testTwoSessionsInDIFFERENTPanesJoinTheFocusedOne() async throws {
+        // Two Claude sessions in two herdr panes is the normal multiplexer
+        // workflow. The focused pane id picks exactly one candidate and the
+        // marker then has to agree with THAT candidate — nothing here is a
+        // "pick" that could land on the other session.
+        let registry = makeRegistry(markers: ["lvx-aaa111", markerValue])
+        ingestRemoteHerdrSession(into: registry, sessionID: "s-other", paneID: "pane-other")
+        ingestRemoteHerdrSession(into: registry, sessionID: "s-remote-1")
+
+        let join = try unwrapAsync(
+            await resolver(
+                registry: registry,
+                panes: RemoteJoinHerdrPanes(focused: focusedPane()),
+                forwards: RecordingForwards()
+            ).resolve(target: ghostty)
+        )
+
+        XCTAssertEqual(join.mechanism, .remoteHerdrPane)
+        XCTAssertEqual(
+            join.snapshot.sessionID,
+            ClaudeRemoteSessionScope.scopedSessionID(hostID: hostID, sessionID: "s-remote-1")
+        )
+        XCTAssertEqual(join.marker.value, markerValue)
+    }
+
+    func testASessionForgingAnotherPaneIDCannotJoinWithoutThatPanesMarker() async throws {
+        // The pane id is a label the host chose, so a session CAN claim
+        // another's. What it cannot do is make the pane's title carry its
+        // marker: markers are broker-allocated, and the one in the pane
+        // belongs to the session actually living there.
+        let registry = makeRegistry(markers: ["lvx-forger", markerValue])
+        // The forger reports the focused pane's id...
+        ingestRemoteHerdrSession(into: registry, sessionID: "s-forger")
+        // ...and the pane's real occupant is evicted, so the forger is the only
+        // candidate matching the pane id.
+        let panes = RemoteJoinHerdrPanes(focused: focusedPane(title: markerValue))
+        let forwards = RecordingForwards()
+
+        let join = await resolver(
+            registry: registry, panes: panes, forwards: forwards, title: markerValue
+        ).resolve(target: ghostty)
+
+        // The forger's marker is lvx-forger; the pane's title carries the other
+        // session's. No join.
+        XCTAssertNil(join)
+        XCTAssertEqual(forwards.closeCount, 1)
+    }
+
+    // MARK: The foreground cross-check's two signals
+
+    func testHookParentPIDMatchJoinsEvenWhenTheProcessIsNamedNode() async throws {
+        // An npm-installed Claude Code is `node` in the process table. The
+        // published `$PPID` is the other half of the same question.
+        let registry = makeRegistry(markers: [markerValue])
+        ingestRemoteHerdrSession(into: registry, hookParentPID: "4711")
+        let panes = RemoteJoinHerdrPanes(
+            focused: focusedPane(),
+            foreground: HerdrPaneForegroundInfo(
+                shellPID: 8000,
+                foregroundProcesses: [HerdrForegroundProcess(pid: 4711, name: "node")]
+            )
+        )
+
+        let join = try unwrapAsync(
+            await resolver(registry: registry, panes: panes, forwards: RecordingForwards())
+                .resolve(target: ghostty)
+        )
+        XCTAssertEqual(join.mechanism, .remoteHerdrPane)
+    }
+
+    func testAgentNameMatchJoinsWhenNoHookParentPIDWasPublished() async throws {
+        let registry = makeRegistry(markers: [markerValue])
+        ingestRemoteHerdrSession(into: registry, hookParentPID: nil)
+        let panes = RemoteJoinHerdrPanes(
+            focused: focusedPane(),
+            foreground: HerdrPaneForegroundInfo(
+                shellPID: 8000,
+                foregroundProcesses: [HerdrForegroundProcess(pid: 1234, name: "/usr/local/bin/claude")]
+            )
+        )
+
+        let join = try unwrapAsync(
+            await resolver(registry: registry, panes: panes, forwards: RecordingForwards())
+                .resolve(target: ghostty)
+        )
+        XCTAssertEqual(join.mechanism, .remoteHerdrPane)
+    }
+
+    func testAHookParentPIDIsComparedAsAStringNotANumber() throws {
+        // A remote pid is a number in another machine's namespace: a snapshot
+        // reporting "0x1247" must not match pid 4711 by some numeric coercion.
+        let registry = makeRegistry(markers: [markerValue])
+        let snapshot = try unwrapAsync(
+            ingestRemoteHerdrSession(into: registry, hookParentPID: "0x1247")
+        )
+        XCTAssertFalse(
+            ClaudeSessionJoinResolver.remoteAgentIsForeground(
+                snapshot: snapshot,
+                foregroundProcesses: [HerdrForegroundProcess(pid: 4711, name: "node")]
+            )
+        )
+    }
+
+    // MARK: Defaults
+
+    func testADefaultResolverNeverProbesTheProcessTableOrForwardsAnything() async throws {
+        // The un-injected seams must leave the arm entirely inert, exactly like
+        // the local herdr probe's default.
+        let registry = makeRegistry(markers: [markerValue])
+        ingestRemoteHerdrSession(into: registry)
+        let resolver = ClaudeSessionJoinResolver(
+            registry: registry,
+            markerInWindowTitle: { _ in nil },
+            focusedTerminalTTY: { [surfaceTTY] _ in surfaceTTY },
+            focusedWindowID: { _ in 101 },
+            herdrPanes: RemoteJoinHerdrPanes(focused: focusedPane())
+        )
+        let join = await resolver.resolve(target: ghostty)
+        XCTAssertNil(join)
+    }
+
+    // MARK: Downstream consequences of the mechanism
+
+    func testARemoteHerdrJoinNeverAuthorizesRawScreenAttachment() async throws {
+        let registry = makeRegistry(markers: [markerValue])
+        ingestRemoteHerdrSession(into: registry)
+        let resolver = resolver(
+            registry: registry,
+            panes: RemoteJoinHerdrPanes(focused: focusedPane()),
+            forwards: RecordingForwards()
+        )
+        let join = try unwrapAsync(await resolver.resolve(target: ghostty))
+        let authorizer = TerminalScreenClaudeJoinAuthorizer(
+            resolver: resolver, currentJoin: { join }
+        )
+        // Same window, same target, live session — and still refused, because
+        // the AX grid is the composite herdr TUI (here, of another machine).
+        XCTAssertFalse(authorizer.isAuthorized(target: ghostty, windowID: 101))
+    }
+
+    func testARemoteHerdrJoinHasNoLocalWorkspaceToCollectARepoFrom() async throws {
+        let registry = makeRegistry(markers: [markerValue])
+        ingestRemoteHerdrSession(into: registry)
+        let join = try unwrapAsync(
+            await resolver(
+                registry: registry,
+                panes: RemoteJoinHerdrPanes(focused: focusedPane()),
+                forwards: RecordingForwards()
+            ).resolve(target: ghostty)
+        )
+        // The remote cwd is a label; there is no type that could carry it to
+        // the filesystem, and the repo collector takes only the type that can.
+        XCTAssertNil(join.localWorkspacePath)
+        XCTAssertNil(join.snapshot.localWorkspacePath)
+    }
+
+    func testTheJoinValueExposesNoWayToReleaseItsForward() async throws {
+        // Ownership lives in the view model, not in the value that travels
+        // (review finding 4). This test is the compile-time half of that: the
+        // handle is reachable for INSPECTION only, and closing it is not part
+        // of the join's API.
+        let registry = makeRegistry(markers: [markerValue])
+        ingestRemoteHerdrSession(into: registry)
+        let forwards = RecordingForwards()
+        let join = try unwrapAsync(
+            await resolver(
+                registry: registry,
+                panes: RemoteJoinHerdrPanes(focused: focusedPane()),
+                forwards: forwards
+            ).resolve(target: ghostty)
+        )
+        XCTAssertNotNil(join.remoteHerdrForward)
+        XCTAssertEqual(forwards.closeCount, 0)
+    }
+
+    // MARK: Forward ownership (review finding 4)
+
+    /// A resolved remote herdr join, with the fake forwards that produced it.
+    private func makeJoinWithForward() async throws -> (ClaudeSessionJoin, RecordingForwards) {
+        let registry = makeRegistry(markers: [markerValue])
+        ingestRemoteHerdrSession(into: registry)
+        let forwards = RecordingForwards()
+        let join = try unwrapAsync(
+            await resolver(
+                registry: registry,
+                panes: RemoteJoinHerdrPanes(focused: focusedPane()),
+                forwards: forwards
+            ).resolve(target: ghostty)
+        )
+        return (join, forwards)
+    }
+
+    private func makeViewModel() -> DictationViewModel {
+        let suiteName = "localvoxtral.RemoteHerdrJoinTests.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defaults.removePersistentDomain(forName: suiteName)
+        addTeardownBlock { defaults.removePersistentDomain(forName: suiteName) }
+        let settings = SettingsStore(defaults: defaults, environment: [:])
+        let viewModel = DictationViewModel(settings: settings, startRuntimeServices: false)
+        Self.retainedViewModels.append(viewModel)
+        return viewModel
+    }
+
+    /// DictationViewModel owns app-lifetime services; retaining test instances
+    /// for the process duration keeps teardown from racing service shutdown.
+    private static var retainedViewModels: [DictationViewModel] = []
+
+    func testAnAbortedConnectClosesTheTunnel() async throws {
+        // The abort path never reaches stopped-session cleanup, so before this
+        // the ssh child stayed up for the rest of the app's life.
+        let (join, forwards) = try await makeJoinWithForward()
+        let viewModel = makeViewModel()
+        viewModel.claudeSessionJoin = join
+        viewModel.retainRemoteHerdrForward(of: join)
+        XCTAssertEqual(viewModel.openRemoteHerdrForwardCount, 1)
+
+        viewModel.abortConnectingSession()
+
+        XCTAssertEqual(forwards.closeCount, 1)
+        XCTAssertEqual(forwards.process.terminations.withLock { $0 }, 1)
+        XCTAssertEqual(viewModel.openRemoteHerdrForwardCount, 0)
+    }
+
+    func testDiscardingTheStartCaptureClosesTheTunnel() async throws {
+        let (join, forwards) = try await makeJoinWithForward()
+        let viewModel = makeViewModel()
+        viewModel.claudeSessionJoin = join
+        viewModel.retainRemoteHerdrForward(of: join)
+
+        viewModel.discardTerminalScreenCapture()
+
+        XCTAssertNil(viewModel.claudeSessionJoin)
+        XCTAssertEqual(forwards.closeCount, 1)
+    }
+
+    func testTheTunnelIsStillOwnedAfterTheCommitPathConsumesTheJoin() async throws {
+        // The quit-during-polish hole: the commit path takes the join, so an
+        // owner that reached the child through `claudeSessionJoin` found nil
+        // and the ssh survived app exit.
+        let (join, forwards) = try await makeJoinWithForward()
+        let viewModel = makeViewModel()
+        viewModel.claudeSessionJoin = join
+        viewModel.retainRemoteHerdrForward(of: join)
+
+        let consumed = viewModel.consumeClaudeSessionJoin()
+        XCTAssertNotNil(consumed)
+        XCTAssertNil(viewModel.claudeSessionJoin)
+        XCTAssertEqual(forwards.closeCount, 0, "the stop-side pane read still needs it")
+
+        // What `applicationWillTerminate` now does.
+        viewModel.closeRemoteHerdrForwards()
+
+        XCTAssertEqual(forwards.closeCount, 1)
+    }
+
+    func testClosingTunnelsIsIdempotentAndSurvivesHavingNone() async throws {
+        let (join, forwards) = try await makeJoinWithForward()
+        let viewModel = makeViewModel()
+        viewModel.retainRemoteHerdrForward(of: join)
+
+        viewModel.closeRemoteHerdrForwards()
+        viewModel.closeRemoteHerdrForwards()
+        viewModel.discardTerminalScreenCapture()
+
+        XCTAssertEqual(forwards.closeCount, 1)
+        XCTAssertEqual(forwards.process.terminations.withLock { $0 }, 1)
+    }
+
+    func testAJoinWithNoTunnelIsNotRetained() {
+        let viewModel = makeViewModel()
+        viewModel.retainRemoteHerdrForward(of: nil)
+        XCTAssertEqual(viewModel.openRemoteHerdrForwardCount, 0)
+    }
+
+    // MARK: Pane screen context over the forward
+
+    func testRemoteHerdrPaneTextIsCapturedAtStartAndReconciledAtStop() async throws {
+        let registry = makeRegistry(markers: [markerValue])
+        ingestRemoteHerdrSession(into: registry)
+        let panes = RemoteJoinHerdrPanes(
+            focused: focusedPane(),
+            texts: ["cargo test\nerror[E0432]: unresolved import", nil]
+        )
+        let forwards = RecordingForwards()
+        let resolver = resolver(registry: registry, panes: panes, forwards: forwards)
+        let join = try unwrapAsync(await resolver.resolve(target: ghostty))
+
+        let start = await SocketPaneScreenContext.captureAtStart(
+            join: join,
+            resolver: resolver,
+            settingEnabled: true,
+            endpointURL: URL(string: "http://127.0.0.1:8472/v1/chat/completions")!,
+            isAccessibilityTrusted: true,
+            trustedEndpointEnabled: false
+        )
+        let capture = try unwrapAsync(start)
+        XCTAssertEqual(capture.paneKey, remotePaneID)
+        XCTAssertTrue(capture.text.contains("E0432"))
+        // The read went over the tunnel, for the joined pane only.
+        let read = try unwrapAsync(panes.requests.withLock { $0.last })
+        XCTAssertEqual(read.method, "pane.read")
+        XCTAssertEqual(read.socketPath, forwards.localSocketPath)
+        XCTAssertEqual(read.paneID, remotePaneID)
+
+        // A failed stop re-read falls back to the composite-AX decision, which
+        // for any herdr join is vocabulary-only at best.
+        let fallback = TerminalScreenContextDecision.vocabularyOnly(
+            startText: "composite AX text", cause: .rawUnauthorized
+        )
+        let decision = await SocketPaneScreenContext.reconcileAtStop(
+            start: capture,
+            join: join,
+            resolver: resolver,
+            fallback: fallback,
+            settingEnabled: true,
+            endpointURL: URL(string: "http://127.0.0.1:8472/v1/chat/completions")!,
+            isAccessibilityTrusted: true,
+            trustedEndpointEnabled: false
+        )
+        XCTAssertEqual(decision, fallback)
+    }
+
+    func testRemoteHerdrPaneTextIsNotCapturedWhenTheScreenSettingIsOff() async throws {
+        let registry = makeRegistry(markers: [markerValue])
+        ingestRemoteHerdrSession(into: registry)
+        let panes = RemoteJoinHerdrPanes(
+            focused: focusedPane(), texts: ["secret pane text"]
+        )
+        let resolver = resolver(registry: registry, panes: panes, forwards: RecordingForwards())
+        let join = try unwrapAsync(await resolver.resolve(target: ghostty))
+        let requestsBefore = panes.requests.withLock { $0.count }
+
+        let start = await SocketPaneScreenContext.captureAtStart(
+            join: join,
+            resolver: resolver,
+            settingEnabled: false,
+            endpointURL: URL(string: "http://127.0.0.1:8472/v1/chat/completions")!,
+            isAccessibilityTrusted: true,
+            trustedEndpointEnabled: false
+        )
+
+        XCTAssertNil(start)
+        // Gated BEFORE the socket, not after: a withheld consent must not
+        // produce a request at all.
+        XCTAssertEqual(panes.requests.withLock { $0.count }, requestsBefore)
+    }
+
+    // MARK: Registry filters
+
+    func testLiveRemoteHerdrSessionsFiltersByHostOriginAndEnvironment() throws {
+        let registry = makeRegistry(markers: ["lvx-a", "lvx-b", "lvx-c", "lvx-d"])
+        ingestRemoteHerdrSession(into: registry, sessionID: "s-a")
+        // Another host entirely.
+        ingestRemoteHerdrSession(into: registry, sessionID: "s-b", host: "h99999999")
+        // Same host, no herdr environment.
+        registry.ingest(
+            ClaudeHookRecord(
+                event: .sessionStart,
+                sessionID: ClaudeRemoteSessionScope.scopedSessionID(
+                    hostID: hostID, sessionID: "s-plain"
+                ),
+                timestamp: epoch.timeIntervalSince1970
+            ),
+            origin: origin
+        )
+        // A local session naming the same pane.
+        registry.ingest(
+            ClaudeHookRecord(
+                event: .sessionStart,
+                sessionID: "s-local",
+                timestamp: epoch.timeIntervalSince1970,
+                process: ClaudeHookProcessInfo(
+                    hookPID: 1,
+                    claudePID: 2,
+                    herdrPaneID: remotePaneID,
+                    herdrSocketPath: remoteSocketPath
+                )
+            ),
+            origin: .localAuthenticated(peerUID: 501)
+        )
+
+        let candidates = registry.liveRemoteHerdrSessions(hostID: hostID)
+        XCTAssertEqual(candidates.count, 1)
+        XCTAssertEqual(
+            candidates.first?.sessionID,
+            ClaudeRemoteSessionScope.scopedSessionID(hostID: hostID, sessionID: "s-a")
+        )
+        XCTAssertTrue(registry.liveRemoteHerdrSessions(hostID: "h00000000").isEmpty)
+    }
+
+    func testAHerdrEnvironmentWithNoSocketPathIsNotACandidate() throws {
+        let registry = makeRegistry(markers: ["lvx-a"])
+        registry.ingest(
+            ClaudeHookRecord(
+                event: .sessionStart,
+                sessionID: ClaudeRemoteSessionScope.scopedSessionID(
+                    hostID: hostID, sessionID: "s-half"
+                ),
+                timestamp: epoch.timeIntervalSince1970
+            ),
+            origin: origin,
+            environment: ClaudeRemoteSessionEnvironment(herdrPaneID: remotePaneID)
+        )
+        XCTAssertTrue(registry.liveRemoteHerdrSessions(hostID: hostID).isEmpty)
+    }
+}
+#endif

--- a/Tests/localvoxtralTests/RemoteHerdrJoinTests.swift
+++ b/Tests/localvoxtralTests/RemoteHerdrJoinTests.swift
@@ -830,11 +830,15 @@ final class RemoteHerdrJoinTests: XCTestCase {
         XCTAssertTrue(panes.requests.withLock { $0.isEmpty })
     }
 
-    func testTheManualHerdrFlowGetsNoContextAtAll() async throws {
+    func testTheManualHerdrFlowGetsNoHerdrJoin() async throws {
         // The documented, accepted limitation: `ssh host`, then typing `herdr`,
-        // leaves no trace in argv. herdr also intercepts OSC 2, so the pane's
-        // marker never reaches the outer terminal — meaning there is no marker
-        // to fall back to either. No join, and no pretending otherwise.
+        // leaves no trace in argv, so the arm cannot bind and no HERDR join
+        // happens. What this does NOT claim is "no context at all" (review
+        // round 7 corrected that): the arm returns `.notApplicable`, so the
+        // title-marker arm still runs — see
+        // `testAPlainSSHSessionNeverReachesTheArmEvenAsTheSoleConnection`,
+        // where a marker in the outer title still wins. Here there is no such
+        // marker, so nothing joins.
         let registry = makeRegistry(markers: [markerValue])
         ingestRemoteHerdrSession(into: registry)
         let forwards = RecordingForwards()

--- a/Tests/localvoxtralTests/SSHDestinationTTYProbeTests.swift
+++ b/Tests/localvoxtralTests/SSHDestinationTTYProbeTests.swift
@@ -1,0 +1,570 @@
+import Foundation
+import XCTest
+@testable import localvoxtral
+
+#if canImport(Darwin)
+import Darwin
+
+/// The probe that binds "the surface the user is looking at" to "an ssh
+/// CONNECTION to this enrolled host".
+///
+/// Everything here is the pure half: both live reads are injected, so the whole
+/// truth table runs without a real tty, a real ssh, or a real process table.
+final class SSHDestinationTTYProbeTests: XCTestCase {
+    private let surface: dev_t = 42
+    private let otherTerminal: dev_t = 43
+
+    private func probe(
+        deviceID: dev_t? = 42,
+        processes: [SSHClientProcess]?
+    ) -> SSHDestinationTTYProbeResult {
+        SSHDestinationTTYProbe.connection(
+            onTTYDevicePath: "/dev/ttys003",
+            deviceID: { _ in deviceID },
+            sshProcesses: { processes }
+        )
+    }
+
+    /// A well-formed foreground ssh on the surface, unless told otherwise.
+    private func ssh(
+        _ arguments: [String]?,
+        pid: Int32 = 501,
+        device: dev_t? = 42,
+        foreground: Bool = true,
+        executable: String? = "/usr/bin/ssh"
+    ) -> SSHClientProcess {
+        SSHClientProcess(
+            pid: pid,
+            ttyDevice: device,
+            processGroupID: pid,
+            terminalForegroundGroupID: foreground ? pid : pid + 1000,
+            executablePath: executable,
+            arguments: arguments
+        )
+    }
+
+    private func connection(_ result: SSHDestinationTTYProbeResult) -> SSHSurfaceConnection? {
+        guard case .connection(let value) = result else { return nil }
+        return value
+    }
+
+    // MARK: - Truth table
+
+    func testNoSSHProcessOnTheDeviceIsAnAbsenceNotAnAbstention() {
+        XCTAssertEqual(probe(processes: []), .noSSHClient)
+    }
+
+    func testUnreadableDeviceAbstains() {
+        XCTAssertEqual(probe(deviceID: nil, processes: [ssh(["ssh", "builder"])]), .undeterminable)
+    }
+
+    func testUnreadableProcessTableAbstains() {
+        XCTAssertEqual(probe(processes: nil), .undeterminable)
+    }
+
+    func testOneForegroundSSHClientReportsItsConnection() throws {
+        let value = try XCTUnwrap(connection(probe(processes: [ssh(["ssh", "builder"])])))
+        XCTAssertEqual(value.destination, "builder")
+        XCTAssertTrue(value.isOnlyConnectionToDestination)
+        XCTAssertFalse(value.indicatesHerdr)
+    }
+
+    func testUnreadableArgvOfAnSSHProcessAbstains() {
+        // Absence of argv is not absence of ssh: this surface IS a remote
+        // session, we just cannot say to where.
+        XCTAssertEqual(probe(processes: [ssh(nil)]), .undeterminable)
+    }
+
+    // MARK: - Executable verification (review finding 2)
+
+    func testAnSSHNamedProcessWithAnotherExecutableAbstains() {
+        // `p_comm` is 16 bytes the process chose, and argv[0] is chosen by
+        // whoever exec'd it. Neither is evidence of running OpenSSH.
+        XCTAssertEqual(
+            probe(processes: [ssh(["ssh", "builder"], executable: "/tmp/evil/ssh")]),
+            .undeterminable
+        )
+        XCTAssertEqual(
+            probe(processes: [ssh(["ssh", "builder"], executable: "/Users/dev/bin/ssh")]),
+            .undeterminable
+        )
+    }
+
+    func testUnknownExecutablePathAbstains() {
+        XCTAssertEqual(
+            probe(processes: [ssh(["ssh", "builder"], executable: nil)]), .undeterminable
+        )
+    }
+
+    func testOnlyTheThreeCanonicalPathsAreTrustedOutright() {
+        for path in SSHDestinationTTYProbe.canonicalSSHExecutablePaths {
+            XCTAssertTrue(
+                SSHDestinationTTYProbe.isTrustedSSHExecutable(path, resolvedPath: { _ in nil }),
+                path
+            )
+        }
+        XCTAssertFalse(
+            SSHDestinationTTYProbe.isTrustedSSHExecutable(
+                "/opt/homebrew/bin/sshpass", resolvedPath: { _ in nil }
+            )
+        )
+    }
+
+    func testAnImpostorInAWritableTreeIsRefused() {
+        // The earlier rule trusted any `ssh` basename under `/opt/homebrew/` or
+        // `/usr/local/` — both user-writable, so a compiled impostor with a
+        // crafted argv passed (review round 3, blocker 2).
+        let impostors = [
+            "/opt/homebrew/tmp/ssh",
+            // A real-looking Cellar path that nothing canonical resolves to.
+            "/opt/homebrew/Cellar/openssh/9.9p1/bin/ssh",
+            "/usr/local/lib/evil/ssh",
+            "/usr/local/bin/../../tmp/ssh",
+            "/tmp/ssh",
+            "ssh",
+        ]
+        for path in impostors {
+            XCTAssertFalse(
+                SSHDestinationTTYProbe.isTrustedSSHExecutable(path, resolvedPath: { _ in nil }),
+                "\(path) must be refused"
+            )
+        }
+    }
+
+    func testAnImpostorIsRefusedByTheProbeItself() {
+        // The same thing one level up: a crafted argv on the surface tty, from
+        // an executable in a writable tree, must not produce a destination.
+        XCTAssertEqual(
+            probe(processes: [ssh(["ssh", "builder"], executable: "/opt/homebrew/tmp/ssh")]),
+            .undeterminable
+        )
+    }
+
+    func testTheHomebrewCellarIsTrustedOnlyWhenItIsWhatBinResolvesTo() {
+        // proc_pidpath reports the RESOLVED path, and Homebrew's bin/ssh is a
+        // symlink into the Cellar. That path is trusted only while the
+        // canonical bin path actually points at it — never because of where it
+        // happens to live.
+        let cellar = "/opt/homebrew/Cellar/openssh/9.9p1/bin/ssh"
+        let resolve: (String) -> String? = { $0 == "/opt/homebrew/bin/ssh" ? cellar : nil }
+        XCTAssertTrue(SSHDestinationTTYProbe.isTrustedSSHExecutable(cellar, resolvedPath: resolve))
+        // A sibling in the very same Cellar tree is not.
+        XCTAssertFalse(
+            SSHDestinationTTYProbe.isTrustedSSHExecutable(
+                "/opt/homebrew/Cellar/openssh/9.9p1/bin/ssh-impostor", resolvedPath: resolve
+            )
+        )
+        XCTAssertFalse(
+            SSHDestinationTTYProbe.isTrustedSSHExecutable(
+                "/opt/homebrew/Cellar/evil/1.0/bin/ssh", resolvedPath: resolve
+            )
+        )
+    }
+
+    func testASymlinkedImpostorInTheSameTreeIsRefused() {
+        // Review round 4, blocker 1: the first symlink rule accepted ANYTHING a
+        // canonical path resolved to, so repointing Homebrew's `ssh` at a
+        // same-tree `ssh-impostor` was trusted. The resolved basename must be
+        // exactly `ssh`.
+        let impostor = "/opt/homebrew/Cellar/openssh/9.9p1/bin/ssh-impostor"
+        let resolve: (String) -> String? = { $0 == "/opt/homebrew/bin/ssh" ? impostor : nil }
+        XCTAssertFalse(
+            SSHDestinationTTYProbe.isTrustedSSHExecutable(impostor, resolvedPath: resolve)
+        )
+    }
+
+    func testASymlinkPointingOUTSIDETheInstallationTreeIsRefused() {
+        // …and the target must stay inside the tree its canonical name lives
+        // in, so `/opt/homebrew/bin/ssh` cannot vouch for `/tmp/evil/ssh`.
+        let outside = "/tmp/evil/ssh"
+        let resolve: (String) -> String? = { $0 == "/opt/homebrew/bin/ssh" ? outside : nil }
+        XCTAssertFalse(
+            SSHDestinationTTYProbe.isTrustedSSHExecutable(outside, resolvedPath: resolve)
+        )
+        let elsewhereInUsr = "/usr/lib/evil/ssh"
+        let usrResolve: (String) -> String? = {
+            $0 == "/usr/local/bin/ssh" ? elsewhereInUsr : nil
+        }
+        // `/usr/local`'s root is `/usr/local`, so `/usr/lib/...` is outside it
+        // even though both live under `/usr`.
+        XCTAssertFalse(
+            SSHDestinationTTYProbe.isTrustedSSHExecutable(elsewhereInUsr, resolvedPath: usrResolve)
+        )
+    }
+
+    func testTheInstallationRootIsDerivedFromTheCanonicalPath() {
+        XCTAssertEqual(
+            SSHDestinationTTYProbe.installationRoot(ofCanonicalPath: "/opt/homebrew/bin/ssh"),
+            "/opt/homebrew"
+        )
+        XCTAssertEqual(
+            SSHDestinationTTYProbe.installationRoot(ofCanonicalPath: "/usr/bin/ssh"), "/usr"
+        )
+        XCTAssertEqual(
+            SSHDestinationTTYProbe.installationRoot(ofCanonicalPath: "/usr/local/bin/ssh"),
+            "/usr/local"
+        )
+        // Not a `bin` directory ⇒ no root ⇒ nothing can be vouched for.
+        XCTAssertNil(SSHDestinationTTYProbe.installationRoot(ofCanonicalPath: "/opt/ssh"))
+    }
+
+    func testTheLiveCanonicalResolutionAcceptsTheSystemSSH() {
+        // The live half of the rule, against this machine's actual /usr/bin/ssh.
+        XCTAssertTrue(SSHDestinationTTYProbe.isTrustedSSHExecutable("/usr/bin/ssh"))
+    }
+
+    // MARK: - Foreground process group (review finding 2)
+
+    func testABackgroundedOrStoppedSSHOnTheSurfaceIsNotTheSurface() {
+        // The user suspended ssh and is back at the shell: the terminal shows a
+        // local prompt, so the remote arm must not apply at all.
+        XCTAssertEqual(
+            probe(processes: [ssh(["ssh", "builder"], foreground: false)]), .noSSHClient
+        )
+    }
+
+    func testAnSSHHelperOfAnotherProcessIsNotTheSurface() {
+        // `scp`/`rsync` spawn ssh in their own process group; the terminal's
+        // foreground group is the scp, not this.
+        let helper = SSHClientProcess(
+            pid: 900,
+            ttyDevice: surface,
+            processGroupID: 800,
+            terminalForegroundGroupID: 700,
+            executablePath: "/usr/bin/ssh",
+            arguments: ["ssh", "builder"]
+        )
+        XCTAssertEqual(probe(processes: [helper]), .noSSHClient)
+    }
+
+    // MARK: - Machine-wide uniqueness (review blocker 1a)
+
+    func testASecondTerminalToTheSameHostRemovesUniqueness() throws {
+        // Codex's scenario: this terminal is a plain shell to `builder`, and
+        // another terminal is attached to herdr on `builder`.
+        let value = try XCTUnwrap(
+            connection(
+                probe(
+                    processes: [
+                        ssh(["ssh", "builder"], pid: 501),
+                        ssh(["ssh", "builder"], pid: 777, device: otherTerminal),
+                    ]
+                )
+            )
+        )
+        XCTAssertEqual(value.destination, "builder")
+        XCTAssertFalse(value.isOnlyConnectionToDestination)
+    }
+
+    func testAnotherTerminalToADIFFERENTHostLeavesUniquenessIntact() throws {
+        let value = try XCTUnwrap(
+            connection(
+                probe(
+                    processes: [
+                        ssh(["ssh", "builder"], pid: 501),
+                        ssh(["ssh", "elsewhere"], pid: 777, device: otherTerminal),
+                    ]
+                )
+            )
+        )
+        XCTAssertTrue(value.isOnlyConnectionToDestination)
+    }
+
+    func testAnUnreadableSSHElsewhereRemovesUniqueness() throws {
+        // Uniqueness is a claim; a process we cannot read cannot be part of one.
+        let value = try XCTUnwrap(
+            connection(
+                probe(
+                    processes: [
+                        ssh(["ssh", "builder"], pid: 501),
+                        ssh(nil, pid: 777, device: otherTerminal),
+                    ]
+                )
+            )
+        )
+        XCTAssertFalse(value.isOnlyConnectionToDestination)
+    }
+
+    func testOurOwnTTYLessForwardDoesNotRemoveUniqueness() throws {
+        // The app's `ssh -N -L … builder` has no controlling terminal, so it is
+        // not a surface anyone can dictate into. (It also carries -N, which the
+        // parser refuses outright — hence unreadable, hence excluded by the
+        // no-terminal rule BEFORE that matters.)
+        let value = try XCTUnwrap(
+            connection(
+                probe(
+                    processes: [
+                        ssh(["ssh", "builder"], pid: 501),
+                        ssh(
+                            ["ssh", "-N", "-L", "/tmp/a.sock:/run/h.sock", "--", "builder"],
+                            pid: 999,
+                            device: nil
+                        ),
+                    ]
+                )
+            )
+        )
+        XCTAssertTrue(value.isOnlyConnectionToDestination)
+    }
+
+    func testTwoForegroundSSHClientsToDifferentHostsOnOneSurfaceAbstain() {
+        XCTAssertEqual(
+            probe(
+                processes: [
+                    ssh(["ssh", "builder"], pid: 501),
+                    ssh(["ssh", "other"], pid: 502),
+                ]
+            ),
+            .undeterminable
+        )
+    }
+
+    // MARK: - herdr connection signal (review blocker 1b)
+
+    func testARemoteCommandNamingHerdrBindsTheConnection() throws {
+        let value = try XCTUnwrap(
+            connection(probe(processes: [ssh(["ssh", "-t", "builder", "herdr", "attach"])]))
+        )
+        XCTAssertTrue(value.indicatesHerdr)
+    }
+
+    func testAnAbsolutePathToHerdrCounts() {
+        XCTAssertTrue(SSHDestinationTTYProbe.commandNamesHerdr(["/usr/local/bin/herdr", "attach"]))
+    }
+
+    func testOnlyTheFirstCommandTokenCounts() {
+        // The forgery the round-3 review found: any token that merely MENTIONED
+        // herdr used to set the signal, so `printf herdr; exec claude` claimed
+        // to be a herdr connection. A shell wrapper is refused for the same
+        // reason it was the exploit — its first token is `sh`, and what it goes
+        // on to run is not something an argv can promise.
+        XCTAssertFalse(
+            SSHDestinationTTYProbe.commandNamesHerdr(["sh", "-lc", "printf herdr; exec claude"])
+        )
+        XCTAssertFalse(SSHDestinationTTYProbe.commandNamesHerdr(["sh", "-lc", "herdr attach main"]))
+        XCTAssertFalse(SSHDestinationTTYProbe.commandNamesHerdr(["echo", "herdr"]))
+        XCTAssertFalse(SSHDestinationTTYProbe.commandNamesHerdr(["cat", "herdr.log"]))
+        XCTAssertFalse(SSHDestinationTTYProbe.commandNamesHerdr(["/srv/herdrless/run"]))
+        XCTAssertFalse(SSHDestinationTTYProbe.commandNamesHerdr([]))
+        XCTAssertFalse(SSHDestinationTTYProbe.commandNamesHerdr([""]))
+    }
+
+    func testAForgedHerdrMentionDoesNotIndicateHerdr() throws {
+        let value = try XCTUnwrap(
+            connection(
+                probe(
+                    processes: [
+                        ssh(["ssh", "builder", "sh", "-lc", "printf herdr; exec claude"]),
+                    ]
+                )
+            )
+        )
+        XCTAssertFalse(value.indicatesHerdr)
+    }
+
+    func testAPlainShellConnectionDoesNotIndicateHerdr() throws {
+        let value = try XCTUnwrap(connection(probe(processes: [ssh(["ssh", "builder"])])))
+        XCTAssertFalse(value.indicatesHerdr)
+    }
+
+    // MARK: - argv parsing
+
+    private func destination(_ argv: [String]) -> String? {
+        SSHDestinationTTYProbe.parse(arguments: argv)?.destination
+    }
+
+    func testPlainDestination() {
+        XCTAssertEqual(destination(["ssh", "builder"]), "builder")
+    }
+
+    func testUserAtHostKeepsOnlyTheHost() {
+        XCTAssertEqual(destination(["ssh", "tom@builder"]), "builder")
+    }
+
+    func testDestinationIsLowercasedForComparison() {
+        XCTAssertEqual(destination(["ssh", "Builder.Local"]), "builder.local")
+    }
+
+    func testAbsolutePathArgumentZeroIsStillSSH() {
+        XCTAssertEqual(destination(["/usr/bin/ssh", "builder"]), "builder")
+    }
+
+    func testAnotherProgramIsNeverParsed() {
+        XCTAssertNil(destination(["scp", "builder:/x", "/tmp"]))
+    }
+
+    func testSeparatedAndGluedInertOptionArgumentsAreSkipped() {
+        XCTAssertEqual(destination(["ssh", "-p", "2222", "builder"]), "builder")
+        XCTAssertEqual(destination(["ssh", "-p2222", "builder"]), "builder")
+        XCTAssertEqual(destination(["ssh", "-i", "/keys/id", "builder"]), "builder")
+    }
+
+    func testClusteredFlagsAreSkipped() {
+        XCTAssertEqual(destination(["ssh", "-tt", "builder"]), "builder")
+        XCTAssertEqual(destination(["ssh", "-AC", "builder"]), "builder")
+    }
+
+    func testJumpHostOptionDoesNotBecomeTheDestination() {
+        XCTAssertEqual(destination(["ssh", "-J", "bastion", "builder"]), "builder")
+    }
+
+    func testDoubleDashIntroducesTheDestination() {
+        XCTAssertEqual(destination(["ssh", "-t", "--", "builder"]), "builder")
+    }
+
+    func testDoubleDashWithNothingAfterItAbstains() {
+        XCTAssertNil(destination(["ssh", "--"]))
+    }
+
+    func testRemoteCommandIsNotMistakenForTheDestination() {
+        // The reason this walks options in order instead of taking the last
+        // non-option token: here that would answer `/tmp`.
+        XCTAssertEqual(destination(["ssh", "builder", "ls", "/tmp"]), "builder")
+    }
+
+    // MARK: - Destination-moving options ABSTAIN (review finding 2)
+
+    func testOptionsThatCanMoveTheDestinationAbstain() {
+        // Every one of these reports `builder` while connecting elsewhere, or
+        // means this is not an interactive session at all.
+        let refused: [[String]] = [
+            ["ssh", "-o", "HostName=other.example", "builder"],
+            ["ssh", "-oHostName=other.example", "builder"],
+            ["ssh", "-o", "ProxyJump=elsewhere", "builder"],
+            ["ssh", "-F", "/tmp/alt.conf", "builder"],
+            ["ssh", "-O", "check", "builder"],
+            ["ssh", "-S", "/tmp/cm.sock", "builder"],
+            ["ssh", "-N", "-L", "/tmp/a:/tmp/b", "builder"],
+            ["ssh", "-f", "builder", "sleep", "60"],
+            ["ssh", "-M", "builder"],
+            ["ssh", "-D", "1080", "builder"],
+            ["ssh", "-W", "host:22", "builder"],
+            ["ssh", "-w", "0:0", "builder"],
+            // Clustered with an inert flag, so the walk cannot miss it by only
+            // looking at the first letter.
+            ["ssh", "-tN", "builder"],
+        ]
+        for argv in refused {
+            XCTAssertNil(destination(argv), "\(argv) must abstain")
+        }
+    }
+
+    func testUnknownOptionLetterAbstains() {
+        XCTAssertNil(destination(["ssh", "-Z", "builder"]))
+    }
+
+    func testTrailingOptionWithNoOperandAbstains() {
+        XCTAssertNil(destination(["ssh", "-p", "2222"]))
+    }
+
+    func testNoOperandAtAllAbstains() {
+        XCTAssertNil(destination(["ssh"]))
+        XCTAssertNil(destination([]))
+    }
+
+    func testURIDestinationIsRefused() {
+        XCTAssertNil(destination(["ssh", "ssh://tom@builder:22"]))
+    }
+
+    func testDestinationOutsideTheHostnameCharsetIsRefused() {
+        XCTAssertNil(destination(["ssh", "builder;rm"]))
+        XCTAssertNil(destination(["ssh", "builder/x"]))
+        XCTAssertNil(destination(["ssh", "[fe80::1]"]))
+    }
+
+    func testEmptyHostPartIsRefused() {
+        XCTAssertNil(destination(["ssh", "tom@"]))
+        XCTAssertNil(SSHDestinationTTYProbe.normalizedDestination(""))
+    }
+
+    func testOverlongDestinationIsRefused() {
+        XCTAssertNil(
+            SSHDestinationTTYProbe.normalizedDestination(String(repeating: "a", count: 254))
+        )
+    }
+
+    func testOptionClassification() {
+        XCTAssertEqual(SSHDestinationTTYProbe.consumption(ofOptionToken: "-tt"), .selfContained)
+        XCTAssertEqual(SSHDestinationTTYProbe.consumption(ofOptionToken: "-p"), .consumesNextArgument)
+        XCTAssertEqual(SSHDestinationTTYProbe.consumption(ofOptionToken: "-p22"), .selfContained)
+        XCTAssertEqual(SSHDestinationTTYProbe.consumption(ofOptionToken: "-tp"), .consumesNextArgument)
+        XCTAssertEqual(SSHDestinationTTYProbe.consumption(ofOptionToken: "-o"), .refused)
+        XCTAssertEqual(SSHDestinationTTYProbe.consumption(ofOptionToken: "-tF"), .refused)
+        XCTAssertEqual(SSHDestinationTTYProbe.consumption(ofOptionToken: "-Z"), .unrecognized)
+    }
+
+    // MARK: - KERN_PROCARGS2 layout
+
+    private func procargs(argc: Int32, execPath: String, arguments: [String]) -> [UInt8] {
+        var buffer = [UInt8]()
+        withUnsafeBytes(of: argc) { buffer.append(contentsOf: $0) }
+        buffer.append(contentsOf: Array(execPath.utf8))
+        buffer.append(0)
+        buffer.append(0) // alignment padding, as the kernel emits
+        for argument in arguments {
+            buffer.append(contentsOf: Array(argument.utf8))
+            buffer.append(0)
+        }
+        buffer.append(contentsOf: Array("SHELL=/bin/zsh".utf8)) // environment, never read
+        buffer.append(0)
+        return buffer
+    }
+
+    func testProcessArgumentsBufferIsParsedUpToArgcAndStopsBeforeTheEnvironment() {
+        let buffer = procargs(
+            argc: 3, execPath: "/usr/bin/ssh", arguments: ["ssh", "-t", "builder"]
+        )
+        XCTAssertEqual(
+            SSHDestinationTTYProbe.parseProcessArguments(buffer), ["ssh", "-t", "builder"]
+        )
+    }
+
+    func testTruncatedProcessArgumentsBufferIsRefused() {
+        // argc says three, and the third string runs off the end of the buffer
+        // with no terminator — a layout we do not understand, so no answer.
+        var buffer = [UInt8]()
+        withUnsafeBytes(of: Int32(3)) { buffer.append(contentsOf: $0) }
+        buffer.append(contentsOf: Array("/usr/bin/ssh".utf8))
+        buffer.append(0)
+        buffer.append(0)
+        buffer.append(contentsOf: Array("ssh".utf8))
+        buffer.append(0)
+        buffer.append(contentsOf: Array("-t".utf8))
+        buffer.append(0)
+        buffer.append(contentsOf: Array("build".utf8))
+        XCTAssertNil(SSHDestinationTTYProbe.parseProcessArguments(buffer))
+    }
+
+    func testZeroArgumentCountIsRefused() {
+        XCTAssertNil(
+            SSHDestinationTTYProbe.parseProcessArguments(
+                procargs(argc: 0, execPath: "/usr/bin/ssh", arguments: [])
+            )
+        )
+    }
+
+    func testEmptyBufferIsRefused() {
+        XCTAssertNil(SSHDestinationTTYProbe.parseProcessArguments([]))
+    }
+
+    // MARK: - The live reads answer at all
+
+    func testTheLiveProcessTableScanReturnsThisProcess() throws {
+        // Cheap smoke over the machine-wide scan: the sizing/fetch pair and the
+        // kinfo_proc decode either work or this test is the first to know.
+        let entries = try XCTUnwrap(TTYProcessTable.allProcesses())
+        let me = entries.first { $0.pid == getpid() }
+        XCTAssertNotNil(me, "the scan must contain the test process itself")
+    }
+
+    func testTheLiveExecutablePathOfThisProcessResolves() throws {
+        let path = try XCTUnwrap(SSHDestinationTTYProbe.executablePath(pid: getpid()))
+        XCTAssertTrue(path.hasPrefix("/"), "got \(path)")
+    }
+
+    func testTheLiveArgumentsOfThisProcessResolve() throws {
+        let arguments = try XCTUnwrap(SSHDestinationTTYProbe.processArguments(pid: getpid()))
+        XCTAssertFalse(arguments.isEmpty)
+    }
+}
+#endif

--- a/Tests/localvoxtralTests/SSHDestinationTTYProbeTests.swift
+++ b/Tests/localvoxtralTests/SSHDestinationTTYProbeTests.swift
@@ -347,6 +347,46 @@ final class SSHDestinationTTYProbeTests: XCTestCase {
         XCTAssertTrue(value.isOnlyConnectionToDestination)
     }
 
+    func testTwoForegroundSSHClientsOnOneSurfaceAbstainEvenToTheSameHost() {
+        // Review round 7: the first version UNIONED the foreground processes —
+        // one destination set, `indicatesHerdr` OR-ed across them — so a group
+        // holding both `ssh builder` and `ssh builder herdr` reported "unique"
+        // AND "is herdr", and the plain, visible connection borrowed the
+        // other's herdr signal. There is no way to tell which one the user is
+        // looking at, so neither answers.
+        XCTAssertEqual(
+            probe(
+                processes: [
+                    ssh(["ssh", "builder"], pid: 501),
+                    ssh(["ssh", "builder", "herdr", "attach"], pid: 502),
+                ]
+            ),
+            .undeterminable
+        )
+    }
+
+    func testAWrapperLaunchingSeveralSSHChildrenInOneGroupAbstains() {
+        // The sibling-process shape: a pipeline or wrapper whose children share
+        // the foreground process group.
+        let first = SSHClientProcess(
+            pid: 601,
+            ttyDevice: surface,
+            processGroupID: 600,
+            terminalForegroundGroupID: 600,
+            executablePath: "/usr/bin/ssh",
+            arguments: ["ssh", "builder", "herdr"]
+        )
+        let second = SSHClientProcess(
+            pid: 602,
+            ttyDevice: surface,
+            processGroupID: 600,
+            terminalForegroundGroupID: 600,
+            executablePath: "/usr/bin/ssh",
+            arguments: ["ssh", "builder"]
+        )
+        XCTAssertEqual(probe(processes: [first, second]), .undeterminable)
+    }
+
     func testTwoForegroundSSHClientsToDifferentHostsOnOneSurfaceAbstain() {
         XCTAssertEqual(
             probe(

--- a/Tests/localvoxtralTests/SSHDestinationTTYProbeTests.swift
+++ b/Tests/localvoxtralTests/SSHDestinationTTYProbeTests.swift
@@ -256,6 +256,46 @@ final class SSHDestinationTTYProbeTests: XCTestCase {
         XCTAssertFalse(value.isOnlyConnectionToDestination)
     }
 
+    func testASuspendedSSHOnTHISDeviceRemovesUniqueness() throws {
+        // Review round 5b, major 2. Repro: `ssh builder herdr`, Ctrl+Z — the
+        // client is stopped but its server side is still attached and its pane
+        // still focused — then a plain `ssh builder` in the foreground of the
+        // SAME terminal. Skipping same-device background processes made that
+        // foreground session claim to be the only connection.
+        let suspendedHerdrClient = SSHClientProcess(
+            pid: 777,
+            ttyDevice: surface,
+            processGroupID: 777,
+            terminalForegroundGroupID: 501, // the plain ssh has the terminal
+            executablePath: "/usr/bin/ssh",
+            arguments: ["ssh", "builder", "herdr", "attach"]
+        )
+        let value = try XCTUnwrap(
+            connection(probe(processes: [ssh(["ssh", "builder"], pid: 501), suspendedHerdrClient]))
+        )
+        XCTAssertEqual(value.destination, "builder")
+        XCTAssertFalse(
+            value.isOnlyConnectionToDestination,
+            "a suspended ssh to the same host is still a second connection"
+        )
+    }
+
+    func testASecondForegroundSSHInAnotherPaneOfTheSameDeviceRemovesUniqueness() throws {
+        // Same rule, without the suspension: two process groups on one device.
+        let sibling = SSHClientProcess(
+            pid: 888,
+            ttyDevice: surface,
+            processGroupID: 888,
+            terminalForegroundGroupID: 501,
+            executablePath: "/usr/bin/ssh",
+            arguments: ["ssh", "builder"]
+        )
+        let value = try XCTUnwrap(
+            connection(probe(processes: [ssh(["ssh", "builder"], pid: 501), sibling]))
+        )
+        XCTAssertFalse(value.isOnlyConnectionToDestination)
+    }
+
     func testAnotherTerminalToADIFFERENTHostLeavesUniquenessIntact() throws {
         let value = try XCTUnwrap(
             connection(


### PR DESCRIPTION
Stacked on **#216** (`remote-env-enrichment`) — base branch is `remote-env-enrichment`, not `main`. Review #216 first; this PR's diff is the second commit only.

## What

A Claude Code session running inside a **herdr on an enrolled REMOTE host** had no join at all. Its pane identity arrives as an untrusted label (#216's `remoteEnvironment`), the local herdr arm is local-only by construction, and the title marker cannot help because herdr swallows OSC 2 per pane. This adds a new join mechanism `.remoteHerdrPane`, tried only after every local arm declines, plus `pane.read` screen context for it — reaching that herdr over an app-managed, on-demand `ssh -L`.

**Four independent bindings, all required**, in cost order so an ordinary ssh session never pays for a tunnel:

1. **The focused surface's own TTY hosts an `ssh` client whose destination is exactly one enrolled host's alias** (`SSHDestinationTTYProbe`: kinfo_proc walk of that device + `KERN_PROCARGS2`). This is the only binding that says anything about what the user is *looking at* — without it, an unattended remote herdr whose focused pane happens to hold a Claude session would join a local editor. The argv walk classifies options **in order** and abstains on anything unrecognized: "last non-option token" would read `ssh host ls /tmp` as `/tmp`, and an unknown option letter could take an argument.
2. **That host has live remote sessions reporting a herdr pane, all from ONE herdr socket** (`ClaudeSessionRegistry.liveRemoteHerdrSessions(hostID:)` — the mirror of the local single-socket rule, `.remote`-origin-only and reading `remoteEnvironment`, never `process`).
3. **Over the forward, that herdr's focused pane is exactly one of them AND its `terminal_title` carries exactly that session's broker-allocated marker.** This is why the marker works here and not locally: herdr captures an inner pane's OSC 2 into `PaneInfo.terminal_title`, and the remote listener already returns a marker to every remote session unconditionally — so it is sitting in the joined pane, invisible to the outer terminal. A host cannot invent a marker; another session's cannot match.
4. **The pane is running that session's agent.**

From (2) onward the arm is **herdr-or-nothing** (no title-marker fallback), for the local arm's reason transposed: a marker in the OUTER window belongs to something else — most likely this same host *before* the user attached herdr. Before (2), every non-answer falls through to the marker arm, so a plain remote session joins exactly as it always did.

### Design decisions worth reviewing

- **ssh-destination probe.** New `SSHDestinationTTYProbe` (both live reads injected, shares a `TTYProcessTable` walk with `HerdrClientTTYProbe`). Three-valued on purpose: `noSSHClient` (a fact — other arms may answer), `destination`, and `undeterminable` (argv unreadable, unknown option grammar, refused destination shape, or two ssh clients to different hosts). Destinations are compared case-insensitively, which is *wider* — safe only because a match is a precondition of the arm and never the join itself.
- **Alias persistence: already there, nothing to add.** `ClaudeRemoteHost.sshHostAlias` is persisted and `isValidHostAlias`-vetted at enrollment (PR #197). New `hosts(matchingSSHDestination:)` returns the *stored* spelling — the vetted string is the only one allowed to reach an argv — and skips revoked hosts.
- **Two options from the approved argv are deliberately ABSENT, both falsified against OpenSSH 10.0 before writing the code** (raw output below):
  - `ClearAllForwardings=yes` clears forwardings *"specified in the configuration files or on the command line"*, applied after all option parsing — it deletes the very `-L` this exists for.
  - `ExitOnForwardFailure=yes` makes the enrolled host's own `RemoteForward` — which the user's live interactive session is normally already holding — fatal for this connection. That collision is not an edge case, it is the exact situation the feature runs in.

  Readiness is proven by dialing the local socket instead (bounded poll, injected clock, ~2 s ceiling that is also a dictation-start latency budget). `ControlPath=none` is added so the forward belongs to our own child and killing it *is* the teardown.
- **Trust inversion, documented in AGENTS.** herdr's socket is full-control; over that forwarded stream one could create panes or write keystrokes. We dial out and send only `pane.current` / `pane.process_info` / `pane.read`. The remote socket path stays a label — never `FileManager`, never `stat`, never dialed locally; its one use is an argv token re-validated for absoluteness, no `:` (it would re-split the `-L` spec), and #216's header charset.
- **Foreground cross-check takes EITHER signal** — a `hookParentPID` match (compared as a **string**; a remote pid is another machine's number) or a process named for the agent. *Deviation from the spec's "and"*: requiring both fails closed forever on two ordinary installs — Claude Code spawns hooks through a shell, so `$PPID` is often that shell, and an npm-installed Claude Code is `node` in the process table. Neither present (suspended agent, user back at the shell) still abstains, which is the case the check exists for.
- **Forward lifetime is the dictation's**, because the stop-side `pane.read` must reach the same herdr the start side did. Closed after the stop reconcile in the commit path, in `discardTerminalScreenCapture()` on every other exit, at `applicationWillTerminate`, and by the handle's `deinit` as a backstop. `close()` is idempotent.
- **Nothing new is authorized.** The authorizer's refusal moved from `!= .herdrPane` to a shared `usesHerdrPaneText` predicate, so raw AX attachment is refused for both herdr arms (that grid is the composite TUI — here, of another machine). Local repo collection is impossible by type: the origin is remote, so `localWorkspacePath` is nil.

## Proof

- [x] **Unit suite green** — `./scripts/remote-build.sh` (full build + unit):

```
Test Suite 'localvoxtralPackageTests.xctest' passed at 2026-08-04 02:33 (rebased onto #216's review-fix commit b5d425f)
	 Executed 2299 tests, with 2 tests skipped and 0 failures (0 unexpected) in 81.097 (81.199) seconds
```

New coverage — 86 tests across four suites, each run individually:

```
Test Suite 'RemoteHerdrJoinTests' passed ... Executed 34 tests, with 0 failures (0 unexpected) in 0.030 seconds
Test Suite 'ClaudeRemoteHerdrForwardTests' passed ... Executed 15 tests, with 0 failures (0 unexpected) in 0.005 seconds
Test Suite 'SSHDestinationTTYProbeTests' passed ... Executed 33 tests, with 0 failures (0 unexpected) in 0.004 seconds
Test Suite 'ClaudeRemoteHostAliasMatchingTests' passed ... Executed 4 tests, with 0 failures (0 unexpected) in 0.008 seconds
```

The abstention matrix is the point of `RemoteHerdrJoinTests`: no ssh on the tty / undeterminable destination / un-enrolled host / revoked host / no herdr candidates (all four fall through to the title marker with **zero** forwards opened), two enrolled hosts sharing the destination, two live herdr sockets, missing forward or pane-query capability, forward spawn failure, focused pane unavailable, pane-id mismatch, two sessions claiming the pane, no title, no marker in the title, two markers in the title, another session's marker, foreground query unavailable, foreground detection unavailable, agent not foreground. Plus: a local session with the same pane id is never a remote candidate, and an un-injected resolver is completely inert.

### Falsification runs (the guards are load-bearing)

Not a bug fix, so there is no "before" — instead, each new guard was deleted in turn and the suite re-run.

**1. Pane-title marker check removed** (`guard marker == snapshot.marker` → tautology):

```
Tests/localvoxtralTests/RemoteHerdrJoinTests.swift:686: error: -[localvoxtralTests.RemoteHerdrJoinTests testPaneTitleMarkerOfAnotherSessionAbstains] : XCTAssertNil failed: "ClaudeSessionJoin(... mechanism: localvoxtral.ClaudeSessionJoinMechanism.remoteHerdrPane ...)"
Tests/localvoxtralTests/RemoteHerdrJoinTests.swift:687: error: ... XCTAssertEqual failed: ("0") is not equal to ("1")
```

(i.e. without it, a pane whose title names a *different* session joins anyway — and leaks the forward.)

**2. Authorizer refusal narrowed back to the local arm** (`!join.mechanism.usesHerdrPaneText` → `join.mechanism != .herdrPane`):

```
Tests/localvoxtralTests/RemoteHerdrJoinTests.swift:838: error: -[localvoxtralTests.RemoteHerdrJoinTests testARemoteHerdrJoinNeverAuthorizesRawScreenAttachment] : XCTAssertFalse failed
```

Both reverted; the full-suite run above is the reverted tree.

### ssh flag interaction, measured (this is why the argv deviates)

Against the build host, OpenSSH 10.0p2, one `-L` to a unix socket:

```
=== Test 1: WITH ClearAllForwardings + -L ===
NO SOCKET (forward was cleared)
=== Test 2: WITHOUT ClearAllForwardings, same -L ===
SOCKET PRESENT
```

And with a second connection colliding on a remote forward the first already holds (multiplexing off):

```
=== Test 3: colliding -R WITH ExitOnForwardFailure=yes ===
Error: remote port forwarding failed for listen port 18473
RESULT: ssh exited
=== Test 4: colliding -R WITHOUT ExitOnForwardFailure ===
Warning: remote port forwarding failed for listen port 18473
RESULT: SOCKET PRESENT (survived)
RESULT: ssh still running
```

`ClaudeRemoteHerdrForwardTests.testArgvOmitsTheTwoOptionsThatWouldBreakTheForward` pins both findings so a future "hardening" pass cannot silently re-add them.

- [x] **LLM lane**: `Sources/localvoxtral/ClaudeContext/*` and `DictationViewModel.swift` are in `scripts/ci/llm-lane-filter.sh`, so CI's polishd live-model lane runs on this PR — result pending at the time of writing; it will appear in the checks.
- [ ] Realtime integration — not run locally; per-push CI covers it (no audio/realtime paths touched).

### NOT verified by hand — for the owner

**No live remote herdr end-to-end run.** Everything above is unit-level with injected seams plus the standalone ssh-flag experiment; no dictation has yet gone through a real `ssh -L` into a real remote herdr. Worth checking on the Mac: that the arm joins on the first try, that the ~2 s readiness ceiling is invisible at dictation start on your LAN, and that no `lvx-herdr-fwd-*` directory survives in the per-user temp dir after a session (`ls $TMPDIR | grep lvx-herdr-fwd`). The local herdr arm and every other join path are covered by the untouched suites.

Also unverified by hand: the `pane.read` excerpt's *content* over a forward (the fixture proves the request shape and routing, not a live herdr's text).


---

## Review round 2 (codex, high effort) — all findings addressed

Base is now `main` (#216 merged); the branch was rebased and the dogfood lane fixed. Commits `dc59313` (review fixes) and `b4f2db6` (precondition wording), on top of a rebase onto #218.

| # | Finding | Disposition |
|---|---|---|
| CI | `.remoteHerdrPane` missing from `DogfoodCapturePipeline`'s switch (only the instrumented build compiles it) | **Fixed.** Dogfood lane green below. |
| 1 | BLOCKER — arm bound to a HOST, not the connection the terminal displays | **Fixed, all three parts.** |
| 2 | BLOCKER — ssh probe forgeable/imprecise | **Fixed.** |
| 3 | MAJOR — contradictory herdr `agent_session` claim ignored | **Fixed** (mirrors the local arm exactly). |
| 4 | MAJOR — forward ownership not centralized | **Fixed** (ownership moved to `DictationViewModel`). |
| 5 | MAJOR — child inherits the alias's full config | **Fixed** + residual documented. |
| 6 | MINOR — tests miss those boundaries | **Fixed**, including the test that blessed two ssh processes on one TTY. |

### 1 — connection-level bind

(a) `SSHDestinationTTYProbe` now scans `KERN_PROC_ALL` and reports `isOnlyConnectionToDestination`: any OTHER terminal hosting an ssh to the same destination (foreground or not, readable or not) removes uniqueness. TTY-less ssh processes are excluded — nobody can dictate into one, and the app's own `ssh -L` is exactly that (`testOurOwnTTYLessForwardDoesNotRemoveUniqueness`).

(b) `indicatesHerdr`: the remote-command tokens are word-boundary matched for a `herdr` basename (`herdr --remote`'s shape, `ssh -t host herdr attach`, `sh -lc "herdr …"`). A positive argv bind makes uniqueness unnecessary; `/srv/herdrless/run` does not count.

(c) The `notApplicable`/`abstained` split now falls exactly where the review put it: steps 1–3 (probe, enrollment, candidates, single socket, connection bind) fall THROUGH to the title marker; herdr-or-nothing begins only once this terminal is bound to a herdr that has live candidates. Two enrolled hosts sharing a destination and two live herdr sockets both changed from abstain to fallthrough.

**Falsification** (guard replaced with `|| true`):
```
Executed 46 tests, with 3 failures
-[RemoteHerdrJoinTests testASecondTerminalToTheSameHostStopsTheArmAndKeepsTheMarkerJoin] : XCTAssertEqual failed …
```
That test asserts all three consequences at once: the join is `.titleMarker`, zero forwards opened, zero herdr queries issued.

**On the last sub-point — "multiple labelled sessions on one socket must abstain" — the reviewed precondition was mis-stated, and the coordinator ruled to keep the current behavior and fix the STATEMENT instead.** Precisely: the arm requires exactly one candidate for the **focused pane id**, not one candidate per socket. Several live sessions on one herdr are expected and fine — two Claude sessions in two panes is the ordinary multiplexer workflow, and serving it is the point of this arm. What abstains is (i) two candidates claiming the SAME pane id (`testTwoSessionsClaimingTheFocusedPaneAbstain`) and (ii) two distinct herdr sockets on the host. The survivor is never a "pick": it is then confirmed independently by the broker-allocated marker in the pane's title, by herdr's own `agent_session` claim, and by the foreground process — so a session forging another's pane id still cannot join (`testASessionForgingAnotherPaneIDCannotJoinWithoutThatPanesMarker`), while the normal two-pane case joins the focused one (`testTwoSessionsInDIFFERENTPanesJoinTheFocusedOne`). The wording is now identical in the resolver's doc comment, at the `matches.count == 1` guard, on `liveRemoteHerdrSessions(hostID:)`, and in AGENTS.md.

### 2 — probe hardening

- Executable verified via `proc_pidpath`: `/usr/bin/ssh` or under `/opt/homebrew/`, `/usr/local/` (Homebrew resolves into the Cellar, so an exact-path rule would silently disable the feature). `/tmp/evil/ssh` and `~/bin/ssh` abstain.
- Foreground process group required (`e_pgid == e_tpgid`): a stopped/background ssh reports `noSSHClient` (the surface is the shell), and scp/rsync's helper — in its own group — likewise.
- `-o -F -O -S -N -f -M -D -W -w` now ABSTAIN, including clustered (`-tN`) and glued (`-oHostName=…`) forms. Pinned by `testOptionsThatCanMoveTheDestinationAbstain` (13 invocations).

### 3 — herdr's session claim

Fail-closed, scoped by the session's own host id and agent before comparison (`ClaudeRemoteSessionScope` then `ClaudeAgentSessionScope`), so a claim can only CONFIRM the pane-id join, never redirect it. **Falsification** (comparison replaced with `claimed.isEmpty`):
```
Executed 46 tests, with 2 failures
-[RemoteHerdrJoinTests testAContradictoryPaneSessionClaimAbstains] : XCTAssertNil failed …
```
The either/or `hookParentPID` relaxation stays, as approved.

### 4 — forward ownership

`DictationViewModel` takes the handle where the join is assigned and closes every open tunnel from `discardTerminalScreenCapture()`, the commit path (after the stop-side pane read), `abortConnectingSession()` — which every abort route funnels through — and `applicationWillTerminate`. `ClaudeSessionJoin.releaseResources()` is gone: the value travels, so it cannot be the owner. Pinned by `testAnAbortedConnectClosesTheTunnel`, `testTheTunnelIsStillOwnedAfterTheCommitPathConsumesTheJoin`, `testClosingTunnelsIsIdempotentAndSurvivesHavingNone`.

### 5 — inherited configuration

argv now forces `-o ForkAfterAuthentication=no -o PermitLocalCommand=no`, and the child is spawned with `posix_spawn` + `POSIX_SPAWN_SETPGROUP` so teardown signals `kill(-pgid)`. `testTerminatingTheLiveChildAlsoKillsItsDescendants` spawns a real `/bin/sh` that forks a grandchild and asserts the grandchild dies with the group.

Residual, as requested: this short-lived connection still requests whatever forwards the alias's `Host` block declares, including the enrollment `RemoteForward`. With #217 merged that is this Mac's own port, so a collision with the user's live session is a warning on a stderr we send to `/dev/null` — which is exactly why `ExitOnForwardFailure=yes` had to go (measured earlier: it makes ssh exit).

### Proof

Full unit suite (`./scripts/remote-build.sh`), on the pushed tree (rebased onto #218, which had landed on main in the meantime and conflicted — that conflict is also why GitHub had spawned no CI run at all):
```
Test Suite 'localvoxtralPackageTests.xctest' passed
	 Executed 2384 tests, with 2 tests skipped and 0 failures (0 unexpected) in 81.853 (81.974) seconds
```

Dogfood capture lane (`./scripts/remote-build.sh dogfood`) — the red CI step, now compiling and green (the mechanism switch now carries both #218's `.browserTab` and this PR's `.remoteHerdrPane`):
```
Test Suite 'localvoxtralPackageTests.xctest' passed
	 Executed 57 tests, with 0 failures (0 unexpected) in 0.121 (0.125) seconds
```

Suite sizes after the round: `RemoteHerdrJoinTests` 46, `SSHDestinationTTYProbeTests` 39, `ClaudeRemoteHerdrForwardTests` 19, `ClaudeRemoteHostAliasMatchingTests` 4.

The rebase onto #218 merged cleanly in intent: the authorizer's mechanism switch (exhaustive since #218) now refuses `.herdrPane, .remoteHerdrPane` in one case and `.browserTab` in its own, and the dogfood arm switch names all five mechanisms.

Still NOT hand-verified: a live remote herdr end-to-end (unchanged from the original PR body), and the two new live-read paths (`KERN_PROC_ALL` scan, `proc_pidpath`) are covered by smoke tests against the test process itself rather than against a real ssh session.


---

## Review round 3 (codex verification) — all findings addressed

Commit `54ca3a9`. Round 2's head `b4f2db6` had CI run [30893278020](https://github.com/T0mSIlver/localvoxtral/actions/runs/30893278020): **success** (it produced no run at all until the branch stopped conflicting with #218 — a conflicting PR gets no `pull_request` event, which is why the earlier heads showed "no checks reported").

| # | Finding | Disposition |
|---|---|---|
| 1a | BLOCKER — `commandNamesHerdr` accepted any token named `herdr` | **Fixed** + demoted to corroboration. |
| 1b | BLOCKER — sole plain ssh still lost its marker fallback | **Fixed**: herdr-or-nothing now begins at confirmation. |
| 2 | BLOCKER — executable trust was prefix-based | **Fixed**: three exact paths, Cellar only via canonical resolution. |
| 3 | MAJOR (new) — teardown observed only the group leader | **Fixed**: unconditional group SIGKILL, tested with a SIGTERM-ignoring descendant. |

All three line references verified against the tree before changing anything; all three reproduced exactly as described.

### 1a — the herdr signal is no longer forgeable, and no longer sufficient

`commandNamesHerdr` is now exactly the first command token's basename. `ssh builder sh -lc 'printf herdr; exec claude'` no longer sets it, and neither does any shell wrapper — its first token is `sh`, and what it goes on to exec is not something an argv can promise.

Beyond that, the signal no longer substitutes for anything: **uniqueness is now required unconditionally**, with the argv match kept as corroboration (logged, nothing more). `testTheHerdrArgvSignalNeverSubstitutesForUniqueness` pins that a non-unique connection claiming herdr gets the marker join, zero forwards, zero herdr queries.

### 1b — herdr-or-nothing begins at CONFIRMATION

The rule is now: pane id match **and** marker equality, both from the herdr on the other end of this connection. Before that point every failure falls through to the title marker — forward-capability missing, forward failed, herdr unreachable, focused pane is someone else's, no title, no single marker, marker names another session, two candidates on one pane id. After it, a fail-closed refusal (herdr's `agent_session` disagreeing, foreground checks) joins nothing at all, because a marker in the outer window could then only describe something else.

`testASolePlainSSHKeepsItsMarkerJoinWhenThePaneIsNotOurs` is the named regression test — a lone ssh to an enrolled host running a detached herdr keeps its marker join, and the tunnel that was opened to ask is closed again. Ten round-2 tests that asserted the old contract were rewritten to the new one (three were exact duplicates of the new boundary tests and were deleted).

### 2 — exact executable allowlist

`/usr/bin/ssh`, `/opt/homebrew/bin/ssh`, `/usr/local/bin/ssh`. A Homebrew Cellar realpath is accepted **only** when resolving one of those canonical paths produces it — so `/opt/homebrew/Cellar/openssh/9.9p1/bin/ssh` passes while `/opt/homebrew/bin/ssh` points at exactly it, and a sibling `ssh-impostor` in the same Cellar tree does not. `testAnImpostorInAWritableTreeIsRefused` covers `/opt/homebrew/tmp/ssh`, `/usr/local/lib/evil/ssh`, `/usr/local/bin/../../tmp/ssh`, `/tmp/ssh` and a relative `ssh`; `testAnImpostorIsRefusedByTheProbeItself` proves the same one level up, through the probe.

### 3 — unconditional group SIGKILL

`terminate()` now SIGTERMs the group, waits the bounded grace for the leader, and then SIGKILLs the group **unconditionally**, no liveness gate. Rationale in code and AGENTS: we observe only the leader, so its exit satisfies `waitForExit` while a stubborn descendant still holds the tunnel; signalling an empty group is an ESRCH nobody reads, and a pgid is not reused while the group has any member.

The old test used `sleep`, which dies on SIGTERM — it never exercised this. Two new tests use `sh -c 'trap "" TERM; sleep 60'` descendants:
- `testTerminatingTheLiveChildAlsoKillsADescendantThatIgnoresSIGTERM`
- `testTerminatingAfterTheLeaderAlreadyExitedStillKillsTheGroup` — kills the leader alone first, so teardown runs against a dead leader and a live descendant, which is the exact shape the review described.

### Falsification (every round-3 fix)

| Reverted | Failing tests |
|---|---|
| `commandNamesHerdr` + prefix executable trust | 10 failures across 5 tests, incl. `testAForgedHerdrMentionDoesNotIndicateHerdr`, `testAnImpostorInAWritableTreeIsRefused`, `testTheHomebrewCellarIsTrustedOnlyWhenItIsWhatBinResolvesTo` |
| `.unconfirmed → .abstained` (confirmation boundary) | 7 failures, incl. `testASolePlainSSHKeepsItsMarkerJoinWhenThePaneIsNotOurs`, `testAnUnreachableHerdrKeepsTheMarkerJoin` |
| unconditional group SIGKILL | `testTerminatingTheLiveChildAlsoKillsADescendantThatIgnoresSIGTERM`, `testTerminatingAfterTheLeaderAlreadyExitedStillKillsTheGroup` |

### Proof

```
Test Suite 'localvoxtralPackageTests.xctest' passed
	 Executed 2394 tests, with 2 tests skipped and 0 failures (0 unexpected) in 83.179 (83.292) seconds
```
```
./scripts/remote-build.sh dogfood
	 Executed 57 tests, with 0 failures (0 unexpected) in 0.151 (0.155) seconds
```

Suite sizes: `RemoteHerdrJoinTests` 49, `SSHDestinationTTYProbeTests` 51, `ClaudeRemoteHerdrForwardTests` 21, `ClaudeRemoteHostAliasMatchingTests` 4.

Unchanged from before: no live remote-herdr end-to-end has been hand-run.


---

## Review round 4 (codex verification) — both blockers fixed; branch rebased onto the merged campaign

Head `53536c7`. Round-3 head `54ca3a9` had CI run [30895305960](https://github.com/T0mSIlver/localvoxtral/actions/runs/30895305960): **success**.

| # | Finding | Disposition |
|---|---|---|
| 1 | BLOCKER — symlink-target bypass survived | **Fixed** (basename + installation-root clauses), with the severity stated honestly. |
| 2 | BLOCKER (new, from the round-3 teardown fix) — PID/PGID reuse after reap | **Fixed**: signal first, reap last, never signal a reaped group. |

### 1 — the symlink target is now constrained, and here is the honest bound

The rule accepted anything `realpath` returned for a canonical path, so pointing `/opt/homebrew/bin/ssh` at a same-tree `bin/ssh-impostor` was trusted. A target must now also (a) have basename exactly `ssh` and (b) stay inside the installation root of the canonical path that vouched for it (`/opt/homebrew/bin/ssh` → `/opt/homebrew`), derived from the canonical path so a future entry brings its own boundary.

**What this is worth, plainly:** anyone who can repoint `/opt/homebrew/bin/ssh` already controls what the user's own `ssh` runs — and could equally name their impostor `ssh`. So this is defense-in-depth against a sloppy target, not a privilege boundary. What it does buy is that the accepted set is describable ("the file Homebrew's `ssh` actually is") rather than "whatever that name points at today".

New tests: `testASymlinkedImpostorInTheSameTreeIsRefused`, `testASymlinkPointingOUTSIDETheInstallationTreeIsRefused`, `testTheInstallationRootIsDerivedFromTheCanonicalPath`.

### 2 — never signal a process group after reaping it

Round 3 made the final group SIGKILL unconditional, which was right, but the exit handler still reaped the leader — and a pid is reserved only while the child is unreaped. After the reap the kernel may hand that pid out as a new group leader, so a later `close()` could `kill(-pid)` a stranger's group. The window is real: a tunnel that exits by itself mid-dictation is reaped, and stop time closes it seconds later.

The two rules are now paired rather than traded off:
- the exit handler only records the exit and wakes the waiter — the zombie it leaves is what keeps `-pid` meaning OUR group;
- teardown signals (SIGTERM → bounded wait → unconditional group SIGKILL) and **reaps last**;
- every later call sends nothing (`signalGroup` refuses once reaped, counted so a test can prove it).

Cost, stated in code and AGENTS: one zombie per open forward for the life of one dictation.

New tests: `testAForwardThatExitsOnItsOwnIsNotReapedUntilTeardown` (asserts the child still exists — pid reserved — before teardown, and is collected after) and `testNoGroupSignalIsSentAfterTheChildHasBeenReaped`. The round-3 stubborn-descendant tests still pass, which is the point: the fix preserves them rather than trading one for the other.

### Falsification

| Reverted | Failing tests |
|---|---|
| basename + installation-root clauses | `testASymlinkedImpostorInTheSameTreeIsRefused`, `testASymlinkPointingOUTSIDETheInstallationTreeIsRefused` |
| reap-in-the-exit-handler (round-3 behavior) | `testAForwardThatExitsOnItsOwnIsNotReapedUntilTeardown`, `testTerminatingAfterTheLeaderAlreadyExitedStillKillsTheGroup` |

### Rebase onto the merged campaign (#217, #220, #221)

The branch was `CONFLICTING` again — everything else in the campaign merged while this was in review — so it is rebased onto current `main` and **squashed to one commit** (four rounds of overlapping edits against three merged PRs meant resolving the same hunks four times; the per-round history is preserved in this PR body). Merge decisions worth reviewing:

- **#220's `SocketPaneScreenContext` supersedes my `HerdrPaneScreenContext`** — that file is deleted, and `.remoteHerdrPane` routes through the shared one (`paneText` sends it to `herdrPaneVisibleText`, since a remote herdr differs only in where its socket is). `socketPaneKey` returns the pane id for both herdr mechanisms.
- **The authorizer's exhaustive switch** (also #220's shape) now refuses `.herdrPane, .cmuxSurface, .remoteHerdrPane` in one case.
- **#221 defines its own `ClaudeRemoteForwardProcess`** for the inbound persistent forward, which collided with mine by name. My types are renamed herdr-specific (`ClaudeRemoteHerdrForwardProcess`, `…Spawning`, `…Spawner`, `…Workspaces`, `LiveHerdrForwardProcess`). The two forwards stay separate on purpose: #221's is a supervised long-lived RemoteForward carrying hook events IN; mine is a per-dictation LocalForward dialing OUT. Worth a follow-up once both have soaked — mine could ride #221's supervisor and drop the per-dictation handshake.
- The cmux and remote-herdr AGENTS bullets are both kept, in that order.

### Proof (on the pushed, rebased tree)

```
Test Suite 'localvoxtralPackageTests.xctest' passed
	 Executed 2573 tests, with 2 tests skipped and 0 failures (0 unexpected) in 91.998 (92.122) seconds
```
```
./scripts/remote-build.sh dogfood
	 Executed 57 tests, with 0 failures (0 unexpected) in 0.090 (0.094) seconds
```

Suite sizes: `RemoteHerdrJoinTests` 49, `SSHDestinationTTYProbeTests` 54, `ClaudeRemoteHerdrForwardTests` 23, `ClaudeRemoteHostAliasMatchingTests` 4.

Unchanged: no live remote-herdr end-to-end has been hand-run.


---

## Review round 5 — the reap itself can fail

Head `d3ccfe9`. Previous head `53536c7` had CI run [30906072902](https://github.com/T0mSIlver/localvoxtral/actions/runs/30906072902): **success**.

**MEDIUM — `reapIfNeeded()` committed `reaped = true` before calling `waitpid` and ignored its result.** Confirmed exactly as reported. A `waitpid` interrupted by a caught signal (`EINTR`) left the child a zombie while the state claimed it collected: the process source was cancelled, and every later teardown refused both to signal and to try again. The documented bound — *one zombie per open forward, for one dictation* — silently became one per dictation, forever.

The loop now:
- retries `EINTR`, because a caught signal is not an answer;
- commits on a successful collection, or on `ECHILD` — the kernel saying there is nothing left, which is definitive and also means the pid is no longer ours to signal;
- leaves **anything else unreaped on purpose**: the zombie is still ours, `-pid` still names our group, and the next teardown (or the handle's `deinit`) tries again rather than leaking it silently. That path logs loudly with the errno.

`waitpid` is now injected (same signature, same errno semantics), so these branches are testable against a REAL child in a REAL process group without arranging signal delivery.

New tests:
- `testAnInterruptedReapIsRetriedRatherThanClaimedAsDone` — two `EINTR`s then a real collection; asserts the retry happened and the child is actually gone.
- `testAFailedReapLeavesTheChildForALaterAttempt` — a hard failure leaves `hasBeenReaped == false`, the group still signallable, the child still present; the next teardown collects it.
- `testAnAlreadyCollectedChildIsDefinitivelyReaped` — `ECHILD` commits, and nothing signals the group afterwards.

**Falsification:** restoring the claim-then-call version fails `testAnInterruptedReapIsRetriedRatherThanClaimedAsDone` and `testAFailedReapLeavesTheChildForALaterAttempt` (3 assertions across the two).

AGENTS.md now states the bound and what preserves it, rather than the bound alone.

### Proof

```
Test Suite 'localvoxtralPackageTests.xctest' passed
	 Executed 2576 tests, with 2 tests skipped and 0 failures (0 unexpected) in 93.099 (93.228) seconds
```
```
./scripts/remote-build.sh dogfood
	 Executed 57 tests, with 0 failures (0 unexpected) in 0.128 (0.132) seconds
```

Suite sizes: `RemoteHerdrJoinTests` 49, `SSHDestinationTTYProbeTests` 54, `ClaudeRemoteHerdrForwardTests` 26, `ClaudeRemoteHostAliasMatchingTests` 4.

Unchanged: no live remote-herdr end-to-end has been hand-run.


---

## Review round 6 (opencode second opinion) — two mis-joins in ordinary usage

Head `4b5d371`. Previous head `d3ccfe9` had CI run [30909079612](https://github.com/T0mSIlver/localvoxtral/actions/runs/30909079612): **success**.

| # | Finding | Disposition |
|---|---|---|
| 1 | MAJOR — "only connection" does not prove this terminal displays herdr | **Fixed**: the ssh session must BE herdr. Limitation documented. |
| 2 | MAJOR — uniqueness scan skipped same-device non-foreground ssh | **Fixed**: every other ssh with a terminal counts. |
| 3 | MINOR — blocking `waitpid` on main-actor paths | **Fixed**: `WNOHANG` + bounded poll + background hand-off. |
| 4 | MINOR — `posix_spawn` setup return values dropped | **Fixed**: all checked; SETPGROUP failure refuses to spawn. |
| 5 | MINOR (UX) — plain sole ssh paid a forward before falling through | **Confirmed gone**, asserted in a test. |
| 6 | NIT — AGENTS listed a precondition the code only logged | **Fixed**: doc and code now say the same thing. |

### 1 — the arm now requires the ssh session to BE herdr

The empirical check first, as instructed. **herdr exposes no read-only attachment signal**, on the installed 0.7.5 socket schema (protocol 17) and in the 0.8.0 docs:

- the only `client.*` methods are `client.window_title.set` and `client.window_title.clear` — both MUTATIONS, so `no_foreground_client` is not an acceptable probe;
- `session.snapshot` returns `agents`, `focused_pane_id`, `focused_tab_id`, `focused_workspace_id`, `layouts`, `panes`, `protocol`, `tabs`, `version`, `workspaces` — no attachment field anywhere;
- the only `is_detached`/`detached_server_daemon` hits in the whole schema are a git worktree's HEAD state and a server capability flag.

So `indicatesHerdr` is promoted from corroboration to a **required** precondition, still matched on the first command token only, and still *alongside* uniqueness rather than instead of it — each covers what the other cannot. This reverses the round-3 instruction, as ruled.

**The accepted limitation, stated plainly:** the manual flow — `ssh host`, then type `herdr` — now gets **no context at all**, not even a marker fallback, because herdr intercepts OSC 2 so the marker never reaches the outer terminal. That is honest; a wrong join is worse than no join. The arm serves `ssh host herdr …` and the ssh that `herdr --remote` spawns.

Tests: `testAPlainSSHSessionNeverReachesTheArmEvenAsTheSoleConnection` (the detached/TTL repro — marker join, **zero** forwards, **zero** herdr queries) and `testTheManualHerdrFlowGetsNoContextAtAll` (no marker either ⇒ nil).

### 2 — uniqueness counts every other connection

The scan skipped `process.ttyDevice != device`, which contradicted its own doc. Now every ssh with a controlling terminal counts on any device; only the surface's own foreground processes are excluded (they ARE this connection), and TTY-less processes remain excluded because nobody can dictate into one — which is also what keeps our own `ssh -L` from counting against us.

Tests: `testASuspendedSSHOnTHISDeviceRemovesUniqueness` (the Ctrl+Z repro) and `testASecondForegroundSSHInAnotherPaneOfTheSameDeviceRemovesUniqueness`.

### 3 — the reap no longer blocks the main actor

`WNOHANG` with a bounded poll (the child has been SIGKILLed, so the first attempt normally collects it); if it is still not collectable, the wait is handed to a utility queue. The definitive-answer rule from round 5 is unchanged — `EINTR` retries, `ECHILD` commits, anything else stays unreaped for the next teardown.

### 4 — spawn setup is checked

`posix_spawn_file_actions_init/addopen` ×3, `posix_spawnattr_init/setflags/setpgroup` all checked. A failed SETPGROUP now throws `processGroupUnavailable` instead of spawning: silently sharing our own process group would make `kill(-pid)` hit nothing and leave an orphan ssh holding the tunnel — a failure that looks exactly like success until someone counts processes.

### 5 — the forward cost is gone

`testAPlainSSHSessionNeverReachesTheArmEvenAsTheSoleConnection` asserts `openCount == 0` and no pane queries, so the ordinary case (plain ssh to an enrolled host with a ≤4h-live herdr candidate) now costs nothing at all.

### Falsification

| Reverted | Failing tests |
|---|---|
| required argv-herdr → corroboration | `testAPlainSSHSessionNeverReachesTheArmEvenAsTheSoleConnection`, `testTheManualHerdrFlowGetsNoContextAtAll` (5 assertions) |
| uniqueness scope → same-device skip | `testASuspendedSSHOnTHISDeviceRemovesUniqueness`, `testASecondForegroundSSHInAnotherPaneOfTheSameDeviceRemovesUniqueness` |

### Proof

```
Test Suite 'localvoxtralPackageTests.xctest' passed
	 Executed 2580 tests, with 2 tests skipped and 0 failures (0 unexpected) in 93.125 (93.253) seconds
```
```
./scripts/remote-build.sh dogfood
	 Executed 57 tests, with 0 failures (0 unexpected) in 0.089 (0.093) seconds
```

Suite sizes: `RemoteHerdrJoinTests` 51, `SSHDestinationTTYProbeTests` 56, `ClaudeRemoteHerdrForwardTests` 26, `ClaudeRemoteHostAliasMatchingTests` 4.

Unchanged: no live remote-herdr end-to-end has been hand-run. With the arm now requiring `ssh host herdr …`, the hand test is specifically that invocation.


---

## Review round 7 — one root cause behind both majors, and the reap simplified

Head `413246e`. Previous head `4b5d371` had CI run [30910752887](https://github.com/T0mSIlver/localvoxtral/actions/runs/30910752887): **success**.

| # | Finding | Disposition |
|---|---|---|
| A | MAJOR ×2 — foreground ssh processes unioned instead of abstained | **Fixed**: exactly one foreground ssh, or abstain. |
| B | "no context at all" was false and had reached AGENTS.md | **Corrected** in doc, code and two stale comments. |
| C | Reap hand-off: infinite block, queue starvation, non-atomic signal, no production retry, no tests | **Simplified**: no blocking wait anywhere. |
| D | MINOR — spawn setup reported `errno` instead of the returned status | **Fixed**. |

### A — both majors were the same union

The probe combined every foreground ssh on the surface TTY: one destination set, `indicatesHerdr` OR-ed across them, all their pids excluded from uniqueness. So a foreground group holding both `ssh builder` and `ssh builder herdr` reported **unique AND is-herdr**, and the plain, visible connection borrowed the other process's herdr signal. A wrapper or pipeline launching several ssh children in one group is the same shape.

Now the rule is the arm's own: **exactly one foreground ssh, or abstain**. Nothing is unioned. Tests: `testTwoForegroundSSHClientsOnOneSurfaceAbstainEvenToTheSameHost`, `testAWrapperLaunchingSeveralSSHChildrenInOneGroupAbstains`.

### B — the honest statement of the manual-flow limitation

I claimed the manual flow gets "no context at all" and wrote that into AGENTS.md. **That was wrong.** A failed argv-herdr check returns `.notApplicable`, so the title-marker arm still runs — my own test shows a marker winning with `indicatesHerdr == false`; the manual-flow test only reached nil because it supplied no title.

Corrected everywhere: the manual flow gets **no herdr join**, and a marker an earlier session left in the outer title **can still win**. The concrete residual — run Claude in a plain ssh so its valid marker sits in the title, suspend it, start herdr by hand, dictate — is pre-existing (it is what remote sessions have always done) and cannot be closed from the surface, since nothing there reveals a remote herdr inside. Also fixed: the resolver comment that still said "either" condition suffices, and the probe comment that still called `indicatesHerdr` corroboration-only.

### C — the reap machinery, simplified rather than patched

**There is no `waitpid(…, 0)` left anywhere in this type.** WNOHANG only: one attempt on the caller's thread (after SIGKILL the child is normally collectable at once), the rest on a **per-handle** queue with a bounded budget, after which the child is left unreaped and logged loudly — which round 5's rule already permits. That deletes the infinite block and the shared-queue starvation together.

- **Atomic signal**: the `reaped` check and `kill(-pid)` now happen under one lock acquisition, closing the window where a background collection could commit `reaped` between them and let a concurrent teardown signal a reused pid.
- **Production retry**: `close()` now always calls `terminate()` (idempotent), so a later close or deinit can collect a child an earlier attempt failed on. Previously only a test calling `terminate()` twice could recover — production had no second attempt.
- **Main-actor cost**: one WNOHANG call plus the existing bounded SIGTERM grace; no polling loop on the caller's thread.
- New tests: `testANeverCollectableChildDoesNotBlockTeardown` (would hang rather than fail if this regressed), `testAChildThatIsNotReadyImmediatelyIsCollectedByTheHandOff`, `testClosingTheHandleAgainRetriesAFailedCollection`.

Three fixtures that asserted `terminations == 1` were updated: `terminate()` is now deliberately re-invoked as the retry path, so the contract is about EFFECTS (workspace removed exactly once, child terminated at all), not invocation counts.

**On whether to abandon posix_spawn for Foundation `Process` (asked directly, so answered directly):** I recommend keeping posix_spawn, now that the blocking wait is gone. The trade is descendant cleanup versus pid-lifecycle bookkeeping. Foundation reaps for us and removes this whole class of bug, but it cannot make the child a process-group leader, so `kill(-pid)` becomes unusable and a stubborn descendant survives — which is precisely what codex demanded be fixed in round 3. With `ForkAfterAuthentication=no`, `PermitLocalCommand=no` and `ControlPath=none` forced, the realistic descendant is a `ProxyCommand` helper, which normally exits on EOF; the group kill is insurance against the one that does not. What made the manual route expensive was the blocking wait and its shared queue, and both are now deleted rather than tuned. If you would still rather have Foundation's semantics, say so and I will do it as a single focused change — but I would be trading a proven guarantee for a bug class I believe is now closed.

### Falsification

| Reverted | Failing tests |
|---|---|
| union the foreground processes again | `testTwoForegroundSSHClientsOnOneSurfaceAbstainEvenToTheSameHost`, `testAWrapperLaunchingSeveralSSHChildrenInOneGroupAbstains` |
| blocking `waitpid` fallback | `testAChildThatIsNotReadyImmediatelyIsCollectedByTheHandOff`, `testAnInterruptedReapIsRetriedRatherThanClaimedAsDone` |

### Proof

```
Test Suite 'localvoxtralPackageTests.xctest' passed
	 Executed 2585 tests, with 2 tests skipped and 0 failures (0 unexpected) in 95.190 (95.332) seconds
```
```
./scripts/remote-build.sh dogfood
	 Executed 57 tests, with 0 failures (0 unexpected) in 0.114 (0.118) seconds
```

Suite sizes: `RemoteHerdrJoinTests` 51, `SSHDestinationTTYProbeTests` 58, `ClaudeRemoteHerdrForwardTests` 29, `ClaudeRemoteHostAliasMatchingTests` 4.

Unchanged: no live remote-herdr end-to-end has been hand-run. The hand test is `ssh host herdr …` (or `herdr --remote`) — the manual flow deliberately does not join.


---

## Review round 8 — the PID-reuse window closed for real

Head `22189a5`. Previous head `413246e` had CI run [30921858170](https://github.com/T0mSIlver/localvoxtral/actions/runs/30921858170): **success**.

**MAJOR — the TOCTOU had moved, not closed.** `collectOnce` ran `waitpid(WNOHANG)` outside the mutex and recorded `reaped` afterwards, while `signalGroup` consulted that state under it. So a background collection could release the pid, and before the flip landed a concurrent `terminate()` could take the lock, still read `reaped == false`, and `kill(-pid)` a group the kernel had already reissued. Two collectors could also enter `waitpid` for the same pid in that gap.

Fixed exactly as directed: **the reaped check, the `waitpid(WNOHANG)`, the flip it causes, and `kill(-pid)` all happen inside the one existing mutex.** No second lock, no "collecting" state machine, no lock-free path. That is only trivially correct because of the round-7 simplification — both syscalls are non-blocking, so the critical section contains no wait at all. Logging and `source.cancel()` stay outside it; neither participates in the invariant.

**Falsified with a real race.** `testAGroupSignalCannotRunWhileTheCollectionIsInFlight` parks a collection inside `waitpid` (via the injected shim) and proves a concurrent teardown cannot get through; moving the reap back outside the lock fails it. The first attempt at this test did NOT discriminate — a 0.3 s window was shorter than the broken path's own grace waits, so it passed against broken code. The window is now sized so the cases cannot be confused: a teardown that *does* get through costs at most two 0.25 s grace waits, well under the 1.2 s sampled, while the collection is parked for 3 s. Progress is observed through the second teardown's own completion, never through a counter that would itself take the mutex.

### The other three

- **MODERATE — the never-collectable test is genuine now.** The poll budget and interval are injectable, so `testTheCollectionBudgetIsExhaustedAndThenReleased` observes exhaustion (total attempts bounded by budget + 1, with a real lower bound proving the hand-off ran) *and* the release that follows (no further calls afterwards). The old test asserted immediately after scheduling the hand-off and verified none of that.
- **MINOR — the "no `waitpid(…, 0)` anywhere" claim was false** and is corrected: the tests used blocking cleanups. They now use a bounded WNOHANG helper, so it is true of them too — but the invariant that matters is the production one, stated precisely as **WNOHANG-only, per-handle queue, attempt-bounded**.
- **MINOR — two stale comments fixed:** a test still calling the argv signal "not required" (it is required), and the probe's `undeterminable` doc describing ambiguity as two ssh processes going to *different* places, which understated the rule that **any** two foreground ssh processes abstain, same destination included.

### Proof

```
Test Suite 'localvoxtralPackageTests.xctest' passed
	 Executed 2587 tests, with 2 tests skipped and 0 failures (0 unexpected) in 96.087 (96.236) seconds
```
```
./scripts/remote-build.sh dogfood
	 Executed 57 tests, with 0 failures (0 unexpected) in 0.112 (0.116) seconds
```

Suite sizes: `RemoteHerdrJoinTests` 51, `SSHDestinationTTYProbeTests` 58, `ClaudeRemoteHerdrForwardTests` 31, `ClaudeRemoteHostAliasMatchingTests` 4.

Unchanged: no live remote-herdr end-to-end has been hand-run. The hand test is `ssh host herdr …` (or `herdr --remote`); the manual flow deliberately does not join.


---

## Review round 8b — both teardown tests now observe what they claim

Head `e66492a`. Previous head `22189a5` had CI run [30925874222](https://github.com/T0mSIlver/localvoxtral/actions/runs/30925874222): **success**.

Two tests could pass for the wrong reason, which pins nothing. Both are fixed with deterministic seams rather than tighter sampling.

### 1 — budget exhaustion is observed, not inferred

The old test accepted any total from 2 through 6 and inferred "the chain finished" from three unchanged 10 ms samples plus a 50 ms wait. Both named false passes were real: one queued poll running with a busy utility queue passed while four polls were still scheduled, and a regression that gave up after a single hand-off poll passed too.

The process now announces the END of the collection effort — collected, definitively failed, or budget exhausted — and the test **waits** for that signal, then asserts **exactly** `attempts + 1` calls (one on the caller's thread plus the full queued budget: no fewer, so an early give-up fails; no more, so an over-running chain fails), and finally that nothing further is scheduled.

### 2 — the race test proves teardown B actually ran

The 1.2 s vs 3 s windows discriminate correctly once B is executing, but nothing established that it was. Under global-queue starvation B could stay queued for the whole interval and the test would report `.timedOut` even with the reap moved back outside the mutex.

A seam now fires whenever a teardown is about to need the state mutex, and the test blocks on that barrier before timing anything.

**The seam had to move, which is itself informative:** B blocks on `terminate()`'s own `reaped` guard — a lock acquisition *earlier* than `signalGroup` — so a signal-attempt-only seam never fired under the correct implementation. It now fires on `terminate()` entry (whose very next statement takes the lock) and before each group signal.

**Re-falsified with the barrier in place:** with the reap moved back outside the mutex, the barrier passes (B reaches the lock) and the *discrimination* assertion fails — B gets through and returns instead of blocking. That is precisely the failure the test exists for, and it is no longer confusable with "B never ran".

### Proof

```
Test Suite 'localvoxtralPackageTests.xctest' passed
	 Executed 2587 tests, with 2 tests skipped and 0 failures (0 unexpected) in 97.514 (97.652) seconds
```
```
./scripts/remote-build.sh dogfood
	 Executed 57 tests, with 0 failures (0 unexpected) in 0.090 (0.093) seconds
```

Suite sizes: `RemoteHerdrJoinTests` 51, `SSHDestinationTTYProbeTests` 58, `ClaudeRemoteHerdrForwardTests` 31, `ClaudeRemoteHostAliasMatchingTests` 4.

Unchanged: no live remote-herdr end-to-end has been hand-run. The hand test is `ssh host herdr …` (or `herdr --remote`); the manual flow deliberately does not join.
