### PR TITLE
`--probe-surface`: resolve the frontmost surface's Claude join once, print it, exit

### DIFF
--- a/Sources/localvoxtral/ClaudeContext/ClaudeJoinAbstentionTap.swift
+++ b/Sources/localvoxtral/ClaudeContext/ClaudeJoinAbstentionTap.swift
@@ -1,0 +1,64 @@
+import Synchronization
+
+/// Collects the resolver's abstention causes for the duration of one resolve.
+///
+/// The resolver reduces every abstention to a log line and returns `nil`, so by
+/// the time an answer comes back the reason it took that answer is gone. A
+/// dogfood build already taps that (`DogfoodCaptureTap`), but that tap does not
+/// exist in a shipping build — and `--probe-surface` has to run in a shipping
+/// build, because a diagnostic that requires a special binary cannot diagnose
+/// the binary the user is actually running.
+///
+/// Disarmed by default and therefore inert in normal operation: `note` takes an
+/// uncontended lock, sees no collector, and returns. Nothing accumulates when
+/// nobody is collecting, which is what keeps this from becoming an unbounded
+/// buffer in a process that runs for weeks.
+///
+/// Scoped rather than global-with-a-reset (`collecting(_:)` arms, runs, and
+/// disarms) so a collection can never outlive the call that wanted it — the
+/// failure mode of the leaked-slot kind that `DogfoodCaptureTap.beginSession`
+/// exists to bound.
+enum ClaudeJoinAbstentionTap {
+    private struct State {
+        var collecting = false
+        var causes: [String] = []
+    }
+
+    /// A resolve visits at most a couple of dozen abstention sites; the cap is
+    /// a backstop against a future loop, not a budget anyone should reach.
+    private static let maxCauses = 64
+
+    private static let state = Mutex(State())
+
+    /// Records one arm's abstention cause, e.g. `"tty: stale"`. A no-op unless
+    /// a `collecting(_:)` call is in progress.
+    static func note(_ cause: String) {
+        state.withLock {
+            guard $0.collecting, $0.causes.count < maxCauses else { return }
+            $0.causes.append(cause)
+        }
+    }
+
+    /// Runs `body` with the tap armed and returns its value alongside every
+    /// cause noted while it ran, oldest first.
+    ///
+    /// Not reentrant, and it does not need to be: the only caller is the probe
+    /// verb, which resolves exactly once per process.
+    ///
+    /// `isolation` inherits the caller's actor so a `@MainActor` resolve can be
+    /// passed in directly — without it the closure would have to cross an
+    /// isolation boundary it has no reason to cross.
+    static func collecting<T>(
+        isolation: isolated (any Actor)? = #isolation,
+        _ body: () async -> T
+    ) async -> (T, [String]) {
+        state.withLock { $0 = State(collecting: true) }
+        let value = await body()
+        let causes = state.withLock { current -> [String] in
+            let causes = current.causes
+            current = State()
+            return causes
+        }
+        return (value, causes)
+    }
+}

--- a/Sources/localvoxtral/ClaudeContext/ClaudeSessionJoinSummary.swift
+++ b/Sources/localvoxtral/ClaudeContext/ClaudeSessionJoinSummary.swift
@@ -1,0 +1,137 @@
+import Foundation
+
+/// The join, reduced to the handful of facts that can be reported outside the
+/// process without leaking anything the logs redact.
+///
+/// One type, two consumers: the dogfood capture record's `join` block and the
+/// `--probe-surface` diagnostic verb. Two mappings of one vocabulary is one too
+/// many — an arm renamed on one side and not the other would make a probe run
+/// and a captured record disagree about the same dictation, which is exactly
+/// the drift a diagnostic must never introduce.
+///
+/// What is deliberately NOT here is the point. A join knows the session id, the
+/// marker, the workspace path, the herdr socket path, the remote host, and (for
+/// a panel-authorized remote join) a live nonce. None of those may cross this
+/// boundary: `workspaceIsLocal` is a Bool rather than the path, `origin` is a
+/// class rather than a host, and `terminal` is the app's name rather than
+/// anything about what it is displaying. `abstentionReason` carries only the
+/// resolver's own content-free outcome categories — the same strings it already
+/// writes to `Log.claudeContext`, which are audited for exactly this.
+struct ClaudeSessionJoinSummary: Codable, Equatable, Sendable {
+    /// `tty`, `titleMarker`, `herdrPane`, `browserTab`, `cmuxSurface`,
+    /// `remoteHerdrPane`, or `none`. The resolver's mechanism vocabulary, not a
+    /// second naming of it.
+    var arm: String
+    /// Every arm that declined, oldest first, joined by `; `. Present even when
+    /// an arm ultimately answered: "the tty arm never answers" is invisible in
+    /// a summary that names only the winner.
+    var abstentionReason: String?
+    /// `local` or `remote` — which context the session was even eligible for.
+    var origin: String?
+    /// `Ghostty`, `iTerm2`, `Terminal.app`, or `cmux`.
+    var terminal: String?
+    /// True when the join carries a herdr pane binding (local or remote), which
+    /// makes the join herdr-or-nothing from that point.
+    var herdrBound: Bool?
+    var workspaceIsLocal: Bool?
+
+    init(
+        arm: String,
+        abstentionReason: String? = nil,
+        origin: String? = nil,
+        terminal: String? = nil,
+        herdrBound: Bool? = nil,
+        workspaceIsLocal: Bool? = nil
+    ) {
+        self.arm = arm
+        self.abstentionReason = abstentionReason
+        self.origin = origin
+        self.terminal = terminal
+        self.herdrBound = herdrBound
+        self.workspaceIsLocal = workspaceIsLocal
+    }
+
+    /// The single place a `ClaudeSessionJoin` becomes reportable.
+    ///
+    /// - Parameter abstentions: the causes collected during the resolve, in
+    ///   order. Empty means the resolver reached its answer without any arm
+    ///   declining — which for `arm == "none"` means no arm ran at all, and
+    ///   that distinction is itself diagnostic.
+    static func summarize(
+        join: ClaudeSessionJoin?,
+        abstentions: [String]
+    ) -> ClaudeSessionJoinSummary {
+        let reason = abstentions.isEmpty ? nil : abstentions.joined(separator: "; ")
+        guard let join else {
+            return ClaudeSessionJoinSummary(
+                arm: "none",
+                abstentionReason: reason,
+                origin: nil,
+                terminal: nil,
+                herdrBound: nil,
+                workspaceIsLocal: nil
+            )
+        }
+        return ClaudeSessionJoinSummary(
+            arm: armName(join.mechanism),
+            abstentionReason: reason,
+            origin: join.snapshot.origin.isLocalAuthenticated ? "local" : "remote",
+            terminal: TerminalScreenAllowlist.displayName(forBundleID: join.target.bundleID),
+            herdrBound: join.herdrPane != nil,
+            workspaceIsLocal: join.snapshot.localWorkspacePath != nil
+        )
+    }
+
+    static func armName(_ mechanism: ClaudeSessionJoinMechanism) -> String {
+        switch mechanism {
+        case .ttyDevice: return "tty"
+        case .titleMarker: return "titleMarker"
+        case .herdrPane: return "herdrPane"
+        case .browserTab: return "browserTab"
+        case .cmuxSurface: return "cmuxSurface"
+        case .remoteHerdrPane: return "remoteHerdrPane"
+        }
+    }
+
+    /// One line of JSON, keys always in this order and nulls always present.
+    ///
+    /// Hand-rendered rather than `JSONEncoder`-ed because the shape IS the
+    /// contract callers assert against: synthesized `Codable` omits nil
+    /// optionals, so an encoder would drop `"origin": null` and turn "the join
+    /// reported no origin" into "this field does not exist in this build".
+    var jsonLine: String {
+        let fields: [(String, String)] = [
+            ("arm", Self.jsonString(arm)),
+            ("abstentionReason", abstentionReason.map(Self.jsonString) ?? "null"),
+            ("origin", origin.map(Self.jsonString) ?? "null"),
+            ("terminal", terminal.map(Self.jsonString) ?? "null"),
+            ("herdrBound", herdrBound.map { $0 ? "true" : "false" } ?? "null"),
+            ("workspaceIsLocal", workspaceIsLocal.map { $0 ? "true" : "false" } ?? "null"),
+        ]
+        let body = fields.map { "\(Self.jsonString($0.0)):\($0.1)" }.joined(separator: ",")
+        return "{\(body)}"
+    }
+
+    /// Escapes through `JSONSerialization` rather than by hand: abstention
+    /// causes are assembled from enum raw values today, but a future one
+    /// carrying a quote or a backslash must not be able to emit invalid JSON.
+    private static func jsonString(_ value: String) -> String {
+        guard let data = try? JSONSerialization.data(withJSONObject: [value], options: []),
+              let array = String(data: data, encoding: .utf8),
+              array.count >= 2
+        else { return "\"\"" }
+        return String(array.dropFirst().dropLast())
+    }
+
+    /// The same six facts as aligned text, for a human reading a terminal.
+    var textLines: String {
+        [
+            "arm:              \(arm)",
+            "abstentionReason: \(abstentionReason ?? "(none)")",
+            "origin:           \(origin ?? "(none)")",
+            "terminal:         \(terminal ?? "(none)")",
+            "herdrBound:       \(herdrBound.map(String.init) ?? "(none)")",
+            "workspaceIsLocal: \(workspaceIsLocal.map(String.init) ?? "(none)")",
+        ].joined(separator: "\n")
+    }
+}

