### PR TITLE
Reap orphaned remote-forward ssh children at launch (fixes stale "Port held")

### DIFF
--- a/Sources/localvoxtral/ClaudeContext/ClaudeRemoteForwardCoordinator.swift
+++ b/Sources/localvoxtral/ClaudeContext/ClaudeRemoteForwardCoordinator.swift
@@ -49,21 +49,49 @@ public final class ClaudeRemoteForwardCoordinator {
     @ObservationIgnored private let makeSupervisor: MakeSupervisor
     @ObservationIgnored private var supervisors: [String: any ClaudeRemoteForwarding] = [:]
 
+    /// Whether the launch-time orphan reap has run yet. Forwards may not start
+    /// before it finishes: the orphan holds exactly the remote port the new
+    /// forward is about to dial, so starting early reproduces the "Port held"
+    /// state the reap exists to clear.
+    private enum OrphanReapPhase { case pending, running, done }
+    @ObservationIgnored private var orphanReap: OrphanReapPhase
+    @ObservationIgnored private let reapOrphans: (@Sendable () async -> Void)?
+
     public init(
         hosts: ClaudeRemoteHostRegistry,
         remoteForwardPort: UInt16,
         listenerPort: UInt16 = ClaudeRemoteListenerLimits.default.port,
         isListenerBound: @escaping @MainActor () -> Bool,
-        makeSupervisor: MakeSupervisor? = nil
+        makeSupervisor: MakeSupervisor? = nil,
+        pidLedger: ClaudeRemoteForwardPidLedger? = nil,
+        reapOrphans: (@Sendable () async -> Void)? = nil
     ) {
         self.hosts = hosts
         self.remoteForwardPort = remoteForwardPort
         self.listenerPort = listenerPort
         self.isListenerBound = isListenerBound
+        self.reapOrphans = reapOrphans
+        // No reaper means nothing to wait for — the seam's absence must not
+        // stall every forward forever.
+        self.orphanReap = reapOrphans == nil ? .done : .pending
         self.makeSupervisor = makeSupervisor ?? { configuration in
             ClaudeRemoteForwardSupervisor(
                 configuration: configuration,
-                launch: { try ClaudeRemoteForwardLiveProcess(argv: $0.argv) }
+                launch: { config in
+                    let process = try ClaudeRemoteForwardLiveProcess(argv: config.argv)
+                    // Written BEFORE the process is handed to the supervisor:
+                    // if this app dies without applicationWillTerminate, the
+                    // record is what lets the next launch find and kill the
+                    // orphan instead of reporting "Port held" at it.
+                    if let pidLedger,
+                       let record = ClaudeRemoteForwardProcessIdentity.snapshot(
+                           pid: process.processIdentifier
+                       )
+                    {
+                        pidLedger.remember(hostID: config.hostID, record: record)
+                    }
+                    return process
+                }
             )
         }
     }
@@ -94,6 +122,33 @@ public final class ClaudeRemoteForwardCoordinator {
                 stopAll()
             }
             return
+        }
+
+        // Orphans from a previous run die BEFORE the first forward dials. The
+        // gate sits after the listener check on purpose: only the instance
+        // holding the listener port gets here, so a second app instance can
+        // never reap the first one's healthy tunnels.
+        switch orphanReap {
+        case .running:
+            return
+        case .pending:
+            guard let reapOrphans else {
+                orphanReap = .done
+                break
+            }
+            orphanReap = .running
+            Log.claudeContext.info(
+                "Claude remote forwards waiting for the orphan reap before first start"
+            )
+            Task { @MainActor [weak self] in
+                await reapOrphans()
+                guard let self else { return }
+                self.orphanReap = .done
+                self.reconcile()
+            }
+            return
+        case .done:
+            break
         }
 
         let eligible = eligibleHosts()

--- a/Sources/localvoxtral/ClaudeContext/ClaudeRemoteForwardLiveProcess.swift
+++ b/Sources/localvoxtral/ClaudeContext/ClaudeRemoteForwardLiveProcess.swift
@@ -35,6 +35,10 @@ final class ClaudeRemoteForwardLiveProcess: ClaudeRemoteForwardProcess, @uncheck
     private let partialLine = Mutex<String>("")
     private let descriptor: Int32
 
