### PR TITLE
[throwaway probe] helper lane gate: neither helper touched

### DIFF
--- a/PolishHelper/Package.swift
+++ b/PolishHelper/Package.swift
@@ -52,3 +52,6 @@ let package = Package(
         ),
     ]
 )
+
+// CI probe (throwaway): touches PolishHelper only, so the polish unit lane
+// must run and the speech unit lane must stay skipped.

--- a/Tests/localvoxtralTests/AudioChunkBufferTests.swift
+++ b/Tests/localvoxtralTests/AudioChunkBufferTests.swift
@@ -89,3 +89,6 @@ final class AudioChunkBufferTests: XCTestCase {
         XCTAssertEqual(result.count, chunkSize * taskCount)
     }
 }
+
+// CI probe (PR #TBD): a non-fast-path diff that touches neither helper.
+// Dropped before merge; the branch exists only to photograph the lane decision.


### PR DESCRIPTION
Throwaway proof branch for the helper-lane gate, based on `ci/helper-lane-filter`. **Do not merge — will be closed.** Its diff is one comment in `Tests/localvoxtralTests/AudioChunkBufferTests.swift`: a non-fast-path change that touches neither helper, so both helper unit lanes must report SKIPPED with a reason.