### PR TITLE
Zero compiler warnings on a cold build (148 -> 0)

### DIFF
--- a/Sources/localvoxtral/ClaudeContext/ClaudePluginInstallService.swift
+++ b/Sources/localvoxtral/ClaudeContext/ClaudePluginInstallService.swift
@@ -223,7 +223,7 @@ public struct ClaudePluginInstallService: Sendable {
     /// first-ever install (uninstalling a not-installed plugin exits 1).
     public func updatePlugin() throws {
         try perform(.addMarketplace)
-        try? perform(.uninstall)
+        _ = try? perform(.uninstall)
         try perform(.install)
     }
 }

--- a/Tests/localvoxtralTests/ClaudeHookPublisherTests.swift
+++ b/Tests/localvoxtralTests/ClaudeHookPublisherTests.swift
@@ -431,7 +431,12 @@ final class ClaudeHookControllingTTYTests: XCTestCase {
             // cases stay covered by the sibling tests above.
             return
         }
-        let slavePath = String(cString: nameBuffer)
+        // `openpty` writes a NUL-terminated device path into the buffer;
+        // decode up to that terminator (the `[CChar]` `String(cString:)`
+        // overload is deprecated precisely because it hides this step).
+        let slavePath = String(
+            decoding: nameBuffer.prefix { $0 != 0 }.map { UInt8(bitPattern: $0) }, as: UTF8.self
+        )
         defer {
             close(master)
             close(slave)
@@ -455,7 +460,7 @@ final class ClaudeHookControllingTTYTests: XCTestCase {
         posix_spawnattr_setflags(&attributes, Int16(0x0400))
 
         var childPID: pid_t = 0
-        var argv: [UnsafeMutablePointer<CChar>?] = [strdup("/bin/sleep"), strdup("30"), nil]
+        let argv: [UnsafeMutablePointer<CChar>?] = [strdup("/bin/sleep"), strdup("30"), nil]
         defer { argv.compactMap { $0 }.forEach { free($0) } }
         guard posix_spawn(&childPID, "/bin/sleep", &actions, &attributes, argv, nil) == 0 else {
             return // Same tolerance as openpty: nothing spawned, nothing to lie.

--- a/Tests/localvoxtralTests/CmuxSocketPasswordStoreTests.swift
+++ b/Tests/localvoxtralTests/CmuxSocketPasswordStoreTests.swift
@@ -34,7 +34,7 @@ private final class FakeCmuxKeychain: CmuxKeychainBackend, @unchecked Sendable {
     }
 
     func delete(service: String, account: String) -> Bool {
-        items.withLock { $0.removeValue(forKey: Key(service: service, account: account)) }
+        items.withLock { _ = $0.removeValue(forKey: Key(service: service, account: account)) }
         return true
     }
 }


### PR DESCRIPTION
## What

Fixes the four compiler-warning sites a cold build of `main` emits. Each is
re-emitted once per compilation of its module, so `grep -ci "warning:"` over a
cold `swift build`+`swift test` log on `main` counts **148**; after this it is
**0**. They surface only on a full recompile (an incremental build reuses the
modules and prints nothing), which is why the zero-warning bar in `AGENTS.md`
was quietly not being met.

Read one at a time rather than blanketed:

| Site | Warning | Fix |
|---|---|---|
| `ClaudePluginInstallService.swift:226` | `result of 'try?' is unused` | `_ = try? perform(.uninstall)` — `@discardableResult` does not survive `try?`, which produces a *new* optional value. The discard is deliberate and already documented right above it ("the uninstall is best-effort so the same button serves the first-ever install"). |
| `CmuxSocketPasswordStoreTests.swift:37` | `result of call to 'withLock' is unused` | Discard `removeValue`'s result *inside* the closure, so `withLock` returns `Void` and there is no result to drop. |
| `ClaudeHookPublisherTests.swift:434` | `'init(cString:)' is deprecated` | Decode up to the NUL `openpty` wrote — exactly what the deprecation message asks for — instead of the deprecated `[CChar]` overload that hides the truncation. |
| `ClaudeHookPublisherTests.swift:458` | `variable 'argv' was never mutated` | `let`. `posix_spawn`'s argv parameter is an `UnsafePointer`, so the array converts without `&` and never needed to be a `var`. |

**No behaviour change.** No assertion, no control flow, and no produced value
differs: the same test count runs and passes before and after.

## Proof

Both runs are COLD (a fresh `LV_BUILD_DIR`, so every warning is emitted), full
`./scripts/remote-build.sh test`.

Before, on `origin/main` @ `8ed07fe`:

```
$ LV_BUILD_DIR=work/localvoxtral-warnings-before ./scripts/remote-build.sh test
$ grep -ci "warning:" .build/last-remote.log
148
$ grep -i "warning:" .build/last-remote.log | grep -oE "[A-Za-z]+\.swift:[0-9]+:[0-9]+: warning: .*" | sort -u
ClaudeHookPublisherTests.swift:434:25: warning: 'init(cString:)' is deprecated: Use String(decoding: array, as: UTF8.self) instead, after truncating the null termination. [#DeprecatedDeclaration]
ClaudeHookPublisherTests.swift:458:13: warning: variable 'argv' was never mutated; consider changing to 'let' constant
ClaudePluginInstallService.swift:226:9: warning: result of 'try?' is unused [#no-usage]
CmuxSocketPasswordStoreTests.swift:37:15: warning: result of call to 'withLock' is unused [#no-usage]

	 Executed 2764 tests, with 2 tests skipped and 0 failures (0 unexpected) in 71.850 (71.995) seconds
```

After, on this branch:

```
$ LV_BUILD_DIR=work/localvoxtral-warnings ./scripts/remote-build.sh test
$ grep -ci "warning:" .build/last-remote.log
0
$ grep -c "error:" .build/last-remote.log
0

	 Executed 2764 tests, with 2 tests skipped and 0 failures (0 unexpected) in 80.066 (80.220) seconds
```

Same 2764 tests, same 2 skips, 0 failures on both sides.

- [x] Unit suite green — `./scripts/remote-build.sh test` (summary line pasted above)
- [ ] Realtime integration green — not run locally: nothing here reaches the realtime client. Tier-1 runs on CI for this PR anyway.
- [ ] Bug fix: regression test added — n/a, this is a warning cleanup with no behaviour change.
- [ ] UI change — n/a.

Conditional lanes: `llm-lane-filter.sh` / `speechd-lane-filter.sh` /
`herdr-lane-filter.sh` do not match these three paths, and nothing here alters
what reaches any model or what the app says to herdr — skipping them is
correct.
