### PR TITLE
integration-herdr: hold the remote-herdr join to a LIVE herdr server over a real ssh forward

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -120,6 +120,7 @@ jobs:
           fi
           if grep -qF '[run-llm-eval]' <<<"$MARKER_TEXT" \
               || grep -qF '[run-speechd-integration]' <<<"$MARKER_TEXT" \
+              || grep -qF '[run-herdr-integration]' <<<"$MARKER_TEXT" \
               || grep -qF '[dogfood-package]' <<<"$MARKER_TEXT"; then
             full_run "explicit lane marker present in PR body / head commit"
           fi
@@ -178,6 +179,7 @@ jobs:
           ./scripts/ci/test-runner-node-resign.sh
           ./scripts/ci/test-ac-power-guard.sh
           ./scripts/ci/test-llm-lane-filter.sh
+          ./scripts/ci/test-herdr-lane-filter.sh
           ./scripts/ci/test-clean-stale-outputs.sh
 
       - name: Clean abandoned test processes in this workspace
@@ -204,6 +206,7 @@ jobs:
           ./scripts/ci/test-run-supervised-command.sh
           ./scripts/ci/test-runner-node-resign.sh
           ./scripts/ci/test-llm-lane-filter.sh
+          ./scripts/ci/test-herdr-lane-filter.sh
 
       - name: Decide LLM eval lane (path filter + [run-llm-eval] marker)
         # CI must not pay ~8 min of 4B weight-loading + live inference on
@@ -333,6 +336,64 @@ jobs:
             echo "Speechd integration lane: SKIPPED ($REASON)" | tee -a "$GITHUB_STEP_SUMMARY"
           fi
 
+      - name: Decide herdr integration lane (path filter + [run-herdr-integration] marker)
+        # The lane starts a real herdr server, a real loopback sshd, and real
+        # herdr clients on ptys, and it takes over this account's herdr config
+        # and an ~/.ssh/config block for the duration of the run. Conditional
+        # for the same reason the model lanes are: it must run when the diff
+        # can change what we say to herdr or believe it said, and stay out of
+        # the way otherwise. Path list: scripts/ci/herdr-lane-filter.sh.
+        id: herdr_lane
+        if: runner.environment == 'self-hosted' && steps.ci_scope.outputs.docs_only != 'true'
+        env:
+          PR_BODY: ${{ github.event.pull_request.body }}
+          PUSH_HEAD_MESSAGE: ${{ github.event.head_commit.message }}
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          PUSH_BEFORE_SHA: ${{ github.event.before }}
+          BASE_REF: ${{ github.base_ref }}
+        run: |
+          set -euo pipefail
+          if [[ "$GITHUB_EVENT_NAME" == "workflow_dispatch" ]]; then
+            # Same rationale as the model lanes: dispatch produces artifacts;
+            # the ref's own push/PR run decided this lane.
+            echo "run=false" >> "$GITHUB_OUTPUT"
+            echo "Herdr integration lane: SKIPPED (manual dispatch — decided by the ref's own push/PR run)" \
+              | tee -a "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+          FILES="$RUNNER_TEMP/herdr-lane-changed-files.txt"
+          MARKER_TEXT="$RUNNER_TEMP/herdr-lane-marker-text.txt"
+
+          BASE=""
+          if [[ "$GITHUB_EVENT_NAME" == "pull_request" ]]; then
+            BASE="$(git merge-base "origin/$BASE_REF" HEAD || true)"
+          elif git cat-file -e "$PUSH_BEFORE_SHA^{commit}" 2>/dev/null; then
+            BASE="$PUSH_BEFORE_SHA"
+          fi
+          if [[ -z "$BASE" ]]; then
+            echo "run=true" >> "$GITHUB_OUTPUT"
+            echo "Herdr integration lane: RUNNING (diff unavailable — failing open)" \
+              | tee -a "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+          git diff --name-only "$BASE" HEAD > "$FILES"
+
+          printf '%s\n' "$PR_BODY" > "$MARKER_TEXT"
+          if [[ "$GITHUB_EVENT_NAME" == "pull_request" ]]; then
+            git log -1 --format=%B "$PR_HEAD_SHA" >> "$MARKER_TEXT" || true
+          else
+            printf '%s\n' "$PUSH_HEAD_MESSAGE" >> "$MARKER_TEXT"
+          fi
+
+          DECISION="$(./scripts/ci/herdr-lane-filter.sh "$FILES" "$MARKER_TEXT")"
+          echo "$DECISION" >> "$GITHUB_OUTPUT"
+          REASON="$(sed -n 's/^reason=//p' <<<"$DECISION")"
+          if [[ "$(sed -n 's/^run=//p' <<<"$DECISION")" == "true" ]]; then
+            echo "Herdr integration lane: RUNNING ($REASON)" | tee -a "$GITHUB_STEP_SUMMARY"
+          else
+            echo "Herdr integration lane: SKIPPED ($REASON)" | tee -a "$GITHUB_STEP_SUMMARY"
+          fi
+
       - name: Decide dogfood artifact lane ([dogfood-package] marker / dispatch input)
         # The instrumented (LOCALVOXTRAL_DOGFOOD) app is packaged and uploaded
         # only on explicit opt-in: the literal marker [dogfood-package] in the
@@ -437,6 +498,7 @@ jobs:
             --skip RealtimeAPIVLLMIntegrationTests \
             --skip SpeechHelperIntegrationTests \
             --skip AgentDictationE2EEvalTests \
+            --skip HerdrIntegrationTests \
             --enable-code-coverage
 
       - name: Upload complete unit-test log
@@ -503,6 +565,22 @@ jobs:
         # stale and recompiles the whole app+test module a second time
         # (~12 s per run for zero information).
         run: swift test --filter RealtimeAPIVLLMIntegrationTests --enable-code-coverage
+
+      - name: Live herdr integration (real server + real ssh -L forward)
+        # Drives the remote-herdr join machinery against a live herdr server
+        # over a forward the app's own coordinator opens, and pins the
+        # EXTERNAL herdr assumptions the surface-authorization argument rests
+        # on (docs/agent/remote-herdr-panel-binding.md). Self-hosted only, and
+        # not because of cost: the fixture provisions a loopback sshd and
+        # takes over the account's herdr config, which a hosted fork-PR runner
+        # must never be asked to do. Local equivalent:
+        # ./scripts/remote-build.sh integration-herdr
+        if: runner.environment == 'self-hosted' && steps.ci_scope.outputs.docs_only != 'true' && steps.herdr_lane.outputs.run == 'true'
+        env:
+          HERDR_INTEGRATION_TEST_ENABLE: "1"
+        # --enable-code-coverage matches the unit step's build flags (same
+        # rationale as the STT integration step above).
+        run: swift test --filter HerdrIntegrationTests --enable-code-coverage
 
       - name: Polishing helper unit tests (PolishHelper package)
         # Self-hosted only: hosted runners would pay a cold Cmlx C++ compile

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -180,6 +180,7 @@ jobs:
           ./scripts/ci/test-ac-power-guard.sh
           ./scripts/ci/test-llm-lane-filter.sh
           ./scripts/ci/test-herdr-lane-filter.sh
+          ./scripts/ci/test-herdr-fixture-recovery.sh
           ./scripts/ci/test-clean-stale-outputs.sh
 
       - name: Clean abandoned test processes in this workspace
@@ -207,6 +208,7 @@ jobs:
           ./scripts/ci/test-runner-node-resign.sh
           ./scripts/ci/test-llm-lane-filter.sh
           ./scripts/ci/test-herdr-lane-filter.sh
+          ./scripts/ci/test-herdr-fixture-recovery.sh
 
       - name: Decide LLM eval lane (path filter + [run-llm-eval] marker)
         # CI must not pay ~8 min of 4B weight-loading + live inference on

--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,6 @@ DerivedData/
 # Never commit: its presence changes what the app is compiled to do.
 /.dogfood-capture-enable
 .fastcontext/
+
+# Transient enable marker for the live herdr integration lane
+/.herdr-integration-enable.json

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,6 +23,7 @@ is machine-local config, set once per clone (never committed):
 ./scripts/remote-build.sh package         # build the .app bundle (also builds both MLX helpers)
 ./scripts/remote-build.sh integration-polishd [hf-repo]  # bundled polish helper vs real model + eval baseline (run package first)
 ./scripts/remote-build.sh integration-speechd [hf-repo]  # packaged speech helper vs real audio/model (run package first)
+./scripts/remote-build.sh integration-herdr [ssh-dest]   # remote-herdr join vs a LIVE herdr over a real ssh -L (hermetic by default)
 ./scripts/remote-build.sh eval-e2e [EvalRecordings/agent-dictation/<set>]  # agent-dictation E2E eval (run package first)
 ./scripts/remote-build.sh dogfood          # build the instrumented tree + run the context-capture suite
 ./scripts/remote-build.sh dogfood-package  # package an instrumented .app for hand-dogfooding
@@ -32,7 +33,10 @@ is machine-local config, set once per clone (never committed):
 
 On a Mac, just `swift build` / `swift test` (but only `package_app.sh` can
 produce working Metal kernels for the helpers — see `PolishHelper/AGENTS.md`
-/ `SpeechHelper/AGENTS.md` before touching either).
+/ `SpeechHelper/AGENTS.md` before touching either). Add
+`--skip HerdrIntegrationTests` to a bare `swift test`: that lane starts a live
+herdr and carries no `XCTSkip` by design, so every scripted lane skips it by
+name instead.
 
 - Before starting long remote work, `./scripts/mac-health.sh` — it fails fast
   when the Mac is asleep/unreachable instead of letting rsync hang.
@@ -74,9 +78,10 @@ This is a real app with daily users. Nothing ships on "it compiles".
 
 Tier 0 (unit suites + packaging + launch smoke) and the tier-1 speechd
 realtime integration run on every non-fast-path PR/push. The live-model LLM
-lanes are CONDITIONAL: they run only for lane-filter path matches
-(`scripts/ci/llm-lane-filter.sh` / `speechd-lane-filter.sh`) or the literal
-markers `[run-llm-eval]` / `[run-speechd-integration]` in the PR body or head
+lanes and the live-herdr lane are CONDITIONAL: they run only for lane-filter
+path matches (`scripts/ci/llm-lane-filter.sh` / `speechd-lane-filter.sh` /
+`herdr-lane-filter.sh`) or the literal markers `[run-llm-eval]` /
+`[run-speechd-integration]` / `[run-herdr-integration]` in the PR body or head
 commit — and the marker must be present when the run is created (rerun reuses
 the old payload; push after adding it). Tier 2 (UI smoke, nightly E2E eval)
 is scheduled, never per-PR.
@@ -85,7 +90,11 @@ The binding rule: changes to prompts, model pins/catalog, sampling, the
 polish request shape or anything that alters what reaches the model, the
 helper engines, or the eval corpus/scorer REQUIRE the matching lane, and the
 PR's Proof section carries either the scoreboard or a one-line justification
-for skipping. Model/prompt changes — and changes to the TTS→ASR→polish
+for skipping. Anything that changes what the app says to herdr, what it
+believes herdr answered, or how the ssh forward reaching it is opened
+REQUIRES `integration-herdr` on the same terms — that lane is what holds the
+EXTERNAL herdr assumptions in `docs/agent/remote-herdr-panel-binding.md` to a
+live server. Model/prompt changes — and changes to the TTS→ASR→polish
 harness itself — additionally paste the eval-e2e scoreboard
 (`remote-build.sh eval-e2e`) or justify skipping it; "tier 2 is scheduled"
 does not waive that duty. Full tier table, lane details, eval-recording and

--- a/Tests/localvoxtralTests/HerdrIntegrationSupport.swift
+++ b/Tests/localvoxtralTests/HerdrIntegrationSupport.swift
@@ -1,0 +1,399 @@
+import Foundation
+import Synchronization
+import XCTest
+
+#if canImport(Darwin)
+
+/// Support for the `integration-herdr` lane: enablement, the live fixture's
+/// lifecycle, and the one thing in that lane that is NOT production code —
+/// reading the focused surface.
+///
+/// The lane's whole point is that everything below the surface is real, so
+/// this file deliberately contains no stand-ins for herdr, ssh, or the app's
+/// own types. It starts the fixture, reads what a real herdr client painted,
+/// and gets out of the way.
+
+// MARK: - Enablement
+
+/// Why the lane could not run. Never an `XCTSkip`: a lane that quietly does
+/// nothing is indistinguishable from a lane that passed, and this one exists
+/// precisely to catch external drift.
+enum HerdrLaneError: Error, CustomStringConvertible {
+    case notEnabled(String)
+    case fixtureFailed(String)
+    case timedOut(String)
+
+    var description: String {
+        switch self {
+        case .notEnabled(let message): return message
+        case .fixtureFailed(let message): return "herdr fixture failed: \(message)"
+        case .timedOut(let message): return "timed out waiting for \(message)"
+        }
+    }
+}
+
+struct HerdrLaneEnablement {
+    /// nil ⇒ the hermetic loopback fixture (its own sshd, its own keys).
+    /// A value aims the same lane at a real second host the caller has
+    /// already configured.
+    let destination: String?
+
+    static let enableEnvironmentKey = "HERDR_INTEGRATION_TEST_ENABLE"
+    static let destinationEnvironmentKey = "HERDR_INTEGRATION_TEST_DESTINATION"
+    static let markerFileName = ".herdr-integration-enable.json"
+
+    private struct Marker: Decodable {
+        let destination: String?
+    }
+
+    static func resolve(repoRoot: URL) throws -> HerdrLaneEnablement {
+        let environment = ProcessInfo.processInfo.environment
+        if environment[enableEnvironmentKey] == "1" {
+            let destination = environment[destinationEnvironmentKey]
+            return HerdrLaneEnablement(
+                destination: destination?.isEmpty == false ? destination : nil
+            )
+        }
+        let markerURL = repoRoot.appendingPathComponent(markerFileName)
+        guard FileManager.default.fileExists(atPath: markerURL.path) else {
+            throw HerdrLaneError.notEnabled(
+                """
+                The live herdr integration lane is not enabled, so it cannot report \
+                anything about herdr. Enable it with \(enableEnvironmentKey)=1 \
+                (optionally \(destinationEnvironmentKey)=<ssh destination>), or run \
+                ./scripts/remote-build.sh integration-herdr [ssh-destination] from the \
+                dev box. Every other lane skips this suite by name.
+                """
+            )
+        }
+        let marker = try JSONDecoder().decode(Marker.self, from: Data(contentsOf: markerURL))
+        return HerdrLaneEnablement(
+            destination: marker.destination?.isEmpty == false ? marker.destination : nil
+        )
+    }
+}
+
+// MARK: - Process helper
+
+enum HerdrLaneProcess {
+    struct Result {
+        let status: Int32
+        let standardOutput: String
+        let standardError: String
+        var succeeded: Bool { status == 0 }
+    }
+
+    /// Output is collected through FILES, never inherited pipes. The fixture
+    /// starts long-lived daemons that inherit whatever descriptors they are
+    /// given, so a parent reading a shared pipe to EOF would block until the
+    /// fixture itself exits — which is never.
+    static func run(
+        executable: URL,
+        arguments: [String],
+        currentDirectory: URL? = nil,
+        environment: [String: String]? = nil
+    ) throws -> Result {
+        let base = NSTemporaryDirectory() + "lvx-herdr-lane-" + UUID().uuidString.prefix(8)
+        let outPath = base + ".out"
+        let errPath = base + ".err"
+        FileManager.default.createFile(atPath: outPath, contents: nil)
+        FileManager.default.createFile(atPath: errPath, contents: nil)
+        defer {
+            try? FileManager.default.removeItem(atPath: outPath)
+            try? FileManager.default.removeItem(atPath: errPath)
+        }
+
+        let process = Process()
+        process.executableURL = executable
+        process.arguments = arguments
+        if let currentDirectory { process.currentDirectoryURL = currentDirectory }
+        if let environment { process.environment = environment }
+        process.standardInput = FileHandle.nullDevice
+        process.standardOutput = try FileHandle(forWritingTo: URL(fileURLWithPath: outPath))
+        process.standardError = try FileHandle(forWritingTo: URL(fileURLWithPath: errPath))
+        try process.run()
+        process.waitUntilExit()
+        if let handle = process.standardOutput as? FileHandle { try? handle.close() }
+        if let handle = process.standardError as? FileHandle { try? handle.close() }
+
+        return Result(
+            status: process.terminationStatus,
+            standardOutput: (try? String(contentsOfFile: outPath, encoding: .utf8)) ?? "",
+            standardError: (try? String(contentsOfFile: errPath, encoding: .utf8)) ?? ""
+        )
+    }
+}
+
+// MARK: - Surface log
+
+/// One fixture surface: a real herdr client running on a pty, read through
+/// the typescript `script(1)` writes for it.
+///
+/// This stands in for `TerminalScreenAXReader` and nothing else. Reads are
+/// always SINCE A MARK, because a typescript is append-only: a token stamped
+/// three assertions ago stays in the file forever, and searching the whole
+/// file would let a stale frame answer a question about the current one.
+final class HerdrSurfaceLog: @unchecked Sendable {
+    let path: String
+    private let mark = Mutex<UInt64>(0)
+
+    init(path: String) {
+        self.path = path
+    }
+
+    var byteCount: UInt64 {
+        let attributes = try? FileManager.default.attributesOfItem(atPath: path)
+        return (attributes?[.size] as? NSNumber)?.uint64Value ?? 0
+    }
+
+    /// Everything painted from here on is what the next read may see.
+    func markCurrentEnd() {
+        let end = byteCount
+        mark.withLock { $0 = end }
+    }
+
+    /// Rendered text painted since the mark, with escape sequences removed.
+    func textSinceMark() -> String? {
+        guard let handle = FileHandle(forReadingAtPath: path) else { return nil }
+        defer { try? handle.close() }
+        do {
+            try handle.seek(toOffset: mark.withLock { $0 })
+        } catch {
+            return nil
+        }
+        let data = handle.readDataToEndOfFile()
+        // isoLatin1 never fails: a typescript is raw bytes, and a UTF-8
+        // sequence split across a flush boundary must not blank a whole read.
+        let raw = String(data: data, encoding: .isoLatin1) ?? ""
+        return Self.visibleText(raw)
+    }
+
+    /// Strip CSI/OSC escapes and control bytes so a rendered cell run reads as
+    /// the string herdr painted.
+    static func visibleText(_ raw: String) -> String {
+        var output = String.UnicodeScalarView()
+        let scalars = Array(raw.unicodeScalars)
+        var index = 0
+        while index < scalars.count {
+            let scalar = scalars[index]
+            guard scalar == "\u{1B}" else {
+                if scalar.value >= 32 || scalar == "\n" {
+                    output.append(scalar)
+                }
+                index += 1
+                continue
+            }
+            index += 1
+            guard index < scalars.count else { break }
+            switch scalars[index] {
+            case "[":
+                index += 1
+                // A CSI sequence ends at its first final byte (0x40..0x7E).
+                while index < scalars.count, !(0x40...0x7E).contains(scalars[index].value) {
+                    index += 1
+                }
+                index += 1
+            case "]":
+                // OSC runs to BEL or ST.
+                while index < scalars.count,
+                      scalars[index] != "\u{07}",
+                      scalars[index] != "\u{1B}" {
+                    index += 1
+                }
+                index += 1
+            default:
+                index += 1
+            }
+        }
+        return String(output)
+    }
+}
+
+// MARK: - Fixture
+
+enum HerdrSurfaceMode: String {
+    /// A whole-view herdr client: the App-mode client that renders the
+    /// agents sidebar.
+    case app
+    /// `herdr terminal attach <pane>`: the raw pane stream, no sidebar. The
+    /// discriminator the panel-binding trust argument rests on.
+    case attach
+}
+
+/// A live herdr server, a real pane, a real loopback sshd, and one or more
+/// real herdr clients on ptys — brought up by
+/// `scripts/herdr-integration-fixture.sh` and torn down deterministically.
+@MainActor
+final class HerdrLiveFixture {
+    struct Info: Decodable {
+        let agentSessionID: String
+        let alias: String
+        /// Same `(hostname, port)` as `alias`, a different `User`.
+        let altUserAlias: String
+        /// Same hostname as `alias`, a different port.
+        let otherPortAlias: String
+        let herdrBinary: String
+        let socketPath: String
+        let paneID: String
+        let primarySurfaceLog: String
+        let provisionedSSH: Bool
+        let workdir: String
+    }
+
+    let info: Info
+    let primarySurface: HerdrSurfaceLog
+    private let scriptURL: URL
+    private let repoRoot: URL
+    private var isTornDown = false
+
+    private init(info: Info, scriptURL: URL, repoRoot: URL) {
+        self.info = info
+        self.scriptURL = scriptURL
+        self.repoRoot = repoRoot
+        self.primarySurface = HerdrSurfaceLog(path: info.primarySurfaceLog)
+    }
+
+    static func bringUp(
+        repoRoot: URL,
+        destination: String?,
+        label: String
+    ) throws -> HerdrLiveFixture {
+        let scriptURL = repoRoot.appendingPathComponent("scripts/herdr-integration-fixture.sh")
+        let workdir = "/tmp/lvx-herdr-fixture-\(label)-\(ProcessInfo.processInfo.processIdentifier)"
+
+        // A previous run that died before its teardown would otherwise make
+        // every later run fail on "workdir already exists".
+        _ = try? HerdrLaneProcess.run(
+            executable: URL(fileURLWithPath: "/bin/bash"),
+            arguments: [scriptURL.path, "down", workdir],
+            currentDirectory: repoRoot
+        )
+
+        var arguments = [scriptURL.path, "up", workdir]
+        if let destination { arguments.append(destination) }
+        let result = try HerdrLaneProcess.run(
+            executable: URL(fileURLWithPath: "/bin/bash"),
+            arguments: arguments,
+            currentDirectory: repoRoot
+        )
+        guard result.succeeded else {
+            throw HerdrLaneError.fixtureFailed(
+                "`up` exited \(result.status)\n\(result.standardError)\(result.standardOutput)"
+            )
+        }
+        guard let line = result.standardOutput
+            .split(separator: "\n")
+            .last(where: { $0.hasPrefix("{") }),
+            let info = try? JSONDecoder().decode(Info.self, from: Data(line.utf8))
+        else {
+            throw HerdrLaneError.fixtureFailed(
+                "`up` printed no fixture description\n\(result.standardOutput)\(result.standardError)"
+            )
+        }
+        return HerdrLiveFixture(info: info, scriptURL: scriptURL, repoRoot: repoRoot)
+    }
+
+    func tearDown() {
+        guard !isTornDown else { return }
+        isTornDown = true
+        _ = try? HerdrLaneProcess.run(
+            executable: URL(fileURLWithPath: "/bin/bash"),
+            arguments: [scriptURL.path, "down", info.workdir],
+            currentDirectory: repoRoot
+        )
+    }
+
+    /// Start an additional real herdr client on its own pty.
+    @discardableResult
+    func startSurface(
+        name: String,
+        mode: HerdrSurfaceMode,
+        paneID: String? = nil
+    ) throws -> HerdrSurfaceLog {
+        var arguments = [scriptURL.path, "surface", info.workdir, name, mode.rawValue]
+        if let paneID { arguments.append(paneID) }
+        let result = try HerdrLaneProcess.run(
+            executable: URL(fileURLWithPath: "/bin/bash"),
+            arguments: arguments,
+            currentDirectory: repoRoot
+        )
+        guard result.succeeded else {
+            throw HerdrLaneError.fixtureFailed(
+                "`surface \(name)` exited \(result.status)\n\(result.standardError)"
+            )
+        }
+        return HerdrSurfaceLog(path: "\(info.workdir)/surface-\(name).log")
+    }
+
+    /// herdr's own CLI against the fixture's socket. Used only to READ herdr's
+    /// state (what it stored, what it thinks a pane is) and to set fixture
+    /// preconditions — never as a stand-in for the app's client.
+    @discardableResult
+    func herdrCLI(_ arguments: [String]) throws -> String {
+        var environment = ProcessInfo.processInfo.environment
+        environment["HERDR_SOCKET_PATH"] = info.socketPath
+        let result = try HerdrLaneProcess.run(
+            executable: URL(fileURLWithPath: info.herdrBinary),
+            arguments: arguments,
+            currentDirectory: repoRoot,
+            environment: environment
+        )
+        return result.standardOutput + result.standardError
+    }
+
+    /// The custom metadata tokens herdr currently holds for the fixture pane.
+    /// An absent `tokens` key is an empty map — that is how herdr represents
+    /// "cleared", and the distinction matters to the clear-semantics test.
+    func paneTokens() throws -> [String: String] {
+        let output = try herdrCLI(["pane", "get", info.paneID])
+        guard let data = output.data(using: .utf8),
+              let root = try JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let result = root["result"] as? [String: Any],
+              let pane = result["pane"] as? [String: Any]
+        else {
+            throw HerdrLaneError.fixtureFailed("could not read pane state: \(output)")
+        }
+        return (pane["tokens"] as? [String: String]) ?? [:]
+    }
+
+    var herdrConfigPath: String {
+        NSHomeDirectory() + "/.config/herdr/config.toml"
+    }
+
+    /// Ask the live server to re-read the config file. Used to put the fixture
+    /// back the way it was after a test rewrote the account's config.
+    func reloadConfig() throws {
+        _ = try HerdrLaneProcess.run(
+            executable: URL(fileURLWithPath: "/bin/bash"),
+            arguments: [scriptURL.path, "reload", info.workdir],
+            currentDirectory: repoRoot
+        )
+    }
+}
+
+// MARK: - Live readiness
+
+enum HerdrLaneWait {
+    /// Wait for a condition about a LIVE external process.
+    ///
+    /// The assertion is always the condition; the deadline is only a bound on
+    /// how long a dead fixture is allowed to look alive. `Task.sleep` (not a
+    /// blocking sleep) so the main actor stays free for the app code under
+    /// test — the forward service and the mic indicator both hop back onto it.
+    @MainActor
+    static func until(
+        _ what: String,
+        timeout: TimeInterval = 20,
+        poll: TimeInterval = 0.1,
+        _ condition: () throws -> Bool
+    ) async throws {
+        let deadline = Date().addingTimeInterval(timeout)
+        while true {
+            if try condition() { return }
+            guard Date() < deadline else { throw HerdrLaneError.timedOut(what) }
+            try? await Task.sleep(for: .milliseconds(Int(poll * 1000)))
+        }
+    }
+}
+
+#endif

