### PR TITLE
Remote herdr join: classify the herdr invocation; block competing herdr views, not every second connection

### DIFF
--- a/Sources/localvoxtral/ClaudeContext/SSHDestinationTTYProbe.swift
+++ b/Sources/localvoxtral/ClaudeContext/SSHDestinationTTYProbe.swift
@@ -3,27 +3,63 @@ import Foundation
 #if canImport(Darwin)
 import Darwin
 
+/// What an ssh remote command says about herdr — a CLASSIFICATION, not a
+/// boolean, because "mentions herdr first" spans shapes that display entirely
+/// different things (verified against herdr v0.8.0 / protocol 19, 2026-08-06):
+///
+/// * a bare client attach displays the server's GLOBAL focused pane — herdr
+///   focus is server-global and multi-client attach is a mirror
+///   (`src/app/api/panes.rs::handle_pane_current`, `tests/multi_client.rs`),
+///   which is the semantic the whole remote arm reads through `pane.current`;
+/// * `herdr terminal attach <id>` renders exactly ONE pane, and
+///   `herdr --session <name>` attaches a DIFFERENT server (named sessions have
+///   separate sockets) — joining the global focus of the candidates' socket
+///   while the user looks at either of those is a mis-join reachable with a
+///   single connection, which is why the boolean had to go.
+enum HerdrInvocation: Sendable, Equatable {
+    /// The remote command is not herdr (or there is no remote command).
+    case notHerdr
+    /// A bare `herdr` whole-view client attach — the only shape whose display
+    /// is the server's global focus. `sessionSelector` is the normalized
+    /// `--session` value (nil = the default session); two connections display
+    /// the same server only when their selectors are byte-identical.
+    case plainClient(sessionSelector: String?)
+    /// herdr with any other subcommand or flag shape: single-pane attaches,
+    /// observers, named-session verbs, `server`, or tokens this classifier
+    /// does not know. Refused by the arm — never a join, never a guess.
+    case otherHerdrSubcommand
+}
+
 /// The ssh connection a terminal surface is displaying, as far as the local
 /// process table can prove it.
 struct SSHSurfaceConnection: Sendable, Equatable {
     /// Normalized destination host/alias.
     var destination: String
-    /// No OTHER terminal on this machine hosts an ssh to the same destination.
+    /// Another terminal on this machine hosts an ssh to the same destination
+    /// that COULD be displaying a different herdr view: a herdr client with a
+    /// different session selector, a single-pane herdr attach, or an ssh whose
+    /// argv cannot rule herdr out.
     ///
-    /// Without this the probe binds to a HOST rather than to a CONNECTION: with
-    /// one terminal on a plain shell to `builder` and another attached to herdr
-    /// on `builder`, both surfaces answer "ssh to builder", and the plain shell
-    /// would join the herdr terminal's session (review blocker 1).
-    var isOnlyConnectionToDestination: Bool
-    /// The argv positively names herdr as the remote command — the shape
-    /// `herdr --remote` spawns, or a hand-typed `ssh host herdr …`. This binds
-    /// the CONNECTION to herdr, which no amount of host-level reasoning can.
-    var indicatesHerdr: Bool
+    /// This is deliberately narrower than the original "only connection to
+    /// the destination" rule. What that rule actually protected against is a
+    /// surface joining a herdr view it is not displaying — and a plain shell
+    /// on another tty can never be that: the probe only ever reads the FOCUSED
+    /// surface's tty, and herdr focus is server-global with mirror attach
+    /// (verified in herdr source, 2026-08-06), so even a second client of the
+    /// SAME server displays the same focused pane. What still competes is a
+    /// client of a DIFFERENT server (session selector mismatch), a single-pane
+    /// attach, or anything unreadable enough that it might be one.
+    var hasCompetingHerdrClient: Bool
+    /// The classified herdr invocation of THIS connection's remote command.
+    /// Binds the CONNECTION to herdr, which no amount of host-level reasoning
+    /// can — argv here is the exec-time vector of a VERIFIED OpenSSH binary,
+    /// i.e. the command ssh actually ran, not a self-report.
+    var herdr: HerdrInvocation
 
-    init(destination: String, isOnlyConnectionToDestination: Bool, indicatesHerdr: Bool) {
+    init(destination: String, hasCompetingHerdrClient: Bool, herdr: HerdrInvocation) {
         self.destination = destination
-        self.isOnlyConnectionToDestination = isOnlyConnectionToDestination
-        self.indicatesHerdr = indicatesHerdr
+        self.hasCompetingHerdrClient = hasCompetingHerdrClient
+        self.herdr = herdr
     }
 }
 
@@ -285,12 +321,13 @@ enum SSHDestinationTTYProbe {
         return .connection(
             SSHSurfaceConnection(
                 destination: parsed.destination,
-                isOnlyConnectionToDestination: isOnlyConnection(
-                    to: parsed.destination,
+                hasCompetingHerdrClient: hasCompetingHerdrClient(
+                    destination: parsed.destination,
+                    surfaceHerdr: parsed.herdr,
                     surfacePID: surfaceProcess.pid,
                     connections: connections
                 ),
-                indicatesHerdr: parsed.indicatesHerdr
+                herdr: parsed.herdr
             )
         )
     }
@@ -312,56 +349,82 @@ enum SSHDestinationTTYProbe {
         return processes.contains { $0.pid == process.parentPID }
     }
 
-    /// Is this terminal's the only connection to that destination?
+    /// Could another terminal be displaying a DIFFERENT herdr view of this
+    /// destination?
     ///
-    /// Every OTHER ssh counts, foreground or not, and — this is the part the
-    /// first version got wrong (review round 5b) — including ones on THIS
-    /// device. Excluding same-device background processes let `ssh builder
-    /// herdr` be suspended with Ctrl+Z, its server side still attached and its
-    /// pane still focused, while a plain `ssh builder` in the foreground of the
-    /// same terminal claimed to be the only connection.
+    /// The successor to the machine-wide "only connection" rule, narrowed to
+    /// what that rule actually defended: the join reads the candidates'
+    /// server-global focused pane, so the only dangerous neighbor is one that
+    /// could be a herdr client of a DIFFERENT server (or of a single pane).
+    /// A plain shell, a build session, an `ssh host ls` — none of those can
+    /// be the surface being dictated into (the probe reads only the focused
+    /// tty), and a second whole-view client of the SAME server mirrors the
+    /// same focused pane (herdr focus is server-global; verified in source,
+    /// 2026-08-06), so joining is correct for both.
     ///
-    /// "The surface shows the shell, not that ssh" is a fact about which
-    /// connection this terminal DISPLAYS — it belongs to destination
-    /// determination above, and says nothing about how many connections exist.
+    /// Every OTHER tty-holding connection still counts, foreground or not,
+    /// including suspended ones on THIS device (review round 5b: a suspended
+    /// `ssh builder herdr <verb>` keeps its server side attached). Excluded:
+    /// the surface's own connection, anything with no controlling terminal
+    /// (our own `ssh -L` forward), and ssh MACHINERY (the caller passes
+    /// connections only — a ProxyJump's `-W` child is its root's transport).
     ///
-    /// Excluded: the surface's own connection (the single foreground ssh this
-    /// answer is about), anything with no controlling terminal — nobody can
-    /// be dictating into one, and our own `ssh -L` forward is exactly that —
-    /// and ssh MACHINERY (the caller passes connections only): a ProxyJump's
-    /// `-W` child carries its root's connection, which is already counted, and
-    /// its refused argv must not read as "an ssh we cannot account for".
-    private static func isOnlyConnection(
-        to destination: String,
+    /// The refusal ladder for a neighbor, most to least readable:
+    /// parsed to another destination — irrelevant (its herdr, if any, is
+    /// another host's server, which our candidates cannot name); parsed to
+    /// this destination — competes exactly when its herdr classification is
+    /// not "the same view" (`.plainClient` with a byte-identical selector, or
+    /// not herdr at all); argv readable but refused — competes only when some
+    /// token contains `herdr` (one-sided: can over-block, never under-block);
+    /// argv or executable unreadable — always competes, an unreadable process
+    /// cannot be ruled out.
+    private static func hasCompetingHerdrClient(
+        destination: String,
+        surfaceHerdr: HerdrInvocation,
         surfacePID: Int32,
         connections: [SSHClientProcess]
     ) -> Bool {
         for process in connections
         where process.ttyDevice != nil && process.pid != surfacePID {
-            guard let parsed = verifiedInvocation(of: process) else {
-                // An ssh elsewhere we cannot read could be to this destination.
-                // Uniqueness is a claim, and an unreadable process cannot be
-                // part of one.
-                return false
+            guard let executablePath = process.executablePath,
+                  isTrustedSSHExecutable(executablePath),
+                  let arguments = process.arguments
+            else { return true }
+            guard let parsed = parse(arguments: arguments) else {
+                if mentionsHerdr(arguments) { return true }
+                continue
             }
-            if parsed.destination == destination { return false }
+            guard parsed.destination == destination else { continue }
+            switch parsed.herdr {
+            case .notHerdr:
+                continue
+            case .plainClient(let selector):
+                guard case .plainClient(let surfaceSelector) = surfaceHerdr,
+                      selector == surfaceSelector
+                else { return true }
+            case .otherHerdrSubcommand:
+                return true
+            }
         }
-        return true
+        return false
     }
 
-    private static func verifiedInvocation(of process: SSHClientProcess) -> ParsedInvocation? {
-        guard let executablePath = process.executablePath,
-              isTrustedSSHExecutable(executablePath),
-              let arguments = process.arguments
-        else { return nil }
-        return parse(arguments: arguments)
+    /// Does any argv token mention herdr at all?
+    ///
+    /// Used ONLY for neighbors whose argv was read but refused by the parser:
+    /// we cannot name their destination, but an argv with no `herdr` substring
+    /// anywhere cannot have run herdr as its remote command. Substring, not
+    /// basename, on purpose — `sh -lc 'exec herdr'` arrives as one token, and
+    /// this test must only ever err toward blocking.
+    static func mentionsHerdr(_ argv: [String]) -> Bool {
+        argv.contains { $0.contains("herdr") }
     }
 
     // MARK: - argv parsing
 
     struct ParsedInvocation: Sendable, Equatable {
         var destination: String
-        var indicatesHerdr: Bool
+        var herdr: HerdrInvocation
     }
 
     /// Options that take no argument, per ssh(1)'s synopsis
@@ -425,8 +488,41 @@ enum SSHDestinationTTYProbe {
         guard let destination = normalizedDestination(destinationOperand) else { return nil }
         return ParsedInvocation(
             destination: destination,
-            indicatesHerdr: commandNamesHerdr(remoteCommand)
+            herdr: classifyHerdrCommand(remoteCommand)
         )
+    }
+
+    /// Classify a remote command's relationship to herdr.
+    ///
+    /// The first token must BE herdr (`commandNamesHerdr` — first token only,
+    /// by basename; a shell wrapper's first token is `sh` and what it goes on
+    /// to run is not something an argv can promise). What follows decides the
+    /// shape: nothing, or `--session <name>` / `--session=<name>`, is the
+    /// whole-view client attach; ANY other token — `terminal attach <id>`,
+    /// `session attach <name>`, `server`, a flag this classifier does not
+    /// know — is `.otherHerdrSubcommand`, refused. Unknown herdr verbs must
+    /// land there and not in `.plainClient`: a verb added by a future herdr
+    /// that displays one pane would otherwise become a mis-join.
+    static func classifyHerdrCommand(_ remoteCommand: [String]) -> HerdrInvocation {
+        guard commandNamesHerdr(remoteCommand) else { return .notHerdr }
+        var selector: String?
+        var index = 1
+        while index < remoteCommand.count {
+            let token = remoteCommand[index]
+            if token == "--session" {
+                guard index + 1 < remoteCommand.count else { return .otherHerdrSubcommand }
+                selector = remoteCommand[index + 1]
+                index += 2
+            } else if token.hasPrefix("--session=") {
+                selector = String(token.dropFirst("--session=".count))
+                index += 1
+            } else {
+                return .otherHerdrSubcommand
+            }
+            // An empty selector is not a name we can compare byte-identically.
+            if selector?.isEmpty == true { return .otherHerdrSubcommand }
+        }
+        return .plainClient(sessionSelector: selector)
     }
 
     /// Is the remote command herdr ITSELF?

--- a/Sources/localvoxtral/ClaudeContext/SSHDestinationTTYProbe.swift
+++ b/Sources/localvoxtral/ClaudeContext/SSHDestinationTTYProbe.swift
@@ -415,7 +415,10 @@ enum SSHDestinationTTYProbe {
     /// we cannot name their destination, but an argv with no `herdr` substring
     /// anywhere cannot have run herdr as its remote command. Substring, not
     /// basename, on purpose — `sh -lc 'exec herdr'` arrives as one token, and
-    /// this test must only ever err toward blocking.
+    /// this test must only ever err toward blocking. Known over-block: a
+    /// HOSTNAME containing "herdr" trips it too (`ssh -o X herdrhost`) —
+    /// accepted, since the cost is an abstention on a refused-argv neighbor,
+    /// never a join.
     static func mentionsHerdr(_ argv: [String]) -> Bool {
         argv.contains { $0.contains("herdr") }
     }
@@ -509,18 +512,24 @@ enum SSHDestinationTTYProbe {
         var index = 1
         while index < remoteCommand.count {
             let token = remoteCommand[index]
+            let value: String
             if token == "--session" {
                 guard index + 1 < remoteCommand.count else { return .otherHerdrSubcommand }
-                selector = remoteCommand[index + 1]
+                value = remoteCommand[index + 1]
                 index += 2
             } else if token.hasPrefix("--session=") {
-                selector = String(token.dropFirst("--session=".count))
+                value = String(token.dropFirst("--session=".count))
                 index += 1
             } else {
                 return .otherHerdrSubcommand
             }
-            // An empty selector is not a name we can compare byte-identically.
-            if selector?.isEmpty == true { return .otherHerdrSubcommand }
+            // An empty selector is not a name we can compare byte-identically,
+            // and a REPEATED --session is refused rather than resolved: which
+            // occurrence herdr honors is its business, and a classifier that
+            // silently picks one can agree with itself while disagreeing with
+            // herdr (review finding, 2026-08-06).
+            guard !value.isEmpty, selector == nil else { return .otherHerdrSubcommand }
+            selector = value
         }
         return .plainClient(sessionSelector: selector)
     }

--- a/Sources/localvoxtral/ClaudeContext/TerminalScreenClaudeJoin.swift
+++ b/Sources/localvoxtral/ClaudeContext/TerminalScreenClaudeJoin.swift
@@ -631,47 +631,61 @@ struct ClaudeSessionJoinResolver {
             return .notApplicable
         }
 
-        // The connection-level bind, and it takes BOTH facts.
+        // The connection-level bind: this connection's own argv must be a
+        // plain herdr whole-view client, and no OTHER connection may be a
+        // competing herdr view of the same destination.
         //
-        // Uniqueness alone was a mis-join (review round 5b): it says nothing
-        // about what this terminal DISPLAYS. A herdr whose client detached —
-        // or whose pane still carries a marker and a running agent inside the
-        // registry TTL — keeps answering `pane.current` with that pane, so a
-        // later sole `ssh builder` passed the gate and every remaining check
-        // (pane id, marker, session claim, foreground) agreed about a session
-        // the user cannot see.
+        // The invocation requirement is the round-5b lesson unchanged: a herdr
+        // whose client detached — or whose pane still carries a marker and a
+        // running agent inside the registry TTL — keeps answering
+        // `pane.current`, so being the sole `ssh builder` proves nothing about
+        // what this terminal DISPLAYS. herdr exposes no read-only attachment
+        // signal (re-verified at v0.8.0 / protocol 19, 2026-08-06: the only
+        // `client.*` methods are still `window_title.set`/`clear`, both
+        // mutations, and `session.snapshot` has no client records), so the
+        // evidence has to come from the invocation — the exec-time argv of a
+        // VERIFIED OpenSSH binary, i.e. the command ssh actually ran.
         //
-        // The honest fix is to require positive evidence that THIS connection
-        // is a herdr client, and herdr does not expose one: verified against
-        // the 0.7.5 socket schema and the 0.8.0 docs, the only `client.*`
-        // methods are `window_title.set`/`clear` — both MUTATIONS, so neither
-        // is usable as a probe — and `session.snapshot` carries no attachment
-        // field. So the evidence has to come from the invocation itself, and
-        // `indicatesHerdr` is promoted from corroboration to a REQUIREMENT.
+        // The competing-client rule REPLACED machine-wide uniqueness
+        // (2026-08-06), on a protocol fact verified in herdr's source: focus
+        // is server-global and multi-client attach is a mirror, so a plain
+        // shell to the same host cannot be displaying "our" herdr, and a
+        // second whole-view client of the SAME server displays the same
+        // focused pane — joining is correct for both. What still blocks is a
+        // possible client of a DIFFERENT herdr view: another session selector,
+        // a single-pane attach, or an argv unreadable enough to be either.
+        // Blanket uniqueness was also not free: its abstention returns
+        // `.notApplicable`, which falls through to the title marker, where a
+        // stale marker left by an earlier session could win.
         //
         // The cost, stated accurately: the manual flow — `ssh host`, then type
-        // `herdr` — gets no HERDR join. It does not get "no context": this
-        // returns `.notApplicable`, so the title-marker arm still runs, and a
-        // marker left in the OUTER title by an earlier session on that host can
-        // still win. That residual is pre-existing (it is what a remote session
-        // has always done) and cannot be closed from here — nothing on the
-        // surface tells us a remote herdr is running inside it. A wrong HERDR
-        // join is what this refuses.
-        //
-        // Uniqueness stays REQUIRED alongside it: argv is written by whoever
-        // launched the process, so it must never be the only thing standing
-        // between two terminals and each other's sessions.
-        guard connection.isOnlyConnectionToDestination else {
+        // `herdr` — still gets no HERDR join (its argv has no remote command).
+        // It does not get "no context": the marker arm still runs. That
+        // residual is pre-existing and cannot be closed from here.
+        guard !connection.hasCompetingHerdrClient else {
             Self.abstainedRemoteHerdrJoin(
-                outcome: "another terminal holds an ssh session to this destination"
+                outcome: "another terminal may hold a different herdr view of this destination"
             )
             return .notApplicable
         }
-        guard connection.indicatesHerdr else {
+        switch connection.herdr {
+        case .notHerdr:
             Self.abstainedRemoteHerdrJoin(
                 outcome: "the ssh command on this terminal is not herdr itself"
             )
             return .notApplicable
+        case .otherHerdrSubcommand:
+            // `herdr terminal attach <id>` renders ONE pane and
+            // `herdr --session <x>` in a shape we could not normalize may be
+            // another server entirely — while the join would read the
+            // candidates' server-global focus. Joining would pair the prompt
+            // with a pane the user is not looking at.
+            Self.abstainedRemoteHerdrJoin(
+                outcome: "this terminal attaches a partial or different herdr view"
+            )
+            return .notApplicable
+        case .plainClient:
+            break
         }
 
         // NOT yet herdr-or-nothing. Registry candidates existing on the host is

--- a/Sources/localvoxtral/ClaudeContext/TerminalScreenClaudeJoin.swift
+++ b/Sources/localvoxtral/ClaudeContext/TerminalScreenClaudeJoin.swift
@@ -662,12 +662,10 @@ struct ClaudeSessionJoinResolver {
         // `herdr` — still gets no HERDR join (its argv has no remote command).
         // It does not get "no context": the marker arm still runs. That
         // residual is pre-existing and cannot be closed from here.
-        guard !connection.hasCompetingHerdrClient else {
-            Self.abstainedRemoteHerdrJoin(
-                outcome: "another terminal may hold a different herdr view of this destination"
-            )
-            return .notApplicable
-        }
+        // The surface's own classification first: when the surface argv is the
+        // problem, the log must say so — a competing neighbor may exist too,
+        // and reporting it instead buried the actionable cause (review nit,
+        // 2026-08-06).
         switch connection.herdr {
         case .notHerdr:
             Self.abstainedRemoteHerdrJoin(
@@ -686,6 +684,12 @@ struct ClaudeSessionJoinResolver {
             return .notApplicable
         case .plainClient:
             break
+        }
+        guard !connection.hasCompetingHerdrClient else {
+            Self.abstainedRemoteHerdrJoin(
+                outcome: "another terminal may hold a different herdr view of this destination"
+            )
+            return .notApplicable
         }
 
         // NOT yet herdr-or-nothing. Registry candidates existing on the host is

--- a/Tests/localvoxtralTests/RemoteHerdrJoinTests.swift
+++ b/Tests/localvoxtralTests/RemoteHerdrJoinTests.swift
@@ -277,7 +277,9 @@ final class RemoteHerdrJoinTests: XCTestCase {
         forwards: (any ClaudeRemoteHerdrForwarding)?,
         sshResult: SSHDestinationTTYProbeResult = .connection(
             SSHSurfaceConnection(
-                destination: "builder", isOnlyConnectionToDestination: true, indicatesHerdr: true
+                destination: "builder",
+                hasCompetingHerdrClient: false,
+                herdr: .plainClient(sessionSelector: nil)
             )
         ),
         hosts: [ClaudeRemoteHost]? = nil,
@@ -407,8 +409,8 @@ final class RemoteHerdrJoinTests: XCTestCase {
                 sshResult: .connection(
                     SSHSurfaceConnection(
                         destination: "someone-elses-box",
-                        isOnlyConnectionToDestination: true,
-                        indicatesHerdr: true
+                        hasCompetingHerdrClient: false,
+                        herdr: .plainClient(sessionSelector: nil)
                     )
                 ),
                 title: markerValue
@@ -728,7 +730,7 @@ final class RemoteHerdrJoinTests: XCTestCase {
 
     // MARK: The connection-level bind (review blocker 1)
 
-    func testASecondTerminalToTheSameHostStopsTheArmAndKeepsTheMarkerJoin() async throws {
+    func testACompetingHerdrViewStopsTheArmAndKeepsTheMarkerJoin() async throws {
         // THE blocker: terminal A is a plain shell to `builder`, terminal B is
         // attached to herdr on `builder`. Dictating in A must not query B's
         // herdr, must not join B's session — and must not lose A's own
@@ -746,8 +748,8 @@ final class RemoteHerdrJoinTests: XCTestCase {
                 sshResult: .connection(
                     SSHSurfaceConnection(
                         destination: "builder",
-                        isOnlyConnectionToDestination: false,
-                        indicatesHerdr: true
+                        hasCompetingHerdrClient: true,
+                        herdr: .plainClient(sessionSelector: nil)
                     )
                 ),
                 title: markerValue
@@ -759,11 +761,13 @@ final class RemoteHerdrJoinTests: XCTestCase {
         XCTAssertTrue(panes.requests.withLock { $0.isEmpty }, "no herdr query may be issued")
     }
 
-    func testTheHerdrArgvSignalNeverSubstitutesForUniqueness() async throws {
-        // argv is written by whoever launched the process, so a remote command
-        // that claims to be herdr must not stand in for the one fact that is
-        // not forgeable — how many connections to that host exist (review
-        // round 3, blocker 1a).
+    func testTheHerdrArgvSignalNeverOverridesACompetingHerdrView() async throws {
+        // The surface naming herdr does not settle WHICH herdr view it
+        // displays: with a possible client of a different herdr server on
+        // another tty (different --session selector, a single-pane attach, or
+        // an unreadable argv), the probe reports competition and the arm must
+        // stand down — the marker arm keeps its chance (review round 3,
+        // blocker 1a, narrowed 2026-08-06).
         let registry = makeRegistry(markers: [markerValue])
         ingestRemoteHerdrSession(into: registry)
         let panes = RemoteJoinHerdrPanes(focused: focusedPane())
@@ -777,8 +781,8 @@ final class RemoteHerdrJoinTests: XCTestCase {
                 sshResult: .connection(
                     SSHSurfaceConnection(
                         destination: "builder",
-                        isOnlyConnectionToDestination: false,
-                        indicatesHerdr: true
+                        hasCompetingHerdrClient: true,
+                        herdr: .plainClient(sessionSelector: nil)
                     )
                 ),
                 title: markerValue
@@ -814,8 +818,8 @@ final class RemoteHerdrJoinTests: XCTestCase {
                 sshResult: .connection(
                     SSHSurfaceConnection(
                         destination: "builder",
-                        isOnlyConnectionToDestination: true,
-                        indicatesHerdr: false
+                        hasCompetingHerdrClient: false,
+                        herdr: .notHerdr
                     )
                 ),
                 title: markerValue
@@ -850,8 +854,8 @@ final class RemoteHerdrJoinTests: XCTestCase {
             sshResult: .connection(
                 SSHSurfaceConnection(
                     destination: "builder",
-                    isOnlyConnectionToDestination: true,
-                    indicatesHerdr: false
+                    hasCompetingHerdrClient: false,
+                    herdr: .notHerdr
                 )
             )
             // No outer title marker: herdr swallowed it.
@@ -877,8 +881,8 @@ final class RemoteHerdrJoinTests: XCTestCase {
                 sshResult: .connection(
                     SSHSurfaceConnection(
                         destination: "builder",
-                        isOnlyConnectionToDestination: true,
-                        indicatesHerdr: true
+                        hasCompetingHerdrClient: false,
+                        herdr: .plainClient(sessionSelector: nil)
                     )
                 )
             ).resolve(target: ghostty)

--- a/Tests/localvoxtralTests/SSHDestinationTTYProbeTests.swift
+++ b/Tests/localvoxtralTests/SSHDestinationTTYProbeTests.swift
@@ -67,8 +67,8 @@ final class SSHDestinationTTYProbeTests: XCTestCase {
     func testOneForegroundSSHClientReportsItsConnection() throws {
         let value = try XCTUnwrap(connection(probe(processes: [ssh(["ssh", "builder"])])))
         XCTAssertEqual(value.destination, "builder")
-        XCTAssertTrue(value.isOnlyConnectionToDestination)
-        XCTAssertFalse(value.indicatesHerdr)
+        XCTAssertFalse(value.hasCompetingHerdrClient)
+        XCTAssertEqual(value.herdr, .notHerdr)
     }
 
     func testUnreadableArgvOfAnSSHProcessAbstains() {
@@ -240,31 +240,176 @@ final class SSHDestinationTTYProbeTests: XCTestCase {
         XCTAssertEqual(probe(processes: [helper]), .noSSHClient)
     }
 
-    // MARK: - Machine-wide uniqueness (review blocker 1a)
+    // MARK: - Competing herdr views (narrowed from machine-wide uniqueness, 2026-08-06)
 
-    func testASecondTerminalToTheSameHostRemovesUniqueness() throws {
-        // Codex's scenario: this terminal is a plain shell to `builder`, and
-        // another terminal is attached to herdr on `builder`.
+    func testAPlainShellToTheSameHostDoesNotCompete() throws {
+        // THE field workflow the blanket uniqueness rule refused: one terminal
+        // attached to herdr, another keeping a plain shell to the same host
+        // for builds. The plain shell is on another tty, so it cannot be the
+        // surface being dictated into, and it runs no herdr — nothing about it
+        // changes what this surface displays.
         let value = try XCTUnwrap(
             connection(
                 probe(
                     processes: [
-                        ssh(["ssh", "builder"], pid: 501),
+                        ssh(["ssh", "-t", "builder", "herdr"], pid: 501),
                         ssh(["ssh", "builder"], pid: 777, device: otherTerminal),
                     ]
                 )
             )
         )
         XCTAssertEqual(value.destination, "builder")
-        XCTAssertFalse(value.isOnlyConnectionToDestination)
+        XCTAssertFalse(value.hasCompetingHerdrClient)
+        XCTAssertEqual(value.herdr, .plainClient(sessionSelector: nil))
     }
 
-    func testASuspendedSSHOnTHISDeviceRemovesUniqueness() throws {
-        // Review round 5b, major 2. Repro: `ssh builder herdr`, Ctrl+Z — the
-        // client is stopped but its server side is still attached and its pane
-        // still focused — then a plain `ssh builder` in the foreground of the
-        // SAME terminal. Skipping same-device background processes made that
-        // foreground session claim to be the only connection.
+    func testASecondWholeViewClientOfTheSameServerDoesNotCompete() throws {
+        // herdr focus is server-global and multi-client attach is a mirror
+        // (verified in herdr source: handle_pane_current resolves the app's
+        // active pane; tests/multi_client.rs broadcasts frames to all
+        // clients), so two whole-view clients of one server display the SAME
+        // focused pane and joining is correct for both.
+        let value = try XCTUnwrap(
+            connection(
+                probe(
+                    processes: [
+                        ssh(["ssh", "-t", "builder", "herdr"], pid: 501),
+                        ssh(["ssh", "builder", "herdr"], pid: 777, device: otherTerminal),
+                    ]
+                )
+            )
+        )
+        XCTAssertFalse(value.hasCompetingHerdrClient)
+    }
+
+    func testAHerdrClientOfAnotherSessionSelectorCompetes() throws {
+        // Named sessions are separate servers with separate sockets. A client
+        // of `--session scratch` displays a different herdr than the default
+        // one the candidates named — the one shape that could put a different
+        // herdr view on another terminal, so it must still block.
+        let value = try XCTUnwrap(
+            connection(
+                probe(
+                    processes: [
+                        ssh(["ssh", "-t", "builder", "herdr"], pid: 501),
+                        ssh(
+                            ["ssh", "builder", "herdr", "--session", "scratch"],
+                            pid: 777,
+                            device: otherTerminal
+                        ),
+                    ]
+                )
+            )
+        )
+        XCTAssertTrue(value.hasCompetingHerdrClient)
+    }
+
+    func testMatchingSessionSelectorsDoNotCompete() throws {
+        let value = try XCTUnwrap(
+            connection(
+                probe(
+                    processes: [
+                        ssh(["ssh", "-t", "builder", "herdr", "--session", "scratch"], pid: 501),
+                        ssh(
+                            ["ssh", "builder", "herdr", "--session=scratch"],
+                            pid: 777,
+                            device: otherTerminal
+                        ),
+                    ]
+                )
+            )
+        )
+        XCTAssertEqual(value.herdr, .plainClient(sessionSelector: "scratch"))
+        XCTAssertFalse(value.hasCompetingHerdrClient)
+    }
+
+    func testASinglePaneHerdrAttachElsewhereCompetes() throws {
+        // `herdr terminal attach <id>` renders one pane, not the server's
+        // focused view — from here it is indistinguishable from a different
+        // herdr view, so it blocks.
+        let value = try XCTUnwrap(
+            connection(
+                probe(
+                    processes: [
+                        ssh(["ssh", "-t", "builder", "herdr"], pid: 501),
+                        ssh(
+                            ["ssh", "builder", "herdr", "terminal", "attach", "w1:p3"],
+                            pid: 777,
+                            device: otherTerminal
+                        ),
+                    ]
+                )
+            )
+        )
+        XCTAssertTrue(value.hasCompetingHerdrClient)
+    }
+
+    func testARefusedArgvElsewhereCompetesOnlyWhenItMentionsHerdr() throws {
+        // An `-o` neighbor cannot have its destination parsed, but an argv
+        // with no `herdr` substring anywhere cannot have run herdr as its
+        // remote command. One-sided on purpose: it can over-block, never
+        // under-block.
+        let harmless = try XCTUnwrap(
+            connection(
+                probe(
+                    processes: [
+                        ssh(["ssh", "-t", "builder", "herdr"], pid: 501),
+                        ssh(
+                            ["ssh", "-o", "Compression=yes", "builder"],
+                            pid: 777,
+                            device: otherTerminal
+                        ),
+                    ]
+                )
+            )
+        )
+        XCTAssertFalse(harmless.hasCompetingHerdrClient)
+
+        let suspicious = try XCTUnwrap(
+            connection(
+                probe(
+                    processes: [
+                        ssh(["ssh", "-t", "builder", "herdr"], pid: 501),
+                        ssh(
+                            ["ssh", "-o", "Compression=yes", "builder", "herdr"],
+                            pid: 777,
+                            device: otherTerminal
+                        ),
+                    ]
+                )
+            )
+        )
+        XCTAssertTrue(suspicious.hasCompetingHerdrClient)
+    }
+
+    func testAnUntrustedExecutableElsewhereCompetes() throws {
+        // A tty-holding "ssh" that is not OpenSSH could be anything, including
+        // a herdr client by other means. Unreadable means unruled-out.
+        let value = try XCTUnwrap(
+            connection(
+                probe(
+                    processes: [
+                        ssh(["ssh", "-t", "builder", "herdr"], pid: 501),
+                        ssh(
+                            ["ssh", "builder"],
+                            pid: 777,
+                            device: otherTerminal,
+                            executable: "/tmp/evil/ssh"
+                        ),
+                    ]
+                )
+            )
+        )
+        XCTAssertTrue(value.hasCompetingHerdrClient)
+    }
+
+    func testASuspendedHerdrVerbOnTHISDeviceStillCompetes() throws {
+        // Review round 5b, major 2, transposed: `ssh builder herdr attach`,
+        // Ctrl+Z — the client is stopped but its server side is still attached
+        // — then a plain `ssh builder` in the foreground of the SAME terminal.
+        // `herdr attach` is not a shape the classifier knows, so it is a
+        // possible different herdr view and still blocks; suspended
+        // connections still count.
         let suspendedHerdrClient = SSHClientProcess(
             pid: 777,
             ttyDevice: surface,
@@ -277,44 +422,48 @@ final class SSHDestinationTTYProbeTests: XCTestCase {
             connection(probe(processes: [ssh(["ssh", "builder"], pid: 501), suspendedHerdrClient]))
         )
         XCTAssertEqual(value.destination, "builder")
-        XCTAssertFalse(
-            value.isOnlyConnectionToDestination,
-            "a suspended ssh to the same host is still a second connection"
+        XCTAssertTrue(
+            value.hasCompetingHerdrClient,
+            "a suspended possible herdr client to the same host still competes"
         )
     }
 
-    func testASecondForegroundSSHInAnotherPaneOfTheSameDeviceRemovesUniqueness() throws {
-        // Same rule, without the suspension: two process groups on one device.
+    func testAHerdrSiblingPaneOnTheSameDeviceCompetesWhenItsViewMayDiffer() throws {
+        // Two process groups on one device (a terminal with split panes):
+        // the sibling attaches a different named session, so it is a different
+        // herdr view and blocks.
         let sibling = SSHClientProcess(
             pid: 888,
             ttyDevice: surface,
             processGroupID: 888,
             terminalForegroundGroupID: 501,
             executablePath: "/usr/bin/ssh",
-            arguments: ["ssh", "builder"]
+            arguments: ["ssh", "builder", "herdr", "--session", "scratch"]
         )
         let value = try XCTUnwrap(
-            connection(probe(processes: [ssh(["ssh", "builder"], pid: 501), sibling]))
+            connection(probe(processes: [ssh(["ssh", "-t", "builder", "herdr"], pid: 501), sibling]))
         )
-        XCTAssertFalse(value.isOnlyConnectionToDestination)
+        XCTAssertTrue(value.hasCompetingHerdrClient)
     }
 
-    func testAnotherTerminalToADIFFERENTHostLeavesUniquenessIntact() throws {
+    func testAHerdrClientToADIFFERENTHostDoesNotCompete() throws {
+        // Its herdr, if any, is another host's server — the candidates are
+        // namespaced by the enrolled host and cannot name it.
         let value = try XCTUnwrap(
             connection(
                 probe(
                     processes: [
-                        ssh(["ssh", "builder"], pid: 501),
-                        ssh(["ssh", "elsewhere"], pid: 777, device: otherTerminal),
+                        ssh(["ssh", "-t", "builder", "herdr"], pid: 501),
+                        ssh(["ssh", "elsewhere", "herdr"], pid: 777, device: otherTerminal),
                     ]
                 )
             )
         )
-        XCTAssertTrue(value.isOnlyConnectionToDestination)
+        XCTAssertFalse(value.hasCompetingHerdrClient)
     }
 
-    func testAnUnreadableSSHElsewhereRemovesUniqueness() throws {
-        // Uniqueness is a claim; a process we cannot read cannot be part of one.
+    func testAnUnreadableSSHElsewhereCompetes() throws {
+        // A process we cannot read cannot be ruled out as a herdr client.
         let value = try XCTUnwrap(
             connection(
                 probe(
@@ -325,10 +474,10 @@ final class SSHDestinationTTYProbeTests: XCTestCase {
                 )
             )
         )
-        XCTAssertFalse(value.isOnlyConnectionToDestination)
+        XCTAssertTrue(value.hasCompetingHerdrClient)
     }
 
-    func testOurOwnTTYLessForwardDoesNotRemoveUniqueness() throws {
+    func testOurOwnTTYLessForwardDoesNotCompete() throws {
         // The app's `ssh -N -L … builder` has no controlling terminal, so it is
         // not a surface anyone can dictate into. (It also carries -N, which the
         // parser refuses outright — hence unreadable, hence excluded by the
@@ -347,7 +496,7 @@ final class SSHDestinationTTYProbeTests: XCTestCase {
                 )
             )
         )
-        XCTAssertTrue(value.isOnlyConnectionToDestination)
+        XCTAssertFalse(value.hasCompetingHerdrClient)
     }
 
     func testTwoForegroundSSHClientsOnOneSurfaceAbstainEvenToTheSameHost() {
@@ -448,8 +597,8 @@ final class SSHDestinationTTYProbeTests: XCTestCase {
             )
         )
         XCTAssertEqual(value.destination, "sandbox-vpn")
-        XCTAssertTrue(value.indicatesHerdr)
-        XCTAssertTrue(value.isOnlyConnectionToDestination)
+        XCTAssertEqual(value.herdr, .plainClient(sessionSelector: nil))
+        XCTAssertFalse(value.hasCompetingHerdrClient)
     }
 
     func testAMultiHopProxyChainIsEntirelyMachinery() throws {
@@ -469,10 +618,10 @@ final class SSHDestinationTTYProbeTests: XCTestCase {
             )
         )
         XCTAssertEqual(value.destination, "sandbox-vpn")
-        XCTAssertTrue(value.isOnlyConnectionToDestination)
+        XCTAssertFalse(value.hasCompetingHerdrClient)
     }
 
-    func testAnotherTerminalsProxyChildDoesNotRemoveUniqueness() throws {
+    func testAnotherTerminalsProxyChildDoesNotCompete() throws {
         // A second terminal to a DIFFERENT host over its own jump: its root is
         // parsed (destination `elsewhere`, no match) and its unreadable -W
         // child is that root's machinery, not an unreadable connection.
@@ -487,29 +636,36 @@ final class SSHDestinationTTYProbeTests: XCTestCase {
                 )
             )
         )
-        XCTAssertTrue(value.isOnlyConnectionToDestination)
+        XCTAssertFalse(value.hasCompetingHerdrClient)
     }
 
-    func testAnotherTerminalsRootToTheSameHostStillRemovesUniquenessDespiteItsChild() throws {
-        // The machinery rule must not swallow the root it serves.
+    func testACompetingRootStillCompetesDespiteItsOwnProxyChild() throws {
+        // The machinery rule must not swallow the root it serves: the other
+        // terminal's root attaches a different named session, and its -W
+        // child changes nothing about that.
         let value = try XCTUnwrap(
             connection(
                 probe(
                     processes: [
                         ssh(["ssh", "sandbox-vpn", "herdr"], pid: 501),
-                        ssh(["ssh", "sandbox-vpn"], pid: 777, device: otherTerminal),
+                        ssh(
+                            ["ssh", "sandbox-vpn", "herdr", "--session", "scratch"],
+                            pid: 777,
+                            device: otherTerminal
+                        ),
                         proxyChild(pid: 778, parent: 777, device: otherTerminal),
                     ]
                 )
             )
         )
-        XCTAssertFalse(value.isOnlyConnectionToDestination)
+        XCTAssertTrue(value.hasCompetingHerdrClient)
     }
 
-    func testAnOrphanedUnreadableSSHElsewhereStillRemovesUniqueness() throws {
+    func testAnOrphanedUnreadableSSHElsewhereStillCompetes() throws {
         // A tty-holding ssh whose parent is NOT an ssh (launchd after a
         // reparent, a shell-mediated ProxyCommand) is still a root, and an
-        // unreadable root still spoils the claim — the paranoia is unchanged.
+        // unreadable root still cannot be ruled out — the paranoia is
+        // unchanged.
         let orphan = SSHClientProcess(
             pid: 777,
             parentPID: 1, // reparented to launchd — a REAL orphan's e_ppid
@@ -529,7 +685,7 @@ final class SSHDestinationTTYProbeTests: XCTestCase {
                 )
             )
         )
-        XCTAssertFalse(value.isOnlyConnectionToDestination)
+        XCTAssertTrue(value.hasCompetingHerdrClient)
     }
 
     func testSiblingForegroundClientsAreNotMachineryAndStillAbstain() {
@@ -562,11 +718,79 @@ final class SSHDestinationTTYProbeTests: XCTestCase {
 
     // MARK: - herdr connection signal (review blocker 1b)
 
-    func testARemoteCommandNamingHerdrBindsTheConnection() throws {
+    func testABareHerdrRemoteCommandBindsTheConnectionAsAWholeViewClient() throws {
         let value = try XCTUnwrap(
+            connection(probe(processes: [ssh(["ssh", "-t", "builder", "herdr"])]))
+        )
+        XCTAssertEqual(value.herdr, .plainClient(sessionSelector: nil))
+    }
+
+    func testAHerdrSubcommandOnTheSurfaceIsClassifiedAsOther() throws {
+        // `herdr terminal attach <id>` renders exactly ONE pane while the join
+        // reads the server's GLOBAL focus — a mis-join the boolean signal
+        // allowed (memo 2026-08-06). The classification refuses every shape
+        // that is not the whole-view client.
+        let attach = try XCTUnwrap(
+            connection(
+                probe(processes: [ssh(["ssh", "builder", "herdr", "terminal", "attach", "w1:p3"])])
+            )
+        )
+        XCTAssertEqual(attach.herdr, .otherHerdrSubcommand)
+
+        let unknownVerb = try XCTUnwrap(
             connection(probe(processes: [ssh(["ssh", "-t", "builder", "herdr", "attach"])]))
         )
-        XCTAssertTrue(value.indicatesHerdr)
+        XCTAssertEqual(unknownVerb.herdr, .otherHerdrSubcommand)
+    }
+
+    func testASessionSelectorOnTheSurfaceIsCarried() throws {
+        let value = try XCTUnwrap(
+            connection(
+                probe(processes: [ssh(["ssh", "-t", "builder", "herdr", "--session", "scratch"])])
+            )
+        )
+        XCTAssertEqual(value.herdr, .plainClient(sessionSelector: "scratch"))
+    }
+
+    func testHerdrCommandClassification() {
+        typealias Probe = SSHDestinationTTYProbe
+        XCTAssertEqual(Probe.classifyHerdrCommand([]), .notHerdr)
+        XCTAssertEqual(Probe.classifyHerdrCommand(["ls"]), .notHerdr)
+        XCTAssertEqual(Probe.classifyHerdrCommand(["herdr"]), .plainClient(sessionSelector: nil))
+        XCTAssertEqual(
+            Probe.classifyHerdrCommand(["/usr/local/bin/herdr"]),
+            .plainClient(sessionSelector: nil)
+        )
+        XCTAssertEqual(
+            Probe.classifyHerdrCommand(["herdr", "--session", "scratch"]),
+            .plainClient(sessionSelector: "scratch")
+        )
+        XCTAssertEqual(
+            Probe.classifyHerdrCommand(["herdr", "--session=scratch"]),
+            .plainClient(sessionSelector: "scratch")
+        )
+        // A selector we cannot compare byte-identically, and every verb —
+        // known or unknown — refuses.
+        XCTAssertEqual(Probe.classifyHerdrCommand(["herdr", "--session"]), .otherHerdrSubcommand)
+        XCTAssertEqual(Probe.classifyHerdrCommand(["herdr", "--session="]), .otherHerdrSubcommand)
+        XCTAssertEqual(Probe.classifyHerdrCommand(["herdr", "server"]), .otherHerdrSubcommand)
+        XCTAssertEqual(
+            Probe.classifyHerdrCommand(["herdr", "session", "attach", "x"]), .otherHerdrSubcommand
+        )
+        XCTAssertEqual(
+            Probe.classifyHerdrCommand(["herdr", "terminal", "session", "observe", "t1"]),
+            .otherHerdrSubcommand
+        )
+    }
+
+    func testMentionsHerdrIsSubstringBased() {
+        // For refused-argv neighbors only: `sh -lc 'exec herdr'` arrives as
+        // one token, and this test must only ever err toward blocking.
+        XCTAssertTrue(SSHDestinationTTYProbe.mentionsHerdr(["ssh", "-o", "X", "b", "herdr"]))
+        XCTAssertTrue(
+            SSHDestinationTTYProbe.mentionsHerdr(["ssh", "-o", "X", "b", "sh", "-lc", "exec herdr"])
+        )
+        XCTAssertFalse(SSHDestinationTTYProbe.mentionsHerdr(["ssh", "-o", "Compression=yes", "b"]))
     }
 
     func testAnAbsolutePathToHerdrCounts() {
@@ -600,12 +824,12 @@ final class SSHDestinationTTYProbeTests: XCTestCase {
                 )
             )
         )
-        XCTAssertFalse(value.indicatesHerdr)
+        XCTAssertEqual(value.herdr, .notHerdr)
     }
 
     func testAPlainShellConnectionDoesNotIndicateHerdr() throws {
         let value = try XCTUnwrap(connection(probe(processes: [ssh(["ssh", "builder"])])))
-        XCTAssertFalse(value.indicatesHerdr)
+        XCTAssertEqual(value.herdr, .notHerdr)
     }
 
     // MARK: - argv parsing

--- a/Tests/localvoxtralTests/SSHDestinationTTYProbeTests.swift
+++ b/Tests/localvoxtralTests/SSHDestinationTTYProbeTests.swift
@@ -446,6 +446,49 @@ final class SSHDestinationTTYProbeTests: XCTestCase {
         XCTAssertTrue(value.hasCompetingHerdrClient)
     }
 
+    func testASuspendedBareHerdrClientOfTheSameServerDoesNotCompete() throws {
+        // The narrowed rule's headline change on the round-5b SHAPE: a
+        // suspended bare `ssh host herdr` next to a foreground bare
+        // `ssh host herdr` is a second whole-view client of the SAME server —
+        // a mirror — so it no longer blocks. (The VERB shape still does:
+        // testASuspendedHerdrVerbOnTHISDeviceStillCompetes.)
+        let suspendedMirror = SSHClientProcess(
+            pid: 777,
+            ttyDevice: surface,
+            processGroupID: 777,
+            terminalForegroundGroupID: 501, // the foreground client has the terminal
+            executablePath: "/usr/bin/ssh",
+            arguments: ["ssh", "builder", "herdr"]
+        )
+        let value = try XCTUnwrap(
+            connection(
+                probe(processes: [ssh(["ssh", "-t", "builder", "herdr"], pid: 501), suspendedMirror])
+            )
+        )
+        XCTAssertFalse(value.hasCompetingHerdrClient)
+    }
+
+    func testAPlainShellSurfaceReportsCompetitionAgainstAHerdrNeighbor() throws {
+        // Boundary pin, not a behavior anyone relies on: a `.notHerdr` surface
+        // has no selector to compare, so a herdr neighbor reads as competing.
+        // Harmless — the resolver refuses a `.notHerdr` surface before the
+        // competition flag matters — but pinned so a refactor that flips it
+        // ("a plain shell never competes with anything") is a deliberate
+        // decision, not an accident.
+        let value = try XCTUnwrap(
+            connection(
+                probe(
+                    processes: [
+                        ssh(["ssh", "builder"], pid: 501),
+                        ssh(["ssh", "builder", "herdr"], pid: 777, device: otherTerminal),
+                    ]
+                )
+            )
+        )
+        XCTAssertEqual(value.herdr, .notHerdr)
+        XCTAssertTrue(value.hasCompetingHerdrClient)
+    }
+
     func testAHerdrClientToADIFFERENTHostDoesNotCompete() throws {
         // Its herdr, if any, is another host's server — the candidates are
         // namespaced by the enrolled host and cannot name it.
@@ -772,6 +815,13 @@ final class SSHDestinationTTYProbeTests: XCTestCase {
         // A selector we cannot compare byte-identically, and every verb —
         // known or unknown — refuses.
         XCTAssertEqual(Probe.classifyHerdrCommand(["herdr", "--session"]), .otherHerdrSubcommand)
+        // Repeated --session is refused, not resolved: which occurrence herdr
+        // honors is herdr's business, and silently picking one lets the
+        // classifier agree with itself while disagreeing with herdr.
+        XCTAssertEqual(
+            Probe.classifyHerdrCommand(["herdr", "--session", "a", "--session", "b"]),
+            .otherHerdrSubcommand
+        )
         XCTAssertEqual(Probe.classifyHerdrCommand(["herdr", "--session="]), .otherHerdrSubcommand)
         XCTAssertEqual(Probe.classifyHerdrCommand(["herdr", "server"]), .otherHerdrSubcommand)
         XCTAssertEqual(

--- a/docs/agent/invariants.md
+++ b/docs/agent/invariants.md
@@ -217,23 +217,48 @@ there is not.
     (`SSHProbeIndeterminacy` — never a host, path, or option letter) into the
     log and the dogfood record, because three field dictations were diagnosed
     blind without one;
-    (2) that ssh session IS herdr — its remote command's first argv token has
-    basename `herdr` — AND this terminal holds the ONLY ssh connection to that
-    destination on the machine (a `KERN_PROC_ALL` scan counting every other ssh
-    with a controlling terminal, including suspended ones on this same device).
-    BOTH, because each covers what the other cannot. Uniqueness alone does not
-    prove what the terminal DISPLAYS: a herdr whose client detached, or whose
-    pane still carries a marker and a running agent inside the registry TTL,
-    keeps answering `pane.current` with that pane, so a later sole `ssh builder`
-    would join a session the user cannot see. The argv signal alone is not
-    enough either — argv is written by whoever launched the process, which is
-    why it is matched on the FIRST command token only (`ssh host sh -lc 'printf
-    herdr; exec claude'` mentions herdr and is not it).
+    (2) that ssh session IS a plain whole-view herdr client — classified, not
+    boolean (`HerdrInvocation`): the remote command's first argv token has
+    basename `herdr` and the rest is empty or `--session <name>`. Every other
+    herdr shape is REFUSED because it displays something other than the
+    server-global focus the join reads: `herdr terminal attach <id>` renders
+    ONE pane, and a `--session` we cannot normalize may be a DIFFERENT server
+    (named sessions have separate sockets) — both were mis-joins reachable
+    with a single connection while the signal was a boolean. AND no OTHER
+    tty-holding ssh root on the machine may be a COMPETING herdr view of that
+    destination (a `KERN_PROC_ALL` scan, including suspended ones on this same
+    device): a client with a different session selector, a herdr subcommand
+    shape, an argv that was refused and mentions `herdr` (substring,
+    one-sided), or anything unreadable. What deliberately does NOT compete
+    (2026-08-06, replacing blanket machine-wide uniqueness): a plain shell or
+    non-herdr ssh to the same host — it is on another tty and the probe only
+    reads the FOCUSED surface's tty — and a second whole-view client with a
+    byte-identical selector, because herdr focus is SERVER-GLOBAL and
+    multi-client attach is a mirror (verified in herdr source at v0.8.0 /
+    protocol 19: `src/app/api/panes.rs::handle_pane_current` resolves the
+    app's single active pane; `tests/multi_client.rs` proves frames broadcast
+    to all clients), so both clients display the same focused pane and the
+    join is correct for either. EXTERNAL ASSUMPTION: that focus model. If
+    herdr ever grows per-client views, same-selector coexistence becomes a
+    mis-join — re-verify `handle_pane_current` + the multi-client tests on
+    herdr upgrades before trusting this paragraph.
+    The argv signal is trustworthy here in a way the old comments undersold:
+    it is the EXEC-TIME vector of a VERIFIED OpenSSH binary (kernel
+    `KERN_PROCARGS2`), i.e. the command ssh actually ran, not a self-report —
+    but it is still matched on the FIRST command token only (`ssh host sh -lc
+    'printf herdr; exec claude'` mentions herdr and is not it), because what a
+    shell wrapper goes on to run is not something any argv can promise. The
+    invocation requirement exists because being the sole connection proves
+    nothing about what the terminal DISPLAYS: a herdr whose client detached,
+    or whose pane still carries a marker and a running agent inside the
+    registry TTL, keeps answering `pane.current`, so a plain `ssh builder`
+    must never reach the join no matter how alone it is.
     Requiring the argv signal is what the absence of a better one forces:
-    herdr exposes NO read-only attachment signal — verified against the 0.7.5
-    socket schema and the 0.8.0 docs, the only `client.*` methods are
+    herdr exposes NO read-only attachment signal — re-verified at v0.8.0 /
+    protocol 19 (2026-08-06), the only `client.*` methods are
     `window_title.set`/`clear`, both MUTATIONS (so `no_foreground_client` is not
-    an acceptable probe), and `session.snapshot` carries no attachment field.
+    an acceptable probe), `session.snapshot` carries no client records, and
+    the event stream has no client lifecycle events.
     The accepted cost, stated accurately: the manual flow — `ssh host`, then
     typing `herdr` — gets no HERDR join. It does NOT get "no context": the arm
     returns `.notApplicable`, so the title-marker arm still runs, and a marker

--- a/docs/agent/invariants.md
+++ b/docs/agent/invariants.md
@@ -241,7 +241,18 @@ there is not.
     join is correct for either. EXTERNAL ASSUMPTION: that focus model. If
     herdr ever grows per-client views, same-selector coexistence becomes a
     mis-join — re-verify `handle_pane_current` + the multi-client tests on
-    herdr upgrades before trusting this paragraph.
+    herdr upgrades before trusting this paragraph. A SECOND external
+    assumption rides with it: "byte-identical selector ⇒ same server" holds
+    only while the remote side derives the socket from the selector alone —
+    a shell with `HERDR_SOCKET_PATH` or a different `XDG_RUNTIME_DIR`
+    exported can attach two bare `herdr` invocations to DIFFERENT servers,
+    which this rule cannot see from the Mac (the argv is all it has). The
+    residual is bounded downstream — candidates spanning two sockets abstain
+    at the single-socket rule, and the pane-id + broker-marker confirmation
+    still has to agree — but a candidate set living entirely on the OTHER
+    server confirms against that server, so the honest statement is: env
+    divergence on the remote defeats the selector comparison, and we accept
+    that because the divergence is the user's own deliberate configuration.
     The argv signal is trustworthy here in a way the old comments undersold:
     it is the EXEC-TIME vector of a VERIFIED OpenSSH binary (kernel
     `KERN_PROCARGS2`), i.e. the command ssh actually ran, not a self-report —


### PR DESCRIPTION
## What

Stacked on #228. Makes the remote-herdr join survive the normal multi-connection workflow (owner request, 2026-08-06): today, keeping *any* second ssh session to the enrolled host — a plain shell for builds — kills every join via the machine-wide uniqueness rule, and the abstention falls through to the title-marker arm where a stale marker can win.

Design follows an Opus research memo with herdr protocol facts verified in source (`herdrdev/herdr@master`, v0.8.0, protocol 19):

- **herdr focus is server-global and multi-client attach is a mirror** (`src/app/api/panes.rs::handle_pane_current` resolves the app's single active pane; `tests/multi_client.rs` proves frames broadcast to all clients, shared agent-panel scroll, min-size clamp). Two whole-view clients of one server display the SAME focused pane — abstaining between them protects nothing.
- herdr still exposes **no** read-only attachment signal at protocol 19 (only `client.window_title.set/clear`, both mutations; no client records in `session.snapshot`; no client lifecycle events) — so the invocation argv remains the binding, and it is trustworthy: the exec-time vector of a verified OpenSSH binary is the command ssh actually ran.

Two changes:

1. **`indicatesHerdr: Bool` → `HerdrInvocation` classification.** Only a bare whole-view client (`herdr`, optionally `--session <name>` / `--session=<name>`) proceeds. This also closes two mis-joins reachable **today with a single connection**, which the memo found: `ssh host herdr terminal attach <id>` renders ONE pane, and `herdr --session <x>` attaches a DIFFERENT server (named sessions have separate sockets) — both satisfied the boolean while the join reads the server-global focus of the candidates' socket. Unknown herdr verbs/flags land in `.otherHerdrSubcommand` and are refused, so future herdr verbs cannot silently become mis-joins.
2. **Blanket uniqueness → competing-herdr-view rule.** Another tty-holding ssh root blocks only when it *could be displaying a different herdr view* of this destination: a client with a non-identical `--session` selector, a herdr subcommand shape, a refused argv that mentions `herdr` anywhere (substring — one-sided, can only over-block), or anything unreadable/untrusted. Plain shells and same-selector whole-view clients stop blocking.

Deliberately preserved: the surface's own argv must still be a herdr client (round 5b — sole plain ssh never joins, detached-herdr case); suspended connections on the same device still count; unreadable roots still block; sibling foreground sshs still abstain; every fail-closed confirmation downstream (single socket, pane id, broker marker, agent_session, foreground) is untouched. `docs/agent/invariants.md` states the server-global focus model as an explicit **external assumption** with an upgrade-recheck obligation.

[dogfood-package]

## Proof

- Full unit suite green after the change: `Executed 2623 tests, with 2 tests skipped and 0 failures (0 unexpected) in 97.949 (98.090) seconds`
- Affected suites: `SSHDestinationTTYProbeTests` 75/75, `RemoteHerdrJoinTests` 51/51.
- Red/green: the API rename (`isOnlyConnectionToDestination`/`indicatesHerdr` → `hasCompetingHerdrClient`/`herdr`) makes a literal pre-fix compile impossible, so the red run reproduces the PRE-CHANGE semantics under the new API (boolean herdr signal + blanket same-destination refusal) as a two-line mutation:
  ```
  Executed 75 tests, with 15 failures (0 unexpected) in 0.247 (0.250) seconds
  failing: testAPlainShellToTheSameHostDoesNotCompete,
  testASecondWholeViewClientOfTheSameServerDoesNotCompete,
  testAHerdrSubcommandOnTheSurfaceIsClassifiedAsOther,
  testARefusedArgvElsewhereCompetesOnlyWhenItMentionsHerdr,
  testMatchingSessionSelectorsDoNotCompete, testHerdrCommandClassification,
  testASessionSelectorOnTheSurfaceIsCarried, … (15 total)
  ```
  Mutation reverted → 75/75 green (same command).
- Review-property preservation pinned by test: `testASuspendedHerdrVerbOnTHISDeviceStillCompetes` (round 5b transposed), `testAnUnreadableSSHElsewhereCompetes`, `testAnUntrustedExecutableElsewhereCompetes`, `testTwoForegroundSSHClientsOnOneSurfaceAbstainEvenToTheSameHost` (round 7), `RemoteHerdrJoinTests.testAPlainSSHSessionNeverReachesTheArmEvenAsTheSoleConnection`.
- LLM lanes: paths are under `Sources/localvoxtral/ClaudeContext/*` so the polishd lane runs by filter; no prompt/model/eval change in this PR.
- Field verification planned: owner installs the stack via `./scripts/try-pr.sh <this PR> --dogfood`, keeps a second plain ssh to `sandbox-vpn` open, dictates — expected `arm: remoteHerdrPane` with the extra connection present; then opens a `--session scratch` client and confirms the join abstains with the named cause.
