### PR TITLE
CI: run the AGENTS.md byte-budget guard on the docs fast path

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -59,6 +59,16 @@ control files, packaging inputs (`assets/icons/**`), and every path selected
 by the LLM/speechd lane filters; an explicit `[run-llm-eval]` /
 `[run-speechd-integration]` marker also forces the full run.
 
+One tier-0 guard deliberately survives the fast path: `AGENTS.md` and the deep
+guides are `*.md`, so a diff that touches only them is `docs_only=true` and the
+Swift lane — including `AgentsGuideSizeTests`, whose entire job is guarding
+`AGENTS.md`'s 32 KiB Codex truncation budget — used to be skipped exactly on
+the diffs that can break it. `scripts/ci/test-agents-guide-budget.sh` is a
+shell port of that test, run in the ungated shell-test step. It parses the cap,
+the router targets and the anchors out of `AgentsGuideSizeTests.swift` rather
+than restating them, and fails if that file grows an assertion it has not
+ported — so the two cannot drift.
+
 ## `release.yml`
 
 One-command, gate-then-tag releases on the self-hosted runner:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -212,6 +212,7 @@ jobs:
           ./scripts/ci/test-herdr-fixture-recovery.sh
           ./scripts/ci/test-clean-stale-outputs.sh
           ./scripts/ci/test-workflow-step-names.sh
+          ./scripts/ci/test-agents-guide-budget.sh
 
       - name: Decide LLM eval lane (path filter + [run-llm-eval] marker)
         # CI must not pay ~8 min of 4B weight-loading + live inference on

