### PR TITLE
release: optional hand-written notes above the generated changelog (+ v0.9.0 notes)

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -73,6 +73,16 @@ unit tests → live integration tests (speechd STT service) → package app bund
 smoke test → zip + dmg → **create tag** → publish GitHub release with
 auto-generated notes and both artifacts.
 
+Release notes: GitHub's generated PR list is always included, and a release
+may additionally ship a **hand-written summary** committed ahead of time at
+`docs/release-notes/<tag>.md` (e.g. `docs/release-notes/v0.9.0.md`, using the
+exact tag release.yml computes). When that file exists it becomes the top of
+the release body and the generated changelog is appended below it;
+`scripts/ci/resolve-release-notes.sh` decides, and its self-test runs in CI's
+shell-test step. The file is optional — with none, the release publishes with
+generated notes exactly as before — but a file that exists and is empty is a
+hard failure rather than a release with a blank human section.
+
 The tag is created only after every gate passes, so a failed release leaves
 no orphan tag. Releases are ad-hoc signed on purpose (a local signing cert
 means nothing on users' machines); proper distribution signing needs a

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -212,6 +212,7 @@ jobs:
           ./scripts/ci/test-herdr-fixture-recovery.sh
           ./scripts/ci/test-clean-stale-outputs.sh
           ./scripts/ci/test-workflow-step-names.sh
+          ./scripts/ci/test-resolve-release-notes.sh
 
       - name: Decide LLM eval lane (path filter + [run-llm-eval] marker)
         # CI must not pay ~8 min of 4B weight-loading + live inference on

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -176,12 +176,40 @@ jobs:
           git tag -a "$TAG" -m "localvoxtral $TAG"
           git push origin "$TAG"
 
+      - name: Resolve hand-written release notes (optional)
+        # A release can ship a human summary written ahead of time at
+        # docs/release-notes/<tag>.md. Optional: with no such file the release
+        # publishes with GitHub's generated notes exactly as before, so a
+        # forgotten file makes a duller release, never a failed one. The one
+        # hard failure is a file that exists and says nothing — see the script.
+        id: notes
+        run: |
+          set -euo pipefail
+          DECISION="$(./scripts/ci/resolve-release-notes.sh "${{ steps.meta.outputs.tag }}")"
+          echo "$DECISION" >> "$GITHUB_OUTPUT"
+          echo "Release notes: $(sed -n 's/^reason=//p' <<<"$DECISION")" \
+            | tee -a "$GITHUB_STEP_SUMMARY"
+
       - name: Publish GitHub release
         uses: softprops/action-gh-release@v2
         with:
           tag_name: ${{ steps.meta.outputs.tag }}
           name: localvoxtral ${{ steps.meta.outputs.tag }}
           prerelease: ${{ steps.meta.outputs.prerelease == 'true' }}
+          # body_path + generate_release_notes, per action-gh-release v2's
+          # README: "If body is specified, the body will be pre-pended to the
+          # automatically generated notes", and "When providing a body and
+          # body_path at the same time, body_path will be attempted first,
+          # then falling back on body if the path can not be read from". So
+          # the hand-written notes lead and GitHub's PR list follows.
+          #
+          # NOT `append_body`: that input means "append to an EXISTING
+          # release's body" (an already-published release being updated), not
+          # "append the generated notes to mine". Setting it here would be a
+          # different feature that happens to sound right.
+          #
+          # An empty body_path is the no-notes case and is simply ignored.
+          body_path: ${{ steps.notes.outputs.path }}
           generate_release_notes: true
           files: |
             dist/localvoxtral-${{ steps.meta.outputs.tag }}.zip

--- a/docs/release-notes/v0.9.0.md
+++ b/docs/release-notes/v0.9.0.md
@@ -1,0 +1,61 @@
+The Claude Code join no longer reads your terminal's window title. That
+mechanism is gone, and the joins that replace it are exact — which is what
+makes remote sessions work with Claude Code's own titles left on.
+
+## Joining a Claude Code session
+
+**Window-title markers are gone.** localvoxtral used to plant a short marker in
+your terminal's title and look for it again when you started dictating. Titles
+are not yours alone: Claude Code writes its conversation title over yours
+mid-turn, multiplexers rewrite pane titles, and you rename windows yourself. On
+a measured session the marker was actually the visible title for **1.26 % of
+the time** — 0.88 seconds out of 69 — and Claude Code's own title held it for
+the rest. A join that depended on catching that window was a lottery, not a
+binding. It has been removed rather than patched.
+
+**You no longer need to disable Claude Code's titles.** If you exported
+`CLAUDE_CODE_DISABLE_TERMINAL_TITLE=1` to make remote joins work, you can drop
+it. Titles can stay on.
+
+**Remote sessions over herdr now join properly through Ghostty and
+Terminal.app.** Inside a [herdr](https://herdr.dev) session the app asks herdr
+itself which pane is focused and binds to that pane by id. Any ambiguity —
+including two live herdr sessions — attaches nothing rather than guessing.
+
+**A plain `ssh` session is now connection-bound**, matched to the SSH
+connection it arrived on rather than to anything drawn on your screen, so it
+cannot attach to the wrong window.
+
+**The TTY join needs Ghostty 1.4 or newer** (currently the tip channel),
+iTerm2, or Terminal.app. Other terminals abstain rather than half-join.
+
+## Action required if you have enrolled a remote host
+
+Enrolled hosts do **not** pick up the new plugin by re-running the setup
+commands. Run this on each enrolled host to get the 1.5.x remote plugin:
+
+```sh
+claude plugin marketplace update localvoxtral
+claude plugin update localvoxtral-remote@localvoxtral
+```
+
+Order matters — refreshing the marketplace clone first is what makes the second
+command an update. Your token is preserved. In the app, every row under
+**Remote Claude Code over SSH** has an **Update Plugin…** button that shows
+these commands and can run them over SSH for you.
+
+Nothing breaks if you skip it: an older plugin keeps working and simply sends
+a response the app now ignores. You just will not get the new join behaviour
+until you update.
+
+## Audio
+
+**Multi-channel input devices are supported.** Professional interfaces that
+present many input channels now work, and you can pick which channel to
+dictate from.
+
+## For anyone running the SSH UI gate
+
+The gate is deliberately never installed or updated by CI — it is the trust
+boundary, so reinstalling it by hand is the correct friction. Reinstall it
+yourself after upgrading.

--- a/scripts/ci/resolve-release-notes.sh
+++ b/scripts/ci/resolve-release-notes.sh
@@ -1,0 +1,62 @@
+#!/bin/bash
+# Resolves the optional hand-written release notes for a tag.
+#
+# Usage:
+#   scripts/ci/resolve-release-notes.sh <tag> [repo-root]
+#
+# stdout is $GITHUB_OUTPUT-shaped:
+#   path=<repo-relative path, or empty when there are none>
+#   reason=<one line, safe for a step summary>
+#
+# Convention: `docs/release-notes/<tag>.md`, e.g. docs/release-notes/v0.9.0.md.
+# The tag is exactly what release.yml computes (`v` + X.Y.Z, or X.Y.Z-rc.N).
+#
+# Optional on purpose. A release with no such file still publishes with
+# GitHub's generated notes, exactly as every release before this one did —
+# the file only ever ADDS a human summary above that list. So a forgotten
+# file is a duller release, never a failed one.
+#
+# The one hard failure is a file that exists but says nothing: an empty or
+# whitespace-only notes file would hand the release action a body_path it can
+# read and produce a release whose human section is blank, which looks like a
+# bug in the pipeline rather than a missing file. Fail loudly instead.
+set -euo pipefail
+
+if [[ $# -lt 1 || $# -gt 2 ]]; then
+  echo "usage: $0 <tag> [repo-root]" >&2
+  exit 2
+fi
+
+TAG="$1"
+ROOT_DIR="${2:-$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)}"
+
+# The tag reaches this script from release.yml's own computation, but it lands
+# in a filesystem path, so validate its shape rather than trusting it: only the
+# grammar release.yml can produce is accepted, which also rules out `..` and
+# any separator.
+if [[ ! "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-rc\.[0-9]+)?$ ]]; then
+  echo "refusing to resolve notes for a tag that is not vX.Y.Z[-rc.N]: $TAG" >&2
+  exit 2
+fi
+
+REL="docs/release-notes/$TAG.md"
+ABS="$ROOT_DIR/$REL"
+
+if [[ ! -e "$ABS" ]]; then
+  echo "path="
+  echo "reason=no $REL — publishing with generated notes only"
+  exit 0
+fi
+
+if [[ ! -f "$ABS" ]]; then
+  echo "$REL exists but is not a regular file" >&2
+  exit 1
+fi
+
+if [[ -z "$(tr -d '[:space:]' <"$ABS")" ]]; then
+  echo "$REL exists but is empty — write the notes or delete the file" >&2
+  exit 1
+fi
+
+echo "path=$REL"
+echo "reason=hand-written notes from $REL, with the generated changelog appended"

--- a/scripts/ci/test-resolve-release-notes.sh
+++ b/scripts/ci/test-resolve-release-notes.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+# Regression test for resolve-release-notes.sh.
+#
+# This is the only automated proof the notes mechanism can have: release.yml
+# publishes real releases and tags, so it is never run to try something out.
+# Everything the workflow decides therefore lives in the script under test,
+# and the workflow's own use of it is one `body_path:` line.
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "$0")/../.." && pwd -P)"
+RESOLVE="$ROOT_DIR/scripts/ci/resolve-release-notes.sh"
+
+TMP_DIR="$(mktemp -d "${TMPDIR:-/tmp}/lv-release-notes-test.XXXXXX")"
+trap 'rm -rf "$TMP_DIR"' EXIT
+mkdir -p "$TMP_DIR/docs/release-notes"
+
+fail() { printf 'FAIL: %s\n' "$*" >&2; exit 1; }
+pass() { printf 'PASS: %s\n' "$*"; }
+
+# expect_ok <tag> <expected-path> <description>
+expect_ok() {
+  local tag="$1" expected="$2" description="$3" out path reason
+  out="$("$RESOLVE" "$tag" "$TMP_DIR")" || fail "$description: exited non-zero"
+  path="$(sed -n 's/^path=//p' <<<"$out")"
+  reason="$(sed -n 's/^reason=//p' <<<"$out")"
+  [[ "$path" == "$expected" ]] \
+    || fail "$description: expected path='$expected', got '$path'"
+  [[ -n "$reason" ]] || fail "$description: reason line is missing"
+  pass "$description ($reason)"
+}
+
+expect_fail() {
+  local description="$1"
+  shift
+  if "$RESOLVE" "$@" >/dev/null 2>&1; then
+    fail "$description: expected a non-zero exit, got 0"
+  fi
+  pass "$description"
+}
+
+# --- the optional-file contract --------------------------------------------
+
+expect_ok v0.9.0 "" "a tag with no notes file publishes with generated notes only"
+
+printf '## Highlights\n\nSomething user-facing.\n' >"$TMP_DIR/docs/release-notes/v0.9.0.md"
+expect_ok v0.9.0 "docs/release-notes/v0.9.0.md" "a tag WITH a notes file resolves it"
+
+printf 'rc notes\n' >"$TMP_DIR/docs/release-notes/v1.0.0-rc.2.md"
+expect_ok v1.0.0-rc.2 "docs/release-notes/v1.0.0-rc.2.md" "prerelease tags follow the same convention"
+
+expect_ok v9.9.9 "" "an unrelated tag does not pick up another tag's file"
+
+# --- the one hard failure ---------------------------------------------------
+# A file that exists but says nothing would publish a release whose human
+# section is blank, which reads as a broken pipeline rather than a missing file.
+
+: >"$TMP_DIR/docs/release-notes/v0.0.1.md"
+expect_fail "an empty notes file is a hard failure, not a silent blank release" \
+  v0.0.1 "$TMP_DIR"
+printf '   \n\t\n' >"$TMP_DIR/docs/release-notes/v0.0.2.md"
+expect_fail "a whitespace-only notes file is a hard failure too" \
+  v0.0.2 "$TMP_DIR"
+
+# --- the tag reaches a filesystem path, so its shape is validated -----------
+
+expect_fail "a tag with a path separator is refused" "v1.0.0/../../etc/passwd" "$TMP_DIR"
+expect_fail "a traversal tag is refused" "../../etc/passwd" "$TMP_DIR"
+expect_fail "an unversioned tag is refused" "latest" "$TMP_DIR"
+expect_fail "a tag without the v prefix is refused" "0.9.0" "$TMP_DIR"
+expect_fail "no arguments is a usage error"
+
+# --- the real repo ----------------------------------------------------------
+# Whatever notes files are committed must all be resolvable and non-empty:
+# a broken one only shows up during a release otherwise.
+shopt -s nullglob
+for f in "$ROOT_DIR"/docs/release-notes/v*.md; do
+  tag="$(basename "$f" .md)"
+  out="$("$RESOLVE" "$tag" "$ROOT_DIR")" \
+    || fail "committed notes file $f does not resolve (empty, or a bad tag name?)"
+  [[ "$(sed -n 's/^path=//p' <<<"$out")" == "docs/release-notes/$tag.md" ]] \
+    || fail "committed notes file $f resolved to something else"
+  pass "committed notes file docs/release-notes/$tag.md resolves"
+done
+
+printf 'OK: resolve-release-notes tests passed\n'


### PR DESCRIPTION
## What

`release.yml` published `generate_release_notes: true` and nothing else, so every release body has been a bare list of merged PRs — accurate, and useless to a user deciding whether an upgrade needs anything **from them**. v0.9.0 needs exactly that: an enrolled remote host must run two plugin commands or it silently keeps the old join behaviour.

A release may now ship a summary written ahead of time at **`docs/release-notes/<tag>.md`**, using the exact tag `release.yml` computes (`v` + `X.Y.Z`, or `X.Y.Z-rc.N`). When present it becomes the top of the release body and GitHub's generated PR list is appended below it.

Also adds `docs/release-notes/v0.9.0.md`.

### The action's semantics, from its README rather than from memory

`softprops/action-gh-release@v2`:

- `generate_release_notes` — *"Whether to automatically generate the name and body for this release… **If body is specified, the body will be pre-pended to the automatically generated notes.**"*
- *"When providing a `body` and `body_path` at the same time, **`body_path` will be attempted first**, then falling back on `body` if the path can not be read from."*
- `body_path` — *"Path to load text communicating notable changes in this release"*

So `body_path` + `generate_release_notes: true` **is** the mechanism: hand-written notes lead, generated changelog follows.

**Deliberately NOT `append_body`.** Its README line is *"Append to existing body instead of overwriting it"* — that is about an already-published release whose body is being updated, not about appending the generated notes to mine. It is a different feature that happens to sound right, and the workflow comment says so.

### Failure modes, chosen on purpose

- **No notes file** → `path=` empty → the action ignores it → the release publishes with generated notes exactly as every release before this one. A forgotten file makes a duller release, never a failed one.
- **A file that exists and says nothing** (empty or whitespace-only) → **hard failure**. It would otherwise publish a release whose human section is blank, which reads as a broken pipeline rather than a missing file.
- **A tag that is not `vX.Y.Z[-rc.N]`** → refused. The tag lands in a filesystem path, so its shape is validated rather than trusted, which also rules out `..` and separators.

## Proof

### Why the proof is a shell test and not a release

**`release.yml` tags and publishes — it is never run to try something out.** So all the decision logic lives in `scripts/ci/resolve-release-notes.sh`, and the workflow's use of it is one `body_path:` line. `scripts/ci/test-resolve-release-notes.sh` (11 assertions) joins the per-push shell-test step:

```
$ ./scripts/ci/test-resolve-release-notes.sh; echo "exit=$?"
PASS: a tag with no notes file publishes with generated notes only (no docs/release-notes/v0.9.0.md — publishing with generated notes only)
PASS: a tag WITH a notes file resolves it (hand-written notes from docs/release-notes/v0.9.0.md, with the generated changelog appended)
PASS: prerelease tags follow the same convention (hand-written notes from docs/release-notes/v1.0.0-rc.2.md, with the generated changelog appended)
PASS: an unrelated tag does not pick up another tag's file (no docs/release-notes/v9.9.9.md — publishing with generated notes only)
PASS: an empty notes file is a hard failure, not a silent blank release
PASS: a whitespace-only notes file is a hard failure too
PASS: a tag with a path separator is refused
PASS: a traversal tag is refused
PASS: an unversioned tag is refused
PASS: a tag without the v prefix is refused
PASS: no arguments is a usage error
PASS: committed notes file docs/release-notes/v0.9.0.md resolves
OK: resolve-release-notes tests passed
exit=0
```

The last assertion is a standing guard, not a fixture: it walks **every** committed `docs/release-notes/v*.md` and fails if one is empty or misnamed. A broken notes file would otherwise only surface during a release.

Against the real tag:

```
$ ./scripts/ci/resolve-release-notes.sh v0.9.0
path=docs/release-notes/v0.9.0.md
reason=hand-written notes from docs/release-notes/v0.9.0.md, with the generated changelog appended
```

```
$ ./scripts/ci/test-workflow-step-names.sh
test-workflow-step-names: OK (100 step names, no duplicates within a job)
```

### What this cannot prove, and why that is safe

The one thing only a real release exercises is whether the action prepends a `body_path`-loaded body to generated notes the same way the README says it does for `body`. The README's fallback sentence says `body_path` is resolved *into* the body, which is the reading this rests on.

**If that reading is wrong the failure is benign**: the release would carry generated notes only — exactly today's behaviour — and the hand-written file is committed in git either way. No release is blocked, nothing is lost, and the next release fixes it. I did not run `release.yml` to find out, because running it publishes a tag and a release.

## The v0.9.0 notes

`docs/release-notes/v0.9.0.md`, written user-facing, no PR numbers (those are the generated section's job). Contents, and where each claim comes from:

- **Window-title markers removed**, with the measurement stated in user terms — the marker was the visible title for *1.26 % of the time, 0.88 s out of 69* (`integrations/claude-code/README.md`, `docs/agent/invariants.md`).
- **`CLAUDE_CODE_DISABLE_TERMINAL_TITLE=1` can be dropped** — the workaround that made the old join fire.
- **Remote herdr joins now work through Ghostty and Terminal.app**, bound to a herdr pane by id, ambiguity attaches nothing.
- **A plain `ssh` session is now connection-bound** — described as the coordinator asked, matched to the SSH connection rather than to anything on screen. ⚠️ **This is the one claim that depends on another worker's PR landing in v0.9.0.** If it slips, delete that paragraph before cutting the release.
- **The TTY join needs Ghostty ≥ 1.4 (tip channel), iTerm2, or Terminal.app** (`integrations/claude-code/README.md`).
- **Action required for enrolled hosts**, with the verbs verified against `integrations/claude-code/README.md`'s "Updating an enrolled host" section (which records that they were checked on Claude Code 2.1.220):
  ```sh
  claude plugin marketplace update localvoxtral
  claude plugin update localvoxtral-remote@localvoxtral
  ```
  Order matters, the token is preserved, and the app's **Update Plugin…** button runs the same pair. The plugin version this gets you is 1.5.x (`plugins/localvoxtral-remote/.claude-plugin/plugin.json` → `"version": "1.5.0"`). Skipping it is not fatal — an older shim keeps working and sends a response the app now ignores — you just do not get the new join behaviour.
- **Multi-channel mic input** (#240, the first outside contribution).
- **UI-gate owners reinstall by hand** — CI deliberately never installs or updates the gate, because it is the trust boundary.

### Note on ordering

Cut from `origin/main`, and it adds one line to the same shell-test step list that #260 and #266 touch — expect a one-line rebase for whichever lands last.

---

### Green in CI — run [33989725181](https://github.com/T0mSIlver/localvoxtral/actions/runs/33989725181)

`build-test` green in 380 s, with the new self-test inside the shell-test step:

```
./scripts/ci/test-resolve-release-notes.sh
OK: resolve-release-notes tests passed
```
