### PR TITLE
ClaudeRemotePluginManifestTests: stop polling for processes that already exited (26 s -> 10.5 s)

### DIFF
--- a/Tests/localvoxtralTests/ClaudeRemotePluginManifestTests.swift
+++ b/Tests/localvoxtralTests/ClaudeRemotePluginManifestTests.swift
@@ -26,6 +26,13 @@ final class ClaudeRemotePluginManifestTests: XCTestCase {
         marketplace = try XCTUnwrap(ClaudePluginAssets.developmentMarketplaceURL())
     }
 
+    /// The shared stub lives for the whole class, so it is removed once here
+    /// rather than by whichever case happened to run last.
+    override class func tearDown() {
+        try? FileManager.default.removeItem(at: stubCurlDirectory)
+        super.tearDown()
+    }
+
     private func json(at url: URL) throws -> [String: Any] {
         let data = try Data(contentsOf: url)
         return try XCTUnwrap(try JSONSerialization.jsonObject(with: data) as? [String: Any])
@@ -458,24 +465,95 @@ final class ClaudeRemotePluginManifestTests: XCTestCase {
         var environment = ProcessInfo.processInfo.environment
         environment["XDG_RUNTIME_DIR"] = state.path
         process.environment = environment
-        let stdin = Pipe()
-        let stdout = Pipe()
-        let stderr = Pipe()
-        process.standardInput = stdin
-        process.standardOutput = stdout
-        process.standardError = stderr
+        return try Self.runToCompletion(process, stdin: Data(#"{"session_id":"s1"}"#.utf8))
+    }
+
+    /// Runs `process` to completion with `stdin` on its standard input, and
+    /// returns its exit status and both streams.
+    ///
+    /// `Process.waitUntilExit()` is deliberately NOT used. It spins the calling
+    /// thread's run loop and re-checks `isRunning` on a fixed interval, so
+    /// every spawn in this file paid that interval as pure latency AFTER the
+    /// script had already exited and both of its pipes had already closed —
+    /// for scripts whose own work is microseconds. With ~90 spawns across these
+    /// 55 cases that polling was most of the suite's runtime.
+    /// `terminationHandler` fires as soon as the kernel reports the exit, so
+    /// the wait costs what waiting should cost.
+    ///
+    /// The read order (stdout to EOF, then stderr) is the one this file already
+    /// used, and it is safe for the same reason it was before: both scripts are
+    /// contractually silent on stderr, and several cases here assert exactly
+    /// that.
+    private static func runToCompletion(
+        _ process: Process, stdin: Data
+    ) throws -> (exitCode: Int32, stdout: String, stderr: String) {
+        let stdinPipe = Pipe()
+        let stdoutPipe = Pipe()
+        let stderrPipe = Pipe()
+        process.standardInput = stdinPipe
+        process.standardOutput = stdoutPipe
+        process.standardError = stderrPipe
+        let exited = DispatchSemaphore(value: 0)
+        process.terminationHandler = { _ in exited.signal() }
         try process.run()
-        stdin.fileHandleForWriting.write(Data(#"{"session_id":"s1"}"#.utf8))
-        stdin.fileHandleForWriting.closeFile()
-        let out = stdout.fileHandleForReading.readDataToEndOfFile()
-        let err = stderr.fileHandleForReading.readDataToEndOfFile()
-        process.waitUntilExit()
+        stdinPipe.fileHandleForWriting.write(stdin)
+        stdinPipe.fileHandleForWriting.closeFile()
+        let out = stdoutPipe.fileHandleForReading.readDataToEndOfFile()
+        let err = stderrPipe.fileHandleForReading.readDataToEndOfFile()
+        exited.wait()
         return (
             process.terminationStatus,
             String(decoding: out, as: UTF8.self),
             String(decoding: err, as: UTF8.self)
         )
     }
+
+    /// The stub `curl` every `runShimWithStubCurl` call puts first on PATH.
+    ///
+    /// Byte-identical on every call, so it is written ONCE for the whole class
+    /// instead of being created, chmodded and torn down on each of the ~40
+    /// calls. What varies per call — the body fixture, the status, the exit
+    /// code, the header dump — is passed in the environment and already was.
+    private static let stubCurlDirectory: URL = {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("shim-stub-\(UUID().uuidString)")
+        let stub = directory.appendingPathComponent("curl")
+        let script = """
+        #!/bin/sh
+        out=""
+        previous=""
+        url=""
+        for argument in "$@"; do
+          [ "$previous" = "--output" ] && out="$argument"
+          if [ "$previous" = "--header" ] && [ -n "${FAKE_CURL_HEADER_DUMP:-}" ]; then
+            case "$argument" in
+            @*) cat "${argument#@}" >>"$FAKE_CURL_HEADER_DUMP" 2>/dev/null ;;
+            esac
+          fi
+          url="$argument"
+          previous="$argument"
+        done
+        # One line per invocation, carrying the URL: proves both THAT curl was
+        # dialed (or was not, during backoff) and WHERE — the per-Mac port is
+        # only real if it reaches the wire.
+        [ -n "${FAKE_CURL_LOG:-}" ] && printf '%s\\n' "$url" >>"$FAKE_CURL_LOG"
+        cat >/dev/null
+        [ -n "$out" ] && cp "$FAKE_CURL_BODY" "$out" 2>/dev/null
+        printf '%s' "$FAKE_CURL_STATUS"
+        exit "${FAKE_CURL_EXIT:-0}"
+        """
+        // A fixture this whole class depends on: if it cannot be written there
+        // is nothing to test, and a silent failure would look like the shim
+        // never dialing.
+        try! FileManager.default.createDirectory(
+            at: directory, withIntermediateDirectories: true
+        )
+        try! script.write(to: stub, atomically: true, encoding: .utf8)
+        try! FileManager.default.setAttributes(
+            [.posixPermissions: 0o755], ofItemAtPath: stub.path
+        )
+        return directory
+    }()
 
     func testStatusLineRendererMapsEachStampStateToItsFixedString() throws {
         let esc = "\u{1B}"
@@ -584,23 +662,7 @@ final class ClaudeRemotePluginManifestTests: XCTestCase {
         processEnvironment["XDG_RUNTIME_DIR"] = isolatedState.path
         processEnvironment.merge(environment) { _, new in new }
         process.environment = processEnvironment
-        let stdin = Pipe()
-        let stdout = Pipe()
-        let stderr = Pipe()
-        process.standardInput = stdin
-        process.standardOutput = stdout
-        process.standardError = stderr
-        try process.run()
-        stdin.fileHandleForWriting.write(Data("{}".utf8))
-        stdin.fileHandleForWriting.closeFile()
-        let out = stdout.fileHandleForReading.readDataToEndOfFile()
-        let err = stderr.fileHandleForReading.readDataToEndOfFile()
-        process.waitUntilExit()
-        return (
-            process.terminationStatus,
-            String(decoding: out, as: UTF8.self),
-            String(decoding: err, as: UTF8.self)
-        )
+        return try Self.runToCompletion(process, stdin: Data("{}".utf8))
     }
 
     // MARK: Shim stdout gate
@@ -710,39 +772,16 @@ final class ClaudeRemotePluginManifestTests: XCTestCase {
         curlExitCode: Int32 = 0,
         extraEnvironment: [String: String] = [:]
     ) throws -> (exitCode: Int32, stdout: String, stderr: String) {
-        let stubDirectory = FileManager.default.temporaryDirectory
-            .appendingPathComponent("shim-stub-\(UUID().uuidString)")
-        try FileManager.default.createDirectory(at: stubDirectory, withIntermediateDirectories: true)
-        defer { try? FileManager.default.removeItem(at: stubDirectory) }
-        let bodyFixture = stubDirectory.appendingPathComponent("body.fixture")
+        // The stub itself is shared (see `stubCurlDirectory`); the body fixture
+        // is the part that differs per call and keeps its own directory, so no
+        // case can read the answer the previous one staged.
+        let stubDirectory = Self.stubCurlDirectory
+        let bodyDirectory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("shim-body-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: bodyDirectory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: bodyDirectory) }
+        let bodyFixture = bodyDirectory.appendingPathComponent("body.fixture")
         try body?.write(to: bodyFixture)
-        let stub = stubDirectory.appendingPathComponent("curl")
-        let script = """
-        #!/bin/sh
-        out=""
-        previous=""
-        url=""
-        for argument in "$@"; do
-          [ "$previous" = "--output" ] && out="$argument"
-          if [ "$previous" = "--header" ] && [ -n "${FAKE_CURL_HEADER_DUMP:-}" ]; then
-            case "$argument" in
-            @*) cat "${argument#@}" >>"$FAKE_CURL_HEADER_DUMP" 2>/dev/null ;;
-            esac
-          fi
-          url="$argument"
-          previous="$argument"
-        done
-        # One line per invocation, carrying the URL: proves both THAT curl was
-        # dialed (or was not, during backoff) and WHERE — the per-Mac port is
-        # only real if it reaches the wire.
-        [ -n "${FAKE_CURL_LOG:-}" ] && printf '%s\\n' "$url" >>"$FAKE_CURL_LOG"
-        cat >/dev/null
-        [ -n "$out" ] && cp "$FAKE_CURL_BODY" "$out" 2>/dev/null
-        printf '%s' "$FAKE_CURL_STATUS"
-        exit "${FAKE_CURL_EXIT:-0}"
-        """
-        try script.write(to: stub, atomically: true, encoding: .utf8)
-        try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: stub.path)
         let systemPath = ProcessInfo.processInfo.environment["PATH"] ?? "/usr/bin:/bin"
         var environment = [
             "CLAUDE_PLUGIN_OPTION_TOKEN": "unit-test-token",

--- a/Tests/localvoxtralTests/ClaudeRemotePluginManifestTests.swift
+++ b/Tests/localvoxtralTests/ClaudeRemotePluginManifestTests.swift
@@ -27,9 +27,10 @@ final class ClaudeRemotePluginManifestTests: XCTestCase {
     }
 
     /// The shared stub lives for the whole class, so it is removed once here
-    /// rather than by whichever case happened to run last.
+    /// rather than by whichever case happened to run last. A no-op when no case
+    /// needed it: `stubCurlRoot` is a path, not a side effect.
     override class func tearDown() {
-        try? FileManager.default.removeItem(at: stubCurlDirectory)
+        try? FileManager.default.removeItem(at: stubCurlRoot)
         super.tearDown()
     }
 
@@ -508,17 +509,13 @@ final class ClaudeRemotePluginManifestTests: XCTestCase {
         )
     }
 
-    /// The stub `curl` every `runShimWithStubCurl` call puts first on PATH.
-    ///
-    /// Byte-identical on every call, so it is written ONCE for the whole class
-    /// instead of being created, chmodded and torn down on each of the ~40
-    /// calls. What varies per call — the body fixture, the status, the exit
-    /// code, the header dump — is passed in the environment and already was.
-    private static let stubCurlDirectory: URL = {
-        let directory = FileManager.default.temporaryDirectory
-            .appendingPathComponent("shim-stub-\(UUID().uuidString)")
-        let stub = directory.appendingPathComponent("curl")
-        let script = """
+    /// Where the stub `curl` lives. A path only — computing it touches nothing,
+    /// so the class teardown that removes this directory cannot bring the stub
+    /// into existence in order to delete it.
+    private static let stubCurlRoot: URL = FileManager.default.temporaryDirectory
+        .appendingPathComponent("shim-stub-\(UUID().uuidString)")
+
+    private static let stubCurlScript = """
         #!/bin/sh
         out=""
         previous=""
@@ -542,18 +539,31 @@ final class ClaudeRemotePluginManifestTests: XCTestCase {
         printf '%s' "$FAKE_CURL_STATUS"
         exit "${FAKE_CURL_EXIT:-0}"
         """
-        // A fixture this whole class depends on: if it cannot be written there
-        // is nothing to test, and a silent failure would look like the shim
-        // never dialing.
-        try! FileManager.default.createDirectory(
-            at: directory, withIntermediateDirectories: true
-        )
-        try! script.write(to: stub, atomically: true, encoding: .utf8)
-        try! FileManager.default.setAttributes(
+
+    /// Materialises the stub on first use and hands back the directory to put
+    /// first on PATH.
+    ///
+    /// The script is byte-identical on every call, so it is written ONCE for
+    /// the whole class instead of being created, chmodded and torn down on each
+    /// of the ~40 calls; a later call pays one `fileExists`. Everything that
+    /// varies per call — the body fixture, the status, the exit code, the
+    /// header dump — is passed in the environment and already was.
+    ///
+    /// `throws` rather than `try!` in a stored property: a temp directory that
+    /// cannot be written should fail the one case that needed it, the way the
+    /// per-call version did, not abort the whole test process and take every
+    /// other class's results with it.
+    private func stubCurlDirectory() throws -> URL {
+        let directory = Self.stubCurlRoot
+        let stub = directory.appendingPathComponent("curl")
+        guard !FileManager.default.fileExists(atPath: stub.path) else { return directory }
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        try Self.stubCurlScript.write(to: stub, atomically: true, encoding: .utf8)
+        try FileManager.default.setAttributes(
             [.posixPermissions: 0o755], ofItemAtPath: stub.path
         )
         return directory
-    }()
+    }
 
     func testStatusLineRendererMapsEachStampStateToItsFixedString() throws {
         let esc = "\u{1B}"
@@ -775,7 +785,7 @@ final class ClaudeRemotePluginManifestTests: XCTestCase {
         // The stub itself is shared (see `stubCurlDirectory`); the body fixture
         // is the part that differs per call and keeps its own directory, so no
         // case can read the answer the previous one staged.
-        let stubDirectory = Self.stubCurlDirectory
+        let stubDirectory = try stubCurlDirectory()
         let bodyDirectory = FileManager.default.temporaryDirectory
             .appendingPathComponent("shim-body-\(UUID().uuidString)")
         try FileManager.default.createDirectory(at: bodyDirectory, withIntermediateDirectories: true)


### PR DESCRIPTION
## What

`ClaudeRemotePluginManifestTests` is 55 cases and ~90 spawns of `/bin/sh`
against the real remote hook shim (`post.sh`) and the real status-line renderer,
some of them behind a stub `curl`. It was ~26 s of the ~80 s unit suite.

Profiled first: the expensive part was **not** the spawning. It was
`Process.waitUntilExit()`, which spins the calling thread's run loop and
re-checks `isRunning` on a fixed interval. Both runners here already read stdout
and stderr **to EOF** before calling it — which means the child had closed its
pipes and exited — and then paid that interval as pure latency. The floor shows
up plainly in the old numbers: nine spawns of a script that does a `cat`, a
`date` and a `case` took 0.900 s, i.e. ~100 ms each.

- **One shared `runToCompletion`** for both spawn sites, waiting on
  `terminationHandler` + a `DispatchSemaphore` instead of a run-loop poll. The
  stream read order is unchanged (stdout to EOF, then stderr) and is safe for
  the same reason it was before: both scripts are contractually silent on
  stderr, and several cases here assert exactly that.
- **The stub `curl` is written once per class.** It is byte-identical on every
  one of the ~40 `runShimWithStubCurl` calls, so it no longer gets created,
  chmodded and torn down per call. Everything that varies per call — the body
  fixture, status, exit code, header dump — was already passed in the
  environment; the **body fixture keeps its own per-call directory**, so no case
  can read the answer the previous one staged.

Every test name, every case inside every loop, and every byte-for-byte
assertion is untouched.

## Proof

**Same 55 cases, same names, before and after** (paired runs, same build dir,
minutes apart, `.build/last-remote.log`):

```
before: Executed 55 tests, with 0 failures (0 unexpected) in 25.895 (25.903) seconds
after:  Executed 55 tests, with 0 failures (0 unexpected) in 10.537 (10.540) seconds

cases before=55 after=55   name set differs: no
```

Per-test, the ones that moved (seconds):

```
  before    after   test
   5.715    6.131   testStatusLineRendererNeverEchoesStampBytes     <- see below
   3.954    0.768   testShimFallsBackToTheLegacyPortWhenTheOptionIsAbsentOrJunk
   3.585    0.768   testShimRefusesToWriteAnEnvValueThatCouldForgeAHeaderLine
   3.425    0.678   testShimStdoutFailsClosedOnAnythingButTheExactAllowlistedBody
   1.208    0.248   testShimAcceptsTheEdgesOfTheDocumentedAcceptableRange
   1.133    0.271   testExpiredCorruptAndFutureStampsAllFailTowardDialing
   1.016    0.192   testShimStampsTheOutcomeOfEveryCompletedDial
   0.900    0.136   testStatusLineRendererMapsEachStampStateToItsFixedString
   0.663    0.124   testUserPromptSubmitDialsThroughAnArmedBackoffAndSuccessClearsIt
   0.652    0.149   testShimDropsMultibyteValuesUnderAUTF8Locale
   0.406    0.065   testTransportFailureArmsTheBackoffAndLaterEventsSkipTheDialEntirely
   0.380    0.090   testShimSendsEveryAllowlistedEnvValueUnderTheHeaderTheListenerReads
```

**Full unit suite green** on this branch:

```
$ LV_BUILD_DIR=work/localvoxtral-warnings ./scripts/remote-build.sh test
	 Executed 2764 tests, with 2 tests skipped and 0 failures (0 unexpected) in 54.889 (55.030) seconds
```

(the paired baseline run in the same directory: `82.120 (82.307) seconds` — the
gap beyond this suite's own 15.4 s is runner load, so treat the 25.9 -> 10.5 s
suite figure as the measurement and the suite totals as context.)

The 8 `warning:` lines that run emits are the four pre-existing sites on `main`
that #262 fixes; none comes from this diff.

**Mutation check** — flip one byte of the shim's stdout grammar in
`hooks/post.sh` (`suppressOutput` -> `suppressOutpuT`) on a throwaway edit and
run the suite both ways:

```
# this branch's suite
Tests/.../ClaudeRemotePluginManifestTests.swift:690: error: -[... testShimPrintsTheListenersRealBodyByteForByte] : XCTAssertEqual failed: ("0 bytes") is not equal to ("23 bytes") - the listener body must pass through byte-for-byte
Tests/.../ClaudeRemotePluginManifestTests.swift:1205: error: -[... testUserPromptSubmitDialsThroughAnArmedBackoffAndSuccessClearsIt] : XCTAssertEqual failed: ("0 bytes") is not equal to ("23 bytes")
	 Executed 55 tests, with 2 failures (0 unexpected) in 8.549 seconds

# the baseline suite, same mutated shim — the SAME two named tests, same messages
Tests/.../ClaudeRemotePluginManifestTests.swift:628: error: -[... testShimPrintsTheListenersRealBodyByteForByte] : XCTAssertEqual failed: ("0 bytes") is not equal to ("23 bytes") - the listener body must pass through byte-for-byte
Tests/.../ClaudeRemotePluginManifestTests.swift:1166: error: -[... testUserPromptSubmitDialsThroughAnArmedBackoffAndSuccessClearsIt] : XCTAssertEqual failed: ("0 bytes") is not equal to ("23 bytes")
	 Executed 55 tests, with 2 failures (0 unexpected) in 32.386 seconds
```

Reverted; the green run above is the same tree without the mutation.

### One case did not get faster, and it is a product finding

`testStatusLineRendererNeverEchoesStampBytes` went 5.715 s -> 6.131 s and is now
58 % of what is left. It is dominated by a single hostile input — a
100 000-byte `hook-status` stamp — and the time is spent inside
`statusline.sh`, not in the harness. Measured directly, one render of that
stamp:

```
/bin/sh (dash)  100k A   0.999s
/bin/bash 5     100k A   3.383s
```

macOS runs the script under bash 3.2 as `/bin/sh`, which is where the ~6 s comes
from. `${LINE%% *}` and `${LINE#* }` over a 100 KB value are what cost it. That
matters beyond the test: the renderer runs on **every status-line refresh in the
user's terminal**, and the stamp file is only 0600 — the premise of that very
test is that another process could have rewritten it. Left alone here on
purpose: fixing it changes a script on the Claude Code context path and deserves
its own PR and its own proof, not a ride on a test-cost change.

## Adversarial review (opencode / GLM-5.2, read-only)

One review across this PR and #263. It verified by inspection that the wait
rewrite is correct (handler set before `run()`, semaphore counts so
signal-before-wait is safe, `terminationStatus` read only after the reap, the
`@Sendable` closure captures only the semaphore), that the 55 test names are
byte-identical before and after, that the stub script's emitted bytes are
unchanged, and that the shared stub cannot leak state between cases (every
varying input arrives by environment; body, header dump and curl log all keep
per-call UUID directories). **No BLOCKER, no SHOULD-FIX**; verdict "safe to
merge as-is". Two nits, one acted on in `9baf471`:

**N3 — `try!` in a stored property.** A temp directory that cannot be written
became a fatal error that aborts the whole xctest process, where the per-call
version it replaced failed exactly one case with a clean error. Worse, the class
teardown removing the directory *touched* the static, so a run in which no case
needed the stub would create it in order to delete it. Now the path is a plain
`static let` (computing it touches nothing) and the stub is materialised by a
throwing instance method on first use, guarded by one `fileExists`. Same single
write per class, failures land on the case that needed it.

Verified after the fix — full unit suite, same 55 cases, still fast:

```
$ LV_BUILD_DIR=work/localvoxtral-warnings ./scripts/remote-build.sh test
Test Suite 'ClaudeRemotePluginManifestTests' passed
	 Executed 55 tests, with 0 failures (0 unexpected) in 8.973 (8.975) seconds
	 Executed 2764 tests, with 2 tests skipped and 0 failures (0 unexpected) in 52.575 (52.706) seconds
$ grep -ci "warning:" .build/last-remote.log
0
```

**N4 — pre-existing, not acted on.** Reading stdout to EOF before draining
stderr can deadlock on a child that writes more than a pipe buffer to stderr.
`main` has the identical order and would hang identically; both scripts are
contractually silent on stderr and several cases here assert it. Recorded, not
changed — this PR is not the place to alter that shape.

- [x] Unit suite green — `./scripts/remote-build.sh test` (summary line above)
- [ ] Realtime integration green — not run locally: nothing here reaches the
      realtime client. Tier-1 runs on CI for this PR.
- [ ] Bug fix: regression test added — n/a, no behaviour change; the mutation
      check above is what stands in for it.
- [ ] UI change — n/a.

## CI status — red for a reason that is not this PR

Run [33991422049](https://github.com/T0mSIlver/localvoxtral/actions/runs/33991422049)
on `9baf471` is RED. The failure, from that run's own `unit-test-log-macOS`
artifact (the step log itself is truncated to its tail, which is why the name is
not visible there):

```
Tests/localvoxtralTests/BackendProcessSupervisorTests.swift:329: error:
  -[localvoxtralTests.BackendProcessSupervisorTests testStopHonorsTERMWithoutRestarting] : XCTAssertTrue failed
Test Case '-[... testStopHonorsTERMWithoutRestarting]' failed (0.427 seconds).
```

That is #268's flake ("14/20 → 0/20 on the hosted lane"), on the 3-core hosted
runner #260 just moved tier 0 onto. It is one Swift test in a file this PR does
not touch; the `mac-lanes` half of the same run passed, the previous commit
(`d471ff7`, run 33988505665) was fully green, and the identical tree passed the
full unit suite on the Mac (`2764 tests … 0 failures`, quoted above). Re-run
once #268 is in.

Conditional lanes, checked rather than assumed:

```
$ scripts/ci/llm-lane-filter.sh <(echo Tests/localvoxtralTests/ClaudeRemotePluginManifestTests.swift)
run=false  reason=no LLM-relevant changes
$ scripts/ci/speechd-lane-filter.sh  ... run=false
$ scripts/ci/herdr-lane-filter.sh    ... run=false
```

Nothing in this diff reaches a model, and nothing changes what the app says to
herdr.
