### PR TITLE
SSH probe: ProxyJump machinery is not a second connection; abstentions name their cause

### DIFF
--- a/Sources/localvoxtral/ClaudeContext/SSHDestinationTTYProbe.swift
+++ b/Sources/localvoxtral/ClaudeContext/SSHDestinationTTYProbe.swift
@@ -27,6 +27,30 @@ struct SSHSurfaceConnection: Sendable, Equatable {
     }
 }
 
+/// WHY the probe could not pin an ssh session down. Deliberately content-free
+/// — a category, never a path, host, or option letter — so it is safe to put
+/// in the log and the dogfood record. Three field dictations were diagnosed
+/// blind (2026-08-06) because every branch collapsed into one word; the cause
+/// had to be reconstructed from the REMOTE host's process table.
+enum SSHProbeIndeterminacy: String, Sendable, Equatable {
+    /// The tty device path did not resolve.
+    case deviceUnreadable = "device unreadable"
+    /// The machine-wide process scan failed. Not evidence of absence.
+    case tableUnreadable = "process table unreadable"
+    /// More than one foreground ssh CONNECTION on the surface.
+    case multipleForegroundClients = "multiple foreground ssh"
+    /// The surface process's executable is not one we trust to be OpenSSH.
+    case untrustedExecutable = "untrusted executable"
+    /// The surface process's argv could not be read.
+    case unreadableArguments = "unreadable argv"
+    /// The argv was read and refused: a destination-moving or non-interactive
+    /// option, an unknown option letter, or a destination shape outside the
+    /// grammar.
+    case refusedArguments = "refused argv"
+    /// The seam default: no live probe was injected, so the arm is disabled.
+    case probeUnavailable = "probe unavailable"
+}
+
 /// What the process table says about ssh clients on ONE terminal device.
 ///
 /// Three answers, and the difference between the last two is the whole point:
@@ -43,7 +67,9 @@ enum SSHDestinationTTYProbeResult: Sendable, Equatable {
     /// surface, whatever their destinations. Two to the same host abstain just
     /// as two to different hosts do: nothing here says which one the user is
     /// looking at, and unioning them let one borrow the other's herdr signal.
-    case undeterminable
+    /// The payload says WHICH refusal fired — it changes logging, never the
+    /// abstention.
+    case undeterminable(SSHProbeIndeterminacy)
 }
 
 /// One ssh process as the probe sees it.
