### PR TITLE
PolishTokenGuard: make URL/path/filename recognition linear in run length (fixes the 30s of unit suite in #222)

### DIFF
--- a/Sources/localvoxtral/PolishContextPreparation.swift
+++ b/Sources/localvoxtral/PolishContextPreparation.swift
@@ -43,6 +43,13 @@ struct PolishContextPreparation: Sendable, Equatable {
     /// in-memory string with a hard size cap, and it now checks
     /// `Task.isCancelled` between batches, so cancelling the commit abandons it
     /// promptly. Boundedness comes from the cap; timeliness from cancellation.
+    ///
+    /// One caveat on "promptly": the batched checks live in the SELECTOR, and
+    /// entity recognition runs before it, inside single `NSRegularExpression`
+    /// sweeps that cannot be interrupted. Those are linear in the buffer, so
+    /// the wait is bounded — but on a hyphen-dense 2M-character paste (the
+    /// residual noted on `PolishTokenGuard`'s filename recognizer) cancellation
+    /// still waits out the sweep.
     nonisolated static func prepared(
         text: String,
         transcript: String,

--- a/Sources/localvoxtral/PolishTokenGuard.swift
+++ b/Sources/localvoxtral/PolishTokenGuard.swift
@@ -43,14 +43,53 @@ enum PolishTokenGuard {
 
     // Static literals: a bad pattern is a coding error we want to crash on
     // immediately (same rationale as TextMergingAlgorithms).
+    //
+    // LINEAR-TIME DISCIPLINE. Recognition runs over the COMPLETE retained
+    // context buffer — up to `PolishContextClipboardReader
+    // .retentionCharacterCap` (2M) characters — so a pattern that is quadratic
+    // in the length of one unbroken character run is a hang, not merely a slow
+    // test. Any recognizer whose greedy character class is followed by a
+    // literal that class CANNOT contain has exactly that shape: on a long run
+    // the engine consumes the run, fails, backs up one character at a time,
+    // fails again, then repeats the whole exercise from the next start
+    // position. Measured on the build host over 40k characters of unbroken
+    // run: `protectedTokens` cost 20.2s, or 130.8s when the run was
+    // hyphen-dense, scaling 4x per doubling. Three fixes apply, and each is either provably
+    // output-identical or a documented bound:
+    //   * possessive quantifiers (`++`, `{n,m}+`) where the following literal
+    //     is outside the class — every position the engine would back up to
+    //     holds a class character, so the backtracking cannot succeed and
+    //     removing it cannot change a match;
+    //   * a lookbehind rejecting start positions INSIDE such a run — a match
+    //     starting mid-run is always subsumed by the longer one starting at
+    //     the run boundary, which the leftmost rule already prefers, so the
+    //     blocked starts never produced output;
+    //   * a length bound on the run itself, where the first two still leave
+    //     the engine re-scanning from many starts.
+    // The guard for this: `PolishContextPreparationTests
+    // .testPreparationOverAPathologicalRunCostsNoMoreThanOverRealSource`.
     private static let backtickSpan = try! NSRegularExpression(pattern: "`[^`\\n]+`")
-    private static let url = try! NSRegularExpression(pattern: "[A-Za-z][A-Za-z0-9+.-]*://[^\\s]+")
+    // The scheme is length-bounded because `://` can never appear inside the
+    // scheme class: unbounded, every letter of a long alphanumeric blob (a
+    // base64 payload, a JWT) starts another full re-scan. RFC 3986 schemes are
+    // short — the longest IANA-registered one is under 40 characters — so 64
+    // is generous, and a longer "scheme" becoming a miss is the
+    // conservative-recognition principle working as intended.
+    private static let url = try! NSRegularExpression(
+        pattern: "(?<![A-Za-z])[A-Za-z][A-Za-z0-9+.-]{0,63}+://[^\\s]+"
+    )
     // A path is an optional leading `/` (absolute paths must protect it — a
     // dropped slash silently turns `/tmp/app.log` relative) plus one or more
     // "segment/" groups and a final segment. Segment chars include `.`, `~`,
     // `-` so `./scripts/foo.sh` and `~/Library/x` match. Inside a URL the
     // `/host/path` sub-span still matches but is dropped by containment.
-    private static let path = try! NSRegularExpression(pattern: "/?(?:[\\w.~-]+/)+[\\w.~-]+")
+    // Segments are possessive (`/` is outside the class, so a shorter segment
+    // can never find one) and starts inside a segment run are rejected; the
+    // OUTER `+` stays greedy, which is what still lets `a/b/` fall back to
+    // matching `a/b`.
+    private static let path = try! NSRegularExpression(
+        pattern: "(?<![\\w.~-])/?(?:[\\w.~-]++/)+[\\w.~-]+"
+    )
     // Standalone dotted filename: stem must be 2+ chars holding a letter/
     // underscore (rejects pure numbers like `3.14` and abbreviations `e.g`/
     // `i.e`), ext is 1–8 all-lowercase alphanumerics (rejects `works.Then` —
@@ -60,9 +99,13 @@ enum PolishTokenGuard {
     // `knownFileExtensions` — see that constant's comment. Accepted losses
     // per the conservative-recognition principle: uppercase-ext files
     // (`Makefile.AM`), single-letter stems (`a.txt`) and unlisted extensions
-    // go unprotected.
+    // go unprotected. The stem is bounded at NAME_MAX (255) — `.` is outside
+    // the stem class, so an unbounded stem re-scans the whole run from every
+    // word boundary in it, and a stem longer than a filesystem allows is not a
+    // filename anyway — and possessive, since a shorter stem always ends on a
+    // stem character, never on the required `.`.
     private static let filename = try! NSRegularExpression(
-        pattern: "\\b(?=[A-Za-z0-9_-]*[A-Za-z_])[A-Za-z0-9_-]{2,}\\.[a-z0-9]{1,8}\\b"
+        pattern: "\\b(?=[A-Za-z0-9_-]{0,255}[A-Za-z_])[A-Za-z0-9_-]{2,255}+\\.[a-z0-9]{1,8}\\b"
     )
     // Conservative allowlist of real file extensions for the standalone
     // dotted-filename recognizer. Lowercase STT glue like "works.then" /

--- a/Sources/localvoxtral/PolishTokenGuard.swift
+++ b/Sources/localvoxtral/PolishTokenGuard.swift
@@ -66,8 +66,16 @@ enum PolishTokenGuard {
     //     blocked starts never produced output;
     //   * a length bound on the run itself, where the first two still leave
     //     the engine re-scanning from many starts.
-    // The guard for this: `PolishContextPreparationTests
-    // .testPreparationOverAPathologicalRunCostsNoMoreThanOverRealSource`.
+    // Past a bound, recognition does not simply stop: the lookbehind and the
+    // bound together mean the next VIABLE start inside the run is used, so the
+    // token can be a SUFFIX of what the unbounded pattern matched (never a
+    // longer or unrelated one). On the shape that actually occurs — a pasted
+    // payload glued to a real URL — that suffix is the token worth having.
+    // `PolishTokenGuardTests.testRecognitionHoldsAtTheSchemeAndStemBounds` and
+    // `.testPastTheBoundsRecognitionFallsBackToASuffixNeverALongerToken` pin
+    // both halves; `PolishContextPreparationTests
+    // .testPreparationOverAPathologicalRunCostsNoMoreThanOverRealSource` guards
+    // the complexity.
     private static let backtickSpan = try! NSRegularExpression(pattern: "`[^`\\n]+`")
     // The scheme is length-bounded because `://` can never appear inside the
     // scheme class: unbounded, every letter of a long alphanumeric blob (a

--- a/Tests/localvoxtralTests/PolishContextPreparationTests.swift
+++ b/Tests/localvoxtralTests/PolishContextPreparationTests.swift
@@ -238,6 +238,66 @@ final class PolishContextPreparationTests: XCTestCase {
         )
     }
 
+    /// The regression this guards: `PolishTokenGuard`'s URL, path and filename
+    /// recognizers were quadratic in the length of ONE unbroken run of their
+    /// character class. Each has a greedy class followed by a literal the class
+    /// cannot hold (`://`, `/`, `.`), so on a run that never supplies that
+    /// literal the engine consumed the run, backed up character by character,
+    /// then repeated the whole exercise from the next start position inside it.
+    /// A pasted minified bundle, base64 payload or JWT is exactly that input,
+    /// and the retained buffer allows 2M characters of it.
+    ///
+    /// Asserted as a budget rather than a stopwatch: preparing a pathological
+    /// buffer must cost about what preparing an equally large REAL source
+    /// buffer costs — the same linear scans over the same number of
+    /// characters, minus the entity work real code legitimately triggers. The
+    /// old behavior cannot fit in any such multiple: against a 0.106s baseline
+    /// the three shapes below cost 41.6s, 30.8s and 131.2s (393x, 291x,
+    /// 1241x). The whole test now runs in under a second.
+    func testPreparationOverAPathologicalRunCostsNoMoreThanOverRealSource() {
+        let size = 40_000
+        // Real source of the same size: the work that legitimately must happen.
+        let benign = CodeHeavyFixture.buffer(minimumCharacters: size, target: target)
+        let benignStart = ContinuousClock.now
+        let benignPrepared = preparedContext(benign)
+        let benignCost = ContinuousClock.now - benignStart
+        XCTAssertFalse(benignPrepared.excerpt.isEmpty, "the baseline must do real work")
+
+        // One unbroken run of each shape that starves a recognizer's trailing
+        // literal: letters only, letters+digits (base64), and letter/hyphen
+        // (base64url, kebab identifiers — the worst of the three).
+        var mixed = ""
+        var dashed = ""
+        for index in 0..<size {
+            mixed.append(index % 3 == 0 ? "3" : "a")
+            dashed.append(index % 2 == 0 ? "-" : "a")
+        }
+        let pathological = [
+            ("letters", String(repeating: "a", count: size)),
+            ("alphanumeric", mixed),
+            ("hyphenated", dashed),
+        ]
+
+        for (shape, text) in pathological {
+            XCTAssertEqual(text.count, size, "\(shape)")
+            let start = ContinuousClock.now
+            _ = preparedContext(text)
+            let cost = ContinuousClock.now - start
+            // Generous multiple: a shape assertion (linear scans vs. a
+            // per-start-position re-scan of the whole run), not a benchmark.
+            XCTAssertLessThan(
+                cost, benignCost * 25,
+                "\(shape) run cost \(cost) vs \(benignCost) for real source of the same size — recognition is quadratic in run length again"
+            )
+        }
+    }
+
+    private func preparedContext(_ text: String) -> PolishContextPreparation {
+        PolishContextPreparation.prepare(
+            text: text, transcript: transcript, renderBudget: 500
+        )
+    }
+
     /// Selection must not need the recognizer at all: given the terms, scoring
     /// is literal/normalized containment plus word overlap.
     func testSelectionWithGroundingTermsKeepsTheRelevantLine() {

--- a/Tests/localvoxtralTests/PolishContextPreparationTests.swift
+++ b/Tests/localvoxtralTests/PolishContextPreparationTests.swift
@@ -261,7 +261,20 @@ final class PolishContextPreparationTests: XCTestCase {
         let benignStart = ContinuousClock.now
         let benignPrepared = preparedContext(benign)
         let benignCost = ContinuousClock.now - benignStart
-        XCTAssertFalse(benignPrepared.excerpt.isEmpty, "the baseline must do real work")
+        // A non-empty excerpt would only prove the SELECTOR ran. Grounding is
+        // what proves the recognizers and the matcher ran over this buffer —
+        // the work the pathological runs below are being compared against.
+        XCTAssertTrue(grounds(benignPrepared), "the baseline must exercise recognition, not just selection")
+        // The budget below is relative to this baseline, so a baseline that
+        // rots widens the budget instead of failing: a future super-linear
+        // recognizer would inflate BOTH sides and could slip through. Anchor it
+        // absolutely. Measured at ~0.1s here and on the CI runner, so this is
+        // ~30x headroom — loose enough never to flake on a contended host,
+        // tight enough that a super-linear baseline fails loudly.
+        XCTAssertLessThan(
+            benignCost, .seconds(3),
+            "preparing 40k characters of ordinary source is ~0.1s; a baseline this slow is itself the regression"
+        )
 
         // One unbroken run of each shape that starves a recognizer's trailing
         // literal: letters only, letters+digits (base64), and letter/hyphen

--- a/Tests/localvoxtralTests/PolishTokenGuardTests.swift
+++ b/Tests/localvoxtralTests/PolishTokenGuardTests.swift
@@ -140,6 +140,77 @@ final class PolishTokenGuardTests: XCTestCase {
         }
     }
 
+    // MARK: - Recognition bounds
+
+    /// The two length bounds are the ONLY intended behavior change from making
+    /// recognition linear in run length, so they are pinned here — nothing else
+    /// in this suite distinguishes the bounded patterns from the unbounded ones
+    /// they replaced, which would let a later "tidy-up" silently restore the
+    /// quadratic sweep.
+    ///
+    /// A scheme is bounded at 64 characters and a filename stem at NAME_MAX
+    /// (255) because `://` and `.` cannot appear inside their own character
+    /// classes — which is exactly what let an unbounded quantifier re-scan a
+    /// long run from every start position inside it.
+    func testRecognitionHoldsAtTheSchemeAndStemBounds() {
+        // One leading letter + 63 continuation characters: the longest scheme
+        // that still resolves.
+        let atSchemeBound = String(repeating: "s", count: 64) + "://x"
+        XCTAssertEqual(
+            PolishTokenGuard.protectedTokens(in: "see \(atSchemeBound) now"),
+            [atSchemeBound],
+            "a 64-character scheme is inside the bound and must still be protected"
+        )
+        let pastSchemeBound = String(repeating: "s", count: 65) + "://x"
+        XCTAssertEqual(
+            PolishTokenGuard.protectedTokens(in: "see \(pastSchemeBound) now"),
+            [],
+            "a 65-character scheme is not a URL any RFC allows; recognition declines it"
+        )
+
+        let atStemBound = String(repeating: "a", count: 255) + ".swift"
+        XCTAssertEqual(
+            PolishTokenGuard.protectedTokens(in: "open \(atStemBound) now"),
+            [atStemBound],
+            "a 255-character stem is inside NAME_MAX and must still be protected"
+        )
+        let pastStemBound = String(repeating: "a", count: 256) + ".swift"
+        XCTAssertEqual(
+            PolishTokenGuard.protectedTokens(in: "open \(pastStemBound) now"),
+            [],
+            "a 256-character stem is longer than any filesystem allows"
+        )
+    }
+
+    /// Past either bound, recognition may still emit a SUFFIX of what the
+    /// unbounded pattern matched — never a longer or unrelated token.
+    ///
+    /// That is the conservative direction (the guard protects less of a blob it
+    /// cannot parse, not more), and on the realistic shape — a pasted payload
+    /// glued to a real URL — the suffix is the token actually worth protecting.
+    /// Pinned because it is the one place the bounds change WHAT is protected
+    /// rather than merely whether anything is.
+    func testPastTheBoundsRecognitionFallsBackToASuffixNeverALongerToken() {
+        // A 101-character scheme-class run glued to a real URL. The run is past
+        // the bound; the URL inside it still resolves.
+        let glued = "a" + String(repeating: "0", count: 100) + "https://api.example.com/x"
+        XCTAssertEqual(
+            PolishTokenGuard.protectedTokens(in: "paste \(glued) end"),
+            ["https://api.example.com/x"],
+            "the real URL inside an oversized scheme run stays protected"
+        )
+
+        // A stem past NAME_MAX whose hyphen offers a later word boundary: the
+        // remaining, in-bound stem is what gets protected.
+        let stem = String(repeating: "a", count: 200) + "-" + String(repeating: "a", count: 100)
+        let suffix = "-" + String(repeating: "a", count: 100) + ".swift"
+        XCTAssertEqual(
+            PolishTokenGuard.protectedTokens(in: "open \(stem).swift now"),
+            [suffix],
+            "an oversized stem degrades to its in-bound suffix, not to a longer token"
+        )
+    }
+
     // MARK: - verifyAndRepair
 
     func testVerifyAndRepairCleanPassThrough() {


### PR DESCRIPTION
Fixes #222.

## What

The issue asked why two `PolishContextPreparationTests` cases cost ~30s of a ~93s unit suite, and offered shrinking the fixtures as the fix. The fixtures turned out to be innocent: the cost is an **O(n²) defect in production recognition**, and the tests were the only thing surfacing it.

`PolishTokenGuard`'s URL, path and filename recognizers each pair a greedy character class with a literal that class **cannot contain** (`://`, `/`, `.`). On an unbroken run of class characters that never supplies that literal, a backtracking engine consumes the run, fails, backs up one character at a time, fails again — and then repeats the whole exercise from the next start position *inside the same run*. Quadratic in run length, over a buffer `PolishContextClipboardReader.retentionCharacterCap` lets grow to **2M characters**.

Measured on the build host — `PolishContextPreparation.prepare` over a 40k-character buffer that is one unbroken run:

| run shape | before | after |
|---|---|---|
| letters (`aaa…`) | 41.6 s | 0.03 s |
| letters+digits (base64) | 30.8 s | 0.09 s |
| letter/hyphen (base64url, JWT, kebab) | **131.2 s** | 0.52 s |
| *real source of the same size (baseline)* | *0.106 s* | *0.103 s* |

Scaling was a clean 4× per doubling — `url` + `path` alone over a run of 5k / 10k / 20k characters cost 0.63 / 2.54 / 10.1 s. So a user who copies a minified bundle, a base64 payload or a JWT and dictates hits a multi-minute stall in the polish commit path — and at the 2M retention cap the same input never finishes. That is the product bug; a third of the unit suite was the symptom.

**The fix** is three transformations, applied only where the trailing literal is outside the class:

* **possessive quantifiers** (`++`, `{n,m}+`) — every position the engine would back up to holds a class character, so that backtracking can never succeed and removing it cannot change a match;
* **a lookbehind rejecting start positions *inside* a run** — a match starting mid-run is always subsumed by the longer one starting at the run boundary, which the leftmost rule already prefers, so those starts never produced output;
* **length bounds** where the first two still leave many start positions: the URL scheme at 64 (RFC 3986 schemes are short; the longest IANA-registered one is under 40) and the filename stem at NAME_MAX (255).

The first two are output-identical by construction. The bounds are the only behavior change, and they only affect "schemes" and filename stems longer than an RFC or a filesystem allows. Within that class the recognizer either declines the token or falls back to a **suffix** of what the unbounded pattern matched — never a longer or unrelated one. (The original wording here said "a miss, not a false positive"; the review falsified that, see the Review section.) A suffix is the conservative direction `PolishTokenGuard`'s stated principle asks for, and on the shape that actually occurs — a pasted payload glued to a real URL — it is the token worth protecting.

Both issue-222 tests keep their fixtures and every assertion, and now serve as regression guards. A new budget-relative test (mirroring `testSelectionOverManyLinesCostsNoMoreThanOneWholeBufferExtraction`, not a stopwatch threshold) pins the shape: preparing a pathological 40k buffer must cost no more than 25× preparing real source of the same size.

### Equivalence evidence

Old vs new patterns, span-for-span (location, length, text), over every `.swift`/`.md`/script file in the checkout — **368 files, 5,972,089 characters: 0 differing files**, plus a hand-case set (`a//b/c`, `a/b//c/d`, `/x`, `//x`, `3http://x`, `_http://x`, `works.Then`, `dr.smith`, `e.g.`, `a-b-c.swift`, `kebab-case-name.ts`, `src/foo.xyz`, `~/Library/x/y`, `./scripts/foo.sh`, …). The only difference produced anywhere was the deliberate one: a synthetic 71-character "scheme" (`xyyy…yyy://z`) is no longer recognized. The 2282-line `PolishTokenGuardTests` suite passes unchanged.

## Proof

### Before/after — the two issue tests (`./scripts/remote-build.sh test --filter PolishContextPreparationTests`)

| test | before | after |
|---|---|---|
| `testOversizedSingleLineIsTruncatedWithAMarkerWithinTheCap` | 20.517 s | **0.030 s** |
| `testOversizedLineIsSkippedSoALaterFittingLineStillRenders` | 10.163 s | **0.019 s** |
| `testTruncationMarkerNeverPushesPastATinyCap` (not in the issue, same cause) | 3.160 s | **0.017 s** |
| `testPreparationOverAPathologicalRunCostsNoMoreThanOverRealSource` (new) | — | 0.748 s |
| whole file | 38.8 s | **5.9 s** |

Before (on `origin/main`):

```
PolishContextPreparationTests testOversizedLineIsSkippedSoALaterFittingLineStillRenders]' passed (10.163 seconds).
PolishContextPreparationTests testOversizedSingleLineIsTruncatedWithAMarkerWithinTheCap]' passed (20.517 seconds).
PolishContextPreparationTests testTruncationMarkerNeverPushesPastATinyCap]' passed (3.160 seconds).
```

After:

```
PolishContextPreparationTests testOversizedLineIsSkippedSoALaterFittingLineStillRenders]' passed (0.019 seconds).
PolishContextPreparationTests testOversizedSingleLineIsTruncatedWithAMarkerWithinTheCap]' passed (0.030 seconds).
PolishContextPreparationTests testPreparationOverAPathologicalRunCostsNoMoreThanOverRealSource]' passed (0.748 seconds).
PolishContextPreparationTests testTruncationMarkerNeverPushesPastATinyCap]' passed (0.017 seconds).
```

### [x] Bug fix: regression test added — failing before the fix, passing after

Failing run, new test on top of the UNFIXED recognizers (`./scripts/remote-build.sh test --filter PolishContextPreparationTests`, exit 1):

```
PolishContextPreparationTests testPreparationOverAPathologicalRunCostsNoMoreThanOverRealSource] : XCTAssertLessThan failed: ("41.583047583 seconds") is not less than ("2.6418771 seconds") - letters run cost 41.583047583 seconds vs 0.105675084 seconds for real source of the same size — recognition is quadratic in run length again
PolishContextPreparationTests testPreparationOverAPathologicalRunCostsNoMoreThanOverRealSource] : XCTAssertLessThan failed: ("30.792653083 seconds") is not less than ("2.6418771 seconds") - alphanumeric run cost 30.792653083 seconds vs 0.105675084 seconds for real source of the same size — recognition is quadratic in run length again
PolishContextPreparationTests testPreparationOverAPathologicalRunCostsNoMoreThanOverRealSource] : XCTAssertLessThan failed: ("131.192808917 seconds") is not less than ("2.6418771 seconds") - hyphenated run cost 131.192808917 seconds vs 0.105675084 seconds for real source of the same size — recognition is quadratic in run length again
PolishContextPreparationTests testPreparationOverAPathologicalRunCostsNoMoreThanOverRealSource]' failed (203.901 seconds).
```

Passing run, same test with the fix:

```
PolishContextPreparationTests testPreparationOverAPathologicalRunCostsNoMoreThanOverRealSource]' passed (0.748 seconds).
```

(393× / 291× / 1241× the baseline before; the whole test is now under a second, so the 25× multiple has ~5× headroom on the worst shape.)

### [x] Unit suite green — `./scripts/remote-build.sh test`

Before, on `origin/main` (same host, same session):

```
Executed 2745 tests, with 2 tests skipped and 0 failures (0 unexpected) in 102.764 (102.897) seconds
```

After:

```
Executed 2746 tests, with 2 tests skipped and 0 failures (0 unexpected) in 68.622 (68.751) seconds
```

**−34.1 s (−33%)** on every non-fast-path PR and push, and the self-hosted unit step's 300 s supervised budget goes from ~34% consumed to ~23%. `grep -ci "warning:" .build/last-remote.log` → `0`.

### LLM lane

`*PolishTokenGuard*` and `*PolishContextPreparation*` both match `scripts/ci/llm-lane-filter.sh`, so the live-model lane fired on this PR automatically — as it should. A local `./scripts/remote-build.sh eval-llm` was not possible: the default `127.0.0.1:8080` chat/completions endpoint has no listener on the build host (`svc-status`: `localvoxtral-polishd not running`, `port 8080 no listener`) and the LAN inference host is unreachable (`No route to host`). CI's `PolishHelperIntegrationTests` step is the same lane on the same machine.

## Not done / notes

* One residual worst case remains, and it is synthetic: a maximally hyphen-dense run (`-a-a-a…`, a hyphen every other character) still costs ~0.5 s per 40k characters in the filename recognizer, because `\b` legitimately opens a start position at every hyphen boundary and each one scans up to the 255-character stem bound. It is now **linear** (200k → 2.4 s, 2M → 24 s, exactly 10× per 10×) rather than the 70 hours the old pattern would have taken at the retention cap, and real hyphenated content (a JWT is ~2.5% hyphens) costs milliseconds. Fixing the constant would need a hand-written scanner rather than a regex; not worth it here.
* No doc updates: `docs/under-the-hood.md` states model pins and backend copy, neither of which moves, and `docs/agent/invariants.md`'s `PolishTokenGuard` entry is about fidelity trade-offs, not recognition complexity. The reasoning lives next to the patterns.

### [x] CI green — run [33968610398](https://github.com/T0mSIlver/localvoxtral/actions/runs/33968610398) on `1799d59`

```
Executed 2770 tests, with 11 tests skipped and 0 failures (0 unexpected) in 72.558 (72.799) seconds
```

The LLM lane ran and passed:

```
LLM eval lane: RUNNING (matched Sources/localvoxtral/PolishTokenGuard.swift (*PolishTokenGuard*))
...
== required: 7/7, known-hard passing: 10/10 ==
== technical: 2/17 ==
== polishd prompt-prefix slots: alternating standard/agent profiles (model: mlx-community/Qwen3.5-4B-OptiQ-4bit) ==
2 slots (default): 2.323s, 0.836s, 0.399s, 0.401s, 0.397s, 0.400s
1 slot  (legacy):  2.340s, 0.828s, 2.291s, 0.828s, 2.264s, 0.830s
```

The first attempt of that run went red on `BackendProcessSupervisorTests.testStopHonorsTERMWithoutRestarting` (`BackendProcessSupervisorTests.swift:329`, 0.933 s) — the known trap-install race under runner load, unrelated to this diff (four other PRs' runs were queued on the same self-hosted Mac at the time). It passed on rerun with nothing changed. This PR's own cases passed in BOTH attempts:

```
PolishContextPreparationTests testOversizedLineIsSkippedSoALaterFittingLineStillRenders]' passed (0.018 seconds).
PolishContextPreparationTests testOversizedSingleLineIsTruncatedWithAMarkerWithinTheCap]' passed (0.029 seconds).
PolishContextPreparationTests testPreparationOverAPathologicalRunCostsNoMoreThanOverRealSource]' passed (0.756 seconds).
```


## Review

One adversarial review — `opencode run --agent reviewer -m zai-coding-plan/glm-5.2`, given this PR body, the full diff, the file, and a written statement of the equivalence method and the informal arguments behind it. Verdict: **safe to merge, no BLOCKER, no MAJOR** — it could not falsify the equivalence claims outside the two documented bound classes. Every counterexample it produced was then run against BOTH the old and new patterns on the build host's real ICU engine (a temporary probe, deleted before commit). All four findings are fixed in `8726555`.

**[MINOR] The bounds substitute, they do not only "miss" — CONFIRMED, claim corrected.** My own 79-input probe used all-letter runs, where every interior start is lookbehind-blocked, so it only ever saw pure misses. The reviewer spotted that a **non-letter** class character (`0-9 . + -`) before a letter leaves a later start viable. Measured on ICU:

```
input=[ "a" + 100x"0" + "https://api.example.com/x" ]
  old=["0:86:aaaa…0https://api.example.com/x"]
  new=["61:25:https://api.example.com/x"]

input=[ 200x"a" + "-" + 100x"a" + ".swift" ]
  old=["0:307:aaa…a-aaa…a.swift"]
  new=["200:107:-aaa…a.swift"]
```

Same input class as documented (scheme > 64, stem > 255), different shape: a suffix, not nothing. The new token is always a substring of the old span. Corrected above and in the source comment.

**[MINOR] Nothing distinguished the bounded patterns from the unbounded ones — fixed.** The whole 2282-line `PolishTokenGuardTests` passed on both, so a later "tidy-up" could have restored the quadratic sweep in silence. Added `testRecognitionHoldsAtTheSchemeAndStemBounds` (64-char scheme protected / 65 not; 255-char stem protected / 256 not) and `testPastTheBoundsRecognitionFallsBackToASuffixNeverALongerToken` (both measured shapes above).

Red on the pre-fix patterns — note that only the past-the-bound assertions fail, so the tests are not trivially red:

```
PolishTokenGuardTests.swift:165: error: … testRecognitionHoldsAtTheSchemeAndStemBounds] : XCTAssertEqual failed: ("["sss…sss://x"]") is not equal to ("[]") - a 65-character scheme is not a URL any RFC allows; recognition declines it
PolishTokenGuardTests.swift:178: error: … : XCTAssertEqual failed: ("["aaa…aaa.swift"]") is not equal to ("[]") - a 256-character stem is longer than any filesystem allows
PolishTokenGuardTests.swift:197: error: … testPastTheBoundsRecognitionFallsBackToASuffixNeverALongerToken] : XCTAssertEqual failed: ("["a000…000https://api.example.com/x"]") is not equal to ("["https://api.example.com/x"]") - the real URL inside an oversized scheme run stays protected
PolishTokenGuardTests.swift:207: error: … : XCTAssertEqual failed: … - an oversized stem degrades to its in-bound suffix, not to a longer token
```

Green with the fix:

```
PolishTokenGuardTests testRecognitionHoldsAtTheSchemeAndStemBounds]' passed (0.000 seconds).
PolishTokenGuardTests testPastTheBoundsRecognitionFallsBackToASuffixNeverALongerToken]' passed (0.000 seconds).
```

**[MINOR] The cost test's budget rides on a baseline that can rot — fixed.** The budget is `benignCost * 25`, and the benign arm runs the same recognizers: a future super-linear baseline would inflate both sides and widen the budget instead of failing it. Anchored with `XCTAssertLessThan(benignCost, .seconds(3))` — ~30× the measured 0.1 s, loose enough not to flake on a contended runner, tight enough that baseline rot fails loudly.

**[NIT] `XCTAssertFalse(excerpt.isEmpty)` proved only that the selector ran — fixed.** It now asserts `grounds(benignPrepared)`, which pins that extraction and matching — the work the pathological arms are compared against — actually happened.

**[NIT] The documented residual is not cancellation-interruptible — documented.** Recognition runs before the selector's batched `Task.isCancelled` checks, inside single `matches()` calls, so `prepared`'s "cancelling the commit abandons it promptly" has an exception on a hyphen-dense 2M paste. Named in that doc comment.

**ReDoS residuals — none.** The reviewer worked through `backtickSpan`, `flag`, `envVar`, `hexHash`, `version` and `supplementalEntityRegex`, finding each linear with per-pattern reasoning (start-gating, quantifier-final position, unique decomposition, or a constant bound). That matches both my own analysis and the measured sweep. No pattern with the fixed three's shape — greedy class + a following literal the class cannot contain + many viable interior starts — remains in the file.

### Proof after the review fixes

`./scripts/remote-build.sh test`:

```
Executed 2763 tests, with 2 tests skipped and 0 failures (0 unexpected) in 67.658 (67.781) seconds
PolishContextPreparationTests testPreparationOverAPathologicalRunCostsNoMoreThanOverRealSource]' passed (0.757 seconds).
```

Adding a test file forced a full recompile of the test module, which surfaces 108 pre-existing warnings in `CmuxSocketPasswordStoreTests.swift` and `ClaudeHookPublisherTests.swift` (both last touched by #230, neither in this diff). **Zero** warnings come from the files this PR changes. Not fixed here: that is a separate diff over someone else's code.


### CI green on the reviewed head — run [33973438139](https://github.com/T0mSIlver/localvoxtral/actions/runs/33973438139) on `8726555`

```
Executed 2802 tests, with 11 tests skipped and 0 failures (0 unexpected) in 72.545 (72.776) seconds
```

The LLM lane fired again on the new head (`LLM eval lane: RUNNING (matched Sources/localvoxtral/PolishTokenGuard.swift (*PolishTokenGuard*))`) and scored identically to the pre-review head — the recognition-bound corrections move nothing the lane measures:

```
== required: 7/7, known-hard passing: 10/10 ==
== technical: 2/17 ==
```