--- a/Sources/localvoxtral/ClaudeContext/ClaudeSurfaceProbe.swift
+++ b/Sources/localvoxtral/ClaudeContext/ClaudeSurfaceProbe.swift
@@ -1,0 +1,153 @@
+import Foundation
+
+/// `localvoxtral --probe-surface [--json]`: resolve the Claude Code join for
+/// whatever surface is frontmost right now, print the answer, exit.
+///
+/// The verb exists because the join is otherwise unobservable. In the field the
+/// only symptom of a join that will not resolve is context that never arrives,
+/// and the resolver reduces every abstention to a `Log.claudeContext` line that
+/// says nothing about which of a dozen causes fired — the gap that made the
+/// Ghostty ssh-wrapper case (2026-08-03, the tty probe reporting
+/// `undeterminable` because the wrapper hid the client) take a remote-probing
+/// session to attribute. Running the verb from the terminal you would dictate
+/// into makes THAT terminal the frontmost surface, so the answer describes
+/// exactly the surface in question.
+///
+/// ## Read-only by construction, not by discipline
+///
+/// The remote-herdr arm can open an `ssh -L` and stamp a `pane.report_metadata`
+/// nonce into a herdr agents panel. A one-shot process is the worst possible
+/// owner for either: it has no supervisor, no idle window, and no second chance
+/// to clear a stamp if it is killed between stamping and clearing. So the probe
+/// does not decline to do those things — it is BUILT UNABLE TO. The forward and
+/// panel-metadata capabilities are passed as `nil`, which is the resolver's own
+/// documented "the arm can never spawn anything" configuration, and no flag
+/// re-enables them. The arm's read-only halves (the process-table ssh probe and
+/// enrolled-host matching) still run, because those are exactly the steps the
+/// field questions are about and they touch nothing.
+///
+/// Everything else the probe wires is a read: the AppleScript focused-pane tty,
+/// the herdr process-table binding, `pane.current`/`pane.process_info` on a
+/// local herdr socket, the AX window title. Nothing is written, nothing
+/// outlives the process, and the printed summary carries no token, nonce, host,
+/// pane id, marker, or path (see `ClaudeSessionJoinSummary`).
+///
+/// ## What this process cannot know
+///
+/// The session registry is per-process and lives only in the running app: it is
+/// built from hook records the app's broker received. A separate one-shot
+/// process therefore starts with an EMPTY registry, so `arm` reports what a
+/// resolve against no known sessions concludes, and the diagnostic value is in
+/// `abstentionReason` — which arms ran, how far each got, and where the surface
+/// stopped being identifiable. `probe: no live Claude sessions in this process`
+/// is noted first whenever that is the case, so the chain can never be misread
+/// as "the surface failed". See `docs/agent/field-debugging.md`.
+@MainActor
+enum ClaudeSurfaceProbe {
+    static let verb = "--probe-surface"
+
+    struct Options: Equatable {
+        /// One line of JSON on stdout instead of the aligned human form.
+        var json = false
+    }
+
+    enum Invocation: Equatable {
+        /// `--probe-surface` was not on the command line; launch the app.
+        case notRequested
+        case run(Options)
+        /// The verb was requested but the rest of the line made no sense.
+        case usageError(String)
+    }
+
+    /// Reasons the PROBE declined before the resolver ever ran.
+    ///
+    /// New strings, unavoidably: they name facts about running as a one-shot
+    /// diagnostic process that no arm has ever had to report. Everything the
+    /// resolver itself can conclude is reported in the resolver's own
+    /// vocabulary, unchanged, and nothing here restates one of those.
+    enum ProbeAbstention: String, Equatable {
+        case accessibilityNotGranted = "probe: accessibility permission not granted"
+        case noFrontmostApplication = "probe: no frontmost application"
+        case unsupportedSurface = "probe: frontmost application is not a joinable surface"
+        case noLiveSessions = "probe: no live Claude sessions in this process"
+        case timedOut = "probe: resolver did not answer within the probe deadline"
+    }
+
+    static let usageText = """
+    usage: localvoxtral --probe-surface [--json]
+
+    Resolves the Claude Code session join for the frontmost surface once and
+    exits. Run it from the terminal you would dictate into: that terminal is
+    the frontmost surface, which is the one being probed.
+
+      --json   one line of JSON instead of the aligned human form
+
+    Exit status: 0 an arm joined, 1 no arm joined, 2 usage error.
+    """
+
+    static func invocation(arguments: [String]) -> Invocation {
+        let arguments = Array(arguments.dropFirst())
+        guard arguments.contains(verb) else { return .notRequested }
+        var options = Options()
+        for argument in arguments {
+            switch argument {
+            case verb: continue
+            case "--json": options.json = true
+            default:
+                return .usageError("unrecognized option for \(verb): \(argument)")
+            }
+        }
+        return .run(options)
+    }
+
+    /// The probe's decision, with every live capability injected.
+    ///
+    /// Pure in the sense that matters: it reads no global state, so a test can
+    /// drive every branch — including the two grant failures — without a
+    /// frontmost app, an Accessibility grant, or a socket.
+    static func summarize(
+        accessibilityTrusted: Bool,
+        frontmostTarget: TerminalScreenTarget?,
+        hasLiveSessions: () -> Bool,
+        resolve: (TerminalScreenTarget) async -> ClaudeSessionJoin?
+    ) async -> ClaudeSessionJoinSummary {
+        // Refused before resolving, not after. Without the grant the marker arm
+        // cannot read a title and the window identity is unknowable, so a
+        // resolve would spend real Apple events to arrive at an answer whose
+        // abstentions would all be misattributed to the arms rather than to the
+        // missing permission.
+        guard accessibilityTrusted else {
+            return abstained(.accessibilityNotGranted)
+        }
+        guard let target = frontmostTarget else {
+            return abstained(.noFrontmostApplication)
+        }
+        guard TerminalScreenAllowlist.isSupported(target.bundleID)
+            || BrowserTabAllowlist.isSupported(target.bundleID)
+        else {
+            // The resolver returns nil for an unlisted bundle without noting a
+            // cause, and "no reason at all" is the least useful thing a
+            // diagnostic can print.
+            return abstained(.unsupportedSurface)
+        }
+
+        let (join, abstentions) = await ClaudeJoinAbstentionTap.collecting {
+            // Noted FIRST so it reads as the frame around everything after it.
+            if !hasLiveSessions() {
+                ClaudeJoinAbstentionTap.note(ProbeAbstention.noLiveSessions.rawValue)
+            }
+            return await resolve(target)
+        }
+        return ClaudeSessionJoinSummary.summarize(join: join, abstentions: abstentions)
+    }
+
+    private static func abstained(_ reason: ProbeAbstention) -> ClaudeSessionJoinSummary {
+        ClaudeSessionJoinSummary.summarize(join: nil, abstentions: [reason.rawValue])
+    }
+
+    /// 0 an arm joined, 1 no arm joined. Split so a shell assertion does not
+    /// have to parse JSON to ask the only question it usually has.
+    static func exitCode(for summary: ClaudeSessionJoinSummary) -> Int32 {
+        summary.arm == "none" ? 1 : 0
+    }
+}