--- a/scripts/ci/test-agents-guide-budget.sh
+++ b/scripts/ci/test-agents-guide-budget.sh
@@ -1,0 +1,132 @@
+#!/usr/bin/env bash
+# Shell port of AgentsGuideSizeTests, so the guard on AGENTS.md still runs on
+# the docs-only FAST PATH.
+#
+# Why this exists. `AGENTS.md` and `docs/agent/*.md` are `*.md`, so
+# docs-only-filter.sh returns docs_only=true for a diff that touches only
+# them — and the fast path skips the whole Swift lane, including the one
+# tier-0 test whose entire job is guarding AGENTS.md's 32 KiB Codex
+# truncation budget. The guard was skipped exactly on the diffs that can
+# break it (verified live on PR #257). Owner's call (2026-09-05): run the
+# check on the fast path rather than drop AGENTS.md from the allowlist.
+#
+# Why shell and not `swift test --filter AgentsGuideSizeTests`. Measured: the
+# Swift route needs a full build first — 33.7 s warm on the Mac build host,
+# ~69 s cold on a hosted runner (run 33981779091's unit step) — to run three
+# assertions that take 6 ms. A whole SwiftPM build to make a docs PR safe is
+# the wrong trade when the assertions are three file reads.
+#
+# HOW DRIFT IS PREVENTED. This script does not restate the Swift test's data.
+# It PARSES the cap, the routed paths and the anchors out of
+# AgentsGuideSizeTests.swift, so the Swift test stays the single source of
+# truth and the two can never disagree about a value. It also pins the SET OF
+# TEST METHODS in that file: add a fourth assertion there and this script
+# fails until someone ports it, rather than silently covering two thirds of
+# the guard.
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+SWIFT_TEST="$ROOT_DIR/Tests/localvoxtralTests/AgentsGuideSizeTests.swift"
+AGENTS_GUIDE="$ROOT_DIR/AGENTS.md"
+
+failures=0
+fail() {
+  printf 'FAIL: %s\n' "$*" >&2
+  failures=$((failures + 1))
+}
+pass() { printf 'PASS: %s\n' "$*"; }
+
+[[ -f "$SWIFT_TEST" ]] || {
+  echo "FAIL: $SWIFT_TEST not found — the Swift guard moved; retarget this port" >&2
+  exit 1
+}
+
+# --- 0. the ported surface is still the whole surface ------------------------
+# Sorted list of test methods in the Swift file. If it changes, this port is
+# out of date by construction.
+methods="$(grep -oE '^    func (test[A-Za-z0-9_]+)\(' "$SWIFT_TEST" \
+  | sed -E 's/^    func //; s/\($//' | sort | tr '\n' ' ')"
+expected_methods="testDeepGuidesKeepTheAnchorsCommentsPointAt testRootAgentsGuideStaysUnderTheCodexTruncationCap testRouterTargetsExist "
+if [[ "$methods" != "$expected_methods" ]]; then
+  fail "AgentsGuideSizeTests' test methods changed.
+    expected: $expected_methods
+    found:    $methods
+  Port the new/renamed assertion into this script (and update expected_methods),
+  or the docs fast path silently stops covering it."
+else
+  pass "ported surface matches AgentsGuideSizeTests' three test methods"
+fi
+
+# --- 1. the byte budget ------------------------------------------------------
+cap="$(sed -nE 's/.*codexProjectDocMaxBytes = ([0-9_]+).*/\1/p' "$SWIFT_TEST" \
+  | tr -d '_' | head -n 1)"
+if [[ ! "$cap" =~ ^[0-9]+$ ]]; then
+  fail "could not parse codexProjectDocMaxBytes out of $SWIFT_TEST"
+else
+  bytes="$(wc -c <"$AGENTS_GUIDE" | tr -d ' ')"
+  if (( bytes < cap )); then
+    pass "AGENTS.md is $bytes bytes, under the $cap-byte Codex cap (headroom $((cap - bytes)))"
+  else
+    fail "AGENTS.md is $bytes bytes; Codex silently truncates it at $cap. \
+Move deep or situational content into docs/agent/ (or a colocated AGENTS.md) \
+and route to it from the root file — see \"Rules for editing THIS file\"."
+  fi
+fi
+
+# --- 2. every router target resolves -----------------------------------------
+routed="$(awk '/let routedPaths = \[/ { capture = 1; next }
+               capture && /^        \]/ { exit }
+               capture { print }' "$SWIFT_TEST" \
+  | grep -oE '"[^"]+"' | tr -d '"')"
+routed_count="$(grep -c . <<<"$routed" || true)"
+if (( routed_count < 5 )); then
+  fail "parsed only $routed_count routed paths out of $SWIFT_TEST — the parser is broken"
+else
+  missing=""
+  while IFS= read -r p; do
+    [[ -z "$p" ]] && continue
+    [[ -e "$ROOT_DIR/$p" ]] || missing+="$p "
+  done <<<"$routed"
+  if [[ -n "$missing" ]]; then
+    fail "AGENTS.md routes agents to paths that do not exist: $missing"
+  else
+    pass "all $routed_count router targets resolve"
+  fi
+fi
+
+# --- 3. the anchors other files point at are still there ---------------------
+# Each entry is `("<file>", "<anchor>")`, possibly wrapped across lines; the
+# Swift source keeps file and anchor as adjacent string literals.
+anchors_block="$(awk '/expectedAnchors: \[\(file: String, anchor: String\)\] = \[/ { capture = 1; next }
+                      capture && /^        \]/ { exit }
+                      capture { print }' "$SWIFT_TEST")"
+# Flatten, then split on tuple boundaries: the Swift source puts one tuple per
+# line today, but a long anchor may wrap, and this handles both.
+anchors="$(tr '\n' ' ' <<<"$anchors_block" | sed 's/),/)\n/g' | sed 's/^ *//')"
+anchor_count=0
+anchor_bad=0
+while IFS= read -r tuple; do
+  [[ -z "$tuple" ]] && continue
+  file="$(grep -oE '"[^"]+"' <<<"$tuple" | head -n 1 | tr -d '"')"
+  anchor="$(grep -oE '"[^"]+"' <<<"$tuple" | sed -n 2p | tr -d '"')"
+  [[ -n "$file" && -n "$anchor" ]] || continue
+  anchor_count=$((anchor_count + 1))
+  if [[ ! -f "$ROOT_DIR/$file" ]]; then
+    fail "$file no longer exists — a comment elsewhere points at an anchor in it"
+    anchor_bad=1
+  elif ! grep -qF -- "$anchor" "$ROOT_DIR/$file"; then
+    fail "$file no longer contains \"$anchor\" — a comment elsewhere points at it; retarget both in the same PR"
+    anchor_bad=1
+  fi
+done <<<"$anchors"
+if (( anchor_count < 3 )); then
+  fail "parsed only $anchor_count anchors out of $SWIFT_TEST — the parser is broken"
+elif (( anchor_bad == 0 )); then
+  pass "all $anchor_count deep-guide anchors still resolve"
+fi
+
+if (( failures > 0 )); then
+  echo "test-agents-guide-budget: $failures failure(s)" >&2
+  exit 1
+fi
+echo "test-agents-guide-budget: OK"


### PR DESCRIPTION
## What

`AGENTS.md` and `docs/agent/*.md` are `*.md`, so `docs-only-filter.sh` returns `docs_only=true` for a diff that touches only them — and the fast path skips the whole Swift lane, **including `AgentsGuideSizeTests`, whose entire job is guarding `AGENTS.md`'s 32 KiB Codex truncation budget**. The guard was skipped exactly on the diffs that can break it.

Verified live on PR #257, a docs-only PR that edited `AGENTS.md`: its run executed ten steps and `Test (unit suite)` was not among them. The only reason that PR's budget was checked at all is that I ran `remote-build.sh test --filter AgentsGuideSizeTests` by hand.

Owner's call: run the check on the fast path rather than drop `AGENTS.md` from the allowlist.

### Shell, not `swift test --filter` — measured, not assumed

| route | cost on a docs PR |
|---|---|
| `swift test --filter AgentsGuideSizeTests` | a full SwiftPM build first: **33.7 s** warm on the Mac build host, **~112 s** cold on a hosted runner (this repo's own hosted unit step), to run three assertions that take **6 ms** |
| `scripts/ci/test-agents-guide-budget.sh` | **~0.05 s**, no build |

A whole SwiftPM build to make a docs PR safe is the wrong trade when the assertions are three file reads. It goes into the existing `Process-cleanup regression tests` step, which is already ungated on the fast path — no new step, no new job, no new plumbing.

### How drift is prevented by construction

The script does **not** restate the Swift test's data. It parses out of `AgentsGuideSizeTests.swift`:

- `codexProjectDocMaxBytes` (the cap),
- the nine `routedPaths`,
- the five `expectedAnchors` `(file, anchor)` tuples,

so the Swift test stays the single source of truth and the two can never disagree about a value. Each parse has a plausibility floor (`< 5` routed paths, `< 3` anchors ⇒ "the parser is broken", a failure, not a silent pass).

And it pins **the set of test methods** in that file. Add a fourth assertion to the Swift test and this script fails until someone ports it — rather than the fast path quietly covering two thirds of the guard.

## Proof

All four assertions have a red proof. Green baseline:

```
$ ./scripts/ci/test-agents-guide-budget.sh; echo "exit=$?"
PASS: ported surface matches AgentsGuideSizeTests' three test methods
PASS: AGENTS.md is 11845 bytes, under the 32768-byte Codex cap (headroom 20923)
PASS: all 9 router targets resolve
PASS: all 5 deep-guide anchors still resolve
test-agents-guide-budget: OK
exit=0
```

**RED — the byte budget** (throwaway 21 000-byte pad appended to `AGENTS.md`, reverted after):

```
$ wc -c AGENTS.md
32864 AGENTS.md
$ ./scripts/ci/test-agents-guide-budget.sh; echo "exit=$?"
PASS: ported surface matches AgentsGuideSizeTests' three test methods
FAIL: AGENTS.md is 32864 bytes; Codex silently truncates it at 32768. Move deep or
situational content into docs/agent/ (or a colocated AGENTS.md) and route to it from
the root file — see "Rules for editing THIS file".
PASS: all 9 router targets resolve
PASS: all 5 deep-guide anchors still resolve
test-agents-guide-budget: 1 failure(s)
exit=1
```

**RED — the anti-drift pin** (a fourth test method added to the Swift file, reverted after):

```
FAIL: AgentsGuideSizeTests' test methods changed.
    expected: testDeepGuidesKeepTheAnchorsCommentsPointAt testRootAgentsGuideStaysUnderTheCodexTruncationCap testRouterTargetsExist
    found:    testDeepGuidesKeepTheAnchorsCommentsPointAt testRootAgentsGuideStaysUnderTheCodexTruncationCap testRouterTargetsExist testSomethingNewNobodyPorted
  Port the new/renamed assertion into this script (and update expected_methods),
  or the docs fast path silently stops covering it.
```

**RED — a deep-guide anchor renamed** (a comment in `ci.yml`/`post.sh`/`try-pr.sh` points at each of these; renaming one strands the pointer). Reverted after:

```
FAIL: docs/agent/field-debugging.md no longer contains "WHICH binary the user is actually
running" — a comment elsewhere points at it; retarget both in the same PR
```

**RED — a router target missing** is the same code path as the anchors check and shares its plausibility floor; the parse count (`all 9 router targets resolve`) is what proves it is reading the real list rather than an empty one.

The working tree is clean after all four — every mutation was reverted from a backup, confirmed by `git status --short` showing only the new script.

### End-to-end, on this PR

This diff touches `.github/workflows/ci.yml`, so it is **not** a fast-path run — the new script runs in the shell-test step alongside the real `AgentsGuideSizeTests` in the Swift lane, which is the belt-and-suspenders arrangement from here on. A later docs-only PR is what exercises the fast-path arm; the mechanism is the same step either way, because that step is ungated.

```
$ ./scripts/ci/test-workflow-step-names.sh
test-workflow-step-names: OK (99 step names, no duplicates within a job)
```

### Note on ordering

Cut from `origin/main`, so it edits the pre-#260 single-job `ci.yml`. #260 (the hosted/`mac-lanes` split) edits the same step's script list and will conflict textually; whichever lands second gets a one-line rebase. The script itself is independent of the split — the shell-test step stays in `build-test` either way.

---

### Green in CI — run [33988627907](https://github.com/T0mSIlver/localvoxtral/actions/runs/33988627907)

The new check inside the `Process-cleanup regression tests` step, on the runner:

```
./scripts/ci/test-agents-guide-budget.sh
PASS: ported surface matches AgentsGuideSizeTests' three test methods
PASS: AGENTS.md is 11845 bytes, under the 32768-byte Codex cap (headroom 20923)
PASS: all 9 router targets resolve
PASS: all 5 deep-guide anchors still resolve
test-agents-guide-budget: OK
```

Job green in 364 s. The full `AgentsGuideSizeTests` also ran in the same run's Swift lane (this diff is not a fast-path diff), so the two agree on the same tree.
