### PR TITLE
Remote-herdr host matching: ssh -G canonicalization fallback for IP/FQDN/alias destinations

### DIFF
--- a/Sources/localvoxtral/ClaudeContext/SSHDestinationCanonicalizer.swift
+++ b/Sources/localvoxtral/ClaudeContext/SSHDestinationCanonicalizer.swift
@@ -1,0 +1,235 @@
+import Foundation
+import Synchronization
+
+/// Resolves ssh destination operands through the user's effective ssh config.
+///
+/// This is deliberately a fallback signal: callers first try the enrolled
+/// alias exactly, and use these identities only when that produces no match.
+final class SSHDestinationCanonicalizer: Sendable {
+    struct Identity: Sendable, Equatable {
+        let hostname: String
+        let port: UInt16
+        /// Parsed for the log's benefit only — NEVER compared. `ssh -G`
+        /// always prints an effective `user` line (defaulting to the local
+        /// username), and the probe strips `user@` from the operand before it
+        /// reaches this type, so the operand side always carries that local
+        /// default. Comparing it against an alias whose config sets `User`
+        /// (the common build-host shape) would reject the very match this
+        /// fallback exists for, while conveying nothing about what the user
+        /// typed. Two enrollments to one (hostname, port) under different
+        /// remote users both match and land in the existing multiple-match
+        /// abstention downstream — fail-closed, as before.
+        let user: String?
+
+        func matches(_ other: Identity) -> Bool {
+            hostname == other.hostname && port == other.port
+        }
+    }
+
+    typealias ProcessRunner = @Sendable (
+        _ executableURL: URL,
+        _ invocation: ClaudeRemoteEnrollmentService.Invocation
+    ) throws -> ClaudeRemoteEnrollmentService.RunResult
+
+    static let executableURL = URL(fileURLWithPath: "/usr/bin/ssh")
+    static let defaultTTL: TimeInterval = 5 * 60
+    static let defaultTimeout: TimeInterval = 2
+    private static let maxCacheEntries = 128
+
+    private enum CachedOutcome: Sendable {
+        case resolved(Identity)
+        case failed
+    }
+
+    private struct CacheEntry: Sendable {
+        let outcome: CachedOutcome
+        let cachedAt: Date
+    }
+
+    private let cache = Mutex<[String: CacheEntry]>([:])
+    private let ttl: TimeInterval
+    private let timeout: TimeInterval
+    private let now: @Sendable () -> Date
+    private let runner: ProcessRunner
+
+    init(
+        ttl: TimeInterval = defaultTTL,
+        timeout: TimeInterval = defaultTimeout,
+        now: @escaping @Sendable () -> Date = { Date() },
+        runner: @escaping ProcessRunner
+    ) {
+        self.ttl = ttl
+        self.timeout = timeout
+        self.now = now
+        self.runner = runner
+    }
+
+    /// Active enrolled hosts sharing the operand's effective `(hostname,
+    /// port, user?)` identity. Any failed resolution rejects the entire
+    /// fallback, so partial subprocess success can never select a host.
+    func matchingHosts(
+        destination: String,
+        enrolledHosts: [ClaudeRemoteHost]
+    ) async -> [ClaudeRemoteHost] {
+        let candidates = enrolledHosts.filter { !$0.isRevoked && $0.sshHostAlias != nil }
+        guard !candidates.isEmpty,
+              let destinationIdentity = await identity(for: destination)
+        else { return [] }
+
+        var identities = Array<Identity?>(repeating: nil, count: candidates.count)
+        await withTaskGroup(of: (Int, Identity?).self) { group in
+            for (index, host) in candidates.enumerated() {
+                guard let alias = host.sshHostAlias else { continue }
+                group.addTask { [self] in (index, await identity(for: alias)) }
+            }
+            for await (index, identity) in group {
+                identities[index] = identity
+            }
+        }
+
+        // A failure for even one candidate makes the canonical view incomplete.
+        // Fall open to the exact-match behavior instead of selecting from a
+        // partial host set.
+        guard identities.allSatisfy({ $0 != nil }) else {
+            Log.claudeContext.info(
+                "SSH destination canonicalization failed for an enrolled host; exact matching retained"
+            )
+            return []
+        }
+
+        let matches: [ClaudeRemoteHost] = candidates.enumerated().compactMap { index, host in
+            guard let identity = identities[index], destinationIdentity.matches(identity) else {
+                return nil
+            }
+            return host
+        }
+        if matches.count == 1 {
+            Log.claudeContext.info("SSH destination matched an enrolled host via canonical config")
+        } else if matches.count > 1 {
+            Log.claudeContext.info(
+                "SSH destination matched multiple enrolled hosts via canonical config"
+            )
+        }
+        return matches
+    }
+
+    private func identity(for operand: String) async -> Identity? {
+        // Apply the probe's existing operand policy BEFORE any subprocess sees
+        // the string. In particular, refused URI/punctuation shapes never
+        // become arguments to a command.
+        guard SSHDestinationTTYProbe.normalizedDestination(operand) != nil else {
+            Log.claudeContext.info(
+                "SSH destination canonicalization failed: operand refused before process spawn"
+            )
+            return nil
+        }
+
+        let timestamp = now()
+        if let cached = cache.withLock({ storage -> CachedOutcome? in
+            guard let entry = storage[operand] else { return nil }
+            guard timestamp.timeIntervalSince(entry.cachedAt) <= ttl else {
+                storage.removeValue(forKey: operand)
+                return nil
+            }
+            return entry.outcome
+        }) {
+            Log.claudeContext.info("SSH destination canonicalization cache hit")
+            switch cached {
+            case .resolved(let identity): return identity
+            case .failed: return nil
+            }
+        }
+
+        let invocation = ClaudeRemoteEnrollmentService.Invocation(
+            argv: ["ssh", "-G", "--", operand],
+            standardInput: Data(),
+            timeout: timeout
+        )
+        let outcome: CachedOutcome
+        do {
+            // `ssh -G` only prints effective configuration; it performs no
+            // network I/O. The live runner closes stdin and bounds the process.
+            let result = try await Task.detached(priority: .utility) { [runner] in
+                try runner(Self.executableURL, invocation)
+            }.value
+            guard result.succeeded, let parsed = Self.parse(result.message) else {
+                Log.claudeContext.info(
+                    "SSH destination canonicalization failed: ssh config output unavailable"
+                )
+                outcome = .failed
+                store(outcome, for: operand, at: timestamp)
+                return nil
+            }
+            outcome = .resolved(parsed)
+        } catch {
+            Log.claudeContext.info(
+                "SSH destination canonicalization failed: ssh config process did not complete"
+            )
+            outcome = .failed
+        }
+        store(outcome, for: operand, at: timestamp)
+        if case .resolved(let identity) = outcome { return identity }
+        return nil
+    }
+
+    private func store(_ outcome: CachedOutcome, for operand: String, at timestamp: Date) {
+        cache.withLock { storage in
+            storage = storage.filter { timestamp.timeIntervalSince($0.value.cachedAt) <= ttl }
+            if storage.count >= Self.maxCacheEntries,
+               let oldest = storage.min(by: { $0.value.cachedAt < $1.value.cachedAt })?.key {
+                storage.removeValue(forKey: oldest)
+            }
+            storage[operand] = CacheEntry(outcome: outcome, cachedAt: timestamp)
+        }
+    }
+
+    static func parse(_ output: String) -> Identity? {
+        var hostname: String?
+        var port: UInt16?
+        var user: String?
+
+        for line in output.split(whereSeparator: \.isNewline) {
+            let fields = line.split(maxSplits: 1, whereSeparator: \.isWhitespace)
+            guard fields.count == 2 else { continue }
+            let key = fields[0].lowercased()
+            let value = String(fields[1])
+            switch key {
+            case "hostname":
+                guard !value.isEmpty, !value.contains(where: \.isWhitespace) else { return nil }
+                let normalized = value.lowercased()
+                guard hostname == nil || hostname == normalized else { return nil }
+                hostname = normalized
+            case "port":
+                guard let parsed = UInt16(value), parsed > 0 else { return nil }
+                guard port == nil || port == parsed else { return nil }
+                port = parsed
+            case "user":
+                guard !value.isEmpty, !value.contains(where: \.isWhitespace) else { return nil }
+                guard user == nil || user == value else { return nil }
+                user = value
+            default:
+                continue
+            }
+        }
+        guard let hostname, let port else { return nil }
+        return Identity(hostname: hostname, port: port, user: user)
+    }
+}
+
+#if canImport(Darwin)
+extension SSHDestinationCanonicalizer {
+    static func live() -> SSHDestinationCanonicalizer {
+        let liveRunner = ClaudeRemoteEnrollmentService.processRunner(sshExecutableURL: executableURL)
+        return SSHDestinationCanonicalizer { executableURL, invocation in
+            guard executableURL == Self.executableURL else {
+                throw LiveRunnerError.unexpectedExecutable
+            }
+            return try liveRunner(invocation)
+        }
+    }
+
+    private enum LiveRunnerError: Error {
+        case unexpectedExecutable
+    }
+}
+#endif

