### PR TITLE
CI: path-gate the two helper unit suites (option 8)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -208,6 +208,7 @@ jobs:
           ./scripts/ci/test-ac-power-guard.sh
           ./scripts/ci/test-llm-lane-filter.sh
           ./scripts/ci/test-herdr-lane-filter.sh
+          ./scripts/ci/test-helper-lane-filter.sh
           ./scripts/ci/test-herdr-fixture-recovery.sh
           ./scripts/ci/test-clean-stale-outputs.sh
           ./scripts/ci/test-workflow-step-names.sh
@@ -449,6 +450,65 @@ jobs:
             echo "Dogfood artifact lane: SKIPPED ($REASON)" | tee -a "$GITHUB_STEP_SUMMARY"
           fi
 
+      - name: Decide helper unit lanes (path filter)
+        # The two helper UNIT suites (11 s + 20 s) ran on every self-hosted run,
+        # including diffs that could not change what they test. Both helpers are
+        # HERMETIC SwiftPM packages — only remote dependencies, no `path:` dep,
+        # no `..`, no symlink out, no source shared with the root package — so a
+        # suite's only inputs are its own directory (Package.swift and
+        # Package.resolved included) plus the CI plumbing that invokes it. The
+        # path list and the event rules live in scripts/ci/helper-lane-filter.sh
+        # so they are testable locally (scripts/ci/test-helper-lane-filter.sh).
+        #
+        # Unlike the live-model lanes this is not an "expensive, so opt in"
+        # gate and there is NO marker: a diff that can affect a suite runs it.
+        # workflow_dispatch and push-to-main run both unconditionally (the
+        # filter decides that, not this step), so a dispatch is the escape
+        # hatch and main stays the ungated parity reference.
+        id: helper_lanes
+        if: runner.environment == 'self-hosted' && steps.ci_scope.outputs.docs_only != 'true'
+        env:
+          PUSH_BEFORE_SHA: ${{ github.event.before }}
+          BASE_REF: ${{ github.base_ref }}
+        run: |
+          set -euo pipefail
+          FILES="$RUNNER_TEMP/helper-lane-changed-files.txt"
+
+          BASE=""
+          if [[ "$GITHUB_EVENT_NAME" == "pull_request" ]]; then
+            BASE="$(git merge-base "origin/$BASE_REF" HEAD || true)"
+          elif git cat-file -e "$PUSH_BEFORE_SHA^{commit}" 2>/dev/null; then
+            BASE="$PUSH_BEFORE_SHA"
+          fi
+          if [[ -z "$BASE" ]]; then
+            # Fail open: an uncomputable diff must never skip a suite. Same
+            # contract as every other lane-decide step here.
+            : >"$FILES"
+            echo "polish_run=true" >> "$GITHUB_OUTPUT"
+            echo "speech_run=true" >> "$GITHUB_OUTPUT"
+            echo "PolishHelper unit lane: RUNNING (diff unavailable — failing open)" \
+              | tee -a "$GITHUB_STEP_SUMMARY"
+            echo "SpeechHelper unit lane: RUNNING (diff unavailable — failing open)" \
+              | tee -a "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+          git diff --name-only "$BASE" HEAD > "$FILES"
+
+          decide() {
+            local helper="$1" label="$2" output_key="$3" decision run reason
+            decision="$(./scripts/ci/helper-lane-filter.sh "$helper" "$FILES" "$GITHUB_EVENT_NAME")"
+            run="$(sed -n 's/^run=//p' <<<"$decision")"
+            reason="$(sed -n 's/^reason=//p' <<<"$decision")"
+            echo "$output_key=$run" >> "$GITHUB_OUTPUT"
+            if [[ "$run" == "true" ]]; then
+              echo "$label unit lane: RUNNING ($reason)" | tee -a "$GITHUB_STEP_SUMMARY"
+            else
+              echo "$label unit lane: SKIPPED ($reason)" | tee -a "$GITHUB_STEP_SUMMARY"
+            fi
+          }
+          decide polish PolishHelper polish_run
+          decide speech SpeechHelper speech_run
+
       # No "Setup Swift" step here on purpose. A prior `swift-actions/setup-swift@v2`
       # step (floating swift-version: "6.2") pinned the swift.org toolchain,
       # which now resolves to 6.2.1 — built with assertions ON, and it asserts
