### PR TITLE
Persistent per-host remote-herdr ssh forward: reuse across dictations, health-checked leases

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Off-screen Claude Code session context for the localvoxtral dictation app. Add this marketplace from a REMOTE host, where there is no app bundle to register a local directory from: claude plugin marketplace add T0mSIlver/localvoxtral",
-    "version": "1.3.0"
+    "version": "1.4.0"
   },
   "plugins": [
     {

--- a/Sources/ClaudeContextWire/ClaudeHookWire.swift
+++ b/Sources/ClaudeContextWire/ClaudeHookWire.swift
@@ -103,6 +103,14 @@ public enum ClaudeHookEvent: String, Sendable, Equatable, CaseIterable, Codable 
     /// TTY's declaration regardless, because a clear can only ever widen
     /// abstention.
     case focusCleared = "FocusCleared"
+    /// A read-only liveness probe, synthesized by the publisher's status-line
+    /// mode (`localvoxtral-claude-hook --statusline`) — NOT a Claude Code hook
+    /// name; Claude Code never sends it and the shim never forwards it. The
+    /// broker answers `accepted == the named session is live in the registry`
+    /// and MUST NOT ingest it: a probe that created or refreshed a session
+    /// would keep dead sessions alive by the very act of asking after them.
+    /// `ClaudeSessionRegistry.ingest` refuses it outright as the backstop.
+    case statusQuery = "StatusQuery"
 }
 
 /// Hard bounds applied at BOTH ends of the wire.
@@ -487,8 +495,10 @@ public enum ClaudeHookWireCodec {
 
     /// Truncate on a Character boundary so the result is always valid UTF-8
     /// (a byte-slice truncation could split a multi-byte scalar and produce a
-    /// string that fails to encode).
-    static func truncate(_ value: String, toUTF8Bytes limit: Int) -> String {
+    /// string that fails to encode). Public because the publisher's
+    /// status-line mode bounds `session_id` with the same rule the wire clamp
+    /// applies — one truncation semantic, not two.
+    public static func truncate(_ value: String, toUTF8Bytes limit: Int) -> String {
         guard value.utf8.count > limit else { return value }
         var result = ""
         var used = 0

--- a/Sources/ClaudeHookPublisherCore/ClaudeHookPublisher.swift
+++ b/Sources/ClaudeHookPublisherCore/ClaudeHookPublisher.swift
@@ -125,6 +125,96 @@ public struct ClaudeHookPublisher: Sendable {
         }
     }
 
+    // MARK: - Status line
+
+    /// What a `--statusline` run learned. Distinct from `Outcome` because the
+    /// contract is inverted: a hook must stay silent on failure, while a
+    /// status line EXISTS to render failure. Every case maps to one fixed
+    /// output string (or none) in `statusLineText(for:)` — nothing read off
+    /// the wire is ever echoed.
+    public enum StatusOutcome: Equatable, Sendable {
+        /// The broker answered: the session is live in the registry.
+        case connected
+        /// The broker answered: it has no live session by that id — the app
+        /// runs but this session's hooks are not reaching it (plugin not
+        /// installed, or the app started after the session's last event).
+        case sessionUnknown
+        /// Nothing answered on the socket: the app is not running (or this
+        /// environment has no resolvable socket path at all).
+        case appUnreachable
+        /// stdin was not a status-line payload with a usable `session_id`.
+        /// Rendered as nothing: a claim about a session we could not even
+        /// identify would be a guess, and the status line must never guess.
+        case unparseablePayload
+    }
+
+    /// Read the status-line payload Claude Code pipes in, ask the broker
+    /// whether that session is live, and say which of the four worlds we are
+    /// in. Never throws, never blocks past the socket deadline — the status
+    /// line re-runs constantly and a slow command stalls its refresh.
+    public func runStatusQuery(stdin: Data) -> StatusOutcome {
+        guard let sessionID = Self.statusLineSessionID(payload: stdin, limits: limits) else {
+            return .unparseablePayload
+        }
+        let record = ClaudeHookRecord(
+            event: .statusQuery,
+            sessionID: sessionID,
+            timestamp: environment.now()
+        )
+        guard let line = ClaudeHookWireCodec.encodeLine(record, limits: limits),
+              let socketPath = ClaudeHookSocketPath.resolve(environment: environment.variables)
+        else {
+            return .appUnreachable
+        }
+        switch publisher.publishAndReadReply(line: line, to: socketPath) {
+        case .failure:
+            return .appUnreachable
+        case .success(let reply):
+            // A listener that answers but does not say `accepted: true` — an
+            // older app dropping the unknown event, a missing or undecodable
+            // reply — lands on "not connected": something owns the socket,
+            // but it did not vouch for this session.
+            guard let reply,
+                  let response = ClaudeBrokerResponse.decodeLine(reply, limits: limits),
+                  response.accepted == true
+            else {
+                return .sessionUnknown
+            }
+            return .connected
+        }
+    }
+
+    /// `session_id` from a Claude Code status-line payload (a JSON object,
+    /// schema owned by Claude Code; `session_id` is documented always-present).
+    /// Bounded exactly like every other identifier that crosses the wire.
+    static func statusLineSessionID(payload: Data, limits: ClaudeHookLimits) -> String? {
+        guard let object = try? JSONSerialization.jsonObject(with: payload),
+              let dictionary = object as? [String: Any],
+              let sessionID = dictionary["session_id"] as? String,
+              !sessionID.isEmpty
+        else {
+            return nil
+        }
+        return ClaudeHookWireCodec.truncate(sessionID, toUTF8Bytes: limits.maxPathBytes)
+    }
+
+    /// The one line to print, or nil for nothing. FIXED strings only, chosen
+    /// by outcome — no wire byte, marker, path, or id is ever interpolated,
+    /// so nothing that crossed a socket can put a byte on the terminal.
+    /// ANSI SGR is deliberate: Claude Code renders it in the status line.
+    public static func statusLineText(for outcome: StatusOutcome) -> String? {
+        switch outcome {
+        case .connected:
+            return "\u{1B}[32m\u{25CF}\u{1B}[0m localvoxtral connected"
+        case .sessionUnknown:
+            return "\u{1B}[33m\u{25CB}\u{1B}[0m localvoxtral not connected"
+        case .appUnreachable:
+            return "\u{1B}[2m\u{25CB} localvoxtral not running\u{1B}[0m"
+        case .unparseablePayload:
+            return nil
+        }
+    }
+
     /// Safe metadata only: identity and location of the terminal, never its
     /// contents and never argv/env beyond an ALLOWLIST — `$TERM_PROGRAM` plus
     /// the multiplexer/bridge handles below.

--- a/Sources/localvoxtral-claude-hook/main.swift
+++ b/Sources/localvoxtral-claude-hook/main.swift
@@ -25,7 +25,24 @@ func parsedEvent(from arguments: [String]) -> String? {
     return arguments[index + 1]
 }
 
-let event = parsedEvent(from: Array(CommandLine.arguments.dropFirst()))
+let arguments = Array(CommandLine.arguments.dropFirst())
+
+// Status-line mode: `localvoxtral-claude-hook --statusline`, wired by the USER
+// into Claude Code's `statusLine` setting (the app never writes that file).
+// Reads the status-line payload, asks the broker whether this session is live,
+// and prints ONE fixed indicator line. The strings are compile-time constants
+// chosen by outcome — nothing read off the socket is ever echoed — and a
+// payload we cannot attribute prints nothing rather than guessing.
+if arguments.contains("--statusline") {
+    let payload = ClaudeHookPublisher.readBoundedStdin()
+    let outcome = ClaudeHookPublisher().runStatusQuery(stdin: payload)
+    if let text = ClaudeHookPublisher.statusLineText(for: outcome) {
+        ClaudeHookPublisher.writeStdout(Data((text + "\n").utf8))
+    }
+    exit(0)
+}
+
+let event = parsedEvent(from: arguments)
 let stdin = ClaudeHookPublisher.readBoundedStdin()
 let outcome = ClaudeHookPublisher().run(stdin: stdin, fallbackEvent: event)
 

--- a/Sources/localvoxtral/ClaudeContext/ClaudeContextBroker.swift
+++ b/Sources/localvoxtral/ClaudeContext/ClaudeContextBroker.swift
@@ -631,6 +631,11 @@ public final class ClaudeContextBroker: Sendable {
     /// Connection-level rejections (foreign uid, unterminated over-cap line,
     /// too many records, read deadline) drop the connection WITHOUT a reply,
     /// unchanged — publishers observe those as an error/close, not a verdict.
+    ///
+    /// The one line that is not an ingest at all: a `StatusQuery` record is a
+    /// read-only probe whose reply reuses `accepted` to mean "that session is
+    /// live in the registry right now". It never reaches `ingest` and never
+    /// carries a marker back.
     @discardableResult
     private func handle(
         line: Data,
@@ -639,6 +644,24 @@ public final class ClaudeContextBroker: Sendable {
     ) -> (marker: ClaudeSessionMarker?, accepted: Bool, isHerdrHosted: Bool, replyVersion: Int) {
         do {
             let record = try ClaudeHookWireCodec.decodeLine(line, limits: limits.wire)
+            // A status probe (`--statusline` mode) is answered here and NEVER
+            // ingested: `accepted` carries "is that session live in the
+            // registry", nothing is created or refreshed by asking, and no
+            // marker ever rides a probe reply — a probe is not a hook, so it
+            // has no terminal to write a title into. `snapshot(sessionID:)`
+            // applies the same TTL + pid-liveness answer every join uses.
+            if record.event == .statusQuery {
+                let scopedID = ClaudeAgentSessionScope.scopedSessionID(
+                    agent: record.agent, sessionID: record.sessionID
+                )
+                let live = registry.snapshot(sessionID: scopedID) != nil
+                Log.claudeContext.debug("Status query: \(live ? "live" : "unknown", privacy: .public)")
+                // Deliberately NOT debugNotify: that seam means "a record was
+                // ingested or rejected", and a probe is neither — status-line
+                // traffic firing it would inflate any test counting real
+                // ingestions.
+                return (nil, live, false, record.version)
+            }
             // Per-agent pid cross-check against the KERNEL's answer. The
             // opencode plugin runs inside the agent process and dials this
             // socket from it, so the pid its records claim must be the pid on

--- a/Sources/localvoxtral/ClaudeContext/ClaudeRemoteContextListener.swift
+++ b/Sources/localvoxtral/ClaudeContext/ClaudeRemoteContextListener.swift
@@ -103,6 +103,9 @@ public final class ClaudeRemoteContextListener: Sendable {
     /// listener on every rebind, and evidence the user has not read yet must not
     /// be erased by enrolling a second host.
     private let rejections: ClaudeRemoteRejectionTally
+    /// Authenticated host activity can pre-start a slow herdr `-L` away from
+    /// dictation latency. The path remains an opaque remote label.
+    private let onRemoteHerdrActivity: @Sendable (String, String) -> Void
 
     #if DEBUG
     private let debugPostAuthenticationHook = Mutex<(@Sendable () -> Void)?>(nil)
@@ -141,7 +144,8 @@ public final class ClaudeRemoteContextListener: Sendable {
         limits: ClaudeRemoteListenerLimits = .default,
         rejections: ClaudeRemoteRejectionTally = ClaudeRemoteRejectionTally(),
         now: @escaping @Sendable () -> Date = { Date() },
-        uptimeNanos: @escaping @Sendable () -> UInt64 = { DispatchTime.now().uptimeNanoseconds }
+        uptimeNanos: @escaping @Sendable () -> UInt64 = { DispatchTime.now().uptimeNanoseconds },
+        onRemoteHerdrActivity: @escaping @Sendable (String, String) -> Void = { _, _ in }
     ) {
         self.registry = registry
         self.hosts = hosts
@@ -149,6 +153,7 @@ public final class ClaudeRemoteContextListener: Sendable {
         self.rejections = rejections
         self.now = now
         self.uptimeNanos = uptimeNanos
+        self.onRemoteHerdrActivity = onRemoteHerdrActivity
     }
 
     public var isRunning: Bool { state.withLock { $0.isRunning } }
@@ -490,6 +495,9 @@ public final class ClaudeRemoteContextListener: Sendable {
             return
         }
         hosts.noteActivity(hostID: host.id)
+        if let socketPath = prepared.environment?.herdrSocketPath {
+            onRemoteHerdrActivity(host.id, socketPath)
+        }
         respond(fd: fd, status: 200, body: ClaudeRemoteHTTPCodec.markerResponseBody(marker: marker?.value))
     }
 

--- a/Sources/localvoxtral/ClaudeContext/ClaudeRemoteForwardCoordinator.swift
+++ b/Sources/localvoxtral/ClaudeContext/ClaudeRemoteForwardCoordinator.swift
@@ -47,6 +47,7 @@ public final class ClaudeRemoteForwardCoordinator {
     @ObservationIgnored private let remoteForwardPort: UInt16
     @ObservationIgnored private let listenerPort: UInt16
     @ObservationIgnored private let makeSupervisor: MakeSupervisor
+    @ObservationIgnored private let reconcileHerdrEnrollment: @MainActor (Set<String>) -> Void
     @ObservationIgnored private var supervisors: [String: any ClaudeRemoteForwarding] = [:]
 
     /// Whether the launch-time orphan reap has run yet. Forwards may not start
@@ -64,13 +65,15 @@ public final class ClaudeRemoteForwardCoordinator {
         isListenerBound: @escaping @MainActor () -> Bool,
         makeSupervisor: MakeSupervisor? = nil,
         pidLedger: ClaudeRemoteForwardPidLedger? = nil,
-        reapOrphans: (@Sendable () async -> Void)? = nil
+        reapOrphans: (@Sendable () async -> Void)? = nil,
+        reconcileHerdrEnrollment: @escaping @MainActor (Set<String>) -> Void = { _ in }
     ) {
         self.hosts = hosts
         self.remoteForwardPort = remoteForwardPort
         self.listenerPort = listenerPort
         self.isListenerBound = isListenerBound
         self.reapOrphans = reapOrphans
+        self.reconcileHerdrEnrollment = reconcileHerdrEnrollment
         // No reaper means nothing to wait for — the seam's absence must not
         // stall every forward forever.
         self.orphanReap = reapOrphans == nil ? .done : .pending
@@ -114,6 +117,7 @@ public final class ClaudeRemoteForwardCoordinator {
     /// twice starts nothing twice, which is what lets every mutation path call
     /// it unconditionally.
     public func reconcile() {
+        reconcileHerdrEnrollment(activeHostIDs())
         guard isListenerBound() else {
             if !supervisors.isEmpty {
                 Log.claudeContext.info(
@@ -205,7 +209,16 @@ public final class ClaudeRemoteForwardCoordinator {
     }
 
     public func stopAll() {
+        // On the revoke-last-host path the Settings model calls stopAll before
+        // the listener closes. Reconcile the independent `-L` entries here too;
+        // on app quit the registry is still active, so this does not mislabel a
+        // quit as revocation (AppDelegate stops them explicitly with that reason).
+        reconcileHerdrEnrollment(activeHostIDs())
         for hostID in Array(supervisors.keys) { stop(hostID: hostID) }
+    }
+
+    private func activeHostIDs() -> Set<String> {
+        Set(hosts.hosts().filter { !$0.isRevoked }.map(\.id))
     }
 
     /// Every teardown still draining, for a caller that must not return until

--- a/Sources/localvoxtral/ClaudeContext/ClaudeRemoteForwardLiveProcess.swift
+++ b/Sources/localvoxtral/ClaudeContext/ClaudeRemoteForwardLiveProcess.swift
@@ -27,8 +27,8 @@ final class ClaudeRemoteForwardLiveProcess: ClaudeRemoteForwardProcess, @uncheck
     /// never resumed — a supervisor hung forever on a process that already
     /// exited.
     private struct ExitState {
-        var status: Int32?
-        var waiters: [CheckedContinuation<Int32, Never>] = []
+        var status: ClaudeRemoteForwardExitStatus?
+        var waiters: [CheckedContinuation<ClaudeRemoteForwardExitStatus, Never>] = []
     }
 
     private let exitState = Mutex(ExitState())
@@ -38,6 +38,7 @@ final class ClaudeRemoteForwardLiveProcess: ClaudeRemoteForwardProcess, @uncheck
     /// The spawned child's pid, for the pid ledger that lets the NEXT launch
     /// find this process should this one die without tearing it down.
     var processIdentifier: pid_t { process.processIdentifier }
+    var isRunning: Bool { process.isRunning }
 
     /// - Parameter argv: complete, including `ssh` at index 0 (the shape
     ///   `Configuration.argv` produces and the enrollment service already uses).
@@ -125,19 +126,21 @@ final class ClaudeRemoteForwardLiveProcess: ClaudeRemoteForwardProcess, @uncheck
         }
         if !tail.isEmpty { continuation.yield(tail) }
         continuation.finish()
-        let waiters = exitState.withLock { state -> [CheckedContinuation<Int32, Never>] in
-            state.status = status
+        let exitStatus = ClaudeRemoteForwardExitStatus.code(status)
+        let waiters = exitState.withLock {
+            state -> [CheckedContinuation<ClaudeRemoteForwardExitStatus, Never>] in
+            state.status = exitStatus
             defer { state.waiters = [] }
             return state.waiters
         }
-        for waiter in waiters { waiter.resume(returning: status) }
+        for waiter in waiters { waiter.resume(returning: exitStatus) }
     }
 
-    func waitUntilExit() async -> Int32 {
+    func waitUntilExit() async -> ClaudeRemoteForwardExitStatus {
         await withCheckedContinuation { continuation in
             // Check-and-register in ONE critical section, so an exit that lands
             // between the two cannot strand this waiter.
-            let alreadyExited = exitState.withLock { state -> Int32? in
+            let alreadyExited = exitState.withLock { state -> ClaudeRemoteForwardExitStatus? in
                 if let status = state.status { return status }
                 state.waiters.append(continuation)
                 return nil

--- a/Sources/localvoxtral/ClaudeContext/ClaudeRemoteForwardOrphanReaper.swift
+++ b/Sources/localvoxtral/ClaudeContext/ClaudeRemoteForwardOrphanReaper.swift
@@ -5,7 +5,7 @@ import Darwin
 #endif
 
 /// Kills forward `ssh` children a previous app run left behind, before this
-/// run's forwards dial the same remote port.
+/// run starts hook `-R` or herdr `-L` forwards.
 ///
 /// The bug this closes (field report, 2026-08-05): quit-and-reopen sometimes
 /// landed the pane on "Port held — close ssh sessions to that host." with a
@@ -13,7 +13,9 @@ import Darwin
 /// `ssh -N -R` from a run that ended without `applicationWillTerminate`
 /// (crash, force-quit) or whose teardown outran the bounded quit drain. It
 /// reparents to launchd, keepalives keep it healthy forever, and nothing else
-/// ever kills it.
+/// ever kills it. Persistent `-L` children share the same ledger and reaper;
+/// their records carry a process-group id so ProxyJump descendants are reaped
+/// with the checked group leader.
 ///
 /// Safety rules, in order of importance:
 ///
@@ -98,7 +100,7 @@ public struct ClaudeRemoteForwardOrphanReaper: Sendable {
     }
 
     private func reap(hostID: String, record: ClaudeRemoteForwardPidRecord) async {
-        guard let current = inspect(pid_t(record.pid)), current == record else {
+        guard record.matchesProcessIdentity(inspect(pid_t(record.pid))) else {
             // Dead, or the pid now names some other process entirely. Either
             // way there is nothing of ours to kill — only a record to retire.
             ledger.forget(hostID: hostID, pid: record.pid)
@@ -107,9 +109,9 @@ public struct ClaudeRemoteForwardOrphanReaper: Sendable {
         // Signal first, log second: the log call would otherwise sit inside
         // the verify-to-signal window the type comment promises is only
         // microseconds wide.
-        sendSignal(pid_t(record.pid), SIGTERM)
+        sendSignal(signalTarget(for: record), SIGTERM)
         Log.claudeContext.notice(
-            "Claude remote forward orphan from a previous run found for host \(hostID, privacy: .public) (pid \(record.pid, privacy: .public)); sent SIGTERM to free the remote port"
+            "Claude remote forward orphan from a previous run found for key \(hostID, privacy: .public) (pid \(record.pid, privacy: .public)); sent SIGTERM"
         )
         if await waitUntilGone(record) {
             Log.claudeContext.info(
@@ -121,7 +123,7 @@ public struct ClaudeRemoteForwardOrphanReaper: Sendable {
         // Re-verify before escalating. `waitUntilGone`'s last poll saw a
         // matching identity at most one interval ago, but SIGKILL is the one
         // signal nothing can decline, so it gets its own fresh check.
-        guard let beforeKill = inspect(pid_t(record.pid)), beforeKill == record else {
+        guard record.matchesProcessIdentity(inspect(pid_t(record.pid))) else {
             Log.claudeContext.info(
                 "Claude remote forward orphan for host \(hostID, privacy: .public) exited before SIGKILL; record retired"
             )
@@ -131,7 +133,7 @@ public struct ClaudeRemoteForwardOrphanReaper: Sendable {
         Log.claudeContext.error(
             "Claude remote forward orphan pid \(record.pid, privacy: .public) ignored SIGTERM; escalating to SIGKILL"
         )
-        sendSignal(pid_t(record.pid), SIGKILL)
+        sendSignal(signalTarget(for: record), SIGKILL)
         if await waitUntilGone(record, within: killGrace) {
             Log.claudeContext.info(
                 "Claude remote forward orphan for host \(hostID, privacy: .public) killed; record retired"
@@ -143,7 +145,7 @@ public struct ClaudeRemoteForwardOrphanReaper: Sendable {
         // poll), and the next launch retrying costs nothing. Forgetting here
         // would make a SIGKILL survivor permanently invisible.
         Log.claudeContext.error(
-            "Claude remote forward orphan pid \(record.pid, privacy: .public) survived SIGKILL; the remote port may stay bound"
+            "Claude remote forward orphan pid \(record.pid, privacy: .public) survived SIGKILL; its forwarding resource may stay bound"
         )
     }
 
@@ -152,10 +154,19 @@ public struct ClaudeRemoteForwardOrphanReaper: Sendable {
     ) async -> Bool {
         let limit = limit ?? terminationGrace
         for _ in 0..<Self.pollCount(limit: limit, interval: pollInterval) {
-            if inspect(pid_t(record.pid)) != record { return true }
+            if !record.matchesProcessIdentity(inspect(pid_t(record.pid))) { return true }
             do { try await sleepFor(pollInterval) } catch { break }
         }
-        return inspect(pid_t(record.pid)) != record
+        return !record.matchesProcessIdentity(inspect(pid_t(record.pid)))
+    }
+
+    /// Negative pid means the whole process group. Only records created by the
+    /// checked POSIX_SPAWN_SETPGROUP path carry this metadata.
+    private func signalTarget(for record: ClaudeRemoteForwardPidRecord) -> pid_t {
+        if let processGroupID = record.processGroupID, processGroupID > 1 {
+            return -pid_t(processGroupID)
+        }
+        return pid_t(record.pid)
     }
 
     /// How many interval sleeps cover `limit`, at least one.

--- a/Sources/localvoxtral/ClaudeContext/ClaudeRemoteForwardPidLedger.swift
+++ b/Sources/localvoxtral/ClaudeContext/ClaudeRemoteForwardPidLedger.swift
@@ -18,12 +18,33 @@ public struct ClaudeRemoteForwardPidRecord: Codable, Equatable, Sendable {
     public var startSeconds: UInt64
     public var startMicroseconds: UInt64
     public var executablePath: String
+    /// The pgid to signal for a child deliberately spawned as its own process
+    /// group leader. Nil for Foundation-spawned forwards and legacy records.
+    /// This is teardown metadata, not part of process identity.
+    public var processGroupID: Int32?
 
-    public init(pid: Int32, startSeconds: UInt64, startMicroseconds: UInt64, executablePath: String) {
+    public init(
+        pid: Int32,
+        startSeconds: UInt64,
+        startMicroseconds: UInt64,
+        executablePath: String,
+        processGroupID: Int32? = nil
+    ) {
         self.pid = pid
         self.startSeconds = startSeconds
         self.startMicroseconds = startMicroseconds
         self.executablePath = executablePath
+        self.processGroupID = processGroupID
+    }
+
+    /// Group ownership does not come from `proc_pidinfo`, so compare only the
+    /// kernel identity fields when re-validating a ledger record.
+    func matchesProcessIdentity(_ current: ClaudeRemoteForwardPidRecord?) -> Bool {
+        guard let current else { return false }
+        return pid == current.pid
+            && startSeconds == current.startSeconds
+            && startMicroseconds == current.startMicroseconds
+            && executablePath == current.executablePath
     }
 }
 
@@ -59,18 +80,17 @@ public enum ClaudeRemoteForwardProcessIdentity {
 /// Which forward `ssh` children this app has spawned, persisted across a death
 /// the app does not get to see coming.
 ///
-/// Why this exists: `applicationWillTerminate` kills the app-held `ssh -N -R`
-/// forwards on a CLEAN quit, but a crash, a force-quit, or a teardown that
-/// outruns the quit drain leaves the ssh reparented to launchd — alive
-/// indefinitely (BatchMode plus ServerAlive keepalives), still holding the
-/// remote port bind. The next launch's fresh forward is then refused and the
-/// pane reports "Port held" at a port this Mac's own orphan is holding, with a
-/// Retry that can only fail. The ledger is what makes that orphan findable:
-/// each spawn is recorded here, and `ClaudeRemoteForwardOrphanReaper` verifies
-/// and kills survivors before the next launch's forwards start.
+/// Why this exists: `applicationWillTerminate` kills the app-held hook `-R`
+/// and herdr `-L` forwards on a CLEAN quit, but a crash, force-quit, or teardown
+/// that outruns the quit drain leaves ssh reparented to launchd. The `-R` can
+/// keep the remote port bound; the `-L` can keep its local socket and any
+/// ProxyJump descendants alive. The ledger makes either orphan findable so
+/// `ClaudeRemoteForwardOrphanReaper` can verify and kill it before new
+/// forwards start.
 ///
-/// One record per host id — a host has at most one live forward at a time, and
-/// a respawn simply overwrites. Records are removed by the reaper (dead or
+/// One record per lifecycle key: the hook `-R` uses the host id and the herdr
+/// `-L` uses a purpose-scoped key for that host. Each purpose has at most one
+/// live forward, and a respawn simply overwrites. Records are removed by the reaper (dead or
 /// killed), never on process exit: a stale record for a dead pid costs one
 /// identity check at the next launch and nothing else. Records deliberately
 /// carry no remote port: an orphan holds whatever port it was spawned with,

--- a/Sources/localvoxtral/ClaudeContext/ClaudeRemoteForwardSupervisor.swift
+++ b/Sources/localvoxtral/ClaudeContext/ClaudeRemoteForwardSupervisor.swift
@@ -2,6 +2,10 @@ import Foundation
 import Observation
 import Synchronization
 
+#if canImport(Darwin)
+import Darwin
+#endif
+
 /// One long-lived `ssh -N -R` process, as a seam.
 ///
 /// A protocol rather than `Process` for the reason the backend supervisor
@@ -9,15 +13,32 @@ import Synchronization
 /// this one spawns **ssh against a real host**. No unit test may do that — not
 /// slowly, not flakily, not at all — so the process is injected and the tests
 /// drive a fake.
+public enum ClaudeRemoteForwardExitStatus: Sendable, Equatable {
+    case code(Int32)
+    /// The process-exit notification did not expose a status, and reaping here
+    /// would violate the local forward's PID/PGID lifetime invariant.
+    case unavailable
+
+    var logDescription: String {
+        switch self {
+        case .code(let status): return String(status)
+        case .unavailable: return "unavailable"
+        }
+    }
+}
+
 public protocol ClaudeRemoteForwardProcess: Sendable {
+    /// Cheap liveness used before reusing an app-held local forward.
+    var isRunning: Bool { get }
     /// stderr, line by line, finishing when the process does.
     ///
     /// stderr is not diagnostics here, it is the PRODUCT: `remote port
     /// forwarding failed` is the only thing that distinguishes "another machine
     /// holds this port" from any other reason ssh exited.
     var standardErrorLines: AsyncStream<String> { get }
-    /// Resumes with the exit status once the process ends.
-    func waitUntilExit() async -> Int32
+    /// Resumes with the exit status once the process ends, or an honest
+    /// unavailable value when observation and collection must stay separate.
+    func waitUntilExit() async -> ClaudeRemoteForwardExitStatus
     /// Ask it to stop (SIGTERM). Must be safe to call more than once, and after
     /// exit.
     func terminate()
@@ -136,6 +157,16 @@ public final class ClaudeRemoteForwardSupervisor: ClaudeRemoteForwarding {
     }
 
     public struct Configuration: Sendable, Equatable {
+        public struct LocalSocketForward: Sendable, Equatable {
+            public var localSocketPath: String
+            public var remoteSocketPath: String
+
+            public init(localSocketPath: String, remoteSocketPath: String) {
+                self.localSocketPath = localSocketPath
+                self.remoteSocketPath = remoteSocketPath
+            }
+        }
+
         public var hostID: String
         public var sshHostAlias: String
         /// The port bound on the REMOTE host — this Mac's allocation.
@@ -169,6 +200,10 @@ public final class ClaudeRemoteForwardSupervisor: ClaudeRemoteForwarding {
         /// so in the log. A process in an uninterruptible wait can outlive even
         /// this; pretending otherwise is how a teardown blocks forever.
         public var killGrace: Duration
+        /// Present for a supervised herdr `-L`; nil for the original hook
+        /// delivery `-R`. The lifecycle is shared, while argv and bind-failure
+        /// interpretation remain direction-specific.
+        public var localSocketForward: LocalSocketForward?
 
         public init(
             hostID: String,
@@ -190,6 +225,33 @@ public final class ClaudeRemoteForwardSupervisor: ClaudeRemoteForwarding {
             self.healthyUptime = healthyUptime
             self.terminationGrace = terminationGrace
             self.killGrace = killGrace
+            self.localSocketForward = nil
+        }
+
+        public init(
+            hostID: String,
+            sshHostAlias: String,
+            localSocketPath: String,
+            remoteSocketPath: String,
+            maxConsecutiveFailures: Int = 5,
+            settleDelay: Duration = .seconds(2),
+            healthyUptime: Duration = .seconds(60),
+            terminationGrace: Duration = .seconds(2),
+            killGrace: Duration = .seconds(1)
+        ) {
+            self.hostID = hostID
+            self.sshHostAlias = sshHostAlias
+            self.remoteForwardPort = 0
+            self.listenerPort = 0
+            self.maxConsecutiveFailures = maxConsecutiveFailures
+            self.settleDelay = settleDelay
+            self.healthyUptime = healthyUptime
+            self.terminationGrace = terminationGrace
+            self.killGrace = killGrace
+            self.localSocketForward = LocalSocketForward(
+                localSocketPath: localSocketPath,
+                remoteSocketPath: remoteSocketPath
+            )
         }
 
         /// The complete argv. No token is involved anywhere on this path — the
@@ -201,7 +263,14 @@ public final class ClaudeRemoteForwardSupervisor: ClaudeRemoteForwarding {
         /// through a failed connection rather than a silently accepted option
         /// (the `-V` lesson from PR #197).
         public var argv: [String] {
-            [
+            if let localSocketForward {
+                return ClaudeRemoteHerdrForwardService.argv(
+                    alias: sshHostAlias,
+                    localSocketPath: localSocketForward.localSocketPath,
+                    remoteSocketPath: localSocketForward.remoteSocketPath
+                )
+            }
+            return [
                 "ssh", "-N",
                 "-o", "BatchMode=yes",
                 "-o", "ExitOnForwardFailure=yes",
@@ -250,6 +319,10 @@ public final class ClaudeRemoteForwardSupervisor: ClaudeRemoteForwarding {
     /// before dialing it again.
     @ObservationIgnored public private(set) var teardown: Task<Void, Never>?
 
+    /// The process half of the reuse health gate. The socket half is owned by
+    /// the herdr service because only it knows the private local path.
+    public var hasRunningProcess: Bool { currentProcess?.isRunning == true }
+
     public init(
         configuration: Configuration,
         launch: @escaping Launch,
@@ -266,9 +339,15 @@ public final class ClaudeRemoteForwardSupervisor: ClaudeRemoteForwarding {
         guard superviseTask == nil else { return }
         stoppingIntentionally = false
         consecutiveFailures = 0
-        Log.claudeContext.info(
-            "Claude remote forward start requested for host \(self.configuration.hostID, privacy: .public) port \(self.configuration.remoteForwardPort, privacy: .public)"
-        )
+        if configuration.localSocketForward != nil {
+            Log.claudeContext.info(
+                "Claude remote herdr forward start requested for host \(self.configuration.hostID, privacy: .public)"
+            )
+        } else {
+            Log.claudeContext.info(
+                "Claude remote forward start requested for host \(self.configuration.hostID, privacy: .public) port \(self.configuration.remoteForwardPort, privacy: .public)"
+            )
+        }
         transition(to: .connecting)
         superviseTask = Task { @MainActor [weak self] in
             await self?.supervise()
@@ -385,6 +464,13 @@ public final class ClaudeRemoteForwardSupervisor: ClaudeRemoteForwarding {
         while !stoppingIntentionally, !Task.isCancelled {
             let process: any ClaudeRemoteForwardProcess
             do {
+                if let localForward = configuration.localSocketForward {
+                    // A SIGKILLed ssh cannot unlink its AF_UNIX listener. The
+                    // predecessor has exited before the restart loop reaches
+                    // this point, and this path lives in the entry's private
+                    // workspace, so clearing its stale name is safe.
+                    _ = Darwin.unlink(localForward.localSocketPath)
+                }
                 process = try launch(configuration)
             } catch {
                 Log.claudeContext.error(
@@ -436,6 +522,15 @@ public final class ClaudeRemoteForwardSupervisor: ClaudeRemoteForwarding {
             // that its stream finishes when the process does.
             let bindFailure = await watcher.value ?? nil
             let status = await process.waitUntilExit()
+            // A posix_spawn-backed local forward deliberately leaves its dead
+            // leader unreaped until teardown can issue the unconditional group
+            // SIGKILL. Calling this after the leader exit is therefore not
+            // redundant: it clears ProxyJump/ProxyCommand descendants before
+            // the pid/pgid can be reused. Foundation-backed `-R` processes make
+            // the call a harmless no-op after exit.
+            if configuration.localSocketForward != nil {
+                process.forceTerminate()
+            }
             currentProcess = nil
             // The process is DEAD. Retire its settle window here, while this
             // iteration's scope is still open — not in a `defer` that runs
@@ -455,7 +550,8 @@ public final class ClaudeRemoteForwardSupervisor: ClaudeRemoteForwarding {
             // config block being inherited, not a contended port (issue #215's
             // migration leaves exactly this behind). Different cause, different
             // fix, so it must not be reported as a held port.
-            if let refusedPort = bindFailure, refusedPort != configuration.remoteForwardPort {
+            if configuration.localSocketForward == nil,
+               let refusedPort = bindFailure, refusedPort != configuration.remoteForwardPort {
                 Log.claudeContext.error(
                     "Claude remote forward for host \(self.configuration.hostID, privacy: .public) inherited a stale RemoteForward for port \(refusedPort, privacy: .public); this Mac asked for \(self.configuration.remoteForwardPort, privacy: .public)"
                 )
@@ -464,7 +560,7 @@ public final class ClaudeRemoteForwardSupervisor: ClaudeRemoteForwarding {
                 return
             }
 
-            if bindFailure != nil {
+            if configuration.localSocketForward == nil, bindFailure != nil {
                 // Terminal by design. Restarting would dial a port another
                 // machine is holding, forever, silently.
                 Log.claudeContext.error(
@@ -499,7 +595,7 @@ public final class ClaudeRemoteForwardSupervisor: ClaudeRemoteForwarding {
 
             consecutiveFailures += 1
             Log.claudeContext.info(
-                "Claude remote forward for host \(self.configuration.hostID, privacy: .public) exited with status \(status, privacy: .public) (failure \(self.consecutiveFailures, privacy: .public))"
+                "Claude remote forward for host \(self.configuration.hostID, privacy: .public) exited with status \(status.logDescription, privacy: .public) (failure \(self.consecutiveFailures, privacy: .public))"
             )
 
             if consecutiveFailures >= max(1, configuration.maxConsecutiveFailures) {
@@ -532,7 +628,8 @@ public final class ClaudeRemoteForwardSupervisor: ClaudeRemoteForwarding {
         var refusedPort: UInt16?
         for await line in process.standardErrorLines {
             let lowered = line.lowercased()
-            if lowered.contains(ClaudeRemoteForwardPort.forwardFailureSignature) {
+            if configuration.localSocketForward == nil,
+               lowered.contains(ClaudeRemoteForwardPort.forwardFailureSignature) {
                 // Fall back to our own port when the number is missing or
                 // unparseable: the refusal is still real, and the
                 // conservative reading is the port we asked for.

--- a/Sources/localvoxtral/ClaudeContext/ClaudeRemoteHerdrForward.swift
+++ b/Sources/localvoxtral/ClaudeContext/ClaudeRemoteHerdrForward.swift
@@ -11,10 +11,9 @@ import Synchronization
 /// Deliberately NOT `ClaudeRemoteEnrollmentService.Runner`: that seam is
 /// run-to-completion (argv in, exit code out), and an `ssh -N` that returns is
 /// an ssh that is no longer forwarding anything. This one is spawn/observe/kill.
-protocol ClaudeRemoteHerdrForwardProcess: AnyObject, Sendable {
-    var isRunning: Bool { get }
+protocol ClaudeRemoteHerdrForwardProcess: ClaudeRemoteForwardProcess, AnyObject {
+    var processIdentifier: pid_t { get }
     /// SIGTERM, then SIGKILL if it does not go. Idempotent.
-    func terminate()
 }
 
 /// Spawns the forward's child process. Injected everywhere, defaulted nowhere:
@@ -44,11 +43,11 @@ protocol ClaudeRemoteHerdrWorkspaceProviding: Sendable {
 
 /// An open `ssh -L` forward to one remote herdr socket.
 ///
-/// Owned by the dictation that opened it and closed when that dictation is
-/// done with it — the stop-side `pane.read` needs the same tunnel the start
-/// side used, so the lifetime is the whole dictation and not one request.
-/// `close()` is idempotent and `deinit` calls it, so a join dropped on a path
-/// nobody thought about still takes the ssh child and the socket with it.
+/// A dictation-scoped lease on an app-owned forward. The stop-side `pane.read`
+/// needs the same local socket the start side used, so the lease lasts for the
+/// whole dictation. `close()` is idempotent and `deinit` calls it; releasing the
+/// last lease starts the service's injected-clock idle policy rather than
+/// killing a healthy process immediately.
 final class ClaudeRemoteHerdrForwardHandle: Sendable, Equatable {
     /// Identity, not value: two handles are the same forward only when they ARE
     /// the same object. This exists so `ClaudeSessionJoin` can stay `Equatable`
@@ -62,9 +61,9 @@ final class ClaudeRemoteHerdrForwardHandle: Sendable, Equatable {
     /// dialable by `HerdrSocketClient`'s unchanged local-socket guard.
     let localSocketPath: String
 
-    private let workspace: ClaudeRemoteHerdrForwardWorkspace
-    private let process: any ClaudeRemoteHerdrForwardProcess
-    private let removeWorkspace: @Sendable (ClaudeRemoteHerdrForwardWorkspace) -> Void
+    private let isProcessRunning: @Sendable () -> Bool
+    private let closeEveryTime: @Sendable () -> Void
+    private let closeOnce: @Sendable () -> Void
     private let closed = Mutex(false)
 
     init(
@@ -73,12 +72,26 @@ final class ClaudeRemoteHerdrForwardHandle: Sendable, Equatable {
         removeWorkspace: @escaping @Sendable (ClaudeRemoteHerdrForwardWorkspace) -> Void
     ) {
         self.localSocketPath = workspace.socketPath
-        self.workspace = workspace
-        self.process = process
-        self.removeWorkspace = removeWorkspace
+        self.isProcessRunning = { process.isRunning }
+        self.closeEveryTime = { process.terminate() }
+        self.closeOnce = {
+            removeWorkspace(workspace)
+            Log.claudeContext.info("Remote herdr forward closed")
+        }
     }
 
-    var isRunning: Bool { process.isRunning }
+    init(
+        localSocketPath: String,
+        isRunning: @escaping @Sendable () -> Bool,
+        release: @escaping @Sendable () -> Void
+    ) {
+        self.localSocketPath = localSocketPath
+        self.isProcessRunning = isRunning
+        self.closeEveryTime = {}
+        self.closeOnce = release
+    }
+
+    var isRunning: Bool { isProcessRunning() }
 
     func close() {
         // ALWAYS, before the idempotence guard: `terminate()` is itself
@@ -87,33 +100,32 @@ final class ClaudeRemoteHerdrForwardHandle: Sendable, Equatable {
         // could only ever be retried by a test calling `terminate()` twice —
         // deinit's `close()` was a no-op, so production had no second attempt
         // at all (review round 7).
-        process.terminate()
+        closeEveryTime()
         let alreadyClosed = closed.withLock { state -> Bool in
             if state { return true }
             state = true
             return false
         }
         guard !alreadyClosed else { return }
-        // The socket is ssh's to unlink on a clean exit, but a killed ssh
-        // leaves it behind — and the directory is ours either way.
-        removeWorkspace(workspace)
-        Log.claudeContext.info("Remote herdr forward closed")
+        closeOnce()
     }
 
     deinit { close() }
 }
 
-/// Opens an on-demand `ssh -L` tunnel to a REMOTE herdr's JSON socket.
+/// Supervises and leases a persistent `ssh -L` tunnel to a remote herdr socket.
 ///
 /// Why an app-managed forward at all: herdr's socket protocol is happy over a
 /// forwarded stream, but nothing on the user's machine forwards it — the
-/// enrollment tunnel is a RemoteForward carrying hook events the other way. So
-/// the join arm dials out for exactly as long as one dictation needs it.
+/// enrollment tunnel is a RemoteForward carrying hook events the other way.
+/// Authenticated host activity pre-starts this direction, and successful cold
+/// joins retain it across dictations until idle, revoke, or quit teardown.
 ///
 /// Every live capability is a seam, and the two that matter most are the
 /// clock and the sleep: readiness is a poll, and a poll with a real clock in it
 /// is a test that sleeps.
-struct ClaudeRemoteHerdrForwardService: ClaudeRemoteHerdrForwarding {
+@MainActor
+final class ClaudeRemoteHerdrForwardService: ClaudeRemoteHerdrForwarding {
     /// How long a forward has to become dialable before it is abandoned.
     ///
     /// This is on the dictation-start path, so it is a latency ceiling as much
@@ -130,6 +142,49 @@ struct ClaudeRemoteHerdrForwardService: ClaudeRemoteHerdrForwarding {
     private let sleepFor: @Sendable (TimeInterval) async -> Void
     private let readinessTimeout: TimeInterval
     private let pollInterval: TimeInterval
+    private let idleTimeout: TimeInterval
+    private let pidLedger: ClaudeRemoteForwardPidLedger?
+    private let processIdentity: @Sendable (pid_t) -> ClaudeRemoteForwardPidRecord?
+    private let hostIDForAlias: @MainActor (String) -> String?
+
+    private final class Entry {
+        let id = UUID()
+        let hostID: String
+        let alias: String
+        let remoteSocketPath: String
+        let workspace: ClaudeRemoteHerdrForwardWorkspace
+        let supervisor: ClaudeRemoteForwardSupervisor
+        var leaseCount = 0
+        var idleGeneration = 0
+        var idleTask: Task<Void, Never>?
+
+        init(
+            hostID: String,
+            alias: String,
+            remoteSocketPath: String,
+            workspace: ClaudeRemoteHerdrForwardWorkspace,
+            supervisor: ClaudeRemoteForwardSupervisor
+        ) {
+            self.hostID = hostID
+            self.alias = alias
+            self.remoteSocketPath = remoteSocketPath
+            self.workspace = workspace
+            self.supervisor = supervisor
+        }
+    }
+
+    private enum TeardownReason: String {
+        case healthFailure = "health failure"
+        case idle = "idle timeout"
+        case revoked = "enrollment revoked"
+        case quit = "app quit"
+        case coldFailure = "cold open failed"
+    }
+
+    private var entries: [String: Entry] = [:]
+    private var pendingTeardowns: [UUID: Task<Void, Never>] = [:]
+    private var orphanReapComplete: Bool
+    private var orphanReapWaiters: [CheckedContinuation<Void, Never>] = []
 
     init(
         spawner: any ClaudeRemoteHerdrForwardSpawning,
@@ -142,7 +197,14 @@ struct ClaudeRemoteHerdrForwardService: ClaudeRemoteHerdrForwarding {
             try? await Task.sleep(nanoseconds: UInt64(max(0, seconds) * 1_000_000_000))
         },
         readinessTimeout: TimeInterval = ClaudeRemoteHerdrForwardService.defaultReadinessTimeout,
-        pollInterval: TimeInterval = 0.025
+        pollInterval: TimeInterval = 0.025,
+        idleTimeout: TimeInterval = 5 * 60,
+        pidLedger: ClaudeRemoteForwardPidLedger? = nil,
+        orphanReapInitiallyComplete: Bool = true,
+        hostIDForAlias: @escaping @MainActor (String) -> String? = { $0 },
+        processIdentity: @escaping @Sendable (pid_t) -> ClaudeRemoteForwardPidRecord? = {
+            ClaudeRemoteForwardProcessIdentity.snapshot(pid: $0)
+        }
     ) {
         self.spawner = spawner
         self.workspaces = workspaces
@@ -151,6 +213,11 @@ struct ClaudeRemoteHerdrForwardService: ClaudeRemoteHerdrForwarding {
         self.sleepFor = sleepFor
         self.readinessTimeout = readinessTimeout
         self.pollInterval = pollInterval
+        self.idleTimeout = idleTimeout
+        self.pidLedger = pidLedger
+        self.orphanReapComplete = orphanReapInitiallyComplete
+        self.hostIDForAlias = hostIDForAlias
+        self.processIdentity = processIdentity
     }
 
     /// Spawn the tunnel and wait for its local end to answer, or nil.
@@ -163,6 +230,7 @@ struct ClaudeRemoteHerdrForwardService: ClaudeRemoteHerdrForwarding {
     /// thing that ever happens to it is being passed through to `ssh`, which
     /// resolves it on the host that named it.
     func open(alias: String, remoteSocketPath: String) async -> ClaudeRemoteHerdrForwardHandle? {
+        await waitForOrphanReap()
         guard ClaudeRemoteEnrollmentService.isValidHostAlias(alias) else {
             Log.claudeContext.info("Remote herdr forward refused: invalid host alias")
             return nil
@@ -171,6 +239,151 @@ struct ClaudeRemoteHerdrForwardService: ClaudeRemoteHerdrForwarding {
             Log.claudeContext.info("Remote herdr forward refused: unusable remote socket path")
             return nil
         }
+        guard let hostID = hostIDForAlias(alias) else {
+            Log.claudeContext.info("Remote herdr forward refused: alias no longer names one enrolled host")
+            return nil
+        }
+
+        if let entry = entries[hostID] {
+            let sameTarget = entry.alias == alias && entry.remoteSocketPath == remoteSocketPath
+            let processAlive = entry.supervisor.hasRunningProcess
+            let socketAnswers = processAlive && isSocketDialable(entry.workspace.socketPath)
+            if sameTarget, processAlive, socketAnswers {
+                Log.claudeContext.info(
+                    "Remote herdr forward reused for host \(hostID, privacy: .public)"
+                )
+                return makeLease(for: entry)
+            }
+            Log.claudeContext.notice(
+                "Remote herdr forward health failed for host \(hostID, privacy: .public) (process alive: \(processAlive, privacy: .public), socket answers: \(socketAnswers, privacy: .public)); replacing it"
+            )
+            await tearDown(hostID: hostID, reason: .healthFailure)
+        }
+
+        guard let entry = makeEntry(
+            hostID: hostID, alias: alias, remoteSocketPath: remoteSocketPath
+        ) else { return nil }
+        entries[hostID] = entry
+        entry.supervisor.start()
+        // `start()` registers supervision synchronously and launches on the
+        // main actor. Give that launch one actor turn before charging the cold
+        // readiness clock; spawn failures used to return before the first poll.
+        await Task.yield()
+
+        // Preserve the existing dictation-start ceiling. Activity-driven
+        // preparation starts the same supervised process off this path, so a
+        // slow ProxyJump can finish before the next dictation asks to reuse it.
+        let deadline = now().addingTimeInterval(max(0, readinessTimeout))
+        var sawRunningProcess = false
+        while true {
+            // Every loop follows an actor suspension (`yield` for the first,
+            // `sleepFor` thereafter). A different-target prepare may have
+            // legitimately replaced this entry while we were away; the cold
+            // opener no longer owns that host slot and must touch nothing.
+            guard let current = entries[hostID], current === entry else {
+                Log.claudeContext.info(
+                    "Remote herdr forward cold open superseded for host \(hostID, privacy: .public)"
+                )
+                return nil
+            }
+            guard now() < deadline else { break }
+            if entry.supervisor.hasRunningProcess {
+                sawRunningProcess = true
+                if isSocketDialable(entry.workspace.socketPath) {
+                    Log.claudeContext.info(
+                        "Remote herdr forward cold spawn ready for host \(hostID, privacy: .public)"
+                    )
+                    return makeLease(for: entry)
+                }
+            }
+            if entry.supervisor.state.isFailure
+                || (sawRunningProcess && !entry.supervisor.hasRunningProcess) {
+                Log.claudeContext.info(
+                    "Remote herdr forward abstained for host \(hostID, privacy: .public): ssh exited before readiness"
+                )
+                await tearDown(entry: entry, reason: .coldFailure)
+                return nil
+            }
+            await sleepFor(pollInterval)
+        }
+        Log.claudeContext.info(
+            "Remote herdr forward abstained for host \(hostID, privacy: .public): readiness timeout"
+        )
+        await tearDown(entry: entry, reason: .coldFailure)
+        return nil
+    }
+
+    /// Start or refresh a forward when an authenticated hook proves the host
+    /// active. Readiness is intentionally not awaited on this background path.
+    func prepare(hostID: String, alias: String, remoteSocketPath: String) async {
+        await waitForOrphanReap()
+        guard ClaudeRemoteEnrollmentService.isValidHostAlias(alias),
+              Self.isForwardableRemoteSocketPath(remoteSocketPath)
+        else {
+            Log.claudeContext.info(
+                "Remote herdr forward preparation refused for host \(hostID, privacy: .public): invalid target"
+            )
+            return
+        }
+        guard hostIDForAlias(alias) == hostID else {
+            Log.claudeContext.info(
+                "Remote herdr forward preparation refused for host \(hostID, privacy: .public): alias no longer uniquely names that enrolled host"
+            )
+            return
+        }
+        if let entry = entries[hostID] {
+            if entry.alias == alias,
+               entry.remoteSocketPath == remoteSocketPath,
+               !entry.supervisor.state.isFailure {
+                Log.claudeContext.info(
+                    "Remote herdr forward activity refresh for host \(hostID, privacy: .public)"
+                )
+                if entry.leaseCount == 0 { armIdleTeardown(for: entry) }
+                return
+            }
+            await tearDown(hostID: hostID, reason: .healthFailure)
+        }
+        guard let entry = makeEntry(
+            hostID: hostID, alias: alias, remoteSocketPath: remoteSocketPath
+        ) else { return }
+        entries[hostID] = entry
+        Log.claudeContext.info(
+            "Remote herdr forward preparing from host activity for host \(hostID, privacy: .public)"
+        )
+        entry.supervisor.start()
+        armIdleTeardown(for: entry)
+    }
+
+    func reconcileEnrollment(activeHostIDs: Set<String>) {
+        for hostID in Array(entries.keys) where !activeHostIDs.contains(hostID) {
+            stopNow(hostID: hostID, reason: .revoked)
+        }
+    }
+
+    func stopAllForQuit() {
+        for hostID in Array(entries.keys) { stopNow(hostID: hostID, reason: .quit) }
+    }
+
+    var drainingTeardowns: [Task<Void, Never>] { Array(pendingTeardowns.values) }
+
+    func markOrphanReapComplete() {
+        guard !orphanReapComplete else { return }
+        orphanReapComplete = true
+        let waiters = orphanReapWaiters
+        orphanReapWaiters = []
+        for waiter in waiters { waiter.resume() }
+    }
+
+    private func waitForOrphanReap() async {
+        guard !orphanReapComplete else { return }
+        await withCheckedContinuation { orphanReapWaiters.append($0) }
+    }
+
+    private func makeEntry(
+        hostID: String,
+        alias: String,
+        remoteSocketPath: String
+    ) -> Entry? {
 
         let workspace: ClaudeRemoteHerdrForwardWorkspace
         do {
@@ -187,49 +400,125 @@ struct ClaudeRemoteHerdrForwardService: ClaudeRemoteHerdrForwarding {
             return nil
         }
 
-        let process: any ClaudeRemoteHerdrForwardProcess
-        do {
-            process = try spawner.spawn(
-                argv: Self.argv(
-                    alias: alias,
-                    localSocketPath: workspace.socketPath,
-                    remoteSocketPath: remoteSocketPath
-                )
-            )
-        } catch {
-            Log.claudeContext.error(
-                "Remote herdr forward failed to spawn: \(String(describing: error), privacy: .public)"
-            )
-            workspaces.remove(workspace)
-            return nil
-        }
-
-        let handle = ClaudeRemoteHerdrForwardHandle(
-            workspace: workspace,
-            process: process,
-            removeWorkspace: { [workspaces] in workspaces.remove($0) }
+        let configuration = ClaudeRemoteForwardSupervisor.Configuration(
+            hostID: hostID,
+            sshHostAlias: alias,
+            localSocketPath: workspace.socketPath,
+            remoteSocketPath: remoteSocketPath
         )
+        let ledgerKey = Self.ledgerKey(hostID: hostID)
+        let supervisor = ClaudeRemoteForwardSupervisor(
+            configuration: configuration,
+            launch: { [spawner, pidLedger, processIdentity] config in
+                let process = try spawner.spawn(argv: config.argv)
+                if let pidLedger,
+                   var record = processIdentity(process.processIdentifier) {
+                    record.processGroupID = process.processIdentifier
+                    pidLedger.remember(hostID: ledgerKey, record: record)
+                }
+                return process
+            }
+        )
+        return Entry(
+            hostID: hostID,
+            alias: alias,
+            remoteSocketPath: remoteSocketPath,
+            workspace: workspace,
+            supervisor: supervisor
+        )
+    }
 
-        let deadline = now().addingTimeInterval(max(0, readinessTimeout))
-        while now() < deadline {
-            // An ssh that has already exited will never open the socket, and
-            // its exit is the common failure (auth refused, host down,
-            // BatchMode with no key). Noticing it is what turns a 2 s stall
-            // into a prompt abstention.
-            guard handle.isRunning else {
-                Log.claudeContext.info("Remote herdr forward abstained: ssh exited before readiness")
-                handle.close()
-                return nil
+    private func makeLease(for entry: Entry) -> ClaudeRemoteHerdrForwardHandle {
+        entry.idleTask?.cancel()
+        entry.idleTask = nil
+        entry.idleGeneration += 1
+        entry.leaseCount += 1
+        let entryID = entry.id
+        let hostID = entry.hostID
+        let generation = entry.idleGeneration
+        return ClaudeRemoteHerdrForwardHandle(
+            localSocketPath: entry.workspace.socketPath,
+            // The service performs the authoritative process+socket health
+            // check before issuing this lease. The handle itself owns no child.
+            isRunning: { true },
+            release: { [weak self] in
+                Task { @MainActor in
+                    self?.releaseLease(
+                        hostID: hostID,
+                        entryID: entryID,
+                        generation: generation
+                    )
+                }
             }
-            if isSocketDialable(workspace.socketPath) {
-                Log.claudeContext.info("Remote herdr forward ready")
-                return handle
-            }
-            await sleepFor(pollInterval)
+        )
+    }
+
+    private func releaseLease(hostID: String, entryID: UUID, generation: Int) {
+        guard let entry = entries[hostID],
+              entry.id == entryID,
+              entry.idleGeneration >= generation
+        else { return }
+        if entry.leaseCount > 0 { entry.leaseCount -= 1 }
+        guard entry.leaseCount == 0 else { return }
+        armIdleTeardown(for: entry)
+    }
+
+    private func armIdleTeardown(for entry: Entry) {
+        entry.idleTask?.cancel()
+        entry.idleGeneration += 1
+        let generation = entry.idleGeneration
+        let deadline = now().addingTimeInterval(max(0, idleTimeout))
+        let hostID = entry.hostID
+        entry.idleTask = Task { @MainActor [weak self] in
+            guard let self else { return }
+            await self.sleepFor(max(0, self.idleTimeout))
+            guard !Task.isCancelled,
+                  let current = self.entries[hostID],
+                  current === entry,
+                  current.idleGeneration == generation,
+                  current.leaseCount == 0,
+                  self.now() >= deadline
+            else { return }
+            await self.tearDown(hostID: hostID, reason: .idle)
         }
-        Log.claudeContext.info("Remote herdr forward abstained: readiness timeout")
-        handle.close()
-        return nil
+    }
+
+    private func tearDown(hostID: String, reason: TeardownReason) async {
+        guard let teardown = stopNow(hostID: hostID, reason: reason) else { return }
+        await teardown.value
+    }
+
+    /// Cold-open failures are allowed to retire only the entry that cold open
+    /// created. The identity check and dictionary removal are one main-actor
+    /// operation, so a replacement cannot land between them.
+    private func tearDown(entry: Entry, reason: TeardownReason) async {
+        guard let current = entries[entry.hostID], current === entry else { return }
+        guard let teardown = stopNow(hostID: entry.hostID, reason: reason) else { return }
+        await teardown.value
+    }
+
+    @discardableResult
+    private func stopNow(hostID: String, reason: TeardownReason) -> Task<Void, Never>? {
+        guard let entry = entries.removeValue(forKey: hostID) else { return nil }
+        entry.idleTask?.cancel()
+        entry.idleTask = nil
+        entry.supervisor.stop()
+        workspaces.remove(entry.workspace)
+        Log.claudeContext.info(
+            "Remote herdr forward teardown for host \(hostID, privacy: .public): \(reason.rawValue, privacy: .public)"
+        )
+        guard let teardown = entry.supervisor.teardown else { return nil }
+        let teardownID = UUID()
+        pendingTeardowns[teardownID] = teardown
+        Task { @MainActor [weak self] in
+            await teardown.value
+            self?.pendingTeardowns[teardownID] = nil
+        }
+        return teardown
+    }
+
+    private static func ledgerKey(hostID: String) -> String {
+        "herdr-local:\(hostID)"
     }
 
     /// The exact argv. Assembled in one static function so a test can assert
@@ -257,8 +546,9 @@ struct ClaudeRemoteHerdrForwardService: ClaudeRemoteHerdrForwarding {
     /// `ControlPath=none` is present for lifetime hygiene: over a shared
     /// master the forward would belong to the user's long-lived connection
     /// rather than to our child, and killing our child would not be a
-    /// teardown. It costs one handshake per dictation.
-    static func argv(
+    /// teardown. Persistence amortizes that handshake across dictations without
+    /// transferring ownership to a user's multiplexed session.
+    nonisolated static func argv(
         alias: String,
         localSocketPath: String,
         remoteSocketPath: String
@@ -299,7 +589,7 @@ struct ClaudeRemoteHerdrForwardService: ClaudeRemoteHerdrForwarding {
     ///   remote path would re-split the argument into a different forward;
     /// * no leading `-` (implied by the absolute rule, asserted anyway) so it
     ///   can never be read as an option.
-    static func isForwardableRemoteSocketPath(_ path: String) -> Bool {
+    nonisolated static func isForwardableRemoteSocketPath(_ path: String) -> Bool {
         guard path.hasPrefix("/"), !path.hasPrefix("-") else { return false }
         guard !path.contains(":") else { return false }
         return ClaudeRemoteEnvironmentCodec.isAcceptableValue(path)
@@ -308,9 +598,9 @@ struct ClaudeRemoteHerdrForwardService: ClaudeRemoteHerdrForwarding {
     /// `sun_path` is 104 bytes on Darwin including the terminator, and a path
     /// that does not fit produces a socket nothing can dial — a failure worth
     /// naming rather than discovering as a readiness timeout.
-    static let maxLocalSocketPathBytes = 100
+    nonisolated static let maxLocalSocketPathBytes = 100
 
-    static func isUsableLocalSocketPath(_ path: String) -> Bool {
+    nonisolated static func isUsableLocalSocketPath(_ path: String) -> Bool {
         path.hasPrefix("/") && !path.contains(":")
             && !path.isEmpty && path.utf8.count <= maxLocalSocketPathBytes
     }
@@ -322,7 +612,7 @@ struct ClaudeRemoteHerdrForwardService: ClaudeRemoteHerdrForwarding {
     /// listener at all — both look identical to `lstat`. A successful connect
     /// proves only the LOCAL listener, which is the point: what is on the other
     /// end is then re-proven by the herdr response itself.
-    static func dial(_ socketPath: String) -> Bool {
+    nonisolated static func dial(_ socketPath: String) -> Bool {
         var address = sockaddr_un()
         address.sun_family = sa_family_t(AF_UNIX)
         address.sun_len = UInt8(MemoryLayout<sockaddr_un>.size)
@@ -347,7 +637,8 @@ struct ClaudeRemoteHerdrForwardService: ClaudeRemoteHerdrForwarding {
 
 /// Protocol the resolver depends on, so the join arm can be tested without any
 /// notion of processes at all.
-protocol ClaudeRemoteHerdrForwarding: Sendable {
+@MainActor
+protocol ClaudeRemoteHerdrForwarding: AnyObject {
     func open(alias: String, remoteSocketPath: String) async -> ClaudeRemoteHerdrForwardHandle?
 }
 
@@ -479,12 +770,16 @@ final class LiveHerdrForwardProcess: ClaudeRemoteHerdrForwardProcess, @unchecked
         /// Signals actually delivered to the group, so a test can prove none is
         /// sent after the reap.
         var groupSignalsSent = 0
+        var exitStatus: ClaudeRemoteForwardExitStatus?
+        var exitWaiters: [CheckedContinuation<ClaudeRemoteForwardExitStatus, Never>] = []
     }
 
     private let pid: pid_t
     private let exited = DispatchSemaphore(value: 0)
     private let state = Mutex(State())
     private let source: any DispatchSourceProcess
+    private let stderrContinuation: AsyncStream<String>.Continuation
+    let standardErrorLines: AsyncStream<String>
     /// `waitpid`, injected so the reap path's error handling is testable
     /// without arranging real signal delivery. Same signature and same errno
     /// semantics as the real thing.
@@ -519,6 +814,9 @@ final class LiveHerdrForwardProcess: ClaudeRemoteHerdrForwardProcess, @unchecked
         reapEffortDidFinish: @escaping @Sendable () -> Void = {},
         willAttemptTeardownLock: @escaping @Sendable () -> Void = {}
     ) {
+        let (stderrLines, stderrContinuation) = AsyncStream<String>.makeStream(of: String.self)
+        self.standardErrorLines = stderrLines
+        self.stderrContinuation = stderrContinuation
         self.pid = pid
         self.waitForChild = waitForChild
         self.reapPollAttempts = reapPollAttempts
@@ -541,6 +839,7 @@ final class LiveHerdrForwardProcess: ClaudeRemoteHerdrForwardProcess, @unchecked
     }
 
     var isRunning: Bool { !state.withLock { $0.leaderExited } }
+    var processIdentifier: pid_t { pid }
 
     /// The group leader's pid. Exposed so the teardown test can kill the LEADER
     /// alone and prove that a dead leader does not suppress the group SIGKILL —
@@ -573,8 +872,8 @@ final class LiveHerdrForwardProcess: ClaudeRemoteHerdrForwardProcess, @unchecked
     /// So the exit source does not reap; it only records and wakes the waiter.
     /// The zombie it leaves is what RESERVES the pid (and with it the pgid) for
     /// as long as we might still need to signal the group. Teardown signals,
-    /// then reaps, and every later call is a no-op. Cost: one zombie per open
-    /// forward, for the life of one dictation.
+    /// then reaps, and every later call is a no-op. Cost: one zombie per
+    /// supervised forward if its leader exits before teardown.
     func terminate() {
         // Announced BEFORE the first thing that needs the mutex — the guard
         // below is itself a lock acquisition, so this is where a teardown
@@ -604,6 +903,24 @@ final class LiveHerdrForwardProcess: ClaudeRemoteHerdrForwardProcess, @unchecked
         // says nothing about the rest of its group.
         signalGroup(SIGKILL)
         reapWithoutBlocking()
+    }
+
+    func forceTerminate() {
+        // `terminate()` already carries the load-bearing sequence: group TERM,
+        // unconditional group KILL, then reap. Re-entering it is the production
+        // retry for a collection that was not definitive the first time.
+        terminate()
+    }
+
+    func waitUntilExit() async -> ClaudeRemoteForwardExitStatus {
+        await withCheckedContinuation { continuation in
+            let status = state.withLock { current -> ClaudeRemoteForwardExitStatus? in
+                if let status = current.exitStatus { return status }
+                current.exitWaiters.append(continuation)
+                return nil
+            }
+            if let status { continuation.resume(returning: status) }
+        }
     }
 
     /// Whether `-pid` still names OUR process group.
@@ -776,7 +1093,17 @@ final class LiveHerdrForwardProcess: ClaudeRemoteHerdrForwardProcess, @unchecked
     /// reap: the zombie is what keeps `-pid` meaning our group until teardown
     /// has finished signalling it.
     private func noteExit() {
-        state.withLock { $0.leaderExited = true }
+        let unavailable = ClaudeRemoteForwardExitStatus.unavailable
+        let waiters = state.withLock {
+            current -> [CheckedContinuation<ClaudeRemoteForwardExitStatus, Never>] in
+            guard current.exitStatus == nil else { return [] }
+            current.leaderExited = true
+            current.exitStatus = unavailable
+            defer { current.exitWaiters = [] }
+            return current.exitWaiters
+        }
+        stderrContinuation.finish()
+        for waiter in waiters { waiter.resume(returning: unavailable) }
         exited.signal()
     }
 }

--- a/Sources/localvoxtral/ClaudeContext/ClaudeRemoteListenerCoordinator.swift
+++ b/Sources/localvoxtral/ClaudeContext/ClaudeRemoteListenerCoordinator.swift
@@ -73,9 +73,18 @@ public final class ClaudeRemoteListenerCoordinator: ClaudeRemoteListenerControll
         self.makeListener = makeListener
     }
 
-    public convenience init(hosts: ClaudeRemoteHostRegistry, sessions: ClaudeSessionRegistry) {
+    public convenience init(
+        hosts: ClaudeRemoteHostRegistry,
+        sessions: ClaudeSessionRegistry,
+        onRemoteHerdrActivity: @escaping @Sendable (String, String) -> Void = { _, _ in }
+    ) {
         self.init(hosts: hosts, sessions: sessions) { registry, rejections in
-            ClaudeRemoteContextListener(registry: sessions, hosts: registry, rejections: rejections)
+            ClaudeRemoteContextListener(
+                registry: sessions,
+                hosts: registry,
+                rejections: rejections,
+                onRemoteHerdrActivity: onRemoteHerdrActivity
+            )
         }
     }
 

--- a/Sources/localvoxtral/ClaudeContext/ClaudeSessionRegistry.swift
+++ b/Sources/localvoxtral/ClaudeContext/ClaudeSessionRegistry.swift
@@ -151,6 +151,13 @@ public final class ClaudeSessionRegistry: Sendable {
         environment: ClaudeRemoteSessionEnvironment? = nil
     ) -> ClaudeSessionSnapshot? {
         let timestamp = now()
+        // A status probe is read-only by contract and is answered by the
+        // broker BEFORE ingest (`ClaudeContextBroker.handle`). Refusing it
+        // here too is the backstop: an ingested probe would CREATE a session
+        // for an id nobody ever hooked, or refresh the activity of one whose
+        // process is gone — the probe would keep alive the very state it
+        // exists to report on.
+        if record.event == .statusQuery { return nil }
         // A LOCAL Claude record whose raw id spells another namespace's prefix
         // is spelling a key that can never be its own: Claude Code ids are
         // bare UUIDs, opencode ids get the prefix added HERE, and remote ids

--- a/Sources/localvoxtral/ClaudeContext/ClaudeSessionRegistry.swift
+++ b/Sources/localvoxtral/ClaudeContext/ClaudeSessionRegistry.swift
@@ -624,6 +624,19 @@ public final class ClaudeSessionRegistry: Sendable {
         }
     }
 
+    /// Whether ANY session is live, without materializing them.
+    ///
+    /// The overlay's join badge asks this once per unjoined dictation purely to
+    /// decide between "nothing attached" and silence, and it needs no snapshot
+    /// — `liveSessions()` would copy every session's recent files and snippets
+    /// to answer a question about emptiness.
+    public func hasLiveSessions() -> Bool {
+        let timestamp = now()
+        return state.withLock { state in
+            state.sessions.values.contains { isFresh($0, now: timestamp) }
+        }
+    }
+
     public func evict(sessionID: String) {
         state.withLock { removeLocked(&$0, sessionID: sessionID) }
     }

--- a/Sources/localvoxtral/ClaudeContext/ClaudeSessionState.swift
+++ b/Sources/localvoxtral/ClaudeContext/ClaudeSessionState.swift
@@ -270,6 +270,13 @@ public enum ClaudeSessionReducer {
             break
         case .sessionEnd:
             snapshot.activity = .ended
+        case .statusQuery:
+            // Unreachable: a status probe is refused at the top of
+            // `ClaudeSessionRegistry.ingest` (and answered by the broker
+            // before that), so it can never be reduced into a snapshot. The
+            // case exists so adding a wire event stays a compile-time
+            // decision here rather than an implicit `break`.
+            break
         }
     }
 

--- a/Sources/localvoxtral/ClaudeContext/TerminalScreenClaudeJoin.swift
+++ b/Sources/localvoxtral/ClaudeContext/TerminalScreenClaudeJoin.swift
@@ -308,6 +308,18 @@ struct ClaudeSessionJoinResolver {
     /// can ONLY join via marker, because their TTY names another machine's
     /// device and `resolve(tty:)` refuses remote candidates outright.
     ///
+    /// Whether the registry currently holds ANY live session.
+    ///
+    /// Not a join and not a step toward one: the overlay's join badge asks it
+    /// to tell "nothing attached" apart from "there was nothing to attach", so
+    /// a Mac that simply is not running Claude Code shows no badge instead of a
+    /// permanent complaint. It reads no title, no TTY, no socket and no
+    /// process table — it cannot influence, or be influenced by, what `resolve`
+    /// decides.
+    func hasLiveSessions() -> Bool {
+        registry.hasLiveSessions()
+    }
+
     /// This remains the only place a join is resolved, once per dictation, at
     /// start — whichever mechanism answers.
     func resolve(target: TerminalScreenTarget) async -> ClaudeSessionJoin? {

--- a/Sources/localvoxtral/DictationOverlayController.swift
+++ b/Sources/localvoxtral/DictationOverlayController.swift
@@ -95,7 +95,8 @@ final class DictationOverlayController {
             errorMessage: nil,
             secureInputActive: false,
             metrics: OverlayLayoutMetrics(bodyFontSize: fontSizeProvider()),
-            polished: false
+            polished: false,
+            claudeJoin: .hidden
         )
         hostingView = TransparentHostingView(rootView: initialView)
         // Without this, NSHostingView probes the SwiftUI content at ∞×∞ and
@@ -143,7 +144,8 @@ final class DictationOverlayController {
             errorMessage: snapshot.errorMessage,
             secureInputActive: snapshot.secureInputActive,
             metrics: metrics,
-            polished: snapshot.polished
+            polished: snapshot.polished,
+            claudeJoin: snapshot.claudeJoin
         )
 
         let contentHeight = metrics.contentHeight(

--- a/Sources/localvoxtral/DictationOverlayView.swift
+++ b/Sources/localvoxtral/DictationOverlayView.swift
@@ -85,6 +85,9 @@ struct DictationOverlayView: View {
     /// see `OverlayLayoutMetrics` for why the two must stay in lockstep.
     let metrics: OverlayLayoutMetrics
     var polished: Bool = false
+    /// What this dictation's Claude Code session join resolved to. `.hidden`
+    /// renders nothing — see `OverlayClaudeJoinBadge`.
+    var claudeJoin: OverlayClaudeJoinBadge = .hidden
     private let cornerRadius: CGFloat = 12
 
     /// Warning text needs explicit light/dark variants: system `.red` over
@@ -142,10 +145,10 @@ struct DictationOverlayView: View {
     private var polishedBadge: some View {
         Label("Polished", systemImage: "wand.and.stars")
             .labelStyle(.titleAndIcon)
-            .font(.system(size: 10, weight: .semibold))
+            .font(.system(size: metrics.badgeFontSize, weight: .semibold))
             .foregroundStyle(.secondary)
-            .padding(.horizontal, 6)
-            .padding(.vertical, 1)
+            .padding(.horizontal, metrics.badgeHorizontalPadding)
+            .padding(.vertical, metrics.badgeVerticalPadding)
             .background(
                 Capsule(style: .continuous).fill(Color.primary.opacity(0.08))
             )
@@ -154,6 +157,62 @@ struct DictationOverlayView: View {
                     .strokeBorder(Color.primary.opacity(0.15), lineWidth: 0.5)
             )
             .accessibilityLabel("Polished by the language model")
+    }
+
+    /// Trailing pill naming the Claude Code session this dictation is grounded
+    /// in, or saying that none attached. Same quiet weight as `polishedBadge`
+    /// deliberately: an unjoined dictation still commits its text correctly, so
+    /// this annotates the panel — it is not an error, and the warning color
+    /// under the transcript is reserved for text that failed to insert.
+    ///
+    /// The distinction rides the icon (`link` vs `link.slash`) and the label,
+    /// not color, so it reads the same on both desktops without a second
+    /// appearance-matched palette.
+    @ViewBuilder
+    private var claudeJoinBadge: some View {
+        switch claudeJoin {
+        case .hidden:
+            EmptyView()
+        case .joined(let label):
+            joinPill(
+                systemImage: "link",
+                title: label,
+                accessibilityLabel: "Grounded in Claude Code session \(label)"
+            )
+        case .unjoined:
+            joinPill(
+                systemImage: "link.slash",
+                title: "No Claude session",
+                accessibilityLabel: "No Claude Code session joined for this dictation"
+            )
+        }
+    }
+
+    private func joinPill(
+        systemImage: String,
+        title: String,
+        accessibilityLabel: String
+    ) -> some View {
+        Label(title, systemImage: systemImage)
+            .labelStyle(.titleAndIcon)
+            .font(.system(size: metrics.badgeFontSize, weight: .semibold))
+            .foregroundStyle(.secondary)
+            .lineLimit(1)
+            .truncationMode(.tail)
+            .padding(.horizontal, metrics.badgeHorizontalPadding)
+            .padding(.vertical, metrics.badgeVerticalPadding)
+            .background(
+                Capsule(style: .continuous).fill(Color.primary.opacity(0.08))
+            )
+            .overlay(
+                Capsule(style: .continuous)
+                    .strokeBorder(Color.primary.opacity(0.15), lineWidth: 0.5)
+            )
+            // Yields header width to the phase title, which is the actionable
+            // half (the secure-input title tells the user what to DO); a long
+            // workspace name truncates instead of pushing it out.
+            .layoutPriority(-1)
+            .accessibilityLabel(accessibilityLabel)
     }
 
     var body: some View {
@@ -167,6 +226,7 @@ struct DictationOverlayView: View {
                         .controlSize(.small)
                 }
                 Spacer(minLength: 0)
+                claudeJoinBadge
                 if polished {
                     polishedBadge
                 }

--- a/Sources/localvoxtral/DictationViewModel+Session.swift
+++ b/Sources/localvoxtral/DictationViewModel+Session.swift
@@ -249,6 +249,11 @@ extension DictationViewModel {
         // review finding on #90). The refuse path / verdict apply below
         // re-set it from the fresh sample.
         sessionSecureInputActive = false
+        // Same rule for the join badge, and it matters more: a stale `.joined`
+        // from the previous dictation would tell the user THIS one is grounded
+        // in a session it never resolved. An attempt that exits before the
+        // capture runs (invalid endpoint, missing mic) must show nothing.
+        sessionClaudeJoinBadge = .hidden
         let requestedOutputMode = outputMode ?? settings.dictationOutputMode
         clearLatchedSessionMetadata()
         sessionOutputMode = requestedOutputMode
@@ -1661,6 +1666,7 @@ extension DictationViewModel {
             lastError = nil
         }
         sessionSecureInputActive = false
+        sessionClaudeJoinBadge = .hidden
         firstChunkPreprocessor.reset()
     }
 
@@ -2449,7 +2455,14 @@ extension DictationViewModel {
     private func startOverlayBufferSession() {
         let anchor = preResolvedOverlayAnchor
         preResolvedOverlayAnchor = nil
-        overlayBufferCoordinator.startSession(preResolvedAnchor: anchor)
+        // The badge travels WITH the start: the join is resolved before the
+        // socket connects and this runs after it, so it is always already
+        // known — and passing it in is what stops a later setter from being
+        // ordered wrong against the reset that starting a session performs.
+        overlayBufferCoordinator.startSession(
+            preResolvedAnchor: anchor,
+            claudeJoin: sessionClaudeJoinBadge
+        )
         if sessionSecureInputActive {
             // The overlay is the surface the user is actually watching while
             // buffering — warn there, not just in the (closed) popover. The

--- a/Sources/localvoxtral/DictationViewModel.swift
+++ b/Sources/localvoxtral/DictationViewModel.swift
@@ -399,7 +399,7 @@ final class DictationViewModel {
     /// prompt. Cleared on every session exit, like the screen capture.
     @ObservationIgnored
     var claudeSessionJoin: ClaudeSessionJoin?
-    /// Remote herdr `ssh -L` children this process has open. See
+    /// Remote herdr `ssh -L` leases this dictation has open. See
     /// `retainRemoteHerdrForward(of:)` for why they are owned here and not by
     /// the join that travels.
     private var liveRemoteHerdrForwards: [ClaudeRemoteHerdrForwardHandle] = []
@@ -2068,9 +2068,8 @@ final class DictationViewModel {
         claudeSessionJoin = nil
         // And the pane text with the join: it is that session's screen.
         socketPaneStartCapture = nil
-        // Every open `ssh -L`, not just this join's — the view model owns them
-        // all, so abandoning a dictation cannot leave one behind for a holder
-        // that no longer exists.
+        // Every `ssh -L` lease, not just this join's — abandoning a dictation
+        // cannot pin a persistent forward as actively used.
         closeRemoteHerdrForwards()
     }
 
@@ -2084,8 +2083,8 @@ final class DictationViewModel {
         liveRemoteHerdrForwards.append(forward)
     }
 
-    /// Closes every open remote herdr tunnel. Idempotent, and safe from any
-    /// path — including ones that never knew a tunnel existed.
+    /// Releases every remote herdr lease. Idempotent, and safe from any path —
+    /// including ones that never knew a tunnel existed.
     ///
     /// Called from every dictation exit (`discardTerminalScreenCapture`, the
     /// commit path once the stop-side pane read is done, `abortConnectingSession`)

--- a/Sources/localvoxtral/DictationViewModel.swift
+++ b/Sources/localvoxtral/DictationViewModel.swift
@@ -257,6 +257,18 @@ final class DictationViewModel {
     /// clear lives in DictationViewModel+Session.swift.
     var sessionSecureInputActive = false
 
+    /// What this session's Claude Code join resolved to, held for the overlay's
+    /// header badge.
+    ///
+    /// Latched here for the same reason `sessionSecureInputActive` is: the join
+    /// is resolved at session start, while the app the user dictated into is
+    /// still frontmost, but the overlay panel does not open until the realtime
+    /// socket connects — and `startSession` clears the state machine, so a
+    /// badge pushed at resolution time would be wiped by the session that is
+    /// supposed to show it. Internal, because the session-end clear lives in
+    /// DictationViewModel+Session.swift.
+    var sessionClaudeJoinBadge: OverlayClaudeJoinBadge = .hidden
+
     /// Ends the refused-start warning when no session is running: the icon
     /// (and the "Blocked" status line) return to normal, while `lastError`
     /// keeps the one-line explanation in the popover. A stopped session that
@@ -1927,6 +1939,11 @@ final class DictationViewModel {
             terminalScreenStartCapture = nil
             claudeSessionJoin = nil
             socketPaneStartCapture = nil
+            // No endpoint means the join is never consumed by anything, so
+            // there is no grounding to report on either way. Saying "no Claude
+            // session" here would be true and useless — nothing would have used
+            // one.
+            sessionClaudeJoinBadge = .hidden
             return
         }
         terminalScreenStartCapture = TerminalScreenContextSource.captureAtStart(
@@ -1943,6 +1960,17 @@ final class DictationViewModel {
         // exactly the moments it mattered — quit during polish, an aborted
         // connect — and the ssh outlived the app (review finding 4).
         retainRemoteHerdrForward(of: claudeSessionJoin)
+        // Read from the ONE resolved join, never by asking again. The badge is
+        // a description of `claudeSessionJoin`, so it cannot disagree with the
+        // context that actually ships.
+        sessionClaudeJoinBadge = OverlayClaudeJoinBadge.resolve(
+            join: claudeSessionJoin,
+            contextFeatureEnabled: settings.terminalScreenContextEnabled
+                || settings.claudeRepoContextEnabled,
+            liveSessionsExist: { [claudeSessionJoinResolver] in
+                claudeSessionJoinResolver?.hasLiveSessions() ?? false
+            }
+        )
         // Only a socket-routed pane join — herdr, remote herdr, or cmux —
         // produces a sample here (the function refuses everything else before
         // any socket request), and it reads exactly the joined pane. Fetched at

--- a/Sources/localvoxtral/OverlayBufferSessionCoordinator.swift
+++ b/Sources/localvoxtral/OverlayBufferSessionCoordinator.swift
@@ -41,7 +41,11 @@ enum OverlayBufferCommitOutcome: Equatable {
 @MainActor
 protocol OverlayBufferSessionCoordinating: AnyObject {
     func resolveAnchorNow() -> OverlayAnchor
-    func startSession(preResolvedAnchor: OverlayAnchor?)
+    /// Opens the overlay for a session. `claudeJoin` is taken here, not through
+    /// a later setter, because starting a session RESETS the panel state — a
+    /// badge pushed beforehand would be wiped, and one pushed afterwards
+    /// depended on a call order nothing enforced.
+    func startSession(preResolvedAnchor: OverlayAnchor?, claudeJoin: OverlayClaudeJoinBadge)
     func beginFinalizing(displayBufferText: String, commitBufferText: String)
     func refresh(displayBufferText: String, commitBufferText: String)
     @discardableResult
@@ -119,7 +123,10 @@ final class OverlayBufferSessionCoordinator: OverlayBufferSessionCoordinating {
         anchorResolver.resolveAnchor()
     }
 
-    func startSession(preResolvedAnchor: OverlayAnchor? = nil) {
+    func startSession(
+        preResolvedAnchor: OverlayAnchor? = nil,
+        claudeJoin: OverlayClaudeJoinBadge = .hidden
+    ) {
         dismissTask?.cancel()
         dismissTask = nil
         commitBufferText = ""
@@ -128,7 +135,7 @@ final class OverlayBufferSessionCoordinator: OverlayBufferSessionCoordinating {
         refreshLiveCommitTargetAppPID()
 
         let anchor = preResolvedAnchor ?? anchorResolver.resolveAnchor()
-        stateMachine.startSession(anchor: anchor)
+        stateMachine.startSession(anchor: anchor, claudeJoin: claudeJoin)
         renderCurrentSnapshot()
         Log.overlay.info("overlay session started (preResolved=\(preResolvedAnchor != nil, privacy: .public))")
     }

--- a/Sources/localvoxtral/OverlayBufferStateMachine.swift
+++ b/Sources/localvoxtral/OverlayBufferStateMachine.swift
@@ -109,6 +109,10 @@ struct OverlayBufferStateMachine {
         /// while the polished text is held before dismissal. Set only by the
         /// stop-commit polish path; cleared on every new session.
         let polished: Bool
+        /// What to say about this dictation's Claude Code session join. Set
+        /// once, from the join resolved at session start; cleared on every new
+        /// session. `.hidden` renders nothing at all.
+        let claudeJoin: OverlayClaudeJoinBadge
         let anchor: OverlayAnchor
     }
 
@@ -117,6 +121,7 @@ struct OverlayBufferStateMachine {
     private(set) var errorMessage: String?
     private(set) var secureInputActive = false
     private(set) var polished = false
+    private(set) var claudeJoin: OverlayClaudeJoinBadge = .hidden
     private(set) var anchor: OverlayAnchor?
 
     var snapshot: Snapshot? {
@@ -127,11 +132,21 @@ struct OverlayBufferStateMachine {
             errorMessage: errorMessage,
             secureInputActive: secureInputActive,
             polished: polished,
+            claudeJoin: claudeJoin,
             anchor: anchor
         )
     }
 
-    mutating func startSession(anchor: OverlayAnchor) {
+    /// Starts a session, taking the Claude join badge WITH the anchor rather
+    /// than through a follow-up setter.
+    ///
+    /// The join is resolved before the realtime socket connects and this call
+    /// happens after it, so the badge is always already known here — unlike
+    /// `polished`, which genuinely arrives later, at commit. Passing it in is
+    /// what makes the ordering unbreakable: a separate setter had to run AFTER
+    /// this method (which resets the session) to survive, and nothing in the
+    /// type system said so.
+    mutating func startSession(anchor: OverlayAnchor, claudeJoin: OverlayClaudeJoinBadge) {
         guard phase == .idle else {
             let currentPhase = phase
             Log.overlay.warning("startSession called but phase is \(String(describing: currentPhase)), not idle — ignoring")
@@ -142,6 +157,10 @@ struct OverlayBufferStateMachine {
         errorMessage = nil
         secureInputActive = false
         polished = false
+        // Assigned, never merely cleared: the previous dictation's join
+        // describes the previous dictation's session, and a badge that survived
+        // into this one would vouch for a grounding this session was not given.
+        self.claudeJoin = claudeJoin
         self.anchor = anchor
     }
 
@@ -196,6 +215,7 @@ struct OverlayBufferStateMachine {
         errorMessage = nil
         secureInputActive = false
         polished = false
+        claudeJoin = .hidden
         anchor = nil
     }
 }

--- a/Sources/localvoxtral/OverlayClaudeJoinBadge.swift
+++ b/Sources/localvoxtral/OverlayClaudeJoinBadge.swift
@@ -1,0 +1,123 @@
+import Foundation
+
+/// What the overlay says about THIS dictation's Claude Code session join.
+///
+/// A read-only description of the ONE answer `ClaudeSessionJoinResolver`
+/// produced at dictation start — never a second resolution and never a probe.
+/// Re-asking at display time would defeat the invariant the single resolution
+/// exists to hold (`docs/agent/invariants.md`): every consumer must describe
+/// the same session, and a badge that re-resolved could name a different one
+/// than the context actually attached.
+///
+/// It exists because a join that silently did not happen and one that did look
+/// identical today. The transcript commits either way; the only difference is
+/// whether the polish call was grounded in the session the user was talking to,
+/// and the user finds out by reading text that mis-transcribed the filenames
+/// they just said.
+///
+/// Three states, not a boolean, for a reason the marker arms make concrete: a
+/// checkmark cannot tell a correct join from a mis-join onto a stale session
+/// (a lingering title marker from an earlier session on the same host can win —
+/// see the residual documented on the remote herdr arm). Naming the joined
+/// workspace is what makes a wrong join recognizable at a glance, and a wrong
+/// join is worse than none.
+enum OverlayClaudeJoinBadge: Equatable, Sendable {
+    /// Nothing to say, so nothing is shown: neither context feature is on, or
+    /// the app knows of no session that could have joined. Silence is the
+    /// honest answer rather than a reassuring one — a user who does not run
+    /// Claude Code must not be told about a join that was never attempted.
+    case hidden
+    /// This dictation is grounded in the named workspace's session.
+    case joined(label: String)
+    /// Live sessions exist and none of them attached. The state the whole badge
+    /// is for: today this is indistinguishable from a working setup until you
+    /// read the committed text.
+    case unjoined
+}
+
+extension OverlayClaudeJoinBadge {
+    /// Longest workspace label the header pill renders. The pill shares one
+    /// header row with the phase title and the "Polished" badge, so the label
+    /// is a name to recognize, not a path to read.
+    static let maximumLabelLength = 24
+
+    /// Shown when a join resolved for a session that never reported a cwd. The
+    /// join is still real — it grounds the prompt — so the badge must not fall
+    /// back to `.unjoined` and call a working setup broken.
+    static let unnamedWorkspaceLabel = "Claude session"
+
+    /// Derives the badge from this dictation's resolved join.
+    ///
+    /// - Parameters:
+    ///   - join: the resolved join, or nil when no arm attached.
+    ///   - contextFeatureEnabled: whether either context feature is on — the
+    ///     SAME condition `resolveClaudeSessionJoin` gates on. Gating the badge
+    ///     on the repo setting alone would hide a real join resolved for screen
+    ///     attachment, which is a join the user cares about just as much.
+    ///   - liveSessionsExist: whether the registry currently holds any session.
+    ///     A closure, and evaluated only on the path that needs it: a resolved
+    ///     join already proves a session exists, and the registry is behind a
+    ///     lock every dictation start is already contending for.
+    static func resolve(
+        join: ClaudeSessionJoin?,
+        contextFeatureEnabled: Bool,
+        liveSessionsExist: () -> Bool
+    ) -> OverlayClaudeJoinBadge {
+        guard contextFeatureEnabled else { return .hidden }
+        if let join {
+            let name = join.snapshot.workspace?.displayName
+            let label = name.flatMap(displayLabel(forWorkspaceName:)) ?? unnamedWorkspaceLabel
+            return .joined(label: label)
+        }
+        // No join AND no session anywhere is the ordinary state of a Mac that
+        // is not running Claude Code. Only a session that COULD have attached
+        // makes "nothing attached" worth a pill.
+        return liveSessionsExist() ? .unjoined : .hidden
+    }
+
+    /// Reduces a workspace display name to something a single-line header pill
+    /// can safely render, or nil when nothing usable survives.
+    ///
+    /// `ClaudeWorkspaceReference.displayName` is already separator-free for a
+    /// REMOTE session (`opaqueLabel` strips it to alphanumerics), but a LOCAL
+    /// one is the last component of a real directory this user's own shell was
+    /// sitting in, and a macOS path component forbids only `/` and NUL — a
+    /// newline, a tab, or a bidi override is a legal directory name. The panel
+    /// is measured from the body text alone (`OverlayLayoutMetrics`), so a
+    /// label carrying a line break would draw outside the height the panel was
+    /// sized for, and a bidi override would reorder the header around it.
+    ///
+    /// Both hazards are neutralized, but not the same way, because they occupy
+    /// different amounts of space:
+    /// - `.control` (Cc — newline, tab) becomes a SPACE. It sits between two
+    ///   runs of text, and deleting it would glue them into one word that names
+    ///   a directory the user does not have.
+    /// - `.format` (Cf — bidi overrides, zero-width joiners) is DROPPED. It is
+    ///   zero-width by definition, so a space in its place would invent one.
+    ///
+    /// Whitespace runs then collapse to a single space — which also covers the
+    /// separator categories (U+2028/U+2029) — so no name can pad the pill wider
+    /// than its own text.
+    static func displayLabel(forWorkspaceName name: String) -> String? {
+        let neutralized = String(
+            String.UnicodeScalarView(
+                name.unicodeScalars.compactMap { scalar -> Unicode.Scalar? in
+                    switch scalar.properties.generalCategory {
+                    case .format: return nil
+                    case .control: return " "
+                    default: return scalar
+                    }
+                }
+            )
+        )
+        let collapsed = neutralized
+            .split(whereSeparator: { $0.isWhitespace })
+            .joined(separator: " ")
+        guard !collapsed.isEmpty else { return nil }
+        guard collapsed.count > maximumLabelLength else { return collapsed }
+        // Head-truncated: the leading characters of a directory name are the
+        // identifying ones, and the ellipsis says the rest was cut rather than
+        // letting a long name read as a different, shorter one.
+        return String(collapsed.prefix(maximumLabelLength - 1)) + "…"
+    }
+}

--- a/Sources/localvoxtral/OverlayLayoutMetrics.swift
+++ b/Sources/localvoxtral/OverlayLayoutMetrics.swift
@@ -28,9 +28,19 @@ struct OverlayLayoutMetrics: Equatable {
 
     var scale: CGFloat { bodyFontSize / Self.baseBodyFontSize }
 
-    // Fonts (11pt title/error at the base 13pt body).
+    // Fonts (11pt title/error, 10pt badge at the base 13pt body).
     var titleFontSize: CGFloat { 11 * scale }
     var errorFontSize: CGFloat { 11 * scale }
+    /// The header's trailing pills ("Polished", the Claude join badge). Scaled
+    /// like every other font here: a fixed 10pt overflowed `headerHeight` at
+    /// the smallest body size (which is `ceil(16 * scale)`, so it shrinks while
+    /// an unscaled pill did not) and shrank to a speck at the largest.
+    var badgeFontSize: CGFloat { 10 * scale }
+    /// Pill chrome, scaled with the pill's own text — unlike `contentPadding`,
+    /// which is deliberately fixed because it frames the panel rather than a
+    /// piece of scaling text.
+    var badgeHorizontalPadding: CGFloat { 6 * scale }
+    var badgeVerticalPadding: CGFloat { 1 * scale }
 
     // Panel geometry (400/420/540 at scale 1.0).
     var panelMinWidth: CGFloat { 400 * scale }

--- a/Sources/localvoxtral/localvoxtralApp.swift
+++ b/Sources/localvoxtral/localvoxtralApp.swift
@@ -156,6 +156,21 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     /// listener binds, and torn down before the app exits so no orphan ssh
     /// outlives the process that spawned it.
     private var claudeRemoteForwards: ClaudeRemoteForwardCoordinator?
+    /// Shared lifecycle for both remote-hook `-R` and remote-herdr `-L`
+    /// children: one ledger/reaper sees every app-held SSH process.
+    private let claudeRemoteForwardPidLedger = ClaudeRemoteForwardPidLedger()
+    private lazy var claudeRemoteHerdrForwards = ClaudeRemoteHerdrForwardService(
+        spawner: ClaudeRemoteHerdrForwardSpawner(),
+        workspaces: ClaudeRemoteHerdrForwardWorkspaces(),
+        pidLedger: claudeRemoteForwardPidLedger,
+        orphanReapInitiallyComplete: false,
+        hostIDForAlias: { [weak self] alias in
+            guard let matches = self?.claudeRemoteHosts?.hosts(
+                matchingSSHDestination: alias
+            ), matches.count == 1 else { return nil }
+            return matches[0].id
+        }
+    )
     /// Customized-but-outdated config files awaiting the user's
     /// update-or-keep decision; held here while onboarding is on screen.
     private var pendingConfigDefaultsPromptFileNames: [String]?
@@ -203,6 +218,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         // nothing about enrollment — the hosts stay enrolled for next launch.
         // Forwards first, listener second — the mirror of startup order.
         claudeRemoteForwards?.stopAll()
+        claudeRemoteHerdrForwards.stopAllForQuit()
         // `stopAll` only STARTS each SIGTERM→SIGKILL escalation. Returning
         // here without it finishing is how an ssh that is slow to die outlives
         // the app: reparented to launchd, still holding the remote bind, and
@@ -219,11 +235,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         // resolving joins against sessions nothing is feeding any more.
         viewModel.claudeSessionJoinResolver = nil
         viewModel.claudeSessionJoin = nil
-        // Quitting mid-dictation must take every remote herdr `ssh -L` with us.
-        // Asked of the view model, which OWNS them: during polish the join has
-        // already been consumed, so a quit that reached the child only through
-        // `claudeSessionJoin` found nil and left the ssh running past app exit
-        // (review finding 4).
+        // Drop any dictation leases after the app-owned service has stopped all
+        // persistent `ssh -L` children. During polish the join has already been
+        // consumed, so the explicit service owner is what makes quit complete.
         viewModel.closeRemoteHerdrForwards()
     }
 
@@ -237,7 +251,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     /// at quit, never a hang, and the escalation's own SIGKILL means the
     /// ordinary case finishes far inside it.
     private func drainRemoteForwardTeardowns(within seconds: TimeInterval) {
-        guard let teardowns = claudeRemoteForwards?.drainingTeardowns, !teardowns.isEmpty else {
+        let teardowns = (claudeRemoteForwards?.drainingTeardowns ?? [])
+            + claudeRemoteHerdrForwards.drainingTeardowns
+        guard !teardowns.isEmpty else {
             return
         }
         let deadline = Date().addingTimeInterval(seconds)
@@ -329,10 +345,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                         enrolledHosts: hosts
                     )
                 },
-                remoteHerdrForwards: ClaudeRemoteHerdrForwardService(
-                    spawner: ClaudeRemoteHerdrForwardSpawner(),
-                    workspaces: ClaudeRemoteHerdrForwardWorkspaces()
-                )
+                remoteHerdrForwards: claudeRemoteHerdrForwards
             )
             viewModel.claudeSessionJoinResolver = resolver
             // Pre-warm the Automation consent sheet OFF the dictation-start
@@ -450,7 +463,24 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         claudeRemoteHosts = registry
 
         let coordinator = registry.map { hosts in
-            ClaudeRemoteListenerCoordinator(hosts: hosts, sessions: claudeSessionRegistry)
+            ClaudeRemoteListenerCoordinator(
+                hosts: hosts,
+                sessions: claudeSessionRegistry,
+                onRemoteHerdrActivity: { [weak self] hostID, remoteSocketPath in
+                    Task { @MainActor [weak self] in
+                        guard let self,
+                              let host = self.claudeRemoteHosts?.host(id: hostID),
+                              !host.isRevoked,
+                              let alias = host.sshHostAlias
+                        else { return }
+                        await self.claudeRemoteHerdrForwards.prepare(
+                            hostID: hostID,
+                            alias: alias,
+                            remoteSocketPath: remoteSocketPath
+                        )
+                    }
+                }
+            )
         }
         claudeRemoteListenerCoordinator = coordinator
 
@@ -473,15 +503,24 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         // outran the quit drain) are killed before this run's forwards dial —
         // otherwise the fresh forward is refused its own port and the pane
         // reports "Port held" terminally at this Mac's own leftover.
-        let forwardPidLedger = ClaudeRemoteForwardPidLedger()
-        let forwardOrphanReaper = ClaudeRemoteForwardOrphanReaper(ledger: forwardPidLedger)
+        let forwardOrphanReaper = ClaudeRemoteForwardOrphanReaper(
+            ledger: claudeRemoteForwardPidLedger
+        )
         let forwards = registry.map { hosts in
             ClaudeRemoteForwardCoordinator(
                 hosts: hosts,
                 remoteForwardPort: remoteForwardPort,
                 isListenerBound: { coordinator?.isListening ?? false },
-                pidLedger: forwardPidLedger,
-                reapOrphans: { await forwardOrphanReaper.reap() }
+                pidLedger: claudeRemoteForwardPidLedger,
+                reapOrphans: { [weak self] in
+                    await forwardOrphanReaper.reap()
+                    await MainActor.run { self?.claudeRemoteHerdrForwards.markOrphanReapComplete() }
+                },
+                reconcileHerdrEnrollment: { [weak self] activeHostIDs in
+                    self?.claudeRemoteHerdrForwards.reconcileEnrollment(
+                        activeHostIDs: activeHostIDs
+                    )
+                }
             )
         }
         claudeRemoteForwards = forwards

--- a/Tests/localvoxtralTests/AgentDictationE2EEvalTests.swift
+++ b/Tests/localvoxtralTests/AgentDictationE2EEvalTests.swift
@@ -1113,7 +1113,7 @@ private final class EvalOverlayCoordinator: OverlayBufferSessionCoordinating {
         )
     }
 
-    func startSession(preResolvedAnchor _: OverlayAnchor?) {}
+    func startSession(preResolvedAnchor _: OverlayAnchor?, claudeJoin _: OverlayClaudeJoinBadge) {}
     func beginFinalizing(displayBufferText _: String, commitBufferText _: String) {}
     func refresh(displayBufferText _: String, commitBufferText _: String) {}
 

--- a/Tests/localvoxtralTests/ClaudeContextBrokerTests.swift
+++ b/Tests/localvoxtralTests/ClaudeContextBrokerTests.swift
@@ -385,6 +385,106 @@ final class ClaudeContextBrokerIntegrationTests: XCTestCase {
         XCTAssertEqual(response.accepted, true)
     }
 
+    // MARK: Status query — the read-only probe behind `--statusline`
+
+    func testUnknownEventLineIsRefusedWithAReplyNotADrop() throws {
+        // The version-skew story `--statusline` leans on: a NEW publisher
+        // sending StatusQuery to an OLD broker relies on the broker's
+        // unknown-event branch REPLYING `accepted: false` (which the
+        // publisher renders as "not connected") rather than dropping the
+        // connection (which would render "not running" against a healthy
+        // app). Pin the shape with an event name no build knows.
+        try broker.start()
+        let line = Data(
+            #"{"v":2,"event":"StatusQueryFromTheFuture","session_id":"skew","ts":1,"files":[]}"#
+                .utf8 + [0x0A]
+        )
+        let result = UnixSocketPublisher(timeout: 2.0).publishAndReadReply(line: line, to: socketPath)
+        guard case .success(let reply) = result else {
+            return XCTFail("an unknown event must still complete the exchange: \(result)")
+        }
+        let response = try XCTUnwrap(ClaudeBrokerResponse.decodeLine(try XCTUnwrap(reply)))
+        XCTAssertEqual(response.accepted, false)
+        XCTAssertNil(response.marker)
+        XCTAssertTrue(registry.liveSessions().isEmpty, "an unknown event must not create a session")
+    }
+
+    func testStatusQueryForALiveSessionRepliesAcceptedWithoutAMarker() throws {
+        try broker.start()
+        // Seed a live session through the front door.
+        let start = ClaudeHookRecord(
+            event: .sessionStart,
+            sessionID: "probe-me",
+            timestamp: 1,
+            rawCwd: "/repo",
+            process: ClaudeHookProcessInfo(hookPID: 4242, claudePID: getpid())
+        )
+        _ = UnixSocketPublisher(timeout: 2.0).publishAndReadReply(
+            line: try XCTUnwrap(ClaudeHookWireCodec.encodeLine(start)), to: socketPath
+        )
+
+        let query = ClaudeHookRecord(event: .statusQuery, sessionID: "probe-me", timestamp: 2)
+        let result = UnixSocketPublisher(timeout: 2.0).publishAndReadReply(
+            line: try XCTUnwrap(ClaudeHookWireCodec.encodeLine(query)), to: socketPath
+        )
+        guard case .success(let reply) = result else {
+            return XCTFail("publish failed: \(result)")
+        }
+        let response = try XCTUnwrap(ClaudeBrokerResponse.decodeLine(try XCTUnwrap(reply)))
+        XCTAssertEqual(response.accepted, true, "a live session must read as connected")
+        // This broker is constructed with the title fallback ON — the one
+        // configuration where a hook reply WOULD carry the marker. A probe is
+        // not a hook and has no terminal, so it must never get one.
+        XCTAssertNil(response.marker, "a probe reply must never carry a marker")
+    }
+
+    func testStatusQueryForAnUnknownSessionRepliesNotAcceptedAndCreatesNothing() throws {
+        try broker.start()
+        let query = ClaudeHookRecord(event: .statusQuery, sessionID: "never-hooked", timestamp: 1)
+        let result = UnixSocketPublisher(timeout: 2.0).publishAndReadReply(
+            line: try XCTUnwrap(ClaudeHookWireCodec.encodeLine(query)), to: socketPath
+        )
+        guard case .success(let reply) = result else {
+            return XCTFail("publish failed: \(result)")
+        }
+        let response = try XCTUnwrap(ClaudeBrokerResponse.decodeLine(try XCTUnwrap(reply)))
+        XCTAssertEqual(response.accepted, false)
+        XCTAssertNil(response.marker)
+        // The probe must not have created the session it asked after —
+        // otherwise the second probe for any id would answer "connected".
+        XCTAssertNil(registry.snapshot(sessionID: "never-hooked"))
+        XCTAssertTrue(registry.liveSessions().isEmpty)
+    }
+
+    func testStatusLineModeEndToEndThroughThePublisher() throws {
+        // The production `--statusline` path: hook seeds the session, then
+        // `runStatusQuery` reads a real status-line payload and asks the same
+        // broker over the same socket.
+        try broker.start()
+        let hookJSON = #"{"hook_event_name":"SessionStart","session_id":"sl-e2e","cwd":"/repo"}"#
+        let seeder = ClaudeHookPublisher(
+            environment: ClaudeHookPublisher.Environment(
+                now: { 1 },
+                pid: { 31_337 },
+                ppid: { getpid() },
+                ttyName: { _ in nil },
+                variables: [ClaudeHookSocketPath.environmentKey: socketPath]
+            )
+        )
+        _ = seeder.run(stdin: Data(hookJSON.utf8), fallbackEvent: nil)
+
+        let payload = #"{"session_id":"sl-e2e","cwd":"/repo","model":{"id":"m","display_name":"M"}}"#
+        XCTAssertEqual(seeder.runStatusQuery(stdin: Data(payload.utf8)), .connected)
+        XCTAssertEqual(
+            seeder.runStatusQuery(stdin: Data(#"{"session_id":"some-other"}"#.utf8)),
+            .sessionUnknown
+        )
+        XCTAssertNil(
+            registry.snapshot(sessionID: "some-other"),
+            "asking after a session must not create it"
+        )
+    }
+
     func testPublisherEmitsMarkerOutputWhenLocalTitleFallbackIsEnabled() throws {
         // The end-to-end join through the production publisher entry point.
         try broker.start()

--- a/Tests/localvoxtralTests/ClaudeHookPublisherTests.swift
+++ b/Tests/localvoxtralTests/ClaudeHookPublisherTests.swift
@@ -270,6 +270,74 @@ final class ClaudeHookPublisherTests: XCTestCase {
         ).run(stdin: Data(json.utf8), fallbackEvent: nil)
         XCTAssertEqual(outcome, .droppedTransport(.socketPathTooLong))
     }
+
+    // MARK: Status line mode — `--statusline`
+
+    func testStatusLinePayloadSessionIDIsExtractedAndBounded() {
+        let payload = #"{"session_id":"abc-123","cwd":"/repo","model":{"id":"m"}}"#
+        XCTAssertEqual(
+            ClaudeHookPublisher.statusLineSessionID(payload: Data(payload.utf8), limits: .default),
+            "abc-123"
+        )
+        // Bounded exactly like every wire identifier.
+        let long = String(repeating: "a", count: 9000)
+        let bounded = ClaudeHookPublisher.statusLineSessionID(
+            payload: Data(#"{"session_id":"\#(long)"}"#.utf8), limits: .default
+        )
+        XCTAssertEqual(bounded?.utf8.count, ClaudeHookLimits.default.maxPathBytes)
+    }
+
+    func testStatusLinePayloadWithoutAUsableSessionIDIsUnparseable() {
+        for payload in [
+            "", "not json", "[]", "{}",
+            #"{"session_id":""}"#,
+            #"{"session_id":42}"#,
+        ] {
+            XCTAssertEqual(
+                publisher().runStatusQuery(stdin: Data(payload.utf8)),
+                .unparseablePayload,
+                "\(payload) must not produce a claim about any session"
+            )
+        }
+    }
+
+    func testStatusQueryAgainstAnAbsentBrokerIsAppUnreachable() {
+        let payload = #"{"session_id":"s1"}"#
+        let outcome = ClaudeHookPublisher(
+            environment: makeEnvironment(
+                variables: [ClaudeHookSocketPath.environmentKey: "/tmp/absent-\(UUID().uuidString).sock"]
+            )
+        ).runStatusQuery(stdin: Data(payload.utf8))
+        XCTAssertEqual(outcome, .appUnreachable)
+    }
+
+    func testStatusQueryWithNoResolvableSocketPathIsAppUnreachable() {
+        XCTAssertEqual(
+            publisher(variables: [:]).runStatusQuery(stdin: Data(#"{"session_id":"s1"}"#.utf8)),
+            .appUnreachable
+        )
+    }
+
+    func testStatusLineTextIsFixedStringsOnly() throws {
+        // The whole output contract: four outcomes, three compile-time
+        // strings and one silence. Nothing here interpolates anything.
+        XCTAssertEqual(
+            ClaudeHookPublisher.statusLineText(for: .connected),
+            "\u{1B}[32m\u{25CF}\u{1B}[0m localvoxtral connected"
+        )
+        XCTAssertEqual(
+            ClaudeHookPublisher.statusLineText(for: .sessionUnknown),
+            "\u{1B}[33m\u{25CB}\u{1B}[0m localvoxtral not connected"
+        )
+        XCTAssertEqual(
+            ClaudeHookPublisher.statusLineText(for: .appUnreachable),
+            "\u{1B}[2m\u{25CB} localvoxtral not running\u{1B}[0m"
+        )
+        XCTAssertNil(
+            ClaudeHookPublisher.statusLineText(for: .unparseablePayload),
+            "a payload we cannot attribute must render as nothing, not a guess"
+        )
+    }
 }
 
 // MARK: - Socket path resolution

--- a/Tests/localvoxtralTests/ClaudeHookWireTests.swift
+++ b/Tests/localvoxtralTests/ClaudeHookWireTests.swift
@@ -46,6 +46,19 @@ final class ClaudeHookWireCodecTests: XCTestCase {
         XCTAssertEqual(try ClaudeHookWireCodec.decodeLine(encoded), original)
     }
 
+    func testStatusQueryRoundTripsOnTheCurrentWire() throws {
+        // The probe record is deliberately minimal: an id and a timestamp,
+        // no cwd, no prompt, no process block. Golden line pinned so the
+        // publisher's `--statusline` mode and the broker agree on bytes.
+        let query = ClaudeHookRecord(event: .statusQuery, sessionID: "sess-probe", timestamp: 7)
+        let encoded = try XCTUnwrap(ClaudeHookWireCodec.encodeLine(query))
+        XCTAssertEqual(
+            String(decoding: encoded, as: UTF8.self),
+            #"{"event":"StatusQuery","files":[],"session_id":"sess-probe","ts":7,"v":2}"# + "\n"
+        )
+        XCTAssertEqual(try ClaudeHookWireCodec.decodeLine(encoded), query)
+    }
+
     func testHerdrProcessFieldsUseGoldenWireNamesAndDecode() throws {
         let record = ClaudeHookRecord(
             event: .sessionStart,

--- a/Tests/localvoxtralTests/ClaudeRemoteContextListenerTests.swift
+++ b/Tests/localvoxtralTests/ClaudeRemoteContextListenerTests.swift
@@ -58,13 +58,15 @@ final class ClaudeRemoteContextListenerTests: XCTestCase {
     ///   tests) — a test that needs expiry advances this seam immediately.
     private func startListener(
         limits: ClaudeRemoteListenerLimits? = nil,
-        uptimeNanos: (@Sendable () -> UInt64)? = nil
+        uptimeNanos: (@Sendable () -> UInt64)? = nil,
+        onRemoteHerdrActivity: @escaping @Sendable (String, String) -> Void = { _, _ in }
     ) throws {
         listener = ClaudeRemoteContextListener(
             registry: sessions,
             hosts: hosts,
             limits: limits ?? ClaudeRemoteListenerLimits(port: port),
-            uptimeNanos: uptimeNanos ?? { DispatchTime.now().uptimeNanoseconds }
+            uptimeNanos: uptimeNanos ?? { DispatchTime.now().uptimeNanoseconds },
+            onRemoteHerdrActivity: onRemoteHerdrActivity
         )
         try listener.start()
     }
@@ -188,6 +190,31 @@ final class ClaudeRemoteContextListenerTests: XCTestCase {
         XCTAssertEqual(
             snapshot.sessionID,
             ClaudeRemoteSessionScope.scopedSessionID(hostID: hostID, sessionID: "s-1")
+        )
+    }
+
+    func testAuthenticatedHerdrActivityIsPublishedForForwardPreparation() throws {
+        struct Activity: Equatable {
+            var hostID: String
+            var socketPath: String
+        }
+        let activities = Mutex<[Activity]>([])
+        try startListener(onRemoteHerdrActivity: { hostID, socketPath in
+            activities.withLock { $0.append(Activity(hostID: hostID, socketPath: socketPath)) }
+        })
+
+        let response = try XCTUnwrap(try send(hookRequest(
+            token: token,
+            extraHeaders: [
+                "X-Lvx-Env-Herdr-Pane-Id: pane-7",
+                "X-Lvx-Env-Herdr-Socket-Path: /run/user/1000/herdr/default.sock",
+            ]
+        )))
+
+        XCTAssertEqual(response.status, 200)
+        XCTAssertEqual(
+            activities.withLock { $0 },
+            [Activity(hostID: hostID, socketPath: "/run/user/1000/herdr/default.sock")]
         )
     }
 

--- a/Tests/localvoxtralTests/ClaudeRemoteForwardCoordinatorTests.swift
+++ b/Tests/localvoxtralTests/ClaudeRemoteForwardCoordinatorTests.swift
@@ -83,7 +83,8 @@ final class ClaudeRemoteForwardCoordinatorTests: XCTestCase {
         registry: ClaudeRemoteHostRegistry,
         spy: ForwardSpy,
         isListenerBound: @escaping @MainActor () -> Bool = { true },
-        reapOrphans: (@Sendable () async -> Void)? = nil
+        reapOrphans: (@Sendable () async -> Void)? = nil,
+        reconcileHerdrEnrollment: @escaping @MainActor (Set<String>) -> Void = { _ in }
     ) -> ClaudeRemoteForwardCoordinator {
         ClaudeRemoteForwardCoordinator(
             hosts: registry,
@@ -91,7 +92,8 @@ final class ClaudeRemoteForwardCoordinatorTests: XCTestCase {
             listenerPort: 8473,
             isListenerBound: isListenerBound,
             makeSupervisor: { spy.makeSupervisor($0) },
-            reapOrphans: reapOrphans
+            reapOrphans: reapOrphans,
+            reconcileHerdrEnrollment: reconcileHerdrEnrollment
         )
     }
 
@@ -138,6 +140,23 @@ final class ClaudeRemoteForwardCoordinatorTests: XCTestCase {
         XCTAssertEqual(spy.started, [host.id])
         XCTAssertEqual(spy.stopped, [host.id])
         XCTAssertNil(coordinator.states[host.id])
+    }
+
+    func testRevocationIsAlsoReconciledIntoPersistentHerdrForwards() throws {
+        let registry = try makeRegistry()
+        let host = try registry.enroll(label: "buildhost", sshHostAlias: "builder").host
+        let seen = Mutex<[Set<String>]>([])
+        let coordinator = makeCoordinator(
+            registry: registry,
+            spy: ForwardSpy(),
+            reconcileHerdrEnrollment: { active in seen.withLock { $0.append(active) } }
+        )
+
+        coordinator.reconcile()
+        try registry.revoke(hostID: host.id)
+        coordinator.reconcile()
+
+        XCTAssertEqual(seen.withLock { $0 }, [[host.id], []])
     }
 
     func testTurningTheToggleOffStopsTheForward() throws {

--- a/Tests/localvoxtralTests/ClaudeRemoteForwardOrphanReaperTests.swift
+++ b/Tests/localvoxtralTests/ClaudeRemoteForwardOrphanReaperTests.swift
@@ -15,6 +15,7 @@ private final class MemoryLedgerStore: ClaudeRemoteHostStoreIO {
 private final class ProcessTableFake: @unchecked Sendable {
     private let live = Mutex<ClaudeRemoteForwardPidRecord?>(nil)
     private let sent = Mutex<[Int32]>([])
+    private let signalTargets = Mutex<[pid_t]>([])
     private let lethalSignals: Set<Int32>
 
     init(live record: ClaudeRemoteForwardPidRecord?, dyingOn lethalSignals: Set<Int32>) {
@@ -23,12 +24,14 @@ private final class ProcessTableFake: @unchecked Sendable {
     }
 
     var signals: [Int32] { sent.withLock { $0 } }
+    var targets: [pid_t] { signalTargets.withLock { $0 } }
 
     func inspect(_ pid: pid_t) -> ClaudeRemoteForwardPidRecord? {
         live.withLock { $0?.pid == Int32(pid) ? $0 : nil }
     }
 
     func sendSignal(_ pid: pid_t, _ signalNumber: Int32) {
+        signalTargets.withLock { $0.append(pid) }
         sent.withLock { $0.append(signalNumber) }
         if lethalSignals.contains(signalNumber) {
             live.withLock { $0 = nil }
@@ -112,6 +115,19 @@ final class ClaudeRemoteForwardOrphanReaperTests: XCTestCase {
         let table = ProcessTableFake(live: orphan, dyingOn: [SIGTERM])
         await makeReaper(ledger: ledger, table: table).reap()
         XCTAssertEqual(table.signals, [SIGTERM], "an orphan that honours SIGTERM is never SIGKILLed")
+        XCTAssertTrue(ledger.records().isEmpty)
+    }
+
+    func testAPosixSpawnForwardReapsItsOwnedProcessGroup() async {
+        var orphan = record(pid: 4242)
+        orphan.processGroupID = 4242
+        let ledger = makeLedger(with: ["herdr-local:host": orphan])
+        let table = ProcessTableFake(live: orphan, dyingOn: [SIGTERM])
+
+        await makeReaper(ledger: ledger, table: table).reap()
+
+        XCTAssertEqual(table.targets, [-4242])
+        XCTAssertEqual(table.signals, [SIGTERM])
         XCTAssertTrue(ledger.records().isEmpty)
     }
 

--- a/Tests/localvoxtralTests/ClaudeRemoteForwardSupervisorTests.swift
+++ b/Tests/localvoxtralTests/ClaudeRemoteForwardSupervisorTests.swift
@@ -11,8 +11,8 @@ private final class FakeForwardProcess: ClaudeRemoteForwardProcess, @unchecked S
     private let continuation: AsyncStream<String>.Continuation
 
     private struct ExitState {
-        var status: Int32?
-        var waiters: [CheckedContinuation<Int32, Never>] = []
+        var status: ClaudeRemoteForwardExitStatus?
+        var waiters: [CheckedContinuation<ClaudeRemoteForwardExitStatus, Never>] = []
     }
 
     private let exitState = Mutex(ExitState())
@@ -29,6 +29,7 @@ private final class FakeForwardProcess: ClaudeRemoteForwardProcess, @unchecked S
     var terminateCount: Int { terminations.withLock { $0 } }
     var forceTerminateCount: Int { forcedTerminations.withLock { $0 } }
     var hasExited: Bool { exitState.withLock { $0.status != nil } }
+    var isRunning: Bool { !hasExited }
 
     init(ignoresTermination: Bool = false) {
         self.ignoresTermination = ignoresTermination
@@ -45,18 +46,20 @@ private final class FakeForwardProcess: ClaudeRemoteForwardProcess, @unchecked S
     /// implementation guarantees, then waiters get the status.
     func finish(status: Int32) {
         continuation.finish()
-        let waiters = exitState.withLock { state -> [CheckedContinuation<Int32, Never>] in
+        let exitStatus = ClaudeRemoteForwardExitStatus.code(status)
+        let waiters = exitState.withLock {
+            state -> [CheckedContinuation<ClaudeRemoteForwardExitStatus, Never>] in
             guard state.status == nil else { return [] }
-            state.status = status
+            state.status = exitStatus
             defer { state.waiters = [] }
             return state.waiters
         }
-        for waiter in waiters { waiter.resume(returning: status) }
+        for waiter in waiters { waiter.resume(returning: exitStatus) }
     }
 
-    func waitUntilExit() async -> Int32 {
+    func waitUntilExit() async -> ClaudeRemoteForwardExitStatus {
         await withCheckedContinuation { continuation in
-            let already = exitState.withLock { state -> Int32? in
+            let already = exitState.withLock { state -> ClaudeRemoteForwardExitStatus? in
                 if let status = state.status { return status }
                 state.waiters.append(continuation)
                 return nil
@@ -87,6 +90,7 @@ private final class ForwardHarness {
     private(set) var processes: [FakeForwardProcess] = []
     private(set) var states: [ClaudeRemoteForwardSupervisor.State] = []
     private(set) var sleeps: [Duration] = []
+    var onLaunch: (@MainActor (ClaudeRemoteForwardSupervisor.Configuration) -> Void)?
 
     struct WaitTimeout: Error {}
 
@@ -178,8 +182,9 @@ private final class ForwardHarness {
     ) -> ClaudeRemoteForwardSupervisor {
         let supervisor = ClaudeRemoteForwardSupervisor(
             configuration: configuration,
-            launch: { [weak self] _ in
+            launch: { [weak self] configuration in
                 if let launchFailure { throw launchFailure }
+                self?.onLaunch?(configuration)
                 let process = FakeForwardProcess(
                     ignoresTermination: self?.processesIgnoreTermination ?? false
                 )
@@ -313,6 +318,18 @@ final class ClaudeRemoteForwardSupervisorTests: XCTestCase {
             remoteForwardPort: 28511,
             listenerPort: 8473,
             maxConsecutiveFailures: maxConsecutiveFailures,
+            settleDelay: .seconds(2)
+        )
+    }
+
+    private func localSocketConfiguration(
+        localSocketPath: String
+    ) -> ClaudeRemoteForwardSupervisor.Configuration {
+        ClaudeRemoteForwardSupervisor.Configuration(
+            hostID: "habc1234",
+            sshHostAlias: "builder",
+            localSocketPath: localSocketPath,
+            remoteSocketPath: "/run/user/1000/herdr/default.sock",
             settleDelay: .seconds(2)
         )
     }
@@ -504,6 +521,39 @@ final class ClaudeRemoteForwardSupervisorTests: XCTestCase {
             [.seconds(2), .milliseconds(500), .seconds(2), .seconds(1)],
             "\(harness.sleeps)"
         )
+    }
+
+    func testLocalSocketIsUnlinkedBeforeEveryLaunchIncludingRestart() async throws {
+        let directory = NSTemporaryDirectory()
+            .appending("lvx-forward-restart-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(atPath: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(atPath: directory) }
+        let socketPath = (directory as NSString).appendingPathComponent("h.sock")
+        XCTAssertTrue(FileManager.default.createFile(atPath: socketPath, contents: Data()))
+
+        let harness = ForwardHarness()
+        var existedAtLaunch: [Bool] = []
+        harness.onLaunch = { configuration in
+            let path = configuration.localSocketForward?.localSocketPath ?? ""
+            existedAtLaunch.append(FileManager.default.fileExists(atPath: path))
+        }
+        let supervisor = harness.makeSupervisor(
+            configuration: localSocketConfiguration(localSocketPath: socketPath)
+        )
+        supervisor.start()
+
+        let first = try await harness.process(0)
+        XCTAssertFalse(FileManager.default.fileExists(atPath: socketPath))
+        XCTAssertTrue(FileManager.default.createFile(atPath: socketPath, contents: Data()))
+        first.finish(status: 255)
+        _ = try await harness.process(1)
+
+        XCTAssertEqual(existedAtLaunch, [false, false])
+        XCTAssertFalse(
+            FileManager.default.fileExists(atPath: socketPath),
+            "a SIGKILLed predecessor may leave the AF_UNIX name behind"
+        )
+        supervisor.stop()
     }
 
     func testAProcessThatDiesInsideItsSettleWindowIsNeverReportedAsUp() async throws {

--- a/Tests/localvoxtralTests/ClaudeRemoteHerdrForwardTests.swift
+++ b/Tests/localvoxtralTests/ClaudeRemoteHerdrForwardTests.swift
@@ -36,6 +36,66 @@ private final class ForwardTestClock: @unchecked Sendable {
     var sleepCount: Int { sleeps.withLock { $0.count } }
 }
 
+/// A readiness clock whose sleeps park until the test releases the matching
+/// duration. That makes the cold-open replacement window orderable without a
+/// wall clock or scheduler guesses.
+private final class HeldForwardTestClock: @unchecked Sendable {
+    private struct PendingSleep {
+        let seconds: TimeInterval
+        let continuation: CheckedContinuation<Void, Never>
+    }
+
+    private struct State {
+        var now = Date(timeIntervalSince1970: 1_700_000_000)
+        var pending: [PendingSleep] = []
+    }
+
+    private let state = Mutex(State())
+
+    var now: @Sendable () -> Date {
+        { [self] in state.withLock { $0.now } }
+    }
+
+    var sleepFor: @Sendable (TimeInterval) async -> Void {
+        { [self] seconds in
+            await withCheckedContinuation { continuation in
+                state.withLock { $0.pending.append(PendingSleep(
+                    seconds: seconds, continuation: continuation
+                )) }
+            }
+        }
+    }
+
+    func advance(by seconds: TimeInterval) {
+        state.withLock { $0.now = $0.now.addingTimeInterval(seconds) }
+    }
+
+    func pendingCount(for seconds: TimeInterval) -> Int {
+        state.withLock { current in
+            current.pending.count { abs($0.seconds - seconds) < 0.000_001 }
+        }
+    }
+
+    func releaseOldestSleep(for seconds: TimeInterval) {
+        let continuation = state.withLock { current -> CheckedContinuation<Void, Never>? in
+            guard let index = current.pending.firstIndex(where: {
+                abs($0.seconds - seconds) < 0.000_001
+            }) else { return nil }
+            return current.pending.remove(at: index).continuation
+        }
+        continuation?.resume()
+    }
+
+    func releaseAllSleeps() {
+        let continuations = state.withLock { current -> [CheckedContinuation<Void, Never>] in
+            let continuations = current.pending.map(\.continuation)
+            current.pending = []
+            return continuations
+        }
+        for continuation in continuations { continuation.resume() }
+    }
+}
+
 /// Counts injected `waitpid` calls across threads (the reap runs on whichever
 /// thread called teardown).
 private final class ReapCallCounter: @unchecked Sendable {
@@ -51,32 +111,97 @@ private final class ReapCallCounter: @unchecked Sendable {
     var value: Int { count.withLock { $0 } }
 }
 
+private final class HerdrForwardMemoryLedgerStore: ClaudeRemoteHostStoreIO {
+    private let contents = Mutex<[String: Data]>([:])
+    func read(from url: URL) throws -> Data? { contents.withLock { $0[url.path] } }
+    func write(_ data: Data, to url: URL) throws { contents.withLock { $0[url.path] = data } }
+}
+
 private final class ForwardTestProcess: ClaudeRemoteHerdrForwardProcess, @unchecked Sendable {
-    private let running = Mutex(true)
+    private struct State {
+        var reportsRunning: Bool
+        var hasExited = false
+        var exitWaiters: [CheckedContinuation<ClaudeRemoteForwardExitStatus, Never>] = []
+    }
+
+    private let state: Mutex<State>
+    private let stderrContinuation: AsyncStream<String>.Continuation
+    let standardErrorLines: AsyncStream<String>
     let terminations = Mutex(0)
 
-    var isRunning: Bool { running.withLock { $0 } }
-    func exit() { running.withLock { $0 = false } }
+    init(reportsRunning: Bool = true) {
+        state = Mutex(State(reportsRunning: reportsRunning))
+        let (stream, continuation) = AsyncStream<String>.makeStream(of: String.self)
+        standardErrorLines = stream
+        stderrContinuation = continuation
+    }
+
+    var isRunning: Bool { state.withLock { $0.reportsRunning && !$0.hasExited } }
+    var processIdentifier: pid_t { 4_242 }
+    func exit() {
+        let waiters = state.withLock {
+            current -> [CheckedContinuation<ClaudeRemoteForwardExitStatus, Never>]? in
+            guard !current.hasExited else { return nil }
+            current.hasExited = true
+            defer { current.exitWaiters = [] }
+            return current.exitWaiters
+        }
+        guard let waiters else { return }
+        stderrContinuation.finish()
+        for waiter in waiters { waiter.resume(returning: .code(0)) }
+    }
+
+    func waitUntilExit() async -> ClaudeRemoteForwardExitStatus {
+        await withCheckedContinuation { continuation in
+            let alreadyExited = state.withLock { current -> Bool in
+                guard !current.hasExited else { return true }
+                current.exitWaiters.append(continuation)
+                return false
+            }
+            if alreadyExited { continuation.resume(returning: .code(0)) }
+        }
+    }
 
     func terminate() {
         terminations.withLock { $0 += 1 }
-        running.withLock { $0 = false }
+        exit()
     }
+
+    func forceTerminate() { terminate() }
 }
 
 private final class ForwardTestSpawner: ClaudeRemoteHerdrForwardSpawning, @unchecked Sendable {
     struct Failure: Error {}
 
     let argv = Mutex<[[String]]>([])
-    let process = ForwardTestProcess()
+    private let currentProcess: Mutex<ForwardTestProcess>
+    let processes = Mutex<[ForwardTestProcess]>([])
     private let fails: Bool
+    private let freshProcessPerSpawn: Bool
+    private let reportsRunning: Bool
 
-    init(fails: Bool = false) { self.fails = fails }
+    init(
+        fails: Bool = false,
+        freshProcessPerSpawn: Bool = false,
+        reportsRunning: Bool = true
+    ) {
+        self.fails = fails
+        self.freshProcessPerSpawn = freshProcessPerSpawn
+        self.reportsRunning = reportsRunning
+        currentProcess = Mutex(ForwardTestProcess(reportsRunning: reportsRunning))
+    }
+
+    var process: ForwardTestProcess { currentProcess.withLock { $0 } }
 
     func spawn(argv: [String]) throws -> any ClaudeRemoteHerdrForwardProcess {
         self.argv.withLock { $0.append(argv) }
         if fails { throw Failure() }
-        return process
+        if freshProcessPerSpawn, spawnCount > 1 {
+            currentProcess.withLock { $0 = ForwardTestProcess(reportsRunning: reportsRunning) }
+        }
+        let spawned = process
+        processes.withLock { $0.append(spawned) }
+        return spawned
     }
 
     var spawnCount: Int { argv.withLock { $0.count } }
@@ -112,6 +237,7 @@ private final class ForwardTestWorkspaces: ClaudeRemoteHerdrWorkspaceProviding, 
 }
 
 /// The app-managed `ssh -L` to a remote herdr socket.
+@MainActor
 final class ClaudeRemoteHerdrForwardTests: XCTestCase {
     private let remoteSocketPath = "/run/user/1000/herdr/default.sock"
     private let localSocketPath = "/tmp/lvx-herdr-fwd-abcd1234/h.sock"
@@ -120,6 +246,33 @@ final class ClaudeRemoteHerdrForwardTests: XCTestCase {
         spawner: ForwardTestSpawner,
         workspaces: ForwardTestWorkspaces,
         clock: ForwardTestClock,
+        dialable: @escaping @Sendable (String) -> Bool,
+        idleTimeout: TimeInterval = 5 * 60,
+        pidLedger: ClaudeRemoteForwardPidLedger? = nil,
+        orphanReapInitiallyComplete: Bool = true,
+        hostIDForAlias: @escaping @MainActor (String) -> String? = { _ in "host" },
+        processIdentity: @escaping @Sendable (pid_t) -> ClaudeRemoteForwardPidRecord? = { _ in nil }
+    ) -> ClaudeRemoteHerdrForwardService {
+        ClaudeRemoteHerdrForwardService(
+            spawner: spawner,
+            workspaces: workspaces,
+            isSocketDialable: dialable,
+            now: clock.now,
+            sleepFor: clock.sleepFor,
+            readinessTimeout: 2.0,
+            pollInterval: 0.025,
+            idleTimeout: idleTimeout,
+            pidLedger: pidLedger,
+            orphanReapInitiallyComplete: orphanReapInitiallyComplete,
+            hostIDForAlias: hostIDForAlias,
+            processIdentity: processIdentity
+        )
+    }
+
+    private func service(
+        spawner: ForwardTestSpawner,
+        workspaces: ForwardTestWorkspaces,
+        clock: HeldForwardTestClock,
         dialable: @escaping @Sendable (String) -> Bool
     ) -> ClaudeRemoteHerdrForwardService {
         ClaudeRemoteHerdrForwardService(
@@ -129,8 +282,22 @@ final class ClaudeRemoteHerdrForwardTests: XCTestCase {
             now: clock.now,
             sleepFor: clock.sleepFor,
             readinessTimeout: 2.0,
-            pollInterval: 0.025
+            pollInterval: 0.025,
+            idleTimeout: 5 * 60,
+            hostIDForAlias: { _ in "host" }
         )
+    }
+
+    private func waitUntil(
+        _ description: String,
+        iterations: Int = 1_000,
+        _ condition: @escaping @MainActor () -> Bool
+    ) async {
+        for _ in 0..<iterations {
+            if condition() { return }
+            await Task.yield()
+        }
+        XCTFail("timed out waiting for \(description)")
     }
 
     // MARK: - argv
@@ -229,12 +396,317 @@ final class ClaudeRemoteHerdrForwardTests: XCTestCase {
         handle.close()
         handle.close()
 
-        // `terminate()` is deliberately re-invoked by every close (it is the
-        // retry path for a failed collection) and is idempotent in EFFECT, so
-        // the contract is about what happened once: the workspace was removed
-        // exactly once, and the child was terminated at all.
+        // A lease release retains the healthy process; the injected idle clock
+        // advances without wall time and performs the bounded teardown.
+        for _ in 0..<10 { await Task.yield() }
+
         XCTAssertGreaterThanOrEqual(spawner.process.terminations.withLock { $0 }, 1)
         XCTAssertEqual(workspaces.removed.withLock { $0.map(\.socketPath) }, [localSocketPath])
+        XCTAssertTrue(clock.sleeps.withLock { $0.contains(5 * 60) })
+    }
+
+    func testAHealthyForwardIsReusedAcrossDictations() async throws {
+        let spawner = ForwardTestSpawner()
+        let workspaces = ForwardTestWorkspaces()
+        let clock = ForwardTestClock()
+        let service = service(
+            spawner: spawner, workspaces: workspaces, clock: clock, dialable: { _ in true }
+        )
+
+        let first = try unwrapAsync(
+            await service.open(alias: "builder", remoteSocketPath: remoteSocketPath)
+        )
+        first.close()
+        let second = try unwrapAsync(
+            await service.open(alias: "builder", remoteSocketPath: remoteSocketPath)
+        )
+
+        XCTAssertEqual(
+            spawner.spawnCount, 1,
+            "the next dictation should reuse the healthy app-held forward"
+        )
+        second.close()
+    }
+
+    func testAnUnhealthyRetainedForwardIsTornDownBeforeColdFallback() async throws {
+        let spawner = ForwardTestSpawner(freshProcessPerSpawn: true)
+        let workspaces = ForwardTestWorkspaces()
+        let clock = ForwardTestClock()
+        let probes = Mutex(0)
+        let service = service(
+            spawner: spawner,
+            workspaces: workspaces,
+            clock: clock,
+            dialable: { _ in
+                probes.withLock { count in
+                    count += 1
+                    return count != 2
+                }
+            }
+        )
+
+        let first = try unwrapAsync(
+            await service.open(alias: "builder", remoteSocketPath: remoteSocketPath)
+        )
+        let firstProcess = spawner.process
+        first.close()
+        let replacement = try unwrapAsync(
+            await service.open(alias: "builder", remoteSocketPath: remoteSocketPath)
+        )
+
+        XCTAssertEqual(spawner.spawnCount, 2)
+        XCTAssertGreaterThanOrEqual(firstProcess.terminations.withLock { $0 }, 1)
+        XCTAssertEqual(workspaces.removeCount, 1, "the unhealthy workspace is retired first")
+        replacement.close()
+    }
+
+    func testAReplacedEntryIgnoresItsOldLeaseRelease() async throws {
+        let spawner = ForwardTestSpawner(freshProcessPerSpawn: true)
+        let workspaces = ForwardTestWorkspaces()
+        let clock = ForwardTestClock()
+        let probes = Mutex(0)
+        let service = service(
+            spawner: spawner,
+            workspaces: workspaces,
+            clock: clock,
+            dialable: { _ in
+                probes.withLock { count in
+                    count += 1
+                    return count != 2
+                }
+            }
+        )
+
+        let oldLease = try unwrapAsync(
+            await service.open(alias: "builder", remoteSocketPath: remoteSocketPath)
+        )
+        let replacementLease = try unwrapAsync(
+            await service.open(alias: "builder", remoteSocketPath: remoteSocketPath)
+        )
+        let replacementProcess = spawner.process
+
+        oldLease.close()
+        for _ in 0..<10 { await Task.yield() }
+
+        XCTAssertEqual(
+            replacementProcess.terminations.withLock { $0 },
+            0,
+            "a lease from the retired entry must not release the replacement"
+        )
+        XCTAssertEqual(workspaces.removeCount, 1)
+
+        replacementLease.close()
+    }
+
+    func testAuthenticatedHostActivityStartsTheForwardOffTheDictationPath() async {
+        let spawner = ForwardTestSpawner()
+        let service = service(
+            spawner: spawner,
+            workspaces: ForwardTestWorkspaces(),
+            clock: ForwardTestClock(),
+            dialable: { _ in true }
+        )
+
+        await service.prepare(
+            hostID: "host", alias: "builder", remoteSocketPath: remoteSocketPath
+        )
+        await Task.yield()
+
+        XCTAssertEqual(spawner.spawnCount, 1)
+    }
+
+    func testColdOpenFailureDoesNotTearDownAReplacementEntry() async throws {
+        let spawner = ForwardTestSpawner(freshProcessPerSpawn: true)
+        let workspaces = ForwardTestWorkspaces()
+        let clock = HeldForwardTestClock()
+        let socketAnswers = Mutex(false)
+        let service = service(
+            spawner: spawner,
+            workspaces: workspaces,
+            clock: clock,
+            dialable: { _ in socketAnswers.withLock { $0 } }
+        )
+
+        let coldOpen = Task { @MainActor in
+            await service.open(alias: "builder", remoteSocketPath: remoteSocketPath)
+        }
+        await waitUntil("cold readiness sleep") {
+            spawner.spawnCount == 1 && clock.pendingCount(for: 0.025) == 1
+        }
+        let firstProcess = try XCTUnwrap(spawner.processes.withLock { $0.first })
+
+        let replacementPath = "/run/user/1000/herdr/replacement.sock"
+        await service.prepare(
+            hostID: "host", alias: "builder", remoteSocketPath: replacementPath
+        )
+        await waitUntil("replacement spawn") { spawner.spawnCount == 2 }
+        let replacement = spawner.process
+        XCTAssertGreaterThanOrEqual(firstProcess.terminations.withLock { $0 }, 1)
+
+        clock.advance(by: 2.0)
+        clock.releaseOldestSleep(for: 0.025)
+        let coldResult = await coldOpen.value
+        XCTAssertNil(coldResult)
+
+        XCTAssertEqual(
+            replacement.terminations.withLock { $0 }, 0,
+            "the failed cold open no longer owns this host entry"
+        )
+        socketAnswers.withLock { $0 = true }
+        let lease = try unwrapAsync(
+            await service.open(alias: "builder", remoteSocketPath: replacementPath)
+        )
+        XCTAssertEqual(spawner.spawnCount, 2, "the replacement must remain registered")
+        service.stopAllForQuit()
+        lease.close()
+        clock.releaseAllSleeps()
+    }
+
+    func testPrepareRefreshesAColdStartingForwardWithoutReplacingIt() async {
+        let spawner = ForwardTestSpawner(
+            freshProcessPerSpawn: true, reportsRunning: false
+        )
+        let clock = HeldForwardTestClock()
+        let service = service(
+            spawner: spawner,
+            workspaces: ForwardTestWorkspaces(),
+            clock: clock,
+            dialable: { _ in false }
+        )
+
+        let coldOpen = Task { @MainActor in
+            await service.open(alias: "builder", remoteSocketPath: remoteSocketPath)
+        }
+        await waitUntil("cold readiness sleep") {
+            spawner.spawnCount == 1 && clock.pendingCount(for: 0.025) == 1
+        }
+        let startingProcess = spawner.process
+
+        await service.prepare(
+            hostID: "host", alias: "builder", remoteSocketPath: remoteSocketPath
+        )
+        await Task.yield()
+
+        XCTAssertEqual(spawner.spawnCount, 1, "the supervisor owns completing its handshake")
+        XCTAssertEqual(startingProcess.terminations.withLock { $0 }, 0)
+
+        clock.advance(by: 2.0)
+        clock.releaseOldestSleep(for: 0.025)
+        let coldResult = await coldOpen.value
+        XCTAssertNil(coldResult)
+        clock.releaseAllSleeps()
+    }
+
+    func testOpenParksUntilTheLaunchOrphanReapCompletes() async throws {
+        let spawner = ForwardTestSpawner()
+        let service = service(
+            spawner: spawner,
+            workspaces: ForwardTestWorkspaces(),
+            clock: ForwardTestClock(),
+            dialable: { _ in true },
+            orphanReapInitiallyComplete: false
+        )
+        let attempted = Mutex(false)
+        let open = Task { @MainActor in
+            attempted.withLock { $0 = true }
+            return await service.open(alias: "builder", remoteSocketPath: remoteSocketPath)
+        }
+
+        await waitUntil("open attempt to reach the orphan-reap gate") {
+            attempted.withLock { $0 }
+        }
+        XCTAssertEqual(spawner.spawnCount, 0, "no ssh may launch ahead of orphan cleanup")
+
+        service.markOrphanReapComplete()
+        let handle = try unwrapAsync(await open.value)
+        XCTAssertEqual(spawner.spawnCount, 1)
+        handle.close()
+    }
+
+    func testPrepareRefusesAnAliasThatDoesNotUniquelyNameItsHostID() async {
+        let spawner = ForwardTestSpawner()
+        let service = service(
+            spawner: spawner,
+            workspaces: ForwardTestWorkspaces(),
+            clock: ForwardTestClock(),
+            dialable: { _ in true },
+            hostIDForAlias: { _ in "a-different-host" }
+        )
+
+        await service.prepare(
+            hostID: "host", alias: "builder", remoteSocketPath: remoteSocketPath
+        )
+        for _ in 0..<20 { await Task.yield() }
+
+        XCTAssertEqual(spawner.spawnCount, 0)
+    }
+
+    func testEnrollmentRevocationTearsDownThePersistentForward() async throws {
+        let spawner = ForwardTestSpawner()
+        let workspaces = ForwardTestWorkspaces()
+        let service = service(
+            spawner: spawner,
+            workspaces: workspaces,
+            clock: ForwardTestClock(),
+            dialable: { _ in true }
+        )
+        _ = try unwrapAsync(
+            await service.open(alias: "builder", remoteSocketPath: remoteSocketPath)
+        )
+
+        service.reconcileEnrollment(activeHostIDs: [])
+
+        XCTAssertGreaterThanOrEqual(spawner.process.terminations.withLock { $0 }, 1)
+        XCTAssertEqual(workspaces.removeCount, 1)
+    }
+
+    func testAppQuitTearsDownThePersistentForward() async throws {
+        let spawner = ForwardTestSpawner()
+        let workspaces = ForwardTestWorkspaces()
+        let service = service(
+            spawner: spawner,
+            workspaces: workspaces,
+            clock: ForwardTestClock(),
+            dialable: { _ in true }
+        )
+        _ = try unwrapAsync(
+            await service.open(alias: "builder", remoteSocketPath: remoteSocketPath)
+        )
+
+        service.stopAllForQuit()
+
+        XCTAssertGreaterThanOrEqual(spawner.process.terminations.withLock { $0 }, 1)
+        XCTAssertEqual(workspaces.removeCount, 1)
+    }
+
+    func testPersistentSpawnIsRecordedAsAnOwnedProcessGroup() async throws {
+        let ledger = ClaudeRemoteForwardPidLedger(
+            fileURL: URL(fileURLWithPath: "/tmp/herdr-forward-ledger.json"),
+            io: HerdrForwardMemoryLedgerStore()
+        )
+        let service = service(
+            spawner: ForwardTestSpawner(),
+            workspaces: ForwardTestWorkspaces(),
+            clock: ForwardTestClock(),
+            dialable: { _ in true },
+            pidLedger: ledger,
+            processIdentity: { pid in
+                ClaudeRemoteForwardPidRecord(
+                    pid: pid,
+                    startSeconds: 111,
+                    startMicroseconds: 7,
+                    executablePath: "/usr/bin/ssh"
+                )
+            }
+        )
+
+        _ = try unwrapAsync(
+            await service.open(alias: "builder", remoteSocketPath: remoteSocketPath)
+        )
+
+        let record = try XCTUnwrap(ledger.records()["herdr-local:host"])
+        XCTAssertEqual(record.pid, 4_242)
+        XCTAssertEqual(record.processGroupID, 4_242)
     }
 
     func testReadinessTimeoutTearsEverythingDown() async throws {
@@ -676,6 +1148,18 @@ final class ClaudeRemoteHerdrForwardTests: XCTestCase {
         for _ in 0..<300 where process.isRunning { usleep(10_000) }
         XCTAssertFalse(process.isRunning, "the child should have exited", file: file, line: line)
         return process
+    }
+
+    func testLiveChildReportsUnavailableStatusInsteadOfFabricatingCleanExit() async throws {
+        let process = try spawnExitingChild(waitForChild: { pid, status, options in
+            waitpid(pid, status, options)
+        })
+
+        let status = await process.waitUntilExit()
+
+        XCTAssertEqual(status, .unavailable)
+        process.terminate()
+        XCTAssertTrue(process.hasBeenReaped)
     }
 
     func testAnInterruptedReapIsRetriedRatherThanClaimedAsDone() throws {

--- a/Tests/localvoxtralTests/ClaudeRemotePluginManifestTests.swift
+++ b/Tests/localvoxtralTests/ClaudeRemotePluginManifestTests.swift
@@ -91,33 +91,44 @@ final class ClaudeRemotePluginManifestTests: XCTestCase {
         }
     }
 
-    func testPluginShipsExactlyOneExecutableTheCurlShim() throws {
+    func testPluginShipsExactlyTwoExecutablesBothPOSIXSh() throws {
         // The premise, updated for the command-hook shape: nothing to install
-        // on the remote but the manifests and ONE POSIX-sh shim. No Python, no
-        // jq, no nc, no Node, no publisher binary. If any other runnable file
-        // ever appears here, the premise is gone.
+        // on the remote but the manifests and TWO POSIX-sh scripts — the curl
+        // shim every hook runs, and the status-line renderer the user may
+        // point their own `statusLine` setting at. No Python, no jq, no nc,
+        // no Node, no publisher binary. If any other runnable file ever
+        // appears here, the premise is gone.
+        let shellScripts: Set<String> = ["hooks/post.sh", "hooks/statusline.sh"]
         let contents = try FileManager.default.subpathsOfDirectory(atPath: pluginRoot.path)
         for path in contents {
             let full = pluginRoot.appendingPathComponent(path)
             var isDirectory: ObjCBool = false
             FileManager.default.fileExists(atPath: full.path, isDirectory: &isDirectory)
             guard !isDirectory.boolValue else { continue }
-            if path == "hooks/post.sh" {
-                // Claude Code's shell resolves the hook command through this
-                // file; without +x every hook errors on the user's turn.
+            if shellScripts.contains(path) {
+                // Claude Code's shell resolves the hook command through
+                // post.sh; without +x every hook errors on the user's turn.
+                // statusline.sh is documented as copy-then-run, so it ships
+                // runnable for the same reason.
                 XCTAssertTrue(
                     FileManager.default.isExecutableFile(atPath: full.path),
-                    "the shim must be executable"
+                    "\(path) must be executable"
                 )
                 continue
             }
             XCTAssertFalse(
                 FileManager.default.isExecutableFile(atPath: full.path),
-                "the remote plugin must ship no executable but the shim, found \(path)"
+                "the remote plugin must ship no executable but its two sh scripts, found \(path)"
             )
             XCTAssertTrue(
                 path.hasSuffix(".json"),
-                "the remote plugin must ship JSON manifests and the shim only, found \(path)"
+                "the remote plugin must ship JSON manifests and its two sh scripts only, found \(path)"
+            )
+        }
+        for script in shellScripts {
+            XCTAssertTrue(
+                FileManager.default.fileExists(atPath: pluginRoot.appendingPathComponent(script).path),
+                "\(script) must exist — the allowlist above is not aspirational"
             )
         }
     }
@@ -351,6 +362,175 @@ final class ClaudeRemotePluginManifestTests: XCTestCase {
             .split(separator: "\n", maxSplits: 1, omittingEmptySubsequences: false)
             .first.map(String.init)
         XCTAssertEqual(firstLine, "#!/bin/sh", "must be POSIX sh, not bash — remote hosts vary")
+    }
+
+    // MARK: Connection-status stamp + status-line renderer
+    //
+    // post.sh records each dial's outcome in a one-line `hook-status` stamp;
+    // statusline.sh (which the user may wire into their own `statusLine`
+    // setting) renders a FIXED string selected by the stamp's first token.
+    // Both halves are proven by running them: the stamp obeys its grammar, and
+    // the renderer can never be made to echo a byte of the stamp file.
+
+    private var statusLineRendererURL: URL {
+        pluginRoot.appendingPathComponent("hooks/statusline.sh")
+    }
+
+    func testStatusLineRendererIsPOSIXShAndExecutable() throws {
+        XCTAssertTrue(
+            FileManager.default.isExecutableFile(atPath: statusLineRendererURL.path),
+            "documented as copy-then-run; without +x the copied file breaks"
+        )
+        let firstLine = try String(contentsOf: statusLineRendererURL, encoding: .utf8)
+            .split(separator: "\n", maxSplits: 1, omittingEmptySubsequences: false)
+            .first.map(String.init)
+        XCTAssertEqual(firstLine, "#!/bin/sh", "must be POSIX sh, not bash — remote hosts vary")
+    }
+
+    func testShimStampsTheOutcomeOfEveryCompletedDial() throws {
+        let state = FileManager.default.temporaryDirectory
+            .appendingPathComponent("stamp-state-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: state, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: state) }
+        let stampURL = state.appendingPathComponent("localvoxtral/hook-status")
+        let ownState = ["XDG_RUNTIME_DIR": state.path]
+        func stamp() throws -> String {
+            try String(contentsOf: stampURL, encoding: .utf8)
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+        }
+        func assertGrammar(_ value: String, file: StaticString = #filePath, line: UInt = #line) {
+            XCTAssertNotNil(
+                value.range(of: #"^(ok|down|unconfigured|http-[0-9]{3}) [0-9]{1,12}$"#,
+                            options: .regularExpression),
+                "stamp \(value) must obey the fixed grammar statusline.sh reads",
+                file: file, line: line
+            )
+        }
+
+        // 200 → ok.
+        _ = try runShimWithStubCurl(
+            status: "200",
+            body: ClaudeRemoteHTTPCodec.markerResponseBody(marker: nil),
+            extraEnvironment: ownState
+        )
+        XCTAssertTrue(try stamp().hasPrefix("ok "), "a 200 exchange must stamp ok")
+        assertGrammar(try stamp())
+
+        // Completed non-200 → http-<code> (the 401 is the one users will see).
+        _ = try runShimWithStubCurl(status: "401", body: nil, extraEnvironment: ownState)
+        XCTAssertTrue(try stamp().hasPrefix("http-401 "), "a completed 401 must stamp http-401")
+        assertGrammar(try stamp())
+
+        // Transport failure → down.
+        _ = try runShimWithStubCurl(
+            status: "000", body: nil, curlExitCode: 7, extraEnvironment: ownState
+        )
+        XCTAssertTrue(try stamp().hasPrefix("down "), "a dead tunnel must stamp down")
+        assertGrammar(try stamp())
+
+        // No token → unconfigured, before any dial.
+        _ = try runShim(environment: ownState)
+        XCTAssertTrue(try stamp().hasPrefix("unconfigured "), "a missing token must stamp unconfigured")
+        assertGrammar(try stamp())
+    }
+
+    /// Runs statusline.sh with an isolated state dir holding the given stamp
+    /// (nil = no stamp at all), a status-line payload on stdin, and captures
+    /// everything.
+    private func runStatusLineRenderer(
+        stamp: String?
+    ) throws -> (exitCode: Int32, stdout: String, stderr: String) {
+        let state = FileManager.default.temporaryDirectory
+            .appendingPathComponent("statusline-state-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: state, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: state) }
+        if let stamp {
+            let directory = state.appendingPathComponent("localvoxtral")
+            try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+            try stamp.write(
+                to: directory.appendingPathComponent("hook-status"), atomically: true, encoding: .utf8
+            )
+        }
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/bin/sh")
+        process.arguments = [statusLineRendererURL.path]
+        var environment = ProcessInfo.processInfo.environment
+        environment["XDG_RUNTIME_DIR"] = state.path
+        process.environment = environment
+        let stdin = Pipe()
+        let stdout = Pipe()
+        let stderr = Pipe()
+        process.standardInput = stdin
+        process.standardOutput = stdout
+        process.standardError = stderr
+        try process.run()
+        stdin.fileHandleForWriting.write(Data(#"{"session_id":"s1"}"#.utf8))
+        stdin.fileHandleForWriting.closeFile()
+        let out = stdout.fileHandleForReading.readDataToEndOfFile()
+        let err = stderr.fileHandleForReading.readDataToEndOfFile()
+        process.waitUntilExit()
+        return (
+            process.terminationStatus,
+            String(decoding: out, as: UTF8.self),
+            String(decoding: err, as: UTF8.self)
+        )
+    }
+
+    func testStatusLineRendererMapsEachStampStateToItsFixedString() throws {
+        let esc = "\u{1B}"
+        // The current time is DATA here, not timing: the renderer compares the
+        // stamp's epoch against its own `date +%s`, so a "fresh" fixture must
+        // be minted at run time (a literal would silently cross the 15-minute
+        // staleness gate one day and start failing). No sleeps, no tolerances.
+        let fresh = String(Int(Date().timeIntervalSince1970))
+        let stale = String(Int(Date().timeIntervalSince1970) - 3600)
+        let cases: [(stamp: String?, expected: String)] = [
+            ("ok \(fresh)", "\(esc)[32m\u{25CF}\(esc)[0m localvoxtral connected\n"),
+            // A green light must expire: ok past the staleness gate demotes to
+            // the dim no-recent-hooks line rather than claiming a live app.
+            ("ok \(stale)", "\(esc)[2m\u{25CB} localvoxtral no recent hooks\(esc)[0m\n"),
+            // Freshness is a refinement, never a new failure mode: an epoch we
+            // cannot read renders exactly as pre-gate ok did.
+            ("ok not-an-epoch", "\(esc)[32m\u{25CF}\(esc)[0m localvoxtral connected\n"),
+            ("ok", "\(esc)[32m\u{25CF}\(esc)[0m localvoxtral connected\n"),
+            // Failure states are never demoted — stale bad news is still the
+            // last known truth, and staying conservative cannot mislead.
+            ("http-401 \(stale)", "\(esc)[33m\u{25CB}\(esc)[0m localvoxtral token rejected\n"),
+            ("http-503 \(fresh)", "\(esc)[33m\u{25CB}\(esc)[0m localvoxtral not connected\n"),
+            ("down \(stale)", "\(esc)[2m\u{25CB} localvoxtral unreachable\(esc)[0m\n"),
+            ("unconfigured \(fresh)", "\(esc)[33m\u{25CB}\(esc)[0m localvoxtral token not configured\n"),
+            (nil, "\(esc)[2m\u{25CB} localvoxtral no hooks yet\(esc)[0m\n"),
+        ]
+        for (stamp, expected) in cases {
+            let result = try runStatusLineRenderer(stamp: stamp)
+            XCTAssertEqual(result.exitCode, 0, "\(stamp ?? "<none>") must exit 0")
+            XCTAssertEqual(result.stdout, expected, "wrong rendering for \(stamp ?? "<none>")")
+            XCTAssertEqual(result.stderr, "", "the renderer must never be noisy")
+        }
+    }
+
+    func testStatusLineRendererNeverEchoesStampBytes() throws {
+        // The stamp file is merely 0600 — anything running as the user could
+        // rewrite it, and stdout renders (with ANSI honored) in the user's
+        // status line. So the stamp's first token only ever SELECTS a fixed
+        // string; unrecognized states render the never-heard-anything default
+        // and not one byte of the file.
+        let defaultLine = "\u{1B}[2m\u{25CB} localvoxtral no hooks yet\u{1B}[0m\n"
+        for hostile in [
+            "$(uname) 1786204746",
+            "ok`uname` 1786204746",
+            "ok\u{1B}]0;evil\u{07} 1786204746",
+            "totally-unknown-state 1786204746",
+            String(repeating: "A", count: 100_000),
+        ] {
+            let result = try runStatusLineRenderer(stamp: hostile)
+            XCTAssertEqual(result.exitCode, 0)
+            XCTAssertEqual(
+                result.stdout, defaultLine,
+                "an unrecognized stamp must render the default, never its own bytes"
+            )
+            XCTAssertEqual(result.stderr, "")
+        }
     }
 
     func testShimFailsOpenSilentlyWithoutATokenAndWithoutCurl() throws {

--- a/Tests/localvoxtralTests/ClaudeSessionRegistryTests.swift
+++ b/Tests/localvoxtralTests/ClaudeSessionRegistryTests.swift
@@ -139,6 +139,28 @@ final class ClaudeSessionRegistryTests: XCTestCase {
         XCTAssertTrue(registry.liveSessions().isEmpty)
     }
 
+    func testStatusQueryIsRefusedByIngestAndNeitherCreatesNorRefreshes() throws {
+        // The broker answers StatusQuery BEFORE ingest; this is the backstop
+        // behind it. An ingested probe would create a session for an id
+        // nobody ever hooked — or refresh the activity of a dying one, keeping
+        // alive the very state it exists to report on.
+        let registry = makeRegistry()
+        XCTAssertNil(registry.ingest(record(.statusQuery), origin: local))
+        XCTAssertNil(registry.snapshot(sessionID: "s1"), "a probe must not create a session")
+        XCTAssertTrue(registry.liveSessions().isEmpty)
+
+        let clock = TestClock(epoch)
+        let refreshable = makeRegistry(clock: clock)
+        refreshable.ingest(record(.sessionStart), origin: local)
+        let before = try XCTUnwrap(refreshable.snapshot(sessionID: "s1")).lastActivity
+        clock.advance(60)
+        XCTAssertNil(refreshable.ingest(record(.statusQuery), origin: local))
+        XCTAssertEqual(
+            try XCTUnwrap(refreshable.snapshot(sessionID: "s1")).lastActivity, before,
+            "a probe must not count as session activity"
+        )
+    }
+
     func testIngestAccumulatesAcrossEvents() throws {
         let registry = makeRegistry()
         registry.ingest(record(.sessionStart), origin: local)

--- a/Tests/localvoxtralTests/ClaudeSessionRegistryTests.swift
+++ b/Tests/localvoxtralTests/ClaudeSessionRegistryTests.swift
@@ -720,6 +720,26 @@ final class ClaudeSessionRegistryTests: XCTestCase {
         XCTAssertEqual(registry.liveSessions().map(\.sessionID), ["second", "first"])
     }
 
+    // `hasLiveSessions` exists so the overlay's join badge can ask about
+    // emptiness without materializing every session's files and snippets. It
+    // must answer exactly what `liveSessions().isEmpty` would — including
+    // across the TTL, or the badge would report "no Claude session" for a live
+    // one, or complain about sessions that have already aged out.
+    func testHasLiveSessionsTracksLiveSessionsExactly() {
+        let clock = TestClock(epoch)
+        let registry = makeRegistry(clock: clock, markers: TestMarkers(["lvx-1"]))
+        XCTAssertFalse(registry.hasLiveSessions())
+        XCTAssertEqual(registry.hasLiveSessions(), !registry.liveSessions().isEmpty)
+
+        registry.ingest(record(.sessionStart), origin: local)
+        XCTAssertTrue(registry.hasLiveSessions())
+        XCTAssertEqual(registry.hasLiveSessions(), !registry.liveSessions().isEmpty)
+
+        clock.advance(ClaudeRegistryLimits.default.sessionTTL + 1)
+        XCTAssertFalse(registry.hasLiveSessions(), "a session past its TTL is not live")
+        XCTAssertEqual(registry.hasLiveSessions(), !registry.liveSessions().isEmpty)
+    }
+
     func testExplicitEvictAndRemoveAll() {
         let registry = makeRegistry(markers: TestMarkers(["lvx-1", "lvx-2"]))
         registry.ingest(record(.sessionStart, session: "s1"), origin: local)

--- a/Tests/localvoxtralTests/DictationViewModelDeltaLoggingTests.swift
+++ b/Tests/localvoxtralTests/DictationViewModelDeltaLoggingTests.swift
@@ -181,7 +181,7 @@ private final class MockOverlayCoordinator: OverlayBufferSessionCoordinating {
     func resolveAnchorNow() -> OverlayAnchor {
         OverlayAnchor(targetRect: CGRect(x: 0, y: 0, width: 100, height: 24), source: .windowCenter)
     }
-    func startSession(preResolvedAnchor: OverlayAnchor?) {}
+    func startSession(preResolvedAnchor: OverlayAnchor?, claudeJoin _: OverlayClaudeJoinBadge) {}
     func beginFinalizing(displayBufferText: String, commitBufferText: String) {}
     func refresh(displayBufferText: String, commitBufferText: String) {}
     func commitIfNeeded(

--- a/Tests/localvoxtralTests/DictationViewModelFailFastUXTests.swift
+++ b/Tests/localvoxtralTests/DictationViewModelFailFastUXTests.swift
@@ -1560,7 +1560,7 @@ private final class NoopOverlayCoordinator: OverlayBufferSessionCoordinating {
     func resolveAnchorNow() -> OverlayAnchor {
         OverlayAnchor(targetRect: .zero, source: .windowCenter)
     }
-    func startSession(preResolvedAnchor: OverlayAnchor?) {}
+    func startSession(preResolvedAnchor: OverlayAnchor?, claudeJoin _: OverlayClaudeJoinBadge) {}
     func beginFinalizing(displayBufferText: String, commitBufferText: String) {}
     func refresh(displayBufferText: String, commitBufferText: String) {}
     @discardableResult

--- a/Tests/localvoxtralTests/DictationViewModelLiveReplacementCorrectorTests.swift
+++ b/Tests/localvoxtralTests/DictationViewModelLiveReplacementCorrectorTests.swift
@@ -337,7 +337,7 @@ private final class MockOverlayCoordinator: OverlayBufferSessionCoordinating {
     func resolveAnchorNow() -> OverlayAnchor {
         OverlayAnchor(targetRect: CGRect(x: 0, y: 0, width: 100, height: 24), source: .windowCenter)
     }
-    func startSession(preResolvedAnchor: OverlayAnchor?) {}
+    func startSession(preResolvedAnchor: OverlayAnchor?, claudeJoin _: OverlayClaudeJoinBadge) {}
     func beginFinalizing(displayBufferText: String, commitBufferText: String) {}
     func refresh(displayBufferText: String, commitBufferText: String) {}
     func commitIfNeeded(

--- a/Tests/localvoxtralTests/DictationViewModelModifierGestureTests.swift
+++ b/Tests/localvoxtralTests/DictationViewModelModifierGestureTests.swift
@@ -216,7 +216,7 @@ private final class GestureTestOverlayCoordinator: OverlayBufferSessionCoordinat
     func resolveAnchorNow() -> OverlayAnchor {
         OverlayAnchor(targetRect: CGRect(x: 0, y: 0, width: 100, height: 24), source: .windowCenter)
     }
-    func startSession(preResolvedAnchor: OverlayAnchor?) {}
+    func startSession(preResolvedAnchor: OverlayAnchor?, claudeJoin _: OverlayClaudeJoinBadge) {}
     func beginFinalizing(displayBufferText: String, commitBufferText: String) {}
     func refresh(displayBufferText: String, commitBufferText: String) {}
     func commitIfNeeded(

--- a/Tests/localvoxtralTests/DictationViewModelOverlayLifecycleTests.swift
+++ b/Tests/localvoxtralTests/DictationViewModelOverlayLifecycleTests.swift
@@ -1246,7 +1246,7 @@ private final class MockOverlayCoordinator: OverlayBufferSessionCoordinating {
         )
     }
 
-    func startSession(preResolvedAnchor: OverlayAnchor?) {
+    func startSession(preResolvedAnchor: OverlayAnchor?, claudeJoin _: OverlayClaudeJoinBadge) {
         startSessionAnchors.append(preResolvedAnchor)
     }
 

--- a/Tests/localvoxtralTests/DictationViewModelPolishFailureDiagnosticsTests.swift
+++ b/Tests/localvoxtralTests/DictationViewModelPolishFailureDiagnosticsTests.swift
@@ -152,7 +152,7 @@ private final class MockOverlayCoordinator: OverlayBufferSessionCoordinating {
         )
     }
 
-    func startSession(preResolvedAnchor _: OverlayAnchor?) {}
+    func startSession(preResolvedAnchor _: OverlayAnchor?, claudeJoin _: OverlayClaudeJoinBadge) {}
     func beginFinalizing(displayBufferText _: String, commitBufferText _: String) {}
     func refresh(displayBufferText _: String, commitBufferText _: String) {}
 

--- a/Tests/localvoxtralTests/DogfoodCaptureWiringTests.swift
+++ b/Tests/localvoxtralTests/DogfoodCaptureWiringTests.swift
@@ -786,7 +786,7 @@ private final class WiringMockOverlayCoordinator: OverlayBufferSessionCoordinati
         )
     }
 
-    func startSession(preResolvedAnchor _: OverlayAnchor?) {}
+    func startSession(preResolvedAnchor _: OverlayAnchor?, claudeJoin _: OverlayClaudeJoinBadge) {}
     func beginFinalizing(displayBufferText _: String, commitBufferText _: String) {}
     func refresh(displayBufferText _: String, commitBufferText _: String) {}
 

--- a/Tests/localvoxtralTests/OnboardingViewModelTests.swift
+++ b/Tests/localvoxtralTests/OnboardingViewModelTests.swift
@@ -235,7 +235,7 @@ private final class OnboardingNoopOverlayCoordinator: OverlayBufferSessionCoordi
     func resolveAnchorNow() -> OverlayAnchor {
         OverlayAnchor(targetRect: .zero, source: .windowCenter)
     }
-    func startSession(preResolvedAnchor: OverlayAnchor?) {}
+    func startSession(preResolvedAnchor: OverlayAnchor?, claudeJoin _: OverlayClaudeJoinBadge) {}
     func beginFinalizing(displayBufferText: String, commitBufferText: String) {}
     func refresh(displayBufferText: String, commitBufferText: String) {}
     @discardableResult

--- a/Tests/localvoxtralTests/OverlayBufferStateMachineTests.swift
+++ b/Tests/localvoxtralTests/OverlayBufferStateMachineTests.swift
@@ -14,7 +14,7 @@ final class OverlayBufferStateMachineTests: XCTestCase {
         machine.setSecureInputWarning()
         XCTAssertNil(machine.snapshot, "no session, no marker")
 
-        machine.startSession(anchor: anchor)
+        machine.startSession(anchor: anchor, claudeJoin: .hidden)
         machine.setSecureInputWarning()
         XCTAssertEqual(machine.snapshot?.secureInputActive, true)
         XCTAssertNil(
@@ -29,7 +29,7 @@ final class OverlayBufferStateMachineTests: XCTestCase {
         )
 
         machine.reset()
-        machine.startSession(anchor: anchor)
+        machine.startSession(anchor: anchor, claudeJoin: .hidden)
         XCTAssertEqual(machine.snapshot?.secureInputActive, false, "a new session starts clean")
 
         machine.beginFinalizing(anchor: nil)
@@ -44,7 +44,7 @@ final class OverlayBufferStateMachineTests: XCTestCase {
         var machine = OverlayBufferStateMachine()
         let anchor = OverlayAnchor(targetRect: CGRect(x: 10, y: 20, width: 100, height: 40), source: .windowCenter)
 
-        machine.startSession(anchor: anchor)
+        machine.startSession(anchor: anchor, claudeJoin: .hidden)
         XCTAssertEqual(machine.phase, .buffering)
 
         machine.updateBuffer(text: "hello world", anchor: nil)
@@ -63,7 +63,7 @@ final class OverlayBufferStateMachineTests: XCTestCase {
         var machine = OverlayBufferStateMachine()
         let anchor = OverlayAnchor(targetRect: CGRect(x: 0, y: 0, width: 40, height: 20), source: .mouseLocation)
 
-        machine.startSession(anchor: anchor)
+        machine.startSession(anchor: anchor, claudeJoin: .hidden)
         machine.updateBuffer(text: "buffered text", anchor: nil)
         machine.beginFinalizing(anchor: nil)
         machine.commitFailed(error: "insert failed", anchor: anchor)
@@ -78,7 +78,7 @@ final class OverlayBufferStateMachineTests: XCTestCase {
         var machine = OverlayBufferStateMachine()
         let anchor = OverlayAnchor(targetRect: CGRect(x: 5, y: 5, width: 80, height: 20), source: .windowCenter)
 
-        machine.startSession(anchor: anchor)
+        machine.startSession(anchor: anchor, claudeJoin: .hidden)
         machine.updateBuffer(text: "hello", anchor: nil)
         machine.beginFinalizing(anchor: nil)
         machine.reset()
@@ -99,7 +99,7 @@ final class OverlayBufferStateMachineTests: XCTestCase {
         machine.setPolished(true)
         XCTAssertNil(machine.snapshot, "no session, no flag")
 
-        machine.startSession(anchor: anchor)
+        machine.startSession(anchor: anchor, claudeJoin: .hidden)
         XCTAssertEqual(machine.snapshot?.polished, false, "a fresh session is unpolished")
 
         machine.beginFinalizing(anchor: nil)
@@ -114,7 +114,7 @@ final class OverlayBufferStateMachineTests: XCTestCase {
 
         machine.setPolished(true)
         machine.reset()
-        machine.startSession(anchor: anchor)
+        machine.startSession(anchor: anchor, claudeJoin: .hidden)
         XCTAssertEqual(
             machine.snapshot?.polished, false,
             "reset + a new session must not carry a stale badge"
@@ -154,5 +154,62 @@ final class OverlayBufferStateMachineTests: XCTestCase {
     func testOverlayAssembler_insertionTextTrimsEdgesOnly() {
         let commitText = OverlayBufferTextAssembler.insertionText(from: "  hello world  ")
         XCTAssertEqual(commitText, "hello world")
+    }
+
+    // MARK: - Claude join badge
+
+    // The badge arrives WITH the session and must ride every later snapshot:
+    // the join it describes is resolved exactly once, so nothing downstream can
+    // change what it should say.
+    func testClaudeJoinBadgeRidesTheWholeSession() {
+        var machine = OverlayBufferStateMachine()
+        let anchor = OverlayAnchor(
+            targetRect: CGRect(x: 0, y: 0, width: 80, height: 24),
+            source: .windowCenter
+        )
+
+        machine.startSession(anchor: anchor, claudeJoin: .joined(label: "localvoxtral"))
+        XCTAssertEqual(machine.snapshot?.claudeJoin, .joined(label: "localvoxtral"))
+
+        machine.updateBuffer(text: "hello", anchor: nil)
+        machine.beginFinalizing(anchor: nil)
+        XCTAssertEqual(
+            machine.snapshot?.claudeJoin, .joined(label: "localvoxtral"),
+            "the badge annotates the whole session, including the polished hold"
+        )
+
+        machine.commitFailed(error: "nope", anchor: nil)
+        XCTAssertEqual(
+            machine.snapshot?.claudeJoin, .joined(label: "localvoxtral"),
+            "a failed insert says nothing about what the dictation was grounded in"
+        )
+    }
+
+    // The badge cannot outlive the dictation it describes, because starting a
+    // session ASSIGNS it rather than merely clearing it: there is no ordering
+    // in which a stale `.joined` can reach the next session's panel, and no
+    // setter that could put one there later.
+    func testEachSessionsBadgeIsItsOwn() {
+        var machine = OverlayBufferStateMachine()
+        let anchor = OverlayAnchor(
+            targetRect: CGRect(x: 0, y: 0, width: 80, height: 24),
+            source: .windowCenter
+        )
+
+        machine.startSession(anchor: anchor, claudeJoin: .joined(label: "localvoxtral"))
+        machine.reset()
+        XCTAssertEqual(machine.claudeJoin, .hidden, "reset holds nothing to render later")
+
+        machine.startSession(anchor: anchor, claudeJoin: .unjoined)
+        XCTAssertEqual(machine.snapshot?.claudeJoin, .unjoined)
+
+        // Even without an intervening reset: a second startSession is refused
+        // outright (guarded on `.idle`), so it cannot half-apply a new badge to
+        // a running session either.
+        machine.startSession(anchor: anchor, claudeJoin: .joined(label: "sneaky"))
+        XCTAssertEqual(
+            machine.snapshot?.claudeJoin, .unjoined,
+            "the running session keeps the badge it was started with"
+        )
     }
 }

--- a/Tests/localvoxtralTests/OverlayClaudeJoinBadgeTests.swift
+++ b/Tests/localvoxtralTests/OverlayClaudeJoinBadgeTests.swift
@@ -1,0 +1,247 @@
+import ClaudeContextWire
+import Foundation
+import Synchronization
+import XCTest
+@testable import localvoxtral
+
+private final class BadgeTestMarkers: Sendable {
+    private let queue: Mutex<[String]>
+    init(_ values: [String]) { queue = Mutex(values) }
+    var allocate: @Sendable () -> String {
+        { [self] in queue.withLock { $0.isEmpty ? "lvx-exhausted" : $0.removeFirst() } }
+    }
+}
+
+/// The overlay's join badge: what it says, when it says nothing, and what it
+/// refuses to render.
+///
+/// Joins are built through the REAL registry and resolver rather than a literal
+/// `ClaudeSessionJoin`, so the workspace label under test is the one the wire
+/// path actually produces for each origin.
+@MainActor
+final class OverlayClaudeJoinBadgeTests: XCTestCase {
+    private let ghostty = TerminalScreenTarget(
+        pid: 4242,
+        bundleID: TerminalScreenAllowlist.ghosttyBundleID
+    )
+    private let local = ClaudeTransportOrigin.localAuthenticated(peerUID: 501)
+    private let remote = ClaudeTransportOrigin.remote(channel: "c1")
+
+    private func registry(markers: [String] = ["lvx-abcd"]) -> ClaudeSessionRegistry {
+        ClaudeSessionRegistry(
+            now: { Date(timeIntervalSince1970: 1_000) },
+            isProcessAlive: { _ in true },
+            allocateMarkerValue: BadgeTestMarkers(markers).allocate
+        )
+    }
+
+    /// A resolved join for a session whose cwd is `cwd`, via the marker arm.
+    private func join(
+        cwd: String?,
+        origin: ClaudeTransportOrigin? = nil
+    ) async -> ClaudeSessionJoin? {
+        let registry = registry()
+        registry.ingest(
+            ClaudeHookRecord(
+                event: .sessionStart,
+                sessionID: "s1",
+                timestamp: 0,
+                rawCwd: cwd,
+                process: ClaudeHookProcessInfo(hookPID: 777, claudePID: 9001)
+            ),
+            origin: origin ?? local
+        )
+        let resolver = ClaudeSessionJoinResolver(
+            registry: registry,
+            markerInWindowTitle: { _ in
+                TerminalScreenAXReader.FocusedWindowMarkerRead(
+                    marker: ClaudeSessionMarker(value: "lvx-abcd"), windowID: 101
+                )
+            }
+        )
+        return await resolver.resolve(target: ghostty)
+    }
+
+    // MARK: - What the badge says
+
+    func testAResolvedLocalJoinNamesItsWorkspace() async {
+        let join = await join(cwd: "/Users/dev/work/localvoxtral")
+        XCTAssertNotNil(join, "positive control: the badge cases below mean nothing without a join")
+        XCTAssertEqual(
+            OverlayClaudeJoinBadge.resolve(
+                join: join,
+                contextFeatureEnabled: true,
+                liveSessionsExist: { true }
+            ),
+            .joined(label: "localvoxtral")
+        )
+    }
+
+    // A remote session's cwd never survives as a path — `opaqueLabel` reduces it
+    // to a bare name. The badge shows that name and nothing else.
+    func testAResolvedRemoteJoinNamesItsOpaqueLabel() async {
+        let join = await join(cwd: "/srv/checkouts/api-gateway", origin: remote)
+        XCTAssertEqual(
+            OverlayClaudeJoinBadge.resolve(
+                join: join,
+                contextFeatureEnabled: true,
+                liveSessionsExist: { true }
+            ),
+            .joined(label: "api-gateway")
+        )
+    }
+
+    // A join with no cwd is still a real join — it grounds the prompt with the
+    // session's prior prompt and files. Falling back to `.unjoined` would call a
+    // working setup broken.
+    func testAJoinWithoutAWorkspaceStaysJoined() async {
+        let join = await join(cwd: nil)
+        XCTAssertEqual(
+            OverlayClaudeJoinBadge.resolve(
+                join: join,
+                contextFeatureEnabled: true,
+                liveSessionsExist: { true }
+            ),
+            .joined(label: OverlayClaudeJoinBadge.unnamedWorkspaceLabel)
+        )
+    }
+
+    // The state the feature exists for: sessions are live, none attached.
+    func testNoJoinWithLiveSessionsIsUnjoined() {
+        XCTAssertEqual(
+            OverlayClaudeJoinBadge.resolve(
+                join: nil,
+                contextFeatureEnabled: true,
+                liveSessionsExist: { true }
+            ),
+            .unjoined
+        )
+    }
+
+    // MARK: - When it says nothing
+
+    // A Mac that is not running Claude Code must not wear a permanent
+    // complaint about a join that was never attempted.
+    func testNoJoinAndNoSessionsIsSilent() {
+        XCTAssertEqual(
+            OverlayClaudeJoinBadge.resolve(
+                join: nil,
+                contextFeatureEnabled: true,
+                liveSessionsExist: { false }
+            ),
+            .hidden
+        )
+    }
+
+    // Both context features off means nothing downstream would have used a
+    // join, so there is nothing to report — even when one resolved before the
+    // settings changed.
+    func testFeaturesOffHideTheBadgeEvenWithAJoin() async {
+        let join = await join(cwd: "/repo")
+        XCTAssertEqual(
+            OverlayClaudeJoinBadge.resolve(
+                join: join,
+                contextFeatureEnabled: false,
+                liveSessionsExist: { true }
+            ),
+            .hidden
+        )
+    }
+
+    // The registry lives behind a lock every dictation start already contends
+    // for, and a resolved join has already proved a session exists.
+    func testTheRegistryIsNotConsultedWhenAJoinResolved() async {
+        let join = await join(cwd: "/repo")
+        let asked = Mutex(0)
+        _ = OverlayClaudeJoinBadge.resolve(
+            join: join,
+            contextFeatureEnabled: true,
+            liveSessionsExist: {
+                asked.withLock { $0 += 1 }
+                return true
+            }
+        )
+        XCTAssertEqual(asked.withLock { $0 }, 0)
+    }
+
+    // The settings gate sits in front of the registry read too: a user with
+    // both features off pays nothing.
+    func testTheRegistryIsNotConsultedWhenFeaturesAreOff() {
+        let asked = Mutex(0)
+        _ = OverlayClaudeJoinBadge.resolve(
+            join: nil,
+            contextFeatureEnabled: false,
+            liveSessionsExist: {
+                asked.withLock { $0 += 1 }
+                return true
+            }
+        )
+        XCTAssertEqual(asked.withLock { $0 }, 0)
+    }
+
+    // MARK: - What it refuses to render
+
+    // A LOCAL workspace name is the last component of a real directory, and a
+    // macOS path component forbids only `/` and NUL. The panel is measured from
+    // the body text alone, so a label carrying a line break would draw outside
+    // the height the panel was sized for.
+    func testControlCharactersAreStrippedFromTheLabel() {
+        XCTAssertEqual(
+            OverlayClaudeJoinBadge.displayLabel(forWorkspaceName: "repo\nname\tx"),
+            "repo name x"
+        )
+    }
+
+    // RIGHT-TO-LEFT OVERRIDE is category Cf, which `controlCharacters` covers —
+    // a header that reorders around a directory name is not a display this
+    // badge may produce.
+    func testBidiOverridesAreStrippedFromTheLabel() {
+        XCTAssertEqual(
+            OverlayClaudeJoinBadge.displayLabel(forWorkspaceName: "repo\u{202E}drowssap"),
+            "repodrowssap"
+        )
+    }
+
+    // U+2028/U+2029 are LINE and PARAGRAPH SEPARATOR: category Zl/Zp, so
+    // neither the `.control` nor the `.format` branch touches them, and they
+    // survive to the whitespace collapse. They break lines like a newline does,
+    // so this is the assertion that stops a future "collapse ASCII whitespace"
+    // refactor from silently letting one through into a single-line header.
+    func testUnicodeLineAndParagraphSeparatorsCollapseToASpace() {
+        XCTAssertEqual(
+            OverlayClaudeJoinBadge.displayLabel(forWorkspaceName: "repo\u{2028}x"),
+            "repo x"
+        )
+        XCTAssertEqual(
+            OverlayClaudeJoinBadge.displayLabel(forWorkspaceName: "repo\u{2029}x"),
+            "repo x"
+        )
+    }
+
+    func testWhitespaceRunsCollapseSoALabelCannotPadThePill() {
+        XCTAssertEqual(
+            OverlayClaudeJoinBadge.displayLabel(forWorkspaceName: "  my    repo  "),
+            "my repo"
+        )
+    }
+
+    func testAnOverlongLabelIsTruncatedWithAnEllipsis() throws {
+        let name = String(repeating: "a", count: 80)
+        let label = try XCTUnwrap(OverlayClaudeJoinBadge.displayLabel(forWorkspaceName: name))
+        XCTAssertEqual(label.count, OverlayClaudeJoinBadge.maximumLabelLength)
+        XCTAssertTrue(label.hasSuffix("…"))
+        XCTAssertTrue(label.hasPrefix("aaa"))
+    }
+
+    func testALabelAtTheLimitIsLeftAlone() throws {
+        let name = String(repeating: "b", count: OverlayClaudeJoinBadge.maximumLabelLength)
+        XCTAssertEqual(OverlayClaudeJoinBadge.displayLabel(forWorkspaceName: name), name)
+    }
+
+    // Nothing usable left is nil, which the resolver turns into the unnamed
+    // fallback rather than an empty pill.
+    func testALabelOfNothingButControlCharactersIsRejected() {
+        XCTAssertNil(OverlayClaudeJoinBadge.displayLabel(forWorkspaceName: "\n\t\u{202E}"))
+        XCTAssertNil(OverlayClaudeJoinBadge.displayLabel(forWorkspaceName: "   "))
+    }
+}

--- a/Tests/localvoxtralTests/OverlayLayoutMetricsTests.swift
+++ b/Tests/localvoxtralTests/OverlayLayoutMetricsTests.swift
@@ -1,3 +1,4 @@
+import AppKit
 import XCTest
 
 @testable import localvoxtral
@@ -99,6 +100,44 @@ final class OverlayLayoutMetricsTests: XCTestCase {
         let nextSession = lock.metrics(currentFontSize: 24)
         XCTAssertEqual(nextSession.bodyFontSize, 24)
         XCTAssertGreaterThan(nextSession.panelWidth, first.panelWidth)
+    }
+
+    // The header's pills ("Polished", the Claude join badge) used a hardcoded
+    // 10pt while `headerHeight` scaled with the body-size setting — so the pill
+    // overflowed the header it sits in at the smallest size and shrank to a
+    // speck at the largest. Every font here scales from the one setting; these
+    // are not exceptions.
+    func testBadgeFontScalesWithTheBodyFontSetting() {
+        let smallest = OverlayLayoutMetrics(bodyFontSize: OverlayLayoutMetrics.minimumBodyFontSize)
+        let base = OverlayLayoutMetrics(bodyFontSize: Double(OverlayLayoutMetrics.baseBodyFontSize))
+        let largest = OverlayLayoutMetrics(bodyFontSize: OverlayLayoutMetrics.maximumBodyFontSize)
+
+        XCTAssertEqual(base.badgeFontSize, 10, "10pt at the base 13pt body, as before")
+        XCTAssertLessThan(smallest.badgeFontSize, base.badgeFontSize)
+        XCTAssertGreaterThan(largest.badgeFontSize, base.badgeFontSize)
+        XCTAssertEqual(smallest.badgeFontSize / smallest.titleFontSize,
+                       largest.badgeFontSize / largest.titleFontSize,
+                       accuracy: 0.0001,
+                       "the pill keeps its proportion to the title at every size")
+    }
+
+    // The pill must fit the header row it is framed by, at BOTH ends of the
+    // setting's range — that containment is what the unscaled font broke.
+    func testBadgePillFitsTheHeaderAtEverySize() {
+        for size in [
+            OverlayLayoutMetrics.minimumBodyFontSize,
+            OverlayLayoutMetrics.defaultBodyFontSize,
+            OverlayLayoutMetrics.maximumBodyFontSize,
+        ] {
+            let metrics = OverlayLayoutMetrics(bodyFontSize: size)
+            let font = NSFont.systemFont(ofSize: metrics.badgeFontSize)
+            let pillHeight = ceil(font.ascender - font.descender + font.leading)
+                + metrics.badgeVerticalPadding * 2
+            XCTAssertLessThanOrEqual(
+                pillHeight, metrics.headerHeight,
+                "badge pill overflows the header at body size \(size)"
+            )
+        }
     }
 
     func testErrorMessageAddsHeight() {

--- a/Tests/localvoxtralTests/PolishTokenGuardTests.swift
+++ b/Tests/localvoxtralTests/PolishTokenGuardTests.swift
@@ -2243,7 +2243,7 @@ private final class MockOverlayCoordinator: OverlayBufferSessionCoordinating {
         )
     }
 
-    func startSession(preResolvedAnchor: OverlayAnchor?) {
+    func startSession(preResolvedAnchor: OverlayAnchor?, claudeJoin _: OverlayClaudeJoinBadge) {
         startSessionAnchors.append(preResolvedAnchor)
     }
 

--- a/Tests/localvoxtralTests/RealtimeAPILivePastePunctuationTests.swift
+++ b/Tests/localvoxtralTests/RealtimeAPILivePastePunctuationTests.swift
@@ -264,7 +264,7 @@ private final class MockOverlayCoordinator: OverlayBufferSessionCoordinating {
     func resolveAnchorNow() -> OverlayAnchor {
         OverlayAnchor(targetRect: CGRect(x: 0, y: 0, width: 100, height: 24), source: .windowCenter)
     }
-    func startSession(preResolvedAnchor: OverlayAnchor?) {}
+    func startSession(preResolvedAnchor: OverlayAnchor?, claudeJoin _: OverlayClaudeJoinBadge) {}
     func beginFinalizing(displayBufferText: String, commitBufferText: String) {}
     func refresh(displayBufferText: String, commitBufferText: String) {}
     func commitIfNeeded(

--- a/Tests/localvoxtralTests/RemoteHerdrJoinTests.swift
+++ b/Tests/localvoxtralTests/RemoteHerdrJoinTests.swift
@@ -68,21 +68,57 @@ private final class RemoteJoinHerdrPanes: HerdrPaneQuerying, @unchecked Sendable
 }
 
 private final class FakeForwardProcess: ClaudeRemoteHerdrForwardProcess, @unchecked Sendable {
-    private let state = Mutex(true)
+    private struct State {
+        var isRunning: Bool
+        var waiters: [CheckedContinuation<ClaudeRemoteForwardExitStatus, Never>] = []
+    }
+
+    private let state: Mutex<State>
+    private let stderrContinuation: AsyncStream<String>.Continuation
+    let standardErrorLines: AsyncStream<String>
     let terminations = Mutex(0)
 
     init(running: Bool = true) {
-        state.withLock { $0 = running }
+        let (stream, continuation) = AsyncStream<String>.makeStream(of: String.self)
+        standardErrorLines = stream
+        stderrContinuation = continuation
+        state = Mutex(State(isRunning: running))
+        if !running { stderrContinuation.finish() }
     }
 
-    var isRunning: Bool { state.withLock { $0 } }
+    var isRunning: Bool { state.withLock { $0.isRunning } }
+    var processIdentifier: pid_t { 4_242 }
 
-    func exit() { state.withLock { $0 = false } }
+    func exit() {
+        let pending = state.withLock {
+            current -> [CheckedContinuation<ClaudeRemoteForwardExitStatus, Never>]? in
+            guard current.isRunning else { return nil }
+            current.isRunning = false
+            defer { current.waiters = [] }
+            return current.waiters
+        }
+        guard let pending else { return }
+        stderrContinuation.finish()
+        for waiter in pending { waiter.resume(returning: .code(0)) }
+    }
+
+    func waitUntilExit() async -> ClaudeRemoteForwardExitStatus {
+        await withCheckedContinuation { continuation in
+            let alreadyExited = state.withLock { current -> Bool in
+                guard current.isRunning else { return true }
+                current.waiters.append(continuation)
+                return false
+            }
+            if alreadyExited { continuation.resume(returning: .code(0)) }
+        }
+    }
 
     func terminate() {
         terminations.withLock { $0 += 1 }
-        state.withLock { $0 = false }
+        exit()
     }
+
+    func forceTerminate() { terminate() }
 }
 
 private final class RecordingSpawner: ClaudeRemoteHerdrForwardSpawning, @unchecked Sendable {
@@ -134,7 +170,8 @@ private final class RecordingWorkspaces: ClaudeRemoteHerdrWorkspaceProviding, @u
 
 /// Stands in for the whole forward service in resolver tests, so the join arm
 /// can be exercised without any notion of processes.
-private final class RecordingForwards: ClaudeRemoteHerdrForwarding, @unchecked Sendable {
+@MainActor
+private final class RecordingForwards: ClaudeRemoteHerdrForwarding {
     struct Opened: Equatable {
         var alias: String
         var remoteSocketPath: String

--- a/Tests/localvoxtralTests/TerminalTargetDetectorTests.swift
+++ b/Tests/localvoxtralTests/TerminalTargetDetectorTests.swift
@@ -843,7 +843,7 @@ private final class TargetDetectorNoopOverlayCoordinator: OverlayBufferSessionCo
     func resolveAnchorNow() -> OverlayAnchor {
         OverlayAnchor(targetRect: .zero, source: .windowCenter)
     }
-    func startSession(preResolvedAnchor: OverlayAnchor?) {}
+    func startSession(preResolvedAnchor: OverlayAnchor?, claudeJoin _: OverlayClaudeJoinBadge) {}
     func beginFinalizing(displayBufferText: String, commitBufferText: String) {}
     func refresh(displayBufferText: String, commitBufferText: String) {}
     var commitOutcome: OverlayBufferCommitOutcome = .succeeded

--- a/docs/agent/invariants.md
+++ b/docs/agent/invariants.md
@@ -181,10 +181,13 @@ there is not.
     `SocketPaneScreenContext` gate as herdr's `pane.read`.
   - A herdr running on an ENROLLED REMOTE host is its own arm
     (`.remoteHerdrPane`), tried only after every local arm declined, and it
-    reaches that herdr over an app-managed, on-demand `ssh -L`
-    (`ClaudeRemoteHerdrForward`) opened at dictation start and closed when the
-    dictation is done with it. The bindings, ALL required, in cost order so an
-    ordinary ssh session never pays for a tunnel:
+    reaches that herdr over an app-managed, supervised `ssh -L`
+    (`ClaudeRemoteHerdrForward`). An authenticated hook carrying a usable herdr
+    socket label starts it off the dictation path; a successful cold join also
+    retains it. Dictations lease the local socket, and the app keeps the process
+    through a bounded injected-clock idle window so later dictations reuse the
+    completed SSH/ProxyJump handshake. The bindings, ALL required, in cost order
+    so an ordinary ssh session never pays for a tunnel:
     (1) the focused surface's own TTY hosts EXACTLY ONE FOREGROUND `ssh`
     session, whose destination identifies exactly one enrolled host. Exact
     alias matching wins without spawning anything; only when it finds no host,
@@ -337,10 +340,13 @@ there is not.
     process named for the agent; requiring both would fail closed forever on
     two ordinary installs (Claude Code spawns hooks through a shell, so `$PPID`
     is often that shell, and an npm install appears as `node`).
-    The tunnel is owned by `DictationViewModel`, never by the join value that
-    travels: the commit path CONSUMES the join, so an owner reaching the child
-    through `claudeSessionJoin` was nil at exactly the moments that mattered
-    (quit during polish, an aborted connect) and the ssh outlived the app.
+    The process is owned by the app-level `ClaudeRemoteHerdrForwardService`,
+    never by the join value that travels: the commit path CONSUMES the join, so
+    an owner reaching the child through `claudeSessionJoin` was nil at exactly
+    the moments that mattered (quit during polish, an aborted connect) and the
+    ssh outlived the app. `DictationViewModel` owns only leases, releasing every
+    one on its existing session-exit paths; the service owns idle, revoke, quit,
+    supervision, pid-ledger and next-launch orphan-reap lifecycles.
   - **The remote herdr forward is a trust inversion, and it is bounded by what
     we SEND, not by what the socket allows.** herdr's JSON socket is
     full-control: over that same forwarded stream one could create panes, write
@@ -360,15 +366,19 @@ there is not.
     session — into a fatal error for this connection (measured: ssh exits).
     Readiness is a bounded connect-poll of the local socket instead, on an
     injected clock, with a ~2 s ceiling that is a dictation-start latency
-    budget as much as a correctness one. The RESIDUAL of dropping them: this
-    short-lived connection still requests whatever forwards the alias's own
+    budget as much as a correctness one and is UNCHANGED for a cold dictation.
+    Before reuse, BOTH the supervised process and a fresh connect to the local
+    socket must be healthy; either failure tears the entry down and returns to
+    that cold path. Activity-driven preparation does not block a dictation, so
+    a slow ProxyJump may finish before the next one. The RESIDUAL of dropping
+    the two options: this retained connection still requests whatever forwards the alias's own
     `Host` block declares, including the enrollment `RemoteForward` — since
     #217 that is this Mac's own port, so a collision with the user's live
     session is a warning on a stderr we send to `/dev/null`, not a failure.
     Three options ARE forced, because the alias's config would otherwise reach
     into this child: `ControlPath=none` (so the forward belongs to our own
-    process and killing it IS the teardown, at the cost of one handshake per
-    dictation), `ForkAfterAuthentication=no` (a detached ssh is an orphan we
+    process and killing it IS the teardown; persistence amortizes the handshake
+    without borrowing the user's master), `ForkAfterAuthentication=no` (a detached ssh is an orphan we
     can neither observe nor kill), and `PermitLocalCommand=no` (a dictation
     must not be able to trigger `LocalCommand` on this machine). Teardown
     signals the process GROUP — the child is spawned as its own group leader
@@ -384,17 +394,18 @@ there is not.
     with it the pgid — is reserved only while the child is unreaped, so the
     zombie is what keeps `-pid` meaning OUR group; teardown signals first and
     reaps last, and once reaped NOTHING may signal that group again (a tunnel
-    that exits by itself mid-dictation is closed at stop time seconds later,
-    which is exactly when a reused pid would be someone else's). Cost: one
-    zombie per open forward, for the life of one dictation — and that bound
+    that exits by itself is finalized by the supervisor before restart, which
+    is exactly when a reused pid could otherwise be someone else's). Cost: one
+    zombie per supervised forward between leader exit and teardown — and that
+    bound
     only holds because the reap COMMITS only on a definitive answer (the child
     collected, or `ECHILD`), retrying `EINTR` and leaving anything else
     unreaped for the next teardown. Claiming the reap before calling `waitpid`
     turned an interrupted collection into a permanent lie about a zombie that
-    was still there, i.e. one leaked per dictation without bound. The collect
+    was still there, i.e. one leaked per restart without bound. The collect
     is also NON-BLOCKING first (`WNOHANG`, bounded poll, then handed to a
-    background queue): every caller is a user-visible path — stop, commit,
-    cancel, app quit, all on the main actor — and a child wedged in an
+    background queue): every caller is a user-visible path — idle, health
+    replacement, revoke, app quit, all on the main actor — and a child wedged in an
     uninterruptible wait must cost a background thread, never the UI.
     A remote herdr join authorizes no more than a local one: never the raw AX
     capture (that grid is the composite herdr TUI, on someone else's machine),

--- a/docs/agent/invariants.md
+++ b/docs/agent/invariants.md
@@ -447,6 +447,28 @@ there is not.
     browser), and each browser needs its own TCC Automation grant — pre-warmed
     by its own `TerminalAutomationConsentPrewarmSettingsObserver` under that
     same setting, since the consent sheet dies with the 1 s read that raised it.
+  - The overlay's join badge (`OverlayClaudeJoinBadge`) DESCRIBES the resolved
+    join; it never resolves one. It reads `claudeSessionJoin` after the single
+    start-time resolution and nothing else — a badge that asked again could name
+    a different session than the context actually attached, which is the exact
+    failure the once-per-dictation rule exists to prevent. Its one extra read is
+    `registry.hasLiveSessions()`, which touches no title, TTY, socket, or process
+    table and only chooses between "nothing attached" and showing nothing at all.
+    What it renders is a length-capped workspace `displayName` with control
+    characters neutralized: a LOCAL name is the last component of a real
+    directory, where a newline is legal and the panel is measured from the body
+    text alone. Cc (newline, tab) becomes a space — deleting it would glue two
+    runs into a directory name the user does not have — while Cf (bidi
+    overrides, zero-width joiners) is dropped, being zero-width already.
+    It names the joined workspace rather than showing a checkmark because a
+    mis-join — a stale marker winning, the residual documented on the marker and
+    remote-herdr arms — is invisible to a boolean and obvious next to the wrong
+    repo's name.
+    The badge travels as a PARAMETER of `startSession`, never a later setter:
+    starting a session resets the panel, so a badge pushed before it was wiped
+    and one pushed after depended on an order nothing enforced. It is always
+    already known there — the join resolves before the realtime socket connects,
+    and the panel opens after it.
   - Lookups abstain rather than guess: no marker, unknown, stale, or ambiguous
     means no context. There is deliberately no sole-session or cwd heuristic —
     it is wrong precisely when it matters.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -36,7 +36,12 @@ Key subsystems:
   `integrations/claude-code/`): off-screen context for dictation into Claude
   Code. Two plugins in one marketplace, structurally separate — never modes of
   each other. Both declare hooks only (no skill/command/agent/statusLine —
-  nothing that spends the user's tokens).
+  nothing that spends the user's tokens). The OPT-IN connection indicator for
+  Claude Code's status line is user-wired, never plugin-declared: locally the
+  user points their own `statusLine` setting at the publisher binary's
+  `--statusline` mode; remotely at a copy of the remote plugin's
+  `statusline.sh`, which renders the outcome post.sh stamped for the last hook
+  dial and never dials anything itself.
   - **Local** (`localvoxtral`): each hook runs `localvoxtral-claude-hook` as a
     CHILD (never `exec` — the shim must outlive a publisher that cannot start,
     or the exec failure becomes the hook's exit code and fail-open stops being

--- a/integrations/claude-code/.claude-plugin/marketplace.json
+++ b/integrations/claude-code/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Off-screen Claude Code session context for the localvoxtral dictation app.",
-    "version": "1.3.0"
+    "version": "1.4.0"
   },
   "plugins": [
     {

--- a/integrations/claude-code/README.md
+++ b/integrations/claude-code/README.md
@@ -198,6 +198,52 @@ Verify:
 claude plugin list
 ```
 
+## Connection indicator (opt-in status line)
+
+One glance at Claude Code's bottom bar answers the question this plugin
+otherwise leaves silent: *is localvoxtral connected to this session?*
+
+Claude Code has no plugin-owned status line, and localvoxtral never writes
+`~/.claude/settings.json` — so this is wired by **you**, once, in your own
+settings. The publisher binary has a `--statusline` mode that reads the
+status-line payload Claude Code pipes in, asks the app's socket whether THIS
+session (by `session_id`) is live in its registry, and prints exactly one of
+three fixed lines:
+
+| Line | Meaning |
+|---|---|
+| `● localvoxtral connected` (green) | the app is running and this session's hooks are reaching it |
+| `○ localvoxtral not connected` (yellow) | the app is running but has no live record of this session — plugin not installed, or the app started after this session's last hook (it catches up on your next prompt) |
+| `○ localvoxtral not running` (dim) | nothing is listening on the socket |
+
+In `~/.claude/settings.json`:
+
+```json
+{
+  "statusLine": {
+    "type": "command",
+    "command": "/Applications/localvoxtral.app/Contents/MacOS/localvoxtral-claude-hook --statusline"
+  }
+}
+```
+
+(Adjust the path for `~/Applications` or a dev build — it is the same binary
+`publisher_path` points at.) If you already have a status line, keep it and
+append ours: buffer stdin once and feed both, e.g.
+
+```sh
+#!/bin/sh
+input=$(cat)
+printf '%s' "$input" | ~/.claude/my-statusline.sh
+printf '%s' "$input" | /Applications/localvoxtral.app/Contents/MacOS/localvoxtral-claude-hook --statusline
+```
+
+The query is read-only by construction: asking never creates a session,
+never refreshes one, and never carries a marker. The three strings above are
+compile-time constants — nothing read off the socket is ever echoed into
+your terminal — and a payload without a usable `session_id` prints nothing
+rather than guessing.
+
 ## Fail-open, always
 
 If localvoxtral is not running, not installed, or its socket is absent, the hook
@@ -377,8 +423,9 @@ If it landed there anyway, rotate the token in the app — that is what rotation
 for.
 
 Nothing else is installed. The marketplace add resolves the repository root's
-`.claude-plugin/marketplace.json`; the plugin is two JSON files and one
-POSIX-sh script that needs only `sh` and `curl` on the host.
+`.claude-plugin/marketplace.json`; the plugin is two JSON files and two
+POSIX-sh scripts — the hook shim, which needs only `sh` and `curl` on the
+host, and the opt-in status-line renderer below, which needs only `sh`.
 
 **3. Check it:**
 
@@ -390,6 +437,59 @@ claude plugin list
 curl -s -o /dev/null -w '%{http_code}\n' -X POST -H 'Content-Type: application/json' \
   -d '{}' http://127.0.0.1:28511/v1/hook/SessionStart
 ```
+
+## Connection indicator (opt-in status line)
+
+The same bottom-bar indicator the local plugin offers, adapted to a host
+where everything fails open by design: it tells you whether hooks from this
+host are actually reaching localvoxtral on your Mac, instead of you finding
+out by dictating into nothing.
+
+It never dials the tunnel — a status line re-runs constantly, and every dial
+against a live forward with no app behind it prints ssh's
+`connect_to …: failed.` onto your terminal (the exact storm the shim's
+backoff exists to end). Instead, `post.sh` records the outcome of each hook
+delivery in a private one-line stamp, and a tiny renderer script turns that
+into one fixed line. The indicator is exactly as fresh as this host's hook
+traffic, which is also what re-runs the status line:
+
+| Line | The last hook dial saw |
+|---|---|
+| `● localvoxtral connected` (green) | a 200 from the app, through the tunnel, within the last 15 minutes |
+| `○ localvoxtral no recent hooks` (dim) | a 200 too — but a while ago. The green light expires rather than vouch for an app that may have gone away since; your next prompt dials and restores the truth either way |
+| `○ localvoxtral unreachable` (dim) | no listener — tunnel down, Mac asleep, or the app not running |
+| `○ localvoxtral token rejected` (yellow) | a 401 — rotate the token, or finish an interrupted rotation |
+| `○ localvoxtral token not configured` (yellow) | the plugin has no `token` in its config at all |
+| `○ localvoxtral not connected` (yellow) | some other completed HTTP error |
+| `○ localvoxtral no hooks yet` (dim) | nothing — no hook has fired since this host last booted (the stamp lives in the runtime dir) |
+
+Set it up on the **remote host** (the plugin ships the renderer; Claude Code's
+versioned plugin cache is no place for a settings path, so copy it somewhere
+stable):
+
+```sh
+cp ~/.claude/plugins/marketplaces/localvoxtral/integrations/claude-code/plugins/localvoxtral-remote/hooks/statusline.sh \
+   ~/.claude/localvoxtral-statusline.sh
+```
+
+and in the host's `~/.claude/settings.json`:
+
+```json
+{
+  "statusLine": {
+    "type": "command",
+    "command": "sh ~/.claude/localvoxtral-statusline.sh"
+  }
+}
+```
+
+The copy does not go stale in any way that matters: the renderer is
+deliberately dumb (read stamp, print fixed string) and the smart half lives
+in `post.sh`, which updates with the plugin. Like everything else on this
+path, the renderer's stdout fails closed: the stamp's first token only ever
+selects one of the strings above — no byte of the stamp file is ever
+echoed into your status line. If you already run a status line on that host,
+call the script from it and append its one line.
 
 ## Sessions nobody is sitting in front of
 

--- a/integrations/claude-code/plugins/localvoxtral-remote/.claude-plugin/plugin.json
+++ b/integrations/claude-code/plugins/localvoxtral-remote/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "localvoxtral-remote",
   "description": "Publishes Claude Code session context from a REMOTE host to localvoxtral on your Mac, over an SSH RemoteForward tunnel. Command hooks running a bundled POSIX-sh shim that POSTs via curl — needs only sh and curl on the remote host, and fails open silently when either is missing.",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "author": {
     "name": "localvoxtral"
   },

--- a/integrations/claude-code/plugins/localvoxtral-remote/hooks/post.sh
+++ b/integrations/claude-code/plugins/localvoxtral-remote/hooks/post.sh
@@ -42,8 +42,58 @@ fail_open() {
   exit 0
 }
 
+# 0700 directories / 0600 files for EVERYTHING this shim creates — the header
+# tempfile below and both state stamps. Set before the first write, not just
+# before the tempfile.
+umask 077
+
+# --- Private per-user state dir --------------------------------------------
+# Holds two single-line stamps, both best-effort and both harmless to lose:
+#   hook-backoff  — epoch of the last transport failure (see backoff below)
+#   hook-status   — outcome of the last completed dial, for the OPT-IN status
+#                   line (statusline.sh in this directory). One line,
+#                   `<state> <epoch>`, state from a fixed grammar:
+#                   ok | down | unconfigured | http-<3 digits>.
+# The status stamp is HOST-level, not per-session, by design: reading a
+# session id would mean parsing (and buffering) the event body this shim
+# deliberately passes through byte-for-byte — and tunnel, token, and port are
+# per-host facts anyway, so one session's outcome answers for all of them.
+if [ -n "${XDG_RUNTIME_DIR:-}" ]; then
+  STAMP_DIR="$XDG_RUNTIME_DIR/localvoxtral"
+elif [ -n "${HOME:-}" ]; then
+  STAMP_DIR="$HOME/.cache/localvoxtral"
+else
+  STAMP_DIR=""
+fi
+STAMP="$STAMP_DIR/hook-backoff"
+STATUS_STAMP="$STAMP_DIR/hook-status"
+NOW="$(date +%s 2>/dev/null)" || NOW=""
+# Digits only, at most 12 of them (epoch seconds are 10 until year 2286): a
+# damaged value must never reach `[` or $(( )), where an oversized constant
+# aborts some shells — with output on stderr.
+case "$NOW" in *[!0-9]* | ?????????????*) NOW="" ;; esac
+
+# Record the last dial's outcome for statusline.sh. Same tempfile + mv -f
+# discipline as the backoff stamp (rename replaces a pre-planted symlink
+# instead of writing through it; a concurrent reader never sees a torn line),
+# and every failure is silent — losing the indicator is nothing next to
+# delivering the hook.
+write_status() {
+  [ -n "$STAMP_DIR" ] && [ -n "$NOW" ] || return 0
+  {
+    mkdir -p "$STAMP_DIR" && chmod 700 "$STAMP_DIR" \
+      && echo "$1 $NOW" >"$STATUS_STAMP.$$" && mv -f "$STATUS_STAMP.$$" "$STATUS_STAMP"
+  } 2>/dev/null || { rm -f "$STATUS_STAMP.$$"; } 2>/dev/null || :
+}
+
 TOKEN="${CLAUDE_PLUGIN_OPTION_TOKEN:-}"
-[ -n "$TOKEN" ] || fail_open
+# No token is the one misconfiguration worth naming before failing open: the
+# plugin was installed without `--config token=…`, every future dial would be
+# a guaranteed 401, and nothing else on this host will ever say so.
+[ -n "$TOKEN" ] || {
+  write_status unconfigured
+  fail_open
+}
 command -v curl >/dev/null 2>&1 || fail_open
 
 # --- Listen port -------------------------------------------------------------
@@ -85,24 +135,11 @@ esac
 # the first prompt after the app comes back is grounded immediately — and its
 # completed exchange clears the backoff for every other event.
 #
-# State is one epoch-seconds stamp in a private per-user dir. Anything odd —
-# no usable dir, no epoch from date, garbage content, a clock that jumped
-# backwards — disables the backoff and the shim simply dials: exactly the
-# pre-backoff behavior, fail-open as ever.
+# State is one epoch-seconds stamp in the private per-user dir derived above.
+# Anything odd — no usable dir, no epoch from date, garbage content, a clock
+# that jumped backwards — disables the backoff and the shim simply dials:
+# exactly the pre-backoff behavior, fail-open as ever.
 BACKOFF_SECONDS=300
-if [ -n "${XDG_RUNTIME_DIR:-}" ]; then
-  STAMP_DIR="$XDG_RUNTIME_DIR/localvoxtral"
-elif [ -n "${HOME:-}" ]; then
-  STAMP_DIR="$HOME/.cache/localvoxtral"
-else
-  STAMP_DIR=""
-fi
-STAMP="$STAMP_DIR/hook-backoff"
-NOW="$(date +%s 2>/dev/null)" || NOW=""
-# Digits only, at most 12 of them (epoch seconds are 10 until year 2286): a
-# damaged value must never reach `[` or $(( )), where an oversized constant
-# aborts some shells — with output on stderr.
-case "$NOW" in *[!0-9]* | ?????????????*) NOW="" ;; esac
 if [ -n "$STAMP_DIR" ] && [ -n "$NOW" ] && [ "$EVENT" != "UserPromptSubmit" ] \
   && [ -r "$STAMP" ]; then
   LAST="$(cat "$STAMP" 2>/dev/null)" || LAST=""
@@ -116,11 +153,10 @@ if [ -n "$STAMP_DIR" ] && [ -n "$NOW" ] && [ "$EVENT" != "UserPromptSubmit" ] \
   esac
 fi
 
-# 0700 directory / 0600 files for the header tempfile; removed on every exit.
-# Known, accepted leak: a SIGKILL (Claude Code escalating past the hook
+# Header tempfile dir (0700/0600 under the umask set above); removed on every
+# exit. Known, accepted leak: a SIGKILL (Claude Code escalating past the hook
 # timeout) skips the traps and strands one 0700 dir — private to the user,
 # bounded by how often hooks get killed.
-umask 077
 WORK="$(mktemp -d 2>/dev/null)" || fail_open
 trap 'rm -rf "$WORK"' EXIT
 trap 'rm -rf "$WORK"; exit 0' HUP INT TERM
@@ -226,8 +262,16 @@ if [ -n "$STAMP_DIR" ] && [ -n "$NOW" ]; then
       mkdir -p "$STAMP_DIR" && chmod 700 "$STAMP_DIR" \
         && echo "$NOW" >"$STAMP.$$" && mv -f "$STAMP.$$" "$STAMP"
     } 2>/dev/null || { rm -f "$STAMP.$$"; } 2>/dev/null || :
+    write_status down
   else
     rm -f "$STAMP" 2>/dev/null || :
+    # The completed exchange's verdict, for statusline.sh. The code is
+    # embedded only after the exact-3-digits match — curl wrote it, but
+    # nothing that fails the grammar may reach a file another script reads.
+    case "$STATUS" in
+    200) write_status ok ;;
+    [0-9][0-9][0-9]) write_status "http-$STATUS" ;;
+    esac
   fi
 fi
 

--- a/integrations/claude-code/plugins/localvoxtral-remote/hooks/statusline.sh
+++ b/integrations/claude-code/plugins/localvoxtral-remote/hooks/statusline.sh
@@ -1,0 +1,89 @@
+#!/bin/sh
+# localvoxtral connection indicator for the Claude Code status line — strict
+# POSIX sh, no dependencies at all (not even curl).
+#
+# NOT a hook, and NOT wired up by the plugin: Claude Code has no plugin-owned
+# status line, and localvoxtral never writes `~/.claude/settings.json` (that
+# file is the user's). The user opts in by copying this script to a stable
+# path and pointing their `statusLine` setting at it — see the README's
+# "Connection indicator" section. It renders whether hooks from THIS host are
+# reaching localvoxtral on the Mac.
+#
+# It never dials the tunnel. A status line re-runs constantly, and every dial
+# against a live forward with no app behind it makes ssh — on the other
+# machine — print `connect_to …: failed.` onto the user's terminal; that is
+# the storm post.sh's backoff exists to end, and a poller would bring it
+# back. Instead it reads the one-line `hook-status` stamp post.sh leaves
+# after each dial (`<state> <epoch>`), so the indicator is exactly as fresh
+# as the session's own hook traffic — which re-runs the status line anyway.
+#
+# stdout renders in the user's status line, so printing fails closed the same
+# way post.sh's stdout gate does: the stamp's first token only ever SELECTS
+# one of the fixed strings below — no byte of the stamp file (which another
+# process could have altered; it is merely 0600) is ever echoed, and an
+# unrecognized state renders as the never-heard-anything default.
+set -u
+
+# Drain the status-line payload (JSON on stdin, unused: the stamp is
+# host-level) so Claude Code's writer never sees EPIPE.
+cat >/dev/null 2>&1
+
+if [ -n "${XDG_RUNTIME_DIR:-}" ]; then
+  STAMP_DIR="$XDG_RUNTIME_DIR/localvoxtral"
+elif [ -n "${HOME:-}" ]; then
+  STAMP_DIR="$HOME/.cache/localvoxtral"
+else
+  STAMP_DIR=""
+fi
+
+STATE=""
+EPOCH=""
+if [ -n "$STAMP_DIR" ] && [ -r "$STAMP_DIR/hook-status" ]; then
+  LINE="$(cat "$STAMP_DIR/hook-status" 2>/dev/null)" || LINE=""
+  STATE="${LINE%% *}"
+  EPOCH="${LINE#* }"
+  [ "$EPOCH" = "$LINE" ] && EPOCH=""
+fi
+
+# A green light must expire. `ok` is a claim about the LAST dial, and the one
+# lie this script could otherwise tell is a green dot hours after the Mac
+# went to sleep — precisely the condition the indicator exists to surface. So
+# an `ok` older than 15 minutes demotes to a dim "no recent hooks"; the next
+# submitted prompt dials (UserPromptSubmit is backoff-exempt) and restores
+# the truth either way. Only `ok` is demoted: a stale failure state is still
+# the last known truth, and staying conservative can't mislead. Both numbers
+# are validated exactly like post.sh's NOW (digits, <=12, no `[`/$(( ))
+# aborts); anything odd disables the demotion and `ok` renders as before —
+# freshness is a refinement, never a new failure mode.
+STALE_SECONDS=900
+STALE=""
+NOW="$(date +%s 2>/dev/null)" || NOW=""
+case "$NOW" in "" | *[!0-9]* | ?????????????*) NOW="" ;; esac
+case "$EPOCH" in "" | *[!0-9]* | ?????????????*) EPOCH="" ;; esac
+if [ -n "$NOW" ] && [ -n "$EPOCH" ] && [ "$EPOCH" -le "$NOW" ] \
+  && [ $((NOW - EPOCH)) -gt "$STALE_SECONDS" ]; then
+  STALE=1
+fi
+
+# Fixed strings only. `printf '%b'` renders the SGR escapes; `\0033` is the
+# strictly-POSIX octal spelling of ESC (the `\0ddd` form is the one XCU
+# guarantees for %b), and the dots are literal UTF-8. printf here is safe in
+# a way it is not in post.sh: there is no secret anywhere in this process,
+# so an external printf putting its argument into an argv leaks nothing.
+# Green dot: the Mac answered 200 to this host's last hook. Everything else
+# names the failure the last dial actually saw.
+case "$STATE" in
+ok)
+  if [ -n "$STALE" ]; then
+    printf '%b\n' '\0033[2m○ localvoxtral no recent hooks\0033[0m'
+  else
+    printf '%b\n' '\0033[32m●\0033[0m localvoxtral connected'
+  fi
+  ;;
+http-401) printf '%b\n' '\0033[33m○\0033[0m localvoxtral token rejected' ;;
+http-*) printf '%b\n' '\0033[33m○\0033[0m localvoxtral not connected' ;;
+down) printf '%b\n' '\0033[2m○ localvoxtral unreachable\0033[0m' ;;
+unconfigured) printf '%b\n' '\0033[33m○\0033[0m localvoxtral token not configured' ;;
+*) printf '%b\n' '\0033[2m○ localvoxtral no hooks yet\0033[0m' ;;
+esac
+exit 0

--- a/scripts/package_app.sh
+++ b/scripts/package_app.sh
@@ -272,6 +272,17 @@ if [[ ! -x "$CLAUDE_HOOK_SHIM" ]]; then
   echo "Claude Code hook shim is not executable: $CLAUDE_HOOK_SHIM"
   exit 1
 fi
+# The remote plugin's shims ship in the same marketplace copy. Claude Code
+# execs post.sh directly; statusline.sh is run by the user's statusLine
+# setting. Same assert-not-hope rule as publish.sh above.
+for REMOTE_SHIM in post.sh statusline.sh; do
+  REMOTE_SHIM_PATH="$APP_DIR/Contents/Resources/claude-code-marketplace/plugins/localvoxtral-remote/hooks/$REMOTE_SHIM"
+  chmod +x "$REMOTE_SHIM_PATH"
+  if [[ ! -x "$REMOTE_SHIM_PATH" ]]; then
+    echo "Claude Code remote shim is not executable: $REMOTE_SHIM_PATH"
+    exit 1
+  fi
+done
 
 cat > "$APP_DIR/Contents/Info.plist" <<PLIST
 <?xml version="1.0" encoding="UTF-8"?>


### PR DESCRIPTION
## What

Keep each enrolled host's remote-herdr `ssh -L` process alive after a successful join, so later dictations reuse the completed SSH and ProxyJump handshake instead of paying a fresh one against the 2-second readiness budget — the "forward unavailable" flake through a jump chain.

Before reuse, both the supervised process must be alive AND the local unix socket must accept a connection (raw connect/close, no bytes — cannot corrupt a protocol exchange). An unhealthy entry is fully torn down before falling back to the unchanged 2-second cold-spawn path. Authenticated host activity (the hook channel) pre-starts the forward away from dictation latency; leases are released on every dictation exit; the app-owned service handles injected-clock idle teardown (5 min), enrollment-revocation and app-quit teardown, supervision, PID-ledger persistence, and next-launch orphan cleanup. The existing `ClaudeRemoteForwardSupervisor` / `ClaudeRemoteForwardPidLedger` / `ClaudeRemoteForwardOrphanReaper` (#226) are shared with the hook `-R` forward; posix-spawned `-L` children are their own process-group leaders (checked `POSIX_SPAWN_SETPGROUP`) and their records carry the pgid, so a later launch reaps ProxyJump descendants with the identity-verified leader. `ClearAllForwardings` and `ExitOnForwardFailure` stay deliberately absent (both measured to break exactly this feature; documented in the argv comment and invariants).

Review-hardened (GLM adversarial review, verdict SHIP-WITH-FIXES; all 7 findings applied):

> Identity-guarded cold-open polling and teardown so a superseded opener cannot kill a replacement; same-target preparation now leaves every non-failed supervisor in charge of completing startup; preparation enforces unique alias-to-host resolution. Exit reporting now records "unavailable" instead of fabricating status 0, immediate teardown clears its idle-task reference, and every local-forward launch unlinks a socket name potentially left by a killed predecessor. Added deterministic coverage for replacement survival, cold-start refresh, alias uniqueness, orphan-reap gating, honest exit status, and restart socket cleanup.

## Proof

- Full unit suite green after review fixes: `Executed 2657 tests, with 2 tests skipped and 0 failures (0 unexpected) in 108.558 (108.719) seconds`
- Core regression (reuse), red before / green after:
  - Red: `testAHealthyForwardIsReusedAcrossDictations`: `XCTAssertEqual failed: ("2") is not equal to ("1") - the next dictation should reuse the healthy app-held forward` — `Executed 1 test, with 1 failure`
  - Green: `Executed 38 tests, with 0 failures`
- Review-finding regressions, red before / green after:
  - F1 (replacement survival): red `Executed 1 test, with 2 failures` (replacement terminated twice, spawn count 3) → green `testColdOpenFailureDoesNotTearDownAReplacementEntry passed`
  - F2 (cold-start refresh): red `Executed 1 test, with 2 failures` (spawn count 2, starter terminated) → green `testPrepareRefreshesAColdStartingForwardWithoutReplacingIt passed`
- Targeted suites: `ClaudeRemoteHerdrForward` 43/43, `ClaudeRemoteForward` 64/64, `ClaudeRemoteContextListenerTests` 41/41, `RemoteHerdrJoinTests` 51/51.
- No wall-clock in tests (injected clock/sleep seams throughout); no `beginDictationSession` reached by new tests.
- LLM lanes: not required — SSH transport lifecycle only; nothing that reaches a model changes.
- UI: no UI change.
