### PR TITLE
Fix the BackendProcessSupervisor TERM-race flake at its source (14/20 → 0/20 on the hosted lane)

### DIFF
--- a/Tests/localvoxtralTests/BackendProcessSupervisorTests.swift
+++ b/Tests/localvoxtralTests/BackendProcessSupervisorTests.swift
@@ -244,11 +244,17 @@ final class BackendProcessSupervisorTests: XCTestCase {
         let script = try writeScript(
             in: directory,
             name: "backend.sh",
+            // Same ordering rule as testStopHonorsTERMWithoutRestarting: arm
+            // the trap BEFORE announcing readiness. This script had it the
+            // other way round, so the supervisor could observe readiness and
+            // send TERM while the shell was still between the two lines, with
+            // the default disposition in force. Nothing asserted on the
+            // difference here, which is exactly why it went unnoticed.
             body: """
             #!/bin/sh
             if [ -f "\(succeedMarker.path)" ]; then
-              touch "\(readyMarker.path)"
               trap 'exit 0' TERM
+              : > "\(readyMarker.path)"
               while true; do sleep 1; done
             fi
             echo "intentional fast failure" >&2
@@ -296,10 +302,21 @@ final class BackendProcessSupervisorTests: XCTestCase {
         let script = try writeScript(
             in: directory,
             name: "backend.sh",
+            // `: > file`, not `touch file`. `touch` is /usr/bin/touch: a fork
+            // AND an exec inside the TERM handler, i.e. in the exact window
+            // where the supervisor is deciding whether to escalate to SIGKILL.
+            // A redirection creates the file in-process, so the child needs one
+            // scheduling slice rather than a whole process spawn.
+            //
+            // ORDER IS LOAD-BEARING: the trap is armed BEFORE the ready marker
+            // exists, so "ready" means "this shell will handle TERM itself".
+            // Reversed, the supervisor could see readiness and send TERM while
+            // the default disposition is still in force, and the child would
+            // die without ever running the handler.
             body: """
             #!/bin/sh
-            trap 'touch "\(termMarker.path)"; exit 0' TERM
-            touch "\(readyMarker.path)"
+            trap ': > "\(termMarker.path)"; exit 0' TERM
+            : > "\(readyMarker.path)"
             while true; do sleep 1 & wait $!; done
             """
         )
@@ -564,6 +581,14 @@ private final class LockedValue<Value>: @unchecked Sendable {
             lock.unlock()
         }
     }
+
+    /// Read-modify-write under one acquisition, for the check-then-set a
+    /// separate `get` and `set` cannot express atomically.
+    func withLock<Result>(_ body: (inout Value) -> Result) -> Result {
+        lock.lock()
+        defer { lock.unlock() }
+        return body(&storage)
+    }
 }
 
 private final class RecordingSleep: @unchecked Sendable {
@@ -715,28 +740,91 @@ private final class TerminationAwareSleep: @unchecked Sendable {
         self.readyMarker = readyMarker
     }
 
+    // Both arms stand in for a real sleep the supervisor performs while waiting
+    // on a REAL child process, so what they must express is "until the child
+    // did the thing", not "for a while".
+    //
+    // They used to spin `for _ in 0 ..< 1_000 { await Task.yield() }` and then
+    // RETURN whether or not the marker had appeared. That budget, not any
+    // clock, is what decided the test: the supervisor's grace loop is a single
+    // 100 ms slice, so when this returned early the very next statement was
+    // `if process.isRunning { SIGKILL }` — killing the child before it could
+    // run its TERM handler, and `termMarker` never appeared.
+    //
+    // And 1000 yields is not "a moment": `Task.yield()` only reschedules on the
+    // cooperative pool, so with nothing else runnable the whole budget elapses
+    // in about a millisecond of wall-clock while spinning a core the child
+    // needs. Measured on the hosted lane (3-core shared VM), that lost the race
+    // 14 times in 20.
+    //
+    // So: wait for the actual filesystem event instead. No polling, no spin, no
+    // budget to tune — it returns the moment the marker exists and not before.
+    // A child that genuinely never writes it hangs the test, which XCTest's own
+    // timeout turns into a failure with `run-supervised-command.sh`'s stack
+    // sample attached; that is the correct bound and the correct diagnostic,
+    // where the old budget silently converted "not yet" into "SIGKILL it".
     func sleep(_ duration: Duration) async throws {
         if duration == .milliseconds(10) {
-            for _ in 0 ..< 1_000 {
-                if FileManager.default.fileExists(atPath: readyMarker.path) {
-                    return
-                }
-                await Task.yield()
-            }
+            await Self.waitForFile(readyMarker)
             return
         }
 
         if duration == .milliseconds(100) {
-            for _ in 0 ..< 1_000 {
-                if FileManager.default.fileExists(atPath: termMarker.path) {
-                    return
-                }
+            await Self.waitForFile(termMarker)
+            return
+        }
+
+        try await controlledSleep.sleep(duration)
+    }
+
+    /// Returns once `url` exists, driven by a directory write event rather than
+    /// by polling.
+    private static func waitForFile(_ url: URL) async {
+        if FileManager.default.fileExists(atPath: url.path) { return }
+
+        let directory = url.deletingLastPathComponent()
+        let descriptor = open(directory.path, O_EVTONLY)
+        guard descriptor >= 0 else {
+            // No watch possible. Fall back to yielding rather than returning
+            // immediately, which would reinstate the early-SIGKILL bug.
+            while !FileManager.default.fileExists(atPath: url.path) {
                 await Task.yield()
             }
             return
         }
 
-        try await controlledSleep.sleep(duration)
+        let source = DispatchSource.makeFileSystemObjectSource(
+            fileDescriptor: descriptor,
+            eventMask: [.write, .extend, .attrib],
+            queue: .global()
+        )
+        let resumed = LockedValue(false)
+
+        await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
+            // One-shot: the event handler can fire more than once (any write to
+            // the directory), and the pre-arm check below can race with it.
+            let finish: @Sendable () -> Void = {
+                var shouldResume = false
+                resumed.withLock { alreadyResumed in
+                    if !alreadyResumed {
+                        alreadyResumed = true
+                        shouldResume = true
+                    }
+                }
+                if shouldResume {
+                    source.cancel()
+                    continuation.resume()
+                }
+            }
+            source.setEventHandler {
+                if FileManager.default.fileExists(atPath: url.path) { finish() }
+            }
+            source.setCancelHandler { close(descriptor) }
+            source.resume()
+            // The marker may have appeared between the check above and the
+            // source being armed; that event is gone, so look once more.
+            if FileManager.default.fileExists(atPath: url.path) { finish() }
+        }
     }
 
     func resumeAll() {


### PR DESCRIPTION
## What

`BackendProcessSupervisorTests.testStopHonorsTERMWithoutRestarting` has been a known load-sensitive flake since 2026-07-12. Moving tier 0 to a 3-core shared hosted runner (#260) made it unmissable — **a 20-run loop on that lane failed 14 times out of 20**, and it is currently the only red on two otherwise-green PRs (#267's `build-test`, and the first attempt of #260's own).

### The race was not what the project notes guessed

The note said the shell loses a race to install its `trap` before TERM arrives, and proposed gating `stop()` on trap-installed readiness. That is not it — in this test the `trap` line already precedes the ready marker, so `.running` implies the trap is armed.

The race is **the test's own sleep stand-in**. `BackendProcessSupervisor.terminate()` is:

```swift
process.terminate()                                  // SIGTERM
while process.isRunning && elapsed < gracePeriod {
    try await sleepFor(sleepSlice)                   // ← injected
    elapsed += sleepSlice
}
if process.isRunning { Darwin.kill(pid, SIGKILL) }
```

with `terminationGracePeriod == 100 ms` and `sleepSlice = min(100 ms, grace) == 100 ms`, so **the loop runs exactly once** and whatever `sleepFor` does decides whether the child gets killed. `TerminationAwareSleep` did:

```swift
for _ in 0 ..< 1_000 {
    if exists(termMarker) { return }
    await Task.yield()
}
return          // ← gives up, and the very next statement is SIGKILL
```

So a child that had not yet written its marker was SIGKILLed, and `termMarker` never appeared. Worse, **1000 yields is not "a moment"**: `Task.yield()` only reschedules on the cooperative pool, so with nothing else runnable the whole budget burns in about a millisecond of wall-clock — while spinning a core the child needs to run its handler. On a fast, idle Mac the child usually won anyway. On a 3-core shared VM it usually lost.

### The fix — three changes, all in the test file, no production change

1. **`TerminationAwareSleep` waits on a real filesystem event** (`DispatchSource.makeFileSystemObjectSource` on the containing directory) instead of a spin budget. It returns the moment the marker exists and not before: no polling, no wall-clock, **no budget to tune**. A child that genuinely never writes the marker now hangs and is failed by XCTest's timeout with `run-supervised-command.sh`'s stack sample attached — the correct bound, and a far better diagnostic than silently escalating to SIGKILL. (Pre-armed existence check, post-arm re-check for the event that fires between them, one-shot resume guard.)

2. **The TERM handler writes its marker with `: > file`, not `touch file`.** `touch` is `/usr/bin/touch` — a fork *and* an exec **inside the signal handler**, i.e. inside the exact window where the supervisor is deciding whether to escalate. A redirection creates the file in-process.

3. **The sibling with the race the note actually described.** `testRestartAfterFailureClearsStaleFailedStateSynchronouslyAndCanRun` armed its trap **after** announcing readiness:

   ```sh
   touch "$readyMarker"
   trap 'exit 0' TERM      # ← too late
   ```

   so the supervisor could observe readiness and send TERM while the default disposition was still in force. Reordered, and the rule is now written down in both scripts: **readiness must mean "this shell will handle TERM itself"**. Nothing asserted on the difference there, which is exactly why it went unnoticed — this is the sibling the flake note asked to be checked for.

`LockedValue` gains a `withLock` for the one-shot continuation guard (a `get` and a `set` cannot express check-then-set atomically).

**No assertion changed. No tolerance widened. Nothing skipped or deleted.** The diff is 102 insertions / 14 deletions in one test file, most of it the comments explaining the above.

## Proof

A 20-run loop of the suite on the hosted lane — the environment that shows the race — before and after, run the same way both times: `mac-lanes` disabled (`if: false`, so the Mac was never touched), the shell-test/packaging steps disabled, `swift build --build-tests` once so the loop measures the race and not compilation, then 20 × `swift test --filter BackendProcessSupervisorTests`, counting.

**BEFORE** — throwaway branch off `origin/main` (`c3025a7`), run [33990822290](https://github.com/T0mSIlver/localvoxtral/actions/runs/33990822290):

```
run 1: PASS    run 6: FAIL    run 11: FAIL   run 16: FAIL
run 2: FAIL    run 7: FAIL    run 12: FAIL   run 17: PASS
run 3: PASS    run 8: FAIL    run 13: FAIL   run 18: FAIL
run 4: FAIL    run 9: FAIL    run 14: PASS   run 19: FAIL
run 5: FAIL    run 10: PASS   run 15: FAIL   run 20: PASS

SUPERVISOR LOOP RESULT: pass=6 fail=14 of 20
```

and every one of those failures is this test — `grep -c "testStopHonorsTERMWithoutRestarting.*failed"` over the accumulated log printed **28** (XCTest emits the failure line twice per occurrence: 14 × 2).

**AFTER** — the same probe on top of this branch (`d0328d1`), run [33991087009](https://github.com/T0mSIlver/localvoxtral/actions/runs/33991087009):

```
run 1..20: PASS

SUPERVISOR LOOP RESULT: pass=20 fail=0 of 20
```

and the same grep printed **0**.

**6/20 → 20/20.** Both probe branches are deleted from origin; neither is merged anywhere.

### Compiles clean under strict concurrency

The after-probe built the test target with the hosted image's toolchain (`Xcode 26.6`, `Apple Swift 6.3.3`) and emitted **no warning in this file**:

```
$ grep -oE "BackendProcessSupervisorTests.swift:[0-9]+:[0-9]+: warning: .*"   (over the run log)
(no output)
```

### Why this matters right now

This is not only a tidy-up. It is the **only** thing red on #267 (`Executed 2773 tests, with 11 tests skipped and 1 failure`, the single failure being `testStopHonorsTERMWithoutRestarting`) and it failed #260's first attempt too. At 14-in-20 on the hosted lane, every PR would have needed a rerun lottery. It should go in before or immediately after the remaining CI PRs.