@@ -613,14 +673,18 @@ jobs:
         # Self-hosted only: hosted runners would pay a cold Cmlx C++ compile
         # every fork PR. These tests are Metal-free (HTTP layer, router,
         # cache locator, watchdog); the Metal path is covered below.
-        if: runner.environment == 'self-hosted' && steps.ci_scope.outputs.docs_only != 'true'
+        # Path-gated by the decide step above — see its comment for why that
+        # is sound and scripts/ci/helper-lane-filter.sh for the rules.
+        if: runner.environment == 'self-hosted' && steps.ci_scope.outputs.docs_only != 'true' && steps.helper_lanes.outputs.polish_run == 'true'
         run: swift test --package-path PolishHelper
 
       - name: Speech helper unit tests (SpeechHelper package)
         # Self-hosted only, matching PolishHelper: this is the per-push,
         # Metal-free codec/delta/watchdog suite. Real Metal inference is the
         # conditional post-packaging lane below.
-        if: runner.environment == 'self-hosted' && steps.ci_scope.outputs.docs_only != 'true'
+        # Path-gated by the decide step above — see its comment for why that
+        # is sound and scripts/ci/helper-lane-filter.sh for the rules.
+        if: runner.environment == 'self-hosted' && steps.ci_scope.outputs.docs_only != 'true' && steps.helper_lanes.outputs.speech_run == 'true'
         run: swift test --package-path SpeechHelper
 
       - name: Dogfood capture suite (instrumented build)

--- a/docs/agent/test-tiers.md
+++ b/docs/agent/test-tiers.md
@@ -2,7 +2,8 @@
 
 | Tier | What | When | Cost |
 |---|---|---|---|
-| 0 | Unit suite (500+ tests) + PolishHelper/SpeechHelper unit suites + packaging + launch smoke | every non-fast-path PR/push, CI (helper unit suites: self-hosted lanes only) | ~1 min |
+| 0 | Unit suite (500+ tests) + packaging + launch smoke | every non-fast-path PR/push, CI | ~1 min |
+| 0 | PolishHelper / SpeechHelper unit suites (Metal-free: router, cache locator, watchdog; codec/delta contract) | self-hosted lanes only, and path-gated per helper — a PR runs a helper's suite only when the diff touches that helper's directory or the shared CI plumbing; `workflow_dispatch` and every push to main run both (`scripts/ci/helper-lane-filter.sh`, no marker). Locally: `remote-build.sh test --package-path PolishHelper` / `SpeechHelper` | 11 s + 20 s |
 | 1 | `RealtimeAPIVLLMIntegrationTests` vs the live local speechd STT test service: real inference through the production websocket client, word-accuracy asserted | every non-fast-path PR/push on the self-hosted runner; locally via `remote-build.sh integration` | ~20 s |
 | 1 | `PolishHelperIntegrationTests`: the packaged polishing helper vs the real pinned model — production request path, shared eval baseline, parent-pid tether | conditional in CI (self-hosted, after packaging): only when the diff touches LLM-relevant paths or the PR opts in with `[run-llm-eval]` — see "When must the LLM lanes run?"; locally via `remote-build.sh integration-polishd` | minutes (4B weights + live inference) |
 | 1 | `SpeechHelperIntegrationTests`: packaged speechd vs real spoken audio/model through the production realtime client — word accuracy, append-only delta/done parity, parent-pid tether | conditional in CI (self-hosted, after packaging): only when the diff touches speechd-relevant paths or the PR opts in with `[run-speechd-integration]`; locally via `remote-build.sh integration-speechd` | minutes (4B weights + live inference) |
