### PR TITLE
test-ui-gate.sh: stop paying its stubs' wall clock (33 s -> 10 s locally)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -189,11 +189,14 @@ jobs:
         # are fast-path-eligible, so these tests are what still exercises a
         # gate-only diff.
         #
-        # No longer cheap: test-ui-gate.sh alone is ~80 s of the ~95 s here
-        # (measured 2026-09-05, PR #238's 105 assertions each re-running the
-        # gate). That makes this the second most expensive step in the job —
-        # keep it to ONE copy, and think before adding another gate suite that
-        # re-execs a shell script per assertion.
+        # No longer cheap, and no longer dominated by one thing: test-ui-gate.sh
+        # was ~80 s of the ~95 s here (measured 2026-09-05) because FOUR of its
+        # ~360 assertions drove the gate's wall-clock waits to their deadline
+        # while its `sleep` stub turned each poll into a fork storm. Those
+        # budgets are seams now and the suite sets them short. What is left is
+        # ~360 fresh `bash` processes, so keep this to ONE copy, and think
+        # before adding another gate suite that re-execs a script per
+        # assertion.
         run: |
           ./scripts/ci/test-cleanup-stale-test-processes.sh
           ./scripts/ci/test-build-gate-process-cleanup.sh

--- a/scripts/ci/test-ui-gate.sh
+++ b/scripts/ci/test-ui-gate.sh
@@ -365,6 +365,11 @@ GATE_STATUS=0
 GATE_STDOUT=""
 GATE_STDERR=""
 
