### PR TITLE
UI gate: a second forced-command SSH gate with semantic, app-scoped UI verbs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -161,8 +161,9 @@ jobs:
         run: ./scripts/ci/cleanup-stale-test-processes.sh "$GITHUB_WORKSPACE"
 
       - name: Process-cleanup regression tests
-        # Pure shell tests for the workspace selector and the SSH build gate's
-        # TERM -> KILL process-group teardown. Runs on hosted fork PRs too.
+        # Pure shell tests for the workspace selector, the SSH build gate's
+        # TERM -> KILL process-group teardown, and the SSH UI gate's allowlist /
+        # lock refusal / window-ownership rules. Runs on hosted fork PRs too.
         # Deliberately NOT gated on the docs-only fast path: the gate script is
         # fast-path-eligible, so these seconds-cheap tests are what still
         # exercises a gate-only diff.
@@ -175,6 +176,7 @@ jobs:
           ./scripts/ci/test-remote-build-gc.sh
           ./scripts/ci/test-run-supervised-command.sh
           ./scripts/ci/test-ui-smoke-guard.sh
+          ./scripts/ci/test-ui-gate.sh
           ./scripts/ci/test-runner-node-resign.sh
           ./scripts/ci/test-ac-power-guard.sh
           ./scripts/ci/test-llm-lane-filter.sh
@@ -189,8 +191,9 @@ jobs:
         run: ./scripts/ci/cleanup-stale-test-processes.sh "$GITHUB_WORKSPACE"
 
       - name: Process-cleanup regression tests
-        # Pure shell tests for the workspace selector and the SSH build gate's
-        # TERM -> KILL process-group teardown. Runs on hosted fork PRs too.
+        # Pure shell tests for the workspace selector, the SSH build gate's
+        # TERM -> KILL process-group teardown, and the SSH UI gate's allowlist /
+        # lock refusal / window-ownership rules. Runs on hosted fork PRs too.
         # Deliberately NOT gated on the docs-only fast path: the gate script is
         # fast-path-eligible, so these seconds-cheap tests are what still
         # exercises a gate-only diff.
@@ -202,6 +205,7 @@ jobs:
           ./scripts/ci/test-remote-build-reap.sh
           ./scripts/ci/test-remote-build-gc.sh
           ./scripts/ci/test-run-supervised-command.sh
+          ./scripts/ci/test-ui-gate.sh
           ./scripts/ci/test-runner-node-resign.sh
           ./scripts/ci/test-llm-lane-filter.sh
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -742,6 +742,59 @@ jobs:
           path: dist/localvoxtral-dsym-dogfood.zip
           retention-days: 30
 
+      - name: Install the dogfood build into the UI gate's artifact root
+        # An agent driving the SSH UI gate can BUILD but cannot INSTALL: there
+        # is no gate verb that runs try-pr.sh and no shell on that account. The
+        # runner closes that gap for free — it is a launchd agent in the
+        # owner's GUI session, so $HOME here IS the GUI account's home (proved
+        # by the workspace path, /Users/tom/actions-runner/...), which is where
+        # the gate's default artifact root lives. Dispatching a build is then
+        # the install, with no hand-copying and no new gate verb.
+        #
+        # workflow_dispatch + dogfood=true ONLY, deliberately narrower than the
+        # dogfood lane itself: the [dogfood-package] marker fires on ordinary
+        # PR pushes, and no PR run should write into the owner's home. The
+        # install destination is what moves here; the gate's roots are
+        # untouched and stay owner-writable only.
+        #
+        # `github.event.inputs.dogfood`, not `inputs.dogfood`: the input is
+        # declared `type: boolean`, and comparing a boolean to the string
+        # 'true' in an expression coerces both to numbers (1 vs NaN) and is
+        # therefore always false — a gate that silently never fires. The event
+        # payload's copy is a string, so it compares as written.
+        if: >-
+          runner.environment == 'self-hosted'
+          && github.event_name == 'workflow_dispatch'
+          && github.event.inputs.dogfood == 'true'
+          && steps.dogfood_lane.outputs.run == 'true'
+        run: |
+          set -uo pipefail
+          # dist/localvoxtral.app is the instrumented bundle at this point (the
+          # dogfood pass overwrote it); install-ui-artifact.sh reads the
+          # LVXDogfoodCapture stamp and picks the dogfood slot accordingly.
+          STATUS=0
+          INSTALLED="$(./scripts/mac/install-ui-artifact.sh dist/localvoxtral.app --no-hint \
+            --label "${GITHUB_REF_NAME} @ ${GITHUB_SHA:0:7} (run ${GITHUB_RUN_ID})")" || STATUS=$?
+          if (( STATUS == 3 )); then
+            # Exit 3 is the one refusal that is not a build problem: that slot
+            # is running, which only the operator can resolve.
+            echo "::warning::UI-gate install skipped — the target bundle is running. Quit it (ssh lv-ui 'quit') and re-dispatch."
+            echo "UI-gate install skipped: the target bundle is running." >>"$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+          if (( STATUS != 0 )); then
+            echo "::error::UI-gate install failed (exit $STATUS)."
+            exit "$STATUS"
+          fi
+          GATE_ARG="${INSTALLED#"$HOME"/}"
+          {
+            echo "### Installed for the UI gate"
+            echo
+            echo '```'
+            echo "ssh lv-ui 'launch --dogfood $GATE_ARG'"
+            echo '```'
+          } >>"$GITHUB_STEP_SUMMARY"
+
       - name: Process leak check (informational)
         # ~15% of runs spend ~105 s in the runner's post-job "Cleaning up
         # orphan processes" phase, and the Worker logs don't name what it

--- a/docs/agent/field-debugging.md
+++ b/docs/agent/field-debugging.md
@@ -18,6 +18,12 @@ Learned the hard way (2026-07-04) — use these instead of manual steps:
   the pid every other gate verb addresses. The gate's roots are owner-writable
   only on purpose, so the install destination moves rather than the roots
   (`scripts/mac/install-ui-artifact.sh`, runbook `scripts/mac/README.md`).
+  An agent driving the gate has no shell on that account: for it, the install
+  is `gh workflow run CI --ref <branch> -f dogfood=true`. The self-hosted
+  runner is a launchd agent in the owner's GUI session, so its `$HOME` is the
+  artifact root's home, and that dispatch (and ONLY a dispatch — the
+  `[dogfood-package]` marker must never write into the owner's home) installs
+  the bundle and prints the `launch` command in the run summary.
 - **Code signing (why TCC used to reset)**: `package_app.sh` signs with
   `$LOCALVOXTRAL_CODESIGN_IDENTITY` when set, else ad-hoc. The owner's Mac
   has a self-signed code-signing cert `localvoxtral-dev`; the identity env

--- a/docs/agent/field-debugging.md
+++ b/docs/agent/field-debugging.md
@@ -12,6 +12,12 @@ Learned the hard way (2026-07-04) — use these instead of manual steps:
   a `workflow_dispatch` with `dogfood=true`); when the target run lacks it,
   the script offers to trigger a dispatch build and shows the latest run
   that has one.
+  `--ui-gate` (composable with `--dogfood`) installs the bundle into the SSH
+  UI gate's artifact root instead of leaving it in `/tmp`, and stops short of
+  launching it — `ssh lv-ui 'launch ...'` is what starts it, and what records
+  the pid every other gate verb addresses. The gate's roots are owner-writable
+  only on purpose, so the install destination moves rather than the roots
+  (`scripts/mac/install-ui-artifact.sh`, runbook `scripts/mac/README.md`).
 - **Code signing (why TCC used to reset)**: `package_app.sh` signs with
   `$LOCALVOXTRAL_CODESIGN_IDENTITY` when set, else ad-hoc. The owner's Mac
   has a self-signed code-signing cert `localvoxtral-dev`; the identity env

--- a/docs/agent/invariants.md
+++ b/docs/agent/invariants.md
@@ -89,6 +89,11 @@ there is not.
     arm works on all three supported terminals), and from that point the join
     is herdr-or-nothing: no
     marker fallback, because a lingering title marker could only mis-join.
+    The same property binds anything OUTSIDE the app that tries to identify a
+    herdr-hosted window by its title: the UI gate's `term open` did exactly
+    that and could never see the window it opened (field failure 2026-08-30),
+    so it now identifies a window by a CGWindowID diff taken before the window
+    exists (`scripts/mac/localvoxtral-ui-gate.sh`).
     The hook publishes `HERDR_PANE_ID`/`HERDR_SOCKET_PATH` from the pane env;
     `HerdrSocketClient` (hand-written and capability-bounded — reads are only
     `pane.current`, `pane.process_info`, and `pane.read`; its sole mutation is

--- a/scripts/ci/screen-lock-state.sh
+++ b/scripts/ci/screen-lock-state.sh
@@ -1,0 +1,132 @@
+#!/usr/bin/env bash
+# screen-lock-state.sh — print the console session's lock state, one word:
+#
+#   locked      a user is on the console and the screen is locked
+#   unlocked    a user is on the console and the screen is not locked
+#   no-session  nobody is logged into the console (or no GUI session at all)
+#   error       the state could not be determined
+#
+# Extracted from ui-smoke-guard.sh so the SSH UI gate
+# (scripts/mac/localvoxtral-ui-gate.sh) and the CI lane share ONE probe.
+# The two callers deliberately apply OPPOSITE policies to `error`, and that
+# asymmetry is the point of keeping the policy out of here:
+#   - ui-smoke-guard fails OPEN (an uncomputable state must never silently
+#     disable a scheduled lane);
+#   - the UI gate fails CLOSED (it drives the owner's personal desktop; an
+#     uncomputable state must never let it act).
+#
+# Two probes, in order:
+#
+# 1. CGSessionCopyCurrentDictionary — correct and cheap, but it only answers
+#    from a process that already belongs to a GUI session. The CI runner is a
+#    LaunchAgent in the console session, so this arm answers there.
+# 2. ioreg IOConsoleUsers — the SAME CGSSessionScreenIsLocked key, read out of
+#    the IORegistry instead of the caller's own session. This arm is what makes
+#    the probe usable from an SSH login (the UI gate's case), where arm 1
+#    returns no-session because the sshd session is not the Aqua session.
+#
+# Arm 2 only runs when arm 1 cannot answer, so the runner's behaviour is
+# unchanged.
+#
+# Test seams (see test-ui-gate.sh):
+#   LV_SCREEN_LOCK_STATE       locked|unlocked|no-session|error — short-circuit
+#   LV_SCREEN_LOCK_SWIFT_CMD   command replacing `swift` for arm 1
+#   LV_SCREEN_LOCK_IOREG_CMD   command replacing `ioreg` for arm 2
+set -euo pipefail
+
+if [[ -n "${LV_SCREEN_LOCK_STATE:-}" ]]; then
+  printf '%s\n' "$LV_SCREEN_LOCK_STATE"
+  exit 0
+fi
+
+swift_probe() {
+  local swift_cmd="${LV_SCREEN_LOCK_SWIFT_CMD:-swift}"
+  command -v "${swift_cmd%% *}" >/dev/null 2>&1 || { echo "error"; return; }
+  # The lock key is only present, with value 1, while the screen is locked.
+  # shellcheck disable=SC2086  # seam is a command line, split on purpose
+  $swift_cmd - <<'SWIFT' 2>/dev/null || echo "error"
+import CoreGraphics
+
+guard let session = CGSessionCopyCurrentDictionary() as? [String: Any] else {
+  print("no-session")
+  exit(0)
+}
+print(session["CGSSessionScreenIsLocked"] != nil ? "locked" : "unlocked")
+SWIFT
+}
+
+# `ioreg -n Root -d1 -a` prints an XML plist whose IOConsoleUsers array holds
+# one dict per console session. Keys of interest, both optional:
+#   kCGSSessionOnConsoleKey    <true/> while that session owns the console
+#   CGSSessionScreenIsLocked   <true/> while its screen is locked
+# The value element follows its <key>, so track the last key seen and inspect
+# the next value. Only sessions currently ON the console count: a
+# fast-user-switched-away session keeps stale lock keys.
+ioreg_probe() {
+  local ioreg_cmd="${LV_SCREEN_LOCK_IOREG_CMD:-ioreg -n Root -d1 -a}"
+  command -v "${ioreg_cmd%% *}" >/dev/null 2>&1 || { echo "error"; return; }
+  local raw
+  # shellcheck disable=SC2086  # seam is a command line, split on purpose
+  raw="$($ioreg_cmd 2>/dev/null)" || raw=""
+  if [[ "$raw" != *IOConsoleUsers* ]]; then
+    echo "error"
+    return
+  fi
+  # Tokenised on `<` rather than parsed line by line: ioreg's XML puts each
+  # element on its own line, but a hand-written or re-serialised plist may pack
+  # several onto one, and a probe that silently reads such a file as
+  # "no-session" would fail OPEN in the CI lane.
+  awk '
+    {
+      n = split($0, parts, "<")
+      for (i = 2; i <= n; i++) {
+        token = "<" parts[i]
+        if (token ~ /^<key>/) {
+          key = substr(token, 6)
+        } else if (token ~ /^<true\/>/ || token ~ /^<false\/>/) {
+          value = (token ~ /^<true\/>/) ? 1 : 0
+          if (key == "kCGSSessionOnConsoleKey") on_console = value
+          else if (key == "CGSSessionScreenIsLocked") locked = value
+          key = ""
+        } else if (token ~ /^<\/dict>/) {
+          # A dict boundary ends one session record: decide it before the next
+          # one overwrites the flags.
+          if (on_console) {
+            found = 1
+            if (locked) any_locked = 1
+          }
+          on_console = 0
+          locked = 0
+          key = ""
+        }
+      }
+    }
+    END {
+      if (!found) print "no-session"
+      else if (any_locked) print "locked"
+      else print "unlocked"
+    }
+  ' <<<"$raw"
+}
+
+state="$(swift_probe)"
+case "$state" in
+  locked | unlocked)
+    printf '%s\n' "$state"
+    exit 0
+    ;;
+esac
+
+# Arm 1 said no-session or error: ask the IORegistry, which answers from
+# outside the caller's session.
+fallback="$(ioreg_probe)"
+case "$fallback" in
+  locked | unlocked | no-session)
+    printf '%s\n' "$fallback"
+    ;;
+  *)
+    # Keep arm 1's answer when it was at least "no-session" — that is more
+    # informative than "error".
+    printf '%s\n' "${state:-error}"
+    ;;
+esac

--- a/scripts/ci/test-ui-gate.sh
+++ b/scripts/ci/test-ui-gate.sh
@@ -408,7 +408,12 @@ EXPECTED_B64="$(printf 'PNGSTUB...' | base64 | tr -d '\n')"
 [[ "$GATE_STDERR" == *"window 8123"* ]] || fail "shot did not report the window id on stderr"
 grep -q -- '-l 8123' "$TMP_DIR/screencapture.log" \
   || fail "screencapture was not scoped to the resolved window id"
-pass "allowed: shot of the app-under-test's own window"
+# The image is the one thing this gate produces that is worth stealing; no exit
+# path may leave it behind.
+if compgen -G "$FAKE_HOME/.localvoxtral-ui-gate/shot.*" >/dev/null; then
+  fail "shot left the captured window image on disk"
+fi
+pass "allowed: shot of the app-under-test's own window, and the file does not survive it"
 
 # Pid reuse: the recorded pid is live but is a different process now.
 assert_denied 'shot settings' 'shot after the recorded pid was recycled' \

--- a/scripts/ci/test-ui-gate.sh
+++ b/scripts/ci/test-ui-gate.sh
@@ -2674,6 +2674,27 @@ run_doctor_local
   || fail "the doctor accepted a key with no forced command at all: $DOCTOR_OUT"
 pass "the doctor flags a key that does not force the gate, or forces it unrestricted"
 
+# A help that trails off mid-sentence into the file's rationale is worse than
+# none, so the range it prints is anchored on the usage block's own last line.
+run_doctor_help() {
+  DOCTOR_STATUS=0
+  env -i PATH="/usr/bin:/bin" HOME="$FAKE_HOME" \
+    bash "$DOCTOR" --help >"$TMP_DIR/doctor.out" 2>&1 || DOCTOR_STATUS=$?
+  DOCTOR_OUT="$(cat "$TMP_DIR/doctor.out")"
+}
+run_doctor_help
+(( DOCTOR_STATUS == 0 )) || fail "--help exited $DOCTOR_STATUS"
+[[ "$DOCTOR_OUT" == *"--remote lv-ui"* && "$DOCTOR_OUT" == *"--state-file"* ]] \
+  || fail "--help does not show all three modes: $DOCTOR_OUT"
+[[ "$DOCTOR_OUT" != *"Why it exists"* ]] \
+  || fail "--help spilled past the usage block into the rationale: $DOCTOR_OUT"
+# The trailing `# on the Mac's GUI account` comments are part of the usage;
+# what must not survive is the leading comment marker of each source line.
+if grep -q '^#' "$TMP_DIR/doctor.out"; then
+  fail "--help printed the source's leading comment markers: $DOCTOR_OUT"
+fi
+pass "the doctor's --help prints the usage block, and stops there"
+
 # The README's numbered list is what this replaces; the pointer has to hold.
 grep -q 'ui-gate-doctor.sh' "$ROOT_DIR/scripts/mac/README.md" \
   || fail "scripts/mac/README.md does not point at the doctor"

--- a/scripts/ci/test-ui-gate.sh
+++ b/scripts/ci/test-ui-gate.sh
@@ -131,7 +131,13 @@ case "$2" in
   axclick | axtype | key | termaction)
     echo ok
     ;;
-  menuopen | menuclick | menudismiss)
+  menuopen)
+    # The real helper prints the CGWindowID of the menu it resolved, so a
+    # caller can tell a real open from a no-op. The stub says one too.
+    [[ -z "${STUB_MENU_FAIL:-}" ]] || exit 1
+    printf '%s\n' "${STUB_MENUOPEN_OUTPUT:-ok window=90210}"
+    ;;
+  menuclick | menudismiss)
     [[ -z "${STUB_MENU_FAIL:-}" ]] || exit 1
     echo ok
     ;;
@@ -275,6 +281,26 @@ run_gate() { # <command> [env assignments...]
 
 log_tail() {
   tail -n 1 "$LOG_FILE" 2>/dev/null || true
+}
+
+# The embedded helper is a heredoc, so its subcommands cannot be exercised
+# without a live desktop — but WHICH evidence a subcommand decides on is a
+# property of the source, and that is the half that regressed. These read one
+# `case "<name>":` body (and one `func` body) out of the heredoc so an
+# assertion can be about that block rather than about the whole 2000-line file.
+helper_case_body() { # <helper subcommand>
+  awk -v want="case \"$1\":" '
+    /^case "[a-z]+":$/ { inside = ($0 == want) }
+    inside { print }
+  ' "$GATE"
+}
+
+helper_func_body() { # <swift function name>
+  awk -v want="func $1(" '
+    index($0, want) == 1 { inside = 1 }
+    inside { print }
+    inside && /^}/ { exit }
+  ' "$GATE"
 }
 
 assert_denied() { # <command> <description> [env...]
@@ -562,6 +588,12 @@ EXPECTED_B64="$(printf 'PNGSTUB...' | base64 | tr -d '\n')"
 [[ "$(printf '%s' "$GATE_STDOUT" | tr -d '\n')" == "$EXPECTED_B64" ]] \
   || fail "shot stdout was not the base64 of the captured file: $GATE_STDOUT"
 [[ "$GATE_STDERR" == *"window 8123"* ]] || fail "shot did not report the window id on stderr"
+# Said twice on purpose: `shot … | base64 -d > x.png` is the documented form,
+# and it is only correct while stdout carries nothing but the payload. The
+# "shot: window …" line reads like a header over an interactive ssh, which
+# delivers both streams to one terminal — it must never actually be one.
+[[ "$GATE_STDOUT" != *"shot:"* ]] \
+  || fail "the shot header reached stdout — a caller piping into base64 -d now needs a tail: $GATE_STDOUT"
 grep -q -- '-l 8123' "$TMP_DIR/screencapture.log" \
   || fail "screencapture was not scoped to the resolved window id"
 # The image is the one thing this gate produces that is worth stealing; no exit
@@ -953,6 +985,77 @@ while read -r line; do
     || fail "a menu helper call did not carry the app-under-test pid: $line"
 done <"$TMP_DIR/swift.log"
 pass "menu addresses only the pid launch recorded"
+
+# `menu open` must report a menu it can SEE, not one that is merely attached.
+#
+# Field check 2026-08-29: against a freshly launched build that had displayed
+# nothing, `menu open` printed "ok already-open" and returned instantly,
+# `shot popover` then reported no popover window owned by that pid, and
+# `ax dump all` returned `[]`. An NSMenu handed to an NSStatusItem is an AXMenu
+# CHILD of the status item whether or not it is on screen, so the pre-check
+# that looked for that child matched every time, the status item was never
+# pressed, and the verb reported success for doing nothing.
+#
+# The suite stubs the helper, so it cannot run these AX/CGWindow calls. What it
+# can pin — and what actually regressed — is which evidence each subcommand
+# decides on.
+: >"$TMP_DIR/swift.log"
+assert_allowed 'menu open' 'menu open passes the helper evidence through' "${APP_ENV[@]}"
+[[ "$GATE_STDOUT" == *"window=90210"* ]] \
+  || fail "menu open swallowed the window id the helper resolved — a caller cannot tell an open from a no-op: $GATE_STDOUT"
+pass "menu open reports the window it resolved, not a bare ok"
+
+grep -q 'func displayedMenuWindow' "$GATE" \
+  || fail "the helper has no displayed-menu test — menu open is deciding openness from something else"
+
+# It must BE `shot popover`'s window rule, not a second copy of it: that is
+# what makes `menu open` succeed exactly when `shot popover` can then find
+# something, and what stops the two verbs drifting apart.
+DISPLAYED_BODY="$(helper_func_body displayedMenuWindow)"
+[[ "$DISPLAYED_BODY" == *'resolveWindow('*'kind: "popover"'* ]] \
+  || fail "displayedMenuWindow does not go through resolveWindow(kind: \"popover\") — menu open and shot popover can now disagree: $DISPLAYED_BODY"
+
+MENUOPEN_BODY="$(helper_case_body menuopen)"
+[[ -n "$MENUOPEN_BODY" ]] || fail "could not read the menuopen case body out of the helper"
+[[ "$MENUOPEN_BODY" == *'displayedMenuWindow('* ]] \
+  || fail "menuopen does not consult the window list — it cannot know a menu is displayed"
+[[ "$MENUOPEN_BODY" != *'attachedMenu('* ]] \
+  || fail "menuopen decides from the ATTACHED AXMenu again: that child exists whether or not a menu is on screen, so the verb reports success without ever pressing (the 2026-08-29 field bug)"
+# The press, and the deliberate not-trusting of its return code, both stay: it
+# reports .cannotComplete while a menu tracks.
+[[ "$MENUOPEN_BODY" == *'_ = AXUIElementPerformAction(item, kAXPressAction as CFString)'* ]] \
+  || fail "menuopen either stopped pressing the status item or started trusting AXPress's return code"
+pass "menu open decides openness from the same window rule shot popover resolves"
+
+# The name was the bug: a function called openMenu that answers "is a menu
+# attached" reads as correct at every call site.
+if grep -q 'func openMenu' "$GATE"; then
+  fail "openMenu(of:) is back — the name says 'open', the test is 'attached', and that gap is the whole 2026-08-29 field bug"
+fi
+
+# `menu click` deliberately does NOT require a displayed menu: AXPress on a
+# menu item works either way, which is how the gate reached Settings while
+# `menu open` was broken. It is the fallback when the window test cannot see a
+# menu that is genuinely up.
+MENUCLICK_BODY="$(helper_case_body menuclick)"
+[[ "$MENUCLICK_BODY" == *'attachedMenu('* ]] \
+  || fail "menu click no longer reaches the attached menu — it must keep working with the menu closed"
+pass "menu click still works against an attached-but-closed menu"
+
+# Dismiss had the same root cause with a worse outcome: its "nothing is open"
+# branch was decided by attachment, which is always true, so it never ran — and
+# the fallback below it presses the status item, which on a CLOSED menu opens
+# one. A dismiss verb must never be able to open a menu.
+MENUDISMISS_BODY="$(helper_case_body menudismiss)"
+[[ "$MENUDISMISS_BODY" == *'displayedMenuWindow('* ]] \
+  || fail "menu dismiss still decides 'nothing is open' from attachment"
+NO_MENU_LINE="$(printf '%s\n' "$MENUDISMISS_BODY" | grep -n 'no-menu-open' | head -n 1 | cut -d: -f1)"
+FIRST_PRESS_LINE="$(printf '%s\n' "$MENUDISMISS_BODY" | grep -n 'kAXPressAction' | head -n 1 | cut -d: -f1)"
+[[ -n "$NO_MENU_LINE" && -n "$FIRST_PRESS_LINE" ]] \
+  || fail "menudismiss lost either its no-menu-open answer or its status-item fallback"
+(( NO_MENU_LINE < FIRST_PRESS_LINE )) \
+  || fail "menu dismiss can reach a status-item press with nothing displayed — a press on a closed menu OPENS one, so dismiss would open the thing it exists to close"
+pass "menu dismiss returns no-menu-open before it can press anything"
 
 # The shell verb and the helper subcommand have to land together: a verb whose
 # helper case is missing fails only on the owner's desktop.
@@ -1565,6 +1668,70 @@ grep -q -- '--last 15m' "$TMP_DIR/log.log" \
   || fail "log did not use its default window: $(cat "$TMP_DIR/log.log")"
 pass "log is predicate-scoped to localvoxtral's own subsystem"
 
+# --- and the subsystem alone is NOT enough on this machine ------------------
+#
+# The Mac that runs this gate is also the self-hosted CI runner, and a unit
+# suite logs under localvoxtral's OWN subsystem from `xctest`. Field check
+# 2026-08-30: `log 2` returned 111 lines of which exactly one was the app under
+# test; the rest were a concurrent CI run, including "Terminal pane joined to a
+# live Claude session via title marker". Attributing that to the dictation you
+# just made is a wrong conclusion drawn from a real log line — the worst kind
+# this verb can produce. So the predicate carries a process as well.
+
+{
+  echo '2026-08-30 12:31:47 xctest[19586] [com.localvoxtral:ClaudeContext] Terminal pane joined to a live Claude session via title marker'
+  echo '2026-08-30 12:31:49 localvoxtral[4242] [com.localvoxtral:ClaudeContext] Remote herdr forward activity refresh'
+} >"$LOG_FIXTURE"
+
+write_app_state 4242
+: >"$TMP_DIR/log.log"
+assert_allowed 'log' 'log with an app under test is scoped to its pid' \
+  "${APP_ENV[@]}" STUB_LOG_OUTPUT_FILE="$LOG_FIXTURE"
+grep -q 'processIdentifier == 4242' "$TMP_DIR/log.log" \
+  || fail "log was not scoped to the pid launch recorded: $(cat "$TMP_DIR/log.log")"
+grep -q 'subsystem == "com.localvoxtral"' "$TMP_DIR/log.log" \
+  || fail "the pid scope replaced the subsystem scope instead of narrowing it: $(cat "$TMP_DIR/log.log")"
+[[ "$GATE_STDERR" != *"not one instance"* ]] \
+  || fail "log warned that it is not pid-scoped while it was: $GATE_STDERR"
+grep -q 'log minutes=15 .*pid=4242' "$LOG_FILE" \
+  || fail "the gate log does not record which scope the read used: $(log_tail)"
+pass "log with an app under test carries the recorded pid in its predicate"
+
+# No app under test: still never `xctest`, but no longer one instance — and it
+# has to SAY so. Silently answering with another process's lines is the one
+# behaviour that is not available.
+clear_state
+: >"$TMP_DIR/log.log"
+assert_allowed 'log' 'log without an app under test falls back to the process name' \
+  STUB_LOG_OUTPUT_FILE="$LOG_FIXTURE"
+grep -q 'process == "localvoxtral"' "$TMP_DIR/log.log" \
+  || fail "the fallback scope is not the app's process name: $(cat "$TMP_DIR/log.log")"
+if grep -q 'processIdentifier' "$TMP_DIR/log.log"; then
+  fail "log claimed a pid scope with no app under test: $(cat "$TMP_DIR/log.log")"
+fi
+[[ "$GATE_STDERR" == *"not one instance"* ]] \
+  || fail "the un-pid-scoped fallback did not say so: $GATE_STDERR"
+grep -q 'not-pid-scoped' "$LOG_FILE" \
+  || fail "the gate log does not record that the read was not pid-scoped: $(log_tail)"
+pass "log without an app under test falls back by process name and says it is not one instance"
+
+# A recycled pid must fall back rather than read a stranger's lines: `log` goes
+# through the same identity check every other verb does.
+write_app_state 4242
+: >"$TMP_DIR/log.log"
+assert_allowed 'log' 'log falls back when the recorded pid was recycled' \
+  STUB_PS_LSTART="Tue Aug 25 11:11:11 2026" \
+  STUB_PS_COMM="$CLEAN_APP/Contents/MacOS/localvoxtral" \
+  STUB_LOG_OUTPUT_FILE="$LOG_FIXTURE"
+if grep -q 'processIdentifier == 4242' "$TMP_DIR/log.log"; then
+  fail "log read the lines of a recycled pid as if it were the app under test"
+fi
+grep -q 'process == "localvoxtral"' "$TMP_DIR/log.log" \
+  || fail "a recycled pid did not fall back to process scoping: $(cat "$TMP_DIR/log.log")"
+pass "a recycled pid falls back instead of scoping the read to a stranger"
+
+clear_state
+
 : >"$TMP_DIR/log.log"
 assert_allowed 'log 42' 'log with an explicit window' STUB_LOG_OUTPUT_FILE="$LOG_FIXTURE"
 grep -q -- '--last 42m' "$TMP_DIR/log.log" || fail "log ignored the requested window"
@@ -1604,6 +1771,10 @@ assert_allowed 'log' 'log caps its own output' STUB_LOG_OUTPUT_FILE="$LOG_FIXTUR
 assert_allowed 'log' 'log says so when there is nothing to report' STUB_LOG_OUTPUT_FILE="$LOG_FIXTURE"
 [[ "$GATE_STDERR" == *"no com.localvoxtral entries"* ]] \
   || fail "an empty log window produced no explanation: $GATE_STDERR"
+# Which scope found nothing is half the answer: "the app said nothing" and
+# "you were reading some other process" look identical without it.
+[[ "$GATE_STDERR" == *"entries for process=localvoxtral"* ]] \
+  || fail "the empty-window message does not name the scope it searched: $GATE_STDERR"
 
 # The restriction the build gate account actually hits (scripts/mac/README.md).
 # It is unverified for the GUI account, so the failure has to name itself.

--- a/scripts/ci/test-ui-gate.sh
+++ b/scripts/ci/test-ui-gate.sh
@@ -883,10 +883,10 @@ run_gate 'term open ghostty lv-attach pane-7' \
   || fail "term open did not say what went wrong: $GATE_STDERR"
 [[ "$GATE_STDERR" == *"terminated the command it started"* ]] \
   || fail "term open did not reclaim the process it started: $GATE_STDERR"
-ORPHAN_PIDFILE="$(find "$FAKE_HOME/.localvoxtral-ui-gate/terms" -name '*.pid' 2>/dev/null | head -n 1)"
+ORPHAN_PIDFILE="$(find "$FAKE_HOME/.localvoxtral-ui-gate/terms" -name '*.pid' 2>/dev/null | head -n 1 || true)"
 [[ -z "$ORPHAN_PIDFILE" ]] \
   || fail "term open left a pid file behind after failing: $ORPHAN_PIDFILE"
-[[ -z "$(find "$FAKE_HOME/.localvoxtral-ui-gate/terms" -name 'term-*.state' 2>/dev/null)" ]] \
+[[ -z "$(find "$FAKE_HOME/.localvoxtral-ui-gate/terms" -name 'term-*.state' 2>/dev/null || true)" ]] \
   || fail "a failed term open registered a terminal anyway"
 pass "a term open that cannot identify its window kills what it started and registers nothing"
 
@@ -933,7 +933,7 @@ run_gate 'term open ghostty lv-attach pane-7' \
   || fail "the ambiguous case did not explain itself: $GATE_STDERR"
 [[ "$GATE_STDERR" == *"terminated the command it started"* ]] \
   || fail "the ambiguous case did not reclaim the process it started: $GATE_STDERR"
-[[ -z "$(find "$FAKE_HOME/.localvoxtral-ui-gate/terms" -name 'term-*.state' 2>/dev/null)" ]] \
+[[ -z "$(find "$FAKE_HOME/.localvoxtral-ui-gate/terms" -name 'term-*.state' 2>/dev/null || true)" ]] \
   || fail "the ambiguous case registered a terminal anyway"
 pass "term open refuses to guess between windows that appeared at the same moment"
 
@@ -2714,11 +2714,11 @@ BASH4_FILES=(
 # pipeline whose status is ignored, an associative array declaration is a
 # syntax error only when reached, and case conversion expands unmodified.
 BASH4_IDIOMS=(
-  'BASHPID::\$\{?BASHPID'
+  'BASHPID::\$[{]?BASHPID'
   'mapfile::(^|[^[:alnum:]_])mapfile[[:space:]]'
   'readarray::(^|[^[:alnum:]_])readarray[[:space:]]'
   'an associative array::(declare|local|typeset)[[:space:]]+-[A-Za-z]*A[A-Za-z]*[[:space:]]'
-  'case-conversion expansion::\$\{[A-Za-z_][A-Za-z0-9_]*(\[[^]]*\])?(\^\^|,,)'
+  'case-conversion expansion::\$[{][A-Za-z_][A-Za-z0-9_]*(\[[^]]*\])?(\^\^|,,)'
   'the |& pipe::[^|]\|&'
 )
 # BASH4-SCANNER-END

--- a/scripts/ci/test-ui-gate.sh
+++ b/scripts/ci/test-ui-gate.sh
@@ -118,17 +118,48 @@ if [[ "$last" == "localvoxtral" ]]; then
   exit 0
 fi
 [[ -n "${STUB_PGREP_PID:-}" ]] || exit 1
-printf '%s\n' "$STUB_PGREP_PID"
+# Space-separated, one per line: the real pgrep answers a bundle-path PREFIX
+# with EVERY match, and the bundle ships localvoxtral-speechd/-polishd beside
+# the app. A stub that could only answer with one pid is what hid that.
+#
+# `-n` is honoured, because it is the half of the bug that bites: it asks for
+# the NEWEST match, and a helper the app just spawned is newer than the app.
+# The list is read as start order, so `-n` is its last entry.
+stub_newest=0
+for stub_arg in "$@"; do [[ "$stub_arg" == "-n" ]] && stub_newest=1; done
+if (( stub_newest == 1 )); then
+  stub_last=""
+  for stub_last in $STUB_PGREP_PID; do :; done
+  printf '%s\n' "$stub_last"
+  exit 0
+fi
+for stub_pid in $STUB_PGREP_PID; do printf '%s\n' "$stub_pid"; done
 STUB
 
 # `ps -p <pid> -o lstart=` and `ps -p <pid> -o comm=` are the two halves of the
 # gate's pid-reuse defence.
 cat >"$STUB_BIN/ps" <<'STUB'
 #!/usr/bin/env bash
+# `-p <pid>` is remembered so `comm=` can answer PER PID: that is the fact that
+# separates the app from a helper of its own that shares the pgrep prefix.
+# STUB_PS_COMM_<pid> wins when set, STUB_PS_COMM is the fallback.
+stub_pid=""
+stub_want_pid=0
 for arg in "$@"; do
+  if (( stub_want_pid == 1 )); then stub_pid="$arg"; stub_want_pid=0; continue; fi
   case "$arg" in
+    -p) stub_want_pid=1 ;;
     lstart=) printf '%s\n' "${STUB_PS_LSTART:-Mon Aug 24 09:00:00 2026}"; exit 0 ;;
-    comm=) printf '%s\n' "${STUB_PS_COMM:-/nonexistent}"; exit 0 ;;
+    comm=)
+      # Indirect expansion is bash 2.0+, so this is safe on the Mac's 3.2.
+      stub_var="STUB_PS_COMM_${stub_pid}"
+      if [[ -n "${!stub_var:-}" ]]; then
+        printf '%s\n' "${!stub_var}"
+      else
+        printf '%s\n' "${STUB_PS_COMM:-/nonexistent}"
+      fi
+      exit 0
+      ;;
   esac
 done
 exit 1
@@ -566,7 +597,26 @@ for forbidden in bash sh zsh ssh osascript python3 claude codex opencode herdr a
   grep -qw "$forbidden" <<<"$FORBIDDEN_BLOCK" \
     || fail "$forbidden is no longer on the permanent denylist"
 done
+# The classes the header's own admission test does NOT catch. `vi`, `less` and
+# `man` expose no flag that takes a command — they reach a shell at RUNTIME
+# (`:!cmd`, `!cmd`, `v`), so reading `--help` clears them, and they are exactly
+# what an owner allowlists meaning "just a viewer". The wrappers below are the
+# opposite shape: running someone else's command IS their normal argv.
+for forbidden in vi vim nvim view ex ed less more man awk sed git swift open \
+  watch nice caffeinate timeout env xargs npx cargo go nc curl wget; do
+  grep -qw "$forbidden" <<<"$FORBIDDEN_BLOCK" \
+    || fail "$forbidden can run a child command and is not on the permanent denylist"
+done
 pass "the default allowlist is empty and the permanent denylist still names every shell and agent CLI"
+
+# The exploit that motivated widening it: an owner allowlists a pager, and
+# `!bash` inside the window is an interactive shell as the GUI user.
+write_conf 'LV_UI_TERM_COMMANDS="less vim git open"'
+assert_denied 'term open ghostty less /etc/hosts' 'conf-allowlisted less is STILL denied'
+assert_denied 'term open ghostty vim /etc/hosts' 'conf-allowlisted vim is STILL denied'
+assert_denied 'term open ghostty git log' 'conf-allowlisted git is STILL denied'
+assert_denied 'term open ghostty open -a Terminal' 'conf-allowlisted open is STILL denied'
+clear_conf
 
 echo "== 5. the screen lock is a hard refusal (fail closed) =="
 
@@ -583,7 +633,8 @@ for locked_command in \
   'ax type role=AXTextField -- hello' \
   'key escape' \
   'term open ghostty lv-attach' \
-  'term focus term-1'; do
+  'term focus term-1' \
+  'term close term-1'; do
   assert_denied "$locked_command" "locked screen refuses: $locked_command" \
     "${APP_ENV[@]}" STUB_PGREP_PID=4242 STUB_WINDOW_RESULT="7 4242"
 done
@@ -721,6 +772,45 @@ run_gate "launch --dogfood $DOGFOOD_APP" \
 grep -q 'debug.dogfood_capture_enabled' "$TMP_DIR/defaults.log" \
   || fail "launch --dogfood did not arm the capture opt-in"
 pass "allowed: launch --dogfood on a stamped bundle"
+
+# The bundle ships localvoxtral-speechd, localvoxtral-polishd and
+# localvoxtral-claude-hook in the SAME Contents/MacOS directory
+# (package_app.sh), so all of them match the pgrep prefix
+# "<bundle>/Contents/MacOS/localvoxtral" — and the app starts its helpers
+# during launch, so `pgrep -n` (newest) can hand back a helper. Recording a
+# helper is worse than failing: every verb then drives a windowless process,
+# and `quit` kills the helper while the real app keeps running, after which
+# `launch` refuses beside "a localvoxtral this gate did not start" and only the
+# owner can unwedge the machine. The executable path is what decides.
+clear_state
+run_gate "launch $CLEAN_APP" \
+  STUB_PS_LSTART="Mon Aug 24 09:00:00 2026" \
+  STUB_PGREP_PID="5000 5100 5200" \
+  STUB_PS_COMM_5000="$CLEAN_APP/Contents/MacOS/localvoxtral" \
+  STUB_PS_COMM_5100="$CLEAN_APP/Contents/MacOS/localvoxtral-speechd" \
+  STUB_PS_COMM_5200="$CLEAN_APP/Contents/MacOS/localvoxtral-polishd"
+(( GATE_STATUS == 0 )) || fail "launch failed while helpers shared the prefix: $GATE_STDERR"
+[[ "$GATE_STDOUT" == *"launched pid=5000"* ]] \
+  || fail "launch recorded a helper instead of the app: $GATE_STDOUT"
+grep -q "pid=5000" "$FAKE_HOME/.localvoxtral-ui-gate/app.state" \
+  || fail "app.state names a helper: $(cat "$FAKE_HOME/.localvoxtral-ui-gate/app.state")"
+grep -q "identity=Mon Aug 24 09:00:00 2026|$CLEAN_APP/Contents/MacOS/localvoxtral$" \
+  "$FAKE_HOME/.localvoxtral-ui-gate/app.state" \
+  || fail "the recorded identity is not the app executable"
+pass "launch records the APP, never a helper sharing the pgrep prefix"
+
+# And the other direction: if the ONLY thing matching the prefix is a helper,
+# there is no app under test and launch must say so rather than adopt it.
+clear_state
+run_gate "launch $CLEAN_APP" \
+  STUB_PS_LSTART="Mon Aug 24 09:00:00 2026" \
+  STUB_PGREP_PID="5100" \
+  STUB_PS_COMM_5100="$CLEAN_APP/Contents/MacOS/localvoxtral-speechd"
+(( GATE_STATUS != 0 )) || fail "launch adopted a helper as the app under test"
+[[ ! -f "$FAKE_HOME/.localvoxtral-ui-gate/app.state" ]] \
+  || fail "launch wrote app.state for a helper"
+pass "a helper alone is not an app under test"
+clear_state
 
 echo "== 8. ax and key verbs =="
 

--- a/scripts/ci/test-ui-gate.sh
+++ b/scripts/ci/test-ui-gate.sh
@@ -441,6 +441,11 @@ grep -q -- "-n $CLEAN_APP" "$TMP_DIR/open.log" \
   || fail "launch did not open the validated bundle"
 pass "allowed: launch records identity, warns audibly, announces completion"
 
+# A second launch while one is recorded would orphan that pid and silently
+# retarget every later verb.
+assert_denied "launch $CLEAN_APP" 'launch while an app is already under test' \
+  "${APP_ENV[@]}" STUB_PGREP_PID=4242
+
 # --dogfood requires the Info.plist stamp AND arms the runtime opt-in.
 clear_state
 : >"$TMP_DIR/defaults.log"

--- a/scripts/ci/test-ui-gate.sh
+++ b/scripts/ci/test-ui-gate.sh
@@ -67,26 +67,33 @@ cat >"$STUB_BIN/open" <<'STUB'
 #!/usr/bin/env bash
 printf '%s\n' "$*" >>"$STUB_OPEN_LOG"
 # With STUB_OPEN_SPAWN set, stand in for a terminal that actually ran the
-# launcher: a long-lived process that recorded its pid the way the launcher's
-# `printf "$$" > <pidfile>` does before `exec`. That is the handle `term open`
-# uses to take back what it started when it cannot identify the window, so the
-# suite has to have a real process to watch die. /bin/sleep, not the stubbed
+# launcher: a process that recorded its own pid the way the launcher's
+# `printf "$$" > <pidfile>` does before `exec`. That pid is the handle
+# `term open` uses to take back what it started when it cannot identify the
+# window, so the suite needs a real process to watch die.
+#
+# `/bin/sh -c` and `$$`, NOT a `( … ) &` subshell and `$BASHPID`: the Mac's
+# /bin/bash is 3.2, where BASHPID does not exist and expands to nothing — the
+# pid file came out empty, the gate correctly read that as "the launcher never
+# ran", and the test failed on the runner while passing on a bash-5 dev box
+# (CI 33313541728). A separate `sh` process makes `$$` its OWN pid, which is
+# also exactly what the real launcher does. `/bin/sleep`, not the stubbed
 # `sleep` that returns instantly.
 case "${STUB_OPEN_SPAWN:-}" in
   "") ;;
   dead)
     # The launcher ran and the command exited immediately — the pid file is
     # there, the process is not. An empty terminal window is what the owner
-    # sees when this happens.
+    # sees when this happens. Run it in the FOREGROUND so it has certainly
+    # exited by the time the gate looks.
     launcher=""
     for launcher in "$@"; do :; done
-    ( printf '%s' "$BASHPID" >"${launcher%.command}.pid" ) &
-    wait
+    /bin/sh -c 'printf "%s" "$$" > "$1"' _ "${launcher%.command}.pid"
     ;;
   *)
     launcher=""
     for launcher in "$@"; do :; done
-    ( printf '%s' "$BASHPID" >"${launcher%.command}.pid"; exec /bin/sleep 300 ) &
+    /bin/sh -c 'printf "%s" "$$" > "$1"; exec /bin/sleep 300' _ "${launcher%.command}.pid" &
     # The pid file has to exist before this returns, or the gate races it.
     for _ in 1 2 3 4 5 6 7 8 9 10; do
       [[ -s "${launcher%.command}.pid" ]] && break
@@ -2670,6 +2677,89 @@ pass "the doctor flags a key that does not force the gate, or forces it unrestri
 # The README's numbered list is what this replaces; the pointer has to hold.
 grep -q 'ui-gate-doctor.sh' "$ROOT_DIR/scripts/mac/README.md" \
   || fail "scripts/mac/README.md does not point at the doctor"
+
+echo
+echo "== 28. nothing here needs a bash newer than the Mac's /bin/bash 3.2 =="
+
+# The gate runs under the Mac's /bin/bash, which is 3.2 (Apple has shipped that
+# since the GPLv3 licence change). A bash-4 idiom is therefore a construct that
+# works perfectly on a Linux dev box and misbehaves on the machine this gate
+# exists for — the worst shape of failure available here, because the dev-box
+# suite goes green and only the runner, or the OWNER, finds out.
+#
+# This branch has now hit it twice: once in a stub (daf6364) and once with
+# BASHPID in the `open` stub, where an empty pid file made the gate report "the
+# launcher never ran" and the test failed only on the runner (CI 33313541728).
+# So it is a check rather than a habit.
+#
+# Two things are stripped before scanning, and both are the same lesson: a scan
+# that cannot tell its own vocabulary from a call reports itself. Comments go
+# (the explanations above name every idiom they warn about), and so does the
+# definition block below, between its own sentinels — that is the grep
+# self-poisoning trap, and the scanner is the most likely thing to trip it.
+
+BASH4_FILES=(
+  "$GATE"
+  "$ATTACH"
+  "$INSTALLER"
+  "$ROOT_DIR/scripts/mac/ui-gate-doctor.sh"
+  "$0"
+)
+
+# BASH4-SCANNER-BEGIN — not scanned; see above.
+#
+# name::extended-regex, `::` because one of the names contains a pipe. Each is
+# bash 4.0+ and misbehaves QUIETLY on 3.2 rather than failing loudly: BASHPID
+# expands to nothing, mapfile/readarray are "command not found" inside a
+# pipeline whose status is ignored, an associative array declaration is a
+# syntax error only when reached, and case conversion expands unmodified.
+BASH4_IDIOMS=(
+  'BASHPID::\$\{?BASHPID'
+  'mapfile::(^|[^[:alnum:]_])mapfile[[:space:]]'
+  'readarray::(^|[^[:alnum:]_])readarray[[:space:]]'
+  'an associative array::(declare|local|typeset)[[:space:]]+-[A-Za-z]*A[A-Za-z]*[[:space:]]'
+  'case-conversion expansion::\$\{[A-Za-z_][A-Za-z0-9_]*(\[[^]]*\])?(\^\^|,,)'
+  'the |& pipe::[^|]\|&'
+)
+# BASH4-SCANNER-END
+
+for bash4_file in "${BASH4_FILES[@]}"; do
+  [[ -f "$bash4_file" ]] || fail "the bash-3.2 scan points at a file that is not there: $bash4_file"
+  # The Swift heredoc goes too: the helper is Swift, where `,,` and `|&` mean
+  # nothing to bash and `${…}` is not an expansion at all.
+  BASH4_CODE="$(awk '/BASH4-SCANNER-BEGIN/ { skip = 1 }
+                     /BASH4-SCANNER-END/   { skip = 0; next }
+                     /^  cat >"\$HELPER_PATH" <<.SWIFT.$/ { skip = 1 }
+                     skip && /^SWIFT$/ { skip = 0; next }
+                     skip { next }
+                     { print }' "$bash4_file" | grep -v '^[[:space:]]*#' || true)"
+  for bash4_idiom in "${BASH4_IDIOMS[@]}"; do
+    idiom_name="${bash4_idiom%%::*}"
+    idiom_re="${bash4_idiom#*::}"
+    if grep -qE "$idiom_re" <<<"$BASH4_CODE"; then
+      fail "$bash4_file uses $idiom_name, which is bash 4+ and misbehaves quietly on the Mac's /bin/bash 3.2: $(grep -nE "$idiom_re" <<<"$BASH4_CODE" | head -n 1)"
+    fi
+  done
+done
+pass "the gate, the wrapper, the installer, the doctor and this suite are bash 3.2 clean"
+
+# An empty array expanded under `set -u` is the OTHER 3.2 trap, and the one the
+# dispatch already carries a comment about: bash 3.2 calls "${a[@]:1}" unbound
+# when the slice is empty. Every such expansion in the gate has to sit behind a
+# length guard, so this pins that none of them is bare.
+GATE_SLICES="$(grep -n '\${[A-Za-z_][A-Za-z0-9_]*\[[@*]\]:[0-9]' "$GATE" \
+  | grep -v '^[0-9]*:[[:space:]]*#' || true)"
+[[ -n "$GATE_SLICES" ]] || fail "no array slices found in the gate — did the scan's pattern rot?"
+while IFS= read -r slice_line; do
+  [[ -n "$slice_line" ]] || continue
+  slice_no="${slice_line%%:*}"
+  # The guard is on the same line (`if (( ${#a[@]} > 1 )); then …`) or within
+  # the two lines above it.
+  if ! sed -n "$(( slice_no > 2 ? slice_no - 2 : 1 )),${slice_no}p" "$GATE" | grep -q '\${#'; then
+    fail "an unguarded array slice at $GATE:$slice_no — bash 3.2 calls an empty slice unbound under set -u: $slice_line"
+  fi
+done <<<"$GATE_SLICES"
+pass "every array slice in the gate sits behind a length guard"
 
 echo
 echo "ui gate tests passed"

--- a/scripts/ci/test-ui-gate.sh
+++ b/scripts/ci/test-ui-gate.sh
@@ -722,5 +722,56 @@ else
   printf 'SKIP: swiftc not available — the embedded Swift helper was not type checked\n'
 fi
 
+# ---------------------------------------------------------------------------
+# 14. `state`'s live probes survive SIGPIPE
+#
+# Regression for the first-install failure (2026-08-28): `state` was reached,
+# authorized, logged ALLOW — and then died with rc 141 and no output. `ioreg`
+# writes far more than the first HIDIdleTime line, `awk` exits on that match,
+# ioreg takes SIGPIPE, and `pipefail` + `set -e` killed the gate before it
+# printed a byte. The suite could not see it because it stubs `ioreg`, so the
+# guard here is twofold: the source shape (everywhere) and a real run (macOS).
+# ---------------------------------------------------------------------------
+
+echo
+echo "== 14. state's live probes survive SIGPIPE =="
+
+for probe in 'ioreg -c IOHIDSystem' 'pmset -g ps'; do
+  line="$(grep -n -- "$probe" "$GATE" | head -n 1 || true)"
+  [[ -n "$line" ]] || fail "no $probe probe found in the gate — did state change shape?"
+done
+
+# The ioreg substitution spans two lines; check the one carrying the pipeline.
+grep -q "awk '/HIDIdleTime/.*|| true)\"" "$GATE" \
+  || fail "the ioreg idle probe lost its \`|| true\` — state will die with rc 141 on a real Mac"
+pass "the ioreg idle probe tolerates SIGPIPE"
+
+grep -q 'pmset -g ps 2>/dev/null | head -n 1 || true' "$GATE" \
+  || fail "the pmset power probe lost its \`|| true\`"
+pass "the pmset power probe tolerates SIGPIPE"
+
+# The source check above pins the shape; this runs the real thing. Extracting
+# from the gate rather than restating the pipeline means a future edit is what
+# gets tested, not a copy of it that can drift.
+if command -v ioreg >/dev/null 2>&1 && command -v pmset >/dev/null 2>&1; then
+  idle_expr="$(sed -n '/idle="\$(ioreg -c IOHIDSystem/,/|| true)"/p' "$GATE")"
+  [[ -n "$idle_expr" ]] || fail "could not extract the idle probe from the gate"
+  power_expr="$(grep -- 'pmset -g ps 2>/dev/null | head -n 1 || true' "$GATE" \
+    | sed 's/^ *case "/probe_out="/; s/" in$/"/')"
+  [[ -n "$power_expr" ]] || fail "could not extract the power probe from the gate"
+
+  if ! ( set -euo pipefail; eval "$idle_expr"; printf '%s' "$idle" >/dev/null ) 2>/dev/null; then
+    fail "the gate's real ioreg idle probe still fails under set -euo pipefail (rc 141 class)"
+  fi
+  pass "the idle probe runs clean against the real ioreg"
+
+  if ! ( set -euo pipefail; eval "$power_expr" ) 2>/dev/null; then
+    fail "the gate's real pmset power probe still fails under set -euo pipefail"
+  fi
+  pass "the power probe runs clean against the real pmset"
+else
+  printf 'SKIP: ioreg/pmset unavailable — the live SIGPIPE probes were not run\n'
+fi
+
 echo
 echo "ui gate tests passed"

--- a/scripts/ci/test-ui-gate.sh
+++ b/scripts/ci/test-ui-gate.sh
@@ -249,6 +249,16 @@ clear_state() {
   rm -rf "$FAKE_HOME/.localvoxtral-ui-gate"
 }
 
+# The machine-local conf is the ONLY way `term open` ever becomes usable, so
+# the opt-in tests go through the real file rather than an env override.
+GATE_CONF="$FAKE_HOME/.localvoxtral-ui-gate.conf"
+write_conf() {
+  printf '%s\n' "$@" >"$GATE_CONF"
+}
+clear_conf() {
+  rm -f "$GATE_CONF"
+}
+
 APP_ENV=(
   STUB_PS_LSTART="Mon Aug 24 09:00:00 2026"
   STUB_PS_COMM="$CLEAN_APP/Contents/MacOS/localvoxtral"
@@ -336,14 +346,66 @@ assert_denied 'term open ghostty bash -c id' 'term open running bash'
 assert_denied 'term open ghostty sh' 'term open running sh'
 assert_denied 'term open ghostty ssh builder@mac' 'term open running ssh'
 assert_denied 'term open ghostty osascript -e id' 'term open running osascript'
-assert_denied 'term open bash herdr' 'a shell in the terminal position'
-assert_denied 'term open ghostty herdr;id' 'metacharacter inside an allowlisted command'
-assert_denied 'term open ghostty herdr `id`' 'backticks in a term command'
-assert_denied 'term open ghostty herdr a b c d e f g h i j k l m' 'more tokens than the cap'
+assert_denied 'term open ghostty python3 -c id' 'term open running python3'
+assert_denied 'term open bash lv-attach' 'a shell in the terminal position'
+assert_denied 'term open ghostty lv-attach;id' 'metacharacter inside a command' \
+  LV_UI_TERM_COMMANDS=lv-attach
+assert_denied 'term open ghostty lv-attach `id`' 'backticks in a term command' \
+  LV_UI_TERM_COMMANDS=lv-attach
+assert_denied 'term open ghostty lv-attach a b c d e f g h i j k l m' 'more tokens than the cap' \
+  LV_UI_TERM_COMMANDS=lv-attach
+
+# An agent CLI is a shell wearing one allowlisted name: only the first token is
+# checked and nothing inspects flags, so `claude -p`, `codex exec`,
+# `opencode run` and `herdr agent start` each execute arbitrary code as the GUI
+# user. An earlier revision shipped all four in the DEFAULT allowlist.
+assert_denied 'term open ghostty claude' 'term open running claude'
+assert_denied 'term open ghostty codex' 'term open running codex'
+assert_denied 'term open ghostty opencode' 'term open running opencode'
+assert_denied 'term open ghostty herdr' 'term open running herdr'
+assert_denied 'term open ghostty aider' 'term open running another agent CLI'
+assert_denied 'term open ghostty claude --dangerously-skip-permissions -p hello' \
+  'the exact escape: claude --dangerously-skip-permissions -p <prompt>'
+assert_denied 'term open ghostty codex exec whatever' 'codex exec'
+assert_denied 'term open ghostty opencode run whatever' 'opencode run'
+assert_denied 'term open ghostty herdr agent start' 'herdr agent start'
+
+# The denylist is checked before the allowlist and is assigned after the conf
+# is sourced, so a machine-local file cannot re-add any of these.
+write_conf 'LV_UI_TERM_COMMANDS="claude codex opencode herdr bash ssh lv-attach"'
+assert_denied 'term open ghostty claude -p hi' 'conf-allowlisted claude is STILL denied'
+assert_denied 'term open ghostty codex exec x' 'conf-allowlisted codex is STILL denied'
+assert_denied 'term open ghostty opencode run x' 'conf-allowlisted opencode is STILL denied'
+assert_denied 'term open ghostty herdr agent start' 'conf-allowlisted herdr is STILL denied'
+assert_denied 'term open ghostty bash -c id' 'conf-allowlisted bash is STILL denied'
+assert_denied 'term open ghostty ssh host' 'conf-allowlisted ssh is STILL denied'
+clear_conf
+
+# With no conf at all the allowlist is empty, so every command denies — the
+# verb is opt-in, not opt-out.
+assert_denied 'term open ghostty lv-attach' 'the default allowlist is empty'
+[[ "$(log_tail)" == *"no allowlisted commands"* ]] \
+  || fail "the empty-allowlist denial did not say why: $(log_tail)"
+
+# Pin the DEFAULT in the source, so re-adding a name fails here and not in the
+# field. The default must be empty; anything else is a review conversation.
+DEFAULT_LINE="$(grep -n 'LV_UI_TERM_COMMANDS="[$]{LV_UI_TERM_COMMANDS' "$GATE" | head -n 1)"
+[[ "$DEFAULT_LINE" == *'LV_UI_TERM_COMMANDS="${LV_UI_TERM_COMMANDS:-}"' ]] \
+  || fail "the default term-open allowlist is no longer empty: $DEFAULT_LINE"
+FORBIDDEN_BLOCK="$(awk '/^LV_UI_TERM_FORBIDDEN=/ { capture = 1 } capture { print } capture && /"$/ { exit }' "$GATE")"
+[[ -n "$FORBIDDEN_BLOCK" ]] || fail "the permanent denylist is gone"
+for forbidden in bash sh zsh ssh osascript python3 claude codex opencode herdr aider; do
+  grep -qw "$forbidden" <<<"$FORBIDDEN_BLOCK" \
+    || fail "$forbidden is no longer on the permanent denylist"
+done
+pass "the default allowlist is empty and the permanent denylist still names every shell and agent CLI"
 
 echo "== 5. the screen lock is a hard refusal (fail closed) =="
 
 write_app_state 4242
+# `term open` is opted in for this block on purpose: with the allowlist empty
+# it would deny anyway, and the test would pass without ever reaching the lock.
+write_conf 'LV_UI_TERM_COMMANDS="lv-attach"'
 LOCK_STATE=locked
 for locked_command in \
   "launch $CLEAN_APP" \
@@ -352,7 +414,7 @@ for locked_command in \
   'ax click role=AXButton,title=General' \
   'ax type role=AXTextField -- hello' \
   'key escape' \
-  'term open ghostty herdr' \
+  'term open ghostty lv-attach' \
   'term focus term-1'; do
   assert_denied "$locked_command" "locked screen refuses: $locked_command" \
     "${APP_ENV[@]}" STUB_PGREP_PID=4242 STUB_WINDOW_RESULT="7 4242"
@@ -385,6 +447,7 @@ run_gate 'state' "${APP_ENV[@]}"
   || fail "state did not report the locked screen: $GATE_STDOUT"
 pass "allowed: state answers on a locked screen and reports it"
 LOCK_STATE=unlocked
+clear_conf
 
 echo "== 6. shot captures only a window owned by the launched pid =="
 
@@ -496,16 +559,19 @@ echo "== 9. term verbs =="
 clear_state
 : >"$LOG_FILE"
 : >"$TMP_DIR/open.log"
-run_gate 'term open ghostty herdr agent list' STUB_PGREP_PID=$$
+# The documented opt-in: a single-purpose wrapper the owner installs, which
+# takes an identifier and execs one fixed command. Never a general-purpose tool.
+write_conf 'LV_UI_TERM_COMMANDS="lv-attach"'
+run_gate 'term open ghostty lv-attach pane-7' STUB_PGREP_PID=$$
 (( GATE_STATUS == 0 )) || fail "term open of an allowlisted command failed: $GATE_STDERR"
 [[ "$GATE_STDOUT" == "opened term-1 "* ]] || fail "term open did not report an id: $GATE_STDOUT"
-grep -q 'command=herdr agent list' "$LOG_FILE" \
+grep -q 'command=lv-attach pane-7' "$LOG_FILE" \
   || fail "term open did not log the command in full"
 SCRIPT_FILE="$(find "$FAKE_HOME/.localvoxtral-ui-gate/terms" -name '*.command' | head -n 1)"
 [[ -n "$SCRIPT_FILE" ]] || fail "term open did not write a launcher script"
-grep -q '^exec herdr agent list$' "$SCRIPT_FILE" \
+grep -q '^exec lv-attach pane-7$' "$SCRIPT_FILE" \
   || fail "launcher script does not exec exactly the validated argv: $(cat "$SCRIPT_FILE")"
-pass "allowed: term open runs an allowlisted command and logs it in full"
+pass "allowed: term open runs an opted-in wrapper and logs the command in full"
 
 assert_allowed 'term focus term-1' 'term focus on a window this gate opened'
 assert_allowed 'term close term-1' 'term close on a window this gate opened'
@@ -574,7 +640,66 @@ expect_lock_state switched-away.plist no-session
 expect_lock_state no-console.plist no-session
 expect_lock_state garbage.plist error
 
-echo "== 12. the embedded Swift helper compiles =="
+echo "== 12. a term-open window is not a lateral path into the app verbs =="
+
+# The reason `term open` can be tolerated at all: every app-driving verb takes
+# its pid from the app.state that `launch` wrote, and `launch` only ever
+# records a validated localvoxtral bundle. With BOTH an app under test (4242)
+# and a terminal this gate opened (this test's own pid) recorded, no verb may
+# ever address the terminal.
+SELF_PID=$$
+clear_state
+write_conf 'LV_UI_TERM_COMMANDS="lv-attach"'
+run_gate 'term open ghostty lv-attach pane-7' STUB_PGREP_PID="$SELF_PID"
+(( GATE_STATUS == 0 )) || fail "scoping fixture: term open failed: $GATE_STDERR"
+write_app_state 4242
+: >"$TMP_DIR/swift.log"
+
+for scoped_command in \
+  'ax dump all' \
+  'ax click role=AXButton,title=General' \
+  'ax type role=AXTextField,title=Endpoint -- typed' \
+  'key escape'; do
+  run_gate "$scoped_command" "${APP_ENV[@]}"
+  (( GATE_STATUS == 0 )) || fail "scoping fixture: '$scoped_command' failed: $GATE_STDERR"
+done
+run_gate 'shot settings' "${APP_ENV[@]}" STUB_WINDOW_RESULT="8123 4242"
+(( GATE_STATUS == 0 )) || fail "scoping fixture: shot failed: $GATE_STDERR"
+
+# Every helper call that can read or actuate the UI carries 4242.
+while read -r line; do
+  case "$line" in
+    *" axdump "* | *" axclick "* | *" axtype "* | *" key "* | *" window "*)
+      [[ "$line" == *" 4242 "* || "$line" == *" 4242" ]] \
+        || fail "an app verb addressed a pid that is not the app under test: $line"
+      ;;
+  esac
+done <"$TMP_DIR/swift.log"
+# "$$(" would start a command substitution, so the pid goes through SELF_PID.
+if grep -qE " (axdump|axclick|axtype|key|window) ${SELF_PID}( |$)" "$TMP_DIR/swift.log"; then
+  fail "an app verb addressed the terminal's pid ($SELF_PID)"
+fi
+pass "ax dump/click/type, key and shot all address the app under test, never the terminal"
+
+# And a window that belongs to the terminal is refused by the same ownership
+# check that refuses any other application's window.
+assert_denied 'shot settings' 'shot of a window owned by the terminal this gate opened' \
+  "${APP_ENV[@]}" STUB_WINDOW_RESULT="9001 $SELF_PID"
+
+# term focus/close do reach the terminal — but they carry no selector, no
+# keystroke and no capture, so nothing typed by this gate can reach a shell.
+: >"$TMP_DIR/swift.log"
+assert_allowed 'term focus term-1' 'term focus reaches the terminal'
+grep -q "termaction ${SELF_PID} " "$TMP_DIR/swift.log" \
+  || fail "term focus did not address the terminal it opened"
+if grep -qE " (axclick|axtype|key) " "$TMP_DIR/swift.log"; then
+  fail "term focus reached an actuation subcommand"
+fi
+pass "term focus/close reach the terminal only to raise or close it"
+clear_conf
+clear_state
+
+echo "== 13. the embedded Swift helper compiles =="
 
 # The gate's CoreGraphics/AX helper is a heredoc, so nothing else ever type
 # checks it — and a helper that does not compile turns every GUI verb into a

--- a/scripts/ci/test-ui-gate.sh
+++ b/scripts/ci/test-ui-gate.sh
@@ -1,0 +1,584 @@
+#!/usr/bin/env bash
+# Security regression tests for the forced-command UI gate
+# (scripts/mac/localvoxtral-ui-gate.sh).
+#
+# The gate drives a GUI this test suite cannot reach, so everything that would
+# need one is stubbed on PATH (open/pgrep/ps/say/screencapture/swift/...) and
+# the gate itself runs UNMODIFIED. What is proved here is the whole trust
+# boundary — the allowlist, the argument validation, the lock refusal, and the
+# "only the pid this gate launched" ownership rule — none of which needs a
+# screen. What is NOT proved here is that the AX/CGWindow calls inside the
+# Swift helper do the right thing on a live desktop; that is the owner's
+# first-install check (scripts/mac/README.md).
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "$0")/../.." && pwd -P)"
+GATE="$ROOT_DIR/scripts/mac/localvoxtral-ui-gate.sh"
+LOCK_PROBE_SRC="$ROOT_DIR/scripts/ci/screen-lock-state.sh"
+# Deliberately /tmp and not $TMPDIR: fixture bundle paths are fed through the
+# gate's token charset, and a macOS per-user $TMPDIR can carry characters that
+# charset rejects — which would fail the test for the wrong reason.
+TMP_DIR="$(mktemp -d "/tmp/lv-ui-gate-test.XXXXXX")"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+FAKE_HOME="$TMP_DIR/home"
+STUB_BIN="$TMP_DIR/stubbin"
+LOG_FILE="$FAKE_HOME/Library/Logs/localvoxtral-ui-gate.log"
+ARTIFACT_ROOT="$FAKE_HOME/localvoxtral-ui-artifacts"
+mkdir -p "$FAKE_HOME/bin" "$STUB_BIN" "$ARTIFACT_ROOT" "$(dirname "$LOG_FILE")"
+: >"$LOG_FILE"
+
+LOCK_STATE=unlocked
+
+fail() {
+  printf 'FAIL: %s\n' "$*" >&2
+  exit 1
+}
+
+pass() {
+  printf 'PASS: %s\n' "$*"
+}
+
+# --- stubs -----------------------------------------------------------------
+# Named so they shadow only what the gate calls out to; sed/awk/date/mkdir
+# stay real.
+
+cat >"$STUB_BIN/say" <<'STUB'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >>"$STUB_SAY_LOG"
+STUB
+
+cat >"$STUB_BIN/sleep" <<'STUB'
+#!/usr/bin/env bash
+exit 0
+STUB
+
+cat >"$STUB_BIN/open" <<'STUB'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >>"$STUB_OPEN_LOG"
+exit "${STUB_OPEN_STATUS:-0}"
+STUB
+
+cat >"$STUB_BIN/pgrep" <<'STUB'
+#!/usr/bin/env bash
+[[ -n "${STUB_PGREP_PID:-}" ]] || exit 1
+printf '%s\n' "$STUB_PGREP_PID"
+STUB
+
+# `ps -p <pid> -o lstart=` and `ps -p <pid> -o comm=` are the two halves of the
+# gate's pid-reuse defence.
+cat >"$STUB_BIN/ps" <<'STUB'
+#!/usr/bin/env bash
+for arg in "$@"; do
+  case "$arg" in
+    lstart=) printf '%s\n' "${STUB_PS_LSTART:-Mon Aug 24 09:00:00 2026}"; exit 0 ;;
+    comm=) printf '%s\n' "${STUB_PS_COMM:-/nonexistent}"; exit 0 ;;
+  esac
+done
+exit 1
+STUB
+
+cat >"$STUB_BIN/screencapture" <<'STUB'
+#!/usr/bin/env bash
+out="${!#}"
+printf '%s\n' "$*" >>"$STUB_SCREENCAPTURE_LOG"
+printf 'PNGSTUB%s' "${STUB_SHOT_PAYLOAD:-...}" >"$out"
+STUB
+
+# Stands in for `swift <helper.swift> <subcommand> ...`: the gate's only route
+# to CoreGraphics/AX. $2 is the subcommand, $3.. the helper's own arguments.
+cat >"$STUB_BIN/swift" <<'STUB'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >>"$STUB_SWIFT_LOG"
+case "$2" in
+  preflight)
+    echo "accessibility=1"; echo "screen_recording=1"; echo "frontmost_pid=$3"
+    ;;
+  window)
+    [[ -n "${STUB_WINDOW_RESULT:-}" ]] || exit 1
+    printf '%s\n' "$STUB_WINDOW_RESULT"
+    ;;
+  termwindow)
+    printf '9001 %s\n' "$3"
+    ;;
+  axdump)
+    echo '[{"role":"AXWindow","children":[]}]'
+    ;;
+  axclick | axtype | key | termaction)
+    echo ok
+    ;;
+  *)
+    exit 1
+    ;;
+esac
+STUB
+
+cat >"$STUB_BIN/ioreg" <<'STUB'
+#!/usr/bin/env bash
+if [[ -n "${STUB_IOREG_FILE:-}" && -f "${STUB_IOREG_FILE}" ]]; then
+  cat "$STUB_IOREG_FILE"
+  exit 0
+fi
+echo '"HIDIdleTime" = 42000000000'
+STUB
+
+cat >"$STUB_BIN/pmset" <<'STUB'
+#!/usr/bin/env bash
+echo "Now drawing from 'AC Power'"
+STUB
+
+cat >"$STUB_BIN/defaults" <<'STUB'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >>"$STUB_DEFAULTS_LOG"
+STUB
+
+chmod +x "$STUB_BIN"/*
+
+install -m 0755 "$LOCK_PROBE_SRC" "$FAKE_HOME/bin/localvoxtral-screen-lock-state.sh"
+
+# --- fixtures --------------------------------------------------------------
+
+make_bundle() { # <name> <bundle-id> <executable> <dogfood-stamp:true|absent>
+  local dir="$ARTIFACT_ROOT/$1" stamp=""
+  mkdir -p "$dir/Contents/MacOS"
+  : >"$dir/Contents/MacOS/$3"
+  chmod +x "$dir/Contents/MacOS/$3"
+  if [[ "$4" == "true" ]]; then
+    stamp=$'  <key>LVXDogfoodCapture</key>\n  <true/>'
+  fi
+  cat >"$dir/Contents/Info.plist" <<PLIST
+<?xml version="1.0" encoding="UTF-8"?>
+<plist version="1.0">
+<dict>
+  <key>CFBundleExecutable</key>
+  <string>$3</string>
+  <key>CFBundleIdentifier</key>
+  <string>$2</string>
+$stamp
+</dict>
+</plist>
+PLIST
+  printf '%s\n' "$dir"
+}
+
+CLEAN_APP="$(make_bundle localvoxtral.app com.localvoxtral.app localvoxtral absent)"
+DOGFOOD_APP="$(make_bundle localvoxtral-dogfood.app com.localvoxtral.app localvoxtral true)"
+IMPOSTOR_APP="$(make_bundle Mail.app com.apple.mail Mail absent)"
+
+# --- gate runner -----------------------------------------------------------
+
+GATE_STATUS=0
+GATE_STDOUT=""
+GATE_STDERR=""
+
+run_gate() { # <command> [env assignments...]
+  local command="$1"
+  shift
+  local out_file="$TMP_DIR/out" err_file="$TMP_DIR/err"
+  GATE_STATUS=0
+  env -i \
+    PATH="$STUB_BIN:/usr/bin:/bin:/usr/sbin:/sbin" \
+    HOME="$FAKE_HOME" \
+    SSH_ORIGINAL_COMMAND="$command" \
+    LV_UI_LOCK_PROBE="$FAKE_HOME/bin/localvoxtral-screen-lock-state.sh" \
+    LV_SCREEN_LOCK_STATE="${LOCK_STATE:-unlocked}" \
+    STUB_SAY_LOG="$TMP_DIR/say.log" \
+    STUB_OPEN_LOG="$TMP_DIR/open.log" \
+    STUB_SWIFT_LOG="$TMP_DIR/swift.log" \
+    STUB_DEFAULTS_LOG="$TMP_DIR/defaults.log" \
+    STUB_SCREENCAPTURE_LOG="$TMP_DIR/screencapture.log" \
+    "$@" \
+    bash "$GATE" >"$out_file" 2>"$err_file" || GATE_STATUS=$?
+  GATE_STDOUT="$(cat "$out_file")"
+  GATE_STDERR="$(cat "$err_file")"
+}
+
+log_tail() {
+  tail -n 1 "$LOG_FILE" 2>/dev/null || true
+}
+
+assert_denied() { # <command> <description> [env...]
+  local command="$1" description="$2"
+  shift 2
+  local before after
+  before="$(wc -l <"$LOG_FILE" 2>/dev/null || echo 0)"
+  run_gate "$command" "$@"
+  (( GATE_STATUS == 126 )) \
+    || fail "$description: expected exit 126, got $GATE_STATUS (stderr: $GATE_STDERR)"
+  [[ "$GATE_STDERR" == *"denied command"* ]] \
+    || fail "$description: stderr did not say 'denied command' ($GATE_STDERR)"
+  after="$(wc -l <"$LOG_FILE" 2>/dev/null || echo 0)"
+  (( after > before )) || fail "$description: nothing was appended to the gate log"
+  [[ "$(log_tail)" == *" DENY "* ]] \
+    || fail "$description: last log line is not a DENY line: $(log_tail)"
+  [[ "$(log_tail)" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2} ]] \
+    || fail "$description: DENY line has no timestamp: $(log_tail)"
+  pass "denied: $description"
+}
+
+assert_allowed() { # <command> <description> [env...]
+  local command="$1" description="$2"
+  shift 2
+  run_gate "$command" "$@"
+  (( GATE_STATUS == 0 )) \
+    || fail "$description: expected exit 0, got $GATE_STATUS (stderr: $GATE_STDERR)"
+  [[ "$(log_tail)" == *" ALLOW "* ]] \
+    || fail "$description: no ALLOW line was logged (last line: $(log_tail))"
+  pass "allowed: $description"
+}
+
+write_app_state() { # <pid>
+  local pid="$1" dir="$FAKE_HOME/.localvoxtral-ui-gate"
+  mkdir -p "$dir"
+  {
+    printf 'pid=%s\n' "$pid"
+    printf 'bundle=%s\n' "$CLEAN_APP"
+    printf 'identity=%s|%s\n' "Mon Aug 24 09:00:00 2026" "$CLEAN_APP/Contents/MacOS/localvoxtral"
+    printf 'dogfood=0\n'
+  } >"$dir/app.state"
+}
+
+clear_state() {
+  rm -rf "$FAKE_HOME/.localvoxtral-ui-gate"
+}
+
+APP_ENV=(
+  STUB_PS_LSTART="Mon Aug 24 09:00:00 2026"
+  STUB_PS_COMM="$CLEAN_APP/Contents/MacOS/localvoxtral"
+)
+
+echo "== 1. unknown verbs and shell escapes =="
+
+assert_denied 'echo pwned' 'echo pwned (the README deny check)'
+assert_denied '' 'empty command'
+assert_denied 'bash -lc id' 'bash -lc'
+assert_denied 'sh -c id' 'sh -c'
+assert_denied 'eval id' 'eval'
+assert_denied 'exec id' 'exec'
+assert_denied 'screenshot' 'unknown verb that looks plausible'
+assert_denied 'STATE' 'verb allowlist is case sensitive'
+assert_denied 'state; id' 'command chaining with ;'
+assert_denied 'state && id' 'command chaining with &&'
+assert_denied 'state | id' 'pipeline'
+assert_denied 'state > /tmp/x' 'output redirection'
+assert_denied 'state `id`' 'backtick substitution'
+assert_denied 'state $(id)' 'dollar-paren substitution'
+assert_denied 'state ${HOME}' 'parameter expansion'
+assert_denied 'state *' 'glob'
+assert_denied 'quit; rm -rf ~' 'chaining onto an allowed verb'
+# A newline must both be denied AND collapse to a single log line: otherwise
+# the denied text writes its own second line, which can be made to read like a
+# genuine ALLOW entry.
+assert_denied "$(printf 'state\nid')" 'embedded newline (only line 1 would ever parse)'
+[[ "$(log_tail)" == *'state?id'* ]] \
+  || fail "the newline in a denied command was not neutralised in the log: $(log_tail)"
+
+assert_denied "$(printf 'state\tid')" 'embedded tab as an argument separator'
+assert_denied "state $(head -c 4000 /dev/zero | tr '\0' 'a')" 'over-long command'
+
+echo "== 2. per-verb argument validation =="
+
+assert_denied 'state extra' 'state takes no arguments'
+assert_denied 'quit now' 'quit takes no arguments'
+assert_denied 'launch' 'launch without an artifact'
+assert_denied "launch --wat $CLEAN_APP" 'launch with an unknown flag'
+assert_denied "launch $CLEAN_APP $DOGFOOD_APP" 'launch with two artifacts'
+assert_denied 'key' 'key without a name'
+assert_denied 'key escape tab' 'key with two names'
+assert_denied 'key cmd+q' 'key outside the three-entry allowlist'
+assert_denied 'key space' 'another key outside the allowlist'
+assert_denied 'shot fullscreen' 'shot of something that is not a window kind'
+assert_denied 'shot screen' 'shot screen (no full-screen capture exists)'
+assert_denied 'shot settings 2' 'shot settings with a stray index'
+assert_denied 'shot window' 'shot window without an index'
+assert_denied 'shot window 0' 'shot window index 0'
+assert_denied 'shot window abc' 'shot window with a non-numeric index'
+assert_denied 'shot window 1 2' 'shot with too many arguments'
+assert_denied 'ax' 'ax without a subverb'
+assert_denied 'ax poke role=AXButton' 'unknown ax subverb'
+assert_denied 'ax dump menus' 'ax dump of an unknown pane'
+assert_denied 'ax dump window' 'ax dump window without an index'
+assert_denied 'ax click' 'ax click without a selector'
+assert_denied 'ax click title' 'selector with no operator'
+assert_denied 'ax click bogus=1' 'selector with an unknown key'
+assert_denied 'ax click index=1' 'selector naming no matchable attribute'
+assert_denied 'ax click title=' 'selector with an empty value'
+assert_denied 'ax click role=AXButton,' 'selector with a trailing comma'
+assert_denied 'ax click window=zero,title=A' 'selector with a non-numeric window index'
+assert_denied 'ax type role=AXTextField hello' 'ax type without the -- separator'
+assert_denied 'ax type role=AXTextField --' 'ax type with an empty text'
+assert_denied 'term' 'term without a subverb'
+assert_denied 'term open' 'term open without a terminal'
+assert_denied 'term open ghostty' 'term open without a command'
+assert_denied 'term focus' 'term focus without an id'
+assert_denied 'term focus term-1 term-2' 'term focus with two ids'
+assert_denied 'term close ../../etc' 'term close with a path as an id'
+assert_denied 'term focus term-9' 'term focus on an id this gate never opened'
+
+echo "== 3. launch refuses anything that is not a localvoxtral bundle =="
+
+assert_denied "launch $IMPOSTOR_APP" 'launch of another vendor .app under the root'
+assert_denied 'launch /Applications/Mail.app' 'launch outside the allowlisted roots'
+assert_denied "launch $ARTIFACT_ROOT/../../etc" 'launch with .. in the path'
+assert_denied "launch $ARTIFACT_ROOT/missing.app" 'launch of a path that does not exist'
+assert_denied "launch --dogfood $CLEAN_APP" 'launch --dogfood on an unstamped bundle'
+
+echo "== 4. term open is not a shell verb =="
+
+assert_denied 'term open ghostty bash -c id' 'term open running bash'
+assert_denied 'term open ghostty sh' 'term open running sh'
+assert_denied 'term open ghostty ssh builder@mac' 'term open running ssh'
+assert_denied 'term open ghostty osascript -e id' 'term open running osascript'
+assert_denied 'term open bash herdr' 'a shell in the terminal position'
+assert_denied 'term open ghostty herdr;id' 'metacharacter inside an allowlisted command'
+assert_denied 'term open ghostty herdr `id`' 'backticks in a term command'
+assert_denied 'term open ghostty herdr a b c d e f g h i j k l m' 'more tokens than the cap'
+
+echo "== 5. the screen lock is a hard refusal (fail closed) =="
+
+write_app_state 4242
+LOCK_STATE=locked
+for locked_command in \
+  "launch $CLEAN_APP" \
+  'shot settings' \
+  'ax dump all' \
+  'ax click role=AXButton,title=General' \
+  'ax type role=AXTextField -- hello' \
+  'key escape' \
+  'term open ghostty herdr' \
+  'term focus term-1'; do
+  assert_denied "$locked_command" "locked screen refuses: $locked_command" \
+    "${APP_ENV[@]}" STUB_PGREP_PID=4242 STUB_WINDOW_RESULT="7 4242"
+done
+
+LOCK_STATE=no-session
+assert_denied 'shot settings' 'no console session refuses shot' \
+  "${APP_ENV[@]}" STUB_WINDOW_RESULT="7 4242"
+LOCK_STATE=error
+assert_denied 'shot settings' 'undeterminable lock state refuses shot' \
+  "${APP_ENV[@]}" STUB_WINDOW_RESULT="7 4242"
+
+# A missing probe must deny, not fall through: this gate drives the owner's
+# personal desktop, so "cannot tell" is never "go ahead".
+GATE_STATUS=0
+env -i PATH="$STUB_BIN:/usr/bin:/bin" HOME="$FAKE_HOME" \
+  SSH_ORIGINAL_COMMAND='shot settings' \
+  LV_UI_LOCK_PROBE="$FAKE_HOME/bin/does-not-exist.sh" \
+  bash "$GATE" >/dev/null 2>&1 || GATE_STATUS=$?
+(( GATE_STATUS == 126 )) || fail "missing lock probe: expected 126, got $GATE_STATUS"
+grep -q 'lock probe missing' "$LOG_FILE" || fail "missing lock probe was not logged with its reason"
+pass "denied: a missing lock probe fails closed"
+
+# `state` is the one verb that still answers while locked — deciding whether it
+# is safe to drive is exactly what it is for.
+LOCK_STATE=locked
+run_gate 'state' "${APP_ENV[@]}"
+(( GATE_STATUS == 0 )) || fail "state should answer on a locked screen (got $GATE_STATUS: $GATE_STDERR)"
+[[ "$GATE_STDOUT" == *'"screen_lock":"locked"'* ]] \
+  || fail "state did not report the locked screen: $GATE_STDOUT"
+pass "allowed: state answers on a locked screen and reports it"
+LOCK_STATE=unlocked
+
+echo "== 6. shot captures only a window owned by the launched pid =="
+
+clear_state
+run_gate 'shot settings' "${APP_ENV[@]}"
+(( GATE_STATUS == 126 )) || fail "shot with no app under test should be denied (got $GATE_STATUS)"
+pass "denied: shot before any launch"
+
+# A resolved window owned by SOMETHING ELSE is refused — the invariant that
+# keeps this verb away from the owner's mail, browser and messages.
+write_app_state 4242
+assert_denied 'shot settings' 'shot of a window owned by another pid' \
+  "${APP_ENV[@]}" STUB_WINDOW_RESULT="8123 999"
+grep -q 'owned by pid 999' "$LOG_FILE" \
+  || fail "the foreign-owner refusal was not logged with the owner pid"
+
+assert_denied 'shot settings' 'shot when the window lookup returns garbage' \
+  "${APP_ENV[@]}" STUB_WINDOW_RESULT="not-a-window"
+
+# Same fixture, correct owner: the capture happens, base64 on stdout only.
+run_gate 'shot settings' "${APP_ENV[@]}" STUB_WINDOW_RESULT="8123 4242"
+(( GATE_STATUS == 0 )) || fail "shot of the app's own window failed: $GATE_STDERR"
+# Round-trip through the SAME base64 binary: BSD and GNU disagree on the
+# decode flag (-D vs -d), and this suite runs on both.
+EXPECTED_B64="$(printf 'PNGSTUB...' | base64 | tr -d '\n')"
+[[ "$(printf '%s' "$GATE_STDOUT" | tr -d '\n')" == "$EXPECTED_B64" ]] \
+  || fail "shot stdout was not the base64 of the captured file: $GATE_STDOUT"
+[[ "$GATE_STDERR" == *"window 8123"* ]] || fail "shot did not report the window id on stderr"
+grep -q -- '-l 8123' "$TMP_DIR/screencapture.log" \
+  || fail "screencapture was not scoped to the resolved window id"
+pass "allowed: shot of the app-under-test's own window"
+
+# Pid reuse: the recorded pid is live but is a different process now.
+assert_denied 'shot settings' 'shot after the recorded pid was recycled' \
+  STUB_PS_LSTART="Tue Aug 25 11:11:11 2026" \
+  STUB_PS_COMM="$CLEAN_APP/Contents/MacOS/localvoxtral" \
+  STUB_WINDOW_RESULT="8123 4242"
+
+echo "== 7. launch happy path, warning, and recorded identity =="
+
+clear_state
+: >"$TMP_DIR/say.log"
+run_gate "launch $CLEAN_APP" "${APP_ENV[@]}" STUB_PGREP_PID=4242
+(( GATE_STATUS == 0 )) || fail "launch of a valid bundle failed: $GATE_STDERR"
+[[ "$GATE_STDOUT" == *"launched pid=4242"* ]] || fail "launch did not report the pid: $GATE_STDOUT"
+grep -q "pid=4242" "$FAKE_HOME/.localvoxtral-ui-gate/app.state" \
+  || fail "launch did not record the pid"
+grep -q "identity=Mon Aug 24 09:00:00 2026|$CLEAN_APP/Contents/MacOS/localvoxtral" \
+  "$FAKE_HOME/.localvoxtral-ui-gate/app.state" \
+  || fail "launch did not record the start time + executable identity"
+grep -q "taking control in 3" "$TMP_DIR/say.log" \
+  || fail "launch did not speak the takeover warning (owner rule)"
+grep -q "done" "$TMP_DIR/say.log" \
+  || fail "launch did not announce completion (owner rule)"
+grep -q -- "-n $CLEAN_APP" "$TMP_DIR/open.log" \
+  || fail "launch did not open the validated bundle"
+pass "allowed: launch records identity, warns audibly, announces completion"
+
+# --dogfood requires the Info.plist stamp AND arms the runtime opt-in.
+clear_state
+: >"$TMP_DIR/defaults.log"
+run_gate "launch --dogfood $DOGFOOD_APP" \
+  STUB_PS_LSTART="Mon Aug 24 09:00:00 2026" \
+  STUB_PS_COMM="$DOGFOOD_APP/Contents/MacOS/localvoxtral" \
+  STUB_PGREP_PID=4343
+(( GATE_STATUS == 0 )) || fail "launch --dogfood of a stamped bundle failed: $GATE_STDERR"
+grep -q 'debug.dogfood_capture_enabled' "$TMP_DIR/defaults.log" \
+  || fail "launch --dogfood did not arm the capture opt-in"
+pass "allowed: launch --dogfood on a stamped bundle"
+
+echo "== 8. ax and key verbs =="
+
+clear_state
+write_app_state 4242
+assert_allowed 'ax dump all' 'ax dump of the app under test' "${APP_ENV[@]}"
+[[ "$GATE_STDOUT" == '[{"role":"AXWindow"'* ]] || fail "ax dump did not emit the helper's JSON"
+assert_allowed 'ax click role=AXButton,title~Text+Processing' 'ax click by role and title' "${APP_ENV[@]}"
+grep -q 'axclick 4242 role=AXButton,title~Text+Processing' "$TMP_DIR/swift.log" \
+  || fail "ax click did not scope the helper call to the launched pid"
+assert_allowed 'key escape' 'key escape' "${APP_ENV[@]}"
+assert_allowed 'key tab' 'key tab' "${APP_ENV[@]}"
+assert_allowed 'key return' 'key return' "${APP_ENV[@]}"
+
+# Typed text takes a wider charset than any other argument, and is the one
+# thing the log must never keep.
+: >"$LOG_FILE"
+assert_allowed 'ax type role=AXTextField,title=Endpoint -- sk-secret-token-42!' \
+  'ax type with a secret-looking value' "${APP_ENV[@]}"
+grep -q -- '-- <redacted>' "$LOG_FILE" || fail "ax type text was not redacted in the log"
+if grep -q 'sk-secret-token-42' "$LOG_FILE"; then
+  fail "ax type leaked the typed text into the log"
+fi
+grep -q 'axtype 4242 role=AXTextField,title=Endpoint sk-secret-token-42!' "$TMP_DIR/swift.log" \
+  || fail "ax type did not pass the text to the helper as argv"
+pass "ax type redacts the typed text in the log but still types it"
+
+echo "== 9. term verbs =="
+
+clear_state
+: >"$LOG_FILE"
+: >"$TMP_DIR/open.log"
+run_gate 'term open ghostty herdr agent list' STUB_PGREP_PID=$$
+(( GATE_STATUS == 0 )) || fail "term open of an allowlisted command failed: $GATE_STDERR"
+[[ "$GATE_STDOUT" == "opened term-1 "* ]] || fail "term open did not report an id: $GATE_STDOUT"
+grep -q 'command=herdr agent list' "$LOG_FILE" \
+  || fail "term open did not log the command in full"
+SCRIPT_FILE="$(find "$FAKE_HOME/.localvoxtral-ui-gate/terms" -name '*.command' | head -n 1)"
+[[ -n "$SCRIPT_FILE" ]] || fail "term open did not write a launcher script"
+grep -q '^exec herdr agent list$' "$SCRIPT_FILE" \
+  || fail "launcher script does not exec exactly the validated argv: $(cat "$SCRIPT_FILE")"
+pass "allowed: term open runs an allowlisted command and logs it in full"
+
+assert_allowed 'term focus term-1' 'term focus on a window this gate opened'
+assert_allowed 'term close term-1' 'term close on a window this gate opened'
+assert_denied 'term focus term-1' 'term focus after the window was closed'
+
+echo "== 10. quit terminates only the recorded process =="
+
+clear_state
+tail -f /dev/null &
+VICTIM_PID=$!
+write_app_state "$VICTIM_PID"
+run_gate 'quit' "${APP_ENV[@]}"
+(( GATE_STATUS == 0 )) || fail "quit failed: $GATE_STDERR"
+wait "$VICTIM_PID" 2>/dev/null || true
+if kill -0 "$VICTIM_PID" 2>/dev/null; then
+  fail "quit did not terminate the recorded process"
+fi
+if [[ -f "$FAKE_HOME/.localvoxtral-ui-gate/app.state" ]]; then
+  fail "quit left the app state behind"
+fi
+pass "allowed: quit terminates the recorded pid and clears the state"
+
+echo "== 11. the shared lock probe's ioreg arm =="
+
+PROBE="$FAKE_HOME/bin/localvoxtral-screen-lock-state.sh"
+FIXTURES="$TMP_DIR/ioreg"
+mkdir -p "$FIXTURES"
+
+cat >"$FIXTURES/locked.plist" <<'XML'
+<plist><dict><key>IOConsoleUsers</key><array><dict>
+  <key>kCGSSessionOnConsoleKey</key><true/>
+  <key>CGSSessionScreenIsLocked</key><true/>
+</dict></array></dict></plist>
+XML
+cat >"$FIXTURES/unlocked.plist" <<'XML'
+<plist><dict><key>IOConsoleUsers</key><array><dict>
+  <key>kCGSSessionOnConsoleKey</key><true/>
+</dict></array></dict></plist>
+XML
+cat >"$FIXTURES/switched-away.plist" <<'XML'
+<plist><dict><key>IOConsoleUsers</key><array><dict>
+  <key>kCGSSessionOnConsoleKey</key><false/>
+  <key>CGSSessionScreenIsLocked</key><true/>
+</dict></array></dict></plist>
+XML
+cat >"$FIXTURES/no-console.plist" <<'XML'
+<plist><dict><key>IOConsoleUsers</key><array/></dict></plist>
+XML
+echo 'garbage' >"$FIXTURES/garbage.plist"
+
+expect_lock_state() { # <fixture> <expected>
+  local actual
+  actual="$(env -i PATH="/usr/bin:/bin" \
+    LV_SCREEN_LOCK_SWIFT_CMD=/nonexistent-swift \
+    LV_SCREEN_LOCK_IOREG_CMD="cat $FIXTURES/$1" \
+    bash "$PROBE")"
+  [[ "$actual" == "$2" ]] || fail "lock probe on $1: expected $2, got $actual"
+  pass "lock probe: $1 -> $2"
+}
+
+expect_lock_state locked.plist locked
+expect_lock_state unlocked.plist unlocked
+# A fast-user-switched-away session keeps stale lock keys; only the session
+# actually on the console decides.
+expect_lock_state switched-away.plist no-session
+expect_lock_state no-console.plist no-session
+expect_lock_state garbage.plist error
+
+echo "== 12. the embedded Swift helper compiles =="
+
+# The gate's CoreGraphics/AX helper is a heredoc, so nothing else ever type
+# checks it — and a helper that does not compile turns every GUI verb into a
+# runtime failure the owner only discovers by hand. On the macOS runner this
+# is a real compile; on a Linux dev box it is skipped (and says so).
+if command -v swiftc >/dev/null 2>&1; then
+  HELPER_DIR="$TMP_DIR/helper"
+  mkdir -p "$HELPER_DIR"
+  awk '/^  cat >"\$HELPER_PATH" <<.SWIFT.$/ { capture = 1; next }
+       capture && /^SWIFT$/ { exit }
+       capture { print }' "$GATE" >"$HELPER_DIR/main.swift"
+  [[ -s "$HELPER_DIR/main.swift" ]] \
+    || fail "could not extract the Swift helper from the gate (heredoc markers changed?)"
+  grep -q 'AXUIElementCreateApplication' "$HELPER_DIR/main.swift" \
+    || fail "the extracted Swift helper does not look like the helper"
+  ( cd "$HELPER_DIR" && swiftc -typecheck main.swift ) \
+    || fail "the embedded Swift helper does not type check"
+  pass "the embedded Swift helper type checks"
+else
+  printf 'SKIP: swiftc not available — the embedded Swift helper was not type checked\n'
+fi
+
+echo
+echo "ui gate tests passed"

--- a/scripts/ci/test-ui-gate.sh
+++ b/scripts/ci/test-ui-gate.sh
@@ -66,6 +66,34 @@ STUB
 cat >"$STUB_BIN/open" <<'STUB'
 #!/usr/bin/env bash
 printf '%s\n' "$*" >>"$STUB_OPEN_LOG"
+# With STUB_OPEN_SPAWN set, stand in for a terminal that actually ran the
+# launcher: a long-lived process that recorded its pid the way the launcher's
+# `printf "$$" > <pidfile>` does before `exec`. That is the handle `term open`
+# uses to take back what it started when it cannot identify the window, so the
+# suite has to have a real process to watch die. /bin/sleep, not the stubbed
+# `sleep` that returns instantly.
+case "${STUB_OPEN_SPAWN:-}" in
+  "") ;;
+  dead)
+    # The launcher ran and the command exited immediately — the pid file is
+    # there, the process is not. An empty terminal window is what the owner
+    # sees when this happens.
+    launcher=""
+    for launcher in "$@"; do :; done
+    ( printf '%s' "$BASHPID" >"${launcher%.command}.pid" ) &
+    wait
+    ;;
+  *)
+    launcher=""
+    for launcher in "$@"; do :; done
+    ( printf '%s' "$BASHPID" >"${launcher%.command}.pid"; exec /bin/sleep 300 ) &
+    # The pid file has to exist before this returns, or the gate races it.
+    for _ in 1 2 3 4 5 6 7 8 9 10; do
+      [[ -s "${launcher%.command}.pid" ]] && break
+      /bin/sleep 0.1
+    done
+    ;;
+esac
 exit "${STUB_OPEN_STATUS:-0}"
 STUB
 
@@ -122,8 +150,23 @@ case "$2" in
     [[ -n "${STUB_WINDOW_RESULT:-}" ]] || exit 1
     printf '%s\n' "$STUB_WINDOW_RESULT"
     ;;
-  termwindow)
-    printf '9001 %s\n' "$3"
+  termsnapshot)
+    # The window ids the terminal owned BEFORE `open`. The gate diffs against
+    # these, so the suite can say "one new window", "none" or "several".
+    printf '%s\n' "${STUB_TERM_SNAPSHOT:-}"
+    ;;
+  termnew)
+    # $3 owner pid, $4 marker, $5 excluded ids. The exit code is the contract:
+    # 0 with `ok <winid> <ownerpid>`, 1 for "nothing new yet", 2 for "several
+    # appeared and I will not guess".
+    case "${STUB_TERMNEW:-ok}" in
+      ok) printf 'ok %s %s\n' "${STUB_TERMNEW_WINDOW:-9001}" "$3" ;;
+      none) exit 1 ;;
+      ambiguous)
+        printf 'helper: 2 windows of pid %s appeared since the snapshot (ids 9001 9002)\n' "$3" >&2
+        exit 2
+        ;;
+    esac
     ;;
   axdump)
     echo '[{"role":"AXWindow","children":[]}]'
@@ -214,6 +257,11 @@ STUB
 chmod +x "$STUB_BIN"/*
 
 install -m 0755 "$LOCK_PROBE_SRC" "$FAKE_HOME/bin/localvoxtral-screen-lock-state.sh"
+# `term open` resolves an allowlisted NAME to an executable file under
+# LV_UI_TERM_COMMAND_DIRS ($HOME/bin) before it opens anything, so the happy
+# paths below need the wrapper actually installed — which is also the state the
+# owner's Mac was NOT in on 2026-08-30.
+install -m 0700 "$ROOT_DIR/scripts/mac/lv-attach.sh" "$FAKE_HOME/bin/lv-attach"
 
 # --- fixtures --------------------------------------------------------------
 
@@ -266,6 +314,7 @@ run_gate() { # <command> [env assignments...]
     HOME="$FAKE_HOME" \
     SSH_ORIGINAL_COMMAND="$command" \
     LV_UI_LOCK_PROBE="$FAKE_HOME/bin/localvoxtral-screen-lock-state.sh" \
+    LV_UI_TERM_OPEN_TIMEOUT_SECONDS="${TERM_OPEN_TIMEOUT:-2}" \
     LV_SCREEN_LOCK_STATE="${LOCK_STATE:-unlocked}" \
     STUB_SAY_LOG="$TMP_DIR/say.log" \
     STUB_OPEN_LOG="$TMP_DIR/open.log" \
@@ -707,13 +756,181 @@ grep -q 'command=lv-attach pane-7' "$LOG_FILE" \
   || fail "term open did not log the command in full"
 SCRIPT_FILE="$(find "$FAKE_HOME/.localvoxtral-ui-gate/terms" -name '*.command' | head -n 1)"
 [[ -n "$SCRIPT_FILE" ]] || fail "term open did not write a launcher script"
-grep -q '^exec lv-attach pane-7$' "$SCRIPT_FILE" \
+grep -q "^exec $FAKE_HOME/bin/lv-attach pane-7\$" "$SCRIPT_FILE" \
   || fail "launcher script does not exec exactly the validated argv: $(cat "$SCRIPT_FILE")"
-pass "allowed: term open runs an opted-in wrapper and logs the command in full"
+pass "allowed: term open runs an opted-in wrapper, by absolute path, and logs the command in full"
 
 assert_allowed 'term focus term-1' 'term focus on a window this gate opened'
 assert_allowed 'term close term-1' 'term close on a window this gate opened'
 assert_denied 'term focus term-1' 'term focus after the window was closed'
+
+# --- the command is resolved to a file BEFORE anything is opened ------------
+#
+# Field failure 2026-08-30: `term open ghostty lv-attach` opened an EMPTY
+# Ghostty window and then failed with a window-identification message. The
+# launcher said `exec lv-attach` and relied on PATH; a script started by
+# `open -n -a Ghostty --args -e <script>` gets no login-shell environment and
+# `$HOME/bin` is on neither its PATH nor sshd's, so the launcher hit `command
+# not found` and exited instantly. The window was real, the diagnosis was not.
+
+# An allowlisted name with nothing behind it must refuse with NOTHING opened,
+# and say which of the two problems it is.
+mv "$FAKE_HOME/bin/lv-attach" "$FAKE_HOME/bin/lv-attach.aside"
+: >"$TMP_DIR/open.log"
+assert_denied 'term open ghostty lv-attach' 'an allowlisted command that is not installed'
+[[ ! -s "$TMP_DIR/open.log" ]] \
+  || fail "term open opened a window for a command it could not resolve: $(cat "$TMP_DIR/open.log")"
+[[ "$(log_tail)" == *"is not an executable file"* ]] \
+  || fail "the unresolvable refusal did not name the real problem: $(log_tail)"
+pass "an allowlisted command that is not installed refuses without opening a window"
+
+# And it is visible BEFORE a verb is tried, which is the whole point.
+run_gate 'state'
+[[ "$GATE_STDOUT" == *'"unresolvable":["lv-attach"]'* ]] \
+  || fail "state did not report the allowlisted name that resolves to nothing: $GATE_STDOUT"
+pass "state reports an allowlisted command with no executable behind it"
+
+# Not executable is the same fault wearing a different hat (a copy that lost
+# its mode bit is exactly what an interrupted install leaves).
+install -m 0600 "$FAKE_HOME/bin/lv-attach.aside" "$FAKE_HOME/bin/lv-attach"
+assert_denied 'term open ghostty lv-attach' 'an allowlisted command that is not executable'
+run_gate 'state'
+[[ "$GATE_STDOUT" == *'"unresolvable":["lv-attach"]'* ]] \
+  || fail "state treated a non-executable file as resolvable: $GATE_STDOUT"
+install -m 0700 "$FAKE_HOME/bin/lv-attach.aside" "$FAKE_HOME/bin/lv-attach"
+rm -f "$FAKE_HOME/bin/lv-attach.aside"
+pass "a file that is not executable does not read as an installed command"
+
+# The allowlist is about NAMES; resolution is about where a name lives. A path
+# in the command position is refused outright rather than resolved.
+write_conf 'LV_UI_TERM_COMMANDS="lv-attach /bin/sh ../bin/lv-attach"'
+assert_denied 'term open ghostty /bin/sh' 'an absolute path in the command position'
+assert_denied 'term open ghostty ../bin/lv-attach' 'a relative path in the command position'
+write_conf 'LV_UI_TERM_COMMANDS="lv-attach"'
+pass "term open takes a command name, never a path"
+
+# --- the window is identified by a CGWindowID, never by a title marker ------
+#
+# Field failure 2026-08-30: `term open ghostty lv-attach` reported "opened
+# Ghostty but never saw a window carrying marker lvui-term-1-…" while a real
+# window sat on the owner's screen. `lv-attach` execs a whole-view herdr
+# client, and herdr owns the terminal title from the moment it starts —
+# docs/agent/invariants.md says a title marker "can neither reach nor come
+# back from a herdr-hosted session", which is also why the app's own
+# titleMarker join arm is suppressed there. The gate reused a title marker
+# anyway, so the one command this verb exists to run could never be seen, and
+# the window it did open was left unregistered: `term focus`/`term close`
+# could not address it, and nothing could close it.
+
+clear_state
+: >"$TMP_DIR/swift.log"
+run_gate 'term open ghostty lv-attach pane-7' STUB_PGREP_PID=$$ STUB_TERM_SNAPSHOT="4001,4002"
+(( GATE_STATUS == 0 )) || fail "term open failed: $GATE_STDERR"
+# The snapshot is taken BEFORE `open`, and the ids it found are what the new
+# window is diffed against. Without that this verb is back to asking the child
+# process to tag its own window.
+grep -q 'termsnapshot' "$TMP_DIR/swift.log" \
+  || fail "term open did not snapshot the terminal's windows before opening one: $(cat "$TMP_DIR/swift.log")"
+grep -q 'termnew .* 4001,4002' "$TMP_DIR/swift.log" \
+  || fail "term open did not exclude the windows that existed before it ran: $(cat "$TMP_DIR/swift.log")"
+TERM_ID="${GATE_STDOUT#opened }"
+TERM_ID="${TERM_ID%% *}"
+grep -q 'window=9001' "$FAKE_HOME/.localvoxtral-ui-gate/terms/$TERM_ID.state" \
+  || fail "term open did not record the window id it resolved"
+pass "term open identifies its window by what appeared since a pre-open snapshot"
+
+: >"$TMP_DIR/swift.log"
+assert_allowed "term focus $TERM_ID" 'term focus by recorded window id'
+grep -q "termaction $$ 9001 focus" "$TMP_DIR/swift.log" \
+  || fail "term focus did not address the recorded window id: $(cat "$TMP_DIR/swift.log")"
+: >"$TMP_DIR/swift.log"
+assert_allowed "term close $TERM_ID" 'term close by recorded window id'
+grep -q "termaction $$ 9001 close" "$TMP_DIR/swift.log" \
+  || fail "term close did not address the recorded window id: $(cat "$TMP_DIR/swift.log")"
+pass "term focus and term close address a window id, not a title"
+
+# The marker survives only as a tie-breaker for commands that leave the title
+# alone. It must not be what any verb depends on.
+TERMNEW_BODY="$(helper_case_body termnew)"
+grep -q 'excluded' <<<"$TERMNEW_BODY" \
+  || fail "termnew no longer decides on the pre-open snapshot"
+grep -q 'TIE-BREAKER' <<<"$TERMNEW_BODY" \
+  || fail "the marker is no longer documented as a tie-breaker in termnew"
+TERMACTION_BODY="$(helper_case_body termaction)"
+grep -q 'marker' <<<"$TERMACTION_BODY" \
+  && fail "termaction still resolves a window by title marker — herdr overwrites it"
+pass "no term verb resolves a window by a title herdr can overwrite"
+
+# --- a failed term open leaves no residue -----------------------------------
+#
+# The same field failure left an orphaned Ghostty window running a herdr client
+# that no verb could reach. If this verb cannot identify what it opened, it
+# must take back what it started.
+
+clear_state
+: >"$TMP_DIR/open.log"
+run_gate 'term open ghostty lv-attach pane-7' \
+  STUB_PGREP_PID=$$ STUB_TERMNEW=none STUB_OPEN_SPAWN=1
+(( GATE_STATUS != 0 )) || fail "term open reported success with no window resolved"
+[[ "$GATE_STDERR" == *"no new window appeared"* ]] \
+  || fail "term open did not say what went wrong: $GATE_STDERR"
+[[ "$GATE_STDERR" == *"terminated the command it started"* ]] \
+  || fail "term open did not reclaim the process it started: $GATE_STDERR"
+ORPHAN_PIDFILE="$(find "$FAKE_HOME/.localvoxtral-ui-gate/terms" -name '*.pid' 2>/dev/null | head -n 1)"
+[[ -z "$ORPHAN_PIDFILE" ]] \
+  || fail "term open left a pid file behind after failing: $ORPHAN_PIDFILE"
+[[ -z "$(find "$FAKE_HOME/.localvoxtral-ui-gate/terms" -name 'term-*.state' 2>/dev/null)" ]] \
+  || fail "a failed term open registered a terminal anyway"
+pass "a term open that cannot identify its window kills what it started and registers nothing"
+
+# --- and it does not tell the wrong story about WHY -------------------------
+#
+# Three faults live behind "no window": the terminal never ran the launcher,
+# the command ran and exited immediately, and the command is running but the
+# window could not be identified. They have completely different fixes, and
+# reporting the second as the third is what produced a confidently wrong root
+# cause on 2026-08-30. The launcher writes its pid before `exec`, so the pid
+# file separates them.
+
+clear_state
+run_gate 'term open ghostty lv-attach pane-7' STUB_PGREP_PID=$$ STUB_TERMNEW=none
+(( GATE_STATUS != 0 )) || fail "term open reported success with no launcher run"
+[[ "$GATE_STDERR" == *"never ran the launcher"* ]] \
+  || fail "a launcher that never ran was not reported as such: $GATE_STDERR"
+[[ "$GATE_STDERR" == *"not a window-identification problem"* ]] \
+  || fail "the message does not rule out the fault it is NOT: $GATE_STDERR"
+pass "a terminal that never ran the launcher says so, and says what it is not"
+
+clear_state
+run_gate 'term open ghostty lv-attach pane-7' \
+  STUB_PGREP_PID=$$ STUB_TERMNEW=none STUB_OPEN_SPAWN=dead
+(( GATE_STATUS != 0 )) || fail "term open reported success for a command that exited"
+[[ "$GATE_STDERR" == *"exited immediately"* ]] \
+  || fail "a command that exited was not reported as such: $GATE_STDERR"
+[[ "$GATE_STDERR" == *"empty terminal window"* ]] \
+  || fail "the message does not connect the fault to what the owner sees: $GATE_STDERR"
+[[ "$GATE_STDERR" == *"$FAKE_HOME/bin/lv-attach pane-7"* ]] \
+  || fail "the message does not hand back the command to run by hand: $GATE_STDERR"
+[[ "$GATE_STDERR" != *"no new window appeared"* ]] \
+  || fail "a failed COMMAND was reported as a window-identification timeout: $GATE_STDERR"
+pass "a command that exits immediately is reported as a failed command, not a missing window"
+
+# Several windows at once: waiting longer cannot make that less ambiguous, and
+# binding the wrong one would point `term close` at whatever the owner just
+# opened. Refuse, say so, and still leave nothing behind.
+clear_state
+run_gate 'term open ghostty lv-attach pane-7' \
+  STUB_PGREP_PID=$$ STUB_TERMNEW=ambiguous STUB_OPEN_SPAWN=1
+(( GATE_STATUS != 0 )) || fail "term open bound a window while several appeared at once"
+[[ "$GATE_STDERR" == *"several windows appeared"* ]] \
+  || fail "the ambiguous case did not explain itself: $GATE_STDERR"
+[[ "$GATE_STDERR" == *"terminated the command it started"* ]] \
+  || fail "the ambiguous case did not reclaim the process it started: $GATE_STDERR"
+[[ -z "$(find "$FAKE_HOME/.localvoxtral-ui-gate/terms" -name 'term-*.state' 2>/dev/null)" ]] \
+  || fail "the ambiguous case registered a terminal anyway"
+pass "term open refuses to guess between windows that appeared at the same moment"
+
+clear_state
 
 echo "== 10. quit terminates only the recorded process =="
 
@@ -828,7 +1045,7 @@ assert_denied 'shot settings' 'shot of a window owned by the terminal this gate 
 # keystroke and no capture, so nothing typed by this gate can reach a shell.
 : >"$TMP_DIR/swift.log"
 assert_allowed 'term focus term-1' 'term focus reaches the terminal'
-grep -q "termaction ${SELF_PID} " "$TMP_DIR/swift.log" \
+grep -q "termaction ${SELF_PID} [0-9]" "$TMP_DIR/swift.log" \
   || fail "term focus did not address the terminal it opened"
 if grep -qE " (axclick|axtype|key) " "$TMP_DIR/swift.log"; then
   fail "term focus reached an actuation subcommand"
@@ -1879,6 +2096,72 @@ assert_attach_refused 'a destination that is an ssh option' 'destination=-oProxy
 assert_attach_refused 'a destination with a space'   'destination=builder sh' 'work'
 assert_attach_refused 'a destination with a colon'   'destination=builder:2222' 'work'
 
+# --- `--check`: the one flag, and the reason the gate has one source of truth
+#
+# The UI gate's `state` asks the INSTALLED wrapper whether its config resolves
+# rather than re-reading ~/.lv-attach.conf itself, so this flag is now part of
+# the boundary's contract. What has to stay true: it prints a verdict, it runs
+# NOTHING, and it does not turn the wrapper into a thing that takes flags.
+
+run_attach $'destination=builder\n' --check
+(( ATTACH_STATUS == 0 )) || fail "--check refused a resolvable config: $ATTACH_STDERR"
+CHECK_OUT="$(cat "$TMP_DIR/attach.out")"
+[[ "$CHECK_OUT" == *"conf=ok"* ]] || fail "--check did not report conf=ok: $CHECK_OUT"
+[[ "$CHECK_OUT" == *"destination_kind=alias"* ]] \
+  || fail "--check did not classify a bare alias: $CHECK_OUT"
+[[ "$CHECK_OUT" == *"destination=builder"* ]] \
+  || fail "--check withheld a bare alias, which is the value an operator needs: $CHECK_OUT"
+[[ "$CHECK_OUT" == *"session=absent"* ]] || fail "--check misreported the session: $CHECK_OUT"
+[[ ! -s "$SSH_LOG" ]] || fail "--check ran ssh: $(cat "$SSH_LOG")"
+pass "lv-attach --check reports a resolvable config and runs nothing"
+
+run_attach $'destination=builder\nsession=work\n' --check
+[[ "$(cat "$TMP_DIR/attach.out")" == *"session=configured"* ]] \
+  || fail "--check did not see the configured default session"
+
+# A `user@host` destination is an account AND an address. The gate's stated
+# posture is that no host, account or session id crosses it (`app` answers in a
+# closed vocabulary for the same reason), so the SHAPE is reported and the
+# value is not. A bare alias is a label in the owner's own ~/.ssh/config and is.
+run_attach $'destination=deploy@build.local\n' --check
+CHECK_OUT="$(cat "$TMP_DIR/attach.out")"
+(( ATTACH_STATUS == 0 )) || fail "--check refused a valid user@host destination"
+[[ "$CHECK_OUT" == *"destination_kind=user@host"* ]] \
+  || fail "--check did not classify a user@host destination: $CHECK_OUT"
+[[ "$CHECK_OUT" != *"build.local"* ]] \
+  || fail "--check echoed a user@host destination — an account and an address must not cross"
+[[ "$CHECK_OUT" != *"deploy"* ]] \
+  || fail "--check echoed the account half of a user@host destination"
+pass "lv-attach --check reports a user@host destination's shape and withholds its value"
+
+for check_case in "no-destination:session=work" "invalid-destination:destination=-oProxyCommand=id"; do
+  expected="${check_case%%:*}"
+  conf="${check_case#*:}"
+  run_attach "$conf" --check
+  (( ATTACH_STATUS != 0 )) || fail "--check reported success for $expected"
+  [[ "$(cat "$TMP_DIR/attach.out")" == *"conf=$expected"* ]] \
+    || fail "--check did not report conf=$expected: $(cat "$TMP_DIR/attach.out")"
+  [[ ! -s "$SSH_LOG" ]] || fail "--check ran ssh while reporting $expected"
+  pass "lv-attach --check reports: $expected"
+done
+# The value it is refusing is arbitrary text from a file; it is not echoed.
+[[ "$(cat "$TMP_DIR/attach.out")" != *"ProxyCommand"* ]] \
+  || fail "--check echoed the destination it was refusing"
+
+rm -f "$ATTACH_CONF"
+ATTACH_STATUS=0
+env -i PATH="$STUB_BIN:/usr/bin:/bin" HOME="$FAKE_HOME" \
+  LV_ATTACH_CONF="$ATTACH_CONF" STUB_SSH_LOG="$SSH_LOG" \
+  bash "$ATTACH" --check >"$TMP_DIR/attach.out" 2>/dev/null || ATTACH_STATUS=$?
+(( ATTACH_STATUS != 0 )) || fail "--check reported success with no config file"
+[[ "$(cat "$TMP_DIR/attach.out")" == *"conf=missing"* ]] \
+  || fail "--check did not report a missing config: $(cat "$TMP_DIR/attach.out")"
+pass "lv-attach --check reports: missing"
+
+# --check must not be a precedent. Every other flag is still refused outright.
+assert_attach_refused 'a flag that is not --check' 'destination=builder' '--session'
+assert_attach_refused 'a flag glued to a value'    'destination=builder' '--check=1'
+
 # Source pins: the properties that make the NAME safe to allowlist, which no
 # argv test can prove on its own.
 # CODE lines only: the file's own header names `bash -c` and `eval` as the
@@ -1937,6 +2220,403 @@ cmp -s "$ROOT_DIR/scripts/mac/lv-attach.sh" "$WRAPPER_HOME/bin/lv-attach" \
   || fail "the installed wrapper is not the reviewed one from the repo"
 pass "a build install ships the reviewed wrapper rather than leaving it hand-maintained"
 
+# The destination is ordinary configuration, and "what is this file called and
+# what goes in it" cost a round trip through the owner. A template is written
+# when nothing is there — with NO active destination, because an installer that
+# filled one in would be guessing which machine to open a terminal onto.
+ATTACH_TEMPLATE="$WRAPPER_HOME/.lv-attach.conf"
+[[ -f "$ATTACH_TEMPLATE" ]] \
+  || fail "the installer left the operator to discover ~/.lv-attach.conf's name and format"
+grep -q '^[[:space:]]*destination=' "$ATTACH_TEMPLATE" \
+  && fail "the installer wrote an ACTIVE destination — it cannot know which machine to reach"
+grep -q '# destination=' "$ATTACH_TEMPLATE" \
+  || fail "the template does not show the destination= line it is asking for"
+# It resolves to a distinguishable verdict rather than looking like a missing
+# file: `no-destination` is what ui-gate-doctor turns into a one-line fix.
+ATTACH_STATUS=0
+env -i PATH="$STUB_BIN:/usr/bin:/bin" HOME="$WRAPPER_HOME" \
+  LV_ATTACH_CONF="$ATTACH_TEMPLATE" STUB_SSH_LOG="$SSH_LOG" \
+  bash "$ATTACH" --check >"$TMP_DIR/attach.out" 2>/dev/null || ATTACH_STATUS=$?
+[[ "$(cat "$TMP_DIR/attach.out")" == *"conf=no-destination"* ]] \
+  || fail "the installed template does not read as no-destination: $(cat "$TMP_DIR/attach.out")"
+
+# Never overwritten: a reinstall that reset the owner's destination would be
+# worse than shipping no template at all.
+printf 'destination=mymachine\n' >"$ATTACH_TEMPLATE"
+env HOME="$WRAPPER_HOME" LV_UI_ARTIFACT_DEST_ROOT="$WRAPPER_ROOT" \
+  bash "$INSTALLER" "$WRAPPER_SRC_APP" --no-hint >/dev/null 2>&1 \
+  || fail "the installer failed on a reinstall"
+[[ "$(cat "$ATTACH_TEMPLATE")" == "destination=mymachine" ]] \
+  || fail "a reinstall clobbered the owner's lv-attach destination"
+pass "the installer templates ~/.lv-attach.conf once and never overwrites it"
+
+# --- and it does NOT write the gate's allowlist -----------------------------
+#
+# LV_UI_TERM_COMMANDS lives in ~/.localvoxtral-ui-gate.conf and is the gate's
+# ALLOWLIST — the same object as the gate script, one layer up. The rule that
+# CI must never write the gate script applies to what the gate will accept for
+# exactly the same reason: an empty default exists to force a deliberate grant,
+# and a grant that arrives with a build is not one. The owner runs one
+# documented append (ui-gate-doctor.sh prints it); this pins that no installer
+# ever does it for them.
+[[ ! -e "$WRAPPER_HOME/.localvoxtral-ui-gate.conf" ]] \
+  || fail "the installer wrote the gate's conf — the term-open allowlist must stay an owner grant"
+grep -q 'LV_UI_TERM_COMMANDS=' "$INSTALLER" \
+  && fail "install-ui-artifact.sh mentions LV_UI_TERM_COMMANDS as an assignment — it must never write the allowlist"
+pass "no installer widens term open's allowlist"
+
+
+echo
+echo "== 25. state reports SETUP readiness, and reports facts rather than contents =="
+
+# Field session 2026-08-30: an operator drove this gate for an hour and hit
+# `term open` refusing everything and `app` denying. The causes were three
+# ABSENT files and one unset default, each a one-line fix, and NONE of them was
+# visible from outside — a missing conf and a broken verb produce the same
+# `denied command`. `state` now answers the question the operator actually has,
+# which is "which verbs will work if I try them".
+
+state_json() { # <description> [env...]
+  local description="$1"
+  shift
+  run_gate 'state' "$@"
+  (( GATE_STATUS == 0 )) \
+    || fail "$description: state exited $GATE_STATUS ($GATE_STDERR)"
+  printf '%s' "$GATE_STDOUT"
+}
+
+state_field() { # <json> <python expression over `s`>
+  python3 -c 'import json,sys; s=json.loads(sys.stdin.read()); print(eval(sys.argv[1]))' "$2" <<<"$1"
+}
+
+clear_state
+clear_conf
+rm -f "$FAKE_HOME/.lv-attach.conf" "$FAKE_HOME/bin/lv-attach"
+
+# 1. The state the owner's Mac was actually in.
+STATE="$(state_json 'the unconfigured machine')"
+python3 -m json.tool <<<"$STATE" >/dev/null || fail "state is no longer valid JSON: $STATE"
+[[ "$(state_field "$STATE" 's["setup"]["gate_conf"]["status"]')" == "absent" ]] \
+  || fail "state did not report the missing gate conf: $STATE"
+[[ "$(state_field "$STATE" 's["setup"]["term_open"]["commands"]')" == "[]" ]] \
+  || fail "state claimed term open would accept something with no conf: $STATE"
+[[ "$(state_field "$STATE" 's["setup"]["lv_attach"]["installed"]')" == "False" ]] \
+  || fail "state claimed the wrapper is installed when it is not: $STATE"
+[[ "$(state_field "$STATE" 's["setup"]["control_socket"]["consent"]')" == "unset" ]] \
+  || fail "state did not report the control socket's runtime consent: $STATE"
+pass "state names every absent piece of setup instead of leaving a verb to fail"
+
+# The prediction has to hold: this is the same refusal the operator hit.
+assert_denied 'term open ghostty lv-attach' 'term open with the setup state above'
+pass "state's report and term open's refusal agree"
+
+# 2. Configured. The wrapper answers for its own config (one validator, in the
+#    file that holds the boundary), so `state` reports what the INSTALLED
+#    wrapper says rather than a second copy of its rules.
+install -m 0700 "$ATTACH" "$FAKE_HOME/bin/lv-attach"
+printf 'destination=builder\nsession=work\n' >"$FAKE_HOME/.lv-attach.conf"
+write_conf 'LV_UI_TERM_COMMANDS="lv-attach"'
+STATE="$(state_json 'the configured machine')"
+[[ "$(state_field "$STATE" 's["setup"]["gate_conf"]["status"]')" == "ok" ]] \
+  || fail "state did not report a parsing conf: $STATE"
+[[ "$(state_field "$STATE" '" ".join(s["setup"]["term_open"]["commands"])')" == "lv-attach" ]] \
+  || fail "state did not report what term open would accept: $STATE"
+[[ "$(state_field "$STATE" 's["setup"]["lv_attach"]["allowlisted"]')" == "True" ]] \
+  || fail "state did not notice the wrapper is allowlisted: $STATE"
+[[ "$(state_field "$STATE" 's["setup"]["lv_attach"]["conf"]')" == "ok" ]] \
+  || fail "state did not resolve the wrapper's config: $STATE"
+[[ "$(state_field "$STATE" 's["setup"]["lv_attach"]["destination"]')" == "builder" ]] \
+  || fail "state withheld a bare ssh alias, which is the value an operator needs: $STATE"
+pass "state predicts a working term open, down to the destination it would reach"
+
+: >"$TMP_DIR/open.log"
+assert_allowed 'term open ghostty lv-attach work' 'term open with the setup state above' \
+  STUB_PGREP_PID=5150
+pass "state's report and term open's success agree"
+
+# 3. A user@host destination is an account and an address. `app`'s reply
+#    vocabulary deliberately carries no host or session id; the same line is
+#    drawn here.
+printf 'destination=deploy@build.local\n' >"$FAKE_HOME/.lv-attach.conf"
+STATE="$(state_json 'a user@host destination')"
+[[ "$(state_field "$STATE" 's["setup"]["lv_attach"]["conf"]')" == "ok" ]] \
+  || fail "a valid user@host destination did not resolve: $STATE"
+[[ "$(state_field "$STATE" 'repr(s["setup"]["lv_attach"]["destination"])')" == "None" ]] \
+  || fail "state echoed a user@host destination: $STATE"
+[[ "$STATE" != *"build.local"* ]] || fail "state leaked a destination host: $STATE"
+[[ "$STATE" != *"deploy"* ]] || fail "state leaked a destination account: $STATE"
+pass "state reports a user@host destination as resolvable without naming it"
+
+printf 'destination=-oProxyCommand=id\n' >"$FAKE_HOME/.lv-attach.conf"
+STATE="$(state_json 'a destination the wrapper refuses')"
+[[ "$(state_field "$STATE" 's["setup"]["lv_attach"]["conf"]')" == "invalid-destination" ]] \
+  || fail "state did not report a refused destination: $STATE"
+[[ "$STATE" != *"ProxyCommand"* ]] || fail "state echoed the destination it was refusing: $STATE"
+pass "state reports a refused destination without quoting it"
+
+printf 'destination=builder\n' >"$FAKE_HOME/.lv-attach.conf"
+
+# 4. A conf that allowlists a permanently-denied name reads as configured and
+#    behaves as unconfigured. Without this the operator sees only "denied".
+write_conf 'LV_UI_TERM_COMMANDS="lv-attach ssh"'
+STATE="$(state_json 'a conf that allowlists a denylisted name')"
+[[ "$(state_field "$STATE" '" ".join(s["setup"]["term_open"]["refused_by_denylist"])')" == "ssh" ]] \
+  || fail "state did not flag an allowlisted name the denylist refuses anyway: $STATE"
+pass "state flags an allowlist entry the permanent denylist refuses"
+
+# 5. A conf with a syntax error used to take the WHOLE gate down: `source`
+#    returns non-zero, `set -e` exits, and the client sees nothing at all. It
+#    now degrades to the closed defaults, says so, and is reported.
+write_conf 'LV_UI_TERM_COMMANDS="lv-attach'
+STATE="$(state_json 'a conf with a syntax error')"
+[[ "$(state_field "$STATE" 's["setup"]["gate_conf"]["status"]')" == "unparsable" ]] \
+  || fail "state did not report an unparsable conf: $STATE"
+[[ "$(state_field "$STATE" 's["setup"]["term_open"]["commands"]')" == "[]" ]] \
+  || fail "an unparsable conf did not fall back to the CLOSED default: $STATE"
+# A fresh run, not the one above: `STATE="$(state_json ...)"` is a command
+# substitution, so run_gate's GATE_STDERR is set in a subshell and never
+# reaches here.
+run_gate 'state'
+[[ "$GATE_STDERR" == *"syntax error"* ]] \
+  || fail "an unparsable conf was ignored silently: $GATE_STDERR"
+[[ "$GATE_STDERR" == *"EMPTY allowlist"* ]] \
+  || fail "the warning does not say what the fallback means: $GATE_STDERR"
+assert_denied 'term open ghostty lv-attach' 'term open under an unparsable conf'
+pass "an unparsable conf degrades to the closed defaults instead of killing every verb"
+clear_conf
+
+# 6. What `launch` would accept, by name — and nothing that is not a validated
+#    localvoxtral bundle. Mail.app sits in the same fixture root.
+STATE="$(state_json 'the artifact roots')"
+ARTIFACT_NAMES="$(state_field "$STATE" '" ".join(sorted(a["name"] for a in s["setup"]["artifacts"]))')"
+[[ "$ARTIFACT_NAMES" == "localvoxtral-dogfood.app localvoxtral.app" ]] \
+  || fail "state listed the wrong launchable bundles: $ARTIFACT_NAMES"
+[[ "$STATE" != *"Mail.app"* ]] \
+  || fail "state listed a bundle launch would refuse — the list must be what launch accepts"
+[[ "$(state_field "$STATE" 'str([a["dogfood"] for a in s["setup"]["artifacts"] if a["name"]=="localvoxtral-dogfood.app"])')" == "[True]" ]] \
+  || fail "state did not distinguish the dogfood slot: $STATE"
+pass "state lists exactly the bundles launch would accept, and which are dogfood"
+
+# 7. The control socket: both halves, because `app` needs both.
+STATE="$(state_json 'the control socket, armed and bound' \
+  STUB_DEFAULT_debug_dogfood_control_socket_enabled=1 \
+  LV_UI_CONTROL_SOCKET="$CONTROL_SOCKET")"
+[[ "$(state_field "$STATE" 's["setup"]["control_socket"]["present"]')" == "True" ]] \
+  || fail "state did not see a bound control socket: $STATE"
+[[ "$(state_field "$STATE" 's["setup"]["control_socket"]["consent"]')" == "on" ]] \
+  || fail "state did not read the runtime consent: $STATE"
+STATE="$(state_json 'the control socket, unbound' LV_UI_CONTROL_SOCKET="$NOT_A_SOCKET")"
+[[ "$(state_field "$STATE" 's["setup"]["control_socket"]["present"]')" == "False" ]] \
+  || fail "a regular file read as a bound socket: $STATE"
+pass "state reports the control socket's consent and whether anything is bound"
+
+# 8. Facts, never contents. A conf is sourced by this gate and read by the
+#    wrapper; neither file's text may reach the caller.
+write_conf 'LV_UI_TERM_COMMANDS="lv-attach"' 'LV_UI_UNRELATED_SECRET="hunter2"'
+printf 'destination=builder\n# a private note about the host\n' >"$FAKE_HOME/.lv-attach.conf"
+STATE="$(state_json 'a conf carrying an unrelated value')"
+[[ "$STATE" != *"hunter2"* ]] || fail "state echoed a conf file's contents: $STATE"
+[[ "$STATE" != *"private note"* ]] || fail "state echoed the lv-attach conf's contents: $STATE"
+[[ "$STATE" != *"LV_UI_UNRELATED_SECRET"* ]] || fail "state echoed a conf key it does not use: $STATE"
+pass "state reports presence and verdicts, never a config file's contents"
+clear_conf
+
+# 9. The gate's own revision — "the gate is old" was one of the explanations
+#    the operator could not rule out.
+STATE="$(state_json 'the gate revision')"
+GATE_REV="$(state_field "$STATE" 's["setup"]["gate"]["revision"]')"
+[[ "$GATE_REV" =~ ^[0-9a-f]{12}$ ]] || fail "state did not report a gate revision: $GATE_REV"
+GATE_SUM="$(shasum -a 256 "$GATE" 2>/dev/null || sha256sum "$GATE" 2>/dev/null || true)"
+[[ "${GATE_SUM:0:12}" == "$GATE_REV" ]] \
+  || fail "the reported revision is not this file's digest ($GATE_REV vs ${GATE_SUM:0:12})"
+pass "state reports which build of the gate answered"
+
+# 10. Still the one verb that answers while locked: readiness is exactly what
+#     an operator needs before deciding whether to ask the owner to unlock.
+LOCK_STATE=locked
+STATE="$(state_json 'state while the screen is locked')"
+[[ "$(state_field "$STATE" 's["screen_lock"]')" == "locked" ]] \
+  || fail "state lost its lock reporting: $STATE"
+[[ -n "$(state_field "$STATE" 's["setup"]["gate"]["revision"]')" ]] \
+  || fail "state stopped reporting setup while locked: $STATE"
+LOCK_STATE=unlocked
+pass "state reports setup while the screen is locked"
+
+echo
+echo "== 26. gate-log — the denial reason, without deny explaining itself =="
+
+# `deny` answers every refusal with the same `denied command` ON PURPOSE: a
+# gate that explains itself is an oracle for state the caller cannot otherwise
+# see. The reason was always written to the gate's own log; what was missing is
+# that no verb could read it back, so an agent over SSH saw the generic line
+# and had to go through the OWNER to learn a one-line fix. That is a round
+# trip, not a boundary. So: a bounded reader, and the deny contract untouched
+# (every assert_denied above still pins stdout, stderr and exit 126).
+
+clear_state
+clear_conf
+assert_denied 'term open ghostty lv-attach' 'the refusal whose reason was invisible'
+assert_allowed 'gate-log 5' 'gate-log reads the gate own log'
+[[ "$GATE_STDOUT" == *"no allowlisted commands"* ]] \
+  || fail "gate-log did not return the reason behind the last denial: $GATE_STDOUT"
+[[ "$GATE_STDOUT" == *"DENY term open ghostty lv-attach"* ]] \
+  || fail "gate-log did not return the denied command: $GATE_STDOUT"
+pass "a denial's reason is reachable in one verb instead of one round trip through the owner"
+
+# Its own ALLOW line is logged BEFORE the read and dropped from the output, so
+# `gate-log 1` means "the entry before this one" and never answers with itself.
+[[ "$GATE_STDOUT" != *"ALLOW gate-log"* ]] \
+  || fail "gate-log returned its own invocation: $GATE_STDOUT"
+grep -q 'ALLOW gate-log 5 (gate-log lines=5)' "$LOG_FILE" \
+  || fail "gate-log did not log its own invocation: $(log_tail)"
+pass "gate-log logs itself and does not answer with itself"
+
+assert_denied 'gate-log 0' 'a zero-line window'
+assert_denied 'gate-log 201' 'a window past the clamp'
+assert_denied 'gate-log all' 'a non-numeric window'
+assert_denied 'gate-log 5 10' 'two windows'
+assert_denied 'gate-log -3' 'a negative window'
+
+# Read-only and focus-free, like `log`: a diagnostic that stops working when
+# the owner locks the machine is the one case an agent most needs it.
+LOCK_STATE=locked
+assert_allowed 'gate-log' 'gate-log survives a locked screen'
+LOCK_STATE=unlocked
+: >"$TMP_DIR/say.log"
+run_gate 'gate-log'
+[[ ! -s "$TMP_DIR/say.log" ]] \
+  || fail "gate-log spoke a takeover warning: $(cat "$TMP_DIR/say.log")"
+
+# It reads ONE file — the one this gate wrote — and it is not a second `log`.
+run_gate 'gate-log' STUB_LOG_RESTRICTED=1
+(( GATE_STATUS == 0 )) || fail "gate-log went near the unified log: $GATE_STDERR"
+pass "gate-log reads the gate's own file and nothing else"
+
+# The same token-shaped scrub the dogfood records and `log` use. These lines
+# are ours, but "every line anyone ever adds is safe" is not worth depending on.
+printf '%s\n' "2026-08-30T10:00:00+0000 DENY launch $(printf 'a%.0s' $(seq 1 43))" >>"$LOG_FILE"
+assert_allowed 'gate-log 3' 'gate-log masks token-shaped runs'
+[[ "$GATE_STDOUT" == *"<redacted>"* ]] \
+  || fail "gate-log did not mask a 43-character base64url run: $GATE_STDOUT"
+[[ "$GATE_STDOUT" != *"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"* ]] \
+  || fail "gate-log emitted a token-shaped run verbatim"
+
+# `ax type`'s text is redacted AT WRITE TIME (it is how an API key reaches the
+# Endpoints pane), so reading the log back cannot resurrect it.
+assert_denied 'ax type role=AXTextField,title~Endpoint -- sk-secret-value' \
+  'ax type with no app under test'
+assert_allowed 'gate-log 2' 'gate-log after an ax type'
+[[ "$GATE_STDOUT" != *"sk-secret-value"* ]] \
+  || fail "gate-log resurrected ax type's text: $GATE_STDOUT"
+[[ "$GATE_STDOUT" == *"<redacted>"* ]] \
+  || fail "gate-log did not show the redaction marker: $GATE_STDOUT"
+pass "gate-log cannot resurrect ax type's text"
+
+# Nothing to show is a sentence, not an empty answer — the same rule `log`
+# follows. Its own ALLOW line is always there by then, so an empty result means
+# one thing and the message says which.
+mv "$LOG_FILE" "$LOG_FILE.aside"
+run_gate 'gate-log'
+(( GATE_STATUS == 0 )) || fail "gate-log failed with no log file: $GATE_STDERR"
+[[ "$GATE_STDERR" == *"no entries before this one"* ]] \
+  || fail "gate-log answered emptily with no log file: $GATE_STDERR"
+[[ -z "$GATE_STDOUT" ]] || fail "gate-log invented output with no log file: $GATE_STDOUT"
+mv "$LOG_FILE.aside" "$LOG_FILE"
+pass "gate-log says so when there is nothing before this invocation"
+
+echo
+echo "== 27. ui-gate-doctor — the first-install checklist, executable =="
+
+DOCTOR="$ROOT_DIR/scripts/mac/ui-gate-doctor.sh"
+DOCTOR_STATE="$TMP_DIR/doctor-state.json"
+
+run_doctor() { # <state-file>
+  DOCTOR_STATUS=0
+  env -i PATH="/usr/bin:/bin" HOME="$FAKE_HOME" \
+    bash "$DOCTOR" --state-file "$1" >"$TMP_DIR/doctor.out" 2>"$TMP_DIR/doctor.err" \
+    || DOCTOR_STATUS=$?
+  DOCTOR_OUT="$(cat "$TMP_DIR/doctor.out")"
+  DOCTOR_ERR="$(cat "$TMP_DIR/doctor.err")"
+}
+
+# The unconfigured machine, rendered from a REAL `state` rather than a
+# hand-written fixture: the doctor and the gate must not drift apart.
+clear_state
+clear_conf
+rm -f "$FAKE_HOME/.lv-attach.conf"
+state_json 'the doctor input' >"$DOCTOR_STATE"
+run_doctor "$DOCTOR_STATE"
+(( DOCTOR_STATUS == 1 )) \
+  || fail "the doctor did not report an unconfigured machine as needing attention (rc $DOCTOR_STATUS): $DOCTOR_ERR"
+[[ "$DOCTOR_OUT" == *"[FIX] gate conf"* ]] \
+  || fail "the doctor did not flag the missing gate conf: $DOCTOR_OUT"
+[[ "$DOCTOR_OUT" == *"[FIX] control socket"* ]] \
+  || fail "the doctor did not flag the control socket consent: $DOCTOR_OUT"
+[[ "$DOCTOR_OUT" == *"[FIX] lv-attach destination"* ]] \
+  || fail "the doctor did not flag the missing lv-attach config: $DOCTOR_OUT"
+pass "the doctor turns each invisible piece of setup into a named item"
+
+# The point of a fix line is that it FIXES it. This runs the one the doctor
+# printed and then asks the gate whether the verb works — the same loop the
+# owner will run, with nothing restated by hand.
+DOCTOR_FIX="$(sed -n 's/^ *fix: //p' "$TMP_DIR/doctor.out" | grep 'LV_UI_TERM_COMMANDS' | head -n 1)"
+[[ -n "$DOCTOR_FIX" ]] || fail "the doctor named no fix for the empty allowlist: $DOCTOR_OUT"
+DOCTOR_FIX="${DOCTOR_FIX//\~\/.localvoxtral-ui-gate.conf/$GATE_CONF}"
+( eval "$DOCTOR_FIX" ) || fail "the doctor's fix command did not run: $DOCTOR_FIX"
+install -m 0700 "$ATTACH" "$FAKE_HOME/bin/lv-attach"
+printf 'destination=builder\n' >"$FAKE_HOME/.lv-attach.conf"
+: >"$TMP_DIR/open.log"
+assert_allowed 'term open ghostty lv-attach' 'term open after running the doctor fix verbatim' \
+  STUB_PGREP_PID=5150
+pass "the doctor's fix line is the command that actually fixes it"
+
+state_json 'the doctor input, configured' \
+  STUB_DEFAULT_debug_dogfood_control_socket_enabled=1 \
+  LV_UI_CONTROL_SOCKET="$CONTROL_SOCKET" >"$DOCTOR_STATE"
+run_doctor "$DOCTOR_STATE"
+[[ "$DOCTOR_OUT" == *"[ok ] term open allowlist"* ]] \
+  || fail "the doctor still flags a configured allowlist: $DOCTOR_OUT"
+[[ "$DOCTOR_OUT" == *"[ok ] control socket"* ]] \
+  || fail "the doctor still flags an armed control socket: $DOCTOR_OUT"
+[[ "$DOCTOR_OUT" == *"[ok ] lv-attach destination"* ]] \
+  || fail "the doctor still flags a resolvable destination: $DOCTOR_OUT"
+pass "the doctor clears each item as it is fixed"
+
+# The 2026-08-30 blocking failure, as a readiness item: allowlisted, and
+# nothing installed behind the name. `term open` used to open an empty window
+# and report a window-identification timeout; the doctor now says which of the
+# two it is before anything is opened.
+mv "$FAKE_HOME/bin/lv-attach" "$FAKE_HOME/bin/lv-attach.aside"
+state_json 'the doctor input, allowlisted but not installed' >"$DOCTOR_STATE"
+run_doctor "$DOCTOR_STATE"
+(( DOCTOR_STATUS == 1 )) || fail "the doctor passed an allowlist that resolves to nothing"
+[[ "$DOCTOR_OUT" == *"no executable in ~/bin: lv-attach"* ]] \
+  || fail "the doctor did not name the allowlisted command with nothing behind it: $DOCTOR_OUT"
+mv "$FAKE_HOME/bin/lv-attach.aside" "$FAKE_HOME/bin/lv-attach"
+pass "the doctor names an allowlisted command that is not installed"
+clear_conf
+
+# An OLD gate answers `state` without a setup section. Reporting "everything is
+# fine" from a document that cannot say otherwise is the failure this whole
+# change exists to end.
+printf '{"screen_lock":"unlocked","tcc":{"accessibility":true,"screen_recording":true},"app":{"running":false}}\n' \
+  >"$DOCTOR_STATE"
+run_doctor "$DOCTOR_STATE"
+(( DOCTOR_STATUS == 2 )) || fail "the doctor accepted a pre-setup state document (rc $DOCTOR_STATUS)"
+[[ "$DOCTOR_ERR" == *"predates setup reporting"* ]] \
+  || fail "the doctor did not say the gate is older than it: $DOCTOR_ERR"
+pass "the doctor refuses to grade a gate that predates setup reporting"
+
+printf 'localvoxtral ui gate: denied command\n' >"$DOCTOR_STATE"
+run_doctor "$DOCTOR_STATE"
+(( DOCTOR_STATUS == 2 )) || fail "the doctor read a non-JSON answer as a verdict"
+[[ "$DOCTOR_ERR" == *"did not return JSON"* ]] \
+  || fail "the doctor did not quote what it got instead of JSON: $DOCTOR_ERR"
+pass "the doctor says what it got when the gate did not answer with JSON"
+
+# The README's numbered list is what this replaces; the pointer has to hold.
+grep -q 'ui-gate-doctor.sh' "$ROOT_DIR/scripts/mac/README.md" \
+  || fail "scripts/mac/README.md does not point at the doctor"
 
 echo
 echo "ui gate tests passed"

--- a/scripts/ci/test-ui-gate.sh
+++ b/scripts/ci/test-ui-gate.sh
@@ -1049,8 +1049,8 @@ pass "menu click still works against an attached-but-closed menu"
 MENUDISMISS_BODY="$(helper_case_body menudismiss)"
 [[ "$MENUDISMISS_BODY" == *'displayedMenuWindow('* ]] \
   || fail "menu dismiss still decides 'nothing is open' from attachment"
-NO_MENU_LINE="$(printf '%s\n' "$MENUDISMISS_BODY" | grep -n 'no-menu-open' | head -n 1 | cut -d: -f1)"
-FIRST_PRESS_LINE="$(printf '%s\n' "$MENUDISMISS_BODY" | grep -n 'kAXPressAction' | head -n 1 | cut -d: -f1)"
+NO_MENU_LINE="$(printf '%s\n' "$MENUDISMISS_BODY" | grep -n 'no-menu-open' | head -n 1 | cut -d: -f1 || true)"
+FIRST_PRESS_LINE="$(printf '%s\n' "$MENUDISMISS_BODY" | grep -n 'kAXPressAction' | head -n 1 | cut -d: -f1 || true)"
 [[ -n "$NO_MENU_LINE" && -n "$FIRST_PRESS_LINE" ]] \
   || fail "menudismiss lost either its no-menu-open answer or its status-item fallback"
 (( NO_MENU_LINE < FIRST_PRESS_LINE )) \

--- a/scripts/ci/test-ui-gate.sh
+++ b/scripts/ci/test-ui-gate.sh
@@ -18,7 +18,11 @@ LOCK_PROBE_SRC="$ROOT_DIR/scripts/ci/screen-lock-state.sh"
 # Deliberately /tmp and not $TMPDIR: fixture bundle paths are fed through the
 # gate's token charset, and a macOS per-user $TMPDIR can carry characters that
 # charset rejects — which would fail the test for the wrong reason.
-TMP_DIR="$(mktemp -d "/tmp/lv-ui-gate-test.XXXXXX")"
+#
+# Resolved with `pwd -P` because `launch` resolves its argument the same way:
+# on macOS /tmp is a symlink to /private/tmp, so an unresolved fixture path
+# would never equal the path the gate records and passes to `open`.
+TMP_DIR="$(cd "$(mktemp -d "/tmp/lv-ui-gate-test.XXXXXX")" && pwd -P)"
 trap 'rm -rf "$TMP_DIR"' EXIT
 
 FAKE_HOME="$TMP_DIR/home"
@@ -80,7 +84,10 @@ STUB
 
 cat >"$STUB_BIN/screencapture" <<'STUB'
 #!/usr/bin/env bash
-out="${!#}"
+# Last argument is the output file. Walked rather than "${!#}" so this runs
+# unchanged under the Mac's bash 3.2.
+out=""
+for out in "$@"; do :; done
 printf '%s\n' "$*" >>"$STUB_SCREENCAPTURE_LOG"
 printf 'PNGSTUB%s' "${STUB_SHOT_PAYLOAD:-...}" >"$out"
 STUB

--- a/scripts/ci/test-ui-gate.sh
+++ b/scripts/ci/test-ui-gate.sh
@@ -14,6 +14,8 @@ set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "$0")/../.." && pwd -P)"
 GATE="$ROOT_DIR/scripts/mac/localvoxtral-ui-gate.sh"
+INSTALLER="$ROOT_DIR/scripts/mac/install-ui-artifact.sh"
+TRY_PR="$ROOT_DIR/scripts/try-pr.sh"
 LOCK_PROBE_SRC="$ROOT_DIR/scripts/ci/screen-lock-state.sh"
 # Deliberately /tmp and not $TMPDIR: fixture bundle paths are fed through the
 # gate's token charset, and a macOS per-user $TMPDIR can carry characters that
@@ -30,6 +32,10 @@ STUB_BIN="$TMP_DIR/stubbin"
 LOG_FILE="$FAKE_HOME/Library/Logs/localvoxtral-ui-gate.log"
 ARTIFACT_ROOT="$FAKE_HOME/localvoxtral-ui-artifacts"
 mkdir -p "$FAKE_HOME/bin" "$STUB_BIN" "$ARTIFACT_ROOT" "$(dirname "$LOG_FILE")"
+# Pinned rather than left to the runner's umask: install-ui-artifact.sh refuses
+# a group/other-writable root, and a umask of 002 would otherwise make that
+# refusal fire on the happy path.
+chmod 0700 "$ARTIFACT_ROOT"
 : >"$LOG_FILE"
 
 LOCK_STATE=unlocked
@@ -63,8 +69,19 @@ printf '%s\n' "$*" >>"$STUB_OPEN_LOG"
 exit "${STUB_OPEN_STATUS:-0}"
 STUB
 
+# `pgrep -x localvoxtral` asks a different question from every other pgrep the
+# gate runs — "is ANY localvoxtral running", the refusal to launch beside an
+# instance this gate did not start — so it gets its own answer. The bundle-path
+# lookup (`-n -f`) and the terminal lookup (`-n -x Ghostty`) keep the old one.
 cat >"$STUB_BIN/pgrep" <<'STUB'
 #!/usr/bin/env bash
+last=""
+for last in "$@"; do :; done
+if [[ "$last" == "localvoxtral" ]]; then
+  [[ -n "${STUB_PGREP_RUNNING:-}" ]] || exit 1
+  printf '%s\n' "$STUB_PGREP_RUNNING"
+  exit 0
+fi
 [[ -n "${STUB_PGREP_PID:-}" ]] || exit 1
 printf '%s\n' "$STUB_PGREP_PID"
 STUB
@@ -114,6 +131,10 @@ case "$2" in
   axclick | axtype | key | termaction)
     echo ok
     ;;
+  menuopen | menuclick | menudismiss)
+    [[ -z "${STUB_MENU_FAIL:-}" ]] || exit 1
+    echo ok
+    ;;
   *)
     exit 1
     ;;
@@ -146,7 +167,13 @@ install -m 0755 "$LOCK_PROBE_SRC" "$FAKE_HOME/bin/localvoxtral-screen-lock-state
 # --- fixtures --------------------------------------------------------------
 
 make_bundle() { # <name> <bundle-id> <executable> <dogfood-stamp:true|absent>
-  local dir="$ARTIFACT_ROOT/$1" stamp=""
+  make_bundle_in "$ARTIFACT_ROOT" "$@"
+}
+
+make_bundle_in() { # <parent> <name> <bundle-id> <executable> <dogfood-stamp>
+  local parent="$1"
+  shift
+  local dir="$parent/$1" stamp=""
   mkdir -p "$dir/Contents/MacOS"
   : >"$dir/Contents/MacOS/$3"
   chmod +x "$dir/Contents/MacOS/$3"
@@ -324,6 +351,12 @@ assert_denied 'ax click role=AXButton,' 'selector with a trailing comma'
 assert_denied 'ax click window=zero,title=A' 'selector with a non-numeric window index'
 assert_denied 'ax type role=AXTextField hello' 'ax type without the -- separator'
 assert_denied 'ax type role=AXTextField --' 'ax type with an empty text'
+assert_denied 'menu' 'menu without a subverb'
+assert_denied 'menu poke' 'unknown menu subverb'
+assert_denied 'menu open now' 'menu open with an argument'
+assert_denied 'menu dismiss all' 'menu dismiss with an argument'
+assert_denied 'menu click' 'menu click without an item title'
+assert_denied 'menu click Settings Advanced' 'menu click with two title words (use + for a space)'
 assert_denied 'term' 'term without a subverb'
 assert_denied 'term open' 'term open without a terminal'
 assert_denied 'term open ghostty' 'term open without a command'
@@ -515,6 +548,26 @@ pass "allowed: launch records identity, warns audibly, announces completion"
 # retarget every later verb.
 assert_denied "launch $CLEAN_APP" 'launch while an app is already under test' \
   "${APP_ENV[@]}" STUB_PGREP_PID=4242
+
+# The same conflict without a recorded pid: the owner's daily driver, started
+# from Finder or try-pr.sh. The gate can neither address it (every verb reads
+# app.state) nor quit it, and a second instance re-registers the global hotkey
+# and fights for the speechd/polishd ports 8471/8472. Field check 2026-08-29:
+# launch would have started one beside pid 91687.
+clear_state
+assert_denied "launch $CLEAN_APP" 'launch beside a localvoxtral this gate did not start' \
+  "${APP_ENV[@]}" STUB_PGREP_PID=4242 STUB_PGREP_RUNNING=91687
+[[ "$(log_tail)" == *"91687"* ]] \
+  || fail "the foreign-instance denial did not name the running pid: $(log_tail)"
+[[ "$(log_tail)" == *"this gate did not start it"* ]] \
+  || fail "the foreign-instance denial did not say why: $(log_tail)"
+# It must be a refusal, not a warning: nothing may have been opened.
+: >"$TMP_DIR/open.log"
+run_gate "launch $CLEAN_APP" "${APP_ENV[@]}" STUB_PGREP_PID=4242 STUB_PGREP_RUNNING=91687
+[[ ! -s "$TMP_DIR/open.log" ]] \
+  || fail "launch opened the bundle despite a foreign instance: $(cat "$TMP_DIR/open.log")"
+pass "launch refuses beside an instance it did not start, and opens nothing"
+clear_state
 
 # --dogfood requires the Info.plist stamp AND arms the runtime opt-in.
 clear_state
@@ -772,6 +825,365 @@ if command -v ioreg >/dev/null 2>&1 && command -v pmset >/dev/null 2>&1; then
 else
   printf 'SKIP: ioreg/pmset unavailable — the live SIGPIPE probes were not run\n'
 fi
+
+echo "== 15. menu — the verb that makes every other verb reachable =="
+
+# Field check 2026-08-29: `launch` worked, `state` reported the app running,
+# and `ax dump all` returned `[]` while `shot settings` reported no window.
+# All correct: localvoxtral is a menu bar app and opens NO window at launch, so
+# every window verb had nothing to address. `menu` is the missing first step.
+
+clear_state
+assert_denied 'menu open' 'menu open with no app under test'
+assert_denied 'menu click Settings' 'menu click with no app under test'
+assert_denied 'menu dismiss' 'menu dismiss with no app under test'
+
+write_app_state 4242
+LOCK_STATE=locked
+assert_denied 'menu open' 'menu open while the screen is locked' "${APP_ENV[@]}"
+assert_denied 'menu click Settings' 'menu click while the screen is locked' "${APP_ENV[@]}"
+assert_denied 'menu dismiss' 'menu dismiss while the screen is locked' "${APP_ENV[@]}"
+LOCK_STATE=unlocked
+
+: >"$TMP_DIR/swift.log"
+: >"$TMP_DIR/say.log"
+assert_allowed 'menu open' 'menu open clicks the status item of the app under test' "${APP_ENV[@]}"
+grep -q "menuopen 4242" "$TMP_DIR/swift.log" \
+  || fail "menu open did not reach the helper for the app under test: $(cat "$TMP_DIR/swift.log")"
+grep -q "taking control in 3" "$TMP_DIR/say.log" \
+  || fail "menu open did not speak the takeover warning (owner rule)"
+grep -q "done" "$TMP_DIR/say.log" \
+  || fail "menu open did not announce completion (owner rule)"
+
+: >"$TMP_DIR/swift.log"
+assert_allowed 'menu click Settings' 'menu click by item title' "${APP_ENV[@]}"
+grep -q "menuclick 4242 Settings" "$TMP_DIR/swift.log" \
+  || fail "menu click did not pass the title through to the helper: $(cat "$TMP_DIR/swift.log")"
+
+# A space in a title is spelled `+`, exactly as selector values are, because
+# the token charset has no room for whitespace.
+: >"$TMP_DIR/swift.log"
+assert_allowed 'menu click Show+Log' 'menu click with + standing in for a space' "${APP_ENV[@]}"
+grep -q "menuclick 4242 Show+Log" "$TMP_DIR/swift.log" \
+  || fail "the + form was not passed through verbatim: $(cat "$TMP_DIR/swift.log")"
+
+# Real menu titles carry characters the charset cannot express (localvoxtral's
+# is "Settings…"). That is denied at the command level, which is why the helper
+# matches by containment — `menu click Settings` is the way in.
+assert_denied "$(printf 'menu click Settings\xe2\x80\xa6')" 'menu click with a non-ASCII title'
+
+# Dismiss gives the screen back rather than taking it, so it does not warn —
+# same rule as `quit`.
+: >"$TMP_DIR/say.log"
+: >"$TMP_DIR/swift.log"
+assert_allowed 'menu dismiss' 'menu dismiss closes the app under test menu' "${APP_ENV[@]}"
+grep -q "menudismiss 4242" "$TMP_DIR/swift.log" \
+  || fail "menu dismiss did not reach the helper: $(cat "$TMP_DIR/swift.log")"
+[[ ! -s "$TMP_DIR/say.log" ]] \
+  || fail "menu dismiss spoke a takeover warning for a verb that steals nothing: $(cat "$TMP_DIR/say.log")"
+
+# A helper that refuses must not be reported as success.
+run_gate 'menu open' "${APP_ENV[@]}" STUB_MENU_FAIL=1
+(( GATE_STATUS != 0 )) || fail "menu open reported success when the helper failed"
+[[ "$GATE_STDERR" == *"status menu did not open"* ]] \
+  || fail "menu open's failure message is unhelpful: $GATE_STDERR"
+pass "a failed status-item click is a failure, not an ok"
+
+# The scoping rule that section 12 pins for the other verbs, restated for
+# `menu`: the pid is app.state's, so no other application's menu bar — the
+# owner's, or a terminal this gate opened — is expressible.
+: >"$TMP_DIR/swift.log"
+run_gate 'menu open' "${APP_ENV[@]}"
+while read -r line; do
+  [[ "$line" == *"menu"* ]] || continue
+  [[ "$line" == *" 4242"* ]] \
+    || fail "a menu helper call did not carry the app-under-test pid: $line"
+done <"$TMP_DIR/swift.log"
+pass "menu addresses only the pid launch recorded"
+
+# The shell verb and the helper subcommand have to land together: a verb whose
+# helper case is missing fails only on the owner's desktop.
+for subcommand in menuopen menuclick menudismiss; do
+  grep -q "case \"$subcommand\":" "$GATE" \
+    || fail "the Swift helper has no $subcommand subcommand"
+done
+# `AXExtrasMenuBar` is the whole mechanism: without it there is no status item.
+grep -q 'AXExtrasMenuBar' "$GATE" \
+  || fail "the helper no longer reaches the status item through AXExtrasMenuBar"
+# The bounded messaging timeout is not a nicety: pressing a status item blocks
+# the AX server for as long as the menu tracks, which without it hangs the SSH
+# session (capture-readme-assets.sh needs `ignoring application responses` for
+# exactly this reason).
+grep -q 'AXUIElementSetMessagingTimeout' "$GATE" \
+  || fail "the status-item press lost its messaging timeout — it can hang the gate"
+pass "the menu helper subcommands, AXExtrasMenuBar and the messaging timeout are all present"
+
+clear_state
+
+echo "== 16. the artifact roots stay owner-only ground =="
+
+# The roots are the whole reason `launch` is not "start any app on the owner's
+# Mac": inside one, a bundle claiming com.localvoxtral.app is trusted. Add a
+# world-writable directory and any local process can plant such a bundle and
+# have the gate start it as the GUI user. The pressure to widen them is real —
+# try-pr.sh extracts to /tmp — so the answer has to stay "move the install",
+# and these assertions are what stops the other answer from landing quietly.
+
+ROOTS_LINE="$(grep 'LV_UI_ARTIFACT_ROOTS="[$]{LV_UI_ARTIFACT_ROOTS' "$GATE" | head -n 1)"
+[[ -n "$ROOTS_LINE" ]] || fail "could not find the default LV_UI_ARTIFACT_ROOTS in the gate"
+ROOTS_DEFAULT="${ROOTS_LINE#*:-}"
+ROOTS_DEFAULT="${ROOTS_DEFAULT%\}\"}"
+[[ -n "$ROOTS_DEFAULT" ]] || fail "the default artifact-root list is empty: $ROOTS_LINE"
+
+# Unquoted on purpose: word-splitting only. The entries are literal text here,
+# so $HOME is NOT expanded — which is exactly what the prefix check wants.
+for root in $ROOTS_DEFAULT; do
+  case "$root" in
+    '$HOME/'*) ;;
+    *) fail "artifact root '$root' is not under \$HOME — only the owner may write a launchable root" ;;
+  esac
+  case "$root" in
+    *'/tmp'* | *'/var/folders'* | *'/Users/Shared'* | *'/dev/shm'* | *'/var/tmp'*)
+      fail "artifact root '$root' is a world-writable location — the gate would launch anything planted there" ;;
+  esac
+done
+pass "every default artifact root is under \$HOME and none is a world-writable location"
+
+mode_of() { # <path> -> octal permission bits (BSD stat, then GNU stat)
+  # Validated per attempt, not chained with ||: GNU stat reads `-f` as
+  # --file-system and prints a block of its own before failing.
+  local mode
+  mode="$(stat -f '%Lp' "$1" 2>/dev/null || true)"
+  [[ "$mode" =~ ^[0-7]+$ ]] || mode="$(stat -c '%a' "$1" 2>/dev/null || true)"
+  printf '%s\n' "$mode"
+}
+
+# The source pin above catches a widened list; this catches the same hole
+# arriving through the filesystem — a root that exists but is group/other
+# writable is as good as /tmp to an attacker.
+for root in $ROOTS_DEFAULT; do
+  expanded="$HOME${root#\$HOME}"
+  [[ -d "$expanded" ]] || continue
+  mode="$(mode_of "$expanded")"
+  [[ "$mode" =~ ^[0-7]+$ ]] || fail "could not read the mode of $expanded"
+  (( (8#$mode & 0022) == 0 )) \
+    || fail "$expanded is mode $mode — group/other writable, so anyone local can plant a bundle the gate will launch"
+  pass "existing artifact root $expanded is mode $mode (owner-writable only)"
+done
+
+# No script in this repo may hand the gate a world-writable root either.
+for source_file in "$GATE" "$INSTALLER" "$TRY_PR"; do
+  assignments="$(grep -h 'LV_UI_ARTIFACT_ROOTS=\|LV_UI_ARTIFACT_DEST_ROOT=' "$source_file" || true)"
+  case "$assignments" in
+    *'/tmp'* | *'/var/folders'* | *'/Users/Shared'* | *'/dev/shm'*)
+      fail "$source_file points an artifact root at a world-writable directory" ;;
+  esac
+done
+pass "no repo script points an artifact root at a world-writable directory"
+
+echo "== 17. install-ui-artifact.sh puts bundles where launch can reach them =="
+
+[[ -x "$INSTALLER" ]] || fail "$INSTALLER is not executable"
+
+# The installer's destination must be one of the gate's roots; if these two
+# defaults ever drift the install silently produces something unlaunchable.
+grep -q 'LV_UI_ARTIFACT_DEST_ROOT:-\$HOME/localvoxtral-ui-artifacts' "$INSTALLER" \
+  || fail "the installer's default destination changed — is it still a gate root?"
+case "$ROOTS_DEFAULT" in
+  *'$HOME/localvoxtral-ui-artifacts'*) ;;
+  *) fail "the installer installs into \$HOME/localvoxtral-ui-artifacts but the gate no longer allowlists it" ;;
+esac
+pass "the installer's default destination is one of the gate's allowlisted roots"
+
+SRC_DIR="$TMP_DIR/src"
+mkdir -p "$SRC_DIR"
+SRC_CLEAN="$(make_bundle_in "$SRC_DIR" build-clean.app com.localvoxtral.app localvoxtral absent)"
+SRC_DOGFOOD="$(make_bundle_in "$SRC_DIR" build-dogfood.app com.localvoxtral.app localvoxtral true)"
+SRC_IMPOSTOR="$(make_bundle_in "$SRC_DIR" Mail.app com.apple.mail Mail absent)"
+INSTALL_ROOT="$FAKE_HOME/install-root"
+
+INSTALL_STATUS=0
+INSTALL_STDOUT=""
+INSTALL_STDERR=""
+INSTALL_ENV=()
+
+run_install() { # <installer args...>   (env via INSTALL_ENV, consumed per call)
+  local out_file="$TMP_DIR/install.out" err_file="$TMP_DIR/install.err"
+  INSTALL_STATUS=0
+  env -i \
+    PATH="$STUB_BIN:/usr/bin:/bin:/usr/sbin:/sbin" \
+    HOME="$FAKE_HOME" \
+    STUB_OPEN_LOG="$TMP_DIR/open.log" \
+    ${INSTALL_ENV[@]+"${INSTALL_ENV[@]}"} \
+    bash "$INSTALLER" "$@" >"$out_file" 2>"$err_file" || INSTALL_STATUS=$?
+  INSTALL_ENV=()
+  INSTALL_STDOUT="$(cat "$out_file")"
+  INSTALL_STDERR="$(cat "$err_file")"
+}
+
+assert_install_refused() { # <description> <installer args...>
+  local description="$1"
+  shift
+  run_install "$@"
+  (( INSTALL_STATUS != 0 )) \
+    || fail "$description: the install succeeded (stdout: $INSTALL_STDOUT)"
+  [[ "$INSTALL_STDERR" == *"install-ui-artifact:"* ]] \
+    || fail "$description: no install-ui-artifact diagnostic (stderr: $INSTALL_STDERR)"
+  pass "refused: $description"
+}
+
+# --- the happy path, into the real default root ----------------------------
+
+: >"$TMP_DIR/open.log"
+run_install "$SRC_CLEAN" --label "pr-238 @ CI run 123"
+(( INSTALL_STATUS == 0 )) || fail "installing a clean bundle failed: $INSTALL_STDERR"
+[[ "$INSTALL_STDOUT" == "$ARTIFACT_ROOT/localvoxtral.app" ]] \
+  || fail "installer stdout is not the installed bundle path: $INSTALL_STDOUT"
+[[ -x "$ARTIFACT_ROOT/localvoxtral.app/Contents/MacOS/localvoxtral" ]] \
+  || fail "the installed bundle has no executable"
+grep -q '^variant=clean$' "$ARTIFACT_ROOT/localvoxtral.app.source" \
+  || fail "the provenance file does not record the clean variant"
+grep -q "^label=pr-238 @ CI run 123$" "$ARTIFACT_ROOT/localvoxtral.app.source" \
+  || fail "the provenance file does not record which build this is"
+[[ ! -s "$TMP_DIR/open.log" ]] \
+  || fail "the installer launched something — launching is the gate's job: $(cat "$TMP_DIR/open.log")"
+# The hint is the gate-relative path, because that is what `launch` resolves.
+[[ "$INSTALL_STDERR" == *"launch localvoxtral-ui-artifacts/localvoxtral.app"* ]] \
+  || fail "no gate-launch hint, or not the path the gate resolves: $INSTALL_STDERR"
+pass "a clean bundle installs into the default root, with provenance and no launch"
+
+run_install "$SRC_CLEAN" --no-hint
+(( INSTALL_STATUS == 0 )) || fail "--no-hint install failed: $INSTALL_STDERR"
+[[ "$INSTALL_STDERR" != *"gate launch"* ]] \
+  || fail "--no-hint still printed a launch hint (try-pr.sh prints its own, later)"
+pass "--no-hint suppresses the duplicate launch hint"
+
+# The point of the whole exercise: the gate accepts what the installer wrote.
+clear_state
+assert_allowed "launch $ARTIFACT_ROOT/localvoxtral.app" \
+  'the gate launches the bundle the installer just installed' \
+  "${APP_ENV[@]}" STUB_PGREP_PID=4242
+clear_state
+
+run_install "$SRC_DOGFOOD"
+(( INSTALL_STATUS == 0 )) || fail "installing a dogfood bundle failed: $INSTALL_STDERR"
+[[ "$INSTALL_STDOUT" == "$ARTIFACT_ROOT/localvoxtral-dogfood.app" ]] \
+  || fail "the stamped bundle did not take the dogfood slot: $INSTALL_STDOUT"
+grep -q '^variant=dogfood$' "$ARTIFACT_ROOT/localvoxtral-dogfood.app.source" \
+  || fail "the provenance file does not record the dogfood variant"
+assert_allowed "launch --dogfood $ARTIFACT_ROOT/localvoxtral-dogfood.app" \
+  'the gate launches the installed dogfood bundle with --dogfood' \
+  STUB_PS_LSTART="Mon Aug 24 09:00:00 2026" \
+  STUB_PS_COMM="$ARTIFACT_ROOT/localvoxtral-dogfood.app/Contents/MacOS/localvoxtral" \
+  STUB_PGREP_PID=4343
+clear_state
+pass "clean and dogfood builds occupy separate slots and both launch"
+
+# --- reinstall replaces its slot -------------------------------------------
+#
+# Two slots, not one per build: N copies of the same bundle id share one
+# defaults domain and one TCC grant, so a stale one is indistinguishable at
+# runtime — the wrong-binary confusion, on disk.
+SRC_SECOND="$(make_bundle_in "$SRC_DIR" build-second.app com.localvoxtral.app localvoxtral absent)"
+printf 'second build\n' >"$SRC_SECOND/Contents/MacOS/localvoxtral"
+chmod +x "$SRC_SECOND/Contents/MacOS/localvoxtral"
+BEFORE_SLOTS="$(ls -d "$ARTIFACT_ROOT"/*.app 2>/dev/null | wc -l | tr -d ' ')"
+INSTALL_ENV=(LV_UI_ARTIFACT_DEST_ROOT="$ARTIFACT_ROOT")
+run_install "$SRC_SECOND"
+(( INSTALL_STATUS == 0 )) || fail "reinstalling failed: $INSTALL_STDERR"
+AFTER_SLOTS="$(ls -d "$ARTIFACT_ROOT"/*.app 2>/dev/null | wc -l | tr -d ' ')"
+[[ "$BEFORE_SLOTS" == "$AFTER_SLOTS" ]] \
+  || fail "a reinstall added a bundle instead of replacing its slot ($BEFORE_SLOTS -> $AFTER_SLOTS)"
+grep -q 'second build' "$ARTIFACT_ROOT/localvoxtral.app/Contents/MacOS/localvoxtral" \
+  || fail "the reinstall did not replace the previous bundle's contents"
+grep -q "^source=$SRC_SECOND$" "$ARTIFACT_ROOT/localvoxtral.app.source" \
+  || fail "the provenance file still points at the previous build"
+[[ -z "$(ls -d "$ARTIFACT_ROOT"/.incoming-* "$ARTIFACT_ROOT"/.outgoing-* 2>/dev/null)" ]] \
+  || fail "the install left staging directories behind"
+pass "a reinstall replaces its slot and leaves no staging droppings"
+
+# --- refusals --------------------------------------------------------------
+
+assert_install_refused 'a source bundle that does not exist' \
+  "$SRC_DIR/nope.app"
+assert_install_refused 'a directory that is not a .app' \
+  "$SRC_DIR"
+assert_install_refused "another vendor's bundle" \
+  "$SRC_IMPOSTOR"
+assert_install_refused 'a .app with no Info.plist' \
+  "$(mkdir -p "$SRC_DIR/empty.app" && printf '%s' "$SRC_DIR/empty.app")"
+assert_install_refused 'an unknown flag' \
+  "$SRC_CLEAN" --launch-it
+
+# A destination the owner cannot write is a broken install, not a silent no-op.
+mkdir -p "$INSTALL_ROOT/readonly"
+chmod 0500 "$INSTALL_ROOT/readonly"
+if [[ "$(id -u)" == "0" ]]; then
+  printf 'SKIP: running as root — the unwritable-destination refusal cannot be exercised\n'
+else
+  INSTALL_ENV=(LV_UI_ARTIFACT_DEST_ROOT="$INSTALL_ROOT/readonly")
+  assert_install_refused 'a destination root that is not writable' "$SRC_CLEAN"
+fi
+chmod 0700 "$INSTALL_ROOT/readonly"
+
+# The install-side half of section 15: the installer refuses to feed a root
+# that anyone local can write, rather than quietly making the gate launchable
+# from one.
+mkdir -p "$INSTALL_ROOT/world"
+chmod 0777 "$INSTALL_ROOT/world"
+INSTALL_ENV=(LV_UI_ARTIFACT_DEST_ROOT="$INSTALL_ROOT/world")
+assert_install_refused 'a group/other-writable destination root' "$SRC_CLEAN"
+[[ "$INSTALL_STDERR" == *"writable"* ]] \
+  || fail "the world-writable refusal did not say why: $INSTALL_STDERR"
+chmod 0755 "$INSTALL_ROOT/world"
+INSTALL_ENV=(LV_UI_ARTIFACT_DEST_ROOT="$INSTALL_ROOT/world")
+run_install "$SRC_CLEAN"
+(( INSTALL_STATUS == 0 )) \
+  || fail "an owner-only-writable root was refused: $INSTALL_STDERR"
+pass "the same root installs fine once group/other write is removed"
+
+# A root the installer creates itself must not be world-writable either.
+INSTALL_ENV=(LV_UI_ARTIFACT_DEST_ROOT="$INSTALL_ROOT/fresh")
+run_install "$SRC_CLEAN"
+(( INSTALL_STATUS == 0 )) || fail "installing into a fresh root failed: $INSTALL_STDERR"
+FRESH_MODE="$(mode_of "$INSTALL_ROOT/fresh")"
+(( (8#$FRESH_MODE & 0022) == 0 )) \
+  || fail "the installer created its root as mode $FRESH_MODE"
+pass "a root the installer creates is owner-writable only (mode $FRESH_MODE)"
+
+# Replacing files under a running process is how you get a half-swapped app.
+# Quitting it is the operator's call (the gate has a `quit` verb); refusing is
+# the installer's.
+INSTALL_ENV=(LV_UI_ARTIFACT_DEST_ROOT="$ARTIFACT_ROOT" STUB_PGREP_PID=4242)
+assert_install_refused 'overwriting a bundle that is currently running' "$SRC_CLEAN"
+[[ "$INSTALL_STDERR" == *"quit it first"* ]] \
+  || fail "the running-bundle refusal did not say what to do: $INSTALL_STDERR"
+
+echo "== 18. try-pr.sh --ui-gate hands off to the gate =="
+
+grep -q -- '--ui-gate) UI_GATE=1' "$TRY_PR" \
+  || fail "try-pr.sh no longer parses --ui-gate"
+grep -q 'mac/install-ui-artifact.sh' "$TRY_PR" \
+  || fail "try-pr.sh --ui-gate no longer delegates to the installer"
+pass "try-pr.sh --ui-gate installs through install-ui-artifact.sh"
+
+# --ui-gate must not `open` the app itself: an instance the gate did not start
+# is invisible to app.state and rivals the one it will start for the global
+# hotkey and the speechd/polishd ports.
+OPEN_LINE="$(grep -n '^open "\$APP"' "$TRY_PR" | head -n 1 | cut -d: -f1)"
+[[ -n "$OPEN_LINE" ]] || fail "try-pr.sh no longer ends by opening the app"
+GUARD_LINE="$(grep -n 'exit 0' "$TRY_PR" | awk -F: -v limit="$OPEN_LINE" '$1 < limit { last = $1 } END { print last }')"
+[[ -n "$GUARD_LINE" ]] \
+  || fail "nothing returns before try-pr.sh's final open — --ui-gate would launch an unrecorded instance"
+awk -v start="$GUARD_LINE" -v stop="$OPEN_LINE" 'NR >= start - 20 && NR <= stop' "$TRY_PR" \
+  | grep -q 'UI_GATE' \
+  || fail "the early return before try-pr.sh's final open is not the --ui-gate branch"
+pass "try-pr.sh --ui-gate returns before the launch, leaving it to the gate"
+
+# The default is unchanged: /tmp, then launch.
+grep -q 'DEST="\$(mktemp -d /tmp/localvoxtral-try.XXXXXX)"' "$TRY_PR" \
+  || fail "try-pr.sh's default extraction directory changed — --ui-gate was meant to be additive"
+pass "try-pr.sh's default (extract to /tmp, then open) is untouched"
 
 echo
 echo "ui gate tests passed"

--- a/scripts/ci/test-ui-gate.sh
+++ b/scripts/ci/test-ui-gate.sh
@@ -135,6 +135,10 @@ case "$2" in
     [[ -z "${STUB_MENU_FAIL:-}" ]] || exit 1
     echo ok
     ;;
+  dictate)
+    [[ -z "${STUB_DICTATE_FAIL:-}" ]] || exit 1
+    echo "ok $5 trigger=$4 frontmost=7777 (Ghostty)"
+    ;;
   *)
     exit 1
     ;;
@@ -155,9 +159,20 @@ cat >"$STUB_BIN/pmset" <<'STUB'
 echo "Now drawing from 'AC Power'"
 STUB
 
+# Reads as well as writes: `dictate` reads the app's OWN trigger settings out
+# of its defaults domain rather than hard-coding a key, so the suite has to be
+# able to say what the app is configured with. `settings.foo` is answered from
+# $STUB_DEFAULT_settings_foo; an unset variable reads as "key absent".
 cat >"$STUB_BIN/defaults" <<'STUB'
 #!/usr/bin/env bash
 printf '%s\n' "$*" >>"$STUB_DEFAULTS_LOG"
+if [[ "${1:-}" == "read" ]]; then
+  key="${3:-}"
+  var="STUB_DEFAULT_${key//./_}"
+  value="${!var:-}"
+  [[ -n "$value" ]] || exit 1
+  printf '%s\n' "$value"
+fi
 STUB
 
 chmod +x "$STUB_BIN"/*
@@ -351,6 +366,12 @@ assert_denied 'ax click role=AXButton,' 'selector with a trailing comma'
 assert_denied 'ax click window=zero,title=A' 'selector with a non-numeric window index'
 assert_denied 'ax type role=AXTextField hello' 'ax type without the -- separator'
 assert_denied 'ax type role=AXTextField --' 'ax type with an empty text'
+assert_denied 'dictate' 'dictate without a subverb'
+assert_denied 'dictate now' 'unknown dictate subverb'
+assert_denied 'dictate tap 3' 'dictate tap with a duration'
+assert_denied 'dictate cancel now' 'dictate cancel with an argument'
+assert_denied 'dictate hold' 'dictate hold without a duration'
+assert_denied 'dictate hold 2 3' 'dictate hold with two durations'
 assert_denied 'menu' 'menu without a subverb'
 assert_denied 'menu poke' 'unknown menu subverb'
 assert_denied 'menu open now' 'menu open with an argument'
@@ -920,7 +941,115 @@ pass "the menu helper subcommands, AXExtrasMenuBar and the messaging timeout are
 
 clear_state
 
-echo "== 16. the artifact roots stay owner-only ground =="
+echo "== 16. dictate — the only verb that can start a session =="
+
+# Without this verb the gate can open the UI but never exercise the thing it
+# exists to debug: the Claude Code / herdr join resolves when a dictation
+# STARTS, and `key`'s allowlist is escape/tab/return while the app's trigger is
+# a modifier-only gesture.
+
+DICTATE_ENV=(
+  "${APP_ENV[@]}"
+  STUB_DEFAULT_settings_modifier_only_hotkey_enabled=1
+  STUB_DEFAULT_settings_modifier_only_hotkey_modifier=right_command
+  STUB_DEFAULT_settings_modifier_only_hold_delay=0.35
+)
+
+clear_state
+assert_denied 'dictate tap' 'dictate with no app under test' "${DICTATE_ENV[@]}"
+
+write_app_state 4242
+LOCK_STATE=locked
+assert_denied 'dictate tap' 'dictate while the screen is locked' "${DICTATE_ENV[@]}"
+assert_denied 'dictate cancel' 'dictate cancel while the screen is locked' "${DICTATE_ENV[@]}"
+LOCK_STATE=unlocked
+
+# Reading the trigger, never assuming it: a guess here is a modifier posted
+# into whatever the owner has focused.
+assert_denied 'dictate tap' 'dictate when the app trigger settings cannot be read' "${APP_ENV[@]}"
+[[ "$(log_tail)" == *"refusing to guess"* ]] \
+  || fail "the unreadable-settings denial did not say why: $(log_tail)"
+assert_denied 'dictate tap' 'dictate when the modifier-only trigger is disabled' \
+  "${APP_ENV[@]}" STUB_DEFAULT_settings_modifier_only_hotkey_enabled=0
+assert_denied 'dictate tap' 'dictate when the configured trigger is unset' \
+  "${APP_ENV[@]}" STUB_DEFAULT_settings_modifier_only_hotkey_enabled=1
+[[ "$(log_tail)" == *"cannot determine the configured trigger"* ]] \
+  || fail "the unset-trigger denial did not say why: $(log_tail)"
+assert_denied 'dictate tap' 'dictate with a trigger the app does not define' \
+  "${APP_ENV[@]}" STUB_DEFAULT_settings_modifier_only_hotkey_enabled=1 \
+  STUB_DEFAULT_settings_modifier_only_hotkey_modifier=left_shift
+
+: >"$TMP_DIR/swift.log"
+: >"$TMP_DIR/say.log"
+assert_allowed 'dictate tap' 'dictate tap posts the configured trigger' "${DICTATE_ENV[@]}"
+grep -q "dictate 4242 right_command tap" "$TMP_DIR/swift.log" \
+  || fail "dictate tap did not post the app's configured trigger: $(cat "$TMP_DIR/swift.log")"
+grep -q "taking control in 3" "$TMP_DIR/say.log" \
+  || fail "dictate tap did not speak the takeover warning (owner rule)"
+[[ "$GATE_STDOUT" == *"frontmost="* ]] \
+  || fail "dictate did not report where the dictation landed: $GATE_STDOUT"
+
+# The configured trigger is read per invocation, not baked in.
+: >"$TMP_DIR/swift.log"
+assert_allowed 'dictate tap' 'dictate follows a changed trigger setting' \
+  "${APP_ENV[@]}" STUB_DEFAULT_settings_modifier_only_hotkey_enabled=1 \
+  STUB_DEFAULT_settings_modifier_only_hotkey_modifier=fn
+grep -q "dictate 4242 fn tap" "$TMP_DIR/swift.log" \
+  || fail "dictate ignored the app's configured trigger: $(cat "$TMP_DIR/swift.log")"
+
+# A hold shorter than the app's own threshold is a TAP: it would open an
+# Overlay Buffer session while the caller asked for Live Auto-Paste, and
+# nothing would say so.
+assert_denied 'dictate hold 0.2' 'a hold shorter than the app hold delay' "${DICTATE_ENV[@]}"
+assert_denied 'dictate hold 0.35' 'a hold exactly equal to the hold delay' "${DICTATE_ENV[@]}"
+assert_denied 'dictate hold 600' 'a hold past the duration cap' "${DICTATE_ENV[@]}"
+assert_denied 'dictate hold soon' 'a non-numeric hold duration' "${DICTATE_ENV[@]}"
+: >"$TMP_DIR/swift.log"
+assert_allowed 'dictate hold 2' 'a hold past the threshold and inside the cap' "${DICTATE_ENV[@]}"
+grep -q "dictate 4242 right_command hold 2" "$TMP_DIR/swift.log" \
+  || fail "dictate hold did not pass the duration through: $(cat "$TMP_DIR/swift.log")"
+# The cap follows the app's configured delay, not a constant.
+assert_allowed 'dictate hold 0.2' 'a hold that clears a SHORTER configured delay' \
+  "${APP_ENV[@]}" STUB_DEFAULT_settings_modifier_only_hotkey_enabled=1 \
+  STUB_DEFAULT_settings_modifier_only_hotkey_modifier=right_command \
+  STUB_DEFAULT_settings_modifier_only_hold_delay=0.1
+
+# Cancel is Escape: it gives a session back rather than taking the screen, so
+# like `quit` it does not warn, and it needs no trigger setting at all.
+: >"$TMP_DIR/say.log"
+: >"$TMP_DIR/swift.log"
+assert_allowed 'dictate cancel' 'dictate cancel with no trigger settings readable' "${APP_ENV[@]}"
+grep -q "dictate 4242 none cancel" "$TMP_DIR/swift.log" \
+  || fail "dictate cancel did not reach the helper: $(cat "$TMP_DIR/swift.log")"
+[[ ! -s "$TMP_DIR/say.log" ]] \
+  || fail "dictate cancel spoke a takeover warning for a verb that takes nothing"
+
+# A refused gesture must not read as a started session.
+run_gate 'dictate tap' "${DICTATE_ENV[@]}" STUB_DICTATE_FAIL=1
+(( GATE_STATUS != 0 )) || fail "dictate reported success when the helper refused"
+[[ "$GATE_STDERR" == *"trigger gesture was refused"* ]] \
+  || fail "dictate's failure message is unhelpful: $GATE_STDERR"
+pass "a refused trigger gesture is a failure, not an ok"
+
+# Source pins for the two things that make this verb work at all and cannot be
+# exercised without a desktop.
+grep -q 'event.type = .flagsChanged' "$GATE" \
+  || fail "the trigger event is no longer a flagsChanged — a plain keyDown never reaches the app's monitor"
+grep -q 'IsSecureEventInputEnabled()' "$GATE" \
+  || fail "the Secure Keyboard Entry guard is gone — the verb would silently no-op"
+grep -q 'DispatchSource.makeSignalSource' "$GATE" \
+  || fail "a killed hold would leave the modifier latched down across the owner's session"
+# Never activate the app under test before dictating: the session grounds its
+# context in whatever is FOCUSED, so stealing focus first defeats the test.
+DICTATE_BODY="$(awk '/^run_dictate\(\) \{/ { capture = 1 } capture { print } capture && /^\}$/ { exit }' "$GATE")"
+[[ -n "$DICTATE_BODY" ]] || fail "could not find run_dictate in the gate"
+grep -q 'activate' <<<"$DICTATE_BODY" \
+  && fail "run_dictate activates something — the dictation must land in the FOCUSED app, not localvoxtral"
+pass "the dictate verb posts a flagsChanged gesture, guards Secure Keyboard Entry, releases on signal, and never steals focus"
+
+clear_state
+
+echo "== 17. the artifact roots stay owner-only ground =="
 
 # The roots are the whole reason `launch` is not "start any app on the owner's
 # Mac": inside one, a bundle claiming com.localvoxtral.app is trusted. Add a
@@ -981,7 +1110,7 @@ for source_file in "$GATE" "$INSTALLER" "$TRY_PR"; do
 done
 pass "no repo script points an artifact root at a world-writable directory"
 
-echo "== 17. install-ui-artifact.sh puts bundles where launch can reach them =="
+echo "== 18. install-ui-artifact.sh puts bundles where launch can reach them =="
 
 [[ -x "$INSTALLER" ]] || fail "$INSTALLER is not executable"
 
@@ -1158,8 +1287,20 @@ INSTALL_ENV=(LV_UI_ARTIFACT_DEST_ROOT="$ARTIFACT_ROOT" STUB_PGREP_PID=4242)
 assert_install_refused 'overwriting a bundle that is currently running' "$SRC_CLEAN"
 [[ "$INSTALL_STDERR" == *"quit it first"* ]] \
   || fail "the running-bundle refusal did not say what to do: $INSTALL_STDERR"
+# That refusal, and ONLY that one, is exit 3: ci.yml turns it into a warning
+# instead of a red build, because the build was fine and the owner merely had
+# the app open. Every other refusal must stay fatal.
+(( INSTALL_STATUS == 3 )) \
+  || fail "the slot-is-running refusal is exit $INSTALL_STATUS, not the documented 3"
+INSTALL_ENV=(LV_UI_ARTIFACT_DEST_ROOT="$INSTALL_ROOT/world")
+chmod 0777 "$INSTALL_ROOT/world"
+assert_install_refused 'a world-writable root (again, to pin its exit code)' "$SRC_CLEAN"
+(( INSTALL_STATUS == 1 )) \
+  || fail "a security refusal used exit $INSTALL_STATUS — ci.yml would treat 3 as a warning"
+chmod 0755 "$INSTALL_ROOT/world"
+pass "only the slot-is-running refusal is exit 3; security refusals stay exit 1"
 
-echo "== 18. try-pr.sh --ui-gate hands off to the gate =="
+echo "== 19. try-pr.sh --ui-gate hands off to the gate =="
 
 grep -q -- '--ui-gate) UI_GATE=1' "$TRY_PR" \
   || fail "try-pr.sh no longer parses --ui-gate"
@@ -1184,6 +1325,48 @@ pass "try-pr.sh --ui-gate returns before the launch, leaving it to the gate"
 grep -q 'DEST="\$(mktemp -d /tmp/localvoxtral-try.XXXXXX)"' "$TRY_PR" \
   || fail "try-pr.sh's default extraction directory changed — --ui-gate was meant to be additive"
 pass "try-pr.sh's default (extract to /tmp, then open) is untouched"
+
+echo "== 20. the dispatched CI build installs itself for the gate =="
+
+# try-pr.sh --ui-gate serves an operator with a shell on the Mac. An agent
+# driving the gate has neither a shell nor a verb that runs try-pr.sh, so the
+# runner does the install instead: it is a launchd agent in the owner's GUI
+# session, which is why $HOME there is the same home the gate's artifact root
+# lives under.
+CI_YML="$ROOT_DIR/.github/workflows/ci.yml"
+INSTALL_STEP="$(awk '/^      - name: Install the dogfood build into the UI gate/ { capture = 1 }
+                     capture && /^      - name: / && ++seen > 1 { exit }
+                     capture { print }' "$CI_YML")"
+[[ -n "$INSTALL_STEP" ]] || fail "ci.yml has no UI-gate install step"
+grep -q 'install-ui-artifact.sh' <<<"$INSTALL_STEP" \
+  || fail "the UI-gate install step does not go through install-ui-artifact.sh"
+
+# The gating is the whole safety story: an ordinary PR push must never write
+# into the owner's home, and the [dogfood-package] marker fires on those.
+STEP_IF="$(awk '/^ *if: >-$/ { capture = 1; next } capture && /^ *run:/ { exit } capture { print }' <<<"$INSTALL_STEP")"
+[[ -n "$STEP_IF" ]] || fail "the UI-gate install step has no multi-line if: gate"
+for required in "runner.environment == 'self-hosted'" \
+                "github.event_name == 'workflow_dispatch'" \
+                "github.event.inputs.dogfood == 'true'"; do
+  grep -qF "$required" <<<"$STEP_IF" \
+    || fail "the UI-gate install step is not gated on $required"
+done
+# `inputs.dogfood` is declared `type: boolean`; comparing a boolean to the
+# string 'true' coerces both to numbers (1 vs NaN), so that form is always
+# false and the step would silently never run. Only the event payload's
+# string copy compares as written.
+grep -q "github\.event\.inputs\.dogfood == 'true'" <<<"$STEP_IF" \
+  || fail "the dogfood gate must read github.event.inputs.dogfood (the boolean input never equals 'true')"
+pass "the UI-gate install step runs only on a workflow_dispatch with dogfood=true"
+
+# Exit 3 (the slot is running) is a warning; anything else fails the build.
+grep -q 'STATUS == 3' <<<"$INSTALL_STEP" \
+  || fail "the install step no longer special-cases the slot-is-running exit code"
+grep -q '::warning::' <<<"$INSTALL_STEP" \
+  || fail "the slot-is-running case must warn, not pass silently"
+grep -q 'STATUS != 0' <<<"$INSTALL_STEP" \
+  || fail "the install step swallows failures other than the slot-is-running one"
+pass "a running slot warns; every other install failure is red"
 
 echo
 echo "ui gate tests passed"

--- a/scripts/ci/test-ui-gate.sh
+++ b/scripts/ci/test-ui-gate.sh
@@ -2614,6 +2614,59 @@ run_doctor "$DOCTOR_STATE"
   || fail "the doctor did not quote what it got instead of JSON: $DOCTOR_ERR"
 pass "the doctor says what it got when the gate did not answer with JSON"
 
+# --- local mode: the two facts the gate cannot report about itself ----------
+#
+# "The gate is old" and "the key does not force the gate" are the two
+# explanations an operator could never rule out from the other end of an SSH
+# connection, and they are the two this mode exists for. It runs the INSTALLED
+# gate exactly as sshd would, so it grades the copy the key actually reaches.
+
+DOCTOR_HOME="$TMP_DIR/doctor-home"
+mkdir -p "$DOCTOR_HOME/bin" "$DOCTOR_HOME/.ssh"
+INSTALLED_GATE="$DOCTOR_HOME/bin/localvoxtral-ui-gate.sh"
+install -m 0755 "$GATE" "$INSTALLED_GATE"
+printf 'restrict,command="%s" ssh-ed25519 AAAA localvoxtral-ui-gate\n' \
+  "$INSTALLED_GATE" >"$DOCTOR_HOME/.ssh/authorized_keys"
+
+run_doctor_local() {
+  DOCTOR_STATUS=0
+  env -i PATH="/usr/bin:/bin" HOME="$DOCTOR_HOME" \
+    LV_UI_INSTALLED_GATE="$INSTALLED_GATE" \
+    bash "$DOCTOR" >"$TMP_DIR/doctor.out" 2>"$TMP_DIR/doctor.err" \
+    || DOCTOR_STATUS=$?
+  DOCTOR_OUT="$(cat "$TMP_DIR/doctor.out")"
+  DOCTOR_ERR="$(cat "$TMP_DIR/doctor.err")"
+}
+
+run_doctor_local
+[[ "$DOCTOR_OUT" == *"matches this checkout"* ]] \
+  || fail "the doctor did not compare the installed gate with this checkout: $DOCTOR_OUT"
+[[ "$DOCTOR_OUT" == *"[ok ] forced command"* ]] \
+  || fail "the doctor did not read the forced-command line: $DOCTOR_OUT"
+pass "the doctor grades the INSTALLED gate, and says whether it is this one"
+
+printf '# an older gate\n' >>"$INSTALLED_GATE"
+run_doctor_local
+[[ "$DOCTOR_OUT" == *"[FIX] gate script"* ]] \
+  || fail "the doctor called a stale installed gate current: $DOCTOR_OUT"
+[[ "$DOCTOR_OUT" == *"install -m 0755"* ]] \
+  || fail "the doctor did not name the reinstall command: $DOCTOR_OUT"
+install -m 0755 "$GATE" "$INSTALLED_GATE"
+pass "an installed gate that differs from this checkout is a FIX, not a silent pass"
+
+# `restrict` is what disables pty, forwarding and user rc files; a forced
+# command without it is a gate with the door left ajar.
+printf 'command="%s" ssh-ed25519 AAAA localvoxtral-ui-gate\n' \
+  "$INSTALLED_GATE" >"$DOCTOR_HOME/.ssh/authorized_keys"
+run_doctor_local
+[[ "$DOCTOR_OUT" == *"without \`restrict\`"* ]] \
+  || fail "the doctor accepted a forced command with no restrict: $DOCTOR_OUT"
+: >"$DOCTOR_HOME/.ssh/authorized_keys"
+run_doctor_local
+[[ "$DOCTOR_OUT" == *"the key would get a shell"* ]] \
+  || fail "the doctor accepted a key with no forced command at all: $DOCTOR_OUT"
+pass "the doctor flags a key that does not force the gate, or forces it unrestricted"
+
 # The README's numbered list is what this replaces; the pointer has to hold.
 grep -q 'ui-gate-doctor.sh' "$ROOT_DIR/scripts/mac/README.md" \
   || fail "scripts/mac/README.md does not point at the doctor"

--- a/scripts/ci/test-ui-gate.sh
+++ b/scripts/ci/test-ui-gate.sh
@@ -139,6 +139,12 @@ case "$2" in
     [[ -z "${STUB_DICTATE_FAIL:-}" ]] || exit 1
     echo "ok $5 trigger=$4 frontmost=7777 (Ghostty)"
     ;;
+  control)
+    # $3 is the socket path, $4 the forwarded line. Echoed back so the suite
+    # can assert exactly what crossed, and nothing more.
+    [[ -z "${STUB_CONTROL_FAIL:-}" ]] || exit 1
+    printf '{"ok":true,"command":"%s","error":null,"result":{}}\n' "$4"
+    ;;
   *)
     exit 1
     ;;
@@ -152,6 +158,30 @@ if [[ -n "${STUB_IOREG_FILE:-}" && -f "${STUB_IOREG_FILE}" ]]; then
   exit 0
 fi
 echo '"HIDIdleTime" = 42000000000'
+STUB
+
+# `log show ...` — the unified-log reader the `log` verb wraps. Answers from
+# fixtures so the suite can exercise the happy path, the restricted-store
+# refusal, and the line cap without a real log store.
+cat >"$STUB_BIN/log" <<'STUB'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >>"$STUB_LOG_LOG"
+if [[ -n "${STUB_LOG_RESTRICTED:-}" ]]; then
+  echo "log: Could not open local log store: Operation not permitted" >&2
+  exit 64
+fi
+if [[ -n "${STUB_LOG_OUTPUT_FILE:-}" && -f "$STUB_LOG_OUTPUT_FILE" ]]; then
+  cat "$STUB_LOG_OUTPUT_FILE"
+  exit 0
+fi
+exit 0
+STUB
+
+# `lv-attach` execs exactly one ssh. The stub records the argv it was handed,
+# which is the whole assertion.
+cat >"$STUB_BIN/ssh" <<'STUB'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >>"$STUB_SSH_LOG"
 STUB
 
 cat >"$STUB_BIN/pmset" <<'STUB'
@@ -236,6 +266,7 @@ run_gate() { # <command> [env assignments...]
     STUB_SWIFT_LOG="$TMP_DIR/swift.log" \
     STUB_DEFAULTS_LOG="$TMP_DIR/defaults.log" \
     STUB_SCREENCAPTURE_LOG="$TMP_DIR/screencapture.log" \
+    STUB_LOG_LOG="$TMP_DIR/log.log" \
     "$@" \
     bash "$GATE" >"$out_file" 2>"$err_file" || GATE_STATUS=$?
   GATE_STDOUT="$(cat "$out_file")"
@@ -276,14 +307,15 @@ assert_allowed() { # <command> <description> [env...]
   pass "allowed: $description"
 }
 
-write_app_state() { # <pid>
-  local pid="$1" dir="$FAKE_HOME/.localvoxtral-ui-gate"
+write_app_state() { # <pid> [dogfood:0|1] [bundle]
+  local pid="$1" dogfood="${2:-0}" bundle="${3:-$CLEAN_APP}"
+  local dir="$FAKE_HOME/.localvoxtral-ui-gate"
   mkdir -p "$dir"
   {
     printf 'pid=%s\n' "$pid"
-    printf 'bundle=%s\n' "$CLEAN_APP"
-    printf 'identity=%s|%s\n' "Mon Aug 24 09:00:00 2026" "$CLEAN_APP/Contents/MacOS/localvoxtral"
-    printf 'dogfood=0\n'
+    printf 'bundle=%s\n' "$bundle"
+    printf 'identity=%s|%s\n' "Mon Aug 24 09:00:00 2026" "$bundle/Contents/MacOS/localvoxtral"
+    printf 'dogfood=%s\n' "$dogfood"
   } >"$dir/app.state"
 }
 
@@ -1367,6 +1399,373 @@ grep -q '::warning::' <<<"$INSTALL_STEP" \
 grep -q 'STATUS != 0' <<<"$INSTALL_STEP" \
   || fail "the install step swallows failures other than the slot-is-running one"
 pass "a running slot warns; every other install failure is red"
+
+echo "== 21. app — the passthrough to the dogfood control socket =="
+
+# The verb exists because two things about the join are invisible from outside
+# the app's process: a dictation has no deterministic trigger, and the session
+# registry is per-process, so `--probe-surface` can only ever resolve against
+# an empty one. What is proved here is that the passthrough stayed a
+# passthrough — one fixed socket, five known shapes, a dogfood-only gate.
+
+DOGFOOD_APP_ENV=(
+  STUB_PS_LSTART="Mon Aug 24 09:00:00 2026"
+  STUB_PS_COMM="$DOGFOOD_APP/Contents/MacOS/localvoxtral"
+)
+
+# A real AF_UNIX inode: `[[ -S ]]` is the gate's "is the app exposing one"
+# check, and a regular file would pass a laxer test while failing this one.
+CONTROL_SOCKET="$TMP_DIR/control.sock"
+command -v python3 >/dev/null 2>&1 \
+  || fail "python3 is needed to create the AF_UNIX fixture socket"
+python3 - "$CONTROL_SOCKET" <<'PYSOCK'
+import socket
+import sys
+
+server = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+server.bind(sys.argv[1])
+server.listen(1)
+PYSOCK
+[[ -S "$CONTROL_SOCKET" ]] || fail "the fixture control socket was not created"
+NOT_A_SOCKET="$TMP_DIR/not-a-socket"
+: >"$NOT_A_SOCKET"
+
+APP_SOCKET_ENV=(LV_UI_CONTROL_SOCKET="$CONTROL_SOCKET")
+
+clear_state
+assert_denied 'app join report' 'app with no app under test' \
+  "${DOGFOOD_APP_ENV[@]}" "${APP_SOCKET_ENV[@]}"
+
+# A shipped build compiles no socket at all, so this refusal is the difference
+# between one clear line and a connect that never answers.
+write_app_state 4242 0 "$CLEAN_APP"
+assert_denied 'app join report' 'app against a build with no dogfood stamp' \
+  "${APP_ENV[@]}" "${APP_SOCKET_ENV[@]}"
+[[ "$(log_tail)" == *"not a dogfood build"* ]] \
+  || fail "the non-dogfood refusal did not say why: $(log_tail)"
+
+write_app_state 4242 1 "$DOGFOOD_APP"
+assert_denied 'app join report' 'app when the app is not exposing a socket' \
+  "${DOGFOOD_APP_ENV[@]}" LV_UI_CONTROL_SOCKET="$NOT_A_SOCKET"
+[[ "$(log_tail)" == *"dogfood_control_socket_enabled"* ]] \
+  || fail "the missing-socket refusal did not name the runtime opt-in: $(log_tail)"
+
+# The forwardable shapes are an allowlist, not "whatever the socket happens to
+# understand today". A verb added to the app must be added here too — which is
+# the point: an already-installed gate must not gain a capability from an app
+# update.
+for hostile in \
+  'app session start' \
+  'app session start turbo' \
+  'app session restart overlay' \
+  'app registry dump' \
+  'app surface read' \
+  'app join' \
+  'app quit' \
+  'app state' \
+  'app rm -rf /'
+do
+  assert_denied "$hostile" "app refuses: ${hostile#app }" \
+    "${DOGFOOD_APP_ENV[@]}" "${APP_SOCKET_ENV[@]}"
+done
+
+# The socket path is not an argument, and there is no verb shape that makes it
+# one — so a second socket on the machine is unreachable through this gate.
+assert_denied "app join report $TMP_DIR/other.sock" 'app cannot be pointed at another socket' \
+  "${DOGFOOD_APP_ENV[@]}" "${APP_SOCKET_ENV[@]}"
+grep -q 'LV_UI_CONTROL_SOCKET' <<<"$(awk '/^run_app\(\) \{/ { capture = 1 } capture { print } capture && /^\}$/ { exit }' "$GATE")" \
+  || fail "run_app no longer reads the fixed socket path"
+
+: >"$TMP_DIR/swift.log"
+: >"$TMP_DIR/say.log"
+assert_allowed 'app join report' 'app forwards a read-only command' \
+  "${DOGFOOD_APP_ENV[@]}" "${APP_SOCKET_ENV[@]}"
+grep -q "control $CONTROL_SOCKET join report" "$TMP_DIR/swift.log" \
+  || fail "app did not forward the line to the fixed socket: $(cat "$TMP_DIR/swift.log")"
+[[ "$GATE_STDOUT" == *'"ok":true'* ]] \
+  || fail "app did not return the socket's reply: $GATE_STDOUT"
+[[ ! -s "$TMP_DIR/say.log" ]] \
+  || fail "a read-only control command spoke a takeover warning"
+
+: >"$TMP_DIR/swift.log"
+assert_allowed 'app registry list' 'app forwards registry list' \
+  "${DOGFOOD_APP_ENV[@]}" "${APP_SOCKET_ENV[@]}"
+grep -q "control $CONTROL_SOCKET registry list" "$TMP_DIR/swift.log" \
+  || fail "registry list did not reach the socket: $(cat "$TMP_DIR/swift.log")"
+
+# Owner rule: anything that takes the keyboard warns and waits first.
+: >"$TMP_DIR/say.log"
+assert_allowed 'app session start overlay' 'app session start warns before taking the screen' \
+  "${DOGFOOD_APP_ENV[@]}" "${APP_SOCKET_ENV[@]}"
+grep -q "taking control in 3" "$TMP_DIR/say.log" \
+  || fail "app session start did not speak the takeover warning (owner rule)"
+
+: >"$TMP_DIR/say.log"
+assert_allowed 'app session stop' 'app session stop gives the session back without warning' \
+  "${DOGFOOD_APP_ENV[@]}" "${APP_SOCKET_ENV[@]}"
+[[ ! -s "$TMP_DIR/say.log" ]] \
+  || fail "session stop spoke a takeover warning for a verb that takes nothing"
+
+# Lock policy is per COMMAND: what takes the keyboard, and what would answer a
+# question about the wrong surface, are both refused; in-process reads are not.
+LOCK_STATE=locked
+assert_denied 'app session start overlay' 'app session start while the screen is locked' \
+  "${DOGFOOD_APP_ENV[@]}" "${APP_SOCKET_ENV[@]}"
+assert_denied 'app session start live' 'app session start live while the screen is locked' \
+  "${DOGFOOD_APP_ENV[@]}" "${APP_SOCKET_ENV[@]}"
+assert_denied 'app surface probe' 'app surface probe while the screen is locked' \
+  "${DOGFOOD_APP_ENV[@]}" "${APP_SOCKET_ENV[@]}"
+assert_allowed 'app join report' 'app join report is a read and survives a locked screen' \
+  "${DOGFOOD_APP_ENV[@]}" "${APP_SOCKET_ENV[@]}"
+assert_allowed 'app registry list' 'app registry list survives a locked screen' \
+  "${DOGFOOD_APP_ENV[@]}" "${APP_SOCKET_ENV[@]}"
+assert_allowed 'app session stop' 'app session stop survives a locked screen' \
+  "${DOGFOOD_APP_ENV[@]}" "${APP_SOCKET_ENV[@]}"
+LOCK_STATE=unlocked
+
+# A socket that does not answer must not read as a completed command.
+run_gate 'app join report' "${DOGFOOD_APP_ENV[@]}" "${APP_SOCKET_ENV[@]}" STUB_CONTROL_FAIL=1
+(( GATE_STATUS != 0 )) || fail "app reported success when the control socket refused"
+[[ "$GATE_STDERR" == *"control socket did not answer"* ]] \
+  || fail "app's failure message is unhelpful: $GATE_STDERR"
+pass "a control socket that does not answer is a failure, not an ok"
+
+# Every invocation is logged with the exact line that crossed.
+grep -q 'ALLOW app join report .*(app=join report' "$LOG_FILE" \
+  || fail "the gate log does not record what was forwarded"
+pass "every app invocation is logged with the forwarded line"
+
+clear_state
+
+echo "== 22. log — bounded, scoped, and never silently empty =="
+
+LOG_FIXTURE="$TMP_DIR/logfixture.txt"
+
+clear_state
+# Read-only and focus-free, so unlike the actuation verbs it needs no app under
+# test and survives a locked screen.
+{
+  echo '2026-08-30 10:00:00 localvoxtral ClaudeContext: join abstained tty: stale'
+  echo '2026-08-30 10:00:01 localvoxtral Backends: speechd ready'
+} >"$LOG_FIXTURE"
+: >"$TMP_DIR/log.log"
+assert_allowed 'log' 'log with no app under test' STUB_LOG_OUTPUT_FILE="$LOG_FIXTURE"
+[[ "$GATE_STDOUT" == *"join abstained"* ]] \
+  || fail "log did not return the app's lines: $GATE_STDOUT"
+
+LOCK_STATE=locked
+assert_allowed 'log' 'log survives a locked screen' STUB_LOG_OUTPUT_FILE="$LOG_FIXTURE"
+LOCK_STATE=unlocked
+
+# The predicate is the difference between a diagnostic and a system-log reader
+# on the owner's personal machine.
+grep -q 'subsystem == "com.localvoxtral"' "$TMP_DIR/log.log" \
+  || fail "log show was not scoped to localvoxtral's subsystem: $(cat "$TMP_DIR/log.log")"
+grep -q -- '--last 15m' "$TMP_DIR/log.log" \
+  || fail "log did not use its default window: $(cat "$TMP_DIR/log.log")"
+pass "log is predicate-scoped to localvoxtral's own subsystem"
+
+: >"$TMP_DIR/log.log"
+assert_allowed 'log 42' 'log with an explicit window' STUB_LOG_OUTPUT_FILE="$LOG_FIXTURE"
+grep -q -- '--last 42m' "$TMP_DIR/log.log" || fail "log ignored the requested window"
+
+assert_denied 'log 0' 'a zero-minute window'
+assert_denied 'log 121' 'a window past the clamp'
+assert_denied 'log soon' 'a non-numeric window'
+assert_denied 'log 15 30' 'two windows'
+assert_denied 'log -5' 'a negative window'
+
+# The app writes its categories `privacy: .public` on purpose; this is the
+# cheap way not to depend on every line anyone ever adds being safe.
+{
+  printf 'token %s in a line\n' "$(printf 'a%.0s' $(seq 1 43))"
+  printf 'not a token %s\n' "$(printf 'b%.0s' $(seq 1 42))"
+} >"$LOG_FIXTURE"
+assert_allowed 'log' 'log masks token-shaped runs' STUB_LOG_OUTPUT_FILE="$LOG_FIXTURE"
+[[ "$GATE_STDOUT" == *"<redacted>"* ]] \
+  || fail "log did not mask a 43-character base64url run: $GATE_STDOUT"
+[[ "$GATE_STDOUT" != *"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"* ]] \
+  || fail "log emitted a token-shaped run verbatim"
+[[ "$GATE_STDOUT" == *"bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"* ]] \
+  || fail "log masked a run that is not the token shape — the rule must match DogfoodCaptureRedaction exactly"
+pass "log applies the same token-shaped scrub as the dogfood records"
+
+# A cap that silently truncated would make a missing line look like a missing
+# event, so the drop is announced.
+seq 1 900 | sed 's/^/2026-08-30 10:00:00 localvoxtral line /' >"$LOG_FIXTURE"
+assert_allowed 'log' 'log caps its own output' STUB_LOG_OUTPUT_FILE="$LOG_FIXTURE"
+(( $(printf '%s\n' "$GATE_STDOUT" | wc -l) <= 400 )) \
+  || fail "log exceeded its line cap"
+[[ "$GATE_STDERR" == *"dropped by the cap"* ]] \
+  || fail "log truncated silently: $GATE_STDERR"
+
+# Nothing to report and the reader being broken must not look the same.
+: >"$LOG_FIXTURE"
+assert_allowed 'log' 'log says so when there is nothing to report' STUB_LOG_OUTPUT_FILE="$LOG_FIXTURE"
+[[ "$GATE_STDERR" == *"no com.localvoxtral entries"* ]] \
+  || fail "an empty log window produced no explanation: $GATE_STDERR"
+
+# The restriction the build gate account actually hits (scripts/mac/README.md).
+# It is unverified for the GUI account, so the failure has to name itself.
+run_gate 'log' STUB_LOG_RESTRICTED=1
+(( GATE_STATUS != 0 )) || fail "a restricted log store read as success"
+[[ "$GATE_STDERR" == *"Could not open local log store"* ]] \
+  || fail "the restricted-store failure did not quote the reason: $GATE_STDERR"
+[[ "$GATE_STDERR" == *"cannot read the unified log"* ]] \
+  || fail "the restricted-store failure did not explain itself: $GATE_STDERR"
+pass "a restricted log store fails loudly and names itself, rather than returning an empty page"
+
+echo "== 23. lv-attach — the wrapper that makes term open usable =="
+
+# `term open` matches the FIRST token only and then trusts the command with
+# every argument it will ever be given, so an allowlisted name is holding the
+# boundary. The documented answer used to be a script the owner wrote by hand;
+# it ships here instead, and these are the properties that make allowlisting it
+# safe.
+
+ATTACH="$ROOT_DIR/scripts/mac/lv-attach.sh"
+ATTACH_CONF="$TMP_DIR/lv-attach.conf"
+SSH_LOG="$TMP_DIR/ssh.log"
+
+run_attach() { # <conf-contents> [args...]
+  local conf="$1"
+  shift
+  printf '%s\n' "$conf" >"$ATTACH_CONF"
+  ATTACH_STATUS=0
+  ATTACH_STDERR=""
+  : >"$SSH_LOG"
+  env -i \
+    PATH="$STUB_BIN:/usr/bin:/bin" \
+    HOME="$FAKE_HOME" \
+    LV_ATTACH_CONF="$ATTACH_CONF" \
+    STUB_SSH_LOG="$SSH_LOG" \
+    bash "$ATTACH" "$@" >"$TMP_DIR/attach.out" 2>"$TMP_DIR/attach.err" \
+    || ATTACH_STATUS=$?
+  ATTACH_STDERR="$(cat "$TMP_DIR/attach.err")"
+}
+
+assert_attach_refused() { # <description> <conf> [args...]
+  local description="$1"
+  shift
+  run_attach "$@"
+  (( ATTACH_STATUS != 0 )) \
+    || fail "lv-attach accepted $description (ssh argv: $(cat "$SSH_LOG"))"
+  [[ ! -s "$SSH_LOG" ]] \
+    || fail "lv-attach ran ssh for $description: $(cat "$SSH_LOG")"
+  pass "lv-attach refuses: $description"
+}
+
+# The only two shapes the app's own HerdrInvocation classifier accepts. A
+# wrapper that opened `herdr terminal attach <pane>` would reliably produce a
+# window the app deliberately never joins.
+run_attach 'destination=builder' work
+(( ATTACH_STATUS == 0 )) || fail "lv-attach refused a valid session name: $ATTACH_STDERR"
+[[ "$(cat "$SSH_LOG")" == "-t -- builder herdr --session work" ]] \
+  || fail "lv-attach built the wrong argv: $(cat "$SSH_LOG")"
+pass "lv-attach execs a fixed whole-view herdr client"
+
+run_attach 'destination=builder'
+(( ATTACH_STATUS == 0 )) || fail "lv-attach refused the no-session form: $ATTACH_STDERR"
+[[ "$(cat "$SSH_LOG")" == "-t -- builder herdr" ]] \
+  || fail "the no-session form built the wrong argv: $(cat "$SSH_LOG")"
+
+run_attach $'destination=builder\nsession=default'
+[[ "$(cat "$SSH_LOG")" == "-t -- builder herdr --session default" ]] \
+  || fail "lv-attach ignored the configured default session: $(cat "$SSH_LOG")"
+
+run_attach 'destination=deploy@build.local' work
+[[ "$(cat "$SSH_LOG")" == "-t -- deploy@build.local herdr --session work" ]] \
+  || fail "lv-attach mangled a user@host destination: $(cat "$SSH_LOG")"
+
+# Injection through the identifier — the only caller-controlled value, and one
+# that ssh assembles into a string a remote login shell interprets.
+assert_attach_refused 'a semicolon in the identifier'   'destination=builder' 'work;id'
+assert_attach_refused 'a command substitution'          'destination=builder' 'work$(id)'
+assert_attach_refused 'a backtick'                      'destination=builder' 'work`id`'
+assert_attach_refused 'a pipe'                          'destination=builder' 'work|id'
+assert_attach_refused 'an ampersand'                    'destination=builder' 'work&'
+assert_attach_refused 'a space'                         'destination=builder' 'work sh'
+assert_attach_refused 'a newline'                       'destination=builder' $'work\nid'
+assert_attach_refused 'a quote'                         'destination=builder' "work'"
+assert_attach_refused 'a slash'                         'destination=builder' 'work/../etc'
+assert_attach_refused 'an ssh option'                   'destination=builder' '-oProxyCommand=id'
+assert_attach_refused 'a leading dash'                  'destination=builder' '-t'
+assert_attach_refused 'a long identifier'               'destination=builder' "$(printf 'a%.0s' $(seq 1 65))"
+assert_attach_refused 'a second argument'               'destination=builder' 'work' 'extra'
+assert_attach_refused 'an empty identifier'             'destination=builder' ''
+
+# The destination is not caller-controlled, but a config file is still a file.
+rm -f "$ATTACH_CONF"
+ATTACH_STATUS=0
+env -i PATH="$STUB_BIN:/usr/bin:/bin" HOME="$FAKE_HOME" \
+  LV_ATTACH_CONF="$ATTACH_CONF" STUB_SSH_LOG="$SSH_LOG" \
+  bash "$ATTACH" work >/dev/null 2>&1 || ATTACH_STATUS=$?
+(( ATTACH_STATUS != 0 )) || fail "lv-attach ran with no config file"
+pass "lv-attach refuses: no config file"
+
+assert_attach_refused 'a config with no destination' 'session=work' 'work'
+assert_attach_refused 'a destination that is an ssh option' 'destination=-oProxyCommand=id' 'work'
+assert_attach_refused 'a destination with a space'   'destination=builder sh' 'work'
+assert_attach_refused 'a destination with a colon'   'destination=builder:2222' 'work'
+
+# Source pins: the properties that make the NAME safe to allowlist, which no
+# argv test can prove on its own.
+# CODE lines only: the file's own header names `bash -c` and `eval` as the
+# things it must not contain, and a scan that could not tell a comment from a
+# call would report the documentation as the violation.
+ATTACH_SRC="$(grep -v '^[[:space:]]*#' "$ATTACH")"
+for forbidden in 'eval ' 'bash -c' 'sh -c' 'source ' '. "$CONF"'; do
+  grep -qF "$forbidden" <<<"$ATTACH_SRC" \
+    && fail "lv-attach contains a path that can run a command of its own: $forbidden"
+done
+# Exactly two exec lines, both the fixed ssh argv.
+EXEC_LINES="$(grep -c '^[[:space:]]*exec ' <<<"$ATTACH_SRC")"
+(( EXEC_LINES == 2 )) || fail "lv-attach has $EXEC_LINES exec lines; expected exactly the two fixed ssh invocations"
+grep -q '^[[:space:]]*exec ssh -t -- "\$DESTINATION" herdr$' <<<"$ATTACH_SRC" \
+  || fail "the no-session exec is no longer the fixed argv"
+grep -q '^[[:space:]]*exec ssh -t -- "\$DESTINATION" herdr --session "\$SESSION"$' <<<"$ATTACH_SRC" \
+  || fail "the session exec is no longer the fixed argv"
+grep -q '"\$@"' <<<"$ATTACH_SRC" \
+  && fail 'lv-attach expands "$@" — an allowlisted command must never forward its arguments to anything'
+pass "lv-attach has no path that runs a command of the caller's choosing"
+
+# `ssh` itself must stay permanently refused: the wrapper is the way in, not a
+# precedent for widening the denylist.
+clear_conf
+write_conf 'LV_UI_TERM_COMMANDS="lv-attach ssh"'
+assert_denied 'term open ghostty ssh builder' 'ssh stays denylisted even when a conf allowlists it'
+: >"$TMP_DIR/open.log"
+assert_allowed 'term open ghostty lv-attach work' 'an allowlisted lv-attach reaches term open' \
+  STUB_PGREP_PID=5150
+clear_conf
+
+echo "== 24. install-ui-artifact.sh ships the wrapper with the build =="
+
+WRAPPER_HOME="$TMP_DIR/wrapper-home"
+mkdir -p "$WRAPPER_HOME"
+WRAPPER_ROOT="$WRAPPER_HOME/localvoxtral-ui-artifacts"
+mkdir -p "$WRAPPER_ROOT"
+chmod 0700 "$WRAPPER_ROOT"
+WRAPPER_SRC_APP="$(make_bundle_in "$TMP_DIR" wrapper-src.app com.localvoxtral.app localvoxtral absent)"
+env HOME="$WRAPPER_HOME" LV_UI_ARTIFACT_DEST_ROOT="$WRAPPER_ROOT" \
+  bash "$INSTALLER" "$WRAPPER_SRC_APP" --no-hint >/dev/null 2>&1 \
+  || fail "the installer failed on a clean bundle"
+[[ -x "$WRAPPER_HOME/bin/lv-attach" ]] \
+  || fail "the installer did not place lv-attach where a GUI terminal can resolve it"
+# It execs ssh as the owner; other accounts do not get to read or run it.
+# BSD stat first, GNU second, each validated on its own — GNU stat's `-f` means
+# --file-system and prints a whole block before failing, so an `a || b`
+# substitution would capture that block instead of a mode (the same trap
+# install-ui-artifact.sh documents).
+WRAPPER_MODE="$(stat -f '%Lp' "$WRAPPER_HOME/bin/lv-attach" 2>/dev/null || true)"
+[[ "$WRAPPER_MODE" =~ ^[0-7]+$ ]] \
+  || WRAPPER_MODE="$(stat -c '%a' "$WRAPPER_HOME/bin/lv-attach" 2>/dev/null || true)"
+[[ "$WRAPPER_MODE" == "700" ]] \
+  || fail "the installed wrapper is mode $WRAPPER_MODE, not 700"
+cmp -s "$ROOT_DIR/scripts/mac/lv-attach.sh" "$WRAPPER_HOME/bin/lv-attach" \
+  || fail "the installed wrapper is not the reviewed one from the repo"
+pass "a build install ships the reviewed wrapper rather than leaving it hand-maintained"
+
 
 echo
 echo "ui gate tests passed"

--- a/scripts/ci/ui-smoke-guard.sh
+++ b/scripts/ci/ui-smoke-guard.sh
@@ -104,18 +104,10 @@ lock_state() {
     echo "$UI_SMOKE_GUARD_LOCK_STATE"
     return
   fi
-  # CGSessionCopyCurrentDictionary needs a GUI session context (the runner is
-  # a LaunchAgent in the console session, so it has one). The lock key is only
-  # present, with value 1, while the screen is actually locked.
-  swift - <<'SWIFT' 2>/dev/null || echo "error"
-import CoreGraphics
-
-guard let session = CGSessionCopyCurrentDictionary() as? [String: Any] else {
-  print("no-session")
-  exit(0)
-}
-print(session["CGSSessionScreenIsLocked"] != nil ? "locked" : "unlocked")
-SWIFT
+  # The CGSessionCopyCurrentDictionary probe moved to screen-lock-state.sh so
+  # the SSH UI gate (scripts/mac/localvoxtral-ui-gate.sh) shares it. This lane
+  # keeps its own fail-OPEN policy below; the helper only reports.
+  "$SCRIPT_DIR/screen-lock-state.sh" 2>/dev/null || echo "error"
 }
 
 age="$(last_success_age_seconds)"

--- a/scripts/mac/README.md
+++ b/scripts/mac/README.md
@@ -542,7 +542,7 @@ full-screen capture anywhere in it:
 | `ax type <selector> -- <text>` | types into a text-bearing element |
 | `key <escape\|tab\|return>` | one keycode from a three-entry allowlist; brings the app under test frontmost first and refuses if that did not take, so a keystroke never lands in whatever the owner last touched |
 | `quit` | terminates the recorded pid |
-| `term open <ghostty\|iterm\|terminal> <command> [args]` | opens a terminal window running an allowlisted command (for herdr / terminal-integration work) |
+| `term open <ghostty\|iterm\|terminal> <command> [args]` | opens a terminal window running an allowlisted command. **The allowlist is empty by default** — see "What may go on `term open`'s allowlist" below |
 | `term focus <id>` / `term close <id>` | acts on one window this gate opened, identified by a random marker it put in that window's title |
 
 Selectors are `key<op>value` pairs joined by `,` — `=` exact, `~` contains,
@@ -567,10 +567,10 @@ Three refusals are load-bearing and are what the regression suite
 
 - **No shell verb.** No `eval`, no `bash -c`, no verb taking a free command
   line. `term open` is the single constrained exception: its first token must
-  be in `LV_UI_TERM_COMMANDS`, every token must survive the same metacharacter
-  blocklist as any other argument, and the command is logged **in full**.
-  Allowlisting something that is itself a shell (`bash`, `ssh`, `osascript`)
-  or that takes an arbitrary child command hands the boundary away.
+  be in `LV_UI_TERM_COMMANDS` (empty by default), must not be on the permanent
+  denylist the conf file cannot override, every token must survive the same
+  metacharacter blocklist as any other argument, and the command is logged
+  **in full**. The rule for that allowlist is below and is not negotiable.
 - **Locked screen = hard refusal**, fail closed. The probe is shared with the
   ui-smoke lane (`scripts/ci/screen-lock-state.sh`); an undeterminable state
   denies here and runs there, on purpose.
@@ -640,11 +640,70 @@ write it can already replace the gate script).
 
 ```bash
 # LV_UI_ARTIFACT_ROOTS="$HOME/localvoxtral-ui-artifacts"  # where launch may look
-# LV_UI_TERM_COMMANDS="herdr claude opencode codex"       # term open's first tokens
+# LV_UI_TERM_COMMANDS="lv-attach"       # term open's first tokens; EMPTY by default
 # LV_UI_TERMINALS="ghostty iterm terminal"
 # LV_UI_WARN_SLEEP_SECONDS=3                              # 0 only if you are sitting there
 # LV_UI_SHOT_MAX_BYTES=8388608
 ```
+
+### What may go on `term open`'s allowlist
+
+**An allowlisted command must not be able to run a child command.** Not "must
+not be a shell" — must not be able to *start* one, at any remove, through any
+flag or subcommand. `list_contains` matches the **first token only** and
+nothing inspects flags, so a name on this list is trusted with every argument
+it will ever be given.
+
+The test to apply before adding a name: read its `--help`. If any flag or
+subcommand takes a command, a script, a prompt, or a file to execute — `-c`,
+`-e`, `exec`, `run`, `--eval`, `-p`, an agent that runs tools — it fails.
+
+That rejects the obvious shells and **every coding-agent CLI**. `claude
+--dangerously-skip-permissions -p <prompt>`, `codex exec`, `opencode run` and
+`herdr agent start` each execute arbitrary code as the GUI user, and none of
+them needs a space or a metacharacter to do it. An earlier revision of the gate
+shipped `herdr claude opencode codex` as the default allowlist; that was a
+fully-permissioned remote shell wearing four allowlisted names, and it is why
+the default is now empty and why `LV_UI_TERM_FORBIDDEN` — a permanent denylist
+assigned *after* the conf file is sourced — refuses those names even if this
+conf allowlists them.
+
+The way to make the verb useful is a **single-purpose wrapper you write and
+install**, which takes an identifier and execs one fixed command:
+
+```bash
+# ~/bin/lv-attach — allowlist THIS, not the tool it calls.
+#!/bin/sh
+case "$1" in
+  pane-[0-9]*) exec ssh -t fixture-host herdr attach "$1" ;;
+  *) echo "lv-attach: unknown pane" >&2; exit 2 ;;
+esac
+```
+
+```bash
+# ~/.localvoxtral-ui-gate.conf
+LV_UI_TERM_COMMANDS="lv-attach"
+```
+
+The wrapper, not the gate, is what decides the command — so review it with the
+same eyes as the gate itself, and never let it take a command from its
+argument.
+
+**Where the agent runs.** For terminal/agent-integration scenarios the agent
+(Claude Code, codex, …) is started on the **fixture side** — the Linux host
+running herdr, driven by the herdr-integration harness — and the Mac's
+`term open` only ever attaches to it, as `lv-attach` above does. The Mac gate
+never launches an agent, so the "allowlist a coding-agent CLI" pressure that
+produced the original hole does not exist.
+
+**Why `term open` is not a way around the app-scoped verbs.** `shot`,
+`ax dump`, `ax click`, `ax type` and `key` all take their pid from the
+`app.state` that `launch` wrote, and `launch` only ever records a validated
+localvoxtral bundle's pid. No verb retargets them at a terminal.
+`term focus`/`term close` do reach a terminal window, but only to raise or
+close it — they carry no selector, no keystroke and no capture, so nothing this
+gate types can reach a shell prompt. `test-ui-gate.sh` section 12 pins this
+with both an app under test and an open terminal recorded.
 
 ### Verifying from the Linux box
 
@@ -659,6 +718,9 @@ ssh lv-ui 'quit'
 ssh lv-ui 'echo pwned'                  # must print "denied command"
 ssh lv-ui 'bash -lc id'                 # must print "denied command"
 ssh lv-ui 'term open ghostty bash -c id' # must print "denied command"
+ssh lv-ui 'term open ghostty claude --dangerously-skip-permissions -p hi'
+                                        # must print "denied command" — the
+                                        # agent CLIs are permanently refused
 ```
 
 Every one of those, allowed or denied, appends a line to
@@ -689,7 +751,8 @@ behaviour, but nothing about a live desktop. On first install, confirm by hand:
    with no run loop, which is exactly where they are least likely to behave —
    if `key` always reports "could not be brought frontmost", that is the
    symptom.
-5. `term open ghostty herdr ...` opens a window whose title carries the
+5. `term open ghostty <your-wrapper> …` opens a window whose title carries the
    `lvui-…` marker, and `term focus`/`term close` find it. Terminal-specific
    flags (`ghostty -e`, the generated `.command` for Terminal/iTerm) are the
-   least-tested part of v1.
+   least-tested part of v1. Nothing here works until you have written a wrapper
+   and allowlisted it — the default allowlist is empty on purpose.

--- a/scripts/mac/README.md
+++ b/scripts/mac/README.md
@@ -819,10 +819,10 @@ account, so it is expected to work here; that has **not** been verified on this
 machine as of 2026-08-30. The verb is built so the difference is impossible to
 miss: a restricted store exits non-zero and quotes the reason rather than
 returning an empty page, and an empty window says "no com.localvoxtral entries
-for <scope> in the last N minute(s)" on stderr. If it does turn out to be restricted for
-the GUI account too, there is no flag that lifts it — the alternatives are
-`mac-crashlog.yml` on the runner (which already ships a subsystem-filtered log)
-or having the app write its own file.
+for <scope> in the last N minute(s)" on stderr. If it does turn out to be
+restricted for the GUI account too, there is no flag that lifts it — the
+alternatives are `mac-crashlog.yml` on the runner (which already ships a
+subsystem-filtered log) or having the app write its own file.
 
 ### Getting a build into the artifact root
 

--- a/scripts/mac/README.md
+++ b/scripts/mac/README.md
@@ -534,7 +534,7 @@ full-screen capture anywhere in it:
 
 | verb | what it does |
 | --- | --- |
-| `state` | JSON: lock state, idle seconds, AC/battery, the Accessibility + Screen Recording preflight, whether an app under test is running, which terminals this gate opened |
+| `state` | JSON: lock state, idle seconds, AC/battery, the Accessibility + Screen Recording preflight, whether an app under test is running, which terminals this gate opened — and a `setup` section that says which verbs will work before you try them (below) |
 | `launch [--dogfood] <artifact>` | launches a `.app` that is under an allowlisted root **and** has `CFBundleIdentifier com.localvoxtral.app`; records pid + start time + executable path; prints the pid. Refuses beside any running localvoxtral, including one this gate did not start |
 | `shot [settings\|popover\|overlay\|window <n>]` | base64 PNG of ONE window, resolved from the window list filtered to that pid, refused if the resolved window's owner is anything else. stdout is pure base64; the `shot: window …` line is on **stderr**, so pipe straight into `base64 -d` — no `tail` |
 | `ax dump [all\|settings\|overlay\|window <n>]` | the AX element tree of that pid's windows, as JSON |
@@ -545,9 +545,10 @@ full-screen capture anywhere in it:
 | `dictate tap` / `dictate hold <seconds>` / `dictate cancel` | posts the app's OWN configured modifier trigger (read from its defaults) as a gesture at the HID tap — the only way to start a dictation, and therefore to exercise the Claude Code / herdr join |
 | `app <control command>` | forwards ONE line to the **dogfood** control socket of the app under test and returns the reply. Five shapes only: `session start overlay\|live`, `session stop`, `join report`, `surface probe`, `registry list`. Refuses a build with no `LVXDogfoodCapture` stamp — see "`app` — asking the app what it joined" |
 | `log [minutes]` | localvoxtral's own unified-log lines over a clamped window (default 15, max 120), line-capped and token-scrubbed. Predicate-scoped to `subsystem == "com.localvoxtral"` **and** to one process — the recorded pid, else the app's process name, which it says. Never a system-log reader. Read-only, so it works while the screen is locked |
+| `gate-log [lines]` | the last N lines of this gate's OWN log (default 20, max 200) — where a denial's reason is written. Read-only, works while the screen is locked |
 | `quit` | terminates the recorded pid |
-| `term open <ghostty\|iterm\|terminal> <command> [args]` | opens a terminal window running an allowlisted command. **The allowlist is empty by default** — see "What may go on `term open`'s allowlist" below |
-| `term focus <id>` / `term close <id>` | acts on one window this gate opened, identified by a random marker it put in that window's title |
+| `term open <ghostty\|iterm\|terminal> <command> [args]` | opens a terminal window running an allowlisted command, resolved to an absolute path under `$HOME/bin` before anything opens. **The allowlist is empty by default** — see "What may go on `term open`'s allowlist" below |
+| `term focus <id>` / `term close <id>` | acts on one window this gate opened, identified by the CGWindowID that appeared while it was opening one |
 
 Selectors are `key<op>value` pairs joined by `,` — `=` exact, `~` contains,
 `+` for a space, keys `role`/`title`/`desc`/`value`/`index`/`window`:
@@ -636,6 +637,98 @@ enqueue verbs the helper already implements. It also side-steps the open
 question below about whether an SSH-hosted process can reach the GUI session at
 all. It is more moving parts than a single reviewed script, so it is not what
 v1 does.
+
+### `state`'s `setup` section — which verbs will work, before you try one
+
+Every refusal in this gate is deliberately uniform: `denied command`, exit 126,
+nothing on stdout. That is right, and it was also the whole problem. Driving
+the installed gate on 2026-08-30 hit `term open` refusing everything and `app`
+denying, and the causes were three files that did not exist and one runtime
+default that was off — each a one-line fix, and none of them distinguishable
+from "the verb is broken" or "the gate is old".
+
+So `state` reports setup:
+
+```json
+"setup": {
+  "gate": {"revision": "f44a91a15001"},
+  "lock_probe": {"installed": true},
+  "gate_conf": {"present": true, "status": "ok"},
+  "artifacts": [{"name": "localvoxtral-dogfood.app", "dogfood": true}],
+  "term_open": {"terminals": ["ghostty", "iterm", "terminal"],
+                "commands": ["lv-attach"], "refused_by_denylist": [],
+                "unresolvable": []},
+  "lv_attach": {"installed": true, "allowlisted": true, "conf": "ok",
+                "destination": "builder", "session_default": true},
+  "control_socket": {"present": false, "consent": "off"}
+}
+```
+
+Reading it:
+
+- `gate.revision` is the first 12 hex of the installed script's SHA-256.
+  Compare with `shasum -a 256 scripts/mac/localvoxtral-ui-gate.sh` to settle
+  "is the gate old", which used to be an unfalsifiable theory.
+- `gate_conf.status` is `absent`, `ok` or `unparsable`. A conf with a syntax
+  error used to take the **whole gate** down — `source` returns non-zero and
+  `set -e` exits before anything prints. It now degrades to the built-in
+  defaults, which are the closed ones, warns on stderr on every invocation,
+  and shows up here.
+- `term_open.commands` is exactly what `term open`'s first token is matched
+  against. `[]` means every command is refused, which is the shipped default.
+  `refused_by_denylist` names allowlisted entries the permanent denylist
+  refuses anyway — a conf that reads as configured and behaves as not.
+  `unresolvable` names allowlisted entries with no executable file behind
+  them, which is the failure below, reported before a verb is tried.
+- `lv_attach.conf` comes from `~/bin/lv-attach --check`, so it is the
+  **installed** wrapper's own verdict rather than a second copy of its rules:
+  `ok`, `missing`, `no-destination`, `invalid-destination`, `invalid-session`,
+  `present-unchecked` (a config with no wrapper to validate it) or
+  `wrapper-too-old`.
+- `artifacts` lists what `launch` would accept, by name, with the dogfood slot
+  marked. Anything that is not a validated localvoxtral bundle is not listed.
+- `control_socket` is the two halves `app` needs: `consent` is
+  `debug.dogfood_control_socket_enabled`, `present` is whether a socket is
+  actually bound.
+
+**What it reports and what it does not.** Presence, parse verdicts, and values
+that are already this gate's own vocabulary — allowlisted command names,
+terminal names, bundle names under a root the gate names in its own refusals.
+Never a config file's contents. The one judgement call is the lv-attach
+destination: a **bare alias** is echoed, because it is a label in the owner's
+own `~/.ssh/config`, names no account and no address, and is the value that
+catches the real failure ("this points at the wrong machine"). A `user@host`
+destination is an account **and** an address, so its shape is reported and its
+value is not — the same line `app`'s closed reply vocabulary draws.
+
+### `gate-log` — reading why something was denied
+
+The reason behind a `denied command` was always written to
+`~/Library/Logs/localvoxtral-ui-gate.log`; what was missing is that no verb
+could read it back, so an agent over SSH saw the generic line and had to go
+through the owner to learn a one-line fix.
+
+```bash
+ssh lv-ui 'term open ghostty lv-attach'   # denied command
+ssh lv-ui 'gate-log 5'
+# 2026-08-30T14:39:37+0200 DENY term open ghostty lv-attach (term open has no
+#   allowlisted commands (the default is empty — see scripts/mac/README.md))
+```
+
+**`deny` still does not explain itself, and that is the point.** A gate that
+answered each refusal with its reason would be an oracle for state the caller
+cannot otherwise see — whether a path exists, whether a bundle validated,
+whether a pid is running, which names a conf allowlists. The fix for an
+invisible reason is a bounded reader, not a chattier refusal.
+
+What `gate-log` can disclose is exactly what this gate wrote about itself: one
+sanitised, printable, 512-byte-capped line per invocation, with `ax type`'s
+text already replaced by `<redacted>` **at write time**, so reading the log
+back cannot resurrect an API key. Output goes through the same 43-character
+base64url scrub `log` uses. It logs its own invocation before reading and drops
+that line from the answer, so `gate-log 1` means "the entry before this one".
+It is read-only and focus-free, so like `log` it works while the screen is
+locked.
 
 ### `menu` — the verb that makes every other verb reachable
 
@@ -765,6 +858,19 @@ What bounds the verb:
   work while locked.
 - **A started session is capped** by the app itself, so an SSH command that
   dies mid-dictation cannot leave it recording.
+- **The socket's runtime consent is a SECOND grant, and stays one.** A dogfood
+  build writes capture records when `debug.dogfood_capture_enabled` is armed
+  (which `launch --dogfood` does); it binds the control socket only when
+  `debug.dogfood_control_socket_enabled` is armed as well, and nothing arms
+  that for you — not `try-pr.sh --ui-gate`, not the CI install step. The split
+  is deliberate: "records what I do" and "accepts commands on a local socket
+  **any** process on this Mac can connect to" are different permissions, and
+  this machine is also the self-hosted CI runner. `state` reports
+  `setup.control_socket.consent`, and the refusal names the fix:
+
+  ```bash
+  defaults write com.localvoxtral.app debug.dogfood_control_socket_enabled -bool true
+  ```
 - The reply is a closed vocabulary of bools, counts and enum names — no
   workspace, marker, tty, pane id, host or session id ever crosses.
 
@@ -883,10 +989,29 @@ write it can already replace the gate script).
 ```bash
 # LV_UI_ARTIFACT_ROOTS="$HOME/localvoxtral-ui-artifacts"  # where launch may look
 # LV_UI_TERM_COMMANDS="lv-attach"       # term open's first tokens; EMPTY by default
+# LV_UI_TERM_COMMAND_DIRS="$HOME/bin"   # where an allowlisted name is resolved
 # LV_UI_TERMINALS="ghostty iterm terminal"
 # LV_UI_WARN_SLEEP_SECONDS=3                              # 0 only if you are sitting there
 # LV_UI_SHOT_MAX_BYTES=8388608
 ```
+
+**No installer writes this file, and none ever should.** `LV_UI_TERM_COMMANDS`
+is the gate's allowlist — the same object as the gate script, one layer up. The
+rule that CI must not write the gate script applies for exactly the same reason
+to what the gate will accept: an empty default exists to force a deliberate
+grant, and a grant that arrives with a build is not one. So the one manual step
+is an **append**, which cannot clobber a file that already exists and wins over
+any earlier assignment when the file is sourced:
+
+```bash
+printf 'LV_UI_TERM_COMMANDS="lv-attach"\n' >> ~/.localvoxtral-ui-gate.conf
+```
+
+`ui-gate-doctor.sh` prints that exact line when the allowlist is empty, and
+`state`'s `setup.term_open.commands` shows the result. A syntax error in this
+file no longer breaks the gate: it is ignored, every setting falls back to its
+built-in (closed) default, and `state` reports `"gate_conf":{"status":
+"unparsable"}`.
 
 ### What may go on `term open`'s allowlist
 
@@ -918,22 +1043,35 @@ weakest possible place for that. `install-ui-artifact.sh` puts it at
 `~/bin/lv-attach` (mode 0700) with every build, so it arrives reviewed and
 stays current.
 
-Allowlist it:
+Allowlist it — append, so the line cannot clobber an existing conf:
 
 ```bash
-# ~/.localvoxtral-ui-gate.conf
-LV_UI_TERM_COMMANDS="lv-attach"
+printf 'LV_UI_TERM_COMMANDS="lv-attach"\n' >> ~/.localvoxtral-ui-gate.conf
 ```
 
 and tell it where to go — the destination is deliberately **not** an argument:
 
 ```bash
-# ~/.lv-attach.conf
+# ~/.lv-attach.conf   (install-ui-artifact.sh writes this as a commented
+#                      template if it does not exist, and never overwrites it)
 destination=builder      # an ssh alias, or user@host
 session=work             # optional default herdr session
 ```
 
+`~/bin/lv-attach --check` answers whether that resolves, and it is the same
+answer `state` reports under `setup.lv_attach` — the gate asks the installed
+wrapper rather than re-reading the file, so the destination validator has one
+implementation and not two.
+
 Then `ssh lv-ui 'term open ghostty lv-attach work'`.
+
+**Why the wrapper's config is templated by the installer and the gate's
+allowlist is not.** A destination is ordinary configuration; the only cost of
+getting it wrong is a terminal that opens onto the wrong machine, and "what is
+this file called and what goes in it" was itself a round trip through the
+owner. The allowlist is the boundary. So the installer writes an
+`~/.lv-attach.conf` with **no active destination** (it cannot know which
+machine you mean) and never touches `~/.localvoxtral-ui-gate.conf`.
 
 **Allowlisting `lv-attach` is safe precisely because it cannot take a command,
 which is the property `ssh` lacks.** `ssh <host> <anything>` runs that
@@ -964,6 +1102,56 @@ running herdr, driven by the herdr-integration harness — and the Mac's
 never launches an agent, so the "allowlist a coding-agent CLI" pressure that
 produced the original hole does not exist.
 
+### `term open` — what it runs, and how it finds the window it opened
+
+Both halves of this were wrong on 2026-08-30, and between them they told the
+operator a story that was false in every particular.
+
+**The command is resolved to an absolute path before anything opens.** The
+launcher used to say `exec lv-attach` and let PATH find it. A script started by
+`open -n -a Ghostty --args -e <script>` gets no login-shell environment, and
+`$HOME/bin` — where `install-ui-artifact.sh` puts the wrapper — is on neither
+that PATH nor sshd's. So the launcher hit `command not found`, exited
+instantly, and left an **empty** Ghostty window. `term open` now resolves the
+allowlisted name against `LV_UI_TERM_COMMAND_DIRS` (default `$HOME/bin`),
+requires a file that exists and is executable, and refuses **with nothing
+opened** when there is none. The directory list stays short on purpose: a name
+resolved out of a directory other accounts can write is the allowlist handed
+away. `state`'s `setup.term_open.unresolvable` reports the same thing without
+opening anything at all.
+
+**The window is identified by a CGWindowID diff, not a title marker.** The
+launcher printed an OSC 0 title carrying a random marker and the gate polled
+for a window with it. That cannot work for the one command this verb exists to
+run: `lv-attach` execs a whole-view herdr client, and herdr owns the title from
+the moment it starts — `docs/agent/invariants.md` says a title marker "can
+neither reach nor come back from a herdr-hosted session", which is why the
+app's own `titleMarker` join arm is suppressed there. So `term open` snapshots
+the terminal application's window ids **before** `open`, then binds the window
+that is new since that snapshot; nothing the command does to its title can hide
+it. The marker survives only as a tie-breaker for commands that leave the title
+alone. `term focus`/`term close` then address that window id, mapped to an AX
+window by frame (AX exposes no window id without private API).
+
+**Three faults, three messages.** "No window" used to mean all of these at
+once, and reporting the second as the third is what produced a confidently
+wrong root cause. The launcher writes its pid before `exec`, which separates
+them:
+
+| what the pid file says | what happened | what to do |
+| --- | --- | --- |
+| absent | the terminal never ran the launcher | the command was never executed; this is not a window problem |
+| present, process gone | the command ran and exited immediately — an empty window is exactly what that looks like | run `~/bin/<command> <args>` by hand as the GUI user and read its error |
+| present, process alive | the command is running; only the window could not be identified | re-run without opening a terminal window yourself at the same moment |
+
+**A failed `term open` leaves nothing behind.** If it cannot confirm which
+window it opened, it kills the process it started (that pid file is the only
+handle once the window is unaddressable), removes the launcher, and registers
+no terminal. In Ghostty the window closes with the command; in Terminal/iTerm
+it stays showing a finished command. Several windows appearing at the same
+moment is refused rather than guessed at — binding the wrong one would point
+`term close` at whatever the owner just opened.
+
 **Why `term open` is not a way around the app-scoped verbs.** `shot`,
 `ax dump`, `ax click`, `ax type` and `key` all take their pid from the
 `app.state` that `launch` wrote, and `launch` only ever records a validated
@@ -976,8 +1164,10 @@ with both an app under test and an open terminal recorded.
 ### Verifying from the Linux box
 
 ```bash
-ssh lv-ui 'state'                       # JSON; check tcc.accessibility and
-                                        # tcc.screen_recording are both true
+./scripts/mac/ui-gate-doctor.sh --remote lv-ui   # every readiness item, ticked
+                                        # or with the one command that fixes it
+ssh lv-ui 'state'                       # the same facts as JSON
+ssh lv-ui 'gate-log 20'                 # why the last thing was denied
 ssh lv-ui 'launch localvoxtral-ui-artifacts/localvoxtral.app'
 ssh lv-ui 'menu open'                   # localvoxtral has NO window until this
 ssh lv-ui 'shot popover' | base64 -d > /tmp/popover.png
@@ -1007,11 +1197,31 @@ ssh lv-ui 'term open ghostty claude --dangerously-skip-permissions -p hi'
 Every one of those, allowed or denied, appends a line to
 `~/Library/Logs/localvoxtral-ui-gate.log` — read it after the first session.
 
-### First-install checks the test suite cannot do
+### First install: run the doctor, then the four things it cannot reach
 
-`test-ui-gate.sh` stubs the GUI, so it proves the allowlist, the argument
-validation, the lock refusal, the window-ownership rule and the log/redaction
-behaviour, but nothing about a live desktop. On first install, confirm by hand:
+```bash
+# On the Mac's GUI account, from the checkout:
+./scripts/mac/ui-gate-doctor.sh
+
+# From the Linux dev box, against the installed gate:
+./scripts/mac/ui-gate-doctor.sh --remote lv-ui
+```
+
+Every line is either `ok` or `FIX` followed by one copy-pasteable command; it
+exits 0 when nothing needs attention, 1 when something does, 2 when the gate
+could not be reached at all. It covers the gate script's revision (and, locally,
+whether the installed copy matches this checkout), the forced-command line, the
+lock probe, both TCC grants as the gate's own preflight saw them, the gate conf
+and what `term open` would accept, whether `lv-attach` is installed, allowlisted
+and pointed somewhere, what `launch` would accept, and the dogfood control
+socket's two consents. Run it again after each fix.
+
+The prose list this replaces is gone on purpose: it was seven numbered items
+the owner read and mis-followed, and every one of them that a script *can*
+check is now checked.
+
+**What no script can check**, and what still has to be done by hand on the
+first install — the doctor prints this list too:
 
 0. `log` returns lines rather than failing. If it prints "Could not open local
    log store: Operation not permitted", the unified log is restricted for this
@@ -1022,34 +1232,34 @@ behaviour, but nothing about a live desktop. On first install, confirm by hand:
    between the gate and a locked machine. It has two arms; over SSH the
    IORegistry arm is the one that has to answer, and it has not been run
    against a real `ioreg` yet.
-2. `tcc.accessibility` and `tcc.screen_recording` are both `true` **in a
-   session that arrived over SSH**. If they are false after granting sshd, the
+2. `tcc.accessibility` and `tcc.screen_recording` are true **in a session that
+   arrived over SSH**. The doctor reports what the gate's preflight saw, which
+   is the right answer only if you ran it through `--remote`; a local run
+   reports a local process's grants. If they are false after granting sshd, the
    sshd-holds-the-grants design does not work on this macOS version and the
    LaunchAgent alternative above is the fix — do not work around it by
    loosening the gate.
 3. `shot settings` returns a PNG of the Settings window and not a black or
    empty image (a black capture means the Screen Recording grant is not
-   reaching the SSH session).
-4. `ax click` actually presses the right control, and `key` works: it calls
-   `NSRunningApplication.activate` and then re-checks `frontmostApplication`.
-   Both of those are AppKit calls made from a short-lived SSH-hosted process
-   with no run loop, which is exactly where they are least likely to behave —
-   if `key` always reports "could not be brought frontmost", that is the
-   symptom.
-5. `term open ghostty <your-wrapper> …` opens a window whose title carries the
-   `lvui-…` marker, and `term focus`/`term close` find it. Terminal-specific
-   flags (`ghostty -e`, the generated `.command` for Terminal/iTerm) are the
-   least-tested part of v1. Nothing here works until you have written a wrapper
-   and allowlisted it — the default allowlist is empty on purpose.
-6. `menu open` prints `ok window=<n>`, `shot popover` then returns a PNG of
-   that same menu, and `menu dismiss` prints `ok`. This is the one behaviour
-   the shell suite cannot reach at all: it stubs the helper, so what it pins is
-   that the decision is made from the window list, never that macOS puts a
-   status menu there. If `menu open` says the status item was pressed but no
-   window appeared at layer ≥ 100, then either the press did nothing or a
-   displayed status menu is not a pid-owned window on this macOS version —
-   check with `menu click Settings` (which works either way) and say which, do
-   not go back to trusting the attached `AXMenu`.
-7. `log` returns only the app under test. Start a build on the runner, then run
+   reaching the SSH session), `ax click` presses the right control, and `key`
+   works — it calls `NSRunningApplication.activate` and re-checks
+   `frontmostApplication`, both AppKit calls made from a short-lived
+   SSH-hosted process with no run loop, which is exactly where they are least
+   likely to behave. "Could not be brought frontmost" is that symptom.
+4. `menu open` prints `ok window=<n>`, `shot popover` returns a PNG of that same
+   menu, and `menu dismiss` prints `ok`. The shell suite stubs the helper, so
+   what it pins is that the decision is made from the window list, never that
+   macOS puts a status menu there. If `menu open` says the status item was
+   pressed but no window appeared at layer >= 100, check with `menu click
+   Settings` (which works either way) and say which — do not go back to
+   trusting the attached `AXMenu`.
+5. `term open ghostty lv-attach` opens a window that actually reaches the
+   configured host, `term focus`/`term close` find it, and a failed one leaves
+   nothing behind. The gate now distinguishes "the command never ran", "the
+   command exited immediately" and "the window could not be identified"; what
+   it cannot tell you is whether the herdr client on the far end attached to
+   the session you meant. Confirm that from the remote host (`last` shows a new
+   pty login from the `-t` ssh).
+6. `log` returns only the app under test. Start a build on the runner, then run
    `log 2` and confirm no `xctest[` line comes back. Without `launch`, the same
    command warns on stderr that it is not pid-scoped.

--- a/scripts/mac/README.md
+++ b/scripts/mac/README.md
@@ -543,6 +543,8 @@ full-screen capture anywhere in it:
 | `key <escape\|tab\|return>` | one keycode from a three-entry allowlist; brings the app under test frontmost first and refuses if that did not take, so a keystroke never lands in whatever the owner last touched |
 | `menu open` / `menu click <item-title>` / `menu dismiss` | drives the status item of the recorded pid. localvoxtral opens no window at launch, so this is what makes every row above it reachable |
 | `dictate tap` / `dictate hold <seconds>` / `dictate cancel` | posts the app's OWN configured modifier trigger (read from its defaults) as a gesture at the HID tap — the only way to start a dictation, and therefore to exercise the Claude Code / herdr join |
+| `app <control command>` | forwards ONE line to the **dogfood** control socket of the app under test and returns the reply. Five shapes only: `session start overlay\|live`, `session stop`, `join report`, `surface probe`, `registry list`. Refuses a build with no `LVXDogfoodCapture` stamp — see "`app` — asking the app what it joined" |
+| `log [minutes]` | localvoxtral's own unified-log lines over a clamped window (default 15, max 120), line-capped and token-scrubbed. Predicate-scoped to `subsystem == "com.localvoxtral"`; never a system-log reader. Read-only, so it works while the screen is locked |
 | `quit` | terminates the recorded pid |
 | `term open <ghostty\|iterm\|terminal> <command> [args]` | opens a terminal window running an allowlisted command. **The allowlist is empty by default** — see "What may go on `term open`'s allowlist" below |
 | `term focus <id>` / `term close <id>` | acts on one window this gate opened, identified by a random marker it put in that window's title |
@@ -700,6 +702,86 @@ appears when terminal-screen or repo context is enabled, and **only Overlay
 Buffer sessions open an overlay at all** — `dictate hold` (Live Auto-Paste)
 never shows one, so `tap` is the oracle.
 
+### `app` — asking the app what it joined
+
+`dictate` can start a session; it cannot tell you what the session **joined**.
+Two things about that are invisible from outside the app's process: a dictation
+has no deterministic trigger (which is what `dictate` works around, at the cost
+of synthesising a gesture), and `ClaudeSessionRegistry` is in-memory and
+per-process — so `localvoxtral --probe-surface`, a separate one-shot process,
+always resolves against an **empty registry** and can never report a real join
+arm.
+
+A dogfood build answers both, over a local AF_UNIX socket it binds only when
+`debug.dogfood_control_socket_enabled` is armed
+(`docs/dogfood-builds.md`). `app` forwards one line to it:
+
+```bash
+ssh lv-ui 'app registry list'         # is the registry empty, or the surface unidentified?
+ssh lv-ui 'app surface probe'         # resolve the FOCUSED surface now, live registry
+ssh lv-ui 'app session start overlay' # a real dictation, through the app's own tap handler
+ssh lv-ui 'app session stop'
+ssh lv-ui 'app join report'           # what the last dictation actually joined
+```
+
+`registry list` is the one to reach for first: an empty registry and a surface
+the resolver could not identify produce the same silence, and that ambiguity is
+the most common dead end in this area.
+
+What bounds the verb:
+
+- **The socket path is fixed**, not an argument. No shape of this verb points
+  it at another socket on the machine.
+- **Dogfood only.** A shipped build compiles no socket at all, so the verb
+  refuses unless `launch --dogfood` recorded a stamped bundle — one clear line
+  instead of a connect that never answers.
+- **Five shapes, allowlisted in the gate.** A verb added to the app's socket is
+  not automatically reachable through an already-installed gate.
+- **Lock policy is per command.** `session start` takes the keyboard, so it is
+  refused on a locked screen and speaks the takeover warning like `dictate`.
+  `surface probe` reads the *focused* surface, and behind a lock screen that is
+  not the surface you are asking about, so it is refused too. `session stop`,
+  `join report` and `registry list` are in-process reads (or a give-back) and
+  work while locked.
+- **A started session is capped** by the app itself, so an SSH command that
+  dies mid-dictation cannot leave it recording.
+- The reply is a closed vocabulary of bools, counts and enum names — no
+  workspace, marker, tty, pane id, host or session id ever crosses.
+
+### `log` — the app's own lines, and nothing else
+
+Join abstentions are diagnosed from `Log.claudeContext`, and without them the
+answer is one category word.
+
+```bash
+ssh lv-ui 'log'        # the last 15 minutes
+ssh lv-ui 'log 60'     # clamped 1..120
+```
+
+Predicate-scoped to `subsystem == "com.localvoxtral"`. It is deliberately not a
+general system-log reader: this is the owner's personal machine, and every
+other application's activity stays out of reach. Output is capped at 400 lines
+(the drop is announced, never silent) and passed through the same 43-character
+base64url scrub the dogfood records use — the app writes its categories
+`privacy: .public` on purpose, but "every line anyone ever adds is safe" is not
+an assumption worth depending on.
+
+It steals no focus and writes nothing, so unlike the actuation verbs it is
+allowed while the screen is locked.
+
+**Caveat, and it is not yet resolved.** `log show` is restricted for
+**non-admin** accounts — the build gate's account hits exactly that, and this
+file records it a few sections down ("Could not open local log store: Operation
+not permitted"). The UI gate runs as the GUI user, a different and *admin*
+account, so it is expected to work here; that has **not** been verified on this
+machine as of 2026-08-30. The verb is built so the difference is impossible to
+miss: a restricted store exits non-zero and quotes the reason rather than
+returning an empty page, and an empty window says "no com.localvoxtral entries
+in the last N minute(s)" on stderr. If it does turn out to be restricted for
+the GUI account too, there is no flag that lifts it — the alternatives are
+`mac-crashlog.yml` on the runner (which already ships a subsystem-filtered log)
+or having the app write its own file.
+
 ### Getting a build into the artifact root
 
 `launch` only accepts bundles under `LV_UI_ARTIFACT_ROOTS`, and those roots
@@ -786,26 +868,52 @@ the default is now empty and why `LV_UI_TERM_FORBIDDEN` — a permanent denylist
 assigned *after* the conf file is sourced — refuses those names even if this
 conf allowlists them.
 
-The way to make the verb useful is a **single-purpose wrapper you write and
-install**, which takes an identifier and execs one fixed command:
+The way to make the verb useful is a **single-purpose wrapper**, which takes
+an identifier and execs one fixed command. That wrapper ships in this repo —
+`scripts/mac/lv-attach.sh` — precisely because it is the thing holding the
+boundary, and an unreviewed shell script written once into `~/bin` is the
+weakest possible place for that. `install-ui-artifact.sh` puts it at
+`~/bin/lv-attach` (mode 0700) with every build, so it arrives reviewed and
+stays current.
 
-```bash
-# ~/bin/lv-attach — allowlist THIS, not the tool it calls.
-#!/bin/sh
-case "$1" in
-  pane-[0-9]*) exec ssh -t fixture-host herdr attach "$1" ;;
-  *) echo "lv-attach: unknown pane" >&2; exit 2 ;;
-esac
-```
+Allowlist it:
 
 ```bash
 # ~/.localvoxtral-ui-gate.conf
 LV_UI_TERM_COMMANDS="lv-attach"
 ```
 
-The wrapper, not the gate, is what decides the command — so review it with the
-same eyes as the gate itself, and never let it take a command from its
-argument.
+and tell it where to go — the destination is deliberately **not** an argument:
+
+```bash
+# ~/.lv-attach.conf
+destination=builder      # an ssh alias, or user@host
+session=work             # optional default herdr session
+```
+
+Then `ssh lv-ui 'term open ghostty lv-attach work'`.
+
+**Allowlisting `lv-attach` is safe precisely because it cannot take a command,
+which is the property `ssh` lacks.** `ssh <host> <anything>` runs that
+anything; that is why `ssh` is on the permanent denylist and why allowlisting
+it would hand the whole boundary away. `lv-attach` takes at most ONE argument,
+a herdr session name matched against `^[A-Za-z0-9._-]{1,64}$` and refused if it
+starts with `-`; it takes no flags, no second positional and no command; it
+*reads* its config with `sed` rather than sourcing it; and it ends in one of
+exactly two fixed `exec ssh -t -- <destination> herdr [--session <name>]`
+lines. `test-ui-gate.sh` section 23 proves the refusals, tries injection
+through the identifier, and pins that the file contains no `eval`, no
+`bash -c`/`sh -c`, no `source`, and no `"$@"` in a command position.
+
+It opens a **whole-view** herdr client rather than `herdr terminal attach
+<pane>` on purpose: the app's `HerdrInvocation` classifier refuses every herdr
+shape except a bare `herdr` or `herdr --session <name>`
+(`docs/agent/invariants.md`), so a pane-attach wrapper would reliably open a
+window the app deliberately never joins — useless for the exact debugging
+`term open` exists for. Pick the pane inside herdr, after attaching.
+
+If you write your own wrapper instead, review it with the same eyes as the
+gate itself, and never let it take a command from its argument.
 
 **Where the agent runs.** For terminal/agent-integration scenarios the agent
 (Claude Code, codex, …) is started on the **fixture side** — the Linux host
@@ -835,6 +943,10 @@ ssh lv-ui 'menu click Settings'         # substring: the real title is Settings�
 ssh lv-ui 'shot settings' | base64 -d > /tmp/settings.png
 ssh lv-ui 'dictate tap'                 # starts an Overlay Buffer session
 ssh lv-ui 'ax dump overlay'             # the Claude-join badge names the session
+ssh lv-ui 'log 5'                       # localvoxtral's own log lines only
+ssh lv-ui 'app registry list'           # dogfood build only; refused otherwise
+ssh lv-ui 'app surface probe'           # resolve the focused surface, live registry
+ssh lv-ui 'app rm -rf /'                # must print "denied command"
 ssh lv-ui 'ax dump settings' | python3 -m json.tool | head
 ssh lv-ui 'ax click role=AXButton,title=Dictation'
 ssh lv-ui 'quit'
@@ -855,6 +967,10 @@ Every one of those, allowed or denied, appends a line to
 validation, the lock refusal, the window-ownership rule and the log/redaction
 behaviour, but nothing about a live desktop. On first install, confirm by hand:
 
+0. `log` returns lines rather than failing. If it prints "Could not open local
+   log store: Operation not permitted", the unified log is restricted for this
+   account too and the verb is dead — say so rather than working around it; see
+   the caveat under "`log` — the app's own lines".
 1. `state` reports `"screen_lock":"unlocked"` while you are logged in, and
    `"locked"` after you lock the screen — this is the ONE probe standing
    between the gate and a locked machine. It has two arms; over SSH the

--- a/scripts/mac/README.md
+++ b/scripts/mac/README.md
@@ -540,7 +540,7 @@ full-screen capture anywhere in it:
 | `ax dump [all\|settings\|overlay\|window <n>]` | the AX element tree of that pid's windows, as JSON |
 | `ax click <selector>` | presses the one element the selector matches |
 | `ax type <selector> -- <text>` | types into a text-bearing element |
-| `key <escape\|tab\|return>` | one keycode from a three-entry allowlist, only while the app under test is frontmost |
+| `key <escape\|tab\|return>` | one keycode from a three-entry allowlist; brings the app under test frontmost first and refuses if that did not take, so a keystroke never lands in whatever the owner last touched |
 | `quit` | terminates the recorded pid |
 | `term open <ghostty\|iterm\|terminal> <command> [args]` | opens a terminal window running an allowlisted command (for herdr / terminal-integration work) |
 | `term focus <id>` / `term close <id>` | acts on one window this gate opened, identified by a random marker it put in that window's title |
@@ -574,9 +574,12 @@ Three refusals are load-bearing and are what the regression suite
 - **Locked screen = hard refusal**, fail closed. The probe is shared with the
   ui-smoke lane (`scripts/ci/screen-lock-state.sh`); an undeterminable state
   denies here and runs there, on purpose.
-- **Owner takeover rule.** Any verb that steals focus speaks a warning, waits
-  3 s, then announces completion or failure (`LV_UI_WARN_SLEEP_SECONDS` in the
-  conf file relaxes the wait; the default is the rule as stated).
+- **Owner takeover rule.** Any verb that steals focus — `launch`, `ax click`,
+  `ax type`, `key`, `term open`, `term focus` — speaks a warning, waits 3 s,
+  then announces completion or failure (`LV_UI_WARN_SLEEP_SECONDS` in the conf
+  file relaxes the wait; the default is the rule as stated). `state`, `shot`,
+  `ax dump`, `quit` and `term close` do not warn: none of them takes the
+  keyboard or raises a window in front of what the owner is doing.
 
 ### One-time install (owner GUI session on the Mac)
 
@@ -680,8 +683,12 @@ behaviour, but nothing about a live desktop. On first install, confirm by hand:
 3. `shot settings` returns a PNG of the Settings window and not a black or
    empty image (a black capture means the Screen Recording grant is not
    reaching the SSH session).
-4. `ax click` actually presses the right control, and `key`'s frontmost check
-   behaves (it refuses when the app under test is not frontmost).
+4. `ax click` actually presses the right control, and `key` works: it calls
+   `NSRunningApplication.activate` and then re-checks `frontmostApplication`.
+   Both of those are AppKit calls made from a short-lived SSH-hosted process
+   with no run loop, which is exactly where they are least likely to behave —
+   if `key` always reports "could not be brought frontmost", that is the
+   symptom.
 5. `term open ghostty herdr ...` opens a window whose title carries the
    `lvui-…` marker, and `term focus`/`term close` find it. Terminal-specific
    flags (`ghostty -e`, the generated `.command` for Terminal/iTerm) are the

--- a/scripts/mac/README.md
+++ b/scripts/mac/README.md
@@ -520,3 +520,169 @@ Notes:
 - Process listings deliberately print pid/user/executable only, never full
   command lines: other users' cmdlines can embed secrets (env assignments in
   remote-ssh invocations), and diag output flows into agent transcripts.
+
+## `localvoxtral-ui-gate.sh` — SSH UI gate (v1)
+
+A **second** forced-command gate, and the only one installed on the **GUI
+account**. The build gate (`builder`) deliberately is not the console user, so
+nothing routed through it can see or touch the desktop; this gate exists so an
+agent can drive the localvoxtral build under test — and only that — without
+being handed the owner's whole session.
+
+It is not a computer-use harness. There is no coordinate input and no
+full-screen capture anywhere in it:
+
+| verb | what it does |
+| --- | --- |
+| `state` | JSON: lock state, idle seconds, AC/battery, the Accessibility + Screen Recording preflight, whether an app under test is running, which terminals this gate opened |
+| `launch [--dogfood] <artifact>` | launches a `.app` that is under an allowlisted root **and** has `CFBundleIdentifier com.localvoxtral.app`; records pid + start time + executable path; prints the pid |
+| `shot [settings\|popover\|overlay\|window <n>]` | base64 PNG of ONE window, resolved from the window list filtered to that pid, refused if the resolved window's owner is anything else |
+| `ax dump [all\|settings\|overlay\|window <n>]` | the AX element tree of that pid's windows, as JSON |
+| `ax click <selector>` | presses the one element the selector matches |
+| `ax type <selector> -- <text>` | types into a text-bearing element |
+| `key <escape\|tab\|return>` | one keycode from a three-entry allowlist, only while the app under test is frontmost |
+| `quit` | terminates the recorded pid |
+| `term open <ghostty\|iterm\|terminal> <command> [args]` | opens a terminal window running an allowlisted command (for herdr / terminal-integration work) |
+| `term focus <id>` / `term close <id>` | acts on one window this gate opened, identified by a random marker it put in that window's title |
+
+Selectors are `key<op>value` pairs joined by `,` — `=` exact, `~` contains,
+`+` for a space, keys `role`/`title`/`desc`/`value`/`index`/`window`:
+
+```
+ax click role=AXButton,title=General
+ax click role=AXButton,title~Text+Processing
+ax type  role=AXTextField,title~Endpoint -- http://127.0.0.1:8471/v1
+```
+
+An ambiguous selector is refused rather than guessed at; add `index=<n>` to
+pick among matches deliberately.
+
+Everything else is denied, and **every** invocation — allowed or denied — is
+logged with a timestamp to `~/Library/Logs/localvoxtral-ui-gate.log`. The one
+thing never written there is `ax type`'s text (it is how an API key gets into
+the Endpoints pane); the log keeps the selector and `-- <redacted>`.
+
+Three refusals are load-bearing and are what the regression suite
+(`scripts/ci/test-ui-gate.sh`, in ci.yml's shell-test step) exists to hold:
+
+- **No shell verb.** No `eval`, no `bash -c`, no verb taking a free command
+  line. `term open` is the single constrained exception: its first token must
+  be in `LV_UI_TERM_COMMANDS`, every token must survive the same metacharacter
+  blocklist as any other argument, and the command is logged **in full**.
+  Allowlisting something that is itself a shell (`bash`, `ssh`, `osascript`)
+  or that takes an arbitrary child command hands the boundary away.
+- **Locked screen = hard refusal**, fail closed. The probe is shared with the
+  ui-smoke lane (`scripts/ci/screen-lock-state.sh`); an undeterminable state
+  denies here and runs there, on purpose.
+- **Owner takeover rule.** Any verb that steals focus speaks a warning, waits
+  3 s, then announces completion or failure (`LV_UI_WARN_SLEEP_SECONDS` in the
+  conf file relaxes the wait; the default is the rule as stated).
+
+### One-time install (owner GUI session on the Mac)
+
+Run from a trusted owner session — **not** through either gate.
+
+```bash
+# 1. On the Linux dev box: a key used for nothing else.
+ssh-keygen -t ed25519 -f ~/.ssh/localvoxtral-ui-gate -C localvoxtral-ui-gate
+
+# 2. On the Mac, as the GUI (console) user:
+cd ~/work/localvoxtral && git pull
+install -d -m 0700 "$HOME/bin"
+install -m 0755 scripts/mac/localvoxtral-ui-gate.sh "$HOME/bin/localvoxtral-ui-gate.sh"
+install -m 0755 scripts/ci/screen-lock-state.sh "$HOME/bin/localvoxtral-screen-lock-state.sh"
+mkdir -p "$HOME/localvoxtral-ui-artifacts"     # where launchable .app bundles go
+
+# 3. Force the command on that key ONLY (one line in ~/.ssh/authorized_keys).
+#    `restrict` disables pty, agent/port/X11 forwarding and user rc files; the
+#    command= is then the entire trust boundary.
+cat >>"$HOME/.ssh/authorized_keys" <<'KEY'
+restrict,command="/Users/<gui-user>/bin/localvoxtral-ui-gate.sh" ssh-ed25519 AAAA...<the key from step 1>... localvoxtral-ui-gate
+KEY
+chmod 600 "$HOME/.ssh/authorized_keys"
+```
+
+Leave `sshd_config`'s `AcceptEnv` at its default (`LANG`/`LC_*`). The gate's
+test seams are ordinary environment variables; sshd fixing the environment is
+what keeps a client from setting them.
+
+Then the TCC grants, in System Settings > Privacy & Security. Both are
+required, and both are granted to **sshd**, not to the gate script — press
+Cmd-Shift-G in the "+" file picker and enter
+`/usr/libexec/sshd-keygen-wrapper`:
+
+- **Accessibility** — `ax dump/click/type` and `key` (AX API + CGEvent).
+- **Screen Recording** — `shot` (`screencapture -l`). Without it the capture
+  silently produces an empty or desktop-picture-only file.
+
+**Be clear-eyed about what that means:** granting those to sshd grants them to
+*everything* that arrives over SSH as this user, so the forced command is the
+only boundary left. That is why this script has no shell verb, why `term
+open`'s allowlist is short, and why it must stay that way.
+
+The stricter alternative, and the documented next hardening step: keep the TCC
+grants off sshd entirely by moving the GUI work into a small signed helper
+binary run by a LaunchAgent in the Aqua session, with the gate reduced to
+writing a request onto a queue the agent reads. Then sshd holds nothing, the
+helper is what macOS keys the grants to, and a compromised SSH session can only
+enqueue verbs the helper already implements. It also side-steps the open
+question below about whether an SSH-hosted process can reach the GUI session at
+all. It is more moving parts than a single reviewed script, so it is not what
+v1 does.
+
+### Machine-local config (`~/.localvoxtral-ui-gate.conf`, GUI account)
+
+Never committed; same trust argument as the build gate's conf (anyone who can
+write it can already replace the gate script).
+
+```bash
+# LV_UI_ARTIFACT_ROOTS="$HOME/localvoxtral-ui-artifacts"  # where launch may look
+# LV_UI_TERM_COMMANDS="herdr claude opencode codex"       # term open's first tokens
+# LV_UI_TERMINALS="ghostty iterm terminal"
+# LV_UI_WARN_SLEEP_SECONDS=3                              # 0 only if you are sitting there
+# LV_UI_SHOT_MAX_BYTES=8388608
+```
+
+### Verifying from the Linux box
+
+```bash
+ssh lv-ui 'state'                       # JSON; check tcc.accessibility and
+                                        # tcc.screen_recording are both true
+ssh lv-ui 'launch localvoxtral-ui-artifacts/localvoxtral.app'
+ssh lv-ui 'shot settings' | base64 -d > /tmp/settings.png
+ssh lv-ui 'ax dump settings' | python3 -m json.tool | head
+ssh lv-ui 'ax click role=AXButton,title=Dictation'
+ssh lv-ui 'quit'
+ssh lv-ui 'echo pwned'                  # must print "denied command"
+ssh lv-ui 'bash -lc id'                 # must print "denied command"
+ssh lv-ui 'term open ghostty bash -c id' # must print "denied command"
+```
+
+Every one of those, allowed or denied, appends a line to
+`~/Library/Logs/localvoxtral-ui-gate.log` — read it after the first session.
+
+### First-install checks the test suite cannot do
+
+`test-ui-gate.sh` stubs the GUI, so it proves the allowlist, the argument
+validation, the lock refusal, the window-ownership rule and the log/redaction
+behaviour, but nothing about a live desktop. On first install, confirm by hand:
+
+1. `state` reports `"screen_lock":"unlocked"` while you are logged in, and
+   `"locked"` after you lock the screen — this is the ONE probe standing
+   between the gate and a locked machine. It has two arms; over SSH the
+   IORegistry arm is the one that has to answer, and it has not been run
+   against a real `ioreg` yet.
+2. `tcc.accessibility` and `tcc.screen_recording` are both `true` **in a
+   session that arrived over SSH**. If they are false after granting sshd, the
+   sshd-holds-the-grants design does not work on this macOS version and the
+   LaunchAgent alternative above is the fix — do not work around it by
+   loosening the gate.
+3. `shot settings` returns a PNG of the Settings window and not a black or
+   empty image (a black capture means the Screen Recording grant is not
+   reaching the SSH session).
+4. `ax click` actually presses the right control, and `key`'s frontmost check
+   behaves (it refuses when the app under test is not frontmost).
+5. `term open ghostty herdr ...` opens a window whose title carries the
+   `lvui-…` marker, and `term focus`/`term close` find it. Terminal-specific
+   flags (`ghostty -e`, the generated `.command` for Terminal/iTerm) are the
+   least-tested part of v1.

--- a/scripts/mac/README.md
+++ b/scripts/mac/README.md
@@ -536,15 +536,15 @@ full-screen capture anywhere in it:
 | --- | --- |
 | `state` | JSON: lock state, idle seconds, AC/battery, the Accessibility + Screen Recording preflight, whether an app under test is running, which terminals this gate opened |
 | `launch [--dogfood] <artifact>` | launches a `.app` that is under an allowlisted root **and** has `CFBundleIdentifier com.localvoxtral.app`; records pid + start time + executable path; prints the pid. Refuses beside any running localvoxtral, including one this gate did not start |
-| `shot [settings\|popover\|overlay\|window <n>]` | base64 PNG of ONE window, resolved from the window list filtered to that pid, refused if the resolved window's owner is anything else |
+| `shot [settings\|popover\|overlay\|window <n>]` | base64 PNG of ONE window, resolved from the window list filtered to that pid, refused if the resolved window's owner is anything else. stdout is pure base64; the `shot: window …` line is on **stderr**, so pipe straight into `base64 -d` — no `tail` |
 | `ax dump [all\|settings\|overlay\|window <n>]` | the AX element tree of that pid's windows, as JSON |
 | `ax click <selector>` | presses the one element the selector matches |
 | `ax type <selector> -- <text>` | types into a text-bearing element |
 | `key <escape\|tab\|return>` | one keycode from a three-entry allowlist; brings the app under test frontmost first and refuses if that did not take, so a keystroke never lands in whatever the owner last touched |
-| `menu open` / `menu click <item-title>` / `menu dismiss` | drives the status item of the recorded pid. localvoxtral opens no window at launch, so this is what makes every row above it reachable |
+| `menu open` / `menu click <item-title>` / `menu dismiss` | drives the status item of the recorded pid. localvoxtral opens no window at launch, so this is what makes every row above it reachable. `open`/`dismiss` confirm the result against the window list — the same layer the `shot popover` row resolves — so they cannot report a menu that is not on screen |
 | `dictate tap` / `dictate hold <seconds>` / `dictate cancel` | posts the app's OWN configured modifier trigger (read from its defaults) as a gesture at the HID tap — the only way to start a dictation, and therefore to exercise the Claude Code / herdr join |
 | `app <control command>` | forwards ONE line to the **dogfood** control socket of the app under test and returns the reply. Five shapes only: `session start overlay\|live`, `session stop`, `join report`, `surface probe`, `registry list`. Refuses a build with no `LVXDogfoodCapture` stamp — see "`app` — asking the app what it joined" |
-| `log [minutes]` | localvoxtral's own unified-log lines over a clamped window (default 15, max 120), line-capped and token-scrubbed. Predicate-scoped to `subsystem == "com.localvoxtral"`; never a system-log reader. Read-only, so it works while the screen is locked |
+| `log [minutes]` | localvoxtral's own unified-log lines over a clamped window (default 15, max 120), line-capped and token-scrubbed. Predicate-scoped to `subsystem == "com.localvoxtral"` **and** to one process — the recorded pid, else the app's process name, which it says. Never a system-log reader. Read-only, so it works while the screen is locked |
 | `quit` | terminates the recorded pid |
 | `term open <ghostty\|iterm\|terminal> <command> [args]` | opens a terminal window running an allowlisted command. **The allowlist is empty by default** — see "What may go on `term open`'s allowlist" below |
 | `term focus <id>` / `term close <id>` | acts on one window this gate opened, identified by a random marker it put in that window's title |
@@ -654,6 +654,26 @@ space is spelled `+`, as in selector values: `menu click Show+Log`.
 `menu dismiss` closes the menu through the app's own AX cancel action rather
 than a synthesised Escape, so no keystroke is ever posted at whatever owns the
 keyboard. It takes nothing from the owner and therefore does not warn.
+
+**How `open` and `dismiss` know a menu is on screen — and why it is not the
+obvious test.** An `NSMenu` handed to an `NSStatusItem` hangs off that item as
+an `AXMenu` child for the app's whole life, displayed or not. Taking that
+attachment for "the menu is open" is what the first cut did, and it made
+`menu open` a no-op that returned `ok already-open` instantly while nothing
+appeared, `shot popover` then found nothing, and `ax dump all` stayed `[]`
+(field check 2026-08-29). Both verbs now ask the **window list** instead: a
+window owned by the recorded pid at layer ≥ 100, which is the very same rule
+`shot popover` resolves with. So `menu open` succeeds exactly when
+`shot popover` can photograph something, by construction, and a press that
+produced nothing is a failure that says so. `menu dismiss` gains a second
+property from the same test: with nothing on screen it returns
+`ok no-menu-open` **without touching the status item**, where before it could
+fall through to a press — and a press on a closed menu opens one.
+
+`menu click` deliberately does *not* require a displayed menu: `AXPress` on a
+menu item works either way, which is how the gate reached Settings while
+`menu open` was broken. Keep it that way — it is the fallback when the window
+test cannot see a menu that is genuinely up.
 
 The mechanism is the Accessibility API (`AXExtrasMenuBar` on the recorded pid),
 not System Events: an Apple event would need a separate Automation grant whose
@@ -766,6 +786,28 @@ base64url scrub the dogfood records use — the app writes its categories
 `privacy: .public` on purpose, but "every line anyone ever adds is safe" is not
 an assumption worth depending on.
 
+**The subsystem alone is not enough on this machine, and that was a real
+finding.** This Mac is also the self-hosted CI runner, and a unit-suite run
+logs under localvoxtral's own subsystem from `xctest`. Field check 2026-08-30:
+`log 2` returned 111 lines of which exactly one came from the app under test;
+the rest were a concurrent CI run, including
+`Terminal pane joined to a live Claude session via title marker`. Attributing
+that to the dictation you just made is a wrong conclusion drawn from a real log
+line, which is the worst thing this verb could do. So the predicate carries a
+process as well:
+
+- with an app under test, `processIdentifier == <the pid launch recorded>` —
+  one instance, scoped exactly like every other verb in the gate;
+- with none, `process == "localvoxtral"`, which still excludes `xctest` but no
+  longer excludes a second instance or a `--probe-surface` one-shot. The verb
+  says so on **stderr, before the lines**, so the caveat is read before the
+  conclusion.
+
+Even correctly scoped, a build running on the runner is writing to the same log
+store at the same time, so timestamps interleave with CI's noise in the
+surrounding system log — the predicate keeps the *lines* clean, not the
+neighbourhood. `state` and the gate's own log tell you which pid is which.
+
 It steals no focus and writes nothing, so unlike the actuation verbs it is
 allowed while the screen is locked.
 
@@ -777,7 +819,7 @@ account, so it is expected to work here; that has **not** been verified on this
 machine as of 2026-08-30. The verb is built so the difference is impossible to
 miss: a restricted store exits non-zero and quotes the reason rather than
 returning an empty page, and an empty window says "no com.localvoxtral entries
-in the last N minute(s)" on stderr. If it does turn out to be restricted for
+for <scope> in the last N minute(s)" on stderr. If it does turn out to be restricted for
 the GUI account too, there is no flag that lifts it — the alternatives are
 `mac-crashlog.yml` on the runner (which already ships a subsystem-filtered log)
 or having the app write its own file.
@@ -939,11 +981,15 @@ ssh lv-ui 'state'                       # JSON; check tcc.accessibility and
 ssh lv-ui 'launch localvoxtral-ui-artifacts/localvoxtral.app'
 ssh lv-ui 'menu open'                   # localvoxtral has NO window until this
 ssh lv-ui 'shot popover' | base64 -d > /tmp/popover.png
+                                        # stdout is pure base64; the
+                                        # "shot: window …" line is on stderr
 ssh lv-ui 'menu click Settings'         # substring: the real title is Settings…
 ssh lv-ui 'shot settings' | base64 -d > /tmp/settings.png
 ssh lv-ui 'dictate tap'                 # starts an Overlay Buffer session
 ssh lv-ui 'ax dump overlay'             # the Claude-join badge names the session
-ssh lv-ui 'log 5'                       # localvoxtral's own log lines only
+ssh lv-ui 'log 5'                       # the app-under-test pid's own lines
+                                        # (subsystem alone also matches CI's
+                                        # xctest runs on this same machine)
 ssh lv-ui 'app registry list'           # dogfood build only; refused otherwise
 ssh lv-ui 'app surface probe'           # resolve the focused surface, live registry
 ssh lv-ui 'app rm -rf /'                # must print "denied command"
@@ -995,3 +1041,15 @@ behaviour, but nothing about a live desktop. On first install, confirm by hand:
    flags (`ghostty -e`, the generated `.command` for Terminal/iTerm) are the
    least-tested part of v1. Nothing here works until you have written a wrapper
    and allowlisted it — the default allowlist is empty on purpose.
+6. `menu open` prints `ok window=<n>`, `shot popover` then returns a PNG of
+   that same menu, and `menu dismiss` prints `ok`. This is the one behaviour
+   the shell suite cannot reach at all: it stubs the helper, so what it pins is
+   that the decision is made from the window list, never that macOS puts a
+   status menu there. If `menu open` says the status item was pressed but no
+   window appeared at layer ≥ 100, then either the press did nothing or a
+   displayed status menu is not a pid-owned window on this macOS version —
+   check with `menu click Settings` (which works either way) and say which, do
+   not go back to trusting the attached `AXMenu`.
+7. `log` returns only the app under test. Start a build on the runner, then run
+   `log 2` and confirm no `xctest[` line comes back. Without `launch`, the same
+   command warns on stderr that it is not pid-scoped.

--- a/scripts/mac/README.md
+++ b/scripts/mac/README.md
@@ -535,12 +535,13 @@ full-screen capture anywhere in it:
 | verb | what it does |
 | --- | --- |
 | `state` | JSON: lock state, idle seconds, AC/battery, the Accessibility + Screen Recording preflight, whether an app under test is running, which terminals this gate opened |
-| `launch [--dogfood] <artifact>` | launches a `.app` that is under an allowlisted root **and** has `CFBundleIdentifier com.localvoxtral.app`; records pid + start time + executable path; prints the pid |
+| `launch [--dogfood] <artifact>` | launches a `.app` that is under an allowlisted root **and** has `CFBundleIdentifier com.localvoxtral.app`; records pid + start time + executable path; prints the pid. Refuses beside any running localvoxtral, including one this gate did not start |
 | `shot [settings\|popover\|overlay\|window <n>]` | base64 PNG of ONE window, resolved from the window list filtered to that pid, refused if the resolved window's owner is anything else |
 | `ax dump [all\|settings\|overlay\|window <n>]` | the AX element tree of that pid's windows, as JSON |
 | `ax click <selector>` | presses the one element the selector matches |
 | `ax type <selector> -- <text>` | types into a text-bearing element |
 | `key <escape\|tab\|return>` | one keycode from a three-entry allowlist; brings the app under test frontmost first and refuses if that did not take, so a keystroke never lands in whatever the owner last touched |
+| `menu open` / `menu click <item-title>` / `menu dismiss` | drives the status item of the recorded pid. localvoxtral opens no window at launch, so this is what makes every row above it reachable |
 | `quit` | terminates the recorded pid |
 | `term open <ghostty\|iterm\|terminal> <command> [args]` | opens a terminal window running an allowlisted command. **The allowlist is empty by default** — see "What may go on `term open`'s allowlist" below |
 | `term focus <id>` / `term close <id>` | acts on one window this gate opened, identified by a random marker it put in that window's title |
@@ -594,7 +595,7 @@ cd ~/work/localvoxtral && git pull
 install -d -m 0700 "$HOME/bin"
 install -m 0755 scripts/mac/localvoxtral-ui-gate.sh "$HOME/bin/localvoxtral-ui-gate.sh"
 install -m 0755 scripts/ci/screen-lock-state.sh "$HOME/bin/localvoxtral-screen-lock-state.sh"
-mkdir -p "$HOME/localvoxtral-ui-artifacts"     # where launchable .app bundles go
+install -d -m 0700 "$HOME/localvoxtral-ui-artifacts"  # where launchable .app bundles go
 
 # 3. Force the command on that key ONLY (one line in ~/.ssh/authorized_keys).
 #    `restrict` disables pty, agent/port/X11 forwarding and user rc files; the
@@ -632,6 +633,63 @@ enqueue verbs the helper already implements. It also side-steps the open
 question below about whether an SSH-hosted process can reach the GUI session at
 all. It is more moving parts than a single reviewed script, so it is not what
 v1 does.
+
+### `menu` — the verb that makes every other verb reachable
+
+localvoxtral is a menu bar app and opens **no window at launch**. Straight
+after `launch`, `ax dump all` returns `[]`, `shot settings` reports no window,
+and `ax click` matches nothing — all correct, and all useless. `menu open`
+clicks the status item; the menu it opens is what `shot popover` photographs,
+and `menu click Settings` is what produces the Settings window every other verb
+then addresses.
+
+Item titles are matched by containment, with an exact title winning and
+ambiguity refused — because a real title (`Settings…`) contains characters the
+gate's token charset cannot carry, so `menu click Settings` is the way in. A
+space is spelled `+`, as in selector values: `menu click Show+Log`.
+
+`menu dismiss` closes the menu through the app's own AX cancel action rather
+than a synthesised Escape, so no keystroke is ever posted at whatever owns the
+keyboard. It takes nothing from the owner and therefore does not warn.
+
+The mechanism is the Accessibility API (`AXExtrasMenuBar` on the recorded pid),
+not System Events: an Apple event would need a separate Automation grant whose
+consent sheet cannot be answered over SSH, while Accessibility is a grant sshd
+already holds.
+
+### Getting a build into the artifact root
+
+`launch` only accepts bundles under `LV_UI_ARTIFACT_ROOTS`, and those roots
+must stay writable by the owner alone: inside one, a bundle claiming
+`com.localvoxtral.app` is trusted, so a world-writable root would let any local
+process plant one and have the gate start it as the GUI user. `try-pr.sh`
+extracts to `/tmp`, which is exactly such a directory — so the bundle moves,
+never the roots.
+
+```bash
+# On the Mac's GUI account. Fetches the CI artifact and installs it; does NOT
+# launch it, because launching is the gate's job.
+./scripts/try-pr.sh 238 --ui-gate
+./scripts/try-pr.sh main --dogfood --ui-gate     # instrumented build
+
+# A locally packaged bundle, same destination:
+./scripts/mac/install-ui-artifact.sh dist/localvoxtral.app
+```
+
+Two slots, replaced in place: `localvoxtral.app` and (for a
+`LVXDogfoodCapture`-stamped build) `localvoxtral-dogfood.app`. Keeping one copy
+per build would be worse than useless — they share a bundle id, a defaults
+domain and a TCC grant, so a stale one is indistinguishable at runtime, which
+is the wrong-binary confusion `docs/agent/field-debugging.md` is about. What
+each slot currently holds is in `<bundle>.app.source` next to it.
+
+The installer refuses a root it cannot write, a root that is group- or
+other-writable, a bundle that is not a validated localvoxtral app, and any
+overwrite of a bundle that is **currently running** from that slot. It does not
+quit anything: `quit` is a gate verb, and only the operator knows whether a
+dictation is in flight. Do quit the running app before `launch` — a second
+instance fights the first for the global hotkey and for the speechd/polishd
+ports 8471/8472.
 
 ### Machine-local config (`~/.localvoxtral-ui-gate.conf`, GUI account)
 
@@ -711,6 +769,9 @@ with both an app under test and an open terminal recorded.
 ssh lv-ui 'state'                       # JSON; check tcc.accessibility and
                                         # tcc.screen_recording are both true
 ssh lv-ui 'launch localvoxtral-ui-artifacts/localvoxtral.app'
+ssh lv-ui 'menu open'                   # localvoxtral has NO window until this
+ssh lv-ui 'shot popover' | base64 -d > /tmp/popover.png
+ssh lv-ui 'menu click Settings'         # substring: the real title is Settings…
 ssh lv-ui 'shot settings' | base64 -d > /tmp/settings.png
 ssh lv-ui 'ax dump settings' | python3 -m json.tool | head
 ssh lv-ui 'ax click role=AXButton,title=Dictation'

--- a/scripts/mac/README.md
+++ b/scripts/mac/README.md
@@ -1197,7 +1197,7 @@ ssh lv-ui 'term open ghostty claude --dangerously-skip-permissions -p hi'
 Every one of those, allowed or denied, appends a line to
 `~/Library/Logs/localvoxtral-ui-gate.log` — read it after the first session.
 
-### First install: run the doctor, then the four things it cannot reach
+### First install: run the doctor, then the checks no script can make
 
 ```bash
 # On the Mac's GUI account, from the checkout:

--- a/scripts/mac/README.md
+++ b/scripts/mac/README.md
@@ -1025,6 +1025,18 @@ The test to apply before adding a name: read its `--help`. If any flag or
 subcommand takes a command, a script, a prompt, or a file to execute — `-c`,
 `-e`, `exec`, `run`, `--eval`, `-p`, an agent that runs tools — it fails.
 
+**That test is necessary and not sufficient, and the gap is the likely
+mistake.** An editor or a pager reaches a shell at *runtime*, not through a
+flag: `vi` and `vim` have `:!cmd`, `less` and `man` have `!cmd` and `v` (which
+opens `$EDITOR`), `awk` has `system()`, `git` runs your editor and your hooks.
+Every one of them passes a `--help` reading, and "I just want a viewer in that
+window" is exactly the reasoning that allowlists one. So does the wrapper class
+whose *normal* argv is somebody else's command — `nice`, `watch`, `timeout`,
+`env`, `xargs`, `open` (`open -a Terminal`), `npx`, `cargo`, `go` — and the
+fetchers that bring code to run, `curl` and `wget`. All of these are on the
+permanent denylist for that reason; if you find yourself wanting one, you want
+a wrapper instead.
+
 That rejects the obvious shells and **every coding-agent CLI**. `claude
 --dangerously-skip-permissions -p <prompt>`, `codex exec`, `opencode run` and
 `herdr agent start` each execute arbitrary code as the GUI user, and none of

--- a/scripts/mac/README.md
+++ b/scripts/mac/README.md
@@ -542,6 +542,7 @@ full-screen capture anywhere in it:
 | `ax type <selector> -- <text>` | types into a text-bearing element |
 | `key <escape\|tab\|return>` | one keycode from a three-entry allowlist; brings the app under test frontmost first and refuses if that did not take, so a keystroke never lands in whatever the owner last touched |
 | `menu open` / `menu click <item-title>` / `menu dismiss` | drives the status item of the recorded pid. localvoxtral opens no window at launch, so this is what makes every row above it reachable |
+| `dictate tap` / `dictate hold <seconds>` / `dictate cancel` | posts the app's OWN configured modifier trigger (read from its defaults) as a gesture at the HID tap — the only way to start a dictation, and therefore to exercise the Claude Code / herdr join |
 | `quit` | terminates the recorded pid |
 | `term open <ghostty\|iterm\|terminal> <command> [args]` | opens a terminal window running an allowlisted command. **The allowlist is empty by default** — see "What may go on `term open`'s allowlist" below |
 | `term focus <id>` / `term close <id>` | acts on one window this gate opened, identified by a random marker it put in that window's title |
@@ -657,6 +658,48 @@ not System Events: an Apple event would need a separate Automation grant whose
 consent sheet cannot be answered over SSH, while Accessibility is a grant sshd
 already holds.
 
+### `dictate` — the only verb that can start a session
+
+The gate exists to debug the Claude Code / herdr join, and that join resolves
+when a dictation **starts**. `key`'s allowlist is `escape|tab|return` and the
+app's trigger is a modifier-only gesture, so nothing else here can start one.
+
+`dictate` posts the app's own configured trigger — read out of
+`com.localvoxtral.app`'s defaults each invocation, never hard-coded — as a
+`flagsChanged` event at the HID tap. That is the same path
+`scripts/record-demo.sh` has driven on this machine since the demo recording;
+the app detects the gesture with an `NSEvent` monitor and filters nothing, so
+this is the real gesture, not a side door. A plain `keyDown` would do nothing:
+the event's type has to be `flagsChanged` and carry the modifier's flag mask.
+
+- `dictate tap` → Overlay Buffer session (a second tap stops it)
+- `dictate hold <seconds>` → Live Auto-Paste push-to-talk, held for that long.
+  Must exceed the app's own `settings.modifier_only_hold_delay`, else it is a
+  tap wearing a hold's name; capped at `LV_UI_MAX_HOLD_SECONDS` (30).
+- `dictate cancel` → Escape, which the app consumes system-wide for the
+  duration of a session.
+
+It refuses when the app is not running, when the screen is locked, when the
+trigger settings cannot be read (**it will not guess which key to press**),
+when the modifier-only trigger is disabled in the app's settings, and when
+Secure Keyboard Entry is held — that last one because the events would be
+silently discarded, which is the worst failure shape to debug. `tap`/`hold`
+take the audible warning; `cancel` does not.
+
+**It does not bring localvoxtral frontmost, on purpose.** The trigger is global
+by design and the dictation grounds its context in whatever *is* focused — a
+terminal running Claude Code. Activating localvoxtral first would make every
+session resolve against the wrong surface, which is the thing under test. The
+result line names the frontmost app instead, so you know where it landed.
+
+Reading the outcome: `ax dump overlay` after a `dictate tap`. The overlay's
+Claude-join badge is a real AX element with an explicit label —
+`Grounded in Claude Code session <workspace>`, or
+`No Claude Code session joined for this dictation`. Two caveats: the badge only
+appears when terminal-screen or repo context is enabled, and **only Overlay
+Buffer sessions open an overlay at all** — `dictate hold` (Live Auto-Paste)
+never shows one, so `tap` is the oracle.
+
 ### Getting a build into the artifact root
 
 `launch` only accepts bundles under `LV_UI_ARTIFACT_ROOTS`, and those roots
@@ -675,6 +718,23 @@ never the roots.
 # A locally packaged bundle, same destination:
 ./scripts/mac/install-ui-artifact.sh dist/localvoxtral.app
 ```
+
+**An agent driving the gate has no shell on that account and no verb that runs
+`try-pr.sh`, so CI does the install instead.** The self-hosted runner is a
+launchd agent inside the owner's GUI session — its `$HOME` is the GUI
+account's home, which is where the artifact root lives — so a
+`workflow_dispatch` of `ci.yml` with `dogfood=true` builds *and* installs:
+
+```bash
+gh workflow run CI --ref <branch> -f dogfood=true
+# the run summary then carries the exact:  ssh lv-ui 'launch --dogfood …'
+```
+
+That step is gated to `workflow_dispatch` **and** `dogfood=true` — narrower
+than the dogfood lane itself, whose `[dogfood-package]` marker fires on
+ordinary PR pushes, none of which should write into the owner's home. If the
+target slot is running the step warns and skips rather than failing the build
+(exit 3 from the installer); every other install failure is red.
 
 Two slots, replaced in place: `localvoxtral.app` and (for a
 `LVXDogfoodCapture`-stamped build) `localvoxtral-dogfood.app`. Keeping one copy
@@ -773,6 +833,8 @@ ssh lv-ui 'menu open'                   # localvoxtral has NO window until this
 ssh lv-ui 'shot popover' | base64 -d > /tmp/popover.png
 ssh lv-ui 'menu click Settings'         # substring: the real title is Settings…
 ssh lv-ui 'shot settings' | base64 -d > /tmp/settings.png
+ssh lv-ui 'dictate tap'                 # starts an Overlay Buffer session
+ssh lv-ui 'ax dump overlay'             # the Claude-join badge names the session
 ssh lv-ui 'ax dump settings' | python3 -m json.tool | head
 ssh lv-ui 'ax click role=AXButton,title=Dictation'
 ssh lv-ui 'quit'

--- a/scripts/mac/install-ui-artifact.sh
+++ b/scripts/mac/install-ui-artifact.sh
@@ -236,6 +236,44 @@ else
   say "WARNING: $WRAPPER_SRC is missing; the term-open wrapper was not installed."
 fi
 
+# --- the wrapper's config, as a template only ------------------------------
+#
+# ~/.lv-attach.conf holds a destination. That is ordinary configuration, and
+# "what is this file called and what goes in it" was one of the unknowns that
+# cost a round trip through the owner — so an empty, commented template is
+# written when the file does not exist. NEVER overwritten: the destination is
+# the owner's, and a reinstall that resets it would be worse than no template.
+#
+# It deliberately arrives with NO active destination. An installer that filled
+# one in would be guessing which machine to open a terminal onto.
+#
+# Note what is NOT written here, and why. `~/.localvoxtral-ui-gate.conf` sets
+# LV_UI_TERM_COMMANDS, which is the gate's ALLOWLIST — the same object as the
+# gate script itself, one layer up. CI must not write the gate; CI must not
+# write what the gate will accept either, or an empty default that exists to
+# force a deliberate grant becomes something that arrives with a build. The
+# owner runs one documented append; `ui-gate-doctor.sh` prints it verbatim and
+# `state` reports the result.
+ATTACH_CONF_DEST="$HOME/.lv-attach.conf"
+if [[ ! -e "$ATTACH_CONF_DEST" ]]; then
+  cat >"$ATTACH_CONF_DEST" <<'ATTACHCONF'
+# lv-attach — where `term open ghostty lv-attach [session]` connects.
+#
+# Uncomment and set the destination. It is an ssh alias from ~/.ssh/config, or
+# user@host; only [A-Za-z0-9._-] (plus one @) is accepted, and it must not
+# start with '-'.
+#
+# destination=builder
+#
+# Optional default herdr session, used when `term open` passes no name:
+# session=work
+#
+# Check it with:  ~/bin/lv-attach --check
+ATTACHCONF
+  chmod 0600 "$ATTACH_CONF_DEST" 2>/dev/null || true
+  say "Wrote a template $ATTACH_CONF_DEST (set destination= before using term open)"
+fi
+
 say "Installed $VARIANT -> $DEST"
 if [[ -n "$LABEL" ]]; then say "  build: $LABEL"; fi
 say "  provenance: $DEST.source"

--- a/scripts/mac/install-ui-artifact.sh
+++ b/scripts/mac/install-ui-artifact.sh
@@ -22,7 +22,13 @@ set -euo pipefail
 DEST_ROOT="${LV_UI_ARTIFACT_DEST_ROOT:-$HOME/localvoxtral-ui-artifacts}"
 
 say() { printf '%s\n' "$*" >&2; }
-die() { printf 'install-ui-artifact: %s\n' "$*" >&2; exit 1; }
+die() { printf 'install-ui-artifact: %s\n' "$*" >&2; exit "${2:-1}"; }
+
+# Exit 3 means ONE thing: the destination slot is executing right now, so the
+# operator can fix it by quitting the app. ci.yml's install step turns that
+# into a warning rather than a red build — the build was fine, the owner just
+# had the app open. Every other refusal stays exit 1 and stays fatal.
+EXIT_SLOT_RUNNING=3
 
 SOURCE=""
 LABEL=""
@@ -151,7 +157,8 @@ DEST="$DEST_ROOT/$NAME"
 if command -v pgrep >/dev/null 2>&1; then
   RUNNING_HERE="$(pgrep -f "^$DEST/Contents/MacOS/localvoxtral" 2>/dev/null || true)"
   if [[ -n "$RUNNING_HERE" ]]; then
-    die "$DEST is running (pid $(printf '%s' "$RUNNING_HERE" | tr '\n' ' ')) — quit it first (ssh lv-ui 'quit', or the menu bar item)"
+    die "$DEST is running (pid $(printf '%s' "$RUNNING_HERE" | tr '\n' ' ')) — quit it first (ssh lv-ui 'quit', or the menu bar item)" \
+      "$EXIT_SLOT_RUNNING"
   fi
   # A localvoxtral running from anywhere else is not a reason to refuse the
   # copy, but it IS a reason the gate's launch will misbehave: two instances

--- a/scripts/mac/install-ui-artifact.sh
+++ b/scripts/mac/install-ui-artifact.sh
@@ -1,0 +1,213 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Install a localvoxtral .app into the UI gate's artifact root, so
+# `ssh lv-ui 'launch ...'` can start it.
+#
+#   scripts/mac/install-ui-artifact.sh <bundle.app> [--label <text>] [--no-hint]
+#
+# The gate (scripts/mac/localvoxtral-ui-gate.sh) refuses to launch anything
+# outside LV_UI_ARTIFACT_ROOTS, and those roots are deliberately owner-writable
+# only — a world-writable root would let any local process plant a bundle
+# carrying com.localvoxtral.app and have the gate launch it. So the fix for
+# "try-pr.sh extracts into /tmp, which the gate cannot launch" is to COPY the
+# bundle into the root, never to widen the root. This script is that copy.
+#
+# Called by `scripts/try-pr.sh <target> --ui-gate`; also usable by hand on a
+# locally packaged bundle (`dist/localvoxtral.app` from package_app.sh).
+#
+# Diagnostics go to stderr; the single line on stdout is the installed bundle
+# path, so callers can do: APP="$(install-ui-artifact.sh "$src")".
+
+DEST_ROOT="${LV_UI_ARTIFACT_DEST_ROOT:-$HOME/localvoxtral-ui-artifacts}"
+
+say() { printf '%s\n' "$*" >&2; }
+die() { printf 'install-ui-artifact: %s\n' "$*" >&2; exit 1; }
+
+SOURCE=""
+LABEL=""
+HINT=1
+while (( $# > 0 )); do
+  case "$1" in
+    --label)
+      shift
+      [[ $# -gt 0 ]] || die "--label needs a value"
+      LABEL="$1"
+      ;;
+    # try-pr.sh prints the launch command itself, at the end, after the
+    # signing output — one hint, where it is still on screen.
+    --no-hint) HINT=0 ;;
+    -*) die "unknown flag: $1" ;;
+    *)
+      [[ -z "$SOURCE" ]] || die "takes exactly one bundle"
+      SOURCE="$1"
+      ;;
+  esac
+  shift
+done
+[[ -n "$SOURCE" ]] || die "usage: $0 <bundle.app> [--label <text>] [--no-hint]"
+
+# --- read the source bundle ------------------------------------------------
+
+# Same reader as the gate's, and for the same reason: PlistBuddy when it
+# exists, an XML fallback so this is exercisable off a Mac.
+plist_value() { # <plist> <key>
+  local plist="$1" key="$2" value
+  if [[ -x /usr/libexec/PlistBuddy ]]; then
+    value="$(/usr/libexec/PlistBuddy -c "Print :$key" "$plist" 2>/dev/null)" || value=""
+    if [[ -n "$value" ]]; then
+      printf '%s\n' "$value"
+      return 0
+    fi
+  fi
+  awk -v want="$key" '
+    /<key>/ { k = $0; sub(/^.*<key>/, "", k); sub(/<\/key>.*$/, "", k); next }
+    k == want {
+      line = $0
+      if (line ~ /<true\/>/) { print "true"; exit }
+      if (line ~ /<false\/>/) { print "false"; exit }
+      if (line ~ /<string>/) {
+        sub(/^.*<string>/, "", line); sub(/<\/string>.*$/, "", line)
+        print line; exit
+      }
+    }
+  ' "$plist" 2>/dev/null
+}
+
+[[ -d "$SOURCE" ]] || die "no such bundle: $SOURCE"
+SOURCE="$(cd "$SOURCE" && pwd -P)"
+[[ "$SOURCE" == *.app ]] || die "not a .app bundle: $SOURCE"
+PLIST="$SOURCE/Contents/Info.plist"
+[[ -f "$PLIST" ]] || die "bundle has no Info.plist: $SOURCE"
+
+# The gate applies exactly this check before launching; failing it here means
+# a bundle that would be installed and then refused. Better to say so now.
+[[ "$(plist_value "$PLIST" CFBundleIdentifier)" == "com.localvoxtral.app" ]] \
+  || die "not a localvoxtral bundle (CFBundleIdentifier is not com.localvoxtral.app): $SOURCE"
+[[ "$(plist_value "$PLIST" CFBundleExecutable)" == "localvoxtral" ]] \
+  || die "bundle's CFBundleExecutable is not 'localvoxtral': $SOURCE"
+[[ -x "$SOURCE/Contents/MacOS/localvoxtral" ]] \
+  || die "bundle has no executable at Contents/MacOS/localvoxtral: $SOURCE"
+
+STAMP="$(plist_value "$PLIST" LVXDogfoodCapture)"
+# Two slots, not one per build: the dogfood and clean bundles differ in kind
+# (the gate's `launch --dogfood` demands the stamp), but N historical copies of
+# the same app would be indistinguishable at runtime — same bundle id, same
+# defaults domain, same TCC grant — and launching a stale one is precisely the
+# wrong-binary confusion docs/agent/field-debugging.md was written about. So a
+# reinstall REPLACES its slot, and the .source file next to it records what it
+# actually is.
+if [[ "$STAMP" == "true" ]]; then
+  NAME="localvoxtral-dogfood.app"
+  VARIANT_KEY="dogfood"
+  VARIANT="dogfood (LVXDogfoodCapture stamped)"
+else
+  NAME="localvoxtral.app"
+  VARIANT_KEY="clean"
+  VARIANT="clean (no LVXDogfoodCapture stamp)"
+fi
+
+# --- the destination root must stay owner-writable only --------------------
+
+world_writable() { # <dir> -> 0 when group- or other-writable
+  # BSD stat first (the Mac), GNU stat second (this also runs in CI's
+  # shell-test step, which is where the refusal is actually proved).
+  # Two attempts, each validated on its own: GNU stat's `-f` means
+  # --file-system and prints a whole block before failing, so an `a || b`
+  # substitution would capture that block AND the octal mode together.
+  local dir="$1" mode="" bits=0
+  mode="$(stat -f '%Lp' "$dir" 2>/dev/null || true)"
+  [[ "$mode" =~ ^[0-7]+$ ]] || mode="$(stat -c '%a' "$dir" 2>/dev/null || true)"
+  # A mode that cannot be read must not answer "safe": fail closed.
+  [[ "$mode" =~ ^[0-7]+$ ]] || return 0
+  bits=$(( 8#$mode ))
+  (( (bits & 0022) != 0 ))
+}
+
+if [[ -e "$DEST_ROOT" ]]; then
+  [[ -d "$DEST_ROOT" ]] || die "artifact root exists but is not a directory: $DEST_ROOT"
+  # Not paranoia about this script: the gate launches anything under the root
+  # that claims com.localvoxtral.app, so a root other users can write to is a
+  # local-process foothold into the owner's GUI session. Refuse to feed one.
+  if world_writable "$DEST_ROOT"; then
+    die "artifact root is group/other-writable, which would let any local process plant a bundle the gate will launch: $DEST_ROOT (fix: chmod go-w)"
+  fi
+else
+  mkdir -p "$DEST_ROOT" || die "cannot create artifact root: $DEST_ROOT"
+  chmod 0700 "$DEST_ROOT" 2>/dev/null || true
+fi
+DEST_ROOT="$(cd "$DEST_ROOT" && pwd -P)"
+[[ -w "$DEST_ROOT" ]] || die "artifact root is not writable: $DEST_ROOT"
+
+DEST="$DEST_ROOT/$NAME"
+
+# --- never overwrite a bundle that is executing ----------------------------
+#
+# Quitting the owner's app is NOT this script's job — the gate has a `quit`
+# verb and the operator is the one who knows whether a dictation is in flight.
+# What an installer must not do is replace files out from under a running
+# process, so the one running instance it refuses to work around is the one
+# living at the destination.
+if command -v pgrep >/dev/null 2>&1; then
+  RUNNING_HERE="$(pgrep -f "^$DEST/Contents/MacOS/localvoxtral" 2>/dev/null || true)"
+  if [[ -n "$RUNNING_HERE" ]]; then
+    die "$DEST is running (pid $(printf '%s' "$RUNNING_HERE" | tr '\n' ' ')) — quit it first (ssh lv-ui 'quit', or the menu bar item)"
+  fi
+  # A localvoxtral running from anywhere else is not a reason to refuse the
+  # copy, but it IS a reason the gate's launch will misbehave: two instances
+  # fight over the global hotkey and over the helper ports 8471/8472.
+  RUNNING_ELSEWHERE="$(pgrep -x localvoxtral 2>/dev/null || true)"
+  if [[ -n "$RUNNING_ELSEWHERE" ]]; then
+    say "WARNING: another localvoxtral is already running (pid $(printf '%s' "$RUNNING_ELSEWHERE" | tr '\n' ' '))."
+    say "         Quit it before 'launch' — a second instance collides on the global"
+    say "         hotkey and on the speechd/polishd ports 8471/8472."
+  fi
+fi
+
+# --- install ---------------------------------------------------------------
+
+STAGING="$DEST_ROOT/.incoming-$NAME.$$"
+OUTGOING="$DEST_ROOT/.outgoing-$NAME.$$"
+cleanup() { rm -rf "$STAGING" "$OUTGOING"; }
+trap cleanup EXIT
+
+rm -rf "$STAGING"
+if command -v ditto >/dev/null 2>&1; then
+  ditto "$SOURCE" "$STAGING" || die "copy failed: $SOURCE -> $STAGING"
+else
+  cp -R "$SOURCE" "$STAGING" || die "copy failed: $SOURCE -> $STAGING"
+fi
+
+# Swap through a rename rather than deleting first: an interrupted install
+# leaves the previous bundle in place instead of no bundle at all.
+if [[ -e "$DEST" ]]; then
+  mv "$DEST" "$OUTGOING" || die "could not move the existing bundle aside: $DEST"
+fi
+mv "$STAGING" "$DEST" || die "could not move the new bundle into place: $DEST"
+rm -rf "$OUTGOING"
+
+{
+  printf 'installed=%s\n' "$(date -u '+%Y-%m-%dT%H:%M:%SZ')"
+  printf 'variant=%s\n' "$VARIANT_KEY"
+  printf 'source=%s\n' "$SOURCE"
+  if [[ -n "$LABEL" ]]; then printf 'label=%s\n' "$LABEL"; fi
+} >"$DEST.source"
+
+# The gate resolves a relative argument against the GUI user's home, which is
+# the form the README's examples use; only a root outside $HOME needs the
+# absolute path.
+GATE_ARG="$DEST"
+case "$DEST" in
+  "$HOME"/*) GATE_ARG="${DEST#"$HOME"/}" ;;
+esac
+GATE_FLAG=""
+[[ "$VARIANT_KEY" == dogfood ]] && GATE_FLAG="--dogfood "
+
+say "Installed $VARIANT -> $DEST"
+if [[ -n "$LABEL" ]]; then say "  build: $LABEL"; fi
+say "  provenance: $DEST.source"
+if (( HINT )); then
+  say "  gate launch: ssh lv-ui 'launch $GATE_FLAG$GATE_ARG'"
+fi
+
+printf '%s\n' "$DEST"

--- a/scripts/mac/install-ui-artifact.sh
+++ b/scripts/mac/install-ui-artifact.sh
@@ -210,6 +210,32 @@ esac
 GATE_FLAG=""
 [[ "$VARIANT_KEY" == dogfood ]] && GATE_FLAG="--dogfood "
 
+# --- the term-open wrapper -------------------------------------------------
+#
+# `term open` allowlists a command by NAME and then trusts it with every
+# argument it will ever be given, so the wrapper that name refers to is holding
+# the boundary. Shipping it here rather than leaving the owner to write one by
+# hand is the point: it arrives with the build, it is reviewed like the rest of
+# the repo, and a fix to it lands the next time a build is installed instead of
+# waiting for someone to remember an unversioned file in ~/bin.
+#
+# ~/bin rather than beside the bundle because a GUI-launched terminal has to be
+# able to RESOLVE the name: `term open` writes a launcher that execs the
+# command, and PATH is how that resolves. ~/bin is already where the gate's
+# lock probe lives.
+WRAPPER_SRC="$(cd "$(dirname "$0")" && pwd -P)/lv-attach.sh"
+WRAPPER_DEST="$HOME/bin/lv-attach"
+if [[ -f "$WRAPPER_SRC" ]]; then
+  mkdir -p "$HOME/bin" || die "cannot create $HOME/bin"
+  # 0700: it execs ssh as the owner, so it is not something other accounts on
+  # the machine get to read or run.
+  install -m 0700 "$WRAPPER_SRC" "$WRAPPER_DEST" \
+    || die "could not install the term-open wrapper to $WRAPPER_DEST"
+  say "Installed term-open wrapper -> $WRAPPER_DEST"
+else
+  say "WARNING: $WRAPPER_SRC is missing; the term-open wrapper was not installed."
+fi
+
 say "Installed $VARIANT -> $DEST"
 if [[ -n "$LABEL" ]]; then say "  build: $LABEL"; fi
 say "  provenance: $DEST.source"

--- a/scripts/mac/localvoxtral-ui-gate.sh
+++ b/scripts/mac/localvoxtral-ui-gate.sh
@@ -294,10 +294,27 @@ fi
 # widen the allowlist but can never re-add one of these. A blocklist is a poor
 # primary defence, which is why it is not the primary defence — it is here so
 # that a mistake in a machine-local file fails loudly instead of silently.
+#
+# Four classes, because "can run a child command" is wider than "is a shell":
+#   * shells and interpreters — the obvious ones;
+#   * coding-agent CLIs — each one IS a shell wearing a product name;
+#   * editors and pagers — `vi`, `less`, `man` all reach a shell at RUNTIME
+#     (`:!cmd`, `!cmd`, `v`). The admission test in the header ("read --help;
+#     if any flag takes a command it fails") does NOT catch these, and they are
+#     the names an owner is likeliest to allowlist meaning "just a viewer";
+#   * command wrappers and toolchains — `nice`, `watch`, `timeout`, `env`,
+#     `git` (hooks, GIT_SSH, its editor), `open` (`open -a Terminal`), `awk`
+#     (`system()`), `npx`/`cargo`/`go`, and the fetchers whose normal argv is
+#     someone else's code.
+# Adding a name here costs nothing; leaving one out costs the boundary.
 LV_UI_TERM_FORBIDDEN="bash sh zsh ksh csh tcsh fish dash ssh scp sftp telnet \
 osascript applescript python python2 python3 perl ruby node deno bun php lua \
 env xargs find sudo doas su nohup script screen tmux herdr expect make just \
-claude codex opencode aider goose amp cursor-agent gemini ollama"
+claude codex opencode aider goose amp cursor-agent gemini ollama \
+vi vim nvim view ex ed emacs nano pico less more most man info \
+awk sed git swift open watch nice caffeinate arch time timeout stdbuf \
+npm npx yarn pnpm cargo go rustc gcc clang cc ld dtrace lldb gdb \
+nc netcat curl wget rsync ftp"
 
 original_command="${SSH_ORIGINAL_COMMAND:-}"
 ARGV=()
@@ -326,6 +343,13 @@ log_command() {
   # exactly like a genuine ALLOW entry. Every non-printable byte becomes `?`,
   # so one invocation is always exactly one line.
   shown="$(printf '%s' "${shown:0:512}" | tr -c '[:print:]' '?')"
+  # The note gets the same treatment, and for the same reason. Today every note
+  # is built from already-charset-checked input, so there is no live injection
+  # — but "one invocation is always exactly one line" was enforced on only half
+  # the line, and the next caller to interpolate something new here would not
+  # know that. Bounded too: a denial's note can otherwise carry the whole
+  # 2048-byte command back into the file.
+  note="$(printf '%s' "${note:0:512}" | tr -c '[:print:]' '?')"
   if [[ -n "$note" ]]; then
     log_line "$verdict $shown (${note})"
   else
@@ -1688,10 +1712,29 @@ run_launch() {
 
   open -n "$bundle" || fail "open refused the bundle"
 
+  # `pgrep -f` matches its pattern as a PREFIX of the whole command line, and
+  # this bundle ships localvoxtral-speechd, localvoxtral-polishd and
+  # localvoxtral-claude-hook in the SAME directory (package_app.sh) — every one
+  # of them matches "<bundle>/Contents/MacOS/localvoxtral". The app starts its
+  # helpers during launch, and `pgrep -n` answers with the NEWEST match, so the
+  # bare prefix could record a helper's pid: `ax dump` then returns [] forever,
+  # `shot` never finds a window, and `quit` kills the helper while the real app
+  # keeps running — after which `launch` refuses beside "a localvoxtral this
+  # gate did not start" and only the owner can unwedge it. Timing-dependent,
+  # and invisible to a stub that answers with one pid.
+  #
+  # So the prefix only nominates candidates; the executable path decides. BSD
+  # `ps -o comm=` is the full path, which is the same fact `process_identity`
+  # already trusts for pid reuse.
+  local app_executable="$bundle/Contents/MacOS/localvoxtral" candidate
   deadline=$((SECONDS + 20))
   while (( SECONDS < deadline )); do
-    pid="$(pgrep -n -f "^$bundle/Contents/MacOS/localvoxtral" 2>/dev/null || true)"
-    [[ -n "$pid" ]] && break
+    for candidate in $(pgrep -f "^$app_executable" 2>/dev/null | sort -rn); do
+      [[ "$(ps -p "$candidate" -o comm= 2>/dev/null)" == "$app_executable" ]] || continue
+      pid="$candidate"
+      break
+    done
+    [[ -n "${pid:-}" ]] && break
     sleep 0.5
   done
   [[ -n "${pid:-}" ]] || fail "the app did not start within 20 seconds"

--- a/scripts/mac/localvoxtral-ui-gate.sh
+++ b/scripts/mac/localvoxtral-ui-gate.sh
@@ -27,15 +27,19 @@ set -euo pipefail
 #   - `ax click` / `ax type` walk the accessibility tree rooted at
 #     AXUIElementCreateApplication(<that same pid>). A selector cannot name an
 #     element of another app.
-#   - `key` posts one keycode from a three-entry allowlist, and only while the
-#     app under test is frontmost.
+#   - `key` posts one keycode from a three-entry allowlist, and only once the
+#     app under test is frontmost — it activates that app first and refuses if
+#     the activation did not take, so a keystroke never lands in whatever the
+#     owner last touched.
 #   - `term focus` / `term close` act only on a window this gate opened,
 #     identified by a random marker it put in that window's title.
 #
 # It refuses everything GUI-touching while the screen is locked (shared probe:
 # scripts/ci/screen-lock-state.sh, fail CLOSED here), and honours the owner's
-# takeover rule: any verb that steals focus speaks a warning, waits, and
-# announces completion.
+# takeover rule: any verb that steals focus (launch, ax click, ax type, key,
+# term open, term focus) speaks a warning, waits, and announces completion.
+# `state`, `shot`, `ax dump`, `quit` and `term close` do not warn: none of them
+# takes the keyboard or raises a window in front of what the owner is doing.
 #
 # Verbs (each documented at its run_* function):
 #   state
@@ -464,6 +468,18 @@ func requirePID(_ raw: String) -> pid_t {
     return pid
 }
 
+// Bring one pid frontmost and give the activation up to two seconds to land.
+// Callers still re-check afterwards — this only asks.
+func activateAndWait(_ pid: pid_t) {
+    if NSWorkspace.shared.frontmostApplication?.processIdentifier == pid { return }
+    _ = NSRunningApplication(processIdentifier: pid)?.activate(options: [])
+    let deadline = Date().addingTimeInterval(2)
+    while Date() < deadline,
+          NSWorkspace.shared.frontmostApplication?.processIdentifier != pid {
+        usleep(100_000)
+    }
+}
+
 guard let subcommand = argv.first else { die("no subcommand") }
 
 switch subcommand {
@@ -548,9 +564,10 @@ case "axtype":
         break
     }
     // Fallback: synthesise the keystrokes. These are SYSTEM-WIDE events, so
-    // they are only posted when the app under test owns the keyboard.
+    // they are only posted once the app under test owns the keyboard.
+    activateAndWait(pid)
     guard NSWorkspace.shared.frontmostApplication?.processIdentifier == pid else {
-        die("AXValue was rejected and the app under test is not frontmost — refusing to synthesise keystrokes")
+        die("AXValue was rejected and the app under test could not be brought frontmost — refusing to synthesise keystrokes")
     }
     guard let source = CGEventSource(stateID: .hidSystemState),
           let down = CGEvent(keyboardEventSource: source, virtualKey: 0, keyDown: true),
@@ -568,8 +585,12 @@ case "key":
     let pid = requirePID(argv[1])
     let codes: [String: CGKeyCode] = ["escape": 53, "tab": 48, "return": 36]
     guard let code = codes[argv[2]] else { die("key not in allowlist") }
+    // A CGEvent goes to whatever owns the keyboard, so the app under test has
+    // to own it. Ask for it, then RE-CHECK: the guarantee is not "we tried to
+    // focus it", it is "the keystroke landed there or nowhere".
+    activateAndWait(pid)
     guard NSWorkspace.shared.frontmostApplication?.processIdentifier == pid else {
-        die("app under test is not frontmost — refusing to post a key event")
+        die("app under test could not be brought frontmost — refusing to post a key event")
     }
     guard let source = CGEventSource(stateID: .hidSystemState),
           let down = CGEvent(keyboardEventSource: source, virtualKey: code, keyDown: true),
@@ -1076,7 +1097,9 @@ load_term_state() { # <id>
   TERM_PID="$(sed -n 's/^pid=//p' "$file" | head -n 1)"
   TERM_MARKER="$(sed -n 's/^marker=//p' "$file" | head -n 1)"
   TERM_KIND="$(sed -n 's/^terminal=//p' "$file" | head -n 1)"
-  [[ "$TERM_PID" =~ ^[0-9]+$ && -n "$TERM_MARKER" ]] || deny "corrupt terminal state for $id"
+  # ^[1-9] on purpose: `kill -0 0` signals the whole process group and always
+  # succeeds, so pid 0 would read as a live terminal.
+  [[ "$TERM_PID" =~ ^[1-9][0-9]*$ && -n "$TERM_MARKER" ]] || deny "corrupt terminal state for $id"
   kill -0 "$TERM_PID" 2>/dev/null || deny "$id's terminal process is gone"
 }
 

--- a/scripts/mac/localvoxtral-ui-gate.sh
+++ b/scripts/mac/localvoxtral-ui-gate.sh
@@ -251,7 +251,15 @@ announce_result() {
     say "localvoxtral u i gate failed" >/dev/null 2>&1 || true
   fi
 }
-trap announce_result EXIT
+
+# One EXIT path for the whole gate: no capture file ever outlives the
+# invocation that took it, whatever exit the verb takes.
+SHOT_FILE=""
+on_exit() {
+  [[ -n "$SHOT_FILE" ]] && rm -f "$SHOT_FILE"
+  announce_result
+}
+trap on_exit EXIT
 
 # ---------------------------------------------------------------------------
 # Swift helper — every CoreGraphics/AX call lives here
@@ -767,7 +775,8 @@ run_state() {
     marker="$(sed -n 's/^marker=//p' "$file" | head -n 1)"
     pid="$(sed -n 's/^pid=//p' "$file" | head -n 1)"
     [[ -n "$terminals" ]] && terminals+=","
-    terminals+="{\"id\":$(json_string "$id"),\"terminal\":$(json_string "$term"),\"pid\":${pid:-0},\"alive\":$(kill -0 "${pid:-0}" 2>/dev/null && echo true || echo false),\"marker\":$(json_string "$marker")}"
+    [[ "$pid" =~ ^[1-9][0-9]*$ ]] || pid=0
+    terminals+="{\"id\":$(json_string "$id"),\"terminal\":$(json_string "$term"),\"pid\":$pid,\"alive\":$( (( pid > 0 )) && kill -0 "$pid" 2>/dev/null && echo true || echo false),\"marker\":$(json_string "$marker")}"
   done
 
   printf '{"screen_lock":%s,"idle_seconds":%s,"power":%s,"tcc":{"accessibility":%s,"screen_recording":%s},"app":%s,"terminals":[%s]}\n' \
@@ -857,18 +866,22 @@ run_shot() {
     || deny "resolved window $winid is owned by pid $owner, not the app under test ($APP_PID)"
 
   log_command ALLOW "window=$winid kind=$kind"
-  file="$STATE_DIR/shot.png"
+  mkdir -p "$STATE_DIR"
+  chmod 0700 "$STATE_DIR" 2>/dev/null || true
+  # Named per invocation (two concurrent shots must not swap images) and with a
+  # .png suffix so screencapture picks the format from it. The EXIT trap owns
+  # deletion, so no exit path leaves a window image on disk.
+  SHOT_FILE="$STATE_DIR/shot.$$.png"
+  file="$SHOT_FILE"
   rm -f "$file"
   screencapture -o -x -l "$winid" "$file" || fail "screencapture failed for window $winid"
   [[ -s "$file" ]] || fail "screencapture produced an empty file (Screen Recording grant?)"
   size="$(wc -c <"$file" | tr -d ' ')"
   if (( size > LV_UI_SHOT_MAX_BYTES )); then
-    rm -f "$file"
     fail "capture is ${size} bytes, over the ${LV_UI_SHOT_MAX_BYTES} byte cap"
   fi
   printf 'shot: window %s (%s), %s bytes\n' "$winid" "$kind" "$size" >&2
   base64 <"$file"
-  rm -f "$file"
   ACTION_COMPLETED=1
 }
 

--- a/scripts/mac/localvoxtral-ui-gate.sh
+++ b/scripts/mac/localvoxtral-ui-gate.sh
@@ -1,0 +1,1187 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# localvoxtral UI gate v1.
+#
+# A SECOND forced-command SSH gate, installed on the Mac's GUI account, next
+# to (never merged with) the build gate. It lets an agent see and drive the
+# localvoxtral build UNDER TEST — and nothing else on the owner's desktop.
+#
+# THE FORCED COMMAND IS THE ENTIRE TRUST BOUNDARY.
+# Everything reachable through this key is in the `case` at the bottom of this
+# file; everything else is denied and logged. There is deliberately NO shell
+# verb: no `eval`, no `bash -c`, no verb that takes a free command line — with
+# one narrowly constrained exception, `term open`, whose command must start
+# with an allowlisted binary, must survive the same metacharacter blocklist as
+# every other token, and is logged IN FULL. Adding a verb that can run
+# arbitrary commands dissolves this boundary completely; do not.
+#
+# Why "semantic" verbs and not a computer-use harness: a generic harness
+# clicks inferred pixel coordinates on whatever is on screen, which on this
+# machine is the owner's mail, browser and messages. This gate cannot do that.
+# There is no coordinate input at all, and no full-screen capture:
+#
+#   - `shot` resolves a CGWindowID from the window list FILTERED to the pid
+#     this gate itself launched, and refuses when the resolved window's owner
+#     is not that pid. It can never photograph another application.
+#   - `ax click` / `ax type` walk the accessibility tree rooted at
+#     AXUIElementCreateApplication(<that same pid>). A selector cannot name an
+#     element of another app.
+#   - `key` posts one keycode from a three-entry allowlist, and only while the
+#     app under test is frontmost.
+#   - `term focus` / `term close` act only on a window this gate opened,
+#     identified by a random marker it put in that window's title.
+#
+# It refuses everything GUI-touching while the screen is locked (shared probe:
+# scripts/ci/screen-lock-state.sh, fail CLOSED here), and honours the owner's
+# takeover rule: any verb that steals focus speaks a warning, waits, and
+# announces completion.
+#
+# Verbs (each documented at its run_* function):
+#   state
+#   launch [--dogfood] <artifact>
+#   shot [settings|popover|overlay|window <n>]
+#   ax dump [settings|overlay|window <n>]
+#   ax click <selector>
+#   ax type <selector> -- <text>
+#   key <escape|tab|return>
+#   quit
+#   term open <ghostty|iterm|terminal> <command> [args...]
+#   term focus <id>
+#   term close <id>
+#
+# Install notes, TCC grants and the deny check: scripts/mac/README.md.
+# Regression tests: scripts/ci/test-ui-gate.sh (runs in ci.yml; no GUI needed).
+
+# Deterministic pattern matching and character classes regardless of the
+# client's locale: [[:print:]] below must mean ASCII 0x20-0x7E, not whatever
+# a forwarded LANG would widen it to.
+export LC_ALL=C
+
+LOG_FILE="${LV_UI_GATE_LOG:-$HOME/Library/Logs/localvoxtral-ui-gate.log}"
+STATE_DIR="${LV_UI_STATE_DIR:-$HOME/.localvoxtral-ui-gate}"
+
+# Where a launchable artifact may live. `launch` resolves the argument with
+# `pwd -P` (so symlinks and .. cannot escape) and requires the result to sit
+# under one of these roots AND to be a real localvoxtral bundle.
+LV_UI_ARTIFACT_ROOTS="${LV_UI_ARTIFACT_ROOTS:-$HOME/Applications $HOME/localvoxtral-ui-artifacts}"
+
+# `term open`'s allowlists. The command allowlist is the ONLY thing standing
+# between this verb and a shell verb, so it holds first tokens only, and an
+# entry that is itself a shell (bash, sh, zsh, ssh, osascript, python) or that
+# takes an arbitrary child command (`claude --dangerously-skip-permissions`)
+# hands the whole boundary away. Keep it to non-shell tools.
+LV_UI_TERMINALS="${LV_UI_TERMINALS:-ghostty iterm terminal}"
+LV_UI_TERM_COMMANDS="${LV_UI_TERM_COMMANDS:-herdr claude opencode codex}"
+LV_UI_MAX_TERM_ARGS="${LV_UI_MAX_TERM_ARGS:-12}"
+
+# Owner rule (2026-07-09): warn audibly and wait before stealing focus, and
+# announce completion. Set to 0 in the conf file only if you are sitting in
+# front of the machine — the default is the rule as stated.
+LV_UI_WARN_SLEEP_SECONDS="${LV_UI_WARN_SLEEP_SECONDS:-3}"
+
+# A window PNG is a few hundred KB; the cap exists so a pathological capture
+# cannot dump tens of MB into an agent transcript.
+LV_UI_SHOT_MAX_BYTES="${LV_UI_SHOT_MAX_BYTES:-8388608}"
+
+LV_UI_MAX_COMMAND_BYTES="${LV_UI_MAX_COMMAND_BYTES:-2048}"
+LV_UI_MAX_TEXT_BYTES="${LV_UI_MAX_TEXT_BYTES:-512}"
+
+# Machine-local overrides (never committed). Same argument as the build gate:
+# anyone who can write this file can already replace this script, so sourcing
+# it adds no new trust.
+GATE_CONF="${LV_UI_GATE_CONF:-$HOME/.localvoxtral-ui-gate.conf}"
+if [[ -f "$GATE_CONF" ]]; then
+  # shellcheck source=/dev/null
+  source "$GATE_CONF"
+fi
+
+original_command="${SSH_ORIGINAL_COMMAND:-}"
+ARGV=()
+ANNOUNCED_TAKEOVER=0
+ACTION_COMPLETED=0
+
+timestamp() {
+  date '+%Y-%m-%dT%H:%M:%S%z'
+}
+
+log_line() {
+  mkdir -p "$(dirname "$LOG_FILE")" 2>/dev/null || true
+  printf '%s %s\n' "$(timestamp)" "$*" >>"$LOG_FILE" 2>/dev/null || true
+}
+
+# Every invocation is logged, allowed or denied. `ax type`'s text is NOT
+# logged: the legitimate use for it is filling in an endpoint's API key field,
+# and this log is read by agents and pasted into PRs.
+log_command() {
+  local verdict="$1" note="${2:-}" shown="${original_command:-<empty>}"
+  case "$shown" in
+    "ax type "*) shown="${shown%% -- *} -- <redacted>" ;;
+  esac
+  # Log-injection defence: a denied command is attacker-chosen text, and a
+  # newline in it would otherwise write a second line into this log that reads
+  # exactly like a genuine ALLOW entry. Every non-printable byte becomes `?`,
+  # so one invocation is always exactly one line.
+  shown="$(printf '%s' "${shown:0:512}" | tr -c '[:print:]' '?')"
+  if [[ -n "$note" ]]; then
+    log_line "$verdict $shown (${note})"
+  else
+    log_line "$verdict $shown"
+  fi
+}
+
+deny() {
+  log_command DENY "${1:-unallowlisted}"
+  printf 'localvoxtral ui gate: denied command\n' >&2
+  exit 126
+}
+
+fail() {
+  printf 'localvoxtral ui gate: %s\n' "$1" >&2
+  exit "${2:-1}"
+}
+
+# ---------------------------------------------------------------------------
+# Input validation
+# ---------------------------------------------------------------------------
+
+# Fail-closed token charset. No whitespace, no quote, no backslash, and none
+# of `$ ; & | < > ( ) { } [ ] ! * ? # ' "` — so a token can never be anything
+# but a literal even if some future code path did the wrong thing with it.
+# Selector values spell a space as `+` (see validate_selector).
+token_is_safe() {
+  [[ "$1" =~ ^[A-Za-z0-9._:/=,~+@%-]+$ ]]
+}
+
+# Selector grammar: comma-separated key<op>value pairs, `=` exact, `~`
+# contains, `+` decodes to a space.
+#   role=AXButton,title=Dictation
+#   role=AXButton,title~Text+Processing,index=0
+# Keys: role, title, desc, value, index, window.
+validate_selector() {
+  local selector="$1" pair key matchable=0
+  token_is_safe "$selector" || return 1
+  (( ${#selector} <= 256 )) || return 1
+  [[ "$selector" == *[=~]* ]] || return 1
+  local IFS=,
+  for pair in $selector; do
+    [[ -n "$pair" ]] || return 1
+    key="${pair%%[=~]*}"
+    [[ "$key" != "$pair" ]] || return 1
+    [[ -n "${pair#*[=~]}" ]] || return 1
+    case "$key" in
+      role | title | desc | value) matchable=1 ;;
+      index | window) [[ "${pair#*[=~]}" =~ ^[0-9]+$ ]] || return 1 ;;
+      *) return 1 ;;
+    esac
+  done
+  # `index=0` alone names no element; it only disambiguates among matches.
+  (( matchable == 1 ))
+}
+
+# Typed text is the one place a wider charset is allowed: it never reaches a
+# shell (the Swift helper receives it as argv) and API keys/URLs need it.
+validate_typed_text() {
+  local text="$1"
+  (( ${#text} >= 1 && ${#text} <= LV_UI_MAX_TEXT_BYTES )) || return 1
+  [[ "$text" =~ ^[[:print:]]+$ ]]
+}
+
+list_contains() {
+  local needle="$1" item
+  shift
+  for item in $*; do
+    [[ "$item" == "$needle" ]] && return 0
+  done
+  return 1
+}
+
+# ---------------------------------------------------------------------------
+# Screen lock — fail CLOSED
+# ---------------------------------------------------------------------------
+
+# The shared probe (scripts/ci/screen-lock-state.sh) is installed alongside
+# this gate. If it is missing or cannot decide, every GUI-touching verb is
+# refused: this drives the owner's personal desktop, so "state unknown" must
+# never mean "go ahead". (ui-smoke-guard.sh applies the opposite policy to the
+# same probe on purpose — see the probe's header.)
+LOCK_PROBE="${LV_UI_LOCK_PROBE:-$HOME/bin/localvoxtral-screen-lock-state.sh}"
+
+screen_lock_state() {
+  if [[ ! -x "$LOCK_PROBE" ]]; then
+    echo "error"
+    return
+  fi
+  "$LOCK_PROBE" 2>/dev/null || echo "error"
+}
+
+require_unlocked_screen() {
+  local state
+  state="$(screen_lock_state)"
+  case "$state" in
+    unlocked) return 0 ;;
+    locked | no-session)
+      deny "screen is $state"
+      ;;
+    *)
+      if [[ ! -x "$LOCK_PROBE" ]]; then
+        deny "lock probe missing at $LOCK_PROBE — install it (scripts/mac/README.md)"
+      fi
+      deny "lock state undeterminable ($state)"
+      ;;
+  esac
+}
+
+# ---------------------------------------------------------------------------
+# Owner rule: audible takeover warning
+# ---------------------------------------------------------------------------
+
+announce_takeover() {
+  local what="$1"
+  say "localvoxtral u i gate taking control in 3: $what" >/dev/null 2>&1 || true
+  ANNOUNCED_TAKEOVER=1
+  sleep "$LV_UI_WARN_SLEEP_SECONDS" 2>/dev/null || true
+}
+
+announce_result() {
+  (( ANNOUNCED_TAKEOVER == 1 )) || return 0
+  if (( ACTION_COMPLETED == 1 )); then
+    say "localvoxtral u i gate done" >/dev/null 2>&1 || true
+  else
+    say "localvoxtral u i gate failed" >/dev/null 2>&1 || true
+  fi
+}
+trap announce_result EXIT
+
+# ---------------------------------------------------------------------------
+# Swift helper — every CoreGraphics/AX call lives here
+# ---------------------------------------------------------------------------
+# The helper receives selectors, text and window kinds as ARGV, never as
+# interpolated source: the heredoc below is a constant. It is written into the
+# 0700 state dir on each invocation and run with `swift <file> <subcommand>`.
+
+HELPER_PATH=""
+
+write_helper() {
+  [[ -n "$HELPER_PATH" ]] && return 0
+  mkdir -p "$STATE_DIR" 2>/dev/null || true
+  chmod 0700 "$STATE_DIR" 2>/dev/null || true
+  HELPER_PATH="$STATE_DIR/ui-gate-helper.swift"
+  cat >"$HELPER_PATH" <<'SWIFT'
+import AppKit
+import ApplicationServices
+import CoreGraphics
+import Foundation
+
+// Subcommands (argv[1..]):
+//   preflight
+//   window <pid> <settings|popover|overlay|window> [index]   -> "<winid> <ownerpid>"
+//   axdump <pid> [all|settings|overlay|window] [index]       -> JSON
+//   axclick <pid> <selector>
+//   axtype <pid> <selector> <text>
+//   key <pid> <escape|tab|return>
+//   termwindow <ownerpid> <marker>                           -> "<winid> <ownerpid>"
+//   termaction <ownerpid> <marker> <focus|close>
+
+let argv = Array(CommandLine.arguments.dropFirst())
+
+func die(_ message: String) -> Never {
+    FileHandle.standardError.write(Data(("helper: " + message + "\n").utf8))
+    exit(1)
+}
+
+func copyAttr(_ element: AXUIElement, _ name: String) -> AnyObject? {
+    var value: AnyObject?
+    return AXUIElementCopyAttributeValue(element, name as CFString, &value) == .success ? value : nil
+}
+
+func str(_ element: AXUIElement, _ name: String) -> String {
+    if let raw = copyAttr(element, name) {
+        if let s = raw as? String { return s }
+        return String(describing: raw)
+    }
+    return ""
+}
+
+func windowsOf(_ pid: pid_t) -> [AXUIElement] {
+    let app = AXUIElementCreateApplication(pid)
+    return (copyAttr(app, kAXWindowsAttribute) as? [AXUIElement]) ?? []
+}
+
+func jsonEscape(_ s: String) -> String {
+    var out = ""
+    for scalar in s.unicodeScalars {
+        switch scalar {
+        case "\"": out += "\\\""
+        case "\\": out += "\\\\"
+        case "\n": out += "\\n"
+        case "\r": out += "\\r"
+        case "\t": out += "\\t"
+        default:
+            if scalar.value < 0x20 { out += String(format: "\\u%04x", scalar.value) }
+            else { out.unicodeScalars.append(scalar) }
+        }
+    }
+    return out
+}
+
+// MARK: - CGWindow list, always filtered to one owner pid
+
+struct CGWindowRecord {
+    let id: Int
+    let ownerPID: Int
+    let layer: Int
+    let area: Double
+    let title: String
+}
+
+func cgWindows(ownedBy pid: Int) -> [CGWindowRecord] {
+    let raw = CGWindowListCopyWindowInfo([.optionOnScreenOnly], kCGNullWindowID) as? [[String: Any]] ?? []
+    var out: [CGWindowRecord] = []
+    for window in raw {
+        guard let owner = window[kCGWindowOwnerPID as String] as? Int, owner == pid,
+              let id = window[kCGWindowNumber as String] as? Int,
+              let layer = window[kCGWindowLayer as String] as? Int,
+              let bounds = window[kCGWindowBounds as String] as? [String: Double],
+              let width = bounds["Width"], let height = bounds["Height"]
+        else { continue }
+        let title = window[kCGWindowName as String] as? String ?? ""
+        out.append(CGWindowRecord(id: id, ownerPID: owner, layer: layer, area: width * height, title: title))
+    }
+    return out.sorted { $0.id < $1.id }
+}
+
+// Window kinds. Layer 0 is a normal window (Settings); an open menu sits at
+// layer >= 100; the dictation overlay is a floating panel in between. Tiny
+// windows (shadows, 1x1 helpers) are excluded by area.
+func resolveWindow(pid: Int, kind: String, index: Int?) -> CGWindowRecord? {
+    let all = cgWindows(ownedBy: pid).filter { $0.area > 10_000 }
+    switch kind {
+    case "window":
+        guard let index, index >= 1, index <= all.count else { return nil }
+        return all[index - 1]
+    case "settings":
+        return all.filter { $0.layer == 0 }.max { $0.area < $1.area }
+    case "popover":
+        return all.filter { $0.layer >= 100 }.max { $0.area < $1.area }
+    case "overlay":
+        return all.filter { $0.layer > 0 && $0.layer < 100 }.max { $0.area < $1.area }
+    default:
+        return nil
+    }
+}
+
+// MARK: - Selector
+
+struct ElementSelector {
+    var role: (String, Bool)?   // (value, exact)
+    var title: (String, Bool)?
+    var desc: (String, Bool)?
+    var value: (String, Bool)?
+    var index: Int?
+    var window: Int?
+
+    init?(_ raw: String) {
+        for pair in raw.split(separator: ",", omittingEmptySubsequences: false) {
+            let text = String(pair)
+            guard let opIndex = text.firstIndex(where: { $0 == "=" || $0 == "~" }) else { return nil }
+            let key = String(text[text.startIndex..<opIndex])
+            let exact = text[opIndex] == "="
+            let rawValue = String(text[text.index(after: opIndex)...]).replacingOccurrences(of: "+", with: " ")
+            if rawValue.isEmpty { return nil }
+            switch key {
+            case "role": role = (rawValue, exact)
+            case "title": title = (rawValue, exact)
+            case "desc": desc = (rawValue, exact)
+            case "value": value = (rawValue, exact)
+            case "index": guard let n = Int(rawValue), n >= 0 else { return nil }; index = n
+            case "window": guard let n = Int(rawValue), n >= 1 else { return nil }; window = n
+            default: return nil
+            }
+        }
+        if role == nil, title == nil, desc == nil, value == nil { return nil }
+    }
+
+    private func matches(_ criterion: (String, Bool)?, _ actual: String) -> Bool {
+        guard let criterion else { return true }
+        return criterion.1 ? actual == criterion.0 : actual.contains(criterion.0)
+    }
+
+    func matches(_ element: AXUIElement) -> Bool {
+        matches(role, str(element, kAXRoleAttribute))
+            && matches(title, str(element, kAXTitleAttribute))
+            && matches(desc, str(element, kAXDescriptionAttribute))
+            && matches(value, str(element, kAXValueAttribute))
+    }
+}
+
+func collectMatches(_ selector: ElementSelector, pid: pid_t) -> [AXUIElement] {
+    var roots = windowsOf(pid)
+    if let window = selector.window {
+        guard window >= 1, window <= roots.count else { return [] }
+        roots = [roots[window - 1]]
+    }
+    var found: [AXUIElement] = []
+    var budget = 20_000
+    func walk(_ element: AXUIElement, depth: Int) {
+        if depth > 40 || budget <= 0 || found.count > 64 { return }
+        budget -= 1
+        if selector.matches(element) { found.append(element) }
+        for child in (copyAttr(element, kAXChildrenAttribute) as? [AXUIElement]) ?? [] {
+            walk(child, depth: depth + 1)
+        }
+    }
+    for root in roots { walk(root, depth: 0) }
+    return found
+}
+
+// An ambiguous selector is refused rather than guessed at: acting on "one of
+// the four buttons that matched" is exactly the mistake-prone behaviour this
+// gate exists to avoid. `index=` disambiguates explicitly.
+func uniqueMatch(_ selector: ElementSelector, pid: pid_t) -> AXUIElement {
+    let matches = collectMatches(selector, pid: pid)
+    if let index = selector.index {
+        guard index < matches.count else { die("selector matched \(matches.count) element(s); index=\(index) is out of range") }
+        return matches[index]
+    }
+    guard matches.count != 0 else { die("selector matched no element") }
+    guard matches.count == 1 else { die("selector matched \(matches.count) elements — add index=<n> or narrow it") }
+    return matches[0]
+}
+
+// MARK: - Subcommands
+
+func requirePID(_ raw: String) -> pid_t {
+    guard let pid = Int32(raw), pid > 0 else { die("bad pid") }
+    return pid
+}
+
+guard let subcommand = argv.first else { die("no subcommand") }
+
+switch subcommand {
+case "preflight":
+    print("accessibility=\(AXIsProcessTrusted() ? 1 : 0)")
+    print("screen_recording=\(CGPreflightScreenCaptureAccess() ? 1 : 0)")
+    let front = NSWorkspace.shared.frontmostApplication?.processIdentifier ?? -1
+    print("frontmost_pid=\(front)")
+
+case "window":
+    guard argv.count >= 3 else { die("usage: window <pid> <kind> [index]") }
+    let pid = Int(requirePID(argv[1]))
+    let index: Int? = argv.count >= 4 ? Int(argv[3]) : nil
+    guard let record = resolveWindow(pid: pid, kind: argv[2], index: index) else {
+        die("no \(argv[2]) window owned by pid \(pid)")
+    }
+    // The ownerpid is echoed so the SHELL can re-assert the ownership
+    // invariant independently of this helper's filtering.
+    print("\(record.id) \(record.ownerPID)")
+
+case "axdump":
+    guard argv.count >= 2 else { die("usage: axdump <pid> [kind] [index]") }
+    let pid = requirePID(argv[1])
+    let kind = argv.count >= 3 ? argv[2] : "all"
+    var roots = windowsOf(pid)
+    switch kind {
+    case "all": break
+    case "window":
+        guard argv.count >= 4, let n = Int(argv[3]), n >= 1, n <= roots.count else { die("window index out of range") }
+        roots = [roots[n - 1]]
+    case "settings":
+        roots = roots.filter { str($0, kAXSubroleAttribute) == "AXStandardWindow" }
+        if roots.isEmpty { die("no standard window owned by pid \(pid)") }
+        roots = [roots[0]]
+    case "overlay":
+        roots = roots.filter { str($0, kAXSubroleAttribute) != "AXStandardWindow" }
+        if roots.isEmpty { die("no non-standard (overlay) window owned by pid \(pid)") }
+        roots = [roots[0]]
+    default:
+        die("unknown dump kind \(kind)")
+    }
+    var out = "["
+    var budget = 20_000
+    func renderNode(_ element: AXUIElement, depth: Int) -> String {
+        if depth > 40 || budget <= 0 { return "" }
+        budget -= 1
+        var node = "{\"role\":\"\(jsonEscape(str(element, kAXRoleAttribute)))\""
+        node += ",\"subrole\":\"\(jsonEscape(str(element, kAXSubroleAttribute)))\""
+        node += ",\"title\":\"\(jsonEscape(str(element, kAXTitleAttribute)))\""
+        node += ",\"desc\":\"\(jsonEscape(str(element, kAXDescriptionAttribute)))\""
+        node += ",\"value\":\"\(jsonEscape(String(str(element, kAXValueAttribute).prefix(200))))\""
+        let children = (copyAttr(element, kAXChildrenAttribute) as? [AXUIElement]) ?? []
+        let rendered = children.map { renderNode($0, depth: depth + 1) }.filter { !$0.isEmpty }
+        node += ",\"children\":[" + rendered.joined(separator: ",") + "]}"
+        return node
+    }
+    out += roots.map { renderNode($0, depth: 0) }.joined(separator: ",")
+    out += "]"
+    print(out)
+
+case "axclick":
+    guard argv.count >= 3, let selector = ElementSelector(argv[2]) else { die("bad selector") }
+    let element = uniqueMatch(selector, pid: requirePID(argv[1]))
+    let result = AXUIElementPerformAction(element, kAXPressAction as CFString)
+    guard result == .success else { die("AXPress failed (\(result.rawValue))") }
+    print("ok")
+
+case "axtype":
+    guard argv.count >= 4, let selector = ElementSelector(argv[2]) else { die("bad selector") }
+    let pid = requirePID(argv[1])
+    let text = argv[3]
+    let element = uniqueMatch(selector, pid: pid)
+    let role = str(element, kAXRoleAttribute)
+    // Only text-bearing roles: typing into a button would just be a keystroke
+    // sprayed at whatever has focus.
+    guard ["AXTextField", "AXTextArea", "AXComboBox", "AXSearchField"].contains(role) else {
+        die("element role \(role) does not accept text")
+    }
+    _ = AXUIElementSetAttributeValue(element, kAXFocusedAttribute as CFString, NSNumber(value: true))
+    if AXUIElementSetAttributeValue(element, kAXValueAttribute as CFString, text as CFTypeRef) == .success {
+        print("ok")
+        break
+    }
+    // Fallback: synthesise the keystrokes. These are SYSTEM-WIDE events, so
+    // they are only posted when the app under test owns the keyboard.
+    guard NSWorkspace.shared.frontmostApplication?.processIdentifier == pid else {
+        die("AXValue was rejected and the app under test is not frontmost — refusing to synthesise keystrokes")
+    }
+    guard let source = CGEventSource(stateID: .hidSystemState),
+          let down = CGEvent(keyboardEventSource: source, virtualKey: 0, keyDown: true),
+          let up = CGEvent(keyboardEventSource: source, virtualKey: 0, keyDown: false)
+    else { die("could not create keyboard events") }
+    var utf16 = Array(text.utf16)
+    down.keyboardSetUnicodeString(stringLength: utf16.count, unicodeString: &utf16)
+    up.keyboardSetUnicodeString(stringLength: utf16.count, unicodeString: &utf16)
+    down.post(tap: .cghidEventTap)
+    up.post(tap: .cghidEventTap)
+    print("ok")
+
+case "key":
+    guard argv.count >= 3 else { die("usage: key <pid> <escape|tab|return>") }
+    let pid = requirePID(argv[1])
+    let codes: [String: CGKeyCode] = ["escape": 53, "tab": 48, "return": 36]
+    guard let code = codes[argv[2]] else { die("key not in allowlist") }
+    guard NSWorkspace.shared.frontmostApplication?.processIdentifier == pid else {
+        die("app under test is not frontmost — refusing to post a key event")
+    }
+    guard let source = CGEventSource(stateID: .hidSystemState),
+          let down = CGEvent(keyboardEventSource: source, virtualKey: code, keyDown: true),
+          let up = CGEvent(keyboardEventSource: source, virtualKey: code, keyDown: false)
+    else { die("could not create keyboard events") }
+    down.post(tap: .cghidEventTap)
+    up.post(tap: .cghidEventTap)
+    print("ok")
+
+case "termwindow":
+    guard argv.count >= 3 else { die("usage: termwindow <ownerpid> <marker>") }
+    let pid = Int(requirePID(argv[1]))
+    let marker = argv[2]
+    guard let record = cgWindows(ownedBy: pid).first(where: { $0.title.contains(marker) }) else {
+        die("no window of pid \(pid) carries marker \(marker)")
+    }
+    print("\(record.id) \(record.ownerPID)")
+
+case "termaction":
+    guard argv.count >= 4 else { die("usage: termaction <ownerpid> <marker> <focus|close>") }
+    let pid = requirePID(argv[1])
+    let marker = argv[2]
+    // The marker in the title is the proof that THIS gate opened the window;
+    // a window without it is never touched.
+    guard let window = windowsOf(pid).first(where: { str($0, kAXTitleAttribute).contains(marker) }) else {
+        die("no AX window of pid \(pid) carries marker \(marker)")
+    }
+    switch argv[3] {
+    case "focus":
+        _ = AXUIElementPerformAction(window, kAXRaiseAction as CFString)
+        _ = NSRunningApplication(processIdentifier: pid)?.activate(options: [])
+        print("ok")
+    case "close":
+        guard let rawButton = copyAttr(window, kAXCloseButtonAttribute) else {
+            die("window has no close button")
+        }
+        let button = rawButton as! AXUIElement
+        let result = AXUIElementPerformAction(button, kAXPressAction as CFString)
+        guard result == .success else { die("close failed (\(result.rawValue))") }
+        print("ok")
+    default:
+        die("unknown termaction")
+    }
+
+default:
+    die("unknown subcommand \(subcommand)")
+}
+SWIFT
+  chmod 0600 "$HELPER_PATH" 2>/dev/null || true
+}
+
+helper() {
+  write_helper
+  swift "$HELPER_PATH" "$@"
+}
+
+# ---------------------------------------------------------------------------
+# App under test — identity that survives pid reuse
+# ---------------------------------------------------------------------------
+# Every window/AX/key verb is scoped to ONE pid: the one `launch` recorded.
+# A recorded pid is only trusted when the live process still has the same
+# start time and the same executable path, so a recycled pid can never inherit
+# the gate's authority to be photographed and driven.
+
+APP_STATE="$STATE_DIR/app.state"
+APP_PID=""
+APP_BUNDLE=""
+APP_DOGFOOD="0"
+
+# Start time AND executable path. Either alone is forgeable by pid reuse:
+# a recycled pid can match the path (relaunch) or the second (another app
+# started in the same second), never both.
+process_identity() { # <pid> -> "<lstart>|<executable>"
+  local pid="$1" started executable
+  started="$(ps -p "$pid" -o lstart= 2>/dev/null)" || return 1
+  executable="$(ps -p "$pid" -o comm= 2>/dev/null)" || return 1
+  [[ -n "$started" && -n "$executable" ]] || return 1
+  printf '%s|%s\n' "$started" "$executable"
+}
+
+load_app_state() {
+  APP_PID=""
+  APP_BUNDLE=""
+  APP_DOGFOOD="0"
+  [[ -f "$APP_STATE" ]] || return 1
+  local pid bundle identity dogfood live
+  pid="$(sed -n 's/^pid=//p' "$APP_STATE" | head -n 1)"
+  bundle="$(sed -n 's/^bundle=//p' "$APP_STATE" | head -n 1)"
+  identity="$(sed -n 's/^identity=//p' "$APP_STATE" | head -n 1)"
+  dogfood="$(sed -n 's/^dogfood=//p' "$APP_STATE" | head -n 1)"
+  [[ "$pid" =~ ^[0-9]+$ ]] || return 1
+  live="$(process_identity "$pid")" || return 1
+  [[ "$live" == "$identity" ]] || return 1
+  APP_PID="$pid"
+  APP_BUNDLE="$bundle"
+  APP_DOGFOOD="${dogfood:-0}"
+}
+
+require_app_under_test() {
+  load_app_state \
+    || deny "no app under test — run \`launch <artifact>\` first"
+}
+
+# ---------------------------------------------------------------------------
+# Bundle validation
+# ---------------------------------------------------------------------------
+
+plist_value() { # <plist> <key>
+  local plist="$1" key="$2" value
+  if [[ -x /usr/libexec/PlistBuddy ]]; then
+    value="$(/usr/libexec/PlistBuddy -c "Print :$key" "$plist" 2>/dev/null)" || value=""
+    if [[ -n "$value" ]]; then
+      printf '%s\n' "$value"
+      return 0
+    fi
+  fi
+  # XML fallback (also what makes bundle validation testable off a Mac): the
+  # value element follows its <key> line.
+  awk -v want="$key" '
+    /<key>/ { k = $0; sub(/^.*<key>/, "", k); sub(/<\/key>.*$/, "", k); next }
+    k == want {
+      line = $0
+      if (line ~ /<true\/>/) { print "true"; exit }
+      if (line ~ /<false\/>/) { print "false"; exit }
+      if (line ~ /<string>/) {
+        sub(/^.*<string>/, "", line); sub(/<\/string>.*$/, "", line)
+        print line; exit
+      }
+    }
+  ' "$plist" 2>/dev/null
+}
+
+# A localvoxtral bundle and nothing else: the identifier, the executable name
+# and a real Mach-O at the expected path all have to agree. This is what stops
+# `launch` from being "start any application on the owner's Mac".
+validate_localvoxtral_bundle() { # <resolved-bundle-path>
+  local bundle="$1" plist="$1/Contents/Info.plist"
+  [[ -d "$bundle" && "$bundle" == *.app ]] || return 1
+  [[ -f "$plist" ]] || return 1
+  [[ "$(plist_value "$plist" CFBundleIdentifier)" == "com.localvoxtral.app" ]] || return 1
+  [[ "$(plist_value "$plist" CFBundleExecutable)" == "localvoxtral" ]] || return 1
+  [[ -f "$bundle/Contents/MacOS/localvoxtral" ]] || return 1
+}
+
+resolve_artifact() { # <argument> -> absolute, symlink-free path under a root
+  local argument="$1" resolved root
+  token_is_safe "$argument" || return 1
+  [[ "$argument" != *".."* ]] || return 1
+  resolved="$(cd "$argument" 2>/dev/null && pwd -P)" || return 1
+  for root in $LV_UI_ARTIFACT_ROOTS; do
+    root="$(cd "$root" 2>/dev/null && pwd -P)" || continue
+    if [[ "$resolved" == "$root"/* ]]; then
+      printf '%s\n' "$resolved"
+      return 0
+    fi
+  done
+  return 1
+}
+
+# ---------------------------------------------------------------------------
+# Verbs
+# ---------------------------------------------------------------------------
+
+json_string() {
+  local value="$1"
+  value="${value//\\/\\\\}"
+  value="${value//\"/\\\"}"
+  printf '"%s"' "$value"
+}
+
+# state — the only verb that answers while the screen is locked, because
+# "is it safe to drive right now" is exactly what it is for. Read-only.
+run_state() {
+  local lock idle power preflight accessibility screen_recording running_json terminals
+  lock="$(screen_lock_state)"
+  idle="$(ioreg -c IOHIDSystem 2>/dev/null \
+    | awk '/HIDIdleTime/ { gsub(/[^0-9]/, "", $NF); if ($NF != "") { print int($NF / 1000000000); exit } }')"
+  [[ "$idle" =~ ^[0-9]+$ ]] || idle="null"
+  case "$(pmset -g ps 2>/dev/null | head -n 1)" in
+    *"AC Power"*) power="ac" ;;
+    *"Battery Power"* | *"UPS Power"*) power="battery" ;;
+    *) power="unknown" ;;
+  esac
+  preflight="$(helper preflight 2>/dev/null || true)"
+  accessibility="$(sed -n 's/^accessibility=//p' <<<"$preflight")"
+  screen_recording="$(sed -n 's/^screen_recording=//p' <<<"$preflight")"
+  [[ "$accessibility" == "1" ]] && accessibility=true || accessibility=false
+  [[ "$screen_recording" == "1" ]] && screen_recording=true || screen_recording=false
+
+  if load_app_state; then
+    running_json="{\"running\":true,\"pid\":$APP_PID,\"bundle\":$(json_string "$APP_BUNDLE"),\"dogfood\":$([[ "$APP_DOGFOOD" == 1 ]] && echo true || echo false)}"
+  else
+    running_json='{"running":false}'
+  fi
+
+  terminals=""
+  local file id term marker pid
+  for file in "$STATE_DIR"/terms/*.state; do
+    [[ -f "$file" ]] || continue
+    id="${file##*/}"
+    id="${id%.state}"
+    term="$(sed -n 's/^terminal=//p' "$file" | head -n 1)"
+    marker="$(sed -n 's/^marker=//p' "$file" | head -n 1)"
+    pid="$(sed -n 's/^pid=//p' "$file" | head -n 1)"
+    [[ -n "$terminals" ]] && terminals+=","
+    terminals+="{\"id\":$(json_string "$id"),\"terminal\":$(json_string "$term"),\"pid\":${pid:-0},\"alive\":$(kill -0 "${pid:-0}" 2>/dev/null && echo true || echo false),\"marker\":$(json_string "$marker")}"
+  done
+
+  printf '{"screen_lock":%s,"idle_seconds":%s,"power":%s,"tcc":{"accessibility":%s,"screen_recording":%s},"app":%s,"terminals":[%s]}\n' \
+    "$(json_string "$lock")" "$idle" "$(json_string "$power")" \
+    "$accessibility" "$screen_recording" "$running_json" "$terminals"
+}
+
+# launch [--dogfood] <artifact>
+run_launch() {
+  local dogfood=0 argument="" bundle stamp pid deadline
+  while (( $# > 0 )); do
+    case "$1" in
+      --dogfood) dogfood=1 ;;
+      -*) deny "unknown launch flag" ;;
+      *)
+        [[ -z "$argument" ]] || deny "launch takes exactly one artifact"
+        argument="$1"
+        ;;
+    esac
+    shift
+  done
+  [[ -n "$argument" ]] || deny "launch needs an artifact path"
+
+  bundle="$(resolve_artifact "$argument")" \
+    || deny "artifact is not inside an allowlisted root ($LV_UI_ARTIFACT_ROOTS)"
+  validate_localvoxtral_bundle "$bundle" \
+    || deny "not a localvoxtral bundle: $bundle"
+
+  stamp="$(plist_value "$bundle/Contents/Info.plist" LVXDogfoodCapture)"
+  if (( dogfood == 1 )) && [[ "$stamp" != "true" ]]; then
+    deny "--dogfood on a bundle without the LVXDogfoodCapture stamp (got: ${stamp:-absent})"
+  fi
+
+  require_unlocked_screen
+  log_command ALLOW "bundle=$bundle dogfood=$dogfood"
+  announce_takeover "launching localvoxtral under test"
+
+  if (( dogfood == 1 )); then
+    # Same runtime opt-in try-pr.sh arms, for the same reason: a dogfood
+    # launch that cannot capture is the wrong-binary confusion in disguise.
+    defaults write com.localvoxtral.app debug.dogfood_capture_enabled -bool true >/dev/null 2>&1 || true
+  fi
+
+  open -n "$bundle" || fail "open refused the bundle"
+
+  deadline=$((SECONDS + 20))
+  while (( SECONDS < deadline )); do
+    pid="$(pgrep -n -f "^$bundle/Contents/MacOS/localvoxtral" 2>/dev/null || true)"
+    [[ -n "$pid" ]] && break
+    sleep 0.5
+  done
+  [[ -n "${pid:-}" ]] || fail "the app did not start within 20 seconds"
+
+  mkdir -p "$STATE_DIR"
+  chmod 0700 "$STATE_DIR" 2>/dev/null || true
+  {
+    printf 'pid=%s\n' "$pid"
+    printf 'bundle=%s\n' "$bundle"
+    printf 'identity=%s\n' "$(process_identity "$pid")"
+    printf 'dogfood=%s\n' "$dogfood"
+  } >"$APP_STATE"
+
+  ACTION_COMPLETED=1
+  printf 'launched pid=%s bundle=%s dogfood=%s\n' "$pid" "$bundle" "$dogfood"
+}
+
+# shot [settings|popover|overlay|window <n>] — ONE window, by CGWindowID, and
+# only if that window's owner is the pid this gate launched.
+run_shot() {
+  local kind="${1:-settings}" index="${2:-}" resolved winid owner file size
+  case "$kind" in
+    settings | popover | overlay) [[ -z "$index" ]] || deny "$kind takes no index" ;;
+    window) [[ "$index" =~ ^[1-9][0-9]{0,2}$ ]] || deny "window needs an index 1..999" ;;
+    *) deny "unknown shot target" ;;
+  esac
+  require_unlocked_screen
+  require_app_under_test
+
+  resolved="$(helper window "$APP_PID" "$kind" ${index:+"$index"} 2>/dev/null)" \
+    || fail "no $kind window owned by the app under test (pid $APP_PID)"
+  winid="${resolved%% *}"
+  owner="${resolved##* }"
+  [[ "$winid" =~ ^[0-9]+$ && "$owner" =~ ^[0-9]+$ ]] || deny "window lookup returned garbage"
+  # The invariant, re-asserted in the shell: a window whose owner is not the
+  # app under test is never captured, whatever the helper thought.
+  [[ "$owner" == "$APP_PID" ]] \
+    || deny "resolved window $winid is owned by pid $owner, not the app under test ($APP_PID)"
+
+  log_command ALLOW "window=$winid kind=$kind"
+  file="$STATE_DIR/shot.png"
+  rm -f "$file"
+  screencapture -o -x -l "$winid" "$file" || fail "screencapture failed for window $winid"
+  [[ -s "$file" ]] || fail "screencapture produced an empty file (Screen Recording grant?)"
+  size="$(wc -c <"$file" | tr -d ' ')"
+  if (( size > LV_UI_SHOT_MAX_BYTES )); then
+    rm -f "$file"
+    fail "capture is ${size} bytes, over the ${LV_UI_SHOT_MAX_BYTES} byte cap"
+  fi
+  printf 'shot: window %s (%s), %s bytes\n' "$winid" "$kind" "$size" >&2
+  base64 <"$file"
+  rm -f "$file"
+  ACTION_COMPLETED=1
+}
+
+run_ax_dump() {
+  local kind="${1:-all}" index="${2:-}"
+  case "$kind" in
+    all | settings | overlay) [[ -z "$index" ]] || deny "$kind takes no index" ;;
+    window) [[ "$index" =~ ^[1-9][0-9]{0,2}$ ]] || deny "window needs an index 1..999" ;;
+    *) deny "unknown dump pane" ;;
+  esac
+  require_unlocked_screen
+  require_app_under_test
+  log_command ALLOW "pane=$kind${index:+ index=$index}"
+  helper axdump "$APP_PID" "$kind" ${index:+"$index"} || fail "AX dump failed"
+  ACTION_COMPLETED=1
+}
+
+run_ax_click() {
+  local selector="$1"
+  validate_selector "$selector" || deny "malformed selector"
+  require_unlocked_screen
+  require_app_under_test
+  log_command ALLOW "selector=$selector"
+  announce_takeover "clicking in localvoxtral"
+  helper axclick "$APP_PID" "$selector" || fail "AX click failed"
+  ACTION_COMPLETED=1
+}
+
+run_ax_type() {
+  local selector="$1" text="$2"
+  validate_selector "$selector" || deny "malformed selector"
+  validate_typed_text "$text" || deny "malformed text"
+  require_unlocked_screen
+  require_app_under_test
+  log_command ALLOW "selector=$selector"
+  announce_takeover "typing into localvoxtral"
+  helper axtype "$APP_PID" "$selector" "$text" || fail "AX type failed"
+  ACTION_COMPLETED=1
+}
+
+run_key() {
+  local name="$1"
+  case "$name" in
+    escape | tab | return) ;;
+    *) deny "key not in allowlist" ;;
+  esac
+  require_unlocked_screen
+  require_app_under_test
+  log_command ALLOW "key=$name"
+  announce_takeover "sending $name to localvoxtral"
+  helper key "$APP_PID" "$name" || fail "key event refused (is the app under test frontmost?)"
+  ACTION_COMPLETED=1
+}
+
+run_quit() {
+  require_app_under_test
+  log_command ALLOW "pid=$APP_PID"
+  kill -TERM "$APP_PID" 2>/dev/null || true
+  local deadline=$((SECONDS + 10))
+  while (( SECONDS < deadline )); do
+    kill -0 "$APP_PID" 2>/dev/null || break
+    sleep 0.5
+  done
+  if kill -0 "$APP_PID" 2>/dev/null; then
+    kill -KILL "$APP_PID" 2>/dev/null || true
+  fi
+  rm -f "$APP_STATE"
+  ACTION_COMPLETED=1
+  printf 'quit pid=%s\n' "$APP_PID"
+}
+
+# ---------------------------------------------------------------------------
+# Terminal verbs
+# ---------------------------------------------------------------------------
+
+terminal_app_name() {
+  case "$1" in
+    ghostty) printf 'Ghostty\n' ;;
+    iterm) printf 'iTerm\n' ;;
+    terminal) printf 'Terminal\n' ;;
+    *) return 1 ;;
+  esac
+}
+
+terminal_process_name() {
+  case "$1" in
+    ghostty) printf 'ghostty\n' ;;
+    iterm) printf 'iTerm2\n' ;;
+    terminal) printf 'Terminal\n' ;;
+    *) return 1 ;;
+  esac
+}
+
+next_term_id() {
+  local counter_file="$STATE_DIR/terms/counter" n=0
+  mkdir -p "$STATE_DIR/terms"
+  [[ -f "$counter_file" ]] && n="$(cat "$counter_file" 2>/dev/null || echo 0)"
+  [[ "$n" =~ ^[0-9]+$ ]] || n=0
+  n=$((n + 1))
+  printf '%s\n' "$n" >"$counter_file"
+  printf 'term-%s\n' "$n"
+}
+
+# term open <terminal> <command> [args...]
+#
+# The widest surface in this gate, and the reason the command allowlist above
+# is deliberately short. The command never reaches a shell as a string: every
+# token has already passed token_is_safe, and the launcher script below is
+# built with %q quoting, so a token is always one argv element.
+run_term_open() {
+  local terminal="$1"
+  shift
+  local -a argv=("$@")
+  list_contains "$terminal" "$LV_UI_TERMINALS" || deny "terminal not allowlisted"
+  (( ${#argv[@]} >= 1 )) || deny "term open needs a command"
+  (( ${#argv[@]} <= LV_UI_MAX_TERM_ARGS )) || deny "term open takes at most $LV_UI_MAX_TERM_ARGS tokens"
+  list_contains "${argv[0]}" "$LV_UI_TERM_COMMANDS" || deny "command not allowlisted: ${argv[0]}"
+  local token
+  for token in "${argv[@]}"; do
+    token_is_safe "$token" || deny "unsafe token in term command"
+  done
+
+  require_unlocked_screen
+  # Logged IN FULL: this is the one verb that carries a command line.
+  log_command ALLOW "terminal=$terminal command=${argv[*]}"
+
+  local id marker script app
+  id="$(next_term_id)"
+  marker="lvui-$id-$RANDOM$RANDOM"
+  app="$(terminal_app_name "$terminal")"
+  mkdir -p "$STATE_DIR/terms"
+  script="$STATE_DIR/terms/$marker.command"
+  {
+    printf '#!/bin/sh\n'
+    # OSC 0 title: how focus/close later prove this window is ours. Terminal
+    # and iTerm also show the script's file name, which carries the marker.
+    printf 'printf %s "%s"\n' "'\\033]0;%s\\007'" "$marker"
+    printf 'exec'
+    printf ' %q' "${argv[@]}"
+    printf '\n'
+  } >"$script"
+  chmod 0700 "$script"
+
+  announce_takeover "opening a $terminal window"
+  case "$terminal" in
+    ghostty) open -n -a "$app" --args -e "$script" || fail "could not open $app" ;;
+    *) open -a "$app" "$script" || fail "could not open $app" ;;
+  esac
+
+  local pid deadline resolved winid owner=""
+  deadline=$((SECONDS + 20))
+  while (( SECONDS < deadline )); do
+    pid="$(pgrep -n -x "$(terminal_process_name "$terminal")" 2>/dev/null || true)"
+    if [[ -n "$pid" ]]; then
+      resolved="$(helper termwindow "$pid" "$marker" 2>/dev/null || true)"
+      if [[ -n "$resolved" ]]; then
+        winid="${resolved%% *}"
+        owner="${resolved##* }"
+        break
+      fi
+    fi
+    sleep 0.5
+  done
+  if [[ -z "$owner" ]]; then
+    fail "opened $app but never saw a window carrying marker $marker"
+  fi
+
+  {
+    printf 'terminal=%s\n' "$terminal"
+    printf 'pid=%s\n' "$owner"
+    printf 'window=%s\n' "$winid"
+    printf 'marker=%s\n' "$marker"
+    printf 'command=%s\n' "${argv[*]}"
+  } >"$STATE_DIR/terms/$id.state"
+
+  ACTION_COMPLETED=1
+  printf 'opened %s terminal=%s pid=%s window=%s\n' "$id" "$terminal" "$owner" "$winid"
+}
+
+load_term_state() { # <id>
+  local id="$1" file
+  [[ "$id" =~ ^term-[0-9]+$ ]] || deny "malformed terminal id"
+  file="$STATE_DIR/terms/$id.state"
+  [[ -f "$file" ]] || deny "unknown terminal id $id — this gate did not open it"
+  TERM_PID="$(sed -n 's/^pid=//p' "$file" | head -n 1)"
+  TERM_MARKER="$(sed -n 's/^marker=//p' "$file" | head -n 1)"
+  TERM_KIND="$(sed -n 's/^terminal=//p' "$file" | head -n 1)"
+  [[ "$TERM_PID" =~ ^[0-9]+$ && -n "$TERM_MARKER" ]] || deny "corrupt terminal state for $id"
+  kill -0 "$TERM_PID" 2>/dev/null || deny "$id's terminal process is gone"
+}
+
+run_term_focus() {
+  local id="$1"
+  require_unlocked_screen
+  load_term_state "$id"
+  log_command ALLOW "id=$id pid=$TERM_PID"
+  announce_takeover "focusing $TERM_KIND window $id"
+  helper termaction "$TERM_PID" "$TERM_MARKER" focus || fail "could not focus $id"
+  ACTION_COMPLETED=1
+  printf 'focused %s\n' "$id"
+}
+
+run_term_close() {
+  local id="$1"
+  require_unlocked_screen
+  load_term_state "$id"
+  log_command ALLOW "id=$id pid=$TERM_PID"
+  helper termaction "$TERM_PID" "$TERM_MARKER" close || fail "could not close $id"
+  rm -f "$STATE_DIR/terms/$id.state" "$STATE_DIR/terms/$TERM_MARKER.command"
+  ACTION_COMPLETED=1
+  printf 'closed %s\n' "$id"
+}
+
+# ---------------------------------------------------------------------------
+# Dispatch — deny by default
+# ---------------------------------------------------------------------------
+
+# Shell regression tests source the reviewed implementation directly; the
+# variable cannot cross the forced-command SSH boundary, where sshd fixes the
+# environment (keep AcceptEnv at its default — see scripts/mac/README.md).
+if [[ "${LOCALVOXTRAL_UI_GATE_SOURCE_ONLY:-0}" == "1" ]]; then
+  if [[ "${BASH_SOURCE[0]}" != "$0" ]]; then
+    return 0
+  fi
+  exit 0
+fi
+
+# Reject the whole command before it is split: no newlines (only the first
+# line would ever be parsed), no control characters, bounded length.
+[[ -n "$original_command" ]] || deny "empty command"
+(( ${#original_command} <= LV_UI_MAX_COMMAND_BYTES )) || deny "command too long"
+[[ "$original_command" =~ ^[[:print:]]+$ ]] || deny "non-printable byte in command"
+
+read -r -a ARGV <<<"$original_command"
+(( ${#ARGV[@]} >= 1 )) || deny "empty command"
+
+# Every token except `ax type`'s free text must survive the charset. The text
+# is validated separately (validate_typed_text) because API keys and URLs need
+# characters no other verb may carry.
+if [[ "${ARGV[0]} ${ARGV[1]:-}" != "ax type" ]]; then
+  for token in "${ARGV[@]}"; do
+    token_is_safe "$token" || deny "unsafe token: $token"
+  done
+fi
+
+case "${ARGV[0]}" in
+  state)
+    (( ${#ARGV[@]} == 1 )) || deny "state takes no arguments"
+    log_command ALLOW
+    run_state
+    ;;
+  launch)
+    (( ${#ARGV[@]} >= 2 )) || deny "launch needs an artifact"
+    run_launch "${ARGV[@]:1}"
+    ;;
+  shot)
+    # Bash 3.2 (the Mac's /bin/bash) treats an empty "${a[@]:1}" as unbound
+    # under set -u, so the no-argument form is dispatched explicitly.
+    (( ${#ARGV[@]} <= 3 )) || deny "too many arguments for shot"
+    if (( ${#ARGV[@]} == 1 )); then run_shot; else run_shot "${ARGV[@]:1}"; fi
+    ;;
+  key)
+    (( ${#ARGV[@]} == 2 )) || deny "key takes exactly one name"
+    run_key "${ARGV[1]}"
+    ;;
+  quit)
+    (( ${#ARGV[@]} == 1 )) || deny "quit takes no arguments"
+    run_quit
+    ;;
+  ax)
+    case "${ARGV[1]:-}" in
+      dump)
+        (( ${#ARGV[@]} <= 4 )) || deny "too many arguments for ax dump"
+        if (( ${#ARGV[@]} == 2 )); then run_ax_dump; else run_ax_dump "${ARGV[@]:2}"; fi
+        ;;
+      click)
+        (( ${#ARGV[@]} == 3 )) || deny "ax click takes exactly one selector"
+        run_ax_click "${ARGV[2]}"
+        ;;
+      type)
+        # `ax type <selector> -- <text>`: the separator is mandatory so the
+        # selector can never absorb text, or the text a selector.
+        (( ${#ARGV[@]} >= 5 )) || deny "ax type needs a selector, --, and text"
+        [[ "${ARGV[3]}" == "--" ]] || deny "ax type needs -- before the text"
+        token_is_safe "${ARGV[2]}" || deny "unsafe selector token"
+        [[ "$original_command" == *" -- "* ]] || deny "ax type needs -- before the text"
+        run_ax_type "${ARGV[2]}" "${original_command#* -- }"
+        ;;
+      *)
+        deny "unknown ax subverb"
+        ;;
+    esac
+    ;;
+  term)
+    case "${ARGV[1]:-}" in
+      open)
+        (( ${#ARGV[@]} >= 4 )) || deny "term open needs a terminal and a command"
+        run_term_open "${ARGV[@]:2}"
+        ;;
+      focus)
+        (( ${#ARGV[@]} == 3 )) || deny "term focus takes exactly one id"
+        run_term_focus "${ARGV[2]}"
+        ;;
+      close)
+        (( ${#ARGV[@]} == 3 )) || deny "term close takes exactly one id"
+        run_term_close "${ARGV[2]}"
+        ;;
+      *)
+        deny "unknown term subverb"
+        ;;
+    esac
+    ;;
+  *)
+    deny
+    ;;
+esac

--- a/scripts/mac/localvoxtral-ui-gate.sh
+++ b/scripts/mac/localvoxtral-ui-gate.sh
@@ -702,16 +702,17 @@ plist_value() { # <plist> <key>
   ' "$plist" 2>/dev/null
 }
 
-# A localvoxtral bundle and nothing else: the identifier, the executable name
-# and a real Mach-O at the expected path all have to agree. This is what stops
-# `launch` from being "start any application on the owner's Mac".
+# A localvoxtral bundle and nothing else: the identifier, the declared
+# executable name and an executable at the path that name implies all have to
+# agree. This is what stops `launch` from being "start any application on the
+# owner's Mac".
 validate_localvoxtral_bundle() { # <resolved-bundle-path>
   local bundle="$1" plist="$1/Contents/Info.plist"
   [[ -d "$bundle" && "$bundle" == *.app ]] || return 1
   [[ -f "$plist" ]] || return 1
   [[ "$(plist_value "$plist" CFBundleIdentifier)" == "com.localvoxtral.app" ]] || return 1
   [[ "$(plist_value "$plist" CFBundleExecutable)" == "localvoxtral" ]] || return 1
-  [[ -f "$bundle/Contents/MacOS/localvoxtral" ]] || return 1
+  [[ -x "$bundle/Contents/MacOS/localvoxtral" ]] || return 1
 }
 
 resolve_artifact() { # <argument> -> absolute, symlink-free path under a root
@@ -808,6 +809,12 @@ run_launch() {
   stamp="$(plist_value "$bundle/Contents/Info.plist" LVXDogfoodCapture)"
   if (( dogfood == 1 )) && [[ "$stamp" != "true" ]]; then
     deny "--dogfood on a bundle without the LVXDogfoodCapture stamp (got: ${stamp:-absent})"
+  fi
+
+  # Refuse to start a second instance: it would orphan the recorded pid (two
+  # menu bar icons, two hotkey owners) and silently retarget every later verb.
+  if load_app_state; then
+    deny "pid $APP_PID is already under test — quit it first"
   fi
 
   require_unlocked_screen

--- a/scripts/mac/localvoxtral-ui-gate.sh
+++ b/scripts/mac/localvoxtral-ui-gate.sh
@@ -41,6 +41,10 @@ set -euo pipefail
 #     app under test is frontmost — it activates that app first and refuses if
 #     the activation did not take, so a keystroke never lands in whatever the
 #     owner last touched.
+#   - `menu open` / `menu click` / `menu dismiss` reach the status item of
+#     that same pid, through AXUIElementCreateApplication(<it>). They exist
+#     because localvoxtral opens no window at launch — without them every verb
+#     above has nothing to address. No other app's menu bar is expressible.
 #   - `term focus` / `term close` act only on a window this gate opened,
 #     identified by a random marker it put in that window's title.
 #
@@ -57,9 +61,10 @@ set -euo pipefail
 # It refuses everything GUI-touching while the screen is locked (shared probe:
 # scripts/ci/screen-lock-state.sh, fail CLOSED here), and honours the owner's
 # takeover rule: any verb that steals focus (launch, ax click, ax type, key,
-# term open, term focus) speaks a warning, waits, and announces completion.
-# `state`, `shot`, `ax dump`, `quit` and `term close` do not warn: none of them
-# takes the keyboard or raises a window in front of what the owner is doing.
+# menu open, menu click, term open, term focus) speaks a warning, waits, and
+# announces completion. `state`, `shot`, `ax dump`, `menu dismiss`, `quit` and
+# `term close` do not warn: none of them takes the keyboard or raises a window
+# in front of what the owner is doing.
 #
 # Verbs (each documented at its run_* function):
 #   state
@@ -69,6 +74,7 @@ set -euo pipefail
 #   ax click <selector>
 #   ax type <selector> -- <text>
 #   key <escape|tab|return>
+#   menu <open|click <item-title>|dismiss>
 #   quit
 #   term open <ghostty|iterm|terminal> <command> [args...]
 #   term focus <id>
@@ -234,6 +240,17 @@ validate_selector() {
   (( matchable == 1 ))
 }
 
+# A menu item title arrives as ONE token in the charset above, `+` for a space
+# (`menu click Show+Log`). Real titles routinely carry characters that charset
+# cannot express — localvoxtral's is "Settings…" — which is why the helper
+# matches by containment with an exact title winning: `menu click Settings` is
+# how you reach it, and an ambiguous substring is refused, not guessed at.
+validate_menu_title() {
+  local title="$1"
+  token_is_safe "$title" || return 1
+  (( ${#title} >= 1 && ${#title} <= 128 ))
+}
+
 # Typed text is the one place a wider charset is allowed: it never reaches a
 # shell (the Swift helper receives it as argv) and API keys/URLs need it.
 validate_typed_text() {
@@ -343,6 +360,9 @@ import Foundation
 //   axclick <pid> <selector>
 //   axtype <pid> <selector> <text>
 //   key <pid> <escape|tab|return>
+//   menuopen <pid>
+//   menuclick <pid> <item-title>
+//   menudismiss <pid>
 //   termwindow <ownerpid> <marker>                           -> "<winid> <ownerpid>"
 //   termaction <ownerpid> <marker> <focus|close>
 
@@ -519,6 +539,42 @@ func requirePID(_ raw: String) -> pid_t {
     return pid
 }
 
+// MARK: - The status item
+//
+// localvoxtral is a menu bar app: it opens NO window at launch, so every
+// window verb above has nothing to address until its status item is clicked.
+// This is that click, and it stays inside the same boundary as everything
+// else — the element is reached from AXUIElementCreateApplication(<the pid
+// `launch` recorded>), so no other application's menu bar is expressible here.
+//
+// AX rather than System Events/AppleScript on purpose: the AX route needs only
+// the Accessibility grant sshd already holds, while an Apple event to System
+// Events would need a separate Automation grant whose consent sheet cannot be
+// answered over SSH.
+func extrasMenuBarItem(_ pid: pid_t) -> AXUIElement {
+    let app = AXUIElementCreateApplication(pid)
+    // Pressing a status item blocks the AX server for as long as the menu
+    // tracks — the same reason capture-readme-assets.sh wraps its AppleScript
+    // in `ignoring application responses`. Bound the wait instead of hanging
+    // the SSH session. This is safe only because the press is verified
+    // afterwards by looking for the menu: a timeout is never read as success.
+    _ = AXUIElementSetMessagingTimeout(app, 2.0)
+    guard let bar = copyAttr(app, "AXExtrasMenuBar") else {
+        die("pid \(pid) exposes no status item (AXExtrasMenuBar)")
+    }
+    let items = (copyAttr(bar as! AXUIElement, kAXChildrenAttribute) as? [AXUIElement]) ?? []
+    guard let item = items.first else { die("pid \(pid) has an empty status menu bar") }
+    return item
+}
+
+func openMenu(of item: AXUIElement) -> AXUIElement? {
+    for child in (copyAttr(item, kAXChildrenAttribute) as? [AXUIElement]) ?? []
+    where str(child, kAXRoleAttribute) == "AXMenu" {
+        return child
+    }
+    return nil
+}
+
 // Bring one pid frontmost and give the activation up to two seconds to land.
 // Callers still re-check afterwards — this only asks.
 func activateAndWait(_ pid: pid_t) {
@@ -649,6 +705,71 @@ case "key":
     else { die("could not create keyboard events") }
     down.post(tap: .cghidEventTap)
     up.post(tap: .cghidEventTap)
+    print("ok")
+
+case "menuopen":
+    guard argv.count >= 2 else { die("usage: menuopen <pid>") }
+    let item = extrasMenuBarItem(requirePID(argv[1]))
+    if openMenu(of: item) != nil {
+        print("ok already-open")
+        break
+    }
+    _ = AXUIElementPerformAction(item, kAXPressAction as CFString)
+    // The press's own status is not the answer — it reports .cannotComplete
+    // while the menu tracks. The menu's existence is the answer.
+    let menuDeadline = Date().addingTimeInterval(3)
+    while Date() < menuDeadline {
+        if openMenu(of: item) != nil {
+            print("ok")
+            exit(0)
+        }
+        usleep(150_000)
+    }
+    die("the status item was pressed but no menu opened")
+
+case "menuclick":
+    guard argv.count >= 3 else { die("usage: menuclick <pid> <item-title>") }
+    let wanted = argv[2].replacingOccurrences(of: "+", with: " ")
+    guard let menu = openMenu(of: extrasMenuBarItem(requirePID(argv[1]))) else {
+        die("no status menu is open — run `menu open` first")
+    }
+    let entries = ((copyAttr(menu, kAXChildrenAttribute) as? [AXUIElement]) ?? [])
+        .filter { !str($0, kAXTitleAttribute).isEmpty }
+    // Menu titles carry characters the gate's token charset cannot express
+    // (localvoxtral's is "Settings…"), so the argument is matched by
+    // containment. An exact title still wins, so "Save" is never ambiguous
+    // with "Save As…"; beyond that, ambiguity is refused rather than guessed
+    // at — the same rule the element selector applies.
+    var menuMatches = entries.filter { str($0, kAXTitleAttribute) == wanted }
+    if menuMatches.isEmpty {
+        menuMatches = entries.filter { str($0, kAXTitleAttribute).contains(wanted) }
+    }
+    guard !menuMatches.isEmpty else {
+        die("no menu item matches \"\(wanted)\"; the menu holds: "
+            + entries.map { str($0, kAXTitleAttribute) }.joined(separator: " | "))
+    }
+    guard menuMatches.count == 1 else {
+        die("\(menuMatches.count) menu items contain \"\(wanted)\" — name more of the title")
+    }
+    let pressResult = AXUIElementPerformAction(menuMatches[0], kAXPressAction as CFString)
+    guard pressResult == .success else { die("AXPress on the menu item failed (\(pressResult.rawValue))") }
+    print("ok")
+
+case "menudismiss":
+    guard argv.count >= 2 else { die("usage: menudismiss <pid>") }
+    let dismissItem = extrasMenuBarItem(requirePID(argv[1]))
+    guard let openMenuElement = openMenu(of: dismissItem) else {
+        print("ok no-menu-open")
+        break
+    }
+    // AXCancel on the app's own menu, not a synthesised Escape: a keystroke
+    // goes to whatever owns the keyboard, and closing a menu never has to.
+    if AXUIElementPerformAction(openMenuElement, kAXCancelAction as CFString) == .success {
+        print("ok")
+        break
+    }
+    // Fall back to toggling the status item shut — still the app's own element.
+    _ = AXUIElementPerformAction(dismissItem, kAXPressAction as CFString)
     print("ok")
 
 case "termwindow":
@@ -872,7 +993,7 @@ run_state() {
 
 # launch [--dogfood] <artifact>
 run_launch() {
-  local dogfood=0 argument="" bundle stamp pid deadline
+  local dogfood=0 argument="" bundle stamp pid deadline foreign
   while (( $# > 0 )); do
     case "$1" in
       --dogfood) dogfood=1 ;;
@@ -900,6 +1021,19 @@ run_launch() {
   # menu bar icons, two hotkey owners) and silently retarget every later verb.
   if load_app_state; then
     deny "pid $APP_PID is already under test — quit it first"
+  fi
+
+  # A localvoxtral this gate did NOT start is the same conflict wearing a
+  # different hat, and the gate cannot quit it (no recorded identity) or
+  # address it (every other verb reads app.state). Two instances re-register
+  # the global hotkey and fight over the speechd/polishd ports 8471/8472, and
+  # the owner's daily driver is exactly what is running on this machine — on
+  # 2026-08-29 `launch` would have started a second one beside pid 91687 and
+  # only the operator noticing prevented it. So: refuse, and name the pid.
+  foreign="$(pgrep -x localvoxtral 2>/dev/null | tr '\n' ' ' || true)"
+  foreign="${foreign% }"
+  if [[ -n "$foreign" ]]; then
+    deny "localvoxtral is already running (pid $foreign) and this gate did not start it — quit it first (its menu bar item, or kill $foreign)"
   fi
 
   require_unlocked_screen
@@ -1025,6 +1159,44 @@ run_key() {
   log_command ALLOW "key=$name"
   announce_takeover "sending $name to localvoxtral"
   helper key "$APP_PID" "$name" || fail "key event refused (is the app under test frontmost?)"
+  ACTION_COMPLETED=1
+}
+
+# menu open | menu click <item-title> | menu dismiss
+#
+# The verb that makes every other verb reachable. localvoxtral opens no window
+# at launch, so until the status item is clicked `shot`, `ax dump`, `ax click`,
+# `ax type` and `key` all correctly report that there is nothing to address
+# (field check, 2026-08-29: `launch` succeeded, `ax dump all` returned `[]`,
+# and every UI verb was unusable). Scoped exactly like the others: the pid is
+# the one `launch` recorded, and the AX element is that app's own status item.
+run_menu_open() {
+  require_unlocked_screen
+  require_app_under_test
+  log_command ALLOW "menu=open pid=$APP_PID"
+  announce_takeover "opening the localvoxtral status menu"
+  helper menuopen "$APP_PID" || fail "the status menu did not open"
+  ACTION_COMPLETED=1
+}
+
+run_menu_click() {
+  local title="$1"
+  validate_menu_title "$title" || deny "malformed menu item title"
+  require_unlocked_screen
+  require_app_under_test
+  log_command ALLOW "menu=click item=$title"
+  announce_takeover "clicking $title in the localvoxtral status menu"
+  helper menuclick "$APP_PID" "$title" || fail "menu item click failed"
+  ACTION_COMPLETED=1
+}
+
+# No takeover warning, for the same reason `quit` has none: closing a menu
+# takes nothing from the owner — it gives the screen back.
+run_menu_dismiss() {
+  require_unlocked_screen
+  require_app_under_test
+  log_command ALLOW "menu=dismiss pid=$APP_PID"
+  helper menudismiss "$APP_PID" || fail "could not dismiss the status menu"
   ACTION_COMPLETED=1
 }
 
@@ -1250,6 +1422,25 @@ case "${ARGV[0]}" in
   quit)
     (( ${#ARGV[@]} == 1 )) || deny "quit takes no arguments"
     run_quit
+    ;;
+  menu)
+    case "${ARGV[1]:-}" in
+      open)
+        (( ${#ARGV[@]} == 2 )) || deny "menu open takes no arguments"
+        run_menu_open
+        ;;
+      click)
+        (( ${#ARGV[@]} == 3 )) || deny "menu click takes exactly one item title"
+        run_menu_click "${ARGV[2]}"
+        ;;
+      dismiss)
+        (( ${#ARGV[@]} == 2 )) || deny "menu dismiss takes no arguments"
+        run_menu_dismiss
+        ;;
+      *)
+        deny "unknown menu subverb"
+        ;;
+    esac
     ;;
   ax)
     case "${ARGV[1]:-}" in

--- a/scripts/mac/localvoxtral-ui-gate.sh
+++ b/scripts/mac/localvoxtral-ui-gate.sh
@@ -45,6 +45,13 @@ set -euo pipefail
 #     that same pid, through AXUIElementCreateApplication(<it>). They exist
 #     because localvoxtral opens no window at launch — without them every verb
 #     above has nothing to address. No other app's menu bar is expressible.
+#   - `dictate` posts the app's OWN configured trigger — read from the app's
+#     defaults, never hard-coded — as a modifier-only gesture at the HID tap.
+#     It is the one verb that does not target a window, because the trigger is
+#     global by design and the dictation grounds itself in whatever is FOCUSED;
+#     activating localvoxtral first would defeat the thing under test. It
+#     refuses unless the app is running, its modifier trigger is enabled in its
+#     own settings, and Secure Keyboard Entry is not held.
 #   - `term focus` / `term close` act only on a window this gate opened,
 #     identified by a random marker it put in that window's title.
 #
@@ -60,11 +67,12 @@ set -euo pipefail
 #
 # It refuses everything GUI-touching while the screen is locked (shared probe:
 # scripts/ci/screen-lock-state.sh, fail CLOSED here), and honours the owner's
-# takeover rule: any verb that steals focus (launch, ax click, ax type, key,
-# menu open, menu click, term open, term focus) speaks a warning, waits, and
-# announces completion. `state`, `shot`, `ax dump`, `menu dismiss`, `quit` and
-# `term close` do not warn: none of them takes the keyboard or raises a window
-# in front of what the owner is doing.
+# takeover rule: any verb that steals focus or takes input (launch, ax click,
+# ax type, key, menu open, menu click, dictate tap/hold, term open, term focus)
+# speaks a warning, waits, and announces completion. `state`, `shot`,
+# `ax dump`, `menu dismiss`, `dictate cancel`, `quit` and `term close` do not
+# warn: none of them takes the keyboard or raises a window in front of what the
+# owner is doing.
 #
 # Verbs (each documented at its run_* function):
 #   state
@@ -75,6 +83,7 @@ set -euo pipefail
 #   ax type <selector> -- <text>
 #   key <escape|tab|return>
 #   menu <open|click <item-title>|dismiss>
+#   dictate <tap|hold <seconds>|cancel>
 #   quit
 #   term open <ghostty|iterm|terminal> <command> [args...]
 #   term focus <id>
@@ -133,6 +142,11 @@ LV_UI_WARN_SLEEP_SECONDS="${LV_UI_WARN_SLEEP_SECONDS:-3}"
 # A window PNG is a few hundred KB; the cap exists so a pathological capture
 # cannot dump tens of MB into an agent transcript.
 LV_UI_SHOT_MAX_BYTES="${LV_UI_SHOT_MAX_BYTES:-8388608}"
+
+# `dictate hold` holds a real modifier down for this long at most. The SSH
+# command blocks for the duration, and a modifier left latched is the owner's
+# problem for the rest of the session, so it is bounded.
+LV_UI_MAX_HOLD_SECONDS="${LV_UI_MAX_HOLD_SECONDS:-30}"
 
 LV_UI_MAX_COMMAND_BYTES="${LV_UI_MAX_COMMAND_BYTES:-2048}"
 LV_UI_MAX_TEXT_BYTES="${LV_UI_MAX_TEXT_BYTES:-512}"
@@ -350,6 +364,7 @@ write_helper() {
   cat >"$HELPER_PATH" <<'SWIFT'
 import AppKit
 import ApplicationServices
+import Carbon.HIToolbox
 import CoreGraphics
 import Foundation
 
@@ -363,6 +378,7 @@ import Foundation
 //   menuopen <pid>
 //   menuclick <pid> <item-title>
 //   menudismiss <pid>
+//   dictate <pid> <fn|right_command|right_option> <tap|hold|cancel> [seconds]
 //   termwindow <ownerpid> <marker>                           -> "<winid> <ownerpid>"
 //   termaction <ownerpid> <marker> <focus|close>
 
@@ -771,6 +787,90 @@ case "menudismiss":
     // Fall back to toggling the status item shut — still the app's own element.
     _ = AXUIElementPerformAction(dismissItem, kAXPressAction as CFString)
     print("ok")
+
+case "dictate":
+    guard argv.count >= 4 else { die("usage: dictate <pid> <modifier> <tap|hold|cancel> [seconds]") }
+    let dictatePID = requirePID(argv[1])
+    guard NSRunningApplication(processIdentifier: dictatePID) != nil else {
+        die("the app under test (pid \(dictatePID)) is not running")
+    }
+    // Secure Keyboard Entry discards synthesised input outright — a locked
+    // screen, a password field, or a terminal with the setting on. Without
+    // this check the verb's failure shape is a silent no-op, which is the
+    // worst one to debug (record-demo.sh checks the same thing before its
+    // live-dictation beat).
+    if IsSecureEventInputEnabled() {
+        die("Secure Keyboard Entry is held by some process — synthesised input would be discarded")
+    }
+    let gesture = argv[3]
+    if gesture == "cancel" {
+        // The app registers a Carbon hotkey on plain Escape for the duration
+        // of a dictation and consumes it system-wide, so cancelling needs
+        // neither the trigger modifier nor a frontmost app.
+        guard let cancelSource = CGEventSource(stateID: .hidSystemState),
+              let escDown = CGEvent(keyboardEventSource: cancelSource, virtualKey: 53, keyDown: true),
+              let escUp = CGEvent(keyboardEventSource: cancelSource, virtualKey: 53, keyDown: false)
+        else { die("could not create keyboard events") }
+        escDown.post(tap: .cghidEventTap)
+        escUp.post(tap: .cghidEventTap)
+        print("ok cancel")
+        break
+    }
+    // The trigger is a modifier-ONLY gesture: a keyboard event whose type is
+    // overridden to .flagsChanged and which carries that modifier's flag mask.
+    // A plain keyDown never reaches the app's handleFlagsChanged and does
+    // nothing at all. This is the shape scripts/record-demo.sh has driven on
+    // this machine since the demo recording.
+    let triggers: [String: (CGKeyCode, CGEventFlags)] = [
+        "fn": (CGKeyCode(kVK_Function), .maskSecondaryFn),
+        "right_command": (CGKeyCode(kVK_RightCommand), .maskCommand),
+        "right_option": (CGKeyCode(kVK_RightOption), .maskAlternate),
+    ]
+    guard let trigger = triggers[argv[2]] else { die("unknown trigger modifier \(argv[2])") }
+    func postTrigger(down: Bool) {
+        guard let event = CGEvent(keyboardEventSource: nil, virtualKey: trigger.0, keyDown: down) else {
+            die("could not create the trigger event")
+        }
+        event.type = .flagsChanged
+        event.flags = down ? trigger.1 : []
+        event.post(tap: .cghidEventTap)
+    }
+    // A hold holds a real modifier down for seconds. If this process is killed
+    // in between — a dropped SSH connection is the ordinary case — the flag
+    // stays latched across the owner's entire session. Release it on the way
+    // out rather than leaving that behind.
+    var signalSources: [DispatchSourceSignal] = []
+    for interrupting in [SIGTERM, SIGINT, SIGHUP] {
+        signal(interrupting, SIG_IGN)
+        let source = DispatchSource.makeSignalSource(signal: interrupting, queue: .global())
+        source.setEventHandler {
+            postTrigger(down: false)
+            exit(1)
+        }
+        source.resume()
+        signalSources.append(source)
+    }
+    switch gesture {
+    case "tap":
+        postTrigger(down: true)
+        Thread.sleep(forTimeInterval: 0.08)
+        postTrigger(down: false)
+    case "hold":
+        guard argv.count >= 5, let seconds = Double(argv[4]), seconds > 0, seconds <= 60 else {
+            die("hold needs a duration in seconds (0 < s <= 60)")
+        }
+        postTrigger(down: true)
+        Thread.sleep(forTimeInterval: seconds)
+        postTrigger(down: false)
+    default:
+        die("unknown gesture \(gesture)")
+    }
+    // Where the dictation actually landed. The trigger is global by design and
+    // the session grounds itself in whatever is focused, so this is the single
+    // most useful thing to report back.
+    let front = NSWorkspace.shared.frontmostApplication
+    let frontName = (front?.localizedName ?? "?").replacingOccurrences(of: "\n", with: " ")
+    print("ok \(gesture) trigger=\(argv[2]) frontmost=\(front?.processIdentifier ?? -1) (\(frontName))")
 
 case "termwindow":
     guard argv.count >= 3 else { die("usage: termwindow <ownerpid> <marker>") }
@@ -1200,6 +1300,96 @@ run_menu_dismiss() {
   ACTION_COMPLETED=1
 }
 
+# dictate tap | dictate hold <seconds> | dictate cancel
+#
+# The gate exists to debug the Claude Code / herdr session join, and that join
+# resolves when a dictation STARTS — but nothing else here can start one.
+# `key`'s allowlist is escape/tab/return and the app's trigger is a
+# modifier-only GESTURE, so without this verb the thing under test cannot be
+# exercised at all.
+#
+# It posts the app's OWN configured trigger, read from the app's defaults
+# rather than hard-coded, at the HID tap — the path scripts/record-demo.sh has
+# driven on this machine since the demo recording. The app detects it with an
+# NSEvent .flagsChanged monitor and filters nothing, so this is the real
+# gesture path, not a side door.
+#
+# It deliberately does NOT bring localvoxtral frontmost, and that is a
+# decision, not an oversight: the modifier trigger is global by design and the
+# session grounds its context in whatever IS focused — a terminal running
+# Claude Code. Activating localvoxtral first would make every session resolve
+# against the wrong surface, which is the exact thing under test. What stands
+# in for the frontmost check is stricter about the only real hazard, a stray
+# modifier landing in the owner's window: the app must be running AND its
+# modifier-only trigger must be enabled in its own settings AND Secure
+# Keyboard Entry must not be held; the frontmost app is then named in the
+# result and the log so the operator knows where the dictation went.
+
+app_default() { # <key> -> the app's stored value, empty when unset
+  defaults read com.localvoxtral.app "$1" 2>/dev/null || true
+}
+
+TRIGGER_MODIFIER=""
+TRIGGER_HOLD_DELAY=""
+
+# Read, never assume. A guess about which key to press is a modifier posted
+# into whatever the owner is doing.
+resolve_dictation_trigger() {
+  local enabled modifier delay
+  enabled="$(app_default settings.modifier_only_hotkey_enabled)"
+  [[ -n "$enabled" ]] \
+    || deny "cannot read com.localvoxtral.app's trigger settings — refusing to guess which key to press"
+  [[ "$enabled" == "1" ]] \
+    || deny "the app's modifier-only trigger is disabled (settings.modifier_only_hotkey_enabled=$enabled); this verb does not synthesise the Carbon shortcut path — enable it in Settings"
+  modifier="$(app_default settings.modifier_only_hotkey_modifier)"
+  case "$modifier" in
+    # fn/Globe is supported because it is a configurable trigger, but only
+    # right_command has been driven synthetically on this machine
+    # (record-demo.sh). If `dictate` reports ok and nothing happens under fn,
+    # that is the first thing to suspect.
+    fn | right_command | right_option) TRIGGER_MODIFIER="$modifier" ;;
+    "") deny "settings.modifier_only_hotkey_modifier is unset — cannot determine the configured trigger" ;;
+    *) deny "unrecognised configured trigger: $modifier" ;;
+  esac
+  delay="$(app_default settings.modifier_only_hold_delay)"
+  # Absent means the app's own default, which is a value rather than an
+  # identity — unlike the trigger, defaulting it guesses nothing.
+  [[ "$delay" =~ ^[0-9]+(\.[0-9]+)?$ ]] || delay="0.35"
+  TRIGGER_HOLD_DELAY="$delay"
+}
+
+run_dictate() {
+  local gesture="$1" seconds="${2:-}"
+  require_unlocked_screen
+  require_app_under_test
+
+  if [[ "$gesture" == "cancel" ]]; then
+    log_command ALLOW "dictate=cancel pid=$APP_PID"
+    # Escape only. It gives a session back rather than taking the screen, so
+    # like `quit` and `menu dismiss` it does not warn.
+    helper dictate "$APP_PID" none cancel || fail "could not post the cancel key"
+    ACTION_COMPLETED=1
+    return
+  fi
+
+  resolve_dictation_trigger
+  if [[ "$gesture" == "hold" ]]; then
+    [[ "$seconds" =~ ^[0-9]+(\.[0-9]+)?$ ]] || deny "hold needs a duration in seconds"
+    # A hold shorter than the app's own threshold is a tap, silently: it would
+    # start an Overlay Buffer session while the caller asked for Live
+    # Auto-Paste, and nothing would say so.
+    awk -v s="$seconds" -v d="$TRIGGER_HOLD_DELAY" -v cap="$LV_UI_MAX_HOLD_SECONDS" \
+      'BEGIN { exit !(s > d && s <= cap) }' \
+      || deny "hold must be longer than the app's hold delay (${TRIGGER_HOLD_DELAY}s) and at most ${LV_UI_MAX_HOLD_SECONDS}s"
+  fi
+
+  log_command ALLOW "dictate=$gesture trigger=$TRIGGER_MODIFIER${seconds:+ seconds=$seconds}"
+  announce_takeover "starting a localvoxtral dictation into the focused window"
+  helper dictate "$APP_PID" "$TRIGGER_MODIFIER" "$gesture" ${seconds:+"$seconds"} \
+    || fail "the trigger gesture was refused"
+  ACTION_COMPLETED=1
+}
+
 run_quit() {
   require_app_under_test
   log_command ALLOW "pid=$APP_PID"
@@ -1422,6 +1612,21 @@ case "${ARGV[0]}" in
   quit)
     (( ${#ARGV[@]} == 1 )) || deny "quit takes no arguments"
     run_quit
+    ;;
+  dictate)
+    case "${ARGV[1]:-}" in
+      tap | cancel)
+        (( ${#ARGV[@]} == 2 )) || deny "dictate ${ARGV[1]} takes no arguments"
+        run_dictate "${ARGV[1]}"
+        ;;
+      hold)
+        (( ${#ARGV[@]} == 3 )) || deny "dictate hold takes exactly one duration in seconds"
+        run_dictate hold "${ARGV[2]}"
+        ;;
+      *)
+        deny "unknown dictate subverb"
+        ;;
+    esac
     ;;
   menu)
     case "${ARGV[1]:-}" in

--- a/scripts/mac/localvoxtral-ui-gate.sh
+++ b/scripts/mac/localvoxtral-ui-gate.sh
@@ -12,8 +12,9 @@ set -euo pipefail
 # file; everything else is denied and logged. There is deliberately NO shell
 # verb: no `eval`, no `bash -c`, no verb that takes a free command line — with
 # one narrowly constrained exception, `term open`, whose command must start
-# with an allowlisted binary, must survive the same metacharacter blocklist as
-# every other token, and is logged IN FULL. Adding a verb that can run
+# with an allowlisted binary, is resolved to an absolute path under
+# LV_UI_TERM_COMMAND_DIRS before anything is opened, must survive the same
+# metacharacter blocklist as every other token, and is logged IN FULL. Adding a verb that can run
 # arbitrary commands dissolves this boundary completely; do not.
 #
 # The invariant that keeps `term open` from BEING that verb, stated positively:
@@ -65,7 +66,11 @@ set -euo pipefail
 #     refuses unless the app is running, its modifier trigger is enabled in its
 #     own settings, and Secure Keyboard Entry is not held.
 #   - `term focus` / `term close` act only on a window this gate opened,
-#     identified by a random marker it put in that window's title.
+#     identified by the CGWindowID that appeared while it was opening one. NOT
+#     by a title marker: the command this verb exists to run is a whole-view
+#     herdr client, and herdr owns the title from the moment it starts, so a
+#     marker never survives to be seen (field failure 2026-08-30; the same
+#     property is why the app's titleMarker join arm is suppressed there).
 #   - `app` forwards ONE line to the control socket of the app under test —
 #     never a shell, never a path of the caller's choosing. The socket only
 #     exists in a dogfood build, so the verb refuses unless `launch --dogfood`
@@ -80,6 +85,17 @@ set -euo pipefail
 #     there is no app under test, which it then says. This Mac is also the
 #     self-hosted CI runner and `xctest` logs under the same subsystem, so
 #     subsystem alone hands back another run's lines (field check 2026-08-30).
+#   - `gate-log` reads THIS gate's own log file and nothing else — the file
+#     this script writes, one sanitised printable line per invocation. It is
+#     how a denial's reason becomes readable without `deny` explaining itself
+#     to the caller, which it deliberately does not.
+#
+# `state` additionally reports SETUP readiness — which config files exist,
+# whether they parse, what `term open` would currently accept, whether the
+# wrapper is installed, whether the app exposes a control socket — because in
+# a real session (2026-08-30) every one of those was indistinguishable from a
+# broken verb. It reports presence, parse verdicts and the gate's own
+# vocabulary; never a file's contents (see setup_json).
 #
 # A `term open` window is therefore NOT a lateral path into the app-driving
 # verbs, and the scoping above is why: `shot`, `ax dump`, `ax click`, `ax type`
@@ -96,8 +112,8 @@ set -euo pipefail
 # takeover rule: any verb that steals focus or takes input (launch, ax click,
 # ax type, key, menu open, menu click, dictate tap/hold, term open, term focus)
 # speaks a warning, waits, and announces completion. `state`, `shot`,
-# `ax dump`, `menu dismiss`, `dictate cancel`, `quit` and `term close` do not
-# warn: none of them takes the keyboard or raises a window in front of what the
+# `ax dump`, `menu dismiss`, `dictate cancel`, `log`, `gate-log`, `quit` and
+# `term close` do not warn: none of them takes the keyboard or raises a window in front of what the
 # owner is doing.
 #
 # Verbs (each documented at its run_* function):
@@ -112,6 +128,7 @@ set -euo pipefail
 #   dictate <tap|hold <seconds>|cancel>
 #   app <control command>
 #   log [minutes]
+#   gate-log [lines]
 #   quit
 #   term open <ghostty|iterm|terminal> <command> [args...]
 #   term focus <id>
@@ -162,6 +179,34 @@ LV_UI_TERMINALS="${LV_UI_TERMINALS:-ghostty iterm terminal}"
 LV_UI_TERM_COMMANDS="${LV_UI_TERM_COMMANDS:-}"
 LV_UI_MAX_TERM_ARGS="${LV_UI_MAX_TERM_ARGS:-12}"
 
+# Where an allowlisted NAME is resolved to a file, and the reason resolution
+# happens here at all (field failure 2026-08-30).
+#
+# `term open` used to write `exec lv-attach` into the launcher and let PATH
+# find it. A script started by `open -n -a Ghostty --args -e <script>` does not
+# get a login shell's environment, `$HOME/bin` is not on the PATH sshd hands
+# this gate either, and the wrapper lives in `$HOME/bin`. So the launcher hit
+# `command not found`, exited instantly, and left an EMPTY terminal window on
+# the owner's desktop — which the gate then reported as a window-identification
+# timeout. Two different faults telling one wrong story cost the operator
+# twenty minutes and produced a confidently wrong root cause on top.
+#
+# So the name is resolved to an absolute path BEFORE anything is opened, the
+# file has to exist and be executable, and a name that does not resolve is
+# refused with nothing opened. `state` reports the same thing under
+# setup.term_open.unresolvable, so it is visible before a verb is tried.
+#
+# The directory list is short on purpose: a name resolved out of a directory
+# other accounts can write is the allowlist handed away. $HOME/bin is where
+# install-ui-artifact.sh puts the wrapper and where the lock probe already
+# lives.
+LV_UI_TERM_COMMAND_DIRS="${LV_UI_TERM_COMMAND_DIRS:-$HOME/bin}"
+
+# How long `term open` waits for its window. A seam, not a knob: the shell
+# suite drives the three failure paths below and a 20-second wall-clock wait
+# per case is most of the suite's runtime.
+LV_UI_TERM_OPEN_TIMEOUT_SECONDS="${LV_UI_TERM_OPEN_TIMEOUT_SECONDS:-20}"
+
 # Owner rule (2026-07-09): warn audibly and wait before stealing focus, and
 # announce completion. Set to 0 in the conf file only if you are sitting in
 # front of the machine — the default is the rule as stated.
@@ -203,13 +248,44 @@ LV_UI_LOG_SUBSYSTEM="${LV_UI_LOG_SUBSYSTEM:-com.localvoxtral}"
 # there is no app under test, and the output says so when it is.
 LV_UI_LOG_PROCESS="${LV_UI_LOG_PROCESS:-localvoxtral}"
 
+# `gate-log`'s bounds. This file is written BY this gate, one sanitised
+# printable line per invocation, so the cap is about transcript size and not
+# about what may be seen.
+LV_UI_GATE_LOG_DEFAULT_LINES="${LV_UI_GATE_LOG_DEFAULT_LINES:-20}"
+LV_UI_GATE_LOG_MAX_LINES="${LV_UI_GATE_LOG_MAX_LINES:-200}"
+
+# The `term open` wrapper `state` interrogates, and the config file the wrapper
+# reads. `state` runs the wrapper's `--check` rather than re-implementing its
+# destination validator: the validator is the load-bearing part of the wrapper
+# and there must be exactly one of it, and asking the INSTALLED copy is what
+# makes "the wrapper is missing" and "the wrapper is older than this gate"
+# different answers instead of the same silence.
+LV_UI_ATTACH_WRAPPER="${LV_UI_ATTACH_WRAPPER:-$HOME/bin/lv-attach}"
+LV_UI_ATTACH_CONF="${LV_UI_ATTACH_CONF:-$HOME/.lv-attach.conf}"
+
 # Machine-local overrides (never committed). Same argument as the build gate:
 # anyone who can write this file can already replace this script, so sourcing
 # it adds no new trust.
+#
+# Parsed before it is sourced, and IGNORED if it does not parse. A syntax error
+# here used to kill every verb: `source` returns non-zero, `set -e` takes the
+# whole gate down, and the client sees an empty answer with no exit line worth
+# reading — the exact shape of failure this gate's setup reporting exists to
+# end. So a broken conf now degrades to the built-in defaults (which are the
+# CLOSED ones: an empty `term open` allowlist), says so on stderr on every
+# invocation, and is reported by `state`.
 GATE_CONF="${LV_UI_GATE_CONF:-$HOME/.localvoxtral-ui-gate.conf}"
+GATE_CONF_STATUS=absent
 if [[ -f "$GATE_CONF" ]]; then
-  # shellcheck source=/dev/null
-  source "$GATE_CONF"
+  if bash -n "$GATE_CONF" 2>/dev/null; then
+    GATE_CONF_STATUS=ok
+    # shellcheck source=/dev/null
+    source "$GATE_CONF"
+  else
+    GATE_CONF_STATUS=unparsable
+    printf 'localvoxtral ui gate: %s has a syntax error and was IGNORED — every setting in it is at its built-in default, which means `term open` has an EMPTY allowlist. Check it with: bash -n %s\n' \
+      "$GATE_CONF" "$GATE_CONF" >&2
+  fi
 fi
 
 # Second layer under the (empty by default) allowlist above: names that can run
@@ -432,8 +508,9 @@ import Foundation
 //   menuclick <pid> <item-title>
 //   menudismiss <pid>
 //   dictate <pid> <fn|right_command|right_option> <tap|hold|cancel> [seconds]
-//   termwindow <ownerpid> <marker>                           -> "<winid> <ownerpid>"
-//   termaction <ownerpid> <marker> <focus|close>
+//   termsnapshot [<pid>...]                                  -> "<id>,<id>,..."
+//   termnew <ownerpid> <marker|-> <excluded-ids|->           -> "ok <winid> <ownerpid>"
+//   termaction <ownerpid> <winid> <focus|close>
 
 let argv = Array(CommandLine.arguments.dropFirst())
 
@@ -458,6 +535,31 @@ func str(_ element: AXUIElement, _ name: String) -> String {
 func windowsOf(_ pid: pid_t) -> [AXUIElement] {
     let app = AXUIElementCreateApplication(pid)
     return (copyAttr(app, kAXWindowsAttribute) as? [AXUIElement]) ?? []
+}
+
+// The AX window whose frame matches a CGWindow's, or nil when zero or several
+// do. Used to act on a window identified by CGWindowID (see termaction).
+func axWindow(pid: pid_t, matching frame: CGRect) -> AXUIElement? {
+    var matches: [AXUIElement] = []
+    for window in windowsOf(pid) {
+        guard let rawPosition = copyAttr(window, kAXPositionAttribute),
+              let rawSize = copyAttr(window, kAXSizeAttribute),
+              CFGetTypeID(rawPosition) == AXValueGetTypeID(),
+              CFGetTypeID(rawSize) == AXValueGetTypeID()
+        else { continue }
+        var origin = CGPoint.zero
+        var size = CGSize.zero
+        guard AXValueGetValue(rawPosition as! AXValue, .cgPoint, &origin),
+              AXValueGetValue(rawSize as! AXValue, .cgSize, &size)
+        else { continue }
+        // A couple of points of slack: the window list and AX round
+        // independently, and a title bar can differ by a hair.
+        if abs(origin.x - frame.origin.x) <= 2, abs(origin.y - frame.origin.y) <= 2,
+           abs(size.width - frame.width) <= 2, abs(size.height - frame.height) <= 2 {
+            matches.append(window)
+        }
+    }
+    return matches.count == 1 ? matches[0] : nil
 }
 
 func jsonEscape(_ s: String) -> String {
@@ -485,6 +587,10 @@ struct CGWindowRecord {
     let layer: Int
     let area: Double
     let title: String
+    // Kept so a CGWindowID can be mapped to an AX window later: AX exposes no
+    // window id without private API, but AXPosition/AXSize are in the same
+    // top-left screen coordinates kCGWindowBounds uses.
+    let frame: CGRect
 }
 
 func cgWindows(ownedBy pid: Int) -> [CGWindowRecord] {
@@ -498,7 +604,9 @@ func cgWindows(ownedBy pid: Int) -> [CGWindowRecord] {
               let width = bounds["Width"], let height = bounds["Height"]
         else { continue }
         let title = window[kCGWindowName as String] as? String ?? ""
-        out.append(CGWindowRecord(id: id, ownerPID: owner, layer: layer, area: width * height, title: title))
+        let frame = CGRect(x: bounds["X"] ?? 0, y: bounds["Y"] ?? 0, width: width, height: height)
+        out.append(CGWindowRecord(id: id, ownerPID: owner, layer: layer, area: width * height,
+                                  title: title, frame: frame))
     }
     return out.sorted { $0.id < $1.id }
 }
@@ -1006,23 +1114,70 @@ case "dictate":
     let frontName = (front?.localizedName ?? "?").replacingOccurrences(of: "\n", with: " ")
     print("ok \(gesture) trigger=\(argv[2]) frontmost=\(front?.processIdentifier ?? -1) (\(frontName))")
 
-case "termwindow":
-    guard argv.count >= 3 else { die("usage: termwindow <ownerpid> <marker>") }
+// The window ids a terminal application owns right now, taken BEFORE `open`.
+// A title marker cannot be the identity of a `term open` window: the one
+// command this verb exists to run is a whole-view herdr client, and herdr owns
+// the terminal title from the moment it starts (docs/agent/invariants.md says
+// so outright, and the app's own titleMarker join arm is suppressed for the
+// same reason). A window that is NEW since this snapshot needs no cooperation
+// from the child process at all.
+case "termsnapshot":
+    var snapshot: [String] = []
+    for raw in argv.dropFirst() {
+        guard let pid = Int(raw), pid > 0 else { continue }
+        snapshot.append(contentsOf: cgWindows(ownedBy: pid).filter { $0.area > 10_000 }.map { String($0.id) })
+    }
+    print(snapshot.joined(separator: ","))
+
+// The window that appeared since that snapshot.
+//
+// Exit codes are the contract: 0 with "ok <winid> <ownerpid>", 1 when nothing
+// new is there yet (the caller polls), 2 when SEVERAL windows appeared and
+// this cannot tell which one it opened — that last one never guesses, because
+// binding the wrong window would point `term close` at whatever the owner just
+// opened.
+case "termnew":
+    guard argv.count >= 4 else { die("usage: termnew <ownerpid> <marker|-> <excluded-ids|->") }
     let pid = Int(requirePID(argv[1]))
     let marker = argv[2]
-    guard let record = cgWindows(ownedBy: pid).first(where: { $0.title.contains(marker) }) else {
-        die("no window of pid \(pid) carries marker \(marker)")
+    let excluded = Set(argv[3].split(separator: ",").compactMap { Int($0) })
+    let candidates = cgWindows(ownedBy: pid).filter { $0.area > 10_000 && !excluded.contains($0.id) }
+    // The OSC title marker is kept as a TIE-BREAKER, never as the identity: it
+    // still disambiguates for commands that leave the title alone, and it is
+    // simply absent for a herdr-hosted one.
+    let tagged = candidates.filter { !marker.isEmpty && marker != "-" && $0.title.contains(marker) }
+    if tagged.count == 1 {
+        print("ok \(tagged[0].id) \(tagged[0].ownerPID)")
+        exit(0)
     }
-    print("\(record.id) \(record.ownerPID)")
+    if candidates.count == 1 {
+        print("ok \(candidates[0].id) \(candidates[0].ownerPID)")
+        exit(0)
+    }
+    if candidates.isEmpty { die("no window of pid \(pid) appeared since the snapshot") }
+    let ids = candidates.map { String($0.id) }.joined(separator: " ")
+    FileHandle.standardError.write(Data((
+        "helper: \(candidates.count) windows of pid \(pid) appeared since the snapshot "
+        + "(ids \(ids)) and none carries the marker — refusing to guess which one this gate opened\n"
+    ).utf8))
+    exit(2)
 
 case "termaction":
-    guard argv.count >= 4 else { die("usage: termaction <ownerpid> <marker> <focus|close>") }
+    guard argv.count >= 4 else { die("usage: termaction <ownerpid> <winid> <focus|close>") }
     let pid = requirePID(argv[1])
-    let marker = argv[2]
-    // The marker in the title is the proof that THIS gate opened the window;
-    // a window without it is never touched.
-    guard let window = windowsOf(pid).first(where: { str($0, kAXTitleAttribute).contains(marker) }) else {
-        die("no AX window of pid \(pid) carries marker \(marker)")
+    guard let winid = Int(argv[2]), winid > 0 else { die("malformed window id") }
+    // The recorded CGWindowID is the proof that THIS gate opened the window,
+    // and it is still checked against the recorded owner pid: a window id is
+    // only ever acted on when the live window list says that pid owns it.
+    guard let record = cgWindows(ownedBy: Int(pid)).first(where: { $0.id == winid }) else {
+        die("no window \(winid) owned by pid \(pid) — it is closed, or it was never this gate's")
+    }
+    // AX exposes no window id without private API, so the bridge is the frame:
+    // AXPosition/AXSize and kCGWindowBounds are the same top-left screen
+    // coordinates. Two windows sharing a frame to the pixel is refused rather
+    // than guessed at.
+    guard let window = axWindow(pid: pid, matching: record.frame) else {
+        die("window \(winid) of pid \(pid) has no unique accessibility window at its frame")
     }
     switch argv[3] {
     case "focus":
@@ -1246,6 +1401,182 @@ json_string() {
   printf '"%s"' "$value"
 }
 
+json_bool() { # <truthy test result as 0/1>
+  (( $1 == 1 )) && printf 'true' || printf 'false'
+}
+
+# A whitespace-separated list -> a JSON array of strings.
+json_word_array() {
+  local word out=""
+  for word in $1; do
+    [[ -n "$out" ]] && out+=","
+    out+="$(json_string "$word")"
+  done
+  printf '[%s]' "$out"
+}
+
+# ---------------------------------------------------------------------------
+# Setup readiness — the half of `state` that predicts a denial
+# ---------------------------------------------------------------------------
+#
+# Why this exists, from a real session (2026-08-30): an operator drove this
+# gate for an hour and hit `term open` refusing everything and `app` denying,
+# and neither refusal was distinguishable from "the verb is broken" or "the
+# gate is old". The causes were three ABSENT files and one unset default —
+# each a one-line fix, each invisible until a verb failed. So `state` now
+# reports the setup, and the bar it is held to is: an operator should be able
+# to predict which verbs will work BEFORE trying them.
+#
+# What it reports and what it does not: file PRESENCE, whether a file PARSES,
+# and the values that are already the gate's own vocabulary (allowlisted
+# command names, terminal names, bundle names under a root this gate names in
+# its own denials). Never a file's contents.
+
+# Which build of this script is installed. The whole reason it is here: "the
+# gate is old" was one of the indistinguishable explanations above, and a
+# 12-character digest the operator can compare against
+# `shasum -a 256 scripts/mac/localvoxtral-ui-gate.sh` settles it in one line.
+gate_revision() {
+  local digest=""
+  if command -v shasum >/dev/null 2>&1; then
+    digest="$(shasum -a 256 "$0" 2>/dev/null || true)"
+  elif command -v sha256sum >/dev/null 2>&1; then
+    digest="$(sha256sum "$0" 2>/dev/null || true)"
+  fi
+  digest="${digest%% *}"
+  [[ "$digest" =~ ^[0-9a-f]{64}$ ]] || { printf 'unknown'; return; }
+  printf '%s' "${digest:0:12}"
+}
+
+# The launchable bundles `launch` would accept, by NAME. Nothing here is a
+# disclosure: the roots are named in `launch`'s own refusal text, and the two
+# names the installer ever writes are in scripts/mac/README.md.
+setup_artifacts_json() {
+  local root bundle out="" name stamp
+  for root in $LV_UI_ARTIFACT_ROOTS; do
+    [[ -d "$root" ]] || continue
+    for bundle in "$root"/*.app; do
+      [[ -d "$bundle" ]] || continue
+      name="${bundle##*/}"
+      validate_localvoxtral_bundle "$bundle" || continue
+      stamp="$(plist_value "$bundle/Contents/Info.plist" LVXDogfoodCapture)"
+      [[ -n "$out" ]] && out+=","
+      out+="{\"name\":$(json_string "$name"),\"dogfood\":$([[ "$stamp" == "true" ]] && echo true || echo false)}"
+    done
+  done
+  printf '[%s]' "$out"
+}
+
+# Every conf-allowlisted name that the permanent denylist refuses anyway. A
+# conf that allowlists `ssh` reads as configured and behaves as unconfigured;
+# without this the operator sees only "denied command".
+setup_denylisted_json() {
+  local name out=""
+  for name in $LV_UI_TERM_COMMANDS; do
+    list_contains "$name" "$LV_UI_TERM_FORBIDDEN" || continue
+    [[ -n "$out" ]] && out+=","
+    out+="$(json_string "$name")"
+  done
+  printf '[%s]' "$out"
+}
+
+# Every allowlisted name with no executable file behind it. This is the whole
+# of the 2026-08-30 failure, reported before a verb is tried: the name was
+# allowlisted, the wrapper was not installed where the launcher could find it,
+# and `term open` opened an empty window rather than saying so.
+setup_unresolvable_json() {
+  local name out=""
+  for name in $LV_UI_TERM_COMMANDS; do
+    list_contains "$name" "$LV_UI_TERM_FORBIDDEN" && continue
+    resolve_term_command "$name" >/dev/null && continue
+    [[ -n "$out" ]] && out+=","
+    out+="$(json_string "$name")"
+  done
+  printf '[%s]' "$out"
+}
+
+ATTACH_CONF_STATUS="absent"
+ATTACH_DESTINATION=""
+ATTACH_SESSION=0
+
+# Ask the INSTALLED wrapper, rather than re-reading its config here.
+#
+# One validator, in the file whose whole job is to hold that boundary: a copy
+# of it in this script could drift, and the copy that matters is the one the
+# `term open` window will actually run. It also makes three different failures
+# three different answers — no wrapper, a wrapper too old to answer, and a
+# wrapper that answers "no destination".
+#
+# `lv-attach --check` reads a file with `sed` and prints; it opens no network
+# connection and starts no child. It is 0700 and owner-written, which is the
+# same trust level as this script and as the conf file this gate sources.
+attach_check() {
+  ATTACH_CONF_STATUS="absent"
+  ATTACH_DESTINATION=""
+  ATTACH_SESSION=0
+  if [[ ! -x "$LV_UI_ATTACH_WRAPPER" ]]; then
+    [[ -f "$LV_UI_ATTACH_CONF" ]] && ATTACH_CONF_STATUS="present-unchecked"
+    return
+  fi
+  local output status destination session
+  output="$(LV_ATTACH_CONF="$LV_UI_ATTACH_CONF" "$LV_UI_ATTACH_WRAPPER" --check 2>/dev/null || true)"
+  # An older wrapper refuses every flag, which is correct of it and is also
+  # exactly how "you are running a wrapper from before this gate" looks.
+  status="$(awk -F= '/^conf=/ { sub(/^conf=/, ""); print; exit }' <<<"$output")"
+  [[ -n "$status" ]] || { ATTACH_CONF_STATUS="wrapper-too-old"; return; }
+  case "$status" in
+    ok | missing | no-destination | invalid-destination) ATTACH_CONF_STATUS="$status" ;;
+    *) ATTACH_CONF_STATUS="unknown" ;;
+  esac
+  destination="$(awk -F= '/^destination=/ { sub(/^destination=/, ""); print; exit }' <<<"$output")"
+  # Re-validated here even though the wrapper validated it: this string is
+  # about to be printed, and a `state` that echoes whatever a file contained
+  # is the disclosure this section exists to avoid.
+  [[ "$destination" =~ ^[A-Za-z0-9._-]{1,64}$ ]] || destination=""
+  ATTACH_DESTINATION="$destination"
+  session="$(awk -F= '/^session=/ { sub(/^session=/, ""); print; exit }' <<<"$output")"
+  [[ "$session" == "configured" ]] && ATTACH_SESSION=1
+}
+
+setup_json() {
+  local socket_consent gate_conf_present lock_probe_present
+  local attach_installed attach_allowlisted
+
+  attach_check
+
+  socket_consent="$(app_default debug.dogfood_control_socket_enabled)"
+  case "$socket_consent" in
+    1) socket_consent="on" ;;
+    0) socket_consent="off" ;;
+    *) socket_consent="unset" ;;
+  esac
+
+  gate_conf_present=0
+  [[ -f "$GATE_CONF" ]] && gate_conf_present=1
+  lock_probe_present=0
+  [[ -x "$LOCK_PROBE" ]] && lock_probe_present=1
+  attach_installed=0
+  [[ -x "$LV_UI_ATTACH_WRAPPER" ]] && attach_installed=1
+  attach_allowlisted=0
+  list_contains lv-attach "$LV_UI_TERM_COMMANDS" && attach_allowlisted=1
+
+  printf '{"gate":{"revision":%s},"lock_probe":{"installed":%s},"gate_conf":{"present":%s,"status":%s},"artifacts":%s,"term_open":{"terminals":%s,"commands":%s,"refused_by_denylist":%s,"unresolvable":%s},"lv_attach":{"installed":%s,"allowlisted":%s,"conf":%s,"destination":%s,"session_default":%s},"control_socket":{"present":%s,"consent":%s}}' \
+    "$(json_string "$(gate_revision)")" \
+    "$(json_bool "$lock_probe_present")" \
+    "$(json_bool "$gate_conf_present")" "$(json_string "$GATE_CONF_STATUS")" \
+    "$(setup_artifacts_json)" \
+    "$(json_word_array "$LV_UI_TERMINALS")" \
+    "$(json_word_array "$LV_UI_TERM_COMMANDS")" \
+    "$(setup_denylisted_json)" \
+    "$(setup_unresolvable_json)" \
+    "$(json_bool "$attach_installed")" "$(json_bool "$attach_allowlisted")" \
+    "$(json_string "$ATTACH_CONF_STATUS")" \
+    "$([[ -n "$ATTACH_DESTINATION" ]] && json_string "$ATTACH_DESTINATION" || printf 'null')" \
+    "$(json_bool "$ATTACH_SESSION")" \
+    "$([[ -S "$LV_UI_CONTROL_SOCKET" ]] && printf 'true' || printf 'false')" \
+    "$(json_string "$socket_consent")"
+}
+
 # state — the only verb that answers while the screen is locked, because
 # "is it safe to drive right now" is exactly what it is for. Read-only.
 run_state() {
@@ -1279,7 +1610,7 @@ run_state() {
   fi
 
   terminals=""
-  local file id term marker pid
+  local file id term marker pid window
   for file in "$STATE_DIR"/terms/*.state; do
     [[ -f "$file" ]] || continue
     id="${file##*/}"
@@ -1287,14 +1618,17 @@ run_state() {
     term="$(sed -n 's/^terminal=//p' "$file" | head -n 1)"
     marker="$(sed -n 's/^marker=//p' "$file" | head -n 1)"
     pid="$(sed -n 's/^pid=//p' "$file" | head -n 1)"
+    window="$(sed -n 's/^window=//p' "$file" | head -n 1)"
     [[ -n "$terminals" ]] && terminals+=","
     [[ "$pid" =~ ^[1-9][0-9]*$ ]] || pid=0
-    terminals+="{\"id\":$(json_string "$id"),\"terminal\":$(json_string "$term"),\"pid\":$pid,\"alive\":$( (( pid > 0 )) && kill -0 "$pid" 2>/dev/null && echo true || echo false),\"marker\":$(json_string "$marker")}"
+    [[ "$window" =~ ^[1-9][0-9]*$ ]] || window=0
+    terminals+="{\"id\":$(json_string "$id"),\"terminal\":$(json_string "$term"),\"pid\":$pid,\"window\":$window,\"alive\":$( (( pid > 0 )) && kill -0 "$pid" 2>/dev/null && echo true || echo false),\"marker\":$(json_string "$marker")}"
   done
 
-  printf '{"screen_lock":%s,"idle_seconds":%s,"power":%s,"tcc":{"accessibility":%s,"screen_recording":%s},"app":%s,"terminals":[%s]}\n' \
+  printf '{"screen_lock":%s,"idle_seconds":%s,"power":%s,"tcc":{"accessibility":%s,"screen_recording":%s},"app":%s,"terminals":[%s],"setup":%s}\n' \
     "$(json_string "$lock")" "$idle" "$(json_string "$power")" \
-    "$accessibility" "$screen_recording" "$running_json" "$terminals"
+    "$accessibility" "$screen_recording" "$running_json" "$terminals" \
+    "$(setup_json)"
 }
 
 # launch [--dogfood] <artifact>
@@ -1794,6 +2128,55 @@ run_log() {
   ACTION_COMPLETED=1
 }
 
+# gate-log [lines]
+#
+# The gate's OWN log — the one file that records why a command was denied.
+#
+# Why a verb and not a reason on stderr. `deny` answers every refusal with the
+# same `denied command` on purpose: a gate that explains itself is an oracle
+# for state the caller cannot otherwise see — whether a path exists, whether a
+# bundle validated, whether a pid is running, which names a conf allowlists.
+# The reason is still written, and it always was; what was missing is that NO
+# verb could read it back, so an agent driving over SSH saw the generic line
+# and had to go through the owner to learn the one-line fix behind it. That is
+# a round trip, not a boundary — so the fix is a bounded reader, and the deny
+# contract is untouched.
+#
+# What this can disclose is exactly what this gate wrote about itself: one
+# sanitised, printable, 512-byte-capped line per invocation, `ax type`'s text
+# already replaced by `<redacted>` at write time. It is passed through the
+# same token-shaped scrub `log` uses, for the same reason — the lines are
+# ours, but "every line anyone ever adds is safe" is not worth depending on.
+#
+# Read-only and focus-free, so it is allowed while the screen is locked: a
+# diagnostic that stops working when the owner locks the machine is the one
+# case an agent most needs it.
+run_gate_log() {
+  local lines="${1:-$LV_UI_GATE_LOG_DEFAULT_LINES}" output
+
+  [[ "$lines" =~ ^[0-9]{1,4}$ ]] || deny "gate-log takes a whole number of lines"
+  (( lines >= 1 )) || deny "gate-log needs at least 1 line"
+  (( lines <= LV_UI_GATE_LOG_MAX_LINES )) \
+    || deny "gate-log is clamped to $LV_UI_GATE_LOG_MAX_LINES lines"
+
+  # Logged BEFORE the read, so this invocation is not in its own output and a
+  # reader is never confused about which line is the one they are looking for.
+  log_command ALLOW "gate-log lines=$lines"
+
+  # The ALLOW line above is this invocation's own; dropping it keeps the
+  # requested count meaning "the N entries before this one". It also means the
+  # file always exists by the time it is read — `log_command` created it — so
+  # an empty answer has exactly one meaning, said below.
+  output="$(tail -n $((lines + 1)) "$LOG_FILE" 2>/dev/null | sed '$d' | redact_token_shaped_runs)"
+  if [[ -z "${output//[[:space:]]/}" ]]; then
+    printf 'localvoxtral ui gate: no entries before this one in %s (this is the first command through this gate).\n' "$LOG_FILE" >&2
+    ACTION_COMPLETED=1
+    return 0
+  fi
+  printf '%s\n' "$output"
+  ACTION_COMPLETED=1
+}
+
 run_quit() {
   require_app_under_test
   log_command ALLOW "pid=$APP_PID"
@@ -1831,6 +2214,23 @@ terminal_process_name() {
     terminal) printf 'Terminal\n' ;;
     *) return 1 ;;
   esac
+}
+
+# An allowlisted NAME -> the absolute path of the file that will run.
+resolve_term_command() { # <name> -> absolute path, or non-zero
+  local name="$1" dir root candidate
+  # A name, never a path: the allowlist matches whole tokens, so `/bin/bash`
+  # would not match `bash` anyway, but refusing the shape keeps the allowlist
+  # about names and this function about where names live.
+  [[ "$name" != */* && "$name" != "." && "$name" != ".." ]] || return 1
+  for dir in $LV_UI_TERM_COMMAND_DIRS; do
+    root="$(cd "$dir" 2>/dev/null && pwd -P)" || continue
+    candidate="$root/$name"
+    [[ -f "$candidate" && -x "$candidate" ]] || continue
+    printf '%s\n' "$candidate"
+    return 0
+  done
+  return 1
 }
 
 next_term_id() {
@@ -1874,25 +2274,72 @@ run_term_open() {
     token_is_safe "$token" || deny "unsafe token in term command"
   done
 
-  # Logged IN FULL: this is the one verb that carries a command line.
-  log_command ALLOW "terminal=$terminal command=${argv[*]}"
+  # Resolved BEFORE anything is opened. An allowlisted name that is not
+  # installed used to open an empty window and then fail with a window-identity
+  # message; this refuses with nothing opened and names the real problem.
+  # Bash 3.2 (the Mac's /bin/bash) errors on an EMPTY array slice under set -u,
+  # so the arguments after the command name are rendered once, guarded, rather
+  # than expanded at each use.
+  local args_text=""
+  if (( ${#argv[@]} > 1 )); then
+    args_text=" ${argv[*]:1}"
+  fi
 
-  local id marker script app
+  local resolved_command
+  resolved_command="$(resolve_term_command "${argv[0]}")" \
+    || deny "${argv[0]} is allowlisted but is not an executable file in $LV_UI_TERM_COMMAND_DIRS — nothing was opened (install it: scripts/mac/install-ui-artifact.sh, or see \`state\`'s setup.term_open.unresolvable)"
+
+  # Logged IN FULL: this is the one verb that carries a command line.
+  log_command ALLOW "terminal=$terminal command=${argv[*]} resolved=$resolved_command"
+
+  local id marker script app procname pidfile
   id="$(next_term_id)"
   marker="lvui-$id-$RANDOM$RANDOM"
   app="$(terminal_app_name "$terminal")"
+  procname="$(terminal_process_name "$terminal")"
   mkdir -p "$STATE_DIR/terms"
   script="$STATE_DIR/terms/$marker.command"
+  pidfile="$STATE_DIR/terms/$marker.pid"
   {
     printf '#!/bin/sh\n'
-    # OSC 0 title: how focus/close later prove this window is ours. Terminal
-    # and iTerm also show the script's file name, which carries the marker.
+    # `exec` keeps this pid, so the file names the process that ends up running
+    # the command inside the window. It is the ONLY handle on that process once
+    # the command has replaced this shell, and it is what lets a `term open`
+    # that cannot identify its window still take back what it started instead
+    # of leaving it on the owner's desktop.
+    printf 'printf %%s "$$" > %q\n' "$pidfile"
+    # OSC 0 title. A TIE-BREAKER, not the identity — see the snapshot below.
     printf 'printf %s "%s"\n' "'\\033]0;%s\\007'" "$marker"
-    printf 'exec'
-    printf ' %q' "${argv[@]}"
+    # The ABSOLUTE path, not the name: PATH is not this launcher's to rely on.
+    printf 'exec %q' "$resolved_command"
+    if (( ${#argv[@]} > 1 )); then
+      printf ' %q' "${argv[@]:1}"
+    fi
     printf '\n'
   } >"$script"
   chmod 0700 "$script"
+
+  # WHY A SNAPSHOT AND NOT THE TITLE MARKER (field failure 2026-08-30).
+  #
+  # The marker used to be the identity: the launcher printed it as an OSC 0
+  # title and the gate polled for a window carrying it. That cannot work for
+  # the one command this verb exists to run. `lv-attach` execs a whole-view
+  # herdr client, and herdr owns the terminal title from the moment it starts
+  # — docs/agent/invariants.md states it outright ("herdr intercepts OSC 2 per
+  # pane, so a title marker can neither reach nor come back from a
+  # herdr-hosted session"), which is also why the app's own titleMarker join
+  # arm is suppressed there. The marker was overwritten before the poll could
+  # see it, so `term open` reported failure while a real window sat on the
+  # owner's screen that `term focus`/`term close` could never address.
+  #
+  # A window that is NEW since a snapshot taken immediately before `open`
+  # needs no cooperation from the child process at all, so nothing the command
+  # does to its title can hide it.
+  local before_pids before_ids
+  before_pids="$(pgrep -x "$procname" 2>/dev/null | tr '\n' ' ' || true)"
+  # shellcheck disable=SC2086
+  before_ids="$(helper termsnapshot $before_pids 2>/dev/null || true)"
+  [[ -n "$before_ids" ]] || before_ids="-"
 
   announce_takeover "opening a $terminal window"
   case "$terminal" in
@@ -1900,22 +2347,65 @@ run_term_open() {
     *) open -a "$app" "$script" || fail "could not open $app" ;;
   esac
 
-  local pid deadline resolved winid owner=""
-  deadline=$((SECONDS + 20))
+  local pid deadline resolved status winid owner="" ambiguous=0
+  deadline=$((SECONDS + LV_UI_TERM_OPEN_TIMEOUT_SECONDS))
   while (( SECONDS < deadline )); do
-    pid="$(pgrep -n -x "$(terminal_process_name "$terminal")" 2>/dev/null || true)"
+    pid="$(pgrep -n -x "$procname" 2>/dev/null || true)"
     if [[ -n "$pid" ]]; then
-      resolved="$(helper termwindow "$pid" "$marker" 2>/dev/null || true)"
-      if [[ -n "$resolved" ]]; then
+      status=0
+      resolved="$(helper termnew "$pid" "$marker" "$before_ids" 2>/dev/null)" || status=$?
+      if (( status == 0 )) && [[ "$resolved" == ok\ * ]]; then
+        resolved="${resolved#ok }"
         winid="${resolved%% *}"
         owner="${resolved##* }"
+        break
+      fi
+      # Several windows appeared at once and none carries the marker. Waiting
+      # longer cannot make that less ambiguous, so stop now rather than binding
+      # whatever the owner just opened.
+      if (( status == 2 )); then
+        ambiguous=1
         break
       fi
     fi
     sleep 0.5
   done
+
   if [[ -z "$owner" ]]; then
-    fail "opened $app but never saw a window carrying marker $marker"
+    # THREE different faults live here and they have completely different
+    # fixes, so they get three different sentences. Reporting a command that
+    # never ran as a window-identification timeout is what sent the last
+    # investigation down the wrong path entirely.
+    #
+    # The launcher writes its pid before `exec`, so the pid file separates
+    # them: absent means the terminal never ran the launcher at all; present
+    # with a dead process means the command ran and exited immediately (an
+    # empty window is exactly what that looks like); present and alive means
+    # the command is running and only the WINDOW could not be identified.
+    local orphan="" reclaimed="nothing was left running"
+    [[ -f "$pidfile" ]] && orphan="$(cat "$pidfile" 2>/dev/null || true)"
+    local launcher_ran=0 still_running=0
+    [[ "$orphan" =~ ^[1-9][0-9]*$ ]] && launcher_ran=1
+    if (( launcher_ran == 1 )) && kill -0 "$orphan" 2>/dev/null; then
+      still_running=1
+      # A term open that cannot confirm what it started must not leave a window
+      # on the owner's desktop. The pid is the only handle on it once the
+      # window is unidentifiable.
+      kill -TERM "$orphan" 2>/dev/null || true
+      reclaimed="terminated the command it started (pid $orphan); in Ghostty the window closes with it, in Terminal/iTerm it stays showing a finished command"
+    fi
+    rm -f "$script" "$pidfile"
+
+    if (( launcher_ran == 0 )); then
+      fail "$app opened but never ran the launcher, so ${argv[0]} was never executed — $reclaimed. This is not a window-identification problem: check that $app accepts the launcher ($script was removed; re-run to regenerate it)."
+    fi
+    if (( still_running == 0 )); then
+      fail "${argv[0]} ran and exited immediately, which is what an empty terminal window means — $reclaimed. This is the COMMAND failing, not the window being unidentifiable: run it by hand as this user ($resolved_command$args_text) and read its error."
+    fi
+    if (( ambiguous == 1 )); then
+      fail "$app opened, ${argv[0]} is running, but several windows appeared at once so this cannot tell which one it opened — $reclaimed. Re-run without opening a terminal window yourself at the same moment."
+    fi
+    fail "$app opened and ${argv[0]} is running, but no new window appeared within $LV_UI_TERM_OPEN_TIMEOUT_SECONDS seconds — $reclaimed"
   fi
 
   {
@@ -1937,10 +2427,12 @@ load_term_state() { # <id>
   [[ -f "$file" ]] || deny "unknown terminal id $id — this gate did not open it"
   TERM_PID="$(sed -n 's/^pid=//p' "$file" | head -n 1)"
   TERM_MARKER="$(sed -n 's/^marker=//p' "$file" | head -n 1)"
+  TERM_WINDOW="$(sed -n 's/^window=//p' "$file" | head -n 1)"
   TERM_KIND="$(sed -n 's/^terminal=//p' "$file" | head -n 1)"
   # ^[1-9] on purpose: `kill -0 0` signals the whole process group and always
   # succeeds, so pid 0 would read as a live terminal.
-  [[ "$TERM_PID" =~ ^[1-9][0-9]*$ && -n "$TERM_MARKER" ]] || deny "corrupt terminal state for $id"
+  [[ "$TERM_PID" =~ ^[1-9][0-9]*$ && "$TERM_WINDOW" =~ ^[1-9][0-9]*$ ]] \
+    || deny "corrupt terminal state for $id"
   kill -0 "$TERM_PID" 2>/dev/null || deny "$id's terminal process is gone"
 }
 
@@ -1950,7 +2442,7 @@ run_term_focus() {
   load_term_state "$id"
   log_command ALLOW "id=$id pid=$TERM_PID"
   announce_takeover "focusing $TERM_KIND window $id"
-  helper termaction "$TERM_PID" "$TERM_MARKER" focus || fail "could not focus $id"
+  helper termaction "$TERM_PID" "$TERM_WINDOW" focus || fail "could not focus $id"
   ACTION_COMPLETED=1
   printf 'focused %s\n' "$id"
 }
@@ -1960,8 +2452,9 @@ run_term_close() {
   require_unlocked_screen
   load_term_state "$id"
   log_command ALLOW "id=$id pid=$TERM_PID"
-  helper termaction "$TERM_PID" "$TERM_MARKER" close || fail "could not close $id"
-  rm -f "$STATE_DIR/terms/$id.state" "$STATE_DIR/terms/$TERM_MARKER.command"
+  helper termaction "$TERM_PID" "$TERM_WINDOW" close || fail "could not close $id"
+  rm -f "$STATE_DIR/terms/$id.state" \
+    "$STATE_DIR/terms/$TERM_MARKER.command" "$STATE_DIR/terms/$TERM_MARKER.pid"
   ACTION_COMPLETED=1
   printf 'closed %s\n' "$id"
 }
@@ -2028,6 +2521,10 @@ case "${ARGV[0]}" in
   log)
     (( ${#ARGV[@]} <= 2 )) || deny "log takes at most a number of minutes"
     if (( ${#ARGV[@]} == 1 )); then run_log; else run_log "${ARGV[1]}"; fi
+    ;;
+  gate-log)
+    (( ${#ARGV[@]} <= 2 )) || deny "gate-log takes at most a number of lines"
+    if (( ${#ARGV[@]} == 1 )); then run_gate_log; else run_gate_log "${ARGV[1]}"; fi
     ;;
   dictate)
     case "${ARGV[1]:-}" in

--- a/scripts/mac/localvoxtral-ui-gate.sh
+++ b/scripts/mac/localvoxtral-ui-gate.sh
@@ -16,6 +16,16 @@ set -euo pipefail
 # every other token, and is logged IN FULL. Adding a verb that can run
 # arbitrary commands dissolves this boundary completely; do not.
 #
+# The invariant that keeps `term open` from BEING that verb, stated positively:
+# AN ALLOWLISTED COMMAND MUST NOT BE ABLE TO RUN A CHILD COMMAND.
+# Not "must not be a shell" — must not be able to start one, at any remove,
+# through any flag or subcommand. Only the first token is checked and nothing
+# inspects flags, so `claude --dangerously-skip-permissions -p <prompt>`,
+# `codex exec`, `opencode run` and `herdr agent start` are each a full shell
+# wearing one allowlisted name. The default allowlist is therefore EMPTY, a
+# permanent denylist sits under it that the conf file cannot override, and the
+# test to apply before adding a name is spelled out at LV_UI_TERM_COMMANDS.
+#
 # Why "semantic" verbs and not a computer-use harness: a generic harness
 # clicks inferred pixel coordinates on whatever is on screen, which on this
 # machine is the owner's mail, browser and messages. This gate cannot do that.
@@ -33,6 +43,16 @@ set -euo pipefail
 #     owner last touched.
 #   - `term focus` / `term close` act only on a window this gate opened,
 #     identified by a random marker it put in that window's title.
+#
+# A `term open` window is therefore NOT a lateral path into the app-driving
+# verbs, and the scoping above is why: `shot`, `ax dump`, `ax click`, `ax type`
+# and `key` all take their pid from the app.state that `launch` wrote, and
+# `launch` only ever records a validated localvoxtral bundle's pid. There is no
+# verb that retargets them at a terminal — `term focus`/`term close` reach a
+# terminal window, but only to raise or close it, and they carry no selector,
+# no keystroke and no capture. Nothing typed by this gate can reach a shell
+# prompt. (test-ui-gate.sh section 12 pins this: with both an app under test
+# and an open terminal recorded, every helper call still carries the app pid.)
 #
 # It refuses everything GUI-touching while the screen is locked (shared probe:
 # scripts/ci/screen-lock-state.sh, fail CLOSED here), and honours the owner's
@@ -70,13 +90,33 @@ STATE_DIR="${LV_UI_STATE_DIR:-$HOME/.localvoxtral-ui-gate}"
 # under one of these roots AND to be a real localvoxtral bundle.
 LV_UI_ARTIFACT_ROOTS="${LV_UI_ARTIFACT_ROOTS:-$HOME/Applications $HOME/localvoxtral-ui-artifacts}"
 
-# `term open`'s allowlists. The command allowlist is the ONLY thing standing
-# between this verb and a shell verb, so it holds first tokens only, and an
-# entry that is itself a shell (bash, sh, zsh, ssh, osascript, python) or that
-# takes an arbitrary child command (`claude --dangerously-skip-permissions`)
-# hands the whole boundary away. Keep it to non-shell tools.
+# `term open`'s allowlists.
+#
+# THE INVARIANT, stated positively: an allowlisted command must not be able to
+# run a child command. Not "must not be a shell" — must not be able to start
+# one, at any remove, through any flag or subcommand.
+#
+# The test to apply before adding a name: read its `--help`. If ANY flag or
+# subcommand takes a command, a script, a prompt, or a file to execute — `-c`,
+# `-e`, `exec`, `run`, `--eval`, `-p`, an agent that runs tools — it fails, and
+# it does not go on this list. `list_contains` matches the FIRST TOKEN ONLY and
+# nothing here inspects flags, so a name that passes the test is trusted with
+# every argument it will ever be given.
+#
+# This rejects the obvious shells (bash, sh, zsh, ssh, osascript, python) AND
+# every coding-agent CLI: `claude --dangerously-skip-permissions -p <prompt>`,
+# `codex exec`, `opencode run` and `herdr agent start` each execute arbitrary
+# code as this user, which is the whole boundary handed away by a default. An
+# earlier revision of this file shipped `herdr claude opencode codex` as the
+# default and was exactly that hole.
+#
+# So the default is EMPTY: `term open` denies until the owner opts in in
+# ~/.localvoxtral-ui-gate.conf. The documented way to make it useful is a
+# single-purpose wrapper the owner writes and installs — one that takes an
+# identifier and execs one fixed command, never a command of the caller's
+# choosing (scripts/mac/README.md).
 LV_UI_TERMINALS="${LV_UI_TERMINALS:-ghostty iterm terminal}"
-LV_UI_TERM_COMMANDS="${LV_UI_TERM_COMMANDS:-herdr claude opencode codex}"
+LV_UI_TERM_COMMANDS="${LV_UI_TERM_COMMANDS:-}"
 LV_UI_MAX_TERM_ARGS="${LV_UI_MAX_TERM_ARGS:-12}"
 
 # Owner rule (2026-07-09): warn audibly and wait before stealing focus, and
@@ -99,6 +139,17 @@ if [[ -f "$GATE_CONF" ]]; then
   # shellcheck source=/dev/null
   source "$GATE_CONF"
 fi
+
+# Second layer under the (empty by default) allowlist above: names that can run
+# a child command are refused even when the conf allowlists them. Deliberately
+# assigned AFTER the conf is sourced and NOT via ${VAR:-...}, so the conf can
+# widen the allowlist but can never re-add one of these. A blocklist is a poor
+# primary defence, which is why it is not the primary defence — it is here so
+# that a mistake in a machine-local file fails loudly instead of silently.
+LV_UI_TERM_FORBIDDEN="bash sh zsh ksh csh tcsh fish dash ssh scp sftp telnet \
+osascript applescript python python2 python3 perl ruby node deno bun php lua \
+env xargs find sudo doas su nohup script screen tmux herdr expect make just \
+claude codex opencode aider goose amp cursor-agent gemini ollama"
 
 original_command="${SSH_ORIGINAL_COMMAND:-}"
 ARGV=()
@@ -654,6 +705,12 @@ helper() {
 # A recorded pid is only trusted when the live process still has the same
 # start time and the same executable path, so a recycled pid can never inherit
 # the gate's authority to be photographed and driven.
+#
+# No verb writes this file except `launch`, and `launch` only ever records a
+# validated localvoxtral bundle's pid — that is what stops a `term open`
+# terminal from ever becoming the target of `shot`/`ax *`/`key`. Forging the
+# file needs local write access to the state dir, which is the same trust level
+# as replacing this script (see GATE_CONF above).
 
 APP_STATE="$STATE_DIR/app.state"
 APP_PID=""
@@ -1023,16 +1080,27 @@ run_term_open() {
   local terminal="$1"
   shift
   local -a argv=("$@")
+  # Lock first, like every other GUI-touching verb: on a locked screen this
+  # denies before any argument is even considered, so no locked-screen test can
+  # pass for an argument-validation reason.
+  require_unlocked_screen
   list_contains "$terminal" "$LV_UI_TERMINALS" || deny "terminal not allowlisted"
   (( ${#argv[@]} >= 1 )) || deny "term open needs a command"
   (( ${#argv[@]} <= LV_UI_MAX_TERM_ARGS )) || deny "term open takes at most $LV_UI_MAX_TERM_ARGS tokens"
+  # The denylist is checked FIRST and cannot be overridden by the conf file, so
+  # allowlisting a shell or an agent CLI by mistake still denies.
+  if list_contains "${argv[0]}" "$LV_UI_TERM_FORBIDDEN"; then
+    deny "command can run a child command and is permanently refused: ${argv[0]}"
+  fi
+  if [[ -z "${LV_UI_TERM_COMMANDS// /}" ]]; then
+    deny "term open has no allowlisted commands (the default is empty — see scripts/mac/README.md)"
+  fi
   list_contains "${argv[0]}" "$LV_UI_TERM_COMMANDS" || deny "command not allowlisted: ${argv[0]}"
   local token
   for token in "${argv[@]}"; do
     token_is_safe "$token" || deny "unsafe token in term command"
   done
 
-  require_unlocked_screen
   # Logged IN FULL: this is the one verb that carries a command line.
   log_command ALLOW "terminal=$terminal command=${argv[*]}"
 

--- a/scripts/mac/localvoxtral-ui-gate.sh
+++ b/scripts/mac/localvoxtral-ui-gate.sh
@@ -824,10 +824,17 @@ json_string() {
 run_state() {
   local lock idle power preflight accessibility screen_recording running_json terminals
   lock="$(screen_lock_state)"
+  # `|| true` is load-bearing, not defensive noise: awk `exit`s on the first
+  # match while ioreg is still writing, so ioreg takes SIGPIPE and `pipefail`
+  # makes the whole substitution non-zero — under `set -e` that killed `state`
+  # with rc 141 and no output at all (first install, 2026-08-28). The validity
+  # guard on the next line already covers an empty result.
   idle="$(ioreg -c IOHIDSystem 2>/dev/null \
-    | awk '/HIDIdleTime/ { gsub(/[^0-9]/, "", $NF); if ($NF != "") { print int($NF / 1000000000); exit } }')"
+    | awk '/HIDIdleTime/ { gsub(/[^0-9]/, "", $NF); if ($NF != "") { print int($NF / 1000000000); exit } }' || true)"
   [[ "$idle" =~ ^[0-9]+$ ]] || idle="null"
-  case "$(pmset -g ps 2>/dev/null | head -n 1)" in
+  # Same SIGPIPE shape as the idle probe above: `head` closes the pipe while
+  # pmset is still writing. `*)` already yields "unknown" for an empty read.
+  case "$(pmset -g ps 2>/dev/null | head -n 1 || true)" in
     *"AC Power"*) power="ac" ;;
     *"Battery Power"* | *"UPS Power"*) power="battery" ;;
     *) power="unknown" ;;

--- a/scripts/mac/localvoxtral-ui-gate.sh
+++ b/scripts/mac/localvoxtral-ui-gate.sh
@@ -54,6 +54,16 @@ set -euo pipefail
 #     own settings, and Secure Keyboard Entry is not held.
 #   - `term focus` / `term close` act only on a window this gate opened,
 #     identified by a random marker it put in that window's title.
+#   - `app` forwards ONE line to the control socket of the app under test —
+#     never a shell, never a path of the caller's choosing. The socket only
+#     exists in a dogfood build, so the verb refuses unless `launch --dogfood`
+#     recorded one, and the forwarded line must be one of the five shapes the
+#     socket's own grammar accepts. The socket answers in a closed vocabulary
+#     of bools, counts and enum names (docs/dogfood-builds.md).
+#   - `log` reads the unified log for localvoxtral's OWN subsystem only, over a
+#     clamped window, with a line cap and token-shaped runs masked. It is not a
+#     general system-log reader; every other application's activity on this
+#     machine stays out of reach.
 #
 # A `term open` window is therefore NOT a lateral path into the app-driving
 # verbs, and the scoping above is why: `shot`, `ax dump`, `ax click`, `ax type`
@@ -84,6 +94,8 @@ set -euo pipefail
 #   key <escape|tab|return>
 #   menu <open|click <item-title>|dismiss>
 #   dictate <tap|hold <seconds>|cancel>
+#   app <control command>
+#   log [minutes]
 #   quit
 #   term open <ghostty|iterm|terminal> <command> [args...]
 #   term focus <id>
@@ -150,6 +162,22 @@ LV_UI_MAX_HOLD_SECONDS="${LV_UI_MAX_HOLD_SECONDS:-30}"
 
 LV_UI_MAX_COMMAND_BYTES="${LV_UI_MAX_COMMAND_BYTES:-2048}"
 LV_UI_MAX_TEXT_BYTES="${LV_UI_MAX_TEXT_BYTES:-512}"
+
+# `app`'s target: the dogfood control socket of the app under test. Not
+# discovered, not passed in — the one path a dogfood build ever binds
+# (DogfoodControlSocket.defaultSocketPath). Overridable only so the test suite
+# can point it at a fixture.
+LV_UI_CONTROL_SOCKET="${LV_UI_CONTROL_SOCKET:-$HOME/Library/Application Support/localvoxtral/dogfood/control/control.sock}"
+
+# `log`'s bounds. The window is clamped the way the build gate's `applog`
+# clamps its own, and the line cap exists so a chatty minute cannot dump tens
+# of thousands of lines into an agent transcript.
+LV_UI_LOG_DEFAULT_MINUTES="${LV_UI_LOG_DEFAULT_MINUTES:-15}"
+LV_UI_LOG_MAX_MINUTES="${LV_UI_LOG_MAX_MINUTES:-120}"
+LV_UI_LOG_MAX_LINES="${LV_UI_LOG_MAX_LINES:-400}"
+# The app's OWN subsystem and nothing else. This is the difference between a
+# diagnostic and a machine-wide log reader on the owner's personal Mac.
+LV_UI_LOG_SUBSYSTEM="${LV_UI_LOG_SUBSYSTEM:-com.localvoxtral}"
 
 # Machine-local overrides (never committed). Same argument as the build gate:
 # anyone who can write this file can already replace this script, so sourcing
@@ -366,6 +394,7 @@ import AppKit
 import ApplicationServices
 import Carbon.HIToolbox
 import CoreGraphics
+import Darwin
 import Foundation
 
 // Subcommands (argv[1..]):
@@ -907,6 +936,78 @@ case "termaction":
         die("unknown termaction")
     }
 
+// control <socket-path> <line>
+//
+// One line to the dogfood control socket of the app under test, one line back.
+// Written here rather than shelled out to `nc` for two reasons: the exact
+// half-close/EOF behaviour of BSD nc's `-U` is a detail this must not depend
+// on, and the embedded helper is compile-checked by test-ui-gate.sh while a
+// shell pipeline would not be.
+//
+// It connects, writes, reads, prints, exits. It has no idea what the line
+// means; the shell side decided that (run_app) and the app's own socket
+// validates it again.
+case "control":
+    guard argv.count >= 3 else { die("usage: control <socket-path> <line>") }
+    let socketPath = argv[1]
+    let line = argv[2]
+    var address = sockaddr_un()
+    address.sun_family = sa_family_t(AF_UNIX)
+    let pathBytes = Array(socketPath.utf8)
+    guard pathBytes.count < MemoryLayout.size(ofValue: address.sun_path) else {
+        die("socket path is too long")
+    }
+    withUnsafeMutableBytes(of: &address.sun_path) { raw in
+        raw.copyBytes(from: pathBytes)
+        raw[pathBytes.count] = 0
+    }
+    address.sun_len = UInt8(MemoryLayout<sockaddr_un>.size)
+    let controlFD = socket(AF_UNIX, SOCK_STREAM, 0)
+    guard controlFD >= 0 else { die("could not create a socket (\(errno))") }
+    defer { close(controlFD) }
+    let connected = withUnsafePointer(to: &address) { pointer in
+        pointer.withMemoryRebound(to: sockaddr.self, capacity: 1) { sockaddrPointer in
+            connect(controlFD, sockaddrPointer, socklen_t(MemoryLayout<sockaddr_un>.size))
+        }
+    }
+    guard connected == 0 else {
+        die("could not connect to the control socket (\(errno)) — is the app a dogfood build with debug.dogfood_control_socket_enabled armed?")
+    }
+    // Bounded on both halves: a wedged app must cost the operator a refusal,
+    // never a hung SSH command.
+    var controlTimeout = timeval(tv_sec: 30, tv_usec: 0)
+    setsockopt(controlFD, SOL_SOCKET, SO_SNDTIMEO, &controlTimeout, socklen_t(MemoryLayout<timeval>.size))
+    setsockopt(controlFD, SOL_SOCKET, SO_RCVTIMEO, &controlTimeout, socklen_t(MemoryLayout<timeval>.size))
+    let outgoing = Array((line + "\n").utf8)
+    var sent = 0
+    while sent < outgoing.count {
+        let written = outgoing.withUnsafeBytes { raw -> Int in
+            write(controlFD, raw.baseAddress!.advanced(by: sent), outgoing.count - sent)
+        }
+        if written <= 0 {
+            if written < 0, errno == EINTR { continue }
+            die("could not send the command (\(errno))")
+        }
+        sent += written
+    }
+    var incoming = [UInt8]()
+    var controlChunk = [UInt8](repeating: 0, count: 4096)
+    // 64 KiB is far past any reply the socket produces; the cap is a backstop
+    // against a peer that is not the app we think it is.
+    while incoming.count < 65_536 {
+        let count = read(controlFD, &controlChunk, controlChunk.count)
+        if count < 0 {
+            if errno == EINTR { continue }
+            die("could not read the reply (\(errno))")
+        }
+        if count == 0 { break }
+        incoming.append(contentsOf: controlChunk[0..<count])
+        if incoming.contains(0x0A) { break }
+    }
+    guard !incoming.isEmpty else { die("the control socket closed without answering") }
+    if let newline = incoming.firstIndex(of: 0x0A) { incoming = Array(incoming[0..<newline]) }
+    print(String(decoding: incoming, as: UTF8.self))
+
 default:
     die("unknown subcommand \(subcommand)")
 }
@@ -1390,6 +1491,162 @@ run_dictate() {
   ACTION_COMPLETED=1
 }
 
+# app <control command>
+#
+# Forwards ONE line to the dogfood control socket of the app under test and
+# prints the reply. This is what makes the join debuggable at all: the socket
+# can start a dictation deterministically (the real trigger is a modifier
+# gesture) and can resolve the focused surface against the app's LIVE session
+# registry, which is per-process and therefore invisible to `--probe-surface`
+# or to anything else outside that process.
+#
+# What keeps it from being a lateral path:
+#
+#   * The socket path is fixed, not an argument. There is no way to point this
+#     verb at another socket on the machine.
+#   * The app under test must be a DOGFOOD build. A shipped build compiles no
+#     socket at all, so forwarding to one would be a lie; refusing on the
+#     recorded stamp says so in one line instead of hanging on a connect.
+#   * The forwarded line must be one of the five shapes below. The socket
+#     validates its own grammar too — this list exists so the GATE knows which
+#     commands take the screen, and so a future socket verb is not
+#     automatically reachable through an already-installed gate.
+#   * Every token already survived the dispatch charset, so the reassembled
+#     line is printable ASCII separated by single spaces, which is exactly what
+#     the socket's parser accepts. Nothing here builds a shell command.
+#
+# Lock policy is per COMMAND, not per verb, because these differ in kind:
+# `session start` takes the keyboard and types into whatever is focused, so it
+# is refused on a locked screen and warns like `dictate`. `surface probe` reads
+# the FOCUSED surface, and behind a lock screen the focused surface is not the
+# one the operator is asking about — a truthful answer to the wrong question is
+# the worst kind — so it is refused too. The rest are in-process reads (or, for
+# `session stop`, a give-back) and are allowed while locked, like `state`.
+run_app() {
+  local -a parts=("$@")
+  local line="${parts[*]}"
+  local steals_focus=0 needs_unlocked=0
+
+  case "$line" in
+    "session start overlay" | "session start live")
+      steals_focus=1
+      needs_unlocked=1
+      ;;
+    # Not a focus steal — a correctness refusal. See above.
+    "surface probe") needs_unlocked=1 ;;
+    "session stop" | "join report" | "registry list") ;;
+    *)
+      deny "not a forwardable control command: $line"
+      ;;
+  esac
+
+  # Lock before anything else the way `term open` does it, so no locked-screen
+  # test can pass for an unrelated reason.
+  if (( needs_unlocked == 1 )); then
+    require_unlocked_screen
+  fi
+  require_app_under_test
+  [[ "$APP_DOGFOOD" == "1" ]] \
+    || deny "the app under test is not a dogfood build (launch it with --dogfood); a shipped build has no control socket"
+  [[ -S "$LV_UI_CONTROL_SOCKET" ]] \
+    || deny "no control socket at $LV_UI_CONTROL_SOCKET — arm it with: defaults write com.localvoxtral.app debug.dogfood_control_socket_enabled -bool true (then relaunch)"
+
+  log_command ALLOW "app=$line pid=$APP_PID"
+  if (( steals_focus == 1 )); then
+    announce_takeover "starting a localvoxtral dictation into the focused window"
+  fi
+  helper control "$LV_UI_CONTROL_SOCKET" "$line" || fail "the control socket did not answer"
+  ACTION_COMPLETED=1
+}
+
+# Masks maximal runs of exactly 43 base64url characters — the remote-enrollment
+# token's shape. Deliberately the SAME rule as DogfoodCaptureRedaction (and the
+# same trade: it over-matches an isolated 43-character identifier, and misses a
+# token glued into a longer run), so a reviewer reading a `<redacted>` here and
+# one in a capture record is reading the same decision.
+redact_token_shaped_runs() {
+  awk '{
+    out = ""; run = ""; n = length($0)
+    for (i = 1; i <= n; i++) {
+      c = substr($0, i, 1)
+      if (c ~ /[A-Za-z0-9_-]/) { run = run c }
+      else {
+        out = out ((length(run) == 43) ? "<redacted>" : run) c
+        run = ""
+      }
+    }
+    print out ((length(run) == 43) ? "<redacted>" : run)
+  }'
+}
+
+# log [minutes]
+#
+# The app's own unified-log lines, and nothing else on this machine.
+#
+# Read-only and focus-free, so unlike every actuation verb it is allowed while
+# the screen is locked — a diagnostic that only works when the owner is sitting
+# there is not a diagnostic for an agent.
+#
+# Three bounds, each doing a different job:
+#   * the PREDICATE scopes to localvoxtral's own subsystem. This is a debugging
+#     aid on a personal machine, not a system-log reader; every other app's
+#     activity stays out of reach and no argument widens it.
+#   * the WINDOW is clamped 1..LV_UI_LOG_MAX_MINUTES, mirroring the build
+#     gate's `applog`.
+#   * the OUTPUT is line-capped and passed through the same token-shaped scrub
+#     the dogfood records use. The app writes its categories `privacy: .public`
+#     on purpose, but "the app's own lines are safe" is an assumption about
+#     every line anyone ever adds, and this is the cheap way not to depend on it.
+#
+# `log show` is restricted for NON-ADMIN accounts — the build gate's account
+# hits exactly that and scripts/mac/README.md records it ("Could not open local
+# log store: Operation not permitted"). The UI gate runs as the GUI user, which
+# is a different, admin account, so it is expected to work here. It is NOT
+# verified as of this writing, so the failure is deliberately loud and
+# specific: a diagnostic that returns an empty page when it is actually
+# forbidden is worse than one that says it is forbidden.
+run_log() {
+  local minutes="${1:-$LV_UI_LOG_DEFAULT_MINUTES}" output="" status=0
+
+  [[ "$minutes" =~ ^[0-9]{1,4}$ ]] || deny "log takes a whole number of minutes"
+  (( minutes >= 1 )) || deny "log needs at least 1 minute"
+  (( minutes <= LV_UI_LOG_MAX_MINUTES )) \
+    || deny "log window is clamped to $LV_UI_LOG_MAX_MINUTES minutes"
+
+  log_command ALLOW "log minutes=$minutes subsystem=$LV_UI_LOG_SUBSYSTEM"
+
+  # `|| status=$?` rather than dying under `set -e`: a restricted log store
+  # exits non-zero AND prints the reason, and the reason is the whole answer.
+  output="$(log show --style compact --info \
+    --last "${minutes}m" \
+    --predicate "subsystem == \"$LV_UI_LOG_SUBSYSTEM\"" 2>&1)" || status=$?
+
+  if (( status != 0 )) || [[ "$output" == *"Could not open local log store"* ]]; then
+    printf 'localvoxtral ui gate: log show failed (status %s).\n' "$status" >&2
+    printf 'localvoxtral ui gate: %s\n' "$(printf '%s' "${output:0:400}" | tr -c '[:print:]' ' ')" >&2
+    printf 'localvoxtral ui gate: if that says "Could not open local log store: Operation not permitted", this account cannot read the unified log — the same restriction scripts/mac/README.md records for the build gate account. No flag lifts it; the alternatives are mac-crashlog.yml on the runner, or the app writing its own file.\n' >&2
+    exit 1
+  fi
+
+  output="$(printf '%s\n' "$output" | redact_token_shaped_runs)"
+
+  local total capped
+  total="$(printf '%s\n' "$output" | wc -l | tr -d ' ')"
+  capped="$(printf '%s\n' "$output" | tail -n "$LV_UI_LOG_MAX_LINES")"
+  printf '%s\n' "$capped"
+  if (( total > LV_UI_LOG_MAX_LINES )); then
+    printf 'localvoxtral ui gate: %s earlier line(s) dropped by the cap of %s\n' \
+      "$(( total - LV_UI_LOG_MAX_LINES ))" "$LV_UI_LOG_MAX_LINES" >&2
+  fi
+  # Never silently empty: "no matching entries" and "the reader is broken" look
+  # identical otherwise, and only one of them is a finding.
+  if [[ -z "${capped//[[:space:]]/}" ]]; then
+    printf 'localvoxtral ui gate: no %s entries in the last %s minute(s).\n' \
+      "$LV_UI_LOG_SUBSYSTEM" "$minutes" >&2
+  fi
+  ACTION_COMPLETED=1
+}
+
 run_quit() {
   require_app_under_test
   log_command ALLOW "pid=$APP_PID"
@@ -1612,6 +1869,18 @@ case "${ARGV[0]}" in
   quit)
     (( ${#ARGV[@]} == 1 )) || deny "quit takes no arguments"
     run_quit
+    ;;
+  app)
+    # Bounded here as well as in run_app: the forwardable shapes are two or
+    # three tokens, so anything longer is refused before it is even joined
+    # into a line.
+    (( ${#ARGV[@]} >= 3 && ${#ARGV[@]} <= 4 )) \
+      || deny "app takes a control command of two or three tokens"
+    run_app "${ARGV[@]:1}"
+    ;;
+  log)
+    (( ${#ARGV[@]} <= 2 )) || deny "log takes at most a number of minutes"
+    if (( ${#ARGV[@]} == 1 )); then run_log; else run_log "${ARGV[1]}"; fi
     ;;
   dictate)
     case "${ARGV[1]:-}" in

--- a/scripts/mac/localvoxtral-ui-gate.sh
+++ b/scripts/mac/localvoxtral-ui-gate.sh
@@ -1129,16 +1129,11 @@ run_term_close() {
 # Dispatch — deny by default
 # ---------------------------------------------------------------------------
 
-# Shell regression tests source the reviewed implementation directly; the
-# variable cannot cross the forced-command SSH boundary, where sshd fixes the
-# environment (keep AcceptEnv at its default — see scripts/mac/README.md).
-if [[ "${LOCALVOXTRAL_UI_GATE_SOURCE_ONLY:-0}" == "1" ]]; then
-  if [[ "${BASH_SOURCE[0]}" != "$0" ]]; then
-    return 0
-  fi
-  exit 0
-fi
-
+# There is deliberately no "source only" escape hatch here (the build gate has
+# one): test-ui-gate.sh executes this script for real against PATH stubs, so
+# nothing needs to suppress dispatch — and an environment variable that turns
+# the gate into a no-op is attack surface with no user.
+#
 # Reject the whole command before it is split: no newlines (only the first
 # line would ever be parsed), no control characters, bounded length.
 [[ -n "$original_command" ]] || deny "empty command"

--- a/scripts/mac/localvoxtral-ui-gate.sh
+++ b/scripts/mac/localvoxtral-ui-gate.sh
@@ -2274,9 +2274,6 @@ run_term_open() {
     token_is_safe "$token" || deny "unsafe token in term command"
   done
 
-  # Resolved BEFORE anything is opened. An allowlisted name that is not
-  # installed used to open an empty window and then fail with a window-identity
-  # message; this refuses with nothing opened and names the real problem.
   # Bash 3.2 (the Mac's /bin/bash) errors on an EMPTY array slice under set -u,
   # so the arguments after the command name are rendered once, guarded, rather
   # than expanded at each use.
@@ -2285,6 +2282,9 @@ run_term_open() {
     args_text=" ${argv[*]:1}"
   fi
 
+  # Resolved BEFORE anything is opened. An allowlisted name that is not
+  # installed used to open an empty window and then fail with a window-identity
+  # message; this refuses with nothing opened and names the real problem.
   local resolved_command
   resolved_command="$(resolve_term_command "${argv[0]}")" \
     || deny "${argv[0]} is allowlisted but is not an executable file in $LV_UI_TERM_COMMAND_DIRS — nothing was opened (install it: scripts/mac/install-ui-artifact.sh, or see \`state\`'s setup.term_open.unresolvable)"

--- a/scripts/mac/localvoxtral-ui-gate.sh
+++ b/scripts/mac/localvoxtral-ui-gate.sh
@@ -33,7 +33,12 @@ set -euo pipefail
 #
 #   - `shot` resolves a CGWindowID from the window list FILTERED to the pid
 #     this gate itself launched, and refuses when the resolved window's owner
-#     is not that pid. It can never photograph another application.
+#     is not that pid. It can never photograph another application. Its stdout
+#     is PURE base64 and nothing else; the `shot: window <id> (<kind>), <n>
+#     bytes` line goes to stderr, so `shot popover | base64 -d > x.png` is
+#     correct as written and needs no `tail`. Over an interactive ssh both
+#     streams land in the same terminal, which is the only reason it can look
+#     like a header.
 #   - `ax click` / `ax type` walk the accessibility tree rooted at
 #     AXUIElementCreateApplication(<that same pid>). A selector cannot name an
 #     element of another app.
@@ -45,6 +50,13 @@ set -euo pipefail
 #     that same pid, through AXUIElementCreateApplication(<it>). They exist
 #     because localvoxtral opens no window at launch — without them every verb
 #     above has nothing to address. No other app's menu bar is expressible.
+#     `menu open` and `menu dismiss` decide "is a menu on screen" from the
+#     WINDOW LIST, using the same layer >= 100 rule `shot popover` resolves,
+#     so the two verbs agree by construction. The AXMenu attached to a status
+#     item is NOT that evidence — it is there whether or not anything is
+#     displayed, and taking it for evidence is what made `menu open` report
+#     "ok already-open" without ever pressing anything (field check
+#     2026-08-29).
 #   - `dictate` posts the app's OWN configured trigger — read from the app's
 #     defaults, never hard-coded — as a modifier-only gesture at the HID tap.
 #     It is the one verb that does not target a window, because the trigger is
@@ -63,7 +75,11 @@ set -euo pipefail
 #   - `log` reads the unified log for localvoxtral's OWN subsystem only, over a
 #     clamped window, with a line cap and token-shaped runs masked. It is not a
 #     general system-log reader; every other application's activity on this
-#     machine stays out of reach.
+#     machine stays out of reach. It is scoped to one PROCESS as well as the
+#     subsystem — the pid `launch` recorded, or the app's process name when
+#     there is no app under test, which it then says. This Mac is also the
+#     self-hosted CI runner and `xctest` logs under the same subsystem, so
+#     subsystem alone hands back another run's lines (field check 2026-08-30).
 #
 # A `term open` window is therefore NOT a lateral path into the app-driving
 # verbs, and the scoping above is why: `shot`, `ax dump`, `ax click`, `ax type`
@@ -178,6 +194,14 @@ LV_UI_LOG_MAX_LINES="${LV_UI_LOG_MAX_LINES:-400}"
 # The app's OWN subsystem and nothing else. This is the difference between a
 # diagnostic and a machine-wide log reader on the owner's personal Mac.
 LV_UI_LOG_SUBSYSTEM="${LV_UI_LOG_SUBSYSTEM:-com.localvoxtral}"
+# The subsystem alone is NOT enough on this machine: the self-hosted CI runner
+# shares it, and `xctest` running the unit suite logs under the very same
+# subsystem (field check 2026-08-30: `log 2` returned 111 lines, all but one
+# of them `xctest[19586]`). So the predicate also carries a process. The pid
+# `launch` recorded is the preferred one — it scopes to the instance under
+# test the way every other verb does; this name is the fallback used when
+# there is no app under test, and the output says so when it is.
+LV_UI_LOG_PROCESS="${LV_UI_LOG_PROCESS:-localvoxtral}"
 
 # Machine-local overrides (never committed). Same argument as the build gate:
 # anyone who can write this file can already replace this script, so sourcing
@@ -612,12 +636,67 @@ func extrasMenuBarItem(_ pid: pid_t) -> AXUIElement {
     return item
 }
 
-func openMenu(of item: AXUIElement) -> AXUIElement? {
+// The AXMenu ATTACHED to the status item — reachable, pressable, and NOT
+// evidence that anything is on screen.
+//
+// An NSMenu handed to an NSStatusItem is an AXMenu child of that item for the
+// whole life of the app, displayed or not. Field check 2026-08-29, against a
+// freshly launched build that had shown nothing: `menu open` printed
+// "ok already-open" and returned instantly, `shot popover` then reported no
+// popover window at all, and `ax dump all` returned `[]`. The pre-check that
+// used this function as "is the menu open" therefore matched every time, the
+// status item was never pressed, and the verb reported success while doing
+// nothing. Whatever else changes here, do not spell this `openMenu` again —
+// the name was the bug.
+//
+// It stays because pressing a menu ITEM through AX works whether or not the
+// menu is displayed (that is how the gate reached Settings while `menu open`
+// was broken), so `menuclick` wants exactly this and not the window test
+// below.
+func attachedMenu(of item: AXUIElement) -> AXUIElement? {
     for child in (copyAttr(item, kAXChildrenAttribute) as? [AXUIElement]) ?? []
     where str(child, kAXRoleAttribute) == "AXMenu" {
         return child
     }
     return nil
+}
+
+// "A menu is DISPLAYED" — the only honest test, and deliberately the SAME one
+// `shot popover` resolves with: a window owned by this pid at layer >= 100
+// (kCGPopUpMenuWindowLevel). Sharing resolveWindow rather than writing a
+// second, similar rule is the point — `menu open` then succeeds exactly when
+// `shot popover` can photograph something, by construction, and the two verbs
+// cannot drift apart. If this ever answers wrongly on a live desktop, both
+// verbs say so together instead of one lying to cover the other.
+//
+// Caveat worth knowing rather than coding around: any pid-owned window at that
+// layer counts, so a context menu open inside Settings reads as "displayed"
+// here. That is the same window `shot popover` would capture, which is the
+// agreement this is for.
+func displayedMenuWindow(pid: pid_t) -> CGWindowRecord? {
+    resolveWindow(pid: Int(pid), kind: "popover", index: nil)
+}
+
+// Poll for the menu window to appear (`open`) or go away (`dismiss`). The AX
+// press's own status is never the answer — it reports .cannotComplete while a
+// menu tracks — so both verbs wait on the window list instead, which keeps
+// answering while the app's AX server is blocked.
+func waitForMenuWindow(pid: pid_t, seconds: Double) -> CGWindowRecord? {
+    let deadline = Date().addingTimeInterval(seconds)
+    while true {
+        if let window = displayedMenuWindow(pid: pid) { return window }
+        if Date() >= deadline { return nil }
+        usleep(150_000)
+    }
+}
+
+func waitForMenuWindowToClose(pid: pid_t, seconds: Double) -> Bool {
+    let deadline = Date().addingTimeInterval(seconds)
+    while true {
+        if displayedMenuWindow(pid: pid) == nil { return true }
+        if Date() >= deadline { return false }
+        usleep(150_000)
+    }
 }
 
 // Bring one pid frontmost and give the activation up to two seconds to land.
@@ -754,29 +833,40 @@ case "key":
 
 case "menuopen":
     guard argv.count >= 2 else { die("usage: menuopen <pid>") }
-    let item = extrasMenuBarItem(requirePID(argv[1]))
-    if openMenu(of: item) != nil {
-        print("ok already-open")
+    let openPID = requirePID(argv[1])
+    // The fast path is kept, but on evidence: a menu already ON SCREEN. The
+    // window id is printed so the caller can see WHY this said ok, and so a
+    // silent no-op can never look like a success again.
+    if let existing = displayedMenuWindow(pid: openPID) {
+        print("ok already-open window=\(existing.id)")
         break
     }
+    let item = extrasMenuBarItem(openPID)
     _ = AXUIElementPerformAction(item, kAXPressAction as CFString)
-    // The press's own status is not the answer — it reports .cannotComplete
-    // while the menu tracks. The menu's existence is the answer.
-    let menuDeadline = Date().addingTimeInterval(3)
-    while Date() < menuDeadline {
-        if openMenu(of: item) != nil {
-            print("ok")
-            exit(0)
-        }
-        usleep(150_000)
+    // The press's own status is deliberately not trusted: it reports
+    // .cannotComplete while the menu tracks. A window on screen is the answer.
+    if let opened = waitForMenuWindow(pid: openPID, seconds: 3) {
+        print("ok window=\(opened.id)")
+        break
     }
-    die("the status item was pressed but no menu opened")
+    // Reached with the press already delivered, so the menu MAY be up and
+    // simply not visible to the window list. Say that, rather than inviting a
+    // second press that would toggle a tracking menu shut.
+    die("the status item of pid \(openPID) was pressed but no window appeared at "
+        + "layer >= 100 within 3s — the same window `shot popover` resolves. "
+        + "Run `menu dismiss` before retrying; `menu click <title>` works "
+        + "without a displayed menu.")
 
 case "menuclick":
     guard argv.count >= 3 else { die("usage: menuclick <pid> <item-title>") }
     let wanted = argv[2].replacingOccurrences(of: "+", with: " ")
-    guard let menu = openMenu(of: extrasMenuBarItem(requirePID(argv[1]))) else {
-        die("no status menu is open — run `menu open` first")
+    // ATTACHED, not displayed, and that is the point: AXPress on a menu item
+    // works whether or not the menu is on screen, so this verb keeps working
+    // when `menu open` cannot resolve a window (it is how the gate reached
+    // Settings on 2026-08-29).
+    let clickPID = requirePID(argv[1])
+    guard let menu = attachedMenu(of: extrasMenuBarItem(clickPID)) else {
+        die("pid \(clickPID) exposes no status menu (no AXMenu under its status item)")
     }
     let entries = ((copyAttr(menu, kAXChildrenAttribute) as? [AXUIElement]) ?? [])
         .filter { !str($0, kAXTitleAttribute).isEmpty }
@@ -802,20 +892,35 @@ case "menuclick":
 
 case "menudismiss":
     guard argv.count >= 2 else { die("usage: menudismiss <pid>") }
-    let dismissItem = extrasMenuBarItem(requirePID(argv[1]))
-    guard let openMenuElement = openMenu(of: dismissItem) else {
+    let dismissPID = requirePID(argv[1])
+    // Nothing on screen: return BEFORE touching the status item. This branch
+    // used to be decided by attachment, which is always true, so it never ran
+    // — and the fallback below presses the status item, which on a closed menu
+    // OPENS one. A dismiss verb must never be able to open a menu.
+    guard displayedMenuWindow(pid: dismissPID) != nil else {
         print("ok no-menu-open")
         break
     }
+    let dismissItem = extrasMenuBarItem(dismissPID)
     // AXCancel on the app's own menu, not a synthesised Escape: a keystroke
     // goes to whatever owns the keyboard, and closing a menu never has to.
-    if AXUIElementPerformAction(openMenuElement, kAXCancelAction as CFString) == .success {
-        print("ok")
+    // Its return code is trusted no further than AXPress's: the window going
+    // away is the answer.
+    if let attached = attachedMenu(of: dismissItem) {
+        _ = AXUIElementPerformAction(attached, kAXCancelAction as CFString)
+        if waitForMenuWindowToClose(pid: dismissPID, seconds: 2) {
+            print("ok")
+            break
+        }
+    }
+    // Fall back to toggling the status item shut — still the app's own
+    // element, and only ever reached with a menu confirmed on screen.
+    _ = AXUIElementPerformAction(dismissItem, kAXPressAction as CFString)
+    if waitForMenuWindowToClose(pid: dismissPID, seconds: 2) {
+        print("ok pressed")
         break
     }
-    // Fall back to toggling the status item shut — still the app's own element.
-    _ = AXUIElementPerformAction(dismissItem, kAXPressAction as CFString)
-    print("ok")
+    die("the menu window of pid \(dismissPID) is still on screen after AXCancel and a status-item press")
 
 case "dictate":
     guard argv.count >= 4 else { die("usage: dictate <pid> <modifier> <tap|hold|cancel> [seconds]") }
@@ -1272,6 +1377,13 @@ run_launch() {
 
 # shot [settings|popover|overlay|window <n>] — ONE window, by CGWindowID, and
 # only if that window's owner is the pid this gate launched.
+#
+# stdout is the base64 of the PNG and NOTHING else, so the documented form
+#   ssh lv-ui 'shot popover' | base64 -d > /tmp/popover.png
+# is correct with no `tail -n +2`. The `shot: window …` line below is on
+# stderr for exactly that reason. It reads like a header only because an
+# interactive ssh delivers both streams to the same terminal; redirect stdout
+# and the header stays behind on the terminal, where it is useful.
 run_shot() {
   local kind="${1:-settings}" index="${2:-}" resolved winid owner file size
   case "$kind" in
@@ -1588,9 +1700,25 @@ redact_token_shaped_runs() {
 # there is not a diagnostic for an agent.
 #
 # Three bounds, each doing a different job:
-#   * the PREDICATE scopes to localvoxtral's own subsystem. This is a debugging
-#     aid on a personal machine, not a system-log reader; every other app's
-#     activity stays out of reach and no argument widens it.
+#   * the PREDICATE scopes to localvoxtral's own subsystem AND to one process.
+#     This is a debugging aid on a personal machine, not a system-log reader;
+#     every other app's activity stays out of reach and no argument widens it.
+#
+#     The process half is not tidiness, it is correctness. This Mac is also the
+#     self-hosted CI runner, and a unit-suite run logs under localvoxtral's own
+#     subsystem from `xctest` — different process, different machine-state,
+#     same subsystem. Field check 2026-08-30: `log 2` returned 111 lines of
+#     which exactly one was the app under test; the rest were a concurrent
+#     xctest run, including "Terminal pane joined to a live Claude session via
+#     title marker". Reading that as the join for the dictation you just made
+#     is a wrong conclusion drawn from a real log line, which is the worst kind
+#     this verb can produce.
+#
+#     So: with an app under test, the predicate carries `processIdentifier ==
+#     <the pid launch recorded>` and the lines are ONE instance's. With none,
+#     it falls back to `process == "localvoxtral"` — still never xctest, but no
+#     longer one instance — and says so on stderr. Silently answering with
+#     another process's lines is the one behaviour that is not available.
 #   * the WINDOW is clamped 1..LV_UI_LOG_MAX_MINUTES, mirroring the build
 #     gate's `applog`.
 #   * the OUTPUT is line-capped and passed through the same token-shaped scrub
@@ -1613,13 +1741,32 @@ run_log() {
   (( minutes <= LV_UI_LOG_MAX_MINUTES )) \
     || deny "log window is clamped to $LV_UI_LOG_MAX_MINUTES minutes"
 
-  log_command ALLOW "log minutes=$minutes subsystem=$LV_UI_LOG_SUBSYSTEM"
+  # Scope, decided before anything is read. `load_app_state` is the same
+  # pid-with-identity check every other verb goes through, so a recycled pid
+  # falls back rather than reading a stranger's lines.
+  local predicate scope
+  if load_app_state; then
+    predicate="subsystem == \"$LV_UI_LOG_SUBSYSTEM\" AND processIdentifier == $APP_PID"
+    scope="pid=$APP_PID"
+  else
+    predicate="subsystem == \"$LV_UI_LOG_SUBSYSTEM\" AND process == \"$LV_UI_LOG_PROCESS\""
+    scope="process=$LV_UI_LOG_PROCESS not-pid-scoped"
+  fi
+
+  log_command ALLOW "log minutes=$minutes subsystem=$LV_UI_LOG_SUBSYSTEM $scope"
+
+  # Said before the lines, not after: an operator who reads the output first
+  # and the caveat second has already drawn the conclusion.
+  if [[ -z "$APP_PID" ]]; then
+    printf 'localvoxtral ui gate: no app under test — these lines are every process named "%s" on this machine, not one instance. Run `launch <artifact>` first to scope them to the build under test.\n' \
+      "$LV_UI_LOG_PROCESS" >&2
+  fi
 
   # `|| status=$?` rather than dying under `set -e`: a restricted log store
   # exits non-zero AND prints the reason, and the reason is the whole answer.
   output="$(log show --style compact --info \
     --last "${minutes}m" \
-    --predicate "subsystem == \"$LV_UI_LOG_SUBSYSTEM\"" 2>&1)" || status=$?
+    --predicate "$predicate" 2>&1)" || status=$?
 
   if (( status != 0 )) || [[ "$output" == *"Could not open local log store"* ]]; then
     printf 'localvoxtral ui gate: log show failed (status %s).\n' "$status" >&2
@@ -1641,8 +1788,8 @@ run_log() {
   # Never silently empty: "no matching entries" and "the reader is broken" look
   # identical otherwise, and only one of them is a finding.
   if [[ -z "${capped//[[:space:]]/}" ]]; then
-    printf 'localvoxtral ui gate: no %s entries in the last %s minute(s).\n' \
-      "$LV_UI_LOG_SUBSYSTEM" "$minutes" >&2
+    printf 'localvoxtral ui gate: no %s entries for %s in the last %s minute(s).\n' \
+      "$LV_UI_LOG_SUBSYSTEM" "$scope" "$minutes" >&2
   fi
   ACTION_COMPLETED=1
 }

--- a/scripts/mac/lv-attach.sh
+++ b/scripts/mac/lv-attach.sh
@@ -1,0 +1,159 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# lv-attach — open a whole-view herdr client on the owner's configured host.
+#
+# THIS SCRIPT EXISTS TO BE ALLOWLISTED, and everything about it is shaped by
+# that. `term open` in the UI gate (scripts/mac/localvoxtral-ui-gate.sh) checks
+# only the FIRST token of a command against LV_UI_TERM_COMMANDS, so an
+# allowlisted name is trusted with every argument it will ever be given. The
+# gate's stated test for adding a name is: AN ALLOWLISTED COMMAND MUST NOT BE
+# ABLE TO RUN A CHILD COMMAND — not "must not be a shell", must not be able to
+# start one through any flag or subcommand. `ssh` fails that test outright and
+# is permanently denylisted; `claude`, `codex`, `opencode` and `herdr agent
+# start` each fail it too.
+#
+# This wrapper passes it, and here is the whole argument:
+#
+#   * It takes ONE optional argument, a herdr session NAME, and nothing else.
+#     No flags. No command. No second positional. Anything unrecognised is
+#     refused, not passed on.
+#   * That name must match ^[A-Za-z0-9._-]{1,64}$ and must not begin with `-`.
+#     There is no character in that set that a shell treats specially, so the
+#     name cannot become a flag to ssh, cannot escape the remote command that
+#     ssh assembles, and cannot reach a remote shell as anything but a literal.
+#   * The destination is NOT an argument. It is read from the owner's own
+#     config file, and validated on the way out.
+#   * The argv is fixed: `ssh -t -- <destination> herdr [--session <name>]`.
+#     There is no code path in this file that runs anything else, and no
+#     `eval`, `bash -c`, `sh -c`, or `$@` in a command position anywhere in it
+#     (pinned by scripts/ci/test-ui-gate.sh).
+#
+# WHY A WHOLE-VIEW CLIENT AND NOT `herdr terminal attach <pane>`:
+# the app classifies the ssh it finds on the focused surface
+# (`HerdrInvocation`, docs/agent/invariants.md) and REFUSES every herdr shape
+# except a bare `herdr` or `herdr --session <name>`. `terminal attach` renders
+# one pane rather than the server-global focus the join reads, so a wrapper
+# that opened one would reliably produce a window the app deliberately never
+# joins — i.e. it would be useless for the exact debugging `term open` exists
+# for. A pane is selected INSIDE herdr, after attaching.
+#
+# CONFIG — the owner writes this, once:
+#
+#   ~/.lv-attach.conf
+#     destination=builder            # an ssh alias, or user@host
+#     session=work                   # optional default session name
+#
+# ALLOWLISTING IT — in ~/.localvoxtral-ui-gate.conf:
+#
+#   LV_UI_TERM_COMMANDS="lv-attach"
+#
+# and `lv-attach` must be on the PATH of a GUI-launched terminal
+# (scripts/mac/install-ui-artifact.sh installs it to ~/bin/lv-attach).
+
+CONF="${LV_ATTACH_CONF:-$HOME/.lv-attach.conf}"
+
+die() {
+  printf 'lv-attach: %s\n' "$1" >&2
+  exit "${2:-1}"
+}
+
+# --- arguments -------------------------------------------------------------
+#
+# Parsed by shape, not by loop-with-fallthrough: there is exactly one accepted
+# shape and everything else is an error. In particular `-*` is refused BEFORE
+# the charset check, so the error message names the real problem.
+
+SESSION=""
+if (( $# > 1 )); then
+  die "takes at most one argument (a herdr session name); got $#"
+fi
+if (( $# == 1 )); then
+  case "$1" in
+    -*) die "does not take flags (got: $1)" ;;
+  esac
+  # An explicitly empty argument is a mistake, not "use the configured
+  # default": silently falling back would make `lv-attach "$SOMETHING_UNSET"`
+  # open a session nobody asked for.
+  [[ -n "$1" ]] || die "the session name is empty"
+  SESSION="$1"
+fi
+
+# --- config ----------------------------------------------------------------
+#
+# READ, never sourced. Sourcing would make the config file a shell script, and
+# the whole point of this wrapper is that no caller-reachable path runs one.
+
+[[ -f "$CONF" ]] || die "no config at $CONF (needs a line: destination=<ssh alias>)"
+
+read_conf_value() { # <key>
+  # First assignment wins; trailing whitespace and comments dropped. `sed`,
+  # not `source`.
+  sed -n "s/^[[:space:]]*$1[[:space:]]*=[[:space:]]*//p" "$CONF" \
+    | sed -e 's/[[:space:]]*#.*$//' -e 's/[[:space:]]*$//' \
+    | head -n 1
+}
+
+DESTINATION="$(read_conf_value destination)"
+[[ -n "$DESTINATION" ]] || die "$CONF has no destination= line"
+
+if [[ -z "$SESSION" ]]; then
+  SESSION="$(read_conf_value session)"
+fi
+
+# --- validation ------------------------------------------------------------
+#
+# Both values are validated the same way and for the same reason: each becomes
+# an argv element of a real ssh invocation, and the session name additionally
+# becomes a token of the REMOTE command, which ssh assembles into a string the
+# remote login shell interprets. The charset below contains nothing a shell
+# treats specially — no whitespace, quote, backslash, `$`, backtick, `;`, `&`,
+# `|`, `<`, `>`, `(`, `)`, `*`, `?`, `!`, `~`, `#`, `=`, `:` or `/` — so a name
+# that passes cannot be anything but a literal on either side.
+#
+# `=` and `:` are excluded deliberately even though a shell would not act on
+# them: they are how an ssh option (`-oProxyCommand=…`) and a `-L` forward spec
+# are written, and a validator that admitted them would be one leading dash
+# away from a hole.
+
+is_safe_name() { # <value>
+  [[ "$1" =~ ^[A-Za-z0-9._-]+$ ]] && [[ "$1" != -* ]] && (( ${#1} <= 64 ))
+}
+
+# The destination may carry a user (`builder@host`); nothing else.
+is_safe_destination() { # <value>
+  local value="$1" user="" host="$1"
+  case "$value" in
+    *@*)
+      user="${value%%@*}"
+      host="${value#*@}"
+      [[ -n "$user" ]] || return 1
+      is_safe_name "$user" || return 1
+      ;;
+  esac
+  [[ "$host" != *@* ]] || return 1
+  is_safe_name "$host"
+}
+
+is_safe_destination "$DESTINATION" \
+  || die "refusing destination from $CONF: must be an alias or user@host of [A-Za-z0-9._-], not starting with '-' (got: $DESTINATION)"
+
+if [[ -n "$SESSION" ]]; then
+  is_safe_name "$SESSION" \
+    || die "refusing session name: must be 1-64 characters of [A-Za-z0-9._-] and must not start with '-' (got: $SESSION)"
+fi
+
+# --- exec ------------------------------------------------------------------
+#
+# `--` before the destination so a destination cannot be read as an option even
+# if the validation above were ever loosened. `-t` because herdr is a TUI and
+# needs a pty; `-t` is the only ssh flag here and it takes no value.
+#
+# The two invocation shapes below are exactly the two `HerdrInvocation` accepts
+# (docs/agent/invariants.md). Adding a third is not a change to this file — it
+# is a change to what the app will join.
+
+if [[ -n "$SESSION" ]]; then
+  exec ssh -t -- "$DESTINATION" herdr --session "$SESSION"
+fi
+exec ssh -t -- "$DESTINATION" herdr

--- a/scripts/mac/lv-attach.sh
+++ b/scripts/mac/lv-attach.sh
@@ -16,8 +16,11 @@ set -euo pipefail
 # This wrapper passes it, and here is the whole argument:
 #
 #   * It takes ONE optional argument, a herdr session NAME, and nothing else.
-#     No flags. No command. No second positional. Anything unrecognised is
-#     refused, not passed on.
+#     No command. No second positional. Anything unrecognised is refused, not
+#     passed on. There is exactly one flag, `--check`, which prints a readiness
+#     verdict and exits WITHOUT running anything (the UI gate's `state` uses it
+#     so the destination validator below has one implementation, not two);
+#     every other `-*` is still refused outright.
 #   * That name must match ^[A-Za-z0-9._-]{1,64}$ and must not begin with `-`.
 #     There is no character in that set that a shell treats specially, so the
 #     name cannot become a flag to ssh, cannot escape the remote command that
@@ -44,6 +47,9 @@ set -euo pipefail
 #     destination=builder            # an ssh alias, or user@host
 #     session=work                   # optional default session name
 #
+#   `lv-attach --check` says whether that file resolves, and
+#   `ssh lv-ui state` reports the same verdict under setup.lv_attach.
+#
 # ALLOWLISTING IT — in ~/.localvoxtral-ui-gate.conf:
 #
 #   LV_UI_TERM_COMMANDS="lv-attach"
@@ -65,26 +71,70 @@ die() {
 # the charset check, so the error message names the real problem.
 
 SESSION=""
+CHECK=0
 if (( $# > 1 )); then
   die "takes at most one argument (a herdr session name); got $#"
 fi
 if (( $# == 1 )); then
   case "$1" in
+    # The ONE accepted flag, and the only code path in this file that does not
+    # end in `exec ssh`. It exists because the UI gate's `state` has to be able
+    # to say whether this wrapper is installed and whether its config resolves,
+    # and re-implementing the validator below inside the gate would give the
+    # boundary two copies that can drift. It reads the same file with the same
+    # `sed`, prints a verdict, and returns — it opens no connection and starts
+    # no child, so allowlisting `lv-attach` still admits nothing that can run a
+    # command. Every other `-*` is refused exactly as before.
+    --check) CHECK=1 ;;
     -*) die "does not take flags (got: $1)" ;;
   esac
-  # An explicitly empty argument is a mistake, not "use the configured
-  # default": silently falling back would make `lv-attach "$SOMETHING_UNSET"`
-  # open a session nobody asked for.
-  [[ -n "$1" ]] || die "the session name is empty"
-  SESSION="$1"
+  if (( CHECK == 0 )); then
+    # An explicitly empty argument is a mistake, not "use the configured
+    # default": silently falling back would make `lv-attach "$SOMETHING_UNSET"`
+    # open a session nobody asked for.
+    [[ -n "$1" ]] || die "the session name is empty"
+    SESSION="$1"
+  fi
 fi
+
+# --- --check's report ------------------------------------------------------
+#
+# key=value lines on stdout, exit 0 only when this wrapper would actually run.
+#
+#   conf=ok|missing|no-destination|invalid-destination|invalid-session
+#   destination_kind=alias|user@host        (present when conf=ok)
+#   destination=<alias>                     (ONLY when the destination is a
+#                                            bare alias — see below)
+#   session=configured|absent               (present when conf=ok)
+#
+# The destination is echoed only when it is a bare alias, and this is a
+# deliberate line rather than squeamishness. A bare alias is a label in the
+# owner's own ~/.ssh/config: it names no account and no address, and it is the
+# value an operator actually needs, because the failure it catches is "this
+# points at the wrong machine". A `user@host` destination IS an account and an
+# address, and this gate's stated posture is that no host, session id or
+# account crosses it (see `app`'s closed reply vocabulary). So the shape is
+# reported and the value is not.
+report_check() { # <status> [kind] [destination] [session]
+  printf 'conf=%s\n' "$1"
+  if [[ "$1" == ok ]]; then
+    printf 'destination_kind=%s\n' "$2"
+    [[ "$2" == alias ]] && printf 'destination=%s\n' "$3"
+    printf 'session=%s\n' "$4"
+    return 0
+  fi
+  return 1
+}
 
 # --- config ----------------------------------------------------------------
 #
 # READ, never sourced. Sourcing would make the config file a shell script, and
 # the whole point of this wrapper is that no caller-reachable path runs one.
 
-[[ -f "$CONF" ]] || die "no config at $CONF (needs a line: destination=<ssh alias>)"
+if [[ ! -f "$CONF" ]]; then
+  if (( CHECK == 1 )); then report_check missing || exit 1; fi
+  die "no config at $CONF (needs a line: destination=<ssh alias>)"
+fi
 
 read_conf_value() { # <key>
   # First assignment wins; trailing whitespace and comments dropped. `sed`,
@@ -95,7 +145,10 @@ read_conf_value() { # <key>
 }
 
 DESTINATION="$(read_conf_value destination)"
-[[ -n "$DESTINATION" ]] || die "$CONF has no destination= line"
+if [[ -z "$DESTINATION" ]]; then
+  if (( CHECK == 1 )); then report_check no-destination || exit 1; fi
+  die "$CONF has no destination= line"
+fi
 
 if [[ -z "$SESSION" ]]; then
   SESSION="$(read_conf_value session)"
@@ -135,12 +188,26 @@ is_safe_destination() { # <value>
   is_safe_name "$host"
 }
 
-is_safe_destination "$DESTINATION" \
-  || die "refusing destination from $CONF: must be an alias or user@host of [A-Za-z0-9._-], not starting with '-' (got: $DESTINATION)"
+if ! is_safe_destination "$DESTINATION"; then
+  # `--check` deliberately does NOT echo the value it is rejecting: a refused
+  # destination is the one case where the file's contents are arbitrary text.
+  if (( CHECK == 1 )); then report_check invalid-destination || exit 1; fi
+  die "refusing destination from $CONF: must be an alias or user@host of [A-Za-z0-9._-], not starting with '-' (got: $DESTINATION)"
+fi
 
-if [[ -n "$SESSION" ]]; then
-  is_safe_name "$SESSION" \
-    || die "refusing session name: must be 1-64 characters of [A-Za-z0-9._-] and must not start with '-' (got: $SESSION)"
+if [[ -n "$SESSION" ]] && ! is_safe_name "$SESSION"; then
+  if (( CHECK == 1 )); then report_check invalid-session || exit 1; fi
+  die "refusing session name: must be 1-64 characters of [A-Za-z0-9._-] and must not start with '-' (got: $SESSION)"
+fi
+
+# Everything this wrapper needs resolved. `--check` stops here, one step short
+# of the only thing this file ever runs.
+if (( CHECK == 1 )); then
+  DESTINATION_KIND=alias
+  [[ "$DESTINATION" == *@* ]] && DESTINATION_KIND=user@host
+  report_check ok "$DESTINATION_KIND" "$DESTINATION" \
+    "$([[ -n "$SESSION" ]] && printf 'configured' || printf 'absent')"
+  exit 0
 fi
 
 # --- exec ------------------------------------------------------------------

--- a/scripts/mac/ui-gate-doctor.sh
+++ b/scripts/mac/ui-gate-doctor.sh
@@ -51,7 +51,9 @@ while (( $# > 0 )); do
       STATE_FILE="$1"
       ;;
     -h | --help)
-      sed -n '3,12p' "$0"
+      # The usage block only — a help that trails off mid-sentence into the
+      # rationale is worse than none.
+      sed -n '/^# ui-gate-doctor —/,/--state-file <f>/p' "$0" | sed 's/^# \{0,1\}//'
       exit 0
       ;;
     *) die "unknown argument: $1" ;;

--- a/scripts/mac/ui-gate-doctor.sh
+++ b/scripts/mac/ui-gate-doctor.sh
@@ -1,0 +1,393 @@
+#!/usr/bin/env bash
+set -uo pipefail
+
+# ui-gate-doctor — the UI gate's first-install checklist, executable.
+#
+#   scripts/mac/ui-gate-doctor.sh                    # on the Mac's GUI account
+#   scripts/mac/ui-gate-doctor.sh --remote lv-ui     # from the Linux dev box
+#   scripts/mac/ui-gate-doctor.sh --state-file <f>   # render a captured `state`
+#
+# Why it exists. Every setup item this reports was, in a real session
+# (2026-08-30), invisible until a verb failed — and each failure looked exactly
+# like a broken verb: `term open` refused everything because
+# ~/.localvoxtral-ui-gate.conf did not exist, `app` denied because the dogfood
+# socket's runtime consent was off, and nobody could see either from outside.
+# The numbered list in scripts/mac/README.md said all of it; prose the owner
+# reads and mis-follows is not a check.
+#
+# Every line is either `ok` or `FIX` followed by ONE copy-pasteable command.
+# Exit 0 when nothing needs attention, 1 when something does, 2 when the gate
+# could not be reached at all.
+#
+# What it cannot do, in any mode: prove that a TCC grant works in a session
+# that arrived over SSH (it reports what the gate's own preflight saw), or that
+# a capture is not black, or that a status menu appears. Those stay in the
+# README's hand list, which now names only the items a script genuinely cannot
+# reach.
+
+ROOT_DIR="$(cd "$(dirname "$0")/../.." && pwd -P)"
+REPO_GATE="$ROOT_DIR/scripts/mac/localvoxtral-ui-gate.sh"
+INSTALLED_GATE="${LV_UI_INSTALLED_GATE:-$HOME/bin/localvoxtral-ui-gate.sh}"
+AUTHORIZED_KEYS="${LV_UI_AUTHORIZED_KEYS:-$HOME/.ssh/authorized_keys}"
+
+MODE=local
+REMOTE_DEST=""
+STATE_FILE=""
+
+die() { printf 'ui-gate-doctor: %s\n' "$1" >&2; exit "${2:-2}"; }
+
+while (( $# > 0 )); do
+  case "$1" in
+    --remote)
+      shift
+      [[ $# -gt 0 ]] || die "--remote needs an ssh destination"
+      MODE=remote
+      REMOTE_DEST="$1"
+      ;;
+    --state-file)
+      shift
+      [[ $# -gt 0 ]] || die "--state-file needs a path"
+      MODE=file
+      STATE_FILE="$1"
+      ;;
+    -h | --help)
+      sed -n '3,12p' "$0"
+      exit 0
+      ;;
+    *) die "unknown argument: $1" ;;
+  esac
+  shift
+done
+
+command -v python3 >/dev/null 2>&1 \
+  || die "python3 is required to read the gate's JSON"
+
+# --- get a `state` document ------------------------------------------------
+
+STATE_JSON=""
+STATE_SOURCE=""
+case "$MODE" in
+  remote)
+    STATE_JSON="$(ssh "$REMOTE_DEST" state 2>/dev/null || true)"
+    STATE_SOURCE="ssh $REMOTE_DEST state"
+    [[ -n "$STATE_JSON" ]] \
+      || die "\`ssh $REMOTE_DEST state\` returned nothing — the key, the forced command or the host is wrong. Try: ssh -v $REMOTE_DEST state"
+    ;;
+  file)
+    [[ -f "$STATE_FILE" ]] || die "no such file: $STATE_FILE"
+    STATE_JSON="$(cat "$STATE_FILE")"
+    STATE_SOURCE="$STATE_FILE"
+    ;;
+  local)
+    [[ -x "$INSTALLED_GATE" ]] \
+      || die "the gate is not installed at $INSTALLED_GATE. Install it: install -d -m 0700 \"\$HOME/bin\" && install -m 0755 $REPO_GATE \"$INSTALLED_GATE\""
+    # Run the INSTALLED copy exactly as sshd would, so this reports the gate
+    # the key actually reaches rather than the one in this checkout.
+    STATE_JSON="$(SSH_ORIGINAL_COMMAND=state "$INSTALLED_GATE" 2>/dev/null || true)"
+    STATE_SOURCE="$INSTALLED_GATE"
+    [[ -n "$STATE_JSON" ]] \
+      || die "$INSTALLED_GATE produced no output for \`state\`. Run it directly to see why: SSH_ORIGINAL_COMMAND=state $INSTALLED_GATE"
+    ;;
+esac
+
+# --- local-only facts the gate cannot report about itself ------------------
+#
+# Passed in as key=value lines; the renderer treats an absent key as
+# "not checkable from here" and stays quiet rather than guessing.
+
+local_facts() {
+  [[ "$MODE" == local ]] || return 0
+
+  local installed_sum="" repo_sum=""
+  installed_sum="$(sha256_of "$INSTALLED_GATE")"
+  repo_sum="$(sha256_of "$REPO_GATE")"
+  if [[ -n "$installed_sum" && -n "$repo_sum" ]]; then
+    if [[ "$installed_sum" == "$repo_sum" ]]; then
+      printf 'installed_gate=current\n'
+    else
+      printf 'installed_gate=stale\n'
+    fi
+  fi
+
+  if [[ -f "$AUTHORIZED_KEYS" ]]; then
+    if grep -q "command=\"$INSTALLED_GATE\"" "$AUTHORIZED_KEYS" 2>/dev/null; then
+      if grep -q "restrict,command=\"$INSTALLED_GATE\"" "$AUTHORIZED_KEYS" 2>/dev/null; then
+        printf 'forced_command=restrict\n'
+      else
+        printf 'forced_command=unrestricted\n'
+      fi
+    else
+      printf 'forced_command=absent\n'
+    fi
+  else
+    printf 'forced_command=no-authorized-keys\n'
+  fi
+
+  printf 'repo_gate=%s\n' "$REPO_GATE"
+  printf 'installed_gate_path=%s\n' "$INSTALLED_GATE"
+}
+
+sha256_of() { # <path> -> lowercase digest, empty when unreadable
+  local out=""
+  [[ -f "$1" ]] || return 0
+  if command -v shasum >/dev/null 2>&1; then
+    out="$(shasum -a 256 "$1" 2>/dev/null || true)"
+  elif command -v sha256sum >/dev/null 2>&1; then
+    out="$(sha256sum "$1" 2>/dev/null || true)"
+  fi
+  out="${out%% *}"
+  [[ "$out" =~ ^[0-9a-f]{64}$ ]] && printf '%s' "$out"
+}
+
+FACTS="$(local_facts)"
+
+# --- render ----------------------------------------------------------------
+
+STATE_JSON="$STATE_JSON" FACTS="$FACTS" STATE_SOURCE="$STATE_SOURCE" MODE="$MODE" \
+python3 <<'PY'
+import json
+import os
+import sys
+
+raw = os.environ["STATE_JSON"]
+facts = dict(
+    line.split("=", 1)
+    for line in os.environ.get("FACTS", "").splitlines()
+    if "=" in line
+)
+mode = os.environ["MODE"]
+
+try:
+    state = json.loads(raw)
+except ValueError:
+    sys.stderr.write(
+        "ui-gate-doctor: %s did not return JSON. First 200 bytes:\n%s\n"
+        % (os.environ["STATE_SOURCE"], raw[:200])
+    )
+    raise SystemExit(2)
+
+setup = state.get("setup")
+if setup is None:
+    sys.stderr.write(
+        "ui-gate-doctor: this `state` has no `setup` section, so the gate that "
+        "answered predates setup reporting. Reinstall it from this checkout:\n"
+        "  install -m 0755 scripts/mac/localvoxtral-ui-gate.sh ~/bin/localvoxtral-ui-gate.sh\n"
+    )
+    raise SystemExit(2)
+
+rows = []          # (status, label, detail, fix)
+def ok(label, detail=""):
+    rows.append(("ok", label, detail, ""))
+def fix(label, detail, command):
+    rows.append(("FIX", label, detail, command))
+def note(label, detail):
+    rows.append(("--", label, detail, ""))
+
+GATE_CONF = "~/.localvoxtral-ui-gate.conf"
+ATTACH_CONF = "~/.lv-attach.conf"
+
+# 1. the gate itself
+rev = setup.get("gate", {}).get("revision", "unknown")
+if facts.get("installed_gate") == "stale":
+    fix("gate script",
+        "the installed gate differs from this checkout (revision %s)" % rev,
+        "install -m 0755 %s %s"
+        % (facts.get("repo_gate", "scripts/mac/localvoxtral-ui-gate.sh"),
+           facts.get("installed_gate_path", "~/bin/localvoxtral-ui-gate.sh")))
+elif facts.get("installed_gate") == "current":
+    ok("gate script", "revision %s, matches this checkout" % rev)
+else:
+    ok("gate script",
+       "revision %s (compare: shasum -a 256 scripts/mac/localvoxtral-ui-gate.sh)" % rev)
+
+# 2. the forced command (local only)
+forced = facts.get("forced_command")
+if forced == "restrict":
+    ok("forced command", "restrict,command= on the gate key")
+elif forced == "unrestricted":
+    fix("forced command",
+        "the key forces the gate but without `restrict` (pty and forwarding stay open)",
+        "edit ~/.ssh/authorized_keys: prefix the gate's key line with  restrict,")
+elif forced == "absent":
+    fix("forced command",
+        "no authorized_keys line forces the gate — the key would get a shell",
+        'add to ~/.ssh/authorized_keys:  restrict,command="%s" <the ui-gate public key>'
+        % facts.get("installed_gate_path", "~/bin/localvoxtral-ui-gate.sh"))
+elif forced == "no-authorized-keys":
+    fix("forced command", "no ~/.ssh/authorized_keys at all",
+        "see scripts/mac/README.md, 'One-time install (owner GUI session on the Mac)'")
+
+# 3. the lock probe — fail-closed, so a missing probe denies every GUI verb
+if setup.get("lock_probe", {}).get("installed"):
+    lock = state.get("screen_lock", "unknown")
+    if lock == "unlocked":
+        ok("screen lock", "unlocked")
+    elif lock == "locked":
+        note("screen lock",
+             "locked — `state`, `log` and `gate-log` answer; every GUI verb denies until you unlock")
+    else:
+        fix("screen lock",
+            "the probe answered %r, which denies every GUI-touching verb (fail closed)" % lock,
+            "run the probe by hand on the Mac: ~/bin/localvoxtral-screen-lock-state.sh")
+else:
+    fix("lock probe",
+        "not installed, so every GUI-touching verb denies (fail closed)",
+        "install -m 0755 scripts/ci/screen-lock-state.sh ~/bin/localvoxtral-screen-lock-state.sh")
+
+# 4. TCC — reported, never proved: this is what the gate's preflight saw.
+tcc = state.get("tcc", {})
+for key, label, verbs in (
+    ("accessibility", "TCC accessibility", "ax dump/click/type, key, menu, dictate"),
+    ("screen_recording", "TCC screen recording", "shot"),
+):
+    if tcc.get(key):
+        ok(label, "granted (%s)" % verbs)
+    else:
+        fix(label, "not granted — %s cannot work" % verbs,
+            "System Settings > Privacy & Security > %s: add /usr/libexec/sshd-keygen-wrapper"
+            % ("Accessibility" if key == "accessibility" else "Screen Recording"))
+
+# 5. the gate conf and the term-open allowlist
+conf = setup.get("gate_conf", {})
+term = setup.get("term_open", {})
+commands = term.get("commands", [])
+blocked = term.get("refused_by_denylist", [])
+if conf.get("status") == "unparsable":
+    fix("gate conf",
+        "%s has a syntax error and is being IGNORED — every setting is at its default"
+        % GATE_CONF,
+        "bash -n %s   # then fix the line it names" % GATE_CONF)
+elif not conf.get("present"):
+    fix("gate conf",
+        "%s does not exist, so `term open` accepts nothing" % GATE_CONF,
+        "printf 'LV_UI_TERM_COMMANDS=\"lv-attach\"\\n' >> %s" % GATE_CONF)
+else:
+    ok("gate conf", "%s present and parses" % GATE_CONF)
+
+unresolvable = term.get("unresolvable", [])
+if not commands:
+    fix("term open allowlist",
+        "empty — `term open` denies every command (this is the shipped default)",
+        "printf 'LV_UI_TERM_COMMANDS=\"lv-attach\"\\n' >> %s" % GATE_CONF)
+elif unresolvable:
+    # The 2026-08-30 failure exactly: allowlisted, and no executable behind it.
+    # `term open` used to open an empty window and then blame the window.
+    fix("term open allowlist",
+        "allowlisted with no executable in ~/bin: %s — `term open` refuses these "
+        "and opens nothing" % " ".join(unresolvable),
+        "./scripts/mac/install-ui-artifact.sh dist/localvoxtral.app   # installs ~/bin/lv-attach")
+elif blocked:
+    fix("term open allowlist",
+        "%s allowlisted but permanently refused (they can run a child command): %s"
+        % (len(blocked), " ".join(blocked)),
+        "remove %s from LV_UI_TERM_COMMANDS in %s" % (" ".join(blocked), GATE_CONF))
+else:
+    ok("term open allowlist", "accepts: %s" % " ".join(commands))
+
+# 6. lv-attach: installed, allowlisted, and its own config resolving
+attach = setup.get("lv_attach", {})
+if not attach.get("installed"):
+    fix("lv-attach wrapper",
+        "not installed at ~/bin/lv-attach, so `term open ... lv-attach` cannot resolve it",
+        "./scripts/mac/install-ui-artifact.sh dist/localvoxtral.app   # ships the wrapper too")
+else:
+    ok("lv-attach wrapper", "installed at ~/bin/lv-attach")
+
+# Only worth its own row when the allowlist is non-empty: an empty one is
+# already the row above, and repeating the same fix three times is how a
+# checklist stops being read.
+if attach.get("allowlisted"):
+    ok("lv-attach allowlisted", "in LV_UI_TERM_COMMANDS")
+elif attach.get("installed") and commands:
+    fix("lv-attach allowlisted",
+        "installed, but LV_UI_TERM_COMMANDS lists only %s" % " ".join(commands),
+        "add lv-attach to LV_UI_TERM_COMMANDS in %s" % GATE_CONF)
+
+attach_conf = attach.get("conf")
+if attach_conf == "ok":
+    where = attach.get("destination") or "a user@host destination (value withheld)"
+    ok("lv-attach destination",
+       "%s resolves -> %s%s"
+       % (ATTACH_CONF, where,
+          ", default session set" if attach.get("session_default") else ""))
+elif attach_conf in ("missing", "absent"):
+    fix("lv-attach destination", "%s does not exist" % ATTACH_CONF,
+        "printf 'destination=<your ssh alias>\\n' > %s" % ATTACH_CONF)
+elif attach_conf == "no-destination":
+    fix("lv-attach destination", "%s has no destination= line" % ATTACH_CONF,
+        "printf 'destination=<your ssh alias>\\n' >> %s" % ATTACH_CONF)
+elif attach_conf == "invalid-destination":
+    fix("lv-attach destination",
+        "%s has a destination the wrapper refuses (it must be [A-Za-z0-9._-], "
+        "optionally user@host, never starting with '-')" % ATTACH_CONF,
+        "edit %s   # then: ~/bin/lv-attach --check" % ATTACH_CONF)
+elif attach_conf == "invalid-session":
+    fix("lv-attach destination",
+        "%s has a session= the wrapper refuses" % ATTACH_CONF,
+        "edit %s   # then: ~/bin/lv-attach --check" % ATTACH_CONF)
+elif attach_conf == "present-unchecked":
+    note("lv-attach destination",
+         "%s exists but no wrapper is installed to validate it" % ATTACH_CONF)
+elif attach_conf == "wrapper-too-old":
+    fix("lv-attach destination",
+        "the installed ~/bin/lv-attach predates `--check`, so its config cannot be validated",
+        "./scripts/mac/install-ui-artifact.sh dist/localvoxtral.app   # refreshes the wrapper")
+
+# 7. something to launch
+artifacts = setup.get("artifacts", [])
+if artifacts:
+    ok("launchable builds",
+       ", ".join("%s%s" % (a.get("name"), " (dogfood)" if a.get("dogfood") else "")
+                 for a in artifacts))
+else:
+    fix("launchable builds",
+        "no localvoxtral bundle under the artifact roots — `launch` has nothing to start",
+        "./scripts/try-pr.sh <pr> --dogfood --ui-gate    # or: gh workflow run CI --ref <branch> -f dogfood=true")
+
+# 8. the app under test
+app = state.get("app", {})
+if app.get("running"):
+    ok("app under test",
+       "pid %s%s" % (app.get("pid"), ", dogfood" if app.get("dogfood") else ", not a dogfood build"))
+else:
+    note("app under test",
+         "none — `launch [--dogfood] <artifact>` first; shot/ax/key/menu/dictate/app all need one")
+
+# 9. the dogfood control socket — TWO consents, deliberately
+socket = setup.get("control_socket", {})
+if socket.get("present"):
+    ok("control socket", "bound; `app <command>` can be forwarded")
+elif socket.get("consent") == "on":
+    note("control socket",
+         "consent armed but no socket bound — relaunch the dogfood build (`quit`, then `launch --dogfood ...`)")
+else:
+    fix("control socket",
+        "debug.dogfood_control_socket_enabled is %s, so `app <command>` denies "
+        "(a second consent on purpose — recording what you do and accepting "
+        "commands on a socket are separate grants, and no installer arms this one)"
+        % socket.get("consent", "unset"),
+        "defaults write com.localvoxtral.app debug.dogfood_control_socket_enabled -bool true   # then relaunch")
+
+width = max(len(label) for _, label, _, _ in rows)
+print("localvoxtral UI gate readiness (%s)" % os.environ["STATE_SOURCE"])
+print()
+for status, label, detail, command in rows:
+    print("  [%-3s] %-*s  %s" % (status, width, label, detail))
+    if command:
+        print("  %s  fix: %s" % (" " * (width + 7), command))
+print()
+
+pending = [r for r in rows if r[0] == "FIX"]
+if pending:
+    print("%d item(s) need attention. Re-run after each fix." % len(pending))
+else:
+    print("Every checkable item is ready.")
+if mode != "local":
+    print("Not checkable from here: the forced-command line and whether the "
+          "installed gate matches this checkout — run this on the Mac for those.")
+print("Never checkable by any script: that a TCC grant works in a session that "
+      "arrived over SSH, that a capture is not black, and that a status menu "
+      "appears — scripts/mac/README.md keeps those as hand checks.")
+
+raise SystemExit(1 if pending else 0)
+PY

--- a/scripts/mac/ui-gate-doctor.sh
+++ b/scripts/mac/ui-gate-doctor.sh
@@ -53,7 +53,9 @@ while (( $# > 0 )); do
     -h | --help)
       # The usage block only — a help that trails off mid-sentence into the
       # rationale is worse than none.
-      sed -n '/^# ui-gate-doctor —/,/--state-file <f>/p' "$0" | sed 's/^# \{0,1\}//'
+      # ASCII-only addresses: this is the one regex in the repo that would
+      # otherwise carry a multibyte character, and BSD sed is what runs it.
+      sed -n '/^# ui-gate-doctor /,/--state-file <f>/p' "$0" | sed 's/^# \{0,1\}//'
       exit 0
       ;;
     *) die "unknown argument: $1" ;;

--- a/scripts/try-pr.sh
+++ b/scripts/try-pr.sh
@@ -9,6 +9,15 @@ set -euo pipefail
 #   ./scripts/try-pr.sh <pr-number>            # e.g. ./scripts/try-pr.sh 30
 #   ./scripts/try-pr.sh main                   # latest green build of main
 #   ./scripts/try-pr.sh main --dogfood         # instrumented dogfood build
+#   ./scripts/try-pr.sh 42 --dogfood --ui-gate # install where the UI gate can launch it
+#
+# --ui-gate installs the bundle into the SSH UI gate's artifact root
+# (~/localvoxtral-ui-artifacts) instead of leaving it in /tmp, and does NOT
+# launch it — starting it is the gate's `launch` verb, which records the pid
+# every other verb then addresses. The gate refuses to launch anything outside
+# that root on purpose (a world-writable root would let any local process plant
+# a bundle claiming com.localvoxtral.app), so the install destination is what
+# moves, never the roots. Default behaviour is unchanged: /tmp, then `open`.
 #
 # --dogfood fetches the LOCALVOXTRAL_DOGFOOD-instrumented artifact
 # (localvoxtral-app-dogfood), verifies its Info.plist stamp, arms the runtime
@@ -25,19 +34,22 @@ if [[ "$(uname)" != "Darwin" ]]; then
   exit 1
 fi
 
+USAGE="usage: $0 <pr-number|main> [--dogfood] [--ui-gate]"
 TARGET=""
 DOGFOOD=0
+UI_GATE=0
 for arg in "$@"; do
   case "$arg" in
     --dogfood) DOGFOOD=1 ;;
+    --ui-gate) UI_GATE=1 ;;
     -*)
       echo "unknown flag: $arg" >&2
-      echo "usage: $0 <pr-number|main> [--dogfood]" >&2
+      echo "$USAGE" >&2
       exit 1
       ;;
     *)
       if [[ -n "$TARGET" ]]; then
-        echo "usage: $0 <pr-number|main> [--dogfood]" >&2
+        echo "$USAGE" >&2
         exit 1
       fi
       TARGET="$arg"
@@ -45,7 +57,7 @@ for arg in "$@"; do
   esac
 done
 if [[ -z "$TARGET" ]]; then
-  echo "usage: $0 <pr-number|main> [--dogfood]" >&2
+  echo "$USAGE" >&2
   exit 1
 fi
 
@@ -203,6 +215,18 @@ if (( ! DOGFOOD )) && [[ "$STAMP" != "absent" ]]; then
   echo "WARNING: this 'clean' artifact is stamped LVXDogfoodCapture=$STAMP — it can capture if armed."
 fi
 
+# --ui-gate: move the bundle out of /tmp and into the gate's artifact root
+# BEFORE signing, so the copy that actually runs is the one that got the
+# ad-hoc re-sign (macOS 26 stalls the first launch of an unsigned-locally
+# downloaded bundle, and TCC keys the grant to the signature of the binary
+# that launches). Done after the stamp check so a wrong-variant artifact is
+# rejected before a few hundred MB get copied.
+if (( UI_GATE )); then
+  APP="$("$(dirname "$0")/mac/install-ui-artifact.sh" "$APP" --no-hint \
+    --label "$TARGET @ CI run $RUN_ID")"
+  xattr -cr "$APP" 2>/dev/null || true
+fi
+
 # Detect whether the downloaded bundle is ad-hoc. The reliable marker is the
 # 'Signature=adhoc' line — and it MUST be read at -dvv (verbose>=2): at -dv the
 # Authority/Signature detail lines are not printed at all, so grepping -dv for
@@ -245,7 +269,11 @@ fi
 
 LAUNCH_LABEL="$SIGNER"
 (( DOGFOOD )) && LAUNCH_LABEL="$LAUNCH_LABEL, dogfood"
-echo "Launching build of '$TARGET' (CI run $RUN_ID, ${LAUNCH_LABEL}): $APP"
+if (( UI_GATE )); then
+  echo "Installed build of '$TARGET' (CI run $RUN_ID, ${LAUNCH_LABEL}): $APP"
+else
+  echo "Launching build of '$TARGET' (CI run $RUN_ID, ${LAUNCH_LABEL}): $APP"
+fi
 # The designated requirement is what TCC keys the Accessibility grant on.
 # Compare this block between two try-pr runs: identical DR => the grant
 # survives; a DR that changes every run (ad-hoc pins the per-build cdhash) is
@@ -260,4 +288,21 @@ if [[ "$SIGNER" == "Authority=ad-hoc" ]]; then
   echo "      An ad-hoc same-repo artifact means the self-hosted runner user lost"
   echo "      the localvoxtral-dev cert (check: security find-identity -v -p codesigning)."
 fi
+
+if (( UI_GATE )); then
+  # Deliberately no `open`: the gate's `launch` records the pid that `ax`,
+  # `key`, `shot` and `quit` all address, and it refuses to start a second
+  # instance. An instance started here would be unrecorded — invisible to the
+  # gate, and a hotkey / port 8471-8472 rival for the one it does start.
+  GATE_ARG="$APP"
+  case "$APP" in
+    "$HOME"/*) GATE_ARG="${APP#"$HOME"/}" ;;
+  esac
+  GATE_FLAG=""
+  (( DOGFOOD )) && GATE_FLAG="--dogfood "
+  echo "Not launched — the UI gate owns launching. From the dev box:"
+  echo "  ssh lv-ui 'launch ${GATE_FLAG}${GATE_ARG}'"
+  exit 0
+fi
+
 open "$APP"


### PR DESCRIPTION
## What

A **second** forced-command SSH gate, `scripts/mac/localvoxtral-ui-gate.sh`, meant for the **GUI account** — so an agent can see and drive the localvoxtral build under test on the owner's MacBook without being handed the desktop. The build gate account is deliberately not the console user, so nothing routed through it can touch the GUI; this closes that gap with a small allowlist of *semantic* verbs instead of a generic computer-use harness.

| verb | behaviour |
| --- | --- |
| `state` | JSON: lock state, idle seconds, AC/battery, the Accessibility + Screen Recording preflight, whether an app under test is running, terminals this gate opened |
| `launch [--dogfood] <artifact>` | launches a `.app` under an allowlisted root whose `CFBundleIdentifier` is `com.localvoxtral.app`; records pid + start time + executable path. Refuses beside **any** running localvoxtral, including one this gate did not start |
| `shot [settings\|popover\|overlay\|window <n>]` | base64 PNG of ONE window, by CGWindowID |
| `ax dump [all\|settings\|overlay\|window <n>]` | AX element tree of that pid's windows, as JSON |
| `ax click <selector>` | presses the one element the selector matches |
| `ax type <selector> -- <text>` | types into a text-bearing element |
| `key <escape\|tab\|return>` | one keycode; brings the app under test frontmost first and refuses if that did not take |
| `menu open` / `menu click <item-title>` / `menu dismiss` | drives the status item of the recorded pid. localvoxtral opens no window at launch, so this is what makes every row above it reachable. `open`/`dismiss` confirm the result against the window list, so they cannot report a menu that is not on screen |
| `dictate tap` / `dictate hold <seconds>` / `dictate cancel` | posts the app's OWN configured modifier trigger (read from its defaults) as a gesture at the HID tap — the only way to start a dictation, and therefore to exercise the Claude Code / herdr join |
| `app <control command>` | forwards ONE line to the **dogfood** control socket of the app under test and returns the reply (`session start overlay\|live`, `session stop`, `join report`, `surface probe`, `registry list`) — see the update below |
| `log [minutes]` | localvoxtral's own unified-log lines, predicate-scoped to `subsystem == "com.localvoxtral"` **and one process** (the recorded pid, else the app's process name), clamped window, line-capped, token-scrubbed |
| `quit` | terminates the recorded pid |
| `term open <ghostty\|iterm\|terminal> <command> [args]` | opens a terminal window running an allowlisted command. **The allowlist is empty by default** |
| `term focus <id>` / `term close <id>` | acts on one window this gate opened |

Selectors are `key<op>value` pairs joined by `,` (`=` exact, `~` contains, `+` for a space), keys `role`/`title`/`desc`/`value`/`index`/`window` — e.g. `ax click role=AXButton,title~Text+Processing`. An ambiguous selector is refused, not guessed at.

**The forced command is the entire trust boundary, and the header says so.** No shell verb: no `eval`, no `bash -c`, no verb taking a free command line. `term open` is the one constrained exception, and the invariant that keeps it from *being* that verb is now stated positively in the header and at the config:

> **An allowlisted command must not be able to run a child command.** Not "must not be a shell" — must not be able to start one, at any remove, through any flag or subcommand.

The default allowlist is **empty**; a permanent denylist (`LV_UI_TERM_FORBIDDEN`, assigned after the conf file is sourced) refuses every shell and coding-agent CLI even if the conf allowlists them; and the documented way to make the verb useful is a single-purpose wrapper the owner writes and allowlists, never a general-purpose tool.

**No coordinate clicking, no full-screen capture.** `shot` resolves a CGWindowID from the window list *filtered to the pid the gate itself launched*, and the shell re-asserts the ownership invariant on the helper's answer. `ax click`/`ax type` walk the tree rooted at `AXUIElementCreateApplication(<that pid>)`. `term focus`/`term close` act only on a window carrying a random marker this gate put in that window's title. The recorded pid is trusted only while its start time **and** executable path still match. The capture file is deleted on every exit path.

**A `term open` window is not a lateral path into the app-driving verbs.** `shot`, `ax dump`, `ax click`, `ax type` and `key` all take their pid from the `app.state` that `launch` wrote, and `launch` only ever records a validated localvoxtral bundle. Nothing retargets them at a terminal; `term focus`/`term close` reach a terminal window but carry no selector, no keystroke and no capture. Pinned by test — section 12 below.

**Locked screen = hard, fail-CLOSED refusal**, outermost guard on every GUI-touching verb. The `CGSSessionScreenIsLocked` probe moves out of `ui-smoke-guard.sh` into `scripts/ci/screen-lock-state.sh` so both callers share one probe, and gains an `ioreg IOConsoleUsers` arm — the CGSession arm only answers from a process already in a GUI session, which an SSH login is not. Each caller keeps its own policy for `error`: the CI lane fails open, the gate fails closed. A missing probe denies too.

**Owner takeover rule**: `launch`, `ax click`, `ax type`, `key`, `menu open`, `menu click`, `dictate tap`/`hold`, `term open` and `term focus` `say` a warning, wait 3 s, and announce completion or failure. `state`, `shot`, `ax dump`, `menu dismiss`, `dictate cancel`, `quit` and `term close` do not: none of them takes the keyboard or raises a window in front of what the owner is doing.

Every invocation is logged with a timestamp, allowed or denied. `ax type`'s text is redacted; non-printable bytes in a denied command are neutralised so attacker-chosen text cannot forge a second log line that reads like an `ALLOW` entry.

Install instructions, the TCC grants, the allowlist rule, the wrapper pattern, the deny check and the caveats are in `scripts/mac/README.md`.

### Fixed in review: the default allowlist was four remote shells

The first revision shipped `LV_UI_TERM_COMMANDS="herdr claude opencode codex"`. Only the first token is checked and nothing inspects flags, so this passed every check in the gate:

```
term open ghostty claude --dangerously-skip-permissions -p <prompt>
```

No space, no metacharacter, well under the token cap — `%q`-quoted into the launcher script and `exec`'d. Arbitrary, fully-permissioned code execution as the GUI user. `codex exec`, `opencode run` and `herdr agent start` are the same shape. The rule was already written three lines above the defect; it is now enforced (empty default + non-overridable denylist) and pinned by tests rather than only stated.

### Added after the first live run against the owner's Mac

The gate is installed and answering (`state` returns `tcc.accessibility: true`, `tcc.screen_recording: true` over SSH). Driving it turned up three things.

**1. The gate could launch the app and then reach none of its UI.** localvoxtral is a menu bar app: it opens **zero** windows at launch, and no verb in the allowlist opened one. So immediately after a successful `launch`:

```
$ launch /Users/tom/localvoxtral-ui-artifacts/localvoxtral.app
launched pid=92265 …
$ ax dump all
[]
$ shot settings
no settings window owned by the app under test (pid 92265)
$ ax click role=AXButton,title=Dictation
helper: selector matched no element
```

Every one of those answers is correct, and the whole set is useless — `shot`, `ax dump`, `ax click`, `ax type` and `key` were unreachable in practice.

`menu open` / `menu click <item-title>` / `menu dismiss` is the missing first step. `menu open` clicks the status item; the menu it opens is what `shot popover` photographs; `menu click Settings` produces the Settings window every other verb then addresses.

Three design points worth the review:

- **Accessibility, not System Events.** The proven mechanism on that machine is `capture-readme-assets.sh`'s AppleScript, but that route needs an Apple event to System Events — a *separate* Automation TCC grant whose consent sheet cannot be answered over SSH (the sheet dies with the event). The AX route reaches the same element (`AXExtrasMenuBar` on the recorded pid → its `AXMenuBarItem`; System Events' "menu bar 2" **is** this) using only the Accessibility grant sshd already holds. Same mechanism, one fewer grant, no unanswerable prompt.
- **The blocking press.** Pressing a status item blocks the AX server for as long as the menu tracks — the reason the AppleScript needs `ignoring application responses`. The AX equivalent is a bounded `AXUIElementSetMessagingTimeout`, and the press's own status is then *not* trusted (it reports `.cannotComplete` while the menu tracks): success is the menu's existence, polled for up to 3 s.
- **Titles are matched by containment, exact-first.** The real item is `Settings…`, and `…` cannot survive the gate's ASCII token charset or its printable-byte check — so `menu click Settings` is the way in. An exact title still wins (so `Save` is never ambiguous with `Save As…`); beyond that, ambiguity is refused rather than guessed at, and the error lists the menu's actual items. `+` spells a space, as in selector values.

`menu dismiss` performs `AXCancel` on the app's own menu rather than posting a global Escape, so no synthesised keystroke ever goes to whatever owns the keyboard. It gives the screen back rather than taking it, so like `quit` it does not warn; `menu open`/`menu click` steal focus and take the audible warning.

**2. `launch` now refuses beside a localvoxtral it did not start.** The owner's daily driver was running (pid 91687, a `try-pr` install) and `launch` would happily have started a second instance: two global-hotkey owners, two claimants on the speechd/polishd ports 8471/8472, and a process the gate can neither address (every verb reads `app.state`) nor quit. Only the operator noticing prevented it. It is now a hard refusal naming the pid and how to quit it.

**3. `try-pr.sh --ui-gate` — the sanctioned installer now lands where the gate can launch.** `try-pr.sh` extracts to `/tmp/localvoxtral-try.<random>`, which is exactly the kind of directory the roots must never include: inside a root, a bundle claiming `com.localvoxtral.app` is trusted, so a world-writable root is a local-process foothold into the GUI session. **The install destination moves; the trust boundary does not.**

`--ui-gate` (composable with `--dogfood`) installs through the new `scripts/mac/install-ui-artifact.sh` into `~/localvoxtral-ui-artifacts`, then stops:

```bash
./scripts/try-pr.sh 238 --dogfood --ui-gate
# …
# Not launched — the UI gate owns launching. From the dev box:
#   ssh lv-ui 'launch --dogfood localvoxtral-ui-artifacts/localvoxtral-dogfood.app'
```

The three judgement calls, stated so they can be argued with:

- **Replace, don't accumulate.** Two slots — `localvoxtral.app` and `localvoxtral-dogfood.app` — and a reinstall replaces its slot. The gate's `launch` takes a path, so N builds *could* coexist, but they would share a bundle id, a defaults domain and a TCC grant: indistinguishable at runtime, which is exactly the wrong-binary confusion `docs/agent/field-debugging.md` exists because of (and a few hundred MB each). Which build a slot holds is recorded in `<bundle>.app.source` beside it.
- **Quitting is the operator's job, not the installer's.** The gate has a `quit` verb and only the operator knows whether a dictation is in flight. What the installer refuses is the one destructive case — overwriting the bundle **currently executing from that slot** — and it warns loudly when any other localvoxtral is running, because `launch` will then refuse (finding 2 above).
- **`--ui-gate` does not launch.** try-pr's `open` would create an instance `app.state` never saw: invisible to the gate, and a hotkey/port rival for the one it does start. So `--ui-gate` returns before the `open`, and prints the `launch` command instead. The bundle is copied *before* the ad-hoc re-sign, so the copy that runs is the one that got signed (the macOS 26 first-launch stall) and its designated requirement — what TCC keys the grant to — is the installed one.

The installer also refuses a destination root that is unwritable, group/other-writable, or not a validated localvoxtral bundle, and creates a root it makes itself as `0700`. The default `try-pr.sh` path (extract to `/tmp`, then `open`) is untouched.


### Added after the second live run: nothing could start a dictation, and an agent could not install a build

**4. `dictate tap` / `dictate hold <seconds>` / `dictate cancel`.** The gate exists to debug the Claude Code / herdr session join, and that join resolves when a dictation *starts*. Nothing in the allowlist could start one: `key` is `escape|tab|return`, and the app's trigger is a modifier-only **gesture** (Fn / Right Command / Right Option, tap vs hold). The loop the gate was built for could not be run at all.

The verb posts the app's **own configured trigger**, read out of `com.localvoxtral.app`'s defaults on every invocation rather than hard-coded, as a `flagsChanged` CGEvent at the HID tap — the path `scripts/record-demo.sh` has driven on this machine since the demo recording. The app detects it with an `NSEvent` monitor and filters synthetic events nowhere, so this is the real gesture path, not a side door. A plain `keyDown` would be inert: the event's `type` has to be overridden to `.flagsChanged` and carry that modifier's flag mask.

**One requirement I did not implement as asked, and why.** The brief said to check the app under test is frontmost and refuse otherwise. `dictate` deliberately does **not** activate localvoxtral, because doing so would break the thing under test: the modifier trigger is global by design, and the dictation grounds its context in whatever *is* focused — a terminal running Claude Code. Bring localvoxtral frontmost first and every session resolves against the wrong surface. (It is also a menu bar app with no window to raise.)

What replaces that check is stricter about the actual hazard — a stray modifier landing in the owner's window:

- the app under test must be running (`app.state`, as everywhere else);
- its modifier-only trigger must be **enabled** in its own settings, else the gesture is literally a stray modifier;
- the trigger must be **readable** — `dictate` refuses to guess which key to press, and says so;
- **Secure Keyboard Entry** must not be held, because the events would otherwise be discarded silently, which is the worst failure shape to debug (`record-demo.sh` checks the same thing before its live beat);
- the frontmost app is named in the result line and the log, so the operator knows where the dictation went.

Two more details worth the review: a `hold` must exceed the app's *own* `settings.modifier_only_hold_delay` — a shorter one is a tap wearing a hold's name, opening an Overlay Buffer session while the caller asked for Live Auto-Paste — and is capped at `LV_UI_MAX_HOLD_SECONDS` (30); and the helper releases the modifier from a signal handler, so a dropped SSH connection mid-hold cannot leave a modifier latched across the owner's whole session. `cancel` is Escape, which the app consumes system-wide for the duration of a session, so it needs neither the trigger nor a frontmost app, and like `quit` it does not warn.

**The overlay oracle holds — with two caveats.** `ax dump overlay` after a `dictate tap` reads the outcome: the join badge from #231 is a real AX element with an explicit label, `Grounded in Claude Code session <workspace>` or `No Claude Code session joined for this dictation` (`DictationOverlayView.swift:171-216`), inside a panel that appears in the app's `kAXWindowsAttribute`. Caveats: the badge is hidden unless terminal-screen or repo context is enabled, and **only Overlay Buffer sessions open an overlay at all** — `dictate hold` (Live Auto-Paste) never shows one. So `tap` is the oracle, not `hold`.

**5. A dispatched CI build now installs itself.** `try-pr.sh --ui-gate` (point 3 above) serves an operator with a shell on the Mac. An agent driving the gate has neither a shell on that account nor a verb that runs `try-pr.sh`, so it could build and not install.

The runner closes that gap for free — **verified, not assumed**: a run's own workspace path is `/Users/tom/actions-runner/_work.noindex/...`, so the self-hosted runner's `$HOME` is the GUI account's home, which is where the gate's default artifact root lives. `ci.yml` now installs `dist/localvoxtral.app` there after the dogfood packaging pass, and prints the exact `ssh lv-ui 'launch --dogfood …'` into the run summary.

```bash
gh workflow run CI --ref mac-ui-gate -f dogfood=true   # builds AND installs
```

Gated to `workflow_dispatch` **and** `dogfood=true` — deliberately narrower than the dogfood lane itself, whose `[dogfood-package]` marker fires on ordinary PR pushes, none of which may write into the owner's home. It reads `github.event.inputs.dogfood`, **not** `inputs.dogfood`: the input is `type: boolean`, and comparing a boolean to the string `'true'` coerces both to numbers (1 vs NaN), so that form is always false and the gate would silently never fire. A test pins the correct form for exactly that reason.

`install-ui-artifact.sh` grew one documented exit code — **3 = the target slot is executing** — so the step can warn and skip in the one case that is not a build problem (the owner had the app open), while every other install failure stays red. A test pins that only that refusal is 3 and that the security refusals stay 1.


## Proof

- [x] **Gate regression suite green — 128 assertions, no GUI needed.** `scripts/ci/test-ui-gate.sh` runs the gate **unmodified** against PATH stubs (`open`/`pgrep`/`ps`/`say`/`screencapture`/`swift`/`ioreg`/`pmset`/`defaults`), so the code under test is the code that ships.

```
$ ./scripts/ci/test-ui-gate.sh
== 1. unknown verbs and shell escapes ==
PASS: denied: echo pwned (the README deny check)
PASS: denied: empty command
PASS: denied: bash -lc
PASS: denied: sh -c
PASS: denied: eval
PASS: denied: exec
PASS: denied: unknown verb that looks plausible
PASS: denied: verb allowlist is case sensitive
PASS: denied: command chaining with ;
PASS: denied: command chaining with &&
PASS: denied: pipeline
PASS: denied: output redirection
PASS: denied: backtick substitution
PASS: denied: dollar-paren substitution
PASS: denied: parameter expansion
PASS: denied: glob
PASS: denied: chaining onto an allowed verb
PASS: denied: embedded newline (only line 1 would ever parse)
PASS: denied: embedded tab as an argument separator
PASS: denied: over-long command
== 2. per-verb argument validation ==
PASS: denied: state takes no arguments
PASS: denied: quit takes no arguments
PASS: denied: launch without an artifact
PASS: denied: launch with an unknown flag
PASS: denied: launch with two artifacts
PASS: denied: key without a name
PASS: denied: key with two names
PASS: denied: key outside the three-entry allowlist
PASS: denied: another key outside the allowlist
PASS: denied: shot of something that is not a window kind
PASS: denied: shot screen (no full-screen capture exists)
PASS: denied: shot settings with a stray index
PASS: denied: shot window without an index
PASS: denied: shot window index 0
PASS: denied: shot window with a non-numeric index
PASS: denied: shot with too many arguments
PASS: denied: ax without a subverb
PASS: denied: unknown ax subverb
PASS: denied: ax dump of an unknown pane
PASS: denied: ax dump window without an index
PASS: denied: ax click without a selector
PASS: denied: selector with no operator
PASS: denied: selector with an unknown key
PASS: denied: selector naming no matchable attribute
PASS: denied: selector with an empty value
PASS: denied: selector with a trailing comma
PASS: denied: selector with a non-numeric window index
PASS: denied: ax type without the -- separator
PASS: denied: ax type with an empty text
PASS: denied: term without a subverb
PASS: denied: term open without a terminal
PASS: denied: term open without a command
PASS: denied: term focus without an id
PASS: denied: term focus with two ids
PASS: denied: term close with a path as an id
PASS: denied: term focus on an id this gate never opened
== 3. launch refuses anything that is not a localvoxtral bundle ==
PASS: denied: launch of another vendor .app under the root
PASS: denied: launch outside the allowlisted roots
PASS: denied: launch with .. in the path
PASS: denied: launch of a path that does not exist
PASS: denied: launch --dogfood on an unstamped bundle
== 4. term open is not a shell verb ==
PASS: denied: term open running bash
PASS: denied: term open running sh
PASS: denied: term open running ssh
PASS: denied: term open running osascript
PASS: denied: term open running python3
PASS: denied: a shell in the terminal position
PASS: denied: metacharacter inside a command
PASS: denied: backticks in a term command
PASS: denied: more tokens than the cap
PASS: denied: term open running claude
PASS: denied: term open running codex
PASS: denied: term open running opencode
PASS: denied: term open running herdr
PASS: denied: term open running another agent CLI
PASS: denied: the exact escape: claude --dangerously-skip-permissions -p <prompt>
PASS: denied: codex exec
PASS: denied: opencode run
PASS: denied: herdr agent start
PASS: denied: conf-allowlisted claude is STILL denied
PASS: denied: conf-allowlisted codex is STILL denied
PASS: denied: conf-allowlisted opencode is STILL denied
PASS: denied: conf-allowlisted herdr is STILL denied
PASS: denied: conf-allowlisted bash is STILL denied
PASS: denied: conf-allowlisted ssh is STILL denied
PASS: denied: the default allowlist is empty
PASS: the default allowlist is empty and the permanent denylist still names every shell and agent CLI
== 5. the screen lock is a hard refusal (fail closed) ==
PASS: denied: locked screen refuses: launch <artifact-root>/localvoxtral.app
PASS: denied: locked screen refuses: shot settings
PASS: denied: locked screen refuses: ax dump all
PASS: denied: locked screen refuses: ax click role=AXButton,title=General
PASS: denied: locked screen refuses: ax type role=AXTextField -- hello
PASS: denied: locked screen refuses: key escape
PASS: denied: locked screen refuses: term open ghostty lv-attach
PASS: denied: locked screen refuses: term focus term-1
PASS: denied: no console session refuses shot
PASS: denied: undeterminable lock state refuses shot
PASS: denied: a missing lock probe fails closed
PASS: allowed: state answers on a locked screen and reports it
== 6. shot captures only a window owned by the launched pid ==
PASS: denied: shot before any launch
PASS: denied: shot of a window owned by another pid
PASS: denied: shot when the window lookup returns garbage
PASS: allowed: shot of the app-under-test's own window, and the file does not survive it
PASS: denied: shot after the recorded pid was recycled
== 7. launch happy path, warning, and recorded identity ==
PASS: allowed: launch records identity, warns audibly, announces completion
PASS: denied: launch while an app is already under test
PASS: allowed: launch --dogfood on a stamped bundle
== 8. ax and key verbs ==
PASS: allowed: ax dump of the app under test
PASS: allowed: ax click by role and title
PASS: allowed: key escape
PASS: allowed: key tab
PASS: allowed: key return
PASS: allowed: ax type with a secret-looking value
PASS: ax type redacts the typed text in the log but still types it
== 9. term verbs ==
PASS: allowed: term open runs an opted-in wrapper and logs the command in full
PASS: allowed: term focus on a window this gate opened
PASS: allowed: term close on a window this gate opened
PASS: denied: term focus after the window was closed
== 10. quit terminates only the recorded process ==
PASS: allowed: quit terminates the recorded pid and clears the state
== 11. the shared lock probe's ioreg arm ==
PASS: lock probe: locked.plist -> locked
PASS: lock probe: unlocked.plist -> unlocked
PASS: lock probe: switched-away.plist -> no-session
PASS: lock probe: no-console.plist -> no-session
PASS: lock probe: garbage.plist -> error
== 12. a term-open window is not a lateral path into the app verbs ==
PASS: ax dump/click/type, key and shot all address the app under test, never the terminal
PASS: denied: shot of a window owned by the terminal this gate opened
PASS: allowed: term focus reaches the terminal
PASS: term focus/close reach the terminal only to raise or close it
== 13. the embedded Swift helper compiles ==
SKIP: swiftc not available — the embedded Swift helper was not type checked

ui gate tests passed
```

- [x] **Negative controls — every invariant bites.** Each weakened one at a time; suite red, restore, green. Control **C** is the reported defect (agent CLIs back in the default) and control **E** is the scoping claim that makes `term open` tolerable:

```
### A. drop the shot ownership re-assert
FAIL: shot of a window owned by another pid: expected exit 126, got 0 (stderr: shot: window 8123 (settings), 10 bytes)

### B. make the locked screen fall through
FAIL: locked screen refuses: shot settings: expected exit 126, got 0 (stderr: shot: window 7 (settings), 10 bytes)

### C. put the agent CLIs back in the DEFAULT allowlist (the reported defect)
FAIL: term open running claude: expected exit 126, got 1 (stderr: localvoxtral ui gate: opened Ghostty but never saw a window carrying marker lvui-term-1-1420017363)

### D. let the conf file re-add a shell (drop the permanent denylist check)
FAIL: conf-allowlisted claude is STILL denied: expected exit 126, got 1 (stderr: localvoxtral ui gate: opened Ghostty but never saw a window carrying marker lvui-term-1-69988194)

### E. point key at a pid other than the app under test
FAIL: an app verb addressed a pid that is not the app under test: <tmp>/lv-ui-gate-test.gL5P6r/home/.localvoxtral-ui-gate/ui-gate-helper.swift key 99999 escape

### F. stop redacting ax type text
FAIL: ax type text was not redacted in the log

### restored — suite green again
ui gate tests passed
```

- [x] **Pre-existing shell suites still green** (the lock probe moved out of `ui-smoke-guard.sh`, so its suite is the regression that matters):

```
test-cleanup-stale-test-processes         OK
test-build-gate-process-cleanup           OK
test-build-gate-reap-command              OK
test-build-gate-gc-command                OK
test-remote-build-reap                    OK
test-remote-build-gc                      OK
test-run-supervised-command               OK
test-ui-smoke-guard                       OK
test-ui-gate                              OK
test-runner-node-resign                   OK
test-ac-power-guard                       OK
test-llm-lane-filter                      OK
test-clean-stale-outputs                  OK
```

- [x] **Whole CI run green on this head** — run [33126408452](https://github.com/T0mSIlver/localvoxtral/actions/runs/33126408452), no failed or cancelled step: tier-0 unit suite, both helper package suites, packaging, launch smoke outside the workspace, the dogfood capture suite, and the tier-1 speechd realtime integration. Unit suite:

```
Executed 2733 tests, with 11 tests skipped and 0 failures (0 unexpected) in 107.638 (107.878) seconds
```

  (This PR changes no Swift source — the diff is shell, workflow and docs.) The same run carries the macOS-only proof this suite cannot produce on Linux, including the new denylist assertions:

```
PASS: denied: the exact escape: claude --dangerously-skip-permissions -p <prompt>
PASS: denied: conf-allowlisted claude is STILL denied
PASS: denied: conf-allowlisted codex is STILL denied
PASS: denied: conf-allowlisted opencode is STILL denied
PASS: denied: conf-allowlisted herdr is STILL denied
PASS: denied: conf-allowlisted bash is STILL denied
PASS: denied: conf-allowlisted ssh is STILL denied
PASS: the default allowlist is empty and the permanent denylist still names every shell and agent CLI
== 11. the shared lock probe's ioreg arm ==
== 12. a term-open window is not a lateral path into the app verbs ==
== 13. the embedded Swift helper compiles ==
PASS: the embedded Swift helper type checks
ui gate tests passed
```

  (Two macOS-only failures were caught that way and fixed: `/tmp` is a symlink to `/private/tmp`, so the fixture path the suite asserted `open` was called with could never equal the path `launch` resolves with `pwd -P`; and a stub read its last argument with `${!#}`, which the Mac's bash 3.2 does not owe us. CI on the current head re-runs all of it.)

  A direct `./scripts/remote-build.sh test` was tried first and wedged on the shared build host under contention — log frozen 12 min mid-suite while a CI job and another agent held the machine — so it was killed rather than left to hang.

### Proof for the three additions above

**Suite green, 174 assertions** (was 128), including the new sections 15 (`menu`), 16 (the artifact roots stay owner-only ground), 17 (`install-ui-artifact.sh`) and 18 (`try-pr.sh --ui-gate`), plus the foreign-instance refusal in section 7:

```
$ ./scripts/ci/test-ui-gate.sh
…
== 7. launch happy path, warning, and recorded identity ==
PASS: allowed: launch records identity, warns audibly, announces completion
PASS: denied: launch while an app is already under test
PASS: denied: launch beside a localvoxtral this gate did not start
PASS: launch refuses beside an instance it did not start, and opens nothing
PASS: allowed: launch --dogfood on a stamped bundle
…
== 15. menu — the verb that makes every other verb reachable ==
PASS: denied: menu open with no app under test
PASS: denied: menu click with no app under test
PASS: denied: menu dismiss with no app under test
PASS: denied: menu open while the screen is locked
PASS: denied: menu click while the screen is locked
PASS: denied: menu dismiss while the screen is locked
PASS: allowed: menu open clicks the status item of the app under test
PASS: allowed: menu click by item title
PASS: allowed: menu click with + standing in for a space
PASS: denied: menu click with a non-ASCII title
PASS: allowed: menu dismiss closes the app under test menu
PASS: a failed status-item click is a failure, not an ok
PASS: menu addresses only the pid launch recorded
PASS: the menu helper subcommands, AXExtrasMenuBar and the messaging timeout are all present
== 16. the artifact roots stay owner-only ground ==
PASS: every default artifact root is under $HOME and none is a world-writable location
PASS: no repo script points an artifact root at a world-writable directory
== 17. install-ui-artifact.sh puts bundles where launch can reach them ==
PASS: the installer's default destination is one of the gate's allowlisted roots
PASS: a clean bundle installs into the default root, with provenance and no launch
PASS: --no-hint suppresses the duplicate launch hint
PASS: allowed: the gate launches the bundle the installer just installed
PASS: allowed: the gate launches the installed dogfood bundle with --dogfood
PASS: clean and dogfood builds occupy separate slots and both launch
PASS: a reinstall replaces its slot and leaves no staging droppings
PASS: refused: a source bundle that does not exist
PASS: refused: a directory that is not a .app
PASS: refused: another vendor's bundle
PASS: refused: a .app with no Info.plist
PASS: refused: an unknown flag
PASS: refused: a destination root that is not writable
PASS: refused: a group/other-writable destination root
PASS: the same root installs fine once group/other write is removed
PASS: a root the installer creates is owner-writable only (mode 700)
PASS: refused: overwriting a bundle that is currently running
== 18. try-pr.sh --ui-gate hands off to the gate ==
PASS: try-pr.sh --ui-gate installs through install-ui-artifact.sh
PASS: try-pr.sh --ui-gate returns before the launch, leaving it to the gate
PASS: try-pr.sh's default (extract to /tmp, then open) is untouched

ui gate tests passed
```

**Red → green, the new tests against the pre-change gate.** `git show origin/mac-ui-gate:scripts/mac/localvoxtral-ui-gate.sh` restored over the gate, new suite run:

```
== 7. launch happy path, warning, and recorded identity ==
PASS: allowed: launch records identity, warns audibly, announces completion
PASS: denied: launch while an app is already under test
FAIL: launch beside a localvoxtral this gate did not start: expected exit 126, got 0 (stderr: )
```

and, with that one assertion removed so the run reaches section 15:

```
== 15. menu — the verb that makes every other verb reachable ==
PASS: denied: menu open with no app under test
…
FAIL: menu open clicks the status item of the app under test: expected exit 0, got 126 (stderr: localvoxtral ui gate: denied command)
```

Gate restored → `ui gate tests passed`.

**Red → green for the "roots are never world-writable" pin**, which is the assertion whose whole job is to fail a future edit. Two shapes of widening, both caught:

```
# LV_UI_ARTIFACT_ROOTS default += /tmp/localvoxtral-try
== 15. the artifact roots stay owner-only ground ==
FAIL: artifact root '/tmp/localvoxtral-try' is not under $HOME — only the owner may write a launchable root
$ echo $?
1

# …and the sneakier one, escaping $HOME rather than naming /tmp outright:
# LV_UI_ARTIFACT_ROOTS default += $HOME/../../private/tmp
FAIL: artifact root '$HOME/../../private/tmp' is a world-writable location — the gate would launch anything planted there
```

Restored → green. (Section numbers shifted to 16 when `menu` took 15; the assertions are identical.)

**The Swift helper compiles, with the new `menuopen`/`menuclick`/`menudismiss` cases.** The suite's section 13 does this on the macOS runner; the same check was run against the build host directly, since the helper is a heredoc and nothing else type checks it:

```
$ ./scripts/remote-build.sh build --package-path <extracted helper package>
Building for debugging...
[4/8] Compiling HelperCheck main.swift
[5/8] Emitting module HelperCheck
[6/8] Linking HelperCheck
Build complete! (6.50s)
```

No warnings. (Throwaway package, not committed.)

**Not run by me:** the shell suite on macOS/bash 3.2 — the build gate's payload allowlist is `swift build|test|package_app.sh`, so `test-ui-gate.sh` cannot be run through it. CI's shell-test step runs it on the Mac runner, which is where the earlier bash-3.2 and `/private/tmp` findings came from. The pgrep stub gained an arm for `pgrep -x localvoxtral` (`launch`'s new refusal asks a different question from the bundle-path lookup); everything else in the suite is unchanged.

**Also not verified — needs the GUI:** `AXExtrasMenuBar` on the live app, whether the bounded-timeout press really opens the menu, and `AXCancel` closing it. These join the checklist below.


### Proof for `dictate` and the dispatched install

**Suite green, 202 assertions** (was 174), with new sections 16 (`dictate`) and 20 (the dispatched install); the earlier sections renumbered around them:

```
$ ./scripts/ci/test-ui-gate.sh
…
== 16. dictate — the only verb that can start a session ==
PASS: denied: dictate with no app under test
PASS: denied: dictate while the screen is locked
PASS: denied: dictate cancel while the screen is locked
PASS: denied: dictate when the app trigger settings cannot be read
PASS: denied: dictate when the modifier-only trigger is disabled
PASS: denied: dictate when the configured trigger is unset
PASS: denied: dictate with a trigger the app does not define
PASS: allowed: dictate tap posts the configured trigger
PASS: allowed: dictate follows a changed trigger setting
PASS: denied: a hold shorter than the app hold delay
PASS: denied: a hold exactly equal to the hold delay
PASS: denied: a hold past the duration cap
PASS: denied: a non-numeric hold duration
PASS: allowed: a hold past the threshold and inside the cap
PASS: allowed: a hold that clears a SHORTER configured delay
PASS: allowed: dictate cancel with no trigger settings readable
PASS: a refused trigger gesture is a failure, not an ok
PASS: the dictate verb posts a flagsChanged gesture, guards Secure Keyboard Entry, releases on signal, and never steals focus
…
== 18. install-ui-artifact.sh puts bundles where launch can reach them ==
…
PASS: refused: overwriting a bundle that is currently running
PASS: refused: a world-writable root (again, to pin its exit code)
PASS: only the slot-is-running refusal is exit 3; security refusals stay exit 1
== 20. the dispatched CI build installs itself for the gate ==
PASS: the UI-gate install step runs only on a workflow_dispatch with dogfood=true
PASS: a running slot warns; every other install failure is red

ui gate tests passed
```

Argument validation for the new verb is in section 2 alongside every other verb's (`dictate` without a subverb, an unknown subverb, `dictate tap 3`, `dictate cancel now`, `dictate hold` with none or two durations — all denied).

**Red → green against the previous commit** (gate and `ci.yml` restored from `3fded52`, new suite run):

```
== 16. dictate — the only verb that can start a session ==
PASS: denied: dictate with no app under test
PASS: denied: dictate while the screen is locked
PASS: denied: dictate when the app trigger settings cannot be read
FAIL: the unreadable-settings denial did not say why: … DENY dictate tap (unallowlisted)
```

(The denials pass trivially — an unknown verb is denied anyway — so the discriminating assertion is the one that fails: the verb did not exist.) With section 16 removed so the run reaches the workflow assertions:

```
== 20. the dispatched CI build installs itself for the gate ==
FAIL: ci.yml has no UI-gate install step
```

Both restored → `ui gate tests passed`.

**The Swift helper still compiles, now with the `dictate` case** (`Carbon.HIToolbox` added for `IsSecureEventInputEnabled`, `DispatchSource` signal handling for the hold release). Run against the build host, since the helper is a heredoc and only section 13 — on the macOS runner — otherwise type checks it:

```
$ ./scripts/remote-build.sh build --package-path <extracted helper package>
Building for debugging...
[3/6] Compiling HelperCheck main.swift
[4/6] Emitting module HelperCheck
[5/7] Linking HelperCheck
Build complete! (1.53s)
```

No warnings. (Throwaway package, not committed.)

**Runner-identity evidence** for point 5, from this PR's own CI run rather than from the docs:

```
$ gh api repos/{owner}/{repo}/actions/jobs/<id>/logs | grep -o '/Users/[A-Za-z0-9_.-]*' | sort | uniq -c
    128 /Users/tom
      2 /Users/Shared
$ … | grep -o '/Users/tom/[A-Za-z0-9_./-]*' | sort -u | head -3
/Users/tom/.gitconfig
/Users/tom/Applications
/Users/tom/actions-runner/_work.noindex/localvoxtral/localvoxtral
```

**Whole CI run green** on the previous head (`3fded52`): `build-test pass 6m7s`, which is what runs `test-ui-gate.sh` on the Mac — the only place the shell suite gets a bash-3.2 and a real `/private/tmp`. The build gate's payload allowlist is `swift build|test|package_app.sh`, so I cannot run the shell suite through it myself.

**CI green on this head — the whole suite on the real Mac**, run [33275338850](https://github.com/T0mSIlver/localvoxtral/actions/runs/33275338850), `build-test success`. That run is where `test-ui-gate.sh` meets bash 3.2, a real `/private/tmp`, and a `swiftc` that type checks the heredoc helper:

```
== 13. the embedded Swift helper compiles ==
PASS: the embedded Swift helper type checks
…
== 17. the artifact roots stay owner-only ground ==
PASS: every default artifact root is under $HOME and none is a world-writable location
PASS: existing artifact root /Users/tom/Applications is mode 700 (owner-writable only)
PASS: existing artifact root /Users/tom/localvoxtral-ui-artifacts is mode 755 (owner-writable only)
PASS: no repo script points an artifact root at a world-writable directory
…
== 20. the dispatched CI build installs itself for the gate ==
PASS: the UI-gate install step runs only on a workflow_dispatch with dogfood=true
PASS: a running slot warns; every other install failure is red
ui gate tests passed
```

The two `existing artifact root …` lines are the live arm of that section: it only reports on roots that exist, and on the owner's Mac both do — and both are owner-writable only. That arm cannot run on a Linux dev box.

**One flake on the first attempt of that run, not from this diff.** `swift test` hit its 300 s cap with `BackendManagerTests.testSecondEnsureReadyAddsPolishingAfterDictationOnlyRun` started and never finished; the `sample` in the artifact shows `swift-package` blocked in `_dispatch_group_wait_slow` waiting on its xctest child. That test is fully faked (`FakeSupervisorFactory`, `FixedLegacyPortDefense` — no real ports), and **neither commit here touches a line of Swift**; the host was simultaneously being driven by hand and by my own remote builds. Rerun on the same head: green, unit suite `Executed 2733 tests … 0 failures`. Recording it rather than hiding it — it belongs to the documented live-host-state family, not to this change.

**Still unverified — needs the GUI:** whether `AXExtrasMenuBar` opens the real status menu, whether the synthesised `flagsChanged` actually trips the app's monitor over SSH (proven for a GUI-session terminal by `record-demo.sh`, not for sshd), and whether Fn/Globe can be synthesised at all — only Right Command has been driven this way on this machine, which the gate says in a comment. These are in the checklist below.


## NOT verified — needs a GUI this agent cannot reach

The GUI account does not accept my key and I cannot install this; the owner does. Everything below is unproven, and is repeated as a first-install checklist in `scripts/mac/README.md`.

1. **Whether an SSH-hosted process can drive the GUI at all.** The big one. The design assumes TCC grants on `/usr/libexec/sshd-keygen-wrapper` let `screencapture -l` and the AX API work from an SSH session. If `state` reports `tcc.accessibility`/`tcc.screen_recording` false over SSH after granting them, that design does not hold on this macOS version — the fix is the LaunchAgent-helper alternative documented in the README, **not** loosening the gate.
2. **The lock probe's ioreg arm against a real `ioreg`.** Parsing is tested against fixtures; it has never seen real `ioreg -n Root -d1 -a` output. This is the single probe standing between the gate and a locked machine, so check `state` says `unlocked` while logged in and `locked` after locking the screen.
3. **`dictate` against the live app.** Whether a synthesised `flagsChanged` posted from an SSH-hosted process trips the app's `NSEvent` global monitor at all — `record-demo.sh` proves it from a GUI-session terminal, not from sshd — and whether Fn/Globe can be synthesised this way (only Right Command has been). Symptom if not: `dictate` reports ok and nothing happens. Check `dictate tap` then `ax dump overlay`.
4. **The `menu` verb against the live status item.** `AXExtrasMenuBar` → `AXMenuBarItem` → `AXPress` is the same element path System Events walks for `menu bar item 1 of menu bar 2`, and the press is verified by polling for the `AXMenu` rather than by its own return code — but none of it has met the real app. Check `menu open` then `shot popover`, `menu click Settings` then `shot settings`, and `menu dismiss`.
5. **Every other CoreGraphics/AX call.** Window-kind classification (`settings` = layer 0, `popover` = layer >= 100, `overlay` = in between) is reasoned from `capture-readme-assets.sh`, not observed. Same for `AXPress` on real controls and the `AXValue`-then-CGEvent fallback in `ax type`.
6. **`key`'s activation.** It calls `NSRunningApplication.activate` then re-checks `NSWorkspace.frontmostApplication` — two AppKit calls from a short-lived SSH-hosted process with no run loop, which is where they are least likely to behave. Symptom if it does not work: `key` always reports "could not be brought frontmost".
7. **`launch`'s pid resolution.** `pgrep -n -f "^<bundle>/Contents/MacOS/localvoxtral"` against a LaunchServices-started GUI app is untested with a real `open -n`.
8. **The terminal verbs — least tested part of v1.** `ghostty -e <script>`, `open -a Terminal <file>.command` for Terminal/iTerm, the OSC-0 title marker actually reaching the window title, and `AXCloseButton` on those windows. The stubs prove the allowlist, the denylist and the state bookkeeping, nothing about the terminals themselves. Note none of it does anything until the owner writes a wrapper and allowlists it.
9. **The audible warning.** `say` is stubbed; whether the wording is intelligible and the 3 s wait feels right is a human judgement.
10. **`--dogfood` arming `debug.dogfood_capture_enabled`** (a real `defaults write` on the owner's domain) — mirrors `try-pr.sh`, but only the stubbed call runs here.

## Owner's one-time install

`scripts/mac/README.md` -> "`localvoxtral-ui-gate.sh` — SSH UI gate (v1)". Summary: mint a dedicated ed25519 key on the dev box; on the Mac **as the GUI user** install `localvoxtral-ui-gate.sh` and `screen-lock-state.sh` into `~/bin`, create `~/localvoxtral-ui-artifacts`, add one `restrict,command="…/localvoxtral-ui-gate.sh"` line to `~/.ssh/authorized_keys`, leave `AcceptEnv` at its default; grant Accessibility **and** Screen Recording to `/usr/libexec/sshd-keygen-wrapper`; then run `ssh <dest> 'state'`, `ssh <dest> 'echo pwned'` and `ssh <dest> 'term open ghostty claude --dangerously-skip-permissions -p hi'` (the last two must print `denied command`). `term open` stays inert until a single-purpose wrapper is written and allowlisted.

---

## Update 2026-08-30 — `app`, `log`, and the term-open wrapper ships in the repo

Three gaps that kept this gate from actually debugging the join, pushed onto
this branch rather than opened as a second PR.

### `app <control command>` — asking the app what it JOINED

`dictate` can start a session; it cannot say what the session joined. Two
things about that are unobservable from outside the app's process: the trigger
is a modifier gesture (which `dictate` works around, at the cost of
synthesising one), and `ClaudeSessionRegistry` is in-memory and per-process, so
`localvoxtral --probe-surface` always resolves against an **empty registry**
and can never report a real join arm.

`app` forwards ONE line to the dogfood control socket added in **#242** and
returns the reply:

```bash
ssh lv-ui 'app registry list'           # empty registry, or unidentified surface?
ssh lv-ui 'app surface probe'           # resolve the FOCUSED surface now, live registry
ssh lv-ui 'app session start overlay'   # a real dictation, through the app's own tap handler
ssh lv-ui 'app session stop'
ssh lv-ui 'app join report'
```

What bounds it:

- **The socket path is fixed**, not an argument. No shape of the verb points it
  at another socket on the machine.
- **Dogfood only.** A shipped build compiles no socket at all, so the verb
  refuses unless `launch --dogfood` recorded a stamped bundle — one clear line
  instead of a connect that never answers.
- **The forwardable set is allowlisted IN THE GATE**, not inherited from
  whatever the app understands. A verb added to the socket is not
  automatically reachable through an already-installed gate.
- **Lock policy is per COMMAND.** `session start` takes the keyboard: refused
  while locked, and it speaks the takeover warning like `dictate`.
  `surface probe` reads the *focused* surface, and behind a lock screen that is
  not the surface being asked about, so it is refused too. `session stop`,
  `join report` and `registry list` are in-process reads (or a give-back) and
  work while locked, like `state`.
- Transport is a new `control` subcommand in the embedded Swift helper rather
  than `nc`: the half-close/EOF semantics stay ours, and section 13 type-checks
  it on the macOS runner where a shell pipeline would not be.
- Every invocation is logged with the exact line that crossed.

### `log [minutes]` — the app's own lines, and nothing else

Join abstentions are diagnosed from `Log.claudeContext`, and there was no way
to read them from here. Predicate-scoped to `subsystem == "com.localvoxtral"`
— deliberately not a general system-log reader, because this is the owner's
personal machine. Window clamped 1..120 (mirroring the build gate's `applog`),
400-line cap whose drop is announced rather than silent, and the output passed
through the same 43-character base64url scrub the dogfood records use. Allowed
while the screen is locked: it steals no focus and writes nothing.

**One thing is unverified, and it is stated rather than assumed.** `log show`
is restricted for **non-admin** accounts — the build gate's account hits
exactly that, and `scripts/mac/README.md` already records it ("Could not open
local log store: Operation not permitted"). The UI gate runs as the GUI user, a
different and *admin* account, so it is expected to work here — but no agent
can check that without the owner's GUI session, and I did not. So the verb is
built so the difference cannot be missed: a restricted store exits non-zero and
quotes the reason, an empty window says "no com.localvoxtral entries in the
last N minute(s)" on stderr, and the README names the alternative
(`mac-crashlog.yml` on the runner, or the app writing its own file) instead of
leaving a diagnostic that fails quietly. It is item 0 on the first-install
checklist.

### `scripts/mac/lv-attach.sh` — the wrapper ships in the repo

`LV_UI_TERM_COMMANDS` is empty by default and `ssh` is permanently denylisted,
so `term open` could do nothing. The documented answer was a wrapper the owner
writes by hand into `~/bin` — which put the boundary that the whole verb rests
on into an unreviewed one-off script.

It ships here instead, and `install-ui-artifact.sh` places it at
`~/bin/lv-attach` (mode 0700) with every build, so it arrives reviewed and
stays current.

**Allowlisting `lv-attach` is safe precisely because it cannot take a command,
which is the property `ssh` lacks.** It takes at most ONE argument, a herdr
session name matched against `^[A-Za-z0-9._-]{1,64}$` and refused on a leading
dash; no flags, no second positional, no command. It *reads* its config with
`sed` rather than sourcing it — the destination is deliberately not an
argument. It ends in one of exactly two fixed
`exec ssh -t -- <destination> herdr [--session <name>]` lines.

Whole-view client, not `herdr terminal attach <pane>`, on purpose: the app's
`HerdrInvocation` classifier refuses every other herdr shape
(`docs/agent/invariants.md`), so a pane-attach wrapper would reliably open a
window the app deliberately never joins — useless for the exact debugging
`term open` exists for. Pick the pane inside herdr, after attaching.

```bash
# ~/.lv-attach.conf
destination=builder
session=work

# ~/.localvoxtral-ui-gate.conf
LV_UI_TERM_COMMANDS="lv-attach"
```

### Proof

```
$ ./scripts/ci/test-ui-gate.sh
...
== 21. app — the passthrough to the dogfood control socket ==
== 22. log — bounded, scoped, and never silently empty ==
== 23. lv-attach — the wrapper that makes term open usable ==
== 24. install-ui-artifact.sh ships the wrapper with the build ==
ui gate tests passed

$ ./scripts/ci/test-ui-gate.sh | grep -c '^PASS'
265        # was 191
```

New assertions, by kind:

- **`app` denials**: no app under test; a build with no `LVXDogfoodCapture`
  stamp (and the message says so); no socket at the fixed path (and the message
  names the runtime opt-in); nine non-forwardable lines including
  `app session start` with no mode, `app registry dump`, `app quit` and
  `app rm -rf /`; and an attempt to pass a second socket path as an argument.
  A source pin that `run_app` still reads the fixed `LV_UI_CONTROL_SOCKET`.
- **`app` behaviour**: the exact line reaching the helper's `control`
  subcommand at the fixed socket; the socket's reply returned verbatim; the
  takeover warning spoken for `session start` and NOT for the reads; the
  per-command lock policy in both directions; a non-answering socket failing
  rather than reading as ok; and the gate log recording what was forwarded. The
  fixture is a real AF_UNIX inode, so `[[ -S ]]` is exercised as itself rather
  than against a regular file.
- **`log`**: predicate and default window asserted from the recorded `log show`
  argv; the clamps (0, 121, non-numeric, two values, negative); the 43-char
  scrub firing on a token-shaped run and NOT on a 42-char one (the rule must
  match `DogfoodCaptureRedaction` exactly); the 400-line cap announcing its
  drop; an empty window explaining itself; and the restricted-store path
  exiting non-zero while quoting the reason.
- **`lv-attach`**: the two accepted argv shapes byte for byte, including
  `user@host` and the configured default session; fourteen refusals, twelve of
  them injection attempts through the identifier (`;`, `$(…)`, backtick, `|`,
  `&`, space, newline, quote, slash, `-oProxyCommand=`, leading dash, 65
  chars) plus a second argument and an empty one; four config refusals (absent
  file, no destination, an ssh option as the destination, a destination with a
  space or a colon); and source pins that the file contains no `eval`,
  `bash -c`, `sh -c`, `source`, or `"$@"` in a command position, with exactly
  two `exec` lines both matching the fixed argv. Plus: `ssh` stays denied even
  when the conf allowlists it, and an allowlisted `lv-attach` does reach
  `term open`.
- **Install**: a build install puts the reviewed wrapper at `~/bin/lv-attach`,
  mode 0700, byte-identical to the repo copy.

### Still not verified by any of this

Everything in the "what a live desktop has to confirm" list above, plus:

- Whether `log show` works for the GUI account at all (above).
- The helper's `control` subcommand against a real socket. The shell suite
  stubs `swift`, and section 13 only type-checks the helper. The app side of
  the same conversation IS covered end to end by `DogfoodControlSocketTests`
  in #242 (real bind, real connect, real peer credentials), so what is untested
  is the seam between them.


---

## Update 2026-08-30 (2) — two verbs were lying, found by driving the installed gate

Different code, same failure shape: a real-looking answer that is not about the
thing under test. Neither was blocking, which is exactly why both were worth
fixing now.

### `menu open` reported success without opening anything

```
$ ssh <gate> 'menu open'
ok already-open
$ ssh <gate> 'shot popover'
no popover window owned by the app under test (pid 15954)
$ ssh <gate> 'ax dump all'
[]
```

An `NSMenu` handed to an `NSStatusItem` is an `AXMenu` **child** of that item
for the app's whole life, displayed or not. `openMenu(of:)` looked for that
child, so it matched every time, `menuopen` short-circuited on its already-open
fast path, and `AXPress` never fired. The name was the bug: a function called
`openMenu` that answers "is a menu *attached*" reads as correct at every call
site. It is now `attachedMenu(of:)`, and a source pin fails if `openMenu` comes
back.

**The evidence, and why this test.** The field output above is itself the
disproof of the AX-attachment test — `ok already-open` on a build that had
displayed nothing. It also rules out the AXMenu-with-children variant the brief
offered as an alternative: `menu click <title>` presses items through AX with
the menu closed and works (it is how Settings got opened and screenshotted),
which means the attached menu's `AXChildren` are populated while nothing is on
screen. Non-zero `AXSize` on a closed menu is untested and I could not test it —
the GUI account was in use, and the build host is not the console user, so no
agent on this repo can drive a live desktop today. So I took the test that does
not need a guess: a CGWindow owned by the recorded pid at layer >= 100, resolved
through **the same `resolveWindow(kind: "popover")` that `shot popover` calls**.
That is a stronger property than "probably right": `menu open` now succeeds
exactly when `shot popover` can then find something, by construction, so if the
window rule is wrong on this macOS version both verbs say so together instead of
one lying to cover the other. It prints the window id, so a caller can tell an
open from a no-op, and a press that produced nothing fails naming what it looked
for and pointing at `menu click`, which works either way.

Everything else about the verb is unchanged: pid scoping, lock refusal, `say` +
3 s, logging, the bounded `AXUIElementSetMessagingTimeout`, and the deliberate
not-trusting of `AXPress`'s return code (`.cannotComplete` while a menu tracks).
The already-open fast path is kept, now on evidence.

**`menu dismiss` had the same root cause with a worse outcome.** Its "nothing is
open" branch was decided by attachment, which is always true — so it never ran,
and the fallback under it presses the status item, which on a **closed** menu
opens one. Dismiss could open the thing it exists to close. It now returns
`ok no-menu-open` before it can touch anything, and confirms the window is gone
before reporting success.

`menu click` deliberately still uses the attached menu. That is the fallback
when the window test cannot see a menu that is genuinely up.

### `log` answered with CI's `xctest` lines

A `log 2` returned 111 lines; exactly one was the app under test. The rest were
`xctest` from a unit-suite run — this Mac is also the self-hosted runner, and
the suite legitimately logs under `subsystem == "com.localvoxtral"`. Among them:
`Terminal pane joined to a live Claude session via title marker`. Attributing
that to the dictation you just made is a wrong conclusion drawn from a real log
line, and diagnosing that join is the verb's entire purpose.

The predicate now carries a process as well as the subsystem:

- **with an app under test**: `processIdentifier == <the pid launch recorded>` —
  one instance, through the same recycled-pid identity check every other verb
  uses, so a recycled pid falls back rather than reading a stranger's lines;
- **with none**: `process == "localvoxtral"` — still never `xctest`, but no
  longer one instance — and it says so **on stderr, before the lines**, so the
  caveat is read before the conclusion. Refusing outright was the other option;
  reading the log after a crash or a `quit` is worth more than the symmetry.

The gate log records which scope each read used, and the empty-window message
names it. README gains the note that even correctly scoped, `log` on this
machine competes with CI for the surrounding system log.

### `shot`'s header: it was already on stderr, and stays there

`printf 'shot: window …' >&2` since the first commit, and section 6 already
asserted stderr carries it. It reads like a header only because an interactive
ssh delivers both streams to one terminal; `shot popover | base64 -d > x.png` is
correct as written and needs no `tail`. Moving it further is not available and
stdout is already pure. So: documented instead — the verb's own comment, the
file header, the README verb table and the walkthrough — and the suite now
asserts stdout carries **no** `shot:` line, rather than only that stderr does.

### Proof

The suite stubs the helper, so it cannot run these AX/CGWindow calls. What it
pins is which evidence each subcommand decides on, read out of the embedded
Swift heredoc one `case` body at a time (two new readers, `helper_case_body` /
`helper_func_body`), plus the log predicate and the stdout/stderr split, which
are shell-side and fully exercised.

**Red — the new checks against the old `openMenu` logic** (`git show HEAD:` of
the gate, new suite):

```
$ git show HEAD:scripts/mac/localvoxtral-ui-gate.sh > scripts/mac/localvoxtral-ui-gate.sh
$ ./scripts/ci/test-ui-gate.sh
...
== 15. menu — the verb that makes every other verb reachable ==
PASS: allowed: menu open passes the helper evidence through
PASS: menu open reports the window it resolved, not a bare ok
FAIL: the helper has no displayed-menu test — menu open is deciding openness from something else
```

**Red — the log predicate reverted to subsystem-only, everything else new:**

```
== 22. log — bounded, scoped, and never silently empty ==
PASS: log is predicate-scoped to localvoxtral's own subsystem
PASS: allowed: log with an app under test is scoped to its pid
FAIL: log was not scoped to the pid launch recorded: show --style compact --info --last 15m --predicate subsystem == "com.localvoxtral"
```

**Green — both fixed:**

```
$ ./scripts/ci/test-ui-gate.sh
...
== 15. menu — the verb that makes every other verb reachable ==
...
PASS: allowed: menu open passes the helper evidence through
PASS: menu open reports the window it resolved, not a bare ok
PASS: menu open decides openness from the same window rule shot popover resolves
PASS: menu click still works against an attached-but-closed menu
PASS: menu dismiss returns no-menu-open before it can press anything
PASS: the menu helper subcommands, AXExtrasMenuBar and the messaging timeout are all present
...
== 22. log — bounded, scoped, and never silently empty ==
...
PASS: allowed: log with an app under test is scoped to its pid
PASS: log with an app under test carries the recorded pid in its predicate
PASS: allowed: log without an app under test falls back to the process name
PASS: log without an app under test falls back by process name and says it is not one instance
PASS: allowed: log falls back when the recorded pid was recycled
PASS: a recycled pid falls back instead of scoping the read to a stranger
...
ui gate tests passed
```

**Green on the macOS runner** — run
[33307620464](https://github.com/T0mSIlver/localvoxtral/actions/runs/33307620464),
`d346a1c`, `completed/success`. Section 13 SKIPs on the Linux dev box and is the
compile proof for the new Swift here:

```
== 13. the embedded Swift helper compiles ==
PASS: the embedded Swift helper type checks
== 15. menu — the verb that makes every other verb reachable ==
...
PASS: menu open passes the helper evidence through
PASS: menu open reports the window it resolved, not a bare ok
PASS: menu open decides openness from the same window rule shot popover resolves
PASS: menu click still works against an attached-but-closed menu
PASS: menu dismiss returns no-menu-open before it can press anything
== 22. log — bounded, scoped, and never silently empty ==
...
PASS: log with an app under test carries the recorded pid in its predicate
PASS: log without an app under test falls back by process name and says it is not one instance
PASS: a recycled pid falls back instead of scoping the read to a stranger
```

### What remains unverifiable without a GUI, stated plainly

The suite proves the *decision*, never the *platform fact*. It cannot confirm
that macOS puts a displayed status menu in the window list at layer >= 100 under
the app's own pid — the one assumption the whole fix rests on, and one
`shot popover`'s existing `popover` kind already made. It is now first-install
check **6** in `scripts/mac/README.md`, with what to conclude if it fails: check
with `menu click Settings` (which works either way), say which half broke, and
do **not** go back to trusting the attached `AXMenu`. Check **7** is the log
one: start a build on the runner, run `log 2`, confirm no `xctest[` line comes
back.

---

## Update: `term open` never ran the command, and nothing could see why (2026-08-30)

Driving the installed gate against the owner's Mac ran into two field failures
and one gap that turned both of them into round trips through the owner.

### 1. `term open` ran a name PATH could not find

```
$ ssh <gate> 'term open ghostty lv-attach'
localvoxtral ui gate: opened Ghostty but never saw a window carrying marker lvui-term-1-2114914884
```

A Ghostty window appeared and was **empty**. The launcher said `exec lv-attach`
and relied on PATH: a script started by `open -n -a Ghostty --args -e <script>`
gets no login-shell environment, and `$HOME/bin` — where
`install-ui-artifact.sh` puts the wrapper — is on neither that PATH nor sshd's.
`command not found`, instant exit, empty window. (Confirmed from the remote
host: `last` showed no new pty login, so the `ssh -t` inside `lv-attach` never
ran.)

The allowlisted **name** is now resolved to an absolute path under
`LV_UI_TERM_COMMAND_DIRS` (default `$HOME/bin`) **before anything is opened**,
must be a file that exists and is executable, and a name that does not resolve
is refused with nothing opened. The directory list stays short on purpose: a
name resolved out of a directory other accounts can write is the allowlist
handed away. A path in the command position (`/bin/sh`, `../bin/x`) is refused
outright — the allowlist is about names, this is about where names live.

### 2. It then looked for a title herdr eats

The window was identified by a random OSC 0 title marker the launcher printed.
That cannot work for the one command this verb exists to run: `lv-attach` execs
a whole-view herdr client, and herdr owns the title from the moment it starts.
`docs/agent/invariants.md` already said so — "herdr intercepts OSC 2 per pane,
so a title marker can neither reach nor come back from a herdr-hosted session"
— which is exactly why the app's own `titleMarker` join arm is suppressed
there. The gate reused a title marker anyway.

Primary identity is now a **CGWindowID diff**: `term open` snapshots the
terminal application's window ids before `open`, then binds the window that is
new since that snapshot. That needs no cooperation from the child process, so
nothing the command does to its title can hide it. `term focus`/`term close`
address that window id, mapped to an AX window by frame (AX exposes no window
id without private API). The marker survives only as a tie-breaker for commands
that leave the title alone. `docs/agent/invariants.md` now carries the
cross-reference so the next thing outside the app does not repeat it.

### 3. "No window" meant three different faults

Reporting a command that never ran as a window-identification timeout is what
produced a confidently wrong root cause on top of the real one. The launcher
writes its pid before `exec`, which separates them:

| pid file | what happened | what to do |
| --- | --- | --- |
| absent | the terminal never ran the launcher | the command was never executed; not a window problem |
| present, process gone | the command ran and exited immediately — an empty window is what that looks like | run the resolved command by hand and read its error |
| present, alive | the command is running, only the window could not be identified | re-run without opening a terminal yourself at the same moment |

And a `term open` that cannot confirm what it opened now **kills what it
started** (that pid is the only handle once the window is unaddressable),
removes the launcher and registers nothing — so a failed `term open` leaves no
residue on the owner's desktop. Several windows appearing at once is refused
rather than guessed at: binding the wrong one would point `term close` at
whatever the owner just opened.

### 4. None of it was visible before a verb failed

`~/.localvoxtral-ui-gate.conf` did not exist, so `term open` refused
everything; `~/bin/lv-attach` may or may not have been installed; the dogfood
socket's runtime consent was off, so `app` denied. Every one a one-line fix,
and each indistinguishable from "the verb is broken" or "the gate is old",
because `deny` answers uniformly and no verb read the log where the reason was
written.

**`state` gains a `setup` section.**

```json
"setup": {
  "gate": {"revision": "1b7d51eb73de"},
  "lock_probe": {"installed": false},
  "gate_conf": {"present": false, "status": "absent"},
  "artifacts": [],
  "term_open": {"terminals": ["ghostty","iterm","terminal"], "commands": [],
                "refused_by_denylist": [], "unresolvable": []},
  "lv_attach": {"installed": false, "allowlisted": false, "conf": "absent",
                "destination": null, "session_default": false},
  "control_socket": {"present": false, "consent": "unset"}
}
```

Facts and verdicts, never a file's contents. The one judgement call is the
lv-attach destination: a **bare alias** is echoed (a label in the owner's own
`~/.ssh/config` — it names no account and no address, and it is the value that
catches "this points at the wrong machine"); a `user@host` destination is an
account **and** an address, so its shape is reported and its value is not,
which is the same line `app`'s closed reply vocabulary already draws. A refused
destination is never quoted back.

`lv_attach.conf` comes from `~/bin/lv-attach --check` — the gate asks the
**installed** wrapper rather than re-implementing its destination validator, so
there is one validator and "wrapper missing" and "wrapper too old to answer"
are different answers. `--check` prints a verdict and runs nothing; every other
flag is still refused outright.

**A conf with a syntax error used to take the whole gate down.** `source`
returns non-zero and `set -e` exits before anything prints:

```
$ SSH_ORIGINAL_COMMAND=state <old gate>          # conf: LV_UI_TERM_COMMANDS="x
/tmp/.../.localvoxtral-ui-gate.conf: line 1: unexpected EOF while looking for matching `"'
exit=2
```

Now it degrades to the built-in (closed) defaults, warns on every invocation,
and is reported:

```
$ SSH_ORIGINAL_COMMAND=state <new gate>
localvoxtral ui gate: /tmp/.../.localvoxtral-ui-gate.conf has a syntax error and was IGNORED — every setting in it is at its built-in default, which means `term open` has an EMPTY allowlist. Check it with: bash -n /tmp/.../.localvoxtral-ui-gate.conf
{... "gate_conf":{"present":true,"status":"unparsable"}, "term_open":{... "commands":[] ...} ...}
exit=0
```

**`gate-log [lines]`** reads the gate's own log, where every denial's reason
already was:

```
$ ssh lv-ui 'term open ghostty lv-attach'
localvoxtral ui gate: denied command
$ ssh lv-ui 'gate-log 5'
2026-08-30T14:39:37+0200 DENY term open ghostty lv-attach (term open has no allowlisted commands (the default is empty — see scripts/mac/README.md))
```

**`deny` still does not explain itself, deliberately.** A gate that answered
each refusal with its reason would be an oracle for state the caller cannot
otherwise see — whether a path exists, whether a bundle validated, whether a
pid is running, which names a conf allowlists. The fix for an invisible reason
is a bounded reader, not a chattier refusal; the existing deny assertions
(stdout empty, `denied command` on stderr, exit 126, one DENY log line) are
untouched and every new refusal is added to them. What `gate-log` can disclose
is exactly what this gate wrote about itself: one sanitised, printable,
512-byte-capped line per invocation, with `ax type`'s text already `<redacted>`
**at write time**, so reading the log back cannot resurrect an API key. Same
43-character token scrub as `log`. It logs itself before reading and drops that
line, so `gate-log 1` means "the entry before this one". Read-only and
focus-free, so it works while the screen is locked.

### 5. Bootstrap: reduced where it is configuration, not where it is a grant

- **`~/.lv-attach.conf` — templated.** A destination is ordinary
  configuration, and "what is this file called and what goes in it" was itself
  a round trip. `install-ui-artifact.sh` writes a commented template when the
  file does not exist, with **no active destination** (it cannot know which
  machine you mean, and guessing would open a terminal onto the wrong host),
  and never overwrites one.
- **`~/.localvoxtral-ui-gate.conf` — NOT written, and no installer ever
  should.** `LV_UI_TERM_COMMANDS` is the gate's allowlist: the same object as
  the gate script, one layer up. The rule that CI must not write the gate
  script applies to what the gate will *accept* for exactly the same reason —
  an empty default exists to force a deliberate grant, and a grant that arrives
  with a build is not one. The manual step is one **append**, which cannot
  clobber an existing file and wins over any earlier assignment when sourced:

  ```bash
  printf 'LV_UI_TERM_COMMANDS="lv-attach"\n' >> ~/.localvoxtral-ui-gate.conf
  ```

  `ui-gate-doctor.sh` prints that line verbatim, and a test runs the printed
  line and then asserts the verb works — so the advice is proved to be the fix,
  not restated by hand. A test also pins that the installer never writes that
  file.
- **`debug.dogfood_control_socket_enabled` — stays a second, separate
  consent.** A `--ui-gate` install is a deliberate act aimed at agent control,
  but the socket is not gate-scoped: it is an AF_UNIX socket in the owner's
  home that **any** local process can connect to, on a machine that is also the
  self-hosted CI runner running jobs as the same user. "Records what I do" and
  "accepts commands on a local socket" are different permissions and the split
  was made on purpose. The missing piece was only that the reason was
  invisible, which `state` and `gate-log` now fix.

### 6. A first-run doctor

`scripts/mac/ui-gate-doctor.sh` replaces the README's seven-item prose list
with a command. Every line is `ok` or `FIX` plus the one copy-pasteable
command that fixes it; exit 0 when nothing needs attention, 1 when something
does, 2 when the gate could not be reached or answered without a `setup`
section (an older gate).

```
$ ./scripts/mac/ui-gate-doctor.sh --state-file <captured state>
localvoxtral UI gate readiness (...)

  [ok ] gate script            revision f44a91a15001 (compare: shasum -a 256 scripts/mac/localvoxtral-ui-gate.sh)
  [FIX] lock probe             not installed, so every GUI-touching verb denies (fail closed)
                                fix: install -m 0755 scripts/ci/screen-lock-state.sh ~/bin/localvoxtral-screen-lock-state.sh
  [FIX] TCC accessibility      not granted — ax dump/click/type, key, menu, dictate cannot work
                                fix: System Settings > Privacy & Security > Accessibility: add /usr/libexec/sshd-keygen-wrapper
  [FIX] gate conf              ~/.localvoxtral-ui-gate.conf does not exist, so `term open` accepts nothing
                                fix: printf 'LV_UI_TERM_COMMANDS="lv-attach"\n' >> ~/.localvoxtral-ui-gate.conf
  [ok ] lv-attach wrapper      installed at ~/bin/lv-attach
  [FIX] launchable builds      no localvoxtral bundle under the artifact roots — `launch` has nothing to start
                                fix: ./scripts/try-pr.sh <pr> --dogfood --ui-gate
  [-- ] app under test         none — `launch [--dogfood] <artifact>` first
  [FIX] control socket         debug.dogfood_control_socket_enabled is unset, so `app <command>` denies (a second consent on purpose ...)
                                fix: defaults write com.localvoxtral.app debug.dogfood_control_socket_enabled -bool true   # then relaunch

8 item(s) need attention. Re-run after each fix.
```

Three modes: `--remote lv-ui` (from the dev box — runs `ssh lv-ui state`),
`--state-file <f>`, and local on the Mac, where it additionally checks the
forced-command line and whether the installed gate matches this checkout.
`scripts/mac/README.md`'s first-install section now names only the items no
script can reach.

## Proof (this update)

**Red — the new section 9 assertions against the gate as it stood at
`d346a1c`.** This is the field failure, reproduced:

```
$ git show d346a1c:scripts/mac/localvoxtral-ui-gate.sh > scripts/mac/localvoxtral-ui-gate.sh
$ ./scripts/ci/test-ui-gate.sh
...
== 9. term verbs ==
FAIL: term open of an allowlisted command failed: localvoxtral ui gate: opened Ghostty but never saw a window carrying marker lvui-term-1-2811424362
```

The old gate on the two other new behaviours:

```
$ SSH_ORIGINAL_COMMAND=state   <old gate>   # no setup section at all
{"screen_lock":"error","idle_seconds":null,"power":"unknown","tcc":{...},"app":{"running":false},"terminals":[]}
exit=0
$ SSH_ORIGINAL_COMMAND=gate-log <old gate>
localvoxtral ui gate: denied command
exit=126
```

### CI found one more, and it was the class this branch keeps hitting

The first push went red on the macOS runner while the same suite was green on
the Linux dev box (run 33313541728):

```
== 9. term verbs ==
...
PASS: no term verb resolves a window by a title herdr can overwrite
FAIL: term open did not say what went wrong: localvoxtral ui gate: Ghostty opened but never ran the launcher, so lv-attach was never executed — nothing was left running. ...
```

The gate was right; the **fixture** was wrong. The stub standing in for a
terminal that ran the launcher recorded its pid with `$BASHPID`, which arrived
in bash 4.0 — the Mac's `/bin/bash` is 3.2, where it expands to nothing. The
fixture wrote an empty pid file, and the gate read that as "the launcher never
ran", which is exactly the distinction this change added. The stub now spawns a
real `/bin/sh -c 'printf "%s" "$$" > "$1"; exec …'`, whose `$$` is its own pid —
which is also what the real launcher does, so fixture and subject record a pid
the same way.

The class matters more than the instance: a bash-4 idiom is green on every dev
box in this repo and only breaks on the one machine the gate exists for. This
branch has hit it twice (`daf6364` was the first), so it is now a check rather
than a habit. **Section 28** scans the gate, the wrapper, the installer, the
doctor and the suite itself for `BASHPID`, `mapfile`, `readarray`, associative
arrays, case-conversion expansion and `|&`, and pins that every array slice in
the gate sits behind a length guard (bash 3.2 calls an empty slice unbound under
`set -u` — the trap the dispatch already carried a comment about). It strips
comments **and its own definition block**: a scan that cannot tell its
vocabulary from a call reports itself.

Both guards shown failing before passing:

```
$ sed -i '1a : "${BASHPID:-}"' scripts/mac/ui-gate-doctor.sh
$ ./scripts/ci/test-ui-gate.sh
FAIL: .../ui-gate-doctor.sh uses BASHPID, which is bash 4+ and misbehaves quietly on the Mac's /bin/bash 3.2: 1:: "${BASHPID:-}"

$ # unguard the launcher's argv slice
$ ./scripts/ci/test-ui-gate.sh
FAIL: an unguarded array slice at .../localvoxtral-ui-gate.sh:2315 — bash 3.2 calls an empty slice unbound under set -u: printf ' %q' "${argv[@]:1}"
```

**Green — 347 assertions, all sections:**

```
$ ./scripts/ci/test-ui-gate.sh
...
== 9. term verbs ==
PASS: allowed: term open runs an opted-in wrapper, by absolute path, and logs the command in full
PASS: allowed: term focus on a window this gate opened
PASS: allowed: term close on a window this gate opened
PASS: denied: term focus after the window was closed
PASS: denied: an allowlisted command that is not installed
PASS: an allowlisted command that is not installed refuses without opening a window
PASS: state reports an allowlisted command with no executable behind it
PASS: denied: an allowlisted command that is not executable
PASS: a file that is not executable does not read as an installed command
PASS: denied: an absolute path in the command position
PASS: denied: a relative path in the command position
PASS: term open takes a command name, never a path
PASS: term open identifies its window by what appeared since a pre-open snapshot
PASS: allowed: term focus by recorded window id
PASS: allowed: term close by recorded window id
PASS: term focus and term close address a window id, not a title
PASS: no term verb resolves a window by a title herdr can overwrite
PASS: a term open that cannot identify its window kills what it started and registers nothing
PASS: a terminal that never ran the launcher says so, and says what it is not
PASS: a command that exits immediately is reported as a failed command, not a missing window
PASS: term open refuses to guess between windows that appeared at the same moment
== 10. quit terminates only the recorded process ==
```

```
== 25. state reports SETUP readiness, and reports facts rather than contents ==
PASS: state names every absent piece of setup instead of leaving a verb to fail
PASS: denied: term open with the setup state above
PASS: state's report and term open's refusal agree
PASS: state predicts a working term open, down to the destination it would reach
PASS: allowed: term open with the setup state above
PASS: state's report and term open's success agree
PASS: state reports a user@host destination as resolvable without naming it
PASS: state reports a refused destination without quoting it
PASS: state flags an allowlist entry the permanent denylist refuses
PASS: denied: term open under an unparsable conf
PASS: an unparsable conf degrades to the closed defaults instead of killing every verb
PASS: state lists exactly the bundles launch would accept, and which are dogfood
PASS: state reports the control socket's consent and whether anything is bound
PASS: state reports presence and verdicts, never a config file's contents
PASS: state reports which build of the gate answered
PASS: state reports setup while the screen is locked

== 26. gate-log — the denial reason, without deny explaining itself ==
PASS: denied: the refusal whose reason was invisible
PASS: allowed: gate-log reads the gate own log
PASS: a denial's reason is reachable in one verb instead of one round trip through the owner
PASS: gate-log logs itself and does not answer with itself
PASS: denied: a zero-line window
PASS: denied: a window past the clamp
PASS: denied: a non-numeric window
PASS: denied: two windows
PASS: denied: a negative window
PASS: allowed: gate-log survives a locked screen
PASS: gate-log reads the gate's own file and nothing else
PASS: allowed: gate-log masks token-shaped runs
PASS: denied: ax type with no app under test
PASS: allowed: gate-log after an ax type
PASS: gate-log cannot resurrect ax type's text
PASS: gate-log says so when there is nothing before this invocation

== 27. ui-gate-doctor — the first-install checklist, executable ==
PASS: the doctor turns each invisible piece of setup into a named item
PASS: allowed: term open after running the doctor fix verbatim
PASS: the doctor's fix line is the command that actually fixes it
PASS: the doctor clears each item as it is fixed
PASS: the doctor names an allowlisted command that is not installed
PASS: the doctor refuses to grade a gate that predates setup reporting
PASS: the doctor says what it got when the gate did not answer with JSON
PASS: the doctor grades the INSTALLED gate, and says whether it is this one
PASS: an installed gate that differs from this checkout is a FIX, not a silent pass
PASS: the doctor flags a key that does not force the gate, or forces it unrestricted
PASS: the doctor's --help prints the usage block, and stops there

== 28. nothing here needs a bash newer than the Mac's /bin/bash 3.2 ==
PASS: the gate, the wrapper, the installer, the doctor and this suite are bash 3.2 clean
PASS: every array slice in the gate sits behind a length guard

ui gate tests passed
```

**The new Swift compiles on macOS.** Section 13 SKIPs on the Linux dev box, so
the helper heredoc was extracted into a scratch SwiftPM package and built on the
Mac build host (the package is not committed; the runner's `swiftc -typecheck`
in section 13 is the permanent check):

```
$ ./scripts/remote-build.sh build --package-path .helper-typecheck
==> Running on builder@...: swift build --package-path .helper-typecheck
Building for debugging...
[4/8] Emitting module HelperTypecheck
[5/8] Compiling HelperTypecheck main.swift
[6/8] Linking HelperTypecheck
Build complete! (10.76s)
```

That was the pre-CI check; the runner has since type-checked the same source in
section 13 (below).

**Green on the macOS runner** — run
[33314216234](https://github.com/T0mSIlver/localvoxtral/actions/runs/33314216234),
`29c2805`, `completed/success`. Section 13 is the permanent compile check and
SKIPs on the Linux dev box, so this is where the new Swift is type-checked:

```
== 13. the embedded Swift helper compiles ==
PASS: the embedded Swift helper type checks
...
== 27. ui-gate-doctor — the first-install checklist, executable ==
PASS: the doctor turns each invisible piece of setup into a named item
PASS: the doctor's fix line is the command that actually fixes it
PASS: the doctor clears each item as it is fixed
PASS: the doctor names an allowlisted command that is not installed
PASS: the doctor refuses to grade a gate that predates setup reporting
PASS: the doctor says what it got when the gate did not answer with JSON
PASS: the doctor grades the INSTALLED gate, and says whether it is this one
PASS: the doctor flags a key that does not force the gate, or forces it unrestricted
PASS: the doctor's --help prints the usage block, and stops there
== 28. nothing here needs a bash newer than the Mac's /bin/bash 3.2 ==
PASS: the gate, the wrapper, the installer, the doctor and this suite are bash 3.2 clean
PASS: every array slice in the gate sits behind a length guard
ui gate tests passed
```

### What cannot be verified without a GUI, stated plainly

- That macOS actually lists a newly opened terminal window under the terminal
  application's pid within the poll window — the platform fact the snapshot diff
  rests on. The suite proves the *decision* (snapshot taken before `open`, the
  pre-existing ids excluded, ambiguity refused), never the platform fact.
- That the AX-window-by-frame mapping resolves on a live desktop. It is
  deterministic and refuses on zero or several matches rather than guessing,
  but it has not run against a real `AXUIElementCopyAttributeValue`.
- Whether `lv-attach` reaches the herdr session the owner meant. The gate can
  now tell you the command ran and stayed running; only the remote host can
  tell you it attached (`last` showing a new pty login from the `-t` ssh). That
  is first-install check 5 in the README.
- Whether `~/bin/lv-attach` was placed by the dispatched CI install on the
  owner's Mac. `state`'s `setup.lv_attach.installed` and
  `setup.term_open.unresolvable` answer it from the dev box now, but this
  branch has not been run against that machine.




## Review (adversarial, GLM 5.2 via opencode — release train)

One read-only adversarial pass with `scripts/mac/README.md`, the gate's own
header, and the full diff, briefed to attack the forced-command boundary
specifically (this gate is installed on a personal machine). The reviewer read
all 2609 lines, then drove the **real gate** in a stubbed sandbox with ~50
hostile `SSH_ORIGINAL_COMMAND` shapes — quoting, charset, unicode homoglyphs,
parser edges, log-forgery, `launch` traversal/symlink shapes, `term open` argv
abuse.

**No boundary escape found.** No path from a fully attacker-controlled
`SSH_ORIGINAL_COMMAND` to a shell, an arbitrary child process, or an arbitrary
file write as the GUI user. The three `term open` invariants are real in code
(empty default, denylist assigned after the conf is sourced and not via
`${VAR:-}`, applied to `argv[0]` before the allowlist); `ax type` text reaches
the helper as one argv element and is never re-parsed by a shell; `launch`'s
`pwd -P` prefix check defeats the symlink and `..` shapes; `app` matches five
fixed strings; the log scrubber redacts at write time and neutralises a
newline-forged `ALLOW`; every GUI-touching verb sits behind the lock probe.

Two real defects were found, both fixed in `05063aa`.

### 1. `launch` could record a HELPER's pid, not the app's — fixed

`pgrep -f` matches its pattern as a prefix of the whole command line, and
`package_app.sh` installs `localvoxtral-speechd` (:573), `localvoxtral-polishd`
(:452) and `localvoxtral-claude-hook` (:249) into the **same**
`Contents/MacOS/` directory — every one of them matches
`^<bundle>/Contents/MacOS/localvoxtral`. The app starts its helpers during
launch, and `pgrep -n` answers with the NEWEST match, so which pid got recorded
came down to timing.

Recording a helper is worse than failing: every verb reads `app.state`, so
`ax dump` returns `[]` forever and `shot` never finds a window — and `quit`
then TERM/KILLs the helper while the real app keeps running, after which
`launch` refuses beside "a localvoxtral this gate did not start" and only the
owner can unwedge the machine. It silently defeats the gate's entire purpose,
non-deterministically.

The prefix now only nominates candidates; `ps -o comm=` — the full path on BSD,
the same fact `process_identity` already trusts against pid reuse — decides.
The old suite could not see this because its `pgrep` stub answered with exactly
one pid and ignored `-n`: a stub that cannot express the platform fact is how
this hid, so both were fixed alongside the gate.

### 2. The permanent denylist missed the runtime-shell class — fixed

`LV_UI_TERM_FORBIDDEN` named shells, interpreters and agent CLIs, but not the
class that reaches a shell at RUNTIME rather than through a flag. The admission
test written in the header and the README — *read its `--help`; if any flag
takes a command it fails* — clears `vi` (`:!cmd`), `less` and `man` (`!cmd`,
`v`), `awk` (`system()`) and `git` (editor, hooks, `GIT_SSH`), because none of
those is a flag. And a pager is exactly what an owner allowlists meaning "I
just want a viewer in that window":

```
# ~/.localvoxtral-ui-gate.conf:  LV_UI_TERM_COMMANDS="less"
ssh lv-ui 'term open ghostty less /etc/hosts'
# then, in the window:  !bash      → interactive shell as the GUI user
```

Editors, pagers, command wrappers (`nice`, `watch`, `timeout`, `env`, `xargs`,
`open`), toolchain drivers and fetchers are denied now; the README says why the
`--help` test is necessary and not sufficient; and the suite pins the new
members so re-adding one fails here rather than in the field.

### Also fixed

- `log_command` capped and scrubbed the command text but appended the **note**
  raw, so "one invocation is exactly one line" was enforced on half the line.
  No live injection today (every note is built from charset-checked input) —
  but the next caller to interpolate something new would not have known. Same
  cap, same `tr -c '[:print:]'`.
- `term close`'s locked-screen refusal existed in the gate with no assertion;
  it is in the section-5 loop beside `term focus` now.

### Not fixed, and why

- **Gate log grows without bound** — real; every invocation appends and a key
  holder can loop `state`. Deliberately left: it is the owner's own machine,
  the file is one short line per invocation, and rotation policy on a personal
  Mac is a `newsyslog` conversation rather than something this gate should
  invent. Worth a follow-up, not a merge blocker.
- **`next_term_id` counter race** — two simultaneous `term open`s can both
  claim `term-1`. The bookkeeping lies, but both windows are gate-opened, no
  verb crosses to the app, and the gate is driven by one operator at a time.
- **`state`'s `terminals[].alive` trusts a bare `kill -0`** — cosmetic;
  `termaction` re-validates window ownership before acting.

### Proof

**RED** — the fix reverted to the bare `pgrep -n -f` prefix, with the stub
answering as the real `pgrep` does (three pids sharing the prefix, `-n`
honoured):

```
$ ./scripts/ci/test-ui-gate.sh
FAIL: launch recorded a helper instead of the app: launched pid=5200 bundle=…/localvoxtral.app dogfood=0
```

pid 5200 is `localvoxtral-polishd`; the app is 5000.

**GREEN** — fix restored, whole suite, now **356 assertions** (was 347):

```
$ ./scripts/ci/test-ui-gate.sh
…
PASS: denied: conf-allowlisted less is STILL denied
PASS: denied: conf-allowlisted vim is STILL denied
PASS: denied: conf-allowlisted git is STILL denied
PASS: denied: conf-allowlisted open is STILL denied
PASS: denied: locked screen refuses: term close term-1
PASS: launch records the APP, never a helper sharing the pgrep prefix
PASS: a helper alone is not an app under test
…
ui gate tests passed
```

**Note for the owner:** the gate installed on the Mac (revision
`4f38be8a22c7`) predates these two fixes. Reinstall from this branch before
relying on `launch` — until then it can still record a helper pid, and the
denylist is the narrower one.
