### PR TITLE
integration-herdr: keep the panel token alive while waiting for the paint

### DIFF
--- a/Tests/localvoxtralTests/HerdrIntegrationTests.swift
+++ b/Tests/localvoxtralTests/HerdrIntegrationTests.swift
@@ -100,14 +100,58 @@ final class HerdrIntegrationTests: XCTestCase {
     }
 
     /// Wait until the whole-view surface has painted `token`, reading only
-    /// what herdr wrote after `mark`.
+    /// what herdr wrote after `mark`, and keep the stamp alive the way the
+    /// product does while waiting.
+    ///
+    /// WHY THE REFRESH. `stamp` carries
+    /// `HerdrPanelBindingProbe.tokenTTLMilliseconds` (8 s), so one stamp
+    /// cannot outlive this wait: at 8 s herdr expires the token and stops
+    /// painting it. The old fixture stamped ONCE and then waited `timeout`
+    /// (20 s), which meant the real budget was 8 s while the signature — and
+    /// every failure message — said 20. On a loaded runner the attach-client
+    /// test crossed 8 s often enough to fail 3 of 5 runs (2026-09-05), always
+    /// at its positive control, and always as a clean 6 s pass / 24 s timeout
+    /// split with nothing in between: the signature of a budget that is not
+    /// the one being reported.
+    ///
+    /// The PRODUCT never relies on a single stamp either.
+    /// `HerdrPanelMicIndicator` re-stamps every `refreshInterval` (4 s) for
+    /// exactly this reason, so the token is refreshed at half its TTL and
+    /// never lapses. The fixture now does the same thing on the same cadence,
+    /// which makes `timeout` mean what it says AND makes the fixture model the
+    /// product instead of a third behaviour that exists nowhere.
+    ///
+    /// Wall-clock here is deliberate and matches `HerdrLaneWait.until`, whose
+    /// comment explains it: this lane waits on LIVE external processes (herdr,
+    /// sshd, a pty) and herdr's own TTL is not a clock this test can inject.
+    /// The loop below is `until`'s, plus the refresh — kept here rather than
+    /// pushed into the shared helper because only the panel token needs it.
     private func waitForToken(
         _ token: String,
         on surface: HerdrSurfaceLog,
+        refreshingThrough client: HerdrSocketClient,
+        socketPath: String,
         timeout: TimeInterval = 20
     ) async throws {
-        try await HerdrLaneWait.until("the surface to paint \(token)", timeout: timeout) {
-            surface.textSinceMark()?.contains(token) == true
+        let deadline = Date().addingTimeInterval(timeout)
+        // First refresh one interval in, exactly like the indicator's loop
+        // (`sleepFor(refreshInterval)` and only then `refreshOnce()`).
+        var nextRefresh = Date().addingTimeInterval(HerdrPanelMicIndicator.refreshInterval)
+        while true {
+            if surface.textSinceMark()?.contains(token) == true { return }
+            guard Date() < deadline else {
+                throw HerdrLaneError.timedOut("the surface to paint \(token)")
+            }
+            if Date() >= nextRefresh {
+                let refreshed = await stamp(token, through: client, socketPath: socketPath)
+                XCTAssertTrue(
+                    refreshed,
+                    "re-stamping the panel token was refused; the wait below would "
+                        + "then be measuring an expired token, not a surface that will not paint"
+                )
+                nextRefresh = Date().addingTimeInterval(HerdrPanelMicIndicator.refreshInterval)
+            }
+            try? await Task.sleep(for: .milliseconds(100))
         }
     }
 
@@ -151,7 +195,12 @@ final class HerdrIntegrationTests: XCTestCase {
             stamped,
             "pane.report_metadata was refused through the forwarded socket"
         )
-        try await waitForToken(token, on: fixture.primarySurface)
+        try await waitForToken(
+            token,
+            on: fixture.primarySurface,
+            refreshingThrough: client,
+            socketPath: handle.localSocketPath
+        )
     }
 
     /// THE load-bearing external assumption.