@@ -80,6 +81,32 @@ filter list in the same PR. `./scripts/remote-build.sh integration-polishd`
 remains the local equivalent. The nightly `eval-e2e.yml` lane is the only
 scheduled eval; the per-PR polishd lane skipped by the filter runs again only
 when a matching change (or the marker) triggers it.
+
+## Why the helper unit suites are path-gated
+
+Owner decision 2026-09-05. The two helper UNIT suites ran on every self-hosted
+run — 11 s + 20 s — including on diffs that could not possibly change what they
+test. They are gated per helper by `scripts/ci/helper-lane-filter.sh`, which is
+sound because **both helpers are hermetic SwiftPM packages**:
+`PolishHelper/Package.swift` and `SpeechHelper/Package.swift` declare only
+REMOTE dependencies — no `path:` dependency, no `..` reference, no symlink out
+of the directory, no source shared with the root package. A helper suite's only
+inputs are therefore its own directory (`Package.swift` and `Package.resolved`
+included — that is the dependency-pin surface), the Xcode toolchain (not a
+diff), and the CI plumbing that invokes it.
+
+So: `PolishHelper/**` → the polish suite; `SpeechHelper/**` → the speech suite;
+`.github/workflows/ci.yml`, `scripts/ci/**` or `scripts/package_app.sh` → BOTH;
+`workflow_dispatch` → BOTH; every push to main → BOTH (main is the parity
+reference and is never gated); an uncomputable diff or an unrecognized event →
+BOTH, failing open exactly like `docs-only-filter.sh`.
+
+**This is not the live-model lanes' "expensive, so opt in" pattern and there is
+no marker.** Nothing here is a judgment call: a diff that can affect a suite
+runs it, and a dispatch is the escape hatch if you ever want both anyway. If
+you make a helper depend on something outside its directory — a local `path:`
+dependency, a shared source directory — the premise breaks and the shared list
+in the filter has to grow in the same PR.
 
 ## Dispatching a run without deepening the queue
 