--- a/Sources/localvoxtral/ClaudeContext/TerminalScreenClaudeJoin.swift
+++ b/Sources/localvoxtral/ClaudeContext/TerminalScreenClaudeJoin.swift
@@ -191,6 +191,7 @@ struct ClaudeSessionJoinResolver {
     private let reportCmuxStatus: @MainActor (CmuxSocketStatus) -> Void
     private let sshDestinationProbe: @Sendable (String) -> SSHDestinationTTYProbeResult
     private let enrolledHosts: @MainActor (String) -> [ClaudeRemoteHost]
+    private let canonicalizedEnrolledHosts: @MainActor (String) async -> [ClaudeRemoteHost]
     private let remoteHerdrForwards: (any ClaudeRemoteHerdrForwarding)?
 
     /// - Parameters:
@@ -247,6 +248,9 @@ struct ClaudeSessionJoinResolver {
     ///     destination. Defaults to none, for the same reason: no enrollment
     ///     lookup, no remote arm. Passed as a closure rather than the registry
     ///     because the host list is built later in launch than this resolver.
+    ///   - canonicalizedEnrolledHosts: the `ssh -G` fallback, consulted only
+    ///     when exact alias matching found nothing. Defaults to none so a test
+    ///     that forgets to inject never spawns a process.
     ///   - remoteHerdrForwards: opens the app-managed `ssh -L`. Nil means the
     ///     arm can never spawn anything, which is what a test that forgets to
     ///     inject must get.
@@ -269,6 +273,9 @@ struct ClaudeSessionJoinResolver {
             .undeterminable(.probeUnavailable)
         },
         enrolledHosts: @escaping @MainActor (String) -> [ClaudeRemoteHost] = { _ in [] },
+        canonicalizedEnrolledHosts: @escaping @MainActor (String) async -> [ClaudeRemoteHost] = {
+            _ in []
+        },
         remoteHerdrForwards: (any ClaudeRemoteHerdrForwarding)? = nil
     ) {
         self.registry = registry
@@ -283,6 +290,7 @@ struct ClaudeSessionJoinResolver {
         self.reportCmuxStatus = reportCmuxStatus
         self.sshDestinationProbe = sshDestinationProbe
         self.enrolledHosts = enrolledHosts
+        self.canonicalizedEnrolledHosts = canonicalizedEnrolledHosts
         self.remoteHerdrForwards = remoteHerdrForwards
     }
 
@@ -605,7 +613,10 @@ struct ClaudeSessionJoinResolver {
             connection = value
         }
 
-        let hosts = enrolledHosts(connection.destination)
+        var hosts = enrolledHosts(connection.destination)
+        if hosts.isEmpty {
+            hosts = await canonicalizedEnrolledHosts(connection.destination)
+        }
         guard !hosts.isEmpty else {
             // An ssh session to a host the user never enrolled. There is no
             // context to join, and the title marker still deserves its chance:

--- a/Sources/localvoxtral/localvoxtralApp.swift
+++ b/Sources/localvoxtral/localvoxtralApp.swift
@@ -295,6 +295,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             // a user who never enables the arm is never prompted for keychain
             // access and the secret is not held in memory between dictations.
             let cmuxPasswords = CmuxSocketPasswordStore()
+            let sshDestinationCanonicalizer = SSHDestinationCanonicalizer.live()
             let resolver = ClaudeSessionJoinResolver(
                 registry: claudeSessionRegistry,
                 focusedTerminalTTY: { await ttyReader.focusedTerminalTTY(bundleID: $0) },
@@ -320,6 +321,13 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                 // registry ⇒ no candidates ⇒ the remote herdr arm never runs.
                 enrolledHosts: { [weak self] destination in
                     self?.claudeRemoteHosts?.hosts(matchingSSHDestination: destination) ?? []
+                },
+                canonicalizedEnrolledHosts: { [weak self] destination in
+                    guard let hosts = self?.claudeRemoteHosts?.hosts() else { return [] }
+                    return await sshDestinationCanonicalizer.matchingHosts(
+                        destination: destination,
+                        enrolledHosts: hosts
+                    )
                 },
                 remoteHerdrForwards: ClaudeRemoteHerdrForwardService(
                     spawner: ClaudeRemoteHerdrForwardSpawner(),

--- a/Tests/localvoxtralTests/RemoteHerdrJoinTests.swift
+++ b/Tests/localvoxtralTests/RemoteHerdrJoinTests.swift
@@ -174,6 +174,35 @@ private final class RemoteJoinTestLiveness: Sendable {
     func kill(_ pid: Int32) { dead.withLock { _ = $0.insert(pid) } }
 }
 
+private final class RemoteJoinSSHConfigRunner: @unchecked Sendable {
+    struct Invocation: Equatable {
+        let executableURL: URL
+        let value: ClaudeRemoteEnrollmentService.Invocation
+    }
+
+    enum Failure: Error { case scripted }
+
+    let invocations = Mutex<[Invocation]>([])
+    private let outputs: [String: String]
+    private let shouldFail: Bool
+
+    init(outputs: [String: String] = [:], shouldFail: Bool = false) {
+        self.outputs = outputs
+        self.shouldFail = shouldFail
+    }
+
+    var run: SSHDestinationCanonicalizer.ProcessRunner {
+        { [self] executableURL, invocation in
+            invocations.withLock { $0.append(Invocation(executableURL: executableURL, value: invocation)) }
+            if shouldFail { throw Failure.scripted }
+            guard let operand = invocation.argv.last, let output = outputs[operand] else {
+                return ClaudeRemoteEnrollmentService.RunResult(exitCode: 1, message: "")
+            }
+            return ClaudeRemoteEnrollmentService.RunResult(exitCode: 0, message: output)
+        }
+    }
+}
+
 // MARK: - Resolver: the remote herdr arm
 
 /// A Claude Code session inside a herdr on an ENROLLED REMOTE host.
@@ -283,6 +312,7 @@ final class RemoteHerdrJoinTests: XCTestCase {
             )
         ),
         hosts: [ClaudeRemoteHost]? = nil,
+        canonicalizer: SSHDestinationCanonicalizer? = nil,
         title: String? = nil
     ) -> ClaudeSessionJoinResolver {
         let hostList = hosts ?? [enrolledHost()]
@@ -306,6 +336,13 @@ final class RemoteHerdrJoinTests: XCTestCase {
                     guard !host.isRevoked, let alias = host.sshHostAlias else { return false }
                     return alias.lowercased() == destination.lowercased()
                 }
+            },
+            canonicalizedEnrolledHosts: { destination in
+                guard let canonicalizer else { return [] }
+                return await canonicalizer.matchingHosts(
+                    destination: destination,
+                    enrolledHosts: hostList
+                )
             },
             remoteHerdrForwards: forwards
         )
@@ -342,6 +379,152 @@ final class RemoteHerdrJoinTests: XCTestCase {
         XCTAssertEqual(requests.map(\.method), ["pane.current", "pane.process_info"])
         XCTAssertTrue(requests.allSatisfy { $0.socketPath == forwards.localSocketPath })
         XCTAssertEqual(requests.compactMap(\.paneID), [remotePaneID])
+    }
+
+    func testIPDestinationJoinsHostViaCanonicalSSHConfig() async throws {
+        let registry = makeRegistry(markers: [markerValue])
+        ingestRemoteHerdrSession(into: registry)
+        let panes = RemoteJoinHerdrPanes(focused: focusedPane())
+        let forwards = RecordingForwards()
+        let config = """
+            host 192.168.1.167
+            user dev
+            hostname 192.168.1.167
+            port 22
+            """
+        let runner = RemoteJoinSSHConfigRunner(
+            outputs: ["192.168.1.167": config, "Builder": config]
+        )
+        let canonicalizer = SSHDestinationCanonicalizer(
+            now: { [epoch] in epoch },
+            runner: runner.run
+        )
+
+        let join = try unwrapAsync(
+            await resolver(
+                registry: registry,
+                panes: panes,
+                forwards: forwards,
+                sshResult: .connection(
+                    SSHSurfaceConnection(
+                        destination: "192.168.1.167",
+                        hasCompetingHerdrClient: false,
+                        herdr: .plainClient(sessionSelector: nil)
+                    )
+                ),
+                canonicalizer: canonicalizer
+            ).resolve(target: ghostty)
+        )
+
+        XCTAssertEqual(join.mechanism, .remoteHerdrPane)
+        XCTAssertEqual(Set(runner.invocations.withLock { $0.map(\.value.argv) }), [
+            ["ssh", "-G", "--", "192.168.1.167"],
+            ["ssh", "-G", "--", "Builder"],
+        ])
+        XCTAssertTrue(
+            runner.invocations.withLock { invocations in
+                invocations.allSatisfy {
+                    $0.executableURL.path == "/usr/bin/ssh"
+                        && $0.value.standardInput.isEmpty
+                        && $0.value.timeout == SSHDestinationCanonicalizer.defaultTimeout
+                }
+            }
+        )
+    }
+
+    func testCanonicalizationFailureKeepsExactMatchFallthroughBehavior() async throws {
+        let registry = makeRegistry(markers: [markerValue])
+        ingestRemoteHerdrSession(into: registry)
+        let forwards = RecordingForwards()
+        let runner = RemoteJoinSSHConfigRunner(shouldFail: true)
+        let canonicalizer = SSHDestinationCanonicalizer(
+            now: { [epoch] in epoch },
+            runner: runner.run
+        )
+
+        let join = try unwrapAsync(
+            await resolver(
+                registry: registry,
+                panes: RemoteJoinHerdrPanes(focused: focusedPane()),
+                forwards: forwards,
+                sshResult: .connection(
+                    SSHSurfaceConnection(
+                        destination: "192.168.1.167",
+                        hasCompetingHerdrClient: false,
+                        herdr: .plainClient(sessionSelector: nil)
+                    )
+                ),
+                canonicalizer: canonicalizer,
+                title: markerValue
+            ).resolve(target: ghostty)
+        )
+
+        XCTAssertEqual(join.mechanism, .titleMarker)
+        XCTAssertEqual(forwards.openCount, 0)
+        XCTAssertEqual(runner.invocations.withLock { $0.count }, 1)
+    }
+
+    func testCanonicalMatchToTwoEnrolledHostsKeepsAmbiguityFatal() async throws {
+        let registry = makeRegistry(markers: [markerValue])
+        ingestRemoteHerdrSession(into: registry)
+        let forwards = RecordingForwards()
+        let config = "user dev\nhostname 192.168.1.167\nport 22\n"
+        let runner = RemoteJoinSSHConfigRunner(outputs: [
+            "192.168.1.167": config,
+            "sandbox-vpn": config,
+            "sandbox-lan": config,
+        ])
+        let canonicalizer = SSHDestinationCanonicalizer(
+            now: { [epoch] in epoch },
+            runner: runner.run
+        )
+
+        let join = try unwrapAsync(
+            await resolver(
+                registry: registry,
+                panes: RemoteJoinHerdrPanes(focused: focusedPane()),
+                forwards: forwards,
+                sshResult: .connection(
+                    SSHSurfaceConnection(
+                        destination: "192.168.1.167",
+                        hasCompetingHerdrClient: false,
+                        herdr: .plainClient(sessionSelector: nil)
+                    )
+                ),
+                hosts: [
+                    enrolledHost(alias: "sandbox-vpn"),
+                    enrolledHost(id: "h9z9z9z9", alias: "sandbox-lan"),
+                ],
+                canonicalizer: canonicalizer,
+                title: markerValue
+            ).resolve(target: ghostty)
+        )
+
+        XCTAssertEqual(join.mechanism, .titleMarker)
+        XCTAssertEqual(forwards.openCount, 0)
+        XCTAssertEqual(runner.invocations.withLock { $0.count }, 3)
+    }
+
+    func testExactMatchNeverInvokesCanonicalizer() async throws {
+        let registry = makeRegistry(markers: [markerValue])
+        ingestRemoteHerdrSession(into: registry)
+        let runner = RemoteJoinSSHConfigRunner(shouldFail: true)
+        let canonicalizer = SSHDestinationCanonicalizer(
+            now: { [epoch] in epoch },
+            runner: runner.run
+        )
+
+        let join = try unwrapAsync(
+            await resolver(
+                registry: registry,
+                panes: RemoteJoinHerdrPanes(focused: focusedPane()),
+                forwards: RecordingForwards(),
+                canonicalizer: canonicalizer
+            ).resolve(target: ghostty)
+        )
+
+        XCTAssertEqual(join.mechanism, .remoteHerdrPane)
+        XCTAssertTrue(runner.invocations.withLock { $0.isEmpty })
     }
 
     func testAJoinedRemoteSessionStaysJoinableByItsMarkerAtCommit() async throws {

--- a/Tests/localvoxtralTests/SSHDestinationCanonicalizerTests.swift
+++ b/Tests/localvoxtralTests/SSHDestinationCanonicalizerTests.swift
@@ -1,0 +1,190 @@
+import Foundation
+import Synchronization
+import XCTest
+@testable import localvoxtral
+
+#if canImport(Darwin)
+
+private final class CanonicalizerTestClock: Sendable {
+    private let value: Mutex<Date>
+
+    init(_ value: Date) { self.value = Mutex(value) }
+    var now: @Sendable () -> Date { { [self] in value.withLock { $0 } } }
+    func advance(_ interval: TimeInterval) {
+        value.withLock { $0 = $0.addingTimeInterval(interval) }
+    }
+}
+
+private final class CanonicalizerRecordingRunner: @unchecked Sendable {
+    struct Call: Equatable {
+        let executableURL: URL
+        let invocation: ClaudeRemoteEnrollmentService.Invocation
+    }
+
+    let calls = Mutex<[Call]>([])
+    private let outputs: [String: String]
+
+    init(outputs: [String: String]) { self.outputs = outputs }
+
+    var run: SSHDestinationCanonicalizer.ProcessRunner {
+        { [self] executableURL, invocation in
+            calls.withLock { $0.append(Call(executableURL: executableURL, invocation: invocation)) }
+            guard let operand = invocation.argv.last, let output = outputs[operand] else {
+                return ClaudeRemoteEnrollmentService.RunResult(exitCode: 1, message: "")
+            }
+            return ClaudeRemoteEnrollmentService.RunResult(exitCode: 0, message: output)
+        }
+    }
+}
+
+final class SSHDestinationCanonicalizerTests: XCTestCase {
+    private let epoch = Date(timeIntervalSince1970: 1_700_000_000)
+
+    private func host(alias: String) -> ClaudeRemoteHost {
+        ClaudeRemoteHost(
+            id: "h1a2b3c4",
+            label: "sandbox",
+            sshHostAlias: alias,
+            createdAt: epoch,
+            lastSeenAt: nil,
+            revokedAt: nil
+        )
+    }
+
+    private func output(hostname: String, user: String? = "dev", port: Int = 22) -> String {
+        [
+            "host ignored",
+            user.map { "user \($0)" },
+            "hostname \(hostname)",
+            "port \(port)",
+            "compression no",
+        ].compactMap { $0 }.joined(separator: "\n")
+    }
+
+    func testParserReadsEffectiveHostnameUserAndPort() {
+        XCTAssertEqual(
+            SSHDestinationCanonicalizer.parse(
+                "host sandbox\nuser deploy\nhostname Build.Example.COM\nport 2202\n"
+            ),
+            SSHDestinationCanonicalizer.Identity(
+                hostname: "build.example.com", port: 2202, user: "deploy"
+            )
+        )
+        XCTAssertNil(SSHDestinationCanonicalizer.parse("hostname host.example\nport nope\n"))
+        XCTAssertNil(SSHDestinationCanonicalizer.parse("user dev\nport 22\n"))
+    }
+
+    func testRefusedOperandNeverReachesProcessRunner() async {
+        let runner = CanonicalizerRecordingRunner(outputs: [:])
+        let canonicalizer = SSHDestinationCanonicalizer(
+            now: { [epoch] in epoch },
+            runner: runner.run
+        )
+
+        let matches = await canonicalizer.matchingHosts(
+            destination: "bad;touch-pwned",
+            enrolledHosts: [host(alias: "sandbox-vpn")]
+        )
+
+        XCTAssertTrue(matches.isEmpty)
+        XCTAssertTrue(runner.calls.withLock { $0.isEmpty })
+    }
+
+    func testAnAliasWithItsOwnUserStillMatchesAnIPOperand() async {
+        // The field shape this fallback exists for: `ssh 192.168.1.167 herdr`
+        // against an enrollment whose config says `Host sandbox-vpn` +
+        // `HostName 192.168.1.167` + `User builder`. Real `ssh -G` ALWAYS
+        // prints a `user` line — the operand side gets the local default
+        // ("dev"), the alias side gets the configured one ("builder") — so a
+        // user comparison would falsely reject exactly this case.
+        let runner = CanonicalizerRecordingRunner(outputs: [
+            "address": output(hostname: "BOX.EXAMPLE", user: "dev"),
+            "sandbox-vpn": output(hostname: "box.example", user: "builder"),
+        ])
+        let canonicalizer = SSHDestinationCanonicalizer(
+            now: { [epoch] in epoch },
+            runner: runner.run
+        )
+
+        let matches = await canonicalizer.matchingHosts(
+            destination: "address",
+            enrolledHosts: [host(alias: "sandbox-vpn")]
+        )
+
+        XCTAssertEqual(matches.map(\.sshHostAlias), ["sandbox-vpn"])
+    }
+
+    func testTwoEnrollmentsToOneBoxUnderDifferentUsersBothMatch() async {
+        // Different remote accounts on one (hostname, port) are
+        // indistinguishable from here — the operand's `user@` was stripped
+        // upstream. Both enrollments must be reported so the join's existing
+        // multiple-match rule abstains, rather than this type guessing.
+        let runner = CanonicalizerRecordingRunner(outputs: [
+            "address": output(hostname: "box.example", user: "dev"),
+            "alias-alice": output(hostname: "box.example", user: "alice"),
+            "alias-bob": output(hostname: "box.example", user: "bob"),
+        ])
+        let canonicalizer = SSHDestinationCanonicalizer(
+            now: { [epoch] in epoch },
+            runner: runner.run
+        )
+
+        let matches = await canonicalizer.matchingHosts(
+            destination: "address",
+            enrolledHosts: [host(alias: "alias-alice"), host(alias: "alias-bob")]
+        )
+
+        XCTAssertEqual(matches.count, 2)
+    }
+
+    func testOneUnresolvableEnrolledAliasRejectsAllCanonicalMatches() async {
+        let config = output(hostname: "box.example")
+        let runner = CanonicalizerRecordingRunner(outputs: [
+            "address": config,
+            "working-alias": config,
+        ])
+        let canonicalizer = SSHDestinationCanonicalizer(
+            now: { [epoch] in epoch },
+            runner: runner.run
+        )
+
+        let matches = await canonicalizer.matchingHosts(
+            destination: "address",
+            enrolledHosts: [host(alias: "working-alias"), host(alias: "broken-alias")]
+        )
+
+        XCTAssertTrue(matches.isEmpty)
+        XCTAssertEqual(runner.calls.withLock { $0.count }, 3)
+    }
+
+    func testCacheUsesInjectedClockAndExpiresAtTTL() async {
+        let clock = CanonicalizerTestClock(epoch)
+        let config = output(hostname: "192.168.1.167")
+        let runner = CanonicalizerRecordingRunner(outputs: [
+            "192.168.1.167": config,
+            "sandbox-vpn": config,
+        ])
+        let canonicalizer = SSHDestinationCanonicalizer(
+            ttl: 300,
+            now: clock.now,
+            runner: runner.run
+        )
+        let hosts = [host(alias: "sandbox-vpn")]
+
+        _ = await canonicalizer.matchingHosts(
+            destination: "192.168.1.167", enrolledHosts: hosts
+        )
+        _ = await canonicalizer.matchingHosts(
+            destination: "192.168.1.167", enrolledHosts: hosts
+        )
+        XCTAssertEqual(runner.calls.withLock { $0.count }, 2)
+
+        clock.advance(301)
+        _ = await canonicalizer.matchingHosts(
+            destination: "192.168.1.167", enrolledHosts: hosts
+        )
+        XCTAssertEqual(runner.calls.withLock { $0.count }, 4)
+    }
+}
+
+#endif

--- a/docs/agent/invariants.md
+++ b/docs/agent/invariants.md
@@ -186,7 +186,18 @@ there is not.
     dictation is done with it. The bindings, ALL required, in cost order so an
     ordinary ssh session never pays for a tunnel:
     (1) the focused surface's own TTY hosts EXACTLY ONE FOREGROUND `ssh`
-    session, whose destination is exactly one enrolled host's alias. One,
+    session, whose destination identifies exactly one enrolled host. Exact
+    alias matching wins without spawning anything; only when it finds no host,
+    the app resolves the operand and each active enrolled alias through the
+    user's effective `ssh -G` config and compares `(hostname, port)` — never
+    `user`, which `ssh -G` always emits and which is always the local default
+    on the operand side because the probe strips `user@` upstream; comparing
+    it would reject an alias that sets `User`, the common build-host shape,
+    while two same-box enrollments still land in the multiple-match
+    abstention. Any refused operand, spawn/timeout
+    failure, or unparseable output discards the whole fallback; two canonical
+    matches remain ambiguous. Results are briefly TTL-cached because ssh config
+    can change on disk. One,
     because several in a group cannot be told apart from here, and unioning
     them let a plain connection borrow a sibling's herdr signal. `SSHDestinationTTYProbe`
     is deliberately paranoid here, because every way an argv can name one host


### PR DESCRIPTION
## What

Stacked on #229. When exact enrolled-alias matching finds no host, the remote-herdr arm now canonicalizes the probed ssh destination through the user's own effective config — `/usr/bin/ssh` with `["ssh", "-G", "--", operand]` (config print only, no network I/O, closed stdin, bounded timeout) — and matches enrolled hosts whose own `ssh -G` resolution yields the same `(hostname, port)`. `ssh 192.168.1.167 herdr`, an FQDN, or a second config alias now reach an enrollment made under `sandbox-vpn`.

Fail-open by construction: operands are refused by the probe's existing destination policy BEFORE any subprocess sees them; any spawn/timeout/parse failure, or a failure for even one enrolled alias, discards the whole fallback and leaves exact-match behavior untouched (a canonicalization can only ADD a match). Two canonical matches keep the existing "matches multiple enrolled hosts" abstention. Results are TTL-cached (5 min, injected clock) because ssh config can change on disk. Exact matches never spawn anything.

One orchestrator review amendment over the codex implementation: the identity comparison originally included `user` when both outputs specified one — but real `ssh -G` ALWAYS emits a `user` line, and the probe strips `user@` from the operand upstream, so the operand side always carries the local default. That comparison falsely rejected exactly the target case (an alias with `User builder` vs an IP operand). `user` is now parsed but never compared; two same-box enrollments under different remote users both match and land in the multiple-match abstention (fail-closed). Pinned by `testAnAliasWithItsOwnUserStillMatchesAnIPOperand` (red under the comparison, green after) and `testTwoEnrollmentsToOneBoxUnderDifferentUsersBothMatch`.

`docs/agent/invariants.md` states the fallback and the user-exclusion rationale.

## Proof

- Full unit suite green after amendment: `Executed 2635 tests, with 2 tests skipped and 0 failures (0 unexpected) in 116.831 (117.043) seconds`
- Focused suites: `SSHDestinationCanonicalizerTests` 6/6, `RemoteHerdrJoinTests` 55/55.
- Regression (worker run): `testIPDestinationJoinsHostViaCanonicalSSHConfig` — red with the fallback disabled and the test unchanged (`XCTUnwrap failed: expected non-nil value of type "ClaudeSessionJoin"`, `Executed 1 test, with 1 failure`), green after (`Executed 1 test, with 0 failures`).
- Safety pins: `testRefusedOperandNeverReachesProcessRunner` (refused shapes never become argv), `testOneUnresolvableEnrolledAliasRejectsAllCanonicalMatches` (no partial host set), `testCacheUsesInjectedClockAndExpiresAtTTL` (no wall-clock).
- LLM lanes: not required — join matching only; nothing that reaches a model changes. (ClaudeContext paths run the polishd lane by filter.)
- UI: no UI change.
