### PR TITLE
SSH probe: accept destination-inert -o SetEnv/SendEnv; scope the competing scan to the surface owner's uid

### DIFF
--- a/Sources/localvoxtral/ClaudeContext/SSHDestinationTTYProbe.swift
+++ b/Sources/localvoxtral/ClaudeContext/SSHDestinationTTYProbe.swift
@@ -123,6 +123,14 @@ struct SSHClientProcess: Sendable, Equatable {
     var processGroupID: Int32
     /// The foreground process group of its controlling terminal.
     var terminalForegroundGroupID: Int32
+    /// Kernel credential (`e_ucred.cr_uid`), never self-reported. A process
+    /// owned by another user stays visible to the SURFACE question — a
+    /// `sudo ssh` in this terminal's foreground must abstain, not vanish —
+    /// but it is invisible to the competing-view scan, and its executable
+    /// path and argv are never read (they would fail cross-uid anyway).
+    /// The default exists for test convenience only; the live scan always
+    /// stamps the real credential.
+    var effectiveUserID: uid_t
     /// Resolved executable path (`proc_pidpath`), not argv[0] and not `p_comm`.
     var executablePath: String?
     var arguments: [String]?
@@ -133,6 +141,7 @@ struct SSHClientProcess: Sendable, Equatable {
         ttyDevice: dev_t?,
         processGroupID: Int32,
         terminalForegroundGroupID: Int32,
+        effectiveUserID: uid_t = 0,
         executablePath: String?,
         arguments: [String]?
     ) {
@@ -141,6 +150,7 @@ struct SSHClientProcess: Sendable, Equatable {
         self.ttyDevice = ttyDevice
         self.processGroupID = processGroupID
         self.terminalForegroundGroupID = terminalForegroundGroupID
+        self.effectiveUserID = effectiveUserID
         self.executablePath = executablePath
         self.arguments = arguments
     }
@@ -169,9 +179,9 @@ struct SSHClientProcess: Sendable, Equatable {
 ///   stopped ssh, a background one, or an ssh spawned by `scp`/`rsync` cannot
 ///   be mistaken for the session on screen;
 /// * any option that can move the destination or means "this is not an
-///   interactive session" — `-o` (HostName/Port/User/ProxyJump/…), `-F`, `-O`,
-///   `-S`, `-N`, `-f`, `-M`, `-D`, `-W`, `-w` — ABSTAINS instead of being
-///   skipped.
+///   interactive session" — `-o` (HostName/Port/User/ProxyJump/…) except
+///   destination-inert `SetEnv`/`SendEnv`, `-F`, `-O`, `-S`, `-N`, `-f`, `-M`,
+///   `-D`, `-W`, `-w` — ABSTAINS instead of being skipped.
 enum SSHDestinationTTYProbe {
     /// The only executables we are willing to believe are OpenSSH: three exact
     /// absolute paths, the system client plus Homebrew's on both architectures.
@@ -325,6 +335,7 @@ enum SSHDestinationTTYProbe {
                     destination: parsed.destination,
                     surfaceHerdr: parsed.herdr,
                     surfacePID: surfaceProcess.pid,
+                    surfaceUserID: surfaceProcess.effectiveUserID,
                     connections: connections
                 ),
                 herdr: parsed.herdr
@@ -366,8 +377,14 @@ enum SSHDestinationTTYProbe {
     /// including suspended ones on THIS device (review round 5b: a suspended
     /// `ssh builder herdr <verb>` keeps its server side attached). Excluded:
     /// the surface's own connection, anything with no controlling terminal
-    /// (our own `ssh -L` forward), and ssh MACHINERY (the caller passes
-    /// connections only — a ProxyJump's `-W` child is its root's transport).
+    /// (our own `ssh -L` forward), ssh MACHINERY (the caller passes
+    /// connections only — a ProxyJump's `-W` child is its root's transport),
+    /// and processes owned by ANOTHER user: their herdr view lives in their
+    /// own login session, not on a surface this user could be dictating
+    /// into, and their metadata is unreadable-by-design, so counting them
+    /// meant every root/other-user ssh on the machine was a blanket
+    /// abstention. (A cross-uid ssh ON the surface never reaches this scan —
+    /// its unreadable executable abstains the probe first.)
     ///
     /// The refusal ladder for a neighbor, most to least readable:
     /// parsed to another destination — irrelevant (its herdr, if any, is
@@ -382,10 +399,12 @@ enum SSHDestinationTTYProbe {
         destination: String,
         surfaceHerdr: HerdrInvocation,
         surfacePID: Int32,
+        surfaceUserID: uid_t,
         connections: [SSHClientProcess]
     ) -> Bool {
         for process in connections
-        where process.ttyDevice != nil && process.pid != surfacePID {
+        where process.ttyDevice != nil && process.pid != surfacePID
+            && process.effectiveUserID == surfaceUserID {
             guard let executablePath = process.executablePath,
                   isTrustedSSHExecutable(executablePath),
                   let arguments = process.arguments
@@ -440,9 +459,10 @@ enum SSHDestinationTTYProbe {
     /// they mean this is not an interactive session on a terminal (`-N`, `-f`,
     /// `-M`, `-O`, `-S`, `-D`, `-W`, `-w`).
     ///
-    /// `-o` is refused wholesale rather than parsed: proving a specific option
-    /// inert means reimplementing OpenSSH's config semantics, and the cost of
-    /// refusing is one join that does not happen.
+    /// `-o` is refused wholesale except for exact `SetEnv=` / `SendEnv=` keys.
+    /// Those only shape the remote environment: they cannot move the
+    /// destination or change whether the session is interactive. No other
+    /// config semantics are reimplemented here.
     private static let refusedOptions = Set("oFOSNfMDWw")
 
     /// The destination host and whether the remote command names herdr, or nil
@@ -466,6 +486,12 @@ enum SSHDestinationTTYProbe {
                 )
             }
             if token.hasPrefix("-"), token.count > 1 {
+                if let consumed = destinationInertOOptionArgumentCount(
+                    token, nextArgument: index + 1 < argv.count ? argv[index + 1] : nil
+                ) {
+                    index += consumed
+                    continue
+                }
                 switch consumption(ofOptionToken: token) {
                 case .unrecognized, .refused:
                     return nil
@@ -588,6 +614,31 @@ enum SSHDestinationTTYProbe {
         return .selfContained
     }
 
+    /// Number of argv elements consumed by an allowlisted `-o`, including
+    /// `-o` after pure flags in a cluster (`-to SetEnv=…`). Anything before the
+    /// `o` that is not a pure flag belongs to the ordinary option parser.
+    private static func destinationInertOOptionArgumentCount(
+        _ token: String, nextArgument: String?
+    ) -> Int? {
+        let characters = Array(token.dropFirst())
+        for (index, character) in characters.enumerated() {
+            if flagOptions.contains(character) { continue }
+            guard character == "o" else { return nil }
+            if index == characters.count - 1 {
+                guard let nextArgument, isDestinationInertOOption(nextArgument) else { return nil }
+                return 2
+            }
+            let value = String(characters[(index + 1)...])
+            return isDestinationInertOOption(value) ? 1 : nil
+        }
+        return nil
+    }
+
+    private static func isDestinationInertOOption(_ value: String) -> Bool {
+        value.range(of: "SetEnv=", options: [.anchored, .caseInsensitive]) != nil
+            || value.range(of: "SendEnv=", options: [.anchored, .caseInsensitive]) != nil
+    }
+
     /// The host part of an ssh destination operand, lowercased, or nil when the
     /// operand is a shape we refuse to interpret.
     ///
@@ -623,22 +674,44 @@ enum SSHDestinationTTYProbe {
 
     // MARK: - Live reads
 
-    /// EVERY ssh process on the machine (`KERN_PROC_ALL`), with the metadata the
-    /// rules above need. One scan answers both the surface question and the
-    /// uniqueness question.
+    /// EVERY ssh process on the machine (`KERN_PROC_ALL`), with the metadata
+    /// the rules above need. One scan answers both the surface question and
+    /// the competing-view question. Cross-uid processes are carried WITHOUT
+    /// their metadata: they must stay visible to the surface count (a
+    /// `sudo ssh` in the foreground abstains rather than reading as "no ssh
+    /// here"), but their executable path and argv are another user's business
+    /// — never read, not merely expected to fail.
     static let liveSSHProcesses: @Sendable () -> [SSHClientProcess]? = {
         guard let entries = TTYProcessTable.allProcesses() else { return nil }
+        return sshProcesses(
+            from: entries,
+            effectiveUserID: geteuid(),
+            readExecutablePath: executablePath,
+            readArguments: processArguments
+        )
+    }
+
+    /// Maps the process-table scan into the ssh-specific shape at the live-read
+    /// boundary, keeping credential handling out of the pure decision code.
+    static func sshProcesses(
+        from entries: [TTYProcessTable.Entry],
+        effectiveUserID: uid_t,
+        readExecutablePath: (Int32) -> String?,
+        readArguments: (Int32) -> [String]?
+    ) -> [SSHClientProcess] {
         return entries
             .filter { $0.name == "ssh" }
             .map { entry in
-                SSHClientProcess(
+                let sameUser = entry.effectiveUserID == effectiveUserID
+                return SSHClientProcess(
                     pid: entry.pid,
                     parentPID: entry.parentProcessID,
                     ttyDevice: entry.ttyDevice,
                     processGroupID: entry.processGroupID,
                     terminalForegroundGroupID: entry.terminalForegroundGroupID,
-                    executablePath: executablePath(pid: entry.pid),
-                    arguments: processArguments(pid: entry.pid)
+                    effectiveUserID: entry.effectiveUserID,
+                    executablePath: sameUser ? readExecutablePath(entry.pid) : nil,
+                    arguments: sameUser ? readArguments(entry.pid) : nil
                 )
             }
     }
@@ -720,6 +793,9 @@ enum TTYProcessTable {
     struct Entry: Sendable, Equatable {
         var pid: Int32
         var parentProcessID: Int32
+        /// Kernel credential from `kp_eproc.e_ucred.cr_uid`, never a value the
+        /// process can choose or report about itself.
+        var effectiveUserID: uid_t
         var name: String
         var ttyDevice: dev_t?
         var processGroupID: Int32
@@ -728,6 +804,7 @@ enum TTYProcessTable {
         init(
             pid: Int32,
             parentProcessID: Int32 = 0,
+            effectiveUserID: uid_t,
             name: String,
             ttyDevice: dev_t? = nil,
             processGroupID: Int32 = 0,
@@ -735,6 +812,7 @@ enum TTYProcessTable {
         ) {
             self.pid = pid
             self.parentProcessID = parentProcessID
+            self.effectiveUserID = effectiveUserID
             self.name = name
             self.ttyDevice = ttyDevice
             self.processGroupID = processGroupID
@@ -789,6 +867,7 @@ enum TTYProcessTable {
             return Entry(
                 pid: process.kp_proc.p_pid,
                 parentProcessID: process.kp_eproc.e_ppid,
+                effectiveUserID: process.kp_eproc.e_ucred.cr_uid,
                 name: name,
                 // NODEV means no controlling terminal — not a surface.
                 ttyDevice: device == ~dev_t(0) ? nil : device,

--- a/Tests/localvoxtralTests/SSHDestinationTTYProbeTests.swift
+++ b/Tests/localvoxtralTests/SSHDestinationTTYProbeTests.swift
@@ -242,6 +242,55 @@ final class SSHDestinationTTYProbeTests: XCTestCase {
 
     // MARK: - Competing herdr views (narrowed from machine-wide uniqueness, 2026-08-06)
 
+    func testGhosttyShellIntegrationOptionsDoNotRefuseTheSurfaceProbe() throws {
+        // Exact argv shape injected by Ghostty's `ghostty +ssh` shell
+        // integration wrapper before the user's destination and command.
+        let value = try XCTUnwrap(
+            connection(
+                probe(
+                    processes: [
+                        ssh([
+                            "ssh",
+                            "-o", "SetEnv=TERM=xterm-ghostty",
+                            "-o", "SendEnv=COLORTERM",
+                            "-o", "SendEnv=TERM_PROGRAM",
+                            "-o", "SendEnv=TERM_PROGRAM_VERSION",
+                            "builder", "herdr",
+                        ]),
+                    ]
+                )
+            )
+        )
+        XCTAssertEqual(value.destination, "builder")
+        XCTAssertEqual(value.herdr, .plainClient(sessionSelector: nil))
+        XCTAssertFalse(value.hasCompetingHerdrClient)
+    }
+
+    func testGhosttyWrappedHerdrInAnotherTabDoesNotCompete() throws {
+        let value = try XCTUnwrap(
+            connection(
+                probe(
+                    processes: [
+                        ssh(["ssh", "-t", "builder", "herdr"], pid: 501),
+                        ssh(
+                            [
+                                "ssh",
+                                "-o", "SetEnv=TERM=xterm-ghostty",
+                                "-o", "SendEnv=COLORTERM",
+                                "-o", "SendEnv=TERM_PROGRAM",
+                                "-o", "SendEnv=TERM_PROGRAM_VERSION",
+                                "builder", "herdr",
+                            ],
+                            pid: 777,
+                            device: otherTerminal
+                        ),
+                    ]
+                )
+            )
+        )
+        XCTAssertFalse(value.hasCompetingHerdrClient)
+    }
+
     func testAPlainShellToTheSameHostDoesNotCompete() throws {
         // THE field workflow the blanket uniqueness rule refused: one terminal
         // attached to herdr, another keeping a plain shell to the same host
@@ -517,6 +566,114 @@ final class SSHDestinationTTYProbeTests: XCTestCase {
                 )
             )
         )
+        XCTAssertTrue(value.hasCompetingHerdrClient)
+    }
+
+    func testCrossUIDUnreadableSSHCompetesBeforeTheScanBoundaryAndIsThenIgnored() throws {
+        // Historical behavior without the owner boundary: an unreadable ssh
+        // from root or another user poisons the decision unconditionally.
+        let unfiltered = try XCTUnwrap(
+            connection(
+                probe(
+                    processes: [
+                        ssh(["ssh", "builder", "herdr"], pid: 501),
+                        ssh(nil, pid: 777, device: otherTerminal),
+                    ]
+                )
+            )
+        )
+        XCTAssertTrue(unfiltered.hasCompetingHerdrClient)
+
+        let processes = SSHDestinationTTYProbe.sshProcesses(
+            from: [
+                TTYProcessTable.Entry(
+                    pid: 501,
+                    effectiveUserID: 501,
+                    name: "ssh",
+                    ttyDevice: surface,
+                    processGroupID: 501,
+                    terminalForegroundGroupID: 501
+                ),
+                TTYProcessTable.Entry(
+                    pid: 777,
+                    effectiveUserID: 0,
+                    name: "ssh",
+                    ttyDevice: otherTerminal,
+                    processGroupID: 777,
+                    terminalForegroundGroupID: 777
+                ),
+            ],
+            effectiveUserID: 501,
+            readExecutablePath: { pid in
+                if pid == 777 { XCTFail("cross-uid metadata must not be read") }
+                return pid == 501 ? "/usr/bin/ssh" : nil
+            },
+            readArguments: { pid in
+                if pid == 777 { XCTFail("cross-uid argv must not be read") }
+                return pid == 501 ? ["ssh", "builder", "herdr"] : nil
+            }
+        )
+        let filtered = try XCTUnwrap(connection(probe(processes: processes)))
+        XCTAssertFalse(filtered.hasCompetingHerdrClient)
+    }
+
+    func testACrossUIDForegroundSSHOnTheSurfaceStillAbstains() {
+        // `sudo ssh host` in THIS terminal's foreground: another user's
+        // process IS the surface. It must abstain exactly as any unreadable
+        // ssh does — reclassifying it as "no ssh here" would hand the surface
+        // to the title-marker arm while a remote session may be on screen.
+        // Its metadata must still never be read.
+        let processes = SSHDestinationTTYProbe.sshProcesses(
+            from: [
+                TTYProcessTable.Entry(
+                    pid: 777,
+                    effectiveUserID: 0,
+                    name: "ssh",
+                    ttyDevice: surface,
+                    processGroupID: 777,
+                    terminalForegroundGroupID: 777
+                )
+            ],
+            effectiveUserID: 501,
+            readExecutablePath: { _ in
+                XCTFail("cross-uid metadata must not be read")
+                return nil
+            },
+            readArguments: { _ in
+                XCTFail("cross-uid argv must not be read")
+                return nil
+            }
+        )
+        XCTAssertEqual(
+            probe(processes: processes), .undeterminable(.untrustedExecutable)
+        )
+    }
+
+    func testSameUIDUnreadableSSHStillCompetesAfterTheScanBoundary() throws {
+        let processes = SSHDestinationTTYProbe.sshProcesses(
+            from: [
+                TTYProcessTable.Entry(
+                    pid: 501,
+                    effectiveUserID: 501,
+                    name: "ssh",
+                    ttyDevice: surface,
+                    processGroupID: 501,
+                    terminalForegroundGroupID: 501
+                ),
+                TTYProcessTable.Entry(
+                    pid: 777,
+                    effectiveUserID: 501,
+                    name: "ssh",
+                    ttyDevice: otherTerminal,
+                    processGroupID: 777,
+                    terminalForegroundGroupID: 777
+                ),
+            ],
+            effectiveUserID: 501,
+            readExecutablePath: { $0 == 501 ? "/usr/bin/ssh" : nil },
+            readArguments: { $0 == 501 ? ["ssh", "builder", "herdr"] : nil }
+        )
+        let value = try XCTUnwrap(connection(probe(processes: processes)))
         XCTAssertTrue(value.hasCompetingHerdrClient)
     }
 
@@ -914,6 +1071,13 @@ final class SSHDestinationTTYProbeTests: XCTestCase {
         XCTAssertEqual(destination(["ssh", "-i", "/keys/id", "builder"]), "builder")
     }
 
+    func testDestinationInertOOptionsAreSkippedInEveryArgvShape() {
+        XCTAssertEqual(destination(["ssh", "-o", "SetEnv=TERM=xterm-ghostty", "builder"]), "builder")
+        XCTAssertEqual(destination(["ssh", "-oSeNdEnV=COLORTERM", "builder"]), "builder")
+        XCTAssertEqual(destination(["ssh", "-to", "SendEnv=TERM_PROGRAM", "builder"]), "builder")
+        XCTAssertEqual(destination(["ssh", "-toSetEnv=TERM=xterm-ghostty", "builder"]), "builder")
+    }
+
     func testClusteredFlagsAreSkipped() {
         XCTAssertEqual(destination(["ssh", "-tt", "builder"]), "builder")
         XCTAssertEqual(destination(["ssh", "-AC", "builder"]), "builder")
@@ -946,6 +1110,10 @@ final class SSHDestinationTTYProbeTests: XCTestCase {
             ["ssh", "-o", "HostName=other.example", "builder"],
             ["ssh", "-oHostName=other.example", "builder"],
             ["ssh", "-o", "ProxyJump=elsewhere", "builder"],
+            ["ssh", "-o", "Compression=yes", "builder"],
+            ["ssh", "-oSetEnvironment=TERM=xterm-ghostty", "builder"],
+            ["ssh", "-to", "HostName=other.example", "builder"],
+            ["ssh", "-toCompression=yes", "builder"],
             ["ssh", "-F", "/tmp/alt.conf", "builder"],
             ["ssh", "-O", "check", "builder"],
             ["ssh", "-S", "/tmp/cm.sock", "builder"],
@@ -1073,6 +1241,10 @@ final class SSHDestinationTTYProbeTests: XCTestCase {
         XCTAssertEqual(
             me?.parentProcessID, getppid(),
             "the parent pid must be plumbed — the machinery rule depends on it"
+        )
+        XCTAssertEqual(
+            me?.effectiveUserID, geteuid(),
+            "the effective uid must come from the kernel process-table entry"
         )
     }
 

--- a/docs/agent/invariants.md
+++ b/docs/agent/invariants.md
@@ -204,7 +204,11 @@ there is not.
     a background one, or `scp`/`rsync`'s helper is not mistaken for the screen),
     and ABSTAINS on `-o`/`-F`/`-O`/`-S`/`-N`/`-f`/`-M`/`-D`/`-W`/`-w` rather
     than skipping them — `ssh -o HostName=other builder` must never answer
-    `builder`. ssh MACHINERY is invisible to this count and to the uniqueness
+    `builder`. The exact, case-insensitive `SetEnv=` and `SendEnv=` `-o` keys
+    are the only exception: they can neither move the destination nor change
+    the session's interactivity, and accepting them keeps terminal wrappers
+    such as Ghostty's from making every probe abstain. ssh MACHINERY is
+    invisible to this count and to the uniqueness
     scan in (2): an ssh that is a direct CHILD of another scanned ssh — a
     ProxyJump's `ssh -W` hop, which OpenSSH spawns on the same tty in the same
     foreground process group (field abstention 2026-08-06) — is its root
@@ -230,7 +234,12 @@ there is not.
     device): a client with a different session selector, a herdr subcommand
     shape, an argv that was refused and mentions `herdr` (substring,
     one-sided), or anything unreadable. What deliberately does NOT compete
-    (2026-08-06, replacing blanket machine-wide uniqueness): a plain shell or
+    (2026-08-06, replacing blanket machine-wide uniqueness): ANOTHER USER's
+    ssh (kernel `e_ucred.cr_uid`, never self-reported) — their herdr view
+    lives in their own login session, not on a surface this user dictates
+    into, and their metadata is never read; a cross-uid ssh ON the focused
+    surface itself (`sudo ssh`) still abstains as an unreadable client rather
+    than vanishing; a plain shell or
     non-herdr ssh to the same host — it is on another tty and the probe only
     reads the FOCUSED surface's tty — and a second whole-view client with a
     byte-identical selector, because herdr focus is SERVER-GLOBAL and


### PR DESCRIPTION
## What

Stacked on #229. Two probe-hardening changes toward "just works" remote-herdr joins, both implemented by a codex worker and review-amended by the orchestrator.

**1. Accept destination-inert `-o SetEnv=` / `-o SendEnv=`.** Ghostty's shell-integration ssh wrapper (`ghostty +ssh`) injects `-o SetEnv=TERM=xterm-ghostty` and `-o SendEnv=…` into the real argv, and the wholesale `-o` refusal made every wrapped probe abstain — worse, a wrapped `ssh host herdr` in ANOTHER tab has refused argv containing the token `herdr`, so it poisoned the competing-herdr-view check for other surfaces (mixing wrapped and unwrapped tabs blocked both). These two keys are matched exactly and case-insensitively (as OpenSSH matches keywords), in separated (`-o SetEnv=…`), glued (`-oSetEnv=…`), and flag-clustered (`-to SetEnv=…`) shapes; they only shape the remote environment and can neither move the destination nor change session interactivity. Every other `-o` value still refuses.

**2. Scope the scans to the surface owner's uid.** The `KERN_PROC_ALL` scan carried every user's ssh; a cross-uid process (root, another login) is unreadable by design, landed in the "unreadable argv" branch, and competed unconditionally — blanket abstention from processes that can never be this user's herdr view. Now `kp_eproc.e_ucred.cr_uid` (kernel credential, never self-reported) rides each entry:

- another user's ssh is **invisible to the competing-view scan**, and its executable path / argv are **never read** (pinned by test, not merely expected to fail);
- a cross-uid ssh **on the focused surface itself** (`sudo ssh host`) still **abstains** as an unreadable client — the orchestrator's review caught that the worker's original scan-boundary filter reclassified it as "no ssh here", which would have handed the surface to the title-marker arm while a remote session may be on screen. The filter was moved into the competing scan and the surface behavior pinned (`testACrossUIDForegroundSSHOnTheSurfaceStillAbstains`);
- an unreadable **same-uid** ssh elsewhere still competes (paranoia pinned by `testSameUIDUnreadableSSHStillCompetesAfterTheScanBoundary`).

`docs/agent/invariants.md` updated for both rules.

## Proof

Change 1 — red (pre-fix), `remote-build.sh test --filter SSHDestinationTTYProbeTests`:

```
testGhosttyShellIntegrationOptionsDoNotRefuseTheSurfaceProbe:
XCTUnwrap failed: expected non-nil value of type "SSHSurfaceConnection"
testGhosttyWrappedHerdrInAnotherTabDoesNotCompete: XCTAssertFalse failed
testDestinationInertOOptionsAreSkippedInEveryArgvShape:
4 × XCTAssertEqual failed: ("nil") is not equal to ("Optional("builder")")
Executed 80 tests, with 6 failures (0 unexpected)
```

Change 1 — green: same command, `Executed 80 tests, with 0 failures (0 unexpected)`.

Change 2 — red (pre-fix):

```
testCrossUIDUnreadableSSHCompetesBeforeTheScanBoundaryAndIsThenIgnored:
failed - cross-uid metadata must not be read
failed - cross-uid argv must not be read
XCTAssertFalse failed
Executed 82 tests, with 3 failures (0 unexpected)
```

Change 2 — green: `Executed 82 tests, with 0 failures (0 unexpected)`. (These runs exercised the worker's intermediate scan-boundary shape; the shipped shape moved the filter into the competing scan and added the surface pin.)

Final state, all probe tests including the amendment's surface pin:

```
Executed 83 tests, with 0 failures (0 unexpected)
```

Full unit suite after the amendment:

```
Executed 2631 tests, with 2 tests skipped and 0 failures (0 unexpected) in 113.948 (114.173) seconds
```

- LLM lanes: not required — no change to prompts, models, or anything that reaches a model. (Paths under `Sources/localvoxtral/ClaudeContext/*`, so the polishd lane runs by filter anyway.)
- UI: no UI change.