--- a/scripts/ci/helper-lane-filter.sh
+++ b/scripts/ci/helper-lane-filter.sh
@@ -1,0 +1,127 @@
+#!/bin/bash
+# Decides whether CI must run one of the two helper-package UNIT suites
+# (`swift test --package-path PolishHelper` / `--package-path SpeechHelper`)
+# for a given change. Kept standalone so the workflow decision is testable
+# locally, exactly like llm-lane-filter.sh / speechd-lane-filter.sh.
+#
+# Usage:
+#   scripts/ci/helper-lane-filter.sh <polish|speech> <changed-files-file> [event-name]
+#
+#   <polish|speech>       which helper's unit suite is being decided
+#   <changed-files-file>  one changed path per line (git diff --name-only)
+#   [event-name]          $GITHUB_EVENT_NAME; absent means "decide on paths
+#                         alone" (what the tests do)
+#
+# stdout is $GITHUB_OUTPUT-shaped:
+#   run=true|false
+#   reason=<one line, safe for a step summary>
+#
+# Exits 0 for both decisions; non-zero only on usage errors. The caller owns
+# fail-open behavior when it cannot produce a diff at all — same contract as
+# the other lane filters.
+#
+# WHY THIS IS SAFE TO GATE AT ALL (owner decision 2026-09-05, "option 8").
+# These two suites ran on every self-hosted run — 11 s + 20 s — including on
+# diffs that could not possibly change what they test. They can be gated
+# because both helpers are HERMETIC packages: `PolishHelper/Package.swift` and
+# `SpeechHelper/Package.swift` declare only REMOTE dependencies (no `path:`
+# dependency, no `..` reference, no symlink out of the directory, no source
+# shared with the root package), so the only inputs to a helper's unit suite
+# are (1) files under its own directory — Package.swift and Package.resolved
+# included, which are the pin surface — (2) the Xcode toolchain, which is not
+# a diff, and (3) the CI plumbing that decides how the suite is invoked.
+# (3) is why the shared list below exists.
+#
+# This is NOT the live-model lane pattern of "expensive, so opt in". Nothing
+# here is a judgment call and there is no marker: a diff that can affect the
+# suite runs it, and `workflow_dispatch` runs both unconditionally, which is
+# the escape hatch. Coverage is unchanged; only redundant executions go.
+set -euo pipefail
+
+# Changes that can alter EITHER helper suite without touching either helper
+# directory: how the step is invoked, what decides whether it is invoked (this
+# file included — every edit to it proves both lanes on its own first run,
+# same discipline as scripts/ci/* in docs-only-filter.sh), and the packaging
+# script that builds both helpers.
+SHARED_PATTERNS=(
+  '.github/workflows/ci.yml'
+  'scripts/ci/*'
+  'scripts/package_app.sh'
+)
+
+if [[ $# -lt 2 || $# -gt 3 ]]; then
+  echo "usage: $0 <polish|speech> <changed-files-file> [event-name]" >&2
+  exit 2
+fi
+
+HELPER="$1"
+CHANGED_FILES_FILE="$2"
+EVENT_NAME="${3:-}"
+
+case "$HELPER" in
+  polish)
+    HELPER_LABEL="PolishHelper"
+    HELPER_PATTERNS=('PolishHelper/*')
+    ;;
+  speech)
+    HELPER_LABEL="SpeechHelper"
+    HELPER_PATTERNS=('SpeechHelper/*')
+    ;;
+  *)
+    echo "unknown helper: $HELPER (expected polish or speech)" >&2
+    exit 2
+    ;;
+esac
+
+if [[ ! -f "$CHANGED_FILES_FILE" ]]; then
+  echo "changed-files file not found: $CHANGED_FILES_FILE" >&2
+  exit 2
+fi
+
+# Event rules come first: they are facts about the run, not about the diff,
+# and they all say "run".
+#   - workflow_dispatch: a dispatch exists to produce a full artifact on
+#     demand and carries no diff the way a PR does. Run both; it is also the
+#     no-new-grammar way for a human to force these suites.
+#   - push: ci.yml's `push:` trigger is `branches: [main]` ONLY, so every push
+#     event here is a push to main — the parity reference every branch is
+#     compared against, which must never be gated.
+#   - anything else (a trigger added later, an empty/garbled event name):
+#     fail open, exactly like docs-only-filter.sh's unknown-path arm. A lane
+#     that cannot classify its own run must run, never skip.
+case "$EVENT_NAME" in
+  pull_request | "")
+    ;;
+  workflow_dispatch)
+    echo "run=true"
+    echo "reason=workflow_dispatch — dispatches build everything"
+    exit 0
+    ;;
+  push)
+    echo "run=true"
+    echo "reason=push to main — main is the parity reference and is never gated"
+    exit 0
+    ;;
+  *)
+    echo "run=true"
+    echo "reason=unrecognized event '$EVENT_NAME' — failing open"
+    exit 0
+    ;;
+esac
+
+while IFS= read -r file; do
+  [[ -z "$file" ]] && continue
+  for pattern in "${HELPER_PATTERNS[@]}" "${SHARED_PATTERNS[@]}"; do
+    # shellcheck disable=SC2254
+    case "$file" in
+      $pattern)
+        echo "run=true"
+        echo "reason=matched $file ($pattern)"
+        exit 0
+        ;;
+    esac
+  done
+done <"$CHANGED_FILES_FILE"
+
+echo "run=false"
+echo "reason=no $HELPER_LABEL-relevant changes ($HELPER_LABEL is a standalone package; nothing outside $HELPER_LABEL/ or the CI plumbing can change what its unit suite tests)"