--- a/Sources/localvoxtral/ClaudeContext/ClaudeSurfaceProbeCommand.swift
+++ b/Sources/localvoxtral/ClaudeContext/ClaudeSurfaceProbeCommand.swift
@@ -1,0 +1,123 @@
+import AppKit
+import ApplicationServices
+import Foundation
+import Synchronization
+
+/// The live half of `--probe-surface`: builds the read-only resolver, runs it
+/// once under a hard deadline, prints, and hands back an exit status.
+///
+/// Deliberately thin, and deliberately the only untested file in this feature.
+/// Everything it decides lives in `ClaudeSurfaceProbe.summarize` behind
+/// injected seams; what remains here is the wiring itself — which capabilities
+/// are handed to the resolver and which are withheld — and that is a diff to
+/// read, not an assertion to write.
+@MainActor
+enum ClaudeSurfaceProbeCommand {
+    /// The resolver spends Apple events, a socket dial, and possibly an
+    /// `ssh -G`. Any of them can block: an Automation consent sheet blocks
+    /// until answered, and a wedged socket blocks until the kernel gives up. A
+    /// diagnostic that hangs is worse than one that abstains, so the whole
+    /// resolve is bounded and a timeout is reported as a named cause.
+    static let deadline: TimeInterval = 25
+
+    /// - Returns: the process exit status. 0 an arm joined, 1 no arm joined.
+    static func run(options: ClaudeSurfaceProbe.Options) -> Int32 {
+        let summary = resolveWithinDeadline()
+        print(options.json ? summary.jsonLine : summary.textLines)
+        return ClaudeSurfaceProbe.exitCode(for: summary)
+    }
+
+    /// Runs the async probe from synchronous top-level code by pumping the main
+    /// run loop, the same shape `AppDelegate.drainRemoteForwardTeardowns` uses
+    /// — blocking the main thread on a semaphore instead would deadlock the
+    /// main-actor task it is waiting for.
+    private static func resolveWithinDeadline() -> ClaudeSessionJoinSummary {
+        let answer = Mutex<ClaudeSessionJoinSummary?>(nil)
+        Task { @MainActor in
+            let summary = await probe()
+            answer.withLock { $0 = summary }
+        }
+        let expiry = Date().addingTimeInterval(deadline)
+        while answer.withLock({ $0 }) == nil, Date() < expiry {
+            RunLoop.current.run(mode: .default, before: Date().addingTimeInterval(0.02))
+        }
+        return answer.withLock { $0 } ?? ClaudeSessionJoinSummary.summarize(
+            join: nil,
+            abstentions: [ClaudeSurfaceProbe.ProbeAbstention.timedOut.rawValue]
+        )
+    }
+
+    private static func probe() async -> ClaudeSessionJoinSummary {
+        let registry = ClaudeSessionRegistry()
+        let resolver = makeResolver(registry: registry)
+        return await ClaudeSurfaceProbe.summarize(
+            // Never `AXIsProcessTrustedWithOptions`: a diagnostic must report
+            // the permission state, not change it by raising the grant sheet.
+            accessibilityTrusted: AXIsProcessTrusted(),
+            frontmostTarget: frontmostTarget(),
+            hasLiveSessions: { registry.hasLiveSessions() },
+            resolve: { await resolver.resolve(target: $0) }
+        )
+    }
+
+    /// The frontmost app as a target. Not `TerminalScreenContextSource`'s
+    /// version, which self-excludes by pid so a dictation never captures our
+    /// own overlay: this process has no window, so the frontmost app is the
+    /// terminal the verb was typed into, and excluding ourselves would only
+    /// hide a surface we do want to describe.
+    private static func frontmostTarget() -> TerminalScreenTarget? {
+        guard let app = NSWorkspace.shared.frontmostApplication,
+              let bundleID = app.bundleIdentifier
+        else { return nil }
+        return TerminalScreenTarget(pid: app.processIdentifier, bundleID: bundleID)
+    }
+
+    /// Every capability decision this feature makes, in one place.
+    ///
+    /// WIRED, all reads: the AppleScript focused-pane tty, the herdr client
+    /// process-table binding, a local herdr socket's `pane.current` /
+    /// `pane.process_info`, the AX window title and window identity, the
+    /// process-table ssh probe, and enrolled-host matching (including the
+    /// `ssh -G` canonicalization, which resolves config and opens no
+    /// connection).
+    ///
+    /// WITHHELD, and each for its own reason:
+    ///
+    /// * `remoteHerdrForwards` / `herdrPanelMetadata` — the forward and the
+    ///   panel nonce. Nil is the resolver's documented "this arm can never
+    ///   spawn anything" configuration, so the probe cannot open an `ssh -L`
+    ///   that outlives it or leave a `lv-mic-…` stamp in someone's agents
+    ///   panel. There is no flag that turns these on.
+    /// * `cmuxSurfaces` / `cmuxJoinEnabled` — the cmux arm reads a Keychain
+    ///   password and talks to another app's control socket behind a user
+    ///   opt-in. A diagnostic must not raise a keychain prompt.
+    /// * `focusedBrowserTabURL` — a tab URL is a page the user is looking at.
+    ///   The browser arm abstains here rather than have a debug verb read the
+    ///   address bar.
+    /// * `readFocusedGrid` — screen text, and only the panel-nonce match ever
+    ///   needed it. The probe reads no screen content at all.
+    private static func makeResolver(registry: ClaudeSessionRegistry) -> ClaudeSessionJoinResolver {
+        let ttyReader = AppleScriptTerminalTTYReader()
+        // Read-only: `init` parses the enrollment file and every query used
+        // here is a pure lookup over the parsed value. An unreadable or absent
+        // file means no candidates, which is the same as no enrollment.
+        let hosts = try? ClaudeRemoteHostRegistry()
+        let canonicalizer = SSHDestinationCanonicalizer.live()
+        return ClaudeSessionJoinResolver(
+            registry: registry,
+            focusedTerminalTTY: { await ttyReader.focusedTerminalTTY(bundleID: $0) },
+            herdrClientProbe: { HerdrClientTTYProbe.isHerdrClient(onTTYDevicePath: $0) },
+            herdrPanes: HerdrSocketClient(),
+            sshDestinationProbe: { SSHDestinationTTYProbe.connection(onTTYDevicePath: $0) },
+            enrolledHosts: { hosts?.hosts(matchingSSHDestination: $0) ?? [] },
+            canonicalizedEnrolledHosts: { destination in
+                guard let enrolled = hosts?.hosts() else { return [] }
+                return await canonicalizer.matchingHosts(
+                    destination: destination,
+                    enrolledHosts: enrolled
+                )
+            },
+            speculativeHosts: { hosts?.hosts() ?? [] }
+        )
+    }
+}

--- a/Sources/localvoxtral/ClaudeContext/HerdrPanelBindingProbe.swift
+++ b/Sources/localvoxtral/ClaudeContext/HerdrPanelBindingProbe.swift
@@ -164,8 +164,10 @@ struct HerdrPanelBindingProbe {
         Log.claudeContext.info(
             "Remote herdr panel binding abstained (\(cause.rawValue, privacy: .public))"
         )
+        let noted = "remoteHerdrPanel: \(cause.rawValue)"
+        ClaudeJoinAbstentionTap.note(noted)
         #if LOCALVOXTRAL_DOGFOOD
-        DogfoodCaptureTap.shared.noteJoinAbstention("remoteHerdrPanel: \(cause.rawValue)")
+        DogfoodCaptureTap.shared.noteJoinAbstention(noted)
         #endif
     }
 }

--- a/Sources/localvoxtral/ClaudeContext/TerminalScreenClaudeJoin.swift
+++ b/Sources/localvoxtral/ClaudeContext/TerminalScreenClaudeJoin.swift
@@ -448,8 +448,20 @@ struct ClaudeSessionJoinResolver {
         Log.claudeContext.info(
             "Focused-pane tty matched no session (\(outcome, privacy: .public)); trying title marker"
         )
+        Self.noteAbstention("tty: \(outcome)")
+    }
+
+    /// Where an abstention cause leaves this resolver as a value rather than as
+    /// a log line (`HerdrPanelBindingProbe` has the one other such point).
+    ///
+    /// Both consumers are diagnostics — the dogfood capture record and
+    /// `--probe-surface` — and both need the SAME string, so they read it from
+    /// here rather than each deriving one. `cause` is already the content-free
+    /// category the log line above carries; nothing else may be passed in.
+    private static func noteAbstention(_ cause: String) {
+        ClaudeJoinAbstentionTap.note(cause)
         #if LOCALVOXTRAL_DOGFOOD
-        DogfoodCaptureTap.shared.noteJoinAbstention("tty: \(outcome)")
+        DogfoodCaptureTap.shared.noteJoinAbstention(cause)
         #endif
     }
 