@@ -192,7 +241,12 @@ final class HerdrIntegrationTests: XCTestCase {
         // Positive control first: the whole-view surface DOES render it, so
         // the negative below is about attach mode and not about a fixture
         // that painted nothing at all.
-        try await waitForToken(token, on: fixture.primarySurface)
+        try await waitForToken(
+            token,
+            on: fixture.primarySurface,
+            refreshingThrough: client,
+            socketPath: handle.localSocketPath
+        )
 
         XCTAssertFalse(
             attachSurface.textSinceMark()?.contains(token) == true,


### PR DESCRIPTION
## What

`HerdrIntegrationTests` stamped the panel token **once**, with `HerdrPanelBindingProbe.tokenTTLMilliseconds` (8 000 ms), and then waited `timeout: 20` for herdr to paint it:

```swift
let stamped = await stamp(token, …)          // TTL 8 s
try await waitForToken(token, on: fixture.primarySurface)   // timeout: 20
```

At 8 s herdr expires the token and stops painting it. **The effective budget was 8 s while the signature — and every failure message — said 20.** That is a defect by construction; you can read it off the two constants without observing a single failure.

The **product never relies on a single stamp either**: `HerdrPanelMicIndicator` re-stamps every `refreshInterval` (4 s), refreshing at half the TTL so the token cannot lapse. `waitForToken` now does the same thing on the same cadence — first refresh one interval in, exactly like the indicator's `sleepFor(refreshInterval)`-then-`refreshOnce()` loop.

So the fixture now **models the product** instead of a third behaviour that exists nowhere, and `timeout: 20` means 20 seconds.

- Every assertion is unchanged, including the negative that carries the surface-authorization argument.
- **No tolerance moved** — 20 s was always what the test claimed to allow; it just never got it.
- The re-stamp is itself asserted, so a refused refresh fails loudly instead of quietly turning the wait back into a measurement of an expired token.
- Wall-clock in the loop is deliberate and matches `HerdrLaneWait.until`, whose own comment explains it: this lane waits on live external processes, and herdr's TTL is not a clock the test can inject. The loop is `until`'s, plus the refresh, kept local because only the panel token needs it.

## Proof

### 10 runs before + 10 after, same machine, back to back, one dispatch

A throwaway probe branch ran the single test 10× against `origin/main`'s fixture and then 10× against this branch's, in one `mac-lanes` job (`build-test` disabled, every other `mac-lanes` step disabled, so nothing else competed). Run [33993905219](https://github.com/T0mSIlver/localvoxtral/actions/runs/33993905219):

```
BEFORE run 1: FAIL
  HerdrIntegrationTests.swift:190: XCTAssertTrue failed
  HerdrIntegrationSupport.swift:393: failed: caught error:
    "timed out waiting for the surface to paint lv-mic-pofnb7u9vm"
BEFORE run 2..10: PASS
HERDR LOOP BEFORE: pass=9 fail=1 of 10

AFTER run 1..10: PASS
HERDR LOOP AFTER: pass=10 fail=0 of 10
```

### What that loop does and does not prove — read this before merging

**It does not prove the fix on failure counts.** 1-in-10 versus 0-in-10 is not a meaningful difference, and — more importantly — **the single pre-fix failure was not a TTL lapse**. `HerdrIntegrationTests.swift:190` on `origin/main` is `XCTAssertTrue(stamped)`: the *initial stamp itself was refused*, so no token was ever set and the paint timeout simply followed from that. Different mechanism, same visible ending.

**What does prove the fix is the mechanism**, which needs no statistics: `tokenTTLMilliseconds = 8_000`, the wait was `20`, and `HerdrPanelMicIndicator.refreshInterval = 4` is the product's own answer to exactly that. The field signature the other worker reported — *binary 6 s pass / 24 s timeout, always at the positive control, never in between* — is what an 8 s budget reported as 20 s looks like, and the sibling test without the second attach client never fails because one client paints well inside 8 s.

So: merge this on the mechanism, and read the loop as "10/10 after, and nothing regressed".

### A SECOND, independent flake in this test — not fixed here

That one pre-fix failure exposed something else: `stamp()` — `HerdrSocketClient(timeout: 5)` calling `pane.report_metadata` through a freshly-opened `ssh -L` forward — **was refused under load**. This PR does not address it, and I did not widen that 5 s timeout, because that would be exactly the kind of tolerance change the proof rules forbid without evidence that the bound is wrong rather than the machine busy.

Worth noting it now cannot hide: post-fix, a refused *re*-stamp fails with its own message saying the wait would otherwise be measuring an expired token. The refused *initial* stamp already had `XCTAssertTrue(stamped)`. Both are loud; neither is fixed.

If it recurs, the question to answer first is whether 5 s is a wrong bound for a cold forwarded socket on a loaded Mac, or whether the forward was not actually ready — and that is a different investigation with a different fix.

### Not run

`./scripts/remote-build.sh integration-herdr` locally: this PR's own CI run **is** that lane — the diff touches `Tests/localvoxtralTests/HerdrIntegrationTests.swift`, which `scripts/ci/herdr-lane-filter.sh` matches, so the live-herdr lane fires on it. The 20 runs above are a superset of what one lane run does for this test.
