### PR TITLE
docs: never dispatch a build behind a queued run for the same ref

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -111,6 +111,9 @@ ablation workflows: `docs/agent/test-tiers.md`.
 - Watch a PR's checks with `./scripts/watch-checks.sh <n>` (or `--run
   <run-id>` for a push/rerun) — unlike bare `gh`, it probes the build host
   and fail-fasts when the Mac stops answering.
+- One runner, so a dispatch behind a queued run costs everyone: check `gh run
+  list --branch <ref>` first — `docs/agent/test-tiers.md` "Dispatching a run
+  without deepening the queue".
 - Releases: `./scripts/release.sh [patch|minor|major|X.Y.Z]` — the pipeline
   gates and owns the tags. Never push release tags by hand.
 - NEVER patch SwiftPM-generated DerivedSources (regenerated clean every

--- a/docs/agent/test-tiers.md
+++ b/docs/agent/test-tiers.md
@@ -81,6 +81,31 @@ remains the local equivalent. The nightly `eval-e2e.yml` lane is the only
 scheduled eval; the per-PR polishd lane skipped by the filter runs again only
 when a matching change (or the marker) triggers it.
 
+## Dispatching a run without deepening the queue
+
+There is ONE self-hosted runner (the owner's MacBook), so CI concurrency is 1
+and every extra run is paid by everything behind it. Measured 2026-09-05: in a
+3.6 h burst with four agents pushing, the runner was **89 % busy** — 26 jobs,
+19 minutes of total idle — and 3.4 h of work produced **8.95 h of accumulated
+queue**. At that utilization a queue is quadratically sensitive to load, so one
+avoidable run costs far more than its own duration.
+
+- **Never dispatch a build for a ref whose push/PR run is still queued.** The
+  dispatch lands in a DIFFERENT concurrency group — `ci-refs/heads/<branch>`
+  vs `ci-refs/pull/<n>/merge` — so `cancel-in-progress` does not deduplicate
+  them and both run to completion. Check first:
+  `gh run list --branch <ref>` (or `--workflow ci.yml`), and wait for the
+  existing run instead. Observed the same day: runs `33973422149` (dispatch)
+  and `33973420824` (PR) on one branch 20 s apart, and `33974946864`
+  (dispatch on main) alongside `33974943655` (that push's own run).
+- **The one exception** is a dispatch that produces something the queued run
+  cannot: `dogfood=true` for an instrumented artifact when the queued run
+  carries no `[dogfood-package]` marker, or any other artifact-only input. A
+  dispatch that would merely re-run the same lanes is never worth its slot.
+- Do not "just rerun" a red run to see if it is flaky before reading its log
+  either — the flake signatures are enumerated in
+  `docs/agent/field-debugging.md`, and a rerun is a full second run.
+
 ## The live herdr lane
 
 `HerdrIntegrationTests` (`remote-build.sh integration-herdr`) is the only


### PR DESCRIPTION
## What

Owner decision (2026-09-05): agents must stop dispatching a build for a ref whose push/PR run is still queued.

There is **one** self-hosted runner, so CI concurrency is 1 and every extra run is paid by everything behind it. A `workflow_dispatch` and the ref's own push/PR run land in **different concurrency groups** — `ci-refs/heads/<branch>` vs `ci-refs/pull/<n>/merge` — so `cancel-in-progress` does not deduplicate them and both run to completion. Agents have been doing this without noticing it costs anything.

Two observed pairs from 2026-09-05, both named in the doc so the shape is recognisable:
- run `33973422149` (dispatch) and `33973420824` (PR) on `fix/herdr-join-field-panel-token-truncation`, created 20 s apart
- run `33974946864` (dispatch on main) alongside `33974943655` (that push's own run)

The rule, its rationale and its **one exception** (a dispatch that produces something the queued run cannot — `dogfood=true` for an instrumented artifact, or any other artifact-only input) go in `docs/agent/test-tiers.md` under a new heading, "Dispatching a run without deepening the queue". `AGENTS.md` gets a single routing line in the CI/shipping section, per its own "Rules for editing THIS file".

Measurement behind the claim (`gh api .../actions/runs/<id>/jobs`, per-step `started_at`/`completed_at`, all self-hosted jobs created 2026-09-05):

```
whole day    : 3.39 h runner busy, 8.95 h accumulated queue (2.6 : 1)
burst window : 12:45–16:22, span 3.62 h, 26 jobs, busy 3.23 h => 89% utilization
               17 idle gaps totalling 19.2 min, largest 4.6 min
queue seconds: n=27  p50=1050  p90=2393  max=4084
runners      : gh api repos/T0mSIlver/localvoxtral/actions/runners -> total_count = 1
```

## Proof

### The tier-0 guard on `AGENTS.md`, run for real on the build host

```
$ ./scripts/remote-build.sh test --filter AgentsGuideSizeTests
Build complete! (33.74s)
Test Case '-[localvoxtralTests.AgentsGuideSizeTests testDeepGuidesKeepTheAnchorsCommentsPointAt]' passed (0.004 seconds).
Test Case '-[localvoxtralTests.AgentsGuideSizeTests testRootAgentsGuideStaysUnderTheCodexTruncationCap]' passed (0.001 seconds).
Test Case '-[localvoxtralTests.AgentsGuideSizeTests testRouterTargetsExist]' passed (0.000 seconds).
Test Suite 'AgentsGuideSizeTests' passed at 2026-09-05 20:00:01.842.
	 Executed 3 tests, with 0 failures (0 unexpected) in 0.006 (0.006) seconds
```

`AGENTS.md` is now **11,845 bytes** against the 32,768-byte Codex truncation cap — 20,923 bytes of headroom. The added line is 3 lines; the router targets and the anchors other files point at are unchanged, and both of the other two assertions in that suite still pass.

No new compiler warnings: `grep -ci "warning:" .build/last-remote.log` → 148, from the same three pre-existing files at the same counts as main's own CI run (`ClaudeHookPublisherTests.swift` 38, `ClaudePluginInstallService.swift` 18, `CmuxSocketPasswordStoreTests.swift` 18). None is in this diff, which is Markdown only.

### ⚠️ This PR's own CI run will NOT run that test — worth knowing

The diff is `AGENTS.md` + `docs/agent/test-tiers.md`, both `*.md`, so it takes the docs-only fast path and skips the whole Swift lane:

```
$ git diff --name-only origin/main
AGENTS.md
docs/agent/test-tiers.md
$ ./scripts/ci/docs-only-filter.sh <that list>
docs_only=true
count=2
reason=all 2 changed path(s) are docs/scripts-only
```

So `AgentsGuideSizeTests` — the tier-0 test whose entire job is guarding `AGENTS.md`'s byte budget — is skipped **exactly on the diffs that can break it**. The remote run above is therefore the only place it executed for this change, not belt-and-braces. Flagging rather than fixing: closing the hole means either excluding `AGENTS.md` from the fast-path allowlist or running that one suite inside the fast path, and both are decisions about the filter's contract rather than part of this change.

### Rendering

Headings and anchors unchanged elsewhere; the new `## Dispatching a run without deepening the queue` sits between "When must the LLM lanes run?" and "The live herdr lane", the two sections `AgentsGuideSizeTests.testDeepGuidesKeepTheAnchorsCommentsPointAt` pins by exact text (both still present, asserted above).