--- a/scripts/ci/test-helper-lane-filter.sh
+++ b/scripts/ci/test-helper-lane-filter.sh
@@ -1,0 +1,148 @@
+#!/usr/bin/env bash
+# Regression test for helper-lane-filter.sh's path and event decisions.
+# Pure shell, no git or network — changed-file lists are written to temp
+# files, so it runs anywhere (hosted fork PRs included).
+#
+# What it pins, in the order the decisions are made:
+#   - the event rules (dispatch / push-to-main / unknown all fail open to run)
+#   - each helper's own directory, INCLUDING its Package.resolved, which is
+#     the dependency-pin surface and the thing most likely to be forgotten
+#   - the shared CI-plumbing list (ci.yml, scripts/ci/*, package_app.sh),
+#     which is the whole reason this can be gated safely
+#   - independence: a PolishHelper diff must NOT run the SpeechHelper suite,
+#     and vice versa — the bug this gate would introduce if the two pattern
+#     lists ever leaked into each other
+#   - the run=false side, which is the point of the change
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "$0")/../.." && pwd -P)"
+FILTER="$ROOT_DIR/scripts/ci/helper-lane-filter.sh"
+
+TMP_DIR="$(mktemp -d "${TMPDIR:-/tmp}/lv-helper-lane-filter-test.XXXXXX")"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+fail() {
+  printf 'FAIL: %s\n' "$*" >&2
+  exit 1
+}
+
+# expect <polish|speech> <true|false> <description> [--event <name>] <changed-path>...
+expect() {
+  local helper="$1" expected="$2" description="$3"
+  shift 3
+  local changed="$TMP_DIR/changed" event=""
+  : >"$changed"
+  while [[ $# -gt 0 ]]; do
+    if [[ "$1" == "--event" ]]; then
+      event="$2"
+      shift 2
+      continue
+    fi
+    printf '%s\n' "$1" >>"$changed"
+    shift
+  done
+  local output
+  if [[ -n "$event" ]]; then
+    output="$("$FILTER" "$helper" "$changed" "$event")" \
+      || fail "$description: filter exited non-zero"
+  else
+    output="$("$FILTER" "$helper" "$changed")" \
+      || fail "$description: filter exited non-zero"
+  fi
+  local run reason
+  run="$(sed -n 's/^run=//p' <<<"$output")"
+  reason="$(sed -n 's/^reason=//p' <<<"$output")"
+  [[ "$run" == "$expected" ]] \
+    || fail "$description: expected run=$expected, got run=$run ($reason)"
+  [[ -n "$reason" ]] || fail "$description: reason line is missing"
+  printf 'PASS: [%s] %s (%s)\n' "$helper" "$description" "$reason"
+}
+
+expect_usage_error() {
+  local description="$1"
+  shift
+  if "$FILTER" "$@" >/dev/null 2>&1; then
+    fail "$description: expected a usage error, got exit 0"
+  fi
+  printf 'PASS: %s\n' "$description"
+}
+
+# --- Event rules (checked before any path) ---------------------------------
+
+expect polish true "workflow_dispatch runs the polish lane whatever the diff" \
+  --event workflow_dispatch README.md
+expect speech true "workflow_dispatch runs the speech lane whatever the diff" \
+  --event workflow_dispatch README.md
+expect polish true "push (ci.yml only pushes on main) runs the polish lane" \
+  --event push README.md
+expect speech true "push (ci.yml only pushes on main) runs the speech lane" \
+  --event push README.md
+expect polish true "an unrecognized event fails open" \
+  --event merge_group README.md
+expect speech true "an unrecognized event fails open" \
+  --event schedule README.md
+expect polish false "pull_request decides on paths alone" \
+  --event pull_request README.md
+
+# --- Each helper's own directory -------------------------------------------
+
+expect polish true "a PolishHelper source change runs the polish lane" \
+  PolishHelper/Sources/PolishHelperCore/PolishRouter.swift
+expect polish true "PolishHelper/Package.resolved is the pin surface" \
+  PolishHelper/Package.resolved
+expect polish true "PolishHelper/Package.swift runs the polish lane" \
+  PolishHelper/Package.swift
+expect polish true "a PolishHelper TEST-only change runs the polish lane" \
+  PolishHelper/Tests/PolishHelperCoreTests/RouterTests.swift
+expect speech true "a SpeechHelper source change runs the speech lane" \
+  SpeechHelper/Sources/SpeechEngineText/StreamingDelta.swift
+expect speech true "SpeechHelper/Package.resolved is the pin surface" \
+  SpeechHelper/Package.resolved
+expect speech true "SpeechHelper/DEPENDENCY.md is inside the helper and counts" \
+  SpeechHelper/DEPENDENCY.md
+
+# --- The shared CI-plumbing list -------------------------------------------
+# These are the only paths outside a helper directory that can change what
+# its unit suite tests: how the step is invoked, what decides it, and what
+# builds the helper.
+
+for helper in polish speech; do
+  expect "$helper" true "ci.yml runs both lanes" .github/workflows/ci.yml
+  expect "$helper" true "any scripts/ci/ change runs both lanes" \
+    scripts/ci/run-supervised-command.sh
+  expect "$helper" true "this filter's own edits prove both lanes first" \
+    scripts/ci/helper-lane-filter.sh
+  expect "$helper" true "package_app.sh builds both helpers" scripts/package_app.sh
+done
+
+# --- Independence: one helper never drags in the other ---------------------
+
+expect speech false "a PolishHelper-only diff must NOT run the speech lane" \
+  PolishHelper/Sources/PolishHelperCore/PolishRouter.swift
+expect polish false "a SpeechHelper-only diff must NOT run the polish lane" \
+  SpeechHelper/Sources/SpeechEngine/RealtimeServer.swift
+
+# --- The run=false side (the point of the change) ---------------------------
+
+expect polish false "root app sources do not run the polish lane" \
+  Sources/localvoxtral/SettingsView.swift Sources/localvoxtral/DictationViewModel.swift
+expect speech false "root app sources do not run the speech lane" \
+  Sources/localvoxtral/SettingsView.swift
+expect polish false "root tests do not run the polish lane" \
+  Tests/localvoxtralTests/DictationViewModelPolishTokenGuardTests.swift
+expect speech false "the root package manifest does not run the speech lane" \
+  Package.swift Package.resolved
+expect polish false "docs do not run the polish lane" README.md AGENTS.md
+expect speech false "a non-ci script does not run the speech lane" \
+  scripts/try-pr.sh
+expect polish false "empty changed-file list decides run=false (caller owns fail-open)" \
+  ""
+
+# --- Usage errors ----------------------------------------------------------
+
+expect_usage_error "an unknown helper name is a usage error" \
+  mystery /dev/null
+expect_usage_error "a missing changed-files file is a usage error" \
+  polish "$TMP_DIR/does-not-exist"
+
+printf 'OK: helper-lane-filter tests passed\n'


### PR DESCRIPTION
## What

Owner decision (option 8, 2026-09-05). The two helper **unit** suites ran on every self-hosted run — **11 s + 20 s measured** — including on diffs that could not possibly change what they test.

`scripts/ci/helper-lane-filter.sh` now decides each one, in the same shape and with the same self-test discipline as `llm-lane-filter.sh` / `speechd-lane-filter.sh` / `herdr-lane-filter.sh`:

| diff / event | polish suite | speech suite |
|---|---|---|
| `PolishHelper/**` (Package.swift, Package.resolved, Sources, Tests, DEPENDENCY.md) | run | skip |
| `SpeechHelper/**` | skip | run |
| `.github/workflows/ci.yml`, `scripts/ci/**`, `scripts/package_app.sh` | **run** | **run** |
| `workflow_dispatch` | **run** | **run** |
| every push to main | **run** | **run** |
| uncomputable diff, or an unrecognized event | **run** | **run** (fail open) |
| anything else | skip | skip |

### Why gating these is sound

**Both helpers are hermetic SwiftPM packages.** `PolishHelper/Package.swift` and `SpeechHelper/Package.swift` declare only REMOTE dependencies:

```
$ find PolishHelper SpeechHelper -type l          # symlinks out of the tree
(no output)
$ grep -rn '\.\./' PolishHelper/Sources PolishHelper/Tests \
      SpeechHelper/Sources SpeechHelper/Tests \
      PolishHelper/Package.swift SpeechHelper/Package.swift
(no output)
```

No `path:` dependency, no `..` reference, no symlink out of the directory, no source shared with the root package. A helper suite's only inputs are therefore (1) its own directory — `Package.resolved` included, which is the dependency-pin surface — (2) the Xcode toolchain, which is not a diff, and (3) the CI plumbing that invokes it. (3) is exactly the shared list in the table above.

**No marker, deliberately.** This is not the live-model lanes' "expensive, so opt in" pattern — nothing here is a judgment call. A diff that can affect a suite runs it; `workflow_dispatch` runs both, which is the escape hatch; main is never gated so it stays the parity reference. **Coverage is unchanged; only redundant executions go.**

Fail-open is modelled on `docs-only-filter.sh`: an uncomputable diff or an unrecognized event runs both rather than skipping, and the filter's own file lives under `scripts/ci/*` so every edit to it proves both lanes on its own first run.

`docs/agent/test-tiers.md` gets the helper suites on their own tier-0 row with the gating rule, plus a "Why the helper unit suites are path-gated" section carrying the hermeticity argument and the condition that would break it (if a helper ever gains a local `path:` dependency, the shared list must grow in the same PR).

## Proof

### Run 1 — a diff touching neither helper: BOTH lanes skipped

Throwaway PR #258 based on this branch, diff = one comment in `Tests/localvoxtralTests/AudioChunkBufferTests.swift` (a **non**-fast-path change, so the decide step really ran). Run **[33983446248](https://github.com/T0mSIlver/localvoxtral/actions/runs/33983446248)**, green, 295 s.

Step summary:

```
PolishHelper unit lane: SKIPPED (no PolishHelper-relevant changes (PolishHelper is a standalone
  package; nothing outside PolishHelper/ or the CI plumbing can change what its unit suite tests))
SpeechHelper unit lane: SKIPPED (no SpeechHelper-relevant changes (SpeechHelper is a standalone
  package; nothing outside SpeechHelper/ or the CI plumbing can change what its unit suite tests))
```

Step conclusions:

```
success  Decide helper unit lanes (path filter)
skipped  Polishing helper unit tests (PolishHelper package)
skipped  Speech helper unit tests (SpeechHelper package)
```

### Run 2 — a diff touching PolishHelper only: polish runs, speech does not

Same branch, one more throwaway commit adding a comment to `PolishHelper/Package.swift`. Run **[33983870517](https://github.com/T0mSIlver/localvoxtral/actions/runs/33983870517)**, green.

```
PolishHelper unit lane: RUNNING (matched PolishHelper/Package.swift (PolishHelper/*))
SpeechHelper unit lane: SKIPPED (no SpeechHelper-relevant changes (…))
```

```
success  2026-09-05T18:32:11Z -> 18:32:23Z  Polishing helper unit tests (PolishHelper package)   (12 s)
skipped                                     Speech helper unit tests (SpeechHelper package)
```

Bonus, from the same run: the **pre-existing** lanes still decide correctly on that diff — the LLM eval lane fired (`Polishing helper integration`, 105 s, `PolishHelper/*` is in `llm-lane-filter.sh` too) and the speechd live lane stayed skipped. The new filter does not disturb them.

Both probe commits are thrown away: PR #258 is closed unmerged and `probe/helper-lane-gate` is deleted from origin.

### Shell self-tests: red before, green after

`scripts/ci/test-helper-lane-filter.sh` — 33 assertions covering the event rules, each helper's directory (including `Package.resolved`), the shared plumbing list, independence in both directions, the `run=false` side, and the two usage errors. It runs in the per-push shell-test step.

GREEN, on the real filter:

```
$ ./scripts/ci/test-helper-lane-filter.sh; echo "exit=$?"
PASS: [polish] workflow_dispatch runs the polish lane whatever the diff (workflow_dispatch — dispatches build everything)
PASS: [polish] push (ci.yml only pushes on main) runs the polish lane (push to main — main is the parity reference and is never gated)
PASS: [polish] an unrecognized event fails open (unrecognized event 'merge_group' — failing open)
PASS: [polish] PolishHelper/Package.resolved is the pin surface (matched PolishHelper/Package.resolved (PolishHelper/*))
PASS: [speech] SpeechHelper/Package.resolved is the pin surface (matched SpeechHelper/Package.resolved (SpeechHelper/*))
PASS: [polish] package_app.sh builds both helpers (matched scripts/package_app.sh (scripts/package_app.sh))
PASS: [speech] a PolishHelper-only diff must NOT run the speech lane (no SpeechHelper-relevant changes …)
PASS: [polish] a SpeechHelper-only diff must NOT run the polish lane (no PolishHelper-relevant changes …)
… 33 assertions …
OK: helper-lane-filter tests passed
exit=0
```

RED, defect A — the shared CI-plumbing list gutted (`scripts/ci/*` and `scripts/package_app.sh` removed), i.e. the bug where a change to how the suite is invoked silently stops the suite running:

```
FAIL: any scripts/ci/ change runs both lanes: expected run=true, got run=false
  (no PolishHelper-relevant changes …)
exit=1
```

RED, defect B — the two helper pattern lists leaking into each other, i.e. the gate that gates nothing:

```
FAIL: a SpeechHelper-only diff must NOT run the polish lane: expected run=false, got run=true
  (matched SpeechHelper/Sources/SpeechEngine/RealtimeServer.swift (SpeechHelper/*))
exit=1
```

### Workflow still well-formed

```
$ ./scripts/ci/test-workflow-step-names.sh
test-workflow-step-names: OK (99 step names, no duplicates within a job)
```

37 steps, no duplicate names, and the two gated steps now read:

```
if: runner.environment == 'self-hosted' && steps.ci_scope.outputs.docs_only != 'true' && steps.helper_lanes.outputs.polish_run == 'true'
if: runner.environment == 'self-hosted' && steps.ci_scope.outputs.docs_only != 'true' && steps.helper_lanes.outputs.speech_run == 'true'
```

### This PR's own run

Its diff touches `.github/workflows/ci.yml` and `scripts/ci/**`, so by the rule above **both lanes must RUN here** — that is the shared-plumbing arm proving itself on the very change that introduces it.

## Note for the record: there is no required status check on `main`

Checked while writing this, because the decision memo claimed option 1 (moving tier 0 to hosted runners) would cost the owner a branch-protection edit:

```
$ gh api repos/T0mSIlver/localvoxtral/rules/branches/main --jq '.[] | {type, ruleset_id}'
{"ruleset_id":12971056,"type":"deletion"}
{"ruleset_id":12971056,"type":"non_fast_forward"}

$ gh api repos/T0mSIlver/localvoxtral/branches/main/protection
gh: Branch not protected (HTTP 404)
```

The ruleset carries **only** `deletion` and `non_fast_forward` — **no required status checks at all**, and no classic branch protection. So splitting `build-test` into two jobs costs **zero** hand steps today: nothing references the check by name. If the owner wants a required check, *adding* one is the hand step, and that is a new decision rather than a migration. Recorded in `local-notes/ci-design-options-2026-09-05.md`.

---

### This PR's own run, now green: run [33984716619](https://github.com/T0mSIlver/localvoxtral/actions/runs/33984716619)

The shared-plumbing arm proving itself on the change that introduces it:

```
PolishHelper unit lane: RUNNING (matched .github/workflows/ci.yml (.github/workflows/ci.yml))
SpeechHelper unit lane: RUNNING (matched .github/workflows/ci.yml (.github/workflows/ci.yml))
```

```
success  18:40:47 -> 18:40:47  Decide helper unit lanes (path filter)          (<1 s)
success  18:42:38 -> 18:42:50  Polishing helper unit tests (PolishHelper)      (12 s)
success  18:42:50 -> 18:43:09  Speech helper unit tests (SpeechHelper)         (19 s)
success  18:39:08 -> 18:40:46  Process-cleanup regression tests                (98 s, now with the 33 new assertions)
```

Job green in 327 s. The decide step itself costs **under a second**.
