### PR TITLE
Tests: silence strict-concurrency warnings in the multi-channel mic tests

### DIFF
--- a/Tests/localvoxtralTests/MicrophoneMultiChannelFormatTests.swift
+++ b/Tests/localvoxtralTests/MicrophoneMultiChannelFormatTests.swift
@@ -1,5 +1,6 @@
-import AVFoundation
+@preconcurrency import AVFoundation
 import AudioToolbox
+import Synchronization
 import XCTest
 
 @testable import localvoxtral
@@ -100,14 +101,18 @@ final class MicrophoneMultiChannelFormatTests: XCTestCase {
 
         let outputBuffer = try XCTUnwrap(
             AVAudioPCMBuffer(pcmFormat: outputFormat, frameCapacity: 4000))
-        var fedInput = false
+        let didFeedInput = Mutex(false)
         var conversionError: NSError?
         converter.convert(to: outputBuffer, error: &conversionError) { _, status in
-            if fedInput {
+            let alreadyFed = didFeedInput.withLock { fed in
+                let was = fed
+                fed = true
+                return was
+            }
+            if alreadyFed {
                 status.pointee = .noDataNow
                 return nil
             }
-            fedInput = true
             status.pointee = .haveData
             return inputBuffer
         }
@@ -151,14 +156,18 @@ final class MicrophoneMultiChannelFormatTests: XCTestCase {
 
         let outputBuffer = try XCTUnwrap(
             AVAudioPCMBuffer(pcmFormat: outputFormat, frameCapacity: 4000))
-        var fedInput = false
+        let didFeedInput = Mutex(false)
         var conversionError: NSError?
         converter.convert(to: outputBuffer, error: &conversionError) { _, status in
-            if fedInput {
+            let alreadyFed = didFeedInput.withLock { fed in
+                let was = fed
+                fed = true
+                return was
+            }
+            if alreadyFed {
                 status.pointee = .noDataNow
                 return nil
             }
-            fedInput = true
             status.pointee = .haveData
             return inputBuffer
         }


### PR DESCRIPTION
## What

Follow-up to #240. The multi-channel mic tests that landed with it emitted 7 warnings under Swift 6.2 strict concurrency:

- capture of the non-Sendable `AVAudioPCMBuffer` in `AVAudioConverter`'s `@Sendable` input block
- reference to, and mutation of, the captured `var fedInput`

Both are already solved in the code under test, so this just mirrors the existing patterns: `MicrophoneCaptureService.swift` imports AVFoundation `@preconcurrency`, and `convertToPCM16Mono` tracks single-consumption with a `Mutex` rather than a captured var.

No behaviour change. The 4 tests assert exactly what they asserted before.

Taken as a follow-up rather than a review round trip on a first-time contributor's PR.

## Proof

Warning count for the file, before (from #240's branch, full suite run):

```
7 Tests/localvoxtralTests/MicrophoneMultiChannelFormatTests.swift
```

After, on this branch — a genuine recompile of that file, not a cache hit:

```
[3/5] Compiling localvoxtralTests MicrophoneMultiChannelFormatTests.swift
Build complete! (5.71s)
Test Suite 'MicrophoneMultiChannelFormatTests' passed
	 Executed 4 tests, with 0 failures (0 unexpected) in 0.011 seconds
```

Warnings emitted by that file after the change: 0.

No new test: this is a warnings-only cleanup of existing tests, and those 4 tests are themselves the regression coverage for #240.
