### PR TITLE
Remote hooks: opt-in app-supervised persistent SSH forward (stacked on #217)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -429,7 +429,22 @@ Key subsystems:
     injection is impossible by construction; the listener re-validates and
     stores them as `ClaudeRemoteSessionEnvironment`, NEVER in
     `ClaudeSessionSnapshot.process` — see the remote-opacity tradeoff below.
-    After a
+    A per-host opt-in (`ClaudeRemoteForwardSupervisor` +
+    `ClaudeRemoteForwardCoordinator`, default off) lets the app hold that
+    forward itself with a supervised `ssh -N -R`, for sessions a harness
+    spawns on the host (t3 code, `claude remote-control`) that have no
+    interactive terminal to hold it. That process uses
+    `ExitOnForwardFailure=yes` — the opposite of the user's config block, on
+    purpose: it IS the nicety, so a bind it cannot get is the detection
+    signal. It never sets `ClearAllForwardings` (that clears the command-line
+    `-R` too, so the tunnel is never created — measured with `ssh -G`), and it
+    forces `ForkAfterAuthentication=no`, `ControlPath=none` and
+    `PermitLocalCommand=no` so the user's own ssh config cannot detach,
+    multiplex, or run a local command underneath it. A refused bind is
+    TERMINAL (no retry storm against a port somebody else holds); an ordinary
+    drop backs off exponentially, and a run that stays up long enough to
+    settle clears the failure count. Listener binds first, forwards start
+    second — always; stopping is the mirror. After a
     transport-level failure the shim backs off for 5 minutes (epoch stamp
     under `$XDG_RUNTIME_DIR`/`~/.cache`) for every event except
     `UserPromptSubmit`: each dial against a live forward with no app behind

--- a/Sources/localvoxtral/ClaudeContext/ClaudeIntegrationSettingsModel.swift
+++ b/Sources/localvoxtral/ClaudeContext/ClaudeIntegrationSettingsModel.swift
@@ -96,6 +96,16 @@ public final class ClaudeIntegrationSettingsModel {
         /// working one, and an answer with a test beats an answer with a
         /// formatter.
         public var statusText: String
+        /// Whether this host opted into the app-held SSH forward, and what that
+        /// forward is doing right now. Both live on the row so the view stays a
+        /// renderer: the toggle reads one Bool, the status line reads one
+        /// already-rendered sentence.
+        public var persistentForwardEnabled: Bool = false
+        public var forwardStatusText: String?
+        public var forwardIsFailure: Bool = false
+        /// A forward can only be offered where we know where to ssh. The label
+        /// is not a substitute for an alias (PR #197).
+        public var canHoldForward: Bool = false
     }
 
     /// "Last context: 2 min ago", from a clock the caller supplies.
@@ -363,6 +373,10 @@ public final class ClaudeIntegrationSettingsModel {
     /// do not exercise the cmux row — the row then reports that it cannot save,
     /// rather than silently pretending it did.
     private let cmuxPasswords: (any CmuxPasswordStoring)?
+    /// Owns the app-held ssh forwards. Optional for the same reason `listener`
+    /// is: previews and plugin-only tests have none, and the pane then simply
+    /// does not offer the toggle.
+    private let forwards: ClaudeRemoteForwardCoordinator?
 
     /// - Parameters:
     ///   - registry: nil when the host file could not be read at launch. The
@@ -404,7 +418,8 @@ public final class ClaudeIntegrationSettingsModel {
         // about per-Mac allocation describes exactly the pre-#215 setup, which
         // still works. Production passes the allocation.
         remoteForwardPort: UInt16 = ClaudeRemoteForwardPort.legacyPort,
-        cmuxPasswords: (any CmuxPasswordStoring)? = nil
+        cmuxPasswords: (any CmuxPasswordStoring)? = nil,
+        forwards: ClaudeRemoteForwardCoordinator? = nil
     ) {
         self.registry = registry
         self.listener = listener
@@ -415,6 +430,7 @@ public final class ClaudeIntegrationSettingsModel {
         self.now = now
         self.remoteForwardPort = remoteForwardPort
         self.cmuxPasswords = cmuxPasswords
+        self.forwards = forwards
         refreshHosts()
         refreshListenerStatus()
         // A presence check, not a read into any field: this is the one place
@@ -533,16 +549,27 @@ public final class ClaudeIntegrationSettingsModel {
         // One clock reading for the whole list, so two rows of the same age
         // cannot disagree about what "now" was.
         let timestamp = now()
-        hosts = (registry?.hosts() ?? []).map {
-            HostRow(
-                id: $0.id,
-                label: $0.label,
-                sshHostAlias: $0.sshHostAlias,
-                isRevoked: $0.isRevoked,
-                lastSeenAt: $0.lastSeenAt,
+        hosts = (registry?.hosts() ?? []).map { host in
+            let forwardState = forwards?.states[host.id]
+            return HostRow(
+                id: host.id,
+                label: host.label,
+                sshHostAlias: host.sshHostAlias,
+                isRevoked: host.isRevoked,
+                lastSeenAt: host.lastSeenAt,
                 statusText: Self.hostStatusText(
-                    isRevoked: $0.isRevoked, lastSeenAt: $0.lastSeenAt, now: timestamp
-                )
+                    isRevoked: host.isRevoked, lastSeenAt: host.lastSeenAt, now: timestamp
+                ),
+                persistentForwardEnabled: host.persistentForwardEnabled,
+                // Nil when this host has no forward running, which is not the
+                // same as a forward that is off: a row with the toggle off has
+                // nothing to report, and a status line saying so would be noise
+                // in a list of hosts.
+                forwardStatusText: forwardState?.text,
+                forwardIsFailure: forwardState?.isFailure ?? false,
+                canHoldForward: forwards != nil
+                    && !host.isRevoked
+                    && host.sshHostAlias.map(ClaudeRemoteEnrollmentService.isValidHostAlias) == true
             )
         }
         refreshRejectionHint()
@@ -689,6 +716,30 @@ public final class ClaudeIntegrationSettingsModel {
         } catch {
             presentRegistryFailure(error, verb: "rotate the token for")
         }
+    }
+
+    /// Turn the app-held forward on or off for one host.
+    ///
+    /// Order matters and is the same as everywhere else in this feature: the
+    /// registry is the source of truth, so it is written FIRST and the
+    /// coordinator reconciles against what was actually persisted. A coordinator
+    /// started before the write could be left running a forward for a flag that
+    /// never made it to disk.
+    public func setPersistentForward(_ enabled: Bool, hostID: String) {
+        guard let registry else { return }
+        do {
+            try registry.setPersistentForwardEnabled(enabled, hostID: hostID)
+            forwards?.reconcile()
+            refreshHosts()
+        } catch {
+            presentRegistryFailure(error, verb: enabled ? "enable the tunnel for" : "disable the tunnel for")
+        }
+    }
+
+    /// Retry one host's failed forward — the move after freeing the port.
+    public func retryPersistentForward(hostID: String) {
+        forwards?.retry(hostID: hostID)
+        refreshHosts()
     }
 
     public func revoke(hostID: String) async {
@@ -1085,7 +1136,19 @@ public final class ClaudeIntegrationSettingsModel {
         do {
             try listener.reconcile()
             listenerStatus = listener.isListening ? .listening(port: listener.boundPort) : .idle
+            // Listener FIRST, forwards second — always, including here. A
+            // forward opened before the bind terminates at a closed port: the
+            // hooks get connection-refused and fail open (silently), while
+            // ssh on this Mac prints `connect_to … failed.` into the user's
+            // remote terminal on every dial. The coordinator enforces the same
+            // rule itself by refusing to run while the listener is unbound;
+            // this ordering is what makes the enabled case take effect without
+            // a relaunch.
+            forwards?.reconcile()
         } catch {
+            // A listener that failed to bind must not leave forwards running
+            // into a dead port.
+            forwards?.stopAll()
             listenerStatus = Self.status(for: error, port: listener.boundPort)
             if presentAlert {
                 alert = DetailAlert(

--- a/Sources/localvoxtral/ClaudeContext/ClaudeIntegrationSettingsModel.swift
+++ b/Sources/localvoxtral/ClaudeContext/ClaudeIntegrationSettingsModel.swift
@@ -437,6 +437,27 @@ public final class ClaudeIntegrationSettingsModel {
         // the stored secret is touched at construction, and only to answer
         // "is one set".
         hasCmuxPassword = cmuxPasswords?.password() != nil
+        // The pane renders COPIES of the rows, so without this the tunnel
+        // status is whatever it happened to be when Settings appeared: the
+        // first "Connecting…" snapshot, frozen, while the real supervisor goes
+        // on to forward, retry, or fail where nobody can see it. Every
+        // transition now patches its row in place.
+        forwards?.onStateChange = { [weak self] hostID in
+            self?.applyForwardState(hostID: hostID)
+        }
+    }
+
+    /// Patch one row's forward fields from the coordinator.
+    ///
+    /// Deliberately NOT `refreshHosts()`: that re-reads the registry file and
+    /// re-derives every row's age text, which is a lot of work to do on a
+    /// transition that changed one string — and it would move the "last seen"
+    /// times under the user mid-read for a reason they never asked for.
+    private func applyForwardState(hostID: String) {
+        guard let index = hosts.firstIndex(where: { $0.id == hostID }) else { return }
+        let state = forwards?.states[hostID]
+        hosts[index].forwardStatusText = state?.text
+        hosts[index].forwardIsFailure = state?.isFailure ?? false
     }
 
     // MARK: - cmux socket
@@ -1133,6 +1154,16 @@ public final class ClaudeIntegrationSettingsModel {
 
     private func reconcileListener(presentAlert: Bool = true) {
         guard let listener else { return }
+        // Shutdown is the MIRROR of startup, and this is the shutdown case:
+        // revoking the last host is about to close the port, so the forwards
+        // into it come down first. Reversed — the documented order everywhere
+        // else in this feature — a hook arriving during `listener.stop()` rides
+        // a live tunnel into a socket that is already gone, and the Mac's ssh
+        // client answers it by printing `connect_to … failed.` into the user's
+        // remote terminal.
+        if listener.isListening, registry?.hasActiveHosts != true {
+            forwards?.stopAll()
+        }
         do {
             try listener.reconcile()
             listenerStatus = listener.isListening ? .listening(port: listener.boundPort) : .idle

--- a/Sources/localvoxtral/ClaudeContext/ClaudeRemoteEnrollmentService.swift
+++ b/Sources/localvoxtral/ClaudeContext/ClaudeRemoteEnrollmentService.swift
@@ -465,6 +465,11 @@ public struct ClaudeRemoteEnrollmentService: Sendable {
                 + "\(remoteForwardPort) on the remote and — because ExitOnForwardFailure is `no` — will "
                 + "connect anyway with no tunnel. The first session keeps the forward, and the verify "
                 + "step above is how you tell that apart from a broken setup.",
+            "Hook events only reach this Mac while something holds the tunnel — normally one of "
+                + "your own SSH sessions. Sessions a harness starts on the host (t3 code, "
+                + "`claude remote-control` services, any headless runner) have no such terminal, so "
+                + "their context goes nowhere. Turn on \"Keep the tunnel open\" in this host's row "
+                + "and the app holds the forward itself, reconnecting as needed.",
             "One-click setup connects with forwarding disabled (the tunnel belongs to your real "
                 + "sessions, not setup) and first resolves `claude` from common install locations — "
                 + "non-interactive SSH shells often lack the user-local PATH entries an interactive "

--- a/Sources/localvoxtral/ClaudeContext/ClaudeRemoteForwardCoordinator.swift
+++ b/Sources/localvoxtral/ClaudeContext/ClaudeRemoteForwardCoordinator.swift
@@ -24,6 +24,24 @@ public final class ClaudeRemoteForwardCoordinator {
     /// Per-host state for the pane, keyed by host id.
     public private(set) var states: [String: ClaudeRemoteForwardSupervisor.State] = [:]
 
+    /// Fired after `states` changes, naming the host that changed.
+    ///
+    /// Settings renders COPIES of these rows, so a dictionary the pane never
+    /// hears about is a pane frozen on whatever it sampled when it appeared —
+    /// which for a tunnel means it shows "Connecting…" forever and never the
+    /// `.forwarding`, `.retrying` or failure that followed. A push, not a
+    /// timer: transitions are rare and a Settings pane redrawing on a schedule
+    /// is a cost with no reader.
+    @ObservationIgnored public var onStateChange: (@MainActor (String) -> Void)?
+
+    /// Teardowns still draining, keyed by host. A replacement forward for the
+    /// same host waits on its entry: the remote port is not free until the old
+    /// ssh has actually exited, and dialing it early reports `portUnavailable`
+    /// at ourselves.
+    /// Identified rather than compared: `Task` is a struct, so "is this still
+    /// the teardown I was waiting on" needs a token of its own.
+    @ObservationIgnored private var pendingTeardowns: [String: (id: UUID, task: Task<Void, Never>)] = [:]
+
     @ObservationIgnored private let hosts: ClaudeRemoteHostRegistry
     @ObservationIgnored private let isListenerBound: @MainActor () -> Bool
     @ObservationIgnored private let remoteForwardPort: UInt16
@@ -97,12 +115,30 @@ public final class ClaudeRemoteForwardCoordinator {
                 )
             )
             supervisors[host.id] = supervisor
-            states[host.id] = supervisor.state
+            setState(supervisor.state, hostID: host.id)
             observe(supervisor, hostID: host.id)
             Log.claudeContext.info(
                 "Claude remote forward starting for host \(host.id, privacy: .public)"
             )
-            supervisor.start()
+            // Registered synchronously above (so nothing starts this host
+            // twice), started only once the previous ssh for the SAME host has
+            // finished dying. Toggling off and straight back on is the ordinary
+            // way a user hits this, and the old process still holds the remote
+            // bind for as long as it takes to honour SIGTERM.
+            if let draining = pendingTeardowns[host.id] {
+                let hostID = host.id
+                Task { @MainActor [weak self, weak supervisor] in
+                    await draining.task.value
+                    guard let self, self.pendingTeardowns[hostID]?.id == draining.id else { return }
+                    self.pendingTeardowns[hostID] = nil
+                    // Still the current supervisor for this host? A reconcile
+                    // during the wait may have retired it already.
+                    guard let supervisor, self.supervisors[hostID] === supervisor else { return }
+                    supervisor.start()
+                }
+            } else {
+                supervisor.start()
+            }
         }
     }
 
@@ -110,21 +146,35 @@ public final class ClaudeRemoteForwardCoordinator {
     /// retried — there is nothing to retry about a healthy one.
     public func retry(hostID: String) {
         supervisors[hostID]?.retry()
-        states[hostID] = supervisors[hostID]?.state
+        setState(supervisors[hostID]?.state, hostID: hostID)
     }
 
     public func stopAll() {
         for hostID in Array(supervisors.keys) { stop(hostID: hostID) }
     }
 
+    /// Every teardown still draining, for a caller that must not return until
+    /// the ssh processes are gone (app termination).
+    public var drainingTeardowns: [Task<Void, Never>] { pendingTeardowns.values.map(\.task) }
+
     private func stop(hostID: String) {
         supervisors[hostID]?.onStateChange = nil
         supervisors[hostID]?.stop()
+        // Keep the escalation, not the supervisor: the port stays bound until
+        // this finishes, and the next start for this host must wait for it.
+        if let teardown = supervisors[hostID]?.teardown {
+            pendingTeardowns[hostID] = (id: UUID(), task: teardown)
+        }
         supervisors[hostID] = nil
-        states[hostID] = nil
+        setState(nil, hostID: hostID)
         Log.claudeContext.info(
             "Claude remote forward stopped for host \(hostID, privacy: .public)"
         )
+    }
+
+    private func setState(_ state: ClaudeRemoteForwardSupervisor.State?, hostID: String) {
+        states[hostID] = state
+        onStateChange?(hostID)
     }
 
     /// Mirror one supervisor's state into `states` so the pane can render it.
@@ -136,7 +186,7 @@ public final class ClaudeRemoteForwardCoordinator {
     /// it a race. The supervisor calls this synchronously from `transition`.
     private func observe(_ supervisor: any ClaudeRemoteForwarding, hostID: String) {
         supervisor.onStateChange = { [weak self] state in
-            self?.states[hostID] = state
+            self?.setState(state, hostID: hostID)
         }
     }
 }

--- a/Sources/localvoxtral/ClaudeContext/ClaudeRemoteForwardCoordinator.swift
+++ b/Sources/localvoxtral/ClaudeContext/ClaudeRemoteForwardCoordinator.swift
@@ -1,0 +1,142 @@
+import Foundation
+import Observation
+
+/// Owns one `ClaudeRemoteForwardSupervisor` per host that opted in, and keeps
+/// that set equal to what the registry says.
+///
+/// **Ordering with `ClaudeRemoteListenerCoordinator` is fixed and load-bearing:
+/// the listener binds FIRST, forwards start second.** A forward is a pipe to
+/// the listener's port; started before the bind, it terminates at a closed port
+/// and every hook on the remote gets connection-refused — which fails open
+/// silently, and makes the Mac's ssh client print `connect_to … failed.` into
+/// the user's remote terminal on every dial. So this type refuses to run any
+/// forward while the listener is not bound, and the app calls
+/// `listenerCoordinator.reconcile()` before `forwards.reconcile()`.
+///
+/// The reverse order (stopping) is the mirror: revoking the last host stops the
+/// forwards and then closes the port.
+@MainActor
+@Observable
+public final class ClaudeRemoteForwardCoordinator {
+    public typealias MakeSupervisor = @MainActor (ClaudeRemoteForwardSupervisor.Configuration) ->
+        any ClaudeRemoteForwarding
+
+    /// Per-host state for the pane, keyed by host id.
+    public private(set) var states: [String: ClaudeRemoteForwardSupervisor.State] = [:]
+
+    @ObservationIgnored private let hosts: ClaudeRemoteHostRegistry
+    @ObservationIgnored private let isListenerBound: @MainActor () -> Bool
+    @ObservationIgnored private let remoteForwardPort: UInt16
+    @ObservationIgnored private let listenerPort: UInt16
+    @ObservationIgnored private let makeSupervisor: MakeSupervisor
+    @ObservationIgnored private var supervisors: [String: any ClaudeRemoteForwarding] = [:]
+
+    public init(
+        hosts: ClaudeRemoteHostRegistry,
+        remoteForwardPort: UInt16,
+        listenerPort: UInt16 = ClaudeRemoteListenerLimits.default.port,
+        isListenerBound: @escaping @MainActor () -> Bool,
+        makeSupervisor: MakeSupervisor? = nil
+    ) {
+        self.hosts = hosts
+        self.remoteForwardPort = remoteForwardPort
+        self.listenerPort = listenerPort
+        self.isListenerBound = isListenerBound
+        self.makeSupervisor = makeSupervisor ?? { configuration in
+            ClaudeRemoteForwardSupervisor(
+                configuration: configuration,
+                launch: { try ClaudeRemoteForwardLiveProcess(argv: $0.argv) }
+            )
+        }
+    }
+
+    /// Which hosts should have a live forward right now.
+    ///
+    /// Three conditions, each of which has to hold: opted in, not revoked, and
+    /// an alias we were actually told. A host with no alias on file is not
+    /// guessable — the label is a different field and can name a different
+    /// machine (PR #197) — so it cannot be forwarded, only re-enrolled.
+    private func eligibleHosts() -> [ClaudeRemoteHost] {
+        hosts.hosts().filter { host in
+            host.persistentForwardEnabled
+                && !host.isRevoked
+                && host.sshHostAlias.map(ClaudeRemoteEnrollmentService.isValidHostAlias) == true
+        }
+    }
+
+    /// Bring the running set in line with the registry. Idempotent: calling it
+    /// twice starts nothing twice, which is what lets every mutation path call
+    /// it unconditionally.
+    public func reconcile() {
+        guard isListenerBound() else {
+            if !supervisors.isEmpty {
+                Log.claudeContext.info(
+                    "Claude remote forwards stopping: listener is not bound"
+                )
+                stopAll()
+            }
+            return
+        }
+
+        let eligible = eligibleHosts()
+        let wanted = Set(eligible.map(\.id))
+
+        // Snapshot the keys: `stop` mutates the dictionary being iterated.
+        for hostID in Array(supervisors.keys) where !wanted.contains(hostID) {
+            stop(hostID: hostID)
+        }
+
+        for host in eligible {
+            guard supervisors[host.id] == nil, let alias = host.sshHostAlias else { continue }
+            let supervisor = makeSupervisor(
+                ClaudeRemoteForwardSupervisor.Configuration(
+                    hostID: host.id,
+                    sshHostAlias: alias,
+                    remoteForwardPort: remoteForwardPort,
+                    listenerPort: listenerPort
+                )
+            )
+            supervisors[host.id] = supervisor
+            states[host.id] = supervisor.state
+            observe(supervisor, hostID: host.id)
+            Log.claudeContext.info(
+                "Claude remote forward starting for host \(host.id, privacy: .public)"
+            )
+            supervisor.start()
+        }
+    }
+
+    /// The user's move after freeing a held port. Only a failed forward can be
+    /// retried — there is nothing to retry about a healthy one.
+    public func retry(hostID: String) {
+        supervisors[hostID]?.retry()
+        states[hostID] = supervisors[hostID]?.state
+    }
+
+    public func stopAll() {
+        for hostID in Array(supervisors.keys) { stop(hostID: hostID) }
+    }
+
+    private func stop(hostID: String) {
+        supervisors[hostID]?.onStateChange = nil
+        supervisors[hostID]?.stop()
+        supervisors[hostID] = nil
+        states[hostID] = nil
+        Log.claudeContext.info(
+            "Claude remote forward stopped for host \(hostID, privacy: .public)"
+        )
+    }
+
+    /// Mirror one supervisor's state into `states` so the pane can render it.
+    ///
+    /// A direct callback, not observation tracking: the pane must show the
+    /// state the supervisor is IN, and `withObservationTracking`'s `onChange`
+    /// fires before the new value is written — which makes every mirrored value
+    /// one transition stale unless you hop a turn, and makes every test about
+    /// it a race. The supervisor calls this synchronously from `transition`.
+    private func observe(_ supervisor: any ClaudeRemoteForwarding, hostID: String) {
+        supervisor.onStateChange = { [weak self] state in
+            self?.states[hostID] = state
+        }
+    }
+}

--- a/Sources/localvoxtral/ClaudeContext/ClaudeRemoteForwardLiveProcess.swift
+++ b/Sources/localvoxtral/ClaudeContext/ClaudeRemoteForwardLiveProcess.swift
@@ -1,0 +1,149 @@
+import Foundation
+import Synchronization
+
+/// The production `ClaudeRemoteForwardProcess`: a real `ssh -N -R`.
+///
+/// Everything interesting about this type is in what it guarantees to the
+/// supervisor, because the supervisor's logic is only sound if these hold:
+///
+/// 1. `standardErrorLines` FINISHES when the process exits. The supervisor
+///    awaits that finish before it reads the exit status, so a stream that
+///    never ends is a supervisor that never restarts.
+/// 2. stderr is read with `POSIXPipeRead`, never `FileHandle.availableData` —
+///    the latter raises an uncatchable ObjC exception on a descriptor error and
+///    aborts the app (field crash, PR #60).
+/// 3. `terminate()` is idempotent and safe after exit.
+///
+/// No token is involved on this path, so there is nothing here to redact.
+final class ClaudeRemoteForwardLiveProcess: ClaudeRemoteForwardProcess, @unchecked Sendable {
+    private let process: Process
+    private let stderrPipe: Pipe
+    private let continuation: AsyncStream<String>.Continuation
+    let standardErrorLines: AsyncStream<String>
+
+    /// Status and waiters under ONE lock. Two locks would leave a window in
+    /// which `waitUntilExit` sees no status, the termination handler drains an
+    /// empty waiter list, and the waiter registered a microsecond later is
+    /// never resumed — a supervisor hung forever on a process that already
+    /// exited.
+    private struct ExitState {
+        var status: Int32?
+        var waiters: [CheckedContinuation<Int32, Never>] = []
+    }
+
+    private let exitState = Mutex(ExitState())
+    private let partialLine = Mutex<String>("")
+    private let descriptor: Int32
+
+    /// - Parameter argv: complete, including `ssh` at index 0 (the shape
+    ///   `Configuration.argv` produces and the enrollment service already uses).
+    init(argv: [String], sshExecutableURL: URL = URL(fileURLWithPath: "/usr/bin/ssh")) throws {
+        precondition(!argv.isEmpty)
+        let (stream, continuation) = AsyncStream<String>.makeStream(of: String.self)
+        standardErrorLines = stream
+        self.continuation = continuation
+
+        process = Process()
+        process.executableURL = sshExecutableURL
+        process.arguments = Array(argv.dropFirst())
+        stderrPipe = Pipe()
+        process.standardError = stderrPipe
+        // ssh -N produces no stdout; discarding it keeps the app out of the
+        // business of draining a pipe nobody reads (a full pipe would block
+        // the child forever).
+        process.standardOutput = FileHandle.nullDevice
+        process.standardInput = FileHandle.nullDevice
+
+        let stderrDescriptor = stderrPipe.fileHandleForReading.fileDescriptor
+        descriptor = stderrDescriptor
+        stderrPipe.fileHandleForReading.readabilityHandler = { [weak self] handle in
+            let data = POSIXPipeRead.nextChunk(fromDescriptor: stderrDescriptor)
+            guard !data.isEmpty else {
+                handle.readabilityHandler = nil
+                return
+            }
+            self?.ingest(data)
+        }
+
+        process.terminationHandler = { [weak self] finished in
+            self?.finish(status: finished.terminationStatus)
+        }
+
+        do {
+            try process.run()
+        } catch {
+            continuation.finish()
+            throw error
+        }
+        Log.claudeContext.info(
+            "Claude remote forward spawned: \(argv.joined(separator: " "), privacy: .public)"
+        )
+    }
+
+    private func ingest(_ data: Data) {
+        guard let text = String(data: data, encoding: .utf8) else { return }
+        let lines: [String] = partialLine.withLock { partial in
+            var buffer = partial + text
+            var complete: [String] = []
+            while let newline = buffer.firstIndex(of: "\n") {
+                complete.append(String(buffer[buffer.startIndex..<newline]))
+                buffer = String(buffer[buffer.index(after: newline)...])
+            }
+            partial = buffer
+            return complete
+        }
+        for line in lines where !line.isEmpty {
+            continuation.yield(line)
+        }
+    }
+
+    /// Called once, from the termination handler. Flushes a trailing partial
+    /// line — OpenSSH's forwarding warning is the LAST thing it prints before
+    /// exiting under `ExitOnForwardFailure=yes`, so dropping an unterminated
+    /// tail would lose exactly the line that matters.
+    private func finish(status: Int32) {
+        // Drain what the pipe still holds BEFORE closing the stream. The
+        // termination handler can fire before the readability handler has been
+        // scheduled for the last chunk, and that last chunk is precisely
+        // `remote port forwarding failed` — the line ssh prints immediately
+        // before exiting. Losing it would turn a diagnosable refusal into an
+        // ordinary crash-restart loop. `POSIXPipeRead` returns empty on EOF and
+        // on any error, so this terminates either way.
+        stderrPipe.fileHandleForReading.readabilityHandler = nil
+        while true {
+            let remaining = POSIXPipeRead.nextChunk(fromDescriptor: descriptor)
+            if remaining.isEmpty { break }
+            ingest(remaining)
+        }
+        let tail = partialLine.withLock { partial -> String in
+            defer { partial = "" }
+            return partial
+        }
+        if !tail.isEmpty { continuation.yield(tail) }
+        continuation.finish()
+        let waiters = exitState.withLock { state -> [CheckedContinuation<Int32, Never>] in
+            state.status = status
+            defer { state.waiters = [] }
+            return state.waiters
+        }
+        for waiter in waiters { waiter.resume(returning: status) }
+    }
+
+    func waitUntilExit() async -> Int32 {
+        await withCheckedContinuation { continuation in
+            // Check-and-register in ONE critical section, so an exit that lands
+            // between the two cannot strand this waiter.
+            let alreadyExited = exitState.withLock { state -> Int32? in
+                if let status = state.status { return status }
+                state.waiters.append(continuation)
+                return nil
+            }
+            if let alreadyExited { continuation.resume(returning: alreadyExited) }
+        }
+    }
+
+    func terminate() {
+        guard process.isRunning else { return }
+        process.terminate()
+    }
+}

--- a/Sources/localvoxtral/ClaudeContext/ClaudeRemoteForwardLiveProcess.swift
+++ b/Sources/localvoxtral/ClaudeContext/ClaudeRemoteForwardLiveProcess.swift
@@ -143,7 +143,39 @@ final class ClaudeRemoteForwardLiveProcess: ClaudeRemoteForwardProcess, @uncheck
     }
 
     func terminate() {
+        signal(SIGTERM)
+    }
+
+    func forceTerminate() {
+        signal(SIGKILL)
+    }
+
+    /// Signal the child — its whole process GROUP when it has one of its own,
+    /// otherwise just the child.
+    ///
+    /// The conditional is not caution for its own sake, it is the difference
+    /// between killing ssh and killing localvoxtral. `Process` gives a child
+    /// OUR process group unless something changes it, and `kill(-pgid, …)` on
+    /// that shared group signals this app (and every other child it has
+    /// spawned: both MLX helpers). Foundation exposes no way to make the child
+    /// a group leader, so instead of assuming either way this asks the kernel
+    /// at signal time: a group of its own gets the group signal — which is what
+    /// reaches any `ProxyCommand`/`askpass` helper ssh started — and a shared
+    /// group gets a signal aimed at the one pid we know is ours to end.
+    ///
+    /// `ForkAfterAuthentication=no` and `ControlPath=none` in the argv are the
+    /// other half: they stop ssh from leaving descendants that outlive the pid
+    /// we track in the first place.
+    private func signal(_ signalNumber: Int32) {
         guard process.isRunning else { return }
-        process.terminate()
+        let pid = process.processIdentifier
+        guard pid > 0 else { return }
+        let childGroup = getpgid(pid)
+        let ownGroup = getpgid(0)
+        if childGroup > 0, childGroup != ownGroup {
+            _ = Darwin.kill(-childGroup, signalNumber)
+        } else {
+            _ = Darwin.kill(pid, signalNumber)
+        }
     }
 }

--- a/Sources/localvoxtral/ClaudeContext/ClaudeRemoteForwardSupervisor.swift
+++ b/Sources/localvoxtral/ClaudeContext/ClaudeRemoteForwardSupervisor.swift
@@ -1,5 +1,6 @@
 import Foundation
 import Observation
+import Synchronization
 
 /// One long-lived `ssh -N -R` process, as a seam.
 ///
@@ -17,8 +18,18 @@ public protocol ClaudeRemoteForwardProcess: Sendable {
     var standardErrorLines: AsyncStream<String> { get }
     /// Resumes with the exit status once the process ends.
     func waitUntilExit() async -> Int32
-    /// Ask it to stop. Must be safe to call more than once, and after exit.
+    /// Ask it to stop (SIGTERM). Must be safe to call more than once, and after
+    /// exit.
     func terminate()
+    /// Make it stop (SIGKILL), for a process that ignored `terminate()`. Same
+    /// safety contract: idempotent, and harmless after exit.
+    ///
+    /// Separate from `terminate()` because the supervisor must be able to
+    /// ESCALATE. An ssh that is wedged — a dead network with unacked data in
+    /// flight, a host that stopped answering — holds the remote bind and this
+    /// Mac's file descriptors, and asking it politely a second time achieves
+    /// nothing.
+    func forceTerminate()
 }
 
 /// Keeps one enrolled host's SSH `RemoteForward` up, without an interactive
@@ -42,10 +53,24 @@ public protocol ClaudeRemoteForwardProcess: Sendable {
 ///   connection storm, an auth-log full of sessions, and possibly a fail2ban
 ///   ban — all while the user is told nothing. One clear failed state, with the
 ///   fix in it, beats an infinite retry that hides the cause.
-/// * `ClearAllForwardings=yes` before `-R`: the ssh config block for this alias
-///   already declares a `RemoteForward`, and inheriting it would make this
-///   process request the port TWICE — the second request failing, which under
-///   `ExitOnForwardFailure=yes` kills the very process meant to hold it.
+/// * NO `ClearAllForwardings`. It was here to stop this process inheriting the
+///   alias's own `RemoteForward` and requesting the port twice — and it does
+///   that, but it ALSO clears the `-R` given on the command line, which is the
+///   only forward this process exists to create. `ssh -G` is the instrument:
+///   with the flag, the effective config contains `clearallforwardings yes`
+///   and NO `remoteforward` line at all, so the supervised ssh connects,
+///   survives its settle window, reports "Tunnel up." and forwards nothing.
+///   The doubling it was guarding against does not happen anyway: an
+///   IDENTICAL forward on the command line and in the config collapses to one
+///   `remoteforward` entry (measured). What does survive is a forward for a
+///   DIFFERENT port left in an old config block — see `staleConfiguredForward`.
+/// * Containment, because this connection is made with the user's ssh config
+///   and any of it can be set per-Host: `ForkAfterAuthentication=no` (a
+///   backgrounded ssh leaves the tracked `Process`, keeps the remote bind and
+///   its stderr pipe, and can be killed by nothing we hold), `ControlPath=none`
+///   (a multiplexed session can outlive the process that started it, and
+///   `ControlPersist` is designed to), `PermitLocalCommand=no` (an inherited
+///   `LocalCommand` would run on this Mac on every reconnect).
 /// What the coordinator actually depends on.
 ///
 /// A protocol so a test can drive the coordinator's decisions — which hosts get
@@ -55,6 +80,9 @@ public protocol ClaudeRemoteForwardProcess: Sendable {
 public protocol ClaudeRemoteForwarding: AnyObject {
     var state: ClaudeRemoteForwardSupervisor.State { get }
     var onStateChange: (@MainActor (ClaudeRemoteForwardSupervisor.State) -> Void)? { get set }
+    /// The in-flight SIGTERM→SIGKILL escalation, if `stop()` started one.
+    /// Whoever dials this host's port next has to wait for it.
+    var teardown: Task<Void, Never>? { get }
     func start()
     func stop()
     func retry()
@@ -70,6 +98,13 @@ public final class ClaudeRemoteForwardSupervisor: ClaudeRemoteForwarding {
         case retrying(attempt: Int)
         /// The remote refused the bind: someone else holds the port.
         case portUnavailable
+        /// The remote refused a bind for a port this supervisor never asked
+        /// for — so the alias's ssh config block still declares an old
+        /// `RemoteForward`, which we inherit and `ExitOnForwardFailure=yes`
+        /// then kills us over. Distinct from `portUnavailable` because the fix
+        /// is the opposite: nothing on the host needs freeing, the user's own
+        /// config needs updating.
+        case staleConfiguredForward(port: UInt16)
         case failed(summary: String)
 
         /// One short sentence for the pane (owner rule: no long text in the
@@ -81,7 +116,13 @@ public final class ClaudeRemoteForwardSupervisor: ClaudeRemoteForwarding {
             case .connecting: return "Connecting…"
             case .forwarding: return "Tunnel up."
             case .retrying(let attempt): return "Reconnecting (attempt \(attempt))."
-            case .portUnavailable: return "Port already held on the host."
+            // Names the thing to close. The overwhelmingly common holder is an
+            // ssh session from THIS Mac — the user's own terminal, or one a
+            // harness left behind — and the previous copy ("Port already held
+            // on the host.") left them with a Retry button that could only
+            // fail again. Still one sentence, by the popover rule.
+            case .portUnavailable: return "Port held — close ssh sessions to that host."
+            case .staleConfiguredForward: return "Old RemoteForward in ~/.ssh/config blocks this."
             case .failed: return "Tunnel stopped."
             }
         }
@@ -89,7 +130,7 @@ public final class ClaudeRemoteForwardSupervisor: ClaudeRemoteForwarding {
         public var isFailure: Bool {
             switch self {
             case .stopped, .connecting, .forwarding, .retrying: return false
-            case .portUnavailable, .failed: return true
+            case .portUnavailable, .staleConfiguredForward, .failed: return true
             }
         }
     }
@@ -110,6 +151,24 @@ public final class ClaudeRemoteForwardSupervisor: ClaudeRemoteForwarding {
         /// allowed to call the tunnel up. Measured on the supervisor's injected
         /// clock, never the wall.
         public var settleDelay: Duration
+        /// How long a connection must have been UP for its eventual drop to
+        /// count as an isolated incident rather than part of a run of
+        /// failures.
+        ///
+        /// Deliberately much longer than `settleDelay`. Surviving the settle
+        /// window only means ssh did not refuse the bind; a tunnel that
+        /// connects, holds for three seconds and dies, over and over, is
+        /// exactly the reconnect storm `maxConsecutiveFailures` exists to stop,
+        /// and treating each of those as "healthy" would make the cap
+        /// unreachable.
+        public var healthyUptime: Duration
+        /// How long a process gets to honour SIGTERM before SIGKILL. Measured
+        /// on the injected clock.
+        public var terminationGrace: Duration
+        /// How long to keep watching after SIGKILL before giving up and saying
+        /// so in the log. A process in an uninterruptible wait can outlive even
+        /// this; pretending otherwise is how a teardown blocks forever.
+        public var killGrace: Duration
 
         public init(
             hostID: String,
@@ -117,7 +176,10 @@ public final class ClaudeRemoteForwardSupervisor: ClaudeRemoteForwarding {
             remoteForwardPort: UInt16,
             listenerPort: UInt16,
             maxConsecutiveFailures: Int = 5,
-            settleDelay: Duration = .seconds(2)
+            settleDelay: Duration = .seconds(2),
+            healthyUptime: Duration = .seconds(60),
+            terminationGrace: Duration = .seconds(2),
+            killGrace: Duration = .seconds(1)
         ) {
             self.hostID = hostID
             self.sshHostAlias = sshHostAlias
@@ -125,6 +187,9 @@ public final class ClaudeRemoteForwardSupervisor: ClaudeRemoteForwarding {
             self.listenerPort = listenerPort
             self.maxConsecutiveFailures = maxConsecutiveFailures
             self.settleDelay = settleDelay
+            self.healthyUptime = healthyUptime
+            self.terminationGrace = terminationGrace
+            self.killGrace = killGrace
         }
 
         /// The complete argv. No token is involved anywhere on this path — the
@@ -140,7 +205,12 @@ public final class ClaudeRemoteForwardSupervisor: ClaudeRemoteForwarding {
                 "ssh", "-N",
                 "-o", "BatchMode=yes",
                 "-o", "ExitOnForwardFailure=yes",
-                "-o", "ClearAllForwardings=yes",
+                // Containment — see the type comment. These are forced rather
+                // than assumed because every one of them is settable per-Host
+                // in the config this connection reads.
+                "-o", "ForkAfterAuthentication=no",
+                "-o", "ControlPath=none",
+                "-o", "PermitLocalCommand=no",
                 "-o", "ServerAliveInterval=30",
                 "-o", "ServerAliveCountMax=3",
                 "-R", "\(remoteForwardPort):127.0.0.1:\(listenerPort)",
@@ -151,6 +221,7 @@ public final class ClaudeRemoteForwardSupervisor: ClaudeRemoteForwarding {
 
     public typealias Launch = @MainActor (Configuration) throws -> any ClaudeRemoteForwardProcess
     public typealias SleepClosure = @Sendable (Duration) async throws -> Void
+    public typealias NowClosure = @MainActor () -> Date
 
     public private(set) var state: State = .stopped
 
@@ -162,26 +233,39 @@ public final class ClaudeRemoteForwardSupervisor: ClaudeRemoteForwarding {
     @ObservationIgnored public let configuration: Configuration
     @ObservationIgnored private let launch: Launch
     @ObservationIgnored private let sleepFor: SleepClosure
+    @ObservationIgnored private let now: NowClosure
     @ObservationIgnored private var superviseTask: Task<Void, Never>?
     @ObservationIgnored private var currentProcess: (any ClaudeRemoteForwardProcess)?
     @ObservationIgnored private var stoppingIntentionally = false
-    /// Bumped per launch. The settle task carries the generation it belongs to
-    /// so a stale one cannot report a dead process as up.
+    /// Bumped per launch AND the moment a process is known dead. The settle
+    /// task carries the generation it belongs to, so a stale one cannot report
+    /// a dead process as up.
     @ObservationIgnored private var runGeneration = 0
+    @ObservationIgnored private var settleTask: Task<Void, Never>?
+    /// Consecutive failures, on the INSTANCE rather than in `supervise()`, so
+    /// the settle task can clear it the moment a connection proves healthy.
+    @ObservationIgnored private var consecutiveFailures = 0
+    /// The in-flight SIGTERM→SIGKILL escalation, if any. Exposed so whoever
+    /// replaces this supervisor can wait for the port to actually be released
+    /// before dialing it again.
+    @ObservationIgnored public private(set) var teardown: Task<Void, Never>?
 
     public init(
         configuration: Configuration,
         launch: @escaping Launch,
-        sleepFor: @escaping SleepClosure = { try await Task.sleep(for: $0) }
+        sleepFor: @escaping SleepClosure = { try await Task.sleep(for: $0) },
+        now: @escaping NowClosure = { Date() }
     ) {
         self.configuration = configuration
         self.launch = launch
         self.sleepFor = sleepFor
+        self.now = now
     }
 
     public func start() {
         guard superviseTask == nil else { return }
         stoppingIntentionally = false
+        consecutiveFailures = 0
         Log.claudeContext.info(
             "Claude remote forward start requested for host \(self.configuration.hostID, privacy: .public) port \(self.configuration.remoteForwardPort, privacy: .public)"
         )
@@ -199,22 +283,105 @@ public final class ClaudeRemoteForwardSupervisor: ClaudeRemoteForwarding {
         )
         superviseTask?.cancel()
         superviseTask = nil
-        currentProcess?.terminate()
+        // Any settle window belongs to a process we are about to kill.
+        invalidateSettleWindow()
+        let process = currentProcess
         currentProcess = nil
         transition(to: .stopped)
+        guard let process else {
+            teardown = nil
+            return
+        }
+        // SIGTERM goes NOW, synchronously. Deferring it into the task below
+        // would put a scheduling hop between the user's click and the signal,
+        // for no benefit: it is the WAITING that has to be asynchronous.
+        process.terminate()
+        // Escalation runs on its own task because `stop()` has synchronous
+        // callers (app termination, the pane's toggle) and none of them may
+        // block the main thread for the grace window. What they CAN do is wait
+        // on `teardown` — and the coordinator does, before replacing this
+        // supervisor with one that dials the same port.
+        teardown = Task { @MainActor [weak self] in
+            await self?.tearDown(process)
+        }
+    }
+
+    /// SIGTERM, bounded wait, SIGKILL, bounded wait. No unbounded wait
+    /// anywhere: an ssh wedged on a dead network is exactly the case this
+    /// exists for, and a teardown that waits forever for it is a quit that
+    /// hangs.
+    /// SIGTERM has ALREADY been sent by `stop()` — sending it again here would
+    /// be a second signal for the same request, which the fake counts and a
+    /// real ssh would simply be handed twice.
+    private func tearDown(_ process: any ClaudeRemoteForwardProcess) async {
+        if await waitForExit(of: process, within: configuration.terminationGrace) { return }
+        Log.claudeContext.error(
+            "Claude remote forward for host \(self.configuration.hostID, privacy: .public) ignored SIGTERM; escalating to SIGKILL"
+        )
+        process.forceTerminate()
+        if await waitForExit(of: process, within: configuration.killGrace) { return }
+        // Nothing left to try. Say so loudly: from here the remote bind is held
+        // by a process this app can no longer end, and the next start will
+        // report the port as unavailable for a reason that IS this Mac.
+        Log.claudeContext.error(
+            "Claude remote forward for host \(self.configuration.hostID, privacy: .public) survived SIGKILL; the remote port may stay bound"
+        )
+    }
+
+    /// True when the process exited within the limit. The loser of the race is
+    /// abandoned rather than awaited — a task group would wait for BOTH
+    /// children, which for a process that never exits is the hang this whole
+    /// method exists to avoid.
+    private func waitForExit(
+        of process: any ClaudeRemoteForwardProcess, within limit: Duration
+    ) async -> Bool {
+        let resolved = Mutex(false)
+        return await withCheckedContinuation { continuation in
+            @Sendable func resume(_ exited: Bool) {
+                let isFirst = resolved.withLock { done -> Bool in
+                    if done { return false }
+                    done = true
+                    return true
+                }
+                if isFirst { continuation.resume(returning: exited) }
+            }
+            Task {
+                _ = await process.waitUntilExit()
+                resume(true)
+            }
+            Task { [sleepFor] in
+                try? await sleepFor(limit)
+                resume(false)
+            }
+        }
     }
 
     /// The user's move after freeing the port. Clears a terminal state and
     /// tries again — nothing else does, on purpose.
+    ///
+    /// It waits for the teardown it just started: restarting while the old ssh
+    /// still holds the remote bind is how a healthy host reports
+    /// `portUnavailable` at ITSELF.
     public func retry() {
         guard state.isFailure else { return }
         stop()
-        start()
+        let pending = teardown
+        Task { @MainActor [weak self] in
+            await pending?.value
+            self?.start()
+        }
+    }
+
+    /// Make any in-flight settle window inert: cancel it AND move the
+    /// generation past it. Cancellation alone loses the race whenever the task
+    /// is already awake past its sleep.
+    private func invalidateSettleWindow() {
+        settleTask?.cancel()
+        settleTask = nil
+        runGeneration += 1
     }
 
     private func supervise() async {
-        var consecutiveFailures = 0
-
         while !stoppingIntentionally, !Task.isCancelled {
             let process: any ClaudeRemoteForwardProcess
             do {
@@ -228,6 +395,7 @@ public final class ClaudeRemoteForwardSupervisor: ClaudeRemoteForwarding {
                 return
             }
             currentProcess = process
+            let startedAt = now()
 
             // ssh with -N says nothing on success, so "forwarding" is the
             // absence of a complaint, not a positive ack. There is no ack to
@@ -259,23 +427,44 @@ public final class ClaudeRemoteForwardSupervisor: ClaudeRemoteForwarding {
                 else { return }
                 self.transitionIfNeeded(to: .forwarding)
             }
-            defer { settle.cancel() }
+            settleTask = settle
             // stderr FIRST, exit status second, and never the other way round:
             // `remote port forwarding failed` arrives microseconds before the
             // exit it causes, so reading the status first and then cancelling
             // the watcher would drop the one line that explains everything.
             // The contract a `ClaudeRemoteForwardProcess` owes is therefore
             // that its stream finishes when the process does.
-            let sawBindFailure = await watcher.value ?? false
+            let bindFailure = await watcher.value ?? nil
             let status = await process.waitUntilExit()
             currentProcess = nil
+            // The process is DEAD. Retire its settle window here, while this
+            // iteration's scope is still open — not in a `defer` that runs
+            // only once the loop leaves the body, because the very next thing
+            // this loop does is park on a backoff that keeps the scope open.
+            // That parked window was the bug: the settle woke up carrying a
+            // generation nothing had advanced, and painted "Tunnel up." over
+            // the `.retrying` of a process that had already exited.
+            invalidateSettleWindow()
 
             guard !stoppingIntentionally, !Task.isCancelled else {
                 superviseTask = nil
                 return
             }
 
-            if sawBindFailure {
+            // A refusal for a port we never requested is the user's own stale
+            // config block being inherited, not a contended port (issue #215's
+            // migration leaves exactly this behind). Different cause, different
+            // fix, so it must not be reported as a held port.
+            if let refusedPort = bindFailure, refusedPort != configuration.remoteForwardPort {
+                Log.claudeContext.error(
+                    "Claude remote forward for host \(self.configuration.hostID, privacy: .public) inherited a stale RemoteForward for port \(refusedPort, privacy: .public); this Mac asked for \(self.configuration.remoteForwardPort, privacy: .public)"
+                )
+                transition(to: .staleConfiguredForward(port: refusedPort))
+                superviseTask = nil
+                return
+            }
+
+            if bindFailure != nil {
                 // Terminal by design. Restarting would dial a port another
                 // machine is holding, forever, silently.
                 Log.claudeContext.error(
@@ -286,9 +475,31 @@ public final class ClaudeRemoteForwardSupervisor: ClaudeRemoteForwarding {
                 return
             }
 
+            // A connection that was UP for a good while and then dropped is an
+            // isolated incident, not the next step in a run of failures. Five
+            // of those spread over five days used to accumulate into "keeps
+            // dropping" and stop the tunnel for good, each retry inheriting a
+            // backoff computed from failures that had nothing to do with each
+            // other.
+            //
+            // Measured as observed uptime rather than by arming another timer:
+            // the elapsed time is already known here, an injected clock makes
+            // it exact in tests, and a timer would be one more thing racing the
+            // exit it is trying to describe.
+            let uptime = now().timeIntervalSince(startedAt)
+            let healthyUptimeSeconds = Double(configuration.healthyUptime.components.seconds)
+            if uptime >= healthyUptimeSeconds {
+                if consecutiveFailures > 0 {
+                    Log.claudeContext.info(
+                        "Claude remote forward for host \(self.configuration.hostID, privacy: .public) had been up \(Int(uptime), privacy: .public)s; clearing \(self.consecutiveFailures, privacy: .public) earlier failure(s)"
+                    )
+                }
+                consecutiveFailures = 0
+            }
+
             consecutiveFailures += 1
             Log.claudeContext.info(
-                "Claude remote forward for host \(self.configuration.hostID, privacy: .public) exited with status \(status, privacy: .public) (failure \(consecutiveFailures, privacy: .public))"
+                "Claude remote forward for host \(self.configuration.hostID, privacy: .public) exited with status \(status, privacy: .public) (failure \(self.consecutiveFailures, privacy: .public))"
             )
 
             if consecutiveFailures >= max(1, configuration.maxConsecutiveFailures) {
@@ -310,13 +521,22 @@ public final class ClaudeRemoteForwardSupervisor: ClaudeRemoteForwarding {
         superviseTask = nil
     }
 
-    /// True if ssh reported that the remote refused the bind.
-    private func watchStandardError(of process: any ClaudeRemoteForwardProcess) async -> Bool {
-        var sawBindFailure = false
+    /// The port whose bind the remote refused, if it refused one.
+    ///
+    /// The PORT, not just a flag: `Warning: remote port forwarding failed for
+    /// listen port 8473` on a supervisor that asked for 28511 is a completely
+    /// different diagnosis from the same warning naming 28511.
+    private func watchStandardError(
+        of process: any ClaudeRemoteForwardProcess
+    ) async -> UInt16? {
+        var refusedPort: UInt16?
         for await line in process.standardErrorLines {
             let lowered = line.lowercased()
             if lowered.contains(ClaudeRemoteForwardPort.forwardFailureSignature) {
-                sawBindFailure = true
+                // Fall back to our own port when the number is missing or
+                // unparseable: the refusal is still real, and the
+                // conservative reading is the port we asked for.
+                refusedPort = Self.refusedPort(in: lowered) ?? configuration.remoteForwardPort
             }
             // The tail goes to the log, never to the pane: ssh stderr is
             // long, and it is exactly the kind of text the popover rule
@@ -325,7 +545,18 @@ public final class ClaudeRemoteForwardSupervisor: ClaudeRemoteForwarding {
                 "Claude remote forward ssh stderr [\(self.configuration.hostID, privacy: .public)]: \(line, privacy: .private)"
             )
         }
-        return sawBindFailure
+        return refusedPort
+    }
+
+    /// The listen port named in OpenSSH's refusal line, if it names one.
+    ///
+    /// Anchored on `listen port `, not "the last number on the line": the
+    /// message also carries host names, and a hostname with digits in it must
+    /// never be read as a port.
+    static func refusedPort(in loweredLine: String) -> UInt16? {
+        guard let marker = loweredLine.range(of: "listen port ") else { return nil }
+        let digits = loweredLine[marker.upperBound...].prefix { $0.isNumber }
+        return digits.isEmpty ? nil : UInt16(digits)
     }
 
     /// Exponential, capped, same shape as the backend supervisor's: 0.5s, 1s,

--- a/Sources/localvoxtral/ClaudeContext/ClaudeRemoteForwardSupervisor.swift
+++ b/Sources/localvoxtral/ClaudeContext/ClaudeRemoteForwardSupervisor.swift
@@ -1,0 +1,349 @@
+import Foundation
+import Observation
+
+/// One long-lived `ssh -N -R` process, as a seam.
+///
+/// A protocol rather than `Process` for the reason the backend supervisor
+/// cannot claim: that one spawns a local binary a test can write itself, while
+/// this one spawns **ssh against a real host**. No unit test may do that — not
+/// slowly, not flakily, not at all — so the process is injected and the tests
+/// drive a fake.
+public protocol ClaudeRemoteForwardProcess: Sendable {
+    /// stderr, line by line, finishing when the process does.
+    ///
+    /// stderr is not diagnostics here, it is the PRODUCT: `remote port
+    /// forwarding failed` is the only thing that distinguishes "another machine
+    /// holds this port" from any other reason ssh exited.
+    var standardErrorLines: AsyncStream<String> { get }
+    /// Resumes with the exit status once the process ends.
+    func waitUntilExit() async -> Int32
+    /// Ask it to stop. Must be safe to call more than once, and after exit.
+    func terminate()
+}
+
+/// Keeps one enrolled host's SSH `RemoteForward` up, without an interactive
+/// session holding it.
+///
+/// Why this exists: hook events only reach the Mac while SOMETHING holds the
+/// forward. A person's own ssh session does that for their own terminal work —
+/// but a harness-spawned session (t3 code, `claude remote-control` services,
+/// any headless runner on the enrolled host) has no such terminal, so its
+/// events go nowhere and the user sees dictation quietly ungrounded.
+///
+/// Deliberate differences from `BackendProcessSupervisor`:
+///
+/// * `ExitOnForwardFailure=yes`. The enrollment ssh block sets `no` on purpose
+///   — a dictation nicety must never cost you a shell. This process IS the
+///   nicety and nothing else: a forward it cannot bind is a process with no
+///   remaining purpose, so the exit is the detection signal we want rather
+///   than a session we would be protecting.
+/// * A bind failure is TERMINAL, not a restart. Something else holds that port
+///   (see issue #215) and will keep holding it; retrying on a timer would be a
+///   connection storm, an auth-log full of sessions, and possibly a fail2ban
+///   ban — all while the user is told nothing. One clear failed state, with the
+///   fix in it, beats an infinite retry that hides the cause.
+/// * `ClearAllForwardings=yes` before `-R`: the ssh config block for this alias
+///   already declares a `RemoteForward`, and inheriting it would make this
+///   process request the port TWICE — the second request failing, which under
+///   `ExitOnForwardFailure=yes` kills the very process meant to hold it.
+/// What the coordinator actually depends on.
+///
+/// A protocol so a test can drive the coordinator's decisions — which hosts get
+/// a forward, and when — without a supervisor that would spawn ssh. The
+/// supervisor's own behavior has its own suite, against a fake process.
+@MainActor
+public protocol ClaudeRemoteForwarding: AnyObject {
+    var state: ClaudeRemoteForwardSupervisor.State { get }
+    var onStateChange: (@MainActor (ClaudeRemoteForwardSupervisor.State) -> Void)? { get set }
+    func start()
+    func stop()
+    func retry()
+}
+
+@MainActor
+@Observable
+public final class ClaudeRemoteForwardSupervisor: ClaudeRemoteForwarding {
+    public enum State: Equatable, Sendable {
+        case stopped
+        case connecting
+        case forwarding
+        case retrying(attempt: Int)
+        /// The remote refused the bind: someone else holds the port.
+        case portUnavailable
+        case failed(summary: String)
+
+        /// One short sentence for the pane (owner rule: no long text in the
+        /// popover, and a Settings status line has the same problem). Full
+        /// detail — the ssh stderr tail — goes to the log, never here.
+        public var text: String {
+            switch self {
+            case .stopped: return "Off."
+            case .connecting: return "Connecting…"
+            case .forwarding: return "Tunnel up."
+            case .retrying(let attempt): return "Reconnecting (attempt \(attempt))."
+            case .portUnavailable: return "Port already held on the host."
+            case .failed: return "Tunnel stopped."
+            }
+        }
+
+        public var isFailure: Bool {
+            switch self {
+            case .stopped, .connecting, .forwarding, .retrying: return false
+            case .portUnavailable, .failed: return true
+            }
+        }
+    }
+
+    public struct Configuration: Sendable, Equatable {
+        public var hostID: String
+        public var sshHostAlias: String
+        /// The port bound on the REMOTE host — this Mac's allocation.
+        public var remoteForwardPort: UInt16
+        /// The port the app listens on HERE. The forward's target.
+        public var listenerPort: UInt16
+        /// After this many consecutive failed connections, stop and say so. A
+        /// tunnel that has failed five times in a row is not one more retry
+        /// away from working, and an unbounded loop against someone's SSH
+        /// server is not a thing to ship.
+        public var maxConsecutiveFailures: Int
+        /// How long a freshly launched ssh must stay alive before the pane is
+        /// allowed to call the tunnel up. Measured on the supervisor's injected
+        /// clock, never the wall.
+        public var settleDelay: Duration
+
+        public init(
+            hostID: String,
+            sshHostAlias: String,
+            remoteForwardPort: UInt16,
+            listenerPort: UInt16,
+            maxConsecutiveFailures: Int = 5,
+            settleDelay: Duration = .seconds(2)
+        ) {
+            self.hostID = hostID
+            self.sshHostAlias = sshHostAlias
+            self.remoteForwardPort = remoteForwardPort
+            self.listenerPort = listenerPort
+            self.maxConsecutiveFailures = maxConsecutiveFailures
+            self.settleDelay = settleDelay
+        }
+
+        /// The complete argv. No token is involved anywhere on this path — the
+        /// credential lives in the remote plugin's config, and this process only
+        /// carries bytes for it.
+        ///
+        /// `--` terminates option parsing: the alias is validated before a
+        /// supervisor is ever built, and this makes an alias that somehow got
+        /// through a failed connection rather than a silently accepted option
+        /// (the `-V` lesson from PR #197).
+        public var argv: [String] {
+            [
+                "ssh", "-N",
+                "-o", "BatchMode=yes",
+                "-o", "ExitOnForwardFailure=yes",
+                "-o", "ClearAllForwardings=yes",
+                "-o", "ServerAliveInterval=30",
+                "-o", "ServerAliveCountMax=3",
+                "-R", "\(remoteForwardPort):127.0.0.1:\(listenerPort)",
+                "--", sshHostAlias,
+            ]
+        }
+    }
+
+    public typealias Launch = @MainActor (Configuration) throws -> any ClaudeRemoteForwardProcess
+    public typealias SleepClosure = @Sendable (Duration) async throws -> Void
+
+    public private(set) var state: State = .stopped
+
+    /// Called synchronously on every transition, on the main actor. The
+    /// coordinator mirrors state into the pane through this rather than through
+    /// observation tracking, whose `onChange` fires before the write lands.
+    @ObservationIgnored public var onStateChange: (@MainActor (State) -> Void)?
+
+    @ObservationIgnored public let configuration: Configuration
+    @ObservationIgnored private let launch: Launch
+    @ObservationIgnored private let sleepFor: SleepClosure
+    @ObservationIgnored private var superviseTask: Task<Void, Never>?
+    @ObservationIgnored private var currentProcess: (any ClaudeRemoteForwardProcess)?
+    @ObservationIgnored private var stoppingIntentionally = false
+    /// Bumped per launch. The settle task carries the generation it belongs to
+    /// so a stale one cannot report a dead process as up.
+    @ObservationIgnored private var runGeneration = 0
+
+    public init(
+        configuration: Configuration,
+        launch: @escaping Launch,
+        sleepFor: @escaping SleepClosure = { try await Task.sleep(for: $0) }
+    ) {
+        self.configuration = configuration
+        self.launch = launch
+        self.sleepFor = sleepFor
+    }
+
+    public func start() {
+        guard superviseTask == nil else { return }
+        stoppingIntentionally = false
+        Log.claudeContext.info(
+            "Claude remote forward start requested for host \(self.configuration.hostID, privacy: .public) port \(self.configuration.remoteForwardPort, privacy: .public)"
+        )
+        transition(to: .connecting)
+        superviseTask = Task { @MainActor [weak self] in
+            await self?.supervise()
+        }
+    }
+
+    public func stop() {
+        guard !stoppingIntentionally else { return }
+        stoppingIntentionally = true
+        Log.claudeContext.info(
+            "Claude remote forward stop requested for host \(self.configuration.hostID, privacy: .public)"
+        )
+        superviseTask?.cancel()
+        superviseTask = nil
+        currentProcess?.terminate()
+        currentProcess = nil
+        transition(to: .stopped)
+    }
+
+    /// The user's move after freeing the port. Clears a terminal state and
+    /// tries again — nothing else does, on purpose.
+    public func retry() {
+        guard state.isFailure else { return }
+        stop()
+        start()
+    }
+
+    private func supervise() async {
+        var consecutiveFailures = 0
+
+        while !stoppingIntentionally, !Task.isCancelled {
+            let process: any ClaudeRemoteForwardProcess
+            do {
+                process = try launch(configuration)
+            } catch {
+                Log.claudeContext.error(
+                    "Claude remote forward launch failed for host \(self.configuration.hostID, privacy: .public): \(String(describing: error), privacy: .public)"
+                )
+                transition(to: .failed(summary: "Could not start ssh."))
+                superviseTask = nil
+                return
+            }
+            currentProcess = process
+
+            // ssh with -N says nothing on success, so "forwarding" is the
+            // absence of a complaint, not a positive ack. There is no ack to
+            // be had: the remote never tells the client the bind took, beyond
+            // not failing. Watching stderr is the whole instrument.
+            let watcher = Task { @MainActor [weak self] in
+                await self?.watchStandardError(of: process)
+            }
+
+            transitionIfNeeded(to: .connecting)
+            // …so "up" is defined as "still alive after the settle window",
+            // measured on the INJECTED clock. A bind failure under
+            // `ExitOnForwardFailure=yes` kills the process in well under a
+            // second, so this window is what keeps the pane from flashing
+            // "Tunnel up." at a tunnel that was already refused.
+            runGeneration += 1
+            let generation = runGeneration
+            let settle = Task { @MainActor [weak self] in
+                guard let self else { return }
+                do { try await self.sleepFor(self.configuration.settleDelay) } catch { return }
+                // Cancellation is checked AFTER a sleep that already returned,
+                // so it is not enough on its own: the generation is. Without
+                // it, a process that died during its own settle window could
+                // still be announced as "Tunnel up." on top of the
+                // `.retrying` the loop had already published.
+                guard !Task.isCancelled,
+                      !self.stoppingIntentionally,
+                      self.runGeneration == generation
+                else { return }
+                self.transitionIfNeeded(to: .forwarding)
+            }
+            defer { settle.cancel() }
+            // stderr FIRST, exit status second, and never the other way round:
+            // `remote port forwarding failed` arrives microseconds before the
+            // exit it causes, so reading the status first and then cancelling
+            // the watcher would drop the one line that explains everything.
+            // The contract a `ClaudeRemoteForwardProcess` owes is therefore
+            // that its stream finishes when the process does.
+            let sawBindFailure = await watcher.value ?? false
+            let status = await process.waitUntilExit()
+            currentProcess = nil
+
+            guard !stoppingIntentionally, !Task.isCancelled else {
+                superviseTask = nil
+                return
+            }
+
+            if sawBindFailure {
+                // Terminal by design. Restarting would dial a port another
+                // machine is holding, forever, silently.
+                Log.claudeContext.error(
+                    "Claude remote forward refused for host \(self.configuration.hostID, privacy: .public): port \(self.configuration.remoteForwardPort, privacy: .public) already bound on \(self.configuration.sshHostAlias, privacy: .public)"
+                )
+                transition(to: .portUnavailable)
+                superviseTask = nil
+                return
+            }
+
+            consecutiveFailures += 1
+            Log.claudeContext.info(
+                "Claude remote forward for host \(self.configuration.hostID, privacy: .public) exited with status \(status, privacy: .public) (failure \(consecutiveFailures, privacy: .public))"
+            )
+
+            if consecutiveFailures >= max(1, configuration.maxConsecutiveFailures) {
+                transition(
+                    to: .failed(summary: "Tunnel to \(configuration.sshHostAlias) keeps dropping.")
+                )
+                superviseTask = nil
+                return
+            }
+
+            transition(to: .retrying(attempt: consecutiveFailures))
+            do {
+                try await sleepFor(Self.backoff(attempt: consecutiveFailures))
+            } catch {
+                superviseTask = nil
+                return
+            }
+        }
+        superviseTask = nil
+    }
+
+    /// True if ssh reported that the remote refused the bind.
+    private func watchStandardError(of process: any ClaudeRemoteForwardProcess) async -> Bool {
+        var sawBindFailure = false
+        for await line in process.standardErrorLines {
+            let lowered = line.lowercased()
+            if lowered.contains(ClaudeRemoteForwardPort.forwardFailureSignature) {
+                sawBindFailure = true
+            }
+            // The tail goes to the log, never to the pane: ssh stderr is
+            // long, and it is exactly the kind of text the popover rule
+            // exists to keep out of the UI.
+            Log.claudeContext.info(
+                "Claude remote forward ssh stderr [\(self.configuration.hostID, privacy: .public)]: \(line, privacy: .private)"
+            )
+        }
+        return sawBindFailure
+    }
+
+    /// Exponential, capped, same shape as the backend supervisor's: 0.5s, 1s,
+    /// 2s, … up to 30s.
+    static func backoff(attempt: Int) -> Duration {
+        .seconds(min(30.0, 0.5 * pow(2.0, Double(max(0, attempt - 1)))))
+    }
+
+    private func transition(to newState: State) {
+        state = newState
+        onStateChange?(newState)
+        Log.claudeContext.info(
+            "Claude remote forward state for host \(self.configuration.hostID, privacy: .public): \(String(describing: newState), privacy: .public)"
+        )
+    }
+
+    private func transitionIfNeeded(to newState: State) {
+        guard state != newState else { return }
+        transition(to: newState)
+    }
+}

--- a/Sources/localvoxtral/ClaudeContext/ClaudeRemoteHostRegistry.swift
+++ b/Sources/localvoxtral/ClaudeContext/ClaudeRemoteHostRegistry.swift
@@ -30,6 +30,16 @@ public struct ClaudeRemoteHost: Sendable, Equatable, Identifiable {
     public var createdAt: Date
     public var lastSeenAt: Date?
     public var revokedAt: Date?
+    /// Whether the app should hold this host's SSH `RemoteForward` open itself
+    /// (`ClaudeRemoteForwardSupervisor`), instead of relying on one of the
+    /// user's interactive sessions to hold it. Off by default: spawning ssh on
+    /// someone's behalf is an opt-in, per host.
+    ///
+    /// It lives HERE rather than in a parallel preference so that removing a
+    /// host removes the flag with it. A separate store would keep a dead host's
+    /// switch alive and, worse, could hand it to a future host that reused the
+    /// id.
+    public var persistentForwardEnabled: Bool = false
 
     public var isRevoked: Bool { revokedAt != nil }
 }
@@ -329,6 +339,11 @@ public final class ClaudeRemoteHostRegistry: Sendable {
         /// ignores the key, and a newer build reading an older file gets nil
         /// and degrades to copy-only — neither loses a host.
         var sshHostAlias: String? = nil
+        /// Absent means off, which is both the default and the safe reading:
+        /// the app never starts spawning ssh for a host because a file it read
+        /// was silent on the subject. Optional for the same
+        /// forward/backward-compatibility reason as the alias above.
+        var persistentForwardEnabled: Bool? = nil
 
         var publicView: ClaudeRemoteHost {
             ClaudeRemoteHost(
@@ -337,7 +352,8 @@ public final class ClaudeRemoteHostRegistry: Sendable {
                 sshHostAlias: sshHostAlias,
                 createdAt: createdAt,
                 lastSeenAt: lastSeenAt,
-                revokedAt: revokedAt
+                revokedAt: revokedAt,
+                persistentForwardEnabled: persistentForwardEnabled ?? false
             )
         }
     }
@@ -602,6 +618,23 @@ public final class ClaudeRemoteHostRegistry: Sendable {
             hosts[index].tokenSalt = ""
         }
         Log.claudeContext.info("Revoked Claude remote host \(hostID, privacy: .public)")
+    }
+
+    /// Turn the app-held forward on or off for one host.
+    ///
+    /// Transactional like every other mutation: a flag memory accepted and disk
+    /// refused would mean an ssh process this app starts on every launch and a
+    /// Settings toggle that reads off.
+    public func setPersistentForwardEnabled(_ enabled: Bool, hostID: String) throws {
+        try transact { hosts in
+            guard let index = hosts.firstIndex(where: { $0.id == hostID }) else {
+                throw StoreError.unknownHost(hostID)
+            }
+            hosts[index].persistentForwardEnabled = enabled
+        }
+        Log.claudeContext.info(
+            "Claude remote persistent forward \(enabled ? "enabled" : "disabled", privacy: .public) for host \(hostID, privacy: .public)"
+        )
     }
 
     public func remove(hostID: String) throws {

--- a/Sources/localvoxtral/SettingsView.swift
+++ b/Sources/localvoxtral/SettingsView.swift
@@ -1117,9 +1117,50 @@ private struct ClaudeRemoteHostsSettingsRow: View {
                             // but offering it mid-run is still offering a race.
                             .disabled(model.isPerformingEnrollmentAction)
                     }
+                    persistentForwardRow(for: host)
                     pluginUpdatePanel(for: host)
                 }
             }
+        }
+    }
+
+    /// The app-held tunnel switch for one host, INSIDE that host's row.
+    ///
+    /// Not a new group: a pane's group structure is constant (owner rule
+    /// 2026-07-04), and this belongs to a host, not to the feature. It is the
+    /// same idiom as `pluginUpdatePanel` — per-host sub-UI under the host line.
+    ///
+    /// A host with no alias on file gets no toggle at all rather than a
+    /// disabled one with an explanation: there is nothing to enable, because we
+    /// were never told where to ssh.
+    @ViewBuilder
+    private func persistentForwardRow(
+        for host: ClaudeIntegrationSettingsModel.HostRow
+    ) -> some View {
+        if host.canHoldForward {
+            HStack(spacing: 8) {
+                Toggle(
+                    "Keep the tunnel open",
+                    isOn: Binding(
+                        get: { host.persistentForwardEnabled },
+                        set: { model.setPersistentForward($0, hostID: host.id) }
+                    )
+                )
+                .toggleStyle(.checkbox)
+                .font(.caption)
+                if let status = host.forwardStatusText {
+                    Text(status)
+                        .font(.caption)
+                        .foregroundStyle(host.forwardIsFailure ? Color.red : .secondary)
+                        .lineLimit(1)
+                }
+                if host.forwardIsFailure {
+                    Button("Retry") { model.retryPersistentForward(hostID: host.id) }
+                        .controlSize(.small)
+                }
+                Spacer()
+            }
+            .padding(.leading, 12)
         }
     }
 

--- a/Sources/localvoxtral/localvoxtralApp.swift
+++ b/Sources/localvoxtral/localvoxtralApp.swift
@@ -1,6 +1,7 @@
 import AppKit
 import ClaudeContextWire
 import SwiftUI
+import Synchronization
 
 @main
 struct localvoxtralApp: App {
@@ -202,6 +203,13 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         // nothing about enrollment — the hosts stay enrolled for next launch.
         // Forwards first, listener second — the mirror of startup order.
         claudeRemoteForwards?.stopAll()
+        // `stopAll` only STARTS each SIGTERM→SIGKILL escalation. Returning
+        // here without it finishing is how an ssh that is slow to die outlives
+        // the app: reparented to launchd, still holding the remote bind, and
+        // no longer reachable by anything that could kill it — so the next
+        // launch finds its own port taken. The wait is bounded and short; a
+        // quit must never hang on a wedged network.
+        drainRemoteForwardTeardowns(within: 3.0)
         claudeRemoteForwards = nil
         claudeRemoteListenerCoordinator?.shutdown()
         claudeRemoteListenerCoordinator = nil
@@ -211,6 +219,35 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         // resolving joins against sessions nothing is feeding any more.
         viewModel.claudeSessionJoinResolver = nil
         viewModel.claudeSessionJoin = nil
+    }
+
+    /// Spin the run loop until every forward teardown has finished, or the
+    /// deadline passes.
+    ///
+    /// `applicationWillTerminate` is synchronous and cannot await, but the
+    /// escalation it just started is asynchronous — so this pumps the main run
+    /// loop, which is what lets those tasks make progress while we wait. The
+    /// deadline is the point: a wedged ssh must cost the user a bounded pause
+    /// at quit, never a hang, and the escalation's own SIGKILL means the
+    /// ordinary case finishes far inside it.
+    private func drainRemoteForwardTeardowns(within seconds: TimeInterval) {
+        guard let teardowns = claudeRemoteForwards?.drainingTeardowns, !teardowns.isEmpty else {
+            return
+        }
+        let deadline = Date().addingTimeInterval(seconds)
+        let finished = Mutex(false)
+        Task { @MainActor in
+            for teardown in teardowns { await teardown.value }
+            finished.withLock { $0 = true }
+        }
+        while !finished.withLock({ $0 }), Date() < deadline {
+            RunLoop.current.run(mode: .default, before: Date().addingTimeInterval(0.02))
+        }
+        if !finished.withLock({ $0 }) {
+            Log.claudeContext.error(
+                "Claude remote forward teardown did not finish before quit; an ssh may survive this process"
+            )
+        }
     }
 
     /// Binds the hook socket and installs the pane authorizer that depends on it.

--- a/Sources/localvoxtral/localvoxtralApp.swift
+++ b/Sources/localvoxtral/localvoxtralApp.swift
@@ -151,6 +151,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     /// through it on every enroll/revoke, so the port follows enrollment without
     /// a relaunch.
     private var claudeRemoteListenerCoordinator: ClaudeRemoteListenerCoordinator?
+    /// Owns the opt-in app-held `ssh -N -R` forwards. Started only after the
+    /// listener binds, and torn down before the app exits so no orphan ssh
+    /// outlives the process that spawned it.
+    private var claudeRemoteForwards: ClaudeRemoteForwardCoordinator?
     /// Customized-but-outdated config files awaiting the user's
     /// update-or-keep decision; held here while onboarding is on screen.
     private var pendingConfigDefaultsPromptFileNames: [String]?
@@ -196,6 +200,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         // Closes the port, so a hook from a surviving remote session gets a
         // connection refused through the tunnel and fails open. Quitting says
         // nothing about enrollment — the hosts stay enrolled for next launch.
+        // Forwards first, listener second — the mirror of startup order.
+        claudeRemoteForwards?.stopAll()
+        claudeRemoteForwards = nil
         claudeRemoteListenerCoordinator?.shutdown()
         claudeRemoteListenerCoordinator = nil
         viewModel.claudeIntegrationSettings = nil
@@ -390,13 +397,28 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             "Claude remote forward port allocated: \(remoteForwardPort, privacy: .public)"
         )
 
+        // App-held ssh forwards, for hosts that opted in. Constructed with the
+        // listener coordinator's bind state as its gate: a forward into an
+        // unbound port is worse than no forward (silent fail-open on the remote,
+        // plus ssh noise in the user's terminal), so it refuses to run without
+        // one. The listener is reconciled FIRST, below.
+        let forwards = registry.map { hosts in
+            ClaudeRemoteForwardCoordinator(
+                hosts: hosts,
+                remoteForwardPort: remoteForwardPort,
+                isListenerBound: { coordinator?.isListening ?? false }
+            )
+        }
+        claudeRemoteForwards = forwards
+
         viewModel.claudeIntegrationSettings = ClaudeIntegrationSettingsModel(
             registry: registry,
             listener: coordinator,
             pluginService: { ClaudePluginInstallService.live() },
             enrollmentService: ClaudeRemoteEnrollmentService.live(),
             remoteForwardPort: remoteForwardPort,
-            cmuxPasswords: CmuxSocketPasswordStore()
+            cmuxPasswords: CmuxSocketPasswordStore(),
+            forwards: forwards
         )
 
         // Route launch through the same model that owns the Settings status.

--- a/Tests/localvoxtralTests/ClaudeIntegrationSettingsModelTests.swift
+++ b/Tests/localvoxtralTests/ClaudeIntegrationSettingsModelTests.swift
@@ -109,6 +109,25 @@ private final class RecordingSSHConfigFileSystem: ClaudeRemoteSSHConfigFileSyste
     }
 }
 
+/// A forward that records instead of spawning ssh. The model's contract is
+/// "persist the flag, then reconcile, then re-render the rows"; whether ssh
+/// reconnects is the supervisor's suite.
+@MainActor
+private final class StubForwarding: ClaudeRemoteForwarding {
+    var state: ClaudeRemoteForwardSupervisor.State = .stopped
+    var onStateChange: (@MainActor (ClaudeRemoteForwardSupervisor.State) -> Void)?
+    private(set) var retried = 0
+
+    func start() { transition(to: .connecting) }
+    func stop() { transition(to: .stopped) }
+    func retry() { retried += 1 }
+
+    func transition(to newState: ClaudeRemoteForwardSupervisor.State) {
+        state = newState
+        onStateChange?(newState)
+    }
+}
+
 @MainActor
 final class ClaudeIntegrationSettingsModelTests: XCTestCase {
     private func makeRegistry() throws -> ClaudeRemoteHostRegistry {
@@ -131,7 +150,8 @@ final class ClaudeIntegrationSettingsModelTests: XCTestCase {
         // Pinned, never derived here: the model must use what it is handed, and
         // a test that computed the allocation would only prove the derivation
         // twice.
-        remoteForwardPort: UInt16 = ClaudeRemoteForwardPort.legacyPort
+        remoteForwardPort: UInt16 = ClaudeRemoteForwardPort.legacyPort,
+        forwards: ClaudeRemoteForwardCoordinator? = nil
     ) -> ClaudeIntegrationSettingsModel {
         ClaudeIntegrationSettingsModel(
             registry: registry,
@@ -160,8 +180,124 @@ final class ClaudeIntegrationSettingsModelTests: XCTestCase {
                 }
             },
             now: now,
-            remoteForwardPort: remoteForwardPort
+            remoteForwardPort: remoteForwardPort,
+            forwards: forwards
         )
+    }
+
+    // MARK: Persistent forward toggle
+
+    /// Holds the stub forwards so a test can drive their state.
+    private final class ForwardStubs: @unchecked Sendable {
+        var byHost: [String: StubForwarding] = [:]
+    }
+
+    private func makeForwardCoordinator(
+        registry: ClaudeRemoteHostRegistry,
+        stubs: ForwardStubs,
+        isListenerBound: @escaping @MainActor () -> Bool = { true }
+    ) -> ClaudeRemoteForwardCoordinator {
+        ClaudeRemoteForwardCoordinator(
+            hosts: registry,
+            remoteForwardPort: 28542,
+            listenerPort: 8473,
+            isListenerBound: isListenerBound,
+            makeSupervisor: { configuration in
+                let stub = StubForwarding()
+                stubs.byHost[configuration.hostID] = stub
+                return stub
+            }
+        )
+    }
+
+    func testEnablingTheTunnelPersistsTheFlagAndStartsTheForward() async throws {
+        let registry = try makeRegistry()
+        let stubs = ForwardStubs()
+        let forwards = makeForwardCoordinator(registry: registry, stubs: stubs)
+        let model = makeModel(
+            registry: registry,
+            listener: StubListener(hosts: registry),
+            remoteForwardPort: 28542,
+            forwards: forwards
+        )
+        model.enrollLabel = "buildhost"
+        model.enrollSSHAlias = "builder"
+        await model.enroll()
+        model.dismissPlan()
+        let hostID = try XCTUnwrap(model.hosts.first).id
+
+        // Off by default: the app must never ssh anywhere unasked.
+        XCTAssertFalse(try XCTUnwrap(model.hosts.first).persistentForwardEnabled)
+        XCTAssertTrue(stubs.byHost.isEmpty)
+
+        model.setPersistentForward(true, hostID: hostID)
+
+        XCTAssertTrue(try XCTUnwrap(registry.host(id: hostID)).persistentForwardEnabled)
+        XCTAssertTrue(try XCTUnwrap(model.hosts.first).persistentForwardEnabled)
+        XCTAssertNotNil(stubs.byHost[hostID], "the flag alone is not a tunnel")
+        XCTAssertTrue(try XCTUnwrap(model.hosts.first).canHoldForward)
+
+        model.setPersistentForward(false, hostID: hostID)
+        XCTAssertFalse(try XCTUnwrap(registry.host(id: hostID)).persistentForwardEnabled)
+        XCTAssertNil(model.hosts.first?.forwardStatusText, "a stopped forward has nothing to report")
+    }
+
+    func testAFailedForwardShowsOneShortSentenceAndOffersRetry() async throws {
+        let registry = try makeRegistry()
+        let stubs = ForwardStubs()
+        let forwards = makeForwardCoordinator(registry: registry, stubs: stubs)
+        let model = makeModel(
+            registry: registry,
+            listener: StubListener(hosts: registry),
+            remoteForwardPort: 28542,
+            forwards: forwards
+        )
+        model.enrollLabel = "buildhost"
+        model.enrollSSHAlias = "builder"
+        await model.enroll()
+        model.dismissPlan()
+        let hostID = try XCTUnwrap(model.hosts.first).id
+        model.setPersistentForward(true, hostID: hostID)
+
+        try XCTUnwrap(stubs.byHost[hostID]).transition(to: .portUnavailable)
+        model.refreshHosts()
+
+        let row = try XCTUnwrap(model.hosts.first)
+        XCTAssertEqual(row.forwardStatusText, "Port already held on the host.")
+        XCTAssertTrue(row.forwardIsFailure)
+        // Owner rule: a Settings status line is one short sentence; the ssh
+        // stderr tail belongs in the log.
+        XCTAssertLessThan(try XCTUnwrap(row.forwardStatusText).count, 60)
+
+        model.retryPersistentForward(hostID: hostID)
+        XCTAssertEqual(try XCTUnwrap(stubs.byHost[hostID]).retried, 1)
+    }
+
+    func testAHostWithNoAliasIsNotOfferedATunnel() async throws {
+        let registry = try makeRegistry()
+        let stubs = ForwardStubs()
+        let forwards = makeForwardCoordinator(registry: registry, stubs: stubs)
+        let enrollment = try registry.enroll(label: "buildhost")
+        let model = makeModel(
+            registry: registry,
+            listener: StubListener(hosts: registry),
+            remoteForwardPort: 28542,
+            forwards: forwards
+        )
+
+        XCTAssertEqual(model.hosts.first?.id, enrollment.host.id)
+        XCTAssertFalse(
+            try XCTUnwrap(model.hosts.first).canHoldForward,
+            "we were never told where to ssh, and the label is not a substitute"
+        )
+    }
+
+    func testNoTunnelIsOfferedWhenTheAppHasNoForwardCoordinator() async throws {
+        let registry = try makeRegistry()
+        let model = makeModel(registry: registry, listener: StubListener(hosts: registry))
+        _ = try registry.enroll(label: "buildhost", sshHostAlias: "builder")
+        model.refreshHosts()
+        XCTAssertFalse(try XCTUnwrap(model.hosts.first).canHoldForward)
     }
 
     // MARK: Local plugin

--- a/Tests/localvoxtralTests/ClaudeIntegrationSettingsModelTests.swift
+++ b/Tests/localvoxtralTests/ClaudeIntegrationSettingsModelTests.swift
@@ -49,12 +49,17 @@ private final class StubListener: ClaudeRemoteListenerControlling {
     /// a night of rejected connections.
     var rejectionSnapshot = ClaudeRemoteRejectionTally.Snapshot()
 
+    /// Shared with the forward stubs so a test can assert the ORDER of the two
+    /// shutdowns, not just that both happened.
+    var journal: ShutdownJournal?
+
     init(hosts: ClaudeRemoteHostRegistry) {
         self.hosts = hosts
     }
 
     func reconcile() throws {
         reconcileCount += 1
+        if isListening, !hosts.hasActiveHosts { journal?.note("listener.stop") }
         if hosts.hasActiveHosts {
             guard !isListening else { return }
             if let bindError { throw bindError }
@@ -113,13 +118,29 @@ private final class RecordingSSHConfigFileSystem: ClaudeRemoteSSHConfigFileSyste
 /// "persist the flag, then reconcile, then re-render the rows"; whether ssh
 /// reconnects is the supervisor's suite.
 @MainActor
+/// Ordered record of the two shutdowns, so "forwards first, listener second"
+/// is asserted as a SEQUENCE. Both happening is not the property — the whole
+/// failure is a hook arriving in the window between them.
+final class ShutdownJournal: @unchecked Sendable {
+    private let entries = Mutex<[String]>([])
+    func note(_ entry: String) { entries.withLock { $0.append(entry) } }
+    var recorded: [String] { entries.withLock { $0 } }
+}
+
 private final class StubForwarding: ClaudeRemoteForwarding {
+    var journal: ShutdownJournal?
     var state: ClaudeRemoteForwardSupervisor.State = .stopped
     var onStateChange: (@MainActor (ClaudeRemoteForwardSupervisor.State) -> Void)?
+    /// Settable so a test can hand the coordinator a teardown that is
+    /// still draining and prove the replacement waits for it.
+    var teardown: Task<Void, Never>?
     private(set) var retried = 0
 
     func start() { transition(to: .connecting) }
-    func stop() { transition(to: .stopped) }
+    func stop() {
+        journal?.note("forward.stop")
+        transition(to: .stopped)
+    }
     func retry() { retried += 1 }
 
     func transition(to newState: ClaudeRemoteForwardSupervisor.State) {
@@ -190,6 +211,7 @@ final class ClaudeIntegrationSettingsModelTests: XCTestCase {
     /// Holds the stub forwards so a test can drive their state.
     private final class ForwardStubs: @unchecked Sendable {
         var byHost: [String: StubForwarding] = [:]
+        var journal: ShutdownJournal?
     }
 
     private func makeForwardCoordinator(
@@ -204,6 +226,7 @@ final class ClaudeIntegrationSettingsModelTests: XCTestCase {
             isListenerBound: isListenerBound,
             makeSupervisor: { configuration in
                 let stub = StubForwarding()
+                stub.journal = stubs.journal
                 stubs.byHost[configuration.hostID] = stub
                 return stub
             }
@@ -259,11 +282,17 @@ final class ClaudeIntegrationSettingsModelTests: XCTestCase {
         let hostID = try XCTUnwrap(model.hosts.first).id
         model.setPersistentForward(true, hostID: hostID)
 
+        // NO refreshHosts() here, deliberately. The manual call is what used to
+        // make this pass: the pane renders copies of these rows and only
+        // rebuilt them on an explicit action or on appear, so in the running
+        // app every transition after the first "Connecting…" snapshot —
+        // forwarding, retrying, portUnavailable — reached the coordinator's
+        // dictionary and stopped there. The user watched a tunnel that had
+        // already failed claim it was still connecting.
         try XCTUnwrap(stubs.byHost[hostID]).transition(to: .portUnavailable)
-        model.refreshHosts()
 
         let row = try XCTUnwrap(model.hosts.first)
-        XCTAssertEqual(row.forwardStatusText, "Port already held on the host.")
+        XCTAssertEqual(row.forwardStatusText, "Port held — close ssh sessions to that host.")
         XCTAssertTrue(row.forwardIsFailure)
         // Owner rule: a Settings status line is one short sentence; the ssh
         // stderr tail belongs in the log.
@@ -271,6 +300,44 @@ final class ClaudeIntegrationSettingsModelTests: XCTestCase {
 
         model.retryPersistentForward(hostID: hostID)
         XCTAssertEqual(try XCTUnwrap(stubs.byHost[hostID]).retried, 1)
+    }
+
+    func testRevokingTheLastHostStopsTheForwardBeforeClosingTheListener() async throws {
+        // Startup order is listener-then-forwards, and shutdown is documented
+        // as its mirror — but revoke ran `listener.reconcile()` (which closes
+        // the port) and only then reconciled the forwards. In that window the
+        // tunnel is still up and its destination is already gone, so a hook
+        // arriving from the remote host gets connection-refused THROUGH a live
+        // forward, and the Mac's ssh client prints `connect_to … failed.` into
+        // the user's remote terminal.
+        let registry = try makeRegistry()
+        let journal = ShutdownJournal()
+        let stubs = ForwardStubs()
+        stubs.journal = journal
+        let listener = StubListener(hosts: registry)
+        listener.journal = journal
+        let forwards = makeForwardCoordinator(registry: registry, stubs: stubs)
+        let model = makeModel(
+            registry: registry,
+            listener: listener,
+            remoteForwardPort: 28542,
+            forwards: forwards
+        )
+        model.enrollLabel = "buildhost"
+        model.enrollSSHAlias = "builder"
+        await model.enroll()
+        model.dismissPlan()
+        let hostID = try XCTUnwrap(model.hosts.first).id
+        model.setPersistentForward(true, hostID: hostID)
+        XCTAssertTrue(listener.isListening)
+
+        await model.revoke(hostID: hostID)
+
+        XCTAssertEqual(
+            journal.recorded, ["forward.stop", "listener.stop"],
+            "shutdown is the mirror of startup: forwards first, listener second"
+        )
+        XCTAssertFalse(listener.isListening)
     }
 
     func testAHostWithNoAliasIsNotOfferedATunnel() async throws {

--- a/Tests/localvoxtralTests/ClaudeRemoteEnrollmentServiceTests.swift
+++ b/Tests/localvoxtralTests/ClaudeRemoteEnrollmentServiceTests.swift
@@ -327,6 +327,16 @@ final class ClaudeRemoteEnrollmentServiceTests: XCTestCase {
         )
     }
 
+    func testNotesSayHowToGroundSessionsNobodyIsSittingInFrontOf() throws {
+        // The failure this answers is silent by construction: a harness-spawned
+        // session on the host publishes hooks into a tunnel no interactive ssh
+        // is holding, and nothing anywhere says so.
+        let notes = try allocatedPlan().notes.joined(separator: "\n")
+        XCTAssertTrue(notes.contains("Keep the tunnel open"), "name the control, not the concept")
+        XCTAssertTrue(notes.lowercased().contains("remote-control"))
+        XCTAssertTrue(notes.lowercased().contains("t3 code"))
+    }
+
     func testNotesExplainTheTwoHalvesAndTheRemainingSingleTenancy() throws {
         let notes = try allocatedPlan().notes.joined(separator: "\n")
         XCTAssertTrue(notes.contains("28511"))

--- a/Tests/localvoxtralTests/ClaudeRemoteForwardCoordinatorTests.swift
+++ b/Tests/localvoxtralTests/ClaudeRemoteForwardCoordinatorTests.swift
@@ -1,0 +1,222 @@
+import Foundation
+import Synchronization
+import XCTest
+@testable import localvoxtral
+
+private final class MemoryHostStore: ClaudeRemoteHostStoreIO {
+    private let contents = Mutex<[String: Data]>([:])
+    func read(from url: URL) throws -> Data? { contents.withLock { $0[url.path] } }
+    func write(_ data: Data, to url: URL) throws { contents.withLock { $0[url.path] = data } }
+}
+
+/// A supervisor stand-in that records rather than spawns. The coordinator's job
+/// is deciding WHICH hosts should have a forward and when — never how ssh
+/// behaves, which is the supervisor's own suite. Nothing here can reach a
+/// process: that is the point of the seam.
+@MainActor
+private final class FakeForwarding: ClaudeRemoteForwarding {
+    let hostID: String
+    private let spy: ForwardSpy
+    var state: ClaudeRemoteForwardSupervisor.State = .stopped
+    var onStateChange: (@MainActor (ClaudeRemoteForwardSupervisor.State) -> Void)?
+
+    init(hostID: String, spy: ForwardSpy) {
+        self.hostID = hostID
+        self.spy = spy
+    }
+
+    func start() {
+        spy.noteStart(hostID)
+        transition(to: .connecting)
+    }
+
+    func stop() {
+        spy.noteStop(hostID)
+        transition(to: .stopped)
+    }
+
+    func retry() { spy.noteRetry(hostID) }
+
+    /// Lets a test drive the pane's view of a forward without a supervisor.
+    func transition(to newState: ClaudeRemoteForwardSupervisor.State) {
+        state = newState
+        onStateChange?(newState)
+    }
+}
+
+@MainActor
+private final class ForwardSpy {
+    private(set) var started: [String] = []
+    private(set) var stopped: [String] = []
+    private(set) var retried: [String] = []
+    private(set) var configurations: [ClaudeRemoteForwardSupervisor.Configuration] = []
+    private(set) var forwards: [String: FakeForwarding] = [:]
+
+    func makeSupervisor(
+        _ configuration: ClaudeRemoteForwardSupervisor.Configuration
+    ) -> any ClaudeRemoteForwarding {
+        configurations.append(configuration)
+        let forwarding = FakeForwarding(hostID: configuration.hostID, spy: self)
+        forwards[configuration.hostID] = forwarding
+        return forwarding
+    }
+
+    func noteStart(_ hostID: String) { started.append(hostID) }
+    func noteStop(_ hostID: String) { stopped.append(hostID) }
+    func noteRetry(_ hostID: String) { retried.append(hostID) }
+}
+
+@MainActor
+final class ClaudeRemoteForwardCoordinatorTests: XCTestCase {
+    private func makeRegistry() throws -> ClaudeRemoteHostRegistry {
+        try ClaudeRemoteHostRegistry(
+            fileURL: URL(fileURLWithPath: "/tmp/lvx-forward-test/\(UUID().uuidString).json"),
+            io: MemoryHostStore(),
+            now: { Date(timeIntervalSince1970: 1_000_000) }
+        )
+    }
+
+    private func makeCoordinator(
+        registry: ClaudeRemoteHostRegistry,
+        spy: ForwardSpy,
+        isListenerBound: @escaping @MainActor () -> Bool = { true }
+    ) -> ClaudeRemoteForwardCoordinator {
+        ClaudeRemoteForwardCoordinator(
+            hosts: registry,
+            remoteForwardPort: 28511,
+            listenerPort: 8473,
+            isListenerBound: isListenerBound,
+            makeSupervisor: { spy.makeSupervisor($0) }
+        )
+    }
+
+    func testOnlyHostsThatOptedInGetAForward() throws {
+        let registry = try makeRegistry()
+        let opted = try registry.enroll(label: "buildhost", sshHostAlias: "builder").host
+        _ = try registry.enroll(label: "other", sshHostAlias: "other")
+        try registry.setPersistentForwardEnabled(true, hostID: opted.id)
+
+        let spy = ForwardSpy()
+        makeCoordinator(registry: registry, spy: spy).reconcile()
+
+        XCTAssertEqual(spy.started, [opted.id], "an app that ssh'd anywhere unasked would be a bug")
+        XCTAssertEqual(spy.configurations.first?.sshHostAlias, "builder")
+        XCTAssertEqual(spy.configurations.first?.remoteForwardPort, 28511)
+        XCTAssertEqual(spy.configurations.first?.listenerPort, 8473)
+    }
+
+    func testAHostWithNoAliasOnFileIsNeverForwarded() throws {
+        // The label is not a substitute for an alias: a host NAMED prod can be
+        // reached as builder, so guessing would ssh somewhere the user never
+        // chose (PR #197).
+        let registry = try makeRegistry()
+        let host = try registry.enroll(label: "buildhost").host
+        try registry.setPersistentForwardEnabled(true, hostID: host.id)
+
+        let spy = ForwardSpy()
+        makeCoordinator(registry: registry, spy: spy).reconcile()
+
+        XCTAssertTrue(spy.started.isEmpty)
+    }
+
+    func testRevokingAHostStopsItsForward() throws {
+        let registry = try makeRegistry()
+        let host = try registry.enroll(label: "buildhost", sshHostAlias: "builder").host
+        try registry.setPersistentForwardEnabled(true, hostID: host.id)
+
+        let spy = ForwardSpy()
+        let coordinator = makeCoordinator(registry: registry, spy: spy)
+        coordinator.reconcile()
+        try registry.revoke(hostID: host.id)
+        coordinator.reconcile()
+
+        XCTAssertEqual(spy.started, [host.id])
+        XCTAssertEqual(spy.stopped, [host.id])
+        XCTAssertNil(coordinator.states[host.id])
+    }
+
+    func testTurningTheToggleOffStopsTheForward() throws {
+        let registry = try makeRegistry()
+        let host = try registry.enroll(label: "buildhost", sshHostAlias: "builder").host
+        try registry.setPersistentForwardEnabled(true, hostID: host.id)
+
+        let spy = ForwardSpy()
+        let coordinator = makeCoordinator(registry: registry, spy: spy)
+        coordinator.reconcile()
+        try registry.setPersistentForwardEnabled(false, hostID: host.id)
+        coordinator.reconcile()
+
+        XCTAssertEqual(spy.stopped, [host.id], "disable must take effect without a relaunch")
+    }
+
+    func testReconcilingTwiceStartsNothingTwice() throws {
+        let registry = try makeRegistry()
+        let host = try registry.enroll(label: "buildhost", sshHostAlias: "builder").host
+        try registry.setPersistentForwardEnabled(true, hostID: host.id)
+
+        let spy = ForwardSpy()
+        let coordinator = makeCoordinator(registry: registry, spy: spy)
+        coordinator.reconcile()
+        coordinator.reconcile()
+
+        XCTAssertEqual(spy.started, [host.id])
+    }
+
+    func testNoForwardRunsWhileTheListenerIsUnbound() throws {
+        // A forward opened before the bind terminates at a closed port: the
+        // hooks get connection-refused and fail open silently, while ssh on
+        // THIS Mac prints `connect_to … failed.` into the user's remote
+        // terminal on every dial. Listener first, always.
+        let registry = try makeRegistry()
+        let host = try registry.enroll(label: "buildhost", sshHostAlias: "builder").host
+        try registry.setPersistentForwardEnabled(true, hostID: host.id)
+
+        let spy = ForwardSpy()
+        let bound = Mutex(false)
+        let coordinator = makeCoordinator(
+            registry: registry, spy: spy, isListenerBound: { bound.withLock { $0 } }
+        )
+        coordinator.reconcile()
+        XCTAssertTrue(spy.started.isEmpty, "no listener, no forward")
+
+        bound.withLock { $0 = true }
+        coordinator.reconcile()
+        XCTAssertEqual(spy.started, [host.id])
+
+        // …and a listener that goes away takes the forwards with it.
+        bound.withLock { $0 = false }
+        coordinator.reconcile()
+        XCTAssertEqual(spy.stopped, [host.id])
+    }
+
+    func testStopAllTearsDownEveryForward() throws {
+        let registry = try makeRegistry()
+        let first = try registry.enroll(label: "one", sshHostAlias: "one").host
+        let second = try registry.enroll(label: "two", sshHostAlias: "two").host
+        try registry.setPersistentForwardEnabled(true, hostID: first.id)
+        try registry.setPersistentForwardEnabled(true, hostID: second.id)
+
+        let spy = ForwardSpy()
+        let coordinator = makeCoordinator(registry: registry, spy: spy)
+        coordinator.reconcile()
+        coordinator.stopAll()
+
+        XCTAssertEqual(Set(spy.stopped), [first.id, second.id])
+        XCTAssertTrue(coordinator.states.isEmpty)
+    }
+
+    func testRetryIsForwardedToTheRightHostOnly() throws {
+        let registry = try makeRegistry()
+        let first = try registry.enroll(label: "one", sshHostAlias: "one").host
+        let second = try registry.enroll(label: "two", sshHostAlias: "two").host
+        try registry.setPersistentForwardEnabled(true, hostID: first.id)
+        try registry.setPersistentForwardEnabled(true, hostID: second.id)
+
+        let spy = ForwardSpy()
+        let coordinator = makeCoordinator(registry: registry, spy: spy)
+        coordinator.reconcile()
+        coordinator.retry(hostID: second.id)
+
+        XCTAssertEqual(spy.retried, [second.id])
+    }
+}

--- a/Tests/localvoxtralTests/ClaudeRemoteForwardCoordinatorTests.swift
+++ b/Tests/localvoxtralTests/ClaudeRemoteForwardCoordinatorTests.swift
@@ -19,6 +19,9 @@ private final class FakeForwarding: ClaudeRemoteForwarding {
     private let spy: ForwardSpy
     var state: ClaudeRemoteForwardSupervisor.State = .stopped
     var onStateChange: (@MainActor (ClaudeRemoteForwardSupervisor.State) -> Void)?
+    /// Settable so a test can hand the coordinator a teardown that is
+    /// still draining and prove the replacement waits for it.
+    var teardown: Task<Void, Never>?
 
     init(hostID: String, spy: ForwardSpy) {
         self.hostID = hostID
@@ -218,5 +221,63 @@ final class ClaudeRemoteForwardCoordinatorTests: XCTestCase {
         coordinator.retry(hostID: second.id)
 
         XCTAssertEqual(spy.retried, [second.id])
+    }
+
+    func testAReplacementForwardWaitsForTheOldOneToFinishDying() async throws {
+        // Toggle off, toggle straight back on — the ordinary way a user retries
+        // something. The remote port is not free until the first ssh has
+        // actually exited, so starting the replacement immediately dials a port
+        // this Mac is still holding and the pane reports `portUnavailable` at
+        // itself, terminally, for a host that is perfectly fine.
+        let registry = try makeRegistry()
+        let spy = ForwardSpy()
+        let coordinator = makeCoordinator(registry: registry, spy: spy)
+        let host = try registry.enroll(label: "buildhost", sshHostAlias: "builder").host
+        try registry.setPersistentForwardEnabled(true, hostID: host.id)
+        coordinator.reconcile()
+        XCTAssertEqual(spy.started, [host.id])
+
+        // Stop it, leaving a teardown that has NOT finished.
+        let release = TeardownGate()
+        try XCTUnwrap(spy.forwards[host.id]).teardown = Task { await release.wait() }
+        try registry.setPersistentForwardEnabled(false, hostID: host.id)
+        coordinator.reconcile()
+        XCTAssertEqual(spy.stopped, [host.id])
+
+        // Back on while the old process is still dying.
+        try registry.setPersistentForwardEnabled(true, hostID: host.id)
+        coordinator.reconcile()
+        for _ in 0..<50 { await Task.yield() }
+        XCTAssertEqual(
+            spy.started, [host.id],
+            "the replacement must not dial a port the old ssh still holds"
+        )
+
+        // Once it is gone, the replacement runs.
+        release.open()
+        for _ in 0..<50 { await Task.yield() }
+        XCTAssertEqual(spy.started, [host.id, host.id])
+    }
+}
+
+/// A teardown a test can hold open and then release.
+private final class TeardownGate: @unchecked Sendable {
+    private let state = Mutex<[CheckedContinuation<Void, Never>]>([])
+    private let opened = Mutex(false)
+
+    func wait() async {
+        if opened.withLock({ $0 }) { return }
+        await withCheckedContinuation { continuation in
+            state.withLock { $0.append(continuation) }
+        }
+    }
+
+    func open() {
+        opened.withLock { $0 = true }
+        let waiters = state.withLock { waiters -> [CheckedContinuation<Void, Never>] in
+            defer { waiters = [] }
+            return waiters
+        }
+        for waiter in waiters { waiter.resume() }
     }
 }

--- a/Tests/localvoxtralTests/ClaudeRemoteForwardSupervisorTests.swift
+++ b/Tests/localvoxtralTests/ClaudeRemoteForwardSupervisorTests.swift
@@ -1,0 +1,446 @@
+import Foundation
+import Synchronization
+import XCTest
+@testable import localvoxtral
+
+/// A fake `ssh -N -R`. Nothing here spawns a process or touches a network:
+/// the supervisor's whole job is deciding what to do when ssh says something
+/// or dies, and both are things a test must be able to cause on demand.
+private final class FakeForwardProcess: ClaudeRemoteForwardProcess, @unchecked Sendable {
+    let standardErrorLines: AsyncStream<String>
+    private let continuation: AsyncStream<String>.Continuation
+
+    private struct ExitState {
+        var status: Int32?
+        var waiters: [CheckedContinuation<Int32, Never>] = []
+    }
+
+    private let exitState = Mutex(ExitState())
+    private let terminations = Mutex(0)
+
+    var terminateCount: Int { terminations.withLock { $0 } }
+
+    init() {
+        let (stream, continuation) = AsyncStream<String>.makeStream(of: String.self)
+        standardErrorLines = stream
+        self.continuation = continuation
+    }
+
+    func emitStandardError(_ line: String) {
+        continuation.yield(line)
+    }
+
+    /// Ends the process: the stderr stream finishes first, exactly as the live
+    /// implementation guarantees, then waiters get the status.
+    func finish(status: Int32) {
+        continuation.finish()
+        let waiters = exitState.withLock { state -> [CheckedContinuation<Int32, Never>] in
+            guard state.status == nil else { return [] }
+            state.status = status
+            defer { state.waiters = [] }
+            return state.waiters
+        }
+        for waiter in waiters { waiter.resume(returning: status) }
+    }
+
+    func waitUntilExit() async -> Int32 {
+        await withCheckedContinuation { continuation in
+            let already = exitState.withLock { state -> Int32? in
+                if let status = state.status { return status }
+                state.waiters.append(continuation)
+                return nil
+            }
+            if let already { continuation.resume(returning: already) }
+        }
+    }
+
+    func terminate() {
+        terminations.withLock { $0 += 1 }
+        finish(status: 143)
+    }
+}
+
+/// Await-driven test harness. No polling and no wall clock: every wait is a
+/// continuation the supervisor itself resumes, through the launch seam or the
+/// state callback.
+@MainActor
+private final class ForwardHarness {
+    private(set) var processes: [FakeForwardProcess] = []
+    private(set) var states: [ClaudeRemoteForwardSupervisor.State] = []
+    private(set) var sleeps: [Duration] = []
+
+    struct WaitTimeout: Error {}
+
+    /// A pending wait. Resolved either by the supervisor doing the thing, or by
+    /// this waiter's own timeout task — which resumes with `nil`/`false` rather
+    /// than leaving the test hung.
+    ///
+    /// Every wait is bounded on purpose. An unbounded one turns a broken
+    /// supervisor into a HUNG SUITE instead of a failing test, which is exactly
+    /// what happened the first time these ran against a deliberately broken
+    /// build, and a hang tells CI nothing. The timeout is only a backstop: a
+    /// passing run is resumed by the supervisor and never sleeps at all, so a
+    /// generous 20s costs nothing and leaves room for the self-hosted runner
+    /// to be running two other agents' jobs at the same time.
+    private struct ProcessWaiter {
+        let id: UUID
+        let index: Int
+        let continuation: CheckedContinuation<FakeForwardProcess?, Never>
+    }
+
+    private struct StateWaiter {
+        let id: UUID
+        let predicate: (ClaudeRemoteForwardSupervisor.State) -> Bool
+        let continuation: CheckedContinuation<Bool, Never>
+    }
+
+    private var processWaiters: [ProcessWaiter] = []
+    private var stateWaiters: [StateWaiter] = []
+
+    /// When true, every injected sleep records its duration and then BLOCKS
+    /// until `releaseSleeps()`. That is what makes "the process died while its
+    /// settle window was still open" an orderable event rather than a race.
+    var holdSleeps = false
+    private var heldSleeps: [CheckedContinuation<Void, Never>] = []
+
+    func recordSleep(_ duration: Duration) async {
+        sleeps.append(duration)
+        guard holdSleeps else { return }
+        await withCheckedContinuation { heldSleeps.append($0) }
+    }
+
+    func releaseSleeps() {
+        let held = heldSleeps
+        heldSleeps = []
+        for continuation in held { continuation.resume() }
+    }
+
+    /// Releases the OLDEST held sleep only. Releasing one at a time is what
+    /// makes "the stale settle window woke up while the supervise loop was
+    /// still parked on its backoff" a state a test can actually stand in,
+    /// rather than a scheduling coin-flip.
+    func releaseOldestSleep() {
+        guard !heldSleeps.isEmpty else { return }
+        heldSleeps.removeFirst().resume()
+    }
+
+    func makeSupervisor(
+        configuration: ClaudeRemoteForwardSupervisor.Configuration,
+        launchFailure: (any Error)? = nil
+    ) -> ClaudeRemoteForwardSupervisor {
+        let supervisor = ClaudeRemoteForwardSupervisor(
+            configuration: configuration,
+            launch: { [weak self] _ in
+                if let launchFailure { throw launchFailure }
+                let process = FakeForwardProcess()
+                self?.record(process)
+                return process
+            },
+            sleepFor: { [weak self] duration in
+                guard let self else { return }
+                await self.recordSleep(duration)
+            }
+        )
+        supervisor.onStateChange = { [weak self] state in self?.record(state) }
+        return supervisor
+    }
+
+    private func record(_ process: FakeForwardProcess) {
+        processes.append(process)
+        let index = processes.count - 1
+        let satisfied = processWaiters.filter { $0.index == index }
+        processWaiters.removeAll { $0.index == index }
+        for waiter in satisfied { waiter.continuation.resume(returning: process) }
+    }
+
+    private func record(_ state: ClaudeRemoteForwardSupervisor.State) {
+        states.append(state)
+        let satisfied = stateWaiters.filter { $0.predicate(state) }
+        stateWaiters.removeAll { waiter in satisfied.contains { $0.id == waiter.id } }
+        for waiter in satisfied { waiter.continuation.resume(returning: true) }
+    }
+
+    func process(
+        _ index: Int, timeout: Duration = .seconds(20), line: UInt = #line
+    ) async throws -> FakeForwardProcess {
+        if processes.count > index { return processes[index] }
+        let id = UUID()
+        let result: FakeForwardProcess? = await withCheckedContinuation { continuation in
+            processWaiters.append(ProcessWaiter(id: id, index: index, continuation: continuation))
+            armTimeout(timeout) { [weak self] in self?.expireProcessWaiter(id) }
+        }
+        guard let result else {
+            XCTFail("timed out waiting for process \(index)", line: line)
+            throw WaitTimeout()
+        }
+        return result
+    }
+
+    func waitForState(
+        timeout: Duration = .seconds(20),
+        line: UInt = #line,
+        _ predicate: @escaping (ClaudeRemoteForwardSupervisor.State) -> Bool
+    ) async throws {
+        if states.contains(where: predicate) { return }
+        let id = UUID()
+        let satisfied: Bool = await withCheckedContinuation { continuation in
+            stateWaiters.append(
+                StateWaiter(id: id, predicate: predicate, continuation: continuation)
+            )
+            armTimeout(timeout) { [weak self] in self?.expireStateWaiter(id) }
+        }
+        guard satisfied else {
+            XCTFail("timed out waiting for a state; saw \(states)", line: line)
+            throw WaitTimeout()
+        }
+    }
+
+    private func armTimeout(_ timeout: Duration, _ expire: @escaping @MainActor () -> Void) {
+        Task { @MainActor in
+            try? await Task.sleep(for: timeout)
+            expire()
+        }
+    }
+
+    private func expireProcessWaiter(_ id: UUID) {
+        guard let index = processWaiters.firstIndex(where: { $0.id == id }) else { return }
+        let waiter = processWaiters.remove(at: index)
+        waiter.continuation.resume(returning: nil)
+    }
+
+    private func expireStateWaiter(_ id: UUID) {
+        guard let index = stateWaiters.firstIndex(where: { $0.id == id }) else { return }
+        let waiter = stateWaiters.remove(at: index)
+        waiter.continuation.resume(returning: false)
+    }
+}
+
+@MainActor
+final class ClaudeRemoteForwardSupervisorTests: XCTestCase {
+    private func configuration(
+        maxConsecutiveFailures: Int = 5
+    ) -> ClaudeRemoteForwardSupervisor.Configuration {
+        ClaudeRemoteForwardSupervisor.Configuration(
+            hostID: "habc1234",
+            sshHostAlias: "builder",
+            remoteForwardPort: 28511,
+            listenerPort: 8473,
+            maxConsecutiveFailures: maxConsecutiveFailures,
+            settleDelay: .seconds(2)
+        )
+    }
+
+    // MARK: Command shape
+
+    func testTheForwardExitsRatherThanRunWithoutItsBind() {
+        // The enrollment ssh block sets `ExitOnForwardFailure no` on purpose —
+        // a dictation nicety must never cost the user a shell. This process IS
+        // the nicety, so the opposite is right: a forward that cannot bind has
+        // no reason to stay connected, and its exit is the detection signal.
+        let argv = configuration().argv
+        XCTAssertTrue(argv.contains("ExitOnForwardFailure=yes"))
+        XCTAssertTrue(argv.contains("BatchMode=yes"))
+        XCTAssertTrue(argv.contains("-N"), "a forward holder must not run a remote command")
+        XCTAssertTrue(argv.contains("-R"))
+        XCTAssertTrue(argv.contains("28511:127.0.0.1:8473"))
+        XCTAssertTrue(argv.contains("ServerAliveInterval=30"))
+        XCTAssertTrue(argv.contains("ServerAliveCountMax=3"))
+    }
+
+    func testInheritedForwardingsAreClearedSoTheProcessCannotFightItself() {
+        // The user's ssh config block for this alias already declares the same
+        // RemoteForward. Inheriting it would make this process request the port
+        // twice — and the second request failing kills it, under the
+        // ExitOnForwardFailure=yes above.
+        XCTAssertTrue(configuration().argv.contains("ClearAllForwardings=yes"))
+    }
+
+    func testTheAliasIsTheLastArgumentAndOptionParsingIsTerminated() {
+        let argv = configuration().argv
+        XCTAssertEqual(argv.last, "builder")
+        XCTAssertEqual(argv[argv.count - 2], "--", "an alias must never be readable as an option")
+        XCTAssertFalse(
+            argv.joined(separator: " ").lowercased().contains("token"),
+            "no credential exists on this path"
+        )
+    }
+
+    // MARK: Lifecycle
+
+    func testAStableTunnelReportsUpAfterTheSettleWindow() async throws {
+        let harness = ForwardHarness()
+        let supervisor = harness.makeSupervisor(configuration: configuration())
+        supervisor.start()
+
+        _ = try await harness.process(0)
+        try await harness.waitForState { $0 == .forwarding }
+        XCTAssertEqual(supervisor.state, .forwarding)
+        XCTAssertEqual(harness.sleeps, [.seconds(2)], "the settle window uses the injected clock")
+    }
+
+    func testARefusedBindIsTerminalAndNeverRestarts() async throws {
+        // The whole point: something else holds that port (issue #215) and will
+        // keep holding it. Retrying on a timer would be a connection storm the
+        // user never sees the cause of.
+        let harness = ForwardHarness()
+        let supervisor = harness.makeSupervisor(configuration: configuration())
+        supervisor.start()
+
+        let process = try await harness.process(0)
+        process.emitStandardError(
+            "Warning: remote port forwarding failed for listen port 28511"
+        )
+        process.finish(status: 255)
+
+        try await harness.waitForState { $0 == .portUnavailable }
+        XCTAssertEqual(supervisor.state, .portUnavailable)
+        XCTAssertEqual(harness.processes.count, 1, "a refused bind must not be retried")
+        XCTAssertFalse(
+            harness.states.contains { if case .retrying = $0 { return true } else { return false } },
+            "a refusal is not a crash: \(harness.states)"
+        )
+        XCTAssertTrue(supervisor.state.isFailure)
+        XCTAssertEqual(supervisor.state.text, "Port already held on the host.")
+        XCTAssertLessThan(supervisor.state.text.count, 60, "owner rule: one short sentence")
+    }
+
+    func testAnOrdinaryExitRestartsWithExponentialBackoff() async throws {
+        let harness = ForwardHarness()
+        let supervisor = harness.makeSupervisor(configuration: configuration())
+        supervisor.start()
+
+        // A dropped connection: ssh dies with no forwarding complaint.
+        let first = try await harness.process(0)
+        first.emitStandardError("Connection to builder closed by remote host.")
+        first.finish(status: 255)
+
+        try await harness.waitForState { $0 == .retrying(attempt: 1) }
+        let second = try await harness.process(1)
+        second.finish(status: 255)
+        try await harness.waitForState { $0 == .retrying(attempt: 2) }
+        _ = try await harness.process(2)
+
+        // 2s settle, 0.5s backoff, 2s settle, 1s backoff — the backoff doubles,
+        // exactly like the backend supervisor's. The prefix, not the whole
+        // array: the third launch's settle sleep is recorded by the supervise
+        // loop after this point, and asserting it here would be asserting on a
+        // race rather than on the backoff.
+        XCTAssertEqual(
+            Array(harness.sleeps.prefix(4)),
+            [.seconds(2), .milliseconds(500), .seconds(2), .seconds(1)],
+            "\(harness.sleeps)"
+        )
+    }
+
+    func testAProcessThatDiesInsideItsSettleWindowIsNeverReportedAsUp() async throws {
+        // The settle task sleeps on the injected clock and only then calls the
+        // tunnel up. Hold that sleep open, kill the process underneath it, and
+        // wake the sleep while the supervise loop is still parked on its
+        // backoff — so the loop has NOT yet cancelled the stale settle task.
+        // Cancellation alone would only usually win that race; the per-launch
+        // generation is what makes it impossible. Without it, the pane gets
+        // "Tunnel up." painted over the `.retrying` of a dead tunnel.
+        let harness = ForwardHarness()
+        harness.holdSleeps = true
+        let supervisor = harness.makeSupervisor(configuration: configuration())
+        supervisor.start()
+
+        let first = try await harness.process(0)   // its settle sleep is now held
+        first.finish(status: 255)
+        try await harness.waitForState { $0 == .retrying(attempt: 1) }
+
+        // Two sleeps are held now: the dead process's settle, then the backoff.
+        // Wake ONLY the settle; the loop stays parked, so nothing has cancelled
+        // it and nothing else can have moved the state.
+        harness.releaseOldestSleep()
+        await Task.yield()
+        await Task.yield()
+
+        XCTAssertFalse(
+            harness.states.contains(.forwarding),
+            "a settle window that outlived its own process must report nothing: \(harness.states)"
+        )
+        XCTAssertEqual(supervisor.state, .retrying(attempt: 1))
+    }
+
+    func testItGivesUpAfterTheConfiguredNumberOfConsecutiveFailures() async throws {
+        // An unbounded reconnect loop against someone's SSH server is not a
+        // thing to ship, and a tunnel that failed five times running is not one
+        // more attempt away from working.
+        let harness = ForwardHarness()
+        let supervisor = harness.makeSupervisor(configuration: configuration(maxConsecutiveFailures: 3))
+        supervisor.start()
+
+        for index in 0..<3 {
+            let process = try await harness.process(index)
+            process.finish(status: 255)
+        }
+
+        try await harness.waitForState { if case .failed = $0 { return true } else { return false } }
+        XCTAssertEqual(harness.processes.count, 3, "it must stop launching, not keep going")
+        XCTAssertTrue(supervisor.state.isFailure)
+        XCTAssertEqual(supervisor.state.text, "Tunnel stopped.")
+    }
+
+    func testStoppingTerminatesTheProcessAndLaunchesNothingMore() async throws {
+        let harness = ForwardHarness()
+        let supervisor = harness.makeSupervisor(configuration: configuration())
+        supervisor.start()
+        let process = try await harness.process(0)
+
+        supervisor.stop()
+
+        XCTAssertEqual(supervisor.state, .stopped)
+        XCTAssertEqual(process.terminateCount, 1)
+        // The supervise loop sees the intentional stop and does not treat the
+        // terminated process as a crash to restart.
+        try await harness.waitForState { $0 == .stopped }
+        XCTAssertEqual(harness.processes.count, 1)
+        XCTAssertFalse(
+            harness.states.contains { if case .retrying = $0 { return true } else { return false } }
+        )
+    }
+
+    func testStartingTwiceRunsOneProcess() async throws {
+        let harness = ForwardHarness()
+        let supervisor = harness.makeSupervisor(configuration: configuration())
+        supervisor.start()
+        _ = try await harness.process(0)
+        supervisor.start()
+        XCTAssertEqual(harness.processes.count, 1, "start must be idempotent")
+    }
+
+    func testALaunchFailureIsReportedAndNotSpunOn() async throws {
+        struct Boom: Error {}
+        let harness = ForwardHarness()
+        let supervisor = harness.makeSupervisor(
+            configuration: configuration(), launchFailure: Boom()
+        )
+        supervisor.start()
+
+        try await harness.waitForState { if case .failed = $0 { return true } else { return false } }
+        XCTAssertEqual(harness.processes.count, 0)
+        XCTAssertTrue(supervisor.state.isFailure)
+    }
+
+    func testOnlyAFailedForwardCanBeRetried() async throws {
+        let harness = ForwardHarness()
+        let supervisor = harness.makeSupervisor(configuration: configuration())
+        supervisor.start()
+        _ = try await harness.process(0)
+        try await harness.waitForState { $0 == .forwarding }
+
+        supervisor.retry()
+        XCTAssertEqual(
+            harness.processes.count, 1,
+            "retrying a healthy tunnel would drop the working one for no reason"
+        )
+    }
+
+    func testBackoffIsExponentialAndCapped() {
+        XCTAssertEqual(ClaudeRemoteForwardSupervisor.backoff(attempt: 1), .milliseconds(500))
+        XCTAssertEqual(ClaudeRemoteForwardSupervisor.backoff(attempt: 2), .seconds(1))
+        XCTAssertEqual(ClaudeRemoteForwardSupervisor.backoff(attempt: 3), .seconds(2))
+        XCTAssertEqual(ClaudeRemoteForwardSupervisor.backoff(attempt: 20), .seconds(30))
+    }
+}

--- a/Tests/localvoxtralTests/ClaudeRemoteForwardSupervisorTests.swift
+++ b/Tests/localvoxtralTests/ClaudeRemoteForwardSupervisorTests.swift
@@ -17,10 +17,21 @@ private final class FakeForwardProcess: ClaudeRemoteForwardProcess, @unchecked S
 
     private let exitState = Mutex(ExitState())
     private let terminations = Mutex(0)
+    private let forcedTerminations = Mutex(0)
+
+    /// When true, `terminate()` signals and RETURNS — the process keeps
+    /// running until the test ends it. A fake that dies synchronously inside
+    /// `terminate()` cannot express the case teardown exists for (an ssh that
+    /// is slow to die, or ignores SIGTERM entirely), so with that fake every
+    /// escalation test passes vacuously.
+    let ignoresTermination: Bool
 
     var terminateCount: Int { terminations.withLock { $0 } }
+    var forceTerminateCount: Int { forcedTerminations.withLock { $0 } }
+    var hasExited: Bool { exitState.withLock { $0.status != nil } }
 
-    init() {
+    init(ignoresTermination: Bool = false) {
+        self.ignoresTermination = ignoresTermination
         let (stream, continuation) = AsyncStream<String>.makeStream(of: String.self)
         standardErrorLines = stream
         self.continuation = continuation
@@ -56,7 +67,15 @@ private final class FakeForwardProcess: ClaudeRemoteForwardProcess, @unchecked S
 
     func terminate() {
         terminations.withLock { $0 += 1 }
+        guard !ignoresTermination else { return }
         finish(status: 143)
+    }
+
+    /// SIGKILL: even the stubborn fake cannot survive it, which is the
+    /// property the escalation depends on.
+    func forceTerminate() {
+        forcedTerminations.withLock { $0 += 1 }
+        finish(status: 137)
     }
 }
 
@@ -97,6 +116,35 @@ private final class ForwardHarness {
     private var processWaiters: [ProcessWaiter] = []
     private var stateWaiters: [StateWaiter] = []
 
+    /// Every fake this harness makes ignores SIGTERM, so teardown has to
+    /// escalate.
+    let processesIgnoreTermination: Bool
+
+    init(processesIgnoreTermination: Bool = false) {
+        self.processesIgnoreTermination = processesIgnoreTermination
+    }
+
+    /// The supervisor's injected clock. Uptime is what decides whether a drop
+    /// counts as part of a run of failures, so a test has to be able to say how
+    /// long a connection lasted — without any of it being real time.
+    private(set) var clock = Date(timeIntervalSince1970: 1_000_000)
+
+    func advanceClock(by seconds: TimeInterval) {
+        clock = clock.addingTimeInterval(seconds)
+    }
+
+    /// Yield until the main actor has nothing left to run.
+    ///
+    /// A fixed number of `Task.yield()`s is a guess about the scheduler, and a
+    /// wrong guess makes a test pass by not letting the buggy code run — which
+    /// is exactly how the settle-window regression hid. This keeps yielding
+    /// while anything is still making progress, so "nothing more happens" is
+    /// something the test observes rather than assumes. Bounded so a live-lock
+    /// fails the test instead of hanging the suite.
+    func drainMainActor(iterations: Int = 200) async {
+        for _ in 0..<iterations { await Task.yield() }
+    }
+
     /// When true, every injected sleep records its duration and then BLOCKS
     /// until `releaseSleeps()`. That is what makes "the process died while its
     /// settle window was still open" an orderable event rather than a race.
@@ -132,14 +180,17 @@ private final class ForwardHarness {
             configuration: configuration,
             launch: { [weak self] _ in
                 if let launchFailure { throw launchFailure }
-                let process = FakeForwardProcess()
+                let process = FakeForwardProcess(
+                    ignoresTermination: self?.processesIgnoreTermination ?? false
+                )
                 self?.record(process)
                 return process
             },
             sleepFor: { [weak self] duration in
                 guard let self else { return }
                 await self.recordSleep(duration)
-            }
+            },
+            now: { [weak self] in self?.clock ?? Date(timeIntervalSince1970: 1_000_000) }
         )
         supervisor.onStateChange = { [weak self] state in self?.record(state) }
         return supervisor
@@ -195,6 +246,42 @@ private final class ForwardHarness {
         }
     }
 
+    /// Waits for the state LIST to reach a length, rather than for a state to
+    /// appear.
+    ///
+    /// `waitForState` answers "has this ever happened", which is the wrong
+    /// question once a value can recur: waiting for `.retrying(attempt: 1)`
+    /// after an earlier `.retrying(attempt: 1)` returns instantly and the test
+    /// then asserts against a sequence that has not been written yet.
+    func waitForStateCount(
+        _ count: Int, timeout: Duration = .seconds(20), line: UInt = #line
+    ) async throws {
+        try await waitForState(timeout: timeout, line: line) { [weak self] _ in
+            (self?.states.count ?? 0) >= count
+        }
+    }
+
+    /// Every `.retrying` attempt number recorded so far, in order.
+    var retryAttempts: [Int] {
+        states.compactMap { state in
+            if case .retrying(let attempt) = state { return attempt } else { return nil }
+        }
+    }
+
+    /// Waits until this many retries have been published.
+    ///
+    /// Counting RETRIES specifically, because a bare "the list grew" wait wakes
+    /// on whatever lands first — and with an instant settle window that is the
+    /// `.forwarding` of the connection that just dropped, not the retry the
+    /// test is about.
+    func waitForRetryCount(
+        _ count: Int, timeout: Duration = .seconds(20), line: UInt = #line
+    ) async throws {
+        try await waitForState(timeout: timeout, line: line) { [weak self] _ in
+            (self?.retryAttempts.count ?? 0) >= count
+        }
+    }
+
     private func armTimeout(_ timeout: Duration, _ expire: @escaping @MainActor () -> Void) {
         Task { @MainActor in
             try? await Task.sleep(for: timeout)
@@ -247,12 +334,48 @@ final class ClaudeRemoteForwardSupervisorTests: XCTestCase {
         XCTAssertTrue(argv.contains("ServerAliveCountMax=3"))
     }
 
-    func testInheritedForwardingsAreClearedSoTheProcessCannotFightItself() {
-        // The user's ssh config block for this alias already declares the same
-        // RemoteForward. Inheriting it would make this process request the port
-        // twice — and the second request failing kills it, under the
-        // ExitOnForwardFailure=yes above.
-        XCTAssertTrue(configuration().argv.contains("ClearAllForwardings=yes"))
+    func testNoOptionCanClearTheForwardTheProcessExistsToCreate() {
+        // The regression that made this whole feature a no-op. The argv used to
+        // carry `ClearAllForwardings=yes` to stop the alias's own RemoteForward
+        // being inherited twice — but ssh_config(5) says that option clears
+        // forwardings given "in the configuration files or on the command
+        // line", so it cleared our `-R` as well. Measured with
+        // `ssh -G -F <config> -o ClearAllForwardings=yes -R 28511:… alias`:
+        // the effective config contains `clearallforwardings yes` and NO
+        // `remoteforward` line, so the supervised ssh connected, settled, and
+        // reported "Tunnel up." while forwarding nothing.
+        //
+        // Asserted as a property — no forwarding-clearing option, whatever it
+        // is called — rather than as the absence of one spelling, so a future
+        // equivalent cannot walk back in.
+        let argv = configuration().argv
+        XCTAssertTrue(argv.contains("-R"), "the forward is the entire point of this process")
+        XCTAssertTrue(argv.contains("28511:127.0.0.1:8473"))
+        let joined = argv.joined(separator: " ").lowercased()
+        XCTAssertFalse(
+            joined.contains("clearallforwardings"),
+            "clearing forwardings also clears the -R: \(argv)"
+        )
+        XCTAssertFalse(joined.contains("noremoteforward"), argv.description)
+    }
+
+    func testTheConnectionCannotDetachMultiplexOrRunALocalCommand() {
+        // Every one of these is settable per-Host in the user's own config, and
+        // each breaks the supervisor's grip in a different way:
+        // ForkAfterAuthentication backgrounds ssh out of the tracked Process
+        // (its parent exits, the child keeps the bind and the stderr pipe, and
+        // neither disable nor quit can reach it); ControlPersist lets a
+        // multiplexed master outlive the process that started it; an inherited
+        // LocalCommand runs on this Mac on every reconnect.
+        let argv = configuration().argv
+        for option in ["ForkAfterAuthentication=no", "ControlPath=none", "PermitLocalCommand=no"] {
+            XCTAssertTrue(argv.contains(option), "missing \(option): \(argv)")
+            // Options must be passed as `-o value` pairs, not smuggled into the
+            // alias or concatenated — the `--` termination only protects the
+            // alias.
+            let index = try? XCTUnwrap(argv.firstIndex(of: option))
+            if let index { XCTAssertEqual(argv[index - 1], "-o") }
+        }
     }
 
     func testTheAliasIsTheLastArgumentAndOptionParsingIsTerminated() {
@@ -300,8 +423,59 @@ final class ClaudeRemoteForwardSupervisorTests: XCTestCase {
             "a refusal is not a crash: \(harness.states)"
         )
         XCTAssertTrue(supervisor.state.isFailure)
-        XCTAssertEqual(supervisor.state.text, "Port already held on the host.")
+        // The copy has to name the thing to close. The overwhelmingly common
+        // holder is an ssh session from this very Mac, and "Port already held
+        // on the host." left the user with a Retry button and no idea what to
+        // do before pressing it.
+        XCTAssertEqual(supervisor.state.text, "Port held — close ssh sessions to that host.")
         XCTAssertLessThan(supervisor.state.text.count, 60, "owner rule: one short sentence")
+    }
+
+    func testARefusalForAPortWeNeverAskedForBlamesTheConfigNotTheHost() async throws {
+        // The #215 migration cohort: the alias's ssh config block still
+        // declares `RemoteForward 8473 …` from before per-Mac ports. Dropping
+        // ClearAllForwardings (which had to go — it cleared our own `-R`) means
+        // that stale forward IS inherited, and under ExitOnForwardFailure=yes
+        // its refusal kills the process. Verified with `ssh -G`: a legacy block
+        // plus our `-R 28511` yields BOTH `remoteforward 28511` and
+        // `remoteforward 8473`.
+        //
+        // Reporting that as "port held" would send the user hunting for a
+        // process on the remote host that does not exist. The fix is in their
+        // own ~/.ssh/config.
+        let harness = ForwardHarness()
+        let supervisor = harness.makeSupervisor(configuration: configuration())
+        supervisor.start()
+
+        let process = try await harness.process(0)
+        process.emitStandardError(
+            "Warning: remote port forwarding failed for listen port 8473"
+        )
+        process.finish(status: 255)
+
+        try await harness.waitForState {
+            if case .staleConfiguredForward = $0 { return true } else { return false }
+        }
+        XCTAssertEqual(supervisor.state, .staleConfiguredForward(port: 8473))
+        XCTAssertTrue(supervisor.state.isFailure, "it cannot fix itself by retrying")
+        XCTAssertEqual(harness.processes.count, 1, "and it must not retry")
+        XCTAssertEqual(supervisor.state.text, "Old RemoteForward in ~/.ssh/config blocks this.")
+        XCTAssertLessThan(supervisor.state.text.count, 60, "owner rule: one short sentence")
+    }
+
+    func testTheRefusedPortIsReadFromTheWarningNotGuessed() {
+        // `listen port` anchors it: the same line carries host names, and a
+        // hostname with digits must never be read as a port.
+        XCTAssertEqual(
+            ClaudeRemoteForwardSupervisor.refusedPort(
+                in: "warning: remote port forwarding failed for listen port 28511"
+            ),
+            28511
+        )
+        XCTAssertNil(
+            ClaudeRemoteForwardSupervisor.refusedPort(in: "remote port forwarding failed")
+        )
+        XCTAssertNil(ClaudeRemoteForwardSupervisor.refusedPort(in: "connection to host99 closed"))
     }
 
     func testAnOrdinaryExitRestartsWithExponentialBackoff() async throws {
@@ -349,18 +523,136 @@ final class ClaudeRemoteForwardSupervisorTests: XCTestCase {
         first.finish(status: 255)
         try await harness.waitForState { $0 == .retrying(attempt: 1) }
 
-        // Two sleeps are held now: the dead process's settle, then the backoff.
-        // Wake ONLY the settle; the loop stays parked, so nothing has cancelled
-        // it and nothing else can have moved the state.
+        // Wake the dead process's settle window while the loop is still parked
+        // on its backoff, so nothing has left the loop-body scope and the old
+        // `defer { settle.cancel() }` has not run.
         harness.releaseOldestSleep()
-        await Task.yield()
-        await Task.yield()
+        // Drain the main actor until it is quiet. TWO yields used to be enough
+        // to make this test pass — and that was the whole reason it passed:
+        // the stale settle task simply had not been scheduled yet. Measured
+        // with an instrumented copy of this scenario, at 50 yields the old code
+        // published `.forwarding` on top of `.retrying(1)` and the final state
+        // was `forwarding`. Waiting for quiescence is what turns this from a
+        // test of the scheduler into a test of the guard.
+        await harness.drainMainActor()
 
         XCTAssertFalse(
             harness.states.contains(.forwarding),
             "a settle window that outlived its own process must report nothing: \(harness.states)"
         )
         XCTAssertEqual(supervisor.state, .retrying(attempt: 1))
+    }
+
+    func testADropAfterALongHealthyRunIsNotPartOfARunOfFailures() async throws {
+        // `consecutiveFailures` never reset, so failures accumulated for the
+        // life of the supervisor. Five drops spread over five days — a laptop
+        // closing its lid five times — hit the cap and stopped the tunnel for
+        // good with "keeps dropping", each retry inheriting a backoff computed
+        // from failures that had nothing to do with each other.
+        let harness = ForwardHarness()
+        let supervisor = harness.makeSupervisor(
+            configuration: configuration(maxConsecutiveFailures: 3)
+        )
+        supervisor.start()
+
+        // Two quick drops: no uptime between them, so they DO accumulate.
+        for index in 0..<2 {
+            let process = try await harness.process(index)
+            process.finish(status: 255)
+            try await harness.waitForState { $0 == .retrying(attempt: index + 1) }
+        }
+
+        // The third connection stays up for an hour before dropping.
+        let healthy = try await harness.process(2)
+        harness.advanceClock(by: 3600)
+        healthy.finish(status: 255)
+
+        // So it is failure number ONE again — not number three, which under a
+        // cap of 3 would have been terminal. Waited for by RETRY COUNT: an
+        // earlier `.retrying(attempt: 1)` is already in the list, so waiting
+        // for that VALUE returns before this drop is processed, and waiting for
+        // the list merely to grow wakes on this connection's own `.forwarding`.
+        try await harness.waitForRetryCount(3)
+        // Asserted on the RECORDED sequence, not on `supervisor.state`: the
+        // backoff is instant on the injected clock, so the loop has usually
+        // relaunched into `.connecting` by the time the test looks.
+        XCTAssertEqual(
+            harness.retryAttempts, [1, 2, 1],
+            "the drop after an hour of uptime must restart the count: \(harness.states)"
+        )
+        XCTAssertFalse(
+            harness.states.contains { if case .failed = $0 { return true } else { return false } },
+            "a tunnel that ran for an hour must not be given up on: \(harness.states)"
+        )
+    }
+
+    func testConnectionsThatDieQuicklyStillHitTheCap() async throws {
+        // The other half of the rule, and the reason "healthy" is not "survived
+        // the 2s settle window": a tunnel that connects, holds briefly and dies
+        // — over and over — is the reconnect storm the cap exists to stop. If
+        // merely settling reset the counter, the cap would be unreachable.
+        let harness = ForwardHarness()
+        let supervisor = harness.makeSupervisor(
+            configuration: configuration(maxConsecutiveFailures: 3)
+        )
+        supervisor.start()
+
+        for index in 0..<3 {
+            let process = try await harness.process(index)
+            // Long enough to settle and be called up, nowhere near healthy.
+            harness.advanceClock(by: 3)
+            process.finish(status: 255)
+        }
+
+        try await harness.waitForState { if case .failed = $0 { return true } else { return false } }
+        XCTAssertTrue(supervisor.state.isFailure)
+        XCTAssertEqual(harness.processes.count, 3, "it must stop launching, not keep going")
+    }
+
+    // MARK: Teardown
+
+    func testStoppingEscalatesToSIGKILLWhenTheProcessIgnoresSIGTERM() async throws {
+        // The case the escalation exists for: ssh wedged on a dead network,
+        // holding the remote bind. Without it the supervisor sends one SIGTERM,
+        // forgets the child, and the port stays bound by a process nothing can
+        // reach any more.
+        let harness = ForwardHarness(processesIgnoreTermination: true)
+        let supervisor = harness.makeSupervisor(configuration: configuration())
+        supervisor.start()
+        let process = try await harness.process(0)
+
+        supervisor.stop()
+        XCTAssertEqual(process.terminateCount, 1, "SIGTERM comes first")
+        XCTAssertEqual(process.forceTerminateCount, 0, "and it gets its grace window")
+        XCTAssertFalse(process.hasExited)
+
+        await supervisor.teardown?.value
+
+        XCTAssertEqual(process.forceTerminateCount, 1, "the grace window expired: SIGKILL")
+        XCTAssertTrue(process.hasExited)
+        XCTAssertEqual(supervisor.state, .stopped)
+    }
+
+    func testAProcessThatHonoursSIGTERMIsNeverKilled() async throws {
+        // The grace window is HELD open for the whole test, so "did it escalate"
+        // cannot be answered by the grace expiring first. The only thing that
+        // can resolve the wait here is the process exiting — which is exactly
+        // the property being asserted.
+        let harness = ForwardHarness()
+        harness.holdSleeps = true
+        let supervisor = harness.makeSupervisor(configuration: configuration())
+        supervisor.start()
+        let process = try await harness.process(0)
+
+        supervisor.stop()
+        await supervisor.teardown?.value
+
+        XCTAssertEqual(process.terminateCount, 1)
+        XCTAssertEqual(
+            process.forceTerminateCount, 0,
+            "SIGKILL on a process that already exited is a bug, not belt-and-braces"
+        )
+        XCTAssertTrue(process.hasExited)
     }
 
     func testItGivesUpAfterTheConfiguredNumberOfConsecutiveFailures() async throws {

--- a/Tests/localvoxtralTests/ClaudeRemoteHostRegistryTests.swift
+++ b/Tests/localvoxtralTests/ClaudeRemoteHostRegistryTests.swift
@@ -266,9 +266,15 @@ final class ClaudeRemoteHostRegistryTests: XCTestCase {
         // and the alternative — guessing it from the label — acted on the wrong
         // machine.
         let properties = Mirror(reflecting: enrollment.host).children.compactMap(\.label)
+        // `persistentForwardEnabled` joined it for the same reason: it is a
+        // per-host preference (does the app hold this host's ssh forward), not
+        // credential material, and the pane has to be able to render it.
         XCTAssertEqual(
             Set(properties),
-            ["id", "label", "sshHostAlias", "createdAt", "lastSeenAt", "revokedAt"]
+            [
+                "id", "label", "sshHostAlias", "createdAt", "lastSeenAt", "revokedAt",
+                "persistentForwardEnabled",
+            ]
         )
         let described = String(describing: enrollment.host)
         XCTAssertFalse(described.contains(enrollment.token))
@@ -424,6 +430,73 @@ final class ClaudeRemoteHostRegistryTests: XCTestCase {
         advance(10)
         registry.noteActivity(hostID: enrollment.host.id)
         XCTAssertEqual(io.written(at: fileURL), before)
+    }
+
+    // MARK: Persistent forward opt-in
+
+    func testThePersistentForwardFlagIsOffUntilItIsTurnedOnAndSurvivesARelaunch() throws {
+        // Spawning ssh on someone's behalf is an opt-in, and "the file was
+        // silent about it" must read as off — never as on.
+        let registry = try makeRegistry()
+        let host = try registry.enroll(label: "buildhost", sshHostAlias: "builder").host
+        XCTAssertFalse(try XCTUnwrap(registry.host(id: host.id)).persistentForwardEnabled)
+
+        try registry.setPersistentForwardEnabled(true, hostID: host.id)
+        XCTAssertTrue(try XCTUnwrap(registry.host(id: host.id)).persistentForwardEnabled)
+
+        // A second registry over the same store is the next launch.
+        let relaunched = try makeRegistry()
+        XCTAssertTrue(try XCTUnwrap(relaunched.host(id: host.id)).persistentForwardEnabled)
+
+        try registry.setPersistentForwardEnabled(false, hostID: host.id)
+        XCTAssertFalse(
+            try XCTUnwrap(makeRegistry().host(id: host.id)).persistentForwardEnabled,
+            "turning it off must persist too, or the app resumes ssh on the next launch"
+        )
+    }
+
+    func testAFileWrittenBeforeTheFlagExistedReadsAsOff() throws {
+        // Forward compatibility, same rule as the alias: an older file has no
+        // key, and the safe reading of silence is "do not start ssh".
+        let registry = try makeRegistry()
+        let host = try registry.enroll(label: "buildhost", sshHostAlias: "builder").host
+        let stored = try XCTUnwrap(io.read(from: fileURL))
+        var json = try XCTUnwrap(
+            try JSONSerialization.jsonObject(with: stored) as? [String: Any]
+        )
+        var hosts = try XCTUnwrap(json["hosts"] as? [[String: Any]])
+        hosts = hosts.map { entry in
+            var copy = entry
+            copy.removeValue(forKey: "persistentForwardEnabled")
+            return copy
+        }
+        json["hosts"] = hosts
+        try io.write(try JSONSerialization.data(withJSONObject: json), to: fileURL)
+
+        XCTAssertFalse(try XCTUnwrap(makeRegistry().host(id: host.id)).persistentForwardEnabled)
+    }
+
+    func testRemovingAHostTakesItsForwardFlagWithIt() throws {
+        // The reason the flag lives in the registry rather than in a parallel
+        // preference: a separate store would keep a dead host's switch, and
+        // could hand it to a future host that reused the id.
+        let registry = try makeRegistry(hostIDs: ["hsame123", "hsame123"])
+        let first = try registry.enroll(label: "buildhost", sshHostAlias: "builder").host
+        try registry.setPersistentForwardEnabled(true, hostID: first.id)
+        try registry.remove(hostID: first.id)
+
+        let second = try registry.enroll(label: "buildhost", sshHostAlias: "builder").host
+        XCTAssertEqual(second.id, first.id, "the id allocator was pinned to reuse it")
+        XCTAssertFalse(second.persistentForwardEnabled)
+    }
+
+    func testSettingTheFlagOnAnUnknownHostIsReportedNotIgnored() throws {
+        let registry = try makeRegistry()
+        XCTAssertThrowsError(try registry.setPersistentForwardEnabled(true, hostID: "hnope")) { error in
+            XCTAssertEqual(
+                error as? ClaudeRemoteHostRegistry.StoreError, .unknownHost("hnope")
+            )
+        }
     }
 
     // MARK: Store integrity

--- a/Tests/localvoxtralTests/ClaudeRemotePluginManifestTests.swift
+++ b/Tests/localvoxtralTests/ClaudeRemotePluginManifestTests.swift
@@ -1221,6 +1221,24 @@ final class ClaudeRemotePluginManifestTests: XCTestCase {
         try assertReadmeHasLine(containing: "Install it on the REMOTE host, not on your Mac")
     }
 
+    func testReadmeExplainsWhenTheAppShouldHoldTheTunnelItself() throws {
+        // Without this section, the app-held forward is a toggle with no
+        // documented reason to exist — and the state it fixes (a harness
+        // session publishing into a tunnel nobody holds) is invisible.
+        try assertReadmeHasLine(
+            containing: "Keep the tunnel open",
+            "name the control the user is looking for"
+        )
+        try assertReadmeHasLine(
+            containing: "ExitOnForwardFailure=yes",
+            "the flag is the opposite of the config block above it, and that needs saying"
+        )
+        try assertReadmeHasLine(
+            containing: "off by default",
+            "an app opening SSH connections unasked would be the worse bug"
+        )
+    }
+
     func testReadmeIsHonestAboutTheHostDependency() throws {
         // The old shape truthfully needed nothing on the host; the command shim
         // needs sh and curl. Understating that would send a user on a minimal

--- a/integrations/claude-code/README.md
+++ b/integrations/claude-code/README.md
@@ -391,6 +391,59 @@ curl -s -o /dev/null -w '%{http_code}\n' -X POST -H 'Content-Type: application/j
   -d '{}' http://127.0.0.1:28511/v1/hook/SessionStart
 ```
 
+## Sessions nobody is sitting in front of
+
+The tunnel exists only while *something* holds it, and normally that something
+is your own `ssh builder` session. Anything the host starts on its own has no
+such session:
+
+* `claude remote-control` servers (systemd user services, lingering enabled)
+* t3 code and other harnesses that spawn Claude Code into a worktree
+* cron jobs, CI runners, anything headless
+
+Those sessions publish hooks exactly like an interactive one — into a tunnel
+that is not there. The result is silent, as always: dictation just is not
+grounded.
+
+So each enrolled host's row in Settings has **Keep the tunnel open**. With it
+on, localvoxtral holds that host's forward itself:
+
+```
+ssh -N -o BatchMode=yes -o ExitOnForwardFailure=yes -o ClearAllForwardings=yes \
+    -o ServerAliveInterval=30 -o ServerAliveCountMax=3 \
+    -R 28511:127.0.0.1:8473 -- builder
+```
+
+It is off by default, per host — an app that opened SSH connections you did not
+ask for would be a worse bug than the one it fixes. No token is involved
+anywhere on this path; the credential lives in the remote plugin's config and
+this process only carries bytes for it. Notes on the flags, since they differ
+from the ones in your `~/.ssh/config` block deliberately:
+
+* **`ExitOnForwardFailure=yes`** — the opposite of your config block, on
+  purpose. Your block says `no` because a dictation nicety must never cost you
+  a shell; this process *is* the nicety and nothing else, so a forward it
+  cannot bind is a process with no reason to live. The exit is the signal: the
+  row then reads **Port already held on the host.** with a **Retry** button,
+  instead of pretending to work.
+* **`ClearAllForwardings=yes`** — your config block already declares this
+  forward for this alias. Without this flag the process would request the port
+  twice, and the second request failing would kill it under the line above.
+* **`ServerAliveInterval=30` / `ServerAliveCountMax=3`** — a NAT or a sleeping
+  laptop otherwise leaves a half-dead connection holding the remote bind, which
+  is precisely the state that makes the next connection fail.
+* Restarts back off exponentially (0.5s, 1s, 2s… capped at 30s) and give up
+  after five consecutive failures rather than hammering your SSH server
+  forever. A **refused bind never retries at all** — something else holds that
+  port and will keep holding it.
+
+The listener binds first and the forwards start second, always: a forward
+opened into an unbound port would give every hook connection-refused (silent,
+fail-open) while making ssh print `connect_to … failed.` into your remote
+terminal on every dial. Turning the toggle on or off takes effect immediately —
+there is no relaunch step — and revoking a host, or quitting the app, stops its
+forward.
+
 ## Updating an enrolled host
 
 When localvoxtral ships a newer version of this plugin, an already-enrolled host


### PR DESCRIPTION
> **Merge order:** merge #217 first, then **retarget this PR to `main` BEFORE the `remote-port-allocation` branch is deleted** — GitHub auto-closes a PR whose base branch disappears, and a closed PR does not simply reopen with its review history intact.

**Stacked on #217 (`remote-port-allocation`) — the base of this PR is that branch, not `main`.** It needs #217's `ClaudeRemoteForwardPort`: the per-Mac port this forward binds, and the `remote port forwarding failed` signature both halves watch for. Review/merge #217 first; the diff here is only the commit on top.

## What

Hook events reach the Mac only while *something* holds the SSH `RemoteForward`. For a person's own terminal work, their own ssh session does that. A session a harness spawns on the enrolled host — t3 code, a `claude remote-control` systemd service, any headless runner — has no such session, so its hooks publish into a tunnel that is not there. Silently, like every other failure on this path: dictation is simply ungrounded.

So: an **opt-in, per host** app-held forward.

- **`ClaudeRemoteForwardSupervisor`** (`@MainActor @Observable`) runs one `ssh -N -R <macPort>:127.0.0.1:8473 -- <alias>` with `BatchMode=yes`, `ExitOnForwardFailure=yes`, `ClearAllForwardings=yes`, `ServerAliveInterval=30`, `ServerAliveCountMax=3`. Ordinary drops back off exponentially (0.5s, 1s, 2s… capped at 30s — the same shape as `BackendProcessSupervisor`), giving up after five consecutive failures rather than hammering someone's SSH server forever.
- **A refused bind is terminal, never retried.** `remote port forwarding failed` on stderr → `.portUnavailable`, stop. Something else holds that port (issue #215) and will keep holding it; a retry timer there is a connection storm, an auth log full of sessions, possibly a fail2ban ban — all while the user is told nothing. The row instead reads **"Port already held on the host."** with a **Retry** button.
- **`ExitOnForwardFailure=yes` is deliberate, and is the opposite of the enrollment ssh block.** That block says `no` because a dictation nicety must never cost you a shell; this process *is* the nicety and nothing else, so a forward it cannot bind is a process with no remaining purpose and its exit is the signal we want. `ClearAllForwardings=yes` matters for the same reason: the user's own config block already declares this forward for this alias, and inheriting it would make the process request the port twice — the second request failing kills it under the flag above.
- **Ordering with the listener is fixed and documented**: the listener binds FIRST, forwards start second, and the coordinator refuses to run at all while the listener is unbound. A forward into an unbound port gives every hook connection-refused (silent, fail-open) *and* makes ssh print `connect_to … failed.` into the user's remote terminal on every dial. Shutdown mirrors it: forwards stop, then the port closes.
- **Settings**: a toggle, a one-sentence status, and a conditional Retry — *inside the existing per-host row* of "Remote Claude Code over SSH". No new group (owner rule: a pane's group structure is constant); same idiom as the existing `pluginUpdatePanel`. Enable/disable takes effect immediately, no relaunch. A host with no alias on file gets no toggle at all rather than a disabled one — there is nothing to enable, because we were never told where to ssh (PR #197's rule).
- **The opt-in lives on the host record** (`persistentForwardEnabled`; optional in the stored JSON, absent = off) rather than in a parallel preference, so removing a host removes its switch. A separate store would keep a dead host's flag and could hand it to a future host that reused the id — there is a test for exactly that.
- **No token exists anywhere on this path.** The credential lives in the remote plugin's config; this process only carries bytes for it.

Every seam is injected: the process (`ClaudeRemoteForwardProcess`), the clock (`sleepFor`), and the supervisor itself behind `ClaudeRemoteForwarding`. **No unit test spawns ssh** — the coordinator's fake `XCTFail`s if a launch is ever attempted.

`ClaudeRemoteForwardLiveProcess` reads stderr with `POSIXPipeRead`, never `FileHandle.availableData` (uncatchable ObjC exception → app abort, PR #60), and drains the pipe in the termination handler *before* finishing the stream: `remote port forwarding failed` is the last thing ssh prints before exiting, so an unflushed tail would turn a diagnosable refusal into an ordinary restart loop. Exit status and waiters live under one lock, so a process that exits between "is it done?" and "register me" cannot strand the supervisor forever.

## Proof

- [x] **Unit suite green** — `./scripts/remote-build.sh test`:

```
Test Suite 'localvoxtralPackageTests.xctest' passed
	 Executed 2242 tests, with 2 tests skipped and 0 failures (0 unexpected) in 82.742 (82.854) seconds

Test Suite 'ClaudeRemoteForwardSupervisorTests' passed — Executed 13 tests, 0 failures
Test Suite 'ClaudeRemoteForwardCoordinatorTests' passed — Executed 8 tests, 0 failures
```

- [x] **The new tests are not vacuous — mutation run.** One character changed in the supervisor so a refused bind falls through to the ordinary restart path (`if sawBindFailure` → `if false, sawBindFailure`), i.e. exactly the behavior this PR exists to prevent:

```
$ ./scripts/remote-build.sh test --filter ClaudeRemoteForwardSupervisorTests
Executed 12 tests, with 2 failures (1 unexpected) in 5.292 seconds

ClaudeRemoteForwardSupervisorTests.swift:265: error: testARefusedBindIsTerminalAndNeverRestarts
    : failed - timed out waiting for a state; saw [...]
ClaudeRemoteForwardSupervisorTests.swift:164: error: testARefusedBindIsTerminalAndNeverRestarts
    : failed: caught error: "WaitTimeout()"
```

Reverted, whole suite green (summary above).

- [x] **Two real defects found by writing those tests, both fixed here:**
  1. **A hang, not a failure.** The first mutation attempt did not fail — it *hung*, because the harness awaited a state that would never arrive. That is worse than a wrong test: CI reports nothing at all. Every wait in `ForwardHarness` is now bounded (5s backstop → `XCTFail` + throw), like `BackendProcessSupervisorTests`' `StateWatcher`. The timeout is only a backstop; a passing run is resumed by the supervisor and never sleeps.
  2. **A stale settle window could report a dead tunnel as up.** "Forwarding" is defined as "still alive after the settle window" (ssh `-N` gives no positive ack), and a process that died *during* its own window could still paint "Tunnel up." over the `.retrying` the loop had already published. Cancellation alone only usually wins that race, so each launch now carries a generation the settle task must still match. `testAProcessThatDiesInsideItsSettleWindowIsNeverReportedAsUp` pins it deterministically: it holds the injected sleep, kills the process, and wakes *only* the stale settle while the supervise loop is still parked on its backoff.

- [x] **State-machine coverage**: refused bind → `.portUnavailable`, launch count 1, no `.retrying` anywhere; ordinary exit → `.retrying(attempt: 1)`, relaunch, recorded sleeps exactly `[2s settle, 0.5s, 2s settle, 1s]`; N consecutive failures → `.failed`, no further launches; `stop()` → terminate called once, `.stopped`, no restart; double `start()` → one process; a launch that throws → `.failed` with zero processes; `retry()` on a healthy tunnel → no-op. Coordinator: only opted-in / non-revoked / aliased hosts get a forward; disable and revoke stop it; reconcile is idempotent; nothing runs while the listener is unbound and everything stops when it goes away. Registry: flag defaults off, round-trips a relaunch, reads as off in a file written before the key existed, dies with its host, and reports an unknown host instead of ignoring it. No wall-clock anywhere in the behavior — the settle window and every backoff are asserted as exact `Duration` sequences on the injected clock.

- [x] **UI change — what was verified and how.** The row's content is asserted at the model layer (`HostRow.persistentForwardEnabled` / `.forwardStatusText` / `.forwardIsFailure` / `.canHoldForward`), including the owner rule that a status line is one short sentence (`< 60` chars, asserted). The SwiftUI change adds rows *inside* the existing group and creates no new group. **Not yet hand-run against a real remote host** — that needs the Mac plus an enrolled host, so it is the remaining owner check via `try-pr.sh`. Worth exercising in that pass: enable it on an enrolled host and confirm a t3-code / remote-control session there now grounds dictation; then hold the same port from another machine and confirm the row says "Port already held on the host." instead of looping.

- [x] **LLM lanes**: not required. Delivery-channel machinery only — a supervised ssh process, a per-host flag, a Settings row. Nothing here changes prompts, model pins, sampling, or anything that reaches the model.



---

## Rebased onto #217's review round (2026-08-04)

#217 took a dual review (codex + opencode) with a blocker and five more findings; its fix commit is `bf7e962` and this branch has been rebased on top of it — **the base of this PR is still `remote-port-allocation`**, now two commits deep. Nothing in this PR's own design changed; the rebase was clean (no conflicts).

What rippled in from the base and matters for reading this diff:

- The allocation range widened to **28473–30472** (2000 slots) and the derivation is now `v2`, so the example port in this PR's docs and tests is still valid but the number a given Mac gets has moved.
- The per-install identity moved out of `UserDefaults` into a 0600 file beside the host registry, claimed with `link(2)`. This PR's supervisor takes the port as a `UInt16` and is unaffected.
- The enrollment verify probe is now three-branch (connection failure / bind failure / clean) after the false-positive and false-negative were reproduced against a live sshd. This PR's supervisor already distinguished those two cases at the process level — a refused bind is terminal, an ordinary exit backs off — so the two halves now agree on what "the port is held" means.

One change of this PR's own in the rebase: the test harness's wait backstop went from 5s to **20s**. It is a backstop, never the mechanism (a passing run is resumed by the supervisor and never sleeps), and the self-hosted runner regularly has two other agents' jobs on it — a scheduling hiccup should not read as a supervisor bug.

Full suite after the rebase: **2237 tests, 2 skipped, 0 failures**.




**Rebased again (2026-08-04)** onto #217's second review round (`cfedad8` — the update panel's copy payload now carries the ssh block too, plus two test remnants). Clean rebase, no conflicts, nothing in this PR's design changed. Full suite on the new base: **2242 tests, 2 skipped, 0 failures**.

The earlier red CI run on this branch did not reproduce — the re-run (`30866755165`) is green. Its failing test name was structurally unrecoverable (the runner prints only a tail, which covers suites `TextMergingAlgorithms`…`WebSocketClientParsing`, so anything alphabetically earlier is invisible), and the profile matches the known `testStopHonorsTERMWithoutRestarting` trap-install flake under shared-host load — three agents were on the Mac at the time. Attributed there per the standing guidance.


---

## Review round 1 (codex, high effort + opencode) — dispositions

Both reviewers said NOT MERGEABLE. Every finding below is fixed. Two of them were provably real before the fix, and the evidence is measurement rather than reading: an `ssh -G` probe for the blocker, and an instrumented copy of the settle-window scenario for the generation guard.

### 0. NEW — the CI red on the previous head, root-caused

Run `30891945561` on `f51059f` failed with 2 failures including `testARefusedBindIsTerminalAndNeverRestarts` "timed out waiting for a state", while the same tree was green locally. It is **not a race in that test**, and the fix was not to re-run it.

A 400-iteration stress of exactly that scenario (temporary test, deleted before push) reached the terminal `.portUnavailable` state **400/400 times, and the slowest took 8 scheduling yields**. Against the harness's 20 s backstop that is four orders of magnitude of headroom — the only way it times out is if the main actor is starved wholesale, which is the runner-contention class this repo already knows (my own full suite was running on the same Mac at 10:24 while CI ran at 10:27, alongside sibling agents). Two further facts point the same way: the run's reported `ClaudeRemoteForwardSupervisorTests.swift:265` is a *synchronous* argv assertion in that exact tree, which cannot "time out waiting for a state"; and CI's extra 9 tests over my local run are all in the +9 skipped delta, so the two runs cover the same executed set.

What DID exist in that tree, and is now gone, is a real way for a terminal state to be overwritten: the stale settle window below could publish `.forwarding` on top of `.portUnavailable`. That is fixed, and the whole suite is green on the pushed head.

### 1. BLOCKER — `ClearAllForwardings=yes` cleared our own `-R`. Valid, fixed

codex is right and opencode's contrary praise is wrong; I measured it rather than taking either on faith. `ssh_config(5)` says the option clears forwardings specified "in the configuration files **or on the command line**", and the effective config confirms it:

```
$ ssh -G -F probe_config -o ExitOnForwardFailure=yes -o ClearAllForwardings=yes -R 28511:127.0.0.1:8473 -- probealias
clearallforwardings yes
exitonforwardfailure yes          # and NO remoteforward line at all
```

So the supervised ssh connected, survived its settle window, reported "Tunnel up." and forwarded nothing — the feature was a no-op end to end.

The flag is gone. The doubling it was meant to prevent does not happen anyway, which the same instrument shows: an identical forward on the command line and in the config **collapses to one entry**.

```
$ ssh -G -F probe_config -o ExitOnForwardFailure=yes -R 28511:127.0.0.1:8473 -- probealias
remoteforward 28511 [127.0.0.1]:8473        # one line, not two
```

Pinned by `testNoOptionCanClearTheForwardTheProcessExistsToCreate`, which asserts the *property* (no forwarding-clearing option, whatever it is spelled) plus the presence of the `-R`, so an equivalent option cannot walk back in.

### 1b. NEW, found by that measurement — a stale config forward is inherited

Dropping the flag means the alias's own `RemoteForward` IS inherited, and for the cohort this PR's parent exists for — users migrating off the legacy 8473 — the old block is still there:

```
$ ssh -G -F stale_config -o ExitOnForwardFailure=yes -R 28511:127.0.0.1:8473 -- stalealias
remoteforward 28511 [127.0.0.1]:8473
remoteforward 8473 [127.0.0.1]:8473        # the stale one we never asked for
```

Under `ExitOnForwardFailure=yes` the stale forward's refusal kills the process, and the old code reported that as `portUnavailable` — sending the user to hunt for a process on the remote host that does not exist. The supervisor now reads the port out of the warning (`refusedPort(in:)`, anchored on `listen port `, never "last number on the line") and reports `.staleConfiguredForward(port:)`: "Old RemoteForward in ~/.ssh/config blocks this." Covered by `testARefusalForAPortWeNeverAskedForBlamesTheConfigNotTheHost` and `testTheRefusedPortIsReadFromTheWarningNotGuessed`.

### 2. BLOCKER — inherited detach/multiplex/local-command. Valid, fixed

`-o ForkAfterAuthentication=no -o ControlPath=none -o PermitLocalCommand=no`, forced rather than assumed because each is settable per-`Host` in the config this connection reads. `testTheConnectionCannotDetachMultiplexOrRunALocalCommand` asserts all three, and that each is passed as a real `-o` pair rather than concatenated.

### 3. MAJOR — the settle window's generation guard. Confirmed real; the old test passed for the wrong reason

Both reviewers predicted the existing test should fail. **It passed — in 0.000 s — and the reason it passed is that it did not let the buggy code run.** I instrumented the exact scenario rather than argue about it:

```
PROBE-RESULT
sleepsAtRelease=[2.0 seconds]   heldAtRelease=1   processesBefore=1
processesAfter=1
statesAfter=[connecting, retrying(attempt: 1), forwarding]
finalState=forwarding
```

With 50 yields instead of 2, the dead process's settle window wakes carrying a generation nothing has advanced, passes all three guards, and paints `.forwarding` over the `.retrying(1)` of a process that has already exited — precisely the mechanism both reviewers described. Two `Task.yield()`s were simply not enough for the stale task to be scheduled, so the test was pinning the scheduler, not the guard. (The probe also corrects the old test's comment: only ONE sleep is held at that point, not two.)

Fixed by retiring the window where the process is known dead — `invalidateSettleWindow()` immediately after `waitUntilExit()`, which both cancels the task and advances the generation — instead of in a `defer` that only runs once the loop body exits, which it does not do while parked on the backoff. The test now drains the main actor to quiescence instead of guessing a yield count, so it fails against the old guard.

### 4. MAJOR — transitions never reached the pane. Valid, fixed

The coordinator now publishes `onStateChange(hostID)` and the settings model patches that row in place (`applyForwardState`), so the pane no longer shows the first "Connecting…" snapshot forever. Deliberately not a `refreshHosts()`: that re-reads the registry and re-derives every row's age text, moving "last seen" under the user for a transition that changed one string. The masking `model.refreshHosts()` is **deleted** from the test, which now asserts the row updates on its own.

### 5. MAJOR — teardown. Valid, fixed

SIGTERM now goes **synchronously** in `stop()` (no scheduling hop between the user's click and the signal); the *waiting* is what became asynchronous. Then a bounded wait on the injected clock, SIGKILL, and a second bounded wait, with the give-up logged loudly. No unbounded wait anywhere — deliberately not a task group, which would wait for both children and hang on exactly the wedged ssh this exists for.

Process-group kill is **conditional, and that is a safety property rather than caution**: `Process` gives a child our own group unless something changes it, and Foundation cannot make it a group leader, so an unconditional `kill(-pgid, …)` would signal localvoxtral itself and both MLX helpers. `signal(_:)` asks the kernel at signal time and only group-signals a child that has a group of its own; the containment flags in finding 2 are the other half, removing the ways ssh could leave descendants at all.

The toggle-off→on race is fixed where it actually lives: the coordinator keeps the draining teardown per host and the replacement waits for it (`testAReplacementForwardWaitsForTheOldOneToFinishDying`), so a healthy host can no longer report `portUnavailable` at itself. Quit drains too, bounded (`drainRemoteForwardTeardowns(within: 3.0)`), because `stopAll()` only *starts* the escalations.

### 6. MAJOR — `consecutiveFailures` never reset. Valid; fixed differently from the suggestion, and the difference matters

Resetting "on healthy settle" as suggested is wrong, and my first implementation did exactly that and **broke three existing tests** — which is how the flaw surfaced. Surviving the 2 s settle window only means ssh did not refuse the bind. A tunnel that connects, holds three seconds and dies, over and over, would reset the counter every cycle and make `maxConsecutiveFailures` unreachable — the reconnect storm the cap exists to stop.

"Healthy" is therefore **observed uptime** (`healthyUptime`, default 60 s), measured on an injected clock at the moment of exit rather than by arming another timer that would race the exit it describes. Both halves are pinned: `testADropAfterALongHealthyRunIsNotPartOfARunOfFailures` (an hour up ⇒ failure count restarts at one) and `testConnectionsThatDieQuicklyStillHitTheCap` (3 s each ⇒ the cap still trips).

### 7. MINOR — shutdown order. Valid, fixed

Revoking the last host now stops the forwards **before** `listener.reconcile()` closes the port. `testRevokingTheLastHostStopsTheForwardBeforeClosingTheListener` asserts the SEQUENCE via a shared journal (`["forward.stop", "listener.stop"]`) — both merely happening is not the property, since the whole failure is a hook arriving in the window between them.

### 8. MINOR — bind-failure copy. Valid, fixed

"Port already held on the host." → **"Port held — close ssh sessions to that host."** The common holder is an ssh session from this very Mac, and the old copy left the user with a Retry button and nothing to do before pressing it. Still one sentence, still under the 60-character assertion the popover rule is enforced with.

### 9. MINOR — synchronous fake. Valid, fixed

`FakeForwardProcess(ignoresTermination:)` models a process that takes SIGTERM and keeps running, so the escalation tests can fail. With the old fake they would have passed vacuously. `testAProcessThatHonoursSIGTERMIsNeverKilled` holds the grace window open for the whole test, so "did it escalate" cannot be answered by the grace expiring first.

### All-clears kept

Both reviewers' all-clears are unchanged by this round: stored-alias validation with `--` termination, fixed `/usr/bin/ssh`, no shell, no token anywhere on this path, `.nullDevice` stdin, short status text with the stderr tail going only to the log, constant Settings group structure, per-host persistence, opt-in default off, missing-key migration, the flag dying with its host, unknown host throwing, listener-first startup ordering, and bind refusal being terminal rather than restart-spamming.


### Suite on the pushed head

Rebased onto `main` at `922cc55` (post-#216/#217/#218/#220). The #220 conflicts were parallel additions in `ClaudeIntegrationSettingsModel` (a stored property, an init parameter, an init body statement, and a new method) plus one initializer call in `localvoxtralApp` — both sides kept in every case, nothing dropped.

```
Executed 2443 tests, with 2 tests skipped and 0 failures (0 unexpected) in 94.530 seconds
```