@@ -517,9 +529,7 @@ struct ClaudeSessionJoinResolver {
         Log.claudeContext.info(
             "Browser tab matched no session (\(outcome, privacy: .public)); Claude context withheld"
         )
-        #if LOCALVOXTRAL_DOGFOOD
-        DogfoodCaptureTap.shared.noteJoinAbstention("browserTab: \(outcome)")
-        #endif
+        Self.noteAbstention("browserTab: \(outcome)")
     }
 
     private func resolveViaHerdr(target: TerminalScreenTarget) async -> ClaudeSessionJoin? {
@@ -1245,9 +1255,7 @@ struct ClaudeSessionJoinResolver {
         Log.claudeContext.info(
             "Remote herdr pane matched no session (\(outcome, privacy: .public)); Claude context withheld"
         )
-        #if LOCALVOXTRAL_DOGFOOD
-        DogfoodCaptureTap.shared.noteJoinAbstention("remote-herdr: \(outcome)")
-        #endif
+        Self.noteAbstention("remote-herdr: \(outcome)")
     }
 
     /// The joined herdr pane's visible text, or nil on any refusal or failure.
@@ -1303,9 +1311,7 @@ struct ClaudeSessionJoinResolver {
         Log.claudeContext.info(
             "Herdr pane matched no session (\(outcome, privacy: .public)); Claude context withheld"
         )
-        #if LOCALVOXTRAL_DOGFOOD
-        DogfoodCaptureTap.shared.noteJoinAbstention("herdr: \(outcome)")
-        #endif
+        Self.noteAbstention("herdr: \(outcome)")
     }
 
     /// The cmux arm: bind the FOCUSED cmux surface to a live session by the
@@ -1561,9 +1567,7 @@ struct ClaudeSessionJoinResolver {
         Log.claudeContext.info(
             "cmux surface matched no session (\(outcome, privacy: .public)); trying title marker"
         )
-        #if LOCALVOXTRAL_DOGFOOD
-        DogfoodCaptureTap.shared.noteJoinAbstention("cmux: \(outcome)")
-        #endif
+        Self.noteAbstention("cmux: \(outcome)")
     }
 
     private func resolveViaMarker(target: TerminalScreenTarget) -> ClaudeSessionJoin? {
@@ -1571,9 +1575,7 @@ struct ClaudeSessionJoinResolver {
             // No marker on screen: this pane is not a joined Claude session, or
             // we cannot tell. Either way there is nothing to resolve.
             Log.claudeContext.info("Terminal pane carries no Claude session marker")
-            #if LOCALVOXTRAL_DOGFOOD
-            DogfoodCaptureTap.shared.noteJoinAbstention("marker: no marker in title")
-            #endif
+            Self.noteAbstention("marker: no marker in title")
             return nil
         }
 
@@ -1593,9 +1595,7 @@ struct ClaudeSessionJoinResolver {
             Log.claudeContext.info(
                 "Terminal pane not joined to a live Claude session; Claude context withheld"
             )
-            #if LOCALVOXTRAL_DOGFOOD
-            DogfoodCaptureTap.shared.noteJoinAbstention("marker: unknown/stale/ambiguous")
-            #endif
+            Self.noteAbstention("marker: unknown/stale/ambiguous")
             return nil
         }
     }

--- a/Sources/localvoxtral/Dogfood/DogfoodCapturePipeline.swift
+++ b/Sources/localvoxtral/Dogfood/DogfoodCapturePipeline.swift
@@ -150,41 +150,28 @@ enum DogfoodCaptureBuilder {
         return "remote"
     }
 
+    /// The record's join block, derived from the SHARED summary rather than
+    /// from a second reading of `ClaudeSessionJoin`.
+    ///
+    /// `--probe-surface` reports the same six facts, and a record and a probe
+    /// run that disagreed about one dictation would make both useless. So the
+    /// arm vocabulary, the origin class, the terminal name, and the abstention
+    /// joining all live in `ClaudeSessionJoinSummary`, and this is a field copy.
     static func join(
         from join: ClaudeSessionJoin?,
         abstentions: [String]
     ) -> DogfoodCaptureRecord.Join {
-        guard let join else {
-            return DogfoodCaptureRecord.Join(
-                arm: "none",
-                abstentionReason: abstentions.isEmpty
-                    ? nil : abstentions.joined(separator: "; "),
-                origin: nil,
-                terminal: nil,
-                herdrBound: nil,
-                workspaceIsLocal: nil
-            )
-        }
-        let arm: String
-        switch join.mechanism {
-        case .ttyDevice: arm = "tty"
-        case .titleMarker: arm = "titleMarker"
-        case .herdrPane: arm = "herdrPane"
-        case .browserTab: arm = "browserTab"
-        case .cmuxSurface: arm = "cmuxSurface"
-        case .remoteHerdrPane: arm = "remoteHerdrPane"
-        }
+        // A resolved join can still have earlier arms' abstentions (tty
+        // abstained, marker answered) — kept, because "the tty arm never
+        // answers" is invisible in a record that only names the winner.
+        let summary = ClaudeSessionJoinSummary.summarize(join: join, abstentions: abstentions)
         return DogfoodCaptureRecord.Join(
-            arm: arm,
-            // A resolved join can still have earlier arms' abstentions (tty
-            // abstained, marker answered) — kept, because "the tty arm never
-            // answers" is invisible in a record that only names the winner.
-            abstentionReason: abstentions.isEmpty
-                ? nil : abstentions.joined(separator: "; "),
-            origin: join.snapshot.origin.isLocalAuthenticated ? "local" : "remote",
-            terminal: join.target.bundleID,
-            herdrBound: join.herdrPane != nil,
-            workspaceIsLocal: join.snapshot.localWorkspacePath != nil
+            arm: summary.arm,
+            abstentionReason: summary.abstentionReason,
+            origin: summary.origin,
+            terminal: summary.terminal,
+            herdrBound: summary.herdrBound,
+            workspaceIsLocal: summary.workspaceIsLocal
         )
     }
 

--- a/Sources/localvoxtral/TerminalScreenContext.swift
+++ b/Sources/localvoxtral/TerminalScreenContext.swift
@@ -116,6 +116,23 @@ enum TerminalScreenAllowlist {
         guard let bundleID, !bundleID.isEmpty else { return false }
         return socketCaptureBundleIDs.contains(bundleID)
     }
+
+    /// The app's name, for the join summaries that leave the process
+    /// (`ClaudeSessionJoinSummary`). Nil for anything not on the allowlist —
+    /// including a browser tab target, which has no terminal at all.
+    ///
+    /// A closed mapping rather than `localizedName` of the running process: a
+    /// diagnostic must name the four supported terminals in exactly one way
+    /// across machines and locales, and an app can call itself anything.
+    static func displayName(forBundleID bundleID: String?) -> String? {
+        switch bundleID {
+        case ghosttyBundleID: return "Ghostty"
+        case iterm2BundleID: return "iTerm2"
+        case appleTerminalBundleID: return "Terminal.app"
+        case cmuxBundleID: return "cmux"
+        default: return nil
+        }
+    }
 }
 
 /// The application a screen capture belongs to. Value type only — no

--- a/Sources/localvoxtral/localvoxtralApp.swift
+++ b/Sources/localvoxtral/localvoxtralApp.swift
@@ -3,7 +3,8 @@ import ClaudeContextWire
 import SwiftUI
 import Synchronization
 
