### PR TITLE
Remote herdr join: agents-panel nonce binding as primary surface authorization (live mic indicator, marker-arm suppression, enroll-time config offer)

### DIFF
--- a/Sources/localvoxtral/ClaudeContext/ClaudeIntegrationSettingsModel.swift
+++ b/Sources/localvoxtral/ClaudeContext/ClaudeIntegrationSettingsModel.swift
@@ -259,6 +259,7 @@ public final class ClaudeIntegrationSettingsModel {
         /// Per-host, because the pane shows one row per host and the outcome
         /// has to render in the row whose button ran it.
         case updateRemotePlugin(hostID: String)
+        case configureHerdrPanel(hostID: String)
     }
 
     public struct EnrollmentConfirmation: Identifiable, Equatable, Sendable {
@@ -313,6 +314,10 @@ public final class ClaudeIntegrationSettingsModel {
     /// dictates and sees no cmux context can read WHY here instead of in the
     /// log. `.ok` renders nothing — a working feature says nothing.
     var cmuxStatus: CmuxSocketStatus = .ok
+
+    /// Set by the join probe after a successful stamp whose value never
+    /// appeared in the focused grid. This is inferential, not a config read.
+    var herdrPanelStatus: HerdrPanelConfigurationStatus = .ok
 
     /// The password field's live text. Never seeded from the Keychain: the
     /// stored secret is not shown back to anyone, and an empty field on a
@@ -933,6 +938,22 @@ public final class ClaudeIntegrationSettingsModel {
         Log.claudeContext.info("Claude remote setup confirmation requested")
     }
 
+    public func requestHerdrPanelConfiguration(hostID: String) {
+        guard !isPerformingEnrollmentAction,
+              let host = hosts.first(where: { $0.id == hostID }),
+              host.sshHostAlias != nil
+        else { return }
+        enrollmentStepStatuses = []
+        enrollmentResultsAction = nil
+        enrollmentConfirmation = EnrollmentConfirmation(
+            action: .configureHerdrPanel(hostID: hostID),
+            title: "Configure this exact herdr agents-panel row?",
+            preview: ClaudeRemoteEnrollmentService.herdrPanelConfigSnippet,
+            confirmButtonTitle: "Confirm Configure"
+        )
+        Log.claudeContext.info("Claude remote herdr panel configuration confirmation requested")
+    }
+
     public func cancelEnrollmentActionConfirmation() {
         enrollmentConfirmation = nil
     }
@@ -944,6 +965,8 @@ public final class ClaudeIntegrationSettingsModel {
             await performPlanAction(confirmation)
         case .updateRemotePlugin:
             await performPluginUpdate(confirmation)
+        case .configureHerdrPanel:
+            await performHerdrPanelConfiguration(confirmation)
         }
     }
 
@@ -969,6 +992,8 @@ public final class ClaudeIntegrationSettingsModel {
             // Routed to performPluginUpdate: that action belongs to a host row,
             // has no plan and no token, and must not run against one.
             return
+        case .configureHerdrPanel:
+            return
         }
         enrollmentConfirmation = nil
         isPerformingEnrollmentAction = true
@@ -987,6 +1012,26 @@ public final class ClaudeIntegrationSettingsModel {
         guard presentedPlan == presentation else { return }
 
         publish(attempt, action: confirmation.action)
+    }
+
+    private func performHerdrPanelConfiguration(_ confirmation: EnrollmentConfirmation) async {
+        guard case .configureHerdrPanel(let hostID) = confirmation.action,
+              let host = hosts.first(where: { $0.id == hostID }),
+              let alias = host.sshHostAlias
+        else { return }
+        enrollmentConfirmation = nil
+        isPerformingEnrollmentAction = true
+        enrollmentStepStatuses = []
+        enrollmentResultsAction = nil
+        defer { isPerformingEnrollmentAction = false }
+
+        let service = enrollmentService
+        let attempt = await performEnrollmentAsync {
+            try service.configureRemoteHerdrPanel(sshHostAlias: alias)
+        }
+        guard hosts.contains(where: { $0.id == hostID }) else { return }
+        publish(attempt, action: confirmation.action)
+        if attempt.failure == nil { herdrPanelStatus = .ok }
     }
 
     private func performPluginUpdate(_ confirmation: EnrollmentConfirmation) async {
@@ -1059,6 +1104,15 @@ public final class ClaudeIntegrationSettingsModel {
                     detail: $0.message
                 )
             }
+        case .configureHerdrPanel:
+            enrollmentStepStatuses = [
+                EnrollmentStepStatus(
+                    id: 0,
+                    text: "Configured the remote herdr agents panel.",
+                    succeeded: true,
+                    detail: attempt.steps.first?.message ?? ""
+                )
+            ]
         }
         enrollmentResultsAction = action
     }
@@ -1067,6 +1121,7 @@ public final class ClaudeIntegrationSettingsModel {
         switch action {
         case .insertSSHConfig, .runRemoteSetup: return "Remote Claude Code setup"
         case .updateRemotePlugin: return "Remote Claude Code plugin"
+        case .configureHerdrPanel: return "Remote herdr panel"
         }
     }
 
