### PR TITLE
CI: drop the duplicated shell-test step (~90 s off every run)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -165,9 +165,15 @@ jobs:
         # Pure shell tests for the workspace selector, the SSH build gate's
         # TERM -> KILL process-group teardown, and the SSH UI gate's allowlist /
         # lock refusal / window-ownership rules. Runs on hosted fork PRs too.
-        # Deliberately NOT gated on the docs-only fast path: the gate script is
-        # fast-path-eligible, so these seconds-cheap tests are what still
-        # exercises a gate-only diff.
+        # Deliberately NOT gated on the docs-only fast path: the gate scripts
+        # are fast-path-eligible, so these tests are what still exercises a
+        # gate-only diff.
+        #
+        # No longer cheap: test-ui-gate.sh alone is ~80 s of the ~95 s here
+        # (measured 2026-09-05, PR #238's 105 assertions each re-running the
+        # gate). That makes this the second most expensive step in the job —
+        # keep it to ONE copy, and think before adding another gate suite that
+        # re-execs a shell script per assertion.
         run: |
           ./scripts/ci/test-cleanup-stale-test-processes.sh
           ./scripts/ci/test-build-gate-process-cleanup.sh
@@ -184,35 +190,7 @@ jobs:
           ./scripts/ci/test-herdr-lane-filter.sh
           ./scripts/ci/test-herdr-fixture-recovery.sh
           ./scripts/ci/test-clean-stale-outputs.sh
-
-      - name: Clean abandoned test processes in this workspace
-        # A cancelled self-hosted job can outlive the Actions process cookie
-        # and leave swift-package/xctest running in this persistent checkout.
-        # Scope by current user + lsof cwd/mapped text; never pkill globally
-        # because the owner and parallel worktrees may run legitimate tests.
-        if: runner.environment == 'self-hosted'
-        run: ./scripts/ci/cleanup-stale-test-processes.sh "$GITHUB_WORKSPACE"
-
-      - name: Process-cleanup regression tests
-        # Pure shell tests for the workspace selector, the SSH build gate's
-        # TERM -> KILL process-group teardown, and the SSH UI gate's allowlist /
-        # lock refusal / window-ownership rules. Runs on hosted fork PRs too.
-        # Deliberately NOT gated on the docs-only fast path: the gate script is
-        # fast-path-eligible, so these seconds-cheap tests are what still
-        # exercises a gate-only diff.
-        run: |
-          ./scripts/ci/test-cleanup-stale-test-processes.sh
-          ./scripts/ci/test-build-gate-process-cleanup.sh
-          ./scripts/ci/test-build-gate-reap-command.sh
-          ./scripts/ci/test-build-gate-gc-command.sh
-          ./scripts/ci/test-remote-build-reap.sh
-          ./scripts/ci/test-remote-build-gc.sh
-          ./scripts/ci/test-run-supervised-command.sh
-          ./scripts/ci/test-ui-gate.sh
-          ./scripts/ci/test-runner-node-resign.sh
-          ./scripts/ci/test-llm-lane-filter.sh
-          ./scripts/ci/test-herdr-lane-filter.sh
-          ./scripts/ci/test-herdr-fixture-recovery.sh
+          ./scripts/ci/test-workflow-step-names.sh
 
       - name: Decide LLM eval lane (path filter + [run-llm-eval] marker)
         # CI must not pay ~8 min of 4B weight-loading + live inference on

