### PR TITLE
Multi-channel mic: choose the input channel, and let the AUHAL do the picking

### DIFF
--- a/Sources/localvoxtral/AudioDeviceManager.swift
+++ b/Sources/localvoxtral/AudioDeviceManager.swift
@@ -28,21 +28,38 @@ enum AudioDeviceManager {
         }
     }
 
-    /// Channels the device's input stream format reports. A 16-in interface
-    /// answers 16 here; the built-in mic answers 1.
+    /// Input channels the device offers, summed across ALL its input streams.
+    ///
+    /// Deliberately not `kAudioDevicePropertyStreamFormat`, which describes
+    /// stream 0 only: MADI/AVB-class interfaces and aggregate devices present
+    /// several input streams, and the AUHAL's element-1 format concatenates
+    /// them. Counting stream 0 alone would offer "Channel 1…8" on a device
+    /// whose channel 11 the capture path can address perfectly well.
     static func inputChannelCount(for deviceID: AudioObjectID) -> UInt32? {
         var address = AudioObjectPropertyAddress(
-            mSelector: kAudioDevicePropertyStreamFormat,
-            mScope: kAudioObjectPropertyScopeInput,
+            mSelector: kAudioDevicePropertyStreamConfiguration,
+            mScope: kAudioDevicePropertyScopeInput,
             mElement: kAudioObjectPropertyElementMain
         )
-        var asbd = AudioStreamBasicDescription()
-        var dataSize = UInt32(MemoryLayout<AudioStreamBasicDescription>.size)
-        guard AudioObjectGetPropertyData(deviceID, &address, 0, nil, &dataSize, &asbd) == noErr
-        else {
-            return nil
-        }
-        return asbd.mChannelsPerFrame
+
+        var dataSize: UInt32 = 0
+        let sizeStatus = AudioObjectGetPropertyDataSize(deviceID, &address, 0, nil, &dataSize)
+        guard sizeStatus == noErr, dataSize > 0 else { return nil }
+
+        let rawPointer = UnsafeMutableRawPointer.allocate(
+            byteCount: Int(dataSize),
+            alignment: MemoryLayout<AudioBufferList>.alignment
+        )
+        defer { rawPointer.deallocate() }
+
+        let dataStatus = AudioObjectGetPropertyData(
+            deviceID, &address, 0, nil, &dataSize, rawPointer)
+        guard dataStatus == noErr else { return nil }
+
+        let audioBufferList = rawPointer.assumingMemoryBound(to: AudioBufferList.self)
+        let buffers = UnsafeMutableAudioBufferListPointer(audioBufferList)
+        let channelCount = buffers.reduce(UInt32(0)) { $0 + $1.mNumberChannels }
+        return channelCount > 0 ? channelCount : nil
     }
 
     static func defaultInputDeviceObjectID() -> AudioObjectID? {

--- a/Sources/localvoxtral/AudioDeviceManager.swift
+++ b/Sources/localvoxtral/AudioDeviceManager.swift
@@ -5,6 +5,13 @@ import Foundation
 struct MicrophoneInputDevice: Identifiable, Hashable {
     let id: String
     let name: String
+    /// Input channels the device reports. Above stereo there is no meaningful
+    /// downmix to mono — a microphone occupies ONE of these channels — so the
+    /// capture path picks a single channel and the UI offers the choice.
+    /// Defaults to 1 for devices whose stream format can't be read.
+    let channelCount: UInt32
+
+    var isMultiChannel: Bool { channelCount > 2 }
 }
 
 enum AudioDeviceManager {
@@ -13,8 +20,29 @@ enum AudioDeviceManager {
             guard isSelectableInputDevice(deviceID) else { return nil }
             guard let uid = deviceUID(for: deviceID) else { return nil }
             let name = deviceName(for: deviceID) ?? "Input \(uid)"
-            return MicrophoneInputDevice(id: uid, name: name)
+            return MicrophoneInputDevice(
+                id: uid,
+                name: name,
+                channelCount: inputChannelCount(for: deviceID) ?? 1
+            )
         }
+    }
+
+    /// Channels the device's input stream format reports. A 16-in interface
+    /// answers 16 here; the built-in mic answers 1.
+    static func inputChannelCount(for deviceID: AudioObjectID) -> UInt32? {
+        var address = AudioObjectPropertyAddress(
+            mSelector: kAudioDevicePropertyStreamFormat,
+            mScope: kAudioObjectPropertyScopeInput,
+            mElement: kAudioObjectPropertyElementMain
+        )
+        var asbd = AudioStreamBasicDescription()
+        var dataSize = UInt32(MemoryLayout<AudioStreamBasicDescription>.size)
+        guard AudioObjectGetPropertyData(deviceID, &address, 0, nil, &dataSize, &asbd) == noErr
+        else {
+            return nil
+        }
+        return asbd.mChannelsPerFrame
     }
 
     static func defaultInputDeviceObjectID() -> AudioObjectID? {

--- a/Sources/localvoxtral/DictationViewModel+Session.swift
+++ b/Sources/localvoxtral/DictationViewModel+Session.swift
@@ -386,7 +386,10 @@ extension DictationViewModel {
         let preferredInputID = selectedInputDeviceID.isEmpty ? nil : selectedInputDeviceID
         do {
             let chunkBuffer = audioChunkBuffer
-            try microphone.start(preferredDeviceID: preferredInputID) { chunk in
+            try microphone.start(
+                preferredDeviceID: preferredInputID,
+                preferredInputChannel: selectedInputChannel
+            ) { chunk in
                 chunkBuffer.append(chunk)
             }
 
@@ -451,8 +454,11 @@ extension DictationViewModel {
             setError: { [weak self] error in
                 self?.lastError = error
             },
-            restartMicrophone: { preferredInputID in
-                try mic.start(preferredDeviceID: preferredInputID) { chunk in
+            restartMicrophone: { [weak self] preferredInputID in
+                try mic.start(
+                    preferredDeviceID: preferredInputID,
+                    preferredInputChannel: self?.selectedInputChannel ?? 0
+                ) { chunk in
                     chunkBuffer.append(chunk)
                 }
             }

--- a/Sources/localvoxtral/DictationViewModel.swift
+++ b/Sources/localvoxtral/DictationViewModel.swift
@@ -1647,6 +1647,30 @@ final class DictationViewModel {
         startDictation()
     }
 
+    /// Channels the selected input device reports. Above 2 the capture path
+    /// picks ONE channel (there is no meaningful downmix), so the popover
+    /// offers the choice; at or below 2 the picker stays hidden.
+    var selectedInputDeviceChannelCount: UInt32 {
+        availableInputDevices.first { $0.id == selectedInputDeviceID }?.channelCount ?? 1
+    }
+
+    var selectedInputChannel: Int {
+        MicrophoneCaptureService.resolvedCaptureChannel(
+            settings.selectedInputChannel,
+            channelCount: AVAudioChannelCount(selectedInputDeviceChannelCount))
+    }
+
+    func selectMicrophoneInputChannel(_ channel: Int) {
+        guard channel >= 0, channel < Int(selectedInputDeviceChannelCount) else { return }
+        guard settings.selectedInputChannel != channel else { return }
+
+        settings.selectedInputChannel = channel
+
+        guard isDictating else { return }
+        stopDictation(reason: "input channel changed by user", finalizeRemainingAudio: false)
+        startDictation()
+    }
+
     func startDictation(outputMode: DictationOutputMode? = nil) {
         guard !isDictating else { return }
         guard !isConnectingRealtimeSession else {

--- a/Sources/localvoxtral/MicrophoneCaptureService.swift
+++ b/Sources/localvoxtral/MicrophoneCaptureService.swift
@@ -868,7 +868,17 @@ final class MicrophoneCaptureService: @unchecked Sendable {
 
     fileprivate func debugLog(_ message: String) {
         guard debugLoggingEnabled else { return }
-        Log.microphone.debug("\(message)")
+        // `privacy: .public` because an interpolated String defaults to
+        // PRIVATE in os_log, and every line here redacted to `<private>` —
+        // which made these diagnostics unreadable on the machines they exist
+        // to diagnose. Reading them otherwise needs the system-wide
+        // Enable-Private-Data profile, which is far too big a hammer for a
+        // capture log. Safe to publish: this carries device names, formats,
+        // channel indices, byte counts and OSStatus values, never audio or
+        // transcript content, and the whole function is already gated behind
+        // the LOCALVOXTRAL_DEBUG opt-in. Same posture as the delta log and
+        // the insertion scalar trace.
+        Log.microphone.debug("\(message, privacy: .public)")
     }
 
     /// Wraps a device ASBD in an AVAudioFormat, falling back to a discrete

--- a/Sources/localvoxtral/MicrophoneCaptureService.swift
+++ b/Sources/localvoxtral/MicrophoneCaptureService.swift
@@ -42,7 +42,14 @@ enum MicrophoneCaptureError: LocalizedError {
 private final class RenderContext: @unchecked Sendable {
     weak var service: MicrophoneCaptureService?
     let auHAL: AudioUnit
+    /// The format the callback renders INTO — i.e. the AUHAL's client format
+    /// on the output scope of element 1. Equals the device format for mono and
+    /// stereo devices; for a multi-channel device narrowed by the AUHAL channel
+    /// map it is mono (see `configureInputBus`).
     var deviceAVFormat: AVAudioFormat
+    /// Device channel carrying the microphone. Already applied by the AUHAL
+    /// when the client format came back mono; used by the converter otherwise.
+    var captureChannel: Int
     let outputFormat: AVAudioFormat
     let chunkHandler: MicrophoneCaptureService.ChunkHandler
     let converterState: MicrophoneCaptureService.ConverterState
@@ -54,6 +61,7 @@ private final class RenderContext: @unchecked Sendable {
         service: MicrophoneCaptureService,
         auHAL: AudioUnit,
         deviceFormat: AVAudioFormat,
+        captureChannel: Int,
         outputFormat: AVAudioFormat,
         chunkHandler: @escaping MicrophoneCaptureService.ChunkHandler,
         processingQueue: DispatchQueue,
@@ -62,6 +70,7 @@ private final class RenderContext: @unchecked Sendable {
         self.service = service
         self.auHAL = auHAL
         self.deviceAVFormat = deviceFormat
+        self.captureChannel = captureChannel
         self.outputFormat = outputFormat
         self.chunkHandler = chunkHandler
         self.converterState = MicrophoneCaptureService.ConverterState()
@@ -69,8 +78,9 @@ private final class RenderContext: @unchecked Sendable {
         self.debugLoggingEnabled = debugLoggingEnabled
     }
 
-    func updateDeviceFormat(_ format: AVAudioFormat) {
+    func updateDeviceFormat(_ format: AVAudioFormat, captureChannel newChannel: Int) {
         deviceAVFormat = format
+        captureChannel = newChannel
         converterState.converter = nil
         converterState.inputFormatDescriptor = nil
     }
@@ -120,7 +130,7 @@ private func auhalInputCallback(
 
     if converterState.converter == nil || converterState.inputFormatDescriptor != inputFormatDescriptor {
         guard let converter = MicrophoneCaptureService.makeTranscriptionConverter(
-            from: inputFormat, to: context.outputFormat
+            from: inputFormat, to: context.outputFormat, channel: context.captureChannel
         ) else {
             if context.debugLoggingEnabled {
                 context.service?.debugLog(
@@ -367,18 +377,21 @@ final class MicrophoneCaptureService: @unchecked Sendable {
             withState { $0.auHALRunning = false }
             AudioUnitUninitialize(auHAL)
 
-            ctx.updateDeviceFormat(newFormat)
-
-            // Mirror on output scope element 1 so the callback receives
-            // raw device samples without internal AUHAL conversion.
-            AudioUnitSetProperty(
-                auHAL,
-                kAudioUnitProperty_StreamFormat,
-                kAudioUnitScope_Output,
-                1,
-                &asbd,
-                UInt32(MemoryLayout<AudioStreamBasicDescription>.size)
-            )
+            // Reconfigure the bus the same way `start` did, so a format change
+            // keeps (or re-establishes) the AUHAL channel map instead of
+            // silently reverting a narrowed bus to the full device format.
+            // The channel is re-clamped: the new format may have fewer
+            // channels than the one the selection was made against.
+            let channel = Self.resolvedCaptureChannel(
+                ctx.captureChannel, channelCount: asbd.mChannelsPerFrame)
+            if let clientFormat = try? configureInputBus(
+                auHAL: auHAL, deviceASBD: &asbd, channel: channel)
+            {
+                ctx.updateDeviceFormat(clientFormat, captureChannel: channel)
+            } else {
+                debugLog("refreshInputTapIfNeeded: input bus reconfigure failed")
+                ctx.updateDeviceFormat(newFormat, captureChannel: channel)
+            }
         } else {
             // Can't read format — do a full reinit to recover.
             AudioOutputUnitStop(auHAL)
@@ -400,8 +413,14 @@ final class MicrophoneCaptureService: @unchecked Sendable {
         return true
     }
 
-    func start(preferredDeviceID: String?, chunkHandler: @escaping ChunkHandler) throws {
-        debugLog("start preferredDeviceID=\(preferredDeviceID ?? "default")")
+    func start(
+        preferredDeviceID: String?,
+        preferredInputChannel: Int = 0,
+        chunkHandler: @escaping ChunkHandler
+    ) throws {
+        debugLog(
+            "start preferredDeviceID=\(preferredDeviceID ?? "default") channel=\(preferredInputChannel)"
+        )
 
         // Resolve the target input device without changing the system default.
         let deviceID = try resolveInputDevice(preferredDeviceID)
@@ -490,30 +509,18 @@ final class MicrophoneCaptureService: @unchecked Sendable {
                     "get device format", getFormatStatus)
             }
 
-            guard let deviceFormat = Self.makeDeviceFormat(&deviceASBD) else {
-                throw MicrophoneCaptureError.invalidInputFormat
-            }
+            let captureChannel = Self.resolvedCaptureChannel(
+                preferredInputChannel, channelCount: deviceASBD.mChannelsPerFrame)
 
-            // Mirror the device format on the output scope of element 1
-            // so the callback receives raw device samples (no internal conversion).
-            let setFormatStatus = AudioUnitSetProperty(
-                auHAL,
-                kAudioUnitProperty_StreamFormat,
-                kAudioUnitScope_Output,
-                1,
-                &deviceASBD,
-                UInt32(MemoryLayout<AudioStreamBasicDescription>.size)
-            )
-            guard setFormatStatus == noErr else {
-                throw MicrophoneCaptureError.auHALConfigurationFailed(
-                    "set output format", setFormatStatus)
-            }
+            let clientFormat = try configureInputBus(
+                auHAL: auHAL, deviceASBD: &deviceASBD, channel: captureChannel)
 
             // Create render context and register the input callback.
             let renderCtx = RenderContext(
                 service: self,
                 auHAL: auHAL,
-                deviceFormat: deviceFormat,
+                deviceFormat: clientFormat,
+                captureChannel: captureChannel,
                 outputFormat: targetOutputFormat,
                 chunkHandler: chunkHandler,
                 processingQueue: processingQueue,
@@ -838,24 +845,118 @@ final class MicrophoneCaptureService: @unchecked Sendable {
         return AVAudioFormat(streamDescription: &asbd, channelLayout: layout)
     }
 
-    /// Builds the capture converter for one device format. For channel counts
+    /// Builds the capture converter for one client format. For channel counts
     /// above stereo there is no downmix matrix to mono — AVAudioConverter
-    /// silently converts every frame to ZEROS — so the interface's first
-    /// input channel is mapped to the mono output instead; that is where a
-    /// microphone lives on a multi-channel interface.
+    /// silently converts every frame to ZEROS — so one input channel is mapped
+    /// to the mono output instead. Reached only when the AUHAL declined to do
+    /// the same narrowing itself (see `configureInputBus`); when it accepted,
+    /// the format here is already mono and the map is unnecessary.
     /// Internal (not fileprivate) for the regression tests.
     static func makeTranscriptionConverter(
         from inputFormat: AVAudioFormat,
-        to outputFormat: AVAudioFormat
+        to outputFormat: AVAudioFormat,
+        channel: Int = 0
     ) -> AVAudioConverter? {
         guard let converter = AVAudioConverter(from: inputFormat, to: outputFormat) else {
             return nil
         }
         converter.sampleRateConverterQuality = AVAudioQuality.max.rawValue
         if inputFormat.channelCount > 2 {
-            converter.channelMap = [0]
+            let source = resolvedCaptureChannel(channel, channelCount: inputFormat.channelCount)
+            converter.channelMap = [NSNumber(value: source)]
         }
         return converter
+    }
+
+    /// Clamps a stored channel index to what the device actually offers. The
+    /// selection persists across launches while devices come and go, so an
+    /// index left over from a 16-in interface must not address channel 9 of a
+    /// stereo one. Out of range falls back to the first channel.
+    static func resolvedCaptureChannel(_ channel: Int, channelCount: AVAudioChannelCount) -> Int {
+        guard channelCount > 0, channel >= 0, channel < Int(channelCount) else { return 0 }
+        return channel
+    }
+
+    /// The AUHAL client format for capturing ONE channel of a multi-channel
+    /// device: same sample rate and sample type, one channel. Returns nil for
+    /// mono and stereo devices, which keep the device format and the
+    /// converter's standard downmix.
+    /// Internal (not fileprivate) for the regression tests.
+    static func narrowedClientFormat(
+        from deviceASBD: AudioStreamBasicDescription,
+        channel: Int
+    ) -> AudioStreamBasicDescription? {
+        guard deviceASBD.mChannelsPerFrame > 2 else { return nil }
+        guard channel >= 0, channel < Int(deviceASBD.mChannelsPerFrame) else { return nil }
+        guard deviceASBD.mBitsPerChannel >= 8 else { return nil }
+
+        var narrowed = deviceASBD
+        narrowed.mChannelsPerFrame = 1
+        let bytesPerSample = deviceASBD.mBitsPerChannel / 8
+        narrowed.mBytesPerFrame = bytesPerSample
+        narrowed.mBytesPerPacket = bytesPerSample * max(1, deviceASBD.mFramesPerPacket)
+        return narrowed
+    }
+
+    /// Configures the AUHAL's input bus and returns the format the callback
+    /// will render into.
+    ///
+    /// Preferred path for a multi-channel device: a MONO client format on the
+    /// output scope of element 1 plus `kAudioOutputUnitProperty_ChannelMap`
+    /// naming the device channel that feeds it, so the unit hands us one
+    /// channel and 15 of every 16 are never copied into the render buffer.
+    /// If the unit rejects either property we mirror the full device format
+    /// instead and let `makeTranscriptionConverter` pick the channel — the
+    /// behaviour that shipped in #240, kept as the fallback because it is the
+    /// one proven against the reporter's hardware.
+    private func configureInputBus(
+        auHAL: AudioUnit,
+        deviceASBD: inout AudioStreamBasicDescription,
+        channel: Int
+    ) throws -> AVAudioFormat {
+        let asbdSize = UInt32(MemoryLayout<AudioStreamBasicDescription>.size)
+
+        if var narrowed = Self.narrowedClientFormat(from: deviceASBD, channel: channel) {
+            let formatStatus = AudioUnitSetProperty(
+                auHAL, kAudioUnitProperty_StreamFormat, kAudioUnitScope_Output, 1,
+                &narrowed, asbdSize)
+            var map: [Int32] = [Int32(channel)]
+            let mapStatus =
+                formatStatus == noErr
+                ? AudioUnitSetProperty(
+                    auHAL, kAudioOutputUnitProperty_ChannelMap, kAudioUnitScope_Output, 1,
+                    &map, UInt32(MemoryLayout<Int32>.size * map.count))
+                : formatStatus
+
+            if formatStatus == noErr, mapStatus == noErr,
+                let clientFormat = Self.makeDeviceFormat(&narrowed)
+            {
+                debugLog(
+                    "input bus narrowed by AUHAL: channel \(channel) of \(deviceASBD.mChannelsPerFrame)"
+                )
+                return clientFormat
+            }
+
+            // One of the two was rejected. The unit may now hold a mono client
+            // format with NO channel map, which downmixes a discrete layout to
+            // silence — so the wide format below is set unconditionally rather
+            // than skipped, putting the bus back in a known-good state.
+            debugLog(
+                "AUHAL channel map unavailable (format=\(formatStatus) map=\(mapStatus)); using converter-side channel selection"
+            )
+        }
+
+        let setFormatStatus = AudioUnitSetProperty(
+            auHAL, kAudioUnitProperty_StreamFormat, kAudioUnitScope_Output, 1,
+            &deviceASBD, asbdSize)
+        guard setFormatStatus == noErr else {
+            throw MicrophoneCaptureError.auHALConfigurationFailed(
+                "set output format", setFormatStatus)
+        }
+        guard let deviceFormat = Self.makeDeviceFormat(&deviceASBD) else {
+            throw MicrophoneCaptureError.invalidInputFormat
+        }
+        return deviceFormat
     }
 
     fileprivate static func inputFormatDescriptor(for format: AVAudioFormat) -> InputFormatDescriptor {

--- a/Sources/localvoxtral/MicrophoneCaptureService.swift
+++ b/Sources/localvoxtral/MicrophoneCaptureService.swift
@@ -47,8 +47,19 @@ private final class RenderContext: @unchecked Sendable {
     /// stereo devices; for a multi-channel device narrowed by the AUHAL channel
     /// map it is mono (see `configureInputBus`).
     var deviceAVFormat: AVAudioFormat
-    /// Device channel carrying the microphone. Already applied by the AUHAL
-    /// when the client format came back mono; used by the converter otherwise.
+    /// Descriptor of the DEVICE format behind `deviceAVFormat`. Kept apart
+    /// because the two diverge the moment the bus is narrowed: the client
+    /// format is mono while the device still reports 16 channels, and the
+    /// unchanged-format skip below must compare device against device.
+    var deviceFormatDescriptor: MicrophoneCaptureService.InputFormatDescriptor
+    /// What the USER picked, unclamped. Held separately from the resolved
+    /// channel so a device that briefly reports fewer channels doesn't
+    /// permanently collapse the choice to 0: each reconfigure resolves this
+    /// original index against the current count.
+    var requestedChannel: Int
+    /// Device channel actually in use: `requestedChannel` clamped to the live
+    /// format. Already applied by the AUHAL when the client format came back
+    /// mono; used by the converter otherwise.
     var captureChannel: Int
     let outputFormat: AVAudioFormat
     let chunkHandler: MicrophoneCaptureService.ChunkHandler
@@ -61,6 +72,8 @@ private final class RenderContext: @unchecked Sendable {
         service: MicrophoneCaptureService,
         auHAL: AudioUnit,
         deviceFormat: AVAudioFormat,
+        deviceFormatDescriptor: MicrophoneCaptureService.InputFormatDescriptor,
+        requestedChannel: Int,
         captureChannel: Int,
         outputFormat: AVAudioFormat,
         chunkHandler: @escaping MicrophoneCaptureService.ChunkHandler,
@@ -70,6 +83,8 @@ private final class RenderContext: @unchecked Sendable {
         self.service = service
         self.auHAL = auHAL
         self.deviceAVFormat = deviceFormat
+        self.deviceFormatDescriptor = deviceFormatDescriptor
+        self.requestedChannel = requestedChannel
         self.captureChannel = captureChannel
         self.outputFormat = outputFormat
         self.chunkHandler = chunkHandler
@@ -78,8 +93,16 @@ private final class RenderContext: @unchecked Sendable {
         self.debugLoggingEnabled = debugLoggingEnabled
     }
 
-    func updateDeviceFormat(_ format: AVAudioFormat, captureChannel newChannel: Int) {
+    /// INVARIANT: the AUHAL must be stopped before calling this. These fields
+    /// are read on the CoreAudio realtime thread with no lock; the only thing
+    /// excluding that reader is `AudioOutputUnitStop` having returned.
+    func updateDeviceFormat(
+        _ format: AVAudioFormat,
+        deviceDescriptor: MicrophoneCaptureService.InputFormatDescriptor,
+        captureChannel newChannel: Int
+    ) {
         deviceAVFormat = format
+        deviceFormatDescriptor = deviceDescriptor
         captureChannel = newChannel
         converterState.converter = nil
         converterState.inputFormatDescriptor = nil
@@ -364,7 +387,11 @@ final class MicrophoneCaptureService: @unchecked Sendable {
            let newFormat = Self.makeDeviceFormat(&asbd)
         {
             let ctx = unmanagedCtx.takeUnretainedValue()
-            let currentDescriptor = Self.inputFormatDescriptor(for: ctx.deviceAVFormat)
+            // Device against device: `ctx.deviceAVFormat` is the CLIENT format,
+            // which is mono for a narrowed bus and so would never equal a
+            // 16-channel device format — the skip below would be dead code for
+            // exactly the devices this path exists to serve.
+            let currentDescriptor = ctx.deviceFormatDescriptor
             let newDescriptor = Self.inputFormatDescriptor(for: newFormat)
 
             guard currentDescriptor != newDescriptor else {
@@ -380,17 +407,26 @@ final class MicrophoneCaptureService: @unchecked Sendable {
             // Reconfigure the bus the same way `start` did, so a format change
             // keeps (or re-establishes) the AUHAL channel map instead of
             // silently reverting a narrowed bus to the full device format.
-            // The channel is re-clamped: the new format may have fewer
-            // channels than the one the selection was made against.
+            // Resolved from the REQUESTED channel, not the last resolved one:
+            // a device that briefly reports stereo must not permanently
+            // collapse a channel-8 selection to channel 1.
             let channel = Self.resolvedCaptureChannel(
-                ctx.captureChannel, channelCount: asbd.mChannelsPerFrame)
-            if let clientFormat = try? configureInputBus(
-                auHAL: auHAL, deviceASBD: &asbd, channel: channel)
-            {
-                ctx.updateDeviceFormat(clientFormat, captureChannel: channel)
-            } else {
-                debugLog("refreshInputTapIfNeeded: input bus reconfigure failed")
-                ctx.updateDeviceFormat(newFormat, captureChannel: channel)
+                ctx.requestedChannel, channelCount: asbd.mChannelsPerFrame)
+            do {
+                let clientFormat = try configureInputBus(
+                    auHAL: auHAL, deviceASBD: &asbd, channel: channel)
+                ctx.updateDeviceFormat(
+                    clientFormat, deviceDescriptor: newDescriptor, captureChannel: channel)
+            } catch {
+                // Both property sets failed, so the bus may hold a mono client
+                // format with no channel map. Restarting the unit in that state
+                // captures silence and mismatches the callback's buffer, so tear
+                // it down instead and let recovery rebuild from `start`.
+                debugLog(
+                    "refreshInputTapIfNeeded: input bus reconfigure failed (\(error)); tearing down for a clean rebuild"
+                )
+                stop()
+                return false
             }
         } else {
             // Can't read format — do a full reinit to recover.
@@ -512,6 +548,11 @@ final class MicrophoneCaptureService: @unchecked Sendable {
             let captureChannel = Self.resolvedCaptureChannel(
                 preferredInputChannel, channelCount: deviceASBD.mChannelsPerFrame)
 
+            guard let deviceFormat = Self.makeDeviceFormat(&deviceASBD) else {
+                throw MicrophoneCaptureError.invalidInputFormat
+            }
+            let deviceDescriptor = Self.inputFormatDescriptor(for: deviceFormat)
+
             let clientFormat = try configureInputBus(
                 auHAL: auHAL, deviceASBD: &deviceASBD, channel: captureChannel)
 
@@ -520,6 +561,8 @@ final class MicrophoneCaptureService: @unchecked Sendable {
                 service: self,
                 auHAL: auHAL,
                 deviceFormat: clientFormat,
+                deviceFormatDescriptor: deviceDescriptor,
+                requestedChannel: preferredInputChannel,
                 captureChannel: captureChannel,
                 outputFormat: targetOutputFormat,
                 chunkHandler: chunkHandler,
@@ -888,13 +931,39 @@ final class MicrophoneCaptureService: @unchecked Sendable {
     ) -> AudioStreamBasicDescription? {
         guard deviceASBD.mChannelsPerFrame > 2 else { return nil }
         guard channel >= 0, channel < Int(deviceASBD.mChannelsPerFrame) else { return nil }
-        guard deviceASBD.mBitsPerChannel >= 8 else { return nil }
+
+        // Only formats whose per-sample storage is unambiguous. mBitsPerChannel
+        // is SIGNIFICANT bits, not the stride: 24-bit samples in 32-bit slots
+        // report 24 while occupying 4 bytes, and shrinking by bits/8 would
+        // declare a frame size that doesn't describe the samples. Everything
+        // else declines here and takes the wide fallback, which costs the
+        // optimization and keeps the behaviour #240 proved.
+        guard deviceASBD.mFormatID == kAudioFormatLinearPCM,
+            deviceASBD.mFormatFlags & kAudioFormatFlagIsPacked != 0,
+            deviceASBD.mFramesPerPacket == 1,
+            deviceASBD.mBitsPerChannel >= 8,
+            deviceASBD.mBitsPerChannel % 8 == 0
+        else { return nil }
+
+        // Interleaved: one frame holds every channel, so the per-sample stride
+        // is the frame size divided by the channel count. Non-interleaved:
+        // mBytesPerFrame already describes ONE channel's buffer.
+        let isInterleaved = deviceASBD.mFormatFlags & kAudioFormatFlagIsNonInterleaved == 0
+        let bytesPerSample: UInt32
+        if isInterleaved {
+            guard deviceASBD.mChannelsPerFrame > 0,
+                deviceASBD.mBytesPerFrame % deviceASBD.mChannelsPerFrame == 0
+            else { return nil }
+            bytesPerSample = deviceASBD.mBytesPerFrame / deviceASBD.mChannelsPerFrame
+        } else {
+            bytesPerSample = deviceASBD.mBytesPerFrame
+        }
+        guard bytesPerSample == deviceASBD.mBitsPerChannel / 8 else { return nil }
 
         var narrowed = deviceASBD
         narrowed.mChannelsPerFrame = 1
-        let bytesPerSample = deviceASBD.mBitsPerChannel / 8
         narrowed.mBytesPerFrame = bytesPerSample
-        narrowed.mBytesPerPacket = bytesPerSample * max(1, deviceASBD.mFramesPerPacket)
+        narrowed.mBytesPerPacket = bytesPerSample
         return narrowed
     }
 
@@ -909,6 +978,26 @@ final class MicrophoneCaptureService: @unchecked Sendable {
     /// instead and let `makeTranscriptionConverter` pick the channel — the
     /// behaviour that shipped in #240, kept as the fallback because it is the
     /// one proven against the reporter's hardware.
+    /// Whether the narrowed bus survived both property calls. Pure so the
+    /// decision table is testable: the `AudioUnitSetProperty` calls themselves
+    /// need multi-channel hardware, but which way we branch on their results
+    /// is exactly the logic whose failure means silence.
+    enum ClientFormatChoice: Equatable {
+        /// Both properties took; the callback renders one channel.
+        case narrowed
+        /// Narrowing was declined or rejected; restore the full device format
+        /// and let the converter pick the channel (the #240 path).
+        case wide
+    }
+
+    static func clientFormatChoice(formatStatus: OSStatus, mapStatus: OSStatus)
+        -> ClientFormatChoice
+    {
+        // BOTH must succeed. A mono client format with no channel map is the
+        // worst state available: a discrete layout downmixes to silence.
+        (formatStatus == noErr && mapStatus == noErr) ? .narrowed : .wide
+    }
+
     private func configureInputBus(
         auHAL: AudioUnit,
         deviceASBD: inout AudioStreamBasicDescription,
@@ -928,7 +1017,8 @@ final class MicrophoneCaptureService: @unchecked Sendable {
                     &map, UInt32(MemoryLayout<Int32>.size * map.count))
                 : formatStatus
 
-            if formatStatus == noErr, mapStatus == noErr,
+            if Self.clientFormatChoice(formatStatus: formatStatus, mapStatus: mapStatus)
+                == .narrowed,
                 let clientFormat = Self.makeDeviceFormat(&narrowed)
             {
                 debugLog(

--- a/Sources/localvoxtral/SettingsStore.swift
+++ b/Sources/localvoxtral/SettingsStore.swift
@@ -262,6 +262,7 @@ final class SettingsStore {
         static let dictationShortcutMode = "settings.dictation_shortcut_mode"
         static let autoCopyEnabled = "settings.auto_copy_enabled"
         static let selectedInputDeviceUID = "settings.selected_input_device_uid"
+        static let selectedInputChannel = "settings.selected_input_channel"
         static let dictationShortcutEnabled = "settings.dictation_shortcut_enabled"
         static let dictationShortcutKeyCode = "settings.dictation_shortcut_key_code"
         static let dictationShortcutCarbonModifierFlags =
@@ -383,6 +384,15 @@ final class SettingsStore {
 
     var selectedInputDeviceUID: String {
         didSet { defaults.set(selectedInputDeviceUID, forKey: Keys.selectedInputDeviceUID) }
+    }
+
+    /// Which input channel of a multi-channel device carries the microphone,
+    /// zero-based. Only consulted for devices above stereo, where there is no
+    /// meaningful downmix to mono (see `MicrophoneCaptureService`). Kept as a
+    /// single global rather than per-device: users have one interface, and a
+    /// stale index for another device is clamped away at capture start.
+    var selectedInputChannel: Int {
+        didSet { defaults.set(selectedInputChannel, forKey: Keys.selectedInputChannel) }
     }
 
     var dictationShortcutEnabled: Bool {
@@ -913,6 +923,11 @@ final class SettingsStore {
             ? defaults.double(forKey: Keys.overlayBufferFontSize)
             : OverlayLayoutMetrics.defaultBodyFontSize
         overlayBufferFontSize = OverlayLayoutMetrics.clampedBodyFontSize(storedOverlayFontSize)
+
+        // Zero-based; negatives are meaningless and an index past the device's
+        // channel count is clamped again at capture start (the device can
+        // change between launches).
+        selectedInputChannel = max(0, defaults.integer(forKey: Keys.selectedInputChannel))
 
         // --- Dual shortcut keys ---
         let hasExistingOverlayKeys = defaults.object(forKey: Keys.overlayBufferShortcutKeyCode) != nil

--- a/Sources/localvoxtral/StatusPopoverView.swift
+++ b/Sources/localvoxtral/StatusPopoverView.swift
@@ -98,6 +98,28 @@ struct StatusPopoverView: View {
                 }
             }
 
+            // Above stereo there is no meaningful downmix to mono, so capture
+            // takes ONE channel and the user says which (a mic sits on one
+            // preamp of a multi-input interface). Hidden for mono/stereo
+            // devices, where the standard downmix applies and the choice would
+            // be meaningless.
+            if viewModel.selectedInputDeviceChannelCount > 2 {
+                Menu("Input Channel") {
+                    ForEach(0..<Int(viewModel.selectedInputDeviceChannelCount), id: \.self) {
+                        channel in
+                        Button {
+                            viewModel.selectMicrophoneInputChannel(channel)
+                        } label: {
+                            if viewModel.selectedInputChannel == channel {
+                                Label("Channel \(channel + 1)", systemImage: "checkmark")
+                            } else {
+                                Text("Channel \(channel + 1)")
+                            }
+                        }
+                    }
+                }
+            }
+
             Button("Copy Latest Segment") {
                 viewModel.copyLatestSegment()
             }

--- a/Tests/localvoxtralTests/MicrophoneInputChannelTests.swift
+++ b/Tests/localvoxtralTests/MicrophoneInputChannelTests.swift
@@ -178,4 +178,82 @@ final class MicrophoneInputChannelTests: XCTestCase {
         }
         return (sumOfSquares / Float(outputBuffer.frameLength)).squareRoot()
     }
+
+    // MARK: - Narrow-vs-fallback decision (review follow-up)
+
+    /// The decision table around the two AUHAL property calls. The calls
+    /// themselves need multi-channel hardware; this is the branch whose
+    /// failure means silence, and it was previously untestable — deleting the
+    /// unconditional wide re-set left every other test green.
+    func testBothPropertiesMustSucceedToKeepTheNarrowedBus() {
+        XCTAssertEqual(
+            MicrophoneCaptureService.clientFormatChoice(formatStatus: noErr, mapStatus: noErr),
+            .narrowed)
+    }
+
+    func testRejectedChannelMapFallsBackToTheWideFormat() {
+        // The dangerous case: format took, map didn't. A mono client format
+        // with no map downmixes a discrete layout to silence.
+        XCTAssertEqual(
+            MicrophoneCaptureService.clientFormatChoice(formatStatus: noErr, mapStatus: -10851),
+            .wide)
+    }
+
+    func testRejectedClientFormatFallsBackToTheWideFormat() {
+        XCTAssertEqual(
+            MicrophoneCaptureService.clientFormatChoice(formatStatus: -10868, mapStatus: -10868),
+            .wide)
+    }
+
+    // MARK: - Narrowing declines formats it cannot describe
+
+    /// 24 significant bits in 32-bit slots: shrinking by mBitsPerChannel/8
+    /// would declare a 3-byte frame for 4-byte samples. Declining costs the
+    /// optimization and keeps the proven wide path.
+    func testNarrowingDeclinesUnpackedSampleStorage() {
+        var asbd = multiChannelASBD(channels: 16)
+        asbd.mFormatFlags = kAudioFormatFlagIsSignedInteger  // not packed
+        asbd.mBitsPerChannel = 24
+        XCTAssertNil(MicrophoneCaptureService.narrowedClientFormat(from: asbd, channel: 0))
+    }
+
+    func testNarrowingDeclinesNonPCMFormats() {
+        var asbd = multiChannelASBD(channels: 16)
+        asbd.mFormatID = kAudioFormatMPEG4AAC
+        XCTAssertNil(MicrophoneCaptureService.narrowedClientFormat(from: asbd, channel: 0))
+    }
+
+    /// Non-interleaved is the HAL default for many interfaces: there
+    /// mBytesPerFrame already describes ONE channel, so the narrowed format
+    /// must keep it rather than divide it by the channel count.
+    func testNarrowingHandlesNonInterleavedDevices() throws {
+        var asbd = multiChannelASBD(channels: 16)
+        asbd.mFormatFlags |= kAudioFormatFlagIsNonInterleaved
+        asbd.mBytesPerFrame = 4
+        asbd.mBytesPerPacket = 4
+
+        let narrowed = try XCTUnwrap(
+            MicrophoneCaptureService.narrowedClientFormat(from: asbd, channel: 5))
+        XCTAssertEqual(narrowed.mChannelsPerFrame, 1)
+        XCTAssertEqual(narrowed.mBytesPerFrame, 4)
+        XCTAssertEqual(
+            narrowed.mFormatFlags, asbd.mFormatFlags,
+            "format flags must survive narrowing or the AUHAL sees a different sample type")
+    }
+
+    /// At or below stereo the channel selection must not be applied at all:
+    /// the standard downmix is correct there, and a stale index from a
+    /// multi-channel device must not reach the converter. Asking for channel 5
+    /// on a MONO input must leave the identity map AVAudioConverter builds
+    /// itself (`[0]`), never `[5]`.
+    func testMonoInputIgnoresTheSelectedChannel() throws {
+        let inputFormat = try XCTUnwrap(
+            AVAudioFormat(
+                commonFormat: .pcmFormatFloat32, sampleRate: 48000, channels: 1,
+                interleaved: false))
+        let converter = try XCTUnwrap(
+            MicrophoneCaptureService.makeTranscriptionConverter(
+                from: inputFormat, to: monoTranscriptionFormat(), channel: 5))
+        XCTAssertEqual(converter.channelMap, [0])
+    }
 }

--- a/Tests/localvoxtralTests/MicrophoneInputChannelTests.swift
+++ b/Tests/localvoxtralTests/MicrophoneInputChannelTests.swift
@@ -1,0 +1,181 @@
+@preconcurrency import AVFoundation
+import AudioToolbox
+import Synchronization
+import XCTest
+
+@testable import localvoxtral
+
+/// Follow-up to the multi-channel work in #240, which hardcoded the FIRST
+/// input channel. A microphone sits on one preamp of a multi-input interface,
+/// and not necessarily the first, so the channel is now a user choice — and
+/// the AUHAL narrows its own input bus to that one channel where it can,
+/// instead of rendering all 16 and discarding 15.
+///
+/// These drive the pure seams (`resolvedCaptureChannel`, `narrowedClientFormat`,
+/// `makeTranscriptionConverter`) with synthetic formats, so they need no audio
+/// hardware. The AUHAL property calls themselves need a real multi-channel
+/// device and are hand-verified (see the PR).
+final class MicrophoneInputChannelTests: XCTestCase {
+
+    private func multiChannelASBD(channels: UInt32) -> AudioStreamBasicDescription {
+        AudioStreamBasicDescription(
+            mSampleRate: 48000,
+            mFormatID: kAudioFormatLinearPCM,
+            mFormatFlags: kAudioFormatFlagIsFloat | kAudioFormatFlagIsPacked,
+            mBytesPerPacket: 4 * channels,
+            mFramesPerPacket: 1,
+            mBytesPerFrame: 4 * channels,
+            mChannelsPerFrame: channels,
+            mBitsPerChannel: 32,
+            mReserved: 0
+        )
+    }
+
+    private func monoTranscriptionFormat() -> AVAudioFormat {
+        AVAudioFormat(
+            commonFormat: .pcmFormatFloat32, sampleRate: 16000, channels: 1, interleaved: false)!
+    }
+
+    // MARK: - Channel clamping
+
+    func testChannelWithinRangeIsKept() {
+        XCTAssertEqual(MicrophoneCaptureService.resolvedCaptureChannel(5, channelCount: 16), 5)
+    }
+
+    /// The selection persists across launches while devices come and go: an
+    /// index left over from a 16-in interface must not address channel 9 of a
+    /// stereo device.
+    func testChannelPastDeviceChannelCountFallsBackToFirst() {
+        XCTAssertEqual(MicrophoneCaptureService.resolvedCaptureChannel(9, channelCount: 2), 0)
+        XCTAssertEqual(MicrophoneCaptureService.resolvedCaptureChannel(0, channelCount: 0), 0)
+        XCTAssertEqual(MicrophoneCaptureService.resolvedCaptureChannel(-1, channelCount: 16), 0)
+    }
+
+    // MARK: - AUHAL client format
+
+    func testNarrowedClientFormatIsSingleChannelAtDeviceRate() throws {
+        let narrowed = try XCTUnwrap(
+            MicrophoneCaptureService.narrowedClientFormat(
+                from: multiChannelASBD(channels: 16), channel: 3))
+
+        XCTAssertEqual(narrowed.mChannelsPerFrame, 1)
+        XCTAssertEqual(narrowed.mSampleRate, 48000)
+        // One float32 sample per frame — this is what stops the AUHAL from
+        // copying 16 channels into every render buffer.
+        XCTAssertEqual(narrowed.mBytesPerFrame, 4)
+        XCTAssertEqual(narrowed.mBytesPerPacket, 4)
+        XCTAssertEqual(narrowed.mBitsPerChannel, 32)
+    }
+
+    /// Mono and stereo devices must keep the device format and the standard
+    /// downmix; narrowing them would be a behaviour change for every ordinary
+    /// microphone.
+    func testNarrowedClientFormatDeclinesMonoAndStereo() {
+        XCTAssertNil(
+            MicrophoneCaptureService.narrowedClientFormat(
+                from: multiChannelASBD(channels: 1), channel: 0))
+        XCTAssertNil(
+            MicrophoneCaptureService.narrowedClientFormat(
+                from: multiChannelASBD(channels: 2), channel: 0))
+    }
+
+    func testNarrowedClientFormatDeclinesOutOfRangeChannel() {
+        XCTAssertNil(
+            MicrophoneCaptureService.narrowedClientFormat(
+                from: multiChannelASBD(channels: 16), channel: 16))
+    }
+
+    // MARK: - Converter fallback
+
+    /// When the AUHAL declines the narrowing, the converter must still pull the
+    /// SELECTED channel, not channel 0. Tone lives only on channel 7.
+    func testConverterFallbackPullsTheSelectedChannel() throws {
+        var asbd = multiChannelASBD(channels: 16)
+        let inputFormat = try XCTUnwrap(MicrophoneCaptureService.makeDeviceFormat(&asbd))
+        let outputFormat = monoTranscriptionFormat()
+        let converter = try XCTUnwrap(
+            MicrophoneCaptureService.makeTranscriptionConverter(
+                from: inputFormat, to: outputFormat, channel: 7))
+
+        let rms = try monoRMS(converter: converter, inputFormat: inputFormat, tonedChannel: 7)
+        XCTAssertGreaterThan(
+            rms, 0.1,
+            "the converter dropped the selected channel: dictation would hear silence")
+    }
+
+    /// The complement: asking for channel 7 must NOT pick up a tone sitting on
+    /// channel 0, or the selection is decorative.
+    func testConverterFallbackIgnoresUnselectedChannels() throws {
+        var asbd = multiChannelASBD(channels: 16)
+        let inputFormat = try XCTUnwrap(MicrophoneCaptureService.makeDeviceFormat(&asbd))
+        let outputFormat = monoTranscriptionFormat()
+        let converter = try XCTUnwrap(
+            MicrophoneCaptureService.makeTranscriptionConverter(
+                from: inputFormat, to: outputFormat, channel: 7))
+
+        let rms = try monoRMS(converter: converter, inputFormat: inputFormat, tonedChannel: 0)
+        XCTAssertLessThan(rms, 0.01, "channel 0 leaked into a capture that selected channel 7")
+    }
+
+    /// An out-of-range stored channel must not produce a silent converter; it
+    /// clamps to the first channel like the rest of the path.
+    func testConverterClampsOutOfRangeChannel() throws {
+        var asbd = multiChannelASBD(channels: 16)
+        let inputFormat = try XCTUnwrap(MicrophoneCaptureService.makeDeviceFormat(&asbd))
+        let outputFormat = monoTranscriptionFormat()
+        let converter = try XCTUnwrap(
+            MicrophoneCaptureService.makeTranscriptionConverter(
+                from: inputFormat, to: outputFormat, channel: 99))
+
+        let rms = try monoRMS(converter: converter, inputFormat: inputFormat, tonedChannel: 0)
+        XCTAssertGreaterThan(rms, 0.1)
+    }
+
+    // MARK: - Helper
+
+    /// Feeds a 440Hz tone placed on exactly one channel of an interleaved
+    /// multi-channel buffer and returns the RMS of the mono output.
+    private func monoRMS(
+        converter: AVAudioConverter,
+        inputFormat: AVAudioFormat,
+        tonedChannel: Int
+    ) throws -> Float {
+        let frames: AVAudioFrameCount = 4800
+        let stride = Int(inputFormat.channelCount)
+        let inputBuffer = try XCTUnwrap(
+            AVAudioPCMBuffer(pcmFormat: inputFormat, frameCapacity: frames))
+        inputBuffer.frameLength = frames
+        let samples = try XCTUnwrap(inputBuffer.floatChannelData)[0]
+        for frame in 0..<Int(frames) {
+            samples[frame * stride + tonedChannel] =
+                0.5 * sin(2 * .pi * 440 * Float(frame) / 48000)
+        }
+
+        let outputBuffer = try XCTUnwrap(
+            AVAudioPCMBuffer(pcmFormat: converter.outputFormat, frameCapacity: 4000))
+        let didFeedInput = Mutex(false)
+        var conversionError: NSError?
+        converter.convert(to: outputBuffer, error: &conversionError) { _, status in
+            let alreadyFed = didFeedInput.withLock { fed in
+                let was = fed
+                fed = true
+                return was
+            }
+            if alreadyFed {
+                status.pointee = .noDataNow
+                return nil
+            }
+            status.pointee = .haveData
+            return inputBuffer
+        }
+
+        XCTAssertNil(conversionError)
+        XCTAssertGreaterThan(outputBuffer.frameLength, 0)
+        let output = try XCTUnwrap(outputBuffer.floatChannelData)[0]
+        var sumOfSquares: Float = 0
+        for frame in 0..<Int(outputBuffer.frameLength) {
+            sumOfSquares += output[frame] * output[frame]
+        }
+        return (sumOfSquares / Float(outputBuffer.frameLength)).squareRoot()
+    }
+}


### PR DESCRIPTION
## What

The two follow-ups from #240's review, which shipped a hardcoded first input channel selected converter-side.

**1. The channel is a user choice.** A microphone sits on one preamp of a multi-input interface, and not necessarily the first. An "Input Channel" submenu now sits next to the existing Microphone device menu in the status popover, shown only for devices above stereo, where there is no meaningful downmix and the choice means something. Mono and stereo devices are untouched. The stored index is clamped against the live device at capture start, so a selection left over from a 16-in interface can't address channel 9 of a stereo one.

**2. The AUHAL does the picking.** The selection narrows the AUHAL's input bus: a mono client format on the output scope of element 1, plus `kAudioOutputUnitProperty_ChannelMap` naming the device channel that feeds it. The unit hands the callback one channel instead of 16. When the unit rejects either property, the bus is put back to the full device format and the converter picks the channel instead — the path #240 proved against the reporter's hardware, so the worst case is today's behaviour.

`configureInputBus` is shared by `start` and the device-format-change listener, so a format change re-establishes the channel map rather than silently reverting a narrowed bus.

Also fixes the microphone log redacting to `<private>`: an interpolated `String` defaults to private in os_log, so the diagnostics designed to prove this feature were unreadable on the machine the feature exists for. Found during the hand test below.

## Proof

Unit suite, `remote-build.sh test`:

```
Executed 2760 tests, with 2 tests skipped and 0 failures (0 unexpected) in 103.311 seconds
```

15 tests in `MicrophoneInputChannelTests`, Metal-free and hardware-free. The two carrying the behaviour: a 440Hz tone on channel 7 reaches the mono output when channel 7 is selected, and a tone on channel 0 does **not** when channel 7 is selected — without the second, the picker could be decorative and everything would still pass. Plus the `clientFormatChoice` decision table, since deleting the unconditional wide re-set previously left every test green.

### Hand test on a real 16-channel device (BlackHole 16ch)

**Verified end to end.** With a 16-channel WAV carrying speech on channel 7 only, played through ffmpeg direct to the device (not `afplay`, which adds a downmix on channels 1–2 at ~2.6× and would mask a wrong-channel read):

```
contemporaneous capture during the dictation
captured channels: 16
channel  7: rms 2125.3   <== SIGNAL
channels 1-6, 8-16: rms 0.0
```

That produced three clean verbatim repetitions of the test sentence and a correct final transcript. A default channel-1 read would have returned digital silence. **The app demonstrably selected channel 7.**

Also confirmed: the submenu appeared for the 16-channel device and persisted the correct zero-based index behind a one-based label (`settings.selected_input_channel = 6` for menu "Channel 7").

### Not verified: which path served it

**The AUHAL narrow path has never been observed running.** `input bus narrowed by AUHAL` versus `AUHAL channel map unavailable` was unreadable on the first run (the `<private>` bug this PR now fixes), and on the retry the BlackHole 16ch driver's internal output→input bridge had died — 5.3 MB muxed into the output half, zeros read from the input half, surviving a `killall coreaudiod`, while BlackHole 2ch passed audio in the same minute.

So both paths remain behaviourally identical from outside, and this PR merges with the optimisation **unproven**. That is not a correctness risk: the fallback is the code that shipped in #240 and is proven against the reporter's UA interface. The open question is whether the AUHAL narrowing ever engages, i.e. whether the callback stops copying 16 channels to discard 15.

Reproducing it on a working 16-channel device is a five-minute job. The traps, each of which cost a run: route the system output to the virtual device and re-read it immediately before playback (`afplay` follows the default and has no device flag); play with ffmpeg rather than `afplay`, and pass `-guess_layout_max 0` so it doesn't guess a layout for a layout-less 16ch file; write the test WAV as `WAVE_FORMAT_EXTENSIBLE`, since a plain PCM header is out of spec above 2 channels; never leave a backgrounded ffmpeg able to write to the terminal, or `SIGTTOU` suspends it holding an audio client indefinitely; launch the app under test detached and quit it cleanly, because repeated unclean AUHAL teardowns wedge a virtual device's internal loopback; and cache device UIDs rather than AudioDeviceIDs, which a coreaudiod restart silently invalidates.

## Reviews

Reviewed by codex and by GLM 5.3, both adversarial, both fixed in `2d690ce`. GLM caught the one that mattered: the unchanged-format skip guard in `refreshInputTapIfNeeded` had become dead code for narrowed devices (client format mono, device format 16ch, never equal), and it shipped green against all 8 original tests. codex caught that a temporary channel-count drop permanently collapsed the user's selection. Both flagged the swallowed `configureInputBus` failure and the single-stream channel count.

## Not done here

Per-device channel memory. One global index, on the assumption of one interface; the clamping keeps a stale index harmless.