--- a/Tests/localvoxtralTests/HerdrIntegrationTests.swift
+++ b/Tests/localvoxtralTests/HerdrIntegrationTests.swift
@@ -1,0 +1,744 @@
+import Foundation
+import Synchronization
+import XCTest
+
+@testable import localvoxtral
+
+#if canImport(Darwin)
+
+/// The `integration-herdr` lane: the remote-herdr join machinery against a
+/// LIVE `herdr` server, over a REAL `ssh -L` forward, with the app's own
+/// production types.
+///
+/// What is real here: `HerdrSocketClient` on a forwarded unix socket,
+/// `ClaudeRemoteHerdrForwardService` spawning a real supervised `ssh -N`,
+/// `SSHDestinationCanonicalizer.live()` running real `ssh -G`,
+/// `ClaudeRemoteEnrollmentService.configureRemoteHerdrPanel` patching a real
+/// `~/.config/herdr/config.toml` over a real ssh session, and
+/// `HerdrPanelBindingProbe` / `HerdrPanelMicIndicator` driving all of it.
+///
+/// The ONE fixture is the focused surface: instead of an accessibility read of
+/// a terminal window, the lane reads the typescript of a real herdr client
+/// running on a pty. Everything the surface displays was painted by herdr.
+///
+/// Why this lane exists: `docs/agent/remote-herdr-panel-binding.md` records
+/// EXTERNAL assumptions about herdr that the join's trust argument rests on —
+/// above all that only a whole-view App client renders the agents sidebar. A
+/// herdr upgrade that changes any of them would silently un-authorize (or
+/// worse, wrongly authorize) field joins. Each such assumption gets its own
+/// named test here so the failure is loud and self-describing.
+///
+/// Enablement (there is deliberately NO `XCTSkip` — a silent skip is
+/// indistinguishable from a pass):
+/// - env `HERDR_INTEGRATION_TEST_ENABLE=1`, optional
+///   `HERDR_INTEGRATION_TEST_DESTINATION=<ssh destination>`
+/// - or the marker file `.herdr-integration-enable.json`, written by
+///   `./scripts/remote-build.sh integration-herdr [destination]` because the
+///   SSH build gate cannot pass per-command environment variables.
+/// Every other lane skips this suite by name.
+@MainActor
+final class HerdrIntegrationTests: XCTestCase {
+    private var fixture: HerdrLiveFixture!
+
+    private var repoRoot: URL {
+        URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent() // localvoxtralTests
+            .deletingLastPathComponent() // Tests
+            .deletingLastPathComponent() // repo root
+    }
+
+    override func setUp() async throws {
+        try await super.setUp()
+        let enablement = try HerdrLaneEnablement.resolve(repoRoot: repoRoot)
+        let label = String(name.filter { $0.isLetter || $0.isNumber }.suffix(24))
+        fixture = try HerdrLiveFixture.bringUp(
+            repoRoot: repoRoot,
+            destination: enablement.destination,
+            label: label
+        )
+    }
+
+    override func tearDown() async throws {
+        fixture?.tearDown()
+        fixture = nil
+        try await super.tearDown()
+    }
+
+    // MARK: - Helpers
+
+    /// Open the app's own supervised `ssh -L` to the fixture's herdr socket.
+    /// Nothing here is stubbed: this spawns OpenSSH and waits for the local
+    /// end to answer.
+    private func openForward(
+        spawner: any ClaudeRemoteHerdrForwardSpawning = ClaudeRemoteHerdrForwardSpawner(),
+        clock: AcceleratedClock = AcceleratedClock(),
+        idleTimeout: TimeInterval = 5 * 60
+    ) async throws -> (
+        service: ClaudeRemoteHerdrForwardService,
+        handle: ClaudeRemoteHerdrForwardHandle
+    ) {
+        let service = ClaudeRemoteHerdrForwardService(
+            spawner: spawner,
+            workspaces: ClaudeRemoteHerdrForwardWorkspaces(),
+            now: clock.now,
+            sleepFor: clock.sleep,
+            // Generous next to the production 2 s: this is a cold OpenSSH
+            // handshake on a machine that may be running another lane, and a
+            // flaky bound would be a flaky lane.
+            readinessTimeout: 20,
+            idleTimeout: idleTimeout
+        )
+        guard let handle = await service.open(
+            alias: fixture.info.alias,
+            remoteSocketPath: fixture.info.socketPath
+        ) else {
+            throw HerdrLaneError.fixtureFailed(
+                "the app's ssh -L forward to \(fixture.info.alias) never became dialable"
+            )
+        }
+        return (service, handle)
+    }
+
+    /// Wait until the whole-view surface has painted `token`, reading only
+    /// what herdr wrote after `mark`.
+    private func waitForToken(
+        _ token: String,
+        on surface: HerdrSurfaceLog,
+        timeout: TimeInterval = 20
+    ) async throws {
+        try await HerdrLaneWait.until("the surface to paint \(token)", timeout: timeout) {
+            surface.textSinceMark()?.contains(token) == true
+        }
+    }
+
+    private func stamp(
+        _ token: String,
+        through client: HerdrSocketClient,
+        socketPath: String,
+        ttl: Int? = HerdrPanelBindingProbe.tokenTTLMilliseconds
+    ) async -> Bool {
+        await client.reportPanelToken(
+            socketPath: socketPath,
+            paneID: fixture.info.paneID,
+            value: token,
+            ttlMilliseconds: ttl
+        )
+    }
+
+    private static func freshToken() -> String {
+        var generator = SystemRandomNumberGenerator()
+        return HerdrPanelBindingProbe.token(randomBits: generator.next())
+    }
+
+    // MARK: - External assumption: what a whole-view client renders
+
+    /// The positive half of the panel-binding premise: a whole-view App client
+    /// renders the configured `$lvmark` row, so a stamped nonce becomes
+    /// readable text on the focused surface.
+    ///
+    /// The stamp travels the production path end to end — real
+    /// `HerdrSocketClient`, real forwarded socket, real ssh.
+    func testWholeViewClientRendersTheStampedPanelToken() async throws {
+        let (service, handle) = try await openForward()
+        defer { handle.close(); service.stopAllForQuit() }
+
+        let client = HerdrSocketClient(timeout: 5)
+        let token = Self.freshToken()
+        fixture.primarySurface.markCurrentEnd()
+
+        let stamped = await stamp(token, through: client, socketPath: handle.localSocketPath)
+        XCTAssertTrue(
+            stamped,
+            "pane.report_metadata was refused through the forwarded socket"
+        )
+        try await waitForToken(token, on: fixture.primarySurface)
+    }
+
+    /// THE load-bearing external assumption.
+    ///
+    /// `docs/agent/remote-herdr-panel-binding.md`: herdr's render loop paints
+    /// the full UI (sidebar included) for App-mode clients and ONLY the raw
+    /// pane for `terminal_attach` / `terminal_observe` clients. That is the
+    /// whole reason a grid match proves the surface displays a WHOLE-VIEW
+    /// client of the stamped server rather than a single-pane attach.
+    ///
+    /// If a herdr upgrade ever renders the sidebar in attach mode, the panel
+    /// binding stops discriminating and this test is what says so. It asserts
+    /// both directions against ONE stamp, so "nothing rendered anywhere"
+    /// (a dead fixture) can never look like a pass.
+    func testAttachClientRendersNoSidebarSoItCannotEchoThePanelToken() async throws {
+        let attachSurface = try fixture.startSurface(
+            name: "attach",
+            mode: .attach,
+            paneID: fixture.info.paneID
+        )
+        // The attach client has to be connected and painting before the stamp,
+        // or its silence would prove nothing.
+        try await HerdrLaneWait.until("the attach client to paint its pane") {
+            attachSurface.byteCount > 0
+        }
+
+        let (service, handle) = try await openForward()
+        defer { handle.close(); service.stopAllForQuit() }
+
+        let client = HerdrSocketClient(timeout: 5)
+        let token = Self.freshToken()
+        fixture.primarySurface.markCurrentEnd()
+        attachSurface.markCurrentEnd()
+
+        let stamped = await stamp(token, through: client, socketPath: handle.localSocketPath)
+        XCTAssertTrue(stamped)
+
+        // Positive control first: the whole-view surface DOES render it, so
+        // the negative below is about attach mode and not about a fixture
+        // that painted nothing at all.
+        try await waitForToken(token, on: fixture.primarySurface)
+
+        XCTAssertFalse(
+            attachSurface.textSinceMark()?.contains(token) == true,
+            """
+            A `herdr terminal attach` client rendered the agents-panel token. \
+            herdr's App-mode/raw-pane split is what makes a grid match prove \
+            the surface displays a whole-view client of the stamped server \
+            (docs/agent/remote-herdr-panel-binding.md). If this is the new \
+            behavior, the remote-herdr surface authorization argument no \
+            longer holds and must be reworked — do not relax this lane.
+            """
+        )
+    }
+
+    // MARK: - External assumption: metadata write semantics
+
+    /// herdr's `PaneReportMetadataParams.tokens` is
+    /// `HashMap<String, Option<String>>`, and `normalize_metadata_tokens`
+    /// treats BOTH `None` and `""` as a clear. The production teardown path
+    /// (`HerdrPanelBindingProbe.clear`) sends JSON null and depends on it;
+    /// the empty string is the documented equivalent.
+    func testPanelTokenIsClearedByBothNullAndEmptyValues() async throws {
+        let (service, handle) = try await openForward()
+        defer { handle.close(); service.stopAllForQuit() }
+        let client = HerdrSocketClient(timeout: 5)
+        let socketPath = handle.localSocketPath
+
+        let first = Self.freshToken()
+        let firstStamped = await stamp(first, through: client, socketPath: socketPath)
+        XCTAssertTrue(firstStamped)
+        XCTAssertEqual(try fixture.paneTokens()["lvmark"], first)
+
+        // The production clear: a JSON null value, no TTL.
+        await HerdrPanelBindingProbe.clear(
+            metadata: client,
+            socketPath: socketPath,
+            paneID: fixture.info.paneID
+        )
+        XCTAssertNil(
+            try fixture.paneTokens()["lvmark"],
+            "a null token value must clear the panel entry"
+        )
+
+        let second = Self.freshToken()
+        let secondStamped = await stamp(second, through: client, socketPath: socketPath)
+        XCTAssertTrue(secondStamped)
+        XCTAssertEqual(try fixture.paneTokens()["lvmark"], second)
+
+        let clearedByEmptyString = await client.reportPanelToken(
+            socketPath: socketPath,
+            paneID: fixture.info.paneID,
+            value: "",
+            ttlMilliseconds: nil
+        )
+        XCTAssertTrue(clearedByEmptyString)
+        XCTAssertNil(
+            try fixture.paneTokens()["lvmark"],
+            "an empty token value must clear the panel entry too"
+        )
+    }
+
+    /// The documented TTL window is 1…86_400_000 ms and the production stamp
+    /// sits inside it. Pinned at both edges so a herdr change to the bound
+    /// fails here rather than as a field abstention.
+    func testPanelTokenTTLBoundsAreEnforcedAtTheDocumentedEdges() async throws {
+        let (service, handle) = try await openForward()
+        defer { handle.close(); service.stopAllForQuit() }
+        let client = HerdrSocketClient(timeout: 5)
+        let socketPath = handle.localSocketPath
+
+        let belowMinimum = await stamp(
+            Self.freshToken(), through: client, socketPath: socketPath, ttl: 0
+        )
+        XCTAssertFalse(
+            belowMinimum,
+            "ttl_ms 0 is below herdr's documented minimum and must be refused"
+        )
+        let atMinimum = await stamp(
+            Self.freshToken(), through: client, socketPath: socketPath, ttl: 1
+        )
+        XCTAssertTrue(atMinimum)
+        let atMaximum = await stamp(
+            Self.freshToken(), through: client, socketPath: socketPath, ttl: 86_400_000
+        )
+        XCTAssertTrue(atMaximum)
+        let aboveMaximum = await stamp(
+            Self.freshToken(), through: client, socketPath: socketPath, ttl: 86_400_001
+        )
+        XCTAssertFalse(
+            aboveMaximum,
+            "ttl_ms above herdr's documented maximum must be refused"
+        )
+        let productionTTL = await stamp(
+            Self.freshToken(),
+            through: client,
+            socketPath: socketPath,
+            ttl: HerdrPanelBindingProbe.tokenTTLMilliseconds
+        )
+        XCTAssertTrue(
+            productionTTL,
+            "the production TTL must remain inside herdr's accepted window"
+        )
+    }
+
+    // MARK: - External assumption: the read surface of the API
+
+    /// `pane.current` and `pane.process_info` decode from the live server into
+    /// the shapes the join arm reads. In particular `foreground_processes`
+    /// must be PRESENT: the client treats an absent key as "herdr could not
+    /// detect a foreground set", which is a different (fail-closed) state.
+    func testFocusedPaneAndProcessInfoDecodeFromTheLiveServer() async throws {
+        let (service, handle) = try await openForward()
+        defer { handle.close(); service.stopAllForQuit() }
+        let client = HerdrSocketClient(timeout: 5)
+
+        guard let pane = await client.focusedPane(socketPath: handle.localSocketPath) else {
+            return XCTFail("pane.current returned nothing through the forwarded socket")
+        }
+        XCTAssertEqual(pane.paneID, fixture.info.paneID)
+
+        guard let info = await client.paneForegroundInfo(
+            socketPath: handle.localSocketPath,
+            paneID: fixture.info.paneID
+        ) else {
+            return XCTFail("pane.process_info returned nothing")
+        }
+        XCTAssertNotNil(info.shellPID, "herdr must still report a shell pid")
+        guard let processes = info.foregroundProcesses else {
+            return XCTFail(
+                "herdr no longer reports foreground_processes; the join's foreground "
+                + "cross-check would silently degrade to 'detection unavailable'"
+            )
+        }
+        XCTAssertFalse(processes.isEmpty)
+        XCTAssertTrue(
+            processes.contains { $0.name?.isEmpty == false },
+            "the remote arm identifies the agent by NAME, so a named process must arrive"
+        )
+    }
+
+    /// `pane.read` returns the joined pane's own text, and a request for a
+    /// pane that does not exist returns nothing rather than another pane's
+    /// text — the property `SocketPaneScreenContext` depends on.
+    func testPaneReadReturnsOnlyTheJoinedPanesText() async throws {
+        let sentinel = "LVXHERDRLANE\(Int.random(in: 100_000...999_999))"
+        _ = try fixture.herdrCLI(["pane", "send-text", fixture.info.paneID, sentinel])
+
+        let (service, handle) = try await openForward()
+        defer { handle.close(); service.stopAllForQuit() }
+        let client = HerdrSocketClient(timeout: 5)
+
+        var text: String?
+        for _ in 0..<40 {
+            text = await client.paneVisibleText(
+                socketPath: handle.localSocketPath,
+                paneID: fixture.info.paneID
+            )
+            if text?.contains(sentinel) == true { break }
+            try? await Task.sleep(for: .milliseconds(200))
+        }
+        XCTAssertEqual(
+            text?.contains(sentinel), true,
+            "pane.read did not return the text typed into the joined pane"
+        )
+
+        let foreign = await client.paneVisibleText(
+            socketPath: handle.localSocketPath,
+            paneID: "w99:p99"
+        )
+        XCTAssertNil(foreign, "a read for an unknown pane must return nothing")
+    }
+
+    // MARK: - The app's forward
+
+    /// A dictation leases the forward; the next one reuses it. The lease is
+    /// what keeps a second dictation from paying the SSH handshake again, and
+    /// releasing the last lease must eventually retire the process — proven
+    /// on the injected clock, not on wall time.
+    func testForwardLeaseIsReusedAcrossDictationsAndTornDownWhenIdle() async throws {
+        let spawner = CountingHerdrForwardSpawner()
+        let clock = AcceleratedClock()
+        let service = ClaudeRemoteHerdrForwardService(
+            spawner: spawner,
+            workspaces: ClaudeRemoteHerdrForwardWorkspaces(),
+            now: clock.now,
+            sleepFor: clock.sleep,
+            readinessTimeout: 20,
+            idleTimeout: 60
+        )
+
+        guard let first = await service.open(
+            alias: fixture.info.alias, remoteSocketPath: fixture.info.socketPath
+        ) else {
+            return XCTFail("the first forward never became dialable")
+        }
+        guard let second = await service.open(
+            alias: fixture.info.alias, remoteSocketPath: fixture.info.socketPath
+        ) else {
+            return XCTFail("the second dictation could not lease the forward")
+        }
+
+        XCTAssertEqual(first.localSocketPath, second.localSocketPath)
+        XCTAssertEqual(
+            spawner.spawnCount, 1,
+            "the second dictation spawned another ssh instead of reusing the lease"
+        )
+
+        // Both leases still open: nothing may be torn down.
+        first.close()
+        XCTAssertTrue(ClaudeRemoteHerdrForwardService.dial(second.localSocketPath))
+
+        let socketPath = second.localSocketPath
+        second.close()
+        // The idle window is spent on the injected clock; the release itself
+        // hops through the main actor, so wait for the observable outcome.
+        try await HerdrLaneWait.until("the idle forward to be torn down", timeout: 30) {
+            !ClaudeRemoteHerdrForwardService.dial(socketPath)
+        }
+        XCTAssertFalse(FileManager.default.fileExists(atPath: socketPath))
+    }
+
+    // MARK: - ssh -G canonicalization
+
+    /// The alias fallback resolves both sides through the user's REAL ssh
+    /// config and compares `(hostname, port)` — never `user`. Two live
+    /// aliases make that concrete: one that differs only in `User` must match,
+    /// one that differs in port must not.
+    func testSSHDestinationCanonicalizationMatchesThroughRealSSHConfig() async throws {
+        let canonicalizer = SSHDestinationCanonicalizer.live()
+        let enrolled = Self.enrolledHost(alias: fixture.info.alias)
+
+        let sameHost = await canonicalizer.matchingHosts(
+            destination: fixture.info.altUserAlias, enrolledHosts: [enrolled]
+        )
+        XCTAssertEqual(
+            sameHost.map(\.id), [enrolled.id],
+            "an alias with the same (hostname, port) but a different User must match; "
+            + "comparing the effective user would reject the common build-host shape"
+        )
+
+        let otherPort = await canonicalizer.matchingHosts(
+            destination: fixture.info.otherPortAlias, enrolledHosts: [enrolled]
+        )
+        XCTAssertTrue(
+            otherPort.isEmpty,
+            "an alias resolving to a different port must not match an enrolled host"
+        )
+
+        let revoked = await canonicalizer.matchingHosts(
+            destination: fixture.info.altUserAlias,
+            enrolledHosts: [Self.enrolledHost(alias: fixture.info.alias, revoked: true)]
+        )
+        XCTAssertTrue(revoked.isEmpty, "a revoked host must never be selected")
+    }
+
+    private static func enrolledHost(alias: String, revoked: Bool = false) -> ClaudeRemoteHost {
+        ClaudeRemoteHost(
+            id: "lvx-herdr-lane-host",
+            label: alias,
+            sshHostAlias: alias,
+            createdAt: Date(timeIntervalSince1970: 0),
+            lastSeenAt: nil,
+            revokedAt: revoked ? Date(timeIntervalSince1970: 1) : nil,
+            persistentForwardEnabled: true
+        )
+    }
+
+    // MARK: - Enrollment-time config patch
+
+    /// The remote config patch, run for real over ssh against a real
+    /// `~/.config/herdr/config.toml`: it appends its block exactly once, it
+    /// reloads the live server, and it refuses to touch a config that already
+    /// carries an agents table — including the trailing-comment header shape
+    /// its grep has to recognise.
+    func testRemoteHerdrPanelConfigPatchAppendsOnceAndRefusesCustomizedTables() async throws {
+        let configPath = fixture.herdrConfigPath
+        let original = try String(contentsOfFile: configPath, encoding: .utf8)
+        defer {
+            try? original.write(toFile: configPath, atomically: true, encoding: .utf8)
+            try? fixture.reloadConfig()
+        }
+
+        let service = ClaudeRemoteEnrollmentService(
+            runner: ClaudeRemoteEnrollmentService.processRunner()
+        )
+        let alias = fixture.info.alias
+
+        // 1. A config with no agents table: the patch appends and reloads.
+        try "[theme]\n".write(toFile: configPath, atomically: true, encoding: .utf8)
+        let steps = try service.configureRemoteHerdrPanel(sshHostAlias: alias, timeout: 60)
+        XCTAssertEqual(steps.count, 1)
+        let patched = try String(contentsOfFile: configPath, encoding: .utf8)
+        XCTAssertTrue(
+            patched.contains(ClaudeRemoteEnrollmentService.herdrPanelConfigSnippet),
+            "the panel snippet was not appended to the remote config"
+        )
+        XCTAssertTrue(patched.hasPrefix("[theme]\n"), "the patch must only APPEND")
+
+        // 2. Idempotence: a second run refuses rather than appending again.
+        XCTAssertThrowsError(
+            try service.configureRemoteHerdrPanel(sshHostAlias: alias, timeout: 60)
+        ) { error in
+            XCTAssertEqual(
+                error as? ClaudeRemoteEnrollmentService.ServiceError,
+                .herdrPanelConfigAlreadyCustomized
+            )
+        }
+        XCTAssertEqual(
+            try String(contentsOfFile: configPath, encoding: .utf8), patched,
+            "the refused second run must leave the config byte-identical"
+        )
+
+        // 3. The trailing-comment header variant its grep must recognise.
+        try "[ui.sidebar.agents]   # mine, hands off\n"
+            .write(toFile: configPath, atomically: true, encoding: .utf8)
+        XCTAssertThrowsError(
+            try service.configureRemoteHerdrPanel(sshHostAlias: alias, timeout: 60)
+        ) { error in
+            XCTAssertEqual(
+                error as? ClaudeRemoteEnrollmentService.ServiceError,
+                .herdrPanelConfigAlreadyCustomized
+            )
+        }
+
+        // 4. A bare `rows =` key anywhere is equally off limits.
+        try "[ui.sidebar.spaces]\nrows = [[\"workspace\"]]\n"
+            .write(toFile: configPath, atomically: true, encoding: .utf8)
+        XCTAssertThrowsError(
+            try service.configureRemoteHerdrPanel(sshHostAlias: alias, timeout: 60)
+        ) { error in
+            XCTAssertEqual(
+                error as? ClaudeRemoteEnrollmentService.ServiceError,
+                .herdrPanelConfigAlreadyCustomized
+            )
+        }
+    }
+
+    // MARK: - The probe and the mic indicator, end to end
+
+    /// The real `HerdrPanelBindingProbe` over the real forward: it matches on
+    /// the whole-view surface and abstains on the attach surface, which is the
+    /// join decision itself rather than its ingredients.
+    func testPanelBindingProbeMatchesWholeViewAndAbstainsOnAttach() async throws {
+        let attachSurface = try fixture.startSurface(
+            name: "attach", mode: .attach, paneID: fixture.info.paneID
+        )
+        try await HerdrLaneWait.until("the attach client to paint its pane") {
+            attachSurface.byteCount > 0
+        }
+
+        let (service, handle) = try await openForward()
+        defer { handle.close(); service.stopAllForQuit() }
+        let client = HerdrSocketClient(timeout: 5)
+        let target = TerminalScreenTarget(pid: 1, bundleID: "com.mitchellh.ghostty")
+
+        let seenTargets = Mutex<[TerminalScreenTarget]>([])
+        let primary = fixture.primarySurface
+        primary.markCurrentEnd()
+        // The probe's settle ALGEBRA (budget, read cap, abstention causes) is
+        // pinned deterministically by HerdrPanelBindingProbeTests. Here the
+        // virtual clock advances exactly as production would while the real
+        // wait is for herdr to paint a frame — so the lane measures herdr's
+        // rendering, never this machine's load.
+        let matchClock = SurfaceSettleClock(surface: primary)
+        let matching = HerdrPanelBindingProbe(
+            metadata: client,
+            readGrid: { readTarget in
+                seenTargets.withLock { $0.append(readTarget) }
+                return primary.textSinceMark()
+            },
+            now: matchClock.now,
+            sleepFor: matchClock.sleep
+        )
+        let outcome = await matching.probe(
+            target: target,
+            socketPath: handle.localSocketPath,
+            paneID: fixture.info.paneID
+        )
+        guard case .matched(let match) = outcome else {
+            return XCTFail("the panel binding probe did not match a whole-view surface: \(outcome)")
+        }
+        XCTAssertTrue(match.token.hasPrefix("lv-mic-"))
+        XCTAssertEqual(
+            seenTargets.withLock { $0.first }, target,
+            "the probe must read the target it was given"
+        )
+
+        attachSurface.markCurrentEnd()
+        let attachClock = SurfaceSettleClock(surface: attachSurface)
+        let abstaining = HerdrPanelBindingProbe(
+            metadata: client,
+            readGrid: { _ in attachSurface.textSinceMark() },
+            now: attachClock.now,
+            sleepFor: attachClock.sleep
+        )
+        let attachOutcome = await abstaining.probe(
+            target: target,
+            socketPath: handle.localSocketPath,
+            paneID: fixture.info.paneID
+        )
+        XCTAssertEqual(
+            attachOutcome, .noMatch(.settleTimeout),
+            "an attach surface must never authorize a remote herdr join"
+        )
+    }
+
+    /// The nonce's whole lifecycle against the live server: a match keeps the
+    /// token alive as the dictation's mic indicator, and every exit path
+    /// clears it before the forward closes.
+    func testMicIndicatorRefreshesTheTokenAndClearsItOnStop() async throws {
+        // The forward's own clock, with a short idle window: releasing the
+        // lease must retire the tunnel, and that is how the test observes that
+        // the indicator really closed its handle.
+        let forwardClock = AcceleratedClock()
+        let (service, handle) = try await openForward(clock: forwardClock, idleTimeout: 60)
+        defer { service.stopAllForQuit() }
+        let client = HerdrSocketClient(timeout: 5)
+        let token = Self.freshToken()
+        let stamped = await stamp(token, through: client, socketPath: handle.localSocketPath)
+        XCTAssertTrue(stamped)
+
+        // A clock of its own, so the refresh cadence cannot move the forward's
+        // idle deadline while the lease is still held.
+        let indicatorClock = AcceleratedClock()
+        let indicator = HerdrPanelMicIndicator(
+            metadata: client,
+            socketPath: handle.localSocketPath,
+            paneID: fixture.info.paneID,
+            token: token,
+            forward: handle,
+            sleepFor: indicatorClock.sleep
+        )
+        indicator.start()
+
+        // Clear the token behind the indicator's back; its next refresh must
+        // put the same value back — that is what keeps the row lit for a
+        // dictation longer than one TTL.
+        await HerdrPanelBindingProbe.clear(
+            metadata: client, socketPath: handle.localSocketPath, paneID: fixture.info.paneID
+        )
+        XCTAssertNil(try fixture.paneTokens()["lvmark"])
+        try await HerdrLaneWait.until("the mic indicator to refresh the token", timeout: 30) {
+            (try? self.fixture.paneTokens()["lvmark"]) == token
+        }
+
+        await indicator.stopAndWait()
+        // The clear is issued while the forward is still open — it has to be,
+        // it travels through it — and only then is the lease released.
+        XCTAssertNil(
+            try fixture.paneTokens()["lvmark"],
+            "stopping the indicator must clear the token before releasing the forward"
+        )
+        let socketPath = handle.localSocketPath
+        try await HerdrLaneWait.until(
+            "the forward released by the indicator to be torn down", timeout: 30
+        ) {
+            !ClaudeRemoteHerdrForwardService.dial(socketPath)
+        }
+    }
+
+}
+
+// MARK: - Test seams
+
+/// The real spawner, counted. Every `ssh` this starts is a real one; only the
+/// bookkeeping is added, so "was the lease reused" is answerable without
+/// weakening what the lane exercises.
+private final class CountingHerdrForwardSpawner: ClaudeRemoteHerdrForwardSpawning, @unchecked Sendable {
+    private let inner = ClaudeRemoteHerdrForwardSpawner()
+    private let count = Mutex(0)
+
+    var spawnCount: Int { count.withLock { $0 } }
+
+    func spawn(argv: [String]) throws -> any ClaudeRemoteHerdrForwardProcess {
+        count.withLock { $0 += 1 }
+        return try inner.spawn(argv: argv)
+    }
+}
+
+/// The panel probe's clock, decoupled from wall time.
+///
+/// `now()` advances by exactly what the probe asked to sleep, so the settle
+/// budget and read cap behave as they do in production. The REAL wait is for
+/// the live surface to paint a frame, bounded — a lane must fail because herdr
+/// stopped rendering the token, never because the Mac was busy for a second.
+final class SurfaceSettleClock: @unchecked Sendable {
+    /// Longest real wait for one frame. Nine of these is the worst case, which
+    /// is still seconds, and only the abstaining (no-paint) path pays it.
+    static let framePatience: TimeInterval = 0.6
+
+    private let elapsed = Mutex<TimeInterval>(0)
+    private let origin = Date()
+    private let surface: HerdrSurfaceLog
+
+    init(surface: HerdrSurfaceLog) {
+        self.surface = surface
+    }
+
+    // `Mutex` is non-copyable, so these closures capture `self` (the class is
+    // a reference type and @unchecked Sendable) rather than the lock itself.
+    var now: @MainActor @Sendable () -> Date {
+        { [self] in origin.addingTimeInterval(elapsed.withLock { $0 }) }
+    }
+
+    var sleep: @Sendable (TimeInterval) async -> Void {
+        { [self] seconds in
+            let before = surface.byteCount
+            let deadline = Date().addingTimeInterval(Self.framePatience)
+            while Date() < deadline, surface.byteCount == before {
+                try? await Task.sleep(for: .milliseconds(20))
+            }
+            elapsed.withLock { $0 += max(0, seconds) }
+        }
+    }
+}
+
+/// A clock that advances by the FULL requested interval while sleeping only a
+/// short real one.
+///
+/// The forward service polls readiness on this seam, so short sleeps must be
+/// honored for real (a live ssh needs actual time to answer). Its idle window
+/// is minutes, and a lane must not wait them out — so long sleeps are
+/// compressed, and `now()` reports the interval as fully elapsed. Every
+/// deadline the service checks is therefore satisfied exactly when it would be
+/// in production, without the wall clock in the assertion.
+final class AcceleratedClock: @unchecked Sendable {
+    /// Sleeps up to this long for real; beyond it, only the virtual clock moves.
+    static let realSleepCeiling: TimeInterval = 0.05
+
+    private let elapsed = Mutex<TimeInterval>(0)
+    private let origin = Date()
+
+    var now: @Sendable () -> Date {
+        { [self] in origin.addingTimeInterval(elapsed.withLock { $0 }) }
+    }
+
+    var sleep: @Sendable (TimeInterval) async -> Void {
+        { [self] seconds in
+            let requested = max(0, seconds)
+            let real = min(requested, Self.realSleepCeiling)
+            if real > 0 {
+                try? await Task.sleep(for: .milliseconds(Int(real * 1000)))
+            }
+            elapsed.withLock { $0 += requested }
+        }
+    }
+}
+
+#endif

