### PR TITLE
Remote listener: stop blaming a healthy plugin for connections that never sent a credential

### DIFF
--- a/Sources/ClaudeContextWire/ClaudeRemoteHTTP.swift
+++ b/Sources/ClaudeContextWire/ClaudeRemoteHTTP.swift
@@ -55,8 +55,25 @@ public struct ClaudeRemoteHTTPLimits: Sendable, Equatable {
 /// cases — no length, no prefix, no digest. A diagnostic that narrows a secret
 /// is not a diagnostic worth having.
 public enum ClaudeRemoteAuthorizationShape: Sendable, Equatable {
-    /// No `Authorization` header, or a `Bearer` scheme with an empty credential.
-    case missing
+    /// No `Authorization` header at all — the caller never attempted to
+    /// authenticate.
+    ///
+    /// Split from `.empty` deliberately, because the two have different
+    /// senders and opposite diagnoses. No generation of the plugin can produce
+    /// this shape: the pre-1.1.0 http hook declared a static
+    /// `Authorization: Bearer ${…}` entry in its manifest, and the command shim
+    /// that replaced it writes the header before it dials and fails open
+    /// without ever dialing when the token is unset. So an absent header means
+    /// something that is not a hook — the enrollment verify probe, a `curl`
+    /// during setup, anything else on loopback.
+    case absent
+    /// An `Authorization` header arrived and yielded no credential: a `Bearer`
+    /// scheme with nothing after it, or a value with no scheme at all.
+    ///
+    /// This is the pre-1.1.0 plugin's exact signature (`Bearer `, from a
+    /// `${CLAUDE_PLUGIN_OPTION_TOKEN}` Claude Code never expanded into an http
+    /// hook) and the only shape that earns the update-the-plugin remedy.
+    case empty
     /// Present, but not a `Bearer` credential we are willing to read.
     case malformed
     case bearer(String)
@@ -253,25 +270,35 @@ public enum ClaudeRemoteHTTPCodec {
     /// hours of rejections said nothing about which of the two fixes — update the
     /// plugin, or re-run enrollment — the user actually needed.
     ///
+    /// `.absent` and `.empty` are likewise kept apart rather than collapsed into
+    /// one "no credential" answer. Collapsing them made the update-the-plugin
+    /// remedy fire for callers that are not hooks at all — the enrollment verify
+    /// probe posts to this endpoint with no `Authorization` header ON PURPOSE
+    /// and reads the 401 as its success signal — so a healthy setup wrote a line
+    /// accusing a current plugin, in the one subsystem whose documented
+    /// diagnostic route is reading the log later.
+    ///
     /// It classifies SHAPE only. The credential is returned for the caller to
     /// authenticate; nothing here measures, hashes, or reports it.
     public static func authorizationShape(
         in headerValue: String?,
         limits: ClaudeRemoteHTTPLimits = .default
     ) -> ClaudeRemoteAuthorizationShape {
-        guard let headerValue else { return .missing }
+        guard let headerValue else { return .absent }
         // Oversized before anything else: a header this long is not a credential
         // we failed to read, it is a header we refuse to read.
         guard headerValue.utf8.count <= limits.maxTokenBytes else { return .malformed }
         let parts = headerValue.split(separator: " ", maxSplits: 1, omittingEmptySubsequences: true)
-        guard let scheme = parts.first else { return .missing }
+        // A header that is present and blank still means the sender TRIED: a
+        // hook whose template expanded to nothing looks like this, and an
+        // anonymous caller does not send the field at all.
+        guard let scheme = parts.first else { return .empty }
         guard scheme.lowercased() == "bearer" else { return .malformed }
         // `Bearer` with an empty credential — including the header parser's
-        // already-trimmed `Bearer ` — is the pre-1.1.0 plugin's exact shape, and
-        // is reported as a missing token rather than a malformed header.
-        guard parts.count == 2 else { return .missing }
+        // already-trimmed `Bearer ` — is the pre-1.1.0 plugin's exact shape.
+        guard parts.count == 2 else { return .empty }
         let token = parts[1].trimmingCharacters(in: .whitespaces)
-        return token.isEmpty ? .missing : .bearer(token)
+        return token.isEmpty ? .empty : .bearer(token)
     }
 
     /// The event name a hook URL carries, e.g. `/v1/hook/SessionStart`.

--- a/Sources/ClaudeContextWire/ClaudeRemoteHTTP.swift
+++ b/Sources/ClaudeContextWire/ClaudeRemoteHTTP.swift
@@ -68,7 +68,8 @@ public enum ClaudeRemoteAuthorizationShape: Sendable, Equatable {
     /// during setup, anything else on loopback.
     case absent
     /// An `Authorization` header arrived and yielded no credential: a `Bearer`
-    /// scheme with nothing after it, or a value with no scheme at all.
+    /// scheme with nothing after it, or a value that is blank. (A non-blank
+    /// value naming some other scheme is `.malformed`, not this.)
     ///
     /// This is the pre-1.1.0 plugin's exact signature (`Bearer `, from a
     /// `${CLAUDE_PLUGIN_OPTION_TOKEN}` Claude Code never expanded into an http

--- a/Sources/localvoxtral/ClaudeContext/ClaudeIntegrationSettingsModel.swift
+++ b/Sources/localvoxtral/ClaudeContext/ClaudeIntegrationSettingsModel.swift
@@ -621,16 +621,19 @@ public final class ClaudeIntegrationSettingsModel {
     /// noise (a busy session produces one every few minutes), while WHICH KIND
     /// they were is the whole diagnosis. The detail stays in the log.
     ///
-    /// The hedge in "a host MAY have" is deliberate. The listener counts every
-    /// rejected connection, and an enrolled host is not the only thing that can
-    /// reach a loopback port: a probe or a curl with no `Authorization` header
-    /// lands in `.missingToken` exactly like a pre-1.1.0 plugin does. Naming a
-    /// cause with certainty would sometimes accuse a host of a fault it does
-    /// not have.
+    /// The hedge in "a host MAY have" is deliberate. An enrolled host is not the
+    /// only thing that can reach a loopback port, and a rejection carries no
+    /// identity — only a shape.
+    ///
+    /// What the hedge no longer has to cover is the anonymous caller. A probe or
+    /// a `curl` with no `Authorization` header used to land in the same category
+    /// as a pre-1.1.0 plugin, so checking your own setup raised a hint accusing
+    /// a healthy host; those are now `.absentAuthorization`, which
+    /// `Snapshot.isEmpty` excludes and this sentence therefore never describes.
     static func rejectionHint(for snapshot: ClaudeRemoteRejectionTally.Snapshot) -> String? {
         guard !snapshot.isEmpty else { return nil }
         let cause: String
-        switch (snapshot.missingToken > 0, snapshot.unknownToken > 0) {
+        switch (snapshot.emptyCredential > 0, snapshot.unknownToken > 0) {
         case (true, true):
             cause = "an outdated plugin or a stale token"
         case (true, false):

--- a/Sources/localvoxtral/ClaudeContext/ClaudeRemoteContextListener.swift
+++ b/Sources/localvoxtral/ClaudeContext/ClaudeRemoteContextListener.swift
@@ -444,7 +444,18 @@ public final class ClaudeRemoteContextListener: Sendable {
                 for: shape, authenticated: authenticatedHost != nil
             ) ?? .unknownToken
             rejections.record(category)
-            Log.claudeContext.error("\(category.logLine, privacy: .public)")
+            // Same line either way, and always logged — but a connection that
+            // never offered a credential is not an error. The verify probe posts
+            // here without one on purpose and reads the 401 as success, so
+            // logging that at `.error` trains the reader to scroll past the
+            // category that means a host really is broken. `.notice` still
+            // persists to disk in the unified log, so nothing stops being
+            // findable later.
+            if category.isFault {
+                Log.claudeContext.error("\(category.logLine, privacy: .public)")
+            } else {
+                Log.claudeContext.notice("\(category.logLine, privacy: .public)")
+            }
             respond(fd: fd, status: 401)
             return
         }

--- a/Sources/localvoxtral/ClaudeContext/ClaudeRemoteRejection.swift
+++ b/Sources/localvoxtral/ClaudeContext/ClaudeRemoteRejection.swift
@@ -2,8 +2,8 @@ import ClaudeContextWire
 import Foundation
 import Synchronization
 
-/// Why the remote listener turned a connection away, in the only three shapes
-/// that have different fixes.
+/// Why the remote listener turned a connection away, in the only shapes that
+/// have different fixes.
 ///
 /// Field report, 2026-07-26: the app's unified log carried an hours-long stream
 /// of one line — "Rejected unauthenticated connection to the remote listener" —
@@ -12,23 +12,43 @@ import Synchronization
 /// empty credential. That line could not tell that apart from a token that had
 /// been rotated out, and the app's UI said nothing at all: remote dictation
 /// simply had no context. Diagnosing it took a dispatched log-collection
-/// workflow. The three cases below each name their own remedy instead.
+/// workflow. The cases below each name their own remedy instead.
+///
+/// The fourth case, `.absentAuthorization`, is the same lesson applied to the
+/// opposite error. `.emptyCredential` used to cover a connection that sent no
+/// `Authorization` header at all, so every unauthenticated probe of this
+/// endpoint — including the enrollment verify step, which posts without a
+/// credential deliberately and treats the 401 as its success signal — wrote a
+/// line telling the reader to update a plugin that was already current. A
+/// remedy that fires on healthy setups is a remedy nobody trusts the next time
+/// it fires on a broken one, and this is the subsystem where reading the log
+/// months later IS the diagnostic route.
 public enum ClaudeRemoteRejectionCategory: String, Sendable, Equatable, CaseIterable {
-    /// No bearer credential at all — the pre-1.1.0 plugin's exact signature.
-    case missingToken
+    /// No `Authorization` header at all: nothing on the connection attempted to
+    /// authenticate. NOT a plugin fault, and naming one would be a lie — see
+    /// `ClaudeRemoteAuthorizationShape.absent` for why no plugin generation can
+    /// produce this shape.
+    case absentAuthorization
+    /// An `Authorization` header arrived carrying no credential — the pre-1.1.0
+    /// plugin's exact signature, and the only shape that earns the
+    /// update-the-plugin remedy.
+    case emptyCredential
     /// A credential arrived and matched no enrolled host.
     case unknownToken
     /// The `Authorization` header was not a bearer credential we would read.
     case malformedAuthorization
 
     /// One line, and never any token material — not the header, not the
-    /// credential, not its length. What the user needs is which of three fixes
-    /// to apply, and that is decided by the SHAPE alone.
+    /// credential, not its length. What the user needs is which fix to apply,
+    /// and that is decided by the SHAPE alone.
     public var logLine: String {
         switch self {
-        case .missingToken:
-            return "Rejected remote connection: no bearer token — a pre-1.1.0 plugin or misconfigured hook; "
-                + "update the plugin on the host"
+        case .absentAuthorization:
+            return "Rejected remote connection: no Authorization header — an unauthenticated probe or "
+                + "setup check; every plugin generation sends the header, so no host is at fault"
+        case .emptyCredential:
+            return "Rejected remote connection: empty bearer credential — a pre-1.1.0 plugin or "
+                + "misconfigured hook; update the plugin on the host"
         case .unknownToken:
             return "Rejected remote connection: no enrolled host matches — rotated token or revoked host; "
                 + "re-run enrollment install with the current token"
@@ -36,6 +56,15 @@ public enum ClaudeRemoteRejectionCategory: String, Sendable, Equatable, CaseIter
             return "Rejected remote connection: malformed Authorization header"
         }
     }
+
+    /// Whether this rejection describes something the user may need to fix.
+    ///
+    /// Only `.absentAuthorization` is routine: the app's own verify probe and
+    /// the documented `curl` check both produce it by design, and the 401 is
+    /// their success signal. It is still logged, once per connection, saying
+    /// exactly what arrived — it is simply not an error, and a log full of
+    /// errors that are not errors is how the real one gets scrolled past.
+    public var isFault: Bool { self != .absentAuthorization }
 
     /// The category a head's authorization shape implies, given whether the
     /// credential it carried authenticated.
@@ -47,7 +76,8 @@ public enum ClaudeRemoteRejectionCategory: String, Sendable, Equatable, CaseIter
         authenticated: Bool
     ) -> ClaudeRemoteRejectionCategory? {
         switch shape {
-        case .missing: return .missingToken
+        case .absent: return .absentAuthorization
+        case .empty: return .emptyCredential
         case .malformed: return .malformedAuthorization
         case .bearer: return authenticated ? nil : .unknownToken
         }
@@ -65,18 +95,36 @@ public enum ClaudeRemoteRejectionCategory: String, Sendable, Equatable, CaseIter
 /// record while the main actor reads for Settings.
 public final class ClaudeRemoteRejectionTally: Sendable {
     public struct Snapshot: Sendable, Equatable {
-        public var missingToken: Int
+        /// Counted, but deliberately outside `isEmpty` — see there.
+        public var absentAuthorization: Int
+        public var emptyCredential: Int
         public var unknownToken: Int
         public var malformedAuthorization: Int
 
-        public init(missingToken: Int = 0, unknownToken: Int = 0, malformedAuthorization: Int = 0) {
-            self.missingToken = missingToken
+        public init(
+            absentAuthorization: Int = 0,
+            emptyCredential: Int = 0,
+            unknownToken: Int = 0,
+            malformedAuthorization: Int = 0
+        ) {
+            self.absentAuthorization = absentAuthorization
+            self.emptyCredential = emptyCredential
             self.unknownToken = unknownToken
             self.malformedAuthorization = malformedAuthorization
         }
 
+        /// True when nothing counted here describes a fault a host could have.
+        ///
+        /// `absentAuthorization` is excluded on purpose. It is what the app's own
+        /// verify probe and the documented `curl` check look like from this side,
+        /// and the hint it would raise is a sentence about a HOST's plugin or
+        /// token — copy that cannot be true of a caller which is not a host's
+        /// hook. Counting it would paint a fault on a healthy pane every time the
+        /// user checked their setup: the same phantom the log used to write,
+        /// moved into the UI. It stays in the snapshot because a stream of
+        /// anonymous dials is still worth being able to read.
         public var isEmpty: Bool {
-            missingToken == 0 && unknownToken == 0 && malformedAuthorization == 0
+            emptyCredential == 0 && unknownToken == 0 && malformedAuthorization == 0
         }
     }
 
@@ -87,7 +135,8 @@ public final class ClaudeRemoteRejectionTally: Sendable {
     public func record(_ category: ClaudeRemoteRejectionCategory) {
         counts.withLock { counts in
             switch category {
-            case .missingToken: counts.missingToken += 1
+            case .absentAuthorization: counts.absentAuthorization += 1
+            case .emptyCredential: counts.emptyCredential += 1
             case .unknownToken: counts.unknownToken += 1
             case .malformedAuthorization: counts.malformedAuthorization += 1
             }

--- a/Tests/localvoxtralTests/ClaudeIntegrationSettingsModelTests.swift
+++ b/Tests/localvoxtralTests/ClaudeIntegrationSettingsModelTests.swift
@@ -1697,7 +1697,7 @@ final class ClaudeIntegrationSettingsModelTests: XCTestCase {
         let model = makeModel(registry: registry, listener: listener)
         XCTAssertNil(model.rejectionHint, "nothing rejected, nothing to say")
 
-        listener.rejectionSnapshot = ClaudeRemoteRejectionTally.Snapshot(missingToken: 42)
+        listener.rejectionSnapshot = ClaudeRemoteRejectionTally.Snapshot(emptyCredential: 42)
         model.refreshHosts()
 
         let hint = try XCTUnwrap(model.rejectionHint)
@@ -1714,7 +1714,7 @@ final class ClaudeIntegrationSettingsModelTests: XCTestCase {
         }
         XCTAssertNil(hint(ClaudeRemoteRejectionTally.Snapshot()))
         XCTAssertEqual(
-            hint(ClaudeRemoteRejectionTally.Snapshot(missingToken: 1)),
+            hint(ClaudeRemoteRejectionTally.Snapshot(emptyCredential: 1)),
             "Rejected connections detected — a host may have an outdated plugin — use Update Plugin."
         )
         XCTAssertEqual(
@@ -1722,7 +1722,7 @@ final class ClaudeIntegrationSettingsModelTests: XCTestCase {
             "Rejected connections detected — a host may have a stale token — rotate it and re-run setup."
         )
         XCTAssertEqual(
-            hint(ClaudeRemoteRejectionTally.Snapshot(missingToken: 1, unknownToken: 1)),
+            hint(ClaudeRemoteRejectionTally.Snapshot(emptyCredential: 1, unknownToken: 1)),
             "Rejected connections detected — a host may have an outdated plugin or a stale token."
         )
         XCTAssertEqual(
@@ -1730,13 +1730,37 @@ final class ClaudeIntegrationSettingsModelTests: XCTestCase {
             "Rejected connections detected — a host may have a malformed authorization header."
         )
         for snapshot in [
-            ClaudeRemoteRejectionTally.Snapshot(missingToken: 1),
+            ClaudeRemoteRejectionTally.Snapshot(emptyCredential: 1),
             ClaudeRemoteRejectionTally.Snapshot(unknownToken: 1),
-            ClaudeRemoteRejectionTally.Snapshot(missingToken: 1, unknownToken: 1),
+            ClaudeRemoteRejectionTally.Snapshot(emptyCredential: 1, unknownToken: 1),
             ClaudeRemoteRejectionTally.Snapshot(malformedAuthorization: 1),
         ] {
             XCTAssertLessThan(hint(snapshot)?.count ?? .max, 110)
         }
+    }
+
+    /// The hint's whole sentence is "a HOST may have <fault>", and a connection
+    /// that sent no credential is not a host's hook — the app's own verify probe
+    /// looks exactly like this. Raising a fault for it would put the log's old
+    /// phantom into the pane, where the user cannot even go read the detail.
+    func testAnUnauthenticatedProbeRaisesNoHintAtAll() throws {
+        let registry = try makeRegistry()
+        let listener = StubListener(hosts: registry)
+        let model = makeModel(registry: registry, listener: listener)
+
+        listener.rejectionSnapshot = ClaudeRemoteRejectionTally.Snapshot(absentAuthorization: 9)
+        model.refreshHosts()
+        XCTAssertNil(model.rejectionHint)
+
+        // A real fault alongside the probes still speaks, and still names only
+        // the fault: the probes never become part of the diagnosis.
+        listener.rejectionSnapshot =
+            ClaudeRemoteRejectionTally.Snapshot(absentAuthorization: 9, unknownToken: 1)
+        model.refreshHosts()
+        XCTAssertEqual(
+            model.rejectionHint,
+            "Rejected connections detected — a host may have a stale token — rotate it and re-run setup."
+        )
     }
 
     func testAModelWithNoListenerNeverInventsAHint() {

--- a/Tests/localvoxtralTests/ClaudeRemoteContextListenerTests.swift
+++ b/Tests/localvoxtralTests/ClaudeRemoteContextListenerTests.swift
@@ -216,9 +216,17 @@ final class ClaudeRemoteContextListenerTests: XCTestCase {
 
         XCTAssertEqual(response.status, 401)
         XCTAssertFalse(witness.consume(mine), "the armed nonce is untouched")
+        // Counted exactly as it would have been without the header. Which
+        // category that is comes from THIS branch's split: the request carries
+        // no `Authorization` header at all, so it is `.absentAuthorization` —
+        // not a plugin fault, because no plugin generation omits the header.
+        // Asserting both halves pins the composition of the two changes: an
+        // unminted probe header makes a request neither a probe nor a host's
+        // fault.
+        XCTAssertEqual(listener.rejectionSnapshot.absentAuthorization, 1)
         XCTAssertEqual(
-            listener.rejectionSnapshot.missingToken, 1,
-            "and it is counted exactly as it would have been without the header"
+            listener.rejectionSnapshot.emptyCredential, 0,
+            "a header we never minted must not be read as a pre-1.1.0 plugin"
         )
     }
 

--- a/Tests/localvoxtralTests/ClaudeRemoteContextListenerTests.swift
+++ b/Tests/localvoxtralTests/ClaudeRemoteContextListenerTests.swift
@@ -474,15 +474,86 @@ final class ClaudeRemoteContextListenerTests: XCTestCase {
         XCTAssertEqual(response.status, 401)
 
         let tally = listener.rejectionSnapshot
-        XCTAssertEqual(tally.missingToken, 1)
+        XCTAssertEqual(tally.emptyCredential, 1)
+        XCTAssertEqual(tally.absentAuthorization, 0)
         XCTAssertEqual(tally.unknownToken, 0)
         XCTAssertEqual(tally.malformedAuthorization, 0)
     }
 
-    func testAnAbsentAuthorizationHeaderCountsAsAMissingToken() throws {
+    /// The regression, stated in the terms that matter to whoever reads this log
+    /// next rather than in the names of our own categories: the line written for
+    /// a connection that offered no credential must not prescribe a fix aimed at
+    /// a host's plugin, and the line written for the pre-1.1.0 signature still
+    /// must.
+    ///
+    /// Deliberately phrased against the SHAPES, so it says the same thing before
+    /// and after the split and cannot be satisfied by softening the pre-1.1.0
+    /// remedy into something vague enough to cover both.
+    func testAnUnauthenticatedProbeIsNeverToldToUpdateAHealthyPlugin() throws {
+        try startListener()
+        // Byte for byte what the enrollment verify step sends, and what any
+        // `curl` against the tunnel sends: no Authorization header at all.
+        XCTAssertEqual(try send(hookRequest(token: nil))?.status, 401)
+
+        let probe = try XCTUnwrap(
+            ClaudeRemoteRejectionCategory.category(
+                for: ClaudeRemoteHTTPCodec.authorizationShape(in: nil), authenticated: false
+            )
+        )
+        XCTAssertFalse(
+            probe.logLine.contains("update the plugin"),
+            "the verify probe posts without a credential ON PURPOSE and reads the 401 as success — "
+                + "telling its reader to update a current plugin sends them chasing a phantom"
+        )
+
+        let pre110 = try XCTUnwrap(
+            ClaudeRemoteRejectionCategory.category(
+                for: ClaudeRemoteHTTPCodec.authorizationShape(in: "Bearer "), authenticated: false
+            )
+        )
+        XCTAssertTrue(
+            pre110.logLine.contains("update the plugin"),
+            "the 2026-07-26 diagnosis is the point of this taxonomy and must survive intact"
+        )
+    }
+
+    /// The mirror of the field case, and the reason this category exists.
+    ///
+    /// The enrollment verify step posts here with NO `Authorization` header on
+    /// purpose and reads the 401 as its success signal, so checking a healthy
+    /// setup used to write a line telling the reader to update a current plugin
+    /// — a phantom for whoever reads this log next, in the subsystem where
+    /// reading the log later IS the diagnostic route. An absent header is its
+    /// own category, carries no host remedy, and is not a fault.
+    func testAnAbsentAuthorizationHeaderIsNotBlamedOnTheHostsPlugin() throws {
         try startListener()
         XCTAssertEqual(try send(hookRequest(token: nil))?.status, 401)
-        XCTAssertEqual(listener.rejectionSnapshot.missingToken, 1)
+
+        let tally = listener.rejectionSnapshot
+        XCTAssertEqual(tally.absentAuthorization, 1)
+        XCTAssertEqual(
+            tally.emptyCredential, 0,
+            "nothing here looks like a plugin: no generation of it omits the header"
+        )
+        XCTAssertEqual(tally.unknownToken, 0)
+        XCTAssertEqual(tally.malformedAuthorization, 0)
+        XCTAssertFalse(
+            ClaudeRemoteRejectionCategory.absentAuthorization.logLine.contains("update the plugin"),
+            "the remedy clause must not reach a caller that is not a host"
+        )
+        XCTAssertFalse(ClaudeRemoteRejectionCategory.absentAuthorization.isFault)
+    }
+
+    /// The tally drives user-facing copy, so our own setup check must not raise
+    /// a hint accusing a host that has nothing wrong with it.
+    func testAnUnauthenticatedProbeLeavesTheUserFacingTallyEmpty() throws {
+        try startListener()
+        // Exactly what the verify step sends: POST, JSON body, no credential.
+        for _ in 0..<3 { XCTAssertEqual(try send(hookRequest(token: nil))?.status, 401) }
+
+        let tally = listener.rejectionSnapshot
+        XCTAssertEqual(tally.absentAuthorization, 3, "still counted — the evidence is not thrown away")
+        XCTAssertTrue(tally.isEmpty, "but nothing here is a fault a host could fix")
     }
 
     /// The other half of the same night's ambiguity: a credential that is a
@@ -493,7 +564,7 @@ final class ClaudeRemoteContextListenerTests: XCTestCase {
 
         let tally = listener.rejectionSnapshot
         XCTAssertEqual(tally.unknownToken, 1)
-        XCTAssertEqual(tally.missingToken, 0, "a token DID arrive; blaming the plugin would misdirect")
+        XCTAssertEqual(tally.emptyCredential, 0, "a token DID arrive; blaming the plugin would misdirect")
         XCTAssertEqual(tally.malformedAuthorization, 0)
     }
 
@@ -502,7 +573,7 @@ final class ClaudeRemoteContextListenerTests: XCTestCase {
         _ = try hosts.rotateToken(hostID: hostID)
         XCTAssertEqual(try send(hookRequest(token: token))?.status, 401)
         XCTAssertEqual(listener.rejectionSnapshot.unknownToken, 1)
-        XCTAssertEqual(listener.rejectionSnapshot.missingToken, 0)
+        XCTAssertEqual(listener.rejectionSnapshot.emptyCredential, 0)
     }
 
     func testANonBearerSchemeIsItsOwnCategory() throws {
@@ -514,14 +585,16 @@ final class ClaudeRemoteContextListenerTests: XCTestCase {
 
         let tally = listener.rejectionSnapshot
         XCTAssertEqual(tally.malformedAuthorization, 1)
-        XCTAssertEqual(tally.missingToken, 0)
+        XCTAssertEqual(tally.emptyCredential, 0)
+        XCTAssertEqual(tally.absentAuthorization, 0)
         XCTAssertEqual(tally.unknownToken, 0)
     }
 
-    func testTheThreeCategoriesAccumulateIndependently() throws {
+    func testEveryCategoryAccumulatesIndependently() throws {
         try startListener()
         _ = try send(hookRequest(token: nil, rawAuthorization: "Bearer "))
         _ = try send(hookRequest(token: nil, rawAuthorization: "Bearer "))
+        _ = try send(hookRequest(token: nil))
         _ = try send(hookRequest(token: ClaudeRemoteTokenDigest.makeToken()))
         _ = try send(hookRequest(token: nil, rawAuthorization: "Basic ZGV2"))
         // A successful request must not be counted as anything.
@@ -530,7 +603,7 @@ final class ClaudeRemoteContextListenerTests: XCTestCase {
         XCTAssertEqual(
             listener.rejectionSnapshot,
             ClaudeRemoteRejectionTally.Snapshot(
-                missingToken: 2, unknownToken: 1, malformedAuthorization: 1
+                absentAuthorization: 1, emptyCredential: 2, unknownToken: 1, malformedAuthorization: 1
             )
         )
     }
@@ -551,7 +624,11 @@ final class ClaudeRemoteContextListenerTests: XCTestCase {
 
     func testShapeAndAuthenticationResultDecideTheCategory() {
         XCTAssertEqual(
-            ClaudeRemoteRejectionCategory.category(for: .missing, authenticated: false), .missingToken
+            ClaudeRemoteRejectionCategory.category(for: .absent, authenticated: false),
+            .absentAuthorization
+        )
+        XCTAssertEqual(
+            ClaudeRemoteRejectionCategory.category(for: .empty, authenticated: false), .emptyCredential
         )
         XCTAssertEqual(
             ClaudeRemoteRejectionCategory.category(for: .malformed, authenticated: false),
@@ -574,8 +651,29 @@ final class ClaudeRemoteContextListenerTests: XCTestCase {
             XCTAssertFalse(line.contains("\n"), "\(category): one line")
             XCTAssertLessThan(line.count, 180, "\(category): the detail belongs in the code, not the log")
         }
-        XCTAssertTrue(ClaudeRemoteRejectionCategory.missingToken.logLine.contains("update the plugin"))
+        XCTAssertTrue(ClaudeRemoteRejectionCategory.emptyCredential.logLine.contains("update the plugin"))
         XCTAssertTrue(ClaudeRemoteRejectionCategory.unknownToken.logLine.contains("re-run enrollment"))
+    }
+
+    /// The pre-1.1.0 diagnosis is the thing this taxonomy exists for, and
+    /// narrowing which shape earns it must not have made it reachable by fewer
+    /// hosts. `Bearer ` — the only shape a pre-1.1.0 plugin could send — still
+    /// gets the full remedy, and no other category borrows it.
+    func testOnlyTheEmptyCredentialCarriesThePluginRemedy() {
+        XCTAssertEqual(
+            ClaudeRemoteRejectionCategory.category(for: .empty, authenticated: false),
+            .emptyCredential
+        )
+        for category in ClaudeRemoteRejectionCategory.allCases where category != .emptyCredential {
+            XCTAssertFalse(
+                category.logLine.contains("update the plugin"),
+                "\(category) must not accuse a host's plugin"
+            )
+        }
+        XCTAssertTrue(
+            ClaudeRemoteRejectionCategory.emptyCredential.isFault,
+            "an empty credential is the field failure; it stays an error"
+        )
     }
 
     func testAnUnparseablePayloadNamesItsEventAndNothingElse() throws {

--- a/Tests/localvoxtralTests/ClaudeRemoteHTTPTests.swift
+++ b/Tests/localvoxtralTests/ClaudeRemoteHTTPTests.swift
@@ -249,15 +249,15 @@ final class ClaudeRemoteHTTPTests: XCTestCase {
 
     // MARK: Authorization shape
 
-    /// Why a header yielded no credential, which decides which of two fixes the
-    /// user needs: update the plugin, or re-run enrollment.
+    /// Why a header yielded no credential, which decides which fix the user
+    /// needs: update the plugin, re-run enrollment, or nothing at all.
     func testAuthorizationShapeSeparatesAMissingCredentialFromAMalformedHeader() {
-        XCTAssertEqual(ClaudeRemoteHTTPCodec.authorizationShape(in: nil), .missing)
+        XCTAssertEqual(ClaudeRemoteHTTPCodec.authorizationShape(in: nil), .absent)
         // The pre-1.1.0 plugin's exact wire shape. The head parser trims the
         // trailing space, so this arrives as a bare scheme.
-        XCTAssertEqual(ClaudeRemoteHTTPCodec.authorizationShape(in: "Bearer"), .missing)
-        XCTAssertEqual(ClaudeRemoteHTTPCodec.authorizationShape(in: "Bearer   "), .missing)
-        XCTAssertEqual(ClaudeRemoteHTTPCodec.authorizationShape(in: ""), .missing)
+        XCTAssertEqual(ClaudeRemoteHTTPCodec.authorizationShape(in: "Bearer"), .empty)
+        XCTAssertEqual(ClaudeRemoteHTTPCodec.authorizationShape(in: "Bearer   "), .empty)
+        XCTAssertEqual(ClaudeRemoteHTTPCodec.authorizationShape(in: ""), .empty)
         XCTAssertEqual(ClaudeRemoteHTTPCodec.authorizationShape(in: "Basic abc"), .malformed)
         XCTAssertEqual(ClaudeRemoteHTTPCodec.authorizationShape(in: "abc"), .malformed)
         XCTAssertEqual(
@@ -266,6 +266,23 @@ final class ClaudeRemoteHTTPTests: XCTestCase {
             "an oversized header is refused, not classified as a credential we failed to read"
         )
         XCTAssertEqual(ClaudeRemoteHTTPCodec.authorizationShape(in: "bearer abc"), .bearer("abc"))
+    }
+
+    /// "Sent no header" and "sent a header carrying nothing" have opposite
+    /// diagnoses, so they may never collapse into one answer.
+    ///
+    /// A hook whose credential template expanded to nothing still SENDS the
+    /// field — that is the pre-1.1.0 signature, and every shape of it belongs to
+    /// `.empty`. Only a caller that is not a hook omits the field entirely.
+    func testAnAbsentHeaderIsNotTheSameShapeAsAnEmptyCredential() {
+        XCTAssertEqual(ClaudeRemoteHTTPCodec.authorizationShape(in: nil), .absent)
+        for present in ["", " ", "Bearer", "Bearer ", "bearer   "] {
+            XCTAssertEqual(
+                ClaudeRemoteHTTPCodec.authorizationShape(in: present),
+                .empty,
+                "a header that arrived and carried nothing is a sender that tried: \(present.debugDescription)"
+            )
+        }
     }
 
     /// The classifier IS the bearer path, so the two can never disagree about

--- a/Tests/localvoxtralTests/ClaudeRemoteListenerCoordinatorTests.swift
+++ b/Tests/localvoxtralTests/ClaudeRemoteListenerCoordinatorTests.swift
@@ -129,7 +129,7 @@ final class ClaudeRemoteListenerCoordinatorTests: XCTestCase {
 
         let enrollment = try hosts.enroll(label: "builder")
         try coordinator.reconcile()
-        handed.all.first?.record(.missingToken)
+        handed.all.first?.record(.emptyCredential)
 
         try hosts.revoke(hostID: enrollment.host.id)
         try coordinator.reconcile()
@@ -140,7 +140,7 @@ final class ClaudeRemoteListenerCoordinatorTests: XCTestCase {
         XCTAssertTrue(handed.all[0] === handed.all[1], "and handed it the same counters")
         XCTAssertEqual(
             coordinator.rejectionSnapshot,
-            ClaudeRemoteRejectionTally.Snapshot(missingToken: 1)
+            ClaudeRemoteRejectionTally.Snapshot(emptyCredential: 1)
         )
     }
 

--- a/docs/agent/invariants.md
+++ b/docs/agent/invariants.md
@@ -567,6 +567,30 @@ there is not.
     budget.
   These paths are in `scripts/ci/llm-lane-filter.sh`: they change what reaches
   the model, so the LLM lanes run on them.
+- **A rejection's remedy is earned by its wire shape, and only one shape earns
+  the plugin remedy.** `ClaudeRemoteRejectionCategory` exists because one
+  undifferentiated "rejected unauthenticated connection" line cost a dispatched
+  log-collection workflow to diagnose (field report, 2026-07-26). Two of its
+  cases turn on a distinction that looks cosmetic and is not: a header that
+  ARRIVED carrying no credential (`Bearer `, from a `${…}` Claude Code never
+  expanded into an http hook) is the pre-1.1.0 plugin's exact signature and
+  keeps the full "update the plugin on the host" clause; NO `Authorization`
+  header at all cannot come from any plugin generation — the pre-1.1.0 manifest
+  declared the header statically, and the command shim that replaced it writes
+  the header before it dials and fails open without dialing when the token is
+  unset — so it is an unauthenticated caller, gets its own line with no host
+  remedy, logs at `.notice` rather than `.error`, and is excluded from
+  `Snapshot.isEmpty` so it raises no Settings hint. That last part is not
+  tidiness: the enrollment verify probe posts here WITHOUT a credential on
+  purpose and reads the 401 as its success signal, so collapsing the two shapes
+  made every setup check write a line accusing a healthy host — a phantom for
+  the next person reading this log, in the one subsystem whose documented
+  diagnostic route is reading the log later. Do not re-collapse them, and do not
+  soften the `.emptyCredential` clause into vagueness to cover both: losing the
+  pre-1.1.0 diagnosis is the worse failure of the two, which is why the split is
+  decided by the request's own bytes rather than by any state this app keeps —
+  there is no window to be outside of and nothing a caller can assert to land in
+  the quieter category that it could not already assert to land in another.
 - **Remote Claude context is opaque by construction.** The remote listener tags
   every accepted session `.remote` regardless of its payload; a local process
   connecting to that listener can only downgrade itself. Remote cwd values are


### PR DESCRIPTION
## What

The remote listener's rejection taxonomy collapsed two different wire shapes into
one category, so it wrote one remedy for both:

> `Rejected remote connection: no bearer token — a pre-1.1.0 plugin or misconfigured hook; update the plugin on the host`

That clause is load-bearing — it is the residue of the 2026-07-26 field report
(hours of an undiagnosable one-line stream, caused by long-running sessions on a
pre-1.1.0 plugin, diagnosed only by a dispatched log-collection workflow). But
`ClaudeRemoteAuthorizationShape.missing` covered **two senders with opposite
diagnoses**:

| wire | sender | right remedy |
|---|---|---|
| `Authorization: Bearer ` (header present, credential empty) | pre-1.1.0 plugin — Claude Code never expanded `${CLAUDE_PLUGIN_OPTION_TOKEN}` into an http hook | update the plugin |
| *no `Authorization` header at all* | not a hook: a setup check, a `curl`, anything else on loopback | **none — nothing is wrong** |

So an unauthenticated `curl` against the tunnel wrote a line accusing a host that
has nothing wrong with it, and told the reader to update a plugin that is current.
The enrollment verify step makes this routine rather than rare: it posts to
`/v1/hook/SessionStart` **without a credential on purpose** and reads the 401 as
its success signal, so checking a healthy setup wrote the accusation every time.
Anyone later diagnosing a genuine remote-context problem finds those lines and
chases a phantom — in the one subsystem whose documented diagnostic route is
reading the log later.

**The change.** Split the shape, not the diagnosis:

- `ClaudeRemoteAuthorizationShape.missing` → `.absent` (no header) and `.empty`
  (header arrived, carried no credential).
- `.emptyCredential` keeps the pre-1.1.0 clause **verbatim**; `.absentAuthorization`
  is new and carries no host remedy:
  `Rejected remote connection: no Authorization header — an unauthenticated probe or setup check; every plugin generation sends the header, so no host is at fault`
- `.absentAuthorization` logs at `.notice` instead of `.error` (still persisted to
  disk in the unified log, still one line per connection — it is simply not an
  error), and is excluded from `Snapshot.isEmpty`, so it raises no Settings hint.
- Invariant recorded in `docs/agent/invariants.md`, including "do not re-collapse
  these, and do not soften the `.emptyCredential` clause into vagueness to cover
  both".

### Why attribution by wire shape, and not by a self-probe window

The obvious alternatives both have to answer "how do we know this was us?".

**A time window** (a flag set for the bounded lifetime of the verify probe, the
listener labelling rejections inside it) works, but it has a race: a genuine
pre-1.1.0 rejection arriving inside the window is mislabelled, and the window has
to be leak-proof against a probe that throws. **The shape carries the answer with
no race at all** — the attribution is decided by the request's own bytes, so there
is no window to be inside or outside of, no clock, and no app state to keep in
sync. And it works for `verifyCommands`' pasted `curl` on `main` today, which no
window can see.

**A `X-localvoxtral-probe: 1` header** was rejected. It lets any unauthenticated
caller suppress a security-relevant log line by asserting a header — mild
anti-forensics — and it would mean reading unauthenticated input to decide a
diagnosis, in the one file whose phase-2 comment says "nothing is discriminated on
until the token is known good". The shape split is not the same thing: "no
`Authorization` header" is the *absence of a claim*, not a claim about identity,
and it buys an attacker nothing they do not already have (sending
`Bearer <garbage>` already lands in `.unknownToken`, whose clause also does not
accuse the plugin — there is no silent bucket in any design, and never was).

### How the pre-1.1.0 diagnosis stays intact

Verified against the plugin's own history, not assumed:

- The pre-1.1.0 manifest (`b328468`) declared `"Authorization": "Bearer ${CLAUDE_PLUGIN_OPTION_TOKEN}"`
  **statically per hook** — it could not send a request without the header.
- The current command shim (`post.sh`, #196) writes `Authorization: Bearer $TOKEN`
  into its header file before it dials, and `fail_open`s without dialing at all
  when the token is unset.

So no plugin generation can produce `.absent`, and every shape one *can* produce
lands in `.emptyCredential` with the full remedy. `testOnlyTheEmptyCredentialCarriesThePluginRemedy`
pins that from the other side: no other category may contain "update the plugin".

**Residual, stated plainly.** A host whose `curl` predates 7.55 does not understand
`--header @file`; if that curl drops the argument rather than sending it verbatim,
its dial lands in `.absentAuthorization` and loses a clause that was pointing at
the wrong fix anyway (the plugin is current; the curl is old). If it sends the
argument verbatim, the colon-less line is a `.malformed` parse → **400, not 401**,
so it never reached this taxonomy on `main` either. Either way this PR loses
nothing that existed, and the shim's own `hook-status` stamp is the channel that
actually describes that host.

**The tally.** `.absentAuthorization` is counted but excluded from `isEmpty`, so it
never raises `rejectionHint`. The hint's sentence is *"a **host** may have
&lt;plugin/token fault&gt;"* — copy that cannot be true of a caller which is not a
host's hook. Counting it would paint a fault on a healthy pane every time the user
checked their setup: the same phantom the log used to write, moved into the UI
where the user cannot even go read the detail. It stays in the snapshot because a
stream of anonymous dials is still worth being able to read.

### Notes

- No wire change, no plugin change, no new header, no clock.
- This also fixes `ClaudeRemoteEnrollmentService.executeVerification` on the
  **unmerged** `ssh-flow-redesign` (#224) with zero changes to that branch: its
  `tunnelProbeScript` sends a plain `curl` with no `Authorization` header, which is
  exactly `.absent`. Nothing under `ssh-flow-redesign` was touched.
- No overlap with the concurrent `ClaudeRemoteForwardCoordinator` /
  `portUnavailable` work — no file here is shared with it.

## Proof

- [x] **Unit suite green** — `./scripts/remote-build.sh test`

```
Test Suite 'localvoxtralPackageTests.xctest' passed at 2026-08-30 15:18:13.550.
	 Executed 2750 tests, with 2 tests skipped and 0 failures (0 unexpected) in 98.992 (99.100) seconds
```

Zero compiler warnings (`grep -ci "warning:" .build/last-remote.log` → `0`).

- [x] **Bug fix: regression test added — failing before, passing after**

`testAnUnauthenticatedProbeIsNeverToldToUpdateAHealthyPlugin` is phrased against the
*shapes* rather than our category names, so it compiles and means the same thing on
both sides of the fix, and cannot be satisfied by softening the pre-1.1.0 remedy
into something vague enough to cover both.

**Before** — the test alone, applied to unmodified `origin/main` (`d38e7eb`),
`LV_BUILD_DIR=work/localvoxtral-rejection-before ./scripts/remote-build.sh test --filter ClaudeRemoteContextListenerTests`:

```
Test Case '-[localvoxtralTests.ClaudeRemoteContextListenerTests testAnUnauthenticatedProbeIsNeverToldToUpdateAHealthyPlugin]' started.
/Users/builder/work/localvoxtral-rejection-before/Tests/localvoxtralTests/ClaudeRemoteContextListenerTests.swift:491: error: -[localvoxtralTests.ClaudeRemoteContextListenerTests testAnUnauthenticatedProbeIsNeverToldToUpdateAHealthyPlugin] : XCTAssertFalse failed - the verify probe posts without a credential ON PURPOSE and reads the 401 as success — telling its reader to update a current plugin sends them chasing a phantom
Test Case '-[localvoxtralTests.ClaudeRemoteContextListenerTests testAnUnauthenticatedProbeIsNeverToldToUpdateAHealthyPlugin]' failed (0.201 seconds).
	 Executed 42 tests, with 1 failure (0 unexpected) in 0.234 (0.237) seconds
```

Note the second assertion in that same test — that `Bearer ` still carries the
plugin remedy — passed on `main` and passes here: the diagnosis was never in
question, only who it was aimed at.

**After** — same test, this branch, plus the rest of the new coverage:

```
Test Case '-[localvoxtralTests.ClaudeRemoteContextListenerTests testAnUnauthenticatedProbeIsNeverToldToUpdateAHealthyPlugin]' passed (0.001 seconds).
Test Case '-[localvoxtralTests.ClaudeRemoteContextListenerTests testAnAbsentAuthorizationHeaderIsNotBlamedOnTheHostsPlugin]' passed (0.001 seconds).
Test Case '-[localvoxtralTests.ClaudeRemoteContextListenerTests testAnUnauthenticatedProbeLeavesTheUserFacingTallyEmpty]' passed (0.001 seconds).
Test Case '-[localvoxtralTests.ClaudeRemoteContextListenerTests testOnlyTheEmptyCredentialCarriesThePluginRemedy]' passed (0.000 seconds).
Test Case '-[localvoxtralTests.ClaudeRemoteContextListenerTests testEveryCategoryAccumulatesIndependently]' passed (0.002 seconds).
Test Case '-[localvoxtralTests.ClaudeRemoteHTTPTests testAnAbsentHeaderIsNotTheSameShapeAsAnEmptyCredential]' passed (0.000 seconds).
Test Case '-[localvoxtralTests.ClaudeIntegrationSettingsModelTests testAnUnauthenticatedProbeRaisesNoHintAtAll]' passed (0.000 seconds).
```

The pre-1.1.0 diagnosis is still pinned by its original test, unchanged in intent:

```
Test Case '-[localvoxtralTests.ClaudeRemoteContextListenerTests testAnEmptyBearerCredentialIsDiagnosedAsAPluginProblem]' passed (0.001 seconds).
```

**On the one replaced test.** `testAnAbsentAuthorizationHeaderCountsAsAMissingToken`
pinned the conflation itself — it asserted the defect. It is replaced by
`testAnAbsentAuthorizationHeaderIsNotBlamedOnTheHostsPlugin`, which asserts strictly
more: the absent header gets its own category, `emptyCredential` stays at zero, the
line carries no plugin remedy, and `isFault` is false. No assertion was deleted, no
threshold moved, no skip added.

- [ ] Realtime integration — not run: nothing here touches the speech pipeline.
- [x] **CI green** — run
  [33314349302](https://github.com/T0mSIlver/localvoxtral/actions/runs/33314349302),
  `build-test: pass (7m35s)`.
- [x] **LLM lane — ran live, not skipped.** `llm-lane-filter.sh` matched on a path,
  so the lane fired inside `build-test` (it is a step, not a separate check):

  ```
  LLM eval lane: RUNNING (matched Sources/localvoxtral/ClaudeContext/ClaudeIntegrationSettingsModel.swift (Sources/localvoxtral/ClaudeContext/*))
  ```

  Scoreboard from `PolishHelperIntegrationTests` against the real pinned 4B model:

  ```
  == required: 6/7, known-hard passing: 10/10 ==
  == technical: 1/17 ==
  == required: 7/7, known-hard passing: 10/10 ==
  == technical: 2/17 ==
  Test Suite 'PolishHelperIntegrationTests' passed
  ```

  Unchanged from baseline, as expected: nothing in this diff changes what reaches
  the model — no prompt, sampling, model pin, request shape, or context-assembly
  path is touched. The diff is a rejection taxonomy, a log level, and one Settings
  hint predicate. The path match is the filter being deliberately conservative
  about `Sources/localvoxtral/ClaudeContext/*`, not a signal this change can move
  the score.
- [x] **herdr lane** — `herdr-lane-filter.sh` → `run=false` (`no herdr-relevant
  changes`). Correct: this changes nothing about what the app says to herdr, what
  it believes herdr answered, or how the forward is opened.
- [ ] UI change: `rejectionHint`'s *sentence* is unchanged; the only behavioral
  difference is that an anonymous unauthenticated connection no longer raises it at
  all. Covered by `testAnUnauthenticatedProbeRaisesNoHintAtAll`, which also asserts
  that a real fault arriving alongside those probes still speaks and still names
  only the fault. Owner popover rule unaffected — the hint is still one short
  sentence, still count-free.