+# Two of the gate's waits are budgets in WALL CLOCK, and this suite stubs
+# `sleep` to return instantly — so a case that drives one of them to its
+# deadline spins for the whole budget instead of polling through it. Both are
+# seams in the gate (defaults 20 s); here they are as short as the case needs.
+# `TERM_OPEN_TIMEOUT` / `LAUNCH_WAIT` override them for a single case.
 run_gate() { # <command> [env assignments...]
   local command="$1"
   shift
@@ -375,7 +380,8 @@ run_gate() { # <command> [env assignments...]
     HOME="$FAKE_HOME" \
     SSH_ORIGINAL_COMMAND="$command" \
     LV_UI_LOCK_PROBE="$FAKE_HOME/bin/localvoxtral-screen-lock-state.sh" \
-    LV_UI_TERM_OPEN_TIMEOUT_SECONDS="${TERM_OPEN_TIMEOUT:-2}" \
+    LV_UI_TERM_OPEN_TIMEOUT_SECONDS="${TERM_OPEN_TIMEOUT:-1}" \
+    LV_UI_LAUNCH_WAIT_SECONDS="${LAUNCH_WAIT:-0}" \
     LV_SCREEN_LOCK_STATE="${LOCK_STATE:-unlocked}" \
     STUB_SAY_LOG="$TMP_DIR/say.log" \
     STUB_OPEN_LOG="$TMP_DIR/open.log" \
@@ -385,8 +391,10 @@ run_gate() { # <command> [env assignments...]
     STUB_LOG_LOG="$TMP_DIR/log.log" \
     "$@" \
     bash "$GATE" >"$out_file" 2>"$err_file" || GATE_STATUS=$?
-  GATE_STDOUT="$(cat "$out_file")"
-  GATE_STDERR="$(cat "$err_file")"
+  # `$(<file)` and not `$(cat file)`: bash reads the file itself, and this runs
+  # twice for every one of the ~240 gate invocations below.
+  GATE_STDOUT="$(<"$out_file")"
+  GATE_STDERR="$(<"$err_file")"
 }
 
 log_tail() {
@@ -416,7 +424,7 @@ helper_func_body() { # <swift function name>
 assert_denied() { # <command> <description> [env...]
   local command="$1" description="$2"
   shift 2
-  local before after
+  local before after last
   before="$(wc -l <"$LOG_FILE" 2>/dev/null || echo 0)"
   run_gate "$command" "$@"
   (( GATE_STATUS == 126 )) \
@@ -425,10 +433,13 @@ assert_denied() { # <command> <description> [env...]
     || fail "$description: stderr did not say 'denied command' ($GATE_STDERR)"
   after="$(wc -l <"$LOG_FILE" 2>/dev/null || echo 0)"
   (( after > before )) || fail "$description: nothing was appended to the gate log"
-  [[ "$(log_tail)" == *" DENY "* ]] \
-    || fail "$description: last log line is not a DENY line: $(log_tail)"
-  [[ "$(log_tail)" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2} ]] \
-    || fail "$description: DENY line has no timestamp: $(log_tail)"
+  # Read the last line ONCE. The three assertions below are unchanged; they
+  # used to re-run `tail` for each of them, five times per denial.
+  last="$(log_tail)"
+  [[ "$last" == *" DENY "* ]] \
+    || fail "$description: last log line is not a DENY line: $last"
+  [[ "$last" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2} ]] \
+    || fail "$description: DENY line has no timestamp: $last"
   pass "denied: $description"
 }
 
@@ -438,8 +449,10 @@ assert_allowed() { # <command> <description> [env...]
   run_gate "$command" "$@"
   (( GATE_STATUS == 0 )) \
     || fail "$description: expected exit 0, got $GATE_STATUS (stderr: $GATE_STDERR)"
-  [[ "$(log_tail)" == *" ALLOW "* ]] \
-    || fail "$description: no ALLOW line was logged (last line: $(log_tail))"
+  local last
+  last="$(log_tail)"
+  [[ "$last" == *" ALLOW "* ]] \
+    || fail "$description: no ALLOW line was logged (last line: $last)"
   pass "allowed: $description"
 }
 
@@ -824,11 +837,20 @@ pass "launch records the APP, never a helper sharing the pgrep prefix"
 
 # And the other direction: if the ONLY thing matching the prefix is a helper,
 # there is no app under test and launch must say so rather than adopt it.
+#
+# The one case in this suite that runs `launch`'s wait loop to its DEADLINE, so
+# it is also the one that pays for it: `sleep` is stubbed to return instantly,
+# which turns the poll into a fork storm that runs for the whole budget. At the
+# gate's 20-second default this single assertion was 19.2 s of a 32.6 s suite
+# (measured 2026-09-05). One second still retries, still expires, still proves
+# exactly what it proved before.
 clear_state
+LAUNCH_WAIT=1
 run_gate "launch $CLEAN_APP" \
   STUB_PS_LSTART="Mon Aug 24 09:00:00 2026" \
   STUB_PGREP_PID="5100" \
   STUB_PS_COMM_5100="$CLEAN_APP/Contents/MacOS/localvoxtral-speechd"
+unset LAUNCH_WAIT
 (( GATE_STATUS != 0 )) || fail "launch adopted a helper as the app under test"
 [[ ! -f "$FAKE_HOME/.localvoxtral-ui-gate/app.state" ]] \
   || fail "launch wrote app.state for a helper"

--- a/scripts/ci/test-ui-gate.sh
+++ b/scripts/ci/test-ui-gate.sh
@@ -857,6 +857,23 @@ unset LAUNCH_WAIT
 pass "a helper alone is not an app under test"
 clear_state
 
+# A hand-edited conf is where `20s` comes from, and the wait budget is consumed
+# by `$(( ))`: a non-numeric value there is an arithmetic error, which under
+# `set -e` kills the gate AFTER `open` has started the app and BEFORE app.state
+# records it — the unrecorded-instance wedge the gate header warns about,
+# reached by a typo. It must degrade to the built-in default instead.
+clear_state
+: >"$TMP_DIR/open.log"
+write_conf 'LV_UI_LAUNCH_WAIT_SECONDS="20s"'
+run_gate "launch $CLEAN_APP" "${APP_ENV[@]}" STUB_PGREP_PID=4242
+clear_conf
+(( GATE_STATUS == 0 )) \
+  || fail "a junk launch budget in the conf broke launch: $GATE_STATUS ($GATE_STDERR)"
+grep -q "pid=4242" "$FAKE_HOME/.localvoxtral-ui-gate/app.state" \
+  || fail "launch opened the app but recorded nothing — the unrecorded-instance wedge"
+pass "a junk launch budget in the conf falls back to the default, never opening without recording"
+clear_state
+
 echo "== 8. ax and key verbs =="
 
 clear_state
@@ -901,6 +918,22 @@ SCRIPT_FILE="$(find "$FAKE_HOME/.localvoxtral-ui-gate/terms" -name '*.command' |
 grep -q "^exec $FAKE_HOME/bin/lv-attach pane-7\$" "$SCRIPT_FILE" \
   || fail "launcher script does not exec exactly the validated argv: $(cat "$SCRIPT_FILE")"
 pass "allowed: term open runs an opted-in wrapper, by absolute path, and logs the command in full"
+
+# The same arithmetic trap as `launch`'s budget, and worse placed: `term open`
+# computes its deadline AFTER `open` has already put a window on the owner's
+# desktop, so a `20s` in the conf left that window behind with no recorded id —
+# unfocusable and uncloseable by this gate.
+write_conf 'LV_UI_TERM_COMMANDS="lv-attach"' 'LV_UI_TERM_OPEN_TIMEOUT_SECONDS="20s"'
+run_gate 'term open ghostty lv-attach pane-9' STUB_PGREP_PID=$$
+write_conf 'LV_UI_TERM_COMMANDS="lv-attach"'
+(( GATE_STATUS == 0 )) \
+  || fail "a junk term-open budget in the conf broke term open: $GATE_STATUS ($GATE_STDERR)"
+[[ "$GATE_STDOUT" == "opened term-"* ]] \
+  || fail "term open opened a window but recorded no id: $GATE_STDOUT"
+JUNK_BUDGET_TERM="${GATE_STDOUT#opened }"
+JUNK_BUDGET_TERM="${JUNK_BUDGET_TERM%% *}"
+assert_allowed "term close $JUNK_BUDGET_TERM" 'closing the window opened under a junk budget'
+pass "a junk term-open budget in the conf falls back to the default, never opening without recording"
 
 assert_allowed 'term focus term-1' 'term focus on a window this gate opened'
 assert_allowed 'term close term-1' 'term close on a window this gate opened'

--- a/scripts/mac/localvoxtral-ui-gate.sh
+++ b/scripts/mac/localvoxtral-ui-gate.sh
@@ -206,6 +206,16 @@ LV_UI_TERM_COMMAND_DIRS="${LV_UI_TERM_COMMAND_DIRS:-$HOME/bin}"
 # suite drives the three failure paths below and a 20-second wall-clock wait
 # per case is most of the suite's runtime.
 LV_UI_TERM_OPEN_TIMEOUT_SECONDS="${LV_UI_TERM_OPEN_TIMEOUT_SECONDS:-20}"
+
+# How long `launch` waits for the app to appear in the process table. The same
+# kind of seam as the one above, for the same reason and with the same evidence
+# behind it: the shell suite drives the "nothing but a helper ever appeared"
+# path, and under the suite's instant `sleep` stub the loop below stops being a
+# poll and becomes a fork storm that runs for the WHOLE budget. Measured
+# 2026-09-05: that single assertion was 19.2 s of the suite's 32.6 s. A shorter
+# budget can only make `launch` give up sooner, never admit anything, so this
+# is a knob no attacker has a use for.
+LV_UI_LAUNCH_WAIT_SECONDS="${LV_UI_LAUNCH_WAIT_SECONDS:-20}"
 # How many windows a refused `term open` may record as UNCONFIRMED so
 # `term close` can still reach them. Bounded because each record is a window
 # this gate could not prove is its own.
@@ -330,7 +340,12 @@ timestamp() {
 }
 
 log_line() {
-  mkdir -p "$(dirname "$LOG_FILE")" 2>/dev/null || true
+  # Every invocation of this gate writes one line here, so the directory is
+  # derived without forking `dirname` and `mkdir` is only reached when the
+  # directory is actually missing — which is the first invocation and no other.
+  local dir="${LOG_FILE%/*}"
+  [[ "$dir" != "$LOG_FILE" ]] || dir="."
+  [[ -d "$dir" ]] || mkdir -p "$dir" 2>/dev/null || true
   printf '%s %s\n' "$(timestamp)" "$*" >>"$LOG_FILE" 2>/dev/null || true
 }
 
@@ -1803,17 +1818,24 @@ run_launch() {
   # `ps -o comm=` is the full path, which is the same fact `process_identity`
   # already trusts for pid reuse.
   local app_executable="$bundle/Contents/MacOS/localvoxtral" candidate
-  deadline=$((SECONDS + 20))
-  while (( SECONDS < deadline )); do
+  # Attempt-then-check, so a budget of 0 still makes exactly ONE attempt. With
+  # any budget >= 1 this is identical to the check-then-attempt loop it
+  # replaces (the deadline is computed from SECONDS immediately above, so the
+  # first check always passed); 0 is what lets the suite drive the give-up path
+  # without spending the budget in wall clock.
+  deadline=$((SECONDS + LV_UI_LAUNCH_WAIT_SECONDS))
+  while :; do
     for candidate in $(pgrep -f "^$app_executable" 2>/dev/null | sort -rn); do
       [[ "$(ps -p "$candidate" -o comm= 2>/dev/null)" == "$app_executable" ]] || continue
       pid="$candidate"
       break
     done
     [[ -n "${pid:-}" ]] && break
+    (( SECONDS < deadline )) || break
     sleep 0.5
   done
-  [[ -n "${pid:-}" ]] || fail "the app did not start within 20 seconds"
+  [[ -n "${pid:-}" ]] \
+    || fail "the app did not start within $LV_UI_LAUNCH_WAIT_SECONDS seconds"
 
   mkdir -p "$STATE_DIR"
   chmod 0700 "$STATE_DIR" 2>/dev/null || true

--- a/scripts/mac/localvoxtral-ui-gate.sh
+++ b/scripts/mac/localvoxtral-ui-gate.sh
@@ -302,6 +302,22 @@ if [[ -f "$GATE_CONF" ]]; then
   fi
 fi
 
+# The two budgets that are consumed by `$(( ))`, normalised AFTER the conf has
+# had its say. A value that is not a plain non-negative integer is an
+# ARITHMETIC ERROR there, and under `set -euo pipefail` that kills the gate
+# mid-verb — in `launch` and `term open` alike, after `open` has already put a
+# window (or the app under test) on the owner's desktop and BEFORE the state
+# file that makes it addressable is written. That is exactly the wedge the
+# header warns about: a running instance this gate never recorded, after which
+# `launch` refuses beside "a localvoxtral this gate did not start" and only the
+# owner can unwedge the machine. A hand-edited machine-local file is where a
+# typo like `20s` comes from, so a bad value falls back to the default instead
+# of taking the gate down. (The other `$(( ))` knobs below have the same shape
+# and are worth the same treatment; these two are the ones whose failure lands
+# after something has already been opened.)
+case "$LV_UI_LAUNCH_WAIT_SECONDS" in "" | *[!0-9]*) LV_UI_LAUNCH_WAIT_SECONDS=20 ;; esac
+case "$LV_UI_TERM_OPEN_TIMEOUT_SECONDS" in "" | *[!0-9]*) LV_UI_TERM_OPEN_TIMEOUT_SECONDS=20 ;; esac
+
 # Second layer under the (empty by default) allowlist above: names that can run
 # a child command are refused even when the conf allowlists them. Deliberately
 # assigned AFTER the conf is sourced and NOT via ${VAR:-...}, so the conf can
@@ -1818,11 +1834,13 @@ run_launch() {
   # `ps -o comm=` is the full path, which is the same fact `process_identity`
   # already trusts for pid reuse.
   local app_executable="$bundle/Contents/MacOS/localvoxtral" candidate
-  # Attempt-then-check, so a budget of 0 still makes exactly ONE attempt. With
-  # any budget >= 1 this is identical to the check-then-attempt loop it
-  # replaces (the deadline is computed from SECONDS immediately above, so the
-  # first check always passed); 0 is what lets the suite drive the give-up path
-  # without spending the budget in wall clock.
+  # Attempt-then-check, so a budget of 0 still makes exactly ONE attempt — that
+  # is what lets the suite drive the give-up path without spending the budget in
+  # wall clock. Against the check-then-attempt loop it replaces it is the same
+  # loop for every budget the field uses, and where it differs it is strictly
+  # more robust: the old form could make ZERO attempts if `SECONDS` happened to
+  # tick over between the assignment below and the first check, which at a
+  # budget of 1 is a real (if narrow) window.
   deadline=$((SECONDS + LV_UI_LAUNCH_WAIT_SECONDS))
   while :; do
     for candidate in $(pgrep -f "^$app_executable" 2>/dev/null | sort -rn); do


### PR DESCRIPTION
## What

`scripts/ci/test-ui-gate.sh` is the most expensive thing in CI's shell-test
step. I profiled it before changing anything, and the expensive thing turned
out not to be the one the step's own comment blames.

The suite re-execs the gate ~240 times, but a plain gate invocation costs
**~13 ms**. **Four** of its ~360 assertions accounted for **75 %** of the
runtime, because each drives one of the gate's *wait* loops to its deadline —
and the suite stubs `sleep` to return instantly, so the poll stops being a poll
and becomes a fork storm that runs for the entire budget in wall clock.

Per-assertion, measured by timestamping every `pass` (Linux dev box,
2026-09-05):

```
 19.205 s  [7] a helper alone is not an app under test
  2.001 s  [9] a command that exits immediately is reported as a failed command
  1.995 s  [9] a terminal that never ran the launcher says so
  1.438 s  [9] a term open that cannot identify its window kills what it started
 ------
 24.6 s of 32.6 s — the other 357 assertions cost ~8 s between them.
```

Changes:

- **`launch`'s 20-second wait becomes a seam**, `LV_UI_LAUNCH_WAIT_SECONDS`
  (default 20) — the same kind of seam as `LV_UI_TERM_OPEN_TIMEOUT_SECONDS`
  directly above it, whose comment already states this exact rationale. The
  loop becomes attempt-then-check so a budget of `0` still makes exactly ONE
  attempt; for any budget >= 1 that is identical to the loop it replaces,
  because the deadline is computed from `SECONDS` immediately above it and the
  first check therefore always passed. A shorter budget can only make `launch`
  give up sooner — it can never admit anything — so it is not a knob an
  attacker has a use for, and it is not reachable from the conf file's
  perspective any differently from the term-open one.
- The suite gives every gate run a 0-second launch budget, and the ONE case
  that must reach the deadline (`a helper alone is not an app under test`) runs
  at 1 s: it still retries, still expires, still asserts exactly what it did.
- `term open`'s budget in the suite drops 2 s -> 1 s for the same reason.
- Three forks per assertion go with no change of meaning: `$(<file)` instead of
  `$(cat file)` for the two captured streams, and reading the gate log's last
  line **once** per assertion instead of re-running `tail` for each assertion
  about it (five times per denial).
- `log_line` derives its directory without forking `dirname`, and only calls
  `mkdir` when the directory is missing — it runs on every single invocation of
  the gate.

### Batching was measured and rejected

The task that produced this PR proposed batching pure-function assertions into
one `bash` that sources the gate. On the evidence I did not do that:

1. **There is no pure-function group to batch.** Every assertion in this suite
   is an end-to-end forced-command shape through `SSH_ORIGINAL_COMMAND` — the
   selector/allowlist/artifact/log-scrubbing rules are *only* asserted through
   dispatch. That is precisely the half that must stay one process each.
2. **Sourcing does not buy what it looks like it buys.** `source` re-parses the
   gate's 2 900 lines on every call; it saves the `env`+`bash` exec, not the
   parse — a fraction of ~13 ms, against 24.6 s sitting in four wall-clock
   waits.
3. The gate's dispatch section states outright that there is deliberately no
   source-only escape hatch, and that decision is not worth overturning for
   that fraction.

No behaviour change to the gate beyond the new seam: same 361 `PASS` lines,
same names, same order.

## Proof

**Assertion count and identity, before vs after** (same machine, back to back;
`PASS` lines are one per assertion):

```
$ # baseline (origin/main working tree)
scripts/ci/test-ui-gate.sh: rc=0 wall=33.30s PASS=361 FAIL=0
scripts/ci/test-ui-gate.sh: rc=0 wall=33.00s PASS=361 FAIL=0

$ # this branch
scripts/ci/test-ui-gate.sh: rc=0 wall=10.46s PASS=361 FAIL=0
scripts/ci/test-ui-gate.sh: rc=0 wall=10.39s PASS=361 FAIL=0
scripts/ci/test-ui-gate.sh: rc=0 wall= 9.87s PASS=361 FAIL=0

$ diff <(grep "^PASS:" base1.txt) <(grep "^PASS:" after1.txt)
104c104
< PASS: denied: locked screen refuses: launch /tmp/lv-ui-gate-test.p7BvtJ/home/localvoxtral-ui-artifacts/localvoxtral.app
---
> PASS: denied: locked screen refuses: launch /tmp/lv-ui-gate-test.Oz2Zgv/home/localvoxtral-ui-artifacts/localvoxtral.app
```

The only difference between the two assertion lists is `mktemp`'s random suffix
in one description. 361 assertions before, 361 after, same order.

**Mutation check** — remove `ssh` from the gate's permanent denylist
(`LV_UI_TERM_FORBIDDEN`) on a throwaway edit and run both suites against the
mutated gate:

```
$ # this branch's suite
scripts/ci/test-ui-gate.sh: rc=1 wall=1.08s PASS=98 FAIL=1
FAIL: ssh is no longer on the permanent denylist

$ # the baseline suite, same mutated gate — the SAME named failure
scripts/ci/test-ui-gate.sh: rc=1 wall=1.30s PASS=98 FAIL=1
FAIL: ssh is no longer on the permanent denylist
```

Reverted; the suite is green again (`rc=0 wall=9.87s PASS=361 FAIL=0` above).

**Wall clock on the Mac (CI's shell-test step, `Process-cleanup regression
tests`)** — baseline runs on the self-hosted `macbook-pro` runner, taken from
`gh api .../jobs`:

| run | step |
|---|---|
| 33986799357 (main) | 19:20:21 -> 19:22:09 = **108 s** |
| 33985936722 (main) | 19:04:00 -> 19:05:36 = **96 s** |
| 33985095083 (main) | 18:46:33 -> 18:48:10 = **97 s** |
| 33987123757 (PR #262) | 19:31:33 -> 19:33:18 = **105 s** |

And this PR's own run on the same runner:

| run | step |
|---|---|
| 33987851602 (this PR, `7bde30f`) | 19:47:18 -> 19:48:39 = **81 s** |
| 33990652758 (this PR, `939e7f5`, +3 assertions) | 20:47:15 -> 20:48:26 = **71 s** |

71-81 s against a 96-108 s baseline band. The step runs 17 scripts, of which
this suite was ~80 s; the runner's own spread across the four baseline runs is
~12 s, so read this as "the wall-clock waits are gone", not as a precise delta.

- [ ] Unit suite green — not the tier this touches; nothing here is Swift. The
      shell-test step is what proves it, and it is a required part of
      `build-test`.
- [x] Shell suite green, unchanged assertion set, mutation check red then green
      (above).
- [ ] Bug fix: regression test added — n/a, no behaviour bug.
- [ ] UI change — n/a; the gate's GUI verbs are unchanged.

## Adversarial review (opencode / GLM-5.2, read-only)

One review across this PR and #265. It executed both suite versions itself
(33.1 s main / 10.0 s branch, 361 identical PASS lines) and checked the seam's
reachability, the single-read log assertions, `log_line`'s directory derivation
against eight path shapes, and bash 3.2 safety. **No BLOCKER, no SHOULD-FIX**;
verdict "safe to merge as-is". Two nits on this branch, both fixed in `939e7f5`:

**N1 — a junk wait budget in the conf wedges a verb mid-flight.** Both budgets
are consumed by `$(( ))`, and `LV_UI_LAUNCH_WAIT_SECONDS=20s` is an arithmetic
error there — which under `set -euo pipefail` kills the gate AFTER `open` has
started the app and BEFORE `app.state` records it. That is the unrecorded-instance
wedge the gate header warns about, reached by a typo in a hand-edited file.
`LV_UI_TERM_OPEN_TIMEOUT_SECONDS` had the identical fault already and is worse
placed still (its deadline is computed after a window is on the owner's
desktop), so both are now normalised to the built-in default *after* the conf
has had its say — the same position the permanent denylist uses. The reviewer
rated it NIT because the variable is unreachable from a forced-command client
(sshd's default `AcceptEnv`); it is fixed anyway because the failure lands after
something has been opened.

Fail-before / pass-after, two new regression tests driving the real conf file:

```
$ # before the gate fix
scripts/ci/test-ui-gate.sh: rc=1 wall=2.21s PASS=128 FAIL=1
FAIL: a junk launch budget in the conf broke launch: 1 (scripts/mac/localvoxtral-ui-gate.sh: line 1826: 20s: value too great for base (error token is "20s"))

$ # after
scripts/ci/test-ui-gate.sh: rc=0 wall=10.10s PASS=364 FAIL=0
scripts/ci/test-ui-gate.sh: rc=0 wall= 9.86s PASS=364 FAIL=0

$ diff <(grep "^PASS:" before-review.txt) <(grep "^PASS:" after-review.txt)   # additions only
> PASS: a junk launch budget in the conf falls back to the default, never opening without recording
> PASS: allowed: closing the window opened under a junk budget
> PASS: a junk term-open budget in the conf falls back to the default, never opening without recording
```

**N2 — the equivalence comment overclaimed.** At a budget of 1 the loop is *not*
identical to the one it replaces: the OLD form could make zero attempts if
`SECONDS` ticked over between the assignment and the first check. The new form
is a strict superset; the comment now says that instead.

Two findings recorded and deliberately not acted on here: the remaining
`$(( ))`-consumed knobs in the gate have the same exposure as N1 but none of
them can fail after something has been opened (a dedicated hardening pass, not a
ride on a test-cost PR), and the stdout-then-stderr read order in #265's
harness is pre-existing on `main`.

## CI status — red for a reason that is not this PR

`eadffd9` (this branch with `origin/main` merged in — #260 landed and moved the
shell-test step into the hosted `build-test` job, which is what the conflict
was) is RED on run
[33992613246](https://github.com/T0mSIlver/localvoxtral/actions/runs/33992613246).
The failure, from that run's own `unit-test-log-macOS` artifact:

```
Tests/localvoxtralTests/BackendProcessSupervisorTests.swift:329: error:
  -[localvoxtralTests.BackendProcessSupervisorTests testStopHonorsTERMWithoutRestarting] : XCTAssertTrue failed
Test Case '-[... testStopHonorsTERMWithoutRestarting]' failed (1.276 seconds).
```

That is #268's flake ("14/20 → 0/20 on the hosted lane"), on the 3-core hosted
runner #260 just moved tier 0 onto. It is one Swift test in a file this PR does
not touch, in a job whose `mac-lanes` half passed. The last run of this branch
before the merge (`939e7f5`, run 33990652758) was fully green. Re-run once #268
is in; nothing here needs changing for it.

Note on the numbers above: they were all measured while `build-test` still ran
on the Mac. #260 moved that job to hosted macOS *after* them, so the step's
absolute wall clock on `main` will now read differently — the work this PR
removes is the same either way.

Conditional lanes: `llm-lane-filter.sh` / `speechd-lane-filter.sh` /
`herdr-lane-filter.sh` do not match `scripts/ci/test-ui-gate.sh`,
`scripts/mac/localvoxtral-ui-gate.sh` or the ci.yml comment, and nothing here
changes what reaches a model or what the app says to herdr — skipping them is
correct.
