### PR TITLE
Remote forward: prove who holds a refused port before calling it contention

### DIFF
--- a/Sources/localvoxtral/ClaudeContext/ClaudeRemoteContextListener.swift
+++ b/Sources/localvoxtral/ClaudeContext/ClaudeRemoteContextListener.swift
@@ -434,6 +434,7 @@ public final class ClaudeRemoteContextListener: Sendable {
         // re-running its enrollment (field report, 2026-07-26). The category is
         // derived from the header's shape and the authentication result only —
         // no token material reaches the log, the tally, or the UI.
+
         // The ONE thing looked at before the token, and the exception proves
         // the rule above rather than weakening it: the value compared is a
         // random nonce THIS process minted moments ago and is still waiting

--- a/Sources/localvoxtral/ClaudeContext/ClaudeRemoteContextListener.swift
+++ b/Sources/localvoxtral/ClaudeContext/ClaudeRemoteContextListener.swift
@@ -103,6 +103,11 @@ public final class ClaudeRemoteContextListener: Sendable {
     /// listener on every rebind, and evidence the user has not read yet must not
     /// be erased by enrolling a second host.
     private let rejections: ClaudeRemoteRejectionTally
+    /// Nonces the forward supervisor minted for an in-flight ownership probe.
+    /// Injected for the same reason the tally is: the coordinator rebuilds the
+    /// listener on every rebind, and a probe in flight across one must not be
+    /// lost. See `ClaudeRemoteForwardProbeWitness` for why this exists at all.
+    private let forwardProbes: ClaudeRemoteForwardProbeWitness
     /// Authenticated host activity can pre-start a slow herdr `-L` away from
     /// dictation latency. The path remains an opaque remote label.
     private let onRemoteHerdrActivity: @Sendable (String, String) -> Void
@@ -143,6 +148,7 @@ public final class ClaudeRemoteContextListener: Sendable {
         hosts: ClaudeRemoteHostRegistry,
         limits: ClaudeRemoteListenerLimits = .default,
         rejections: ClaudeRemoteRejectionTally = ClaudeRemoteRejectionTally(),
+        forwardProbes: ClaudeRemoteForwardProbeWitness = ClaudeRemoteForwardProbeWitness(),
         now: @escaping @Sendable () -> Date = { Date() },
         uptimeNanos: @escaping @Sendable () -> UInt64 = { DispatchTime.now().uptimeNanoseconds },
         onRemoteHerdrActivity: @escaping @Sendable (String, String) -> Void = { _, _ in }
@@ -151,6 +157,7 @@ public final class ClaudeRemoteContextListener: Sendable {
         self.hosts = hosts
         self.limits = limits
         self.rejections = rejections
+        self.forwardProbes = forwardProbes
         self.now = now
         self.uptimeNanos = uptimeNanos
         self.onRemoteHerdrActivity = onRemoteHerdrActivity
@@ -427,6 +434,25 @@ public final class ClaudeRemoteContextListener: Sendable {
         // re-running its enrollment (field report, 2026-07-26). The category is
         // derived from the header's shape and the authentication result only —
         // no token material reaches the log, the tally, or the UI.
+        // The ONE thing looked at before the token, and the exception proves
+        // the rule above rather than weakening it: the value compared is a
+        // random nonce THIS process minted moments ago and is still waiting
+        // for, so a peer that did not receive it cannot produce a match, and a
+        // peer that did learns nothing from having produced one. The response
+        // is byte-for-byte the same 401 either way — this branch exists to keep
+        // our own probe out of the rejection tally, whose whole job is telling
+        // the user which of three real fixes to apply. Nothing is ingested,
+        // nothing is authorized: the arrival itself is the entire signal.
+        if forwardProbes.note(
+            headerValue: request.headers[ClaudeRemoteForwardProbeWitness.headerName]
+        ) {
+            Log.claudeContext.info(
+                "Claude remote forward ownership probe arrived on this listener"
+            )
+            respond(fd: fd, status: 401)
+            return
+        }
+
         let shape = ClaudeRemoteHTTPCodec.authorizationShape(
             in: request.headers["authorization"], limits: limits.http
         )

--- a/Sources/localvoxtral/ClaudeContext/ClaudeRemoteForwardCoordinator.swift
+++ b/Sources/localvoxtral/ClaudeContext/ClaudeRemoteForwardCoordinator.swift
@@ -64,6 +64,9 @@ public final class ClaudeRemoteForwardCoordinator {
         listenerPort: UInt16 = ClaudeRemoteListenerLimits.default.port,
         isListenerBound: @escaping @MainActor () -> Bool,
         makeSupervisor: MakeSupervisor? = nil,
+        // Handed to every supervisor this coordinator builds itself. Nil keeps
+        // the fail-closed behaviour: a refused bind stays `portUnavailable`.
+        ownershipProbe: ClaudeRemoteForwardOwnershipProbe? = nil,
         pidLedger: ClaudeRemoteForwardPidLedger? = nil,
         reapOrphans: (@Sendable () async -> Void)? = nil,
         reconcileHerdrEnrollment: @escaping @MainActor (Set<String>) -> Void = { _ in }
@@ -94,7 +97,8 @@ public final class ClaudeRemoteForwardCoordinator {
                         pidLedger.remember(hostID: config.hostID, record: record)
                     }
                     return process
-                }
+                },
+                ownershipProbe: ownershipProbe
             )
         }
     }

--- a/Sources/localvoxtral/ClaudeContext/ClaudeRemoteForwardOrphanReaper.swift
+++ b/Sources/localvoxtral/ClaudeContext/ClaudeRemoteForwardOrphanReaper.swift
@@ -8,8 +8,7 @@ import Darwin
 /// run starts hook `-R` or herdr `-L` forwards.
 ///
 /// The bug this closes (field report, 2026-08-05): quit-and-reopen sometimes
-/// landed the pane on "Port held — close ssh sessions to that host." with a
-/// Retry that could only fail. The holder was this Mac's own orphan — an
+/// landed the pane on the port-held status with a Retry that could only fail. The holder was this Mac's own orphan — an
 /// `ssh -N -R` from a run that ended without `applicationWillTerminate`
 /// (crash, force-quit) or whose teardown outran the bounded quit drain. It
 /// reparents to launchd, keepalives keep it healthy forever, and nothing else

--- a/Sources/localvoxtral/ClaudeContext/ClaudeRemoteForwardOwnership.swift
+++ b/Sources/localvoxtral/ClaudeContext/ClaudeRemoteForwardOwnership.swift
@@ -1,0 +1,235 @@
+import Foundation
+import Synchronization
+
+/// Who holds the remote listen port when OpenSSH refuses this Mac's bind.
+///
+/// The refusal itself cannot tell the two apart, and they want opposite things
+/// from the user (field report, 2026-08-29):
+///
+/// * a stranger — another Mac's forward, a leftover tunnel, an unrelated
+///   service — is a real failure the user has to go and clear;
+/// * **our own `RemoteForward`, already established by an ordinary ssh session
+///   that read the enrollment block out of `~/.ssh/config`**, is the desired
+///   end state reached by another route. It is what happens to everybody who
+///   actually ssh's to the host they enrolled, and the app was telling them to
+///   close the session providing the working tunnel.
+public enum ClaudeRemoteForwardOwnership: Sendable, Equatable {
+    /// A nonce this process minted seconds ago came back in on this Mac's own
+    /// listener, through the port in question. Nothing else can produce that.
+    case ourListener
+    /// Everything else, including every way the check could not be run.
+    /// The only safe default: see `ClaudeRemoteForwardProbeWitness`.
+    case unproved
+}
+
+/// Nonces minted for an in-flight ownership probe, and which of them the
+/// listener has SEEN arrive.
+///
+/// **This is the whole trust argument, so it is worth being explicit about what
+/// is and is not evidence.**
+///
+/// The obvious probe — curl the port from the remote host and read the status
+/// code — is not evidence of anything. Our 401 (and the 411 an empty POST gets)
+/// is public: the listener's source, its response shape and its paths are all in
+/// this repository, so any process on the remote host can bind the port and
+/// reproduce those bytes exactly. Worse, it is not even a correct *diagnosis*:
+/// a SECOND Mac enrolled against the same host answers a genuine, honest 401 of
+/// its own, and that is precisely the contention `ClaudeRemoteForwardPort`
+/// exists to make visible.
+///
+/// So the probe does not read the answer at all. It sends a fresh random nonce
+/// TO the port and then asks THIS process whether its own loopback listener saw
+/// that nonce. That inverts the question into one only the real topology can
+/// answer:
+///
+/// * if the port is held by our own `RemoteForward`, the request travels the
+///   tunnel and lands here — match;
+/// * if a stranger holds the port, it receives the nonce and can do nothing
+///   with it. The listener binds `127.0.0.1` on this Mac and the only route to
+///   it from that host is a forward — which, by hypothesis, the stranger is the
+///   reason we do not have. It cannot deliver the nonce, so it cannot be
+///   adopted;
+/// * if another Mac holds the port, the nonce lands on THAT Mac's listener,
+///   which has never heard of it. No match here, which is the right answer.
+///
+/// Everything else — no `curl` on the host, ssh refused, a timeout, no probe
+/// wired in at all — produces `.unproved`, which keeps the old
+/// `portUnavailable` behaviour. Fail closed is the default, not a branch.
+public final class ClaudeRemoteForwardProbeWitness: Sendable {
+    /// The header the probe rides in. Named like the env enrichment headers so
+    /// it is recognisably ours in a capture, and deliberately NOT a new URL
+    /// path: the listener authenticates on the head before it judges a path, and
+    /// this must not become the second thing that is judged earlier.
+    public static let headerName = "x-lvx-forward-probe"
+
+    /// A hard ceiling on armed nonces. Arm/disarm are paired by the one caller,
+    /// so this can only ever be reached by a bug — and a bug that leaks entries
+    /// should leak a bounded number of dead strings, not grow a set forever.
+    static let maximumArmed = 8
+
+    private struct State {
+        /// Armed nonces in arming order, each with whether it has been seen.
+        var entries: [(nonce: String, observed: Bool)] = []
+    }
+
+    private let state = Mutex(State())
+
+    public init() {}
+
+    /// 128 bits of CSPRNG as lowercase hex.
+    ///
+    /// Hex rather than base64url because this value is interpolated into a
+    /// generated `sh` script and an HTTP header value; `[0-9a-f]` needs quoting
+    /// in neither, and the header parser's charset rules cannot be tripped by it.
+    public static func randomNonce() -> String {
+        var bytes = [UInt8](repeating: 0, count: 16)
+        for index in bytes.indices { bytes[index] = UInt8.random(in: .min ... .max) }
+        return bytes.map { String(format: "%02x", $0) }.joined()
+    }
+
+    /// Start watching for `nonce`. Paired with exactly one `consume`.
+    public func arm(_ nonce: String) {
+        state.withLock { state in
+            state.entries.removeAll { $0.nonce == nonce }
+            state.entries.append((nonce: nonce, observed: false))
+            while state.entries.count > Self.maximumArmed { state.entries.removeFirst() }
+        }
+    }
+
+    /// Stop watching for `nonce`, and report whether it ever arrived.
+    public func consume(_ nonce: String) -> Bool {
+        state.withLock { state in
+            guard let index = state.entries.firstIndex(where: { $0.nonce == nonce }) else {
+                return false
+            }
+            return state.entries.remove(at: index).observed
+        }
+    }
+
+    /// Listener side: mark an armed nonce as seen.
+    ///
+    /// - Returns: true only when `headerValue` is exactly an armed nonce. A
+    ///   header that is absent, empty, or anything we did not mint is not
+    ///   distinguishable from the other by anything the caller then does — the
+    ///   response bytes are identical either way, by construction at the call
+    ///   site.
+    @discardableResult
+    public func note(headerValue: String?) -> Bool {
+        guard let headerValue, !headerValue.isEmpty else { return false }
+        return state.withLock { state in
+            // Constant-time against every armed entry, and no early exit on the
+            // first match: a loop that breaks tells a caller how many nonces are
+            // armed and roughly where theirs sits.
+            var matched = false
+            for index in state.entries.indices
+            where ClaudeRemoteTokenDigest.constantTimeEquals(
+                state.entries[index].nonce, headerValue
+            ) {
+                state.entries[index].observed = true
+                matched = true
+            }
+            return matched
+        }
+    }
+
+    /// Test seam: is this nonce still armed?
+    var armedCount: Int { state.withLock { $0.entries.count } }
+}
+
+/// Asks a host whether the refused port forwards to THIS Mac.
+///
+/// - Parameters:
+///   - sshHostAlias: the enrolled alias, already validated by the caller.
+///   - remoteForwardPort: the port the bind was refused for.
+public typealias ClaudeRemoteForwardOwnershipProbe = @Sendable (
+    _ sshHostAlias: String, _ remoteForwardPort: UInt16
+) async -> ClaudeRemoteForwardOwnership
+
+/// Internal, not public, for one concrete reason: its default runner is the
+/// enrollment service's live `Process` runner, which is internal — and a public
+/// entry point whose default argument reaches for an internal declaration does
+/// not compile. Nothing outside this module builds one.
+enum ClaudeRemoteForwardOwnershipCheck {
+    /// Bounded on purpose and short: this runs inside a supervise loop that the
+    /// user is watching a status line for, and a wedged ssh must not park it.
+    static let defaultTimeout: TimeInterval = 10
+
+    /// The remote half of the probe.
+    ///
+    /// It is a `curl` on the REMOTE host because that is where the port is
+    /// bound — nothing on this Mac can reach it. No token is sent, and none
+    /// would be accepted: the request is expected to be refused, and the
+    /// refusal is not what is being read.
+    ///
+    /// Sent over stdin rather than argv so the nonce never appears in a remote
+    /// process listing, the same rule the enrollment scripts follow for the
+    /// token.
+    static func script(nonce: String, remoteForwardPort: UInt16) -> String {
+        """
+        exec >/dev/null 2>&1
+        command -v curl >/dev/null 2>&1 || exit 3
+        curl -s -o /dev/null --max-time 5 -X POST \
+          -H 'Content-Type: application/json' \
+          -H '\(ClaudeRemoteForwardProbeWitness.headerName): \(nonce)' \
+          -d '{}' \
+          'http://127.0.0.1:\(remoteForwardPort)/v1/hook/SessionStart'
+        """
+    }
+
+    /// `ClearAllForwardings=yes` HERE, unlike the supervised herdr `-L`
+    /// (`docs/agent/invariants.md`): this connection carries no forward of its
+    /// own and must not inherit the alias's `RemoteForward`, which would have it
+    /// contend for the very port it is asking about and print the warning that
+    /// started this whole diagnosis. `--` for the `-V` lesson (PR #197).
+    static func argv(sshHostAlias: String) -> [String] {
+        [
+            "ssh",
+            "-o", "BatchMode=yes",
+            "-o", "ClearAllForwardings=yes",
+            "-o", "ConnectTimeout=5",
+            "--", sshHostAlias, "/bin/sh", "-s",
+        ]
+    }
+
+    static func live(
+        witness: ClaudeRemoteForwardProbeWitness,
+        runner: @escaping ClaudeRemoteEnrollmentService.Runner =
+            ClaudeRemoteEnrollmentService.processRunner(),
+        makeNonce: @escaping @Sendable () -> String = {
+            ClaudeRemoteForwardProbeWitness.randomNonce()
+        },
+        timeout: TimeInterval = defaultTimeout
+    ) -> ClaudeRemoteForwardOwnershipProbe {
+        { sshHostAlias, remoteForwardPort in
+            // Re-validated rather than assumed: this is the only place in the
+            // forward path that hands an alias to a NEW process, and `--`
+            // covers option injection but not a caller mistake.
+            guard ClaudeRemoteEnrollmentService.isValidHostAlias(sshHostAlias) else {
+                return .unproved
+            }
+            let nonce = makeNonce()
+            witness.arm(nonce)
+            // `Process` + its semaphore waits are blocking, and every caller of
+            // this probe is on the main actor.
+            let ran = await Task.detached(priority: .utility) { () -> Bool in
+                let invocation = ClaudeRemoteEnrollmentService.Invocation(
+                    argv: argv(sshHostAlias: sshHostAlias),
+                    standardInput: Data(
+                        script(nonce: nonce, remoteForwardPort: remoteForwardPort).utf8
+                    ),
+                    timeout: timeout
+                )
+                return (try? runner(invocation)) != nil
+            }.value
+            // The exit status is NOT the answer and is not consulted for one:
+            // curl exits 0 against a stranger that answered, and non-zero
+            // against our own listener if the connection is torn down after the
+            // request lands. Only the witness decides.
+            let observed = witness.consume(nonce)
+            Log.claudeContext.info(
+                "Claude remote forward ownership probe on port \(remoteForwardPort, privacy: .public) ran=\(String(ran), privacy: .public) ourListener=\(String(observed), privacy: .public)"
+            )
+            return observed ? .ourListener : .unproved
+        }
+    }
+}

--- a/Sources/localvoxtral/ClaudeContext/ClaudeRemoteForwardOwnership.swift
+++ b/Sources/localvoxtral/ClaudeContext/ClaudeRemoteForwardOwnership.swift
@@ -164,6 +164,10 @@ enum ClaudeRemoteForwardOwnershipCheck {
     /// Sent over stdin rather than argv so the nonce never appears in a remote
     /// process listing, the same rule the enrollment scripts follow for the
     /// token.
+    ///
+    /// The first line discards both streams on purpose. Whatever holds that
+    /// port gets to write a response, and none of it is evidence — so none of
+    /// it is carried back into this process to be captured, capped, or logged.
     static func script(nonce: String, remoteForwardPort: UInt16) -> String {
         """
         exec >/dev/null 2>&1

--- a/Sources/localvoxtral/ClaudeContext/ClaudeRemoteForwardOwnership.swift
+++ b/Sources/localvoxtral/ClaudeContext/ClaudeRemoteForwardOwnership.swift
@@ -14,8 +14,13 @@ import Synchronization
 ///   actually ssh's to the host they enrolled, and the app was telling them to
 ///   close the session providing the working tunnel.
 public enum ClaudeRemoteForwardOwnership: Sendable, Equatable {
-    /// A nonce this process minted seconds ago came back in on this Mac's own
-    /// listener, through the port in question. Nothing else can produce that.
+    /// A nonce this process minted seconds ago, posted into the disputed port
+    /// on the remote host, came back in on this Mac's own listener.
+    ///
+    /// Read that literally: what is proved is that the nonce REACHED this
+    /// listener, not the route it took. See the residual in
+    /// `ClaudeRemoteForwardProbeWitness` — an arrival is attributable to the
+    /// disputed port only while that host has exactly one live forward to us.
     case ourListener
     /// Everything else, including every way the check could not be run.
     /// The only safe default: see `ClaudeRemoteForwardProbeWitness`.
@@ -45,12 +50,31 @@ public enum ClaudeRemoteForwardOwnership: Sendable, Equatable {
 /// * if the port is held by our own `RemoteForward`, the request travels the
 ///   tunnel and lands here — match;
 /// * if a stranger holds the port, it receives the nonce and can do nothing
-///   with it. The listener binds `127.0.0.1` on this Mac and the only route to
-///   it from that host is a forward — which, by hypothesis, the stranger is the
-///   reason we do not have. It cannot deliver the nonce, so it cannot be
-///   adopted;
+///   with it. The listener binds `127.0.0.1` on this Mac, so the only route to
+///   it from that host is a `RemoteForward` terminating here — and the disputed
+///   one, by hypothesis, is the forward the stranger is the reason we do not
+///   have. It cannot deliver the nonce, so it cannot be adopted;
 /// * if another Mac holds the port, the nonce lands on THAT Mac's listener,
 ///   which has never heard of it. No match here, which is the right answer.
+///
+/// ## The residual, stated rather than glossed
+///
+/// The step above is sound only while that host has ONE live forward to this
+/// Mac. Every `-R` this app supervises terminates at the same local listener
+/// (`-R <derived>:127.0.0.1:<listenerPort>`), so arrival identifies the
+/// LISTENER, never the remote port that carried it. Where a second live forward
+/// to us exists from the same host — a legacy `RemoteForward 8473` left in the
+/// user's own `~/.ssh/config` block and carried by an interactive session is
+/// the realistic one — a holder of the disputed port that is actively hostile
+/// can read our request off its own socket and replay it down that other
+/// forward, and the witness will match.
+///
+/// That is bounded, and is the reason this is a residual rather than a hole:
+/// the replay needs code execution on the enrolled host, and anything with code
+/// execution there already holds the plugin's bearer token and can already
+/// receive every hook — it gains a suppressed status row, not a credential.
+/// `.ourListener` is therefore a diagnosis, and must never be read as an
+/// authorization or as proof that the channel is private.
 ///
 /// Everything else — no `curl` on the host, ssh refused, a timeout, no probe
 /// wired in at all — produces `.unproved`, which keeps the old
@@ -89,10 +113,24 @@ public final class ClaudeRemoteForwardProbeWitness: Sendable {
 
     /// Start watching for `nonce`. Paired with exactly one `consume`.
     public func arm(_ nonce: String) {
-        state.withLock { state in
+        let evicted: Int = state.withLock { state in
             state.entries.removeAll { $0.nonce == nonce }
             state.entries.append((nonce: nonce, observed: false))
-            while state.entries.count > Self.maximumArmed { state.entries.removeFirst() }
+            var evicted = 0
+            while state.entries.count > Self.maximumArmed {
+                state.entries.removeFirst()
+                evicted += 1
+            }
+            return evicted
+        }
+        // Loud, because an eviction silently turns some OTHER host's probe into
+        // `.unproved` — and the supervisor then logs "bound by something that
+        // is not this Mac's listener", a negative that probe never established.
+        // Arm/disarm are paired by the one caller, so reaching this is a bug.
+        if evicted > 0 {
+            Log.claudeContext.error(
+                "Claude remote forward probe witness evicted \(evicted, privacy: .public) armed nonce(s) at the \(Self.maximumArmed, privacy: .public) cap; their probes will report unproved"
+            )
         }
     }
 
@@ -161,8 +199,23 @@ enum ClaudeRemoteForwardOwnershipCheck {
     /// would be accepted: the request is expected to be refused, and the
     /// refusal is not what is being read.
     ///
-    /// Sent over stdin rather than argv so the nonce never appears in a remote
-    /// process listing, the same rule the enrollment scripts follow for the
+    /// The script is sent over stdin rather than argv, the same rule the
+    /// enrollment scripts follow for the token. Read precisely: that keeps the
+    /// nonce out of the SSH argv on THIS Mac, which is the half that matters
+    /// here — this machine is also the self-hosted CI runner, so its process
+    /// list is readable by anything a PR can run.
+    ///
+    /// It does NOT keep the nonce out of the remote host's process list: `sh`
+    /// then runs `curl` with the header as a literal argument, so for up to the
+    /// `--max-time` window a local user there can read it. Left as it is, on
+    /// purpose. `curl --header @file` is the technique that would fix it (the
+    /// plugin shim uses exactly that), but it needs curl >= 7.55 on an
+    /// arbitrary enrolled host, and a host that lacks it would silently stop
+    /// producing arrivals — a probe that quietly degrades to "not ours" is a
+    /// worse failure than the exposure it removes. The exposure buys a reader
+    /// nothing on its own: spending the nonce still requires a live forward
+    /// from that host to this listener (see the residual on the witness), and
+    /// anyone with local execution there already holds the plugin's bearer
     /// token.
     ///
     /// The first line discards both streams on purpose. Whatever holds that

--- a/Sources/localvoxtral/ClaudeContext/ClaudeRemoteForwardSupervisor.swift
+++ b/Sources/localvoxtral/ClaudeContext/ClaudeRemoteForwardSupervisor.swift
@@ -73,7 +73,12 @@ public protocol ClaudeRemoteForwardProcess: Sendable {
 ///   (see issue #215) and will keep holding it; retrying on a timer would be a
 ///   connection storm, an auth-log full of sessions, and possibly a fail2ban
 ///   ban — all while the user is told nothing. One clear failed state, with the
-///   fix in it, beats an infinite retry that hides the cause.
+///   fix in it, beats an infinite retry that hides the cause. The ONE exception
+///   is `externallyForwarded`, where the holder is our own forward and the
+///   thing being waited for — that session ending, and our bind then
+///   succeeding — is expected rather than hoped for; that one re-checks on a
+///   deliberately long interval, because a state claiming a channel exists must
+///   be able to stop claiming it.
 /// * NO `ClearAllForwardings`. It was here to stop this process inheriting the
 ///   alias's own `RemoteForward` and requesting the port twice — and it does
 ///   that, but it ALSO clears the `-R` given on the command line, which is the
@@ -117,8 +122,17 @@ public final class ClaudeRemoteForwardSupervisor: ClaudeRemoteForwarding {
         case connecting
         case forwarding
         case retrying(attempt: Int)
-        /// The remote refused the bind: someone else holds the port.
+        /// The remote refused the bind, and the port did NOT prove to be ours:
+        /// someone else holds it.
         case portUnavailable
+        /// The remote refused the bind because our OWN `RemoteForward` is
+        /// already established — an ordinary ssh session of the user's, carrying
+        /// the enrollment block out of `~/.ssh/config`, is providing exactly the
+        /// tunnel this process exists to provide. Not a failure: the channel
+        /// works, and this supervisor simply has nothing to do until that
+        /// session ends. Proved, never assumed — see
+        /// `ClaudeRemoteForwardProbeWitness`.
+        case externallyForwarded
         /// The remote refused a bind for a port this supervisor never asked
         /// for — so the alias's ssh config block still declares an old
         /// `RemoteForward`, which we inherit and `ExitOnForwardFailure=yes`
@@ -137,12 +151,20 @@ public final class ClaudeRemoteForwardSupervisor: ClaudeRemoteForwarding {
             case .connecting: return "Connecting…"
             case .forwarding: return "Tunnel up."
             case .retrying(let attempt): return "Reconnecting (attempt \(attempt))."
-            // Names the thing to close. The overwhelmingly common holder is an
-            // ssh session from THIS Mac — the user's own terminal, or one a
-            // harness left behind — and the previous copy ("Port already held
-            // on the host.") left them with a Retry button that could only
-            // fail again. Still one sentence, by the popover rule.
-            case .portUnavailable: return "Port held — close ssh sessions to that host."
+            // No longer "close ssh sessions to that host" (field report,
+            // 2026-08-29): the overwhelmingly common holder turned out to be
+            // the user's own session carrying the enrollment block, i.e. the
+            // WORKING tunnel, and that case is `externallyForwarded` now. What
+            // reaches here is a holder that was measurably not this Mac's
+            // listener, which closing a session may not fix at all — so this
+            // states the fact and leaves the Retry button to be the action.
+            // Still one sentence, by the popover rule.
+            case .portUnavailable: return "Port held by another program on that host."
+            // Nothing for the user to do, so nothing is asked of them — and
+            // "up" comes first because that is the fact that matters. The
+            // clause is there so a later plain "Tunnel up." does not read as a
+            // change of state.
+            case .externallyForwarded: return "Tunnel up — an ssh session already holds it."
             case .staleConfiguredForward: return "Old RemoteForward in ~/.ssh/config blocks this."
             case .failed: return "Tunnel stopped."
             }
@@ -150,7 +172,8 @@ public final class ClaudeRemoteForwardSupervisor: ClaudeRemoteForwarding {
 
         public var isFailure: Bool {
             switch self {
-            case .stopped, .connecting, .forwarding, .retrying: return false
+            case .stopped, .connecting, .forwarding, .retrying, .externallyForwarded:
+                return false
             case .portUnavailable, .staleConfiguredForward, .failed: return true
             }
         }
@@ -200,6 +223,22 @@ public final class ClaudeRemoteForwardSupervisor: ClaudeRemoteForwarding {
         /// so in the log. A process in an uninterruptible wait can outlive even
         /// this; pretending otherwise is how a teardown blocks forever.
         public var killGrace: Duration
+        /// How long `externallyForwarded` may go unverified.
+        ///
+        /// That state says a channel EXISTS but is held by a session this
+        /// process does not own, so it can vanish with no event reaching here —
+        /// the user closes the terminal, and the app would otherwise keep
+        /// claiming a tunnel it does not have. On this interval the supervisor
+        /// simply tries its own `-R` again: if the session ended, the bind now
+        /// succeeds and the app takes the tunnel over; if it did not, ownership
+        /// is proved again from scratch.
+        ///
+        /// Long on purpose. This is the one place the type's "a refused bind is
+        /// terminal, never a retry loop" rule is relaxed, and it is defensible
+        /// only because the outcome being waited for — our own bind succeeding —
+        /// is expected rather than hoped for. Five minutes is a bounded
+        /// staleness window, not a reconnect storm.
+        public var externalForwardRecheckInterval: Duration
         /// Present for a supervised herdr `-L`; nil for the original hook
         /// delivery `-R`. The lifecycle is shared, while argv and bind-failure
         /// interpretation remain direction-specific.
@@ -214,7 +253,8 @@ public final class ClaudeRemoteForwardSupervisor: ClaudeRemoteForwarding {
             settleDelay: Duration = .seconds(2),
             healthyUptime: Duration = .seconds(60),
             terminationGrace: Duration = .seconds(2),
-            killGrace: Duration = .seconds(1)
+            killGrace: Duration = .seconds(1),
+            externalForwardRecheckInterval: Duration = .seconds(300)
         ) {
             self.hostID = hostID
             self.sshHostAlias = sshHostAlias
@@ -225,6 +265,7 @@ public final class ClaudeRemoteForwardSupervisor: ClaudeRemoteForwarding {
             self.healthyUptime = healthyUptime
             self.terminationGrace = terminationGrace
             self.killGrace = killGrace
+            self.externalForwardRecheckInterval = externalForwardRecheckInterval
             self.localSocketForward = nil
         }
 
@@ -248,6 +289,9 @@ public final class ClaudeRemoteForwardSupervisor: ClaudeRemoteForwarding {
             self.healthyUptime = healthyUptime
             self.terminationGrace = terminationGrace
             self.killGrace = killGrace
+            // Unreachable for a `-L`: ownership is a question about the `-R`'s
+            // remote listen port, and this initializer never has one.
+            self.externalForwardRecheckInterval = .seconds(300)
             self.localSocketForward = LocalSocketForward(
                 localSocketPath: localSocketPath,
                 remoteSocketPath: remoteSocketPath
@@ -301,6 +345,14 @@ public final class ClaudeRemoteForwardSupervisor: ClaudeRemoteForwarding {
 
     @ObservationIgnored public let configuration: Configuration
     @ObservationIgnored private let launch: Launch
+    /// Asked, on a refused bind, whether the port that refused us is already
+    /// forwarding to THIS Mac's listener.
+    ///
+    /// Optional, and `nil` is the fail-closed answer: without a probe every
+    /// refusal stays `portUnavailable`, exactly as before. The herdr `-L`
+    /// supervisor never has one, because a `-L` binds locally and its failures
+    /// are a different question entirely.
+    @ObservationIgnored private let ownershipProbe: ClaudeRemoteForwardOwnershipProbe?
     @ObservationIgnored private let sleepFor: SleepClosure
     @ObservationIgnored private let now: NowClosure
     @ObservationIgnored private var superviseTask: Task<Void, Never>?
@@ -326,11 +378,13 @@ public final class ClaudeRemoteForwardSupervisor: ClaudeRemoteForwarding {
     public init(
         configuration: Configuration,
         launch: @escaping Launch,
+        ownershipProbe: ClaudeRemoteForwardOwnershipProbe? = nil,
         sleepFor: @escaping SleepClosure = { try await Task.sleep(for: $0) },
         now: @escaping NowClosure = { Date() }
     ) {
         self.configuration = configuration
         self.launch = launch
+        self.ownershipProbe = ownershipProbe
         self.sleepFor = sleepFor
         self.now = now
     }
@@ -491,7 +545,12 @@ public final class ClaudeRemoteForwardSupervisor: ClaudeRemoteForwarding {
                 await self?.watchStandardError(of: process)
             }
 
-            transitionIfNeeded(to: .connecting)
+            // A five-minute liveness re-check of an EXTERNALLY held tunnel
+            // must not blink the pane through "Connecting…" and back: nothing
+            // about the channel changed, and a status line that flickers is one
+            // the user learns to distrust. Every other entry to this loop is a
+            // real connection attempt and says so.
+            if state != .externallyForwarded { transitionIfNeeded(to: .connecting) }
             // …so "up" is defined as "still alive after the settle window",
             // measured on the INJECTED clock. A bind failure under
             // `ExitOnForwardFailure=yes` kills the process in well under a
@@ -561,10 +620,40 @@ public final class ClaudeRemoteForwardSupervisor: ClaudeRemoteForwarding {
             }
 
             if configuration.localSocketForward == nil, bindFailure != nil {
+                // A refused bind is TWO opposite situations wearing one stderr
+                // line, and the app used to publish the harmful reading of both
+                // (field report, 2026-08-29). Ask which one this is before
+                // concluding anything; the probe answers `.unproved` for every
+                // way it cannot tell, so the fail-closed path below is also the
+                // default and the no-probe path.
+                let ownership = await resolveOwnership()
+                guard !stoppingIntentionally, !Task.isCancelled else {
+                    superviseTask = nil
+                    return
+                }
+                if ownership == .ourListener {
+                    // Not a failure and not a run of them: the channel this
+                    // process exists to provide is up, provided by someone else.
+                    consecutiveFailures = 0
+                    Log.claudeContext.info(
+                        "Claude remote forward for host \(self.configuration.hostID, privacy: .public): port \(self.configuration.remoteForwardPort, privacy: .public) on \(self.configuration.sshHostAlias, privacy: .public) already forwards to this Mac's listener; leaving it to the session that holds it"
+                    )
+                    transition(to: .externallyForwarded)
+                    // Park, then try our own bind again. The holder is a session
+                    // we do not own and cannot be notified about, so a bounded
+                    // staleness window is the only honest claim available.
+                    do {
+                        try await sleepFor(configuration.externalForwardRecheckInterval)
+                    } catch {
+                        superviseTask = nil
+                        return
+                    }
+                    continue
+                }
                 // Terminal by design. Restarting would dial a port another
                 // machine is holding, forever, silently.
                 Log.claudeContext.error(
-                    "Claude remote forward refused for host \(self.configuration.hostID, privacy: .public): port \(self.configuration.remoteForwardPort, privacy: .public) already bound on \(self.configuration.sshHostAlias, privacy: .public)"
+                    "Claude remote forward refused for host \(self.configuration.hostID, privacy: .public): port \(self.configuration.remoteForwardPort, privacy: .public) already bound on \(self.configuration.sshHostAlias, privacy: .public) by something that is not this Mac's listener"
                 )
                 transition(to: .portUnavailable)
                 superviseTask = nil
@@ -615,6 +704,18 @@ public final class ClaudeRemoteForwardSupervisor: ClaudeRemoteForwarding {
             }
         }
         superviseTask = nil
+    }
+
+    /// Whether the refused port is already forwarding to this Mac's listener.
+    ///
+    /// The absence of a probe is an answer, not a gap: `unproved` keeps the
+    /// pre-existing `portUnavailable` behaviour, so nothing about this path can
+    /// be reached by failing to configure something.
+    private func resolveOwnership() async -> ClaudeRemoteForwardOwnership {
+        guard let ownershipProbe else { return .unproved }
+        return await ownershipProbe(
+            configuration.sshHostAlias, configuration.remoteForwardPort
+        )
     }
 
     /// The port whose bind the remote refused, if it refused one.

--- a/Sources/localvoxtral/ClaudeContext/ClaudeRemoteListenerCoordinator.swift
+++ b/Sources/localvoxtral/ClaudeContext/ClaudeRemoteListenerCoordinator.swift
@@ -73,9 +73,15 @@ public final class ClaudeRemoteListenerCoordinator: ClaudeRemoteListenerControll
         self.makeListener = makeListener
     }
 
+    /// - Parameter forwardProbes: shared with the forward supervisors, which
+    ///   mint the nonces this listener watches for. Passed in rather than owned
+    ///   for the same reason the tally is held here rather than in a listener:
+    ///   the object must survive a rebind, and a probe answered across one would
+    ///   otherwise be lost and read as contention.
     public convenience init(
         hosts: ClaudeRemoteHostRegistry,
         sessions: ClaudeSessionRegistry,
+        forwardProbes: ClaudeRemoteForwardProbeWitness = ClaudeRemoteForwardProbeWitness(),
         onRemoteHerdrActivity: @escaping @Sendable (String, String) -> Void = { _, _ in }
     ) {
         self.init(hosts: hosts, sessions: sessions) { registry, rejections in
@@ -83,6 +89,7 @@ public final class ClaudeRemoteListenerCoordinator: ClaudeRemoteListenerControll
                 registry: sessions,
                 hosts: registry,
                 rejections: rejections,
+                forwardProbes: forwardProbes,
                 onRemoteHerdrActivity: onRemoteHerdrActivity
             )
         }

--- a/Sources/localvoxtral/localvoxtralApp.swift
+++ b/Sources/localvoxtral/localvoxtralApp.swift
@@ -160,6 +160,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     /// Shared lifecycle for both remote-hook `-R` and remote-herdr `-L`
     /// children: one ledger/reaper sees every app-held SSH process.
     private let claudeRemoteForwardPidLedger = ClaudeRemoteForwardPidLedger()
+    /// Shared by the remote listener and the forward supervisors: one mints
+    /// ownership-probe nonces, the other reports the ones that arrive. It lives
+    /// here because both are rebuilt independently and neither may own it.
+    private let claudeRemoteForwardProbes = ClaudeRemoteForwardProbeWitness()
     private lazy var claudeRemoteHerdrForwards = ClaudeRemoteHerdrForwardService(
         spawner: ClaudeRemoteHerdrForwardSpawner(),
         workspaces: ClaudeRemoteHerdrForwardWorkspaces(),
@@ -478,6 +482,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             ClaudeRemoteListenerCoordinator(
                 hosts: hosts,
                 sessions: claudeSessionRegistry,
+                forwardProbes: claudeRemoteForwardProbes,
                 onRemoteHerdrActivity: { [weak self] hostID, remoteSocketPath in
                     Task { @MainActor [weak self] in
                         guard let self,
@@ -523,6 +528,14 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                 hosts: hosts,
                 remoteForwardPort: remoteForwardPort,
                 isListenerBound: { coordinator?.isListening ?? false },
+                // Turns "the remote refused our bind" from one verdict into
+                // two: a stranger holds the port, or our own forward is already
+                // up because the user has an ssh session to that host. Only the
+                // nonce round-trip can tell them apart, and without it every
+                // refusal stays the pessimistic reading.
+                ownershipProbe: ClaudeRemoteForwardOwnershipCheck.live(
+                    witness: claudeRemoteForwardProbes
+                ),
                 pidLedger: claudeRemoteForwardPidLedger,
                 reapOrphans: { [weak self] in
                     await forwardOrphanReaper.reap()

--- a/Tests/localvoxtralTests/ClaudeIntegrationSettingsModelTests.swift
+++ b/Tests/localvoxtralTests/ClaudeIntegrationSettingsModelTests.swift
@@ -292,7 +292,7 @@ final class ClaudeIntegrationSettingsModelTests: XCTestCase {
         try XCTUnwrap(stubs.byHost[hostID]).transition(to: .portUnavailable)
 
         let row = try XCTUnwrap(model.hosts.first)
-        XCTAssertEqual(row.forwardStatusText, "Port held — close ssh sessions to that host.")
+        XCTAssertEqual(row.forwardStatusText, "Port held by another program on that host.")
         XCTAssertTrue(row.forwardIsFailure)
         // Owner rule: a Settings status line is one short sentence; the ssh
         // stderr tail belongs in the log.

--- a/Tests/localvoxtralTests/ClaudeRemoteContextListenerTests.swift
+++ b/Tests/localvoxtralTests/ClaudeRemoteContextListenerTests.swift
@@ -58,6 +58,7 @@ final class ClaudeRemoteContextListenerTests: XCTestCase {
     ///   tests) — a test that needs expiry advances this seam immediately.
     private func startListener(
         limits: ClaudeRemoteListenerLimits? = nil,
+        forwardProbes: ClaudeRemoteForwardProbeWitness = ClaudeRemoteForwardProbeWitness(),
         uptimeNanos: (@Sendable () -> UInt64)? = nil,
         onRemoteHerdrActivity: @escaping @Sendable (String, String) -> Void = { _, _ in }
     ) throws {
@@ -65,6 +66,7 @@ final class ClaudeRemoteContextListenerTests: XCTestCase {
             registry: sessions,
             hosts: hosts,
             limits: limits ?? ClaudeRemoteListenerLimits(port: port),
+            forwardProbes: forwardProbes,
             uptimeNanos: uptimeNanos ?? { DispatchTime.now().uptimeNanoseconds },
             onRemoteHerdrActivity: onRemoteHerdrActivity
         )
@@ -163,6 +165,79 @@ final class ClaudeRemoteContextListenerTests: XCTestCase {
         text += "Content-Length: \(contentLengthOverride ?? body.count)\r\n\r\n"
         if contentLengthOverride != nil { body = Data() }
         return Data(text.utf8) + body
+    }
+
+    // MARK: - Forward-ownership probe (field report, 2026-08-29)
+
+    private func probeHeader(_ nonce: String) -> String {
+        "X-Lvx-Forward-Probe: \(nonce)"
+    }
+
+    /// A refused `RemoteForward` cannot say WHO holds the port, so the
+    /// supervisor mints a nonce, sends it down the port from the remote host,
+    /// and asks whether it came out here. This is the "came out here" half, and
+    /// what it must not do is disturb anything: the peer gets the same 401 as
+    /// any other unauthenticated request, and the rejection tally — which tells
+    /// the user which of three real fixes to apply — stays clean.
+    func testAnOwnershipProbeArrivesWithoutBeingCountedAsARejection() throws {
+        let witness = ClaudeRemoteForwardProbeWitness()
+        let nonce = ClaudeRemoteForwardProbeWitness.randomNonce()
+        witness.arm(nonce)
+        try startListener(forwardProbes: witness)
+
+        let response = try XCTUnwrap(
+            try send(hookRequest(token: nil, extraHeaders: [probeHeader(nonce)]))
+        )
+
+        XCTAssertEqual(response.status, 401, "an unauthenticated peer is still refused")
+        XCTAssertTrue(witness.consume(nonce), "arrival IS the proof; nothing else is read")
+        XCTAssertTrue(
+            listener.rejectionSnapshot.isEmpty,
+            "our own probe must not look like a host that needs re-enrolling"
+        )
+        XCTAssertTrue(sessions.liveSessions().isEmpty)
+    }
+
+    /// A nonce this process did not mint proves nothing and is not treated as
+    /// anything: the request is the ordinary unauthenticated one it looks like.
+    /// This is what keeps a stranger on the remote port from being adopted — it
+    /// can reproduce every byte of our responses, but it cannot produce a value
+    /// we are currently waiting for.
+    func testAProbeHeaderWeNeverMintedIsJustAnUnauthenticatedRequest() throws {
+        let witness = ClaudeRemoteForwardProbeWitness()
+        let mine = ClaudeRemoteForwardProbeWitness.randomNonce()
+        witness.arm(mine)
+        try startListener(forwardProbes: witness)
+
+        let stranger = ClaudeRemoteForwardProbeWitness.randomNonce()
+        let response = try XCTUnwrap(
+            try send(hookRequest(token: nil, extraHeaders: [probeHeader(stranger)]))
+        )
+
+        XCTAssertEqual(response.status, 401)
+        XCTAssertFalse(witness.consume(mine), "the armed nonce is untouched")
+        XCTAssertEqual(
+            listener.rejectionSnapshot.missingToken, 1,
+            "and it is counted exactly as it would have been without the header"
+        )
+    }
+
+    /// The probe branch runs before authentication, so it has to be provably
+    /// incapable of laundering anything past it: a matching nonce short-circuits
+    /// to the same 401 even when a perfectly good token rides along, and nothing
+    /// is ingested.
+    func testAMatchingNonceCannotCarryAPayloadPastAuthentication() throws {
+        let witness = ClaudeRemoteForwardProbeWitness()
+        let nonce = ClaudeRemoteForwardProbeWitness.randomNonce()
+        witness.arm(nonce)
+        try startListener(forwardProbes: witness)
+
+        let response = try XCTUnwrap(
+            try send(hookRequest(token: token, extraHeaders: [probeHeader(nonce)]))
+        )
+
+        XCTAssertEqual(response.status, 401)
+        XCTAssertTrue(sessions.liveSessions().isEmpty, "no record, no marker, no session")
     }
 
     // MARK: - Happy path

--- a/Tests/localvoxtralTests/ClaudeRemoteForwardOwnershipTests.swift
+++ b/Tests/localvoxtralTests/ClaudeRemoteForwardOwnershipTests.swift
@@ -197,10 +197,16 @@ final class ClaudeRemoteForwardOwnershipTests: XCTestCase {
         XCTAssertTrue(spy.recorded.isEmpty)
     }
 
-    /// The nonce is a short-lived secret while it is in flight: an argv is
-    /// world-readable on the remote host, so it goes down stdin like the
-    /// enrollment token does.
-    func testTheNonceTravelsOnStdinAndNeverInArgv() async throws {
+    /// The nonce is a short-lived secret while it is in flight, and this pins
+    /// exactly which process list it stays out of: THIS Mac's.
+    ///
+    /// Named for what it asserts. The old name claimed the nonce is never in
+    /// any argv, which the last assertion here shows is untrue on the far side
+    /// — `sh` runs `curl` with the header as a literal argument. That exposure
+    /// is deliberate and argued at `ClaudeRemoteForwardOwnershipCheck.script`;
+    /// it is asserted rather than merely tolerated so that changing it is a
+    /// decision someone makes, not a diff nobody notices.
+    func testTheNonceTravelsOnStdinAndNeverInTheSSHArgv() async throws {
         let witness = ClaudeRemoteForwardProbeWitness()
         let spy = RunnerSpy()
         let probe = ClaudeRemoteForwardOwnershipCheck.live(
@@ -221,6 +227,17 @@ final class ClaudeRemoteForwardOwnershipTests: XCTestCase {
         XCTAssertFalse(
             call.standardInput.lowercased().contains("authorization"),
             "the probe carries no credential — the refusal is the point"
+        )
+        // The known residual, pinned. On the REMOTE host the nonce is a curl
+        // argument for the --max-time window. `curl --header @file` would move
+        // it, needs curl >= 7.55 on an arbitrary host, and fails silently
+        // below it — so it is not used, and this assertion is what makes that
+        // a stated choice instead of an oversight.
+        XCTAssertTrue(
+            call.standardInput.contains(
+                "-H '\(ClaudeRemoteForwardProbeWitness.headerName): 0123456789abcdef0123456789abcdef'"
+            ),
+            "the header the far side sends; see the residual on `script`"
         )
     }
 
@@ -243,5 +260,36 @@ final class ClaudeRemoteForwardOwnershipTests: XCTestCase {
         XCTAssertTrue(argv.contains("--"))
         let terminator = try XCTUnwrap(argv.firstIndex(of: "--"))
         XCTAssertEqual(argv[terminator + 1], "builder", "the alias follows the terminator")
+    }
+
+    /// Both bounds on the probe, asserted rather than only stated.
+    ///
+    /// This runs inside the supervise loop the user is watching a status line
+    /// for, on a path the main actor awaits. Dropping `ConnectTimeout` lets a
+    /// black-holed route spend the entire outer budget in the TCP connect, and
+    /// raising the outer cap parks the loop for that long — neither shows up in
+    /// any other assertion here, so a regression in either would ship green.
+    func testTheProbeIsBoundedAtBothTheConnectAndTheWholeRun() async throws {
+        let witness = ClaudeRemoteForwardProbeWitness()
+        let spy = RunnerSpy()
+        let probe = ClaudeRemoteForwardOwnershipCheck.live(
+            witness: witness, runner: spy.runner
+        )
+
+        _ = await probe("builder", 28511)
+
+        let call = try XCTUnwrap(spy.recorded.first)
+        XCTAssertTrue(
+            call.argv.contains("ConnectTimeout=5"),
+            "a host that black-holes the port must not eat the whole budget in connect(): \(call.argv)"
+        )
+        XCTAssertEqual(
+            call.timeout, ClaudeRemoteForwardOwnershipCheck.defaultTimeout,
+            "the outer cap is what stops a wedged ssh parking the supervise loop"
+        )
+        XCTAssertEqual(ClaudeRemoteForwardOwnershipCheck.defaultTimeout, 10)
+        // curl's own ceiling, inside the outer cap, so the far side cannot hold
+        // the connection open for the full run either.
+        XCTAssertTrue(call.standardInput.contains("--max-time 5"))
     }
 }

--- a/Tests/localvoxtralTests/ClaudeRemoteForwardOwnershipTests.swift
+++ b/Tests/localvoxtralTests/ClaudeRemoteForwardOwnershipTests.swift
@@ -1,0 +1,247 @@
+import Foundation
+import Synchronization
+import XCTest
+@testable import localvoxtral
+
+/// The discriminator behind `externallyForwarded`.
+///
+/// Every case here is about one question: what is allowed to convince this Mac
+/// that a port it could not bind is nevertheless its own tunnel. The answer has
+/// to be "a nonce we minted, arriving on our own listener", and nothing else —
+/// because the alternative reading of a refused bind is a stranger who is
+/// receiving the remote plugin's bearer token on every hook.
+final class ClaudeRemoteForwardOwnershipTests: XCTestCase {
+
+    // MARK: - The witness
+
+    func testAnArmedNonceIsObservedOnce() {
+        let witness = ClaudeRemoteForwardProbeWitness()
+        let nonce = ClaudeRemoteForwardProbeWitness.randomNonce()
+        witness.arm(nonce)
+        XCTAssertTrue(witness.note(headerValue: nonce))
+        XCTAssertTrue(witness.consume(nonce))
+        // Consumed means disarmed: a replay after the probe finished proves
+        // nothing about the topology NOW.
+        XCTAssertFalse(witness.note(headerValue: nonce))
+        XCTAssertFalse(witness.consume(nonce))
+        XCTAssertEqual(witness.armedCount, 0)
+    }
+
+    func testNothingButAnArmedNonceMatches() {
+        let witness = ClaudeRemoteForwardProbeWitness()
+        let nonce = ClaudeRemoteForwardProbeWitness.randomNonce()
+        witness.arm(nonce)
+        XCTAssertFalse(witness.note(headerValue: nil))
+        XCTAssertFalse(witness.note(headerValue: ""))
+        XCTAssertFalse(witness.note(headerValue: String(nonce.dropLast())))
+        XCTAssertFalse(witness.note(headerValue: nonce + "0"))
+        XCTAssertFalse(witness.note(headerValue: nonce.uppercased()))
+        XCTAssertFalse(
+            witness.consume(nonce), "none of those may count as the probe arriving"
+        )
+    }
+
+    func testANonceThatWasNeverArmedIsNeverObserved() {
+        let witness = ClaudeRemoteForwardProbeWitness()
+        let nonce = ClaudeRemoteForwardProbeWitness.randomNonce()
+        XCTAssertFalse(witness.note(headerValue: nonce))
+        XCTAssertFalse(witness.consume(nonce))
+    }
+
+    func testArmedNoncesAreBounded() {
+        let witness = ClaudeRemoteForwardProbeWitness()
+        let nonces = (0..<(ClaudeRemoteForwardProbeWitness.maximumArmed + 3)).map { _ in
+            ClaudeRemoteForwardProbeWitness.randomNonce()
+        }
+        for nonce in nonces { witness.arm(nonce) }
+        XCTAssertEqual(witness.armedCount, ClaudeRemoteForwardProbeWitness.maximumArmed)
+        XCTAssertFalse(
+            witness.note(headerValue: nonces[0]), "the oldest entries are evicted, not kept"
+        )
+        XCTAssertTrue(witness.note(headerValue: nonces[nonces.count - 1]))
+    }
+
+    func testNoncesAreLongRandomHex() {
+        let first = ClaudeRemoteForwardProbeWitness.randomNonce()
+        let second = ClaudeRemoteForwardProbeWitness.randomNonce()
+        XCTAssertEqual(first.count, 32, "128 bits, hex")
+        XCTAssertNotEqual(first, second)
+        XCTAssertTrue(first.allSatisfy { $0.isHexDigit && !$0.isUppercase })
+    }
+
+    // MARK: - The probe
+
+    private final class RunnerSpy: Sendable {
+        struct Call: Sendable {
+            var argv: [String]
+            var standardInput: String
+            var timeout: TimeInterval
+        }
+
+        private let calls = Mutex<[Call]>([])
+        private let body: @Sendable (Call) throws -> ClaudeRemoteEnrollmentService.RunResult
+
+        init(
+            body: @escaping @Sendable (Call) throws -> ClaudeRemoteEnrollmentService.RunResult = {
+                _ in ClaudeRemoteEnrollmentService.RunResult(exitCode: 0, message: "")
+            }
+        ) {
+            self.body = body
+        }
+
+        var recorded: [Call] { calls.withLock { $0 } }
+
+        var runner: ClaudeRemoteEnrollmentService.Runner {
+            { invocation in
+                let call = Call(
+                    argv: invocation.argv,
+                    standardInput: String(decoding: invocation.standardInput, as: UTF8.self),
+                    timeout: invocation.timeout
+                )
+                self.calls.withLock { $0.append(call) }
+                return try self.body(call)
+            }
+        }
+    }
+
+    /// THE case. A process on the remote host binds the port and answers the
+    /// probe perfectly — our exact 401, our headers, whatever it likes, because
+    /// all of that is public in this repository. It still cannot deliver the
+    /// nonce to a listener bound to 127.0.0.1 on this Mac, and so it is never
+    /// adopted as a context channel.
+    func testAHostThatAnswersButCannotDeliverTheNonceIsNotOurs() async throws {
+        let witness = ClaudeRemoteForwardProbeWitness()
+        let spy = RunnerSpy()
+        let probe = ClaudeRemoteForwardOwnershipCheck.live(
+            witness: witness, runner: spy.runner
+        )
+
+        let ownership = await probe("builder", 28511)
+
+        XCTAssertEqual(ownership, .unproved)
+        XCTAssertEqual(spy.recorded.count, 1, "the probe did run; its ANSWER is what is ignored")
+        XCTAssertEqual(witness.armedCount, 0, "the nonce is disarmed either way")
+    }
+
+    /// The forward is real, so the request lands here. The fake runner plays the
+    /// tunnel: it takes the nonce out of the script it was handed and delivers
+    /// it to the witness, exactly as the listener does on arrival.
+    func testANonceThatArrivesOnOurListenerProvesTheForwardIsOurs() async throws {
+        let witness = ClaudeRemoteForwardProbeWitness()
+        let spy = RunnerSpy(body: { call in
+            let header = "\(ClaudeRemoteForwardProbeWitness.headerName): "
+            guard let range = call.standardInput.range(of: header) else {
+                return ClaudeRemoteEnrollmentService.RunResult(exitCode: 7, message: "")
+            }
+            let nonce = call.standardInput[range.upperBound...].prefix { $0.isHexDigit }
+            witness.note(headerValue: String(nonce))
+            return ClaudeRemoteEnrollmentService.RunResult(exitCode: 0, message: "")
+        })
+        let probe = ClaudeRemoteForwardOwnershipCheck.live(
+            witness: witness, runner: spy.runner
+        )
+
+        let ownership = await probe("builder", 28511)
+
+        XCTAssertEqual(ownership, .ourListener)
+        XCTAssertEqual(witness.armedCount, 0)
+    }
+
+    /// The exit status is not the signal, in either direction: a curl that
+    /// failed after the request landed must not undo a delivered nonce.
+    func testDeliveryWinsOverANonZeroExitStatus() async throws {
+        let witness = ClaudeRemoteForwardProbeWitness()
+        let spy = RunnerSpy(body: { call in
+            let header = "\(ClaudeRemoteForwardProbeWitness.headerName): "
+            let range = try XCTUnwrap(call.standardInput.range(of: header))
+            let nonce = call.standardInput[range.upperBound...].prefix { $0.isHexDigit }
+            witness.note(headerValue: String(nonce))
+            throw ClaudeRemoteEnrollmentService.RunnerFailure.timedOut(
+                seconds: 10, message: "ssh timed out"
+            )
+        })
+        let probe = ClaudeRemoteForwardOwnershipCheck.live(
+            witness: witness, runner: spy.runner
+        )
+
+        let ownership = await probe("builder", 28511)
+        XCTAssertEqual(ownership, .ourListener)
+        XCTAssertEqual(spy.recorded.count, 1)
+    }
+
+    func testAFailedProbeIsUnproved() async throws {
+        let witness = ClaudeRemoteForwardProbeWitness()
+        let spy = RunnerSpy(body: { _ in
+            throw ClaudeRemoteEnrollmentService.RunnerFailure.timedOut(
+                seconds: 10, message: "ssh timed out"
+            )
+        })
+        let probe = ClaudeRemoteForwardOwnershipCheck.live(
+            witness: witness, runner: spy.runner
+        )
+
+        let ownership = await probe("builder", 28511)
+        XCTAssertEqual(ownership, .unproved)
+        XCTAssertEqual(witness.armedCount, 0, "a failed probe leaves nothing armed")
+    }
+
+    func testAnInvalidAliasNeverReachesAProcess() async throws {
+        let witness = ClaudeRemoteForwardProbeWitness()
+        let spy = RunnerSpy()
+        let probe = ClaudeRemoteForwardOwnershipCheck.live(
+            witness: witness, runner: spy.runner
+        )
+
+        let ownership = await probe("-oProxyCommand=touch /tmp/pwned", 28511)
+        XCTAssertEqual(ownership, .unproved)
+        XCTAssertTrue(spy.recorded.isEmpty)
+    }
+
+    /// The nonce is a short-lived secret while it is in flight: an argv is
+    /// world-readable on the remote host, so it goes down stdin like the
+    /// enrollment token does.
+    func testTheNonceTravelsOnStdinAndNeverInArgv() async throws {
+        let witness = ClaudeRemoteForwardProbeWitness()
+        let spy = RunnerSpy()
+        let probe = ClaudeRemoteForwardOwnershipCheck.live(
+            witness: witness,
+            runner: spy.runner,
+            makeNonce: { "0123456789abcdef0123456789abcdef" }
+        )
+
+        _ = await probe("builder", 28511)
+
+        let call = try XCTUnwrap(spy.recorded.first)
+        XCTAssertFalse(
+            call.argv.contains { $0.contains("0123456789abcdef") },
+            "argv: \(call.argv)"
+        )
+        XCTAssertTrue(call.standardInput.contains("0123456789abcdef0123456789abcdef"))
+        XCTAssertTrue(call.standardInput.contains("127.0.0.1:28511"))
+        XCTAssertFalse(
+            call.standardInput.lowercased().contains("authorization"),
+            "the probe carries no credential — the refusal is the point"
+        )
+    }
+
+    /// `ClearAllForwardings=yes` matters here specifically: without it this
+    /// connection inherits the alias's own `RemoteForward` and contends for the
+    /// very port it is asking about.
+    func testTheProbeConnectionCarriesNoForwardsAndCannotPrompt() async throws {
+        let witness = ClaudeRemoteForwardProbeWitness()
+        let spy = RunnerSpy()
+        let probe = ClaudeRemoteForwardOwnershipCheck.live(
+            witness: witness, runner: spy.runner
+        )
+
+        _ = await probe("builder", 28511)
+
+        let argv = try XCTUnwrap(spy.recorded.first).argv
+        XCTAssertEqual(argv.first, "ssh")
+        XCTAssertTrue(argv.contains("BatchMode=yes"))
+        XCTAssertTrue(argv.contains("ClearAllForwardings=yes"))
+        XCTAssertTrue(argv.contains("--"))
+        let terminator = try XCTUnwrap(argv.firstIndex(of: "--"))
+        XCTAssertEqual(argv[terminator + 1], "builder", "the alias follows the terminator")
+    }
+}

--- a/Tests/localvoxtralTests/ClaudeRemoteForwardSupervisorTests.swift
+++ b/Tests/localvoxtralTests/ClaudeRemoteForwardSupervisorTests.swift
@@ -176,10 +176,28 @@ private final class ForwardHarness {
         heldSleeps.removeFirst().resume()
     }
 
+    /// Answers handed to the supervisor's ownership probe, in order — one per
+    /// refused bind. Running out means `.unproved`, which is also the answer a
+    /// supervisor with no probe at all gets.
+    var ownershipAnswers: [ClaudeRemoteForwardOwnership] = []
+    private(set) var ownershipProbeCalls: [(alias: String, port: UInt16)] = []
+    /// Nil unless a test asks for one, so every pre-existing test keeps
+    /// exercising the no-probe (fail-closed) path unchanged.
+    var providesOwnershipProbe = false
+
     func makeSupervisor(
         configuration: ClaudeRemoteForwardSupervisor.Configuration,
         launchFailure: (any Error)? = nil
     ) -> ClaudeRemoteForwardSupervisor {
+        let answer: ClaudeRemoteForwardOwnershipProbe = { [weak self] alias, port in
+            await MainActor.run { () -> ClaudeRemoteForwardOwnership in
+                guard let self else { return .unproved }
+                self.ownershipProbeCalls.append((alias: alias, port: port))
+                guard !self.ownershipAnswers.isEmpty else { return .unproved }
+                return self.ownershipAnswers.removeFirst()
+            }
+        }
+        let probe: ClaudeRemoteForwardOwnershipProbe? = providesOwnershipProbe ? answer : nil
         let supervisor = ClaudeRemoteForwardSupervisor(
             configuration: configuration,
             launch: { [weak self] configuration in
@@ -191,6 +209,7 @@ private final class ForwardHarness {
                 self?.record(process)
                 return process
             },
+            ownershipProbe: probe,
             sleepFor: { [weak self] duration in
                 guard let self else { return }
                 await self.recordSleep(duration)
@@ -440,12 +459,158 @@ final class ClaudeRemoteForwardSupervisorTests: XCTestCase {
             "a refusal is not a crash: \(harness.states)"
         )
         XCTAssertTrue(supervisor.state.isFailure)
-        // The copy has to name the thing to close. The overwhelmingly common
-        // holder is an ssh session from this very Mac, and "Port already held
-        // on the host." left the user with a Retry button and no idea what to
-        // do before pressing it.
-        XCTAssertEqual(supervisor.state.text, "Port held — close ssh sessions to that host.")
+        // No probe on this harness, so ownership is unproved and the pessimistic
+        // reading is the right one. The copy no longer tells the user to close
+        // ssh sessions: the case where a session of theirs is the holder is
+        // `externallyForwarded`, and this state is what is left over.
+        XCTAssertEqual(supervisor.state.text, "Port held by another program on that host.")
         XCTAssertLessThan(supervisor.state.text.count, 60, "owner rule: one short sentence")
+    }
+
+    // MARK: - Ownership of a refused port (field report, 2026-08-29)
+
+    /// The bug this exists for: the owner's own ssh session to the enrolled
+    /// host carries the enrollment block's `RemoteForward`, so it BINDS the
+    /// port — and the supervised probe ssh is then refused by the very tunnel
+    /// it wanted to create. The app reported that as contention and told the
+    /// user to close the session providing the working channel, while hooks
+    /// from that host were arriving over it the whole time.
+    func testARefusedBindThatIsOurOwnLiveForwardIsNotContention() async throws {
+        let harness = ForwardHarness()
+        harness.providesOwnershipProbe = true
+        harness.ownershipAnswers = [.ourListener]
+        // The recheck park has to block, or the loop would immediately dial
+        // again and the state under test would not be observable.
+        harness.holdSleeps = true
+        let supervisor = harness.makeSupervisor(configuration: configuration())
+        supervisor.start()
+
+        let process = try await harness.process(0)
+        process.emitStandardError(
+            "Warning: remote port forwarding failed for listen port 28511"
+        )
+        process.finish(status: 255)
+
+        try await harness.waitForState { $0 == .externallyForwarded }
+        // Let the loop reach its park before reading the recorded sleeps: the
+        // state lands synchronously in `transition`, the sleep one hop later.
+        await harness.drainMainActor()
+        XCTAssertEqual(supervisor.state, .externallyForwarded)
+        XCTAssertFalse(
+            supervisor.state.isFailure,
+            "a working channel must not paint the row red or offer a Retry button"
+        )
+        XCTAssertFalse(
+            harness.states.contains(.portUnavailable),
+            "the harmful verdict must never be published, not even in passing: \(harness.states)"
+        )
+        XCTAssertEqual(
+            harness.ownershipProbeCalls.map(\.port), [28511],
+            "the probe asks about the port that was refused"
+        )
+        XCTAssertEqual(harness.ownershipProbeCalls.map(\.alias), ["builder"])
+        XCTAssertEqual(harness.processes.count, 1, "nothing is redialed while the tunnel is up")
+        XCTAssertTrue(
+            harness.sleeps.contains(.seconds(300)),
+            "the claim is bounded by a recheck park: \(harness.sleeps)"
+        )
+    }
+
+    /// The other half, and the one that must not regress: anything the probe
+    /// cannot PROVE is ours stays contention. A stranger on that port — an
+    /// unrelated service, another Mac's forward, something hostile — receives
+    /// the remote plugin's bearer token on every hook, so "probably fine" is
+    /// exactly the wrong default.
+    func testARefusedBindWithUnprovedOwnershipStaysContention() async throws {
+        let harness = ForwardHarness()
+        harness.providesOwnershipProbe = true
+        harness.ownershipAnswers = [.unproved]
+        let supervisor = harness.makeSupervisor(configuration: configuration())
+        supervisor.start()
+
+        let process = try await harness.process(0)
+        process.emitStandardError(
+            "Warning: remote port forwarding failed for listen port 28511"
+        )
+        process.finish(status: 255)
+
+        try await harness.waitForState { $0 == .portUnavailable }
+        XCTAssertEqual(supervisor.state, .portUnavailable)
+        XCTAssertTrue(supervisor.state.isFailure)
+        XCTAssertEqual(harness.ownershipProbeCalls.count, 1)
+        XCTAssertEqual(harness.processes.count, 1, "still terminal, still no retry storm")
+    }
+
+    /// The lifecycle answer. The session holding the tunnel is not ours and
+    /// ends without telling us, so the state is re-proved on a long park — and
+    /// when the port comes free the app takes the tunnel over instead of
+    /// sitting in a state it can never leave.
+    func testAnExternallyHeldForwardIsTakenOverOnceTheSessionEnds() async throws {
+        let harness = ForwardHarness()
+        harness.providesOwnershipProbe = true
+        harness.ownershipAnswers = [.ourListener]
+        harness.holdSleeps = true
+        let supervisor = harness.makeSupervisor(configuration: configuration())
+        supervisor.start()
+
+        let refused = try await harness.process(0)
+        refused.emitStandardError(
+            "Warning: remote port forwarding failed for listen port 28511"
+        )
+        refused.finish(status: 255)
+        try await harness.waitForState { $0 == .externallyForwarded }
+
+        // The user closes their terminal. The recheck park expires and the
+        // second dial binds cleanly — no stderr, so no refusal.
+        harness.holdSleeps = false
+        harness.releaseSleeps()
+
+        _ = try await harness.process(1)
+        try await harness.waitForState { $0 == .forwarding }
+        XCTAssertEqual(supervisor.state, .forwarding)
+        XCTAssertEqual(
+            harness.ownershipProbeCalls.count, 1,
+            "a bind that succeeded asks nobody anything"
+        )
+    }
+
+    /// And the fail-closed half of the lifecycle: if the re-check can no longer
+    /// prove the port is ours, the app stops claiming a channel it does not
+    /// have — rather than keeping a comfortable state because it once held.
+    func testAnExternallyHeldForwardStopsClaimingTheChannelWhenTheProofFails() async throws {
+        let harness = ForwardHarness()
+        harness.providesOwnershipProbe = true
+        harness.ownershipAnswers = [.ourListener, .unproved]
+        harness.holdSleeps = true
+        let supervisor = harness.makeSupervisor(configuration: configuration())
+        supervisor.start()
+
+        let first = try await harness.process(0)
+        first.emitStandardError("Warning: remote port forwarding failed for listen port 28511")
+        first.finish(status: 255)
+        try await harness.waitForState { $0 == .externallyForwarded }
+
+        harness.holdSleeps = false
+        harness.releaseSleeps()
+
+        let second = try await harness.process(1)
+        second.emitStandardError("Warning: remote port forwarding failed for listen port 28511")
+        second.finish(status: 255)
+
+        try await harness.waitForState { $0 == .portUnavailable }
+        XCTAssertEqual(supervisor.state, .portUnavailable)
+        XCTAssertTrue(supervisor.state.isFailure)
+        XCTAssertEqual(harness.ownershipProbeCalls.count, 2)
+    }
+
+    func testTheExternallyForwardedCopyAsksTheUserForNothing() {
+        let text = ClaudeRemoteForwardSupervisor.State.externallyForwarded.text
+        XCTAssertEqual(text, "Tunnel up — an ssh session already holds it.")
+        XCTAssertLessThan(text.count, 60, "owner rule: one short sentence")
+        XCTAssertFalse(
+            text.lowercased().contains("close"),
+            "the old advice was to close the session providing the tunnel"
+        )
     }
 
     func testARefusalForAPortWeNeverAskedForBlamesTheConfigNotTheHost() async throws {

--- a/Tests/localvoxtralTests/ClaudeRemoteForwardSupervisorTests.swift
+++ b/Tests/localvoxtralTests/ClaudeRemoteForwardSupervisorTests.swift
@@ -572,6 +572,15 @@ final class ClaudeRemoteForwardSupervisorTests: XCTestCase {
             harness.ownershipProbeCalls.count, 1,
             "a bind that succeeded asks nobody anything"
         )
+        // The re-check must not blink the row through "Connecting…". Claimed in
+        // the PR and previously pinned by nothing: reintroducing the blink
+        // regressed no assertion, and a status row that flickers back to
+        // "Connecting…" every 5 minutes reads as an unstable tunnel.
+        let afterProof = harness.states.drop { $0 != .externallyForwarded }.dropFirst()
+        XCTAssertFalse(
+            afterProof.contains(.connecting),
+            "the re-check re-dials silently; states after the proof were \(Array(afterProof))"
+        )
     }
 
     /// And the fail-closed half of the lifecycle: if the re-check can no longer

--- a/docs/agent/invariants.md
+++ b/docs/agent/invariants.md
@@ -587,6 +587,53 @@ there is not.
   `hookParentPID` is a String on purpose: a pid in another host's namespace is
   not a number this process may probe, only a label to compare against another
   label.
+- **A refused `RemoteForward` bind is not a diagnosis, and only a nonce
+  round-trip may upgrade it to one.** OpenSSH's `remote port forwarding failed`
+  says a port is held, never by whom, and the two holders want opposite things
+  from the user: a stranger is a failure they must clear, while their own ssh
+  session carrying the enrollment block's `RemoteForward` IS the working
+  channel — the normal state for anyone who ssh's to the host they enrolled.
+  Reporting the second as contention told them to close the session providing
+  the tunnel (field report, 2026-08-29). `ClaudeRemoteForwardOwnershipCheck`
+  separates them, and the rule about HOW is load-bearing:
+  - **The remote host's answer is never the evidence.** Our 401 (and the 411 an
+    empty POST gets) is public in this repository, so any process that binds
+    that port can reproduce it byte for byte; and a SECOND Mac enrolled against
+    the same host returns a genuine 401 of its own, which is exactly the
+    contention `ClaudeRemoteForwardPort` exists to surface. A status-code probe
+    would adopt both.
+  - **The evidence is arrival.** The probe posts a fresh 128-bit nonce into the
+    disputed port FROM the remote host (`ssh -o BatchMode=yes -o
+    ClearAllForwardings=yes`, bounded timeout, nonce on stdin so it is never in
+    a remote argv, and no token — the request is expected to be refused), and
+    the verdict is whether THIS process's own listener saw that nonce
+    (`ClaudeRemoteForwardProbeWitness`). A stranger receives the nonce and can
+    do nothing with it: the listener binds `127.0.0.1` on the Mac and the only
+    route to it from that host is the forward the stranger is the reason we do
+    not have. Another Mac's listener has never heard of it. The probe's exit
+    status is deliberately not consulted in either direction.
+  - **Every other outcome is `portUnavailable`.** No probe wired in, no `curl`
+    on the host, ssh refused, a timeout, an unparseable anything — all
+    `.unproved`, which is also the default when the seam is nil. Fail closed is
+    not a branch here, it is the absence of one, because the alternative is
+    telling the user everything is fine while a stranger collects the remote
+    plugin's bearer token from every hook.
+  - **The listener's one pre-auth look is not an oracle.** The nonce check runs
+    before the token because a self-probe must not land in the rejection tally
+    the user reads for "which of three fixes do I need". It compares only a
+    value this process minted and is still waiting for, it returns the same 401
+    with the same headers and the same empty body either way, and a match
+    short-circuits — so a matching nonce cannot carry a payload past
+    authentication even when a valid token rides with it.
+  - **A proved channel is a claim with an expiry.** `externallyForwarded` is
+    held by a session the app does not own and cannot be notified about, so the
+    supervisor re-attempts its own `-R` on a long injected-clock park
+    (5 minutes): the session ending means the bind now succeeds and the app
+    takes the tunnel over, and a holder that stops proving ownership drops back
+    to `portUnavailable`. This is the ONE relaxation of "a refused bind is
+    terminal" and it is bounded by that interval; a state that claims a channel
+    must be able to stop claiming it.
+
 - **Remote enrollment execution is opt-in, preview-first, and keeps the token
   out of process arguments.** `ClaudeRemoteEnrollmentService` generates a
   copyable plan (idempotent ssh config block, `claude plugin` commands,

--- a/docs/agent/invariants.md
+++ b/docs/agent/invariants.md
@@ -604,14 +604,29 @@ there is not.
     would adopt both.
   - **The evidence is arrival.** The probe posts a fresh 128-bit nonce into the
     disputed port FROM the remote host (`ssh -o BatchMode=yes -o
-    ClearAllForwardings=yes`, bounded timeout, nonce on stdin so it is never in
-    a remote argv, and no token — the request is expected to be refused), and
-    the verdict is whether THIS process's own listener saw that nonce
+    ClearAllForwardings=yes`, bounded timeout, the script on stdin so the nonce
+    is never in the ssh argv on THIS Mac — which is also the CI runner — and no
+    token, since the request is expected to be refused), and the verdict is
+    whether THIS process's own listener saw that nonce
     (`ClaudeRemoteForwardProbeWitness`). A stranger receives the nonce and can
     do nothing with it: the listener binds `127.0.0.1` on the Mac and the only
-    route to it from that host is the forward the stranger is the reason we do
-    not have. Another Mac's listener has never heard of it. The probe's exit
-    status is deliberately not consulted in either direction.
+    route to it from that host is a `RemoteForward` terminating here — and the
+    disputed one is the forward the stranger is the reason we do not have.
+    Another Mac's listener has never heard of it. The probe's exit status is
+    deliberately not consulted in either direction.
+  - **Two residuals, stated because the next reader will otherwise assume they
+    are not there.** (1) Arrival identifies the LISTENER, not the port that
+    carried the nonce: every supervised `-R` ends at the same local listener, so
+    where a host has a SECOND live forward to this Mac (a legacy
+    `RemoteForward 8473` left in the user's own config block and carried by an
+    interactive session), a hostile holder of the disputed port can replay our
+    request down that other forward and forge a match. (2) The nonce is out of
+    the ssh argv but is in `curl`'s argv on the REMOTE host for the `--max-time`
+    window; `--header @file` would fix that and is not used because it needs
+    curl >= 7.55 on an arbitrary host and would fail silently below it. Both
+    residuals require code execution on the enrolled host, which already implies
+    possession of the plugin's bearer token — so `.ourListener` is a DIAGNOSIS
+    and never an authorization. Do not restate either claim absolutely.
   - **Every other outcome is `portUnavailable`.** No probe wired in, no `curl`
     on the host, ssh refused, a timeout, an unparseable anything — all
     `.unproved`, which is also the default when the seam is nil. Fail closed is

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -89,7 +89,18 @@ Key subsystems:
     forces `ForkAfterAuthentication=no`, `ControlPath=none` and
     `PermitLocalCommand=no` so the user's own ssh config cannot detach,
     multiplex, or run a local command underneath it. A refused bind is
-    TERMINAL (no retry storm against a port somebody else holds); an ordinary
+    TERMINAL (no retry storm against a port somebody else holds) — unless the
+    port turns out to be OURS. A refused bind means only "somebody holds it",
+    and on a host the user actually ssh's to, that somebody is normally their
+    own session carrying the same `RemoteForward` out of `~/.ssh/config` — the
+    working tunnel. `ClaudeRemoteForwardOwnershipCheck` tells the two apart by
+    sending a fresh nonce down the disputed port from the remote host and
+    asking whether this Mac's own listener saw it arrive
+    (`ClaudeRemoteForwardProbeWitness`); a status code would prove nothing,
+    since a stranger can reproduce ours and a SECOND Mac answers an honest 401
+    of its own. Proof gives `externallyForwarded` — not a failure, re-proved on
+    a long park so a session that ends is noticed; anything unproved stays
+    `portUnavailable`. An ordinary
     drop backs off exponentially, and a run that stays up long enough to
     settle clears the failure count. Listener binds first, forwards start
     second — always; stopping is the mirror. After a


### PR DESCRIPTION
## What

Settings showed **"Port held — close ssh sessions to that host."** for a host whose
tunnel was working. The log's diagnosis was correct and its conclusion was not:
the port on the remote host was bound by an interactive `sshd-session` of the
owner's, carrying `RemoteForward 29891 127.0.0.1:8473` — the block the app's own
enrollment plan put in `~/.ssh/config`. So the holder was **the forward the
supervisor was trying to create, already established and delivering hooks**, and
the app told the user to close it.

`remote port forwarding failed` says a port is held, never by whom, and the two
holders want opposite things:

* a stranger — an unrelated service, a leftover tunnel, **another Mac's forward** —
  is a real failure the user has to clear;
* our own `RemoteForward`, put there by an ordinary ssh session, is the desired end
  state reached by another route. That is the normal case for anyone who ssh's to
  the host they enrolled, i.e. everybody.

This splits them. Proof gives a new non-failure state `externallyForwarded`
("Tunnel up — an ssh session already holds it.", no Retry button, nothing asked of
the user); everything else stays `portUnavailable`.

### The discriminator, and why it is not the status code

The brief proposed reusing the 401 that an unauthenticated POST gets. Two problems,
and both are load-bearing:

1. **It is not evidence.** The listener's source, response shape and paths are in
   this repository. Any process that binds that port can reproduce our 401 byte for
   byte — including the `WWW-Authenticate: Bearer` and the empty JSON body. Adopting
   it would let a squatter be blessed as a context channel while it collects the
   remote plugin's bearer token from every hook.
2. **It is not even a correct diagnosis.** A SECOND Mac enrolled against the same
   host answers a genuine, honest 401 of its own — which is precisely the contention
   `ClaudeRemoteForwardPort` exists to surface (issue #215). A status-code probe
   adopts that too.

So the probe never reads the answer. It posts a fresh 128-bit nonce **into** the
disputed port from the remote host and asks whether **this process's own listener
saw it arrive**:

* our forward holds the port → the request rides the tunnel and lands here — match;
* a stranger holds the port → it receives the nonce and can do nothing with it. The
  listener binds `127.0.0.1` on the Mac, and the only route to it from that host is
  the forward the stranger is the reason we do not have;
* another Mac holds the port → the nonce lands on *that* Mac's listener, which has
  never heard of it. No match here, which is the right answer.

### Fail-closed

`.unproved` is the default, not a branch: no probe wired in (the seam is nil — which
is what the herdr `-L` supervisor gets), no `curl` on the host, ssh refused, a
timeout, an unparseable anything — all keep the pre-existing `portUnavailable`. The
probe's **exit status is deliberately never consulted** in either direction; only
arrival counts.

The one pre-auth look in the listener is not an oracle. It compares only a value this
process minted and is still waiting for (constant-time, one-shot, bounded set), it
returns the same 401 with the same headers and the same empty body either way, and a
match short-circuits — so a matching nonce cannot carry a payload past authentication
even with a valid token riding along. It runs before the token solely so a self-probe
does not land in the rejection tally the user reads for "which of three fixes do I
need".

The probe connection carries no credential (`ssh -o BatchMode=yes -o
ClearAllForwardings=yes -o ConnectTimeout=5 -- <alias> /bin/sh -s`, 10 s cap), and the
nonce goes down **stdin**, never argv — an argv is world-readable on the remote host.
`ClearAllForwardings=yes` matters here specifically: without it this connection
inherits the alias's own `RemoteForward` and contends for the very port it is asking
about. (That is the opposite of the herdr `-L`, where the same option deletes the
`-L` — `docs/agent/invariants.md` covers both.)

### Lifecycle

`externallyForwarded` is a claim with an expiry. The holder is a session the app does
not own and cannot be notified about, so the supervisor re-attempts its own `-R` on a
long injected-clock park (5 min): the session ending means the bind now succeeds and
the app **takes the tunnel over**; a holder that stops proving ownership drops back to
`portUnavailable`. Both directions are pinned by tests. This is the one relaxation of
the type's "a refused bind is terminal" rule and it is bounded by that interval — two
connections per 5 minutes against the user's own host, not a reconnect storm. The
re-check deliberately does not blink the row through "Connecting…".

### Copy

| state | before | after |
| --- | --- | --- |
| our own session holds it | `Port held — close ssh sessions to that host.` (+ a Retry that could only fail) | `Tunnel up — an ssh session already holds it.` (not a failure; no Retry) |
| anything else holds it | same string | `Port held by another program on that host.` |

The old advice is now wrong twice over: in the common case it names the working
tunnel, and in what is left the holder was measurably *not* an ssh session of ours.
Both are one short sentence (owner popover rule, asserted).

### Not fixed here, and not a bug

"Last context: 20 days ago" beside a live tunnel is honest — `lastSeenAt` is the last
hook this Mac *ingested*, and the tunnel merely answers on demand.

### One correction to the report

`ClaudeRemoteEnrollmentService.executeVerification` does not exist — #224 shipped
`verifyCommands`, the copy-pasteable text a person runs, which already documents the
three-outcome reading. There was no in-app probe to reuse; the runner seam
(`ClaudeRemoteEnrollmentService.Runner` / `processRunner()`) is reused instead.

## Proof

- [x] **Unit suite green** — `./scripts/remote-build.sh test`

```
Test Suite 'localvoxtralPackageTests.xctest' passed at 2026-08-30 14:49:54.305.
	 Executed 2765 tests, with 2 tests skipped and 0 failures (0 unexpected) in 104.097 (104.235) seconds
```

- [x] **Bug fix: regression tests added — failing before, passing after.**

"Before" is this tree with the two behavioural decisions reverted and the new types
kept, so the tests compile and measure exactly the fix: `resolveOwnership()` returns
`.unproved` unconditionally (the old "a refusal is always contention"), and the
listener's pre-auth nonce branch is deleted.

**BEFORE — `./scripts/remote-build.sh test --filter ClaudeRemoteForwardSupervisorTests`**

```
Test Case '-[...testARefusedBindThatIsOurOwnLiveForwardIsNotContention]' failed (20.047 seconds).
Test Case '-[...testARefusedBindWithUnprovedOwnershipStaysContention]' failed (0.003 seconds).
Test Case '-[...testAnExternallyHeldForwardIsTakenOverOnceTheSessionEnds]' failed (20.247 seconds).
Test Case '-[...testAnExternallyHeldForwardStopsClaimingTheChannelWhenTheProofFails]' failed (20.008 seconds).
	 Executed 26 tests, with 7 failures (3 unexpected) in 60.339 (60.341) seconds

Tests/localvoxtralTests/ClaudeRemoteForwardSupervisorTests.swift:494: error: -[...testARefusedBindThatIsOurOwnLiveForwardIsNotContention] : failed - timed out waiting for a state; saw [....State.connecting, ....State.portUnavailable]
Tests/localvoxtralTests/ClaudeRemoteForwardSupervisorTests.swift:540: error: -[...testARefusedBindWithUnprovedOwnershipStaysContention] : XCTAssertEqual failed: ("0") is not equal to ("1")
Tests/localvoxtralTests/ClaudeRemoteForwardSupervisorTests.swift:561: error: -[...testAnExternallyHeldForwardIsTakenOverOnceTheSessionEnds] : failed - timed out waiting for a state; saw [....State.connecting, ....State.portUnavailable]
Tests/localvoxtralTests/ClaudeRemoteForwardSupervisorTests.swift:591: error: -[...testAnExternallyHeldForwardStopsClaimingTheChannelWhenTheProofFails] : failed - timed out waiting for a state; saw [....State.connecting, ....State.portUnavailable]
```

`saw [.connecting, .portUnavailable]` **is the field bug**, reproduced in a test.

**BEFORE — `./scripts/remote-build.sh test --filter ClaudeRemoteContextListenerTests`**

```
Test Case '-[...testAMatchingNonceCannotCarryAPayloadPastAuthentication]' failed (0.013 seconds).
Test Case '-[...testAnOwnershipProbeArrivesWithoutBeingCountedAsARejection]' failed (0.001 seconds).
	 Executed 44 tests, with 4 failures (0 unexpected) in 0.043 (0.045) seconds

Tests/.../ClaudeRemoteContextListenerTests.swift:193: error: -[...testAnOwnershipProbeArrivesWithoutBeingCountedAsARejection] : XCTAssertTrue failed - arrival IS the proof; nothing else is read
Tests/.../ClaudeRemoteContextListenerTests.swift:194: error: -[...testAnOwnershipProbeArrivesWithoutBeingCountedAsARejection] : XCTAssertTrue failed - our own probe must not look like a host that needs re-enrolling
Tests/.../ClaudeRemoteContextListenerTests.swift:239: error: -[...testAMatchingNonceCannotCarryAPayloadPastAuthentication] : XCTAssertEqual failed: ("200") is not equal to ("401")
Tests/.../ClaudeRemoteContextListenerTests.swift:240: error: -[...testAMatchingNonceCannotCarryAPayloadPastAuthentication] : XCTAssertTrue failed - no record, no marker, no session
```

**AFTER — same filters, this tree**

```
Test Suite 'ClaudeRemoteForwardSupervisorTests'
	 Executed 26 tests, with 0 failures (0 unexpected) in 0.031 (0.032) seconds

Test Suite 'ClaudeRemoteContextListenerTests'
	 Executed 44 tests, with 0 failures (0 unexpected) in 0.033 (0.035) seconds

Test Suite 'ClaudeRemoteForwardOwnershipTests' passed at 2026-08-30 14:47:26.230.
	 Executed 12 tests, with 0 failures (0 unexpected) in 0.004 (0.005) seconds
```

The fail-closed cases are their own tests, not comments:
`testAHostThatAnswersButCannotDeliverTheNonceIsNotOurs` (a squatter answering
perfectly is still `.unproved`), `testAProbeHeaderWeNeverMintedIsJustAnUnauthenticatedRequest`,
`testAMatchingNonceCannotCarryAPayloadPastAuthentication`,
`testTheNonceTravelsOnStdinAndNeverInArgv`, `testAnInvalidAliasNeverReachesAProcess`.

- [x] **`integration-herdr` green** — `./scripts/remote-build.sh integration-herdr`

```
Test Suite 'HerdrIntegrationTests' passed at 2026-08-30 14:53:56.204.
	 Executed 11 tests, with 0 failures (0 unexpected) in 60.725 (60.726) seconds
```

Run rather than justified away. Strictly, nothing about how the herdr `-L` is opened
changed — `ClaudeRemoteHerdrForwardService.argv` is untouched, the ownership seam is
nil on that path by construction, and `externallyForwarded` is unreachable for a `-L`
— but the supervisor's lifecycle is shared code, so the lane is the cheap answer.

- [x] **No wall clock added.** The re-check park is the existing injected `sleepFor`
  seam; the tests assert `.seconds(300)` was requested rather than waiting for it.
  Nothing here reaches `beginDictationSession`.

- [ ] UI change verified by hand — **not done.** The only UI surface is the
  per-host status string and the presence of the Retry button, both driven by
  `State.text` / `State.isFailure` and both asserted (supervisor suite +
  `ClaudeIntegrationSettingsModelTests`). The field state that motivates this needs a
  real contended port on a real host to reproduce.

## Files

* `ClaudeRemoteForwardOwnership.swift` — new: ownership verdict, nonce witness, probe.
* `ClaudeRemoteForwardSupervisor.swift` — `externallyForwarded`, the probe seam, the
  bounded re-check, new copy.
* `ClaudeRemoteContextListener.swift` — the pre-auth nonce observation.
* `ClaudeRemoteForwardCoordinator.swift` / `ClaudeRemoteListenerCoordinator.swift` /
  `localvoxtralApp.swift` — one shared witness between listener and supervisors.
* `docs/agent/invariants.md`, `docs/architecture.md` — the trust argument and the
  lifecycle bound, where the next person will look for them.



## Review (adversarial, GLM 5.2 via opencode — release train)

One read-only adversarial pass over the branch with `docs/agent/invariants.md`
and the full diff. Verdict: **three real findings, all fixed in `3db0940`;
three rejected with the argument below.** `origin/main` (through #246) was
merged into the branch first — clean, no conflicts.

### Fixed

**1. The invariants claim was absolute and is not true.** The doc said the only
route from that host to our listener is "the forward the stranger is the reason
we do not have". Every supervised `-R` ends at the SAME local listener
(`-R <derived>:127.0.0.1:<listenerPort>`, `ClaudeRemoteForwardSupervisor.swift:329`),
so an arrival identifies the LISTENER, not the remote port that carried the
nonce. Where a host has a second live forward to this Mac — a legacy
`RemoteForward 8473` in the user's own config block, carried by an interactive
session; the cohort `staleConfiguredForward` exists for — a hostile holder of
the disputed port can read our request off its own socket and replay it down
that other forward, and the witness matches. Both the doc and the
`ClaudeRemoteForwardProbeWitness` comment now state the residual, and say that
`.ourListener` is a diagnosis and never an authorization.

The reviewer graded this a merge blocker; I did not, and shipped it as a stated
residual instead. The replay needs code execution on the enrolled host, and
anything with code execution there **already holds the plugin's bearer token**
(it is in that host's plugin config) and already receives every hook. It gains
a suppressed status row, not a credential — so this is a diagnostic that can be
fooled by an adversary who has already won, not a control that can be bypassed.
What was genuinely wrong was writing the absolute form into the one file agents
trust; that is what is fixed.

**2. "nonce on stdin so it is never in a remote argv" is false.** stdin keeps
the nonce out of the **ssh** argv on this Mac — load-bearing, since this
machine is also the self-hosted CI runner — but the remote `sh` then runs
`curl` with `-H '<header>: <nonce>'` as a literal argument, readable in that
host's process list for the `--max-time` window. `--header @file` is the fix
(the plugin shim uses exactly that) and is deliberately **not** adopted: it
needs curl >= 7.55 on an arbitrary enrolled host, and below that the probe
would stop producing arrivals with no signal at all — a silent degrade to "not
ours" is worse than the exposure, which on its own buys a reader nothing
(spending the nonce still needs a live forward to this listener). Claim
corrected; `testTheNonceTravelsOnStdinAndNeverInArgv` renamed to
`...NeverInTheSSHArgv` and given an assertion that pins the remote-argv
exposure, so changing it is a decision and not an unnoticed diff.

**3. Two claimed bounds had no assertion.** `ConnectTimeout=5` and the 10 s
outer cap appeared in no test — dropping either shipped green while a
black-holed route parked the main-actor-awaited supervise loop for the full
budget. Same for "the re-check deliberately does not blink the row through
Connecting…". Both are now asserted, and both assertions were shown to bite
(red/green below). `arm()` also logs an eviction at the `maximumArmed` cap:
it silently turns another host's probe into `.unproved`, after which the
supervisor logs "bound by something that is not this Mac's listener" — a
negative that probe never established.

### Rejected

- **"A late-arriving probe is counted as a real `missingToken` rejection"**
  (millisecond window where `consume` disarms before the request is parsed).
  Real, and its stated harm does not survive the next commit on this train:
  the probe sends no `Authorization` header, so under #248 it lands in
  `.absentAuthorization`, which `isFault` is false for, which logs at `.notice`
  and which `Snapshot.isEmpty` excludes — it raises no hint and appears in no
  "which of three fixes" surface. Not worth a grace list.
- **"No test runs the composed path (script -> real ssh -> curl -> tunnel ->
  listener -> witness -> supervisor)."** Accurate, and already stated in the
  body's unchecked box: reproducing it needs a genuinely contended port on a
  real enrolled host. `integration-herdr` cannot cover it (the ownership seam
  is nil on the `-L` path by construction). Named, not papered over.
- **The `~100-col` comment reflow nit** in `ClaudeRemoteForwardOrphanReaper` —
  cosmetic, and the file has no enforced column rule.

### Proof for the review fixes

**RED** — `ConnectTimeout=5` deleted from `argv` and `transition(to: .connecting)`
re-added before the re-check park, i.e. exactly the two properties removed:

```
$ ./scripts/remote-build.sh test --filter ClaudeRemoteForwardOwnershipTests
ClaudeRemoteForwardOwnershipTests.swift:282: error: -[...testTheProbeIsBoundedAtBothTheConnectAndTheWholeRun] : XCTAssertTrue failed - a host that black-holes the port must not eat the whole budget in connect(): ["ssh", "-o", "BatchMode=yes", "-o", "ClearAllForwardings=yes", "--", "builder", "/bin/sh", "-s"]
	 Executed 13 tests, with 1 failure (0 unexpected) in 0.191 (0.191) seconds

$ ./scripts/remote-build.sh test --filter ClaudeRemoteForwardSupervisorTests
ClaudeRemoteForwardSupervisorTests.swift:580: error: -[...testAnExternallyHeldForwardIsTakenOverOnceTheSessionEnds] : XCTAssertFalse failed - the re-check re-dials silently; states after the proof were [....State.connecting, ....State.forwarding]
ClaudeRemoteForwardSupervisorTests.swift:498: error: -[...testARefusedBindThatIsOurOwnLiveForwardIsNotContention] : XCTAssertEqual failed: ("connecting") is not equal to ("externallyForwarded")
	 Executed 26 tests, with 2 failures (0 unexpected) in 0.073 (0.074) seconds
```

**GREEN** — both restored, same filters:

```
$ ./scripts/remote-build.sh test --filter ClaudeRemoteForwardOwnershipTests
	 Executed 13 tests, with 0 failures (0 unexpected) in 0.004 (0.005) seconds

$ ./scripts/remote-build.sh test --filter ClaudeRemoteForwardSupervisorTests
	 Executed 26 tests, with 0 failures (0 unexpected) in 0.026 (0.027) seconds
```

Findings 1 and 2 are documentation-accuracy fixes and change no behaviour, so
they carry no red/green — the code they describe is unchanged.
