### PR TITLE
Fix main's dogfood build: the control-socket tests still used the removed marker API

### DIFF
--- a/Tests/localvoxtralTests/DogfoodControlServiceTests.swift
+++ b/Tests/localvoxtralTests/DogfoodControlServiceTests.swift
@@ -290,15 +290,14 @@ final class DogfoodControlServiceTests: XCTestCase {
         XCTAssertEqual(row?["remoteHerdrSocket"] as? Bool, false)
     }
 
-    /// Field by field: the registry holds a marker, a workspace path, a tty, a
-    /// pane id, a socket path and a session id, and NONE of them may cross.
+    /// Field by field: the registry holds a workspace path, a tty, a pane id,
+    /// a socket path and a session id, and NONE of them may cross.
     func testRegistryListNamesNothingThatIdentifiesASession() async {
         let service = makeService(viewModel: makeViewModel(), sessions: [Self.localSnapshot()])
         let raw = await expectSuccessRaw(service, .registryList)
 
         for secret in [
             Self.sessionID,
-            Self.markerValue,
             Self.workspacePath,
             Self.ttyPath,
             Self.paneID,
@@ -467,7 +466,6 @@ final class DogfoodControlServiceTests: XCTestCase {
     // MARK: - Fixtures
 
     private static let sessionID = "11111111-2222-3333-4444-555555555555"
-    private static let markerValue = "lvx-marker-abcdef0123456789"
     private static let workspacePath = "/Users/owner/work/secret-project"
     private static let ttyPath = "/dev/ttys004"
     private static let paneID = "pane-9f3c2a"
@@ -478,7 +476,6 @@ final class DogfoodControlServiceTests: XCTestCase {
         var snapshot = ClaudeSessionSnapshot(
             sessionID: sessionID,
             origin: .localAuthenticated(peerUID: 501),
-            marker: ClaudeSessionMarker(value: markerValue),
             firstSeen: Date(timeIntervalSince1970: 1_000)
         )
         snapshot.workspace = ClaudeWorkspaceReference.make(
@@ -505,7 +502,6 @@ final class DogfoodControlServiceTests: XCTestCase {
         var snapshot = ClaudeSessionSnapshot(
             sessionID: sessionID,
             origin: .remote(channel: "remote-listener"),
-            marker: ClaudeSessionMarker(value: markerValue),
             firstSeen: Date(timeIntervalSince1970: 1_000)
         )
         snapshot.remoteEnvironment = ClaudeRemoteSessionEnvironment(


### PR DESCRIPTION
## What

**`main` does not compile in the instrumented configuration, and has not since
#250 landed.** This unblocks it.

`DogfoodControlServiceTests.swift` constructs `ClaudeSessionSnapshot` with
`marker: ClaudeSessionMarker(...)`. #250 removed both the type and that init
parameter, so the dogfood build fails:

```
DogfoodControlServiceTests.swift:443:21: error: cannot find 'ClaudeSessionMarker' in scope
DogfoodControlServiceTests.swift:443:21: error: extra argument 'marker' in call
```

`ClaudeSessionMarker` exists nowhere in `Sources/` on `d53e8a0` — confirmed with
`git grep -l ClaudeSessionMarker d53e8a0 -- Sources`, which returns nothing.

> **CORRECTION (added after merge).** The "Why no CI caught it" section below
> is WRONG on its central claim, and the mistake matters more than the typo it
> looks like, so it stays visible rather than being quietly rewritten.
>
> The dogfood capture suite is **not** opt-in. Its step is gated only on
> `runner.environment == 'self-hosted' && steps.ci_scope.outputs.docs_only != 'true'`
> (`.github/workflows/ci.yml`, "Dogfood capture suite (instrumented build)"),
> so it runs on every non-docs self-hosted run — pushes to `main` included.
>
> CI *did* catch this, immediately. `main`'s own push run for `d53e8a0` —
> run 33974943655 — **failed on exactly this step**, at 15:29Z. It then failed
> the same way on `7d6d9b2` (run 33976504063), with `adb0d97`'s run cancelled
> in between. `main` was red for three consecutive merges and merging carried
> on regardless.
>
> So the gap is not coverage, and adding an instrumented build to main pushes
> would be a no-op — it is already there. The gap is that **a red `main` push
> run neither blocked nor announced itself**. The two claims below that DO
> hold: the ordinary unit lane cannot see this file (it is behind
> `#if LOCALVOXTRAL_DOGFOOD`), and #250's branch predates #242 so its own
> green dogfood run was correct — the broken tree only existed after the
> squash. What is false is "no such run happened on `main`"; three did, and
> all three said so.
>
> The fix in this PR is unaffected — it was verified by running the
> instrumented configuration directly.

## Why no CI caught it

Three ordinary things lined up, and each one on its own is correct:

- The file is behind `#if LOCALVOXTRAL_DOGFOOD`, so the **ordinary unit lane
  never compiles it**. `remote-build.sh test` is green on broken `main` right
  now — 2760 tests — and says nothing about this.
- **#250's branch predates #242**, so it did not contain this file at all
  (`git ls-tree 35f01af -- Tests/localvoxtralTests/DogfoodControlServiceTests.swift`
  is empty). Its own dogfood dispatch, run 33971811359, was green *and correct*:
  there was nothing there to break. The two trees first met at the squash merge,
  which no PR run had built.
- The **dogfood capture suite is opt-in** — `[dogfood-package]` in the body/head
  commit, or a dispatch. No such run happened on `main` between `d53e8a0` and
  today, so the first build of the merged combination was a dogfood dispatch of
  `main` (run 33974946864), about four merges later.

Worth stating plainly because the shape will recur: this is a **cross-PR
semantic conflict that neither PR's CI could see**, in a configuration that is
only built on request. A branch cut before a file exists cannot be tested
against it, and a squash merge produces a tree nobody compiled.

#253 is not the cause. It added a second call site in `remoteSnapshot()`, but
its own run was green because it was cut from pre-#250 `main`; the breakage
arrived with `d53e8a0` and #253 inherited it.

## The change

Removes the marker from both fixtures and drops the now-nonexistent
`markerValue` constant. It also takes the marker out of the "names nothing that
identifies a session" list, and the sentence promising it: with the registry no
longer holding a marker, asserting that the string does not leak is a **vacuous
test, not a stricter one**, and leaving it would suggest coverage that is not
there.

## Proof

- [x] Dogfood (instrumented) configuration — `./scripts/remote-build.sh dogfood`.
      This is the configuration that is broken on `main`; it now builds and
      passes.

```
	 Executed 116 tests, with 0 failures (0 unexpected) in 1.209 (1.215) seconds
```

including `DogfoodControlServiceTests`, `DogfoodControlBuildBoundaryTests`,
`DogfoodControlProtocolTests`, `DogfoodControlSocketTests` and
`DogfoodEditSignalTests`.

- [x] Standard configuration unaffected — `./scripts/remote-build.sh test`

```
	 Executed 2760 tests, with 2 tests skipped and 0 failures (0 unexpected) in 69.216 (69.344) seconds
```

- [x] Failing before: the run that surfaced it is `33974946864`, step
      "Dogfood capture suite (instrumented build)", with the two errors quoted
      above. The same step is red on the `main` push run `33974943655`.

- [ ] UI change — none. Test-only.

## Please merge ahead of the queue

This blocks every dogfood artifact, and the dogfood artifact is what the UI
gate's `--dogfood` slot installs — so field verification of the remote-herdr
join on `main` cannot proceed until it lands.

**Follow-up, corrected:** the suggestion originally here — compile the
instrumented configuration on every `main` push — is already what CI does, so
there is nothing to add. The real follow-up is that `main`'s push run was red
for three consecutive merges without stopping anyone. That is a branch-
protection / notification question for the owner, not a workflow-file change.

