### PR TITLE
Claude Code bottom-bar connection indicator (local --statusline query + remote hook-status stamp)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Off-screen Claude Code session context for the localvoxtral dictation app. Add this marketplace from a REMOTE host, where there is no app bundle to register a local directory from: claude plugin marketplace add T0mSIlver/localvoxtral",
-    "version": "1.3.0"
+    "version": "1.4.0"
   },
   "plugins": [
     {

--- a/Sources/ClaudeContextWire/ClaudeHookWire.swift
+++ b/Sources/ClaudeContextWire/ClaudeHookWire.swift
@@ -103,6 +103,14 @@ public enum ClaudeHookEvent: String, Sendable, Equatable, CaseIterable, Codable 
     /// TTY's declaration regardless, because a clear can only ever widen
     /// abstention.
     case focusCleared = "FocusCleared"
+    /// A read-only liveness probe, synthesized by the publisher's status-line
+    /// mode (`localvoxtral-claude-hook --statusline`) — NOT a Claude Code hook
+    /// name; Claude Code never sends it and the shim never forwards it. The
+    /// broker answers `accepted == the named session is live in the registry`
+    /// and MUST NOT ingest it: a probe that created or refreshed a session
+    /// would keep dead sessions alive by the very act of asking after them.
+    /// `ClaudeSessionRegistry.ingest` refuses it outright as the backstop.
+    case statusQuery = "StatusQuery"
 }
 
 /// Hard bounds applied at BOTH ends of the wire.
@@ -487,8 +495,10 @@ public enum ClaudeHookWireCodec {
 
     /// Truncate on a Character boundary so the result is always valid UTF-8
     /// (a byte-slice truncation could split a multi-byte scalar and produce a
-    /// string that fails to encode).
-    static func truncate(_ value: String, toUTF8Bytes limit: Int) -> String {
+    /// string that fails to encode). Public because the publisher's
+    /// status-line mode bounds `session_id` with the same rule the wire clamp
+    /// applies — one truncation semantic, not two.
+    public static func truncate(_ value: String, toUTF8Bytes limit: Int) -> String {
         guard value.utf8.count > limit else { return value }
         var result = ""
         var used = 0

--- a/Sources/ClaudeHookPublisherCore/ClaudeHookPublisher.swift
+++ b/Sources/ClaudeHookPublisherCore/ClaudeHookPublisher.swift
@@ -125,6 +125,96 @@ public struct ClaudeHookPublisher: Sendable {
         }
     }
 
+    // MARK: - Status line
+
+    /// What a `--statusline` run learned. Distinct from `Outcome` because the
+    /// contract is inverted: a hook must stay silent on failure, while a
+    /// status line EXISTS to render failure. Every case maps to one fixed
+    /// output string (or none) in `statusLineText(for:)` — nothing read off
+    /// the wire is ever echoed.
+    public enum StatusOutcome: Equatable, Sendable {
+        /// The broker answered: the session is live in the registry.
+        case connected
+        /// The broker answered: it has no live session by that id — the app
+        /// runs but this session's hooks are not reaching it (plugin not
+        /// installed, or the app started after the session's last event).
+        case sessionUnknown
+        /// Nothing answered on the socket: the app is not running (or this
+        /// environment has no resolvable socket path at all).
+        case appUnreachable
+        /// stdin was not a status-line payload with a usable `session_id`.
+        /// Rendered as nothing: a claim about a session we could not even
+        /// identify would be a guess, and the status line must never guess.
+        case unparseablePayload
+    }
+
+    /// Read the status-line payload Claude Code pipes in, ask the broker
+    /// whether that session is live, and say which of the four worlds we are
+    /// in. Never throws, never blocks past the socket deadline — the status
+    /// line re-runs constantly and a slow command stalls its refresh.
+    public func runStatusQuery(stdin: Data) -> StatusOutcome {
+        guard let sessionID = Self.statusLineSessionID(payload: stdin, limits: limits) else {
+            return .unparseablePayload
+        }
+        let record = ClaudeHookRecord(
+            event: .statusQuery,
+            sessionID: sessionID,
+            timestamp: environment.now()
+        )
+        guard let line = ClaudeHookWireCodec.encodeLine(record, limits: limits),
+              let socketPath = ClaudeHookSocketPath.resolve(environment: environment.variables)
+        else {
+            return .appUnreachable
+        }
+        switch publisher.publishAndReadReply(line: line, to: socketPath) {
+        case .failure:
+            return .appUnreachable
+        case .success(let reply):
+            // A listener that answers but does not say `accepted: true` — an
+            // older app dropping the unknown event, a missing or undecodable
+            // reply — lands on "not connected": something owns the socket,
+            // but it did not vouch for this session.
+            guard let reply,
+                  let response = ClaudeBrokerResponse.decodeLine(reply, limits: limits),
+                  response.accepted == true
+            else {
+                return .sessionUnknown
+            }
+            return .connected
+        }
+    }
+
+    /// `session_id` from a Claude Code status-line payload (a JSON object,
+    /// schema owned by Claude Code; `session_id` is documented always-present).
+    /// Bounded exactly like every other identifier that crosses the wire.
+    static func statusLineSessionID(payload: Data, limits: ClaudeHookLimits) -> String? {
+        guard let object = try? JSONSerialization.jsonObject(with: payload),
+              let dictionary = object as? [String: Any],
+              let sessionID = dictionary["session_id"] as? String,
+              !sessionID.isEmpty
+        else {
+            return nil
+        }
+        return ClaudeHookWireCodec.truncate(sessionID, toUTF8Bytes: limits.maxPathBytes)
+    }
+
+    /// The one line to print, or nil for nothing. FIXED strings only, chosen
+    /// by outcome — no wire byte, marker, path, or id is ever interpolated,
+    /// so nothing that crossed a socket can put a byte on the terminal.
+    /// ANSI SGR is deliberate: Claude Code renders it in the status line.
+    public static func statusLineText(for outcome: StatusOutcome) -> String? {
+        switch outcome {
+        case .connected:
+            return "\u{1B}[32m\u{25CF}\u{1B}[0m localvoxtral connected"
+        case .sessionUnknown:
+            return "\u{1B}[33m\u{25CB}\u{1B}[0m localvoxtral not connected"
+        case .appUnreachable:
+            return "\u{1B}[2m\u{25CB} localvoxtral not running\u{1B}[0m"
+        case .unparseablePayload:
+            return nil
+        }
+    }
+
     /// Safe metadata only: identity and location of the terminal, never its
     /// contents and never argv/env beyond an ALLOWLIST — `$TERM_PROGRAM` plus
     /// the multiplexer/bridge handles below.

--- a/Sources/localvoxtral-claude-hook/main.swift
+++ b/Sources/localvoxtral-claude-hook/main.swift
@@ -25,7 +25,24 @@ func parsedEvent(from arguments: [String]) -> String? {
     return arguments[index + 1]
 }
 
-let event = parsedEvent(from: Array(CommandLine.arguments.dropFirst()))
+let arguments = Array(CommandLine.arguments.dropFirst())
+
+// Status-line mode: `localvoxtral-claude-hook --statusline`, wired by the USER
+// into Claude Code's `statusLine` setting (the app never writes that file).
+// Reads the status-line payload, asks the broker whether this session is live,
+// and prints ONE fixed indicator line. The strings are compile-time constants
+// chosen by outcome — nothing read off the socket is ever echoed — and a
+// payload we cannot attribute prints nothing rather than guessing.
+if arguments.contains("--statusline") {
+    let payload = ClaudeHookPublisher.readBoundedStdin()
+    let outcome = ClaudeHookPublisher().runStatusQuery(stdin: payload)
+    if let text = ClaudeHookPublisher.statusLineText(for: outcome) {
+        ClaudeHookPublisher.writeStdout(Data((text + "\n").utf8))
+    }
+    exit(0)
+}
+
+let event = parsedEvent(from: arguments)
 let stdin = ClaudeHookPublisher.readBoundedStdin()
 let outcome = ClaudeHookPublisher().run(stdin: stdin, fallbackEvent: event)
 

--- a/Sources/localvoxtral/ClaudeContext/ClaudeContextBroker.swift
+++ b/Sources/localvoxtral/ClaudeContext/ClaudeContextBroker.swift
@@ -656,9 +656,10 @@ public final class ClaudeContextBroker: Sendable {
                 )
                 let live = registry.snapshot(sessionID: scopedID) != nil
                 Log.claudeContext.debug("Status query: \(live ? "live" : "unknown", privacy: .public)")
-                #if DEBUG
-                debugNotify(.success(record))
-                #endif
+                // Deliberately NOT debugNotify: that seam means "a record was
+                // ingested or rejected", and a probe is neither — status-line
+                // traffic firing it would inflate any test counting real
+                // ingestions.
                 return (nil, live, false, record.version)
             }
             // Per-agent pid cross-check against the KERNEL's answer. The

--- a/Sources/localvoxtral/ClaudeContext/ClaudeContextBroker.swift
+++ b/Sources/localvoxtral/ClaudeContext/ClaudeContextBroker.swift
@@ -631,6 +631,11 @@ public final class ClaudeContextBroker: Sendable {
     /// Connection-level rejections (foreign uid, unterminated over-cap line,
     /// too many records, read deadline) drop the connection WITHOUT a reply,
     /// unchanged — publishers observe those as an error/close, not a verdict.
+    ///
+    /// The one line that is not an ingest at all: a `StatusQuery` record is a
+    /// read-only probe whose reply reuses `accepted` to mean "that session is
+    /// live in the registry right now". It never reaches `ingest` and never
+    /// carries a marker back.
     @discardableResult
     private func handle(
         line: Data,
@@ -639,6 +644,23 @@ public final class ClaudeContextBroker: Sendable {
     ) -> (marker: ClaudeSessionMarker?, accepted: Bool, isHerdrHosted: Bool, replyVersion: Int) {
         do {
             let record = try ClaudeHookWireCodec.decodeLine(line, limits: limits.wire)
+            // A status probe (`--statusline` mode) is answered here and NEVER
+            // ingested: `accepted` carries "is that session live in the
+            // registry", nothing is created or refreshed by asking, and no
+            // marker ever rides a probe reply — a probe is not a hook, so it
+            // has no terminal to write a title into. `snapshot(sessionID:)`
+            // applies the same TTL + pid-liveness answer every join uses.
+            if record.event == .statusQuery {
+                let scopedID = ClaudeAgentSessionScope.scopedSessionID(
+                    agent: record.agent, sessionID: record.sessionID
+                )
+                let live = registry.snapshot(sessionID: scopedID) != nil
+                Log.claudeContext.debug("Status query: \(live ? "live" : "unknown", privacy: .public)")
+                #if DEBUG
+                debugNotify(.success(record))
+                #endif
+                return (nil, live, false, record.version)
+            }
             // Per-agent pid cross-check against the KERNEL's answer. The
             // opencode plugin runs inside the agent process and dials this
             // socket from it, so the pid its records claim must be the pid on

--- a/Sources/localvoxtral/ClaudeContext/ClaudeSessionRegistry.swift
+++ b/Sources/localvoxtral/ClaudeContext/ClaudeSessionRegistry.swift
@@ -151,6 +151,13 @@ public final class ClaudeSessionRegistry: Sendable {
         environment: ClaudeRemoteSessionEnvironment? = nil
     ) -> ClaudeSessionSnapshot? {
         let timestamp = now()
+        // A status probe is read-only by contract and is answered by the
+        // broker BEFORE ingest (`ClaudeContextBroker.handle`). Refusing it
+        // here too is the backstop: an ingested probe would CREATE a session
+        // for an id nobody ever hooked, or refresh the activity of one whose
+        // process is gone — the probe would keep alive the very state it
+        // exists to report on.
+        if record.event == .statusQuery { return nil }
         // A LOCAL Claude record whose raw id spells another namespace's prefix
         // is spelling a key that can never be its own: Claude Code ids are
         // bare UUIDs, opencode ids get the prefix added HERE, and remote ids

--- a/Sources/localvoxtral/ClaudeContext/ClaudeSessionState.swift
+++ b/Sources/localvoxtral/ClaudeContext/ClaudeSessionState.swift
@@ -270,6 +270,13 @@ public enum ClaudeSessionReducer {
             break
         case .sessionEnd:
             snapshot.activity = .ended
+        case .statusQuery:
+            // Unreachable: a status probe is refused at the top of
+            // `ClaudeSessionRegistry.ingest` (and answered by the broker
+            // before that), so it can never be reduced into a snapshot. The
+            // case exists so adding a wire event stays a compile-time
+            // decision here rather than an implicit `break`.
+            break
         }
     }
 

--- a/Tests/localvoxtralTests/ClaudeContextBrokerTests.swift
+++ b/Tests/localvoxtralTests/ClaudeContextBrokerTests.swift
@@ -387,6 +387,28 @@ final class ClaudeContextBrokerIntegrationTests: XCTestCase {
 
     // MARK: Status query — the read-only probe behind `--statusline`
 
+    func testUnknownEventLineIsRefusedWithAReplyNotADrop() throws {
+        // The version-skew story `--statusline` leans on: a NEW publisher
+        // sending StatusQuery to an OLD broker relies on the broker's
+        // unknown-event branch REPLYING `accepted: false` (which the
+        // publisher renders as "not connected") rather than dropping the
+        // connection (which would render "not running" against a healthy
+        // app). Pin the shape with an event name no build knows.
+        try broker.start()
+        let line = Data(
+            #"{"v":2,"event":"StatusQueryFromTheFuture","session_id":"skew","ts":1,"files":[]}"#
+                .utf8 + [0x0A]
+        )
+        let result = UnixSocketPublisher(timeout: 2.0).publishAndReadReply(line: line, to: socketPath)
+        guard case .success(let reply) = result else {
+            return XCTFail("an unknown event must still complete the exchange: \(result)")
+        }
+        let response = try XCTUnwrap(ClaudeBrokerResponse.decodeLine(try XCTUnwrap(reply)))
+        XCTAssertEqual(response.accepted, false)
+        XCTAssertNil(response.marker)
+        XCTAssertTrue(registry.liveSessions().isEmpty, "an unknown event must not create a session")
+    }
+
     func testStatusQueryForALiveSessionRepliesAcceptedWithoutAMarker() throws {
         try broker.start()
         // Seed a live session through the front door.

--- a/Tests/localvoxtralTests/ClaudeContextBrokerTests.swift
+++ b/Tests/localvoxtralTests/ClaudeContextBrokerTests.swift
@@ -385,6 +385,84 @@ final class ClaudeContextBrokerIntegrationTests: XCTestCase {
         XCTAssertEqual(response.accepted, true)
     }
 
+    // MARK: Status query — the read-only probe behind `--statusline`
+
+    func testStatusQueryForALiveSessionRepliesAcceptedWithoutAMarker() throws {
+        try broker.start()
+        // Seed a live session through the front door.
+        let start = ClaudeHookRecord(
+            event: .sessionStart,
+            sessionID: "probe-me",
+            timestamp: 1,
+            rawCwd: "/repo",
+            process: ClaudeHookProcessInfo(hookPID: 4242, claudePID: getpid())
+        )
+        _ = UnixSocketPublisher(timeout: 2.0).publishAndReadReply(
+            line: try XCTUnwrap(ClaudeHookWireCodec.encodeLine(start)), to: socketPath
+        )
+
+        let query = ClaudeHookRecord(event: .statusQuery, sessionID: "probe-me", timestamp: 2)
+        let result = UnixSocketPublisher(timeout: 2.0).publishAndReadReply(
+            line: try XCTUnwrap(ClaudeHookWireCodec.encodeLine(query)), to: socketPath
+        )
+        guard case .success(let reply) = result else {
+            return XCTFail("publish failed: \(result)")
+        }
+        let response = try XCTUnwrap(ClaudeBrokerResponse.decodeLine(try XCTUnwrap(reply)))
+        XCTAssertEqual(response.accepted, true, "a live session must read as connected")
+        // This broker is constructed with the title fallback ON — the one
+        // configuration where a hook reply WOULD carry the marker. A probe is
+        // not a hook and has no terminal, so it must never get one.
+        XCTAssertNil(response.marker, "a probe reply must never carry a marker")
+    }
+
+    func testStatusQueryForAnUnknownSessionRepliesNotAcceptedAndCreatesNothing() throws {
+        try broker.start()
+        let query = ClaudeHookRecord(event: .statusQuery, sessionID: "never-hooked", timestamp: 1)
+        let result = UnixSocketPublisher(timeout: 2.0).publishAndReadReply(
+            line: try XCTUnwrap(ClaudeHookWireCodec.encodeLine(query)), to: socketPath
+        )
+        guard case .success(let reply) = result else {
+            return XCTFail("publish failed: \(result)")
+        }
+        let response = try XCTUnwrap(ClaudeBrokerResponse.decodeLine(try XCTUnwrap(reply)))
+        XCTAssertEqual(response.accepted, false)
+        XCTAssertNil(response.marker)
+        // The probe must not have created the session it asked after —
+        // otherwise the second probe for any id would answer "connected".
+        XCTAssertNil(registry.snapshot(sessionID: "never-hooked"))
+        XCTAssertTrue(registry.liveSessions().isEmpty)
+    }
+
+    func testStatusLineModeEndToEndThroughThePublisher() throws {
+        // The production `--statusline` path: hook seeds the session, then
+        // `runStatusQuery` reads a real status-line payload and asks the same
+        // broker over the same socket.
+        try broker.start()
+        let hookJSON = #"{"hook_event_name":"SessionStart","session_id":"sl-e2e","cwd":"/repo"}"#
+        let seeder = ClaudeHookPublisher(
+            environment: ClaudeHookPublisher.Environment(
+                now: { 1 },
+                pid: { 31_337 },
+                ppid: { getpid() },
+                ttyName: { _ in nil },
+                variables: [ClaudeHookSocketPath.environmentKey: socketPath]
+            )
+        )
+        _ = seeder.run(stdin: Data(hookJSON.utf8), fallbackEvent: nil)
+
+        let payload = #"{"session_id":"sl-e2e","cwd":"/repo","model":{"id":"m","display_name":"M"}}"#
+        XCTAssertEqual(seeder.runStatusQuery(stdin: Data(payload.utf8)), .connected)
+        XCTAssertEqual(
+            seeder.runStatusQuery(stdin: Data(#"{"session_id":"some-other"}"#.utf8)),
+            .sessionUnknown
+        )
+        XCTAssertNil(
+            registry.snapshot(sessionID: "some-other"),
+            "asking after a session must not create it"
+        )
+    }
+
     func testPublisherEmitsMarkerOutputWhenLocalTitleFallbackIsEnabled() throws {
         // The end-to-end join through the production publisher entry point.
         try broker.start()

--- a/Tests/localvoxtralTests/ClaudeHookPublisherTests.swift
+++ b/Tests/localvoxtralTests/ClaudeHookPublisherTests.swift
@@ -270,6 +270,74 @@ final class ClaudeHookPublisherTests: XCTestCase {
         ).run(stdin: Data(json.utf8), fallbackEvent: nil)
         XCTAssertEqual(outcome, .droppedTransport(.socketPathTooLong))
     }
+
+    // MARK: Status line mode — `--statusline`
+
+    func testStatusLinePayloadSessionIDIsExtractedAndBounded() {
+        let payload = #"{"session_id":"abc-123","cwd":"/repo","model":{"id":"m"}}"#
+        XCTAssertEqual(
+            ClaudeHookPublisher.statusLineSessionID(payload: Data(payload.utf8), limits: .default),
+            "abc-123"
+        )
+        // Bounded exactly like every wire identifier.
+        let long = String(repeating: "a", count: 9000)
+        let bounded = ClaudeHookPublisher.statusLineSessionID(
+            payload: Data(#"{"session_id":"\#(long)"}"#.utf8), limits: .default
+        )
+        XCTAssertEqual(bounded?.utf8.count, ClaudeHookLimits.default.maxPathBytes)
+    }
+
+    func testStatusLinePayloadWithoutAUsableSessionIDIsUnparseable() {
+        for payload in [
+            "", "not json", "[]", "{}",
+            #"{"session_id":""}"#,
+            #"{"session_id":42}"#,
+        ] {
+            XCTAssertEqual(
+                publisher().runStatusQuery(stdin: Data(payload.utf8)),
+                .unparseablePayload,
+                "\(payload) must not produce a claim about any session"
+            )
+        }
+    }
+
+    func testStatusQueryAgainstAnAbsentBrokerIsAppUnreachable() {
+        let payload = #"{"session_id":"s1"}"#
+        let outcome = ClaudeHookPublisher(
+            environment: makeEnvironment(
+                variables: [ClaudeHookSocketPath.environmentKey: "/tmp/absent-\(UUID().uuidString).sock"]
+            )
+        ).runStatusQuery(stdin: Data(payload.utf8))
+        XCTAssertEqual(outcome, .appUnreachable)
+    }
+
+    func testStatusQueryWithNoResolvableSocketPathIsAppUnreachable() {
+        XCTAssertEqual(
+            publisher(variables: [:]).runStatusQuery(stdin: Data(#"{"session_id":"s1"}"#.utf8)),
+            .appUnreachable
+        )
+    }
+
+    func testStatusLineTextIsFixedStringsOnly() throws {
+        // The whole output contract: four outcomes, three compile-time
+        // strings and one silence. Nothing here interpolates anything.
+        XCTAssertEqual(
+            ClaudeHookPublisher.statusLineText(for: .connected),
+            "\u{1B}[32m\u{25CF}\u{1B}[0m localvoxtral connected"
+        )
+        XCTAssertEqual(
+            ClaudeHookPublisher.statusLineText(for: .sessionUnknown),
+            "\u{1B}[33m\u{25CB}\u{1B}[0m localvoxtral not connected"
+        )
+        XCTAssertEqual(
+            ClaudeHookPublisher.statusLineText(for: .appUnreachable),
+            "\u{1B}[2m\u{25CB} localvoxtral not running\u{1B}[0m"
+        )
+        XCTAssertNil(
+            ClaudeHookPublisher.statusLineText(for: .unparseablePayload),
+            "a payload we cannot attribute must render as nothing, not a guess"
+        )
+    }
 }
 
 // MARK: - Socket path resolution

--- a/Tests/localvoxtralTests/ClaudeHookWireTests.swift
+++ b/Tests/localvoxtralTests/ClaudeHookWireTests.swift
@@ -46,6 +46,19 @@ final class ClaudeHookWireCodecTests: XCTestCase {
         XCTAssertEqual(try ClaudeHookWireCodec.decodeLine(encoded), original)
     }
 
+    func testStatusQueryRoundTripsOnTheCurrentWire() throws {
+        // The probe record is deliberately minimal: an id and a timestamp,
+        // no cwd, no prompt, no process block. Golden line pinned so the
+        // publisher's `--statusline` mode and the broker agree on bytes.
+        let query = ClaudeHookRecord(event: .statusQuery, sessionID: "sess-probe", timestamp: 7)
+        let encoded = try XCTUnwrap(ClaudeHookWireCodec.encodeLine(query))
+        XCTAssertEqual(
+            String(decoding: encoded, as: UTF8.self),
+            #"{"event":"StatusQuery","files":[],"session_id":"sess-probe","ts":7,"v":2}"# + "\n"
+        )
+        XCTAssertEqual(try ClaudeHookWireCodec.decodeLine(encoded), query)
+    }
+
     func testHerdrProcessFieldsUseGoldenWireNamesAndDecode() throws {
         let record = ClaudeHookRecord(
             event: .sessionStart,

--- a/Tests/localvoxtralTests/ClaudeRemotePluginManifestTests.swift
+++ b/Tests/localvoxtralTests/ClaudeRemotePluginManifestTests.swift
@@ -91,33 +91,44 @@ final class ClaudeRemotePluginManifestTests: XCTestCase {
         }
     }
 
-    func testPluginShipsExactlyOneExecutableTheCurlShim() throws {
+    func testPluginShipsExactlyTwoExecutablesBothPOSIXSh() throws {
         // The premise, updated for the command-hook shape: nothing to install
-        // on the remote but the manifests and ONE POSIX-sh shim. No Python, no
-        // jq, no nc, no Node, no publisher binary. If any other runnable file
-        // ever appears here, the premise is gone.
+        // on the remote but the manifests and TWO POSIX-sh scripts — the curl
+        // shim every hook runs, and the status-line renderer the user may
+        // point their own `statusLine` setting at. No Python, no jq, no nc,
+        // no Node, no publisher binary. If any other runnable file ever
+        // appears here, the premise is gone.
+        let shellScripts: Set<String> = ["hooks/post.sh", "hooks/statusline.sh"]
         let contents = try FileManager.default.subpathsOfDirectory(atPath: pluginRoot.path)
         for path in contents {
             let full = pluginRoot.appendingPathComponent(path)
             var isDirectory: ObjCBool = false
             FileManager.default.fileExists(atPath: full.path, isDirectory: &isDirectory)
             guard !isDirectory.boolValue else { continue }
-            if path == "hooks/post.sh" {
-                // Claude Code's shell resolves the hook command through this
-                // file; without +x every hook errors on the user's turn.
+            if shellScripts.contains(path) {
+                // Claude Code's shell resolves the hook command through
+                // post.sh; without +x every hook errors on the user's turn.
+                // statusline.sh is documented as copy-then-run, so it ships
+                // runnable for the same reason.
                 XCTAssertTrue(
                     FileManager.default.isExecutableFile(atPath: full.path),
-                    "the shim must be executable"
+                    "\(path) must be executable"
                 )
                 continue
             }
             XCTAssertFalse(
                 FileManager.default.isExecutableFile(atPath: full.path),
-                "the remote plugin must ship no executable but the shim, found \(path)"
+                "the remote plugin must ship no executable but its two sh scripts, found \(path)"
             )
             XCTAssertTrue(
                 path.hasSuffix(".json"),
-                "the remote plugin must ship JSON manifests and the shim only, found \(path)"
+                "the remote plugin must ship JSON manifests and its two sh scripts only, found \(path)"
+            )
+        }
+        for script in shellScripts {
+            XCTAssertTrue(
+                FileManager.default.fileExists(atPath: pluginRoot.appendingPathComponent(script).path),
+                "\(script) must exist — the allowlist above is not aspirational"
             )
         }
     }
@@ -351,6 +362,160 @@ final class ClaudeRemotePluginManifestTests: XCTestCase {
             .split(separator: "\n", maxSplits: 1, omittingEmptySubsequences: false)
             .first.map(String.init)
         XCTAssertEqual(firstLine, "#!/bin/sh", "must be POSIX sh, not bash — remote hosts vary")
+    }
+
+    // MARK: Connection-status stamp + status-line renderer
+    //
+    // post.sh records each dial's outcome in a one-line `hook-status` stamp;
+    // statusline.sh (which the user may wire into their own `statusLine`
+    // setting) renders a FIXED string selected by the stamp's first token.
+    // Both halves are proven by running them: the stamp obeys its grammar, and
+    // the renderer can never be made to echo a byte of the stamp file.
+
+    private var statusLineRendererURL: URL {
+        pluginRoot.appendingPathComponent("hooks/statusline.sh")
+    }
+
+    func testStatusLineRendererIsPOSIXShAndExecutable() throws {
+        XCTAssertTrue(
+            FileManager.default.isExecutableFile(atPath: statusLineRendererURL.path),
+            "documented as copy-then-run; without +x the copied file breaks"
+        )
+        let firstLine = try String(contentsOf: statusLineRendererURL, encoding: .utf8)
+            .split(separator: "\n", maxSplits: 1, omittingEmptySubsequences: false)
+            .first.map(String.init)
+        XCTAssertEqual(firstLine, "#!/bin/sh", "must be POSIX sh, not bash — remote hosts vary")
+    }
+
+    func testShimStampsTheOutcomeOfEveryCompletedDial() throws {
+        let state = FileManager.default.temporaryDirectory
+            .appendingPathComponent("stamp-state-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: state, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: state) }
+        let stampURL = state.appendingPathComponent("localvoxtral/hook-status")
+        let ownState = ["XDG_RUNTIME_DIR": state.path]
+        func stamp() throws -> String {
+            try String(contentsOf: stampURL, encoding: .utf8)
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+        }
+        func assertGrammar(_ value: String, file: StaticString = #filePath, line: UInt = #line) {
+            XCTAssertNotNil(
+                value.range(of: #"^(ok|down|unconfigured|http-[0-9]{3}) [0-9]{1,12}$"#,
+                            options: .regularExpression),
+                "stamp \(value) must obey the fixed grammar statusline.sh reads",
+                file: file, line: line
+            )
+        }
+
+        // 200 → ok.
+        _ = try runShimWithStubCurl(
+            status: "200",
+            body: ClaudeRemoteHTTPCodec.markerResponseBody(marker: nil),
+            extraEnvironment: ownState
+        )
+        XCTAssertTrue(try stamp().hasPrefix("ok "), "a 200 exchange must stamp ok")
+        assertGrammar(try stamp())
+
+        // Completed non-200 → http-<code> (the 401 is the one users will see).
+        _ = try runShimWithStubCurl(status: "401", body: nil, extraEnvironment: ownState)
+        XCTAssertTrue(try stamp().hasPrefix("http-401 "), "a completed 401 must stamp http-401")
+        assertGrammar(try stamp())
+
+        // Transport failure → down.
+        _ = try runShimWithStubCurl(
+            status: "000", body: nil, curlExitCode: 7, extraEnvironment: ownState
+        )
+        XCTAssertTrue(try stamp().hasPrefix("down "), "a dead tunnel must stamp down")
+        assertGrammar(try stamp())
+
+        // No token → unconfigured, before any dial.
+        _ = try runShim(environment: ownState)
+        XCTAssertTrue(try stamp().hasPrefix("unconfigured "), "a missing token must stamp unconfigured")
+        assertGrammar(try stamp())
+    }
+
+    /// Runs statusline.sh with an isolated state dir holding the given stamp
+    /// (nil = no stamp at all), a status-line payload on stdin, and captures
+    /// everything.
+    private func runStatusLineRenderer(
+        stamp: String?
+    ) throws -> (exitCode: Int32, stdout: String, stderr: String) {
+        let state = FileManager.default.temporaryDirectory
+            .appendingPathComponent("statusline-state-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: state, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: state) }
+        if let stamp {
+            let directory = state.appendingPathComponent("localvoxtral")
+            try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+            try stamp.write(
+                to: directory.appendingPathComponent("hook-status"), atomically: true, encoding: .utf8
+            )
+        }
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/bin/sh")
+        process.arguments = [statusLineRendererURL.path]
+        var environment = ProcessInfo.processInfo.environment
+        environment["XDG_RUNTIME_DIR"] = state.path
+        process.environment = environment
+        let stdin = Pipe()
+        let stdout = Pipe()
+        let stderr = Pipe()
+        process.standardInput = stdin
+        process.standardOutput = stdout
+        process.standardError = stderr
+        try process.run()
+        stdin.fileHandleForWriting.write(Data(#"{"session_id":"s1"}"#.utf8))
+        stdin.fileHandleForWriting.closeFile()
+        let out = stdout.fileHandleForReading.readDataToEndOfFile()
+        let err = stderr.fileHandleForReading.readDataToEndOfFile()
+        process.waitUntilExit()
+        return (
+            process.terminationStatus,
+            String(decoding: out, as: UTF8.self),
+            String(decoding: err, as: UTF8.self)
+        )
+    }
+
+    func testStatusLineRendererMapsEachStampStateToItsFixedString() throws {
+        let esc = "\u{1B}"
+        let cases: [(stamp: String?, expected: String)] = [
+            ("ok 1786204746", "\(esc)[32m\u{25CF}\(esc)[0m localvoxtral connected\n"),
+            ("http-401 1786204746", "\(esc)[33m\u{25CB}\(esc)[0m localvoxtral token rejected\n"),
+            ("http-503 1786204746", "\(esc)[33m\u{25CB}\(esc)[0m localvoxtral not connected\n"),
+            ("down 1786204746", "\(esc)[2m\u{25CB} localvoxtral unreachable\(esc)[0m\n"),
+            ("unconfigured 1786204746", "\(esc)[33m\u{25CB}\(esc)[0m localvoxtral token not configured\n"),
+            (nil, "\(esc)[2m\u{25CB} localvoxtral no hooks yet\(esc)[0m\n"),
+        ]
+        for (stamp, expected) in cases {
+            let result = try runStatusLineRenderer(stamp: stamp)
+            XCTAssertEqual(result.exitCode, 0, "\(stamp ?? "<none>") must exit 0")
+            XCTAssertEqual(result.stdout, expected, "wrong rendering for \(stamp ?? "<none>")")
+            XCTAssertEqual(result.stderr, "", "the renderer must never be noisy")
+        }
+    }
+
+    func testStatusLineRendererNeverEchoesStampBytes() throws {
+        // The stamp file is merely 0600 — anything running as the user could
+        // rewrite it, and stdout renders (with ANSI honored) in the user's
+        // status line. So the stamp's first token only ever SELECTS a fixed
+        // string; unrecognized states render the never-heard-anything default
+        // and not one byte of the file.
+        let defaultLine = "\u{1B}[2m\u{25CB} localvoxtral no hooks yet\u{1B}[0m\n"
+        for hostile in [
+            "$(uname) 1786204746",
+            "ok`uname` 1786204746",
+            "ok\u{1B}]0;evil\u{07} 1786204746",
+            "totally-unknown-state 1786204746",
+            String(repeating: "A", count: 100_000),
+        ] {
+            let result = try runStatusLineRenderer(stamp: hostile)
+            XCTAssertEqual(result.exitCode, 0)
+            XCTAssertEqual(
+                result.stdout, defaultLine,
+                "an unrecognized stamp must render the default, never its own bytes"
+            )
+            XCTAssertEqual(result.stderr, "")
+        }
     }
 
     func testShimFailsOpenSilentlyWithoutATokenAndWithoutCurl() throws {

--- a/Tests/localvoxtralTests/ClaudeRemotePluginManifestTests.swift
+++ b/Tests/localvoxtralTests/ClaudeRemotePluginManifestTests.swift
@@ -478,12 +478,27 @@ final class ClaudeRemotePluginManifestTests: XCTestCase {
 
     func testStatusLineRendererMapsEachStampStateToItsFixedString() throws {
         let esc = "\u{1B}"
+        // The current time is DATA here, not timing: the renderer compares the
+        // stamp's epoch against its own `date +%s`, so a "fresh" fixture must
+        // be minted at run time (a literal would silently cross the 15-minute
+        // staleness gate one day and start failing). No sleeps, no tolerances.
+        let fresh = String(Int(Date().timeIntervalSince1970))
+        let stale = String(Int(Date().timeIntervalSince1970) - 3600)
         let cases: [(stamp: String?, expected: String)] = [
-            ("ok 1786204746", "\(esc)[32m\u{25CF}\(esc)[0m localvoxtral connected\n"),
-            ("http-401 1786204746", "\(esc)[33m\u{25CB}\(esc)[0m localvoxtral token rejected\n"),
-            ("http-503 1786204746", "\(esc)[33m\u{25CB}\(esc)[0m localvoxtral not connected\n"),
-            ("down 1786204746", "\(esc)[2m\u{25CB} localvoxtral unreachable\(esc)[0m\n"),
-            ("unconfigured 1786204746", "\(esc)[33m\u{25CB}\(esc)[0m localvoxtral token not configured\n"),
+            ("ok \(fresh)", "\(esc)[32m\u{25CF}\(esc)[0m localvoxtral connected\n"),
+            // A green light must expire: ok past the staleness gate demotes to
+            // the dim no-recent-hooks line rather than claiming a live app.
+            ("ok \(stale)", "\(esc)[2m\u{25CB} localvoxtral no recent hooks\(esc)[0m\n"),
+            // Freshness is a refinement, never a new failure mode: an epoch we
+            // cannot read renders exactly as pre-gate ok did.
+            ("ok not-an-epoch", "\(esc)[32m\u{25CF}\(esc)[0m localvoxtral connected\n"),
+            ("ok", "\(esc)[32m\u{25CF}\(esc)[0m localvoxtral connected\n"),
+            // Failure states are never demoted — stale bad news is still the
+            // last known truth, and staying conservative cannot mislead.
+            ("http-401 \(stale)", "\(esc)[33m\u{25CB}\(esc)[0m localvoxtral token rejected\n"),
+            ("http-503 \(fresh)", "\(esc)[33m\u{25CB}\(esc)[0m localvoxtral not connected\n"),
+            ("down \(stale)", "\(esc)[2m\u{25CB} localvoxtral unreachable\(esc)[0m\n"),
+            ("unconfigured \(fresh)", "\(esc)[33m\u{25CB}\(esc)[0m localvoxtral token not configured\n"),
             (nil, "\(esc)[2m\u{25CB} localvoxtral no hooks yet\(esc)[0m\n"),
         ]
         for (stamp, expected) in cases {

--- a/Tests/localvoxtralTests/ClaudeSessionRegistryTests.swift
+++ b/Tests/localvoxtralTests/ClaudeSessionRegistryTests.swift
@@ -139,6 +139,28 @@ final class ClaudeSessionRegistryTests: XCTestCase {
         XCTAssertTrue(registry.liveSessions().isEmpty)
     }
 
+    func testStatusQueryIsRefusedByIngestAndNeitherCreatesNorRefreshes() throws {
+        // The broker answers StatusQuery BEFORE ingest; this is the backstop
+        // behind it. An ingested probe would create a session for an id
+        // nobody ever hooked — or refresh the activity of a dying one, keeping
+        // alive the very state it exists to report on.
+        let registry = makeRegistry()
+        XCTAssertNil(registry.ingest(record(.statusQuery), origin: local))
+        XCTAssertNil(registry.snapshot(sessionID: "s1"), "a probe must not create a session")
+        XCTAssertTrue(registry.liveSessions().isEmpty)
+
+        let clock = TestClock(epoch)
+        let refreshable = makeRegistry(clock: clock)
+        refreshable.ingest(record(.sessionStart), origin: local)
+        let before = try XCTUnwrap(refreshable.snapshot(sessionID: "s1")).lastActivity
+        clock.advance(60)
+        XCTAssertNil(refreshable.ingest(record(.statusQuery), origin: local))
+        XCTAssertEqual(
+            try XCTUnwrap(refreshable.snapshot(sessionID: "s1")).lastActivity, before,
+            "a probe must not count as session activity"
+        )
+    }
+
     func testIngestAccumulatesAcrossEvents() throws {
         let registry = makeRegistry()
         registry.ingest(record(.sessionStart), origin: local)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -36,7 +36,12 @@ Key subsystems:
   `integrations/claude-code/`): off-screen context for dictation into Claude
   Code. Two plugins in one marketplace, structurally separate — never modes of
   each other. Both declare hooks only (no skill/command/agent/statusLine —
-  nothing that spends the user's tokens).
+  nothing that spends the user's tokens). The OPT-IN connection indicator for
+  Claude Code's status line is user-wired, never plugin-declared: locally the
+  user points their own `statusLine` setting at the publisher binary's
+  `--statusline` mode; remotely at a copy of the remote plugin's
+  `statusline.sh`, which renders the outcome post.sh stamped for the last hook
+  dial and never dials anything itself.
   - **Local** (`localvoxtral`): each hook runs `localvoxtral-claude-hook` as a
     CHILD (never `exec` — the shim must outlive a publisher that cannot start,
     or the exec failure becomes the hook's exit code and fail-open stops being

--- a/integrations/claude-code/.claude-plugin/marketplace.json
+++ b/integrations/claude-code/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Off-screen Claude Code session context for the localvoxtral dictation app.",
-    "version": "1.3.0"
+    "version": "1.4.0"
   },
   "plugins": [
     {

--- a/integrations/claude-code/README.md
+++ b/integrations/claude-code/README.md
@@ -198,6 +198,52 @@ Verify:
 claude plugin list
 ```
 
+## Connection indicator (opt-in status line)
+
+One glance at Claude Code's bottom bar answers the question this plugin
+otherwise leaves silent: *is localvoxtral connected to this session?*
+
+Claude Code has no plugin-owned status line, and localvoxtral never writes
+`~/.claude/settings.json` — so this is wired by **you**, once, in your own
+settings. The publisher binary has a `--statusline` mode that reads the
+status-line payload Claude Code pipes in, asks the app's socket whether THIS
+session (by `session_id`) is live in its registry, and prints exactly one of
+three fixed lines:
+
+| Line | Meaning |
+|---|---|
+| `● localvoxtral connected` (green) | the app is running and this session's hooks are reaching it |
+| `○ localvoxtral not connected` (yellow) | the app is running but has no live record of this session — plugin not installed, or the app started after this session's last hook (it catches up on your next prompt) |
+| `○ localvoxtral not running` (dim) | nothing is listening on the socket |
+
+In `~/.claude/settings.json`:
+
+```json
+{
+  "statusLine": {
+    "type": "command",
+    "command": "/Applications/localvoxtral.app/Contents/MacOS/localvoxtral-claude-hook --statusline"
+  }
+}
+```
+
+(Adjust the path for `~/Applications` or a dev build — it is the same binary
+`publisher_path` points at.) If you already have a status line, keep it and
+append ours: buffer stdin once and feed both, e.g.
+
+```sh
+#!/bin/sh
+input=$(cat)
+printf '%s' "$input" | ~/.claude/my-statusline.sh
+printf '%s' "$input" | /Applications/localvoxtral.app/Contents/MacOS/localvoxtral-claude-hook --statusline
+```
+
+The query is read-only by construction: asking never creates a session,
+never refreshes one, and never carries a marker. The three strings above are
+compile-time constants — nothing read off the socket is ever echoed into
+your terminal — and a payload without a usable `session_id` prints nothing
+rather than guessing.
+
 ## Fail-open, always
 
 If localvoxtral is not running, not installed, or its socket is absent, the hook
@@ -377,8 +423,9 @@ If it landed there anyway, rotate the token in the app — that is what rotation
 for.
 
 Nothing else is installed. The marketplace add resolves the repository root's
-`.claude-plugin/marketplace.json`; the plugin is two JSON files and one
-POSIX-sh script that needs only `sh` and `curl` on the host.
+`.claude-plugin/marketplace.json`; the plugin is two JSON files and two
+POSIX-sh scripts — the hook shim, which needs only `sh` and `curl` on the
+host, and the opt-in status-line renderer below, which needs only `sh`.
 
 **3. Check it:**
 
@@ -390,6 +437,58 @@ claude plugin list
 curl -s -o /dev/null -w '%{http_code}\n' -X POST -H 'Content-Type: application/json' \
   -d '{}' http://127.0.0.1:28511/v1/hook/SessionStart
 ```
+
+## Connection indicator (opt-in status line)
+
+The same bottom-bar indicator the local plugin offers, adapted to a host
+where everything fails open by design: it tells you whether hooks from this
+host are actually reaching localvoxtral on your Mac, instead of you finding
+out by dictating into nothing.
+
+It never dials the tunnel — a status line re-runs constantly, and every dial
+against a live forward with no app behind it prints ssh's
+`connect_to …: failed.` onto your terminal (the exact storm the shim's
+backoff exists to end). Instead, `post.sh` records the outcome of each hook
+delivery in a private one-line stamp, and a tiny renderer script turns that
+into one fixed line. The indicator is exactly as fresh as this host's hook
+traffic, which is also what re-runs the status line:
+
+| Line | The last hook dial saw |
+|---|---|
+| `● localvoxtral connected` (green) | a 200 from the app, through the tunnel |
+| `○ localvoxtral unreachable` (dim) | no listener — tunnel down, Mac asleep, or the app not running |
+| `○ localvoxtral token rejected` (yellow) | a 401 — rotate the token, or finish an interrupted rotation |
+| `○ localvoxtral token not configured` (yellow) | the plugin has no `token` in its config at all |
+| `○ localvoxtral not connected` (yellow) | some other completed HTTP error |
+| `○ localvoxtral no hooks yet` (dim) | nothing — no hook has fired since this host last booted (the stamp lives in the runtime dir) |
+
+Set it up on the **remote host** (the plugin ships the renderer; Claude Code's
+versioned plugin cache is no place for a settings path, so copy it somewhere
+stable):
+
+```sh
+cp ~/.claude/plugins/marketplaces/localvoxtral/integrations/claude-code/plugins/localvoxtral-remote/hooks/statusline.sh \
+   ~/.claude/localvoxtral-statusline.sh
+```
+
+and in the host's `~/.claude/settings.json`:
+
+```json
+{
+  "statusLine": {
+    "type": "command",
+    "command": "sh ~/.claude/localvoxtral-statusline.sh"
+  }
+}
+```
+
+The copy does not go stale in any way that matters: the renderer is
+deliberately dumb (read stamp, print fixed string) and the smart half lives
+in `post.sh`, which updates with the plugin. Like everything else on this
+path, the renderer's stdout fails closed: the stamp's first token only ever
+selects one of the six strings above — no byte of the stamp file is ever
+echoed into your status line. If you already run a status line on that host,
+call the script from it and append its one line.
 
 ## Sessions nobody is sitting in front of
 

--- a/integrations/claude-code/README.md
+++ b/integrations/claude-code/README.md
@@ -455,7 +455,8 @@ traffic, which is also what re-runs the status line:
 
 | Line | The last hook dial saw |
 |---|---|
-| `● localvoxtral connected` (green) | a 200 from the app, through the tunnel |
+| `● localvoxtral connected` (green) | a 200 from the app, through the tunnel, within the last 15 minutes |
+| `○ localvoxtral no recent hooks` (dim) | a 200 too — but a while ago. The green light expires rather than vouch for an app that may have gone away since; your next prompt dials and restores the truth either way |
 | `○ localvoxtral unreachable` (dim) | no listener — tunnel down, Mac asleep, or the app not running |
 | `○ localvoxtral token rejected` (yellow) | a 401 — rotate the token, or finish an interrupted rotation |
 | `○ localvoxtral token not configured` (yellow) | the plugin has no `token` in its config at all |
@@ -486,7 +487,7 @@ The copy does not go stale in any way that matters: the renderer is
 deliberately dumb (read stamp, print fixed string) and the smart half lives
 in `post.sh`, which updates with the plugin. Like everything else on this
 path, the renderer's stdout fails closed: the stamp's first token only ever
-selects one of the six strings above — no byte of the stamp file is ever
+selects one of the strings above — no byte of the stamp file is ever
 echoed into your status line. If you already run a status line on that host,
 call the script from it and append its one line.
 

--- a/integrations/claude-code/plugins/localvoxtral-remote/.claude-plugin/plugin.json
+++ b/integrations/claude-code/plugins/localvoxtral-remote/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "localvoxtral-remote",
   "description": "Publishes Claude Code session context from a REMOTE host to localvoxtral on your Mac, over an SSH RemoteForward tunnel. Command hooks running a bundled POSIX-sh shim that POSTs via curl — needs only sh and curl on the remote host, and fails open silently when either is missing.",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "author": {
     "name": "localvoxtral"
   },

--- a/integrations/claude-code/plugins/localvoxtral-remote/hooks/post.sh
+++ b/integrations/claude-code/plugins/localvoxtral-remote/hooks/post.sh
@@ -42,8 +42,58 @@ fail_open() {
   exit 0
 }
 
+# 0700 directories / 0600 files for EVERYTHING this shim creates — the header
+# tempfile below and both state stamps. Set before the first write, not just
+# before the tempfile.
+umask 077
+
+# --- Private per-user state dir --------------------------------------------
+# Holds two single-line stamps, both best-effort and both harmless to lose:
+#   hook-backoff  — epoch of the last transport failure (see backoff below)
+#   hook-status   — outcome of the last completed dial, for the OPT-IN status
+#                   line (statusline.sh in this directory). One line,
+#                   `<state> <epoch>`, state from a fixed grammar:
+#                   ok | down | unconfigured | http-<3 digits>.
+# The status stamp is HOST-level, not per-session, by design: reading a
+# session id would mean parsing (and buffering) the event body this shim
+# deliberately passes through byte-for-byte — and tunnel, token, and port are
+# per-host facts anyway, so one session's outcome answers for all of them.
+if [ -n "${XDG_RUNTIME_DIR:-}" ]; then
+  STAMP_DIR="$XDG_RUNTIME_DIR/localvoxtral"
+elif [ -n "${HOME:-}" ]; then
+  STAMP_DIR="$HOME/.cache/localvoxtral"
+else
+  STAMP_DIR=""
+fi
+STAMP="$STAMP_DIR/hook-backoff"
+STATUS_STAMP="$STAMP_DIR/hook-status"
+NOW="$(date +%s 2>/dev/null)" || NOW=""
+# Digits only, at most 12 of them (epoch seconds are 10 until year 2286): a
+# damaged value must never reach `[` or $(( )), where an oversized constant
+# aborts some shells — with output on stderr.
+case "$NOW" in *[!0-9]* | ?????????????*) NOW="" ;; esac
+
+# Record the last dial's outcome for statusline.sh. Same tempfile + mv -f
+# discipline as the backoff stamp (rename replaces a pre-planted symlink
+# instead of writing through it; a concurrent reader never sees a torn line),
+# and every failure is silent — losing the indicator is nothing next to
+# delivering the hook.
+write_status() {
+  [ -n "$STAMP_DIR" ] && [ -n "$NOW" ] || return 0
+  {
+    mkdir -p "$STAMP_DIR" && chmod 700 "$STAMP_DIR" \
+      && echo "$1 $NOW" >"$STATUS_STAMP.$$" && mv -f "$STATUS_STAMP.$$" "$STATUS_STAMP"
+  } 2>/dev/null || { rm -f "$STATUS_STAMP.$$"; } 2>/dev/null || :
+}
+
 TOKEN="${CLAUDE_PLUGIN_OPTION_TOKEN:-}"
-[ -n "$TOKEN" ] || fail_open
+# No token is the one misconfiguration worth naming before failing open: the
+# plugin was installed without `--config token=…`, every future dial would be
+# a guaranteed 401, and nothing else on this host will ever say so.
+[ -n "$TOKEN" ] || {
+  write_status unconfigured
+  fail_open
+}
 command -v curl >/dev/null 2>&1 || fail_open
 
 # --- Listen port -------------------------------------------------------------
@@ -85,24 +135,11 @@ esac
 # the first prompt after the app comes back is grounded immediately — and its
 # completed exchange clears the backoff for every other event.
 #
-# State is one epoch-seconds stamp in a private per-user dir. Anything odd —
-# no usable dir, no epoch from date, garbage content, a clock that jumped
-# backwards — disables the backoff and the shim simply dials: exactly the
-# pre-backoff behavior, fail-open as ever.
+# State is one epoch-seconds stamp in the private per-user dir derived above.
+# Anything odd — no usable dir, no epoch from date, garbage content, a clock
+# that jumped backwards — disables the backoff and the shim simply dials:
+# exactly the pre-backoff behavior, fail-open as ever.
 BACKOFF_SECONDS=300
-if [ -n "${XDG_RUNTIME_DIR:-}" ]; then
-  STAMP_DIR="$XDG_RUNTIME_DIR/localvoxtral"
-elif [ -n "${HOME:-}" ]; then
-  STAMP_DIR="$HOME/.cache/localvoxtral"
-else
-  STAMP_DIR=""
-fi
-STAMP="$STAMP_DIR/hook-backoff"
-NOW="$(date +%s 2>/dev/null)" || NOW=""
-# Digits only, at most 12 of them (epoch seconds are 10 until year 2286): a
-# damaged value must never reach `[` or $(( )), where an oversized constant
-# aborts some shells — with output on stderr.
-case "$NOW" in *[!0-9]* | ?????????????*) NOW="" ;; esac
 if [ -n "$STAMP_DIR" ] && [ -n "$NOW" ] && [ "$EVENT" != "UserPromptSubmit" ] \
   && [ -r "$STAMP" ]; then
   LAST="$(cat "$STAMP" 2>/dev/null)" || LAST=""
@@ -116,11 +153,10 @@ if [ -n "$STAMP_DIR" ] && [ -n "$NOW" ] && [ "$EVENT" != "UserPromptSubmit" ] \
   esac
 fi
 
-# 0700 directory / 0600 files for the header tempfile; removed on every exit.
-# Known, accepted leak: a SIGKILL (Claude Code escalating past the hook
+# Header tempfile dir (0700/0600 under the umask set above); removed on every
+# exit. Known, accepted leak: a SIGKILL (Claude Code escalating past the hook
 # timeout) skips the traps and strands one 0700 dir — private to the user,
 # bounded by how often hooks get killed.
-umask 077
 WORK="$(mktemp -d 2>/dev/null)" || fail_open
 trap 'rm -rf "$WORK"' EXIT
 trap 'rm -rf "$WORK"; exit 0' HUP INT TERM
@@ -226,8 +262,16 @@ if [ -n "$STAMP_DIR" ] && [ -n "$NOW" ]; then
       mkdir -p "$STAMP_DIR" && chmod 700 "$STAMP_DIR" \
         && echo "$NOW" >"$STAMP.$$" && mv -f "$STAMP.$$" "$STAMP"
     } 2>/dev/null || { rm -f "$STAMP.$$"; } 2>/dev/null || :
+    write_status down
   else
     rm -f "$STAMP" 2>/dev/null || :
+    # The completed exchange's verdict, for statusline.sh. The code is
+    # embedded only after the exact-3-digits match — curl wrote it, but
+    # nothing that fails the grammar may reach a file another script reads.
+    case "$STATUS" in
+    200) write_status ok ;;
+    [0-9][0-9][0-9]) write_status "http-$STATUS" ;;
+    esac
   fi
 fi
 

--- a/integrations/claude-code/plugins/localvoxtral-remote/hooks/statusline.sh
+++ b/integrations/claude-code/plugins/localvoxtral-remote/hooks/statusline.sh
@@ -1,0 +1,60 @@
+#!/bin/sh
+# localvoxtral connection indicator for the Claude Code status line — strict
+# POSIX sh, no dependencies at all (not even curl).
+#
+# NOT a hook, and NOT wired up by the plugin: Claude Code has no plugin-owned
+# status line, and localvoxtral never writes `~/.claude/settings.json` (that
+# file is the user's). The user opts in by copying this script to a stable
+# path and pointing their `statusLine` setting at it — see the README's
+# "Connection indicator" section. It renders whether hooks from THIS host are
+# reaching localvoxtral on the Mac.
+#
+# It never dials the tunnel. A status line re-runs constantly, and every dial
+# against a live forward with no app behind it makes ssh — on the other
+# machine — print `connect_to …: failed.` onto the user's terminal; that is
+# the storm post.sh's backoff exists to end, and a poller would bring it
+# back. Instead it reads the one-line `hook-status` stamp post.sh leaves
+# after each dial (`<state> <epoch>`), so the indicator is exactly as fresh
+# as the session's own hook traffic — which re-runs the status line anyway.
+#
+# stdout renders in the user's status line, so printing fails closed the same
+# way post.sh's stdout gate does: the stamp's first token only ever SELECTS
+# one of the fixed strings below — no byte of the stamp file (which another
+# process could have altered; it is merely 0600) is ever echoed, and an
+# unrecognized state renders as the never-heard-anything default.
+set -u
+
+# Drain the status-line payload (JSON on stdin, unused: the stamp is
+# host-level) so Claude Code's writer never sees EPIPE.
+cat >/dev/null 2>&1
+
+if [ -n "${XDG_RUNTIME_DIR:-}" ]; then
+  STAMP_DIR="$XDG_RUNTIME_DIR/localvoxtral"
+elif [ -n "${HOME:-}" ]; then
+  STAMP_DIR="$HOME/.cache/localvoxtral"
+else
+  STAMP_DIR=""
+fi
+
+STATE=""
+if [ -n "$STAMP_DIR" ] && [ -r "$STAMP_DIR/hook-status" ]; then
+  LINE="$(cat "$STAMP_DIR/hook-status" 2>/dev/null)" || LINE=""
+  STATE="${LINE%% *}"
+fi
+
+# Fixed strings only. `printf '%b'` renders the SGR escapes; `\0033` is the
+# strictly-POSIX octal spelling of ESC (the `\0ddd` form is the one XCU
+# guarantees for %b), and the dots are literal UTF-8. printf here is safe in
+# a way it is not in post.sh: there is no secret anywhere in this process,
+# so an external printf putting its argument into an argv leaks nothing.
+# Green dot: the Mac answered 200 to this host's last hook. Everything else
+# names the failure the last dial actually saw.
+case "$STATE" in
+ok) printf '%b\n' '\0033[32m●\0033[0m localvoxtral connected' ;;
+http-401) printf '%b\n' '\0033[33m○\0033[0m localvoxtral token rejected' ;;
+http-*) printf '%b\n' '\0033[33m○\0033[0m localvoxtral not connected' ;;
+down) printf '%b\n' '\0033[2m○ localvoxtral unreachable\0033[0m' ;;
+unconfigured) printf '%b\n' '\0033[33m○\0033[0m localvoxtral token not configured' ;;
+*) printf '%b\n' '\0033[2m○ localvoxtral no hooks yet\0033[0m' ;;
+esac
+exit 0

--- a/integrations/claude-code/plugins/localvoxtral-remote/hooks/statusline.sh
+++ b/integrations/claude-code/plugins/localvoxtral-remote/hooks/statusline.sh
@@ -37,9 +37,32 @@ else
 fi
 
 STATE=""
+EPOCH=""
 if [ -n "$STAMP_DIR" ] && [ -r "$STAMP_DIR/hook-status" ]; then
   LINE="$(cat "$STAMP_DIR/hook-status" 2>/dev/null)" || LINE=""
   STATE="${LINE%% *}"
+  EPOCH="${LINE#* }"
+  [ "$EPOCH" = "$LINE" ] && EPOCH=""
+fi
+
+# A green light must expire. `ok` is a claim about the LAST dial, and the one
+# lie this script could otherwise tell is a green dot hours after the Mac
+# went to sleep — precisely the condition the indicator exists to surface. So
+# an `ok` older than 15 minutes demotes to a dim "no recent hooks"; the next
+# submitted prompt dials (UserPromptSubmit is backoff-exempt) and restores
+# the truth either way. Only `ok` is demoted: a stale failure state is still
+# the last known truth, and staying conservative can't mislead. Both numbers
+# are validated exactly like post.sh's NOW (digits, <=12, no `[`/$(( ))
+# aborts); anything odd disables the demotion and `ok` renders as before —
+# freshness is a refinement, never a new failure mode.
+STALE_SECONDS=900
+STALE=""
+NOW="$(date +%s 2>/dev/null)" || NOW=""
+case "$NOW" in "" | *[!0-9]* | ?????????????*) NOW="" ;; esac
+case "$EPOCH" in "" | *[!0-9]* | ?????????????*) EPOCH="" ;; esac
+if [ -n "$NOW" ] && [ -n "$EPOCH" ] && [ "$EPOCH" -le "$NOW" ] \
+  && [ $((NOW - EPOCH)) -gt "$STALE_SECONDS" ]; then
+  STALE=1
 fi
 
 # Fixed strings only. `printf '%b'` renders the SGR escapes; `\0033` is the
@@ -50,7 +73,13 @@ fi
 # Green dot: the Mac answered 200 to this host's last hook. Everything else
 # names the failure the last dial actually saw.
 case "$STATE" in
-ok) printf '%b\n' '\0033[32m●\0033[0m localvoxtral connected' ;;
+ok)
+  if [ -n "$STALE" ]; then
+    printf '%b\n' '\0033[2m○ localvoxtral no recent hooks\0033[0m'
+  else
+    printf '%b\n' '\0033[32m●\0033[0m localvoxtral connected'
+  fi
+  ;;
 http-401) printf '%b\n' '\0033[33m○\0033[0m localvoxtral token rejected' ;;
 http-*) printf '%b\n' '\0033[33m○\0033[0m localvoxtral not connected' ;;
 down) printf '%b\n' '\0033[2m○ localvoxtral unreachable\0033[0m' ;;

--- a/scripts/package_app.sh
+++ b/scripts/package_app.sh
@@ -272,6 +272,17 @@ if [[ ! -x "$CLAUDE_HOOK_SHIM" ]]; then
   echo "Claude Code hook shim is not executable: $CLAUDE_HOOK_SHIM"
   exit 1
 fi
+# The remote plugin's shims ship in the same marketplace copy. Claude Code
+# execs post.sh directly; statusline.sh is run by the user's statusLine
+# setting. Same assert-not-hope rule as publish.sh above.
+for REMOTE_SHIM in post.sh statusline.sh; do
+  REMOTE_SHIM_PATH="$APP_DIR/Contents/Resources/claude-code-marketplace/plugins/localvoxtral-remote/hooks/$REMOTE_SHIM"
+  chmod +x "$REMOTE_SHIM_PATH"
+  if [[ ! -x "$REMOTE_SHIM_PATH" ]]; then
+    echo "Claude Code remote shim is not executable: $REMOTE_SHIM_PATH"
+    exit 1
+  fi
+done
 
 cat > "$APP_DIR/Contents/Info.plist" <<PLIST
 <?xml version="1.0" encoding="UTF-8"?>


### PR DESCRIPTION
## What

A connection indicator for Claude Code's bottom bar that answers, per session: **is localvoxtral connected to this Claude Code session?** Until now every failure on this path was silent by design (fail-open everywhere), so the only way to notice a dead tunnel, a stale token, or a not-running app was dictating into nothing.

Claude Code has no plugin-owned `statusLine`, and this app never writes `~/.claude/settings.json` — so the indicator is **user-wired** (one settings snippet, documented in the README) and the plugins still declare hooks only.

**Local** — the publisher binary gains a `--statusline` mode users point their `statusLine` setting at (stable app-bundle path, no versioned-plugin-dir fragility). It reads the status-line payload's `session_id`, sends a new read-only `StatusQuery` over the existing AF_UNIX socket, and prints one of three fixed ANSI lines: `● localvoxtral connected` / `○ localvoxtral not connected` / `○ localvoxtral not running`. The broker answers `accepted = session live in registry` (same TTL + pid-liveness answer joins use) and **never ingests the probe**: asking cannot create a session, refresh one, or receive a marker. `ClaudeSessionRegistry.ingest` refuses `.statusQuery` outright as the backstop, and the reducer's new case is compile-time unreachable.

**Remote** — no binary, no token in the statusline subprocess (`CLAUDE_PLUGIN_OPTION_*` is command-hook-only), and a statusline that dialed the tunnel would resurrect the `connect_to …: failed.` ssh-stderr storm the backoff exists to end. So `post.sh` now stamps each dial's outcome (`ok` / `down` / `http-<code>` / `unconfigured`, fixed grammar, tempfile+`mv` in its existing private state dir), and a new sh-only `hooks/statusline.sh` renders the stamp as one of six fixed strings. Host-level by design: reading a session id would mean buffering the event body the shim deliberately passes through byte-for-byte, and tunnel/token/port are per-host facts anyway. The missing-token case now stamps `unconfigured` before failing open — the one misconfiguration that is otherwise a guaranteed-401-forever with no symptom.

Both renderers fail closed on output: outcomes/stamp tokens only **select** compile-time strings; no byte read off a socket or stamp file is ever echoed into a terminal.

Also: remote plugin + both marketplace manifests bumped to 1.4.0; `package_app.sh` asserts both remote shims ship executable; README gains "Connection indicator" sections for both plugins; `docs/architecture.md` updated.

## Proof

- [x] Unit suite green — `./scripts/remote-build.sh` (full tier 0):
  ```
  Executed 2620 tests, with 2 tests skipped and 0 failures (0 unexpected) in 100.010 (100.142) seconds
  ```
- [x] New behavior, named tests (all in the run above; touched suites also run in isolation — 55/55 `ClaudeRemotePluginManifestTests`, 141/141 broker/publisher/registry/wire/manifest/assets):
  - `testStatusQueryForALiveSessionRepliesAcceptedWithoutAMarker` — probe answers over the real socket, marker withheld even with the title fallback ON
  - `testStatusQueryForAnUnknownSessionRepliesNotAcceptedAndCreatesNothing` — probe cannot create the session it asks after
  - `testStatusLineModeEndToEndThroughThePublisher` — production `--statusline` path against the production broker
  - `testStatusQueryIsRefusedByIngestAndNeitherCreatesNorRefreshes` — registry backstop: probe is not activity
  - `testStatusLineTextIsFixedStringsOnly`, `testStatusLinePayloadWithoutAUsableSessionIDIsUnparseable` — output contract
  - `testShimStampsTheOutcomeOfEveryCompletedDial` — RUNS post.sh against the stub curl: 200→`ok`, 401→`http-401`, transport failure→`down`, no token→`unconfigured`, all grammar-checked
  - `testStatusLineRendererMapsEachStampStateToItsFixedString`, `testStatusLineRendererNeverEchoesStampBytes` — RUNS statusline.sh; hostile stamp contents (`$(uname)`, backticks, OSC injection, 100 KB) all render the fixed default, byte-for-byte
  - `testPluginShipsExactlyTwoExecutablesBothPOSIXSh` — deliberate extension of the old exactly-one-executable premise (post.sh + statusline.sh, both `#!/bin/sh`)
- [x] Existing stdout-gate and fail-open shim tests unchanged and green — the delivery path's contract is untouched.
- [x] Hand-verified on the enrolled dev host (Linux, real `~/.claude` install): `statusline.sh` renders `○ localvoxtral no hooks yet` — honest, since the installed plugin (1.1.0) predates the stamp. Full stamp cycle (`unconfigured`/`down`/`ok`/`http-401`, incl. 0700 dir / 0600 file perms and the HOME fallback) exercised end-to-end with the real scripts under an isolated state dir.
- [ ] UI change on the Mac side: `--statusline` in a live Claude Code status line not yet hand-run (needs an installed build; the swift-level e2e test covers publisher→socket→broker→render; only the 5-line argv branch in `main.swift` is exercised by tests indirectly). Will dogfood via `try-pr.sh` after review.
- LLM lanes: this PR triggers the lane filters by path (`integrations/claude-code/**`) but changes nothing that reaches any model — no prompt, pin, sampling, request-shape, or eval change. No scoreboard expected.

## Review (opencode GLM-5.2, read-only agent, full-diff brief with the 10 invariants)

Verdict: safe to merge; all ten invariants traced against code. Four LOW findings, three fixed in the follow-up commit:

- **Fixed** — stale `ok` stamp rendered green forever: `statusline.sh` now demotes an `ok` older than 15 min to a dim `○ localvoxtral no recent hooks` (failure states never demote; unreadable epochs disable the gate — freshness is a refinement, never a new failure mode). Boundary-smoked at 899 s / 901 s / future-epoch / garbage; pinned in `testStatusLineRendererMapsEachStampStateToItsFixedString` with run-time-minted epochs.
- **Fixed** — skew shape now pinned: `testUnknownEventLineIsRefusedWithAReplyNotADrop` proves an old-broker-style unknown event gets a refusal REPLY (renders "not connected"), never a dropped connection (which would lie "not running").
- **Fixed** — the StatusQuery branch no longer fires the DEBUG ingest seam (probe is neither accepted nor rejected ingest).
- **Skipped (documented non-goal)** — opencode sessions render "not connected": opencode owns its TUI, publishes under its own session scope, and has no statusline integration; nothing here claims otherwise.

Post-fix: 95/95 across the two touched suites on the Mac builder; CI re-running on the follow-up commit.