+    /// The spawned child's pid, for the pid ledger that lets the NEXT launch
+    /// find this process should this one die without tearing it down.
+    var processIdentifier: pid_t { process.processIdentifier }
+
     /// - Parameter argv: complete, including `ssh` at index 0 (the shape
     ///   `Configuration.argv` produces and the enrollment service already uses).
     init(argv: [String], sshExecutableURL: URL = URL(fileURLWithPath: "/usr/bin/ssh")) throws {

--- a/Sources/localvoxtral/ClaudeContext/ClaudeRemoteForwardOrphanReaper.swift
+++ b/Sources/localvoxtral/ClaudeContext/ClaudeRemoteForwardOrphanReaper.swift
@@ -1,0 +1,131 @@
+import Foundation
+
+#if canImport(Darwin)
+import Darwin
+#endif
+
+/// Kills forward `ssh` children a previous app run left behind, before this
+/// run's forwards dial the same remote port.
+///
+/// The bug this closes (field report, 2026-08-05): quit-and-reopen sometimes
+/// landed the pane on "Port held — close ssh sessions to that host." with a
+/// Retry that could only fail. The holder was this Mac's own orphan — an
+/// `ssh -N -R` from a run that ended without `applicationWillTerminate`
+/// (crash, force-quit) or whose teardown outran the bounded quit drain. It
+/// reparents to launchd, keepalives keep it healthy forever, and nothing else
+/// ever kills it.
+///
+/// Safety rules, in order of importance:
+///
+/// * **Never kill by pid alone.** A record is actioned only when the pid's
+///   CURRENT kernel identity — start time and resolved executable path —
+///   equals what the ledger captured at spawn. A reused pid cannot match, so
+///   an innocent process cannot be signalled, and a mismatch just retires the
+///   record.
+/// * **Only run while this instance holds the listener.** The caller
+///   (`ClaudeRemoteForwardCoordinator`) gates the reap behind its listener
+///   bind, which is what makes a SECOND app instance harmless: it cannot bind
+///   8473 while the first instance lives, so it can never reap the first
+///   instance's healthy tunnels.
+/// * **Escalate like the supervisor does.** SIGTERM, a bounded wait, SIGKILL,
+///   a bounded wait — on the injected clock, since the supervisor's own suite
+///   set the no-wall-clock rule for this subsystem. A survivor of SIGKILL
+///   keeps its record, so the next launch tries again.
+public struct ClaudeRemoteForwardOrphanReaper: Sendable {
+    public typealias Inspect = @Sendable (pid_t) -> ClaudeRemoteForwardPidRecord?
+    public typealias SendSignal = @Sendable (pid_t, Int32) -> Void
+    public typealias SleepFor = @Sendable (Duration) async throws -> Void
+
+    private let ledger: ClaudeRemoteForwardPidLedger
+    private let inspect: Inspect
+    private let sendSignal: SendSignal
+    private let sleepFor: SleepFor
+    private let terminationGrace: Duration
+    private let killGrace: Duration
+    private let pollInterval: Duration
+
+    public init(
+        ledger: ClaudeRemoteForwardPidLedger,
+        inspect: @escaping Inspect = { ClaudeRemoteForwardProcessIdentity.snapshot(pid: $0) },
+        sendSignal: @escaping SendSignal = { pid, signalNumber in
+            #if canImport(Darwin)
+            _ = Darwin.kill(pid, signalNumber)
+            #endif
+        },
+        sleepFor: @escaping SleepFor = { try await Task.sleep(for: $0) },
+        terminationGrace: Duration = .seconds(2),
+        killGrace: Duration = .seconds(1),
+        pollInterval: Duration = .milliseconds(50)
+    ) {
+        self.ledger = ledger
+        self.inspect = inspect
+        self.sendSignal = sendSignal
+        self.sleepFor = sleepFor
+        self.terminationGrace = terminationGrace
+        self.killGrace = killGrace
+        self.pollInterval = pollInterval
+    }
+
+    public func reap() async {
+        let records = ledger.records()
+        guard !records.isEmpty else { return }
+        for (hostID, record) in records {
+            await reap(hostID: hostID, record: record)
+        }
+    }
+
+    private func reap(hostID: String, record: ClaudeRemoteForwardPidRecord) async {
+        guard let current = inspect(pid_t(record.pid)), current == record else {
+            // Dead, or the pid now names some other process entirely. Either
+            // way there is nothing of ours to kill — only a record to retire.
+            ledger.forget(hostID: hostID, pid: record.pid)
+            return
+        }
+        Log.claudeContext.notice(
+            "Claude remote forward orphan from a previous run found for host \(hostID, privacy: .public) (pid \(record.pid, privacy: .public)); terminating it to free the remote port"
+        )
+        sendSignal(pid_t(record.pid), SIGTERM)
+        if await waitUntilGone(record) {
+            ledger.forget(hostID: hostID, pid: record.pid)
+            return
+        }
+        Log.claudeContext.error(
+            "Claude remote forward orphan pid \(record.pid, privacy: .public) ignored SIGTERM; escalating to SIGKILL"
+        )
+        sendSignal(pid_t(record.pid), SIGKILL)
+        if await waitUntilGone(record, within: killGrace) {
+            ledger.forget(hostID: hostID, pid: record.pid)
+            return
+        }
+        // Keep the record: it still names OUR process (identity-checked every
+        // poll), and the next launch retrying costs nothing. Forgetting here
+        // would make a SIGKILL survivor permanently invisible.
+        Log.claudeContext.error(
+            "Claude remote forward orphan pid \(record.pid, privacy: .public) survived SIGKILL; the remote port may stay bound"
+        )
+    }
+
+    private func waitUntilGone(
+        _ record: ClaudeRemoteForwardPidRecord, within limit: Duration? = nil
+    ) async -> Bool {
+        let limit = limit ?? terminationGrace
+        for _ in 0..<Self.pollCount(limit: limit, interval: pollInterval) {
+            if inspect(pid_t(record.pid)) != record { return true }
+            do { try await sleepFor(pollInterval) } catch { break }
+        }
+        return inspect(pid_t(record.pid)) != record
+    }
+
+    /// How many interval sleeps cover `limit`, at least one.
+    static func pollCount(limit: Duration, interval: Duration) -> Int {
+        let limitNanos = max(Int64(1), nanoseconds(of: limit))
+        let intervalNanos = max(Int64(1), nanoseconds(of: interval))
+        return Int(max(1, (limitNanos + intervalNanos - 1) / intervalNanos))
+    }
+
+    private static func nanoseconds(of duration: Duration) -> Int64 {
+        let components = duration.components
+        return components.seconds * 1_000_000_000
+            + Int64(components.attoseconds / 1_000_000_000)
+    }
+}

--- a/Sources/localvoxtral/ClaudeContext/ClaudeRemoteForwardOrphanReaper.swift
+++ b/Sources/localvoxtral/ClaudeContext/ClaudeRemoteForwardOrphanReaper.swift
@@ -19,9 +19,13 @@ import Darwin
 ///
 /// * **Never kill by pid alone.** A record is actioned only when the pid's
 ///   CURRENT kernel identity — start time and resolved executable path —
-///   equals what the ledger captured at spawn. A reused pid cannot match, so
-///   an innocent process cannot be signalled, and a mismatch just retires the
-///   record.
+///   equals what the ledger captured at spawn, re-verified immediately before
+///   each signal. A mismatch retires the record without signalling. What
+///   remains is the microsecond window between a verify and its signal, in
+///   which the kernel would have to reap the orphan AND re-issue its pid —
+///   stated because a single inspect-then-act cannot close it, not because it
+///   is reachable in practice (macOS allocates pids incrementally and skips
+///   recently used ones).
 /// * **Only run while this instance holds the listener.** The caller
 ///   (`ClaudeRemoteForwardCoordinator`) gates the reap behind its listener
 ///   bind, which is what makes a SECOND app instance harmless: it cannot bind
@@ -31,6 +35,12 @@ import Darwin
 ///   a bounded wait — on the injected clock, since the supervisor's own suite
 ///   set the no-wall-clock rule for this subsystem. A survivor of SIGKILL
 ///   keeps its record, so the next launch tries again.
+///
+/// Records reap sequentially, so the worst case — every enrolled host left a
+/// live orphan that ignores SIGTERM — holds the forwards for
+/// `hosts × (terminationGrace + killGrace)`. Accepted: real orphan counts are
+/// one or two, the common path returns at the first inspect, and only the
+/// forwards wait on it (the listener is already up).
 public struct ClaudeRemoteForwardOrphanReaper: Sendable {
     public typealias Inspect = @Sendable (pid_t) -> ClaudeRemoteForwardPidRecord?
     public typealias SendSignal = @Sendable (pid_t, Int32) -> Void
@@ -47,11 +57,7 @@ public struct ClaudeRemoteForwardOrphanReaper: Sendable {
     public init(
         ledger: ClaudeRemoteForwardPidLedger,
         inspect: @escaping Inspect = { ClaudeRemoteForwardProcessIdentity.snapshot(pid: $0) },
-        sendSignal: @escaping SendSignal = { pid, signalNumber in
-            #if canImport(Darwin)
-            _ = Darwin.kill(pid, signalNumber)
-            #endif
-        },
+        sendSignal: SendSignal? = nil,
         sleepFor: @escaping SleepFor = { try await Task.sleep(for: $0) },
         terminationGrace: Duration = .seconds(2),
         killGrace: Duration = .seconds(1),
@@ -59,11 +65,28 @@ public struct ClaudeRemoteForwardOrphanReaper: Sendable {
     ) {
         self.ledger = ledger
         self.inspect = inspect
-        self.sendSignal = sendSignal
+        // In the body, not as a default argument value: the default needs
+        // `Log`, which is internal, and a public init's default arguments may
+        // only name public symbols.
+        self.sendSignal = sendSignal ?? Self.defaultSendSignal
         self.sleepFor = sleepFor
         self.terminationGrace = terminationGrace
         self.killGrace = killGrace
         self.pollInterval = pollInterval
+    }
+
+    /// Loud on failure (repo rule for lifecycle paths): a discarded EPERM
+    /// would otherwise surface later as the WRONG failure — "survived SIGKILL"
+    /// about a signal that was never delivered. ESRCH is not a failure here;
+    /// the poll reads it as "gone".
+    private static let defaultSendSignal: SendSignal = { pid, signalNumber in
+        #if canImport(Darwin)
+        if Darwin.kill(pid, signalNumber) != 0, errno != ESRCH {
+            Log.claudeContext.error(
+                "Claude remote forward orphan reaper could not signal pid \(pid, privacy: .public): errno \(errno, privacy: .public)"
+            )
+        }
+        #endif
     }
 
     public func reap() async {
@@ -81,11 +104,27 @@ public struct ClaudeRemoteForwardOrphanReaper: Sendable {
             ledger.forget(hostID: hostID, pid: record.pid)
             return
         }
-        Log.claudeContext.notice(
-            "Claude remote forward orphan from a previous run found for host \(hostID, privacy: .public) (pid \(record.pid, privacy: .public)); terminating it to free the remote port"
-        )
+        // Signal first, log second: the log call would otherwise sit inside
+        // the verify-to-signal window the type comment promises is only
+        // microseconds wide.
         sendSignal(pid_t(record.pid), SIGTERM)
+        Log.claudeContext.notice(
+            "Claude remote forward orphan from a previous run found for host \(hostID, privacy: .public) (pid \(record.pid, privacy: .public)); sent SIGTERM to free the remote port"
+        )
         if await waitUntilGone(record) {
+            Log.claudeContext.info(
+                "Claude remote forward orphan for host \(hostID, privacy: .public) honoured SIGTERM; record retired"
+            )
+            ledger.forget(hostID: hostID, pid: record.pid)
+            return
+        }
+        // Re-verify before escalating. `waitUntilGone`'s last poll saw a
+        // matching identity at most one interval ago, but SIGKILL is the one
+        // signal nothing can decline, so it gets its own fresh check.
+        guard let beforeKill = inspect(pid_t(record.pid)), beforeKill == record else {
+            Log.claudeContext.info(
+                "Claude remote forward orphan for host \(hostID, privacy: .public) exited before SIGKILL; record retired"
+            )
             ledger.forget(hostID: hostID, pid: record.pid)
             return
         }
@@ -94,6 +133,9 @@ public struct ClaudeRemoteForwardOrphanReaper: Sendable {
         )
         sendSignal(pid_t(record.pid), SIGKILL)
         if await waitUntilGone(record, within: killGrace) {
+            Log.claudeContext.info(
+                "Claude remote forward orphan for host \(hostID, privacy: .public) killed; record retired"
+            )
             ledger.forget(hostID: hostID, pid: record.pid)
             return
         }

--- a/Sources/localvoxtral/ClaudeContext/ClaudeRemoteForwardPidLedger.swift
+++ b/Sources/localvoxtral/ClaudeContext/ClaudeRemoteForwardPidLedger.swift
@@ -72,7 +72,10 @@ public enum ClaudeRemoteForwardProcessIdentity {
 /// One record per host id — a host has at most one live forward at a time, and
 /// a respawn simply overwrites. Records are removed by the reaper (dead or
 /// killed), never on process exit: a stale record for a dead pid costs one
-/// identity check at the next launch and nothing else.
+/// identity check at the next launch and nothing else. Records deliberately
+/// carry no remote port: an orphan holds whatever port it was spawned with,
+/// so a per-install port change between launches must not exempt the old
+/// orphan from reaping.
 ///
 /// Storage piggybacks on `ClaudeRemoteHostStoreIO` (atomic 0600 writes, same
 /// hardening) in a file beside the host registry. Unlike the registry, a

--- a/Sources/localvoxtral/ClaudeContext/ClaudeRemoteForwardPidLedger.swift
+++ b/Sources/localvoxtral/ClaudeContext/ClaudeRemoteForwardPidLedger.swift
@@ -1,0 +1,171 @@
+import Foundation
+import Synchronization
+
+#if canImport(Darwin)
+import Darwin
+#endif
+
+/// The identity of one spawned forward `ssh`, precise enough to kill by.
+///
+/// A pid alone is not an identity — the kernel reuses them, and a reaper that
+/// killed by pid could shoot whatever innocent process inherited the number
+/// after a reboot. Pid PLUS kernel start time is unique for the machine's
+/// uptime, and the executable path is belt-and-braces on top: all three must
+/// match what was recorded at spawn, or the record is stale and the process is
+/// not ours to touch.
+public struct ClaudeRemoteForwardPidRecord: Codable, Equatable, Sendable {
+    public var pid: Int32
+    public var startSeconds: UInt64
+    public var startMicroseconds: UInt64
+    public var executablePath: String
+
+    public init(pid: Int32, startSeconds: UInt64, startMicroseconds: UInt64, executablePath: String) {
+        self.pid = pid
+        self.startSeconds = startSeconds
+        self.startMicroseconds = startMicroseconds
+        self.executablePath = executablePath
+    }
+}
+
+/// Reads a live process's identity from the kernel.
+public enum ClaudeRemoteForwardProcessIdentity {
+    /// Nil when the pid is gone (or was never valid) — which for the reaper is
+    /// an answer, not an error: a dead process needs no reaping.
+    public static func snapshot(pid: pid_t) -> ClaudeRemoteForwardPidRecord? {
+        #if canImport(Darwin)
+        guard pid > 0 else { return nil }
+        var info = proc_bsdinfo()
+        let size = Int32(MemoryLayout<proc_bsdinfo>.size)
+        guard proc_pidinfo(pid, PROC_PIDTBSDINFO, 0, &info, size) == size else { return nil }
+        // Resolved executable (`proc_pidpath`), not argv[0] and not `p_comm` —
+        // the same rule SSHDestinationTTYProbe follows, for the same reason:
+        // argv is written by whoever launched the process.
+        var buffer = [CChar](repeating: 0, count: 4_096)
+        let length = proc_pidpath(pid, &buffer, UInt32(buffer.count))
+        guard length > 0 else { return nil }
+        let pathBytes = buffer.prefix { $0 != 0 }.map { UInt8(bitPattern: $0) }
+        return ClaudeRemoteForwardPidRecord(
+            pid: pid,
+            startSeconds: info.pbi_start_tvsec,
+            startMicroseconds: info.pbi_start_tvusec,
+            executablePath: String(decoding: pathBytes, as: UTF8.self)
+        )
+        #else
+        return nil
+        #endif
+    }
+}
+
+/// Which forward `ssh` children this app has spawned, persisted across a death
+/// the app does not get to see coming.
+///
+/// Why this exists: `applicationWillTerminate` kills the app-held `ssh -N -R`
+/// forwards on a CLEAN quit, but a crash, a force-quit, or a teardown that
+/// outruns the quit drain leaves the ssh reparented to launchd — alive
+/// indefinitely (BatchMode plus ServerAlive keepalives), still holding the
+/// remote port bind. The next launch's fresh forward is then refused and the
+/// pane reports "Port held" at a port this Mac's own orphan is holding, with a
+/// Retry that can only fail. The ledger is what makes that orphan findable:
+/// each spawn is recorded here, and `ClaudeRemoteForwardOrphanReaper` verifies
+/// and kills survivors before the next launch's forwards start.
+///
+/// One record per host id — a host has at most one live forward at a time, and
+/// a respawn simply overwrites. Records are removed by the reaper (dead or
+/// killed), never on process exit: a stale record for a dead pid costs one
+/// identity check at the next launch and nothing else.
+///
+/// Storage piggybacks on `ClaudeRemoteHostStoreIO` (atomic 0600 writes, same
+/// hardening) in a file beside the host registry. Unlike the registry, a
+/// corrupt or unreadable ledger is treated as EMPTY: it is a cleanup aid, and
+/// the safe reading of "cannot tell what we spawned" is "kill nothing".
+public final class ClaudeRemoteForwardPidLedger: Sendable {
+    private struct Contents: Codable {
+        var version: Int
+        var records: [String: ClaudeRemoteForwardPidRecord]
+    }
+
+    private static let version = 1
+
+    private let fileURL: URL
+    private let io: any ClaudeRemoteHostStoreIO
+    /// One lock around read-modify-write, so two supervisors remembering at
+    /// once cannot interleave and drop each other's record.
+    private let lock = Mutex<Void>(())
+
+    public init(
+        fileURL: URL = ClaudeRemoteForwardPidLedger.defaultFileURL(),
+        io: any ClaudeRemoteHostStoreIO = ClaudeRemoteHostFileStoreIO()
+    ) {
+        self.fileURL = fileURL
+        self.io = io
+    }
+
+    /// Beside `claude-remote-hosts.json`, deliberately — same directory, same
+    /// survival across a preferences reset.
+    public static func defaultFileURL() -> URL {
+        ClaudeRemoteHostRegistry.defaultFileURL()
+            .deletingLastPathComponent()
+            .appendingPathComponent("claude-remote-forward-pids.json")
+    }
+
+    public func records() -> [String: ClaudeRemoteForwardPidRecord] {
+        lock.withLock { _ in load() }
+    }
+
+    public func remember(hostID: String, record: ClaudeRemoteForwardPidRecord) {
+        lock.withLock { _ in
+            var records = load()
+            records[hostID] = record
+            store(records)
+        }
+    }
+
+    /// Pid-scoped on purpose: a forget racing a fresh spawn for the same host
+    /// must not erase the NEW process's record.
+    public func forget(hostID: String, pid: Int32) {
+        lock.withLock { _ in
+            var records = load()
+            guard records[hostID]?.pid == pid else { return }
+            records[hostID] = nil
+            store(records)
+        }
+    }
+
+    private func load() -> [String: ClaudeRemoteForwardPidRecord] {
+        let data: Data?
+        do {
+            data = try io.read(from: fileURL)
+        } catch {
+            // Loud, then empty: an unreadable ledger means any orphan from a
+            // previous run stays for the user to close by hand, which the
+            // "Port held" state already tells them how to do.
+            Log.claudeContext.error(
+                "Claude remote forward pid ledger unreadable: \(String(describing: error), privacy: .public)"
+            )
+            return [:]
+        }
+        guard let data else { return [:] }
+        guard let contents = try? JSONDecoder().decode(Contents.self, from: data),
+              contents.version == Self.version
+        else {
+            Log.claudeContext.error(
+                "Claude remote forward pid ledger corrupt; skipping orphan cleanup this launch"
+            )
+            return [:]
+        }
+        return contents.records
+    }
+
+    private func store(_ records: [String: ClaudeRemoteForwardPidRecord]) {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys]
+        do {
+            let data = try encoder.encode(Contents(version: Self.version, records: records))
+            try io.write(data, to: fileURL)
+        } catch {
+            Log.claudeContext.error(
+                "Claude remote forward pid ledger write failed: \(String(describing: error), privacy: .public)"
+            )
+        }
+    }
+}

--- a/Sources/localvoxtral/localvoxtralApp.swift
+++ b/Sources/localvoxtral/localvoxtralApp.swift
@@ -460,11 +460,20 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         // unbound port is worse than no forward (silent fail-open on the remote,
         // plus ssh noise in the user's terminal), so it refuses to run without
         // one. The listener is reconciled FIRST, below.
+        // Every spawned forward ssh is recorded here, and orphans a previous
+        // run left holding the remote port (crash, force-quit, a teardown that
+        // outran the quit drain) are killed before this run's forwards dial —
+        // otherwise the fresh forward is refused its own port and the pane
+        // reports "Port held" terminally at this Mac's own leftover.
+        let forwardPidLedger = ClaudeRemoteForwardPidLedger()
+        let forwardOrphanReaper = ClaudeRemoteForwardOrphanReaper(ledger: forwardPidLedger)
         let forwards = registry.map { hosts in
             ClaudeRemoteForwardCoordinator(
                 hosts: hosts,
                 remoteForwardPort: remoteForwardPort,
-                isListenerBound: { coordinator?.isListening ?? false }
+                isListenerBound: { coordinator?.isListening ?? false },
+                pidLedger: forwardPidLedger,
+                reapOrphans: { await forwardOrphanReaper.reap() }
             )
         }
         claudeRemoteForwards = forwards

--- a/Tests/localvoxtralTests/ClaudeRemoteForwardCoordinatorTests.swift
+++ b/Tests/localvoxtralTests/ClaudeRemoteForwardCoordinatorTests.swift
@@ -82,14 +82,16 @@ final class ClaudeRemoteForwardCoordinatorTests: XCTestCase {
     private func makeCoordinator(
         registry: ClaudeRemoteHostRegistry,
         spy: ForwardSpy,
-        isListenerBound: @escaping @MainActor () -> Bool = { true }
+        isListenerBound: @escaping @MainActor () -> Bool = { true },
+        reapOrphans: (@Sendable () async -> Void)? = nil
     ) -> ClaudeRemoteForwardCoordinator {
         ClaudeRemoteForwardCoordinator(
             hosts: registry,
             remoteForwardPort: 28511,
             listenerPort: 8473,
             isListenerBound: isListenerBound,
-            makeSupervisor: { spy.makeSupervisor($0) }
+            makeSupervisor: { spy.makeSupervisor($0) },
+            reapOrphans: reapOrphans
         )
     }
 
@@ -257,6 +259,80 @@ final class ClaudeRemoteForwardCoordinatorTests: XCTestCase {
         release.open()
         for _ in 0..<50 { await Task.yield() }
         XCTAssertEqual(spy.started, [host.id, host.id])
+    }
+
+    func testForwardsWaitForTheOrphanReapBeforeStarting() async throws {
+        // The regression behind this gate (field report, 2026-08-05): an app
+        // run that ended without a clean quit left its `ssh -N -R` alive and
+        // holding the remote port, so the NEXT launch's forward was refused
+        // its own port and the pane showed "Port held" terminally. The reap
+        // kills that orphan first; a forward started before it finishes would
+        // dial a port the orphan still holds and reproduce exactly that state.
+        let registry = try makeRegistry()
+        let host = try registry.enroll(label: "buildhost", sshHostAlias: "builder").host
+        try registry.setPersistentForwardEnabled(true, hostID: host.id)
+
+        let spy = ForwardSpy()
+        let reapGate = TeardownGate()
+        let coordinator = makeCoordinator(
+            registry: registry, spy: spy, reapOrphans: { await reapGate.wait() }
+        )
+        coordinator.reconcile()
+        for _ in 0..<50 { await Task.yield() }
+        XCTAssertTrue(
+            spy.started.isEmpty, "an orphan may still hold the port until the reap finishes"
+        )
+
+        reapGate.open()
+        for _ in 0..<50 { await Task.yield() }
+        XCTAssertEqual(spy.started, [host.id])
+    }
+
+    func testTheOrphanReapRunsExactlyOnce() async throws {
+        // The gate protects the FIRST start only. Records written after launch
+        // belong to this instance's own live supervisors, and reaping again
+        // would kill them.
+        let registry = try makeRegistry()
+        let host = try registry.enroll(label: "buildhost", sshHostAlias: "builder").host
+        try registry.setPersistentForwardEnabled(true, hostID: host.id)
+
+        let spy = ForwardSpy()
+        let reapCount = Mutex(0)
+        let coordinator = makeCoordinator(
+            registry: registry, spy: spy, reapOrphans: { reapCount.withLock { $0 += 1 } }
+        )
+        coordinator.reconcile()
+        for _ in 0..<50 { await Task.yield() }
+        XCTAssertEqual(spy.started, [host.id])
+
+        try registry.setPersistentForwardEnabled(false, hostID: host.id)
+        coordinator.reconcile()
+        try registry.setPersistentForwardEnabled(true, hostID: host.id)
+        coordinator.reconcile()
+        for _ in 0..<50 { await Task.yield() }
+        XCTAssertEqual(reapCount.withLock { $0 }, 1)
+    }
+
+    func testNoReapWhileTheListenerIsUnbound() async throws {
+        // Multi-instance safety. A second app instance cannot bind the
+        // listener while the first lives — and it must not reap either, or it
+        // would kill the first instance's perfectly healthy tunnels.
+        let registry = try makeRegistry()
+        let host = try registry.enroll(label: "buildhost", sshHostAlias: "builder").host
+        try registry.setPersistentForwardEnabled(true, hostID: host.id)
+
+        let spy = ForwardSpy()
+        let reapCount = Mutex(0)
+        let coordinator = makeCoordinator(
+            registry: registry,
+            spy: spy,
+            isListenerBound: { false },
+            reapOrphans: { reapCount.withLock { $0 += 1 } }
+        )
+        coordinator.reconcile()
+        for _ in 0..<50 { await Task.yield() }
+        XCTAssertEqual(reapCount.withLock { $0 }, 0, "no listener, no reap")
+        XCTAssertTrue(spy.started.isEmpty)
     }
 }
 

--- a/Tests/localvoxtralTests/ClaudeRemoteForwardOrphanReaperTests.swift
+++ b/Tests/localvoxtralTests/ClaudeRemoteForwardOrphanReaperTests.swift
@@ -1,0 +1,148 @@
+import Foundation
+import Synchronization
+import XCTest
+@testable import localvoxtral
+
+private final class MemoryLedgerStore: ClaudeRemoteHostStoreIO {
+    private let contents = Mutex<[String: Data]>([:])
+    func read(from url: URL) throws -> Data? { contents.withLock { $0[url.path] } }
+    func write(_ data: Data, to url: URL) throws { contents.withLock { $0[url.path] = data } }
+}
+
+/// A stand-in kernel process table: what `inspect` answers, and which signals
+/// actually end the process. No wall clock anywhere — the reaper polls on an
+/// injected sleep that returns immediately.
+private final class ProcessTableFake: @unchecked Sendable {
+    private let live = Mutex<ClaudeRemoteForwardPidRecord?>(nil)
+    private let sent = Mutex<[Int32]>([])
+    private let lethalSignals: Set<Int32>
+
+    init(live record: ClaudeRemoteForwardPidRecord?, dyingOn lethalSignals: Set<Int32>) {
+        live.withLock { $0 = record }
+        self.lethalSignals = lethalSignals
+    }
+
+    var signals: [Int32] { sent.withLock { $0 } }
+
+    func inspect(_ pid: pid_t) -> ClaudeRemoteForwardPidRecord? {
+        live.withLock { $0?.pid == Int32(pid) ? $0 : nil }
+    }
+
+    func sendSignal(_ pid: pid_t, _ signalNumber: Int32) {
+        sent.withLock { $0.append(signalNumber) }
+        if lethalSignals.contains(signalNumber) {
+            live.withLock { $0 = nil }
+        }
+    }
+}
+
+final class ClaudeRemoteForwardOrphanReaperTests: XCTestCase {
+    private func makeLedger(
+        with records: [String: ClaudeRemoteForwardPidRecord]
+    ) -> ClaudeRemoteForwardPidLedger {
+        let ledger = ClaudeRemoteForwardPidLedger(
+            fileURL: URL(fileURLWithPath: "/tmp/lvx-reaper-test/\(UUID().uuidString).json"),
+            io: MemoryLedgerStore()
+        )
+        for (hostID, record) in records { ledger.remember(hostID: hostID, record: record) }
+        return ledger
+    }
+
+    private func makeReaper(
+        ledger: ClaudeRemoteForwardPidLedger, table: ProcessTableFake
+    ) -> ClaudeRemoteForwardOrphanReaper {
+        ClaudeRemoteForwardOrphanReaper(
+            ledger: ledger,
+            inspect: { table.inspect($0) },
+            sendSignal: { table.sendSignal($0, $1) },
+            sleepFor: { _ in }
+        )
+    }
+
+    private func record(
+        pid: Int32, startSeconds: UInt64 = 111
+    ) -> ClaudeRemoteForwardPidRecord {
+        ClaudeRemoteForwardPidRecord(
+            pid: pid,
+            startSeconds: startSeconds,
+            startMicroseconds: 7,
+            executablePath: "/usr/bin/ssh"
+        )
+    }
+
+    func testADeadRecordIsRetiredWithoutSignals() async {
+        let ledger = makeLedger(with: ["host": record(pid: 4242)])
+        let table = ProcessTableFake(live: nil, dyingOn: [])
+        await makeReaper(ledger: ledger, table: table).reap()
+        XCTAssertTrue(table.signals.isEmpty, "a dead process needs no reaping")
+        XCTAssertTrue(ledger.records().isEmpty)
+    }
+
+    func testAReusedPidIsNeverSignalled() async {
+        // The safety property the whole design hangs on: after a reboot the
+        // recorded pid can belong to anything. Identity is pid PLUS kernel
+        // start time, and a mismatch retires the record without a signal.
+        let ledger = makeLedger(with: ["host": record(pid: 4242, startSeconds: 111)])
+        let table = ProcessTableFake(
+            live: record(pid: 4242, startSeconds: 999), dyingOn: [SIGTERM, SIGKILL]
+        )
+        await makeReaper(ledger: ledger, table: table).reap()
+        XCTAssertTrue(table.signals.isEmpty, "an innocent process inherited this pid")
+        XCTAssertTrue(ledger.records().isEmpty)
+    }
+
+    func testALiveOrphanDiesOnSIGTERMAndIsForgotten() async {
+        let orphan = record(pid: 4242)
+        let ledger = makeLedger(with: ["host": orphan])
+        let table = ProcessTableFake(live: orphan, dyingOn: [SIGTERM])
+        await makeReaper(ledger: ledger, table: table).reap()
+        XCTAssertEqual(table.signals, [SIGTERM], "an orphan that honours SIGTERM is never SIGKILLed")
+        XCTAssertTrue(ledger.records().isEmpty)
+    }
+
+    func testASurvivorOfSIGTERMGetsSIGKILL() async {
+        let orphan = record(pid: 4242)
+        let ledger = makeLedger(with: ["host": orphan])
+        let table = ProcessTableFake(live: orphan, dyingOn: [SIGKILL])
+        await makeReaper(ledger: ledger, table: table).reap()
+        XCTAssertEqual(table.signals, [SIGTERM, SIGKILL])
+        XCTAssertTrue(ledger.records().isEmpty)
+    }
+
+    func testASurvivorOfSIGKILLKeepsItsRecord() async {
+        // A process wedged in an uninterruptible wait can outlive SIGKILL for
+        // now. Its record still names OUR process, and keeping it is what lets
+        // the next launch try again instead of going blind.
+        let orphan = record(pid: 4242)
+        let ledger = makeLedger(with: ["host": orphan])
+        let table = ProcessTableFake(live: orphan, dyingOn: [])
+        await makeReaper(ledger: ledger, table: table).reap()
+        XCTAssertEqual(table.signals, [SIGTERM, SIGKILL])
+        XCTAssertEqual(ledger.records(), ["host": orphan])
+    }
+
+    func testEveryRecordedHostIsReaped() async {
+        let first = record(pid: 4242)
+        let second = record(pid: 4343)
+        let ledger = makeLedger(with: ["one": first, "two": second])
+        let table = ProcessTableFake(live: first, dyingOn: [SIGTERM])
+        await makeReaper(ledger: ledger, table: table).reap()
+        XCTAssertEqual(table.signals, [SIGTERM], "only the live orphan is signalled")
+        XCTAssertTrue(ledger.records().isEmpty)
+    }
+
+    func testPollCountCoversTheGraceWindow() {
+        XCTAssertEqual(
+            ClaudeRemoteForwardOrphanReaper.pollCount(
+                limit: .seconds(2), interval: .milliseconds(50)
+            ),
+            40
+        )
+        XCTAssertEqual(
+            ClaudeRemoteForwardOrphanReaper.pollCount(
+                limit: .milliseconds(1), interval: .seconds(1)
+            ),
+            1, "a limit shorter than one interval still polls once"
+        )
+    }
+}

--- a/Tests/localvoxtralTests/ClaudeRemoteForwardOrphanReaperTests.swift
+++ b/Tests/localvoxtralTests/ClaudeRemoteForwardOrphanReaperTests.swift
@@ -91,6 +91,21 @@ final class ClaudeRemoteForwardOrphanReaperTests: XCTestCase {
         XCTAssertTrue(ledger.records().isEmpty)
     }
 
+    func testADifferentExecutableAtTheSamePidIsNeverSignalled() async {
+        // The path is not decoration on the start-time check: a record whose
+        // pid AND start time somehow both match must still be retired without
+        // a signal when the executable is not the one we spawned. Pins that
+        // `executablePath` participates in identity.
+        let recorded = record(pid: 4242)
+        var impostor = recorded
+        impostor.executablePath = "/bin/cat"
+        let ledger = makeLedger(with: ["host": recorded])
+        let table = ProcessTableFake(live: impostor, dyingOn: [SIGTERM, SIGKILL])
+        await makeReaper(ledger: ledger, table: table).reap()
+        XCTAssertTrue(table.signals.isEmpty, "not the binary we spawned")
+        XCTAssertTrue(ledger.records().isEmpty)
+    }
+
     func testALiveOrphanDiesOnSIGTERMAndIsForgotten() async {
         let orphan = record(pid: 4242)
         let ledger = makeLedger(with: ["host": orphan])

--- a/Tests/localvoxtralTests/ClaudeRemoteForwardPidLedgerTests.swift
+++ b/Tests/localvoxtralTests/ClaudeRemoteForwardPidLedgerTests.swift
@@ -1,0 +1,79 @@
+import Foundation
+import Synchronization
+import XCTest
+@testable import localvoxtral
+
+private final class MemoryLedgerStore: ClaudeRemoteHostStoreIO {
+    private let contents = Mutex<[String: Data]>([:])
+    func read(from url: URL) throws -> Data? { contents.withLock { $0[url.path] } }
+    func write(_ data: Data, to url: URL) throws { contents.withLock { $0[url.path] = data } }
+}
+
+final class ClaudeRemoteForwardPidLedgerTests: XCTestCase {
+    private func makeURL() -> URL {
+        URL(fileURLWithPath: "/tmp/lvx-pid-ledger-test/\(UUID().uuidString).json")
+    }
+
+    private func record(
+        pid: Int32, startSeconds: UInt64 = 111
+    ) -> ClaudeRemoteForwardPidRecord {
+        ClaudeRemoteForwardPidRecord(
+            pid: pid,
+            startSeconds: startSeconds,
+            startMicroseconds: 7,
+            executablePath: "/usr/bin/ssh"
+        )
+    }
+
+    func testRememberAndForgetRoundTrip() {
+        let ledger = ClaudeRemoteForwardPidLedger(fileURL: makeURL(), io: MemoryLedgerStore())
+        let recorded = record(pid: 4242)
+        ledger.remember(hostID: "host", record: recorded)
+        XCTAssertEqual(ledger.records(), ["host": recorded])
+        ledger.forget(hostID: "host", pid: 4242)
+        XCTAssertTrue(ledger.records().isEmpty)
+    }
+
+    func testARecordSurvivesReconstruction() {
+        // The whole point of the ledger: the process that wrote it is dead by
+        // the time anyone reads it, so the record must round-trip through the
+        // store, not through the instance.
+        let url = makeURL()
+        let store = MemoryLedgerStore()
+        let recorded = record(pid: 4242)
+        ClaudeRemoteForwardPidLedger(fileURL: url, io: store)
+            .remember(hostID: "host", record: recorded)
+        let reloaded = ClaudeRemoteForwardPidLedger(fileURL: url, io: store)
+        XCTAssertEqual(reloaded.records(), ["host": recorded])
+    }
+
+    func testForgetIsPidScoped() {
+        // A forget racing a fresh spawn for the same host must not erase the
+        // NEW process's record — that record is the next launch's only way to
+        // find an orphan.
+        let ledger = ClaudeRemoteForwardPidLedger(fileURL: makeURL(), io: MemoryLedgerStore())
+        let replacement = record(pid: 4343)
+        ledger.remember(hostID: "host", record: record(pid: 4242))
+        ledger.remember(hostID: "host", record: replacement)
+        ledger.forget(hostID: "host", pid: 4242)
+        XCTAssertEqual(ledger.records(), ["host": replacement])
+    }
+
+    func testCorruptContentsReadAsEmpty() throws {
+        // The ledger is a cleanup aid, not a registry: the safe reading of
+        // "cannot tell what we spawned" is "kill nothing".
+        let url = makeURL()
+        let store = MemoryLedgerStore()
+        try store.write(Data("not json".utf8), to: url)
+        XCTAssertTrue(
+            ClaudeRemoteForwardPidLedger(fileURL: url, io: store).records().isEmpty
+        )
+    }
+
+    func testMissingFileReadsAsEmpty() {
+        XCTAssertTrue(
+            ClaudeRemoteForwardPidLedger(fileURL: makeURL(), io: MemoryLedgerStore())
+                .records().isEmpty
+        )
+    }
+}


### PR DESCRIPTION
## What

Field report (2026-08-05): quitting and reopening the app sometimes lands the SSH settings pane on **"Port held — close ssh sessions to that host."** with a Retry that can only fail. The holder was this Mac's own orphan: an app run that ends without `applicationWillTerminate` (crash, force-quit) — or whose SIGTERM→SIGKILL teardown outruns the bounded 3 s quit drain — leaves the app-held `ssh -N -R` reparented to launchd, alive indefinitely (BatchMode + ServerAlive keepalives), still holding the remote port bind. The next launch's fresh forward is refused its own port, and the supervisor's bind refusal is terminal by design.

The fix, following the `LegacyVoxmlxPortDefense` precedent:

- **`ClaudeRemoteForwardPidLedger`** — every spawned forward ssh is recorded (pid + kernel start time + resolved executable path) in a 0600 file beside the host registry, reusing `ClaudeRemoteHostFileStoreIO`'s hardened atomic writes. Written before the supervisor takes the process, so it survives any death the app doesn't see coming. A corrupt/unreadable ledger reads as EMPTY (loudly): it is a cleanup aid, and the safe reading of "cannot tell what we spawned" is "kill nothing".
- **`ClaudeRemoteForwardOrphanReaper`** — at launch, verifies each record against the pid's *current* kernel identity and kills matches with SIGTERM → bounded wait → SIGKILL on the injected clock. All three identity fields must match, so a reused pid can never get an innocent process signalled — a mismatch just retires the record. A SIGKILL survivor keeps its record so the next launch retries.
- **`ClaudeRemoteForwardCoordinator`** — gates the first forward start behind the reap. The gate sits *after* the listener-bound check on purpose: a second app instance cannot bind 8473 while the first lives, so it can never reap the first instance's healthy tunnels. The reap runs exactly once per launch; records written afterwards belong to this instance's own live supervisors.

Not fixed (stated honestly): "Port held" can still appear legitimately when the user's own interactive ssh session holds the enrollment `RemoteForward`, or when the server side holds a half-open session after a network drop (only sshd's own keepalive clears that). This PR removes the case where the holder was the app's own orphan — the one where Retry was hopeless.

## Proof

- [x] Unit suite green — `./scripts/remote-build.sh` (full suite):
  ```
  Executed 2602 tests, with 2 tests skipped and 0 failures (0 unexpected) in 96.649 (96.783) seconds
  ```
- [x] Bug fix: regression test added — failing before the fix, passing after.

  Red (reap gate neutered to pre-fix behavior — forwards start immediately):
  ```
  ClaudeRemoteForwardCoordinatorTests.swift:282: error: -[localvoxtralTests.ClaudeRemoteForwardCoordinatorTests testForwardsWaitForTheOrphanReapBeforeStarting] : XCTAssertTrue failed - an orphan may still hold the port until the reap finishes
  Test Case '-[localvoxtralTests.ClaudeRemoteForwardCoordinatorTests testForwardsWaitForTheOrphanReapBeforeStarting]' failed (0.185 seconds).
  ClaudeRemoteForwardCoordinatorTests.swift:313: error: -[localvoxtralTests.ClaudeRemoteForwardCoordinatorTests testTheOrphanReapRunsExactlyOnce] : XCTAssertEqual failed: ("0") is not equal to ("1")
  ```
  Green (fix restored, `./scripts/remote-build.sh test --filter ClaudeRemoteForward`):
  ```
  Test Suite 'ClaudeRemoteForwardCoordinatorTests' passed at 2026-08-05 23:07:39.628.
  Test Suite 'ClaudeRemoteForwardOrphanReaperTests' passed at 2026-08-05 23:07:39.630.
  Test Suite 'ClaudeRemoteForwardPidLedgerTests' passed at 2026-08-05 23:07:39.631.
  	 Executed 60 tests, with 0 failures (0 unexpected) in 0.045 (0.049) seconds
  ```
  New coverage: the pid-reuse safety property (`testAReusedPidIsNeverSignalled`), the SIGTERM→SIGKILL escalation ladder, SIGKILL-survivor record retention, ledger round-trip/pid-scoped-forget/corrupt-reads-as-empty, and the coordinator gate (waits for reap, runs once, never reaps while the listener is unbound).
- LLM lanes skipped: backend-supervision/lifecycle paths only — nothing on this diff changes what reaches any model.