### PR TITLE
MicrophoneCaptureService: support multi-channel input devices (pro audio interfaces)

### DIFF
--- a/Sources/localvoxtral/MicrophoneCaptureService.swift
+++ b/Sources/localvoxtral/MicrophoneCaptureService.swift
@@ -119,7 +119,9 @@ private func auhalInputCallback(
     let inputFormatDescriptor = MicrophoneCaptureService.inputFormatDescriptor(for: inputFormat)
 
     if converterState.converter == nil || converterState.inputFormatDescriptor != inputFormatDescriptor {
-        guard let converter = AVAudioConverter(from: inputFormat, to: context.outputFormat) else {
+        guard let converter = MicrophoneCaptureService.makeTranscriptionConverter(
+            from: inputFormat, to: context.outputFormat
+        ) else {
             if context.debugLoggingEnabled {
                 context.service?.debugLog(
                     "converter creation failed sampleRate=\(inputFormat.sampleRate) channels=\(inputFormat.channelCount)"
@@ -132,7 +134,6 @@ private func auhalInputCallback(
             }
             return noErr
         }
-        converter.sampleRateConverterQuality = AVAudioQuality.max.rawValue
         converterState.converter = converter
         converterState.inputFormatDescriptor = inputFormatDescriptor
         converterState.consecutiveFailureCount = 0
@@ -350,7 +351,7 @@ final class MicrophoneCaptureService: @unchecked Sendable {
         )
 
         if formatStatus == noErr, asbd.mSampleRate > 0,
-           let newFormat = AVAudioFormat(streamDescription: &asbd)
+           let newFormat = Self.makeDeviceFormat(&asbd)
         {
             let ctx = unmanagedCtx.takeUnretainedValue()
             let currentDescriptor = Self.inputFormatDescriptor(for: ctx.deviceAVFormat)
@@ -489,7 +490,7 @@ final class MicrophoneCaptureService: @unchecked Sendable {
                     "get device format", getFormatStatus)
             }
 
-            guard let deviceFormat = AVAudioFormat(streamDescription: &deviceASBD) else {
+            guard let deviceFormat = Self.makeDeviceFormat(&deviceASBD) else {
                 throw MicrophoneCaptureError.invalidInputFormat
             }
 
@@ -818,6 +819,43 @@ final class MicrophoneCaptureService: @unchecked Sendable {
     fileprivate func debugLog(_ message: String) {
         guard debugLoggingEnabled else { return }
         Log.microphone.debug("\(message)")
+    }
+
+    /// Wraps a device ASBD in an AVAudioFormat, falling back to a discrete
+    /// channel layout for channel counts that have no standard layout.
+    /// Pro audio interfaces (e.g. a 16-input Universal Audio Thunderbolt)
+    /// report such formats natively, and the layout-less initializer returns
+    /// nil for them — which used to surface as "Microphone input format is
+    /// invalid" even though the device works fine.
+    /// Internal (not fileprivate) for the regression tests.
+    static func makeDeviceFormat(
+        _ asbd: inout AudioStreamBasicDescription
+    ) -> AVAudioFormat? {
+        if let format = AVAudioFormat(streamDescription: &asbd) { return format }
+        guard asbd.mChannelsPerFrame > 0 else { return nil }
+        let tag = kAudioChannelLayoutTag_DiscreteInOrder | asbd.mChannelsPerFrame
+        guard let layout = AVAudioChannelLayout(layoutTag: tag) else { return nil }
+        return AVAudioFormat(streamDescription: &asbd, channelLayout: layout)
+    }
+
+    /// Builds the capture converter for one device format. For channel counts
+    /// above stereo there is no downmix matrix to mono — AVAudioConverter
+    /// silently converts every frame to ZEROS — so the interface's first
+    /// input channel is mapped to the mono output instead; that is where a
+    /// microphone lives on a multi-channel interface.
+    /// Internal (not fileprivate) for the regression tests.
+    static func makeTranscriptionConverter(
+        from inputFormat: AVAudioFormat,
+        to outputFormat: AVAudioFormat
+    ) -> AVAudioConverter? {
+        guard let converter = AVAudioConverter(from: inputFormat, to: outputFormat) else {
+            return nil
+        }
+        converter.sampleRateConverterQuality = AVAudioQuality.max.rawValue
+        if inputFormat.channelCount > 2 {
+            converter.channelMap = [0]
+        }
+        return converter
     }
 
     fileprivate static func inputFormatDescriptor(for format: AVAudioFormat) -> InputFormatDescriptor {

--- a/Tests/localvoxtralTests/MicrophoneMultiChannelFormatTests.swift
+++ b/Tests/localvoxtralTests/MicrophoneMultiChannelFormatTests.swift
@@ -1,0 +1,175 @@
+import AVFoundation
+import AudioToolbox
+import XCTest
+
+@testable import localvoxtral
+
+/// Regression tests for multi-channel input devices (pro audio interfaces).
+///
+/// A 16-input Universal Audio Thunderbolt broke capture twice over
+/// (field bug, 2026-08-29):
+///
+/// 1. Its native format — 16ch interleaved Float32, a channel count with no
+///    standard layout — makes `AVAudioFormat(streamDescription:)` return nil,
+///    so `startCapture` threw `invalidInputFormat` before opening a device
+///    that works fine in every browser.
+/// 2. Once wrapped (discrete layout), `AVAudioConverter` has no downmix
+///    matrix from a discrete multi-channel layout to mono and silently
+///    converts every frame to ZEROS — the mic "worked" and dictation heard
+///    nothing.
+///
+/// These tests drive the same two seams the capture path uses
+/// (`makeDeviceFormat`, `makeTranscriptionConverter`) with a synthetic
+/// 16-channel format, so they run Metal-free and without audio hardware.
+final class MicrophoneMultiChannelFormatTests: XCTestCase {
+
+    /// 16ch interleaved Float32 @ 48kHz — byte-for-byte what the interface
+    /// reports through kAudioUnitProperty_StreamFormat.
+    private func sixteenChannelASBD() -> AudioStreamBasicDescription {
+        AudioStreamBasicDescription(
+            mSampleRate: 48000,
+            mFormatID: kAudioFormatLinearPCM,
+            mFormatFlags: kAudioFormatFlagIsFloat | kAudioFormatFlagIsPacked,
+            mBytesPerPacket: 64,
+            mFramesPerPacket: 1,
+            mBytesPerFrame: 64,
+            mChannelsPerFrame: 16,
+            mBitsPerChannel: 32,
+            mReserved: 0
+        )
+    }
+
+    private func monoTranscriptionFormat() -> AVAudioFormat {
+        AVAudioFormat(
+            commonFormat: .pcmFormatFloat32, sampleRate: 16000, channels: 1, interleaved: false)!
+    }
+
+    func testMakeDeviceFormatWrapsSixteenChannelDevice() {
+        var asbd = sixteenChannelASBD()
+
+        let format = MicrophoneCaptureService.makeDeviceFormat(&asbd)
+
+        XCTAssertNotNil(
+            format,
+            "16ch device format must wrap (discrete layout fallback); nil here is the "
+                + "\"Microphone input format is invalid\" field failure")
+        XCTAssertEqual(format?.channelCount, 16)
+        XCTAssertEqual(format?.sampleRate, 48000)
+    }
+
+    func testMakeDeviceFormatKeepsStereoUntouched() {
+        var asbd = AudioStreamBasicDescription(
+            mSampleRate: 48000,
+            mFormatID: kAudioFormatLinearPCM,
+            mFormatFlags: kAudioFormatFlagIsFloat | kAudioFormatFlagIsPacked,
+            mBytesPerPacket: 8,
+            mFramesPerPacket: 1,
+            mBytesPerFrame: 8,
+            mChannelsPerFrame: 2,
+            mBitsPerChannel: 32,
+            mReserved: 0
+        )
+
+        let format = MicrophoneCaptureService.makeDeviceFormat(&asbd)
+
+        XCTAssertNotNil(format)
+        XCTAssertEqual(format?.channelCount, 2)
+    }
+
+    /// The silence bug: convert a 440Hz tone that lives ONLY on channel 0 of
+    /// the 16-channel device (where a microphone lives on such interfaces)
+    /// and assert the mono output still carries signal. Without the channel
+    /// map the converter "succeeds" while writing zeros for every frame.
+    func testSixteenChannelToMonoConversionPreservesFirstChannelSignal() throws {
+        var asbd = sixteenChannelASBD()
+        let inputFormat = try XCTUnwrap(MicrophoneCaptureService.makeDeviceFormat(&asbd))
+        let outputFormat = monoTranscriptionFormat()
+        let converter = try XCTUnwrap(
+            MicrophoneCaptureService.makeTranscriptionConverter(
+                from: inputFormat, to: outputFormat))
+
+        let frames: AVAudioFrameCount = 4800
+        let inputBuffer = try XCTUnwrap(
+            AVAudioPCMBuffer(pcmFormat: inputFormat, frameCapacity: frames))
+        inputBuffer.frameLength = frames
+        let samples = try XCTUnwrap(inputBuffer.floatChannelData)[0]
+        for frame in 0..<Int(frames) {
+            // Interleaved: channel 0 of each 16-sample frame carries the tone.
+            samples[frame * 16] = 0.5 * sin(2 * .pi * 440 * Float(frame) / 48000)
+        }
+
+        let outputBuffer = try XCTUnwrap(
+            AVAudioPCMBuffer(pcmFormat: outputFormat, frameCapacity: 4000))
+        var fedInput = false
+        var conversionError: NSError?
+        converter.convert(to: outputBuffer, error: &conversionError) { _, status in
+            if fedInput {
+                status.pointee = .noDataNow
+                return nil
+            }
+            fedInput = true
+            status.pointee = .haveData
+            return inputBuffer
+        }
+
+        XCTAssertNil(conversionError)
+        XCTAssertGreaterThan(outputBuffer.frameLength, 0)
+        let output = try XCTUnwrap(outputBuffer.floatChannelData)[0]
+        var sumOfSquares: Float = 0
+        for frame in 0..<Int(outputBuffer.frameLength) {
+            sumOfSquares += output[frame] * output[frame]
+        }
+        let rms = (sumOfSquares / Float(outputBuffer.frameLength)).squareRoot()
+        // Input RMS is ~0.354; anything close to full level proves the tone
+        // survived. The pre-fix converter produced rms == 0 exactly.
+        XCTAssertGreaterThan(
+            rms, 0.1,
+            "mono output is (near-)silent: the multi-channel downmix dropped the "
+                + "microphone channel — dictation hears nothing")
+    }
+
+    /// Stereo inputs keep the standard downmix (no channel map): a tone on
+    /// the LEFT channel must still reach the mono output.
+    func testStereoToMonoConversionStillDownmixes() throws {
+        let inputFormat = try XCTUnwrap(
+            AVAudioFormat(
+                commonFormat: .pcmFormatFloat32, sampleRate: 48000, channels: 2,
+                interleaved: false))
+        let outputFormat = monoTranscriptionFormat()
+        let converter = try XCTUnwrap(
+            MicrophoneCaptureService.makeTranscriptionConverter(
+                from: inputFormat, to: outputFormat))
+
+        let frames: AVAudioFrameCount = 4800
+        let inputBuffer = try XCTUnwrap(
+            AVAudioPCMBuffer(pcmFormat: inputFormat, frameCapacity: frames))
+        inputBuffer.frameLength = frames
+        let left = try XCTUnwrap(inputBuffer.floatChannelData)[0]
+        for frame in 0..<Int(frames) {
+            left[frame] = 0.5 * sin(2 * .pi * 440 * Float(frame) / 48000)
+        }
+
+        let outputBuffer = try XCTUnwrap(
+            AVAudioPCMBuffer(pcmFormat: outputFormat, frameCapacity: 4000))
+        var fedInput = false
+        var conversionError: NSError?
+        converter.convert(to: outputBuffer, error: &conversionError) { _, status in
+            if fedInput {
+                status.pointee = .noDataNow
+                return nil
+            }
+            fedInput = true
+            status.pointee = .haveData
+            return inputBuffer
+        }
+
+        XCTAssertNil(conversionError)
+        let output = try XCTUnwrap(outputBuffer.floatChannelData)[0]
+        var sumOfSquares: Float = 0
+        for frame in 0..<Int(outputBuffer.frameLength) {
+            sumOfSquares += output[frame] * output[frame]
+        }
+        let rms = (sumOfSquares / Float(max(outputBuffer.frameLength, 1))).squareRoot()
+        XCTAssertGreaterThan(rms, 0.05)
+    }
+}


### PR DESCRIPTION
## What

A 16-input Universal Audio Thunderbolt interface (default input on a Mac mini with no built-in mic) breaks capture twice over:

1. **The device cannot be opened.** Its native format — 16ch interleaved Float32 @ 48kHz, a channel count with no standard channel layout — makes `AVAudioFormat(streamDescription:)` return nil, so `startCapture` throws `invalidInputFormat` ("Microphone input format is invalid") for a device used successfully elsewhere.
2. **Once opened, dictation hears silence.** `AVAudioConverter` has no downmix matrix from a discrete multi-channel layout to mono, and silently converts every frame to zeros: sessions run, transcripts come back empty.

Fixes, both scoped to `MicrophoneCaptureService`:

- `makeDeviceFormat` falls back to a `DiscreteInOrder` channel layout when the layout-less initializer returns nil (both call sites: capture start and the format-change listener).
- Converter creation is extracted into `makeTranscriptionConverter`, which maps the interface's **first input channel** to the mono output (`channelMap = [0]`) for `channelCount > 2` — that's where a microphone lives on such interfaces. Mono/stereo devices are untouched (standard downmix keeps working, covered by a test).

Both helpers are internal rather than fileprivate so the regression tests can drive them; no behavior change for existing devices.

## Proof

- [x] Unit suite green — `swift test` on this branch:
  ```
  Executed 2749 tests, with 20 tests skipped and 0 failures (0 unexpected) in 100.366 seconds
  ```
- [x] Bug fix: regression test added (`MicrophoneMultiChannelFormatTests`, 4 tests, Metal-free, no audio hardware needed — a synthetic 16ch ASBD and a 440Hz tone on channel 0).

  Failing before the fix (helpers reverted to pre-fix behavior):
  ```
  error: testMakeDeviceFormatWrapsSixteenChannelDevice : XCTAssertNotNil failed - 16ch device format must wrap (discrete layout fallback); nil here is the "Microphone input format is invalid" field failure
  error: testSixteenChannelToMonoConversionPreservesFirstChannelSignal : XCTUnwrap failed: expected non-nil value of type "AVAudioFormat"
  Executed 4 tests, with 4 failures (0 unexpected) in 0.246 seconds
  ```
  Passing after:
  ```
  Executed 4 tests, with 0 failures (0 unexpected) in 0.004 seconds
  ```
- [x] Hand-verified on the affected hardware (UA Thunderbolt, 16 in, macOS 26): stock build → "Microphone input format is invalid"; format fix alone → mic opens, every session finalizes with an empty transcript (silence confirmed by feeding a synthetic single-channel tone through the exact converter: output RMS was 0.0000, and `channelMap = [0]` restores it to full level); both fixes → dictation works end to end, verified against the raw delta log.

Diagnosed and written with Claude Code on the affected machine; happy to test follow-up changes on this hardware.