--- a/docs/agent/invariants.md
+++ b/docs/agent/invariants.md
@@ -213,7 +213,14 @@ there is not.
     clients still omit the sidebar (`src/server/headless.rs` render loop) and
     that all App clients still render one server-global panel/focus
     (`tests/multi_client.rs`). Per-client focus or a sidebar in attach mode
-    invalidates this authorization argument.
+    invalidates this authorization argument. The first half is now MEASURED
+    rather than assumed: the `integration-herdr` lane stamps a nonce through a
+    real forward and asserts that a whole-view client renders it while a
+    `terminal attach` client of the same pane does not
+    (`HerdrIntegrationTests`, `docs/agent/test-tiers.md`). The server-global
+    focus half remains unmeasured — see the panel-binding doc's "Pinned against
+    a live server" section for exactly which assumptions are covered and which
+    are still documented hopes.
 
     Any stamp refusal, unavailable grid, hidden/unconfigured/scrolled panel row,
     or bounded settle timeout can only produce NO MATCH. It closes that attempt

--- a/docs/agent/remote-herdr-panel-binding.md
+++ b/docs/agent/remote-herdr-panel-binding.md
@@ -206,6 +206,46 @@ paths stay loud (`Log.backends` convention).
   argv, where the manual flow still gets no join).
 - The marker-arm suppression rule and its exact category set.
 