-@main
+// No `@main`: `Sources/localvoxtral/main.swift` is the entry point, so
+// `--probe-surface` can answer and exit before any scene is constructed.
 struct localvoxtralApp: App {
     @NSApplicationDelegateAdaptor(AppDelegate.self) private var appDelegate
 

--- a/Sources/localvoxtral/main.swift
+++ b/Sources/localvoxtral/main.swift
@@ -1,0 +1,18 @@
+import Foundation
+
+/// The executable's entry point, ahead of the SwiftUI app.
+///
+/// `localvoxtralApp` used to carry `@main`; a diagnostic verb has to answer and
+/// exit without a menu bar item, a Settings scene, or an `NSApplication` run
+/// loop, and there is no way back out of `App.main()`. So the argument check
+/// happens here, before anything is constructed. Without the verb this file
+/// does exactly what `@main` did.
+switch ClaudeSurfaceProbe.invocation(arguments: CommandLine.arguments) {
+case .notRequested:
+    localvoxtralApp.main()
+case .run(let options):
+    exit(ClaudeSurfaceProbeCommand.run(options: options))
+case .usageError(let message):
+    FileHandle.standardError.write(Data("\(message)\n\n\(ClaudeSurfaceProbe.usageText)\n".utf8))
+    exit(2)
+}

--- a/Tests/localvoxtralTests/ClaudeSurfaceProbeTests.swift
+++ b/Tests/localvoxtralTests/ClaudeSurfaceProbeTests.swift
@@ -1,0 +1,445 @@
+import ClaudeContextWire
+import Foundation
+import Synchronization
+import XCTest
+@testable import localvoxtral
+
+/// Test clock — the registry never reads the wall clock itself (AGENTS: no
+/// wall-clock in tests), and the probe under test never reads one at all.
+private final class ProbeTestClock: Sendable {
+    private let value: Mutex<Date>
+    init(_ start: Date) { value = Mutex(start) }
+    var now: @Sendable () -> Date { { [self] in value.withLock { $0 } } }
+}
+
+private final class ProbeTestLiveness: Sendable {
+    private let dead: Mutex<Set<Int32>> = Mutex([])
+    var probe: @Sendable (Int32) -> Bool { { [self] pid in dead.withLock { !$0.contains(pid) } } }
+}
+
+private final class ProbeTestMarkers: Sendable {
+    private let queue: Mutex<[String]>
+    init(_ values: [String]) { queue = Mutex(values) }
+    var allocate: @Sendable () -> String {
+        { [self] in queue.withLock { $0.isEmpty ? "lvx-exhausted" : $0.removeFirst() } }
+    }
+}
+
+private struct ProbeTestHerdrPanes: HerdrPaneQuerying {
+    var focused: HerdrFocusedPane?
+    var foreground: HerdrPaneForegroundInfo?
+
+    func focusedPane(socketPath _: String) async -> HerdrFocusedPane? { focused }
+
+    func paneForegroundInfo(
+        socketPath _: String,
+        paneID _: String
+    ) async -> HerdrPaneForegroundInfo? { foreground }
+
+    func paneVisibleText(socketPath _: String, paneID _: String) async -> String? { nil }
+}
+
+/// `--probe-surface`: the read-only verb that answers "which arm would this
+/// surface join on, and if none, where did it stop?".
+///
+/// The asymmetry these tests defend is different from the join's own. A wrong
+/// join poisons a prompt; a wrong PROBE sends whoever is debugging in the wrong
+/// direction, and the expensive failure is a probe whose silence about the
+/// permission it lacks reads as "the surface is fine". So every refusal the
+/// probe makes before the resolver runs has to arrive as a named cause, and the
+/// causes the resolver itself produces have to reach the output unchanged.
+@MainActor
+final class ClaudeSurfaceProbeTests: XCTestCase {
+    private let epoch = Date(timeIntervalSince1970: 2_000_000)
+    private let local = ClaudeTransportOrigin.localAuthenticated(peerUID: 501)
+    private let ghostty = TerminalScreenTarget(
+        pid: 4242,
+        bundleID: TerminalScreenAllowlist.ghosttyBundleID
+    )
+
+    // MARK: - Fixtures
+
+    private func record(
+        session: String = "s1",
+        claudePID: Int32? = 9001,
+        tty: String? = nil,
+        herdrPaneID: String? = nil,
+        herdrSocketPath: String? = nil
+    ) -> ClaudeHookRecord {
+        ClaudeHookRecord(
+            event: .sessionStart,
+            sessionID: session,
+            timestamp: 0,
+            rawCwd: "/repo",
+            prompt: nil,
+            files: [],
+            process: claudePID.map {
+                ClaudeHookProcessInfo(
+                    hookPID: 777,
+                    claudePID: $0,
+                    tty: tty,
+                    herdrPaneID: herdrPaneID,
+                    herdrSocketPath: herdrSocketPath
+                )
+            }
+        )
+    }
+
+    /// Every seam injected, always: a registry on the DEFAULT liveness probe
+    /// would run a real `kill(pid, 0)` against whatever holds that pid on the
+    /// host, which is the live-host-state flake class this repo pins seams for.
+    private func makeRegistry(markers: [String] = ["lvx-abcd"]) -> ClaudeSessionRegistry {
+        ClaudeSessionRegistry(
+            limits: .default,
+            now: ProbeTestClock(epoch).now,
+            isProcessAlive: ProbeTestLiveness().probe,
+            allocateMarkerValue: ProbeTestMarkers(markers).allocate
+        )
+    }
+
+    private func resolver(
+        registry: ClaudeSessionRegistry,
+        focusedTTY: String? = nil,
+        herdrClient: Bool = false,
+        herdrPanes: HerdrPaneQuerying? = nil
+    ) -> ClaudeSessionJoinResolver {
+        ClaudeSessionJoinResolver(
+            registry: registry,
+            markerInWindowTitle: { _ in nil },
+            focusedTerminalTTY: { _ in focusedTTY },
+            focusedWindowID: { _ in 101 },
+            herdrClientProbe: { _ in herdrClient },
+            herdrPanes: herdrPanes
+        )
+    }
+
+    // MARK: - Argument parsing
+
+    func testVerbIsOnlyRecognizedWhenAskedFor() {
+        XCTAssertEqual(
+            ClaudeSurfaceProbe.invocation(arguments: ["/usr/bin/localvoxtral"]),
+            .notRequested,
+            "a normal launch must reach the app, not the probe"
+        )
+        XCTAssertEqual(
+            ClaudeSurfaceProbe.invocation(arguments: ["localvoxtral", "--probe-surface"]),
+            .run(ClaudeSurfaceProbe.Options(json: false))
+        )
+        XCTAssertEqual(
+            ClaudeSurfaceProbe.invocation(arguments: ["localvoxtral", "--probe-surface", "--json"]),
+            .run(ClaudeSurfaceProbe.Options(json: true))
+        )
+        XCTAssertEqual(
+            ClaudeSurfaceProbe.invocation(arguments: ["localvoxtral", "--json", "--probe-surface"]),
+            .run(ClaudeSurfaceProbe.Options(json: true)),
+            "flag order is not part of the contract"
+        )
+    }
+
+    func testUnrecognizedOptionIsAUsageErrorRatherThanASilentDefault() {
+        // A typo that fell through to a default would print a normal-looking
+        // summary for something the caller did not ask for.
+        guard case .usageError(let message) = ClaudeSurfaceProbe.invocation(
+            arguments: ["localvoxtral", "--probe-surface", "--jsonn"]
+        ) else {
+            return XCTFail("an unknown option must not resolve to a runnable invocation")
+        }
+        XCTAssertTrue(message.contains("--jsonn"), "the message must name what it rejected")
+    }
+
+    func testArgumentZeroIsNeverParsedAsAnOption() {
+        // An executable installed at a path that happens to contain the verb
+        // must not turn every launch into a probe.
+        XCTAssertEqual(
+            ClaudeSurfaceProbe.invocation(arguments: ["/opt/--json/localvoxtral"]),
+            .notRequested
+        )
+    }
+
+    // MARK: - Refusals before the resolver runs
+
+    func testMissingAccessibilityGrantIsANamedReasonAndSkipsTheResolve() async {
+        let resolved = Mutex(false)
+        let summary = await ClaudeSurfaceProbe.summarize(
+            accessibilityTrusted: false,
+            frontmostTarget: ghostty,
+            hasLiveSessions: { true },
+            resolve: { _ in
+                resolved.withLock { $0 = true }
+                return nil
+            }
+        )
+        XCTAssertEqual(summary.arm, "none")
+        XCTAssertEqual(
+            summary.abstentionReason,
+            ClaudeSurfaceProbe.ProbeAbstention.accessibilityNotGranted.rawValue
+        )
+        XCTAssertFalse(
+            resolved.withLock { $0 },
+            "without the grant the resolve would spend Apple events to reach abstentions that "
+                + "all misattribute the missing permission to the arms"
+        )
+    }
+
+    func testNoFrontmostApplicationIsANamedReason() async {
+        let summary = await ClaudeSurfaceProbe.summarize(
+            accessibilityTrusted: true,
+            frontmostTarget: nil,
+            hasLiveSessions: { true },
+            resolve: { _ in XCTFail("nothing to resolve"); return nil }
+        )
+        XCTAssertEqual(summary.arm, "none")
+        XCTAssertEqual(
+            summary.abstentionReason,
+            ClaudeSurfaceProbe.ProbeAbstention.noFrontmostApplication.rawValue
+        )
+    }
+
+    func testUnsupportedFrontmostAppIsNamedRatherThanSilent() async {
+        // VS Code is terminal-like for insertion and explicitly excluded from
+        // joins. The resolver returns nil for it without noting a cause, and a
+        // bare `arm: none` with no reason is the least useful diagnostic there
+        // is — so the probe names it itself.
+        let summary = await ClaudeSurfaceProbe.summarize(
+            accessibilityTrusted: true,
+            frontmostTarget: TerminalScreenTarget(pid: 900, bundleID: "com.microsoft.VSCode"),
+            hasLiveSessions: { true },
+            resolve: { _ in XCTFail("an unlisted bundle must not reach the resolver"); return nil }
+        )
+        XCTAssertEqual(summary.arm, "none")
+        XCTAssertEqual(
+            summary.abstentionReason,
+            ClaudeSurfaceProbe.ProbeAbstention.unsupportedSurface.rawValue
+        )
+    }
+
+    // MARK: - The resolver's own vocabulary reaches the output
+
+    func testEmptyRegistryIsFramedBeforeTheArmsThatFailBecauseOfIt() async {
+        // A one-shot process holds no hook records, so every arm declines for
+        // the same reason. Noted FIRST so the chain cannot be misread as the
+        // surface having failed.
+        let registry = makeRegistry()
+        let joinResolver = resolver(registry: registry, focusedTTY: "/dev/ttys003")
+        let summary = await ClaudeSurfaceProbe.summarize(
+            accessibilityTrusted: true,
+            frontmostTarget: ghostty,
+            hasLiveSessions: { registry.hasLiveSessions() },
+            resolve: { await joinResolver.resolve(target: $0) }
+        )
+        XCTAssertEqual(summary.arm, "none")
+        let reason = summary.abstentionReason ?? ""
+        XCTAssertTrue(
+            reason.hasPrefix(ClaudeSurfaceProbe.ProbeAbstention.noLiveSessions.rawValue),
+            "expected the empty-registry frame first, got \(reason)"
+        )
+        XCTAssertTrue(
+            reason.contains("tty: no live session on this device"),
+            "the tty arm's own cause must survive verbatim, not be re-worded by the probe: \(reason)"
+        )
+    }
+
+    func testAbstentionCausesAreOrderedOldestFirstAcrossArms() async {
+        // One session on another device: the tty arm declines, the remote-herdr
+        // arm finds nothing it can read, then the marker arm declines. All
+        // three, in that order — the ORDER is what tells a reader how far the
+        // resolve got, and a set would not.
+        //
+        // The middle cause comes from this resolver's un-injected ssh seam,
+        // which is the same `.undeterminable(.probeUnavailable)` a shipped
+        // build reports when it cannot inspect the surface's process table.
+        let registry = makeRegistry()
+        XCTAssertNotNil(registry.ingest(record(tty: "/dev/ttys009"), origin: local))
+        let joinResolver = resolver(registry: registry, focusedTTY: "/dev/ttys003")
+        let summary = await ClaudeSurfaceProbe.summarize(
+            accessibilityTrusted: true,
+            frontmostTarget: ghostty,
+            hasLiveSessions: { registry.hasLiveSessions() },
+            resolve: { await joinResolver.resolve(target: $0) }
+        )
+        XCTAssertEqual(
+            summary.abstentionReason,
+            "tty: no live session on this device"
+                + "; remote-herdr: ssh session undeterminable (probe unavailable)"
+                + "; marker: no marker in title"
+        )
+    }
+
+    func testATTYJoinReportsEveryFieldTheSummaryPromises() async {
+        let registry = makeRegistry()
+        XCTAssertNotNil(registry.ingest(record(tty: "/dev/ttys003"), origin: local))
+        let joinResolver = resolver(registry: registry, focusedTTY: "/dev/ttys003")
+        let summary = await ClaudeSurfaceProbe.summarize(
+            accessibilityTrusted: true,
+            frontmostTarget: ghostty,
+            hasLiveSessions: { registry.hasLiveSessions() },
+            resolve: { await joinResolver.resolve(target: $0) }
+        )
+        XCTAssertEqual(summary.arm, "tty")
+        XCTAssertNil(summary.abstentionReason, "no arm declined on the way to this answer")
+        XCTAssertEqual(summary.origin, "local")
+        XCTAssertEqual(
+            summary.terminal, "Ghostty",
+            "the four supported terminals are named the same way on every machine"
+        )
+        XCTAssertEqual(
+            summary.herdrBound, false,
+            "a tty join is not a herdr binding, and the output must not imply one"
+        )
+        XCTAssertEqual(summary.workspaceIsLocal, true)
+        XCTAssertEqual(ClaudeSurfaceProbe.exitCode(for: summary), 0)
+    }
+
+    func testAHerdrJoinReportsHerdrBound() async {
+        let registry = makeRegistry()
+        XCTAssertNotNil(
+            registry.ingest(
+                record(
+                    tty: "/dev/ttys-inner",
+                    herdrPaneID: "pane-a",
+                    herdrSocketPath: "/tmp/herdr-a.sock"
+                ),
+                origin: local
+            )
+        )
+        let joinResolver = resolver(
+            registry: registry,
+            focusedTTY: "/dev/ttys-outer",
+            herdrClient: true,
+            herdrPanes: ProbeTestHerdrPanes(
+                focused: HerdrFocusedPane(paneID: "pane-a", claimedClaudeSessionID: "s1"),
+                foreground: HerdrPaneForegroundInfo(shellPID: 8000, foregroundPIDs: [9001])
+            )
+        )
+        let summary = await ClaudeSurfaceProbe.summarize(
+            accessibilityTrusted: true,
+            frontmostTarget: ghostty,
+            hasLiveSessions: { registry.hasLiveSessions() },
+            resolve: { await joinResolver.resolve(target: $0) }
+        )
+        XCTAssertEqual(summary.arm, "herdrPane")
+        XCTAssertEqual(summary.herdrBound, true)
+        XCTAssertEqual(summary.terminal, "Ghostty")
+    }
+
+    func testExitStatusSplitsJoinedFromNotJoined() {
+        XCTAssertEqual(
+            ClaudeSurfaceProbe.exitCode(
+                for: ClaudeSessionJoinSummary(arm: "none", abstentionReason: nil)
+            ),
+            1
+        )
+        XCTAssertEqual(
+            ClaudeSurfaceProbe.exitCode(
+                for: ClaudeSessionJoinSummary(arm: "tty", abstentionReason: nil)
+            ),
+            0
+        )
+    }
+
+    // MARK: - The tap
+
+    func testTheAbstentionTapIsInertOutsideACollection() async {
+        // The tap is compiled into shipping builds. A note that accumulated
+        // while nobody was collecting would be an unbounded buffer in a process
+        // that runs for weeks — and would leak one probe's causes into the next.
+        ClaudeJoinAbstentionTap.note("stray: before")
+        let (_, causes) = await ClaudeJoinAbstentionTap.collecting {
+            ClaudeJoinAbstentionTap.note("inside: one")
+        }
+        XCTAssertEqual(causes, ["inside: one"])
+
+        ClaudeJoinAbstentionTap.note("stray: after")
+        let (_, second) = await ClaudeJoinAbstentionTap.collecting {}
+        XCTAssertEqual(second, [], "a collection must start empty, whatever ran before it")
+    }
+}
+
+/// The JSON shape is the contract every future assertion is written against, so
+/// it is asserted literally rather than by round-tripping through a decoder
+/// that would forgive a dropped key.
+@MainActor
+final class ClaudeSessionJoinSummaryJSONTests: XCTestCase {
+    func testAbstainedSummaryEmitsEveryKeyWithExplicitNulls() {
+        let summary = ClaudeSessionJoinSummary.summarize(
+            join: nil, abstentions: ["tty: stale"]
+        )
+        XCTAssertEqual(
+            summary.jsonLine,
+            #"{"arm":"none","abstentionReason":"tty: stale","origin":null,"terminal":null,"#
+                + #""herdrBound":null,"workspaceIsLocal":null}"#
+        )
+    }
+
+    func testFullSummaryEmitsBoolsUnquotedAndKeysInTheDocumentedOrder() {
+        let summary = ClaudeSessionJoinSummary(
+            arm: "remoteHerdrPane",
+            abstentionReason: nil,
+            origin: "remote",
+            terminal: "Ghostty",
+            herdrBound: true,
+            workspaceIsLocal: false
+        )
+        let expected = #"{"arm":"remoteHerdrPane","abstentionReason":null,"#
+            + #""origin":"remote","terminal":"Ghostty","#
+            + #""herdrBound":true,"workspaceIsLocal":false}"#
+        XCTAssertEqual(summary.jsonLine, expected)
+    }
+
+    func testACauseCarryingQuotesCannotEmitBrokenJSON() throws {
+        let summary = ClaudeSessionJoinSummary.summarize(
+            join: nil, abstentions: [#"tty: "odd" \ cause"#]
+        )
+        let data = Data(summary.jsonLine.utf8)
+        let object = try XCTUnwrap(
+            try JSONSerialization.jsonObject(with: data) as? [String: Any]
+        )
+        XCTAssertEqual(object["abstentionReason"] as? String, #"tty: "odd" \ cause"#)
+        XCTAssertTrue(object["origin"] is NSNull, "null must survive as null, not vanish")
+        XCTAssertEqual(object.keys.count, 6)
+    }
+
+    func testEveryMechanismHasItsOwnArmName() {
+        // Two arms sharing a name would make a probe run and a dogfood record
+        // agree on a lie.
+        let mechanisms: [ClaudeSessionJoinMechanism] = [
+            .ttyDevice, .titleMarker, .herdrPane, .browserTab, .cmuxSurface, .remoteHerdrPane,
+        ]
+        let names = mechanisms.map(ClaudeSessionJoinSummary.armName)
+        XCTAssertEqual(
+            names, ["tty", "titleMarker", "herdrPane", "browserTab", "cmuxSurface",
+                    "remoteHerdrPane"]
+        )
+        XCTAssertFalse(names.contains("none"), "`none` means no arm answered at all")
+        XCTAssertEqual(Set(names).count, names.count)
+    }
+
+    func testTerminalNamesCoverExactlyTheJoinableTerminals() {
+        XCTAssertEqual(
+            TerminalScreenAllowlist.displayName(forBundleID: TerminalScreenAllowlist.ghosttyBundleID),
+            "Ghostty"
+        )
+        XCTAssertEqual(
+            TerminalScreenAllowlist.displayName(forBundleID: TerminalScreenAllowlist.iterm2BundleID),
+            "iTerm2"
+        )
+        XCTAssertEqual(
+            TerminalScreenAllowlist.displayName(
+                forBundleID: TerminalScreenAllowlist.appleTerminalBundleID
+            ),
+            "Terminal.app"
+        )
+        XCTAssertEqual(
+            TerminalScreenAllowlist.displayName(forBundleID: TerminalScreenAllowlist.cmuxBundleID),
+            "cmux"
+        )
+        for bundleID in TerminalScreenAllowlist.supportedBundleIDs {
+            XCTAssertNotNil(
+                TerminalScreenAllowlist.displayName(forBundleID: bundleID),
+                "a joinable terminal with no name would report `terminal: null` on a real join"
+            )
+        }
+        XCTAssertNil(TerminalScreenAllowlist.displayName(forBundleID: "com.microsoft.VSCode"))
+        XCTAssertNil(TerminalScreenAllowlist.displayName(forBundleID: nil))
+    }
+}

--- a/Tests/localvoxtralTests/DogfoodCaptureWiringTests.swift
+++ b/Tests/localvoxtralTests/DogfoodCaptureWiringTests.swift
@@ -520,7 +520,12 @@ final class DogfoodCaptureWiringTests: XCTestCase {
             abstentions: []
         )
         XCTAssertEqual(cmuxJoin.arm, "cmuxSurface")
-        XCTAssertEqual(cmuxJoin.terminal, TerminalScreenAllowlist.cmuxBundleID)
+        XCTAssertEqual(
+            cmuxJoin.terminal, "cmux",
+            "the record and `--probe-surface` derive this field from one shared summary, so it "
+                + "carries the terminal's NAME (as this type has always documented) rather than "
+                + "its bundle id"
+        )
         XCTAssertEqual(cmuxJoin.origin, "local")
         XCTAssertEqual(
             cmuxJoin.herdrBound, false,

--- a/docs/agent/field-debugging.md
+++ b/docs/agent/field-debugging.md
@@ -46,6 +46,53 @@ Learned the hard way (2026-07-04) — use these instead of manual steps:
   `scripts/mac-diag.sh` on the Mac, Export Diagnostics… in Settings > About,
   and (once the v2 gate is installed — owner runbook: `scripts/mac/README.md`)
   `./scripts/remote-build.sh diag|applog|voxlog|svc-status|disk|gc`.
+- **"Why won't this terminal join a Claude session?"** — `--probe-surface`
+  resolves the join for the frontmost surface once, prints it, and exits
+  without a menu bar item or any other UI:
+
+  ```
+  /Applications/localvoxtral.app/Contents/MacOS/localvoxtral --probe-surface
+  /Applications/localvoxtral.app/Contents/MacOS/localvoxtral --probe-surface --json
+  ```
+
+  Run it **from the terminal you would dictate into**: that terminal is the
+  frontmost application, so it is the surface being probed. Run the binary
+  **inside the .app bundle**, not a `.build/debug` copy: TCC keys grants to a
+  code signature, so an unsigned loose build can only ever report
+  `probe: accessibility permission not granted`. UNVERIFIED as of this writing
+  (2026-08-28), and worth confirming on the first real run: whether a bundled
+  binary started from a shell is attributed to the app's own identity or to the
+  terminal as its responsible process. If it is the latter, the first probe
+  raises consent prompts naming the terminal, and a refused Accessibility grant
+  shows up as that same named reason rather than as anything about the surface.
+
+  `--json` prints one line: `arm`, `abstentionReason`, `origin`, `terminal`,
+  `herdrBound`, `workspaceIsLocal` — the same six fields, from the same
+  mapper, as a dogfood record's `join` block
+  (`ClaudeSessionJoinSummary`). Exit status is 0 when an arm joined, 1 when
+  none did, 2 on a usage error.
+
+  **`abstentionReason` is the diagnostic**, not `arm`. It is the resolver's own
+  cause chain, oldest arm first — `tty: no live session on this device;
+  remote-herdr: ssh session undeterminable (unreadableArguments); marker: no
+  marker in title` says the tty read worked and the ssh probe could not read
+  the client's arguments, which is a completely different bug from an empty
+  chain (the surface was never identified at all). This is the signal that was
+  missing when a Ghostty ssh wrapper made every remote probe report
+  `undeterminable` (2026-08-03).
+
+  Two limits to read the output with. **The registry is per-process**: live
+  session records live in the running app, built from hook traffic its broker
+  received, so a separate one-shot process starts with none and says so first
+  (`probe: no live Claude sessions in this process`) — the arms then decline
+  for that reason, and what you are reading is how far each one got on the
+  SURFACE side. **The remote-herdr arm is read-only here by construction**: the
+  forward and panel-metadata capabilities are passed as `nil`, so the probe
+  cannot open an `ssh -L` that outlives it or leave an `lv-mic-…` stamp in an
+  agents panel, and there is no flag that turns them on. It reaches
+  `forward capability unavailable` and stops. Same reasoning withholds the cmux
+  arm (Keychain prompt), the browser arm (reads the address bar), and every
+  screen read.
 - **README demo video**: `./scripts/record-demo.sh` on the Mac (GUI session)
   stages the scene, drives the real Right-Command tap/hold gesture with
   synthetic CGEvents, records, and encodes `dist/demo/demo.mp4`; the operator

--- a/docs/agent/invariants.md
+++ b/docs/agent/invariants.md
@@ -451,6 +451,32 @@ there is not.
     capture (that grid is the composite herdr TUI, on someone else's machine),
     and never local repo collection — the origin is remote, so
     `localWorkspacePath` is nil by type.
+  - **The `--probe-surface` diagnostic verb runs the real resolver, so its
+    read-only-ness is enforced by what it is HANDED, not by what it chooses to
+    do.** A one-shot process is the worst possible owner for the two arms that
+    write anything: an `ssh -L` it opens has no supervisor and no idle window,
+    and a `pane.report_metadata` `lv-mic-…` stamp it leaves behind has nobody
+    left to clear it if the process is killed between stamping and clearing. So
+    `ClaudeSurfaceProbeCommand` passes `remoteHerdrForwards` and
+    `herdrPanelMetadata` as `nil` — the resolver's own documented "this arm can
+    never spawn anything" configuration — and the arm reaches `forward
+    capability unavailable` and stops. There is no flag that re-enables them,
+    which is the point: an opt-in would be a cleanup obligation, and this is the
+    absence of the capability. The arm's read-only halves (the process-table
+    ssh probe, enrolled-host matching including `ssh -G`, which resolves config
+    and opens no connection) DO run, because they are what the field questions
+    are about. Withheld for their own reasons and by the same construction:
+    `cmuxSurfaces`/`cmuxJoinEnabled` (the arm reads a Keychain password — a
+    diagnostic must not raise that prompt), `focusedBrowserTabURL` (a tab URL
+    is a page the user is looking at), and `readFocusedGrid` (screen text; only
+    the panel-nonce match ever needed it, and that match cannot happen here).
+    What the verb PRINTS is bounded by `ClaudeSessionJoinSummary`, the single
+    mapper the dogfood record also uses: an arm name, the resolver's own
+    content-free abstention categories, an origin CLASS, a terminal NAME, and
+    two Bools — never a marker, session id, pane id, socket path, host, nonce,
+    or workspace path. The registry is per-process and therefore empty in that
+    process; the verb says so as its first cause rather than letting the arms'
+    resulting declines read as a surface failure.
   - Screen capture is split by ROUTE (`TerminalScreenAllowlist`): raw AX grid
     capture remains Ghostty-only (its single-`AXTextArea` grid is verified;
     iTerm2's AX tree is ambiguous across splits, Terminal.app's unverified).

--- a/docs/dogfood-builds.md
+++ b/docs/dogfood-builds.md
@@ -71,7 +71,11 @@ High level ([`DogfoodCaptureRecord.swift`](../Sources/localvoxtral/Dogfood/Dogfo
 - **Session**: target app kind, output mode, prompt profile, endpoint
   *class* only (`loopback`/`lan`/`remote` — never the URL).
 - **Join**: which arm resolved the Claude Code session (`tty` / `herdrPane` /
-  `titleMarker` / `none`) and every abstention reason along the way.
+  `remoteHerdrPane` / `cmuxSurface` / `browserTab` / `titleMarker` / `none`)
+  and every abstention reason along the way. Same six fields, from the same
+  mapper, that `localvoxtral --probe-surface` prints for the frontmost surface
+  — so a probe run and a record can be compared directly
+  (`docs/agent/field-debugging.md`).
 - **Screen**: capture route, the render / vocabulary-only / drop decision and
   its cause, and the sanitized screen text (capped, truncation recorded).
 - **Budget**: per source, characters demanded vs granted vs rendered.


### PR DESCRIPTION
## What

Adds `localvoxtral --probe-surface [--json]`: run the Claude Code session-join
resolver once against the frontmost surface, print the outcome, exit. No menu
bar item, no Settings scene, no `NSApplication` run loop.

The join is otherwise unobservable. In the field the only symptom of a join
that will not resolve is context that never arrives, and every abstention is
reduced to a `Log.claudeContext` line that does not say which of a dozen causes
fired — the gap that made the Ghostty ssh-wrapper case (2026-08-03, the tty
probe reporting `undeterminable` because the wrapper hid the client) take a
remote-probing session to attribute.

Output is one line of JSON, keys in a fixed order, nulls always present:

```json
{"arm":"tty","abstentionReason":null,"origin":"local","terminal":"Ghostty","herdrBound":false,"workspaceIsLocal":true}
```

`arm` is the resolver's own mechanism vocabulary (`tty`, `titleMarker`,
`herdrPane`, `browserTab`, `cmuxSurface`, `remoteHerdrPane`, `none`).
`abstentionReason` is the resolver's own content-free cause chain, oldest arm
first, joined by `; `. Exit status: 0 an arm joined, 1 none did, 2 usage error.

### One mapper, two consumers

`ClaudeSessionJoinSummary` is now the single place a `ClaudeSessionJoin` becomes
reportable, and `DogfoodCaptureBuilder.join` is a field copy of it. A probe run
and a dogfood record can be compared directly, and an arm renamed on one side
cannot silently disagree with the other.

Two follow-on changes fall out of sharing it:

* **`terminal` now carries the terminal's NAME** (`Ghostty`, `iTerm2`,
  `Terminal.app`, `cmux`) rather than its bundle id, via a new closed
  `TerminalScreenAllowlist.displayName(forBundleID:)`. This is what
  `DogfoodCaptureRecord.Join.terminal` has always documented ("Terminal the
  surface belonged to (Ghostty, iTerm2, Terminal.app, cmux)") and what the
  implementation did not do. No `schemaVersion` bump: the field's MEANING is
  unchanged, and nothing reads it — the reviewer and corpus converter never
  touch it. `DogfoodCaptureWiringTests` is updated to the name, with the reason
  in the assertion message.
* **Abstention causes are now observable in a shipping build.** They were noted
  only behind `#if LOCALVOXTRAL_DOGFOOD`, and a diagnostic that requires a
  special binary cannot diagnose the binary the user is running.
  `ClaudeJoinAbstentionTap` is disarmed by default (one uncontended lock, no
  accumulation) and scoped: `collecting(_:)` arms, runs, and disarms, so a
  collection cannot outlive the call that wanted it. The dogfood tap is
  untouched and still fires alongside it.

### Read-only decision for the remote arm: no capability, not an opt-in

The task allowed remote probing behind an explicit flag with guaranteed
cleanup. I took the stronger option: **there is no flag, because there is no
capability.** `ClaudeSurfaceProbeCommand` passes `remoteHerdrForwards` and
`herdrPanelMetadata` as `nil` — the resolver's own documented "this arm can
never spawn anything" configuration — so the probe cannot open an `ssh -L` that
outlives it and cannot leave an `lv-mic-…` `pane.report_metadata` stamp behind.
The arm reaches `forward capability unavailable` and stops.

A one-shot process is the worst possible owner for either: no supervisor, no
idle window, and nothing left to clear a stamp if it is killed between stamping
and clearing. An opt-in flag would be a cleanup obligation; absence of the
capability is not.

The arm's **read-only halves do run**, because they are what the field questions
are about: the process-table ssh probe and enrolled-host matching (including the
`ssh -G` canonicalization, which resolves config and opens no connection). So
`remote-herdr: ssh session undeterminable (unreadableArguments)` — the exact
2026-08-03 symptom — is reportable.

Withheld by the same construction, each for its own reason: `cmuxSurfaces` /
`cmuxJoinEnabled` (the arm reads a Keychain password; a diagnostic must not
raise that prompt), `focusedBrowserTabURL` (a tab URL is a page the user is
looking at), `readFocusedGrid` (screen text — only the panel-nonce match ever
needed it, and that match cannot happen here). The probe reads no screen
content at all, and `AXIsProcessTrusted()` is used rather than
`AXIsProcessTrustedWithOptions` so it reports the permission state instead of
changing it.

Nothing printed can leak: `ClaudeSessionJoinSummary` carries an arm name, the
resolver's content-free categories, an origin CLASS, a terminal NAME, and two
Bools — never a marker, session id, pane id, socket path, host, nonce, or
workspace path.

### Known limit, stated in the code and the docs

The session registry is per-process: it is built from hook records the running
app's broker received, so a separate one-shot process starts with none. The
probe says so as its FIRST cause (`probe: no live Claude sessions in this
process`) rather than letting the arms' resulting declines read as a surface
failure — the diagnostic value on the owner's Mac is in the chain (how far each
arm got on the SURFACE side), not in `arm`. Getting truthful arms from a live
app would mean a broker-side query verb, which is a new IPC capability and an
owner call, not something to slip into a debug verb. Noted as a follow-up.

Entry point: `localvoxtralApp` loses `@main`; `Sources/localvoxtral/main.swift`
dispatches. Without the verb it does exactly what `@main` did.

## Proof

- [x] Unit suite green — `./scripts/remote-build.sh`

```
Test Suite 'localvoxtralPackageTests.xctest' passed at 2026-08-28 00:47:04.586.
	 Executed 2741 tests, with 2 tests skipped and 0 failures (0 unexpected) in 107.492 (107.646) seconds
```

- [x] New tests

`./scripts/remote-build.sh test --filter ClaudeSurfaceProbeTests`

```
Test Suite 'ClaudeSurfaceProbeTests' passed at 2026-08-28 00:48:31.212.
	 Executed 12 tests, with 0 failures (0 unexpected) in 0.006 (0.007) seconds
```

`./scripts/remote-build.sh test --filter ClaudeSessionJoinSummaryJSONTests`

```
Test Suite 'ClaudeSessionJoinSummaryJSONTests' passed
	 Executed 5 tests, with 0 failures (0 unexpected) in 0.002 (0.002) seconds
```

Names: `testVerbIsOnlyRecognizedWhenAskedFor`,
`testUnrecognizedOptionIsAUsageErrorRatherThanASilentDefault`,
`testArgumentZeroIsNeverParsedAsAnOption`,
`testMissingAccessibilityGrantIsANamedReasonAndSkipsTheResolve`,
`testNoFrontmostApplicationIsANamedReason`,
`testUnsupportedFrontmostAppIsNamedRatherThanSilent`,
`testEmptyRegistryIsFramedBeforeTheArmsThatFailBecauseOfIt`,
`testAbstentionCausesAreOrderedOldestFirstAcrossArms`,
`testATTYJoinReportsEveryFieldTheSummaryPromises`,
`testAHerdrJoinReportsHerdrBound`, `testExitStatusSplitsJoinedFromNotJoined`,
`testTheAbstentionTapIsInertOutsideACollection`;
`testAbstainedSummaryEmitsEveryKeyWithExplicitNulls`,
`testFullSummaryEmitsBoolsUnquotedAndKeysInTheDocumentedOrder`,
`testACauseCarryingQuotesCannotEmitBrokenJSON`,
`testEveryMechanismHasItsOwnArmName`,
`testTerminalNamesCoverExactlyTheJoinableTerminals`.

- [x] Red → green on the core new behavior

The core behavior is that the resolver's abstention causes reach a shipping
build. RED — `ClaudeJoinAbstentionTap.note(cause)` removed from
`ClaudeSessionJoinResolver.noteAbstention`, i.e. exactly the pre-change tree
where causes were noted only under `LOCALVOXTRAL_DOGFOOD`:

```
Tests/localvoxtralTests/ClaudeSurfaceProbeTests.swift:260: error: -[localvoxtralTests.ClaudeSurfaceProbeTests testAbstentionCausesAreOrderedOldestFirstAcrossArms] : XCTAssertEqual failed: ("nil") is not equal to ("Optional("tty: no live session on this device; remote-herdr: ssh session undeterminable (probe unavailable); marker: no marker in title")")
Tests/localvoxtralTests/ClaudeSurfaceProbeTests.swift:236: error: -[localvoxtralTests.ClaudeSurfaceProbeTests testEmptyRegistryIsFramedBeforeTheArmsThatFailBecauseOfIt] : XCTAssertTrue failed - the tty arm's own cause must survive verbatim, not be re-worded by the probe: probe: no live Claude sessions in this process
	 Executed 12 tests, with 2 failures (0 unexpected) in 0.199 (0.200) seconds
```

GREEN — line restored, nothing else changed:

```
Test Suite 'ClaudeSurfaceProbeTests' passed at 2026-08-28 00:48:31.212.
	 Executed 12 tests, with 0 failures (0 unexpected) in 0.006 (0.007) seconds
```

- [x] Dogfood lane green (this PR changes `DogfoodCapturePipeline` and its test)
  — `./scripts/remote-build.sh dogfood`

```
Test Suite 'localvoxtralPackageTests.xctest' passed at 2026-08-28 00:47:39.911.
	 Executed 64 tests, with 0 failures (0 unexpected) in 0.159 (0.162) seconds
```

- [x] Packaging green after the entry-point change —
  `./scripts/remote-build.sh package` (the `@main` → `main.swift` move is
  exactly the #87 class of risk, so the bundle is built here rather than left
  to CI alone). CI's launch smoke is the binding check.

```
Packaged app: .../dist/localvoxtral.app
Contents/MacOS:
  localvoxtral
  localvoxtral-claude-hook
  localvoxtral-polishd
  localvoxtral-speechd
```


### Verified by hand vs. unit-covered only

**Not verified by hand at all, and that is a gap the owner should close on the
first run.** The Mac build host's SSH gate allows only `build`/`test`/`package`
verbs, so I could not execute the produced binary. Nobody has yet run
`--probe-surface` against a live surface.

Unit-covered: every decision — argument parsing, all three pre-resolve refusals,
the empty-registry framing, cause ordering across arms, a real `tty` join and a
real `herdrPane` join through the real resolver with injected seams, the exact
JSON bytes, and the tap's inertness outside a collection.

Untested by construction: `ClaudeSurfaceProbeCommand` — the live wiring, the
run-loop pump, and the 25 s deadline. What it decides lives in
`ClaudeSurfaceProbe.summarize` behind seams; what remains is which capabilities
are handed to the resolver and which are withheld, which is a diff to read.

One thing the first run should settle, flagged as UNVERIFIED in
`docs/agent/field-debugging.md`: whether a bundled binary started from a shell
is attributed by TCC to the app's own identity or to the terminal as its
responsible process. If it is the terminal, the first probe raises consent
prompts naming the terminal.

### CI note

The first `build-test` run failed in the tier-1 live STT integration
(`testVLLMProcessesSpokenSyntheticAudio_meetsExpectedAccuracy`, `Exceeded
timeout of 60 seconds ... "final transcript"`) while a local
`remote-build.sh package` was saturating the same Mac with two xcodebuild MLX
helper builds. Nothing in this PR touches the realtime path. Reran on a quiet
host: green in 7m46s.

## Docs

- `docs/agent/field-debugging.md` — how to run it, why to run it from the
  terminal you would dictate into, why to use the bundled binary, that
  `abstentionReason` (not `arm`) is the diagnostic, and both limits.
- `docs/agent/invariants.md` — the read-only-by-construction argument, next to
  the join-arm trust boundaries it depends on.
- `docs/dogfood-builds.md` — the record's `join` block now names every arm and
  points at the shared summary.