--- a/scripts/ci/test-workflow-step-names.sh
+++ b/scripts/ci/test-workflow-step-names.sh
@@ -55,7 +55,7 @@ for file in "$WORKFLOW_DIR"/*.yml; do
   duplicates="$(check_file "$file" | sort | uniq -d || true)"
   if [[ -n "$duplicates" ]]; then
     echo "FAIL: $(basename "$file") declares the same step name twice in one job:" >&2
-    printf '  %s\n' "$duplicates" >&2
+    sed 's/^/  /' <<<"$duplicates" >&2
     failures=$((failures + 1))
   fi
 done

--- a/scripts/ci/test-workflow-step-names.sh
+++ b/scripts/ci/test-workflow-step-names.sh
@@ -1,0 +1,76 @@
+#!/bin/bash
+# Regression test: no workflow job may declare the same step name twice.
+#
+# Why this exists: ci.yml carried two byte-identical copies of the
+# "Clean abandoned test processes" + "Process-cleanup regression tests" pair
+# from PR #150 (2026-07-20) until 2026-09-05 — a rebase artifact that no
+# reviewer or check could see, because a duplicated step is perfectly valid
+# YAML and both copies pass. It went unnoticed for six weeks because the
+# shell-test step cost ~13 s; PR #238 added scripts/ci/test-ui-gate.sh and the
+# duplicate silently became ~90 s of every single CI run.
+#
+# A repeated step name in one job is never intentional here: it is either
+# copy-paste work that should have been one step, or a merge artifact. The
+# check is name-based on purpose — that is the symptom a human reads in the
+# Actions UI ("Process-cleanup regression tests" twice) and the one a rebase
+# reproduces.
+#
+# Pure bash, no YAML library: macOS system python3 ships no PyYAML and this
+# must run on hosted fork-PR runners too. Steps are matched structurally by
+# indentation (a step name is the `- name:` at the deepest list level), and
+# names are grouped per `jobs:` entry so two jobs may legitimately share one.
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+WORKFLOW_DIR="$ROOT_DIR/.github/workflows"
+
+failures=0
+
+check_file() {
+  local file="$1"
+  # awk state machine:
+  #   - a line matching /^  [A-Za-z0-9_-]+:$/ at two-space indent inside the
+  #     top-level `jobs:` mapping starts a new job;
+  #   - a line matching /^ +- name: / is a step name (steps are the only
+  #     deeper list of named mappings in these workflows);
+  #   - names are printed as "<job>\t<name>" so the caller can group.
+  awk '
+    /^jobs:[[:space:]]*$/ { in_jobs = 1; next }
+    /^[^[:space:]#]/      { in_jobs = 0 }
+    in_jobs && /^  [A-Za-z0-9_.-]+:[[:space:]]*$/ {
+      job = $0
+      sub(/^  /, "", job); sub(/:[[:space:]]*$/, "", job)
+      next
+    }
+    in_jobs && job != "" && /^[[:space:]]+- name: / {
+      name = $0
+      sub(/^[[:space:]]+- name: /, "", name)
+      print job "\t" name
+    }
+  ' "$file"
+}
+
+for file in "$WORKFLOW_DIR"/*.yml; do
+  [[ -e "$file" ]] || continue
+  duplicates="$(check_file "$file" | sort | uniq -d || true)"
+  if [[ -n "$duplicates" ]]; then
+    echo "FAIL: $(basename "$file") declares the same step name twice in one job:" >&2
+    printf '  %s\n' "$duplicates" >&2
+    failures=$((failures + 1))
+  fi
+done
+
+# The check is only worth anything if it actually saw steps. A silent zero
+# (indentation convention changed, directory moved) must fail, not pass.
+total="$(for file in "$WORKFLOW_DIR"/*.yml; do check_file "$file"; done | wc -l | tr -d ' ')"
+if [[ "$total" -lt 50 ]]; then
+  echo "FAIL: only $total step names parsed across $WORKFLOW_DIR — the parser is broken" >&2
+  failures=$((failures + 1))
+fi
+
+if (( failures > 0 )); then
+  echo "test-workflow-step-names: $failures failure(s)" >&2
+  exit 1
+fi
+
+echo "test-workflow-step-names: OK ($total step names, no duplicates within a job)"


### PR DESCRIPTION
## What

`ci.yml`'s `build-test` job declared **"Clean abandoned test processes in this workspace"** and **"Process-cleanup regression tests" twice**. The second pair arrived in #150 (2026-07-20) as a rebase artifact — perfectly valid YAML, both copies pass, so nothing in CI or review could see it. It cost ~13 s a run and went unnoticed for six weeks; then #238 added `scripts/ci/test-ui-gate.sh` (105 assertions, each re-running the gate) and the step jumped to ~95 s. Every CI run since 2026-09-05 has paid that twice.

The **surviving copy is the superset**. The deleted one had drifted and was missing `test-ui-smoke-guard.sh`, `test-ac-power-guard.sh` and `test-clean-stale-outputs.sh`; the first copy runs all sixteen suites. No assertion is lost — this deletes a second execution of a strict subset.

Also:
- **Regression test** `scripts/ci/test-workflow-step-names.sh`, wired into the very step it guards: fails when any workflow job declares the same step name twice. Pure bash + awk on purpose (macOS system python3 has no PyYAML, and this must run on hosted fork-PR runners); names are grouped per `jobs:` entry so two jobs may legitimately share one; it fails rather than passes if it parses implausibly few steps.
- Corrects the step's `seconds-cheap` comment, which is exactly what made a duplicate invisible. It is now the **second most expensive step in the job**.

No lane gating changes, no test weakened, no behaviour change to what is tested.

## Proof

### Measured cost of the duplicate — real CI step timings

`gh api repos/T0mSIlver/localvoxtral/actions/runs/<id>/jobs`, per-step `started_at`/`completed_at`, last 34 `build-test` jobs. `cleanup1`/`cleanup2` are the two copies of the shell-test step:

```
run           event             concl       cleanup1  cleanup2   unit    pkg  total
--- after #238 merged (2026-09-05 14:15) ---
33973438139   pull_request      success           96        88     94     48    559
33973412587   pull_request      success           98        90    132     49    495
33973152305   pull_request      success           94        90    109      7    434
33972091536   push              success           97        91    131     51    604
33971811359   workflow_dispatch success           98        92    108     46    529
33971761891   pull_request      success           98        92    131     59    775
33971253184   pull_request      success           95        89    125     53    602
33971242328   push              success           93        88    115     48    533
33970188418   pull_request      success           94        91    109      7    486
33968773534   pull_request      success          105        96    129     50    600
--- before #238 merged ---
33970153127   push              success           16        12    122     51    429
33968888057   pull_request      success           15        12    119     57    471
33968610398   pull_request      success           16        12     92     55    409
33968334463   pull_request      success           15        12    116     49    502
33967483397   push              success           15        12    123     50    433
33967124538   pull_request      success           16        12    125     48    439
33332956662   pull_request      success           15        11    127     55    464
33314723741   push              success           16        13    116     50    322
33313803329   pull_request      success           15        12    115     48    500
33312900746   pull_request      success           16        13    124     48    430
```

Median of the second copy across the ten post-#238 jobs: **90 s**, on a job whose median wall-clock is 470–530 s → **~19 % of every run**. (Pre-#238 it was 12 s / ~3 %.)

The two branches that carried #238 before it merged show the same jump on their own PR runs (`33307620464` 57/51, `33306881901` 54/51, `33315311922` 74/74, `33314216234` 80/74), which is what identifies `test-ui-gate.sh` as the cause rather than host load.

### Bug fix: regression test, failing before / passing after

Red — the new test against `origin/main`'s `ci.yml` (`git checkout origin/main -- .github/workflows/ci.yml`):

```
$ ./scripts/ci/test-workflow-step-names.sh; echo "exit=$?"
FAIL: ci.yml declares the same step name twice in one job:
  build-test	Clean abandoned test processes in this workspace
build-test	Process-cleanup regression tests
test-workflow-step-names: 1 failure(s)
exit=1
```

Green — same test against this branch's `ci.yml`:

```
$ ./scripts/ci/test-workflow-step-names.sh; echo "exit=$?"
test-workflow-step-names: OK (98 step names, no duplicates within a job)
exit=0
```

### The awk parser is not guessing

Cross-checked the script's awk program against a real `yaml.safe_load()` of every workflow — same `(job, step name)` set, file by file:

```
ok capture-assets.yml 5 steps
ci.yml 36 steps      (only diff: awk keeps the raw source line
                      "Installer asset-resolution regression test (issue #131)"
                      where YAML strips "#131)" as a comment — the raw line is
                      the right key for duplicate detection)
ok dmg-test.yml 5 steps
ok eval-e2e.yml 10 steps
ok hosted-tcc-probe.yml 13 steps
ok mac-crashlog.yml 6 steps
ok record-demo.yml 6 steps
ok release.yml 11 steps
ok ui-smoke.yml 6 steps
```

And the resulting workflow still parses with the same 36 steps and no duplicate names:

```
$ python3 -c "import yaml,collections; d=yaml.safe_load(open('.github/workflows/ci.yml')); s=d['jobs']['build-test']['steps']; print('steps:',len(s)); print([n for n,c in collections.Counter(x.get('name') for x in s).items() if c>1] or 'no dups')"
steps: 36
no dups
```

### Not run, and why

- `./scripts/remote-build.sh test` — no Swift file changes; the diff is `ci.yml` (one deleted step pair) plus a new shell script. The self-hosted runner was six runs deep all afternoon and a unit run would have added queue depth for zero information. **This PR's own CI run is the after-measurement**: the `Process-cleanup regression tests` step must appear exactly once, and the whole build-test job should land ~90 s below the post-#238 median of ~500 s.
- No conditional lane markers: nothing here touches LLM/speechd/herdr lane inputs.

---

## After-measurement: two real CI runs on the same base commit

Both jobs are `build-test` on the self-hosted runner, both green, both on
`fea0687` (the merge of #254) — same tree, same day, same lanes skipped
(LLM / speechd / herdr / dogfood all `false` in both), 20 minutes apart.

| | **BEFORE** — run [33979090366](https://github.com/T0mSIlver/localvoxtral/actions/runs/33979090366) (push to main, `fea0687`) | **AFTER** — run [33979233883](https://github.com/T0mSIlver/localvoxtral/actions/runs/33979233883) (this PR, `f16fbcf`) |
|---|---:|---:|
| **job wall-clock** | **446 s** | **376 s** |
| Process-cleanup regression tests | 89 s | 94 s |
| Process-cleanup regression tests *(2nd copy)* | **91 s** | **— gone** |
| Test (unit suite) | 93 s | 96 s |
| Package app bundle | 47 s | 51 s |
| Dogfood capture suite | 23 s | 27 s |
| Integration tests (live STT service) | 24 s | 24 s |
| Speech helper unit tests | 20 s | 20 s |
| Zip dSYM / Upload dSYM | 13 s / 5 s | 15 s / 6 s |
| Polishing helper unit tests | 11 s | 12 s |
| Zip app / Upload app | 4 s / 5 s | 4 s / 4 s |
| Format lint | 5 s | 6 s |
| Smoke test packaged app launch | 3 s | 2 s |

**−70 s, −16 % of the job.** Every other step moved by ≤ 5 s (host-load
jitter); the only structural change is the vanished duplicate. The full step
list of the after-run shows `Process-cleanup regression tests` exactly once.

Because the single self-hosted runner sat at **89 % utilization** during
today's burst (measured: 26 jobs, 3.23 h busy in a 3.62 h window, 19 min total
idle), 70 s off the service time is worth considerably more than 70 s to
anything queued behind it.

Note on the run history of this PR: the first attempt
([33978192063](https://github.com/T0mSIlver/localvoxtral/actions/runs/33978192063))
failed in `Dogfood capture suite` on `cannot find 'ClaudeSessionMarker' in
scope` — main's own breakage at `7d6d9b2`, fixed by #254. It still proves the
step-count half: `Process-cleanup regression tests` ran once, for 93 s. The
branch was then rebased onto `fea0687` and re-run green.

### Also verified green in the after-run

`scripts/ci/test-workflow-step-names.sh` ran inside the step it guards, on the
self-hosted runner's system bash/awk (the local red/green above was on Linux):
the step passed, so the awk parser and the `<50 step names` sanity floor both
behave on macOS.