+## Pinned against a live server
+
+Everything above was read out of herdr's source and is therefore an EXTERNAL
+assumption: true of the version that was read, not guaranteed of the next one.
+The `integration-herdr` lane (`HerdrIntegrationTests`,
+`scripts/herdr-integration-fixture.sh`, `remote-build.sh integration-herdr`)
+holds the checkable half of it to a running herdr — a real server, a real
+pane, a real `ssh -L` forward, and a real whole-view client on a pty whose
+rendered text is the surface the probe reads. Each assumption has its own
+named test, so an upgrade that changes one fails with a message naming it.
+
+Measured against herdr 0.8.2 (protocol 20) while writing that lane:
+
+- A whole-view App client renders the `$lvmark` row; a
+  `herdr terminal attach <pane>` client of the SAME pane never does. This is
+  the discriminator the trust argument rests on and it holds.
+- The agents panel renders per AGENT-BEARING pane, so a pane with no reported
+  agent renders no row and therefore no token at all. A join targets a pane
+  running an agent, so this is the shape that matters — but it means "the row
+  is configured" is not sufficient for a token to appear.
+- `pane.report_metadata` clears on BOTH a JSON `null` and an empty string, as
+  `normalize_metadata_tokens` promised. The production teardown sends null.
+- `ttl_ms` is enforced at exactly 1…86_400_000; 0 and 86_400_001 are refused
+  with `invalid_metadata_ttl`.
+- CORRECTION to the constraints above: an 81-character token VALUE is
+  ACCEPTED, not refused. Nothing may be built on a length refusal. The
+  production token is 17 characters, well inside whatever bound exists.
+- `pane.current` did NOT carry an `agent_session` field for a pane whose
+  agent session id was reported through `herdr pane report-agent[-session]`,
+  so `claimedClaudeSessionID` came back nil. The join's "herdr's own claim
+  must not disagree" cross-check is therefore vacuous for panes in that
+  state — it can still catch a disagreement, but absence is the common case
+  and the pane-id plus broker-marker confirmations carry the weight.
+
+Unpinnable from the Mac side, and still documented hopes: that all App-mode
+clients share one server-global focus (a second whole-view client on the same
+socket disturbed the fixture's own pane rather than mirroring it, so the lane
+does not assert it), and that `terminal_observe` behaves like
+`terminal_attach` (herdr 0.8.2's CLI exposes no observe subcommand).
+
 ## Out of scope (recorded follow-ups)
 
 - Per-socket distinct nonces to lift the single-socket-per-host abstention.

--- a/docs/agent/test-tiers.md
+++ b/docs/agent/test-tiers.md
@@ -6,6 +6,7 @@
 | 1 | `RealtimeAPIVLLMIntegrationTests` vs the live local speechd STT test service: real inference through the production websocket client, word-accuracy asserted | every non-fast-path PR/push on the self-hosted runner; locally via `remote-build.sh integration` | ~20 s |
 | 1 | `PolishHelperIntegrationTests`: the packaged polishing helper vs the real pinned model — production request path, shared eval baseline, parent-pid tether | conditional in CI (self-hosted, after packaging): only when the diff touches LLM-relevant paths or the PR opts in with `[run-llm-eval]` — see "When must the LLM lanes run?"; locally via `remote-build.sh integration-polishd` | minutes (4B weights + live inference) |
 | 1 | `SpeechHelperIntegrationTests`: packaged speechd vs real spoken audio/model through the production realtime client — word accuracy, append-only delta/done parity, parent-pid tether | conditional in CI (self-hosted, after packaging): only when the diff touches speechd-relevant paths or the PR opts in with `[run-speechd-integration]`; locally via `remote-build.sh integration-speechd` | minutes (4B weights + live inference) |
+| 1 | `HerdrIntegrationTests`: the remote-herdr join machinery vs a LIVE `herdr` server over a REAL `ssh -L` forward — real socket client, real forward coordinator, real `ssh -G` canonicalization, real `~/.config/herdr/config.toml` patch; the only fixture is the focused surface (a real herdr client on a pty) | conditional in CI (self-hosted): only when the diff touches herdr-relevant paths or the PR opts in with `[run-herdr-integration]`; locally via `remote-build.sh integration-herdr [ssh-destination]` | ~1 min (no model weights) |
 | 2 | `ui-smoke.yml` AX smoke drill (status item, settings tabs, lazy managed-backend launch invariant); dictation-with-audio remains future work | evening lock-aware slots (18:00/19:30/21:00 UTC; `ui-smoke-guard.sh` skips green when the Mac is on battery, the screen is locked, or a slot's drill already ran and passed that day — the drill needs an unlocked GUI session) + manual on the self-hosted GUI runner | — |
 | 2 | `AgentDictationE2EEvalTests` (`eval-e2e.yml`): wide agent-dictation eval — human WAVs or TTS(`say`) → live speechd ASR → bundled polishd through the production stop-commit path, scored against `EvalCorpus/agent-dictation/` (7 migrated required cases asserted; the rest XFAIL; WER informational; raw-model pre-safety diagnostic column) | nightly (skips green when the Mac is on battery — `ac-power-guard.sh`, owner rule 2026-07-24: scheduled lanes never run unplugged; manual dispatch always runs) + manual, NEVER per-PR (owner decision 2026-07-11); locally via `remote-build.sh eval-e2e [EvalRecordings/agent-dictation/<set>]` (run `package` first) | many minutes (live ASR/4B polish over ~160 cases; TTS WAVs cached on the host) |
 
@@ -79,6 +80,65 @@ filter list in the same PR. `./scripts/remote-build.sh integration-polishd`
 remains the local equivalent. The nightly `eval-e2e.yml` lane is the only
 scheduled eval; the per-PR polishd lane skipped by the filter runs again only
 when a matching change (or the marker) triggers it.
+
+## The live herdr lane
+
+`HerdrIntegrationTests` (`remote-build.sh integration-herdr`) is the only
+place anything checks that **herdr still behaves the way the remote-herdr
+join assumes it does**. `docs/agent/remote-herdr-panel-binding.md` records
+those assumptions; before this lane they were documented hopes. Each one that
+a live server can answer has its own named test, so a herdr upgrade that
+changes it fails with a message naming the assumption rather than silently
+un-authorizing field joins.
+
+What is real in the lane: `HerdrSocketClient` on a forwarded unix socket,
+`ClaudeRemoteHerdrForwardService` spawning a real supervised `ssh -N -L`,
+`SSHDestinationCanonicalizer.live()` running real `ssh -G`,
+`ClaudeRemoteEnrollmentService.configureRemoteHerdrPanel` patching a real
+`~/.config/herdr/config.toml` over a real ssh session, and
+`HerdrPanelBindingProbe` / `HerdrPanelMicIndicator` on top of all of it. The
+ONE fixture is the focused surface: a real herdr client on a pty, read from
+its typescript instead of through accessibility.
+
+Assumptions currently pinned against the live server: only a whole-view App
+client renders the agents sidebar (`terminal attach` renders the raw pane and
+cannot echo the token — the load-bearing one); both a JSON `null` and an
+empty string clear a `pane.report_metadata` token; the `ttl_ms` window is
+1…86_400_000 inclusive; `pane.process_info` still reports named foreground
+processes; `pane.read` answers only about the pane asked for; and `ssh -G`
+identity matching accepts an alias that differs only in `User` while
+rejecting one that differs in port.
+
+Fixture and host requirements (`scripts/herdr-integration-fixture.sh`):
+
+- `herdr` must be installed on the machine running the lane. Its absence is a
+  LOUD failure naming the install step, never a skip — a lane that quietly
+  does nothing about herdr is indistinguishable from one that passed.
+- With no destination the fixture provisions its OWN loopback sshd (its own
+  host key, user key and `authorized_keys` file — the account's are never
+  touched), so the lane is hermetic and needs no second machine. Pass an ssh
+  destination to run the identical lane against a real second host.
+- For the duration of a run the fixture OWNS the account's
+  `~/.config/herdr/config.toml` and `session.json` and appends a delimited
+  block to `~/.ssh/config`, restoring all three on teardown (including when
+  `up` fails partway). It refuses to start at all when a herdr server is
+  already running for that account, rather than trampling a human's session.
+- The suite has no `XCTSkip`. Every other lane skips it by name
+  (`--skip HerdrIntegrationTests` in `remote-build.sh test` and in CI's unit
+  step), and running it without its marker fails with the enablement
+  instructions.
+
+When must it run? For `scripts/ci/herdr-lane-filter.sh` path matches or the
+literal `[run-herdr-integration]` marker, on the same event-payload terms as
+the LLM lanes. The rule behind the list: anything that changes what the app
+SAYS to herdr, what it BELIEVES herdr answered, how the forward reaching
+herdr is opened or leased, which host that forward reaches, or the recorded
+assumptions themselves. Editing
+`docs/agent/remote-herdr-panel-binding.md` matches too — a changed assumption
+that was never re-measured is exactly the failure this lane exists to
+prevent. Not required for UI, insertion, audio, or model work. Either way the
+PR's Proof section carries the scoreboard or a one-line justification for
+skipping.
 
 The speechd live-model lane follows the same owner constraint: it runs only for
 `scripts/ci/speechd-lane-filter.sh` matches or `[run-speechd-integration]`.

--- a/docs/agent/test-tiers.md
+++ b/docs/agent/test-tiers.md
@@ -119,10 +119,23 @@ Fixture and host requirements (`scripts/herdr-integration-fixture.sh`):
   touched), so the lane is hermetic and needs no second machine. Pass an ssh
   destination to run the identical lane against a real second host.
 - For the duration of a run the fixture OWNS the account's
-  `~/.config/herdr/config.toml` and `session.json` and appends a delimited
-  block to `~/.ssh/config`, restoring all three on teardown (including when
-  `up` fails partway). It refuses to start at all when a herdr server is
-  already running for that account, rather than trampling a human's session.
+  `~/.config/herdr/config.toml` and `session.json` and appends two delimited
+  blocks to `~/.ssh/config`. It touches the REAL ssh config on purpose: the
+  code under test never passes `-F`, so an alias that lived only in a
+  fixture-local file would exercise an invocation shape the app never
+  produces. The ssh config is restored by REMOVING those blocks, not by
+  writing a copy back, so an edit made while the lane runs survives.
+- Because nothing runs on SIGKILL, the pristine originals live at a stable
+  path (`~/.localvoxtral-herdr-fixture-hold/`) with a manifest naming the run
+  that took them — never in the run's own temp dir, which a killed run would
+  strand. `up` restores a dead run's hold before touching anything and
+  refuses while a live run owns it; it will never back up an already-modified
+  file over a pristine copy, which is the step that would destroy the
+  originals. `status` and `recover` do it by hand
+  (`scripts/mac/README.md`), and `scripts/ci/test-herdr-fixture-recovery.sh`
+  holds that behavior per-push without needing herdr at all.
+- It refuses to start when a herdr server is already running for that account,
+  rather than trampling a human's session.
 - The suite has no `XCTSkip`. Every other lane skips it by name
   (`--skip HerdrIntegrationTests` in `remote-build.sh test` and in CI's unit
   step), and running it without its marker fails with the enablement

--- a/scripts/ci/clean-stale-outputs.sh
+++ b/scripts/ci/clean-stale-outputs.sh
@@ -30,4 +30,5 @@ rm -rf dist logs format-lint.txt default.profraw
 # pattern): clean: false preserves them across runs, and a stray one would
 # flip a marker-gated live suite ON in a plain unit step.
 rm -f .agent-eval-e2e-enable.json .llm-polish-eval-enable.json \
-  .polishd-integration-enable.json .speechd-integration-enable.json
+  .polishd-integration-enable.json .speechd-integration-enable.json \
+  .herdr-integration-enable.json

--- a/scripts/ci/herdr-lane-filter.sh
+++ b/scripts/ci/herdr-lane-filter.sh
@@ -1,0 +1,89 @@
+#!/bin/bash
+# Decides whether CI's live-herdr integration lane must run for a given
+# change. Kept standalone so the workflow decision is testable locally.
+#
+# Usage:
+#   scripts/ci/herdr-lane-filter.sh <changed-files-file> [marker-text-file]
+#
+#   <changed-files-file>  one changed path per line (git diff --name-only)
+#   [marker-text-file]    optional free text (PR body + head commit message);
+#                         if it contains [run-herdr-integration], the lane
+#                         runs regardless of the diff
+#
+# stdout is $GITHUB_OUTPUT-shaped:
+#   run=true|false
+#   reason=<one line, safe for a step summary>
+#
+# Exits 0 for both decisions; non-zero only on usage errors. The caller owns
+# fail-open behavior when it cannot produce a diff at all.
+set -euo pipefail
+
+MARKER='[run-herdr-integration]'
+
+# The lane proves EXTERNAL assumptions about a live herdr server and a real
+# ssh forward. A path belongs here when changing it can alter what the app
+# sends herdr, what it believes herdr answered, how the forward to herdr is
+# opened or leased, which host that forward reaches, or the trust argument
+# those assumptions support.
+#
+# Deliberately NOT here: everything else in the Claude context path that never
+# talks to herdr (repo collection, prompt blocks, insertion). Those are
+# covered by the tier-0 unit suite; adding them would make a live-service lane
+# run on ordinary UI work.
+PATTERNS=(
+  '*HerdrSocketClient*'                              # the wire client: every request/response shape
+  '*HerdrPanelBindingProbe*'                         # the nonce stamp, settle loop, and mic indicator
+  '*HerdrClientTTYProbe*'                            # which surface is bound to a herdr client at all
+  '*ClaudeRemoteHerdrForward*'                       # the ssh -L forward, its argv, leases and teardown
+  '*ClaudeRemoteForwardSupervisor*'                  # the process supervision under that forward
+  '*ClaudeRemoteForwardCoordinator*'                 # which hosts get a forward, and in what order
+  '*SSHDestinationCanonicalizer*'                    # ssh -G identity matching for the destination
+  '*SSHDestinationTTYProbe*'                         # the argv fallback the panel binding falls through to
+  '*ClaudeRemoteEnrollmentService*'                  # the remote herdr config patch + its refusal rules
+  '*SocketPaneScreenContext*'                        # what a herdr join is allowed to read back
+  '*TerminalScreenClaudeJoin*'                       # the arm that consumes all of the above
+  'docs/agent/remote-herdr-panel-binding.md'         # the assumptions this lane exists to pin
+  'scripts/herdr-integration-fixture.sh'             # the fixture itself
+  'scripts/ci/herdr-lane-filter.sh'
+  '*HerdrIntegration*'                               # the lane's own suite and support
+)
+
+if [[ $# -lt 1 || $# -gt 2 ]]; then
+  echo "usage: $0 <changed-files-file> [marker-text-file]" >&2
+  exit 2
+fi
+
+CHANGED_FILES_FILE="$1"
+MARKER_TEXT_FILE="${2:-}"
+
+if [[ ! -f "$CHANGED_FILES_FILE" ]]; then
+  echo "changed-files file not found: $CHANGED_FILES_FILE" >&2
+  exit 2
+fi
+
+if [[ -n "$MARKER_TEXT_FILE" && -f "$MARKER_TEXT_FILE" ]] \
+    && grep -qF "$MARKER" "$MARKER_TEXT_FILE"; then
+  echo "run=true"
+  echo "reason=explicit $MARKER marker"
+  exit 0
+fi
+
+while IFS= read -r file; do
+  [[ -z "$file" ]] && continue
+  for pattern in "${PATTERNS[@]}"; do
+    # shellcheck disable=SC2254
+    case "$file" in
+      $pattern)
+        echo "run=true"
+        echo "reason=matched $file ($pattern)"
+        exit 0
+        ;;
+    esac
+  done
+done <"$CHANGED_FILES_FILE"
+
+echo "run=false"
+# "and push": the marker is only read from the event payload at run-creation
+# time — editing the PR body after a skipped run creates no new run, and
+# reruns reuse the original payload, so a late-added marker needs a push.
+echo "reason=no herdr-relevant changes; add $MARKER to the PR body or commit message and push to opt in"

--- a/scripts/ci/test-herdr-fixture-recovery.sh
+++ b/scripts/ci/test-herdr-fixture-recovery.sh
@@ -1,0 +1,191 @@
+#!/usr/bin/env bash
+# Regression test for the herdr fixture's crash recovery.
+#
+# The fixture borrows three of the account's real files (herdr `config.toml`,
+# `session.json`, and delimited blocks in `~/.ssh/config`). `down` gives them
+# back — but a run can be SIGKILLed, and nothing runs on SIGKILL. The pristine
+# copies therefore live at a stable path, and the next `up` must restore them
+# rather than back up the ALREADY-MODIFIED files over them, which is the step
+# that would destroy the originals permanently.
+#
+# This drives that logic directly against a fake HOME, so it runs anywhere —
+# no herdr, no ssh, no live server. Same sourced-mode pattern as
+# scripts/ci/test-build-gate-*.sh.
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "$0")/../.." && pwd -P)"
+FIXTURE="$ROOT_DIR/scripts/herdr-integration-fixture.sh"
+
+TMP_DIR="$(mktemp -d "${TMPDIR:-/tmp}/lv-herdr-fixture-recovery.XXXXXX")"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+fail() {
+  printf 'FAIL: %s\n' "$*" >&2
+  exit 1
+}
+
+pass() { printf 'PASS: %s\n' "$*"; }
+
+PRISTINE_CONFIG='# the human own herdr config
+[theme]
+name = "kanagawa"
+'
+PRISTINE_SSH='Host prod
+  HostName prod.example
+  User someone
+'
+PRISTINE_SESSION='{"workspaces":["the human own session"]}'
+
+GOLDEN="$TMP_DIR/golden"
+
+# A fresh fake account with all three files as the human left them, plus
+# byte-exact golden copies kept OUTSIDE that home so the assertions compare
+# bytes rather than shell-stripped strings.
+setup_home() {
+  export HOME="$TMP_DIR/home"
+  rm -rf "$HOME"
+  mkdir -p "$HOME/.config/herdr" "$HOME/.ssh" "$GOLDEN"
+  printf '%s' "$PRISTINE_CONFIG" > "$HOME/.config/herdr/config.toml"
+  printf '%s' "$PRISTINE_SESSION" > "$HOME/.config/herdr/session.json"
+  printf '%s' "$PRISTINE_SSH" > "$HOME/.ssh/config"
+  cp "$HOME/.config/herdr/config.toml" "$GOLDEN/config.toml"
+  cp "$HOME/.config/herdr/session.json" "$GOLDEN/session.json"
+  cp "$HOME/.ssh/config" "$GOLDEN/ssh_config"
+  # Sourced with HOME already set: the fixture resolves the account paths at
+  # load, exactly as it does for a real invocation.
+  # shellcheck source=/dev/null
+  LOCALVOXTRAL_HERDR_FIXTURE_SOURCE_ONLY=1 source "$FIXTURE"
+}
+
+# Everything `up` does to the account's files, without herdr or ssh: take the
+# hold, then modify. A run "killed" after this leaves exactly this state.
+simulate_up_then_kill() {
+  local dir="$1"
+  mkdir -p "$dir"
+  hold_account_files "$dir"
+  printf 'onboarding = false\n[ui.sidebar.agents]\n' > "$HERDR_CONFIG_FILE"
+  rm -f "$HERDR_SESSION_FILE"
+  {
+    printf '%s\n' "$SSH_CONFIG_BEGIN"
+    printf 'Host lvx-herdr-fixture\n  HostName 127.0.0.1\n  Port 24601\n'
+    printf '%s\n' "$SSH_CONFIG_END"
+    printf '%s\n' "$SSH_CONFIG_ALT_BEGIN"
+    printf 'Host lvx-herdr-fixture-altuser\n  HostName 127.0.0.1\n'
+    printf '%s\n' "$SSH_CONFIG_ALT_END"
+  } >> "$SSH_CONFIG_FILE"
+  # The manifest records THIS shell's pid, which is very much alive. A killed
+  # run's pid is not, so overwrite it with one that cannot be running.
+  sed -e 's/^pid=.*/pid=999999/' "$HOLD_MANIFEST" > "$HOLD_MANIFEST.tmp"
+  mv "$HOLD_MANIFEST.tmp" "$HOLD_MANIFEST"
+}
+
+assert_account_is_pristine() {
+  local what="$1"
+  cmp -s "$GOLDEN/config.toml" "$HERDR_CONFIG_FILE" \
+    || fail "$what: herdr config was not restored byte for byte:
+$(cat "$HERDR_CONFIG_FILE" 2>&1)"
+  cmp -s "$GOLDEN/session.json" "$HERDR_SESSION_FILE" \
+    || fail "$what: herdr session was not restored byte for byte"
+  cmp -s "$GOLDEN/ssh_config" "$SSH_CONFIG_FILE" \
+    || fail "$what: ssh config was not restored byte for byte:
+$(cat "$SSH_CONFIG_FILE" 2>&1)"
+  [[ ! -e "$HOLD_DIR" ]] || fail "$what: the hold directory survived the restore"
+}
+
+# --- 1. A killed run is detected and restored by the next `up` -------------
+
+setup_home
+simulate_up_then_kill "$TMP_DIR/lvx-herdr-fixture-run1"
+cmp -s "$GOLDEN/config.toml" "$HERDR_CONFIG_FILE" \
+  && fail "the simulated run did not actually modify the config"
+hold_is_present || fail "the simulated run left no hold"
+
+reclaim_or_refuse_stale_hold 2>/dev/null
+assert_account_is_pristine "after reclaiming a killed run"
+pass "a killed run's held files are restored by the next up"
+
+# --- 2. `recover` does the same by hand, with no workdir argument ----------
+
+setup_home
+simulate_up_then_kill "$TMP_DIR/lvx-herdr-fixture-run2"
+rm -rf "$TMP_DIR/lvx-herdr-fixture-run2"   # the run dir is gone; the hold is not
+command_recover 2>/dev/null
+assert_account_is_pristine "after recover"
+pass "recover restores without the run directory"
+
+# --- 3. Two consecutive interrupted runs cannot lose the originals ---------
+# This is the defect: if the second run backed up the FIRST run's modified
+# files, the human's originals would be gone for good after its teardown.
+
+setup_home
+simulate_up_then_kill "$TMP_DIR/lvx-herdr-fixture-runA"
+reclaim_or_refuse_stale_hold 2>/dev/null
+simulate_up_then_kill "$TMP_DIR/lvx-herdr-fixture-runB"
+# The step that would destroy the originals: run B's backup must be the
+# HUMAN'S file, not run A's modified one.
+cmp -s "$GOLDEN/config.toml" "$HOLD_DIR/herdr-config.pristine" \
+  || fail "the second interrupted run backed up the first run's modified config"
+reclaim_or_refuse_stale_hold 2>/dev/null
+assert_account_is_pristine "after two consecutive interrupted runs"
+pass "the pristine originals survive two consecutive interrupted runs"
+
+# --- 4. A hold is never overwritten ---------------------------------------
+# The direct guard on the data-loss step, independent of who calls it.
+
+setup_home
+simulate_up_then_kill "$TMP_DIR/lvx-herdr-fixture-runC"
+if ( hold_account_files "$TMP_DIR/lvx-herdr-fixture-runD" ) 2>/dev/null; then
+  fail "hold_account_files overwrote an existing hold"
+fi
+cmp -s "$GOLDEN/config.toml" "$HOLD_DIR/herdr-config.pristine" \
+  || fail "the pristine copy was replaced by the modified file"
+pass "a second hold is refused rather than overwriting the pristine copies"
+
+# --- 5. A LIVE run's hold is refused, not reclaimed ------------------------
+# Two lanes racing for one account must not restore each other's files. The
+# liveness evidence is "a process with the fixture's name is running under
+# that pid", so the decoy has to carry that name for this to test anything.
+
+setup_home
+DECOY="$TMP_DIR/herdr-integration-fixture-decoy.sh"
+printf '#!/bin/sh\nsleep 30\n' > "$DECOY"
+chmod +x "$DECOY"
+"$DECOY" &
+DECOY_PID=$!
+mkdir -p "$TMP_DIR/lvx-herdr-fixture-live"
+hold_account_files "$TMP_DIR/lvx-herdr-fixture-live" 2>/dev/null
+sed -e "s/^pid=.*/pid=$DECOY_PID/" "$HOLD_MANIFEST" > "$HOLD_MANIFEST.tmp"
+mv "$HOLD_MANIFEST.tmp" "$HOLD_MANIFEST"
+
+hold_owner_is_alive \
+  || fail "the decoy was not recognised as a live fixture run; the refusal branch is untested"
+if ( reclaim_or_refuse_stale_hold ) 2>/dev/null; then
+  kill "$DECOY_PID" 2>/dev/null || true
+  fail "a live run's hold was reclaimed instead of refused"
+fi
+hold_is_present || fail "the refusal must leave the live run's hold intact"
+pass "a live run's hold is refused rather than reclaimed"
+
+kill "$DECOY_PID" 2>/dev/null || true
+wait "$DECOY_PID" 2>/dev/null || true
+release_account_files 2>/dev/null || true
+
+# --- 6. Restoring absent files means removing them, not writing empties ----
+
+export HOME="$TMP_DIR/home-empty"
+rm -rf "$HOME"
+mkdir -p "$HOME"
+# shellcheck source=/dev/null
+LOCALVOXTRAL_HERDR_FIXTURE_SOURCE_ONLY=1 source "$FIXTURE"
+mkdir -p "$TMP_DIR/lvx-herdr-fixture-empty"
+hold_account_files "$TMP_DIR/lvx-herdr-fixture-empty" 2>/dev/null
+printf 'onboarding = false\n' > "$HERDR_CONFIG_FILE"
+printf '%s\nHost x\n%s\n' "$SSH_CONFIG_BEGIN" "$SSH_CONFIG_END" >> "$SSH_CONFIG_FILE"
+release_account_files 2>/dev/null
+[[ ! -e "$HERDR_CONFIG_FILE" ]] \
+  || fail "a config that did not exist before must not exist after"
+[[ ! -e "$SSH_CONFIG_FILE" ]] \
+  || fail "an ssh config the fixture created must be removed again, not left empty"
+pass "files the account never had are removed, not left behind"
+
+printf '\nAll herdr fixture recovery checks passed.\n'

--- a/scripts/ci/test-herdr-lane-filter.sh
+++ b/scripts/ci/test-herdr-lane-filter.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+# Regression test for herdr-lane-filter.sh's path decisions and marker opt-in.
+# Pure shell, no git or network — changed-file lists are written to temp files,
+# so it runs anywhere (hosted fork PRs included).
+#
+# Not a mirror of the whole pattern list: it pins the decisions that decide
+# whether a live-service lane runs at all — every path that can change what we
+# say to herdr or believe it said, the doc the assumptions live in, and the
+# run=false side that keeps ordinary UI/doc work off a lane that starts real
+# servers.
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "$0")/../.." && pwd -P)"
+FILTER="$ROOT_DIR/scripts/ci/herdr-lane-filter.sh"
+
+TMP_DIR="$(mktemp -d "${TMPDIR:-/tmp}/lv-herdr-lane-filter-test.XXXXXX")"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+fail() {
+  printf 'FAIL: %s\n' "$*" >&2
+  exit 1
+}
+
+# expect <true|false> <description> <changed-path>... [--marker <text>]
+expect() {
+  local expected="$1" description="$2"
+  shift 2
+  local changed="$TMP_DIR/changed" marker_file=""
+  : >"$changed"
+  while [[ $# -gt 0 ]]; do
+    if [[ "$1" == "--marker" ]]; then
+      marker_file="$TMP_DIR/marker"
+      printf '%s\n' "$2" >"$marker_file"
+      shift 2
+      continue
+    fi
+    printf '%s\n' "$1" >>"$changed"
+    shift
+  done
+  local output
+  if [[ -n "$marker_file" ]]; then
+    output="$("$FILTER" "$changed" "$marker_file")" || fail "$description: filter exited non-zero"
+  else
+    output="$("$FILTER" "$changed")" || fail "$description: filter exited non-zero"
+  fi
+  local run reason
+  run="$(sed -n 's/^run=//p' <<<"$output")"
+  reason="$(sed -n 's/^reason=//p' <<<"$output")"
+  [[ "$run" == "$expected" ]] \
+    || fail "$description: expected run=$expected, got run=$run ($reason)"
+  [[ -n "$reason" ]] || fail "$description: reason line is missing"
+  printf 'PASS: %s (%s)\n' "$description" "$reason"
+}
+
+# --- What we say to herdr, and what we believe it said ---------------------
+
+expect true "socket client changes run the lane" \
+  Sources/localvoxtral/ClaudeContext/HerdrSocketClient.swift
+expect true "panel binding probe changes run the lane" \
+  Sources/localvoxtral/ClaudeContext/HerdrPanelBindingProbe.swift
+expect true "the ssh -L forward runs the lane" \
+  Sources/localvoxtral/ClaudeContext/ClaudeRemoteHerdrForward.swift
+expect true "forward supervision runs the lane" \
+  Sources/localvoxtral/ClaudeContext/ClaudeRemoteForwardSupervisor.swift
+expect true "ssh -G canonicalization runs the lane" \
+  Sources/localvoxtral/ClaudeContext/SSHDestinationCanonicalizer.swift
+expect true "the remote herdr config patch runs the lane" \
+  Sources/localvoxtral/ClaudeContext/ClaudeRemoteEnrollmentService.swift
+expect true "the join arm that consumes all of it runs the lane" \
+  Sources/localvoxtral/ClaudeContext/TerminalScreenClaudeJoin.swift
+
+# --- The assumptions themselves -------------------------------------------
+# The doc is the record of what the lane pins. Editing it without re-running
+# the lane is exactly how a stale assumption survives a herdr upgrade.
+
+expect true "editing the panel-binding design doc runs the lane" \
+  docs/agent/remote-herdr-panel-binding.md
+expect true "the fixture itself runs the lane" \
+  scripts/herdr-integration-fixture.sh
+expect true "the lane's own suite runs the lane" \
+  Tests/localvoxtralTests/HerdrIntegrationTests.swift
+
+# --- Marker opt-in ---------------------------------------------------------
+
+expect true "the explicit marker runs the lane on an unrelated diff" \
+  README.md --marker 'fixes a thing [run-herdr-integration] please run it'
+expect false "a lookalike marker does not run the lane" \
+  README.md --marker 'run-herdr-integration without the brackets'
+
+# --- The run=false side ----------------------------------------------------
+# A live-service lane that runs on everything is a lane people learn to
+# ignore. These are the diffs that must NOT start a herdr server.
+
+expect false "UI-only changes do not run the lane" \
+  Sources/localvoxtral/SettingsView.swift
+expect false "polish-model work does not run the lane" \
+  Sources/localvoxtral/Resources/Config/llm_polish.toml
+expect false "docs outside the assumption record do not run the lane" \
+  README.md docs/architecture.md
+expect false "an empty diff does not run the lane"
+
+printf '\nAll herdr lane filter checks passed.\n'

--- a/scripts/herdr-integration-fixture.sh
+++ b/scripts/herdr-integration-fixture.sh
@@ -1,0 +1,485 @@
+#!/usr/bin/env bash
+# Stand up (and tear down) the live fixture the `integration-herdr` lane runs
+# against: a real `herdr` server with a real pane, a real loopback sshd the
+# app's own `ssh -L` forward can dial, and a real whole-view herdr client
+# rendered into a pty whose output is the "focused surface" the panel-binding
+# probe reads.
+#
+# Everything BELOW the focused surface is production code in that lane. The
+# only fixture is the surface itself: a pty running the real herdr client,
+# scraped from its typescript instead of from a terminal's accessibility tree.
+#
+# Usage:
+#   scripts/herdr-integration-fixture.sh up      <workdir> [ssh-destination]
+#   scripts/herdr-integration-fixture.sh surface <workdir> <name> <app|attach> [pane-id]
+#   scripts/herdr-integration-fixture.sh reload  <workdir>
+#   scripts/herdr-integration-fixture.sh down    <workdir>
+#
+# `up` prints one JSON object on stdout describing the fixture; every other
+# diagnostic goes to stderr. With no ssh-destination it provisions its OWN
+# loopback sshd (hermetic: no second machine, nothing added to the account's
+# real authorized_keys) and uses the alias `lvx-herdr-fixture`. Pass a
+# destination to aim the same lane at a real second host instead; the ssh half
+# is then the caller's own already-working configuration and is left untouched.
+#
+# Deliberately loud: every precondition that cannot be met exits non-zero with
+# the exact provisioning step. This lane must never look green because
+# something was missing.
+set -euo pipefail
+
+FIXTURE_ALIAS="lvx-herdr-fixture"
+# The integration id the fixture reports its pane's agent under. Deliberately
+# NOT "localvoxtral": the app's own metadata source must stay distinguishable
+# from the fixture's agent report in herdr's own records.
+FIXTURE_AGENT_SOURCE="lvxfixture"
+SSH_CONFIG_BEGIN="# BEGIN localvoxtral herdr integration fixture"
+SSH_CONFIG_END="# END localvoxtral herdr integration fixture"
+SSH_CONFIG_ALT_BEGIN="# BEGIN localvoxtral herdr integration fixture aliases"
+SSH_CONFIG_ALT_END="# END localvoxtral herdr integration fixture aliases"
+# Wide enough that herdr renders the desktop layout with its agents sidebar
+# (herdr's mobile_width_threshold is 64 columns and the sidebar is 26).
+SURFACE_COLUMNS=130
+SURFACE_ROWS=45
+READY_TIMEOUT_SECONDS=30
+
+log() { printf '[herdr-fixture] %s\n' "$*" >&2; }
+
+# Set while `up` holds account-level files (herdr config/session, an
+# ~/.ssh/config block). Cleared once `up` has fully succeeded.
+UP_IN_PROGRESS_DIR=""
+
+restore_after_failed_up() {
+  local status=$?
+  if (( status != 0 )) && [[ -n "$UP_IN_PROGRESS_DIR" ]]; then
+    log "up failed (status $status) — restoring this account's files"
+    command_down "$UP_IN_PROGRESS_DIR" >/dev/null 2>&1 || true
+  fi
+}
+trap restore_after_failed_up EXIT
+
+die() {
+  printf '[herdr-fixture] ERROR: %s\n' "$*" >&2
+  exit 1
+}
+
+# Absolute path to the herdr binary. PATH first (so an owner's own install
+# wins), then the two package-manager prefixes; never a relative path.
+resolve_herdr() {
+  if [[ -n "${HERDR_BIN:-}" ]]; then
+    [[ -x "$HERDR_BIN" ]] || die "HERDR_BIN is set but not executable: $HERDR_BIN"
+    printf '%s\n' "$HERDR_BIN"
+    return 0
+  fi
+  local candidate
+  if candidate="$(command -v herdr 2>/dev/null)"; then
+    printf '%s\n' "$candidate"
+    return 0
+  fi
+  for candidate in /opt/homebrew/bin/herdr /usr/local/bin/herdr "$HOME/.cargo/bin/herdr" "$HOME/bin/herdr"; do
+    if [[ -x "$candidate" ]]; then
+      printf '%s\n' "$candidate"
+      return 0
+    fi
+  done
+  die "herdr is not installed on this machine.
+  The integration-herdr lane exercises a LIVE herdr server; it cannot be
+  simulated. Install it (brew install herdr, or https://herdr.dev) or point
+  HERDR_BIN at an existing binary, then re-run the lane."
+}
+
+validate_workdir() {
+  local dir="$1"
+  [[ "$dir" == /* ]] || die "workdir must be an absolute path: $dir"
+  [[ "$dir" != "/" && "$dir" != "$HOME" ]] || die "refusing to use $dir as a workdir"
+  case "$dir" in
+    */lvx-herdr-fixture-*) ;;
+    *) die "workdir basename must start with lvx-herdr-fixture- (got $dir)" ;;
+  esac
+}
+
+free_port() {
+  # A loopback port nothing is listening on. Deliberately not "bind 0 and
+  # release": that races the same way and needs a language runtime. A
+  # collision here is not silent — sshd fails to bind and `up` dies on the
+  # readiness wait with its log attached.
+  local attempt port
+  for attempt in $(seq 1 40); do
+    port=$(( 20000 + RANDOM % 20000 ))
+    if ! nc -z -w 1 127.0.0.1 "$port" >/dev/null 2>&1; then
+      printf '%s\n' "$port"
+      return 0
+    fi
+  done
+  die "could not find a free loopback port for the fixture sshd"
+}
+
+# ---------------------------------------------------------------- up
+
+provision_loopback_sshd() {
+  local dir="$1" port
+  port="$(free_port)"
+
+  ssh-keygen -q -t ed25519 -N '' -f "$dir/hostkey" -C "localvoxtral-herdr-fixture-host"
+  ssh-keygen -q -t ed25519 -N '' -f "$dir/id" -C "localvoxtral-herdr-fixture-user"
+  chmod 600 "$dir/hostkey" "$dir/id"
+
+  # The fixture's OWN authorized_keys file — never the account's. The
+  # environment= options are what make the remote half of the enrollment
+  # config patch (`herdr server reload-config`) resolvable in a
+  # non-interactive shell, which is where a real deployment gets it from the
+  # user's login profile instead.
+  {
+    printf 'environment="PATH=%s:/usr/bin:/bin:/usr/sbin:/sbin",' \
+      "$(dirname "$HERDR_BINARY")"
+    printf 'environment="HERDR_SOCKET_PATH=%s" ' "$HERDR_SOCKET_PATH"
+    cat "$dir/id.pub"
+  } > "$dir/authorized_keys"
+  chmod 600 "$dir/authorized_keys"
+
+  printf '[127.0.0.1]:%s ' "$port" > "$dir/known_hosts"
+  cat "$dir/hostkey.pub" >> "$dir/known_hosts"
+
+  cat > "$dir/sshd_config" <<EOF
+Port $port
+ListenAddress 127.0.0.1
+HostKey $dir/hostkey
+PidFile $dir/sshd.pid
+AuthorizedKeysFile $dir/authorized_keys
+StrictModes no
+UsePAM no
+PermitUserEnvironment yes
+PasswordAuthentication no
+KbdInteractiveAuthentication no
+AllowTcpForwarding yes
+AllowStreamLocalForwarding yes
+PrintMotd no
+LogLevel DEBUG1
+EOF
+
+  # Detached from this shell's stdio on purpose: a daemon that keeps the
+  # caller's stdout pipe open makes every `up` look like a hang to a parent
+  # that reads to EOF.
+  /usr/sbin/sshd -D -f "$dir/sshd_config" -E "$dir/sshd.log" \
+    </dev/null >>"$dir/sshd.out" 2>&1 &
+  echo $! > "$dir/sshd.child.pid"
+  log "loopback sshd starting on 127.0.0.1:$port"
+
+  local waited=0
+  until nc -z -w 1 127.0.0.1 "$port" >/dev/null 2>&1; do
+    (( waited < READY_TIMEOUT_SECONDS )) || die "loopback sshd never listened on $port; see $dir/sshd.log"
+    sleep 1
+    waited=$((waited + 1))
+  done
+
+  {
+    printf '%s\n' "$SSH_CONFIG_BEGIN"
+    printf 'Host %s\n' "$FIXTURE_ALIAS"
+    printf '  HostName 127.0.0.1\n'
+    printf '  Port %s\n' "$port"
+    printf '  User %s\n' "$(id -un)"
+    printf '  IdentityFile %s\n' "$dir/id"
+    printf '  IdentitiesOnly yes\n'
+    printf '  UserKnownHostsFile %s\n' "$dir/known_hosts"
+    printf '  StrictHostKeyChecking yes\n'
+    printf '%s\n' "$SSH_CONFIG_END"
+  } >> "$HOME/.ssh/config"
+  chmod 600 "$HOME/.ssh/config"
+  printf '%s\n' "$port" > "$dir/sshd.port"
+}
+
+# Two extra aliases the canonicalization test needs, derived from wherever the
+# lane's destination actually points:
+#   <alias>-altuser    same (hostname, port), a DIFFERENT User — must still
+#                      match, because `ssh -G` always prints an effective user
+#                      and comparing it would reject the alias shape this
+#                      fallback exists for.
+#   <alias>-otherport  same hostname, a different port — must NOT match.
+# Written for BOTH modes so the test asserts the same thing whether the lane
+# runs hermetically or against a real second host.
+write_canonicalization_aliases() {
+  local dir="$1" alias_used="$2" hostname port other_port
+  hostname="$(ssh -G -- "$alias_used" 2>/dev/null | awk '$1 == "hostname" { print $2; exit }')"
+  port="$(ssh -G -- "$alias_used" 2>/dev/null | awk '$1 == "port" { print $2; exit }')"
+  if [[ -z "$hostname" || -z "$port" ]]; then
+    die "ssh -G could not resolve '$alias_used'; the lane needs a destination ssh can configure"
+  fi
+  if (( port >= 65535 )); then other_port=$((port - 1)); else other_port=$((port + 1)); fi
+  {
+    printf '%s\n' "$SSH_CONFIG_ALT_BEGIN"
+    printf 'Host %s-altuser\n' "$alias_used"
+    printf '  HostName %s\n' "$hostname"
+    printf '  Port %s\n' "$port"
+    printf '  User lvxaltuser\n'
+    printf 'Host %s-otherport\n' "$alias_used"
+    printf '  HostName %s\n' "$hostname"
+    printf '  Port %s\n' "$other_port"
+    printf '%s\n' "$SSH_CONFIG_ALT_END"
+  } >> "$HOME/.ssh/config"
+  chmod 600 "$HOME/.ssh/config"
+}
+
+start_surface() {
+  local dir="$1" name="$2" mode="$3" pane="${4:-}" inner
+  case "$mode" in
+    app) inner="$HERDR_BINARY" ;;
+    attach)
+      [[ -n "$pane" ]] || die "surface mode 'attach' needs a pane id"
+      inner="$HERDR_BINARY terminal attach $pane"
+      ;;
+    *) die "unknown surface mode: $mode" ;;
+  esac
+  # `script` gives the client a real pty; `stty` fixes the geometry so the
+  # rendered layout is deterministic (herdr drops the sidebar entirely below
+  # its mobile width threshold, which would make a no-match meaningless).
+  # `-t 0` flushes the typescript on every I/O event. Without it `script`
+  # buffers in 4 KiB blocks, so a freshly painted frame can sit unwritten and
+  # the surface read would answer about the past.
+  TERM=xterm-256color HERDR_SOCKET_PATH="$HERDR_SOCKET_PATH" \
+    script -q -t 0 "$dir/surface-$name.log" \
+    /bin/sh -c "stty rows $SURFACE_ROWS cols $SURFACE_COLUMNS; exec $inner" \
+    </dev/null >/dev/null 2>&1 &
+  echo $! >> "$dir/surface.pids"
+  log "surface '$name' ($mode) started -> $dir/surface-$name.log"
+}
+
+herdr_cli() {
+  HERDR_SOCKET_PATH="$HERDR_SOCKET_PATH" "$HERDR_BINARY" "$@"
+}
+
+command_up() {
+  local dir="$1" destination="${2:-}"
+  validate_workdir "$dir"
+  [[ ! -e "$dir" ]] || die "workdir already exists: $dir (run 'down' first)"
+
+  HERDR_BINARY="$(resolve_herdr)"
+  log "herdr binary: $HERDR_BINARY ($("$HERDR_BINARY" --version 2>&1 | head -1))"
+
+  # The fixture owns this account's `~/.config/herdr/config.toml`, its
+  # `session.json`, and a block in `~/.ssh/config` for the duration of the
+  # lane. If the account already has a herdr running, those files belong to a
+  # human right now — refuse rather than trample them.
+  if "$HERDR_BINARY" status server 2>/dev/null | grep -q '^status: running'; then
+    die "a herdr server is already running for $(id -un).
+  This lane takes over the account's herdr config and session state for the
+  duration of the run, so it refuses to start beside a live one. Quit herdr
+  (or run the lane as a different account) and try again."
+  fi
+
+  mkdir -p "$dir"
+  chmod 700 "$dir"
+  # From here on the fixture holds account-level files. Any failure must put
+  # them back: a half-provisioned `up` that left the account's herdr config
+  # replaced would be worse than no lane at all.
+  UP_IN_PROGRESS_DIR="$dir"
+  HERDR_SOCKET_PATH="$dir/herdr.sock"
+  export HERDR_SOCKET_PATH
+  # Recorded first, so `down` can still reach the binary if `up` dies partway.
+  printf '%s\n' "$HERDR_BINARY" > "$dir/herdr.bin"
+
+  # The forward under test builds its argv from the ALIAS alone, so the
+  # fixture's connection details have to live where ssh finds them: the
+  # account's ~/.ssh/config, in delimited blocks `down` removes again. This is
+  # the same file the app's own enrollment writes its host blocks into.
+  mkdir -p "$HOME/.ssh"
+  chmod 700 "$HOME/.ssh"
+  if [[ -f "$HOME/.ssh/config" ]]; then
+    cp "$HOME/.ssh/config" "$dir/ssh_config.bak"
+    if grep -qF "$SSH_CONFIG_BEGIN" "$HOME/.ssh/config" \
+      || grep -qF "$SSH_CONFIG_ALT_BEGIN" "$HOME/.ssh/config"; then
+      die "an earlier fixture block is still in ~/.ssh/config; run 'down' first"
+    fi
+  else
+    : > "$dir/ssh_config.absent"
+  fi
+
+  local alias_used="$destination" provisioned_ssh=0
+  if [[ -z "$destination" ]]; then
+    alias_used="$FIXTURE_ALIAS"
+    provisioned_ssh=1
+    provision_loopback_sshd "$dir"
+  else
+    log "using caller-supplied ssh destination '$destination' (no sshd provisioned)"
+  fi
+  write_canonicalization_aliases "$dir" "$alias_used"
+
+  # The panel row the whole-view client must render for the binding probe.
+  # Written as the account's REAL herdr config (backed up here, restored by
+  # `down`), because that is the file `herdr server reload-config` reads.
+  mkdir -p "$HOME/.config/herdr"
+  if [[ -f "$HOME/.config/herdr/config.toml" ]]; then
+    cp "$HOME/.config/herdr/config.toml" "$dir/herdr-config.bak"
+  else
+    : > "$dir/herdr-config.absent"
+  fi
+  # herdr persists its workspace/pane layout and restores it on the next
+  # start. A leftover session makes pane ids (and how many panes exist)
+  # depend on what ran before, which is exactly what a lane must not do.
+  if [[ -f "$HOME/.config/herdr/session.json" ]]; then
+    cp "$HOME/.config/herdr/session.json" "$dir/herdr-session.bak"
+  else
+    : > "$dir/herdr-session.absent"
+  fi
+  rm -f "$HOME/.config/herdr/session.json"
+  # `onboarding = false` matters: herdr's first-run setup screen has no
+  # workspace and therefore no pane, so `pane.current` answers pane_not_found
+  # forever and the fixture would never become ready. The update checks are
+  # off so the lane makes no network requests.
+  cat > "$HOME/.config/herdr/config.toml" <<'EOF'
+onboarding = false
+
+[update]
+version_check = false
+manifest_check = false
+
+[ui.sidebar.agents]
+rows = [["state_icon", "workspace", "tab"], ["agent"], [{ token = "$lvmark", dim = true }]]
+EOF
+
+  herdr_cli server </dev/null >"$dir/server.log" 2>&1 &
+  echo $! > "$dir/server.child.pid"
+  local waited=0
+  until [[ -S "$HERDR_SOCKET_PATH" ]]; do
+    (( waited < READY_TIMEOUT_SECONDS )) || die "herdr server never created $HERDR_SOCKET_PATH; see $dir/server.log"
+    sleep 1
+    waited=$((waited + 1))
+  done
+  log "herdr server listening on $HERDR_SOCKET_PATH"
+
+  # The whole-view client is what CREATES the first pane, so the pane the
+  # lane binds to and the surface that renders it are the same real client.
+  : > "$dir/surface.pids"
+  start_surface "$dir" "primary" "app"
+
+  local pane_id=""
+  waited=0
+  while true; do
+    # `|| true`: before the client has painted, `pane current` answers with a
+    # pane_not_found ERROR and a non-zero status, which `pipefail` would
+    # otherwise turn into an abort on the very first poll.
+    pane_id="$({ herdr_cli pane current 2>/dev/null || true; } \
+      | sed -n 's/.*"pane_id":"\([^"]*\)".*/\1/p' | head -1)"
+    if [[ -n "$pane_id" ]]; then
+      break
+    fi
+    if (( waited >= READY_TIMEOUT_SECONDS )); then
+      die "herdr never reported a focused pane; see $dir/surface-primary.log and $dir/server.log"
+    fi
+    sleep 1
+    waited=$((waited + 1))
+  done
+  log "focused pane: $pane_id"
+
+  # The agents panel renders rows PER AGENT-BEARING PANE, so a plain shell
+  # pane renders no row at all and no custom token could ever appear. This is
+  # the shape a real join targets: a pane whose agent an integration reported.
+  local agent_session_id="lvx-fixture-session-0001"
+  herdr_cli pane report-agent "$pane_id" \
+    --source "$FIXTURE_AGENT_SOURCE" --agent claude --state working \
+    --agent-session-id "$agent_session_id" >/dev/null
+  log "pane $pane_id marked agent-bearing (session $agent_session_id)"
+
+  printf '{"agentSessionID":"%s","alias":"%s","altUserAlias":"%s-altuser","otherPortAlias":"%s-otherport","herdrBinary":"%s","socketPath":"%s","paneID":"%s","primarySurfaceLog":"%s","provisionedSSH":%s,"workdir":"%s"}\n' \
+    "$agent_session_id" "$alias_used" "$alias_used" "$alias_used" \
+    "$HERDR_BINARY" "$HERDR_SOCKET_PATH" "$pane_id" \
+    "$dir/surface-primary.log" \
+    "$([[ $provisioned_ssh == 1 ]] && echo true || echo false)" \
+    "$dir" \
+    | tee "$dir/fixture.json"
+  UP_IN_PROGRESS_DIR=""
+}
+
+# --------------------------------------------------------------- misc
+
+load_context() {
+  local dir="$1"
+  validate_workdir "$dir"
+  [[ -d "$dir" ]] || die "workdir not found: $dir"
+  HERDR_BINARY="$(cat "$dir/herdr.bin" 2>/dev/null || true)"
+  [[ -x "$HERDR_BINARY" ]] || die "fixture workdir has no usable herdr binary record: $dir"
+  HERDR_SOCKET_PATH="$dir/herdr.sock"
+  export HERDR_SOCKET_PATH
+}
+
+command_surface() {
+  local dir="$1" name="$2" mode="$3" pane="${4:-}"
+  load_context "$dir"
+  start_surface "$dir" "$name" "$mode" "$pane"
+}
+
+command_reload() {
+  local dir="$1"
+  load_context "$dir"
+  herdr_cli server reload-config
+}
+
+command_down() {
+  local dir="$1"
+  validate_workdir "$dir"
+  if [[ ! -d "$dir" ]]; then
+    log "nothing to tear down at $dir"
+    return 0
+  fi
+  HERDR_BINARY="$(cat "$dir/herdr.bin" 2>/dev/null || true)"
+  HERDR_SOCKET_PATH="$dir/herdr.sock"
+  export HERDR_SOCKET_PATH
+
+  local pid
+  if [[ -f "$dir/surface.pids" ]]; then
+    while IFS= read -r pid; do
+      [[ -n "$pid" ]] && kill "$pid" 2>/dev/null || true
+    done < "$dir/surface.pids"
+  fi
+  if [[ -x "$HERDR_BINARY" ]]; then
+    HERDR_SOCKET_PATH="$HERDR_SOCKET_PATH" "$HERDR_BINARY" server stop >/dev/null 2>&1 || true
+  fi
+  for pid in "$dir/server.child.pid" "$dir/sshd.child.pid"; do
+    kill "$(cat "$pid" 2>/dev/null || true)" 2>/dev/null || true
+  done
+  if [[ -f "$dir/sshd.pid" ]]; then
+    kill "$(cat "$dir/sshd.pid" 2>/dev/null || true)" 2>/dev/null || true
+  fi
+
+  # Restore the account's files before anything else can fail.
+  if [[ -f "$dir/ssh_config.bak" ]]; then
+    cp "$dir/ssh_config.bak" "$HOME/.ssh/config"
+  elif [[ -f "$dir/ssh_config.absent" ]]; then
+    rm -f "$HOME/.ssh/config"
+  fi
+  if [[ -f "$dir/herdr-config.bak" ]]; then
+    cp "$dir/herdr-config.bak" "$HOME/.config/herdr/config.toml"
+  elif [[ -f "$dir/herdr-config.absent" ]]; then
+    rm -f "$HOME/.config/herdr/config.toml"
+  fi
+  if [[ -f "$dir/herdr-session.bak" ]]; then
+    cp "$dir/herdr-session.bak" "$HOME/.config/herdr/session.json"
+  elif [[ -f "$dir/herdr-session.absent" ]]; then
+    rm -f "$HOME/.config/herdr/session.json"
+  fi
+
+  rm -rf "$dir"
+  log "torn down $dir"
+}
+
+VERB="${1:-}"
+shift || true
+case "$VERB" in
+  up)
+    [[ $# -ge 1 && $# -le 2 ]] || die "usage: $0 up <workdir> [ssh-destination]"
+    command_up "$@"
+    ;;
+  surface)
+    [[ $# -ge 3 && $# -le 4 ]] || die "usage: $0 surface <workdir> <name> <app|attach> [pane-id]"
+    command_surface "$@"
+    ;;
+  reload)
+    [[ $# -eq 1 ]] || die "usage: $0 reload <workdir>"
+    command_reload "$@"
+    ;;
+  down)
+    [[ $# -eq 1 ]] || die "usage: $0 down <workdir>"
+    command_down "$@"
+    ;;
+  *)
+    die "usage: $0 [up|surface|reload|down] ..."
+    ;;
+esac

--- a/scripts/herdr-integration-fixture.sh
+++ b/scripts/herdr-integration-fixture.sh
@@ -14,17 +14,44 @@
 #   scripts/herdr-integration-fixture.sh surface <workdir> <name> <app|attach> [pane-id]
 #   scripts/herdr-integration-fixture.sh reload  <workdir>
 #   scripts/herdr-integration-fixture.sh down    <workdir>
+#   scripts/herdr-integration-fixture.sh recover
+#   scripts/herdr-integration-fixture.sh status
 #
 # `up` prints one JSON object on stdout describing the fixture; every other
 # diagnostic goes to stderr. With no ssh-destination it provisions its OWN
 # loopback sshd (hermetic: no second machine, nothing added to the account's
 # real authorized_keys) and uses the alias `lvx-herdr-fixture`. Pass a
 # destination to aim the same lane at a real second host instead; the ssh half
-# is then the caller's own already-working configuration and is left untouched.
+# is then the caller's own already-working configuration.
+#
+# ## Files this borrows from the account, and how they come back
+#
+# For the duration of a run the fixture replaces the account's herdr
+# `config.toml`, removes its `session.json`, and appends two delimited blocks
+# to its `~/.ssh/config`. It has to touch the REAL ssh config because the code
+# under test never passes `-F`: the app's forward argv and
+# `SSHDestinationCanonicalizer.live()` both run `ssh` / `ssh -G` against the
+# user's default configuration chain, so an alias that only existed in a
+# fixture-local file would exercise an invocation shape the app never
+# produces.
+#
+# Because a run can be SIGKILLed (a torn-down runner, a sleeping Mac, a manual
+# kill of a wedged xctest), the pristine originals do NOT live in the run's own
+# temp dir — that would strand them when the run dies, and the NEXT run would
+# then back up the already-modified files and destroy the originals for good.
+# They live at a stable, discoverable path instead:
+#
+#   ~/.localvoxtral-herdr-fixture-hold/   manifest + pristine copies
+#
+# The manifest is written AFTER the pristine copies and BEFORE the first
+# modification, so a crash at any point leaves either nothing held or a
+# complete, restorable hold. `up` refuses to overwrite an existing hold; it
+# restores a dead run's hold first, and refuses outright while a live run owns
+# it. `recover` restores by hand.
 #
 # Deliberately loud: every precondition that cannot be met exits non-zero with
-# the exact provisioning step. This lane must never look green because
-# something was missing.
+# the exact recovery or provisioning step. This lane must never look green
+# because something was missing.
 set -euo pipefail
 
 FIXTURE_ALIAS="lvx-herdr-fixture"
@@ -42,10 +69,19 @@ SURFACE_COLUMNS=130
 SURFACE_ROWS=45
 READY_TIMEOUT_SECONDS=30
 
+# Account-level paths, resolved once at load. A sourcing test sets HOME before
+# sourcing this file (see scripts/ci/test-herdr-fixture-recovery.sh).
+HERDR_CONFIG_FILE="$HOME/.config/herdr/config.toml"
+HERDR_SESSION_FILE="$HOME/.config/herdr/session.json"
+SSH_CONFIG_FILE="$HOME/.ssh/config"
+HOLD_DIR="$HOME/.localvoxtral-herdr-fixture-hold"
+HOLD_MANIFEST="$HOLD_DIR/manifest"
+
 log() { printf '[herdr-fixture] %s\n' "$*" >&2; }
 
-# Set while `up` holds account-level files (herdr config/session, an
-# ~/.ssh/config block). Cleared once `up` has fully succeeded.
+# Set while `up` is between "started modifying things" and "fully succeeded".
+# A failure in that window restores through the EXIT trap; a KILL in it (or at
+# any point afterwards) is what the hold directory exists for.
 UP_IN_PROGRESS_DIR=""
 
 restore_after_failed_up() {
@@ -55,12 +91,165 @@ restore_after_failed_up() {
     command_down "$UP_IN_PROGRESS_DIR" >/dev/null 2>&1 || true
   fi
 }
-trap restore_after_failed_up EXIT
 
 die() {
   printf '[herdr-fixture] ERROR: %s\n' "$*" >&2
   exit 1
 }
+
+recovery_hint() {
+  printf '%s recover' "${BASH_SOURCE[0]}"
+}
+
+# ---------------------------------------------------------- held state
+
+hold_is_present() { [[ -f "$HOLD_MANIFEST" ]]; }
+
+hold_field() {
+  local key="$1"
+  [[ -f "$HOLD_MANIFEST" ]] || return 0
+  sed -n "s/^${key}=//p" "$HOLD_MANIFEST" | head -1
+}
+
+# Is the process that took the hold still running THIS script? A pid alone
+# would be fooled by reuse; the command check makes a false "live" essentially
+# impossible, and a false "dead" only costs a restore that was going to happen
+# anyway.
+hold_owner_is_alive() {
+  local pid
+  pid="$(hold_field pid)"
+  [[ -n "$pid" ]] || return 1
+  kill -0 "$pid" 2>/dev/null || return 1
+  ps -o command= -p "$pid" 2>/dev/null | grep -q 'herdr-integration-fixture' || return 1
+  return 0
+}
+
+# Copy the account's files aside and COMMIT the manifest, in that order, before
+# anything is modified. Refuses if a hold already exists: overwriting a
+# pristine copy with an already-modified file is the one step that turns a
+# recoverable interruption into permanent data loss.
+hold_account_files() {
+  local dir="$1"
+  if hold_is_present; then
+    die "held state already exists at $HOLD_DIR; refusing to overwrite the pristine copies.
+  Run: $(recovery_hint)"
+  fi
+  mkdir -p "$HOLD_DIR"
+  chmod 700 "$HOLD_DIR"
+  rm -f "$HOLD_DIR"/*.pristine "$HOLD_DIR"/*.absent "$HOLD_DIR"/*.created 2>/dev/null || true
+
+  mkdir -p "$(dirname "$HERDR_CONFIG_FILE")"
+  if [[ -f "$HERDR_CONFIG_FILE" ]]; then
+    cp "$HERDR_CONFIG_FILE" "$HOLD_DIR/herdr-config.pristine"
+  else
+    : > "$HOLD_DIR/herdr-config.absent"
+  fi
+  if [[ -f "$HERDR_SESSION_FILE" ]]; then
+    cp "$HERDR_SESSION_FILE" "$HOLD_DIR/herdr-session.pristine"
+  else
+    : > "$HOLD_DIR/herdr-session.absent"
+  fi
+  mkdir -p "$(dirname "$SSH_CONFIG_FILE")"
+  chmod 700 "$(dirname "$SSH_CONFIG_FILE")"
+  if [[ -f "$SSH_CONFIG_FILE" ]]; then
+    # Informational only — the ssh config is restored by REMOVING our
+    # delimited blocks, never by writing this copy back, so an edit the user
+    # makes while the lane runs survives.
+    cp "$SSH_CONFIG_FILE" "$HOLD_DIR/ssh-config.pristine"
+  else
+    : > "$HOLD_DIR/ssh-config.created"
+  fi
+
+  # Manifest last, and atomically: a crash before this leaves pristine copies
+  # nobody will read and nothing modified; a crash after it leaves a hold that
+  # `up` or `recover` can act on.
+  {
+    printf 'workdir=%s\n' "$dir"
+    printf 'pid=%s\n' "$$"
+    printf 'startedAt=%s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+    printf 'home=%s\n' "$HOME"
+  } > "$HOLD_DIR/manifest.tmp"
+  mv "$HOLD_DIR/manifest.tmp" "$HOLD_MANIFEST"
+  log "holding this account's herdr config, session and ssh config (backups in $HOLD_DIR)"
+}
+
+# Drop our delimited blocks from the ssh config in place. Idempotent, and it
+# leaves anything the user added while the lane ran untouched.
+strip_ssh_config_blocks() {
+  [[ -f "$SSH_CONFIG_FILE" ]] || return 0
+  local tmp
+  tmp="$(mktemp "${TMPDIR:-/tmp}/lvx-sshcfg.XXXXXX")"
+  awk -v b1="$SSH_CONFIG_BEGIN" -v e1="$SSH_CONFIG_END" \
+      -v b2="$SSH_CONFIG_ALT_BEGIN" -v e2="$SSH_CONFIG_ALT_END" '
+    $0 == b1 || $0 == b2 { skip = 1; next }
+    $0 == e1 || $0 == e2 { skip = 0; next }
+    !skip { print }
+  ' "$SSH_CONFIG_FILE" > "$tmp"
+  cat "$tmp" > "$SSH_CONFIG_FILE"
+  rm -f "$tmp"
+  chmod 600 "$SSH_CONFIG_FILE"
+  # Only remove the file if the fixture is the reason it exists at all.
+  if [[ ! -s "$SSH_CONFIG_FILE" && -f "$HOLD_DIR/ssh-config.created" ]]; then
+    rm -f "$SSH_CONFIG_FILE"
+  fi
+}
+
+# Put the account back and drop the hold. Safe to call when nothing is held.
+release_account_files() {
+  hold_is_present || return 0
+  mkdir -p "$(dirname "$HERDR_CONFIG_FILE")"
+  if [[ -f "$HOLD_DIR/herdr-config.pristine" ]]; then
+    cp "$HOLD_DIR/herdr-config.pristine" "$HERDR_CONFIG_FILE"
+  elif [[ -f "$HOLD_DIR/herdr-config.absent" ]]; then
+    rm -f "$HERDR_CONFIG_FILE"
+  fi
+  if [[ -f "$HOLD_DIR/herdr-session.pristine" ]]; then
+    cp "$HOLD_DIR/herdr-session.pristine" "$HERDR_SESSION_FILE"
+  elif [[ -f "$HOLD_DIR/herdr-session.absent" ]]; then
+    rm -f "$HERDR_SESSION_FILE"
+  fi
+  strip_ssh_config_blocks
+  rm -rf "$HOLD_DIR"
+  log "restored this account's herdr config, session and ssh config"
+}
+
+# `down <dir>` must not release a hold that belongs to a DIFFERENT run.
+release_account_files_if_held_by() {
+  local dir="$1" owner
+  hold_is_present || return 0
+  owner="$(hold_field workdir)"
+  if [[ -n "$owner" && "$owner" != "$dir" ]]; then
+    log "held state belongs to $owner, not $dir — leaving it alone"
+    return 0
+  fi
+  release_account_files
+}
+
+# Called at the START of `up`. A hold from a run that is still alive means two
+# lanes are racing for one account: refuse. A hold from a dead run is exactly
+# what the stable path exists for: restore it, loudly, and carry on.
+reclaim_or_refuse_stale_hold() {
+  hold_is_present || return 0
+  local owner started
+  owner="$(hold_field workdir)"
+  started="$(hold_field startedAt)"
+  if hold_owner_is_alive; then
+    die "another herdr fixture run (pid $(hold_field pid), started $started) is holding
+  this account's files. Wait for it to finish, or if you know it is dead:
+    $(recovery_hint)"
+  fi
+  log "found held state from an interrupted run (started $started, workdir $owner)"
+  if [[ -n "$owner" && -d "$owner" ]]; then
+    stop_workdir_processes "$owner"
+    rm -rf "$owner"
+  fi
+  release_account_files
+  if hold_is_present; then
+    die "could not restore the interrupted run's held state. Run: $(recovery_hint)"
+  fi
+}
+
+# ------------------------------------------------------------- helpers
 
 # Absolute path to the herdr binary. PATH first (so an owner's own install
 # wins), then the two package-manager prefixes; never a relative path.
@@ -111,6 +300,28 @@ free_port() {
     fi
   done
   die "could not find a free loopback port for the fixture sshd"
+}
+
+herdr_cli() {
+  HERDR_SOCKET_PATH="$HERDR_SOCKET_PATH" "$HERDR_BINARY" "$@"
+}
+
+# Kill whatever a run left behind in its own workdir. Touches no account files.
+stop_workdir_processes() {
+  local dir="$1" pid binary
+  [[ -d "$dir" ]] || return 0
+  binary="$(cat "$dir/herdr.bin" 2>/dev/null || true)"
+  if [[ -f "$dir/surface.pids" ]]; then
+    while IFS= read -r pid; do
+      [[ -n "$pid" ]] && kill "$pid" 2>/dev/null || true
+    done < "$dir/surface.pids"
+  fi
+  if [[ -x "$binary" ]]; then
+    HERDR_SOCKET_PATH="$dir/herdr.sock" "$binary" server stop >/dev/null 2>&1 || true
+  fi
+  for pid in "$dir/server.child.pid" "$dir/sshd.child.pid" "$dir/sshd.pid"; do
+    kill "$(cat "$pid" 2>/dev/null || true)" 2>/dev/null || true
+  done
 }
 
 # ---------------------------------------------------------------- up
@@ -182,8 +393,8 @@ EOF
     printf '  UserKnownHostsFile %s\n' "$dir/known_hosts"
     printf '  StrictHostKeyChecking yes\n'
     printf '%s\n' "$SSH_CONFIG_END"
-  } >> "$HOME/.ssh/config"
-  chmod 600 "$HOME/.ssh/config"
+  } >> "$SSH_CONFIG_FILE"
+  chmod 600 "$SSH_CONFIG_FILE"
   printf '%s\n' "$port" > "$dir/sshd.port"
 }
 
@@ -197,7 +408,7 @@ EOF
 # Written for BOTH modes so the test asserts the same thing whether the lane
 # runs hermetically or against a real second host.
 write_canonicalization_aliases() {
-  local dir="$1" alias_used="$2" hostname port other_port
+  local alias_used="$1" hostname port other_port
   hostname="$(ssh -G -- "$alias_used" 2>/dev/null | awk '$1 == "hostname" { print $2; exit }')"
   port="$(ssh -G -- "$alias_used" 2>/dev/null | awk '$1 == "port" { print $2; exit }')"
   if [[ -z "$hostname" || -z "$port" ]]; then
@@ -214,8 +425,8 @@ write_canonicalization_aliases() {
     printf '  HostName %s\n' "$hostname"
     printf '  Port %s\n' "$other_port"
     printf '%s\n' "$SSH_CONFIG_ALT_END"
-  } >> "$HOME/.ssh/config"
-  chmod 600 "$HOME/.ssh/config"
+  } >> "$SSH_CONFIG_FILE"
+  chmod 600 "$SSH_CONFIG_FILE"
 }
 
 start_surface() {
@@ -242,10 +453,6 @@ start_surface() {
   log "surface '$name' ($mode) started -> $dir/surface-$name.log"
 }
 
-herdr_cli() {
-  HERDR_SOCKET_PATH="$HERDR_SOCKET_PATH" "$HERDR_BINARY" "$@"
-}
-
 command_up() {
   local dir="$1" destination="${2:-}"
   validate_workdir "$dir"
@@ -254,10 +461,10 @@ command_up() {
   HERDR_BINARY="$(resolve_herdr)"
   log "herdr binary: $HERDR_BINARY ($("$HERDR_BINARY" --version 2>&1 | head -1))"
 
-  # The fixture owns this account's `~/.config/herdr/config.toml`, its
-  # `session.json`, and a block in `~/.ssh/config` for the duration of the
-  # lane. If the account already has a herdr running, those files belong to a
-  # human right now — refuse rather than trample them.
+  # The fixture owns this account's herdr config, its session state and a
+  # block in its ssh config for the duration of the lane. If the account
+  # already has a herdr running, those files belong to a human right now —
+  # refuse rather than trample them.
   if "$HERDR_BINARY" status server 2>/dev/null | grep -q '^status: running'; then
     die "a herdr server is already running for $(id -un).
   This lane takes over the account's herdr config and session state for the
@@ -265,31 +472,28 @@ command_up() {
   (or run the lane as a different account) and try again."
   fi
 
+  # Before anything is created or modified: hand back whatever an interrupted
+  # run left held, or refuse if a live run owns it.
+  reclaim_or_refuse_stale_hold
+
   mkdir -p "$dir"
   chmod 700 "$dir"
-  # From here on the fixture holds account-level files. Any failure must put
-  # them back: a half-provisioned `up` that left the account's herdr config
-  # replaced would be worse than no lane at all.
   UP_IN_PROGRESS_DIR="$dir"
   HERDR_SOCKET_PATH="$dir/herdr.sock"
   export HERDR_SOCKET_PATH
-  # Recorded first, so `down` can still reach the binary if `up` dies partway.
+  # Recorded first, so teardown can still reach the binary if `up` dies partway.
   printf '%s\n' "$HERDR_BINARY" > "$dir/herdr.bin"
 
-  # The forward under test builds its argv from the ALIAS alone, so the
-  # fixture's connection details have to live where ssh finds them: the
-  # account's ~/.ssh/config, in delimited blocks `down` removes again. This is
-  # the same file the app's own enrollment writes its host blocks into.
-  mkdir -p "$HOME/.ssh"
-  chmod 700 "$HOME/.ssh"
-  if [[ -f "$HOME/.ssh/config" ]]; then
-    cp "$HOME/.ssh/config" "$dir/ssh_config.bak"
-    if grep -qF "$SSH_CONFIG_BEGIN" "$HOME/.ssh/config" \
-      || grep -qF "$SSH_CONFIG_ALT_BEGIN" "$HOME/.ssh/config"; then
-      die "an earlier fixture block is still in ~/.ssh/config; run 'down' first"
-    fi
-  else
-    : > "$dir/ssh_config.absent"
+  hold_account_files "$dir"
+
+  # The forward under test builds its argv from the ALIAS alone and never
+  # passes -F, so the fixture's connection details have to live where ssh
+  # actually looks: the account's ~/.ssh/config, in delimited blocks teardown
+  # removes again. This is the same file the app's own enrollment writes its
+  # host blocks into.
+  if [[ -f "$SSH_CONFIG_FILE" ]] \
+    && grep -qF "$SSH_CONFIG_BEGIN" "$SSH_CONFIG_FILE"; then
+    die "a fixture block is still in $SSH_CONFIG_FILE. Run: $(recovery_hint)"
   fi
 
   local alias_used="$destination" provisioned_ssh=0
@@ -300,31 +504,17 @@ command_up() {
   else
     log "using caller-supplied ssh destination '$destination' (no sshd provisioned)"
   fi
-  write_canonicalization_aliases "$dir" "$alias_used"
+  write_canonicalization_aliases "$alias_used"
 
-  # The panel row the whole-view client must render for the binding probe.
-  # Written as the account's REAL herdr config (backed up here, restored by
-  # `down`), because that is the file `herdr server reload-config` reads.
-  mkdir -p "$HOME/.config/herdr"
-  if [[ -f "$HOME/.config/herdr/config.toml" ]]; then
-    cp "$HOME/.config/herdr/config.toml" "$dir/herdr-config.bak"
-  else
-    : > "$dir/herdr-config.absent"
-  fi
   # herdr persists its workspace/pane layout and restores it on the next
-  # start. A leftover session makes pane ids (and how many panes exist)
-  # depend on what ran before, which is exactly what a lane must not do.
-  if [[ -f "$HOME/.config/herdr/session.json" ]]; then
-    cp "$HOME/.config/herdr/session.json" "$dir/herdr-session.bak"
-  else
-    : > "$dir/herdr-session.absent"
-  fi
-  rm -f "$HOME/.config/herdr/session.json"
+  # start. A leftover session makes pane ids (and how many panes exist) depend
+  # on what ran before, which is exactly what a lane must not do.
+  rm -f "$HERDR_SESSION_FILE"
   # `onboarding = false` matters: herdr's first-run setup screen has no
   # workspace and therefore no pane, so `pane.current` answers pane_not_found
   # forever and the fixture would never become ready. The update checks are
   # off so the lane makes no network requests.
-  cat > "$HOME/.config/herdr/config.toml" <<'EOF'
+  cat > "$HERDR_CONFIG_FILE" <<'EOF'
 onboarding = false
 
 [update]
@@ -424,50 +614,61 @@ command_reload() {
 command_down() {
   local dir="$1"
   validate_workdir "$dir"
-  if [[ ! -d "$dir" ]]; then
+  if [[ -d "$dir" ]]; then
+    stop_workdir_processes "$dir"
+    rm -rf "$dir"
+    log "torn down $dir"
+  else
     log "nothing to tear down at $dir"
+  fi
+  release_account_files_if_held_by "$dir"
+}
+
+# The verb a human runs after a killed run. Needs no workdir: everything it
+# needs is in the hold directory.
+command_recover() {
+  if ! hold_is_present; then
+    log "nothing held — this account's files are already its own"
     return 0
   fi
-  HERDR_BINARY="$(cat "$dir/herdr.bin" 2>/dev/null || true)"
-  HERDR_SOCKET_PATH="$dir/herdr.sock"
-  export HERDR_SOCKET_PATH
-
-  local pid
-  if [[ -f "$dir/surface.pids" ]]; then
-    while IFS= read -r pid; do
-      [[ -n "$pid" ]] && kill "$pid" 2>/dev/null || true
-    done < "$dir/surface.pids"
+  local owner
+  owner="$(hold_field workdir)"
+  if hold_owner_is_alive; then
+    die "a herdr fixture run (pid $(hold_field pid)) is still alive and holding these
+  files. Stop it first, then re-run recover."
   fi
-  if [[ -x "$HERDR_BINARY" ]]; then
-    HERDR_SOCKET_PATH="$HERDR_SOCKET_PATH" "$HERDR_BINARY" server stop >/dev/null 2>&1 || true
+  log "recovering held state from $owner (started $(hold_field startedAt))"
+  if [[ -n "$owner" && -d "$owner" ]]; then
+    stop_workdir_processes "$owner"
+    rm -rf "$owner"
   fi
-  for pid in "$dir/server.child.pid" "$dir/sshd.child.pid"; do
-    kill "$(cat "$pid" 2>/dev/null || true)" 2>/dev/null || true
-  done
-  if [[ -f "$dir/sshd.pid" ]]; then
-    kill "$(cat "$dir/sshd.pid" 2>/dev/null || true)" 2>/dev/null || true
-  fi
-
-  # Restore the account's files before anything else can fail.
-  if [[ -f "$dir/ssh_config.bak" ]]; then
-    cp "$dir/ssh_config.bak" "$HOME/.ssh/config"
-  elif [[ -f "$dir/ssh_config.absent" ]]; then
-    rm -f "$HOME/.ssh/config"
-  fi
-  if [[ -f "$dir/herdr-config.bak" ]]; then
-    cp "$dir/herdr-config.bak" "$HOME/.config/herdr/config.toml"
-  elif [[ -f "$dir/herdr-config.absent" ]]; then
-    rm -f "$HOME/.config/herdr/config.toml"
-  fi
-  if [[ -f "$dir/herdr-session.bak" ]]; then
-    cp "$dir/herdr-session.bak" "$HOME/.config/herdr/session.json"
-  elif [[ -f "$dir/herdr-session.absent" ]]; then
-    rm -f "$HOME/.config/herdr/session.json"
-  fi
-
-  rm -rf "$dir"
-  log "torn down $dir"
+  release_account_files
 }
+
+command_status() {
+  if ! hold_is_present; then
+    printf 'held=false\n'
+    return 0
+  fi
+  printf 'held=true\n'
+  printf 'workdir=%s\n' "$(hold_field workdir)"
+  printf 'pid=%s\n' "$(hold_field pid)"
+  printf 'startedAt=%s\n' "$(hold_field startedAt)"
+  printf 'ownerAlive=%s\n' "$(hold_owner_is_alive && echo true || echo false)"
+  printf 'backups=%s\n' "$HOLD_DIR"
+}
+
+# Shell regression tests source the reviewed implementation directly, exactly
+# like scripts/mac/localvoxtral-build-gate.sh does. This variable cannot make
+# a real invocation behave differently: it only suppresses dispatch.
+if [[ "${LOCALVOXTRAL_HERDR_FIXTURE_SOURCE_ONLY:-0}" == "1" ]]; then
+  if [[ "${BASH_SOURCE[0]}" != "$0" ]]; then
+    return 0
+  fi
+  exit 0
+fi
+
+trap restore_after_failed_up EXIT
 
 VERB="${1:-}"
 shift || true
@@ -488,7 +689,15 @@ case "$VERB" in
     [[ $# -eq 1 ]] || die "usage: $0 down <workdir>"
     command_down "$@"
     ;;
+  recover)
+    [[ $# -eq 0 ]] || die "usage: $0 recover"
+    command_recover
+    ;;
+  status)
+    [[ $# -eq 0 ]] || die "usage: $0 status"
+    command_status
+    ;;
   *)
-    die "usage: $0 [up|surface|reload|down] ..."
+    die "usage: $0 [up|surface|reload|down|recover|status] ..."
     ;;
 esac

--- a/scripts/herdr-integration-fixture.sh
+++ b/scripts/herdr-integration-fixture.sh
@@ -350,20 +350,29 @@ EOF
   : > "$dir/surface.pids"
   start_surface "$dir" "primary" "app"
 
-  local pane_id=""
+  # The pane the lane binds to must be the one the CLIENT owns, not herdr's
+  # transient startup pane. A headless server spawns a pane of its own before
+  # any client connects; the whole-view client then retires it and creates its
+  # own in a new workspace. Reading `pane current` once can latch that dying
+  # pane, and every later request answers `pane_not_found` for it (seen on the
+  # CI runner, where the timing differed from the dev box). So: require the id
+  # to be UNCHANGED across two reads a second apart AND to still resolve.
+  local pane_id="" previous=""
   waited=0
   while true; do
-    # `|| true`: before the client has painted, `pane current` answers with a
+    # `|| true`: before a pane exists, `pane current` answers with a
     # pane_not_found ERROR and a non-zero status, which `pipefail` would
     # otherwise turn into an abort on the very first poll.
     pane_id="$({ herdr_cli pane current 2>/dev/null || true; } \
       | sed -n 's/.*"pane_id":"\([^"]*\)".*/\1/p' | head -1)"
-    if [[ -n "$pane_id" ]]; then
+    if [[ -n "$pane_id" && "$pane_id" == "$previous" ]] \
+      && herdr_cli pane get "$pane_id" >/dev/null 2>&1; then
       break
     fi
     if (( waited >= READY_TIMEOUT_SECONDS )); then
-      die "herdr never reported a focused pane; see $dir/surface-primary.log and $dir/server.log"
+      die "herdr never settled on a focused pane; see $dir/surface-primary.log and $dir/server.log"
     fi
+    previous="$pane_id"
     sleep 1
     waited=$((waited + 1))
   done

--- a/scripts/mac/README.md
+++ b/scripts/mac/README.md
@@ -20,6 +20,29 @@ metal` succeeds even when the component is missing (the shim exists), so
 only an actual invocation (`xcrun metal --version`) proves it works. Runs
 as a normal user, no sudo needed.
 
+## herdr, for the live integration lane
+
+`./scripts/remote-build.sh integration-herdr` (and CI's conditional herdr
+lane) needs the `herdr` binary present on this machine. It is the only
+prerequisite — the lane provisions its own loopback sshd, its own keys and its
+own `authorized_keys` file, so nothing is added to any account's real SSH
+trust.
+
+```bash
+brew install herdr        # or https://herdr.dev; HERDR_BIN overrides the lookup
+herdr --version           # 0.8.2 is what the lane's assumptions were measured against
+```
+
+Its absence fails the lane loudly with the install step rather than skipping.
+
+What the lane borrows while it runs, and gives back on teardown: the running
+account's `~/.config/herdr/config.toml` and `session.json`, plus a delimited
+block in its `~/.ssh/config`. It refuses to start at all if that account
+already has a herdr server running, so it can never trample a live session —
+if the owner is using herdr on the runner account, the lane fails instead of
+taking over. Details and the full assumption list: `docs/agent/test-tiers.md`
+and `docs/agent/remote-herdr-panel-binding.md`.
+
 ## On-demand test servers (speechd + polishd) — owner runbook
 
 The two build-host model servers used by the integration/eval suites are the

--- a/scripts/mac/README.md
+++ b/scripts/mac/README.md
@@ -36,12 +36,31 @@ herdr --version           # 0.8.2 is what the lane's assumptions were measured a
 Its absence fails the lane loudly with the install step rather than skipping.
 
 What the lane borrows while it runs, and gives back on teardown: the running
-account's `~/.config/herdr/config.toml` and `session.json`, plus a delimited
-block in its `~/.ssh/config`. It refuses to start at all if that account
+account's `~/.config/herdr/config.toml` and `session.json`, plus two delimited
+blocks in its `~/.ssh/config`. It refuses to start at all if that account
 already has a herdr server running, so it can never trample a live session —
 if the owner is using herdr on the runner account, the lane fails instead of
-taking over. Details and the full assumption list: `docs/agent/test-tiers.md`
-and `docs/agent/remote-herdr-panel-binding.md`.
+taking over.
+
+### If a run is killed before it gives them back
+
+Nothing runs on SIGKILL, so the pristine originals do not live in the run's
+temp dir — they live at a stable path, `~/.localvoxtral-herdr-fixture-hold/`,
+with a manifest naming the run that took them. The next `up` restores a dead
+run's hold before doing anything else and refuses while a live run owns it, so
+a killed run heals itself and two runs never fight over one account. To do it
+by hand:
+
+```bash
+./scripts/herdr-integration-fixture.sh status    # is anything held, and by whom
+./scripts/herdr-integration-fixture.sh recover   # restore and drop the hold
+```
+
+`recover` needs no arguments and works even if the run's temp dir is gone. It
+refuses while the holding process is still alive — stop that first.
+
+Details and the full assumption list: `docs/agent/test-tiers.md` and
+`docs/agent/remote-herdr-panel-binding.md`.
 
 ## On-demand test servers (speechd + polishd) — owner runbook
 

--- a/scripts/remote-build.sh
+++ b/scripts/remote-build.sh
@@ -6,7 +6,7 @@ set -euo pipefail
 # tree (no commit needed) and runs the toolchain remotely over SSH.
 #
 # Usage:
-#   ./scripts/remote-build.sh [build|test|integration|integration-polishd|integration-speechd|speechd-bench|eval-llm|eval-e2e|dogfood|dogfood-package|package|exec|diag|applog|voxlog|svc-status|disk|gc] [extra args...]
+#   ./scripts/remote-build.sh [build|test|integration|integration-polishd|integration-speechd|integration-herdr|speechd-bench|eval-llm|eval-e2e|dogfood|dogfood-package|package|exec|diag|applog|voxlog|svc-status|disk|gc] [extra args...]
 #     build        swift build
 #     test         swift build + unit tests (default; skips live-backend suites)
 #     integration  realtime pipeline tests against the live speechd STT service
@@ -18,6 +18,14 @@ set -euo pipefail
 #                  spawn the packaged speech helper (built by `package`),
 #                  transcribe real audio through the production websocket
 #                  client, and assert accuracy + delta + parent-pid contracts
+#     integration-herdr
+#                  the remote-herdr join machinery against a LIVE herdr server
+#                  over a REAL ssh -L forward: real HerdrSocketClient, real
+#                  forward coordinator, real ssh -G canonicalization, real
+#                  ~/.config/herdr/config.toml patch. With no argument the
+#                  fixture provisions its own loopback sshd (hermetic); pass an
+#                  ssh destination for a true two-host run. Needs `herdr`
+#                  installed on the build host.
 #     speechd-bench run the packaged speech helper's streaming benchmark;
 #                  optional args = seconds (default 60), cadence ms
 #                  (default 100 = the production step cadence), and
@@ -247,7 +255,8 @@ esac
 
 UNIT_TEST_SKIPS=(--skip RealtimeAPIVLLMIntegrationTests --skip LLMPolishPromptEvalTests
   --skip PolishHelperIntegrationTests --skip SpeechHelperIntegrationTests
-  --skip SpeechdStreamingBenchTests --skip AgentDictationE2EEvalTests)
+  --skip SpeechdStreamingBenchTests --skip AgentDictationE2EEvalTests
+  --skip HerdrIntegrationTests)
 
 # On-demand test server to warm before the suite runs (empty = none). The
 # build host's speechd/polishd launchd test services are launch-on-demand to
@@ -314,6 +323,42 @@ case "$CMD" in
         >"$SPEECHD_MARKER"
     fi
     REMOTE_CMD=(swift test --filter SpeechHelperIntegrationTests)
+    ;;
+  integration-herdr)
+    # Live herdr join machinery: a real `herdr` server, a real `ssh -L`
+    # forward opened by the app's own coordinator, and the real socket
+    # client/probe/enrollment patch on top of them. Same
+    # marker-through-the-tree shape as the other live lanes, because the SSH
+    # build gate only allowlists exact `swift test ...` payloads and cannot
+    # carry per-command environment.
+    #
+    # With no argument the suite's fixture provisions its OWN loopback sshd
+    # (its own keys, its own authorized_keys file — the account's are never
+    # touched), so the lane is hermetic and needs no second machine. Pass an
+    # ssh destination to run the identical lane against a real second host
+    # you have already configured.
+    #
+    # Requires `herdr` on the build host; its absence fails the lane loudly
+    # rather than skipping (see docs/agent/test-tiers.md).
+    if [[ $# -gt 1 ]]; then
+      echo "integration-herdr accepts at most one argument (ssh destination)" >&2
+      exit 1
+    fi
+    HERDR_DESTINATION="${1:-}"
+    if [[ -n "$HERDR_DESTINATION" && ! "$HERDR_DESTINATION" =~ ^[A-Za-z0-9._-]+$ ]]; then
+      echo "integration-herdr destination must be a plain ssh alias or host" >&2
+      exit 1
+    fi
+    HERDR_MARKER="$ROOT_DIR/.herdr-integration-enable.json"
+    # Registered before the marker exists, so no kill window leaves a stale
+    # marker behind — locally or in the remote work dir.
+    trap 'cleanup_transient_marker "$HERDR_MARKER"' EXIT
+    if [[ -n "$HERDR_DESTINATION" ]]; then
+      printf '{"destination": "%s"}\n' "$HERDR_DESTINATION" >"$HERDR_MARKER"
+    else
+      printf '{}\n' >"$HERDR_MARKER"
+    fi
+    REMOTE_CMD=(swift test --filter HerdrIntegrationTests)
     ;;
   speechd-bench)
     # The SSH gate does not allow arbitrary packaged-binary execution. A marker-gated
@@ -468,7 +513,7 @@ case "$CMD" in
     REMOTE_CMD=("$@")
     ;;
   *)
-    echo "Usage: $0 [build|test|integration|integration-polishd|integration-speechd|speechd-bench|eval-llm|eval-e2e|dogfood|dogfood-package|package|exec|diag|applog|voxlog|svc-status] [extra args...]" >&2
+    echo "Usage: $0 [build|test|integration|integration-polishd|integration-speechd|integration-herdr|speechd-bench|eval-llm|eval-e2e|dogfood|dogfood-package|package|exec|diag|applog|voxlog|svc-status] [extra args...]" >&2
     exit 1
     ;;
 esac


### PR DESCRIPTION
## What

A conditional tier-1 lane, `integration-herdr`, that exercises the **real** remote-herdr join machinery against a **live `herdr` server over a real ssh forward**.

Until now that whole path was unit-tested with injected seams only. Every claim about herdr itself — above all that **only a whole-view App client renders the agents sidebar**, which is what makes a grid match prove the focused surface displays the stamped server — was a documented hope, re-read out of herdr's source and never measured. A herdr upgrade could silently un-authorize (or wrongly authorize) field joins with nothing turning red.

What is real in the lane:

- `HerdrSocketClient` on a real forwarded unix socket
- `ClaudeRemoteHerdrForwardService` spawning a real supervised `ssh -N -L` (real leases, real teardown)
- `SSHDestinationCanonicalizer.live()` running real `ssh -G` against a real `~/.ssh/config`
- `ClaudeRemoteEnrollmentService.configureRemoteHerdrPanel` patching a real `~/.config/herdr/config.toml` over a real ssh session, including the live `herdr server reload-config`
- `HerdrPanelBindingProbe` / `HerdrPanelMicIndicator` driving all of it

The **one** fixture is the focused surface: instead of an accessibility read of a terminal window, the lane reads the typescript of a real herdr client running on a pty. Everything that surface displays was painted by herdr.

**Hermetic by default.** `scripts/herdr-integration-fixture.sh` provisions its own loopback sshd with its own host key, user key and `authorized_keys` file — the account's real SSH trust is never touched — so the lane needs no second machine and is safe in CI. `integration-herdr <destination>` aims the identical lane at a real second host. The fixture refuses to start beside a live herdr rather than trampling a human's session, and restores the account's herdr config, session state and `~/.ssh/config` block even when `up` fails partway.

Also: `scripts/ci/herdr-lane-filter.sh` (+ shell regression test), the `[run-herdr-integration]` marker, CI wiring (self-hosted only — fork PRs still never reach the self-hosted runner), and docs.

### Assumptions now pinned against a live server (herdr 0.8.2, protocol 20)

| Assumption | Test |
|---|---|
| Only a whole-view App client renders the sidebar; `terminal attach` renders the raw pane and cannot echo the token | `testAttachClientRendersNoSidebarSoItCannotEchoThePanelToken` (load-bearing) |
| A whole-view client renders the stamped `$lvmark` nonce | `testWholeViewClientRendersTheStampedPanelToken` |
| Both JSON `null` and `""` clear a `pane.report_metadata` token | `testPanelTokenIsClearedByBothNullAndEmptyValues` |
| `ttl_ms` is 1…86_400_000 inclusive; the production TTL sits inside it | `testPanelTokenTTLBoundsAreEnforcedAtTheDocumentedEdges` |
| `pane.current` / `pane.process_info` decode, and `foreground_processes` is present and named | `testFocusedPaneAndProcessInfoDecodeFromTheLiveServer` |
| `pane.read` answers only about the pane asked for | `testPaneReadReturnsOnlyTheJoinedPanesText` |
| `ssh -G` identity matching accepts a `User` difference, rejects a port difference, never selects a revoked host | `testSSHDestinationCanonicalizationMatchesThroughRealSSHConfig` |
| The config patch appends once, reloads the live server, and refuses an existing agents table — including the trailing-comment header variant | `testRemoteHerdrPanelConfigPatchAppendsOnceAndRefusesCustomizedTables` |
| A forward lease is reused across dictations and retired when idle | `testForwardLeaseIsReusedAcrossDictationsAndTornDownWhenIdle` |
| The probe matches a whole-view surface and abstains on an attach surface | `testPanelBindingProbeMatchesWholeViewAndAbstainsOnAttach` |
| The nonce is refreshed while dictating and explicitly cleared before the forward is released | `testMicIndicatorRefreshesTheTokenAndClearsItOnStop` |

**Two measurements corrected `docs/agent/remote-herdr-panel-binding.md`** (both recorded there under "Pinned against a live server"):

1. An **81-character token value is ACCEPTED**, not refused. The doc claimed a ≤80 hard cap; nothing may be built on a length refusal. (The production token is 17 chars.)
2. `pane.current` carried **no `agent_session` field** for a pane whose session id was reported through `pane report-agent[-session]`, so `claimedClaudeSessionID` came back nil — the join's "herdr's own claim must not disagree" cross-check is vacuous for panes in that state.

Also found: the agents panel renders per **agent-bearing** pane, so a configured `$lvmark` row is necessary but not sufficient — a plain shell pane renders no row at all.

### Still unpinnable

- **Server-global focus across App clients.** Starting a second whole-view client on the same socket disturbed the fixture's own pane rather than mirroring it, so the lane does not assert it. The invariant that two local surfaces of one server render the same token remains a source-read assumption.
- **`terminal_observe`.** herdr 0.8.2's CLI exposes no observe subcommand; only `terminal attach` is reachable.
- **TTL expiry timing.** Deliberately not asserted — it would be a wall-clock wait. The bounds are pinned instead.

### No `XCTSkip`

Deliberate: a silent skip is indistinguishable from a pass, and this lane exists to catch external drift. `remote-build.sh test`, CI's unit step and the AGENTS.md dev-box instruction all skip it by name; running it without its marker fails with the enablement instructions, and a missing `herdr` fails with the install step.

## Proof

### The lane, green against a live herdr — `./scripts/remote-build.sh integration-herdr`

```
Test Case '-[localvoxtralTests.HerdrIntegrationTests testAttachClientRendersNoSidebarSoItCannotEchoThePanelToken]' passed (4.189 seconds).
Test Case '-[localvoxtralTests.HerdrIntegrationTests testFocusedPaneAndProcessInfoDecodeFromTheLiveServer]' passed (4.070 seconds).
Test Case '-[localvoxtralTests.HerdrIntegrationTests testForwardLeaseIsReusedAcrossDictationsAndTornDownWhenIdle]' passed (3.977 seconds).
Test Case '-[localvoxtralTests.HerdrIntegrationTests testMicIndicatorRefreshesTheTokenAndClearsItOnStop]' passed (4.808 seconds).
Test Case '-[localvoxtralTests.HerdrIntegrationTests testPanelBindingProbeMatchesWholeViewAndAbstainsOnAttach]' passed (9.078 seconds).
Test Case '-[localvoxtralTests.HerdrIntegrationTests testPanelTokenIsClearedByBothNullAndEmptyValues]' passed (4.538 seconds).
Test Case '-[localvoxtralTests.HerdrIntegrationTests testPanelTokenTTLBoundsAreEnforcedAtTheDocumentedEdges]' passed (4.417 seconds).
Test Case '-[localvoxtralTests.HerdrIntegrationTests testPaneReadReturnsOnlyTheJoinedPanesText]' passed (4.160 seconds).
Test Case '-[localvoxtralTests.HerdrIntegrationTests testRemoteHerdrPanelConfigPatchAppendsOnceAndRefusesCustomizedTables]' passed (4.057 seconds).
Test Case '-[localvoxtralTests.HerdrIntegrationTests testSSHDestinationCanonicalizationMatchesThroughRealSSHConfig]' passed (3.797 seconds).
Test Case '-[localvoxtralTests.HerdrIntegrationTests testWholeViewClientRendersTheStampedPanelToken]' passed (4.061 seconds).
	 Executed 11 tests, with 0 failures (0 unexpected) in 51.151 (51.155) seconds
```

Fixture bring-up from the same run (`herdr 0.8.2`, a real loopback sshd, a real pane, a real whole-view client):

```
[herdr-fixture] herdr binary: /opt/homebrew/bin/herdr (herdr 0.8.2)
[herdr-fixture] loopback sshd starting on 127.0.0.1:24015
[herdr-fixture] herdr server listening on /tmp/lvx-herdr-fixture-.../herdr.sock
[herdr-fixture] surface 'primary' (app) started -> .../surface-primary.log
[herdr-fixture] focused pane: w2:p1
[herdr-fixture] pane w2:p1 marked agent-bearing (session lvx-fixture-session-0001)
```

The forward under test is the production argv verbatim, and herdr answers through it:

```
ssh -N -o BatchMode=yes -o ControlPath=none -o ForkAfterAuthentication=no \
  -o PermitLocalCommand=no -L <workdir>/local.sock:<home>/.config/herdr/herdr.sock -- lvx-herdr-fixture
srw-------  1 builder  wheel  0 <workdir>/local.sock
{"id":"probe","result":{"type":"pane_list","panes":[]}}
```

And the sidebar really renders the stamped nonce (ANSI stripped from the whole-view client's typescript):

```
claude                │   lv-mic-abcd012345
```

### Red → green on the load-bearing assumption

The premise under test is "a `herdr terminal attach` client renders no sidebar, so it can never echo the panel token". Violation simulated by making the surface the test believes is an attach client show what a whole-view client shows — i.e. exactly the situation where herdr started rendering the sidebar in attach mode:

```diff
-        let attachSurface = try fixture.startSurface(
-            name: "attach", mode: .attach, paneID: fixture.info.paneID)
+        let attachSurface = HerdrSurfaceLog(path: fixture.info.primarySurfaceLog)
+        _ = try fixture.startSurface(
+            name: "attach", mode: .attach, paneID: fixture.info.paneID)
```

**RED** (`./scripts/remote-build.sh integration-herdr` with the violation applied):

```
Test Case '-[localvoxtralTests.HerdrIntegrationTests testAttachClientRendersNoSidebarSoItCannotEchoThePanelToken]' started.
HerdrIntegrationTests.swift:198: error: -[localvoxtralTests.HerdrIntegrationTests testAttachClientRendersNoSidebarSoItCannotEchoThePanelToken] : XCTAssertFalse failed - A `herdr terminal attach` client rendered the agents-panel token. herdr's App-mode/raw-pane split is what makes a grid match prove the surface displays a whole-view client of the stamped server (docs/agent/remote-herdr-panel-binding.md). If this is the new behavior, the remote-herdr surface authorization argument no longer holds and must be reworked — do not relax this lane.
Test Case '-[localvoxtralTests.HerdrIntegrationTests testAttachClientRendersNoSidebarSoItCannotEchoThePanelToken]' failed (4.222 seconds).
	 Executed 11 tests, with 1 failure (0 unexpected) in 49.784 (49.786) seconds
```

Only that test fails — the other ten stay green, so the failure is about the assumption and not about a broken fixture. The test's positive control (the whole-view surface DOES render the token) runs before the negative assertion, so "nothing rendered anywhere" can never look like a pass.

**GREEN** (violation reverted): the 11/11 run pasted above.

### Unit suite still green — `./scripts/remote-build.sh test`

```
Test Suite 'localvoxtralPackageTests.xctest' passed at 2026-08-28 01:24:58.332.
	 Executed 2724 tests, with 2 tests skipped and 0 failures (0 unexpected) in 103.379 (103.514) seconds
```

No new warnings under Swift 6.2 strict concurrency (`grep warning: .build/last-remote.log | grep HerdrIntegration` → empty). `AgentsGuideSizeTests` passes: AGENTS.md is 11,586 bytes of the 32,768 cap.

### Lane filter — `./scripts/ci/test-herdr-lane-filter.sh`

```
PASS: socket client changes run the lane (matched Sources/localvoxtral/ClaudeContext/HerdrSocketClient.swift (*HerdrSocketClient*))
PASS: panel binding probe changes run the lane (matched .../HerdrPanelBindingProbe.swift (*HerdrPanelBindingProbe*))
PASS: the ssh -L forward runs the lane (matched .../ClaudeRemoteHerdrForward.swift (*ClaudeRemoteHerdrForward*))
PASS: forward supervision runs the lane (matched .../ClaudeRemoteForwardSupervisor.swift (*ClaudeRemoteForwardSupervisor*))
PASS: ssh -G canonicalization runs the lane (matched .../SSHDestinationCanonicalizer.swift (*SSHDestinationCanonicalizer*))
PASS: the remote herdr config patch runs the lane (matched .../ClaudeRemoteEnrollmentService.swift (*ClaudeRemoteEnrollmentService*))
PASS: the join arm that consumes all of it runs the lane (matched .../TerminalScreenClaudeJoin.swift (*TerminalScreenClaudeJoin*))
PASS: editing the panel-binding design doc runs the lane (matched docs/agent/remote-herdr-panel-binding.md ...)
PASS: the fixture itself runs the lane (matched scripts/herdr-integration-fixture.sh ...)
PASS: the lane's own suite runs the lane (matched Tests/localvoxtralTests/HerdrIntegrationTests.swift (*HerdrIntegration*))
PASS: the explicit marker runs the lane on an unrelated diff (explicit [run-herdr-integration] marker)
PASS: a lookalike marker does not run the lane (...)
PASS: UI-only changes do not run the lane (...)
PASS: polish-model work does not run the lane (...)
PASS: docs outside the assumption record do not run the lane (...)
PASS: an empty diff does not run the lane (...)

All herdr lane filter checks passed.
```

`./scripts/ci/test-clean-stale-outputs.sh` also passes (the new marker joined the transient-marker sweep).

### Lanes not run, and why

- **LLM lanes (`[run-llm-eval]`)**: skipped. This PR adds a test lane and its wiring; no prompt, model pin, sampling, polish-request shape or eval corpus/scorer changes. `ClaudeRemoteEnrollmentService.swift` is on the LLM path list but is **unmodified** here — only the docs and CI around it changed.
- **speechd (`[run-speechd-integration]`)**: skipped. No SpeechHelper, packaging or realtime-contract change.
- **eval-e2e**: skipped. No model, prompt or TTS→ASR→polish harness change.

### No wall clock in assertions

`AcceleratedClock` advances the forward service's injected clock by the full requested interval while really sleeping at most 50 ms, so the 5-minute idle teardown is proven without waiting it out and the readiness polls still take real time. `SurfaceSettleClock` gives the panel probe production settle algebra while the real wait is for herdr to paint a frame, so the lane measures herdr's rendering rather than the Mac's load. Live-fixture readiness uses `HerdrLaneWait.until`, where the assertion is always the condition and the deadline only bounds how long a dead fixture may look alive — same shape as the existing live lanes.

### Hand-verified

Nothing user-visible changes; no UI surface is touched.
