### PR TITLE
registry list: report a REMOTE session's herdr labels

### DIFF
--- a/Sources/localvoxtral/Dogfood/DogfoodControlService.swift
+++ b/Sources/localvoxtral/Dogfood/DogfoodControlService.swift
@@ -383,10 +383,27 @@ final class DogfoodControlService {
     /// none of them is here: no session id, no marker, no workspace, no tty, no
     /// pane id, no socket path, no bridge id, no host. Every field below is a
     /// bool, a count or a closed enum name.
+    ///
+    /// The `has*` fields read the LOCAL process block and the `remote*` fields
+    /// read the remote environment, and they are separate on purpose — the same
+    /// reason `ClaudeRemoteSessionEnvironment` is a separate type from
+    /// `ClaudeHookProcessInfo`, rather than more fields on it. A remote label
+    /// names a pane on ANOTHER machine and no local arm may read it, so folding
+    /// the two into one boolean would report a fact the resolver does not have.
+    ///
+    /// Both halves are needed, though, and the second was missing: a remote
+    /// session has no process block at all, so `hasHerdrPane`/`hasHerdrSocket`
+    /// were structurally `false` for every remote row and this verb could not
+    /// answer the one question it exists for on the remote path — did the
+    /// herdr labels arrive from that host, or not. Field session 2026-09-05:
+    /// `registry list` said `hasHerdrPane: false` for a session whose labels HAD
+    /// arrived, and the only way to tell was an unrelated forward line in the
+    /// unified log.
     private func registryList() -> String {
         let sessions = liveSessions()
         let rows = sessions.map { snapshot -> String in
             let process = snapshot.process
+            let remote = snapshot.remoteSessionEnvironment
             return DogfoodControlJSON.object([
                 ("origin", DogfoodControlJSON.string(
                     snapshot.origin.isLocalAuthenticated ? "local" : "remote"
@@ -399,9 +416,10 @@ final class DogfoodControlService {
                 ("hasHerdrSocket", DogfoodControlJSON.bool(process?.herdrSocketPath != nil)),
                 ("hasCmuxSurface", DogfoodControlJSON.bool(process?.cmuxSurfaceID != nil)),
                 ("hasBridgeSession", DogfoodControlJSON.bool(snapshot.bridgeSessionID != nil)),
-                ("hasRemoteEnvironment", DogfoodControlJSON.bool(
-                    snapshot.remoteSessionEnvironment != nil
-                )),
+                ("hasRemoteEnvironment", DogfoodControlJSON.bool(remote != nil)),
+                ("remoteHerdrPane", DogfoodControlJSON.bool(remote?.herdrPaneID != nil)),
+                ("remoteHerdrSocket", DogfoodControlJSON.bool(remote?.herdrSocketPath != nil)),
+                ("remoteCmuxSurface", DogfoodControlJSON.bool(remote?.cmuxSurfaceID != nil)),
                 ("recentFiles", DogfoodControlJSON.int(snapshot.recentFiles.count)),
                 ("hasPriorPrompt", DogfoodControlJSON.bool(
                     snapshot.latestPriorUserPrompt != nil

--- a/Tests/localvoxtralTests/DogfoodControlServiceTests.swift
+++ b/Tests/localvoxtralTests/DogfoodControlServiceTests.swift
@@ -252,6 +252,44 @@ final class DogfoodControlServiceTests: XCTestCase {
         XCTAssertEqual(row?["workspaceIsLocal"] as? Bool, true)
     }
 
+    /// A REMOTE session has no process block at all, so the `has*` fields are
+    /// structurally false for it. Without a remote half this verb could not
+    /// answer the one thing it exists for on the remote path — did the herdr
+    /// labels arrive from that host — and a field session on 2026-09-05 read
+    /// `hasHerdrPane: false` for a session whose labels HAD arrived.
+    func testRegistryListReportsARemoteSessionsHerdrLabels() async {
+        let service = makeService(viewModel: makeViewModel(), sessions: [Self.remoteSnapshot()])
+        let reply = await expectSuccess(service, .registryList)
+        let row = ((reply["sessions"] as? [[String: Any]]) ?? []).first
+
+        XCTAssertEqual(row?["origin"] as? String, "remote")
+        // Unchanged, and still false: these read the LOCAL process block, and a
+        // remote label is not one. Reporting it here would claim the resolver
+        // has a local binding it does not have.
+        XCTAssertEqual(row?["hasProcessBlock"] as? Bool, false)
+        XCTAssertEqual(row?["hasHerdrPane"] as? Bool, false)
+        XCTAssertEqual(row?["hasHerdrSocket"] as? Bool, false)
+        // The half that was missing.
+        XCTAssertEqual(row?["hasRemoteEnvironment"] as? Bool, true)
+        XCTAssertEqual(row?["remoteHerdrPane"] as? Bool, true)
+        XCTAssertEqual(row?["remoteHerdrSocket"] as? Bool, true)
+        XCTAssertEqual(row?["remoteCmuxSurface"] as? Bool, false)
+    }
+
+    /// And a remote session that reported no herdr at all is distinguishable
+    /// from one that did — which is the whole point of adding the fields.
+    func testRegistryListSeparatesARemoteSessionWithNoHerdrLabels() async {
+        var snapshot = Self.remoteSnapshot()
+        snapshot.remoteEnvironment = ClaudeRemoteSessionEnvironment(sshTTY: "/dev/pts/4")
+        let service = makeService(viewModel: makeViewModel(), sessions: [snapshot])
+        let reply = await expectSuccess(service, .registryList)
+        let row = ((reply["sessions"] as? [[String: Any]]) ?? []).first
+
+        XCTAssertEqual(row?["hasRemoteEnvironment"] as? Bool, true)
+        XCTAssertEqual(row?["remoteHerdrPane"] as? Bool, false)
+        XCTAssertEqual(row?["remoteHerdrSocket"] as? Bool, false)
+    }
+
     /// Field by field: the registry holds a marker, a workspace path, a tty, a
     /// pane id, a socket path and a session id, and NONE of them may cross.
     func testRegistryListNamesNothingThatIdentifiesASession() async {
@@ -456,6 +494,23 @@ final class DogfoodControlServiceTests: XCTestCase {
             herdrPaneID: paneID,
             herdrSocketPath: herdrSocketPath,
             bridgeSessionID: bridgeSessionID
+        )
+        return snapshot
+    }
+
+    /// The shape a remote host's hooks actually produce: no process block (the
+    /// pids and the tty are another machine's), and the herdr handles carried
+    /// as untrusted labels in the remote environment instead.
+    private static func remoteSnapshot() -> ClaudeSessionSnapshot {
+        var snapshot = ClaudeSessionSnapshot(
+            sessionID: sessionID,
+            origin: .remote(channel: "remote-listener"),
+            marker: ClaudeSessionMarker(value: markerValue),
+            firstSeen: Date(timeIntervalSince1970: 1_000)
+        )
+        snapshot.remoteEnvironment = ClaudeRemoteSessionEnvironment(
+            herdrPaneID: paneID,
+            herdrSocketPath: herdrSocketPath
         )
         return snapshot
     }


### PR DESCRIPTION
## What

Follow-up to #242, found by using it. `registry list` is blind to a remote
session's herdr labels, which is the one path where it matters most.

`hasHerdrPane` and `hasHerdrSocket` read `snapshot.process`, and a remote
session has **no process block at all** — the pids and the tty are another
machine's. So both are structurally `false` for every remote row, and the verb
cannot answer, on the remote path, the exact question it was added to answer:
did the herdr labels arrive from that host, or did the join fail earlier?

Field session 2026-09-05, verifying the remote-herdr join end to end:

```
{"count":1,"sessions":[{"origin":"remote", … "hasHerdrPane":false,"hasHerdrSocket":false,
 … "hasRemoteEnvironment":true, …}]}
```

The labels *had* arrived. The only evidence was an unrelated line in the
unified log — `Remote herdr forward preparing from host activity for host …`,
which the app only emits when a hook carries a usable herdr socket label. That
is precisely the "no sessions registered" vs "surface resolution failed" dead
end #242 exists to close, reappearing one level down.

## The change

Three new booleans read from `snapshot.remoteSessionEnvironment`:
`remoteHerdrPane`, `remoteHerdrSocket`, `remoteCmuxSurface`.

They are **separate fields rather than folded into the existing ones**, for the
same reason `ClaudeRemoteSessionEnvironment` is a separate type from
`ClaudeHookProcessInfo` rather than more fields on it: a remote label names a
pane on another machine, every local arm pairs an `origin.isLocalAuthenticated`
filter with a `process` read, and one merged boolean would report a binding the
resolver does not have. `has*` keeps meaning the local process block; `remote*`
means the remote environment; a reader can tell which side a session's join key
came from, which is the actual diagnostic.

Additive, so nothing reading the existing keys changes. Still bools only — no
pane id, no socket path, no host.

## Proof

- [x] Bug fix: regression tests added — failing before, passing after.

RED (`DogfoodControlService.swift` reverted to `origin/main`, tests in place),
`./scripts/remote-build.sh dogfood --filter DogfoodControlServiceTests`:

```
DogfoodControlServiceTests.swift:274: error: -[localvoxtralTests.DogfoodControlServiceTests testRegistryListReportsARemoteSessionsHerdrLabels] : XCTAssertEqual failed: ("nil") is not equal to ("Optional(true)")
DogfoodControlServiceTests.swift:275: error: -[localvoxtralTests.DogfoodControlServiceTests testRegistryListReportsARemoteSessionsHerdrLabels] : XCTAssertEqual failed: ("nil") is not equal to ("Optional(true)")
DogfoodControlServiceTests.swift:276: error: -[localvoxtralTests.DogfoodControlServiceTests testRegistryListReportsARemoteSessionsHerdrLabels] : XCTAssertEqual failed: ("nil") is not equal to ("Optional(false)")
DogfoodControlServiceTests.swift:289: error: -[localvoxtralTests.DogfoodControlServiceTests testRegistryListSeparatesARemoteSessionWithNoHerdrLabels] : XCTAssertEqual failed: ("nil") is not equal to ("Optional(false)")
DogfoodControlServiceTests.swift:290: error: -[localvoxtralTests.DogfoodControlServiceTests testRegistryListSeparatesARemoteSessionWithNoHerdrLabels] : XCTAssertEqual failed: ("nil") is not equal to ("Optional(false)")
Test Suite 'localvoxtralPackageTests.xctest' failed at 2026-09-05 16:55:39.280.
	 Executed 116 tests, with 5 failures (0 unexpected) in 1.563 (1.570) seconds
```

GREEN, same command:

```
Test Suite 'localvoxtralPackageTests.xctest' passed at 2026-09-05 16:55:59.290.
	 Executed 116 tests, with 0 failures (0 unexpected) in 1.228 (1.234) seconds
```

The first test also pins the half that must NOT change: `hasProcessBlock`,
`hasHerdrPane` and `hasHerdrSocket` stay `false` for a remote row. The second
separates a remote session that reported herdr from one that reported only an
`SSH_TTY`, which is the distinction the fields exist to make.

- [x] Unit suite green (standard configuration) — `./scripts/remote-build.sh test`

```
Test Suite 'localvoxtralPackageTests.xctest' passed at 2026-09-05 17:00
	 Executed 2790 tests, with 2 tests skipped and 0 failures (0 unexpected) in 110.805 (110.943) seconds
```

No new warnings: every `warning:` in the log is in files this PR does not touch
(`ClaudePluginInstallService.swift`, `ClaudeHookPublisherTests.swift`,
`CmuxSocketPasswordStoreTests.swift`), all pre-existing on `main`.

- [ ] UI change — none. Dogfood-only code, unchanged build boundary
      (`DogfoodControlBuildBoundaryTests` still runs in both configurations).