@@ -1099,7 +1154,15 @@ public final class ClaudeIntegrationSettingsModel {
         default:
             var text = "Remote setup failed."
             if case .updateRemotePlugin = action { text = "Plugin update failed." }
-            return [EnrollmentStepStatus(id: 0, text: text, succeeded: false, detail: failure.describedError)]
+            if case .configureHerdrPanel = action { text = "Herdr panel setup failed." }
+            let detail: String
+            if failure.serviceError == .herdrPanelConfigAlreadyCustomized {
+                detail = "Add this row manually:\n\n"
+                    + ClaudeRemoteEnrollmentService.herdrPanelConfigSnippet
+            } else {
+                detail = failure.describedError
+            }
+            return [EnrollmentStepStatus(id: 0, text: text, succeeded: false, detail: detail)]
         }
         let succeeded = (0..<failedStep).map {
             EnrollmentStepStatus(id: $0, text: "Step \($0 + 1) succeeded.", succeeded: true, detail: "")
@@ -1123,6 +1186,7 @@ public final class ClaudeIntegrationSettingsModel {
     ) -> String {
         var subject = "SSH setup"
         if case .updateRemotePlugin = action { subject = "Plugin update" }
+        if case .configureHerdrPanel = action { subject = "Herdr panel setup" }
         switch failure.serviceError {
         case .commandTimedOut(_, _, let seconds, let message):
             let output = message.isEmpty ? "" : "\n\n\(message)"
@@ -1147,6 +1211,9 @@ public final class ClaudeIntegrationSettingsModel {
             return "Running commands over SSH is not available in this build."
         case .invalidHostAlias:
             return "The SSH host alias is invalid."
+        case .herdrPanelConfigAlreadyCustomized:
+            return "The remote herdr config already has an agents table or rows key, so localvoxtral left it unchanged. Add this row manually:\n\n"
+                + ClaudeRemoteEnrollmentService.herdrPanelConfigSnippet
         case .none:
             return failure.describedError
         }

--- a/Sources/localvoxtral/ClaudeContext/ClaudeRemoteEnrollmentService.swift
+++ b/Sources/localvoxtral/ClaudeContext/ClaudeRemoteEnrollmentService.swift
@@ -134,6 +134,10 @@ public struct ClaudeRemoteEnrollmentService: Sendable {
         case commandTimedOut(step: Int, command: String, seconds: TimeInterval, message: String)
         case runnerFailed(step: Int, command: String, message: String)
         case invalidHostAlias
+        /// The remote config already contains an agents table or a rows key.
+        /// Automatic merging would overwrite user intent, so Settings must show
+        /// the snippet for manual placement instead.
+        case herdrPanelConfigAlreadyCustomized
     }
 
     /// Invocation in, result out. The stdin field is load-bearing: the bearer
@@ -167,6 +171,13 @@ public struct ClaudeRemoteEnrollmentService: Sendable {
     /// always emits both halves together for that reason; changing one alone
     /// fails open, which looks exactly like nothing happening.
     public static let portConfigKey = "port"
+
+    public static let herdrPanelConfigSnippet = """
+        [ui.sidebar.agents]
+        rows = [["state_icon", "workspace", "tab"], ["agent"], [{ token = "$lvmark", dim = true }]]
+        """
+    static let herdrPanelExistingConfigMarker =
+        "localvoxtral: existing herdr agents/sidebar rows configuration; no changes made"
 
     private let runner: Runner?
     private let sshConfigFileSystem: (any ClaudeRemoteSSHConfigFileSystem)?
@@ -675,6 +686,98 @@ public struct ClaudeRemoteEnrollmentService: Sendable {
             timeout: timeout,
             label: "plugin update"
         )
+    }
+
+    /// Append localvoxtral's agents-panel row only when the remote config has
+    /// no agents table and no rows key. The caller must obtain explicit consent
+    /// immediately before invoking this method.
+    @discardableResult
+    public func configureRemoteHerdrPanel(
+        sshHostAlias: String,
+        timeout: TimeInterval = defaultRemoteSetupTimeout
+    ) throws -> [ExecutionStep] {
+        guard let runner else { throw ServiceError.executionNotConfigured }
+        guard Self.isValidHostAlias(sshHostAlias) else { throw ServiceError.invalidHostAlias }
+
+        let script = """
+            set -eu
+            lv_config=${HERDR_CONFIG_PATH:-${XDG_CONFIG_HOME:-$HOME/.config}/herdr/config.toml}
+            if [ -f "$lv_config" ] && grep -Eq '^[[:space:]]*\\[ui\\.sidebar\\.agents\\][[:space:]]*(#.*)?$|^[[:space:]]*rows[[:space:]]*=' "$lv_config"; then
+              echo '\(Self.herdrPanelExistingConfigMarker)' >&2
+              exit 42
+            fi
+            mkdir -p "$(dirname "$lv_config")"
+            touch "$lv_config"
+            cat >> "$lv_config" <<'LOCALVOXTRAL_HERDR_PANEL'
+            \(Self.herdrPanelConfigSnippet)
+            LOCALVOXTRAL_HERDR_PANEL
+            herdr server reload-config
+            """
+        let invocation = Invocation(
+            argv: [
+                "ssh", "-o", "BatchMode=yes", "-o", "ClearAllForwardings=yes", "--",
+                sshHostAlias, "/bin/sh", "-s",
+            ],
+            standardInput: Data(script.utf8),
+            timeout: timeout
+        )
+        Log.claudeContext.info("Claude remote herdr panel configuration requested")
+        let result: RunResult
+        do {
+            result = try runner(invocation)
+        } catch let failure as RunnerFailure {
+            let error: ServiceError
+            switch failure {
+            case .timedOut(let seconds, let message):
+                error = .commandTimedOut(
+                    step: 0,
+                    command: "configure herdr agents panel",
+                    seconds: seconds,
+                    message: message
+                )
+            case .outputTooLarge(_, let message):
+                error = .runnerFailed(
+                    step: 0,
+                    command: "configure herdr agents panel",
+                    message: message
+                )
+            }
+            Log.claudeContext.error(
+                "Claude remote herdr panel configuration failed: \(String(describing: error), privacy: .public)"
+            )
+            throw error
+        } catch {
+            let failure = ServiceError.runnerFailed(
+                step: 0,
+                command: "configure herdr agents panel",
+                message: String(describing: error)
+            )
+            Log.claudeContext.error(
+                "Claude remote herdr panel configuration failed: \(String(describing: failure), privacy: .public)"
+            )
+            throw failure
+        }
+        if result.exitCode == 42,
+           result.message.contains(Self.herdrPanelExistingConfigMarker) {
+            Log.claudeContext.info(
+                "Claude remote herdr panel configuration refused: existing table or rows key; add manually:\n\(Self.herdrPanelConfigSnippet, privacy: .public)"
+            )
+            throw ServiceError.herdrPanelConfigAlreadyCustomized
+        }
+        guard result.succeeded else {
+            let failure = ServiceError.commandFailed(
+                step: 0,
+                command: "configure herdr agents panel",
+                exitCode: result.exitCode,
+                message: result.message
+            )
+            Log.claudeContext.error(
+                "Claude remote herdr panel configuration failed: \(String(describing: failure), privacy: .public)"
+            )
+            throw failure
+        }
+        Log.claudeContext.info("Claude remote herdr panel configuration completed")
+        return [ExecutionStep(index: 0, command: "configure herdr agents panel", message: result.message)]
     }
 
     private func execute(

--- a/Sources/localvoxtral/ClaudeContext/HerdrPanelBindingProbe.swift
+++ b/Sources/localvoxtral/ClaudeContext/HerdrPanelBindingProbe.swift
@@ -1,0 +1,302 @@
+import Foundation
+import Synchronization
+
+enum HerdrPanelBindingAbstention: String, Sendable, Equatable {
+    case rowNotRendered = "row-not-rendered"
+    case gridReadUnavailable = "ax-read-unavailable"
+    case stampRefused = "stamp-refused"
+    case settleTimeout = "settle-timeout"
+    case forwardUnavailable = "forward-unavailable"
+    case speculativeForwardUnavailable = "forward-unavailable-for-speculative-candidate"
+    case multiHostDoubleMatch = "multi-host-double-match"
+}
+
+enum HerdrPanelConfigurationStatus: Sendable, Equatable {
+    case ok
+    case likelyNotConfigured
+
+    var message: String? {
+        switch self {
+        case .ok: return nil
+        case .likelyNotConfigured:
+            return "The herdr agents-panel row may need setup."
+        }
+    }
+}
+
+protocol HerdrPanelMetadataReporting: Sendable {
+    func reportPanelToken(
+        socketPath: String,
+        paneID: String,
+        value: String?,
+        ttlMilliseconds: Int?
+    ) async -> Bool
+}
+
+/// Positive proof that the focused terminal surface renders an App-mode client
+/// for the herdr server reached through `socketPath`.
+///
+/// The nonce is stamped into the focused pane's agents-panel metadata and then
+/// read back through the terminal's existing focused-grid route. A raw string
+/// match is safe here only because the value is fresh, private to this socket
+/// exchange, short-lived, and unguessable (the production nonce retains more
+/// than 40 random bits). A terminal-attach/observe client never renders the
+/// sidebar and therefore cannot echo the token through this route.
+@MainActor
+struct HerdrPanelBindingProbe {
+    struct Match: Sendable, Equatable {
+        let token: String
+    }
+
+    enum Outcome: Sendable, Equatable {
+        case matched(Match)
+        case noMatch(HerdrPanelBindingAbstention)
+    }
+
+    typealias GridRead = @MainActor @Sendable (TerminalScreenTarget) -> String?
+    typealias Now = @MainActor @Sendable () -> Date
+    typealias SleepFor = @Sendable (TimeInterval) async -> Void
+    typealias RandomBits = @MainActor @Sendable () -> UInt64
+
+    static let tokenTTLMilliseconds = 8_000
+    static let settleDelay: TimeInterval = 0.12
+    static let settleBudget: TimeInterval = 0.5
+    static let maxGridReads = 2
+
+    private let metadata: any HerdrPanelMetadataReporting
+    private let readGrid: GridRead
+    private let now: Now
+    private let sleepFor: SleepFor
+    private let randomBits: RandomBits
+
+    init(
+        metadata: any HerdrPanelMetadataReporting,
+        readGrid: @escaping GridRead,
+        now: @escaping Now = Date.init,
+        sleepFor: @escaping SleepFor = { seconds in
+            try? await Task.sleep(for: .seconds(seconds))
+        },
+        randomBits: @escaping RandomBits = {
+            var generator = SystemRandomNumberGenerator()
+            return generator.next()
+        }
+    ) {
+        self.metadata = metadata
+        self.readGrid = readGrid
+        self.now = now
+        self.sleepFor = sleepFor
+        self.randomBits = randomBits
+    }
+
+    func probe(
+        target: TerminalScreenTarget,
+        socketPath: String,
+        paneID: String
+    ) async -> Outcome {
+        let token = Self.token(randomBits: randomBits())
+        guard await metadata.reportPanelToken(
+            socketPath: socketPath,
+            paneID: paneID,
+            value: token,
+            ttlMilliseconds: Self.tokenTTLMilliseconds
+        ) else {
+            return .noMatch(.stampRefused)
+        }
+
+        let startedAt = now()
+        for readIndex in 0..<Self.maxGridReads {
+            guard let grid = readGrid(target) else {
+                return .noMatch(.gridReadUnavailable)
+            }
+            if grid.contains(token) {
+                return .matched(Match(token: token))
+            }
+
+            guard readIndex + 1 < Self.maxGridReads else {
+                Self.noteAbstention(.rowNotRendered)
+                return .noMatch(.settleTimeout)
+            }
+            await sleepFor(Self.settleDelay)
+            guard now().timeIntervalSince(startedAt) <= Self.settleBudget else {
+                Self.noteAbstention(.rowNotRendered)
+                return .noMatch(.settleTimeout)
+            }
+        }
+        Self.noteAbstention(.rowNotRendered)
+        return .noMatch(.settleTimeout)
+    }
+
+    static func clear(
+        metadata: any HerdrPanelMetadataReporting,
+        socketPath: String,
+        paneID: String
+    ) async {
+        // JSON null is an intentional wire-level clear. In herdr source,
+        // PaneReportMetadataParams.tokens is HashMap<String, Option<String>>
+        // (src/api/schema/panes.rs:365), and normalize_metadata_tokens tests
+        // pin both None and "" as clears (src/app/api_helpers.rs:290-299).
+        _ = await metadata.reportPanelToken(
+            socketPath: socketPath,
+            paneID: paneID,
+            value: nil,
+            ttlMilliseconds: nil
+        )
+    }
+
+    static func token(randomBits: UInt64) -> String {
+        // Ten base-36 digits retain log2(36^10) ~= 51.7 bits. Keeping the low
+        // ten digits also makes the length fixed and leaves the complete
+        // `lv-mic-` token at 17 columns, under herdr's 22-column continuation
+        // row budget.
+        let digits = String(randomBits, radix: 36, uppercase: false)
+        let suffix = String(digits.suffix(10))
+        return "lv-mic-" + String(repeating: "0", count: 10 - suffix.count) + suffix
+    }
+
+    static func noteAbstention(_ cause: HerdrPanelBindingAbstention) {
+        Log.claudeContext.info(
+            "Remote herdr panel binding abstained (\(cause.rawValue, privacy: .public))"
+        )
+        #if LOCALVOXTRAL_DOGFOOD
+        DogfoodCaptureTap.shared.noteJoinAbstention("remoteHerdrPanel: \(cause.rawValue)")
+        #endif
+    }
+}
+
+/// Keeps a successfully matched panel token visible as the dictation's mic
+/// indicator. The view model starts and stops this lease alongside the forward
+/// it owns; tests inject `sleepFor`, so no assertion depends on wall clock.
+final class HerdrPanelMicIndicator: @unchecked Sendable, Equatable {
+    typealias SleepFor = @Sendable (TimeInterval) async -> Void
+
+    static let refreshInterval: TimeInterval = 4
+
+    private struct State {
+        var started = false
+        var stopped = false
+        var task: Task<Void, Never>?
+        var stopTask: Task<Void, Never>?
+    }
+
+    private let state = Mutex(State())
+    private let metadata: any HerdrPanelMetadataReporting
+    private let socketPath: String
+    private let paneID: String
+    private let token: String
+    private let forward: ClaudeRemoteHerdrForwardHandle
+    private let sleepFor: SleepFor
+
+    init(
+        metadata: any HerdrPanelMetadataReporting,
+        socketPath: String,
+        paneID: String,
+        token: String,
+        forward: ClaudeRemoteHerdrForwardHandle,
+        sleepFor: @escaping SleepFor = { seconds in
+            try? await Task.sleep(for: .seconds(seconds))
+        }
+    ) {
+        self.metadata = metadata
+        self.socketPath = socketPath
+        self.paneID = paneID
+        self.token = token
+        self.forward = forward
+        self.sleepFor = sleepFor
+    }
+
+    static func == (lhs: HerdrPanelMicIndicator, rhs: HerdrPanelMicIndicator) -> Bool {
+        lhs === rhs
+    }
+
+    func start() {
+        let shouldStart = state.withLock { state in
+            guard !state.started, !state.stopped else { return false }
+            state.started = true
+            return true
+        }
+        guard shouldStart else { return }
+
+        // Keep the task behind a one-value gate until its handle is recorded.
+        // Without this, an immediate teardown on another thread can clear the
+        // token while an unrecorded first refresh races in afterwards.
+        let (startSignal, startContinuation) = AsyncStream.makeStream(of: Void.self)
+        let task = Task.detached(priority: .utility) { [weak self] in
+            guard let self else { return }
+            var startIterator = startSignal.makeAsyncIterator()
+            guard await startIterator.next() != nil, !Task.isCancelled else { return }
+            while true {
+                await self.sleepFor(Self.refreshInterval)
+                guard !Task.isCancelled,
+                      self.state.withLock({ !$0.stopped })
+                else { return }
+                let refreshed = await self.refreshOnce()
+                if !refreshed {
+                    Log.claudeContext.info("Remote herdr mic indicator refresh was refused")
+                }
+            }
+        }
+        state.withLock { state in
+            if state.stopped {
+                task.cancel()
+            } else {
+                state.task = task
+            }
+        }
+        startContinuation.yield()
+        startContinuation.finish()
+    }
+
+    /// Idempotent. Clear is attempted while the forward is still open, and the
+    /// forward closes only after that bounded socket request returns.
+    func stop() {
+        _ = makeStopTask()
+    }
+
+    @discardableResult
+    func refreshOnce() async -> Bool {
+        guard state.withLock({ !$0.stopped }) else { return false }
+        return await metadata.reportPanelToken(
+            socketPath: socketPath,
+            paneID: paneID,
+            value: token,
+            ttlMilliseconds: HerdrPanelBindingProbe.tokenTTLMilliseconds
+        )
+    }
+
+    /// Async seam used by deterministic tests; production calls `stop()`,
+    /// which performs this same bounded sequence off the main actor.
+    func stopAndWait() async {
+        await makeStopTask().value
+    }
+
+    /// Every caller shares one teardown task. In particular, a test awaiting
+    /// `stopAndWait()` after view-model teardown must wait for the clear/close
+    /// that `stop()` already started rather than returning at `stopped == true`.
+    private func makeStopTask() -> Task<Void, Never> {
+        let metadata = metadata
+        let socketPath = socketPath
+        let paneID = paneID
+        let forward = forward
+        return state.withLock { state in
+            if let stopTask = state.stopTask { return stopTask }
+            state.stopped = true
+            let refreshTask = state.task
+            state.task = nil
+            refreshTask?.cancel()
+            let stopTask = Task.detached(priority: .utility) {
+                // A refresh may already be inside the socket request when
+                // teardown begins. Wait for it before clearing so a late
+                // refresh can never recreate the token after the clear.
+                await refreshTask?.value
+                await HerdrPanelBindingProbe.clear(
+                    metadata: metadata,
+                    socketPath: socketPath,
+                    paneID: paneID
+                )
+                forward.close()
+            }
+            state.stopTask = stopTask
+            return stopTask
+        }
+    }
+}

--- a/Sources/localvoxtral/ClaudeContext/HerdrPanelBindingProbe.swift
+++ b/Sources/localvoxtral/ClaudeContext/HerdrPanelBindingProbe.swift
@@ -60,8 +60,15 @@ struct HerdrPanelBindingProbe {
 
     static let tokenTTLMilliseconds = 8_000
     static let settleDelay: TimeInterval = 0.12
-    static let settleBudget: TimeInterval = 0.5
-    static let maxGridReads = 2
+    /// The stamp must cross the forward, herdr must paint a frame, ssh must
+    /// carry it back, and the terminal must render it — over a ProxyJump
+    /// chain that is several hundred milliseconds end to end. The first field
+    /// dictation (2026-08-09) timed out at two reads ~120 ms apart while the
+    /// row was visibly rendering moments later; the budget below is what the
+    /// loop actually honors now, with `maxGridReads` only as a hard cap so a
+    /// test clock that never advances cannot loop forever.
+    static let settleBudget: TimeInterval = 1.0
+    static let maxGridReads = 9
 
     private let metadata: any HerdrPanelMetadataReporting
     private let readGrid: GridRead

--- a/Sources/localvoxtral/ClaudeContext/HerdrSocketClient.swift
+++ b/Sources/localvoxtral/ClaudeContext/HerdrSocketClient.swift
@@ -75,12 +75,14 @@ protocol HerdrPaneQuerying: Sendable {
     func paneVisibleText(socketPath: String, paneID: String) async -> String?
 }
 
-/// Minimal read-only client for herdr's one-request-per-connection JSON API.
+/// Minimal capability-bounded client for herdr's one-request-per-connection
+/// JSON API. Reads are limited to the focused/joined pane; the sole mutation is
+/// the short-lived `lvmark` panel token used by remote surface authorization.
 ///
 /// Every syscall shares one absolute monotonic deadline. A per-phase timeout
 /// would let a slow connect, write, and response each consume the whole budget,
 /// while a per-read timeout would let a trickling peer retain the task forever.
-struct HerdrSocketClient: HerdrPaneQuerying {
+struct HerdrSocketClient: HerdrPaneQuerying, HerdrPanelMetadataReporting {
     private let timeout: TimeInterval
     private let uptimeNanos: @Sendable () -> UInt64
     private let socketMetadata: @Sendable (String) -> ClaudeSocketGuard.PathMetadata?
@@ -189,6 +191,34 @@ struct HerdrSocketClient: HerdrPaneQuerying {
                 return nil
             }
             return result.read.text
+        }.value
+    }
+
+    func reportPanelToken(
+        socketPath: String,
+        paneID: String,
+        value: String?,
+        ttlMilliseconds: Int?
+    ) async -> Bool {
+        await Task.detached(priority: .userInitiated) { [self] in
+            let request = Request(
+                id: Self.requestID(),
+                method: "pane.report_metadata",
+                params: PaneReportMetadataParams(
+                    paneID: paneID,
+                    tokens: ["lvmark": value],
+                    ttlMilliseconds: ttlMilliseconds
+                )
+            )
+            guard let line = query(socketPath: socketPath, request: request),
+                  let envelope = try? JSONDecoder().decode(Envelope<OKResult>.self, from: line),
+                  envelope.id == request.id,
+                  envelope.result?.type == "ok"
+            else {
+                Log.claudeContext.info("Herdr panel metadata report abstained: invalid response")
+                return false
+            }
+            return true
         }.value
     }
 
@@ -410,6 +440,20 @@ struct HerdrSocketClient: HerdrPaneQuerying {
         }
     }
 
+    private struct PaneReportMetadataParams: Encodable {
+        var paneID: String
+        var source = "localvoxtral"
+        var tokens: [String: String?]
+        var ttlMilliseconds: Int?
+
+        enum CodingKeys: String, CodingKey {
+            case paneID = "pane_id"
+            case source
+            case tokens
+            case ttlMilliseconds = "ttl_ms"
+        }
+    }
+
     private struct Envelope<Result: Decodable>: Decodable {
         var id: String
         var result: Result?
@@ -440,6 +484,10 @@ struct HerdrSocketClient: HerdrPaneQuerying {
     private struct ErrorBody: Decodable {
         var code: String
         var message: String
+    }
+
+    private struct OKResult: Decodable {
+        var type: String
     }
 
     private struct PaneCurrentResult: Decodable {

--- a/Sources/localvoxtral/ClaudeContext/SSHDestinationTTYProbe.swift
+++ b/Sources/localvoxtral/ClaudeContext/SSHDestinationTTYProbe.swift
@@ -87,6 +87,21 @@ enum SSHProbeIndeterminacy: String, Sendable, Equatable {
     case probeUnavailable = "probe unavailable"
 }
 
+extension SSHProbeIndeterminacy {
+    /// An ssh process is present on the focused surface, but trusting its
+    /// destination would require guessing. A title there may be stale from the
+    /// pre-herdr outer session, so these categories suppress that arm too.
+    var suppressesTitleMarker: Bool {
+        switch self {
+        case .multipleForegroundClients, .untrustedExecutable,
+             .unreadableArguments, .refusedArguments:
+            return true
+        case .deviceUnreadable, .tableUnreadable, .probeUnavailable:
+            return false
+        }
+    }
+}
+
 /// What the process table says about ssh clients on ONE terminal device.
 ///
 /// Three answers, and the difference between the last two is the whole point:

--- a/Sources/localvoxtral/ClaudeContext/TerminalScreenClaudeJoin.swift
+++ b/Sources/localvoxtral/ClaudeContext/TerminalScreenClaudeJoin.swift
@@ -97,6 +97,9 @@ struct ClaudeSessionJoin: Sendable, Equatable {
     /// Closing it is the holder's job (`close()` is idempotent, and the handle
     /// closes itself on deinit as a backstop).
     let remoteHerdrForward: ClaudeRemoteHerdrForwardHandle?
+    /// The agents-panel token lease for a panel-authorized remote join. The
+    /// view model starts it after taking ownership and stops it on every exit.
+    let remoteHerdrIndicator: HerdrPanelMicIndicator?
 
     init(
         target: TerminalScreenTarget,
@@ -107,7 +110,8 @@ struct ClaudeSessionJoin: Sendable, Equatable {
         herdrPane: ClaudeHerdrPaneBinding? = nil,
         browserTab: ClaudeBrowserTabBinding? = nil,
         cmuxSurface: ClaudeCmuxSurfaceBinding? = nil,
-        remoteHerdrForward: ClaudeRemoteHerdrForwardHandle? = nil
+        remoteHerdrForward: ClaudeRemoteHerdrForwardHandle? = nil,
+        remoteHerdrIndicator: HerdrPanelMicIndicator? = nil
     ) {
         self.target = target
         self.marker = marker
@@ -118,6 +122,7 @@ struct ClaudeSessionJoin: Sendable, Equatable {
         self.browserTab = browserTab
         self.cmuxSurface = cmuxSurface
         self.remoteHerdrForward = remoteHerdrForward
+        self.remoteHerdrIndicator = remoteHerdrIndicator
     }
 
     /// The per-pane socket route this join owns, if any: the herdr pane id or
@@ -192,7 +197,15 @@ struct ClaudeSessionJoinResolver {
     private let sshDestinationProbe: @Sendable (String) -> SSHDestinationTTYProbeResult
     private let enrolledHosts: @MainActor (String) -> [ClaudeRemoteHost]
     private let canonicalizedEnrolledHosts: @MainActor (String) async -> [ClaudeRemoteHost]
+    private let speculativeHosts: @MainActor () -> [ClaudeRemoteHost]
     private let remoteHerdrForwards: (any ClaudeRemoteHerdrForwarding)?
+    private let herdrPanelMetadata: (any HerdrPanelMetadataReporting)?
+    private let readFocusedGrid: HerdrPanelBindingProbe.GridRead
+    private let panelNow: HerdrPanelBindingProbe.Now
+    private let panelSleepFor: HerdrPanelBindingProbe.SleepFor
+    private let panelRandomBits: HerdrPanelBindingProbe.RandomBits
+    private let indicatorSleepFor: HerdrPanelMicIndicator.SleepFor
+    private let reportPanelStatus: @MainActor (HerdrPanelConfigurationStatus) -> Void
 
     /// - Parameters:
     ///   - markerInWindowTitle: reads the PID-pinned focused window title,
@@ -276,7 +289,22 @@ struct ClaudeSessionJoinResolver {
         canonicalizedEnrolledHosts: @escaping @MainActor (String) async -> [ClaudeRemoteHost] = {
             _ in []
         },
-        remoteHerdrForwards: (any ClaudeRemoteHerdrForwarding)? = nil
+        speculativeHosts: @escaping @MainActor () -> [ClaudeRemoteHost] = { [] },
+        remoteHerdrForwards: (any ClaudeRemoteHerdrForwarding)? = nil,
+        herdrPanelMetadata: (any HerdrPanelMetadataReporting)? = nil,
+        readFocusedGrid: @escaping HerdrPanelBindingProbe.GridRead = { _ in nil },
+        panelNow: @escaping HerdrPanelBindingProbe.Now = Date.init,
+        panelSleepFor: @escaping HerdrPanelBindingProbe.SleepFor = { seconds in
+            try? await Task.sleep(for: .seconds(seconds))
+        },
+        panelRandomBits: @escaping HerdrPanelBindingProbe.RandomBits = {
+            var generator = SystemRandomNumberGenerator()
+            return generator.next()
+        },
+        indicatorSleepFor: @escaping HerdrPanelMicIndicator.SleepFor = { seconds in
+            try? await Task.sleep(for: .seconds(seconds))
+        },
+        reportPanelStatus: @escaping @MainActor (HerdrPanelConfigurationStatus) -> Void = { _ in }
     ) {
         self.registry = registry
         self.markerInWindowTitle = markerInWindowTitle
@@ -291,7 +319,15 @@ struct ClaudeSessionJoinResolver {
         self.sshDestinationProbe = sshDestinationProbe
         self.enrolledHosts = enrolledHosts
         self.canonicalizedEnrolledHosts = canonicalizedEnrolledHosts
+        self.speculativeHosts = speculativeHosts
         self.remoteHerdrForwards = remoteHerdrForwards
+        self.herdrPanelMetadata = herdrPanelMetadata
+        self.readFocusedGrid = readFocusedGrid
+        self.panelNow = panelNow
+        self.panelSleepFor = panelSleepFor
+        self.panelRandomBits = panelRandomBits
+        self.indicatorSleepFor = indicatorSleepFor
+        self.reportPanelStatus = reportPanelStatus
     }
 
     /// The join for `target`, or nil on any abstention.
@@ -383,6 +419,8 @@ struct ClaudeSessionJoinResolver {
                 return nil
             case .notApplicable:
                 break
+            case .suppressMarker:
+                return nil
             }
         }
 
@@ -564,6 +602,9 @@ struct ClaudeSessionJoinResolver {
     enum RemoteHerdrArmOutcome {
         /// Nothing here is about a remote herdr; other arms may still answer.
         case notApplicable
+        /// An unreadable ssh is present on the surface. Its outer marker may be
+        /// stale from before herdr started, so no later arm may consume it.
+        case suppressMarker
         /// This surface IS an enrolled host's herdr and the join still failed.
         case abstained
         case joined(ClaudeSessionJoin)
@@ -571,9 +612,12 @@ struct ClaudeSessionJoinResolver {
 
     /// A Claude Code session inside a herdr on an ENROLLED REMOTE host.
     ///
-    /// Bindings, all required, in cost order — the free local reads first, so an
-    /// ordinary ssh session never pays for a forward:
+    /// The agents-panel nonce is the primary surface authorization. A readable
+    /// ssh destination narrows it to one enrolled host; otherwise up to three
+    /// live herdr-bearing hosts are tried. Only when that proof cannot render
+    /// does the pre-existing argv path below become the fallback.
     ///
+    /// The fallback bindings, all required, remain:
     /// 1. the focused surface's TTY hosts EXACTLY ONE foreground ssh session,
     ///    whose destination is exactly one enrolled host's alias. One, because
     ///    several in a group cannot be told apart from here and unioning them
@@ -608,8 +652,20 @@ struct ClaudeSessionJoinResolver {
         target: TerminalScreenTarget,
         tty: String
     ) async -> RemoteHerdrArmOutcome {
+        let sshResult = sshDestinationProbe(tty)
+
+        // PRIMARY authorization: stamp each plausible server with a fresh
+        // nonce and require that exact value in the focused terminal grid.
+        // argv is consulted only after this direct surface proof fails.
+        if let panelOutcome = await resolveViaRemoteHerdrPanel(
+            target: target,
+            sshResult: sshResult
+        ) {
+            return panelOutcome
+        }
+
         let connection: SSHSurfaceConnection
-        switch sshDestinationProbe(tty) {
+        switch sshResult {
         case .noSSHClient:
             // The overwhelmingly common case: a local shell. Not logged — this
             // is not an abstention, it is the arm not applying.
@@ -620,7 +676,7 @@ struct ClaudeSessionJoinResolver {
             // the dogfood record. Three field dictations were diagnosed blind
             // without it (2026-08-06).
             Self.abstainedRemoteHerdrJoin(outcome: "ssh session undeterminable (\(cause.rawValue))")
-            return .notApplicable
+            return cause.suppressesTitleMarker ? .suppressMarker : .notApplicable
         case .connection(let value):
             connection = value
         }
@@ -681,10 +737,11 @@ struct ClaudeSessionJoinResolver {
         // `.notApplicable`, which falls through to the title marker, where a
         // stale marker left by an earlier session could win.
         //
-        // The cost, stated accurately: the manual flow — `ssh host`, then type
-        // `herdr` — still gets no HERDR join (its argv has no remote command).
-        // It does not get "no context": the marker arm still runs. That
-        // residual is pre-existing and cannot be closed from here.
+        // The residual cost after panel fallback: a manual `ssh host`, then
+        // `herdr` flow still gets no HERDR join when the sidebar row cannot
+        // render (collapsed/narrow/covered/unconfigured), because its argv has
+        // no remote command. Marker fallback is separately suppressed for the
+        // four present-but-unreadable ssh categories above.
         // The surface's own classification first: when the surface argv is the
         // problem, the log must say so — a competing neighbor may exist too,
         // and reporting it instead buried the actionable cause (review nit,
@@ -762,6 +819,230 @@ struct ClaudeSessionJoinResolver {
             forward.close()
             return .abstained
         }
+    }
+
+    private struct PanelCandidateMatch {
+        let host: ClaudeRemoteHost
+        let pane: HerdrFocusedPane
+        let snapshot: ClaudeSessionSnapshot
+        let forward: ClaudeRemoteHerdrForwardHandle
+        let token: String
+    }
+
+    /// Returns nil only when the panel did not authorize any server, which is
+    /// the one condition that permits the argv fallback below it.
+    private func resolveViaRemoteHerdrPanel(
+        target: TerminalScreenTarget,
+        sshResult: SSHDestinationTTYProbeResult
+    ) async -> RemoteHerdrArmOutcome? {
+        guard let herdrPanes,
+              let remoteHerdrForwards,
+              let herdrPanelMetadata
+        else { return nil }
+
+        let selectedHosts: [ClaudeRemoteHost]
+        let speculative: Bool
+        switch sshResult {
+        case .connection(let connection):
+            let matching = enrolledHosts(connection.destination).filter {
+                !$0.isRevoked && $0.sshHostAlias != nil
+            }
+            guard matching.count == 1 else { return nil }
+            selectedHosts = matching
+            speculative = false
+        case .noSSHClient:
+            // A surface with NO ssh at all is a local shell — the
+            // overwhelmingly common dictation target. It must not pay remote
+            // latency (a cold forward per candidate host) and must not flash
+            // a nonce in remote panels the user is not looking at, so it
+            // never probes. The cost: a nested wrapper whose inner ssh lives
+            // on another pty (tmux) stays unjoinable until a warm-forward
+            // speculative mode exists.
+            return nil
+        case .undeterminable:
+            // An ssh IS present but its argv cannot be read (a wrapper the
+            // parser refuses). That is a strong prior that the surface shows
+            // a remote session, so plausible servers are probed. Registry
+            // liveness bounds the candidates, and the hard prefix keeps one
+            // join from opening an unbounded number of forwards.
+            selectedHosts = Array(speculativeHosts().filter { host in
+                !host.isRevoked
+                    && host.sshHostAlias != nil
+                    && !registry.liveRemoteHerdrSessions(hostID: host.id).isEmpty
+            }.prefix(3))
+            speculative = true
+        }
+        guard !selectedHosts.isEmpty else { return nil }
+
+        let probe = HerdrPanelBindingProbe(
+            metadata: herdrPanelMetadata,
+            readGrid: readFocusedGrid,
+            now: panelNow,
+            sleepFor: panelSleepFor,
+            randomBits: panelRandomBits
+        )
+        var matches: [PanelCandidateMatch] = []
+
+        for host in selectedHosts {
+            guard let alias = host.sshHostAlias else { continue }
+            let candidates = registry.liveRemoteHerdrSessions(hostID: host.id)
+            let socketPaths = Set(candidates.compactMap {
+                $0.remoteSessionEnvironment?.herdrSocketPath
+            })
+            guard socketPaths.count == 1, let remoteSocketPath = socketPaths.first else {
+                Self.abstainedRemoteHerdrJoin(outcome: "panel candidate has multiple live herdr sockets")
+                continue
+            }
+            guard let forward = await remoteHerdrForwards.open(
+                alias: alias,
+                remoteSocketPath: remoteSocketPath
+            ) else {
+                let cause: HerdrPanelBindingAbstention = speculative
+                    ? .speculativeForwardUnavailable : .forwardUnavailable
+                HerdrPanelBindingProbe.noteAbstention(cause)
+                continue
+            }
+
+            let socketPath = forward.localSocketPath
+            guard let pane = await herdrPanes.focusedPane(socketPath: socketPath) else {
+                Self.abstainedRemoteHerdrJoin(outcome: "panel candidate focused pane unavailable")
+                forward.close()
+                continue
+            }
+            let paneMatches = candidates.filter {
+                $0.remoteSessionEnvironment?.herdrPaneID == pane.paneID
+            }
+            guard paneMatches.count == 1, let snapshot = paneMatches.first else {
+                Self.abstainedRemoteHerdrJoin(
+                    outcome: paneMatches.isEmpty
+                        ? "panel candidate focused pane has no live session"
+                        : "panel candidate focused pane is ambiguous"
+                )
+                forward.close()
+                continue
+            }
+
+            switch await probe.probe(
+                target: target,
+                socketPath: socketPath,
+                paneID: pane.paneID
+            ) {
+            case .matched(let match):
+                matches.append(PanelCandidateMatch(
+                    host: host,
+                    pane: pane,
+                    snapshot: snapshot,
+                    forward: forward,
+                    token: match.token
+                ))
+            case .noMatch(let cause):
+                HerdrPanelBindingProbe.noteAbstention(cause)
+                // Only a destination-known probe may diagnose the row: a
+                // speculative candidate's token not rendering usually means
+                // the user is not looking at THAT server, not that its
+                // config is missing.
+                if cause == .settleTimeout, !speculative {
+                    reportPanelStatus(.likelyNotConfigured)
+                    Log.claudeContext.info(
+                        "Remote herdr panel token was stamped but not rendered; agents-panel row likely not configured"
+                    )
+                }
+                await HerdrPanelBindingProbe.clear(
+                    metadata: herdrPanelMetadata,
+                    socketPath: socketPath,
+                    paneID: pane.paneID
+                )
+                forward.close()
+            }
+        }
+
+        if !matches.isEmpty { reportPanelStatus(.ok) }
+        guard matches.count <= 1 else {
+            HerdrPanelBindingProbe.noteAbstention(.multiHostDoubleMatch)
+            for match in matches {
+                await HerdrPanelBindingProbe.clear(
+                    metadata: herdrPanelMetadata,
+                    socketPath: match.forward.localSocketPath,
+                    paneID: match.pane.paneID
+                )
+                match.forward.close()
+            }
+            return .abstained
+        }
+        guard let match = matches.first else { return nil }
+
+        return await confirmPanelAuthorizedRemoteHerdr(
+            target: target,
+            match: match,
+            metadata: herdrPanelMetadata,
+            herdrPanes: herdrPanes
+        )
+    }
+
+    private func confirmPanelAuthorizedRemoteHerdr(
+        target: TerminalScreenTarget,
+        match: PanelCandidateMatch,
+        metadata: any HerdrPanelMetadataReporting,
+        herdrPanes: HerdrPaneQuerying
+    ) async -> RemoteHerdrArmOutcome {
+        let pane = match.pane
+        let snapshot = match.snapshot
+        let socketPath = match.forward.localSocketPath
+
+        func refuse(_ outcome: String) async -> RemoteHerdrArmOutcome {
+            Self.abstainedRemoteHerdrJoin(outcome: outcome)
+            await HerdrPanelBindingProbe.clear(
+                metadata: metadata,
+                socketPath: socketPath,
+                paneID: pane.paneID
+            )
+            match.forward.close()
+            return .abstained
+        }
+
+        guard let title = pane.terminalTitle,
+              let marker = ClaudeMarkerTitleParser.marker(inTitle: title),
+              marker == snapshot.marker
+        else { return await refuse("panel-bound pane marker confirmation failed") }
+
+        if let claimed = pane.claimedClaudeSessionID,
+           Self.scopedRemoteSessionID(
+               claimed: claimed, hostID: match.host.id, agent: snapshot.agent
+           ) != snapshot.sessionID {
+            return await refuse("pane session claim disagrees")
+        }
+        guard let foreground = await herdrPanes.paneForegroundInfo(
+            socketPath: socketPath, paneID: pane.paneID
+        ) else { return await refuse("foreground process query unavailable") }
+        guard let processes = foreground.foregroundProcesses else {
+            return await refuse("foreground process detection unavailable")
+        }
+        guard Self.remoteAgentIsForeground(
+            snapshot: snapshot,
+            foregroundProcesses: processes
+        ) else { return await refuse("registered remote agent is not foreground") }
+
+        let indicator = HerdrPanelMicIndicator(
+            metadata: metadata,
+            socketPath: socketPath,
+            paneID: pane.paneID,
+            token: match.token,
+            forward: match.forward,
+            sleepFor: indicatorSleepFor
+        )
+        Log.claudeContext.info(
+            "Terminal pane joined to a live Claude session via remote herdr agents-panel binding"
+        )
+        return .joined(ClaudeSessionJoin(
+            target: target,
+            marker: snapshot.marker,
+            snapshot: snapshot,
+            windowID: focusedWindowID(target.pid),
+            mechanism: .remoteHerdrPane,
+            herdrPane: ClaudeHerdrPaneBinding(paneID: pane.paneID, socketPath: socketPath),
+            remoteHerdrForward: match.forward,
+            remoteHerdrIndicator: indicator
+        ))
     }
 
     /// What the over-the-forward half concluded.

--- a/Sources/localvoxtral/ClaudeContext/TerminalScreenClaudeJoin.swift
+++ b/Sources/localvoxtral/ClaudeContext/TerminalScreenClaudeJoin.swift
@@ -886,73 +886,90 @@ struct ClaudeSessionJoinResolver {
         for host in selectedHosts {
             guard let alias = host.sshHostAlias else { continue }
             let candidates = registry.liveRemoteHerdrSessions(hostID: host.id)
+            // Two live sockets on one host used to abstain outright (the argv
+            // fallback still does — it has no way to tell the servers apart).
+            // The nonce CAN tell them apart: each socket is stamped with its
+            // own fresh token, and only the server this surface displays can
+            // render its token. A stale socket — a session registered under a
+            // previous herdr boot, inside the registry TTL — simply fails its
+            // forward and is skipped (field abstention 2026-08-09). Sorted for
+            // determinism; bounded like the host prefix.
             let socketPaths = Set(candidates.compactMap {
                 $0.remoteSessionEnvironment?.herdrSocketPath
-            })
-            guard socketPaths.count == 1, let remoteSocketPath = socketPaths.first else {
-                Self.abstainedRemoteHerdrJoin(outcome: "panel candidate has multiple live herdr sockets")
-                continue
-            }
-            guard let forward = await remoteHerdrForwards.open(
-                alias: alias,
-                remoteSocketPath: remoteSocketPath
-            ) else {
-                let cause: HerdrPanelBindingAbstention = speculative
-                    ? .speculativeForwardUnavailable : .forwardUnavailable
-                HerdrPanelBindingProbe.noteAbstention(cause)
-                continue
-            }
+            }).sorted().prefix(3)
 
-            let socketPath = forward.localSocketPath
-            guard let pane = await herdrPanes.focusedPane(socketPath: socketPath) else {
-                Self.abstainedRemoteHerdrJoin(outcome: "panel candidate focused pane unavailable")
-                forward.close()
-                continue
-            }
-            let paneMatches = candidates.filter {
-                $0.remoteSessionEnvironment?.herdrPaneID == pane.paneID
-            }
-            guard paneMatches.count == 1, let snapshot = paneMatches.first else {
-                Self.abstainedRemoteHerdrJoin(
-                    outcome: paneMatches.isEmpty
-                        ? "panel candidate focused pane has no live session"
-                        : "panel candidate focused pane is ambiguous"
-                )
-                forward.close()
-                continue
-            }
-
-            switch await probe.probe(
-                target: target,
-                socketPath: socketPath,
-                paneID: pane.paneID
-            ) {
-            case .matched(let match):
-                matches.append(PanelCandidateMatch(
-                    host: host,
-                    pane: pane,
-                    snapshot: snapshot,
-                    forward: forward,
-                    token: match.token
-                ))
-            case .noMatch(let cause):
-                HerdrPanelBindingProbe.noteAbstention(cause)
-                // Only a destination-known probe may diagnose the row: a
-                // speculative candidate's token not rendering usually means
-                // the user is not looking at THAT server, not that its
-                // config is missing.
-                if cause == .settleTimeout, !speculative {
-                    reportPanelStatus(.likelyNotConfigured)
-                    Log.claudeContext.info(
-                        "Remote herdr panel token was stamped but not rendered; agents-panel row likely not configured"
-                    )
+            socketLoop: for remoteSocketPath in socketPaths {
+                let socketCandidates = candidates.filter {
+                    $0.remoteSessionEnvironment?.herdrSocketPath == remoteSocketPath
                 }
-                await HerdrPanelBindingProbe.clear(
-                    metadata: herdrPanelMetadata,
+                guard let forward = await remoteHerdrForwards.open(
+                    alias: alias,
+                    remoteSocketPath: remoteSocketPath
+                ) else {
+                    let cause: HerdrPanelBindingAbstention = speculative
+                        ? .speculativeForwardUnavailable : .forwardUnavailable
+                    HerdrPanelBindingProbe.noteAbstention(cause)
+                    continue
+                }
+
+                let socketPath = forward.localSocketPath
+                guard let pane = await herdrPanes.focusedPane(socketPath: socketPath) else {
+                    Self.abstainedRemoteHerdrJoin(outcome: "panel candidate focused pane unavailable")
+                    forward.close()
+                    continue
+                }
+                let paneMatches = socketCandidates.filter {
+                    $0.remoteSessionEnvironment?.herdrPaneID == pane.paneID
+                }
+                guard paneMatches.count == 1, let snapshot = paneMatches.first else {
+                    Self.abstainedRemoteHerdrJoin(
+                        outcome: paneMatches.isEmpty
+                            ? "panel candidate focused pane has no live session"
+                            : "panel candidate focused pane is ambiguous"
+                    )
+                    forward.close()
+                    continue
+                }
+
+                switch await probe.probe(
+                    target: target,
                     socketPath: socketPath,
                     paneID: pane.paneID
-                )
-                forward.close()
+                ) {
+                case .matched(let match):
+                    matches.append(PanelCandidateMatch(
+                        host: host,
+                        pane: pane,
+                        snapshot: snapshot,
+                        forward: forward,
+                        token: match.token
+                    ))
+                    // One grid renders exactly one server's panel, and the
+                    // forward service holds one entry per host — opening the
+                    // NEXT socket would tear down this matched forward. First
+                    // match ends the socket loop; the cross-HOST double-match
+                    // abstention below is untouched.
+                    break socketLoop
+                case .noMatch(let cause):
+                    HerdrPanelBindingProbe.noteAbstention(cause)
+                    // Only a destination-known SINGLE-socket probe may
+                    // diagnose the row: with a speculative host or a second
+                    // socket in play, a token not rendering usually means the
+                    // user is not looking at THAT server, not that its config
+                    // is missing.
+                    if cause == .settleTimeout, !speculative, socketPaths.count == 1 {
+                        reportPanelStatus(.likelyNotConfigured)
+                        Log.claudeContext.info(
+                            "Remote herdr panel token was stamped but not rendered; agents-panel row likely not configured"
+                        )
+                    }
+                    await HerdrPanelBindingProbe.clear(
+                        metadata: herdrPanelMetadata,
+                        socketPath: socketPath,
+                        paneID: pane.paneID
+                    )
+                    forward.close()
+                }
             }
         }
 

--- a/Sources/localvoxtral/DictationViewModel.swift
+++ b/Sources/localvoxtral/DictationViewModel.swift
@@ -399,6 +399,11 @@ final class DictationViewModel {
     /// prompt. Cleared on every session exit, like the screen capture.
     @ObservationIgnored
     var claudeSessionJoin: ClaudeSessionJoin?
+    /// Panel indicators own their associated remote forward until an explicit
+    /// token clear has completed, so teardown cannot close the tunnel before
+    /// the clear request reaches herdr.
+    @ObservationIgnored
+    var liveRemoteHerdrIndicators: [HerdrPanelMicIndicator] = []
     /// Remote herdr `ssh -L` leases this dictation has open. See
     /// `retainRemoteHerdrForward(of:)` for why they are owned here and not by
     /// the join that travels.
@@ -2079,6 +2084,11 @@ final class DictationViewModel {
     /// commit path and captured into a Task), and a resource whose owner is
     /// "whoever currently holds the value" has no owner at all.
     func retainRemoteHerdrForward(of join: ClaudeSessionJoin?) {
+        if let indicator = join?.remoteHerdrIndicator {
+            liveRemoteHerdrIndicators.append(indicator)
+            indicator.start()
+            return
+        }
         guard let forward = join?.remoteHerdrForward else { return }
         liveRemoteHerdrForwards.append(forward)
     }
@@ -2092,6 +2102,10 @@ final class DictationViewModel {
     /// is what makes a leaked handle from some path nobody thought of
     /// self-healing at the next exit.
     func closeRemoteHerdrForwards() {
+        let indicators = liveRemoteHerdrIndicators
+        liveRemoteHerdrIndicators = []
+        for indicator in indicators { indicator.stop() }
+
         guard !liveRemoteHerdrForwards.isEmpty else { return }
         let forwards = liveRemoteHerdrForwards
         liveRemoteHerdrForwards = []
@@ -2099,7 +2113,9 @@ final class DictationViewModel {
     }
 
     /// Test seam: how many tunnels this view model is holding open.
-    var openRemoteHerdrForwardCount: Int { liveRemoteHerdrForwards.count }
+    var openRemoteHerdrForwardCount: Int {
+        liveRemoteHerdrForwards.count + liveRemoteHerdrIndicators.count
+    }
 
     /// Reconciles the start capture against a stop-time re-read of the SAME
     /// PID/bundle and clears it. See `TerminalScreenContext.reconcile` for the

--- a/Sources/localvoxtral/SettingsView.swift
+++ b/Sources/localvoxtral/SettingsView.swift
@@ -1048,6 +1048,7 @@ private struct ClaudeRemoteHostsSettingsRow: View {
                     }
                     enrollmentForm
                     listenerStatus
+                    herdrPanelSetup
                 }
 
                 SettingsHelpText(
@@ -1269,6 +1270,43 @@ private struct ClaudeRemoteHostsSettingsRow: View {
                 .lineLimit(3)
         }
     }
+
+    @ViewBuilder
+    private var herdrPanelSetup: some View {
+        if let message = model.herdrPanelStatus.message {
+            SettingsInlineMessage(message, color: .orange)
+            Text(ClaudeRemoteEnrollmentService.herdrPanelConfigSnippet)
+                .font(.system(.caption2, design: .monospaced))
+                .textSelection(.enabled)
+                .padding(6)
+                .background(Color.secondary.opacity(0.08), in: RoundedRectangle(cornerRadius: 4))
+            ForEach(model.hosts.filter { !$0.isRevoked && $0.sshHostAlias != nil }) { host in
+                let action = ClaudeIntegrationSettingsModel.EnrollmentAction.configureHerdrPanel(
+                    hostID: host.id
+                )
+                if let confirmation = model.enrollmentConfirmation,
+                   confirmation.action == action {
+                    Text(confirmation.title).font(.caption).bold()
+                    HStack {
+                        Button("Cancel") { model.cancelEnrollmentActionConfirmation() }
+                        Button(confirmation.confirmButtonTitle) {
+                            Task { await model.confirmEnrollmentAction() }
+                        }
+                        .buttonStyle(.borderedProminent)
+                    }
+                    .controlSize(.small)
+                } else {
+                    Button("Configure on \(host.label)…") {
+                        model.requestHerdrPanelConfiguration(hostID: host.id)
+                    }
+                    .controlSize(.small)
+                }
+                if model.enrollmentResultsAction == action {
+                    ClaudeEnrollmentStepResults(statuses: model.enrollmentStepStatuses)
+                }
+            }
+        }
+    }
 }
 
 /// One action's outcome, rendered inside the section whose button ran it.
@@ -1360,6 +1398,16 @@ private struct ClaudeRemoteEnrollmentSheet: View {
                         actionTitle: presentation.canRunRemoteSetup ? "Run on SSH host" : nil,
                         enrollmentAction: .runRemoteSetup,
                         action: presentation.canRunRemoteSetup ? { model.requestRemoteSetup() } : nil
+                    )
+                    section(
+                        "3. Show the dictation indicator in herdr",
+                        body: ClaudeRemoteEnrollmentService.herdrPanelConfigSnippet,
+                        note: "After confirmation, localvoxtral appends this only when no agents table or rows key exists; otherwise it leaves the file unchanged.",
+                        actionTitle: presentation.canRunRemoteSetup ? "Configure on SSH host" : nil,
+                        enrollmentAction: .configureHerdrPanel(hostID: presentation.host.id),
+                        action: presentation.canRunRemoteSetup
+                            ? { model.requestHerdrPanelConfiguration(hostID: presentation.host.id) }
+                            : nil
                     )
                     section("Verify", body: plan.verifyCommands.joined(separator: "\n"), note: nil)
                     section(

--- a/Sources/localvoxtral/localvoxtralApp.swift
+++ b/Sources/localvoxtral/localvoxtralApp.swift
@@ -307,6 +307,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             // test that forgot to inject — constructs them.
             let ttyReader = AppleScriptTerminalTTYReader()
             let browserTabReader = AppleScriptFocusedBrowserTabURLReader()
+            let herdrClient = HerdrSocketClient()
             // The cmux password is read from the Keychain lazily, per query, so
             // a user who never enables the arm is never prompted for keychain
             // access and the secret is not held in memory between dictations.
@@ -319,7 +320,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                 herdrClientProbe: {
                     HerdrClientTTYProbe.isHerdrClient(onTTYDevicePath: $0)
                 },
-                herdrPanes: HerdrSocketClient(),
+                herdrPanes: herdrClient,
                 cmuxSurfaces: CmuxSocketClient(password: { cmuxPasswords.password() }),
                 cmuxJoinEnabled: { [weak viewModel] in
                     viewModel?.settings.cmuxSurfaceJoinEnabled ?? false
@@ -345,7 +346,17 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                         enrolledHosts: hosts
                     )
                 },
-                remoteHerdrForwards: claudeRemoteHerdrForwards
+                speculativeHosts: { [weak self] in
+                    self?.claudeRemoteHosts?.hosts() ?? []
+                },
+                remoteHerdrForwards: claudeRemoteHerdrForwards,
+                herdrPanelMetadata: herdrClient,
+                readFocusedGrid: { target in
+                    TerminalScreenContextSource.readVisibleScreen(target: target)?.text
+                },
+                reportPanelStatus: { [weak viewModel] status in
+                    viewModel?.claudeIntegrationSettings?.herdrPanelStatus = status
+                }
             )
             viewModel.claudeSessionJoinResolver = resolver
             // Pre-warm the Automation consent sheet OFF the dictation-start

--- a/Tests/localvoxtralTests/ClaudeIntegrationSettingsModelTests.swift
+++ b/Tests/localvoxtralTests/ClaudeIntegrationSettingsModelTests.swift
@@ -627,6 +627,80 @@ final class ClaudeIntegrationSettingsModelTests: XCTestCase {
         XCTAssertTrue(model.enrollmentStepStatuses.isEmpty)
     }
 
+    func testHerdrPanelOfferRequiresConsentAndClearsLikelyMissingStatusOnSuccess() async throws {
+        let registry = try makeRegistry()
+        let calls = Mutex<[ClaudeRemoteEnrollmentService.Invocation]>([])
+        let service = ClaudeRemoteEnrollmentService(runner: { invocation in
+            calls.withLock { $0.append(invocation) }
+            return .init(exitCode: 0, message: "reloaded")
+        })
+        let model = makeModel(
+            registry: registry,
+            listener: StubListener(hosts: registry),
+            enrollmentService: service
+        )
+        model.enrollLabel = "buildhost"
+        model.enrollSSHAlias = "builder"
+        await model.enroll()
+        let hostID = try XCTUnwrap(model.hosts.first?.id)
+        model.herdrPanelStatus = .likelyNotConfigured
+
+        model.requestHerdrPanelConfiguration(hostID: hostID)
+
+        XCTAssertTrue(calls.withLock { $0 }.isEmpty, "the offer itself must never ssh")
+        let confirmation = try XCTUnwrap(model.enrollmentConfirmation)
+        XCTAssertEqual(confirmation.action, .configureHerdrPanel(hostID: hostID))
+        XCTAssertEqual(
+            confirmation.preview,
+            ClaudeRemoteEnrollmentService.herdrPanelConfigSnippet
+        )
+
+        await model.confirmEnrollmentAction()
+
+        XCTAssertEqual(calls.withLock { $0 }.count, 1)
+        XCTAssertEqual(model.herdrPanelStatus, .ok)
+        XCTAssertEqual(model.enrollmentResultsAction, .configureHerdrPanel(hostID: hostID))
+        XCTAssertEqual(
+            model.enrollmentStepStatuses.first?.text,
+            "Configured the remote herdr agents panel."
+        )
+    }
+
+    func testCustomizedHerdrPanelIsLeftUntouchedAndSurfacesTheManualSnippet() async throws {
+        let registry = try makeRegistry()
+        let service = ClaudeRemoteEnrollmentService(runner: { _ in
+            .init(
+                exitCode: 42,
+                message: ClaudeRemoteEnrollmentService.herdrPanelExistingConfigMarker
+            )
+        })
+        let model = makeModel(
+            registry: registry,
+            listener: StubListener(hosts: registry),
+            enrollmentService: service
+        )
+        model.enrollLabel = "buildhost"
+        model.enrollSSHAlias = "builder"
+        await model.enroll()
+        let hostID = try XCTUnwrap(model.hosts.first?.id)
+        model.herdrPanelStatus = .likelyNotConfigured
+
+        model.requestHerdrPanelConfiguration(hostID: hostID)
+        await model.confirmEnrollmentAction()
+
+        XCTAssertEqual(model.herdrPanelStatus, .likelyNotConfigured)
+        XCTAssertEqual(model.enrollmentStepStatuses.first?.text, "Herdr panel setup failed.")
+        XCTAssertTrue(
+            model.enrollmentStepStatuses.first?.detail.contains(
+                ClaudeRemoteEnrollmentService.herdrPanelConfigSnippet
+            ) == true
+        )
+        XCTAssertTrue(
+            model.alert?.detail.contains(ClaudeRemoteEnrollmentService.herdrPanelConfigSnippet)
+                == true
+        )
+    }
+
     func testANewEnrollmentSheetDoesNotInheritThePreviousHostsStepResults() async throws {
         let registry = try makeRegistry()
         let service = ClaudeRemoteEnrollmentService(runner: { _ in

--- a/Tests/localvoxtralTests/ClaudeRemoteEnrollmentServiceTests.swift
+++ b/Tests/localvoxtralTests/ClaudeRemoteEnrollmentServiceTests.swift
@@ -63,6 +63,28 @@ final class ClaudeRemoteEnrollmentServiceTests: XCTestCase {
         try ClaudeRemoteEnrollmentService.plan(host: host, sshHostAlias: alias, token: token)
     }
 
+    private func runShellScript(
+        _ script: Data,
+        environment: [String: String]
+    ) throws -> (status: Int32, output: String) {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/bin/sh")
+        process.arguments = ["-s"]
+        process.environment = ProcessInfo.processInfo.environment.merging(environment) { _, new in new }
+        let input = Pipe()
+        let output = Pipe()
+        process.standardInput = input
+        process.standardOutput = output
+        process.standardError = output
+
+        try process.run()
+        input.fileHandleForWriting.write(script)
+        try input.fileHandleForWriting.close()
+        process.waitUntilExit()
+        let data = try output.fileHandleForReading.readToEnd() ?? Data()
+        return (process.terminationStatus, String(decoding: data, as: UTF8.self))
+    }
+
     // MARK: SSH config snippet
 
     func testSSHSnippetForwardsTheListenerPortBothWays() throws {
@@ -1271,5 +1293,148 @@ final class ClaudeRemoteEnrollmentServiceTests: XCTestCase {
         for invocation in calls.withLock({ $0 }) {
             XCTAssertFalse(invocation.argv.joined(separator: " ").contains(".ssh/config"))
         }
+    }
+
+    // MARK: herdr agents-panel configuration
+
+    func testHerdrPanelConfigurationIsRefusedWithoutAnInjectedRunner() {
+        XCTAssertThrowsError(
+            try ClaudeRemoteEnrollmentService().configureRemoteHerdrPanel(
+                sshHostAlias: "builder"
+            )
+        ) { error in
+            XCTAssertEqual(
+                error as? ClaudeRemoteEnrollmentService.ServiceError,
+                .executionNotConfigured
+            )
+        }
+    }
+
+    func testHerdrPanelConfigurationUsesTheEnrollmentSSHChannelAndConservativePatch() throws {
+        let calls = Mutex<[ClaudeRemoteEnrollmentService.Invocation]>([])
+        let service = ClaudeRemoteEnrollmentService(runner: { invocation in
+            calls.withLock { $0.append(invocation) }
+            return .init(exitCode: 0, message: "reloaded")
+        })
+
+        let steps = try service.configureRemoteHerdrPanel(sshHostAlias: "builder")
+
+        let recorded = calls.withLock { $0 }
+        XCTAssertEqual(recorded.count, 1)
+        let invocation = try XCTUnwrap(recorded.first)
+        XCTAssertEqual(invocation.argv, [
+            "ssh", "-o", "BatchMode=yes", "-o", "ClearAllForwardings=yes", "--",
+            "builder", "/bin/sh", "-s",
+        ])
+        let script = String(decoding: invocation.standardInput, as: UTF8.self)
+        XCTAssertTrue(script.contains("ui\\.sidebar\\.agents"))
+        XCTAssertTrue(script.contains("rows[[:space:]]*="))
+        XCTAssertTrue(script.contains("exit 42"), "existing user configuration must be refused")
+        XCTAssertTrue(script.contains(ClaudeRemoteEnrollmentService.herdrPanelConfigSnippet))
+        XCTAssertTrue(script.contains("herdr server reload-config"))
+        XCTAssertEqual(steps, [
+            .init(index: 0, command: "configure herdr agents panel", message: "reloaded")
+        ])
+    }
+
+    func testExistingHerdrAgentsConfigurationIsNeverOverwritten() {
+        let service = ClaudeRemoteEnrollmentService(runner: { _ in
+            .init(
+                exitCode: 42,
+                message: ClaudeRemoteEnrollmentService.herdrPanelExistingConfigMarker
+            )
+        })
+
+        XCTAssertThrowsError(
+            try service.configureRemoteHerdrPanel(sshHostAlias: "builder")
+        ) { error in
+            XCTAssertEqual(
+                error as? ClaudeRemoteEnrollmentService.ServiceError,
+                .herdrPanelConfigAlreadyCustomized
+            )
+        }
+    }
+
+    func testHerdrAgentsHeaderWithTrailingCommentIsRefusedWithoutEditingTheConfig() throws {
+        let calls = Mutex<[ClaudeRemoteEnrollmentService.Invocation]>([])
+        let service = ClaudeRemoteEnrollmentService(runner: { invocation in
+            calls.withLock { $0.append(invocation) }
+            return .init(exitCode: 0, message: "captured")
+        })
+        _ = try service.configureRemoteHerdrPanel(sshHostAlias: "builder")
+        let invocation = try XCTUnwrap(calls.withLock { $0.first })
+
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("lvx-herdr-panel-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let configURL = directory.appendingPathComponent("config.toml")
+        let original = "[ui.sidebar.agents] # keep my custom panel\n"
+        try Data(original.utf8).write(to: configURL)
+
+        let result = try runShellScript(
+            invocation.standardInput,
+            environment: [
+                "HERDR_CONFIG_PATH": configURL.path,
+                "PATH": "/usr/bin:/bin",
+            ]
+        )
+
+        XCTAssertEqual(result.status, 42, "the existing table must take the refusal path")
+        XCTAssertTrue(result.output.contains(ClaudeRemoteEnrollmentService.herdrPanelExistingConfigMarker))
+        XCTAssertEqual(try String(contentsOf: configURL, encoding: .utf8), original)
+    }
+
+    func testHerdrReloadExit42WithoutTheRefusalMarkerIsACommandFailure() {
+        let service = ClaudeRemoteEnrollmentService(runner: { _ in
+            .init(exitCode: 42, message: "reload failed")
+        })
+
+        XCTAssertThrowsError(
+            try service.configureRemoteHerdrPanel(sshHostAlias: "builder")
+        ) { error in
+            guard case .commandFailed(_, _, let exitCode, let message)? =
+                error as? ClaudeRemoteEnrollmentService.ServiceError
+            else { return XCTFail("expected commandFailed, got \(error)") }
+            XCTAssertEqual(exitCode, 42)
+            XCTAssertEqual(message, "reload failed")
+        }
+    }
+
+    func testHerdrPanelConfigurationPreservesRunnerTimeoutCategory() {
+        let service = ClaudeRemoteEnrollmentService(runner: { _ in
+            throw ClaudeRemoteEnrollmentService.RunnerFailure.timedOut(
+                seconds: 12,
+                message: "ssh timed out"
+            )
+        })
+
+        XCTAssertThrowsError(
+            try service.configureRemoteHerdrPanel(sshHostAlias: "builder")
+        ) { error in
+            guard case .commandTimedOut(_, _, let seconds, let message)? =
+                error as? ClaudeRemoteEnrollmentService.ServiceError
+            else { return XCTFail("expected commandTimedOut, got \(error)") }
+            XCTAssertEqual(seconds, 12)
+            XCTAssertEqual(message, "ssh timed out")
+        }
+    }
+
+    func testHerdrPanelConfigurationRefusesAnInvalidAliasBeforeSSH() {
+        let calls = Mutex(0)
+        let service = ClaudeRemoteEnrollmentService(runner: { _ in
+            calls.withLock { $0 += 1 }
+            return .init(exitCode: 0, message: "")
+        })
+
+        XCTAssertThrowsError(
+            try service.configureRemoteHerdrPanel(sshHostAlias: "builder; touch /tmp/no")
+        ) { error in
+            XCTAssertEqual(
+                error as? ClaudeRemoteEnrollmentService.ServiceError,
+                .invalidHostAlias
+            )
+        }
+        XCTAssertEqual(calls.withLock { $0 }, 0)
     }
 }

--- a/Tests/localvoxtralTests/HerdrPanelBindingProbeTests.swift
+++ b/Tests/localvoxtralTests/HerdrPanelBindingProbeTests.swift
@@ -1,0 +1,230 @@
+import Foundation
+import Synchronization
+import XCTest
+@testable import localvoxtral
+
+#if canImport(Darwin)
+
+private final class PanelMetadataRecorder: HerdrPanelMetadataReporting, @unchecked Sendable {
+    struct Report: Equatable {
+        var socketPath: String
+        var paneID: String
+        var value: String?
+        var ttlMilliseconds: Int?
+    }
+
+    let reports = Mutex<[Report]>([])
+    private let results = Mutex<[Bool]>([])
+
+    init(results: [Bool] = []) {
+        self.results.withLock { $0 = results }
+    }
+
+    func reportPanelToken(
+        socketPath: String,
+        paneID: String,
+        value: String?,
+        ttlMilliseconds: Int?
+    ) async -> Bool {
+        reports.withLock {
+            $0.append(Report(
+                socketPath: socketPath,
+                paneID: paneID,
+                value: value,
+                ttlMilliseconds: ttlMilliseconds
+            ))
+        }
+        return results.withLock { $0.isEmpty ? true : $0.removeFirst() }
+    }
+}
+
+private final class PanelIndicatorProcess: ClaudeRemoteHerdrForwardProcess, @unchecked Sendable {
+    private let running = Mutex(true)
+    let terminationCount = Mutex(0)
+
+    var isRunning: Bool { running.withLock { $0 } }
+
+    func terminate() {
+        terminationCount.withLock { $0 += 1 }
+        running.withLock { $0 = false }
+    }
+}
+
+@MainActor
+final class HerdrPanelBindingProbeTests: XCTestCase {
+    private let target = TerminalScreenTarget(pid: 42, bundleID: "com.mitchellh.ghostty")
+
+    func testProbeStampsFreshBoundedTokenAndMatchesTheFocusedGrid() async throws {
+        let metadata = PanelMetadataRecorder()
+        var randomValues: [UInt64] = [7, 8]
+        let grids = Mutex<[String]>([
+            "agents \(HerdrPanelBindingProbe.token(randomBits: 7))",
+            "agents \(HerdrPanelBindingProbe.token(randomBits: 8))",
+        ])
+        let probe = HerdrPanelBindingProbe(
+            metadata: metadata,
+            readGrid: { _ in grids.withLock { $0.removeFirst() } },
+            now: { Date(timeIntervalSince1970: 1_000) },
+            sleepFor: { _ in XCTFail("a first-read match must not sleep") },
+            randomBits: { randomValues.removeFirst() }
+        )
+
+        let first = await probe.probe(target: target, socketPath: "/tmp/herdr.sock", paneID: "p1")
+        let second = await probe.probe(target: target, socketPath: "/tmp/herdr.sock", paneID: "p1")
+
+        guard case .matched(let firstMatch) = first,
+              case .matched(let secondMatch) = second
+        else { return XCTFail("both fresh tokens should match") }
+        XCTAssertNotEqual(firstMatch.token, secondMatch.token)
+        for token in [firstMatch.token, secondMatch.token] {
+            XCTAssertTrue(token.hasPrefix("lv-mic-"))
+            XCTAssertLessThanOrEqual(token.count, 20)
+            XCTAssertTrue(token.allSatisfy { $0.isLowercase || $0.isNumber || $0 == "-" })
+        }
+        XCTAssertEqual(metadata.reports.withLock { $0.map(\.ttlMilliseconds) }, [8_000, 8_000])
+    }
+
+    func testProbeUsesAtMostTwoInjectedSettleReads() async throws {
+        let metadata = PanelMetadataRecorder()
+        let token = HerdrPanelBindingProbe.token(randomBits: 9)
+        var grids = ["agents", "agents \(token)"]
+        let sleeps = Mutex<[TimeInterval]>([])
+        let probe = HerdrPanelBindingProbe(
+            metadata: metadata,
+            readGrid: { _ in grids.removeFirst() },
+            now: { Date(timeIntervalSince1970: 1_000) },
+            sleepFor: { seconds in sleeps.withLock { $0.append(seconds) } },
+            randomBits: { 9 }
+        )
+
+        let outcome = await probe.probe(
+            target: target, socketPath: "/tmp/herdr.sock", paneID: "p1"
+        )
+        XCTAssertEqual(outcome, .matched(.init(token: token)))
+        XCTAssertEqual(sleeps.withLock { $0 }, [HerdrPanelBindingProbe.settleDelay])
+        XCTAssertTrue(grids.isEmpty, "the successful second read must be the final poll")
+    }
+
+    func testStampRefusalReadsNoGrid() async {
+        let metadata = PanelMetadataRecorder(results: [false])
+        var readCount = 0
+        let probe = HerdrPanelBindingProbe(
+            metadata: metadata,
+            readGrid: { _ in readCount += 1; return "unused" },
+            now: { Date(timeIntervalSince1970: 1_000) },
+            sleepFor: { _ in },
+            randomBits: { 10 }
+        )
+
+        let outcome = await probe.probe(
+            target: target, socketPath: "/tmp/herdr.sock", paneID: "p1"
+        )
+        XCTAssertEqual(outcome, .noMatch(.stampRefused))
+        XCTAssertEqual(readCount, 0)
+    }
+
+    func testUnavailableGridAndSettleTimeoutAreDistinct() async {
+        let metadata = PanelMetadataRecorder()
+        let unavailable = HerdrPanelBindingProbe(
+            metadata: metadata,
+            readGrid: { _ in nil },
+            now: { Date(timeIntervalSince1970: 1_000) },
+            sleepFor: { _ in },
+            randomBits: { 11 }
+        )
+        let unavailableOutcome = await unavailable.probe(
+            target: target, socketPath: "/tmp/herdr.sock", paneID: "p1"
+        )
+        XCTAssertEqual(unavailableOutcome, .noMatch(.gridReadUnavailable))
+
+        var readCount = 0
+        let timeout = HerdrPanelBindingProbe(
+            metadata: metadata,
+            readGrid: { _ in readCount += 1; return "no token" },
+            now: { Date(timeIntervalSince1970: 1_000) },
+            sleepFor: { _ in },
+            randomBits: { 12 }
+        )
+        let timeoutOutcome = await timeout.probe(
+            target: target, socketPath: "/tmp/herdr.sock", paneID: "p1"
+        )
+        XCTAssertEqual(timeoutOutcome, .noMatch(.settleTimeout))
+        XCTAssertEqual(readCount, 2)
+    }
+
+    func testMicIndicatorRefreshesAtFourSecondsThenClearsBeforeClosingForward() async {
+        let metadata = PanelMetadataRecorder()
+        let process = PanelIndicatorProcess()
+        let removed = Mutex(0)
+        let forward = ClaudeRemoteHerdrForwardHandle(
+            workspace: .init(directoryPath: "/tmp/lvx-panel-test", socketPath: "/tmp/lvx-panel-test/h.sock"),
+            process: process,
+            removeWorkspace: { _ in removed.withLock { $0 += 1 } }
+        )
+        let (ticks, tickContinuation) = AsyncStream.makeStream(of: Void.self)
+        let intervals = Mutex<[TimeInterval]>([])
+        let indicator = HerdrPanelMicIndicator(
+            metadata: metadata,
+            socketPath: forward.localSocketPath,
+            paneID: "p1",
+            token: "lv-mic-0000000001",
+            forward: forward,
+            sleepFor: { seconds in
+                intervals.withLock { $0.append(seconds) }
+                var iterator = ticks.makeAsyncIterator()
+                _ = await iterator.next()
+            }
+        )
+
+        indicator.start()
+        while intervals.withLock({ $0.isEmpty }) { await Task.yield() }
+        XCTAssertEqual(intervals.withLock { $0.first }, HerdrPanelMicIndicator.refreshInterval)
+        tickContinuation.yield()
+        while metadata.reports.withLock({ $0.isEmpty }) { await Task.yield() }
+
+        await indicator.stopAndWait()
+        tickContinuation.finish()
+
+        let reports = metadata.reports.withLock { $0 }
+        XCTAssertEqual(reports.first?.value, "lv-mic-0000000001")
+        XCTAssertEqual(reports.first?.ttlMilliseconds, 8_000)
+        XCTAssertNil(reports.last?.value, "teardown must explicitly clear the token")
+        XCTAssertNil(reports.last?.ttlMilliseconds)
+        XCTAssertEqual(process.terminationCount.withLock { $0 }, 1)
+        XCTAssertEqual(removed.withLock { $0 }, 1)
+
+        await indicator.stopAndWait()
+        XCTAssertEqual(metadata.reports.withLock { $0.count }, 2, "stop is idempotent")
+    }
+
+    func testImmediateIndicatorTeardownCannotRefreshAfterItsClear() async {
+        let metadata = PanelMetadataRecorder()
+        let process = PanelIndicatorProcess()
+        let forward = ClaudeRemoteHerdrForwardHandle(
+            workspace: .init(directoryPath: "/tmp/lvx-panel-race", socketPath: "/tmp/lvx-panel-race/h.sock"),
+            process: process,
+            removeWorkspace: { _ in }
+        )
+        let (ticks, tickContinuation) = AsyncStream.makeStream(of: Void.self)
+        let indicator = HerdrPanelMicIndicator(
+            metadata: metadata,
+            socketPath: forward.localSocketPath,
+            paneID: "p1",
+            token: "lv-mic-0000000002",
+            forward: forward,
+            sleepFor: { _ in
+                var iterator = ticks.makeAsyncIterator()
+                _ = await iterator.next()
+            }
+        )
+
+        indicator.start()
+        await indicator.stopAndWait()
+        tickContinuation.finish()
+
+        XCTAssertEqual(metadata.reports.withLock { $0.count }, 1)
+        XCTAssertNil(metadata.reports.withLock { $0.first?.value })
+    }
+}
+
+#endif

--- a/Tests/localvoxtralTests/HerdrPanelBindingProbeTests.swift
+++ b/Tests/localvoxtralTests/HerdrPanelBindingProbeTests.swift
@@ -41,12 +41,30 @@ private final class PanelMetadataRecorder: HerdrPanelMetadataReporting, @uncheck
 private final class PanelIndicatorProcess: ClaudeRemoteHerdrForwardProcess, @unchecked Sendable {
     private let running = Mutex(true)
     let terminationCount = Mutex(0)
+    let standardErrorLines: AsyncStream<String>
+    private let stderrContinuation: AsyncStream<String>.Continuation
+
+    init() {
+        let (stream, continuation) = AsyncStream.makeStream(of: String.self)
+        standardErrorLines = stream
+        stderrContinuation = continuation
+    }
 
     var isRunning: Bool { running.withLock { $0 } }
+    var processIdentifier: pid_t { 4_243 }
+
+    func waitUntilExit() async -> ClaudeRemoteForwardExitStatus {
+        .unavailable
+    }
 
     func terminate() {
         terminationCount.withLock { $0 += 1 }
         running.withLock { $0 = false }
+        stderrContinuation.finish()
+    }
+
+    func forceTerminate() {
+        terminate()
     }
 }
 

--- a/Tests/localvoxtralTests/HerdrPanelBindingProbeTests.swift
+++ b/Tests/localvoxtralTests/HerdrPanelBindingProbeTests.swift
@@ -84,7 +84,7 @@ final class HerdrPanelBindingProbeTests: XCTestCase {
         XCTAssertEqual(metadata.reports.withLock { $0.map(\.ttlMilliseconds) }, [8_000, 8_000])
     }
 
-    func testProbeUsesAtMostTwoInjectedSettleReads() async throws {
+    func testProbeMatchesOnTheSecondReadWithoutFurtherPolls() async throws {
         let metadata = PanelMetadataRecorder()
         let token = HerdrPanelBindingProbe.token(randomBits: 9)
         var grids = ["agents", "agents \(token)"]
@@ -103,6 +103,59 @@ final class HerdrPanelBindingProbeTests: XCTestCase {
         XCTAssertEqual(outcome, .matched(.init(token: token)))
         XCTAssertEqual(sleeps.withLock { $0 }, [HerdrPanelBindingProbe.settleDelay])
         XCTAssertTrue(grids.isEmpty, "the successful second read must be the final poll")
+    }
+
+    func testASlowRemoteRenderStillMatchesWithinTheSettleBudget() async throws {
+        // The first field dictation (2026-08-09): stamp accepted, row visibly
+        // rendering — but over a ProxyJump chain the frame took longer than
+        // two 120 ms polls, so the probe abstained with settle-timeout while
+        // the user watched the token appear. The loop must keep polling for
+        // the whole budget, not a fixed two reads.
+        let metadata = PanelMetadataRecorder()
+        let token = HerdrPanelBindingProbe.token(randomBits: 21)
+        var grids = Array(repeating: "agents", count: 7) + ["agents \(token)"]
+        let clock = Mutex(Date(timeIntervalSince1970: 1_000))
+        let sleeps = Mutex<[TimeInterval]>([])
+        let probe = HerdrPanelBindingProbe(
+            metadata: metadata,
+            readGrid: { _ in grids.removeFirst() },
+            now: { clock.withLock { $0 } },
+            sleepFor: { seconds in
+                sleeps.withLock { $0.append(seconds) }
+                clock.withLock { $0 = $0.addingTimeInterval(seconds) }
+            },
+            randomBits: { 21 }
+        )
+
+        let outcome = await probe.probe(
+            target: target, socketPath: "/tmp/herdr.sock", paneID: "p1"
+        )
+        XCTAssertEqual(outcome, .matched(.init(token: token)))
+        XCTAssertEqual(sleeps.withLock { $0.count }, 7)
+        XCTAssertTrue(grids.isEmpty)
+    }
+
+    func testAFrozenClockIsStillBoundedByTheHardReadCap() async {
+        // The budget is the real limit; the cap exists so an injected clock
+        // that never advances cannot loop forever.
+        let metadata = PanelMetadataRecorder()
+        let readCount = Mutex(0)
+        let probe = HerdrPanelBindingProbe(
+            metadata: metadata,
+            readGrid: { _ in
+                readCount.withLock { $0 += 1 }
+                return "agents panel without the token"
+            },
+            now: { Date(timeIntervalSince1970: 1_000) },
+            sleepFor: { _ in },
+            randomBits: { 22 }
+        )
+
+        let outcome = await probe.probe(
+            target: target, socketPath: "/tmp/herdr.sock", paneID: "p1"
+        )
+        XCTAssertEqual(outcome, .noMatch(.settleTimeout))
+        XCTAssertEqual(readCount.withLock { $0 }, HerdrPanelBindingProbe.maxGridReads)
     }
 
     func testStampRefusalReadsNoGrid() async {
@@ -149,7 +202,7 @@ final class HerdrPanelBindingProbeTests: XCTestCase {
             target: target, socketPath: "/tmp/herdr.sock", paneID: "p1"
         )
         XCTAssertEqual(timeoutOutcome, .noMatch(.settleTimeout))
-        XCTAssertEqual(readCount, 2)
+        XCTAssertEqual(readCount, HerdrPanelBindingProbe.maxGridReads)
     }
 
     func testMicIndicatorRefreshesAtFourSecondsThenClearsBeforeClosingForward() async {

--- a/Tests/localvoxtralTests/HerdrSocketClientTests.swift
+++ b/Tests/localvoxtralTests/HerdrSocketClientTests.swift
@@ -165,6 +165,52 @@ private func herdrResponse(
 
 @MainActor
 final class HerdrSocketClientTests: XCTestCase {
+    func testPanelMetadataReportUsesTheBoundedLocalvoxtralTokenShape() async throws {
+        let server = try HerdrOneShotServer { request in
+            herdrResponse(for: request, result: ["type": "ok"])
+        }
+        defer { server.stop() }
+
+        let reported = await HerdrSocketClient().reportPanelToken(
+            socketPath: server.socketPath,
+            paneID: "pane-a",
+            value: "lv-mic-0000000001",
+            ttlMilliseconds: 8_000
+        )
+        XCTAssertTrue(reported)
+
+        let request = try XCTUnwrap(server.requestLine.flatMap(herdrRequest))
+        XCTAssertEqual(request["method"] as? String, "pane.report_metadata")
+        let params = try XCTUnwrap(request["params"] as? [String: Any])
+        XCTAssertEqual(params["pane_id"] as? String, "pane-a")
+        XCTAssertEqual(params["source"] as? String, "localvoxtral")
+        XCTAssertEqual(params["ttl_ms"] as? Int, 8_000)
+        XCTAssertEqual(
+            (params["tokens"] as? [String: Any])?["lvmark"] as? String,
+            "lv-mic-0000000001"
+        )
+    }
+
+    func testPanelMetadataClearSendsANullTokenAndNoTTL() async throws {
+        let server = try HerdrOneShotServer { request in
+            herdrResponse(for: request, result: ["type": "ok"])
+        }
+        defer { server.stop() }
+
+        let cleared = await HerdrSocketClient().reportPanelToken(
+            socketPath: server.socketPath,
+            paneID: "pane-a",
+            value: nil,
+            ttlMilliseconds: nil
+        )
+        XCTAssertTrue(cleared)
+
+        let request = try XCTUnwrap(server.requestLine.flatMap(herdrRequest))
+        let params = try XCTUnwrap(request["params"] as? [String: Any])
+        XCTAssertNil(params["ttl_ms"])
+        XCTAssertTrue((params["tokens"] as? [String: Any])?["lvmark"] is NSNull)
+    }
+
     func testFocusedPaneHappyPathUsesStringIDAndRequiredEmptyParams() async throws {
         let server = try HerdrOneShotServer { request in
             herdrResponse(

--- a/Tests/localvoxtralTests/RemoteHerdrJoinTests.swift
+++ b/Tests/localvoxtralTests/RemoteHerdrJoinTests.swift
@@ -198,17 +198,25 @@ private final class RecordingForwards: ClaudeRemoteHerdrForwarding {
     let opens = Mutex<[Opened]>([])
     let localSocketPath: String
     private let succeeds: Bool
+    /// Remote socket labels whose forward fails to open — a stale socket from
+    /// a previous herdr boot, still inside the registry TTL.
+    private let failingRemoteSocketPaths: Set<String>
     let process = FakeForwardProcess()
     let workspaces = RecordingWorkspaces()
 
-    init(succeeds: Bool = true, localSocketPath: String = "/tmp/lvx-herdr-fwd-test/h.sock") {
+    init(
+        succeeds: Bool = true,
+        localSocketPath: String = "/tmp/lvx-herdr-fwd-test/h.sock",
+        failingRemoteSocketPaths: Set<String> = []
+    ) {
         self.succeeds = succeeds
         self.localSocketPath = localSocketPath
+        self.failingRemoteSocketPaths = failingRemoteSocketPaths
     }
 
     func open(alias: String, remoteSocketPath: String) async -> ClaudeRemoteHerdrForwardHandle? {
         opens.withLock { $0.append(Opened(alias: alias, remoteSocketPath: remoteSocketPath)) }
-        guard succeeds else { return nil }
+        guard succeeds, !failingRemoteSocketPaths.contains(remoteSocketPath) else { return nil }
         return ClaudeRemoteHerdrForwardHandle(
             workspace: ClaudeRemoteHerdrForwardWorkspace(
                 directoryPath: (localSocketPath as NSString).deletingLastPathComponent,
@@ -518,6 +526,79 @@ final class RemoteHerdrJoinTests: XCTestCase {
 
         XCTAssertEqual(join.mechanism, .remoteHerdrPane)
         XCTAssertTrue(statuses.recorded.isEmpty)
+    }
+
+    func testTwoLiveSocketsResolveToTheOneWhoseNonceRenders() async throws {
+        // Two herdr servers (or one live plus one stale registration) on one
+        // host used to abstain outright. The nonce disambiguates: each socket
+        // is stamped with its own fresh token, and only the displayed server
+        // can render its token in the focused grid.
+        let secondMarker = "lvx-def456"
+        let registry = makeRegistry(markers: [markerValue, secondMarker])
+        _ = ingestRemoteHerdrSession(
+            into: registry, sessionID: "s-remote-1", socketPath: "/run/a.sock"
+        )
+        _ = ingestRemoteHerdrSession(
+            into: registry, sessionID: "s-remote-2", socketPath: "/run/b.sock"
+        )
+        let panes = RemoteJoinHerdrPanes(focused: focusedPane(title: secondMarker))
+        let forwards = RecordingForwards()
+        var bits: [UInt64] = [5, 6]
+        let secondToken = HerdrPanelBindingProbe.token(randomBits: 6)
+
+        let join = try unwrapAsync(await resolver(
+            registry: registry,
+            panes: panes,
+            forwards: forwards,
+            panelMetadata: panes,
+            panelGrid: "agents  \(secondToken)",
+            panelRandomBitsProvider: { bits.removeFirst() }
+        ).resolve(target: ghostty))
+
+        XCTAssertEqual(join.mechanism, .remoteHerdrPane)
+        XCTAssertEqual(
+            forwards.opens.withLock { $0.map(\.remoteSocketPath) },
+            ["/run/a.sock", "/run/b.sock"],
+            "sockets are probed in sorted order until one's nonce renders"
+        )
+        XCTAssertEqual(
+            join.snapshot.sessionID,
+            ClaudeRemoteSessionScope.scopedSessionID(hostID: hostID, sessionID: "s-remote-2"),
+            "the join must bind the session of the socket whose nonce rendered"
+        )
+    }
+
+    func testAStaleSocketWhoseForwardFailsIsSkipped() async throws {
+        // The exact field shape (2026-08-09): a session registered under a
+        // previous herdr boot lingers inside the registry TTL with a socket
+        // that no longer exists. Its forward fails; the live socket wins.
+        let secondMarker = "lvx-def456"
+        let registry = makeRegistry(markers: [markerValue, secondMarker])
+        _ = ingestRemoteHerdrSession(
+            into: registry, sessionID: "s-remote-1", socketPath: "/run/a.sock"
+        )
+        _ = ingestRemoteHerdrSession(
+            into: registry, sessionID: "s-remote-2", socketPath: "/run/b.sock"
+        )
+        let panes = RemoteJoinHerdrPanes(focused: focusedPane(title: secondMarker))
+        let forwards = RecordingForwards(failingRemoteSocketPaths: ["/run/a.sock"])
+        let token = HerdrPanelBindingProbe.token(randomBits: 6)
+
+        let join = try unwrapAsync(await resolver(
+            registry: registry,
+            panes: panes,
+            forwards: forwards,
+            panelMetadata: panes,
+            panelGrid: "agents  \(token)",
+            panelRandomBits: 6
+        ).resolve(target: ghostty))
+
+        XCTAssertEqual(join.mechanism, .remoteHerdrPane)
+        XCTAssertEqual(forwards.openCount, 2)
+        XCTAssertEqual(
+            panes.panelReports.withLock { $0.count }, 1,
+            "the stale socket must never be stamped — its forward already failed"
+        )
     }
 
     func testASpeculativeSettleTimeoutDoesNotClaimTheRowIsMissing() async {

--- a/Tests/localvoxtralTests/RemoteHerdrJoinTests.swift
+++ b/Tests/localvoxtralTests/RemoteHerdrJoinTests.swift
@@ -19,7 +19,9 @@ private func unwrapAsync<T>(
 
 /// Scripted herdr socket, recording every request so a test can prove which
 /// socket path and which pane the client was pointed at.
-private final class RemoteJoinHerdrPanes: HerdrPaneQuerying, @unchecked Sendable {
+private final class RemoteJoinHerdrPanes:
+    HerdrPaneQuerying, HerdrPanelMetadataReporting, @unchecked Sendable
+{
     struct Request: Equatable {
         var method: String
         var socketPath: String
@@ -30,16 +32,20 @@ private final class RemoteJoinHerdrPanes: HerdrPaneQuerying, @unchecked Sendable
     private let focused: HerdrFocusedPane?
     private let foreground: HerdrPaneForegroundInfo?
     private let visibleTexts = Mutex<[String?]>([])
+    let panelReports = Mutex<[(socketPath: String, paneID: String, value: String?, ttl: Int?)]>([])
+    private let panelReportSucceeds: Bool
 
     init(
         focused: HerdrFocusedPane?,
         foreground: HerdrPaneForegroundInfo? = HerdrPaneForegroundInfo(
             shellPID: 8000, foregroundProcesses: [HerdrForegroundProcess(pid: 9001, name: "claude")]
         ),
-        texts: [String?] = []
+        texts: [String?] = [],
+        panelReportSucceeds: Bool = true
     ) {
         self.focused = focused
         self.foreground = foreground
+        self.panelReportSucceeds = panelReportSucceeds
         visibleTexts.withLock { $0 = texts }
     }
 
@@ -64,6 +70,18 @@ private final class RemoteJoinHerdrPanes: HerdrPaneQuerying, @unchecked Sendable
             $0.append(Request(method: "pane.read", socketPath: socketPath, paneID: paneID))
         }
         return visibleTexts.withLock { $0.isEmpty ? nil : $0.removeFirst() }
+    }
+
+    func reportPanelToken(
+        socketPath: String,
+        paneID: String,
+        value: String?,
+        ttlMilliseconds: Int?
+    ) async -> Bool {
+        panelReports.withLock {
+            $0.append((socketPath, paneID, value, ttlMilliseconds))
+        }
+        return panelReportSucceeds
     }
 }
 
@@ -211,6 +229,12 @@ private final class RemoteJoinTestLiveness: Sendable {
     func kill(_ pid: Int32) { dead.withLock { _ = $0.insert(pid) } }
 }
 
+private final class PanelStatusRecorder: @unchecked Sendable {
+    private let values = Mutex<[HerdrPanelConfigurationStatus]>([])
+    func append(_ value: HerdrPanelConfigurationStatus) { values.withLock { $0.append(value) } }
+    var recorded: [HerdrPanelConfigurationStatus] { values.withLock { $0 } }
+}
+
 private final class RemoteJoinSSHConfigRunner: @unchecked Sendable {
     struct Invocation: Equatable {
         let executableURL: URL
@@ -350,9 +374,16 @@ final class RemoteHerdrJoinTests: XCTestCase {
         ),
         hosts: [ClaudeRemoteHost]? = nil,
         canonicalizer: SSHDestinationCanonicalizer? = nil,
-        title: String? = nil
+        title: String? = nil,
+        panelMetadata: (any HerdrPanelMetadataReporting)? = nil,
+        panelGrid: String? = nil,
+        panelRandomBits: UInt64 = 1,
+        panelRandomBitsProvider: HerdrPanelBindingProbe.RandomBits? = nil,
+        panelStatuses: PanelStatusRecorder? = nil,
+        indicatorSleepFor: @escaping HerdrPanelMicIndicator.SleepFor = { _ in }
     ) -> ClaudeSessionJoinResolver {
         let hostList = hosts ?? [enrolledHost()]
+        let fixedNow = epoch
         return ClaudeSessionJoinResolver(
             registry: registry,
             markerInWindowTitle: { _ in
@@ -381,11 +412,231 @@ final class RemoteHerdrJoinTests: XCTestCase {
                     enrolledHosts: hostList
                 )
             },
-            remoteHerdrForwards: forwards
+            speculativeHosts: { hostList },
+            remoteHerdrForwards: forwards,
+            herdrPanelMetadata: panelMetadata,
+            readFocusedGrid: { _ in panelGrid },
+            panelNow: { fixedNow },
+            panelSleepFor: { _ in },
+            panelRandomBits: panelRandomBitsProvider ?? { panelRandomBits },
+            indicatorSleepFor: indicatorSleepFor,
+            reportPanelStatus: { status in
+                panelStatuses?.append(status)
+            }
         )
     }
 
     // MARK: Happy path
+
+    func testPanelBindingIsPrimaryWhenSSHArgvSaysPlainShell() async throws {
+        let registry = makeRegistry(markers: [markerValue])
+        ingestRemoteHerdrSession(into: registry)
+        let panes = RemoteJoinHerdrPanes(focused: focusedPane())
+        let forwards = RecordingForwards()
+        let token = HerdrPanelBindingProbe.token(randomBits: 7)
+
+        let join = try unwrapAsync(await resolver(
+            registry: registry,
+            panes: panes,
+            forwards: forwards,
+            sshResult: .connection(SSHSurfaceConnection(
+                destination: "builder",
+                hasCompetingHerdrClient: false,
+                herdr: .notHerdr
+            )),
+            panelMetadata: panes,
+            panelGrid: "agents  \(token)",
+            panelRandomBits: 7
+        ).resolve(target: ghostty))
+
+        XCTAssertEqual(join.mechanism, .remoteHerdrPane)
+        XCTAssertNotNil(join.remoteHerdrIndicator)
+        XCTAssertEqual(forwards.openCount, 1, "argv fallback must not open a second forward")
+        XCTAssertEqual(panes.panelReports.withLock { $0.first?.value }, token)
+    }
+
+    func testUnreadableSSHUsesSpeculativePanelCandidateBeforeSuppressingMarker() async throws {
+        let registry = makeRegistry(markers: [markerValue])
+        ingestRemoteHerdrSession(into: registry)
+        let panes = RemoteJoinHerdrPanes(focused: focusedPane())
+        let token = HerdrPanelBindingProbe.token(randomBits: 8)
+
+        let join = try unwrapAsync(await resolver(
+            registry: registry,
+            panes: panes,
+            forwards: RecordingForwards(),
+            sshResult: .undeterminable(.unreadableArguments),
+            title: markerValue,
+            panelMetadata: panes,
+            panelGrid: token,
+            panelRandomBits: 8
+        ).resolve(target: ghostty))
+
+        XCTAssertEqual(join.mechanism, .remoteHerdrPane)
+    }
+
+    func testMissingPanelRowFallsBackToTheExistingArgvJoinAndOffersConfiguration() async throws {
+        let registry = makeRegistry(markers: [markerValue])
+        ingestRemoteHerdrSession(into: registry)
+        let panes = RemoteJoinHerdrPanes(focused: focusedPane())
+        let forwards = RecordingForwards()
+        let statuses = PanelStatusRecorder()
+
+        let join = try unwrapAsync(await resolver(
+            registry: registry,
+            panes: panes,
+            forwards: forwards,
+            panelMetadata: panes,
+            panelGrid: "agents panel without the configured row",
+            panelStatuses: statuses
+        ).resolve(target: ghostty))
+
+        XCTAssertEqual(join.mechanism, .remoteHerdrPane)
+        XCTAssertNil(join.remoteHerdrIndicator, "the argv fallback has no panel lease")
+        XCTAssertEqual(forwards.openCount, 2, "the failed primary probe closes before argv fallback")
+        XCTAssertEqual(statuses.recorded, [.likelyNotConfigured])
+        XCTAssertTrue(
+            panes.panelReports.withLock { $0 }.contains { $0.value == nil },
+            "a failed stamp/read attempt must clear its short-lived token"
+        )
+    }
+
+    func testUnavailableGridFallsBackWithoutClaimingThePanelRowIsMissing() async throws {
+        let registry = makeRegistry(markers: [markerValue])
+        ingestRemoteHerdrSession(into: registry)
+        let panes = RemoteJoinHerdrPanes(focused: focusedPane())
+        let statuses = PanelStatusRecorder()
+
+        let join = try unwrapAsync(await resolver(
+            registry: registry,
+            panes: panes,
+            forwards: RecordingForwards(),
+            panelMetadata: panes,
+            panelGrid: nil,
+            panelStatuses: statuses
+        ).resolve(target: ghostty))
+
+        XCTAssertEqual(join.mechanism, .remoteHerdrPane)
+        XCTAssertTrue(statuses.recorded.isEmpty)
+    }
+
+    func testASpeculativeSettleTimeoutDoesNotClaimTheRowIsMissing() async {
+        // A speculative candidate's token not rendering usually means the user
+        // is not looking at THAT server. Diagnosing "row likely not
+        // configured" from it would nag a correctly configured host.
+        let registry = makeRegistry(markers: [markerValue])
+        ingestRemoteHerdrSession(into: registry)
+        let panes = RemoteJoinHerdrPanes(focused: focusedPane())
+        let statuses = PanelStatusRecorder()
+
+        let join = await resolver(
+            registry: registry,
+            panes: panes,
+            forwards: RecordingForwards(),
+            sshResult: .undeterminable(.refusedArguments),
+            panelMetadata: panes,
+            panelGrid: "agents panel showing some other server",
+            panelStatuses: statuses
+        ).resolve(target: ghostty)
+
+        XCTAssertNil(join, "unreadable ssh with no panel match suppresses every fallback")
+        XCTAssertTrue(statuses.recorded.isEmpty)
+    }
+
+    func testUnreadableSSHSpeculationIsHardBoundedToThreeHosts() async {
+        let markers = ["lvx-one111", "lvx-two222", "lvx-three33", "lvx-four444"]
+        let registry = makeRegistry(markers: markers)
+        let hosts = (1...4).map { index in
+            let id = "hpanel\(index)"
+            ingestRemoteHerdrSession(
+                into: registry,
+                sessionID: "s-\(index)",
+                paneID: remotePaneID,
+                host: id
+            )
+            return enrolledHost(id: id, alias: "builder\(index)")
+        }
+        let panes = RemoteJoinHerdrPanes(focused: focusedPane(title: markers[0]))
+        let forwards = RecordingForwards()
+
+        let join = await resolver(
+            registry: registry,
+            panes: panes,
+            forwards: forwards,
+            sshResult: .undeterminable(.unreadableArguments),
+            hosts: hosts,
+            panelMetadata: panes,
+            panelGrid: "no rendered token"
+        ).resolve(target: ghostty)
+
+        XCTAssertNil(join)
+        XCTAssertEqual(forwards.openCount, 3)
+        XCTAssertEqual(Set(forwards.opens.withLock { $0.map(\.alias) }).count, 3)
+    }
+
+    func testTwoSpeculativeHostsWhoseDistinctTokensBothRenderAbstain() async {
+        let registry = makeRegistry(markers: ["lvx-host111", "lvx-host222"])
+        let hosts = [
+            enrolledHost(id: "hpanel1", alias: "builder1"),
+            enrolledHost(id: "hpanel2", alias: "builder2"),
+        ]
+        ingestRemoteHerdrSession(into: registry, sessionID: "s-1", host: hosts[0].id)
+        ingestRemoteHerdrSession(into: registry, sessionID: "s-2", host: hosts[1].id)
+        let panes = RemoteJoinHerdrPanes(focused: focusedPane(title: "lvx-host111"))
+        let forwards = RecordingForwards()
+        let bits = Mutex<[UInt64]>([21, 22])
+        let grid = [21, 22]
+            .map { HerdrPanelBindingProbe.token(randomBits: UInt64($0)) }
+            .joined(separator: " ")
+
+        let join = await resolver(
+            registry: registry,
+            panes: panes,
+            forwards: forwards,
+            sshResult: .undeterminable(.unreadableArguments),
+            hosts: hosts,
+            panelMetadata: panes,
+            panelGrid: grid,
+            panelRandomBitsProvider: { bits.withLock { $0.removeFirst() } }
+        ).resolve(target: ghostty)
+
+        XCTAssertNil(join)
+        XCTAssertEqual(forwards.openCount, 2)
+        XCTAssertEqual(forwards.closeCount, 2)
+        XCTAssertFalse(
+            panes.requests.withLock { $0 }.contains { $0.method == "pane.process_info" },
+            "no downstream session confirmation may run after surface ambiguity"
+        )
+    }
+
+    func testPanelAuthorizationStillRequiresTheBrokerMarkerAndSuppressesOuterFallback() async {
+        let registry = makeRegistry(markers: [markerValue])
+        ingestRemoteHerdrSession(into: registry)
+        let panes = RemoteJoinHerdrPanes(
+            focused: focusedPane(title: "lvx-another-session")
+        )
+        let forwards = RecordingForwards()
+        let token = HerdrPanelBindingProbe.token(randomBits: 23)
+
+        let join = await resolver(
+            registry: registry,
+            panes: panes,
+            forwards: forwards,
+            sshResult: .connection(.init(
+                destination: "builder",
+                hasCompetingHerdrClient: false,
+                herdr: .notHerdr
+            )),
+            title: markerValue,
+            panelMetadata: panes,
+            panelGrid: token,
+            panelRandomBits: 23
+        ).resolve(target: ghostty)
+
+        XCTAssertNil(join, "a panel match authorizes only the surface, never the session")
+        XCTAssertEqual(forwards.openCount, 1)
+        XCTAssertEqual(forwards.closeCount, 1)
+    }
 
     func testEveryBindingAgreeingResolvesARemoteHerdrJoin() async throws {
         let registry = makeRegistry(markers: [markerValue])
@@ -579,41 +830,93 @@ final class RemoteHerdrJoinTests: XCTestCase {
     // MARK: Fallthrough — the arm does not apply
 
     func testNoSSHClientOnTheSurfaceFallsThroughToTheTitleMarker() async throws {
+        // The strong version of this pin: the panel machinery is fully wired
+        // and a grid that WOULD match is on screen — a local shell must still
+        // never stamp, never open a forward, and never pay remote latency.
+        // (A weaker version passed with panel metadata absent, which proved
+        // only that a disabled panel does not probe.)
         let registry = makeRegistry(markers: [markerValue])
         ingestRemoteHerdrSession(into: registry)
         let forwards = RecordingForwards()
+        let panes = RemoteJoinHerdrPanes(focused: focusedPane())
+        let token = HerdrPanelBindingProbe.token(randomBits: 7)
 
         let join = try unwrapAsync(
             await resolver(
                 registry: registry,
-                panes: RemoteJoinHerdrPanes(focused: focusedPane()),
+                panes: panes,
                 forwards: forwards,
                 sshResult: .noSSHClient,
-                title: markerValue
+                title: markerValue,
+                panelMetadata: panes,
+                panelGrid: "agents  \(token)",
+                panelRandomBits: 7
             ).resolve(target: ghostty)
         )
 
         XCTAssertEqual(join.mechanism, .titleMarker)
+        XCTAssertEqual(forwards.openCount, 0)
+        XCTAssertNil(panes.panelReports.withLock { $0.first })
+    }
+
+    func testUnreadableSSHOnSurfaceSuppressesAStaleTitleMarkerJoin() async throws {
+        let registry = makeRegistry(markers: [markerValue])
+        ingestRemoteHerdrSession(into: registry)
+        let forwards = RecordingForwards()
+
+        let join = await resolver(
+            registry: registry,
+            panes: RemoteJoinHerdrPanes(focused: focusedPane()),
+            forwards: forwards,
+            sshResult: .undeterminable(.multipleForegroundClients),
+            // Stale outer title from the ssh session that occupied this surface
+            // before the user launched herdr manually.
+            title: markerValue
+        ).resolve(target: ghostty)
+
+        XCTAssertNil(join)
         XCTAssertEqual(forwards.openCount, 0)
     }
 
-    func testUndeterminableSSHDestinationFallsThroughToTheTitleMarker() async throws {
-        let registry = makeRegistry(markers: [markerValue])
-        ingestRemoteHerdrSession(into: registry)
-        let forwards = RecordingForwards()
-
-        let join = try unwrapAsync(
-            await resolver(
+    func testEveryPresentButUnreadableSSHCategorySuppressesTitleMarker() async {
+        let causes: [SSHProbeIndeterminacy] = [
+            .multipleForegroundClients,
+            .untrustedExecutable,
+            .unreadableArguments,
+            .refusedArguments,
+        ]
+        for cause in causes {
+            let registry = makeRegistry(markers: [markerValue])
+            ingestRemoteHerdrSession(into: registry)
+            let join = await resolver(
                 registry: registry,
                 panes: RemoteJoinHerdrPanes(focused: focusedPane()),
-                forwards: forwards,
-                sshResult: .undeterminable(.multipleForegroundClients),
+                forwards: RecordingForwards(),
+                sshResult: .undeterminable(cause),
                 title: markerValue
             ).resolve(target: ghostty)
-        )
+            XCTAssertNil(join, "\(cause.rawValue) must suppress a possibly stale marker")
+        }
+    }
 
-        XCTAssertEqual(join.mechanism, .titleMarker)
-        XCTAssertEqual(forwards.openCount, 0)
+    func testProbeWideIndeterminacyStillAllowsLocalTitleMarker() async throws {
+        let causes: [SSHProbeIndeterminacy] = [
+            .deviceUnreadable,
+            .tableUnreadable,
+            .probeUnavailable,
+        ]
+        for cause in causes {
+            let registry = makeRegistry(markers: [markerValue])
+            ingestRemoteHerdrSession(into: registry)
+            let join = try unwrapAsync(await resolver(
+                registry: registry,
+                panes: RemoteJoinHerdrPanes(focused: focusedPane()),
+                forwards: RecordingForwards(),
+                sshResult: .undeterminable(cause),
+                title: markerValue
+            ).resolve(target: ghostty))
+            XCTAssertEqual(join.mechanism, .titleMarker)
+        }
     }
 
     func testSSHToAnUnenrolledHostFallsThroughToTheTitleMarker() async throws {
@@ -1544,6 +1847,53 @@ final class RemoteHerdrJoinTests: XCTestCase {
         viewModel.closeRemoteHerdrForwards()
         viewModel.discardTerminalScreenCapture()
 
+        XCTAssertEqual(forwards.closeCount, 1)
+        XCTAssertEqual(forwards.process.terminations.withLock { $0 }, 1)
+    }
+
+    func testClosingAPanelAuthorizedJoinClearsItsTokenAndClosesItsForward() async throws {
+        let registry = makeRegistry(markers: [markerValue])
+        ingestRemoteHerdrSession(into: registry)
+        let panes = RemoteJoinHerdrPanes(focused: focusedPane())
+        let forwards = RecordingForwards()
+        let token = HerdrPanelBindingProbe.token(randomBits: 31)
+        let (ticks, tickContinuation) = AsyncStream.makeStream(of: Void.self)
+        let join = try unwrapAsync(await resolver(
+            registry: registry,
+            panes: panes,
+            forwards: forwards,
+            panelMetadata: panes,
+            panelGrid: token,
+            panelRandomBits: 31,
+            indicatorSleepFor: { _ in
+                var iterator = ticks.makeAsyncIterator()
+                _ = await iterator.next()
+            }
+        ).resolve(target: ghostty))
+        let indicator = try XCTUnwrap(join.remoteHerdrIndicator)
+        let viewModel = makeViewModel()
+
+        viewModel.retainRemoteHerdrForward(of: join)
+        XCTAssertEqual(viewModel.openRemoteHerdrForwardCount, 1)
+        XCTAssertEqual(
+            viewModel.liveRemoteHerdrIndicators,
+            [indicator],
+            "the view model must retain the indicator owner, not only its raw forward"
+        )
+        viewModel.closeRemoteHerdrForwards()
+        await indicator.stopAndWait()
+        tickContinuation.finish()
+
+        XCTAssertEqual(viewModel.openRemoteHerdrForwardCount, 0)
+        XCTAssertTrue(
+            panes.panelReports.withLock { $0 }.contains {
+                $0.socketPath == forwards.localSocketPath
+                    && $0.paneID == remotePaneID
+                    && $0.value == nil
+                    && $0.ttl == nil
+            },
+            "view-model teardown must explicitly clear the retained panel token"
+        )
         XCTAssertEqual(forwards.closeCount, 1)
         XCTAssertEqual(forwards.process.terminations.withLock { $0 }, 1)
     }

--- a/docs/agent/invariants.md
+++ b/docs/agent/invariants.md
@@ -90,8 +90,10 @@ there is not.
     is herdr-or-nothing: no
     marker fallback, because a lingering title marker could only mis-join.
     The hook publishes `HERDR_PANE_ID`/`HERDR_SOCKET_PATH` from the pane env;
-    `HerdrSocketClient` (hand-written and READ-ONLY — only `pane.current`,
-    `pane.process_info`, `pane.read` are ever sent. herdr was AGPL when this
+    `HerdrSocketClient` (hand-written and capability-bounded — reads are only
+    `pane.current`, `pane.process_info`, and `pane.read`; its sole mutation is
+    the remote panel probe's short-lived `lvmark` through
+    `pane.report_metadata`. herdr was AGPL when this
     was written and is Apache-2.0 since v0.8.0, repo `herdrdev/herdr`, so its
     docs and source are freely readable; the client stays hand-written anyway,
     because a vendored dependency would be a second implementation of the trust
@@ -186,9 +188,38 @@ there is not.
     socket label starts it off the dictation path; a successful cold join also
     retains it. Dictations lease the local socket, and the app keeps the process
     through a bounded injected-clock idle window so later dictations reuse the
-    completed SSH/ProxyJump handshake. The bindings, ALL required, in cost order
-    so an ordinary ssh session never pays for a tunnel:
-    (1) the focused surface's own TTY hosts EXACTLY ONE FOREGROUND `ssh`
+    completed SSH/ProxyJump handshake. Its PRIMARY surface authorization is the
+    herdr agents-panel binding, not ssh argv. For each plausible enrolled host
+    (the readable ssh destination when available; when an ssh is PRESENT but
+    unreadable, at most three enrolled hosts with live herdr-bearing
+    sessions; a surface with NO ssh at all never probes — a local shell must
+    not pay cold-forward latency or flash nonces in panels the user is not
+    looking at), the resolver preserves the
+    single-socket rule, opens the forward, reads `pane.current`, and identifies
+    the unique live session claiming that pane. It then stamps that pane through
+    `pane.report_metadata` with a fresh `lv-mic-…` nonce (more than 40 random
+    bits, 8 s TTL) and requires that exact token in the focused terminal's
+    existing visible-grid route within a bounded injected-clock settle window.
+    A whole-view
+    App client renders the agents sidebar; `terminal_attach` and
+    `terminal_observe` render only the raw pane and cannot render this token.
+    The nonce travels only over the owner/mode-checked forwarded socket and is
+    unguessable inside its short lease, so remote-influenceable terminal text
+    cannot manufacture the match without already observing that herdr server.
+    Two hosts whose distinct nonces both appear abstain. A matched token stays
+    alive as the dictation's visible mic indicator (refresh about every 4 s,
+    TTL 8 s) and is explicitly cleared before its forward closes.
+    EXTERNAL ASSUMPTION: herdr upgrades must re-verify BOTH that attach/observe
+    clients still omit the sidebar (`src/server/headless.rs` render loop) and
+    that all App clients still render one server-global panel/focus
+    (`tests/multi_client.rs`). Per-client focus or a sidebar in attach mode
+    invalidates this authorization argument.
+
+    Any stamp refusal, unavailable grid, hidden/unconfigured/scrolled panel row,
+    or bounded settle timeout can only produce NO MATCH. It closes that attempt
+    and falls through to the pre-existing argv authorization below; it never
+    weakens the pane-level confirmations. The fallback first requires that the
+    focused surface's own TTY host EXACTLY ONE FOREGROUND `ssh`
     session, whose destination identifies exactly one enrolled host. Exact
     alias matching wins without spawning anything; only when it finds no host,
     the app resolves the operand and each active enrolled alias through the
@@ -223,10 +254,10 @@ there is not.
     the session's interactivity, and accepting them keeps terminal wrappers
     such as Ghostty's from making every probe abstain. ssh MACHINERY is
     invisible to this count and to the uniqueness
-    scan in (2): an ssh that is a direct CHILD of another scanned ssh — a
-    ProxyJump's `ssh -W` hop, which OpenSSH spawns on the same tty in the same
-    foreground process group (field abstention 2026-08-06) — is its root
-    connection's transport, not a second connection. The partition rides
+    competing-view scan below: an ssh that is a direct CHILD of another scanned
+    ssh — a ProxyJump's `ssh -W` hop, which OpenSSH spawns on the same tty in
+    the same foreground process group (field abstention 2026-08-06) — is its
+    root connection's transport, not a second connection. The partition rides
     kernel ppid, which no launcher gets to write, so it cannot hide a
     connection (the demoting parent is itself counted); sibling ssh processes
     in one group have no ssh parent and stay refused, and a shell-mediated
@@ -235,7 +266,7 @@ there is not.
     (`SSHProbeIndeterminacy` — never a host, path, or option letter) into the
     log and the dogfood record, because three field dictations were diagnosed
     blind without one;
-    (2) that ssh session IS a plain whole-view herdr client — classified, not
+    It then requires that ssh session to BE a plain whole-view herdr client — classified, not
     boolean (`HerdrInvocation`): the remote command's first argv token has
     basename `herdr` and the rest is empty or `--session <name>`. Every other
     herdr shape is REFUSED because it displays something other than the
@@ -287,38 +318,46 @@ there is not.
     or whose pane still carries a marker and a running agent inside the
     registry TTL, keeps answering `pane.current`, so a plain `ssh builder`
     must never reach the join no matter how alone it is.
-    Requiring the argv signal is what the absence of a better one forces:
+    The argv fallback remains necessary when the direct panel proof cannot
+    render. Its historical limitation is:
     herdr exposes NO read-only attachment signal — re-verified at v0.8.0 /
     protocol 19 (2026-08-06), the only `client.*` methods are
     `window_title.set`/`clear`, both MUTATIONS (so `no_foreground_client` is not
     an acceptable probe), `session.snapshot` carries no client records, and
     the event stream has no client lifecycle events.
-    The accepted cost, stated accurately: the manual flow — `ssh host`, then
-    typing `herdr` — gets no HERDR join. It does NOT get "no context": the arm
-    returns `.notApplicable`, so the title-marker arm still runs, and a marker
-    an earlier session on that host left in the OUTER title can still win. That
-    residual is pre-existing (it is what remote sessions have always done) and
-    cannot be closed from here, because nothing on the surface reveals a remote
-    herdr running inside it — e.g. run Claude in a plain ssh so its marker sits
-    in the title, suspend it, then start herdr by hand: dictation joins the
-    suspended session. What this arm refuses is a wrong HERDR join. It also
-    makes the arm free for everyone else: a plain ssh to an enrolled host no
-    longer spawns a forward before falling through;
-    (3) that host has live remote sessions reporting a herdr pane, all from ONE
+    The manual flow — `ssh host`, then typing `herdr` — now joins through the
+    panel binding whenever the agents sidebar and configured token row are
+    visible. Its residual is narrow/collapsed/covered sidebar or an unconfigured
+    row: panel authorization fails closed, then argv still cannot identify the
+    manually launched herdr. In that residual the title arm is NOT universally
+    allowed. When `SSHDestinationTTYProbe` reports an ssh present but unreadable
+    as exactly `multipleForegroundClients`, `untrustedExecutable`,
+    `unreadableArguments`, or `refusedArguments`, the title arm is suppressed;
+    its outer marker may be stale from before herdr started. `deviceUnreadable`,
+    `tableUnreadable`, and `probeUnavailable` do not suppress it because those
+    mean the probe could not inspect the surface at all and may describe an
+    ordinary local marker join.
+
+    Both surface-authorization paths retain the remaining bounds: the host has
+    live remote sessions reporting a herdr pane, all from ONE
     herdr socket (`liveRemoteHerdrSessions(hostID:)`, the mirror of the local
     single-socket rule). The count that matters is SOCKETS, not sessions:
     several live sessions on one herdr are expected and fine — panes are what a
     multiplexer is for, and serving that workflow is the point of this arm — so
     only two herdr SERVERS leave the surface ambiguous;
-    (4) over the forward, exactly ONE of those candidates claims that herdr's
+    over the forward, exactly ONE of those candidates claims that herdr's
     FOCUSED pane id (two candidates claiming the same pane id abstain), and that
     pane's captured `terminal_title` carries exactly that session's
     broker-allocated marker;
-    (5) herdr's own `agent_session` claim for the pane does not disagree, and
+    and herdr's own `agent_session` claim for the pane does not disagree, and
     the pane is running that session's agent.
-    Herdr-or-nothing begins at CONFIRMATION, not before: everything up to and
-    including step 4 falls THROUGH to the title marker on failure, and only
-    steps after it abstain. Registry candidates existing on the host is not a
+    Herdr-or-nothing begins as soon as the panel nonce matches: that match binds
+    this focused surface to the stamped server, so any later broker-marker,
+    `agent_session`, or foreground refusal suppresses the unrelated outer title.
+    On the argv fallback, the older boundary remains at pane-id plus broker-marker
+    confirmation: earlier failures can fall through to the title (subject to the
+    exact unreadable-ssh suppression above), and later failures abstain. Registry
+    candidates existing on the host is not a
     binding for this connection — a detached herdr, or one whose sessions are
     merely still inside their TTL, would otherwise cost a sole plain ssh session
     the outer marker join it has always had. Once the pane id AND our own
@@ -351,7 +390,8 @@ there is not.
     we SEND, not by what the socket allows.** herdr's JSON socket is
     full-control: over that same forwarded stream one could create panes, write
     keystrokes into them, kill them. We dial OUT to it and send only
-    `pane.current` / `pane.process_info` / `pane.read`, and that restraint —
+    `pane.current` / `pane.process_info` / `pane.read`, plus only the bounded
+    `pane.report_metadata` `lvmark` lease described above, and that restraint —
     plus the one client in the codebase being hand-written — is the whole
     boundary. In exchange, `ClaudeRemoteSessionEnvironment.herdrSocketPath`
     stays what PR #216 made it: a label that is NEVER handed to `FileManager`,

--- a/docs/agent/remote-herdr-panel-binding.md
+++ b/docs/agent/remote-herdr-panel-binding.md
@@ -1,0 +1,207 @@
+# Remote herdr join: agents-panel binding (design)
+
+Status: approved by owner 2026-08-09 (token UX = live mic indicator; enrollment
+= enroll-time offer; fallback = argv path with the title-marker arm suppressed
+on unreadable-ssh abstentions). Supersedes the argv invocation signal as the
+PRIMARY binding for `.remoteHerdrPane` joins; the argv path (#228/#229)
+remains as fallback.
+
+## Problem
+
+The remote herdr join must prove that the FOCUSED LOCAL terminal surface is
+displaying a whole-view client of a specific remote herdr server before
+grounding a dictation in that server's focused pane. Until now the only
+evidence was the local ssh process table: argv classification of the surface's
+ssh, a machine-wide competing-view scan, and a trusted-executable list. That
+inference fails closed in many innocent configurations (Ghostty's
+shell-integration ssh wrapper injects `-o` options; the manual flow — `ssh
+host`, then typing `herdr` — carries no argv signal at all; cross-uid ssh
+processes are unreadable and abstain everything).
+
+A window-title nonce probe was considered and REJECTED by the owner: title
+flicker is unacceptable UX.
+
+## Mechanism
+
+herdr (verified in source at v0.8.x, checkout `../herdr`) provides everything
+needed with no upstream change:
+
+1. **Write channel** — `pane.report_metadata` (handler
+   `src/app/api/panes.rs:1260`) sets arbitrary custom tokens on a pane:
+   `{"method":"pane.report_metadata","params":{"pane_id":"…",
+   "source":"localvoxtral","tokens":{"lvmark":"<token>"},"ttl_ms":8000}}`.
+   Constraints (`src/app/api_helpers.rs:205-282`): key
+   `^[A-Za-z0-9_-]{1,32}$`, value ≤80 chars with control chars stripped,
+   TTL 1..86_400_000 ms, self-clearing on expiry; empty or null value clears
+   (verified: `normalize_metadata_tokens` treats both as a clear).
+   Token patches ignore agent guards; no official herdr integration writes
+   custom tokens, so a private key is uncontested.
+2. **Render** — the bottom-left agents panel (`src/ui/sidebar.rs:1423`)
+   renders configured rows per agent-bearing pane. Custom tokens render ONLY
+   when the user's herdr config adds a row for them:
+
+   ```toml
+   [ui.sidebar.agents]
+   rows = [["state_icon", "workspace", "tab"], ["agent"], [{ token = "$lvmark", dim = true }]]
+   ```
+
+   A row whose tokens are all absent is elided entirely
+   (`src/ui/sidebar/tokens.rs:84-86`), so the row is invisible except while we
+   set it. Applied live via `herdr server reload-config`.
+3. **Read channel** — the existing local screen capture route
+   (`TerminalScreenAXReader`; Ghostty's single-AXTextArea grid, iTerm2 /
+   Terminal.app capture equivalents) reads the rendered TUI text of the
+   focused surface, agents panel included. This is a one-shot read at join
+   time to locate the token — NOT a screen-context attachment; the existing
+   refusal of raw AX attachment for `.remoteHerdrPane` joins stands.
+
+## The trust argument
+
+Why a grid match is sufficient evidence, to the standard of review rounds 1–7:
+
+- **App-mode discriminator.** The server's render loop
+  (`src/server/headless.rs:4074-4190`) paints the full UI (sidebar included)
+  for every App-mode client and ONLY the raw terminal for
+  `terminal_attach`/`terminal_observe` clients. A surface whose grid shows the
+  panel token is therefore a WHOLE-VIEW client of the server that owns the
+  socket we stamped — single-pane attaches and observers structurally cannot
+  match. This is the discriminator #229 approximated with argv
+  classification, obtained directly.
+- **Server-global focus makes client identity irrelevant.** All App-mode
+  clients mirror one shared `AppState`; per-client divergence is size and
+  scroll only (`tests/multi_client.rs`). Two local surfaces showing the same
+  server would render the same token, and joining either is the same join —
+  the #229 insight, unchanged. We read only the FOCUSED surface's grid, so
+  the dictation grounds where the user is looking.
+- **Nonce freshness bounds forgery.** The token value is a fresh random nonce
+  per join attempt (≥40 bits, ASCII `[a-z0-9]`, full rendered string ≤20
+  chars including a fixed `lv-` prefix), transmitted only over the forwarded
+  unix socket (mode-checked, owner-checked — existing `HerdrSocketClient`
+  guards). A process that merely prints plausible-looking panel text cannot
+  know the nonce. An observer who CAN see the nonce is an attached client of
+  that server or a reader of its socket — already inside the trust boundary
+  this join accepts (it is about to ground dictation in that server's focused
+  pane). Remote-influenceable grid text is therefore not a forgeable
+  authorization input: matching requires knowledge only trusted parties have,
+  within an ~8 s TTL window.
+- **Failure direction.** Every failure mode is a NO-MATCH → abstain → argv
+  fallback: sidebar collapsed (collapsed-compact renders 4 cols, no text),
+  client width ≤ 64 (mobile layout, no sidebar), panel row not configured,
+  entry scrolled out of the panel body, modal overlay painted over the
+  sidebar, AX read unavailable. The probe can only fail to join; it can never
+  join a surface that is not displaying the stamped server.
+
+## Join-time sequence (replaces argv classification + competing-view for the primary path)
+
+1. Determine candidate hosts. If the surface's ssh argv is readable, its
+   destination selects the enrolled host as today — this includes the manual
+   flow (`ssh host`, then typing `herdr`: the argv is a plain readable ssh).
+   If an ssh IS present but unreadable (a wrapper the parser refuses), fall
+   back to SPECULATIVE candidates: every enrolled host that has live remote
+   sessions reporting a herdr pane (registry), bounded to ≤3 hosts, tried
+   sequentially. This bound is a guideline the implementer may tighten,
+   never widen. A surface with NO ssh at all NEVER probes (amended
+   2026-08-09 over the original draft): a local shell is the overwhelmingly
+   common dictation target, and probing it would pay cold-forward latency
+   per candidate and flash nonces in remote panels the user is not looking
+   at. The accepted cost: an inner ssh on another pty (tmux nesting) stays
+   unjoinable until a warm-forward-only speculative mode exists (recorded
+   follow-up).
+2. Per candidate host (existing machinery): open the forward, apply the
+   single-socket rule (unchanged in this PR; per-socket distinct nonces can
+   lift it later — noted as follow-up, out of scope), query `pane_current`,
+   find the unique candidate session claiming the focused pane (existing
+   logic, unchanged).
+3. Stamp: `pane.report_metadata` on that pane with `tokens:{lvmark:
+   "lv-<nonce>"}`, `source:"localvoxtral"`, `ttl_ms:8000`.
+4. Read the focused surface's grid once; require the exact rendered token as
+   a contiguous string. Allow a short bounded settle (herdr must paint, the
+   terminal must render; ≤2 polls with injected clock — NO wall-clock sleeps
+   in tests, use the `now:`/`sleepFor:` seam pattern of
+   `OverlayBufferSessionCoordinator`).
+5. On match: proceed with the UNCHANGED downstream confirmations — broker
+   marker in the pane's `terminal_title`, `agent_session` claim agreement,
+   foreground process check. The panel token AUTHORIZES the surface binding;
+   it does not replace pane-level session confirmation.
+6. Two candidate hosts matching in one grid (distinct nonces both present):
+   abstain. Should be impossible; abstention is the correct posture.
+7. On no-match after the bounded settle: fall through to the argv path with
+   #228/#229 semantics exactly.
+
+## Live mic indicator (owner decision)
+
+After a successful join, keep the token alive for the dictation as a visible
+mic indicator: refresh `pane.report_metadata` with the SAME token every ~4 s
+(`ttl_ms:8000` — TTL is the backstop, refresh keeps it lit), and clear
+explicitly (empty or null value) on dictation stop, session end, or join teardown.
+The rendered value may carry a short static prefix so the row reads as a mic
+indicator rather than line noise (e.g. `lv-mic-<nonce>` if ≤20 chars renders
+intact at herdr's default sidebar width 26 — verify against the row budget:
+24/22 cols first/continuation row, prefix-truncation only). Refresh timers
+must be injected-clock, never wall-clock, and must not outlive the session
+(see PR #66 timer debt — do not add more armed wall-clock timers).
+
+## Title-marker arm suppression (owner decision)
+
+When the ssh probe returns `.undeterminable` with a category that means "an
+ssh session is present on the surface but cannot be read" —
+`multipleForegroundClients`, `untrustedExecutable`, `unreadableArguments`,
+`refusedArguments` — the title-marker fallback arm is SKIPPED for that
+dictation. Rationale: an unreadable ssh means the surface may be a remote
+session, and the outer title marker may be stale from an earlier session on
+that host (the documented mis-join residual). `deviceUnreadable` /
+`tableUnreadable` / `probeUnavailable` do NOT suppress the marker arm: they
+mean we could not look at all, and suppressing there would break local marker
+joins on machines where the probe itself is unavailable. This needs a
+red/green regression test pair: stale-marker mis-join reproduced under an
+unreadable-ssh probe result before the change, refused after.
+
+## Enrollment-time config offer (owner decision)
+
+- Enrollment (and a re-check offered when a join fails with "panel row not
+  configured" symptoms — i.e. stamp succeeded, everything else healthy, grid
+  shows no token) detects the missing row and OFFERS to patch the remote
+  herdr config over the enrollment ssh channel, with explicit user consent in
+  Settings — never silently.
+- Patch rule, conservative: if the remote config has NO `[ui.sidebar.agents]`
+  table, append the three-row block above verbatim, then
+  `herdr server reload-config`. If the table (or a `rows` key) EXISTS, do NOT
+  edit it — show the snippet and instructions instead (Settings detail +
+  log; popover gets one short sentence per the owner rule, never config
+  text).
+- Detection of "row missing" from the Mac side is inferential (no config-read
+  API): treat stamp-succeeded + grid-no-match as "likely not configured" in
+  the diagnostics string, not as a proven fact — and only for
+  DESTINATION-KNOWN probes. A speculative candidate's token not rendering
+  usually means the user is not looking at that server; diagnosing the row
+  from it would nag correctly configured hosts.
+
+## Diagnosability
+
+Every abstention names its cause in `Log.claudeContext` and the dogfood
+join-abstention string, following #228's `SSHProbeIndeterminacy` pattern:
+distinct content-free categories for at least — row-not-rendered (no token in
+grid), AX-read-unavailable, forward-unavailable-for-speculative-candidate,
+stamp-refused (API error), multi-host-double-match, settle-timeout. Backend
+paths stay loud (`Log.backends` convention).
+
+## Invariants doc duties (same PR)
+
+- `docs/agent/invariants.md`: state the panel binding as the primary surface
+  authorization for `.remoteHerdrPane`, with the App-mode-render and
+  nonce-freshness arguments and their EXTERNAL-ASSUMPTION bounds (herdr
+  upgrade obligation: re-verify that attach/observe clients still render no
+  sidebar and that the panel renders identically on all App clients —
+  `src/server/headless.rs` render loop, `tests/multi_client.rs`).
+- Update the "manual flow gets no herdr join" accepted-cost paragraph: it is
+  now closed by the panel binding when the panel is visible; the residual is
+  restated (collapsed sidebar / narrow client / unconfigured row fall back to
+  argv, where the manual flow still gets no join).
+- The marker-arm suppression rule and its exact category set.
+
+## Out of scope (recorded follow-ups)
+
+- Per-socket distinct nonces to lift the single-socket-per-host abstention.
+- Persistent per-host forwards (separate PR, in flight).
+- Any upstream herdr change (`client.list` branch stays parked;
+  Discussions-only upstream).

--- a/docs/agent/remote-herdr-panel-binding.md
+++ b/docs/agent/remote-herdr-panel-binding.md
@@ -107,11 +107,18 @@ Why a grid match is sufficient evidence, to the standard of review rounds 1–7:
    at. The accepted cost: an inner ssh on another pty (tmux nesting) stays
    unjoinable until a warm-forward-only speculative mode exists (recorded
    follow-up).
-2. Per candidate host (existing machinery): open the forward, apply the
-   single-socket rule (unchanged in this PR; per-socket distinct nonces can
-   lift it later — noted as follow-up, out of scope), query `pane_current`,
-   find the unique candidate session claiming the focused pane (existing
-   logic, unchanged).
+2. Per candidate host: iterate its live herdr SOCKETS (sorted, ≤3 — the
+   single-socket abstention is lifted HERE and only here, because each
+   socket gets its own fresh nonce and only the displayed server can render
+   its token; a stale socket from a previous herdr boot fails its forward
+   and is skipped — field abstention 2026-08-09; the argv fallback keeps
+   the single-socket abstention, having no way to tell servers apart). Per
+   socket: open the forward, query `pane_current`, find the unique
+   candidate session of THAT socket claiming the focused pane. First
+   rendered match ends the socket loop (one grid renders one server, and
+   the per-host forward service would tear down the matched forward if a
+   further socket were opened); the cross-host double-match abstention
+   stays.
 3. Stamp: `pane.report_metadata` on that pane with `tokens:{lvmark:
    "lv-<nonce>"}`, `source:"localvoxtral"`, `ttl_ms:8000`.
 4. Read the focused surface's grid once; require the exact rendered token as


### PR DESCRIPTION
## What

Top of the stack. Implements `docs/agent/remote-herdr-panel-binding.md` (committed in this PR — the owner-approved design, 2026-08-09): the herdr **agents-panel nonce binding** becomes the PRIMARY surface authorization for `.remoteHerdrPane` joins, replacing ssh-argv inference for the positive path.

Per plausible enrolled host (readable ssh destination when available; when an ssh is present but unreadable, ≤3 speculative hosts with live herdr-bearing sessions; **a surface with no ssh at all never probes** — local shells stay zero-cost), the resolver keeps the single-socket rule, opens the forward, finds the unique live session claiming herdr's focused pane, stamps that pane via `pane.report_metadata` with a fresh `lv-mic-<nonce>` token (~51.7 random bits, fixed 17 columns, 8 s TTL), and requires that exact token in the focused terminal's existing grid route within two injected-clock reads. herdr renders the sidebar only for whole-view App clients (attach/observe render the raw pane alone), so a grid match positively proves the surface displays a whole-view client of the stamped server — the discriminator #229 approximated with argv, obtained directly. All downstream confirmations are unchanged: broker marker in the pane title, `agent_session` claim, foreground process.

This closes the two abstention classes argv could never close: the **Ghostty ssh-wrapper** surface (unreadable argv → speculative panel proof) and the **manual flow** (`ssh host`, then typing `herdr` — readable destination, panel-authorized despite `.notHerdr` argv).

Also in this PR, per the owner's decisions:

- **Live mic indicator**: a matched token stays visible in the panel for the dictation (refresh ~4 s / TTL 8 s, injected clocks), explicitly cleared before its forward closes; the view model owns the lease on every exit path.
- **Title-marker suppression**: the four "ssh present but unreadable" probe categories (`multipleForegroundClients`, `untrustedExecutable`, `unreadableArguments`, `refusedArguments`) now suppress the title-marker fallback — killing the documented stale-marker mis-join residual — while probe-wide categories (`deviceUnreadable`, `tableUnreadable`, `probeUnavailable`) leave local marker joins intact. Each side pinned by test.
- **Enroll-time config offer**: consent-gated, conservative remote patch of `[ui.sidebar.agents]` over the existing enrollment ssh channel — appends the three-row block only when no agents table/rows key exists (including trailing-comment header variants), otherwise surfaces the snippet in Settings; inferential "row likely not configured" diagnostics only from destination-known probes.
- Content-free abstention categories for every new failure path (log + dogfood), and the invariants doc restates the trust argument with its herdr-upgrade external-assumption obligations.

Review-hardened twice:

- Orchestrator review: speculative probing originally fired on `.noSSHClient` (the design doc's own error) — every local-shell dictation would have paid cold-forward latency and flashed nonces in remote panels, with false config diagnostics. Amended: no-ssh surfaces never probe; speculation requires an ssh present-but-unreadable; diagnostics gated to destination-known probes. The original `noSSHClient` test had passed only because panel metadata was unwired (passing-for-the-wrong-reason); it now pins the fix with the machinery fully wired.
- GLM adversarial review (SHIP-WITH-FIXES): its potential blocker — JSON `null` vs empty-string clear — was resolved against herdr source (`tokens: HashMap<String, Option<String>>`, `normalize_metadata_tokens` pins both `None` and `""` as clears) and documented; applied fixes: trailing-comment config detection, panel-authorized view-model lifecycle coverage (with concurrent `stopAndWait` callers awaiting one clear/close), and coalesced `rowNotRendered` dogfood notes. GLM independently confirmed: no path reaches a `.remoteHerdrPane` join without a grid-verified nonce for the exact stamped socket or the full #229 argv chain; per-host fresh nonces cannot cross-authorize; downstream confirmations not weakened; no nonce/host/path in any log.

[dogfood-package]

## Proof

- Full unit suite green (after both review rounds): `Executed 2653 tests, with 2 tests skipped and 0 failures (0 unexpected)`
- Red/green pairs:
  - Marker suppression: `testUnreadableSSHOnSurfaceSuppressesAStaleTitleMarkerJoin` — red `XCTAssertNil failed: received a .titleMarker join` → green.
  - Panel-primary: `testPanelBindingIsPrimaryWhenSSHArgvSaysPlainShell` — red `XCTUnwrap failed` → green.
  - Enrollment patch: `testHerdrPanelConfigurationUsesTheEnrollmentSSHChannelAndConservativePatch` — red (1 failure in 68) → green.
  - Orchestrator amendment: `testNoSSHClientOnTheSurfaceFallsThroughToTheTitleMarker` (strengthened, panel wired) — red `Executed 1 test, with 3 failures` → green; `testASpeculativeSettleTimeoutDoesNotClaimTheRowIsMissing` — red `XCTAssertTrue failed` → green.
  - GLM F2: trailing-comment header — red `71 tests, 3 failures` (exit 127, duplicate table appended) → green 71/71.
  - GLM F3: view-model lifecycle — red (3 assertions, `stopAndWait` returned early) → green 62/62.
- Targeted suites: `RemoteHerdrJoinTests` 62/62, `HerdrPanelBindingProbeTests` 6/6, `ClaudeRemoteEnrollmentServiceTests` 71/71, `ClaudeIntegrationSettingsModelTests` 55/55, `HerdrSocketClientTests` 18/18.
- LLM lanes: not required — nothing that reaches a model changes (ClaudeContext paths run the polishd lane by filter).
- UI: Settings shows the config offer/status in the existing Context group (content only — group structure unchanged per owner rule); popover strings are one short sentence. Not hand-verified on a Mac; covered by `ClaudeIntegrationSettingsModelTests`. Field verification planned: owner installs the stack via `./scripts/try-pr.sh <this PR> --dogfood`, adds the `$lvmark` row on the enrolled host (or accepts the enroll-time offer), and dictates over the ProxyJump connection with the Ghostty wrapper active — expected `arm: remoteHerdrPane` with the mic row visible, and named categories on any abstention.
