### PR TITLE
Overlay: name the Claude Code session this dictation is grounded in

### DIFF
--- a/Sources/localvoxtral/ClaudeContext/ClaudeSessionRegistry.swift
+++ b/Sources/localvoxtral/ClaudeContext/ClaudeSessionRegistry.swift
@@ -624,6 +624,19 @@ public final class ClaudeSessionRegistry: Sendable {
         }
     }
 
+    /// Whether ANY session is live, without materializing them.
+    ///
+    /// The overlay's join badge asks this once per unjoined dictation purely to
+    /// decide between "nothing attached" and silence, and it needs no snapshot
+    /// — `liveSessions()` would copy every session's recent files and snippets
+    /// to answer a question about emptiness.
+    public func hasLiveSessions() -> Bool {
+        let timestamp = now()
+        return state.withLock { state in
+            state.sessions.values.contains { isFresh($0, now: timestamp) }
+        }
+    }
+
     public func evict(sessionID: String) {
         state.withLock { removeLocked(&$0, sessionID: sessionID) }
     }

--- a/Sources/localvoxtral/ClaudeContext/TerminalScreenClaudeJoin.swift
+++ b/Sources/localvoxtral/ClaudeContext/TerminalScreenClaudeJoin.swift
@@ -300,6 +300,18 @@ struct ClaudeSessionJoinResolver {
     /// can ONLY join via marker, because their TTY names another machine's
     /// device and `resolve(tty:)` refuses remote candidates outright.
     ///
+    /// Whether the registry currently holds ANY live session.
+    ///
+    /// Not a join and not a step toward one: the overlay's join badge asks it
+    /// to tell "nothing attached" apart from "there was nothing to attach", so
+    /// a Mac that simply is not running Claude Code shows no badge instead of a
+    /// permanent complaint. It reads no title, no TTY, no socket and no
+    /// process table — it cannot influence, or be influenced by, what `resolve`
+    /// decides.
+    func hasLiveSessions() -> Bool {
+        registry.hasLiveSessions()
+    }
+
     /// This remains the only place a join is resolved, once per dictation, at
     /// start — whichever mechanism answers.
     func resolve(target: TerminalScreenTarget) async -> ClaudeSessionJoin? {

--- a/Sources/localvoxtral/DictationOverlayController.swift
+++ b/Sources/localvoxtral/DictationOverlayController.swift
@@ -95,7 +95,8 @@ final class DictationOverlayController {
             errorMessage: nil,
             secureInputActive: false,
             metrics: OverlayLayoutMetrics(bodyFontSize: fontSizeProvider()),
-            polished: false
+            polished: false,
+            claudeJoin: .hidden
         )
         hostingView = TransparentHostingView(rootView: initialView)
         // Without this, NSHostingView probes the SwiftUI content at ∞×∞ and
@@ -143,7 +144,8 @@ final class DictationOverlayController {
             errorMessage: snapshot.errorMessage,
             secureInputActive: snapshot.secureInputActive,
             metrics: metrics,
-            polished: snapshot.polished
+            polished: snapshot.polished,
+            claudeJoin: snapshot.claudeJoin
         )
 
         let contentHeight = metrics.contentHeight(

--- a/Sources/localvoxtral/DictationOverlayView.swift
+++ b/Sources/localvoxtral/DictationOverlayView.swift
@@ -145,10 +145,10 @@ struct DictationOverlayView: View {
     private var polishedBadge: some View {
         Label("Polished", systemImage: "wand.and.stars")
             .labelStyle(.titleAndIcon)
-            .font(.system(size: 10, weight: .semibold))
+            .font(.system(size: metrics.badgeFontSize, weight: .semibold))
             .foregroundStyle(.secondary)
-            .padding(.horizontal, 6)
-            .padding(.vertical, 1)
+            .padding(.horizontal, metrics.badgeHorizontalPadding)
+            .padding(.vertical, metrics.badgeVerticalPadding)
             .background(
                 Capsule(style: .continuous).fill(Color.primary.opacity(0.08))
             )
@@ -195,12 +195,12 @@ struct DictationOverlayView: View {
     ) -> some View {
         Label(title, systemImage: systemImage)
             .labelStyle(.titleAndIcon)
-            .font(.system(size: 10, weight: .semibold))
+            .font(.system(size: metrics.badgeFontSize, weight: .semibold))
             .foregroundStyle(.secondary)
             .lineLimit(1)
             .truncationMode(.tail)
-            .padding(.horizontal, 6)
-            .padding(.vertical, 1)
+            .padding(.horizontal, metrics.badgeHorizontalPadding)
+            .padding(.vertical, metrics.badgeVerticalPadding)
             .background(
                 Capsule(style: .continuous).fill(Color.primary.opacity(0.08))
             )

--- a/Sources/localvoxtral/DictationOverlayView.swift
+++ b/Sources/localvoxtral/DictationOverlayView.swift
@@ -85,6 +85,9 @@ struct DictationOverlayView: View {
     /// see `OverlayLayoutMetrics` for why the two must stay in lockstep.
     let metrics: OverlayLayoutMetrics
     var polished: Bool = false
+    /// What this dictation's Claude Code session join resolved to. `.hidden`
+    /// renders nothing — see `OverlayClaudeJoinBadge`.
+    var claudeJoin: OverlayClaudeJoinBadge = .hidden
     private let cornerRadius: CGFloat = 12
 
     /// Warning text needs explicit light/dark variants: system `.red` over
@@ -156,6 +159,62 @@ struct DictationOverlayView: View {
             .accessibilityLabel("Polished by the language model")
     }
 
+    /// Trailing pill naming the Claude Code session this dictation is grounded
+    /// in, or saying that none attached. Same quiet weight as `polishedBadge`
+    /// deliberately: an unjoined dictation still commits its text correctly, so
+    /// this annotates the panel — it is not an error, and the warning color
+    /// under the transcript is reserved for text that failed to insert.
+    ///
+    /// The distinction rides the icon (`link` vs `link.slash`) and the label,
+    /// not color, so it reads the same on both desktops without a second
+    /// appearance-matched palette.
+    @ViewBuilder
+    private var claudeJoinBadge: some View {
+        switch claudeJoin {
+        case .hidden:
+            EmptyView()
+        case .joined(let label):
+            joinPill(
+                systemImage: "link",
+                title: label,
+                accessibilityLabel: "Grounded in Claude Code session \(label)"
+            )
+        case .unjoined:
+            joinPill(
+                systemImage: "link.slash",
+                title: "No Claude session",
+                accessibilityLabel: "No Claude Code session joined for this dictation"
+            )
+        }
+    }
+
+    private func joinPill(
+        systemImage: String,
+        title: String,
+        accessibilityLabel: String
+    ) -> some View {
+        Label(title, systemImage: systemImage)
+            .labelStyle(.titleAndIcon)
+            .font(.system(size: 10, weight: .semibold))
+            .foregroundStyle(.secondary)
+            .lineLimit(1)
+            .truncationMode(.tail)
+            .padding(.horizontal, 6)
+            .padding(.vertical, 1)
+            .background(
+                Capsule(style: .continuous).fill(Color.primary.opacity(0.08))
+            )
+            .overlay(
+                Capsule(style: .continuous)
+                    .strokeBorder(Color.primary.opacity(0.15), lineWidth: 0.5)
+            )
+            // Yields header width to the phase title, which is the actionable
+            // half (the secure-input title tells the user what to DO); a long
+            // workspace name truncates instead of pushing it out.
+            .layoutPriority(-1)
+            .accessibilityLabel(accessibilityLabel)
+    }
+
     var body: some View {
         VStack(alignment: .leading, spacing: OverlayLayoutMetrics.stackSpacing) {
             HStack(alignment: .center, spacing: 6) {
@@ -167,6 +226,7 @@ struct DictationOverlayView: View {
                         .controlSize(.small)
                 }
                 Spacer(minLength: 0)
+                claudeJoinBadge
                 if polished {
                     polishedBadge
                 }

--- a/Sources/localvoxtral/DictationViewModel+Session.swift
+++ b/Sources/localvoxtral/DictationViewModel+Session.swift
@@ -249,6 +249,11 @@ extension DictationViewModel {
         // review finding on #90). The refuse path / verdict apply below
         // re-set it from the fresh sample.
         sessionSecureInputActive = false
+        // Same rule for the join badge, and it matters more: a stale `.joined`
+        // from the previous dictation would tell the user THIS one is grounded
+        // in a session it never resolved. An attempt that exits before the
+        // capture runs (invalid endpoint, missing mic) must show nothing.
+        sessionClaudeJoinBadge = .hidden
         let requestedOutputMode = outputMode ?? settings.dictationOutputMode
         clearLatchedSessionMetadata()
         sessionOutputMode = requestedOutputMode
@@ -1661,6 +1666,7 @@ extension DictationViewModel {
             lastError = nil
         }
         sessionSecureInputActive = false
+        sessionClaudeJoinBadge = .hidden
         firstChunkPreprocessor.reset()
     }
 
@@ -2450,6 +2456,10 @@ extension DictationViewModel {
         let anchor = preResolvedOverlayAnchor
         preResolvedOverlayAnchor = nil
         overlayBufferCoordinator.startSession(preResolvedAnchor: anchor)
+        // After startSession, never before: it clears the state machine, so a
+        // badge set at join-resolution time (which happens before the socket
+        // connects) would be wiped by the very session meant to display it.
+        overlayBufferCoordinator.markClaudeJoin(sessionClaudeJoinBadge)
         if sessionSecureInputActive {
             // The overlay is the surface the user is actually watching while
             // buffering — warn there, not just in the (closed) popover. The

--- a/Sources/localvoxtral/DictationViewModel+Session.swift
+++ b/Sources/localvoxtral/DictationViewModel+Session.swift
@@ -2455,11 +2455,14 @@ extension DictationViewModel {
     private func startOverlayBufferSession() {
         let anchor = preResolvedOverlayAnchor
         preResolvedOverlayAnchor = nil
-        overlayBufferCoordinator.startSession(preResolvedAnchor: anchor)
-        // After startSession, never before: it clears the state machine, so a
-        // badge set at join-resolution time (which happens before the socket
-        // connects) would be wiped by the very session meant to display it.
-        overlayBufferCoordinator.markClaudeJoin(sessionClaudeJoinBadge)
+        // The badge travels WITH the start: the join is resolved before the
+        // socket connects and this runs after it, so it is always already
+        // known — and passing it in is what stops a later setter from being
+        // ordered wrong against the reset that starting a session performs.
+        overlayBufferCoordinator.startSession(
+            preResolvedAnchor: anchor,
+            claudeJoin: sessionClaudeJoinBadge
+        )
         if sessionSecureInputActive {
             // The overlay is the surface the user is actually watching while
             // buffering — warn there, not just in the (closed) popover. The

--- a/Sources/localvoxtral/DictationViewModel.swift
+++ b/Sources/localvoxtral/DictationViewModel.swift
@@ -257,6 +257,18 @@ final class DictationViewModel {
     /// clear lives in DictationViewModel+Session.swift.
     var sessionSecureInputActive = false
 
+    /// What this session's Claude Code join resolved to, held for the overlay's
+    /// header badge.
+    ///
+    /// Latched here for the same reason `sessionSecureInputActive` is: the join
+    /// is resolved at session start, while the app the user dictated into is
+    /// still frontmost, but the overlay panel does not open until the realtime
+    /// socket connects — and `startSession` clears the state machine, so a
+    /// badge pushed at resolution time would be wiped by the session that is
+    /// supposed to show it. Internal, because the session-end clear lives in
+    /// DictationViewModel+Session.swift.
+    var sessionClaudeJoinBadge: OverlayClaudeJoinBadge = .hidden
+
     /// Ends the refused-start warning when no session is running: the icon
     /// (and the "Blocked" status line) return to normal, while `lastError`
     /// keeps the one-line explanation in the popover. A stopped session that
@@ -1927,6 +1939,11 @@ final class DictationViewModel {
             terminalScreenStartCapture = nil
             claudeSessionJoin = nil
             socketPaneStartCapture = nil
+            // No endpoint means the join is never consumed by anything, so
+            // there is no grounding to report on either way. Saying "no Claude
+            // session" here would be true and useless — nothing would have used
+            // one.
+            sessionClaudeJoinBadge = .hidden
             return
         }
         terminalScreenStartCapture = TerminalScreenContextSource.captureAtStart(
@@ -1943,6 +1960,17 @@ final class DictationViewModel {
         // exactly the moments it mattered — quit during polish, an aborted
         // connect — and the ssh outlived the app (review finding 4).
         retainRemoteHerdrForward(of: claudeSessionJoin)
+        // Read from the ONE resolved join, never by asking again. The badge is
+        // a description of `claudeSessionJoin`, so it cannot disagree with the
+        // context that actually ships.
+        sessionClaudeJoinBadge = OverlayClaudeJoinBadge.resolve(
+            join: claudeSessionJoin,
+            contextFeatureEnabled: settings.terminalScreenContextEnabled
+                || settings.claudeRepoContextEnabled,
+            liveSessionsExist: { [claudeSessionJoinResolver] in
+                claudeSessionJoinResolver?.hasLiveSessions() ?? false
+            }
+        )
         // Only a socket-routed pane join — herdr, remote herdr, or cmux —
         // produces a sample here (the function refuses everything else before
         // any socket request), and it reads exactly the joined pane. Fetched at

--- a/Sources/localvoxtral/OverlayBufferSessionCoordinator.swift
+++ b/Sources/localvoxtral/OverlayBufferSessionCoordinator.swift
@@ -61,11 +61,15 @@ protocol OverlayBufferSessionCoordinating: AnyObject {
     /// transcript, so the overlay shows the "Polished" badge while the polished
     /// text is held before dismissal. Defaulted so test doubles stay unchanged.
     func markPolished(_ polished: Bool)
+    /// Records what this dictation's Claude Code join resolved to, for the
+    /// overlay's join badge. Defaulted so test doubles stay unchanged.
+    func markClaudeJoin(_ badge: OverlayClaudeJoinBadge)
 }
 
 extension OverlayBufferSessionCoordinating {
     func showSecureInputWarning() {}
     func markPolished(_ polished: Bool) {}
+    func markClaudeJoin(_ badge: OverlayClaudeJoinBadge) {}
 }
 
 @MainActor
@@ -265,6 +269,11 @@ final class OverlayBufferSessionCoordinator: OverlayBufferSessionCoordinating {
 
     func markPolished(_ polished: Bool) {
         stateMachine.setPolished(polished)
+        renderCurrentSnapshot()
+    }
+
+    func markClaudeJoin(_ badge: OverlayClaudeJoinBadge) {
+        stateMachine.setClaudeJoin(badge)
         renderCurrentSnapshot()
     }
 

--- a/Sources/localvoxtral/OverlayBufferSessionCoordinator.swift
+++ b/Sources/localvoxtral/OverlayBufferSessionCoordinator.swift
@@ -41,7 +41,11 @@ enum OverlayBufferCommitOutcome: Equatable {
 @MainActor
 protocol OverlayBufferSessionCoordinating: AnyObject {
     func resolveAnchorNow() -> OverlayAnchor
-    func startSession(preResolvedAnchor: OverlayAnchor?)
+    /// Opens the overlay for a session. `claudeJoin` is taken here, not through
+    /// a later setter, because starting a session RESETS the panel state — a
+    /// badge pushed beforehand would be wiped, and one pushed afterwards
+    /// depended on a call order nothing enforced.
+    func startSession(preResolvedAnchor: OverlayAnchor?, claudeJoin: OverlayClaudeJoinBadge)
     func beginFinalizing(displayBufferText: String, commitBufferText: String)
     func refresh(displayBufferText: String, commitBufferText: String)
     @discardableResult
@@ -61,15 +65,11 @@ protocol OverlayBufferSessionCoordinating: AnyObject {
     /// transcript, so the overlay shows the "Polished" badge while the polished
     /// text is held before dismissal. Defaulted so test doubles stay unchanged.
     func markPolished(_ polished: Bool)
-    /// Records what this dictation's Claude Code join resolved to, for the
-    /// overlay's join badge. Defaulted so test doubles stay unchanged.
-    func markClaudeJoin(_ badge: OverlayClaudeJoinBadge)
 }
 
 extension OverlayBufferSessionCoordinating {
     func showSecureInputWarning() {}
     func markPolished(_ polished: Bool) {}
-    func markClaudeJoin(_ badge: OverlayClaudeJoinBadge) {}
 }
 
 @MainActor
@@ -123,7 +123,10 @@ final class OverlayBufferSessionCoordinator: OverlayBufferSessionCoordinating {
         anchorResolver.resolveAnchor()
     }
 
-    func startSession(preResolvedAnchor: OverlayAnchor? = nil) {
+    func startSession(
+        preResolvedAnchor: OverlayAnchor? = nil,
+        claudeJoin: OverlayClaudeJoinBadge = .hidden
+    ) {
         dismissTask?.cancel()
         dismissTask = nil
         commitBufferText = ""
@@ -132,7 +135,7 @@ final class OverlayBufferSessionCoordinator: OverlayBufferSessionCoordinating {
         refreshLiveCommitTargetAppPID()
 
         let anchor = preResolvedAnchor ?? anchorResolver.resolveAnchor()
-        stateMachine.startSession(anchor: anchor)
+        stateMachine.startSession(anchor: anchor, claudeJoin: claudeJoin)
         renderCurrentSnapshot()
         Log.overlay.info("overlay session started (preResolved=\(preResolvedAnchor != nil, privacy: .public))")
     }
@@ -269,11 +272,6 @@ final class OverlayBufferSessionCoordinator: OverlayBufferSessionCoordinating {
 
     func markPolished(_ polished: Bool) {
         stateMachine.setPolished(polished)
-        renderCurrentSnapshot()
-    }
-
-    func markClaudeJoin(_ badge: OverlayClaudeJoinBadge) {
-        stateMachine.setClaudeJoin(badge)
         renderCurrentSnapshot()
     }
 

--- a/Sources/localvoxtral/OverlayBufferStateMachine.swift
+++ b/Sources/localvoxtral/OverlayBufferStateMachine.swift
@@ -109,6 +109,10 @@ struct OverlayBufferStateMachine {
         /// while the polished text is held before dismissal. Set only by the
         /// stop-commit polish path; cleared on every new session.
         let polished: Bool
+        /// What to say about this dictation's Claude Code session join. Set
+        /// once, from the join resolved at session start; cleared on every new
+        /// session. `.hidden` renders nothing at all.
+        let claudeJoin: OverlayClaudeJoinBadge
         let anchor: OverlayAnchor
     }
 
@@ -117,6 +121,7 @@ struct OverlayBufferStateMachine {
     private(set) var errorMessage: String?
     private(set) var secureInputActive = false
     private(set) var polished = false
+    private(set) var claudeJoin: OverlayClaudeJoinBadge = .hidden
     private(set) var anchor: OverlayAnchor?
 
     var snapshot: Snapshot? {
@@ -127,6 +132,7 @@ struct OverlayBufferStateMachine {
             errorMessage: errorMessage,
             secureInputActive: secureInputActive,
             polished: polished,
+            claudeJoin: claudeJoin,
             anchor: anchor
         )
     }
@@ -142,6 +148,10 @@ struct OverlayBufferStateMachine {
         errorMessage = nil
         secureInputActive = false
         polished = false
+        // The previous dictation's join describes the previous dictation's
+        // session. A badge that survived into this one would vouch for a
+        // grounding this session has not been given.
+        claudeJoin = .hidden
         self.anchor = anchor
     }
 
@@ -152,6 +162,16 @@ struct OverlayBufferStateMachine {
     mutating func setPolished(_ value: Bool) {
         guard phase != .idle else { return }
         polished = value
+    }
+
+    /// Records what this dictation's Claude Code join turned out to be, for the
+    /// header badge. Set from session start, where the join is resolved; the
+    /// badge then rides every later snapshot unchanged, because the join it
+    /// describes is likewise resolved exactly once. Ignored when idle (no
+    /// session to annotate); a new session clears it.
+    mutating func setClaudeJoin(_ badge: OverlayClaudeJoinBadge) {
+        guard phase != .idle else { return }
+        claudeJoin = badge
     }
 
     /// Marks the buffering session as running under Secure Keyboard Entry.
@@ -196,6 +216,7 @@ struct OverlayBufferStateMachine {
         errorMessage = nil
         secureInputActive = false
         polished = false
+        claudeJoin = .hidden
         anchor = nil
     }
 }

--- a/Sources/localvoxtral/OverlayBufferStateMachine.swift
+++ b/Sources/localvoxtral/OverlayBufferStateMachine.swift
@@ -137,7 +137,16 @@ struct OverlayBufferStateMachine {
         )
     }
 
-    mutating func startSession(anchor: OverlayAnchor) {
+    /// Starts a session, taking the Claude join badge WITH the anchor rather
+    /// than through a follow-up setter.
+    ///
+    /// The join is resolved before the realtime socket connects and this call
+    /// happens after it, so the badge is always already known here — unlike
+    /// `polished`, which genuinely arrives later, at commit. Passing it in is
+    /// what makes the ordering unbreakable: a separate setter had to run AFTER
+    /// this method (which resets the session) to survive, and nothing in the
+    /// type system said so.
+    mutating func startSession(anchor: OverlayAnchor, claudeJoin: OverlayClaudeJoinBadge) {
         guard phase == .idle else {
             let currentPhase = phase
             Log.overlay.warning("startSession called but phase is \(String(describing: currentPhase)), not idle — ignoring")
@@ -148,10 +157,10 @@ struct OverlayBufferStateMachine {
         errorMessage = nil
         secureInputActive = false
         polished = false
-        // The previous dictation's join describes the previous dictation's
-        // session. A badge that survived into this one would vouch for a
-        // grounding this session has not been given.
-        claudeJoin = .hidden
+        // Assigned, never merely cleared: the previous dictation's join
+        // describes the previous dictation's session, and a badge that survived
+        // into this one would vouch for a grounding this session was not given.
+        self.claudeJoin = claudeJoin
         self.anchor = anchor
     }
 
@@ -162,16 +171,6 @@ struct OverlayBufferStateMachine {
     mutating func setPolished(_ value: Bool) {
         guard phase != .idle else { return }
         polished = value
-    }
-
-    /// Records what this dictation's Claude Code join turned out to be, for the
-    /// header badge. Set from session start, where the join is resolved; the
-    /// badge then rides every later snapshot unchanged, because the join it
-    /// describes is likewise resolved exactly once. Ignored when idle (no
-    /// session to annotate); a new session clears it.
-    mutating func setClaudeJoin(_ badge: OverlayClaudeJoinBadge) {
-        guard phase != .idle else { return }
-        claudeJoin = badge
     }
 
     /// Marks the buffering session as running under Secure Keyboard Entry.

--- a/Sources/localvoxtral/OverlayClaudeJoinBadge.swift
+++ b/Sources/localvoxtral/OverlayClaudeJoinBadge.swift
@@ -1,0 +1,123 @@
+import Foundation
+
+/// What the overlay says about THIS dictation's Claude Code session join.
+///
+/// A read-only description of the ONE answer `ClaudeSessionJoinResolver`
+/// produced at dictation start — never a second resolution and never a probe.
+/// Re-asking at display time would defeat the invariant the single resolution
+/// exists to hold (`docs/agent/invariants.md`): every consumer must describe
+/// the same session, and a badge that re-resolved could name a different one
+/// than the context actually attached.
+///
+/// It exists because a join that silently did not happen and one that did look
+/// identical today. The transcript commits either way; the only difference is
+/// whether the polish call was grounded in the session the user was talking to,
+/// and the user finds out by reading text that mis-transcribed the filenames
+/// they just said.
+///
+/// Three states, not a boolean, for a reason the marker arms make concrete: a
+/// checkmark cannot tell a correct join from a mis-join onto a stale session
+/// (a lingering title marker from an earlier session on the same host can win —
+/// see the residual documented on the remote herdr arm). Naming the joined
+/// workspace is what makes a wrong join recognizable at a glance, and a wrong
+/// join is worse than none.
+enum OverlayClaudeJoinBadge: Equatable, Sendable {
+    /// Nothing to say, so nothing is shown: neither context feature is on, or
+    /// the app knows of no session that could have joined. Silence is the
+    /// honest answer rather than a reassuring one — a user who does not run
+    /// Claude Code must not be told about a join that was never attempted.
+    case hidden
+    /// This dictation is grounded in the named workspace's session.
+    case joined(label: String)
+    /// Live sessions exist and none of them attached. The state the whole badge
+    /// is for: today this is indistinguishable from a working setup until you
+    /// read the committed text.
+    case unjoined
+}
+
+extension OverlayClaudeJoinBadge {
+    /// Longest workspace label the header pill renders. The pill shares one
+    /// header row with the phase title and the "Polished" badge, so the label
+    /// is a name to recognize, not a path to read.
+    static let maximumLabelLength = 24
+
+    /// Shown when a join resolved for a session that never reported a cwd. The
+    /// join is still real — it grounds the prompt — so the badge must not fall
+    /// back to `.unjoined` and call a working setup broken.
+    static let unnamedWorkspaceLabel = "Claude session"
+
+    /// Derives the badge from this dictation's resolved join.
+    ///
+    /// - Parameters:
+    ///   - join: the resolved join, or nil when no arm attached.
+    ///   - contextFeatureEnabled: whether either context feature is on — the
+    ///     SAME condition `resolveClaudeSessionJoin` gates on. Gating the badge
+    ///     on the repo setting alone would hide a real join resolved for screen
+    ///     attachment, which is a join the user cares about just as much.
+    ///   - liveSessionsExist: whether the registry currently holds any session.
+    ///     A closure, and evaluated only on the path that needs it: a resolved
+    ///     join already proves a session exists, and the registry is behind a
+    ///     lock every dictation start is already contending for.
+    static func resolve(
+        join: ClaudeSessionJoin?,
+        contextFeatureEnabled: Bool,
+        liveSessionsExist: () -> Bool
+    ) -> OverlayClaudeJoinBadge {
+        guard contextFeatureEnabled else { return .hidden }
+        if let join {
+            let name = join.snapshot.workspace?.displayName
+            let label = name.flatMap(displayLabel(forWorkspaceName:)) ?? unnamedWorkspaceLabel
+            return .joined(label: label)
+        }
+        // No join AND no session anywhere is the ordinary state of a Mac that
+        // is not running Claude Code. Only a session that COULD have attached
+        // makes "nothing attached" worth a pill.
+        return liveSessionsExist() ? .unjoined : .hidden
+    }
+
+    /// Reduces a workspace display name to something a single-line header pill
+    /// can safely render, or nil when nothing usable survives.
+    ///
+    /// `ClaudeWorkspaceReference.displayName` is already separator-free for a
+    /// REMOTE session (`opaqueLabel` strips it to alphanumerics), but a LOCAL
+    /// one is the last component of a real directory this user's own shell was
+    /// sitting in, and a macOS path component forbids only `/` and NUL — a
+    /// newline, a tab, or a bidi override is a legal directory name. The panel
+    /// is measured from the body text alone (`OverlayLayoutMetrics`), so a
+    /// label carrying a line break would draw outside the height the panel was
+    /// sized for, and a bidi override would reorder the header around it.
+    ///
+    /// Both hazards are neutralized, but not the same way, because they occupy
+    /// different amounts of space:
+    /// - `.control` (Cc — newline, tab) becomes a SPACE. It sits between two
+    ///   runs of text, and deleting it would glue them into one word that names
+    ///   a directory the user does not have.
+    /// - `.format` (Cf — bidi overrides, zero-width joiners) is DROPPED. It is
+    ///   zero-width by definition, so a space in its place would invent one.
+    ///
+    /// Whitespace runs then collapse to a single space — which also covers the
+    /// separator categories (U+2028/U+2029) — so no name can pad the pill wider
+    /// than its own text.
+    static func displayLabel(forWorkspaceName name: String) -> String? {
+        let neutralized = String(
+            String.UnicodeScalarView(
+                name.unicodeScalars.compactMap { scalar -> Unicode.Scalar? in
+                    switch scalar.properties.generalCategory {
+                    case .format: return nil
+                    case .control: return " "
+                    default: return scalar
+                    }
+                }
+            )
+        )
+        let collapsed = neutralized
+            .split(whereSeparator: { $0.isWhitespace })
+            .joined(separator: " ")
+        guard !collapsed.isEmpty else { return nil }
+        guard collapsed.count > maximumLabelLength else { return collapsed }
+        // Head-truncated: the leading characters of a directory name are the
+        // identifying ones, and the ellipsis says the rest was cut rather than
+        // letting a long name read as a different, shorter one.
+        return String(collapsed.prefix(maximumLabelLength - 1)) + "…"
+    }
+}

--- a/Sources/localvoxtral/OverlayLayoutMetrics.swift
+++ b/Sources/localvoxtral/OverlayLayoutMetrics.swift
@@ -28,9 +28,19 @@ struct OverlayLayoutMetrics: Equatable {
 
     var scale: CGFloat { bodyFontSize / Self.baseBodyFontSize }
 
-    // Fonts (11pt title/error at the base 13pt body).
+    // Fonts (11pt title/error, 10pt badge at the base 13pt body).
     var titleFontSize: CGFloat { 11 * scale }
     var errorFontSize: CGFloat { 11 * scale }
+    /// The header's trailing pills ("Polished", the Claude join badge). Scaled
+    /// like every other font here: a fixed 10pt overflowed `headerHeight` at
+    /// the smallest body size (which is `ceil(16 * scale)`, so it shrinks while
+    /// an unscaled pill did not) and shrank to a speck at the largest.
+    var badgeFontSize: CGFloat { 10 * scale }
+    /// Pill chrome, scaled with the pill's own text — unlike `contentPadding`,
+    /// which is deliberately fixed because it frames the panel rather than a
+    /// piece of scaling text.
+    var badgeHorizontalPadding: CGFloat { 6 * scale }
+    var badgeVerticalPadding: CGFloat { 1 * scale }
 
     // Panel geometry (400/420/540 at scale 1.0).
     var panelMinWidth: CGFloat { 400 * scale }

--- a/Tests/localvoxtralTests/AgentDictationE2EEvalTests.swift
+++ b/Tests/localvoxtralTests/AgentDictationE2EEvalTests.swift
@@ -1113,7 +1113,7 @@ private final class EvalOverlayCoordinator: OverlayBufferSessionCoordinating {
         )
     }
 
-    func startSession(preResolvedAnchor _: OverlayAnchor?) {}
+    func startSession(preResolvedAnchor _: OverlayAnchor?, claudeJoin _: OverlayClaudeJoinBadge) {}
     func beginFinalizing(displayBufferText _: String, commitBufferText _: String) {}
     func refresh(displayBufferText _: String, commitBufferText _: String) {}
 

--- a/Tests/localvoxtralTests/ClaudeSessionRegistryTests.swift
+++ b/Tests/localvoxtralTests/ClaudeSessionRegistryTests.swift
@@ -720,6 +720,26 @@ final class ClaudeSessionRegistryTests: XCTestCase {
         XCTAssertEqual(registry.liveSessions().map(\.sessionID), ["second", "first"])
     }
 
+    // `hasLiveSessions` exists so the overlay's join badge can ask about
+    // emptiness without materializing every session's files and snippets. It
+    // must answer exactly what `liveSessions().isEmpty` would — including
+    // across the TTL, or the badge would report "no Claude session" for a live
+    // one, or complain about sessions that have already aged out.
+    func testHasLiveSessionsTracksLiveSessionsExactly() {
+        let clock = TestClock(epoch)
+        let registry = makeRegistry(clock: clock, markers: TestMarkers(["lvx-1"]))
+        XCTAssertFalse(registry.hasLiveSessions())
+        XCTAssertEqual(registry.hasLiveSessions(), !registry.liveSessions().isEmpty)
+
+        registry.ingest(record(.sessionStart), origin: local)
+        XCTAssertTrue(registry.hasLiveSessions())
+        XCTAssertEqual(registry.hasLiveSessions(), !registry.liveSessions().isEmpty)
+
+        clock.advance(ClaudeRegistryLimits.default.sessionTTL + 1)
+        XCTAssertFalse(registry.hasLiveSessions(), "a session past its TTL is not live")
+        XCTAssertEqual(registry.hasLiveSessions(), !registry.liveSessions().isEmpty)
+    }
+
     func testExplicitEvictAndRemoveAll() {
         let registry = makeRegistry(markers: TestMarkers(["lvx-1", "lvx-2"]))
         registry.ingest(record(.sessionStart, session: "s1"), origin: local)

--- a/Tests/localvoxtralTests/DictationViewModelDeltaLoggingTests.swift
+++ b/Tests/localvoxtralTests/DictationViewModelDeltaLoggingTests.swift
@@ -181,7 +181,7 @@ private final class MockOverlayCoordinator: OverlayBufferSessionCoordinating {
     func resolveAnchorNow() -> OverlayAnchor {
         OverlayAnchor(targetRect: CGRect(x: 0, y: 0, width: 100, height: 24), source: .windowCenter)
     }
-    func startSession(preResolvedAnchor: OverlayAnchor?) {}
+    func startSession(preResolvedAnchor: OverlayAnchor?, claudeJoin _: OverlayClaudeJoinBadge) {}
     func beginFinalizing(displayBufferText: String, commitBufferText: String) {}
     func refresh(displayBufferText: String, commitBufferText: String) {}
     func commitIfNeeded(

--- a/Tests/localvoxtralTests/DictationViewModelFailFastUXTests.swift
+++ b/Tests/localvoxtralTests/DictationViewModelFailFastUXTests.swift
@@ -1560,7 +1560,7 @@ private final class NoopOverlayCoordinator: OverlayBufferSessionCoordinating {
     func resolveAnchorNow() -> OverlayAnchor {
         OverlayAnchor(targetRect: .zero, source: .windowCenter)
     }
-    func startSession(preResolvedAnchor: OverlayAnchor?) {}
+    func startSession(preResolvedAnchor: OverlayAnchor?, claudeJoin _: OverlayClaudeJoinBadge) {}
     func beginFinalizing(displayBufferText: String, commitBufferText: String) {}
     func refresh(displayBufferText: String, commitBufferText: String) {}
     @discardableResult

--- a/Tests/localvoxtralTests/DictationViewModelLiveReplacementCorrectorTests.swift
+++ b/Tests/localvoxtralTests/DictationViewModelLiveReplacementCorrectorTests.swift
@@ -337,7 +337,7 @@ private final class MockOverlayCoordinator: OverlayBufferSessionCoordinating {
     func resolveAnchorNow() -> OverlayAnchor {
         OverlayAnchor(targetRect: CGRect(x: 0, y: 0, width: 100, height: 24), source: .windowCenter)
     }
-    func startSession(preResolvedAnchor: OverlayAnchor?) {}
+    func startSession(preResolvedAnchor: OverlayAnchor?, claudeJoin _: OverlayClaudeJoinBadge) {}
     func beginFinalizing(displayBufferText: String, commitBufferText: String) {}
     func refresh(displayBufferText: String, commitBufferText: String) {}
     func commitIfNeeded(

--- a/Tests/localvoxtralTests/DictationViewModelModifierGestureTests.swift
+++ b/Tests/localvoxtralTests/DictationViewModelModifierGestureTests.swift
@@ -216,7 +216,7 @@ private final class GestureTestOverlayCoordinator: OverlayBufferSessionCoordinat
     func resolveAnchorNow() -> OverlayAnchor {
         OverlayAnchor(targetRect: CGRect(x: 0, y: 0, width: 100, height: 24), source: .windowCenter)
     }
-    func startSession(preResolvedAnchor: OverlayAnchor?) {}
+    func startSession(preResolvedAnchor: OverlayAnchor?, claudeJoin _: OverlayClaudeJoinBadge) {}
     func beginFinalizing(displayBufferText: String, commitBufferText: String) {}
     func refresh(displayBufferText: String, commitBufferText: String) {}
     func commitIfNeeded(

--- a/Tests/localvoxtralTests/DictationViewModelOverlayLifecycleTests.swift
+++ b/Tests/localvoxtralTests/DictationViewModelOverlayLifecycleTests.swift
@@ -1246,7 +1246,7 @@ private final class MockOverlayCoordinator: OverlayBufferSessionCoordinating {
         )
     }
 
-    func startSession(preResolvedAnchor: OverlayAnchor?) {
+    func startSession(preResolvedAnchor: OverlayAnchor?, claudeJoin _: OverlayClaudeJoinBadge) {
         startSessionAnchors.append(preResolvedAnchor)
     }
 

--- a/Tests/localvoxtralTests/DictationViewModelPolishFailureDiagnosticsTests.swift
+++ b/Tests/localvoxtralTests/DictationViewModelPolishFailureDiagnosticsTests.swift
@@ -152,7 +152,7 @@ private final class MockOverlayCoordinator: OverlayBufferSessionCoordinating {
         )
     }
 
-    func startSession(preResolvedAnchor _: OverlayAnchor?) {}
+    func startSession(preResolvedAnchor _: OverlayAnchor?, claudeJoin _: OverlayClaudeJoinBadge) {}
     func beginFinalizing(displayBufferText _: String, commitBufferText _: String) {}
     func refresh(displayBufferText _: String, commitBufferText _: String) {}
 

--- a/Tests/localvoxtralTests/DogfoodCaptureWiringTests.swift
+++ b/Tests/localvoxtralTests/DogfoodCaptureWiringTests.swift
@@ -786,7 +786,7 @@ private final class WiringMockOverlayCoordinator: OverlayBufferSessionCoordinati
         )
     }
 
-    func startSession(preResolvedAnchor _: OverlayAnchor?) {}
+    func startSession(preResolvedAnchor _: OverlayAnchor?, claudeJoin _: OverlayClaudeJoinBadge) {}
     func beginFinalizing(displayBufferText _: String, commitBufferText _: String) {}
     func refresh(displayBufferText _: String, commitBufferText _: String) {}
 

--- a/Tests/localvoxtralTests/OnboardingViewModelTests.swift
+++ b/Tests/localvoxtralTests/OnboardingViewModelTests.swift
@@ -235,7 +235,7 @@ private final class OnboardingNoopOverlayCoordinator: OverlayBufferSessionCoordi
     func resolveAnchorNow() -> OverlayAnchor {
         OverlayAnchor(targetRect: .zero, source: .windowCenter)
     }
-    func startSession(preResolvedAnchor: OverlayAnchor?) {}
+    func startSession(preResolvedAnchor: OverlayAnchor?, claudeJoin _: OverlayClaudeJoinBadge) {}
     func beginFinalizing(displayBufferText: String, commitBufferText: String) {}
     func refresh(displayBufferText: String, commitBufferText: String) {}
     @discardableResult

--- a/Tests/localvoxtralTests/OverlayBufferStateMachineTests.swift
+++ b/Tests/localvoxtralTests/OverlayBufferStateMachineTests.swift
@@ -14,7 +14,7 @@ final class OverlayBufferStateMachineTests: XCTestCase {
         machine.setSecureInputWarning()
         XCTAssertNil(machine.snapshot, "no session, no marker")
 
-        machine.startSession(anchor: anchor)
+        machine.startSession(anchor: anchor, claudeJoin: .hidden)
         machine.setSecureInputWarning()
         XCTAssertEqual(machine.snapshot?.secureInputActive, true)
         XCTAssertNil(
@@ -29,7 +29,7 @@ final class OverlayBufferStateMachineTests: XCTestCase {
         )
 
         machine.reset()
-        machine.startSession(anchor: anchor)
+        machine.startSession(anchor: anchor, claudeJoin: .hidden)
         XCTAssertEqual(machine.snapshot?.secureInputActive, false, "a new session starts clean")
 
         machine.beginFinalizing(anchor: nil)
@@ -44,7 +44,7 @@ final class OverlayBufferStateMachineTests: XCTestCase {
         var machine = OverlayBufferStateMachine()
         let anchor = OverlayAnchor(targetRect: CGRect(x: 10, y: 20, width: 100, height: 40), source: .windowCenter)
 
-        machine.startSession(anchor: anchor)
+        machine.startSession(anchor: anchor, claudeJoin: .hidden)
         XCTAssertEqual(machine.phase, .buffering)
 
         machine.updateBuffer(text: "hello world", anchor: nil)
@@ -63,7 +63,7 @@ final class OverlayBufferStateMachineTests: XCTestCase {
         var machine = OverlayBufferStateMachine()
         let anchor = OverlayAnchor(targetRect: CGRect(x: 0, y: 0, width: 40, height: 20), source: .mouseLocation)
 
-        machine.startSession(anchor: anchor)
+        machine.startSession(anchor: anchor, claudeJoin: .hidden)
         machine.updateBuffer(text: "buffered text", anchor: nil)
         machine.beginFinalizing(anchor: nil)
         machine.commitFailed(error: "insert failed", anchor: anchor)
@@ -78,7 +78,7 @@ final class OverlayBufferStateMachineTests: XCTestCase {
         var machine = OverlayBufferStateMachine()
         let anchor = OverlayAnchor(targetRect: CGRect(x: 5, y: 5, width: 80, height: 20), source: .windowCenter)
 
-        machine.startSession(anchor: anchor)
+        machine.startSession(anchor: anchor, claudeJoin: .hidden)
         machine.updateBuffer(text: "hello", anchor: nil)
         machine.beginFinalizing(anchor: nil)
         machine.reset()
@@ -99,7 +99,7 @@ final class OverlayBufferStateMachineTests: XCTestCase {
         machine.setPolished(true)
         XCTAssertNil(machine.snapshot, "no session, no flag")
 
-        machine.startSession(anchor: anchor)
+        machine.startSession(anchor: anchor, claudeJoin: .hidden)
         XCTAssertEqual(machine.snapshot?.polished, false, "a fresh session is unpolished")
 
         machine.beginFinalizing(anchor: nil)
@@ -114,7 +114,7 @@ final class OverlayBufferStateMachineTests: XCTestCase {
 
         machine.setPolished(true)
         machine.reset()
-        machine.startSession(anchor: anchor)
+        machine.startSession(anchor: anchor, claudeJoin: .hidden)
         XCTAssertEqual(
             machine.snapshot?.polished, false,
             "reset + a new session must not carry a stale badge"
@@ -158,26 +158,17 @@ final class OverlayBufferStateMachineTests: XCTestCase {
 
     // MARK: - Claude join badge
 
-    // The badge is set from session start and must ride every later snapshot:
+    // The badge arrives WITH the session and must ride every later snapshot:
     // the join it describes is resolved exactly once, so nothing downstream can
     // change what it should say.
-    func testClaudeJoinBadgeRidesTheSessionAndClearsOnTheNextOne() {
+    func testClaudeJoinBadgeRidesTheWholeSession() {
         var machine = OverlayBufferStateMachine()
         let anchor = OverlayAnchor(
             targetRect: CGRect(x: 0, y: 0, width: 80, height: 24),
             source: .windowCenter
         )
 
-        machine.setClaudeJoin(.joined(label: "localvoxtral"))
-        XCTAssertNil(machine.snapshot, "no session, no badge")
-
-        machine.startSession(anchor: anchor)
-        XCTAssertEqual(
-            machine.snapshot?.claudeJoin, .hidden,
-            "a session starts with nothing to say about a join"
-        )
-
-        machine.setClaudeJoin(.joined(label: "localvoxtral"))
+        machine.startSession(anchor: anchor, claudeJoin: .joined(label: "localvoxtral"))
         XCTAssertEqual(machine.snapshot?.claudeJoin, .joined(label: "localvoxtral"))
 
         machine.updateBuffer(text: "hello", anchor: nil)
@@ -192,25 +183,33 @@ final class OverlayBufferStateMachineTests: XCTestCase {
             machine.snapshot?.claudeJoin, .joined(label: "localvoxtral"),
             "a failed insert says nothing about what the dictation was grounded in"
         )
-
-        // The next dictation's badge is its own. A stale `.joined` surviving
-        // would tell the user THIS session is grounded in one it never resolved.
-        machine.reset()
-        machine.startSession(anchor: anchor)
-        XCTAssertEqual(machine.snapshot?.claudeJoin, .hidden)
     }
 
-    func testClaudeJoinBadgeIsIgnoredWhenIdle() {
+    // The badge cannot outlive the dictation it describes, because starting a
+    // session ASSIGNS it rather than merely clearing it: there is no ordering
+    // in which a stale `.joined` can reach the next session's panel, and no
+    // setter that could put one there later.
+    func testEachSessionsBadgeIsItsOwn() {
         var machine = OverlayBufferStateMachine()
         let anchor = OverlayAnchor(
             targetRect: CGRect(x: 0, y: 0, width: 80, height: 24),
             source: .windowCenter
         )
-        machine.startSession(anchor: anchor)
-        machine.setClaudeJoin(.unjoined)
+
+        machine.startSession(anchor: anchor, claudeJoin: .joined(label: "localvoxtral"))
         machine.reset()
-        machine.setClaudeJoin(.joined(label: "sneaky"))
-        XCTAssertNil(machine.snapshot, "idle renders nothing at all")
-        XCTAssertEqual(machine.claudeJoin, .hidden, "and holds nothing to render later")
+        XCTAssertEqual(machine.claudeJoin, .hidden, "reset holds nothing to render later")
+
+        machine.startSession(anchor: anchor, claudeJoin: .unjoined)
+        XCTAssertEqual(machine.snapshot?.claudeJoin, .unjoined)
+
+        // Even without an intervening reset: a second startSession is refused
+        // outright (guarded on `.idle`), so it cannot half-apply a new badge to
+        // a running session either.
+        machine.startSession(anchor: anchor, claudeJoin: .joined(label: "sneaky"))
+        XCTAssertEqual(
+            machine.snapshot?.claudeJoin, .unjoined,
+            "the running session keeps the badge it was started with"
+        )
     }
 }

--- a/Tests/localvoxtralTests/OverlayBufferStateMachineTests.swift
+++ b/Tests/localvoxtralTests/OverlayBufferStateMachineTests.swift
@@ -155,4 +155,62 @@ final class OverlayBufferStateMachineTests: XCTestCase {
         let commitText = OverlayBufferTextAssembler.insertionText(from: "  hello world  ")
         XCTAssertEqual(commitText, "hello world")
     }
+
+    // MARK: - Claude join badge
+
+    // The badge is set from session start and must ride every later snapshot:
+    // the join it describes is resolved exactly once, so nothing downstream can
+    // change what it should say.
+    func testClaudeJoinBadgeRidesTheSessionAndClearsOnTheNextOne() {
+        var machine = OverlayBufferStateMachine()
+        let anchor = OverlayAnchor(
+            targetRect: CGRect(x: 0, y: 0, width: 80, height: 24),
+            source: .windowCenter
+        )
+
+        machine.setClaudeJoin(.joined(label: "localvoxtral"))
+        XCTAssertNil(machine.snapshot, "no session, no badge")
+
+        machine.startSession(anchor: anchor)
+        XCTAssertEqual(
+            machine.snapshot?.claudeJoin, .hidden,
+            "a session starts with nothing to say about a join"
+        )
+
+        machine.setClaudeJoin(.joined(label: "localvoxtral"))
+        XCTAssertEqual(machine.snapshot?.claudeJoin, .joined(label: "localvoxtral"))
+
+        machine.updateBuffer(text: "hello", anchor: nil)
+        machine.beginFinalizing(anchor: nil)
+        XCTAssertEqual(
+            machine.snapshot?.claudeJoin, .joined(label: "localvoxtral"),
+            "the badge annotates the whole session, including the polished hold"
+        )
+
+        machine.commitFailed(error: "nope", anchor: nil)
+        XCTAssertEqual(
+            machine.snapshot?.claudeJoin, .joined(label: "localvoxtral"),
+            "a failed insert says nothing about what the dictation was grounded in"
+        )
+
+        // The next dictation's badge is its own. A stale `.joined` surviving
+        // would tell the user THIS session is grounded in one it never resolved.
+        machine.reset()
+        machine.startSession(anchor: anchor)
+        XCTAssertEqual(machine.snapshot?.claudeJoin, .hidden)
+    }
+
+    func testClaudeJoinBadgeIsIgnoredWhenIdle() {
+        var machine = OverlayBufferStateMachine()
+        let anchor = OverlayAnchor(
+            targetRect: CGRect(x: 0, y: 0, width: 80, height: 24),
+            source: .windowCenter
+        )
+        machine.startSession(anchor: anchor)
+        machine.setClaudeJoin(.unjoined)
+        machine.reset()
+        machine.setClaudeJoin(.joined(label: "sneaky"))
+        XCTAssertNil(machine.snapshot, "idle renders nothing at all")
+        XCTAssertEqual(machine.claudeJoin, .hidden, "and holds nothing to render later")
+    }
 }

--- a/Tests/localvoxtralTests/OverlayClaudeJoinBadgeTests.swift
+++ b/Tests/localvoxtralTests/OverlayClaudeJoinBadgeTests.swift
@@ -202,6 +202,22 @@ final class OverlayClaudeJoinBadgeTests: XCTestCase {
         )
     }
 
+    // U+2028/U+2029 are LINE and PARAGRAPH SEPARATOR: category Zl/Zp, so
+    // neither the `.control` nor the `.format` branch touches them, and they
+    // survive to the whitespace collapse. They break lines like a newline does,
+    // so this is the assertion that stops a future "collapse ASCII whitespace"
+    // refactor from silently letting one through into a single-line header.
+    func testUnicodeLineAndParagraphSeparatorsCollapseToASpace() {
+        XCTAssertEqual(
+            OverlayClaudeJoinBadge.displayLabel(forWorkspaceName: "repo\u{2028}x"),
+            "repo x"
+        )
+        XCTAssertEqual(
+            OverlayClaudeJoinBadge.displayLabel(forWorkspaceName: "repo\u{2029}x"),
+            "repo x"
+        )
+    }
+
     func testWhitespaceRunsCollapseSoALabelCannotPadThePill() {
         XCTAssertEqual(
             OverlayClaudeJoinBadge.displayLabel(forWorkspaceName: "  my    repo  "),

--- a/Tests/localvoxtralTests/OverlayClaudeJoinBadgeTests.swift
+++ b/Tests/localvoxtralTests/OverlayClaudeJoinBadgeTests.swift
@@ -1,0 +1,231 @@
+import ClaudeContextWire
+import Foundation
+import Synchronization
+import XCTest
+@testable import localvoxtral
+
+private final class BadgeTestMarkers: Sendable {
+    private let queue: Mutex<[String]>
+    init(_ values: [String]) { queue = Mutex(values) }
+    var allocate: @Sendable () -> String {
+        { [self] in queue.withLock { $0.isEmpty ? "lvx-exhausted" : $0.removeFirst() } }
+    }
+}
+
+/// The overlay's join badge: what it says, when it says nothing, and what it
+/// refuses to render.
+///
+/// Joins are built through the REAL registry and resolver rather than a literal
+/// `ClaudeSessionJoin`, so the workspace label under test is the one the wire
+/// path actually produces for each origin.
+@MainActor
+final class OverlayClaudeJoinBadgeTests: XCTestCase {
+    private let ghostty = TerminalScreenTarget(
+        pid: 4242,
+        bundleID: TerminalScreenAllowlist.ghosttyBundleID
+    )
+    private let local = ClaudeTransportOrigin.localAuthenticated(peerUID: 501)
+    private let remote = ClaudeTransportOrigin.remote(channel: "c1")
+
+    private func registry(markers: [String] = ["lvx-abcd"]) -> ClaudeSessionRegistry {
+        ClaudeSessionRegistry(
+            now: { Date(timeIntervalSince1970: 1_000) },
+            isProcessAlive: { _ in true },
+            allocateMarkerValue: BadgeTestMarkers(markers).allocate
+        )
+    }
+
+    /// A resolved join for a session whose cwd is `cwd`, via the marker arm.
+    private func join(
+        cwd: String?,
+        origin: ClaudeTransportOrigin? = nil
+    ) async -> ClaudeSessionJoin? {
+        let registry = registry()
+        registry.ingest(
+            ClaudeHookRecord(
+                event: .sessionStart,
+                sessionID: "s1",
+                timestamp: 0,
+                rawCwd: cwd,
+                process: ClaudeHookProcessInfo(hookPID: 777, claudePID: 9001)
+            ),
+            origin: origin ?? local
+        )
+        let resolver = ClaudeSessionJoinResolver(
+            registry: registry,
+            markerInWindowTitle: { _ in
+                TerminalScreenAXReader.FocusedWindowMarkerRead(
+                    marker: ClaudeSessionMarker(value: "lvx-abcd"), windowID: 101
+                )
+            }
+        )
+        return await resolver.resolve(target: ghostty)
+    }
+
+    // MARK: - What the badge says
+
+    func testAResolvedLocalJoinNamesItsWorkspace() async {
+        let join = await join(cwd: "/Users/dev/work/localvoxtral")
+        XCTAssertNotNil(join, "positive control: the badge cases below mean nothing without a join")
+        XCTAssertEqual(
+            OverlayClaudeJoinBadge.resolve(
+                join: join,
+                contextFeatureEnabled: true,
+                liveSessionsExist: { true }
+            ),
+            .joined(label: "localvoxtral")
+        )
+    }
+
+    // A remote session's cwd never survives as a path — `opaqueLabel` reduces it
+    // to a bare name. The badge shows that name and nothing else.
+    func testAResolvedRemoteJoinNamesItsOpaqueLabel() async {
+        let join = await join(cwd: "/srv/checkouts/api-gateway", origin: remote)
+        XCTAssertEqual(
+            OverlayClaudeJoinBadge.resolve(
+                join: join,
+                contextFeatureEnabled: true,
+                liveSessionsExist: { true }
+            ),
+            .joined(label: "api-gateway")
+        )
+    }
+
+    // A join with no cwd is still a real join — it grounds the prompt with the
+    // session's prior prompt and files. Falling back to `.unjoined` would call a
+    // working setup broken.
+    func testAJoinWithoutAWorkspaceStaysJoined() async {
+        let join = await join(cwd: nil)
+        XCTAssertEqual(
+            OverlayClaudeJoinBadge.resolve(
+                join: join,
+                contextFeatureEnabled: true,
+                liveSessionsExist: { true }
+            ),
+            .joined(label: OverlayClaudeJoinBadge.unnamedWorkspaceLabel)
+        )
+    }
+
+    // The state the feature exists for: sessions are live, none attached.
+    func testNoJoinWithLiveSessionsIsUnjoined() {
+        XCTAssertEqual(
+            OverlayClaudeJoinBadge.resolve(
+                join: nil,
+                contextFeatureEnabled: true,
+                liveSessionsExist: { true }
+            ),
+            .unjoined
+        )
+    }
+
+    // MARK: - When it says nothing
+
+    // A Mac that is not running Claude Code must not wear a permanent
+    // complaint about a join that was never attempted.
+    func testNoJoinAndNoSessionsIsSilent() {
+        XCTAssertEqual(
+            OverlayClaudeJoinBadge.resolve(
+                join: nil,
+                contextFeatureEnabled: true,
+                liveSessionsExist: { false }
+            ),
+            .hidden
+        )
+    }
+
+    // Both context features off means nothing downstream would have used a
+    // join, so there is nothing to report — even when one resolved before the
+    // settings changed.
+    func testFeaturesOffHideTheBadgeEvenWithAJoin() async {
+        let join = await join(cwd: "/repo")
+        XCTAssertEqual(
+            OverlayClaudeJoinBadge.resolve(
+                join: join,
+                contextFeatureEnabled: false,
+                liveSessionsExist: { true }
+            ),
+            .hidden
+        )
+    }
+
+    // The registry lives behind a lock every dictation start already contends
+    // for, and a resolved join has already proved a session exists.
+    func testTheRegistryIsNotConsultedWhenAJoinResolved() async {
+        let join = await join(cwd: "/repo")
+        let asked = Mutex(0)
+        _ = OverlayClaudeJoinBadge.resolve(
+            join: join,
+            contextFeatureEnabled: true,
+            liveSessionsExist: {
+                asked.withLock { $0 += 1 }
+                return true
+            }
+        )
+        XCTAssertEqual(asked.withLock { $0 }, 0)
+    }
+
+    // The settings gate sits in front of the registry read too: a user with
+    // both features off pays nothing.
+    func testTheRegistryIsNotConsultedWhenFeaturesAreOff() {
+        let asked = Mutex(0)
+        _ = OverlayClaudeJoinBadge.resolve(
+            join: nil,
+            contextFeatureEnabled: false,
+            liveSessionsExist: {
+                asked.withLock { $0 += 1 }
+                return true
+            }
+        )
+        XCTAssertEqual(asked.withLock { $0 }, 0)
+    }
+
+    // MARK: - What it refuses to render
+
+    // A LOCAL workspace name is the last component of a real directory, and a
+    // macOS path component forbids only `/` and NUL. The panel is measured from
+    // the body text alone, so a label carrying a line break would draw outside
+    // the height the panel was sized for.
+    func testControlCharactersAreStrippedFromTheLabel() {
+        XCTAssertEqual(
+            OverlayClaudeJoinBadge.displayLabel(forWorkspaceName: "repo\nname\tx"),
+            "repo name x"
+        )
+    }
+
+    // RIGHT-TO-LEFT OVERRIDE is category Cf, which `controlCharacters` covers —
+    // a header that reorders around a directory name is not a display this
+    // badge may produce.
+    func testBidiOverridesAreStrippedFromTheLabel() {
+        XCTAssertEqual(
+            OverlayClaudeJoinBadge.displayLabel(forWorkspaceName: "repo\u{202E}drowssap"),
+            "repodrowssap"
+        )
+    }
+
+    func testWhitespaceRunsCollapseSoALabelCannotPadThePill() {
+        XCTAssertEqual(
+            OverlayClaudeJoinBadge.displayLabel(forWorkspaceName: "  my    repo  "),
+            "my repo"
+        )
+    }
+
+    func testAnOverlongLabelIsTruncatedWithAnEllipsis() throws {
+        let name = String(repeating: "a", count: 80)
+        let label = try XCTUnwrap(OverlayClaudeJoinBadge.displayLabel(forWorkspaceName: name))
+        XCTAssertEqual(label.count, OverlayClaudeJoinBadge.maximumLabelLength)
+        XCTAssertTrue(label.hasSuffix("…"))
+        XCTAssertTrue(label.hasPrefix("aaa"))
+    }
+
+    func testALabelAtTheLimitIsLeftAlone() throws {
+        let name = String(repeating: "b", count: OverlayClaudeJoinBadge.maximumLabelLength)
+        XCTAssertEqual(OverlayClaudeJoinBadge.displayLabel(forWorkspaceName: name), name)
+    }
+
+    // Nothing usable left is nil, which the resolver turns into the unnamed
+    // fallback rather than an empty pill.
+    func testALabelOfNothingButControlCharactersIsRejected() {
+        XCTAssertNil(OverlayClaudeJoinBadge.displayLabel(forWorkspaceName: "\n\t\u{202E}"))
+        XCTAssertNil(OverlayClaudeJoinBadge.displayLabel(forWorkspaceName: "   "))
+    }
+}

--- a/Tests/localvoxtralTests/OverlayLayoutMetricsTests.swift
+++ b/Tests/localvoxtralTests/OverlayLayoutMetricsTests.swift
@@ -1,3 +1,4 @@
+import AppKit
 import XCTest
 
 @testable import localvoxtral
@@ -99,6 +100,44 @@ final class OverlayLayoutMetricsTests: XCTestCase {
         let nextSession = lock.metrics(currentFontSize: 24)
         XCTAssertEqual(nextSession.bodyFontSize, 24)
         XCTAssertGreaterThan(nextSession.panelWidth, first.panelWidth)
+    }
+
+    // The header's pills ("Polished", the Claude join badge) used a hardcoded
+    // 10pt while `headerHeight` scaled with the body-size setting — so the pill
+    // overflowed the header it sits in at the smallest size and shrank to a
+    // speck at the largest. Every font here scales from the one setting; these
+    // are not exceptions.
+    func testBadgeFontScalesWithTheBodyFontSetting() {
+        let smallest = OverlayLayoutMetrics(bodyFontSize: OverlayLayoutMetrics.minimumBodyFontSize)
+        let base = OverlayLayoutMetrics(bodyFontSize: Double(OverlayLayoutMetrics.baseBodyFontSize))
+        let largest = OverlayLayoutMetrics(bodyFontSize: OverlayLayoutMetrics.maximumBodyFontSize)
+
+        XCTAssertEqual(base.badgeFontSize, 10, "10pt at the base 13pt body, as before")
+        XCTAssertLessThan(smallest.badgeFontSize, base.badgeFontSize)
+        XCTAssertGreaterThan(largest.badgeFontSize, base.badgeFontSize)
+        XCTAssertEqual(smallest.badgeFontSize / smallest.titleFontSize,
+                       largest.badgeFontSize / largest.titleFontSize,
+                       accuracy: 0.0001,
+                       "the pill keeps its proportion to the title at every size")
+    }
+
+    // The pill must fit the header row it is framed by, at BOTH ends of the
+    // setting's range — that containment is what the unscaled font broke.
+    func testBadgePillFitsTheHeaderAtEverySize() {
+        for size in [
+            OverlayLayoutMetrics.minimumBodyFontSize,
+            OverlayLayoutMetrics.defaultBodyFontSize,
+            OverlayLayoutMetrics.maximumBodyFontSize,
+        ] {
+            let metrics = OverlayLayoutMetrics(bodyFontSize: size)
+            let font = NSFont.systemFont(ofSize: metrics.badgeFontSize)
+            let pillHeight = ceil(font.ascender - font.descender + font.leading)
+                + metrics.badgeVerticalPadding * 2
+            XCTAssertLessThanOrEqual(
+                pillHeight, metrics.headerHeight,
+                "badge pill overflows the header at body size \(size)"
+            )
+        }
     }
 
     func testErrorMessageAddsHeight() {

--- a/Tests/localvoxtralTests/PolishTokenGuardTests.swift
+++ b/Tests/localvoxtralTests/PolishTokenGuardTests.swift
@@ -2243,7 +2243,7 @@ private final class MockOverlayCoordinator: OverlayBufferSessionCoordinating {
         )
     }
 
-    func startSession(preResolvedAnchor: OverlayAnchor?) {
+    func startSession(preResolvedAnchor: OverlayAnchor?, claudeJoin _: OverlayClaudeJoinBadge) {
         startSessionAnchors.append(preResolvedAnchor)
     }
 

--- a/Tests/localvoxtralTests/RealtimeAPILivePastePunctuationTests.swift
+++ b/Tests/localvoxtralTests/RealtimeAPILivePastePunctuationTests.swift
@@ -264,7 +264,7 @@ private final class MockOverlayCoordinator: OverlayBufferSessionCoordinating {
     func resolveAnchorNow() -> OverlayAnchor {
         OverlayAnchor(targetRect: CGRect(x: 0, y: 0, width: 100, height: 24), source: .windowCenter)
     }
-    func startSession(preResolvedAnchor: OverlayAnchor?) {}
+    func startSession(preResolvedAnchor: OverlayAnchor?, claudeJoin _: OverlayClaudeJoinBadge) {}
     func beginFinalizing(displayBufferText: String, commitBufferText: String) {}
     func refresh(displayBufferText: String, commitBufferText: String) {}
     func commitIfNeeded(

--- a/Tests/localvoxtralTests/TerminalTargetDetectorTests.swift
+++ b/Tests/localvoxtralTests/TerminalTargetDetectorTests.swift
@@ -843,7 +843,7 @@ private final class TargetDetectorNoopOverlayCoordinator: OverlayBufferSessionCo
     func resolveAnchorNow() -> OverlayAnchor {
         OverlayAnchor(targetRect: .zero, source: .windowCenter)
     }
-    func startSession(preResolvedAnchor: OverlayAnchor?) {}
+    func startSession(preResolvedAnchor: OverlayAnchor?, claudeJoin _: OverlayClaudeJoinBadge) {}
     func beginFinalizing(displayBufferText: String, commitBufferText: String) {}
     func refresh(displayBufferText: String, commitBufferText: String) {}
     var commitOutcome: OverlayBufferCommitOutcome = .succeeded

--- a/docs/agent/invariants.md
+++ b/docs/agent/invariants.md
@@ -379,6 +379,22 @@ there is not.
     browser), and each browser needs its own TCC Automation grant — pre-warmed
     by its own `TerminalAutomationConsentPrewarmSettingsObserver` under that
     same setting, since the consent sheet dies with the 1 s read that raised it.
+  - The overlay's join badge (`OverlayClaudeJoinBadge`) DESCRIBES the resolved
+    join; it never resolves one. It reads `claudeSessionJoin` after the single
+    start-time resolution and nothing else — a badge that asked again could name
+    a different session than the context actually attached, which is the exact
+    failure the once-per-dictation rule exists to prevent. Its one extra read is
+    `registry.hasLiveSessions()`, which touches no title, TTY, socket, or process
+    table and only chooses between "nothing attached" and showing nothing at all.
+    What it renders is a length-capped workspace `displayName` with control
+    characters neutralized: a LOCAL name is the last component of a real
+    directory, where a newline is legal and the panel is measured from the body
+    text alone. Cc (newline, tab) becomes a space — deleting it would glue two
+    runs into a directory name the user does not have — while Cf (bidi
+    overrides, zero-width joiners) is dropped, being zero-width already. It names the joined workspace
+    rather than showing a checkmark because a mis-join — a stale marker winning,
+    the residual documented on the marker and remote-herdr arms — is invisible to
+    a boolean and obvious next to the wrong repo's name.
   - Lookups abstain rather than guess: no marker, unknown, stale, or ambiguous
     means no context. There is deliberately no sole-session or cwd heuristic —
     it is wrong precisely when it matters.

--- a/docs/agent/invariants.md
+++ b/docs/agent/invariants.md
@@ -391,10 +391,16 @@ there is not.
     directory, where a newline is legal and the panel is measured from the body
     text alone. Cc (newline, tab) becomes a space — deleting it would glue two
     runs into a directory name the user does not have — while Cf (bidi
-    overrides, zero-width joiners) is dropped, being zero-width already. It names the joined workspace
-    rather than showing a checkmark because a mis-join — a stale marker winning,
-    the residual documented on the marker and remote-herdr arms — is invisible to
-    a boolean and obvious next to the wrong repo's name.
+    overrides, zero-width joiners) is dropped, being zero-width already.
+    It names the joined workspace rather than showing a checkmark because a
+    mis-join — a stale marker winning, the residual documented on the marker and
+    remote-herdr arms — is invisible to a boolean and obvious next to the wrong
+    repo's name.
+    The badge travels as a PARAMETER of `startSession`, never a later setter:
+    starting a session resets the panel, so a badge pushed before it was wiped
+    and one pushed after depended on an order nothing enforced. It is always
+    already known there — the join resolves before the realtime socket connects,
+    and the panel opens after it.
   - Lookups abstain rather than guess: no marker, unknown, stale, or ambiguous
     means no context. There is deliberately no sole-session or cwd heuristic —
     it is wrong precisely when it matters.


### PR DESCRIPTION
## What

Names the Claude Code session a dictation is grounded in, in the overlay buffer's header — or says that none attached.

A join that silently did not happen and one that did look identical today. The transcript commits either way; the only difference is whether the polish call was grounded, and you find out by reading text that mis-transcribed the filenames you just said. That is how the ProxyJump/herdr abstention #228 fixes was found in the first place.

**Why the overlay rather than a status line or the menu bar.** The join is resolved on this Mac at dictation start, and the overlay opens on this Mac at dictation start. So the badge is a read of the ONE resolved answer: no wire format, no stamp file, no staleness gate, no host-vs-session attribution, no parsing in the remote shim, and nothing new on the dictation-start latency path (the probe already ran). Coverage is exact rather than partial: `capturedClaudeJoin` is consumed only inside the `if let endpointURL = polishingConfig?.endpointURL` branch, and polish is Overlay Buffer only — the join never matters where there is no overlay.

**Three states, not a boolean.**

| Badge | Meaning |
|---|---|
| `🔗 <workspace>` | this dictation is grounded in that session |
| `🔗̸ No Claude session` | live sessions exist and none attached |
| *(nothing)* | neither context feature is on, or no session could have joined |

A checkmark cannot tell a correct join from a mis-join onto a stale session — the residual documented on the marker and remote-herdr arms, where a lingering title marker from an earlier session can win. Naming the workspace is what makes a wrong join recognizable at a glance. And a Mac that is not running Claude Code wears no permanent complaint: silence is the honest answer when nothing was attempted.

Same quiet weight as the existing "Polished" pill, deliberately — an unjoined dictation still commits its text correctly, so this annotates the panel. It is not an error, and the warning color under the transcript stays reserved for text that failed to insert. The distinction rides the icon (`link` / `link.slash`) and the label, not color, so it needs no second appearance-matched palette.

**Invariants kept.** The badge DESCRIBES the resolved join; it never resolves one. Re-asking at display time is exactly what the once-per-dictation rule exists to prevent — a second resolution could name a different session than the context actually attached. Its one extra read is `registry.hasLiveSessions()`, which touches no title, TTY, socket, or process table, and is consulted only when no join resolved (a resolved join already proves a session exists). `docs/agent/invariants.md` updated.

The label is a length-capped workspace `displayName` with control characters neutralized. A LOCAL workspace name is the last component of a real directory, and a macOS path component forbids only `/` and NUL — a newline is a legal directory name, and the panel is measured from the body text alone, so a label carrying a line break would draw outside the height the panel was sized for. Cc (newline, tab) becomes a space; deleting it would glue two runs into a directory the user does not have. Cf (bidi overrides, zero-width joiners) is dropped, being zero-width already.

Ordering trap, documented at both ends: the join resolves before the realtime socket connects, but `startSession` clears the state machine — so the badge is latched on the view model (exactly like `sessionSecureInputActive`) and pushed after `startSession`, not at resolution time.

[dogfood-package]

## Proof

- Unit suite green — full run after the change:
  `Executed 2638 tests, with 2 tests skipped and 0 failures (0 unexpected) in 105.216 (105.354) seconds`
- New suite alone, `./scripts/remote-build.sh test --filter OverlayClaudeJoinBadgeTests`:
  `Executed 14 tests, with 0 failures (0 unexpected) in 0.005 (0.005) seconds`
- Red/green, and it caught a real deficiency rather than confirming one. The first full run failed on the label test:
  ```
  OverlayClaudeJoinBadgeTests.swift:189: error: testControlCharactersAreStrippedFromTheLabel :
  XCTAssertEqual failed: ("Optional("reponamex")") is not equal to ("Optional("repo name x")")
  Executed 2638 tests, with 2 tests skipped and 1 failure (0 unexpected) in 105.953 (106.101) seconds
  ```
  `\n` and `\t` are Cc, so filtering `CharacterSet.controlCharacters` deleted them outright and glued `repo\nname` into `reponame` — a label naming a directory that does not exist. Fixed by splitting the two categories (Cc → space, Cf → dropped) rather than by relaxing the expectation; green above.
- Behavior pinned by name, not just by count:
  - `testAResolvedLocalJoinNamesItsWorkspace`, `testAResolvedRemoteJoinNamesItsOpaqueLabel` — joins built through the REAL registry + resolver, so the label under test is what the wire path actually produces per origin.
  - `testAJoinWithoutAWorkspaceStaysJoined` — a cwd-less join is still a real join; falling back to `.unjoined` would call a working setup broken.
  - `testNoJoinWithLiveSessionsIsUnjoined` / `testNoJoinAndNoSessionsIsSilent` / `testFeaturesOffHideTheBadgeEvenWithAJoin` — the three-way gate.
  - `testTheRegistryIsNotConsultedWhenAJoinResolved`, `testTheRegistryIsNotConsultedWhenFeaturesAreOff` — the extra read stays off the paths that do not need it.
  - `testBidiOverridesAreStrippedFromTheLabel`, `testControlCharactersAreStrippedFromTheLabel`, `testWhitespaceRunsCollapseSoALabelCannotPadThePill`, `testAnOverlongLabelIsTruncatedWithAnEllipsis`, `testALabelAtTheLimitIsLeftAlone`, `testALabelOfNothingButControlCharactersIsRejected`.
  - `OverlayBufferStateMachineTests.testClaudeJoinBadgeRidesTheSessionAndClearsOnTheNextOne` / `…IsIgnoredWhenIdle` — the badge annotates the whole session including the polished hold and a failed commit, and a new session starts clean. These two are also what pin the ordering rule the view model depends on: set before `startSession`, it is dropped.
  - `ClaudeSessionRegistryTests.testHasLiveSessionsTracksLiveSessionsExactly` — asserted equal to `!liveSessions().isEmpty` on both sides of the TTL, on the injected clock (no wall-clock).
- LLM lanes: nothing here alters what reaches the model — the badge is display-only and reads a join that was already resolved. `Sources/localvoxtral/ClaudeContext/*` is in `llm-lane-filter.sh`, so the polishd lane runs by filter anyway.
- **UI change — NOT yet verified by hand.** This was written from a Linux box; I cannot run the app. What is verified is the state machine's contract, the badge derivation, and the label sanitizer, all above. What is NOT: how the pill actually looks in the header next to a long phase title (the secure-input title is the worst case) and next to the "Polished" pill, and whether `.layoutPriority(-1)` truncates the workspace name the way it should rather than squeezing the title. `[dogfood-package]` is set — owner please install via `./scripts/try-pr.sh <this PR> --dogfood`, dictate once with a Claude session joined and once without, and confirm both pills coexist without pushing the title out.
