### PR TITLE
CI: move tier 0 to GitHub-hosted macOS, keep only Mac-bound work on the Mac (option 1)

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -2,14 +2,40 @@
 
 ## `ci.yml`
 
-Every non-fast-path PR and push to main: build, advisory format lint (`.swift-format`;
-flips to `--strict` after the one-shot tree reformat), unit tests with a
-coverage summary (`llvm-cov report` over Sources — visibility for the PR
-Proof section, not a gate), live STT-service integration tests, app packaging,
-launch smoke test, an installable app artifact (`localvoxtral-app`, fetch
-with `scripts/try-pr.sh`), and a `localvoxtral-dsym` artifact (30-day
-retention) for symbolicating field crashes. Same-repo branches run on the
-self-hosted Mac runner; fork PRs run on GitHub-hosted macOS.
+`ci.yml` runs **two jobs in parallel**, split by what actually needs the
+owner's Mac (owner decision 2026-09-05):
+
+**`build-test` — GitHub-hosted macOS (`macos-latest`), every event, every
+contributor.** The required status check on main, and the portable half of CI:
+the pure-shell gate/process-cleanup suites, the installer-resolution test,
+advisory format lint (`.swift-format`; flips to `--strict` after the one-shot
+tree reformat), the unit suite with a coverage summary (`llvm-cov report` over
+Sources — visibility for the PR Proof section, not a gate), and the complete
+unit-test log as an artifact. Same-repo PRs run here too, not just forks: the
+single self-hosted runner was 89 % busy during a four-agent burst and 3.4 h of
+work produced 8.95 h of queue, while a measured hosted run executed the
+identical 2769 test cases in the same wall-clock with an 8 s queue — and
+hosted runners are free for public repositories.
+
+A **fork PR gets only this job** (`mac-lanes` never runs untrusted code on the
+owner's machine), so on a fork it additionally packages, uploads and
+launch-smokes an ad-hoc-signed bundle. Same-repo runs skip those steps here
+because `mac-lanes` does them with the real signing identity.
+
+**`mac-lanes` — the self-hosted Mac, same-repo PRs / pushes to main /
+dispatches only.** Everything a hosted runner cannot supply: packaging and
+launch-smoking the bundle signed with the stable `localvoxtral-dev` identity
+(an ad-hoc signature would invalidate the owner's Accessibility grant on every
+`scripts/try-pr.sh` install), the installable `localvoxtral-app` artifact and
+`localvoxtral-dsym` (30-day retention) for symbolicating field crashes, the
+live STT-service integration, the conditional polishd/speechd/herdr live-model
+lanes, the two MLX helper unit suites (kept here for the warm Cmlx build), the
+dogfood capture suite and packaging, the UI-gate install, and the process leak
+check. It keeps `clean: false` — the persistent warm `.build` that makes those
+lanes affordable.
+
+The two jobs run in parallel and share no artifact; each computes the
+docs-only fast-path decision itself rather than serialising behind a `needs:`.
 
 Both lanes build with whatever Xcode toolchain is already on the machine —
 no `Setup Swift` step. Fork PRs previously pinned a separate swift.org
@@ -17,15 +43,15 @@ toolchain (`swift-actions/setup-swift@v2`, `swift-version: "6.2"`), but its
 6.2.1 resolution ships with assertions enabled and asserts compiling this
 app's `@MainActor deinit`; Xcode's bundled toolchain doesn't have that
 problem, so hosted runners now use it too, same as self-hosted. Neither
-lane pins a version, so the hosted job records `xcodebuild -version` and
+lane pins a version, so `build-test` records `xcodebuild -version` and
 `swift --version` in its step summary and keys the SwiftPM cache on them —
 when the image's default Xcode moves, the log says which build ran and no
 `.build` tree crosses toolchains.
 
 Opt-in dogfood artifact: with the literal marker `[dogfood-package]` in the
 PR body / head commit message, or a `workflow_dispatch` with `dogfood=true`,
-the job packages a second, `LOCALVOXTRAL_DOGFOOD`-instrumented bundle after
-the launch smoke and uploads it as `localvoxtral-app-dogfood` (7-day
+`mac-lanes` packages a second, `LOCALVOXTRAL_DOGFOOD`-instrumented bundle
+after the launch smoke and uploads it as `localvoxtral-app-dogfood` (7-day
 retention) plus `localvoxtral-dsym-dogfood` (30-day — the instrumented
 binary's UUID differs from the clean dSYM's). Fetch and launch it with
 `scripts/try-pr.sh <pr|main> --dogfood`,
@@ -33,31 +59,24 @@ which also arms the runtime capture default. On manual dispatch the
 conditional live-model lanes (polishd/speechd) skip — the dispatched ref's
 own push/PR run already decided them.
 
-Forcing the hosted lane: `workflow_dispatch` with `hosted=true` runs
-`build-test` for a same-repo ref on `macos-latest` instead of the Mac —
+The `hosted` dispatch input is a **no-op** now: it existed to force
+`build-test` onto a hosted runner, which is where it always runs. It is kept
+for one release so a scripted `-f hosted=true` does not fail on an unknown
+input, and cannot be repurposed to move `mac-lanes` — that job exists
+precisely because its work needs that Mac.
 
-```bash
-gh workflow run CI --ref <branch> -f hosted=true
-```
-
-That is the only way to exercise the fork-PR lane without a fork, and it is
-also the switch for moving tier 0 off the personal Mac. Everything keyed on
-`runner.environment == 'self-hosted'` skips exactly as it does for a fork PR:
-the workspace process cleanup, all four lane-decide steps, the live STT /
-polishd / speechd / herdr lanes, both helper unit suites, the dogfood capture
-suite and packaging, the Metal-toolchain probe, and the process leak check.
-What remains is the shell-test step, the installer test, format lint, the unit
-suite, packaging (helpers skipped, ad-hoc signature), the artifacts, and the
-launch smoke. The input can only move a job toward `macos-latest`; no input
-value can pull a fork PR onto the self-hosted runner.
-
-The same `build-test` check takes a docs/scripts-only fast path when every
-changed file passes `scripts/ci/docs-only-filter.sh`; it then skips all Swift,
-helper, packaging, artifact, smoke, warm, and integration steps. The filter
-fails open to the full run for unknown or ambiguous diffs and excludes CI
-control files, packaging inputs (`assets/icons/**`), and every path selected
-by the LLM/speechd lane filters; an explicit `[run-llm-eval]` /
+The docs/scripts-only fast path applies to both jobs when every changed file
+passes `scripts/ci/docs-only-filter.sh`; they then skip all Swift, helper,
+packaging, artifact, smoke, warm, and integration steps. The filter fails open
+to the full run for unknown or ambiguous diffs and excludes CI control files,
+packaging inputs (`assets/icons/**`), and every path selected by the
+LLM/speechd lane filters; an explicit `[run-llm-eval]` /
 `[run-speechd-integration]` marker also forces the full run.
+
+The two helper unit suites are additionally path-gated per helper
+(`scripts/ci/helper-lane-filter.sh`): a PR runs a helper's suite only when the
+diff touches that helper's directory or the shared CI plumbing, while
+dispatches and every push to main run both.
 
 ## `release.yml`
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1180,8 +1180,14 @@ jobs:
         # 'true' in an expression coerces both to numbers (1 vs NaN) and is
         # therefore always false — a gate that silently never fires. The event
         # payload's copy is a string, so it compares as written.
+        # `runner.environment == 'self-hosted'` is redundant now that this
+        # whole job is self-hosted, and it stays on purpose: this is the one
+        # step that writes into the OWNER'S HOME. A guard that costs nothing
+        # and would catch someone moving the step to the wrong job is worth
+        # keeping, and scripts/ci/test-ui-gate.sh asserts it by name.
         if: >-
-          github.event_name == 'workflow_dispatch'
+          runner.environment == 'self-hosted'
+          && github.event_name == 'workflow_dispatch'
           && github.event.inputs.dogfood == 'true'
           && steps.dogfood_lane.outputs.run == 'true'
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,8 +14,15 @@ on:
         description: "Also package the dogfood-instrumented app (artifact: localvoxtral-app-dogfood)"
         type: boolean
         default: false
+      # REDUNDANT since build-test moved to hosted runners for every event
+      # (this PR): the job it used to redirect is now always on macos-latest,
+      # so this input has no effect on anything. Kept for one release so a
+      # scripted `gh workflow run CI -f hosted=true` does not start failing on
+      # an unknown input; delete it once nothing passes it. It cannot be
+      # repurposed to move mac-lanes — that job exists precisely because its
+      # work needs THAT Mac.
       hosted:
-        description: "Run build-test on a GitHub-hosted macOS runner instead of the Mac (the fork-PR lane)"
+        description: "No-op since build-test always runs on GitHub-hosted macOS. Retained for compatibility."
         type: boolean
         default: false
 
@@ -24,27 +31,391 @@ concurrency:
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 jobs:
+  # TIER 0 — GitHub-hosted macOS, for every event and every contributor.
+  #
+  # This is the required status check on main, and it is deliberately the
+  # portable half of CI: shell tests, format lint, the unit suite, coverage.
+  # It runs on hosted runners for SAME-REPO PRs too (owner decision
+  # 2026-09-05, "option 1"), which is what took tier 0 off the owner's
+  # personal MacBook — the single self-hosted runner was 89 % busy during a
+  # four-agent burst and 3.4 h of work produced 8.95 h of queue. Hosted
+  # runners are free for public repositories and start in seconds; the
+  # measured hosted lane (run 33981779091) executed the identical 2769 test
+  # cases in the same wall-clock a warm Mac run took, with an 8 s queue.
+  #
+  # A fork PR gets ONLY this job (mac-lanes refuses to run untrusted code on
+  # the owner's machine), so on a fork PR it also packages, uploads and
+  # launch-smokes an ad-hoc-signed bundle — the coverage a fork would
+  # otherwise lose. For same-repo runs mac-lanes does that with the real
+  # signing identity, so those steps are skipped here rather than duplicated.
   build-test:
-    # Same-repo branches run on the self-hosted Mac (persistent workspace, warm
-    # incremental builds). Fork PRs run on GitHub-hosted macOS so untrusted code
-    # never executes on the build machine.
-    #
-    # `workflow_dispatch` with hosted=true sends a SAME-REPO ref onto the hosted
-    # lane instead. Two uses: it is the only way to exercise the fork-PR lane
-    # without a fork (that lane's last real run predates #244's toolchain fix
-    # and nothing has proved it since), and it is the switch a decision to move
-    # tier 0 off the personal Mac would flip. The term only ever moves a job
-    # TOWARD macos-latest — a fork PR can never be pulled onto the self-hosted
-    # runner by an input, whatever it is set to.
-    #
-    # `github.event.inputs.hosted`, not `inputs.hosted`: the input is declared
-    # `type: boolean`, and comparing a boolean to the string 'true' in an
-    # expression coerces both to numbers (1 vs NaN) and is therefore always
-    # false. The event payload's copy is a string, so it compares as written.
-    # (Same trap as the dogfood UI-gate install step below; it cost a silently
-    # dead gate once already.) For push/pull_request the field is absent, which
-    # compares as '' and leaves the original routing untouched.
-    runs-on: ${{ (github.event.inputs.hosted != 'true' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)) && fromJSON('["self-hosted", "macOS", "ARM64"]') || 'macos-latest' }}
+    runs-on: macos-latest
+    timeout-minutes: 30
+    env:
+      # Step-level `if:` can read `env`; job-level `if:` cannot. Computed once
+      # here so every fork-only step reads the same expression.
+      IS_FORK_PR: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          # Full history + tags so package_app.sh can git-describe the
+          # artifact version (shallow clones can't, and fall back to 0.0.0-dev).
+          fetch-depth: 0
+          # No `clean: false` here: hosted runners are ephemeral, so there
+          # is no warm .build to preserve and nothing a previous run left
+          # behind. The persistent-workspace machinery lives in mac-lanes.
+
+      - name: Decide CI fast path
+        id: ci_scope
+        env:
+          PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          PUSH_BEFORE_SHA: ${{ github.event.before }}
+          PUSH_AFTER_SHA: ${{ github.event.after }}
+          # env indirection, not inline ${{ }} in the script body: PR bodies
+          # and commit messages are attacker-shaped strings (same discipline as
+          # the lane-decide steps below).
+          PR_BODY: ${{ github.event.pull_request.body }}
+          PUSH_HEAD_MESSAGE: ${{ github.event.head_commit.message }}
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -uo pipefail
+          FILES="$RUNNER_TEMP/ci-fast-path-changed-files.txt"
+
+          full_run() {
+            local reason="$1"
+            echo "docs_only=false" >> "$GITHUB_OUTPUT"
+            echo "CI fast path: full run ($reason)" | tee -a "$GITHUB_STEP_SUMMARY"
+            exit 0
+          }
+
+          # Both runner types use the same job. Fetch the event's exact diff
+          # endpoints explicitly: the persistent checkout uses clean: false,
+          # and checkout/history behavior must never be trusted as a skip gate.
+          if [[ "$GITHUB_EVENT_NAME" == "pull_request" ]]; then
+            if [[ -z "$PR_BASE_SHA" ]] \
+                || ! git fetch --no-tags origin "$PR_BASE_SHA" \
+                || ! git cat-file -e "$PR_BASE_SHA^{commit}" 2>/dev/null; then
+              full_run "PR base unavailable — failing open"
+            fi
+            BASE="$PR_BASE_SHA"
+            TARGET="HEAD"
+          elif [[ "$GITHUB_EVENT_NAME" == "push" ]]; then
+            if [[ -z "$PUSH_BEFORE_SHA" || "$PUSH_BEFORE_SHA" =~ ^0+$ ]]; then
+              full_run "push before SHA is empty/all-zero — failing open"
+            fi
+            if [[ -z "$PUSH_AFTER_SHA" ]] \
+                || ! git fetch --no-tags origin "$PUSH_AFTER_SHA" \
+                || ! git cat-file -e "$PUSH_AFTER_SHA^{commit}" 2>/dev/null; then
+              full_run "push after SHA unavailable — failing open"
+            fi
+            if ! git cat-file -e "$PUSH_BEFORE_SHA^{commit}" 2>/dev/null \
+                && ! git fetch --no-tags origin "$PUSH_BEFORE_SHA"; then
+              full_run "push before SHA unavailable — failing open"
+            fi
+            if ! git cat-file -e "$PUSH_BEFORE_SHA^{commit}" 2>/dev/null; then
+              full_run "push before SHA is not a commit — failing open"
+            fi
+            BASE="$PUSH_BEFORE_SHA"
+            TARGET="$PUSH_AFTER_SHA"
+          else
+            full_run "unsupported event $GITHUB_EVENT_NAME — failing open"
+          fi
+
+          if ! git diff --name-only "$BASE" "$TARGET" -- > "$FILES"; then
+            full_run "changed-file diff failed — failing open"
+          fi
+          # The explicit lane markers are an opt-in contract (docs/agent/test-tiers.md "When
+          # must the LLM lanes run?"): they must keep working even when the
+          # diff itself is docs-only, so they force the full path BEFORE the
+          # filter can decide otherwise.
+          MARKER_TEXT="${PR_BODY}"$'\n'"${PUSH_HEAD_MESSAGE}"
+          if [[ "$GITHUB_EVENT_NAME" == "pull_request" && -n "$PR_HEAD_SHA" ]]; then
+            # On PRs, head_commit.message is empty and HEAD is the synthetic
+            # merge commit. The marker contract includes the PR's real head
+            # commit message (the lane decide steps below read it), so this
+            # fast-path escape hatch must read it too — otherwise a marker
+            # carried only by the head commit of a docs-only diff would be
+            # skipped straight past the lane it asked for.
+            MARKER_TEXT+=$'\n'"$(git log -1 --format=%B "$PR_HEAD_SHA" 2>/dev/null || true)"
+          fi
+          if grep -qF '[run-llm-eval]' <<<"$MARKER_TEXT" \
+              || grep -qF '[run-speechd-integration]' <<<"$MARKER_TEXT" \
+              || grep -qF '[run-herdr-integration]' <<<"$MARKER_TEXT" \
+              || grep -qF '[dogfood-package]' <<<"$MARKER_TEXT"; then
+            full_run "explicit lane marker present in PR body / head commit"
+          fi
+
+          if ! DECISION="$(./scripts/ci/docs-only-filter.sh "$FILES")"; then
+            full_run "docs-only filter failed — failing open"
+          fi
+
+          DOCS_ONLY="$(sed -n 's/^docs_only=//p' <<<"$DECISION")"
+          COUNT="$(sed -n 's/^count=//p' <<<"$DECISION")"
+          REASON="$(sed -n 's/^reason=//p' <<<"$DECISION")"
+          if [[ "$DOCS_ONLY" != "true" && "$DOCS_ONLY" != "false" ]] \
+              || [[ ! "$COUNT" =~ ^[0-9]+$ ]] || [[ -z "$REASON" ]]; then
+            full_run "docs-only filter returned an ambiguous decision — failing open"
+          fi
+
+          echo "$DECISION" >> "$GITHUB_OUTPUT"
+          if [[ "$DOCS_ONLY" == "true" ]]; then
+            echo "CI fast path: docs/scripts-only diff — Swift lanes skipped ($COUNT changed file(s))" \
+              | tee -a "$GITHUB_STEP_SUMMARY"
+          else
+            echo "CI fast path: full run ($REASON)" | tee -a "$GITHUB_STEP_SUMMARY"
+          fi
+
+      - name: Process-cleanup regression tests
+        # Pure shell tests for the workspace selector, the SSH build gate's
+        # TERM -> KILL process-group teardown, and the SSH UI gate's allowlist /
+        # lock refusal / window-ownership rules. Pure shell against PATH stubs,
+        # so it needs no Mac and no GUI — which is why it belongs here rather
+        # than on the runner whose gates it is testing.
+        # Deliberately NOT gated on the docs-only fast path: the gate scripts
+        # are fast-path-eligible, so these tests are what still exercises a
+        # gate-only diff. That also makes them the bulk of a fast-path run.
+        #
+        # Not cheap: test-ui-gate.sh alone is ~80 s of the ~95 s here
+        # (measured 2026-09-05, PR #238's 105 assertions each re-running the
+        # gate). Keep it to ONE copy — a duplicated pair of these steps went
+        # unnoticed for six weeks (#255) — and think before adding another
+        # gate suite that re-execs a shell script per assertion.
+        run: |
+          ./scripts/ci/test-cleanup-stale-test-processes.sh
+          ./scripts/ci/test-build-gate-process-cleanup.sh
+          ./scripts/ci/test-build-gate-reap-command.sh
+          ./scripts/ci/test-build-gate-gc-command.sh
+          ./scripts/ci/test-remote-build-reap.sh
+          ./scripts/ci/test-remote-build-gc.sh
+          ./scripts/ci/test-run-supervised-command.sh
+          ./scripts/ci/test-ui-smoke-guard.sh
+          ./scripts/ci/test-ui-gate.sh
+          ./scripts/ci/test-runner-node-resign.sh
+          ./scripts/ci/test-ac-power-guard.sh
+          ./scripts/ci/test-llm-lane-filter.sh
+          ./scripts/ci/test-herdr-lane-filter.sh
+          ./scripts/ci/test-helper-lane-filter.sh
+          ./scripts/ci/test-herdr-fixture-recovery.sh
+          ./scripts/ci/test-clean-stale-outputs.sh
+          ./scripts/ci/test-workflow-step-names.sh
+
+      - name: Record hosted toolchain
+        id: hosted_toolchain
+        if: steps.ci_scope.outputs.docs_only != 'true'
+        run: |
+          xcodebuild -version | tee -a "$GITHUB_STEP_SUMMARY"
+          swift --version | tee -a "$GITHUB_STEP_SUMMARY"
+          # Cache-key component: a .build tree produced by one toolchain must
+          # never be restored into a build running under another.
+          SLUG="$(swift --version | head -1 | tr -cs 'a-zA-Z0-9.' '-' | cut -c1-48)"
+          echo "slug=$SLUG" >> "$GITHUB_OUTPUT"
+
+      - name: Cache SwiftPM build
+        if: steps.ci_scope.outputs.docs_only != 'true'
+        uses: actions/cache@v4
+        with:
+          path: .build
+          # Keyed on the toolchain as well as Package.resolved: the old key
+          # (and its bare `swiftpm-macOS-` restore prefix) would happily
+          # restore a swift.org-6.2.1-built .build into an Xcode build.
+          key: swiftpm-${{ runner.os }}-${{ runner.arch }}-${{ steps.hosted_toolchain.outputs.slug }}-${{ hashFiles('Package.resolved') }}
+          restore-keys: swiftpm-${{ runner.os }}-${{ runner.arch }}-${{ steps.hosted_toolchain.outputs.slug }}-
+
+      - name: Installer asset-resolution regression test (issue #131)
+        # Pure bash against a stubbed curl — no network, sub-second.
+        run: ./scripts/ci/test-install-resolve.sh
+
+      - name: Format lint (advisory)
+        # Advisory until the one-shot tree reformat lands: swift-format exits 0
+        # on findings without --strict. After the reformat, add --strict here
+        # to make style regressions block.
+        if: steps.ci_scope.outputs.docs_only != 'true'
+        run: |
+          swift format lint --recursive --parallel Sources Tests Package.swift 2>&1 \
+            | tee format-lint.txt | tail -n 5
+          echo "format-lint findings: $(wc -l < format-lint.txt | tr -d ' ')"
+
+      - name: Test (unit suite)
+        # The integration suite needs a live inference backend and is exercised
+        # manually; see CLAUDE.md. This is also the job's compile gate: the
+        # old standalone `swift build` step built plain-debug products that
+        # nothing downstream consumed (tests rebuild with coverage flags,
+        # packaging builds release), so it was pure duplicate compilation.
+        if: steps.ci_scope.outputs.docs_only != 'true'
+        run: |
+          # AgentDictationE2EEvalTests is skipped explicitly (belt) on top of
+          # the marker cleanup above (suspenders): it is the nightly
+          # eval-e2e.yml lane, never tier 0, and a leftover enable marker must
+          # not turn the unit step into a many-minute live-inference run.
+          #
+          # 900 s flat. This step used to pick 300 s on the self-hosted runner
+          # and 900 s on hosted; it now only ever runs hosted, where the build
+          # is cold (~70 s) and the machine is a 3-core shared VM, so the
+          # generous bound is the right one. The point of the supervisor is
+          # forensics on a HANG (it samples the wedged xctest before killing
+          # it), not a tight performance budget.
+          ./scripts/ci/run-supervised-command.sh \
+            900 "$RUNNER_TEMP/localvoxtral-unit-tests.log" -- \
+            swift test \
+            --skip RealtimeAPIVLLMIntegrationTests \
+            --skip SpeechHelperIntegrationTests \
+            --skip AgentDictationE2EEvalTests \
+            --skip HerdrIntegrationTests \
+            --enable-code-coverage
+
+      - name: Upload complete unit-test log
+        if: ${{ always() && steps.ci_scope.outputs.docs_only != 'true' }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: unit-test-log-${{ runner.os }}
+          path: ${{ runner.temp }}/localvoxtral-unit-tests.log
+          if-no-files-found: error
+          retention-days: 7
+
+      - name: Coverage summary
+        # Visibility, not a gate: lets a PR's Proof section cite real coverage
+        # of the changed files instead of "a test exists".
+        if: steps.ci_scope.outputs.docs_only != 'true'
+        run: |
+          set -euo pipefail
+          BIN="$(find .build -type f -name localvoxtralPackageTests -path '*.xctest/Contents/MacOS/*' | head -n 1)"
+          PROF="$(find .build -type f -name default.profdata -path '*debug*' | head -n 1)"
+          if [[ -z "$BIN" || -z "$PROF" ]]; then
+            echo "coverage data not found under .build"; exit 1
+          fi
+          xcrun llvm-cov report "$BIN" -instr-profile "$PROF" \
+            -ignore-filename-regex '(Tests|\.build)/'
+
+      - name: Package app bundle
+        # FORK PRs ONLY. A fork gets no mac-lanes job, so this is the only
+        # place its change is packaged, launch-smoked and turned into a
+        # downloadable artifact — without it a fork would lose that coverage
+        # entirely. Same-repo runs skip it because mac-lanes packages with the
+        # real localvoxtral-dev identity a few minutes later, and building the
+        # bundle twice per run would be pure waste.
+        #
+        # Ad-hoc signature and no MLX helpers, both unavoidable here: the
+        # signing cert lives in the owner's keychain, and a hosted runner has
+        # no MetalToolchain component (a cold MLX C++ build would dominate
+        # fork-PR CI anyway). The helpers' real Metal build is a mac-lanes job.
+        if: steps.ci_scope.outputs.docs_only != 'true' && env.IS_FORK_PR == 'true'
+        env:
+          LOCALVOXTRAL_CODESIGN_IDENTITY: localvoxtral-dev
+          LOCALVOXTRAL_SKIP_POLISHD: "1"
+          LOCALVOXTRAL_SKIP_SPEECHD: "1"
+          # Self-hosted lanes (same-repo PRs, main) MUST ship an identity-signed
+          # bundle so try-pr.sh leaves the signature untouched and the owner's
+          # Accessibility (TCC) grant survives across builds. Fail the build
+          # loudly rather than silently upload an ad-hoc artifact if the runner
+          # user's keychain has lost the cert. Hosted fork-PR runners have no
+          # cert and are expected to be ad-hoc, so the requirement is off there.
+          LOCALVOXTRAL_REQUIRE_CODESIGN_IDENTITY: "0"
+        run: ./scripts/package_app.sh release
+
+      - name: Zip app for artifact upload
+        # upload-artifact mangles symlinks/exec bits in .app bundles; ditto-zip
+        # first so the downloaded app keeps a valid signature.
+        if: steps.ci_scope.outputs.docs_only != 'true' && env.IS_FORK_PR == 'true'
+        run: ditto -c -k --sequesterRsrc --keepParent dist/localvoxtral.app dist/localvoxtral-app.zip
+
+      - name: Upload app artifact
+        if: steps.ci_scope.outputs.docs_only != 'true' && env.IS_FORK_PR == 'true'
+        uses: actions/upload-artifact@v4
+        with:
+          name: localvoxtral-app
+          path: dist/localvoxtral-app.zip
+          retention-days: 7
+
+      - name: Zip dSYM for artifact upload
+        # Includes helper dSYMs when present (self-hosted lanes) — helper
+        # crashes (MLX C++/Metal) are the likeliest field
+        # crashes, and a dSYM that never leaves the runner symbolizes nothing.
+        if: steps.ci_scope.outputs.docs_only != 'true' && env.IS_FORK_PR == 'true'
+        run: |
+          ditto -c -k --keepParent dist/localvoxtral.dSYM dist/localvoxtral-dSYM.zip
+          if [[ -d dist/localvoxtral-polishd.dSYM ]]; then
+            ditto -c -k --keepParent dist/localvoxtral-polishd.dSYM dist/localvoxtral-polishd-dSYM.zip
+          fi
+          if [[ -d dist/localvoxtral-speechd.dSYM ]]; then
+            ditto -c -k --keepParent dist/localvoxtral-speechd.dSYM dist/localvoxtral-speechd-dSYM.zip
+          fi
+
+      - name: Upload dSYM artifact
+        # Longer retention than the app: field crashes surface days after the
+        # try-pr build that produced them.
+        if: steps.ci_scope.outputs.docs_only != 'true' && env.IS_FORK_PR == 'true'
+        uses: actions/upload-artifact@v4
+        with:
+          name: localvoxtral-dsym
+          path: |
+            dist/localvoxtral-dSYM.zip
+            dist/localvoxtral-polishd-dSYM.zip
+            dist/localvoxtral-speechd-dSYM.zip
+          retention-days: 30
+
+      - name: Smoke test packaged app launch (end-user simulation)
+        if: steps.ci_scope.outputs.docs_only != 'true' && env.IS_FORK_PR == 'true'
+        env:
+          # TCC attributes the launched app's permission checks to the
+          # runner's bundled node (the service's responsible process). A
+          # runner auto-update swaps that node and invalidates its
+          # Accessibility grant, so the app's startup prompt pops a REAL
+          # dialog on the runner's GUI session on every run (2026-07-24).
+          # Suppress only the startup prompts; the launch path stays
+          # production-shaped.
+          LOCALVOXTRAL_SUPPRESS_STARTUP_PERMISSION_PROMPTS: "1"
+        run: |
+          # Launch a COPY of the packaged app from outside the workspace with
+          # the workspace .build renamed away. A same-tree launch silently
+          # passes even when the binary's resource lookup depends on the
+          # builder's absolute .build path (SwiftPM's generated Bundle.module
+          # accessor falls back to it) — which crashes at launch on every
+          # OTHER machine. That masking shipped launch-broken artifacts (#87).
+          SMOKE_DIR="$(mktemp -d)"
+          ditto dist/localvoxtral.app "$SMOKE_DIR/localvoxtral.app"
+          mv .build .build.smoke-hidden
+          trap 'mv .build.smoke-hidden .build' EXIT
+          SMOKE_APP="$SMOKE_DIR/localvoxtral.app" python3 - <<'PY'
+          import os
+          import subprocess
+          import time
+
+          app_binary = os.environ["SMOKE_APP"] + "/Contents/MacOS/localvoxtral"
+          process = subprocess.Popen([app_binary])
+          time.sleep(2)
+
+          exit_code = process.poll()
+          if exit_code is not None:
+            raise SystemExit(f"packaged app exited during smoke test: {exit_code}")
+
+          process.terminate()
+          try:
+            process.wait(timeout=5)
+          except subprocess.TimeoutExpired:
+            process.kill()
+            process.wait(timeout=5)
+          PY
+
+  # EVERYTHING THAT NEEDS THIS PARTICULAR MAC, and nothing else.
+  #
+  # The owner's personal MacBook holds the things a hosted runner cannot
+  # supply: the stable `localvoxtral-dev` signing identity (an ad-hoc
+  # signature would invalidate the owner's Accessibility grant on every
+  # try-pr.sh install), the launch-on-demand speechd STT service and the
+  # multi-GB model weights the live lanes need, a real Metal toolchain for
+  # the two MLX helpers, the herdr/sshd fixture, and the GUI session the
+  # UI-gate artifact root lives in.
+  #
+  # Runs in PARALLEL with build-test, not after it: they share no artifact,
+  # and each computes the fast-path decision itself (a sub-second step)
+  # rather than serialising behind a `needs:`.
+  #
+  # NEVER runs for a fork PR — the whole point of the split above.
+  mac-lanes:
+    if: >-
+      github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: [self-hosted, macOS, ARM64]
     timeout-minutes: 30
     steps:
       - name: Checkout
@@ -178,40 +549,7 @@ jobs:
         # and leave swift-package/xctest running in this persistent checkout.
         # Scope by current user + lsof cwd/mapped text; never pkill globally
         # because the owner and parallel worktrees may run legitimate tests.
-        if: runner.environment == 'self-hosted'
         run: ./scripts/ci/cleanup-stale-test-processes.sh "$GITHUB_WORKSPACE"
-
-      - name: Process-cleanup regression tests
-        # Pure shell tests for the workspace selector, the SSH build gate's
-        # TERM -> KILL process-group teardown, and the SSH UI gate's allowlist /
-        # lock refusal / window-ownership rules. Runs on hosted fork PRs too.
-        # Deliberately NOT gated on the docs-only fast path: the gate scripts
-        # are fast-path-eligible, so these tests are what still exercises a
-        # gate-only diff.
-        #
-        # No longer cheap: test-ui-gate.sh alone is ~80 s of the ~95 s here
-        # (measured 2026-09-05, PR #238's 105 assertions each re-running the
-        # gate). That makes this the second most expensive step in the job —
-        # keep it to ONE copy, and think before adding another gate suite that
-        # re-execs a shell script per assertion.
-        run: |
-          ./scripts/ci/test-cleanup-stale-test-processes.sh
-          ./scripts/ci/test-build-gate-process-cleanup.sh
-          ./scripts/ci/test-build-gate-reap-command.sh
-          ./scripts/ci/test-build-gate-gc-command.sh
-          ./scripts/ci/test-remote-build-reap.sh
-          ./scripts/ci/test-remote-build-gc.sh
-          ./scripts/ci/test-run-supervised-command.sh
-          ./scripts/ci/test-ui-smoke-guard.sh
-          ./scripts/ci/test-ui-gate.sh
-          ./scripts/ci/test-runner-node-resign.sh
-          ./scripts/ci/test-ac-power-guard.sh
-          ./scripts/ci/test-llm-lane-filter.sh
-          ./scripts/ci/test-herdr-lane-filter.sh
-          ./scripts/ci/test-helper-lane-filter.sh
-          ./scripts/ci/test-herdr-fixture-recovery.sh
-          ./scripts/ci/test-clean-stale-outputs.sh
-          ./scripts/ci/test-workflow-step-names.sh
 
       - name: Decide LLM eval lane (path filter + [run-llm-eval] marker)
         # CI must not pay ~8 min of 4B weight-loading + live inference on
@@ -224,7 +562,7 @@ jobs:
         # "When must the LLM lanes run?". The PolishHelper UNIT suite and the
         # tier-1 speechd realtime integration stay per-push.
         id: llm_lane
-        if: runner.environment == 'self-hosted' && steps.ci_scope.outputs.docs_only != 'true'
+        if: steps.ci_scope.outputs.docs_only != 'true'
         env:
           # env indirection, not inline ${{ }} in the script body: PR bodies
           # and commit messages are attacker-shaped strings.
@@ -291,7 +629,7 @@ jobs:
         # Real speechd inference loads the multi-GB Voxtral model on the
         # personal-Mac runner, so keep it conditional just like polishd.
         id: speechd_lane
-        if: runner.environment == 'self-hosted' && steps.ci_scope.outputs.docs_only != 'true'
+        if: steps.ci_scope.outputs.docs_only != 'true'
         env:
           PR_BODY: ${{ github.event.pull_request.body }}
           PUSH_HEAD_MESSAGE: ${{ github.event.head_commit.message }}
@@ -349,7 +687,7 @@ jobs:
         # can change what we say to herdr or believe it said, and stay out of
         # the way otherwise. Path list: scripts/ci/herdr-lane-filter.sh.
         id: herdr_lane
-        if: runner.environment == 'self-hosted' && steps.ci_scope.outputs.docs_only != 'true'
+        if: steps.ci_scope.outputs.docs_only != 'true'
         env:
           PR_BODY: ${{ github.event.pull_request.body }}
           PUSH_HEAD_MESSAGE: ${{ github.event.head_commit.message }}
@@ -409,7 +747,7 @@ jobs:
         # NEXT clean run recompiles it back. No path filter: dogfooding is a
         # human decision, not a diff property.
         id: dogfood_lane
-        if: runner.environment == 'self-hosted' && steps.ci_scope.outputs.docs_only != 'true'
+        if: steps.ci_scope.outputs.docs_only != 'true'
         env:
           # env indirection, not inline ${{ }} in the script body: PR bodies
           # and commit messages are attacker-shaped strings.
@@ -466,7 +804,7 @@ jobs:
         # filter decides that, not this step), so a dispatch is the escape
         # hatch and main stays the ungated parity reference.
         id: helper_lanes
-        if: runner.environment == 'self-hosted' && steps.ci_scope.outputs.docs_only != 'true'
+        if: steps.ci_scope.outputs.docs_only != 'true'
         env:
           PUSH_BEFORE_SHA: ${{ github.event.before }}
           BASE_REF: ${{ github.base_ref }}
@@ -524,92 +862,6 @@ jobs:
       # did — so the step below records it, both for the log and for the cache
       # key. A toolchain that is too old fails loudly at compile time; the
       # package needs swift-tools-version 6.2 to parse the manifest at all.
-      - name: Record hosted toolchain
-        id: hosted_toolchain
-        if: runner.environment == 'github-hosted' && steps.ci_scope.outputs.docs_only != 'true'
-        run: |
-          xcodebuild -version | tee -a "$GITHUB_STEP_SUMMARY"
-          swift --version | tee -a "$GITHUB_STEP_SUMMARY"
-          # Cache-key component: a .build tree produced by one toolchain must
-          # never be restored into a build running under another.
-          SLUG="$(swift --version | head -1 | tr -cs 'a-zA-Z0-9.' '-' | cut -c1-48)"
-          echo "slug=$SLUG" >> "$GITHUB_OUTPUT"
-
-      - name: Cache SwiftPM build
-        if: runner.environment == 'github-hosted' && steps.ci_scope.outputs.docs_only != 'true'
-        uses: actions/cache@v4
-        with:
-          path: .build
-          # Keyed on the toolchain as well as Package.resolved: the old key
-          # (and its bare `swiftpm-macOS-` restore prefix) would happily
-          # restore a swift.org-6.2.1-built .build into an Xcode build.
-          key: swiftpm-${{ runner.os }}-${{ runner.arch }}-${{ steps.hosted_toolchain.outputs.slug }}-${{ hashFiles('Package.resolved') }}
-          restore-keys: swiftpm-${{ runner.os }}-${{ runner.arch }}-${{ steps.hosted_toolchain.outputs.slug }}-
-
-      - name: Installer asset-resolution regression test (issue #131)
-        # Pure bash against a stubbed curl — no network, sub-second.
-        run: ./scripts/ci/test-install-resolve.sh
-
-      - name: Format lint (advisory)
-        # Advisory until the one-shot tree reformat lands: swift-format exits 0
-        # on findings without --strict. After the reformat, add --strict here
-        # to make style regressions block.
-        if: steps.ci_scope.outputs.docs_only != 'true'
-        run: |
-          swift format lint --recursive --parallel Sources Tests Package.swift 2>&1 \
-            | tee format-lint.txt | tail -n 5
-          echo "format-lint findings: $(wc -l < format-lint.txt | tr -d ' ')"
-
-      - name: Test (unit suite)
-        # The integration suite needs a live inference backend and is exercised
-        # manually; see CLAUDE.md. This is also the job's compile gate: the
-        # old standalone `swift build` step built plain-debug products that
-        # nothing downstream consumed (tests rebuild with coverage flags,
-        # packaging builds release), so it was pure duplicate compilation.
-        if: steps.ci_scope.outputs.docs_only != 'true'
-        env:
-          RUNNER_ENVIRONMENT: ${{ runner.environment }}
-        run: |
-          # AgentDictationE2EEvalTests is skipped explicitly (belt) on top of
-          # the marker cleanup above (suspenders): it is the nightly
-          # eval-e2e.yml lane, never tier 0, and a leftover enable marker in
-          # this persistent workspace must not turn the unit step into a
-          # many-minute live-inference run.
-          timeout_seconds=900
-          if [[ "$RUNNER_ENVIRONMENT" == "self-hosted" ]]; then
-            timeout_seconds=300
-          fi
-          ./scripts/ci/run-supervised-command.sh \
-            "$timeout_seconds" "$RUNNER_TEMP/localvoxtral-unit-tests.log" -- \
-            swift test \
-            --skip RealtimeAPIVLLMIntegrationTests \
-            --skip SpeechHelperIntegrationTests \
-            --skip AgentDictationE2EEvalTests \
-            --skip HerdrIntegrationTests \
-            --enable-code-coverage
-
-      - name: Upload complete unit-test log
-        if: ${{ always() && steps.ci_scope.outputs.docs_only != 'true' }}
-        uses: actions/upload-artifact@v4
-        with:
-          name: unit-test-log-${{ runner.os }}
-          path: ${{ runner.temp }}/localvoxtral-unit-tests.log
-          if-no-files-found: error
-          retention-days: 7
-
-      - name: Coverage summary
-        # Visibility, not a gate: lets a PR's Proof section cite real coverage
-        # of the changed files instead of "a test exists".
-        if: steps.ci_scope.outputs.docs_only != 'true'
-        run: |
-          set -euo pipefail
-          BIN="$(find .build -type f -name localvoxtralPackageTests -path '*.xctest/Contents/MacOS/*' | head -n 1)"
-          PROF="$(find .build -type f -name default.profdata -path '*debug*' | head -n 1)"
-          if [[ -z "$BIN" || -z "$PROF" ]]; then
-            echo "coverage data not found under .build"; exit 1
-          fi
-          xcrun llvm-cov report "$BIN" -instr-profile "$PROF" \
-            -ignore-filename-regex '(Tests|\.build)/'
 
       - name: Warm on-demand speechd server
         # The build host's speechd STT test service is launch-on-demand (its
@@ -617,8 +869,8 @@ jobs:
         # Touch its trigger and block until port 8000 is healthy so the
         # integration suite below hits warm weights; this also resets the idle
         # window, so a burst of CI runs reuses one warm process and the reaper
-        # frees the RAM only after the machine goes quiet. Self-hosted only —
-        # hosted runners have no backend and the suite self-skips.
+        # frees the RAM only after the machine goes quiet. This service is the
+        # reason the live-STT lane cannot leave this machine.
         #
         # The `ensure speechd` name works whether the host still runs the retired
         # Python voxmlx plist or the swapped-in Swift speechd plist: both are
@@ -629,7 +881,7 @@ jobs:
         # run dir is absent and there is nothing to warm — the still-resident
         # STT service serves the suite, so skip cleanly instead of failing CI.
         # The integration step below is the real gate on the STT service.
-        if: runner.environment == 'self-hosted' && steps.ci_scope.outputs.docs_only != 'true'
+        if: steps.ci_scope.outputs.docs_only != 'true'
         run: |
           if [ -d /Users/Shared/localvoxtral/run ]; then
             ./scripts/mac/lv-test-servers.sh ensure speechd
@@ -641,9 +893,9 @@ jobs:
       - name: Integration tests (live STT service)
         # The self-hosted runner has the STT test service serving locally
         # (launchd service com.localvoxtral.testspeechd, warmed on-demand by the
-        # step above). On GitHub-hosted runners there is no backend and the suite
-        # self-skips, so this step is self-hosted only.
-        if: runner.environment == 'self-hosted' && steps.ci_scope.outputs.docs_only != 'true'
+        # step above). Nowhere else has that backend, which is why this lane
+        # stayed behind when tier 0 moved to hosted runners.
+        if: steps.ci_scope.outputs.docs_only != 'true'
         env:
           VLLM_REALTIME_TEST_ENABLE: "1"
           VLLM_REALTIME_TEST_MODEL: T0mSIlver/Voxtral-Mini-4B-Realtime-2602-4bit-qhead
@@ -662,7 +914,7 @@ jobs:
         # takes over the account's herdr config, which a hosted fork-PR runner
         # must never be asked to do. Local equivalent:
         # ./scripts/remote-build.sh integration-herdr
-        if: runner.environment == 'self-hosted' && steps.ci_scope.outputs.docs_only != 'true' && steps.herdr_lane.outputs.run == 'true'
+        if: steps.ci_scope.outputs.docs_only != 'true' && steps.herdr_lane.outputs.run == 'true'
         env:
           HERDR_INTEGRATION_TEST_ENABLE: "1"
         # --enable-code-coverage matches the unit step's build flags (same
@@ -670,21 +922,22 @@ jobs:
         run: swift test --filter HerdrIntegrationTests --enable-code-coverage
 
       - name: Polishing helper unit tests (PolishHelper package)
-        # Self-hosted only: hosted runners would pay a cold Cmlx C++ compile
-        # every fork PR. These tests are Metal-free (HTTP layer, router,
-        # cache locator, watchdog); the Metal path is covered below.
+        # Metal-free (HTTP layer, router, cache locator, watchdog); the Metal
+        # path is the packaging step below. Kept on the Mac rather than moved
+        # to build-test because a hosted runner would pay a cold Cmlx C++
+        # compile for it on every single run, warm here via clean: false.
         # Path-gated by the decide step above — see its comment for why that
         # is sound and scripts/ci/helper-lane-filter.sh for the rules.
-        if: runner.environment == 'self-hosted' && steps.ci_scope.outputs.docs_only != 'true' && steps.helper_lanes.outputs.polish_run == 'true'
+        if: steps.ci_scope.outputs.docs_only != 'true' && steps.helper_lanes.outputs.polish_run == 'true'
         run: swift test --package-path PolishHelper
 
       - name: Speech helper unit tests (SpeechHelper package)
-        # Self-hosted only, matching PolishHelper: this is the per-push,
-        # Metal-free codec/delta/watchdog suite. Real Metal inference is the
+        # Matching PolishHelper: the Metal-free codec/delta/watchdog suite,
+        # kept here for the same warm-Cmlx reason. Real Metal inference is the
         # conditional post-packaging lane below.
         # Path-gated by the decide step above — see its comment for why that
         # is sound and scripts/ci/helper-lane-filter.sh for the rules.
-        if: runner.environment == 'self-hosted' && steps.ci_scope.outputs.docs_only != 'true' && steps.helper_lanes.outputs.speech_run == 'true'
+        if: steps.ci_scope.outputs.docs_only != 'true' && steps.helper_lanes.outputs.speech_run == 'true'
         run: swift test --package-path SpeechHelper
 
       - name: Dogfood capture suite (instrumented build)
@@ -694,9 +947,10 @@ jobs:
         # this step the capture would rot silently: nothing else in CI ever
         # builds it, and it is only ever exercised by hand.
         #
-        # Self-hosted only, matching the helper suites: it is a second full
-        # compile of the app target, which a fork PR should not pay for.
-        if: runner.environment == 'self-hosted' && steps.ci_scope.outputs.docs_only != 'true'
+        # Kept on the Mac, matching the helper suites: it is a second full
+        # compile of the app target against a warm .build, which a cold hosted
+        # runner would pay from scratch.
+        if: steps.ci_scope.outputs.docs_only != 'true'
         env:
           LOCALVOXTRAL_DOGFOOD: "1"
         run: swift test --filter 'Dogfood'
@@ -708,7 +962,7 @@ jobs:
         # (`xcrun --find metal` succeeds even when the component is missing)
         # and self-provision loudly; the asset is cached system-wide, so a
         # re-activation here is quick.
-        if: runner.environment == 'self-hosted' && steps.ci_scope.outputs.docs_only != 'true'
+        if: steps.ci_scope.outputs.docs_only != 'true'
         run: |
           if ! xcrun metal --version >/dev/null 2>&1; then
             echo "Metal toolchain not active for $(whoami); installing component..."
@@ -723,31 +977,30 @@ jobs:
           fi
 
       - name: Package app bundle
-        # The self-hosted runner's keychain holds the stable localvoxtral-dev
-        # signing cert, keeping TCC grants valid across builds; anywhere the
-        # identity is absent (hosted runners), packaging falls back to ad-hoc.
-        # Hosted runners skip both bundled MLX helpers (no MetalToolchain
-        # component + cold MLX C++ builds would dominate fork-PR CI); every
-        # self-hosted lane (same-repo PRs, main, releases) builds them.
+        # THE SIGNED bundle, and the reason this job cannot move: the runner's
+        # keychain holds the stable localvoxtral-dev cert, which is what keeps
+        # the owner's Accessibility (TCC) grant valid across try-pr.sh installs.
+        # An ad-hoc signature would break it on every build. Both bundled MLX
+        # helpers are built here for real (Metal kernels via xcodebuild).
         if: steps.ci_scope.outputs.docs_only != 'true'
         env:
           LOCALVOXTRAL_CODESIGN_IDENTITY: localvoxtral-dev
-          LOCALVOXTRAL_SKIP_POLISHD: ${{ runner.environment == 'github-hosted' && '1' || '0' }}
-          LOCALVOXTRAL_SKIP_SPEECHD: ${{ runner.environment == 'github-hosted' && '1' || '0' }}
+          LOCALVOXTRAL_SKIP_POLISHD: "0"
+          LOCALVOXTRAL_SKIP_SPEECHD: "0"
           # Self-hosted lanes (same-repo PRs, main) MUST ship an identity-signed
           # bundle so try-pr.sh leaves the signature untouched and the owner's
           # Accessibility (TCC) grant survives across builds. Fail the build
           # loudly rather than silently upload an ad-hoc artifact if the runner
           # user's keychain has lost the cert. Hosted fork-PR runners have no
           # cert and are expected to be ad-hoc, so the requirement is off there.
-          LOCALVOXTRAL_REQUIRE_CODESIGN_IDENTITY: ${{ runner.environment == 'github-hosted' && '0' || '1' }}
+          LOCALVOXTRAL_REQUIRE_CODESIGN_IDENTITY: "1"
         run: ./scripts/package_app.sh release
 
       - name: Speech helper integration (real audio + live model)
         # Runs packaged speechd through RealtimeAPIWebSocketClient with the
         # tier-1 spoken fixture. Conditional because it loads the multi-GB
         # Voxtral model. Local equivalent: remote-build.sh integration-speechd.
-        if: runner.environment == 'self-hosted' && steps.ci_scope.outputs.docs_only != 'true' && steps.speechd_lane.outputs.run == 'true'
+        if: steps.ci_scope.outputs.docs_only != 'true' && steps.speechd_lane.outputs.run == 'true'
         env:
           SPEECHD_INTEGRATION_TEST_ENABLE: "1"
           SPEECHD_INTEGRATION_TEST_PATH: dist/localvoxtral.app/Contents/MacOS/localvoxtral-speechd
@@ -765,7 +1018,7 @@ jobs:
         # above (path filter + [run-llm-eval] marker) says whether this
         # change can affect what the lane measures. Local equivalent:
         # ./scripts/remote-build.sh integration-polishd
-        if: runner.environment == 'self-hosted' && steps.ci_scope.outputs.docs_only != 'true' && steps.llm_lane.outputs.run == 'true'
+        if: steps.ci_scope.outputs.docs_only != 'true' && steps.llm_lane.outputs.run == 'true'
         env:
           LOCALVOXTRAL_POLISHD_TEST_ENABLE: "1"
           LOCALVOXTRAL_POLISHD_TEST_PATH: PolishHelper/.build/xcode/Build/Products/Release/localvoxtral-polishd
@@ -874,7 +1127,7 @@ jobs:
         #   grant — is identical when switching between the two.
         # - package_app.sh self-verifies the LVXDogfoodCapture Info.plist
         #   stamp and fails loudly on mismatch; no re-check needed here.
-        if: runner.environment == 'self-hosted' && steps.ci_scope.outputs.docs_only != 'true' && steps.dogfood_lane.outputs.run == 'true'
+        if: steps.ci_scope.outputs.docs_only != 'true' && steps.dogfood_lane.outputs.run == 'true'
         env:
           LOCALVOXTRAL_CODESIGN_IDENTITY: localvoxtral-dev
           LOCALVOXTRAL_REQUIRE_CODESIGN_IDENTITY: "1"
@@ -890,7 +1143,7 @@ jobs:
           ditto -c -k --keepParent dist/localvoxtral.dSYM dist/localvoxtral-dsym-dogfood.zip
 
       - name: Upload dogfood app artifact
-        if: runner.environment == 'self-hosted' && steps.ci_scope.outputs.docs_only != 'true' && steps.dogfood_lane.outputs.run == 'true'
+        if: steps.ci_scope.outputs.docs_only != 'true' && steps.dogfood_lane.outputs.run == 'true'
         uses: actions/upload-artifact@v4
         with:
           name: localvoxtral-app-dogfood
@@ -900,7 +1153,7 @@ jobs:
       - name: Upload dogfood dSYM artifact
         # Same longer retention rationale as localvoxtral-dsym: field crashes
         # surface days after the build that produced them.
-        if: runner.environment == 'self-hosted' && steps.ci_scope.outputs.docs_only != 'true' && steps.dogfood_lane.outputs.run == 'true'
+        if: steps.ci_scope.outputs.docs_only != 'true' && steps.dogfood_lane.outputs.run == 'true'
         uses: actions/upload-artifact@v4
         with:
           name: localvoxtral-dsym-dogfood
@@ -928,8 +1181,7 @@ jobs:
         # therefore always false — a gate that silently never fires. The event
         # payload's copy is a string, so it compares as written.
         if: >-
-          runner.environment == 'self-hosted'
-          && github.event_name == 'workflow_dispatch'
+          github.event_name == 'workflow_dispatch'
           && github.event.inputs.dogfood == 'true'
           && steps.dogfood_lane.outputs.run == 'true'
         run: |
@@ -967,7 +1219,7 @@ jobs:
         # occurrence identifies itself. UID/state distinguish another account
         # and harmless zombies; names stay ucomm-only (no paths or arguments)
         # because this log is public. Informational — never fails the job.
-        if: ${{ always() && runner.environment == 'self-hosted' }}
+        if: always()
         run: |
           survivors="$(ps -axo pid,uid,etime,state,ucomm \
             | grep -iE 'localvoxtral|polishd|speechd|xctest|swiftpm-testing|XCBBuildService' \

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -102,9 +102,11 @@ ablation workflows: `docs/agent/test-tiers.md`.
 
 ## CI / shipping
 
-- Same-repo branches run on the self-hosted Mac runner; fork PRs run on
-  GitHub-hosted macOS. Never move fork-PR jobs to the self-hosted runner —
-  it is a personal machine.
+- CI is two parallel jobs: `build-test` (tier 0, GitHub-hosted, EVERY event
+  and contributor, the required check) and `mac-lanes` (self-hosted, never
+  for fork PRs). A new lane goes in `build-test` unless you can name what on
+  the owner's Mac it needs — signing identity, STT service, Metal, herdr
+  fixture, GUI session. Never move fork-PR work to the self-hosted runner.
 - Docs-only diffs take a fast path (`scripts/ci/docs-only-filter.sh`,
   conservative allowlist; unknown paths fail open to the full run). Only
   `build-test` fast-paths; release and every other workflow stay fully gated.

--- a/docs/agent/test-tiers.md
+++ b/docs/agent/test-tiers.md
@@ -2,7 +2,8 @@
 
 | Tier | What | When | Cost |
 |---|---|---|---|
-| 0 | Unit suite (500+ tests) + packaging + launch smoke | every non-fast-path PR/push, CI | ~1 min |
+| 0 | Unit suite (500+ tests) + shell gate suites + format lint + coverage | every non-fast-path PR/push, in CI's `build-test` job on **GitHub-hosted macOS** (owner decision 2026-09-05 — same-repo PRs too, not just forks; the Mac is the queue bottleneck and hosted runners are free for public repos) | ~4 min hosted, ~0 s queue |
+| 0 | Packaging + launch smoke of the **signed** bundle, and the installable artifact | every non-fast-path PR/push, in CI's `mac-lanes` job on the self-hosted Mac — the `localvoxtral-dev` identity is what keeps the owner's TCC grant valid across `try-pr.sh` installs. Fork PRs get an ad-hoc-signed equivalent inside `build-test` instead, since `mac-lanes` never runs for them | ~1 min |
 | 0 | PolishHelper / SpeechHelper unit suites (Metal-free: router, cache locator, watchdog; codec/delta contract) | self-hosted lanes only, and path-gated per helper — a PR runs a helper's suite only when the diff touches that helper's directory or the shared CI plumbing; `workflow_dispatch` and every push to main run both (`scripts/ci/helper-lane-filter.sh`, no marker). Locally: `remote-build.sh test --package-path PolishHelper` / `SpeechHelper` | 11 s + 20 s |
 | 1 | `RealtimeAPIVLLMIntegrationTests` vs the live local speechd STT test service: real inference through the production websocket client, word-accuracy asserted | every non-fast-path PR/push on the self-hosted runner; locally via `remote-build.sh integration` | ~20 s |
 | 1 | `PolishHelperIntegrationTests`: the packaged polishing helper vs the real pinned model — production request path, shared eval baseline, parent-pid tether | conditional in CI (self-hosted, after packaging): only when the diff touches LLM-relevant paths or the PR opts in with `[run-llm-eval]` — see "When must the LLM lanes run?"; locally via `remote-build.sh integration-polishd` | minutes (4B weights + live inference) |
@@ -81,6 +82,28 @@ filter list in the same PR. `./scripts/remote-build.sh integration-polishd`
 remains the local equivalent. The nightly `eval-e2e.yml` lane is the only
 scheduled eval; the per-PR polishd lane skipped by the filter runs again only
 when a matching change (or the marker) triggers it.
+
+## Which runner a lane lands on
+
+`ci.yml` is two parallel jobs, and which one a lane is in is a statement about
+what it needs, not about cost:
+
+- **`build-test`, GitHub-hosted `macos-latest`, every event and every
+  contributor** — the required status check on main. Anything that needs only
+  a macOS toolchain: the pure-shell gate suites, the installer test, format
+  lint, the unit suite, coverage. A fork PR gets ONLY this job, so it also
+  packages/uploads/smokes an ad-hoc-signed bundle there.
+- **`mac-lanes`, the self-hosted Mac, same-repo PRs + pushes + dispatches** —
+  anything that needs THAT machine: the `localvoxtral-dev` signing identity
+  (an ad-hoc signature invalidates the owner's Accessibility grant on every
+  `try-pr.sh` install), the launch-on-demand speechd STT service and the
+  multi-GB weights, a real Metal toolchain for the two MLX helpers, the
+  herdr/sshd fixture, the GUI session the UI-gate artifact root lives in, and
+  the warm `clean: false` `.build` the helper suites depend on.
+
+**Adding a lane: put it in `build-test` unless you can name the thing on the
+owner's Mac that it needs.** The Mac is a single runner and a personal machine;
+`build-test` is free and starts in seconds.
 
 ## Why the helper unit suites are path-gated
 


### PR DESCRIPTION
## What

Owner decision 2026-09-05, "option 1". `ci.yml` becomes **two parallel jobs**, split by what actually needs the owner's Mac.

| | `build-test` | `mac-lanes` |
|---|---|---|
| runs on | `macos-latest` (hosted) | self-hosted Mac |
| runs for | **every** event, every contributor | same-repo PRs, pushes to main, dispatches — **never a fork PR** |
| holds | shell gate suites, installer test, format lint, unit suite, coverage, unit-test-log artifact | signed packaging + launch smoke + `localvoxtral-app`/`localvoxtral-dsym`, live STT lane, conditional polishd/speechd/herdr lanes, both MLX helper unit suites, dogfood capture + packaging, UI-gate install, process leak check |

**Why this split and not another:** a lane belongs on the Mac only if you can name the thing on *that machine* it needs — the `localvoxtral-dev` signing identity (an ad-hoc signature invalidates the owner's Accessibility grant on every `try-pr.sh` install), the launch-on-demand speechd service and the multi-GB weights, a real Metal toolchain for the MLX helpers, the herdr/sshd fixture, the GUI session the UI-gate artifact root lives in, and the warm `clean: false` `.build` the helper suites lean on. Everything else is portable and moves.

**A fork PR still gets exactly one job.** `build-test` additionally packages, uploads and launch-smokes an ad-hoc-signed bundle when `IS_FORK_PR` — the coverage a fork would otherwise lose now that `mac-lanes` is where signed packaging lives. Same-repo runs skip those steps there rather than build the bundle twice.

The two jobs run in parallel, share no artifact, and each computes the docs-only fast-path decision itself (a sub-second step) rather than serialising behind a `needs:`. Fail-open lane filters, the fast path, `clean: false`, and the artifact names are unchanged.

**The `hosted` input from #256 is now a no-op** — the job it redirected always runs hosted. Kept for one release so a scripted `-f hosted=true` does not fail on an unknown input; its description and the workflow comment say so. It cannot be repurposed to move `mac-lanes`.

The unit step's 300 s self-hosted timeout branch went with the lane: 900 s flat, because the hosted build is cold and the supervisor exists for hang forensics, not a performance budget.

Docs: `.github/workflows/README.md` rewritten for the two jobs, `docs/agent/test-tiers.md` gets a "Which runner a lane lands on" section plus split tier-0 rows, and AGENTS.md's CI bullet is replaced (its old first line — "same-repo branches run on the self-hosted Mac runner" — was the whole truth and is not any more).

## Proof

### One PR run, both jobs green — run [33987397824](https://github.com/T0mSIlver/localvoxtral/actions/runs/33987397824)

```
=== mac-lanes [self-hosted,macOS,ARM64]  success  19:43:17 -> 19:46:15   178 s
  Checkout / Decide CI fast path / Clean stale outputs / Clean abandoned test processes
  Decide LLM · speechd · herdr · dogfood · helper lanes        (<1 s total)
  Warm on-demand speechd server                                  1 s
  Integration tests (live STT service)                          32 s
  Polishing helper unit tests (PolishHelper package)            12 s
  Speech helper unit tests (SpeechHelper package)               20 s
  Dogfood capture suite (instrumented build)                    25 s
  Ensure Metal toolchain                                         1 s
  Package app bundle (localvoxtral-dev signed, both helpers)    45 s
  Zip + Upload app / Zip + Upload dSYM                          30 s
  Smoke test packaged app launch                                 2 s
  Process leak check (informational)                             1 s

=== build-test [macos-latest]  success  19:47:58 -> 19:54:28   390 s
  Process-cleanup regression tests                             140 s
  Record hosted toolchain / Cache SwiftPM build                  2 s
  Installer asset-resolution regression test                    <1 s
  Format lint (advisory)                                         4 s
  Test (unit suite)                                            225 s  (112 s cold build + 99 s tests)
  Upload complete unit-test log / Coverage summary               4 s
  Post Cache SwiftPM build                                       7 s
```

**Mac service time: 178 s, against 327 s for the last comparable single-job run** ([33984716619](https://github.com/T0mSIlver/localvoxtral/actions/runs/33984716619), PR #259, same shape — both helper suites ran, no live-model lane). **−149 s, −46 %.** Against the 468 s p50 measured across 22 PR runs it is **−290 s, −62 %**. The hosted job runs in parallel, for free, and never touches the Mac.

### Identical unit coverage

```
Executed 2773 tests, with 11 tests skipped and 0 failures (0 unexpected) in 98.878 seconds
```

2773 — the same count the Mac ran on this base. (The earlier 2769 figure in my notes was against an older main.)

### The split did not silently drop a guard — a regression test caught the one thing it did drop

First attempt failed, and correctly:

```
== 20. the dispatched CI build installs itself for the gate ==
FAIL: the UI-gate install step is not gated on runner.environment == 'self-hosted'
```

I had removed that guard from the UI-gate install step as redundant once `mac-lanes` became self-hosted-only. `scripts/ci/test-ui-gate.sh` section 20 exists precisely because that step **writes into the owner's home**, and it asserts the guard by name. Restored, with a comment saying it is deliberately redundant: the job-level guarantee is real, but a zero-cost guard is what catches someone moving the step to the wrong job later. Not a test weakened — a guard put back.

### One thing the owner should weigh before merging: a known flake is now more exposed

The second attempt's first run failed on **`BackendProcessSupervisorTests.testStopHonorsTERMWithoutRestarting`**, and only that:

```
BackendProcessSupervisorTests.swift:329: error: XCTAssertTrue failed
Executed 2773 tests, with 11 tests skipped and 1 failure (0 unexpected)
```

This is a **pre-existing, documented, load-sensitive flake**, not a consequence of the diff: the test spawns a real `/bin/sh` whose `trap 'touch termMarker' TERM` must win a race against the supervisor's stop, and it has been observed failing on the Mac before, under load, during unrelated PRs. It passed on rerun (attempt 2 above, 0 failures).

But the honest reading is that **a 3-core shared hosted VM is a permanently loaded host**, so this test is more likely to flake there than on the Mac. Observed today: 1 failure in 3 hosted full-suite runs. I did not touch the test — no skip, no widened tolerance, no weakened assertion. The real fix is already written down in the project's own notes: have the script signal *trap-installed* readiness and gate `stop()` on that rather than on `readyMarker` alone. **I recommend that as an immediate follow-up**, and it is a genuine improvement independent of where the suite runs.

### Everything else

```
$ ./scripts/ci/test-workflow-step-names.sh
test-workflow-step-names: OK (107 step names, no duplicates within a job)
$ ./scripts/ci/test-ui-gate.sh          → ui gate tests passed
$ ./scripts/ci/test-helper-lane-filter.sh, test-llm-lane-filter.sh,
  test-clean-stale-outputs.sh, test-ui-smoke-guard.sh, test-runner-node-resign.sh,
  test-cleanup-stale-test-processes.sh, test-build-gate-gc-command.sh,
  test-remote-build-gc.sh, test-run-supervised-command.sh,
  test-herdr-fixture-recovery.sh, test-ac-power-guard.sh   → all OK
```

AGENTS.md byte budget after the CI-bullet rewrite: **12046 / 32768 bytes**, and the router-target and anchor assertions still pass (all three `AgentsGuideSizeTests` assertions replicated locally; the suite itself runs in the hosted `build-test` above).

### Not proven here, deliberately

- **A push-to-main run.** By construction it cannot exist before merge. Both jobs run for `push` exactly as they do for a same-repo PR, and `mac-lanes` keeps every lane a push runs today — main stays the parity reference. Worth watching the first one.
- **A fork PR.** No fork PR is open. The fork path is `IS_FORK_PR == 'true'`, which turns on the same packaging/upload/smoke steps that ran green on a hosted runner in #256's dispatch (run 33981779091), from the same job, with the same env.
- **The hosted SwiftPM cache is still a miss** (`Cache not found for input keys: …`) because Actions caches do not cross from a branch to another branch. It will only start paying once this is on main and main saves one; the ~112 s cold build should then mostly go.

## Owner action after merging

`build-test` is preserved as a job name, so the required status check keeps resolving. **Add `mac-lanes` as a required status check too** — otherwise a PR could go green on the hosted half alone while signing, the live STT lane and the launch smoke never ran.

One caveat to check when you do: `mac-lanes` is skipped by `if:` on fork PRs, and GitHub reports a skipped job as its own conclusion. Confirm on the next fork PR that a required-and-skipped `mac-lanes` does not block it; if it does, the fix is to make the job always run and no-op its steps instead.
