### PR TITLE
CI: a dispatch switch that runs build-test on GitHub-hosted macOS (and the first green hosted run)

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -33,6 +33,24 @@ which also arms the runtime capture default. On manual dispatch the
 conditional live-model lanes (polishd/speechd) skip — the dispatched ref's
 own push/PR run already decided them.
 
+Forcing the hosted lane: `workflow_dispatch` with `hosted=true` runs
+`build-test` for a same-repo ref on `macos-latest` instead of the Mac —
+
+```bash
+gh workflow run CI --ref <branch> -f hosted=true
+```
+
+That is the only way to exercise the fork-PR lane without a fork, and it is
+also the switch for moving tier 0 off the personal Mac. Everything keyed on
+`runner.environment == 'self-hosted'` skips exactly as it does for a fork PR:
+the workspace process cleanup, all four lane-decide steps, the live STT /
+polishd / speechd / herdr lanes, both helper unit suites, the dogfood capture
+suite and packaging, the Metal-toolchain probe, and the process leak check.
+What remains is the shell-test step, the installer test, format lint, the unit
+suite, packaging (helpers skipped, ad-hoc signature), the artifacts, and the
+launch smoke. The input can only move a job toward `macos-latest`; no input
+value can pull a fork PR onto the self-hosted runner.
+
 The same `build-test` check takes a docs/scripts-only fast path when every
 changed file passes `scripts/ci/docs-only-filter.sh`; it then skips all Swift,
 helper, packaging, artifact, smoke, warm, and integration steps. The filter

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,10 @@ on:
         description: "Also package the dogfood-instrumented app (artifact: localvoxtral-app-dogfood)"
         type: boolean
         default: false
+      hosted:
+        description: "Run build-test on a GitHub-hosted macOS runner instead of the Mac (the fork-PR lane)"
+        type: boolean
+        default: false
 
 concurrency:
   group: ci-${{ github.ref }}
@@ -24,7 +28,23 @@ jobs:
     # Same-repo branches run on the self-hosted Mac (persistent workspace, warm
     # incremental builds). Fork PRs run on GitHub-hosted macOS so untrusted code
     # never executes on the build machine.
-    runs-on: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && fromJSON('["self-hosted", "macOS", "ARM64"]') || 'macos-latest' }}
+    #
+    # `workflow_dispatch` with hosted=true sends a SAME-REPO ref onto the hosted
+    # lane instead. Two uses: it is the only way to exercise the fork-PR lane
+    # without a fork (that lane's last real run predates #244's toolchain fix
+    # and nothing has proved it since), and it is the switch a decision to move
+    # tier 0 off the personal Mac would flip. The term only ever moves a job
+    # TOWARD macos-latest — a fork PR can never be pulled onto the self-hosted
+    # runner by an input, whatever it is set to.
+    #
+    # `github.event.inputs.hosted`, not `inputs.hosted`: the input is declared
+    # `type: boolean`, and comparing a boolean to the string 'true' in an
+    # expression coerces both to numbers (1 vs NaN) and is therefore always
+    # false. The event payload's copy is a string, so it compares as written.
+    # (Same trap as the dogfood UI-gate install step below; it cost a silently
+    # dead gate once already.) For push/pull_request the field is absent, which
+    # compares as '' and leaves the original routing untouched.
+    runs-on: ${{ (github.event.inputs.hosted != 'true' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)) && fromJSON('["self-hosted", "macOS", "ARM64"]') || 'macos-latest' }}
     timeout-minutes: 30
     steps:
       - name: Checkout


### PR DESCRIPTION
## What

`workflow_dispatch` gains a `hosted: boolean` input. With `hosted=true` a **same-repo** ref runs `build-test` on `macos-latest` instead of the Mac:

```bash
gh workflow run CI --ref <branch> -f hosted=true
```

Two reasons to want this.

1. **The fork-PR lane is currently unproven.** Its last real execution was PR #240 on 2026-08-29, and it **failed** — on exactly the swift.org-toolchain assertion that #244 then fixed. No fork PR has opened since, so #244's fix has never actually been run. Before this input there was no way to exercise that lane without a fork.
2. It is the switch a decision to move tier 0 off the owner's personal MacBook would flip, so the measurement and the mechanism are the same object.

**Minimal by construction.** The routing term only ever moves a job *toward* `macos-latest` — no input value can pull a fork PR onto the self-hosted runner. Not one step's `if:` changes: everything already keyed on `runner.environment == 'self-hosted'` skips exactly as it does for a fork PR.

`github.event.inputs.hosted`, not `inputs.hosted`: a `type: boolean` input compared against the string `'true'` coerces both to numbers (1 vs NaN) and is always false. That trap already produced one silently dead gate in the dogfood UI-gate install step, whose comment records it. For `push`/`pull_request` the field is absent, compares as `''`, and the original routing is untouched.

Documented in `.github/workflows/README.md`, including the full list of what skips.

## Proof

### The hosted lane is green — run [33981779091](https://github.com/T0mSIlver/localvoxtral/actions/runs/33981779091)

`gh workflow run CI --ref ci/hosted-lane-dispatch -f hosted=true`, watched end to end.

```
$ gh api repos/T0mSIlver/localvoxtral/actions/runs/33981779091/jobs --jq '.jobs[] | [.name,(.labels|join(",")),.conclusion]'
build-test    macos-latest    success
```