@@ -201,35 +227,59 @@ enum SSHDestinationTTYProbe {
         deviceID: @Sendable (String) -> dev_t?,
         sshProcesses: @Sendable () -> [SSHClientProcess]?
     ) -> SSHDestinationTTYProbeResult {
-        guard let device = deviceID(path), let processes = sshProcesses() else {
-            // A device we cannot resolve, or a process table we cannot read, is
-            // not evidence of absence.
-            return .undeterminable
+        guard let device = deviceID(path) else {
+            // A device we cannot resolve is not evidence of absence.
+            return .undeterminable(.deviceUnreadable)
         }
+        guard let processes = sshProcesses() else {
+            return .undeterminable(.tableUnreadable)
+        }
+
+        // CONNECTIONS are the ssh processes with no ssh parent. OpenSSH spawns
+        // its own helpers as direct children — a ProxyJump's `ssh -W` hop, on
+        // the SAME tty and in the SAME foreground process group as the session
+        // it carries (field abstention, 2026-08-06) — and such machinery is
+        // not a second connection anywhere below: not on the surface, and not
+        // in the uniqueness claim (its connection is its root, which is always
+        // also in this scan). The partition rides kernel ppid, which no
+        // launcher gets to write, so it cannot be used to HIDE a connection:
+        // only a real ssh parent demotes a process, and that parent is
+        // counted. A shell-mediated ProxyCommand (sh alive between the two
+        // sshs) stays a root and still abstains — refusing to guess there is
+        // cheaper than trusting one un-attested hop.
+        let connections = processes.filter { !hasSSHParent($0, in: processes) }
 
         // Only the foreground process group of THIS terminal can be what the
         // user is looking at. A backgrounded or stopped ssh on the same device
         // means the surface is showing the shell, not a remote session.
-        let onSurface = processes.filter {
+        let onSurface = connections.filter {
             $0.ttyDevice == device && $0.isForegroundOfItsTerminal
         }
         guard !onSurface.isEmpty else { return .noSSHClient }
 
-        // EXACTLY ONE foreground ssh, or nothing. The first version combined
-        // several — one destination set, `indicatesHerdr` OR-ed across them —
-        // and that union was itself a mis-join (review round 7): a foreground
-        // group holding both `ssh builder` and `ssh builder herdr` reported
-        // "unique" AND "is herdr", so the plain, visible connection joined the
-        // other process's herdr session. A pipeline or wrapper that launches
-        // several ssh children in one group is the same shape.
+        // EXACTLY ONE foreground ssh connection, or nothing. The first version
+        // combined several — one destination set, `indicatesHerdr` OR-ed across
+        // them — and that union was itself a mis-join (review round 7): a
+        // foreground group holding both `ssh builder` and `ssh builder herdr`
+        // reported "unique" AND "is herdr", so the plain, visible connection
+        // joined the other process's herdr session. A pipeline or wrapper that
+        // launches several ssh children in one group is the same shape — and
+        // stays refused: siblings have no ssh parent, so the machinery rule
+        // never reduces them to one.
         //
         // There is no way to tell from here WHICH of them the user is looking
         // at, and this arm's rule is to abstain rather than guess.
         guard onSurface.count == 1, let surfaceProcess = onSurface.first else {
-            return .undeterminable
+            return .undeterminable(.multipleForegroundClients)
         }
-        guard let parsed = verifiedInvocation(of: surfaceProcess) else {
-            return .undeterminable
+        guard let executablePath = surfaceProcess.executablePath,
+              isTrustedSSHExecutable(executablePath)
+        else { return .undeterminable(.untrustedExecutable) }
+        guard let arguments = surfaceProcess.arguments else {
+            return .undeterminable(.unreadableArguments)
+        }
+        guard let parsed = parse(arguments: arguments) else {
+            return .undeterminable(.refusedArguments)
         }
 
         return .connection(
@@ -238,11 +288,26 @@ enum SSHDestinationTTYProbe {
                 isOnlyConnectionToDestination: isOnlyConnection(
                     to: parsed.destination,
                     surfacePID: surfaceProcess.pid,
-                    processes: processes
+                    connections: connections
                 ),
                 indicatesHerdr: parsed.indicatesHerdr
             )
         )
+    }
+
+    /// Is this process a direct child of another ssh in the same scan?
+    ///
+    /// One hop is the whole walk on purpose: the scan holds only ssh
+    /// processes, so an ssh-to-ssh ancestry link IS a direct parent link
+    /// (multi-hop ProxyJump chains demote each hop by its own parent), and a
+    /// non-ssh intermediary — a shell running a ProxyCommand — breaks the
+    /// chain, leaving the grandchild a root. That is the conservative side:
+    /// an extra root can only ever cause an abstention, never a join.
+    private static func hasSSHParent(
+        _ process: SSHClientProcess, in processes: [SSHClientProcess]
+    ) -> Bool {
+        guard process.parentPID > 0, process.parentPID != process.pid else { return false }
+        return processes.contains { $0.pid == process.parentPID }
     }
 
     /// Is this terminal's the only connection to that destination?
@@ -259,14 +324,17 @@ enum SSHDestinationTTYProbe {
     /// determination above, and says nothing about how many connections exist.
     ///
     /// Excluded: the surface's own connection (the single foreground ssh this
-    /// answer is about), and anything with no controlling terminal — nobody can
-    /// be dictating into one, and our own `ssh -L` forward is exactly that.
+    /// answer is about), anything with no controlling terminal — nobody can
+    /// be dictating into one, and our own `ssh -L` forward is exactly that —
+    /// and ssh MACHINERY (the caller passes connections only): a ProxyJump's
+    /// `-W` child carries its root's connection, which is already counted, and
+    /// its refused argv must not read as "an ssh we cannot account for".
     private static func isOnlyConnection(
         to destination: String,
         surfacePID: Int32,
-        processes: [SSHClientProcess]
+        connections: [SSHClientProcess]
     ) -> Bool {
-        for process in processes
+        for process in connections
         where process.ttyDevice != nil && process.pid != surfacePID {
             guard let parsed = verifiedInvocation(of: process) else {
                 // An ssh elsewhere we cannot read could be to this destination.

--- a/Sources/localvoxtral/ClaudeContext/SSHDestinationTTYProbe.swift
+++ b/Sources/localvoxtral/ClaudeContext/SSHDestinationTTYProbe.swift
@@ -49,6 +49,11 @@ enum SSHDestinationTTYProbeResult: Sendable, Equatable {
 /// One ssh process as the probe sees it.
 struct SSHClientProcess: Sendable, Equatable {
     var pid: Int32
+    /// Kernel-reported parent pid (`e_ppid`). This is what lets ProxyJump
+    /// machinery be told apart from a connection: OpenSSH spawns its `-W`
+    /// stdio-forward hop as a direct CHILD, and ppid is kernel truth — unlike
+    /// argv, no launcher gets to choose it.
+    var parentPID: Int32
     /// Controlling terminal device, or nil when it has none. A process with no
     /// terminal is not a surface anyone can be dictating into — our OWN
     /// `ssh -L` forward is exactly that, which is why it must not count.
@@ -62,6 +67,7 @@ struct SSHClientProcess: Sendable, Equatable {
 
     init(
         pid: Int32,
+        parentPID: Int32 = 0,
         ttyDevice: dev_t?,
         processGroupID: Int32,
         terminalForegroundGroupID: Int32,
@@ -69,6 +75,7 @@ struct SSHClientProcess: Sendable, Equatable {
         arguments: [String]?
     ) {
         self.pid = pid
+        self.parentPID = parentPID
         self.ttyDevice = ttyDevice
         self.processGroupID = processGroupID
         self.terminalForegroundGroupID = terminalForegroundGroupID
@@ -451,6 +458,7 @@ enum SSHDestinationTTYProbe {
             .map { entry in
                 SSHClientProcess(
                     pid: entry.pid,
+                    parentPID: entry.parentProcessID,
                     ttyDevice: entry.ttyDevice,
                     processGroupID: entry.processGroupID,
                     terminalForegroundGroupID: entry.terminalForegroundGroupID,
@@ -536,6 +544,7 @@ enum SSHDestinationTTYProbe {
 enum TTYProcessTable {
     struct Entry: Sendable, Equatable {
         var pid: Int32
+        var parentProcessID: Int32
         var name: String
         var ttyDevice: dev_t?
         var processGroupID: Int32
@@ -543,12 +552,14 @@ enum TTYProcessTable {
 
         init(
             pid: Int32,
+            parentProcessID: Int32 = 0,
             name: String,
             ttyDevice: dev_t? = nil,
             processGroupID: Int32 = 0,
             terminalForegroundGroupID: Int32 = 0
         ) {
             self.pid = pid
+            self.parentProcessID = parentProcessID
             self.name = name
             self.ttyDevice = ttyDevice
             self.processGroupID = processGroupID
@@ -602,6 +613,7 @@ enum TTYProcessTable {
             let device = process.kp_eproc.e_tdev
             return Entry(
                 pid: process.kp_proc.p_pid,
+                parentProcessID: process.kp_eproc.e_ppid,
                 name: name,
                 // NODEV means no controlling terminal — not a surface.
                 ttyDevice: device == ~dev_t(0) ? nil : device,

--- a/Sources/localvoxtral/ClaudeContext/SSHDestinationTTYProbe.swift
+++ b/Sources/localvoxtral/ClaudeContext/SSHDestinationTTYProbe.swift
@@ -306,6 +306,8 @@ enum SSHDestinationTTYProbe {
     private static func hasSSHParent(
         _ process: SSHClientProcess, in processes: [SSHClientProcess]
     ) -> Bool {
+        // The self-parent clause is defensive against hand-built test data
+        // only — no Darwin process is its own parent.
         guard process.parentPID > 0, process.parentPID != process.pid else { return false }
         return processes.contains { $0.pid == process.parentPID }
     }

--- a/Sources/localvoxtral/ClaudeContext/TerminalScreenClaudeJoin.swift
+++ b/Sources/localvoxtral/ClaudeContext/TerminalScreenClaudeJoin.swift
@@ -266,7 +266,7 @@ struct ClaudeSessionJoinResolver {
         cmuxJoinEnabled: @escaping @MainActor () -> Bool = { false },
         reportCmuxStatus: @escaping @MainActor (CmuxSocketStatus) -> Void = { _ in },
         sshDestinationProbe: @escaping @Sendable (String) -> SSHDestinationTTYProbeResult = { _ in
-            .undeterminable
+            .undeterminable(.probeUnavailable)
         },
         enrolledHosts: @escaping @MainActor (String) -> [ClaudeRemoteHost] = { _ in [] },
         remoteHerdrForwards: (any ClaudeRemoteHerdrForwarding)? = nil
@@ -594,8 +594,12 @@ struct ClaudeSessionJoinResolver {
             // The overwhelmingly common case: a local shell. Not logged — this
             // is not an abstention, it is the arm not applying.
             return .notApplicable
-        case .undeterminable:
-            Self.abstainedRemoteHerdrJoin(outcome: "ssh session undeterminable")
+        case .undeterminable(let cause):
+            // The category is content-free by type (`SSHProbeIndeterminacy` —
+            // never a host, path, or option), so it may ride into the log and
+            // the dogfood record. Three field dictations were diagnosed blind
+            // without it (2026-08-06).
+            Self.abstainedRemoteHerdrJoin(outcome: "ssh session undeterminable (\(cause.rawValue))")
             return .notApplicable
         case .connection(let value):
             connection = value

--- a/Tests/localvoxtralTests/RemoteHerdrJoinTests.swift
+++ b/Tests/localvoxtralTests/RemoteHerdrJoinTests.swift
@@ -385,7 +385,7 @@ final class RemoteHerdrJoinTests: XCTestCase {
                 registry: registry,
                 panes: RemoteJoinHerdrPanes(focused: focusedPane()),
                 forwards: forwards,
-                sshResult: .undeterminable,
+                sshResult: .undeterminable(.multipleForegroundClients),
                 title: markerValue
             ).resolve(target: ghostty)
         )

--- a/Tests/localvoxtralTests/SSHDestinationTTYProbeTests.swift
+++ b/Tests/localvoxtralTests/SSHDestinationTTYProbeTests.swift
@@ -460,7 +460,10 @@ final class SSHDestinationTTYProbeTests: XCTestCase {
                     processes: [
                         ssh(["ssh", "sandbox-vpn", "herdr"], pid: 501),
                         proxyChild(pid: 502, parent: 501),
-                        proxyChild(pid: 503, parent: 502),
+                        // One device has ONE foreground pgid; what this test
+                        // pins is parent-chain demotion, not foreground
+                        // semantics, so the grandchild reports the same one.
+                        proxyChild(pid: 503, parent: 502, foregroundGroup: 501),
                     ]
                 )
             )
@@ -507,12 +510,21 @@ final class SSHDestinationTTYProbeTests: XCTestCase {
         // A tty-holding ssh whose parent is NOT an ssh (launchd after a
         // reparent, a shell-mediated ProxyCommand) is still a root, and an
         // unreadable root still spoils the claim — the paranoia is unchanged.
+        let orphan = SSHClientProcess(
+            pid: 777,
+            parentPID: 1, // reparented to launchd — a REAL orphan's e_ppid
+            ttyDevice: otherTerminal,
+            processGroupID: 777,
+            terminalForegroundGroupID: 777,
+            executablePath: "/usr/bin/ssh",
+            arguments: nil
+        )
         let value = try XCTUnwrap(
             connection(
                 probe(
                     processes: [
                         ssh(["ssh", "sandbox-vpn", "herdr"], pid: 501),
-                        ssh(nil, pid: 777, device: otherTerminal),
+                        orphan,
                     ]
                 )
             )
@@ -542,9 +554,10 @@ final class SSHDestinationTTYProbeTests: XCTestCase {
             executablePath: "/usr/bin/ssh",
             arguments: ["ssh", "builder"]
         )
-        guard case .undeterminable = probe(processes: [first, second]) else {
-            return XCTFail("two sibling foreground connections must abstain")
-        }
+        XCTAssertEqual(
+            probe(processes: [first, second]),
+            .undeterminable(.multipleForegroundClients)
+        )
     }
 
     // MARK: - herdr connection signal (review blocker 1b)

--- a/Tests/localvoxtralTests/SSHDestinationTTYProbeTests.swift
+++ b/Tests/localvoxtralTests/SSHDestinationTTYProbeTests.swift
@@ -55,11 +55,13 @@ final class SSHDestinationTTYProbeTests: XCTestCase {
     }
 
     func testUnreadableDeviceAbstains() {
-        XCTAssertEqual(probe(deviceID: nil, processes: [ssh(["ssh", "builder"])]), .undeterminable)
+        XCTAssertEqual(probe(deviceID: nil, processes: [ssh(["ssh", "builder"])]),
+            .undeterminable(.deviceUnreadable)
+        )
     }
 
     func testUnreadableProcessTableAbstains() {
-        XCTAssertEqual(probe(processes: nil), .undeterminable)
+        XCTAssertEqual(probe(processes: nil), .undeterminable(.tableUnreadable))
     }
 
     func testOneForegroundSSHClientReportsItsConnection() throws {
@@ -72,7 +74,7 @@ final class SSHDestinationTTYProbeTests: XCTestCase {
     func testUnreadableArgvOfAnSSHProcessAbstains() {
         // Absence of argv is not absence of ssh: this surface IS a remote
         // session, we just cannot say to where.
-        XCTAssertEqual(probe(processes: [ssh(nil)]), .undeterminable)
+        XCTAssertEqual(probe(processes: [ssh(nil)]), .undeterminable(.unreadableArguments))
     }
 
     // MARK: - Executable verification (review finding 2)
@@ -82,17 +84,18 @@ final class SSHDestinationTTYProbeTests: XCTestCase {
         // whoever exec'd it. Neither is evidence of running OpenSSH.
         XCTAssertEqual(
             probe(processes: [ssh(["ssh", "builder"], executable: "/tmp/evil/ssh")]),
-            .undeterminable
+            .undeterminable(.untrustedExecutable)
         )
         XCTAssertEqual(
             probe(processes: [ssh(["ssh", "builder"], executable: "/Users/dev/bin/ssh")]),
-            .undeterminable
+            .undeterminable(.untrustedExecutable)
         )
     }
 
     func testUnknownExecutablePathAbstains() {
         XCTAssertEqual(
-            probe(processes: [ssh(["ssh", "builder"], executable: nil)]), .undeterminable
+            probe(processes: [ssh(["ssh", "builder"], executable: nil)]),
+            .undeterminable(.untrustedExecutable)
         )
     }
 
@@ -136,7 +139,7 @@ final class SSHDestinationTTYProbeTests: XCTestCase {
         // an executable in a writable tree, must not produce a destination.
         XCTAssertEqual(
             probe(processes: [ssh(["ssh", "builder"], executable: "/opt/homebrew/tmp/ssh")]),
-            .undeterminable
+            .undeterminable(.untrustedExecutable)
         )
     }
 
@@ -361,7 +364,7 @@ final class SSHDestinationTTYProbeTests: XCTestCase {
                     ssh(["ssh", "builder", "herdr", "attach"], pid: 502),
                 ]
             ),
-            .undeterminable
+            .undeterminable(.multipleForegroundClients)
         )
     }
 
@@ -384,7 +387,7 @@ final class SSHDestinationTTYProbeTests: XCTestCase {
             executablePath: "/usr/bin/ssh",
             arguments: ["ssh", "builder"]
         )
-        XCTAssertEqual(probe(processes: [first, second]), .undeterminable)
+        XCTAssertEqual(probe(processes: [first, second]), .undeterminable(.multipleForegroundClients))
     }
 
     func testTwoForegroundSSHClientsToDifferentHostsOnOneSurfaceAbstain() {
@@ -395,7 +398,16 @@ final class SSHDestinationTTYProbeTests: XCTestCase {
                     ssh(["ssh", "other"], pid: 502),
                 ]
             ),
-            .undeterminable
+            .undeterminable(.multipleForegroundClients)
+        )
+    }
+
+    func testARefusedOptionOnTheSurfaceClientReportsItsOwnCause() {
+        // The categories exist because three field dictations were diagnosed
+        // blind (2026-08-06): every branch collapsed into one word.
+        XCTAssertEqual(
+            probe(processes: [ssh(["ssh", "-o", "HostName=other", "builder"])]),
+            .undeterminable(.refusedArguments)
         )
     }
 

--- a/Tests/localvoxtralTests/SSHDestinationTTYProbeTests.swift
+++ b/Tests/localvoxtralTests/SSHDestinationTTYProbeTests.swift
@@ -399,6 +399,142 @@ final class SSHDestinationTTYProbeTests: XCTestCase {
         )
     }
 
+    // MARK: - ProxyJump machinery (field abstention, 2026-08-06)
+
+    /// The field shape verbatim: `Host sandbox-vpn` with `ProxyJump dell1`
+    /// makes OpenSSH spawn `ssh -W [ip]:22 dell1` as a direct child on the
+    /// SAME tty and in the SAME foreground process group. That child is the
+    /// connection's transport, not a second connection — kernel ppid says so —
+    /// and it must neither break the exactly-one surface rule nor the
+    /// machine-wide uniqueness claim.
+    private func proxyChild(
+        pid: Int32,
+        parent: Int32,
+        device: dev_t? = 42,
+        foregroundGroup: Int32? = nil
+    ) -> SSHClientProcess {
+        SSHClientProcess(
+            pid: pid,
+            parentPID: parent,
+            ttyDevice: device,
+            processGroupID: parent,
+            terminalForegroundGroupID: foregroundGroup ?? parent,
+            executablePath: "/usr/bin/ssh",
+            arguments: ["ssh", "-W", "[192.168.1.98]:22", "dell1"]
+        )
+    }
+
+    func testAProxyJumpChildIsMachineryNotASecondSurfaceClient() throws {
+        let value = try XCTUnwrap(
+            connection(
+                probe(
+                    processes: [
+                        ssh(["ssh", "-t", "sandbox-vpn", "herdr"], pid: 68369),
+                        proxyChild(pid: 68370, parent: 68369),
+                    ]
+                )
+            )
+        )
+        XCTAssertEqual(value.destination, "sandbox-vpn")
+        XCTAssertTrue(value.indicatesHerdr)
+        XCTAssertTrue(value.isOnlyConnectionToDestination)
+    }
+
+    func testAMultiHopProxyChainIsEntirelyMachinery() throws {
+        // `ProxyJump a,b` nests: the -W child spawns its own -W child.
+        let value = try XCTUnwrap(
+            connection(
+                probe(
+                    processes: [
+                        ssh(["ssh", "sandbox-vpn", "herdr"], pid: 501),
+                        proxyChild(pid: 502, parent: 501),
+                        proxyChild(pid: 503, parent: 502),
+                    ]
+                )
+            )
+        )
+        XCTAssertEqual(value.destination, "sandbox-vpn")
+        XCTAssertTrue(value.isOnlyConnectionToDestination)
+    }
+
+    func testAnotherTerminalsProxyChildDoesNotRemoveUniqueness() throws {
+        // A second terminal to a DIFFERENT host over its own jump: its root is
+        // parsed (destination `elsewhere`, no match) and its unreadable -W
+        // child is that root's machinery, not an unreadable connection.
+        let value = try XCTUnwrap(
+            connection(
+                probe(
+                    processes: [
+                        ssh(["ssh", "sandbox-vpn", "herdr"], pid: 501),
+                        ssh(["ssh", "elsewhere"], pid: 777, device: otherTerminal),
+                        proxyChild(pid: 778, parent: 777, device: otherTerminal),
+                    ]
+                )
+            )
+        )
+        XCTAssertTrue(value.isOnlyConnectionToDestination)
+    }
+
+    func testAnotherTerminalsRootToTheSameHostStillRemovesUniquenessDespiteItsChild() throws {
+        // The machinery rule must not swallow the root it serves.
+        let value = try XCTUnwrap(
+            connection(
+                probe(
+                    processes: [
+                        ssh(["ssh", "sandbox-vpn", "herdr"], pid: 501),
+                        ssh(["ssh", "sandbox-vpn"], pid: 777, device: otherTerminal),
+                        proxyChild(pid: 778, parent: 777, device: otherTerminal),
+                    ]
+                )
+            )
+        )
+        XCTAssertFalse(value.isOnlyConnectionToDestination)
+    }
+
+    func testAnOrphanedUnreadableSSHElsewhereStillRemovesUniqueness() throws {
+        // A tty-holding ssh whose parent is NOT an ssh (launchd after a
+        // reparent, a shell-mediated ProxyCommand) is still a root, and an
+        // unreadable root still spoils the claim — the paranoia is unchanged.
+        let value = try XCTUnwrap(
+            connection(
+                probe(
+                    processes: [
+                        ssh(["ssh", "sandbox-vpn", "herdr"], pid: 501),
+                        ssh(nil, pid: 777, device: otherTerminal),
+                    ]
+                )
+            )
+        )
+        XCTAssertFalse(value.isOnlyConnectionToDestination)
+    }
+
+    func testSiblingForegroundClientsAreNotMachineryAndStillAbstain() {
+        // The round-7 review case must survive the machinery rule: a wrapper
+        // launching two ssh SIBLINGS in one foreground group has no ssh
+        // parent on either, so both are connections and neither answers.
+        let first = SSHClientProcess(
+            pid: 601,
+            parentPID: 600, // a shell, not in the ssh scan
+            ttyDevice: surface,
+            processGroupID: 600,
+            terminalForegroundGroupID: 600,
+            executablePath: "/usr/bin/ssh",
+            arguments: ["ssh", "builder", "herdr"]
+        )
+        let second = SSHClientProcess(
+            pid: 602,
+            parentPID: 600,
+            ttyDevice: surface,
+            processGroupID: 600,
+            terminalForegroundGroupID: 600,
+            executablePath: "/usr/bin/ssh",
+            arguments: ["ssh", "builder"]
+        )
+        guard case .undeterminable = probe(processes: [first, second]) else {
+            return XCTFail("two sibling foreground connections must abstain")
+        }
+    }
+
     // MARK: - herdr connection signal (review blocker 1b)
 
     func testARemoteCommandNamingHerdrBindsTheConnection() throws {
@@ -635,6 +771,10 @@ final class SSHDestinationTTYProbeTests: XCTestCase {
         let entries = try XCTUnwrap(TTYProcessTable.allProcesses())
         let me = entries.first { $0.pid == getpid() }
         XCTAssertNotNil(me, "the scan must contain the test process itself")
+        XCTAssertEqual(
+            me?.parentProcessID, getppid(),
+            "the parent pid must be plumbed — the machinery rule depends on it"
+        )
     }
 
     func testTheLiveExecutablePathOfThisProcessResolves() throws {

--- a/docs/agent/invariants.md
+++ b/docs/agent/invariants.md
@@ -204,7 +204,19 @@ there is not.
     a background one, or `scp`/`rsync`'s helper is not mistaken for the screen),
     and ABSTAINS on `-o`/`-F`/`-O`/`-S`/`-N`/`-f`/`-M`/`-D`/`-W`/`-w` rather
     than skipping them — `ssh -o HostName=other builder` must never answer
-    `builder`;
+    `builder`. ssh MACHINERY is invisible to this count and to the uniqueness
+    scan in (2): an ssh that is a direct CHILD of another scanned ssh — a
+    ProxyJump's `ssh -W` hop, which OpenSSH spawns on the same tty in the same
+    foreground process group (field abstention 2026-08-06) — is its root
+    connection's transport, not a second connection. The partition rides
+    kernel ppid, which no launcher gets to write, so it cannot hide a
+    connection (the demoting parent is itself counted); sibling ssh processes
+    in one group have no ssh parent and stay refused, and a shell-mediated
+    ProxyCommand's grandchild stays a root and abstains — conservative on
+    purpose. Probe abstentions carry a content-free cause category
+    (`SSHProbeIndeterminacy` — never a host, path, or option letter) into the
+    log and the dogfood record, because three field dictations were diagnosed
+    blind without one;
     (2) that ssh session IS herdr — its remote command's first argv token has
     basename `herdr` — AND this terminal holds the ONLY ssh connection to that
     destination on the machine (a `KERN_PROC_ALL` scan counting every other ssh


### PR DESCRIPTION
## What

Fixes the field abstention that blocked every remote-herdr join for a `ProxyJump` ssh config (owner dogfooding, 2026-08-06): OpenSSH spawns the jump hop as `ssh -W <ip>:22 <jumphost>` — a direct child on the SAME tty, in the SAME foreground process group — so `SSHDestinationTTYProbe` saw two foreground ssh clients on the surface and returned `.undeterminable` on every dictation. The `-W` child also poisoned the machine-wide uniqueness scan (its argv parse is refused, which read as "an ssh we cannot account for").

The rule: an ssh that is a **direct child of another scanned ssh is that connection's machinery, not a second connection** — invisible to both the exactly-one surface count and the uniqueness claim. The partition rides kernel ppid, which no launcher gets to write, so it cannot hide a connection (the demoting parent is itself counted). Deliberately preserved paranoia:

- sibling ssh processes in one foreground group (review round 7) have no ssh parent and still abstain;
- a shell-mediated `ProxyCommand` grandchild stays a root and still abstains — an extra root can only cause an abstention, never a join;
- an unreadable root elsewhere still spoils uniqueness, exactly as before.

Second change, same story: `.undeterminable` now carries a content-free `SSHProbeIndeterminacy` category (device/table read, multiple foreground clients, untrusted executable, unreadable argv, refused argv, probe unavailable) into `Log.claudeContext` and the dogfood join-abstention string. Three field dictations in a row were diagnosed blind because every branch collapsed into one word; the actual cause had to be reconstructed from the remote host's process table.

`docs/agent/invariants.md` updated to state the machinery rule and its bounds.

[dogfood-package]

## Proof

- Unit suite green — full run after the fix:
  `Executed 2613 tests, with 2 tests skipped and 0 failures (0 unexpected) in 95.990 (96.131) seconds`
- Bug fix: regression tests added, shown failing before the fix (commit 1, `b284e32`) and passing after (commit 2):
  - Red (pre-fix), `remote-build.sh test --filter SSHDestinationTTYProbeTests`:
    ```
    testAProxyJumpChildIsMachineryNotASecondSurfaceClient : XCTUnwrap failed: expected non-nil value of type "SSHSurfaceConnection"
    testAMultiHopProxyChainIsEntirelyMachinery : XCTUnwrap failed: expected non-nil value of type "SSHSurfaceConnection"
    testAnotherTerminalsProxyChildDoesNotRemoveUniqueness : XCTAssertTrue failed
    Executed 64 tests, with 3 failures (0 unexpected)
    ```
  - Green (post-fix): `Executed 65 tests, with 0 failures (0 unexpected)` (probe suite) and `Executed 51 tests, with 0 failures (0 unexpected)` (RemoteHerdrJoinTests, covers the categorized abstention falling through to the title marker).
- `testAProxyJumpChildIsMachineryNotASecondSurfaceClient` is the field shape verbatim (`ssh -t sandbox-vpn herdr` + child `ssh -W [ip]:22 dell1`, same pgid/tty, from the owner's Mac `ps` output).
- Review-property preservation pinned by test: `testSiblingForegroundClientsAreNotMachineryAndStillAbstain`, `testAnotherTerminalsRootToTheSameHostStillRemovesUniquenessDespiteItsChild`, `testAnOrphanedUnreadableSSHElsewhereStillRemovesUniqueness`.
- LLM lanes: not required — no change to prompts, models, or anything that reaches the model; this alters only whether a join resolves, and the join/context paths' behavior is covered by the unit suites above. (Paths are under `Sources/localvoxtral/ClaudeContext/*`, so the lane filter will run the polishd lane anyway.)
- Field verification planned: owner installs via `./scripts/try-pr.sh <this PR> --dogfood` and dictates over the ProxyJump connection; the dogfood record should now either join via `.remoteHerdrPane` or name the exact refusal category.