**This is the first green hosted `build-test` in the repo's history** — the previous one (PR #240) failed. #244's claim that dropping `swift-actions/setup-swift` fixes the hosted lane is no longer unproven; it is executed.

**Timings.**

| | hosted (this run) | self-hosted baseline ([33979233883](https://github.com/T0mSIlver/localvoxtral/actions/runs/33979233883), `fea0687`) |
|---|---:|---:|
| **queue (run created → job started)** | **8 s** | 378 s p50, up to 4084 s observed today |
| **job wall-clock** | **372 s** | 376 s |
| Process-cleanup regression tests | 107 s | 94 s |
| Test (unit suite) | 160 s (cold: 69.3 s build + 80.5 s tests) | 96 s (warm) |
| Package app bundle | 77 s (helpers skipped, cold release build) | 51 s (warm, both helpers) |
| Format lint | 3 s | 6 s |
| Zip app / Upload app | 1 s / 1 s | 4 s / 4 s |
| Zip dSYM / Upload dSYM | 1 s / 1 s | 15 s / 6 s |
| Smoke test packaged app launch | 2 s | 2 s |
| Record hosted toolchain / Cache restore / Cache save | <1 s / 1 s / 7 s | n/a |

A **cold** hosted run costs the same wall-clock as a **warm** Mac run, with essentially no queue. The dSYM steps are cheap because the helper dSYMs are absent on hosted.

**The unit suite is not diminished.** Both runs executed the identical set of test cases — the set difference is empty in both directions:

```
mac=2769 hosted=2769
ONLY ON THE MAC (0):
ONLY ON HOSTED (0):
```

(computed from the `unit-test-log-macOS` artifacts of both runs, matching `Test Case '-[<suite> <case>]' started`). Hosted result line: `Executed 2769 tests, with 11 tests skipped and 0 failures (0 unexpected) in 80.509 seconds`.

**Toolchain the image gave us** (no `Setup Swift` step, as #244 intended):

```
Xcode 26.6
Build version 17F113
Apple Swift version 6.3.3 (swiftlang-6.3.3.1.3 clang-2100.1.1.101)
Target: arm64-apple-macosx26.0
```

**Cache behaviour** — miss on this first run (the key is new), then saved, so the next hosted run starts warm:

```
Cache not found for input keys: swiftpm-macOS-ARM64-Apple-Swift-version-6.3.3-swiftlang-6.3.3.1.3-cl-f20ab0af…
Cache saved with key:           swiftpm-macOS-ARM64-Apple-Swift-version-6.3.3-swiftlang-6.3.3.1.3-cl-f20ab0af…
```

**19 steps skipped, all of them `runner.environment == 'self-hosted'`-keyed** — the workspace process cleanup, all four lane-decide steps, the warm-speechd step, the live STT / herdr / polishd / speechd lanes, both helper unit suites, the dogfood capture suite, the Metal-toolchain probe, the dogfood packaging + its two uploads, the UI-gate install, and the process leak check.

**What ran:** Set up job, Checkout, Decide CI fast path, Clean stale outputs, Process-cleanup regression tests, Record hosted toolchain, Cache SwiftPM build, Installer asset-resolution test, Format lint, Test (unit suite), Upload unit-test log, Coverage summary, Package app bundle, Zip/Upload app, Zip/Upload dSYM, Smoke test packaged app launch, Post Cache, Post Checkout.

### Nothing the hosted image lacked

- **Metal toolchain**: not needed — `LOCALVOXTRAL_SKIP_POLISHD/SKIP_SPEECHD=1` on hosted, and the `Ensure Metal toolchain` step is self-hosted-only. Packaging succeeded without it.
- **python3**: present; the launch smoke's inline `python3 - <<'PY'` ran and the packaged app survived its 2 s liveness check.
- **codesign**: no `localvoxtral-dev` identity, and `LOCALVOXTRAL_REQUIRE_CODESIGN_IDENTITY=0` on hosted — fell back to ad-hoc exactly as designed, and the ad-hoc-signed bundle still launched in the smoke.
- **herdr / sshd / STT service**: not needed; those lanes are self-hosted-only and skipped.
- **`swift format`**: present (`Format lint` 3 s).
- No hosted-only compiler warnings: the same three files warn on both lanes (`ClaudeHookPublisherTests.swift`, `CmuxSocketPasswordStoreTests.swift`, `ClaudePluginInstallService.swift`) — pre-existing on main, higher counts on hosted only because the cold build re-emits every one.

### Workflow still well-formed

```
$ ./scripts/ci/test-workflow-step-names.sh
test-workflow-step-names: OK (98 step names, no duplicates within a job)
$ python3 -c "import yaml; d=yaml.safe_load(open('.github/workflows/ci.yml')); print(list(d['on']['workflow_dispatch']['inputs'])); print(len(d['jobs']['build-test']['steps']))"
['dogfood', 'hosted']
36
```

### Not run, and why

- `./scripts/remote-build.sh test` — no Swift changed; the diff is `ci.yml`'s dispatch routing plus README prose. The hosted run above executed the whole unit suite (2769 cases, 0 failures) on this exact commit, which is a stronger statement than a local run would be.
- No lane markers: nothing here touches LLM/speechd/herdr lane inputs.
