### PR TITLE
Plain-ssh join: make the ControlMaster abstention say which shape it saw

### DIFF
--- a/Sources/localvoxtral/ClaudeContext/SSHDestinationTTYProbe.swift
+++ b/Sources/localvoxtral/ClaudeContext/SSHDestinationTTYProbe.swift
@@ -68,27 +68,9 @@ struct SSHSurfaceConnection: Sendable, Equatable {
     /// empty array is a positive claim about a process and a failed syscall
     /// is not one.
     var sockets: [SSHClientSocket]?
-    /// Another same-uid ssh CONNECTION to this destination holds no
-    /// established TCP socket of its own — the shape of an OpenSSH
-    /// **ControlMaster mux client**, and the one way a session's
-    /// `$SSH_CONNECTION` can be honest and still describe a different
-    /// terminal's surface.
-    ///
-    /// With `ControlMaster auto` in `~/.ssh/config` (invisible in argv — the
-    /// probe refuses `-M`/`-S` but does not read config), terminal A's ssh
-    /// owns the TCP connection and terminal B's `ssh host` is a mux client
-    /// over an AF_UNIX control path with no TCP socket at all. sshd derives
-    /// `$SSH_CONNECTION` from the underlying CONNECTION, so a Claude session
-    /// started in B truthfully reports A's ports; dictating into A — a plain
-    /// shell with no agent in it — would then match and join B's session.
-    /// Found by review, 2026-09-05.
-    ///
-    /// So the flag is about a NEIGHBOR, not about this process: a socketless
-    /// (or unreadable) sibling to the same destination means connection
-    /// multiplexing cannot be ruled out, and the plain-ssh arm abstains. It
-    /// costs the ordinary two-terminals-two-connections case nothing — those
-    /// each hold their own socket and are told apart by their ports.
-    var hasSocketlessSiblingToDestination: Bool
+    /// What the OTHER ssh sessions to this destination look like — the
+    /// evidence for or against OpenSSH connection multiplexing.
+    var siblings: SSHSiblingSurvey
 
     init(
         destination: String,
@@ -96,15 +78,57 @@ struct SSHSurfaceConnection: Sendable, Equatable {
         herdr: HerdrInvocation,
         usesProxyJump: Bool = false,
         sockets: [SSHClientSocket]? = nil,
-        hasSocketlessSiblingToDestination: Bool = false
+        siblings: SSHSiblingSurvey = SSHSiblingSurvey()
     ) {
         self.destination = destination
         self.hasCompetingHerdrClient = hasCompetingHerdrClient
         self.herdr = herdr
         self.usesProxyJump = usesProxyJump
         self.sockets = sockets
-        self.hasSocketlessSiblingToDestination = hasSocketlessSiblingToDestination
+        self.siblings = siblings
     }
+}
+
+/// The OTHER interactive ssh sessions to one destination, counted by what the
+/// kernel could say about each.
+///
+/// This started life as a single `hasSocketlessSiblingToDestination: Bool` and
+/// the field immediately showed why that was not enough: a dictation on the
+/// owner's Mac reported `this destination may be carrying multiplexed ssh
+/// sessions` and there was NO WAY, from the abstention alone, to tell "a real
+/// ControlMaster client is open in another window" from "some ssh's fd table
+/// could not be read" (field report, 2026-09-06). Both abstain — that part was
+/// right — but they call for opposite fixes, and a diagnostic that cannot tell
+/// them apart costs a round trip to the owner's machine every time.
+///
+/// WHY EITHER ABSTAINS. With `ControlMaster auto` in `~/.ssh/config` (invisible
+/// in argv — the probe refuses `-M`/`-S` but does not read config), terminal
+/// A's ssh owns the TCP connection and terminal B's `ssh host` is a mux client
+/// over an AF_UNIX control path with no TCP socket at all. sshd derives
+/// `$SSH_CONNECTION` from the underlying CONNECTION, so a Claude session
+/// started in B truthfully reports A's ports; dictating into A — a plain shell
+/// with no agent in it — would otherwise match and join B's session. An
+/// UNREADABLE sibling is the same claim with less evidence, and an unreadable
+/// process cannot be ruled out.
+struct SSHSiblingSurvey: Sendable, Equatable {
+    /// Same-uid ssh CONNECTIONS, with a controlling terminal, whose argv parses
+    /// to this same destination, excluding this surface's own and excluding
+    /// ssh processes this app spawned.
+    var considered: Int
+    /// Of those, how many were readable and held no established TCP socket —
+    /// the ControlMaster mux-client shape.
+    var socketless: Int
+    /// Of those, how many had an fd table we could not read at all.
+    var unreadable: Int
+
+    init(considered: Int = 0, socketless: Int = 0, unreadable: Int = 0) {
+        self.considered = considered
+        self.socketless = socketless
+        self.unreadable = unreadable
+    }
+
+    /// Does any sibling leave connection multiplexing un-ruled-out?
+    var leavesMultiplexingPossible: Bool { socketless > 0 || unreadable > 0 }
 }
 
 /// WHY the probe could not pin an ssh session down. Deliberately content-free
@@ -318,11 +342,16 @@ enum SSHDestinationTTYProbe {
     ///   never reach the kernel's fd tables, and so every caller that has no
     ///   business with sockets keeps the pre-existing behaviour: the only arm
     ///   that reads them treats nil as an abstention.
+    /// - Parameter ownProcessID: this process, so ssh children the APP spawned
+    ///   (its `RemoteForward` supervisor, its herdr `ssh -L`) are never
+    ///   mistaken for somebody's terminal session. Injected rather than read
+    ///   here so the rule is testable without spawning anything.
     static func connection(
         onTTYDevicePath path: String,
         deviceID: @Sendable (String) -> dev_t?,
         sshProcesses: @Sendable () -> [SSHClientProcess]?,
-        readSockets: @Sendable (Int32) -> [SSHClientSocket]? = { _ in nil }
+        readSockets: @Sendable (Int32) -> [SSHClientSocket]? = { _ in nil },
+        ownProcessID: Int32 = getpid()
     ) -> SSHDestinationTTYProbeResult {
         guard let device = deviceID(path) else {
             // A device we cannot resolve is not evidence of absence.
@@ -394,12 +423,13 @@ enum SSHDestinationTTYProbe {
                 // Read for the ONE process the surface rules just proved is
                 // the foreground ssh on the focused tty — never machine-wide.
                 sockets: readSockets(surfaceProcess.pid),
-                hasSocketlessSiblingToDestination: hasSocketlessSibling(
+                siblings: surveySiblings(
                     destination: parsed.destination,
                     surfacePID: surfaceProcess.pid,
                     surfaceUserID: surfaceProcess.effectiveUserID,
                     connections: connections,
-                    readSockets: readSockets
+                    readSockets: readSockets,
+                    ownProcessID: ownProcessID
                 )
             )
         )
@@ -508,25 +538,45 @@ enum SSHDestinationTTYProbe {
     ///   competitor scan takes: a process we cannot describe cannot be ruled
     ///   out. The cost is one abstained dictation when a neighbor exits
     ///   between the scan and the read.
-    private static func hasSocketlessSibling(
+    static func surveySiblings(
         destination: String,
         surfacePID: Int32,
         surfaceUserID: uid_t,
         connections: [SSHClientProcess],
-        readSockets: @Sendable (Int32) -> [SSHClientSocket]?
-    ) -> Bool {
+        readSockets: @Sendable (Int32) -> [SSHClientSocket]?,
+        ownProcessID: Int32
+    ) -> SSHSiblingSurvey {
+        var survey = SSHSiblingSurvey()
         for process in connections
         where process.pid != surfacePID && process.effectiveUserID == surfaceUserID {
+            // OUR OWN ssh children are not somebody's terminal session. The
+            // app runs a `RemoteForward` supervisor and a herdr `ssh -L`, both
+            // to the very hosts this arm is about, and both are direct
+            // children of this process — kernel ppid, which no launcher gets
+            // to write. Their argv is refused by the parser today (`-N`), so
+            // this is belt and braces; it stops a future forward whose argv
+            // happens to parse from abstaining every dictation on that host.
+            guard process.parentPID != ownProcessID else { continue }
+            // A ControlMaster client that could mis-join is a session in
+            // ANOTHER WINDOW, so it holds a controlling terminal. A tty-less
+            // ssh is machinery (a `-N` forward, an `ssh host command` in a
+            // script): it is not a surface anyone runs an agent on, and
+            // counting it made transient helpers look like mux clients.
+            guard process.ttyDevice != nil else { continue }
             guard let executablePath = process.executablePath,
                   isTrustedSSHExecutable(executablePath),
                   let arguments = process.arguments,
                   let parsed = parse(arguments: arguments),
                   parsed.destination == destination
             else { continue }
-            guard let sockets = readSockets(process.pid) else { return true }
-            if sockets.isEmpty { return true }
+            survey.considered += 1
+            guard let sockets = readSockets(process.pid) else {
+                survey.unreadable += 1
+                continue
+            }
+            if sockets.isEmpty { survey.socketless += 1 }
         }
-        return false
+        return survey
     }
 
     /// Does any argv token mention herdr at all?

--- a/Sources/localvoxtral/ClaudeContext/TerminalScreenClaudeJoin.swift
+++ b/Sources/localvoxtral/ClaudeContext/TerminalScreenClaudeJoin.swift
@@ -1268,29 +1268,48 @@ struct ClaudeSessionJoinResolver {
             Self.abstainedPlainSSHJoin(outcome: "the connection goes through a jump host")
             return nil
         }
-        guard !connection.hasSocketlessSiblingToDestination else {
-            // The ControlMaster case: another ssh to this destination holds no
-            // TCP socket of its own, so one connection may be carrying several
-            // terminals' sessions and a truthful `$SSH_CONNECTION` no longer
-            // identifies a surface. See
-            // `SSHSurfaceConnection.hasSocketlessSiblingToDestination`.
+        // The ControlMaster case, in TWO causes rather than one. Both abstain,
+        // and they always did — but the field could not tell them apart from
+        // the abstention alone (2026-09-06), and they call for opposite fixes:
+        // a real mux client is the user's own ssh config, an unreadable
+        // sibling is a bug or a permission we do not have. The counts ride
+        // along because "1 of 1" and "1 of 6" are different stories and
+        // neither names a host, a port, or a path.
+        let siblings = connection.siblings
+        if siblings.socketless > 0 {
             Self.abstainedPlainSSHJoin(
-                outcome: "this destination may be carrying multiplexed ssh sessions"
+                outcome: "another ssh session to this destination holds no connection of "
+                    + "its own (\(siblings.socketless) of \(siblings.considered))"
+            )
+            return nil
+        }
+        if siblings.unreadable > 0 {
+            Self.abstainedPlainSSHJoin(
+                outcome: "another ssh session to this destination is unreadable "
+                    + "(\(siblings.unreadable) of \(siblings.considered))"
             )
             return nil
         }
         guard let sockets = connection.sockets else {
             // Nil is UNREADABLE. Treating it as "no sockets" would turn a
             // failed syscall into a decline that looks exactly like a genuine
-            // mismatch.
-            Self.abstainedPlainSSHJoin(outcome: "socket table unreadable")
+            // mismatch. `SSHProcessSocketReaderCrossProcessTests` is what says
+            // a same-user process this app did not spawn IS readable, so this
+            // cause means something went wrong rather than "as expected".
+            Self.abstainedPlainSSHJoin(outcome: "this ssh's socket table is unreadable")
             return nil
         }
         guard !sockets.isEmpty else {
-            // A `ProxyCommand` from ssh_config (invisible in argv) is the
-            // ordinary way to get here: the client talks over a pipe to a
-            // helper and holds no TCP socket of its own.
-            Self.abstainedPlainSSHJoin(outcome: "no established connection on this ssh")
+            // Readable, and holding nothing. Two ordinary causes, and the
+            // wording says so because the field hit this and could not tell
+            // which: a `ProxyCommand` from ssh_config (the client talks over a
+            // pipe to a helper), or an OpenSSH ControlMaster CLIENT, whose
+            // whole session rides another process's connection over an AF_UNIX
+            // control path.
+            Self.abstainedPlainSSHJoin(
+                outcome: "this ssh holds no connection of its own "
+                    + "(a ControlMaster client or a ProxyCommand)"
+            )
             return nil
         }
 

--- a/Sources/localvoxtral/Dogfood/DogfoodControlService.swift
+++ b/Sources/localvoxtral/Dogfood/DogfoodControlService.swift
@@ -420,6 +420,20 @@ final class DogfoodControlService {
                 ("remoteHerdrPane", DogfoodControlJSON.bool(remote?.herdrPaneID != nil)),
                 ("remoteHerdrSocket", DogfoodControlJSON.bool(remote?.herdrSocketPath != nil)),
                 ("remoteCmuxSurface", DogfoodControlJSON.bool(remote?.cmuxSurfaceID != nil)),
+                // The plain-ssh arm's own header. Without it a field run could
+                // not tell "the host is on an old plugin" from "the ports did
+                // not match" — the first field report of that arm was exactly
+                // that ambiguity (2026-09-06). Bool, not the value: the tuple
+                // it carries is the join material.
+                ("remoteSSHConnection", DogfoodControlJSON.bool(remote?.sshConnection != nil)),
+                ("remoteSSHTTY", DogfoodControlJSON.bool(remote?.sshTTY != nil)),
+                ("remoteMultiplexerLabel", DogfoodControlJSON.bool(
+                    remote.map { environment in
+                        ClaudeSessionJoinResolver.multiplexerLabels.contains {
+                            environment[$0] != nil
+                        }
+                    } ?? false
+                )),
                 ("recentFiles", DogfoodControlJSON.int(snapshot.recentFiles.count)),
                 ("hasPriorPrompt", DogfoodControlJSON.bool(
                     snapshot.latestPriorUserPrompt != nil

--- a/Tests/localvoxtralTests/DogfoodControlServiceTests.swift
+++ b/Tests/localvoxtralTests/DogfoodControlServiceTests.swift
@@ -276,6 +276,61 @@ final class DogfoodControlServiceTests: XCTestCase {
         XCTAssertEqual(row?["remoteCmuxSurface"] as? Bool, false)
     }
 
+    /// The plain-ssh arm's own three facts.
+    ///
+    /// A field run on 2026-09-06 produced `no join` for a live plain-ssh
+    /// session and there was no way, from the app, to tell whether the
+    /// `$SSH_CONNECTION` header had even ARRIVED — the same ambiguity the
+    /// herdr fields were added for a day earlier. Bools only: the connection
+    /// tuple is the join material and never crosses this boundary.
+    func testRegistryListReportsWhetherThePlainSSHJoinsInputsArrived() async {
+        var snapshot = Self.remoteSnapshot()
+        snapshot.remoteEnvironment = ClaudeRemoteSessionEnvironment(
+            sshTTY: "/dev/pts/4", sshConnection: "10.0.0.2,51960,10.0.0.9,22"
+        )
+        let service = makeService(viewModel: makeViewModel(), sessions: [snapshot])
+        let reply = await expectSuccess(service, .registryList)
+        let row = ((reply["sessions"] as? [[String: Any]]) ?? []).first
+
+        XCTAssertEqual(row?["remoteSSHConnection"] as? Bool, true)
+        XCTAssertEqual(row?["remoteSSHTTY"] as? Bool, true)
+        XCTAssertEqual(
+            row?["remoteMultiplexerLabel"] as? Bool, false,
+            "a plain ssh shell carries no multiplexer label — that is what makes it joinable"
+        )
+    }
+
+    func testRegistryListSeparatesASessionThatReportedNoConnectionFromOneInsideAMultiplexer()
+        async
+    {
+        // The two shapes that both end in "no join" and need opposite fixes:
+        // a host on a plugin older than 1.6.0 publishes no connection at all,
+        // while a session inside tmux publishes one that belongs to whichever
+        // connection started the server.
+        var old = Self.remoteSnapshot()
+        old.remoteEnvironment = ClaudeRemoteSessionEnvironment(sshTTY: "/dev/pts/4")
+        var multiplexed = Self.remoteSnapshot()
+        multiplexed.remoteEnvironment = ClaudeRemoteSessionEnvironment(
+            tmux: "/tmp/tmux-1000/default,3721,0",
+            sshTTY: "/dev/pts/4",
+            sshConnection: "10.0.0.2,51960,10.0.0.9,22"
+        )
+
+        let first = await expectSuccess(
+            makeService(viewModel: makeViewModel(), sessions: [old]), .registryList
+        )
+        let oldRow = ((first["sessions"] as? [[String: Any]]) ?? []).first
+        XCTAssertEqual(oldRow?["remoteSSHConnection"] as? Bool, false)
+        XCTAssertEqual(oldRow?["remoteMultiplexerLabel"] as? Bool, false)
+
+        let second = await expectSuccess(
+            makeService(viewModel: makeViewModel(), sessions: [multiplexed]), .registryList
+        )
+        let multiplexedRow = ((second["sessions"] as? [[String: Any]]) ?? []).first
+        XCTAssertEqual(multiplexedRow?["remoteSSHConnection"] as? Bool, true)
+        XCTAssertEqual(multiplexedRow?["remoteMultiplexerLabel"] as? Bool, true)
+    }
+
     /// And a remote session that reported no herdr at all is distinguishable
     /// from one that did — which is the whole point of adding the fields.
     func testRegistryListSeparatesARemoteSessionWithNoHerdrLabels() async {

--- a/Tests/localvoxtralTests/PlainSSHConnectionJoinTests.swift
+++ b/Tests/localvoxtralTests/PlainSSHConnectionJoinTests.swift
@@ -109,7 +109,7 @@ final class PlainSSHConnectionJoinTests: XCTestCase {
         usesProxyJump: Bool = false,
         sockets: [SSHClientSocket]? = nil,
         unreadableSockets: Bool = false,
-        socketlessSibling: Bool = false
+        siblings: SSHSiblingSurvey = SSHSiblingSurvey()
     ) -> SSHDestinationTTYProbeResult {
         .connection(
             SSHSurfaceConnection(
@@ -118,7 +118,7 @@ final class PlainSSHConnectionJoinTests: XCTestCase {
                 herdr: .notHerdr,
                 usesProxyJump: usesProxyJump,
                 sockets: unreadableSockets ? nil : (sockets ?? [surfaceSocket]),
-                hasSocketlessSiblingToDestination: socketlessSibling
+                siblings: siblings
             )
         )
     }
@@ -412,7 +412,7 @@ final class PlainSSHConnectionJoinTests: XCTestCase {
         ingestRemoteSession(into: registry)
         await assertNoJoin(
             surfaceConnection(unreadableSockets: true), registry: registry,
-            expectedCause: "socket table unreadable"
+            expectedCause: "this ssh's socket table is unreadable"
         )
     }
 
@@ -423,7 +423,8 @@ final class PlainSSHConnectionJoinTests: XCTestCase {
         ingestRemoteSession(into: registry)
         await assertNoJoin(
             surfaceConnection(sockets: []), registry: registry,
-            expectedCause: "no established connection on this ssh"
+            expectedCause: "this ssh holds no connection of its own "
+                + "(a ControlMaster client or a ProxyCommand)"
         )
     }
 
@@ -525,9 +526,38 @@ final class PlainSSHConnectionJoinTests: XCTestCase {
         let registry = makeRegistry()
         ingestRemoteSession(into: registry)
         await assertNoJoin(
-            surfaceConnection(socketlessSibling: true), registry: registry,
-            expectedCause: "this destination may be carrying multiplexed ssh sessions"
+            surfaceConnection(siblings: SSHSiblingSurvey(considered: 1, socketless: 1)),
+            registry: registry,
+            expectedCause: "another ssh session to this destination holds no connection "
+                + "of its own (1 of 1)"
         )
+    }
+
+    func testAnUnreadableSiblingAbstainsUnderItsOWNCause() async {
+        // Same abstention, different story, and the field needs to be able to
+        // tell them apart: a real ControlMaster client is the user's ssh
+        // config, an unreadable process is a bug or a missing permission.
+        let registry = makeRegistry()
+        ingestRemoteSession(into: registry)
+        await assertNoJoin(
+            surfaceConnection(siblings: SSHSiblingSurvey(considered: 6, unreadable: 2)),
+            registry: registry,
+            expectedCause: "another ssh session to this destination is unreadable (2 of 6)"
+        )
+    }
+
+    func testSiblingsThatAllHoldTheirOwnConnectionDoNotAbstain() async throws {
+        // The ordinary shape — several terminals, several connections — must
+        // keep joining. This is what the counted survey is FOR: `considered`
+        // can be large as long as nothing is socketless or unreadable.
+        let registry = makeRegistry()
+        ingestRemoteSession(into: registry)
+        let resolved = await resolver(
+            registry: registry,
+            sshResult: surfaceConnection(siblings: SSHSiblingSurvey(considered: 4))
+        ).resolve(target: ghostty)
+        let join = try XCTUnwrap(resolved)
+        XCTAssertEqual(join.mechanism, .remoteSSHConnection)
     }
 
     func testASessionInsideScreenDoesNotJoinThroughThisArm() async {

--- a/Tests/localvoxtralTests/SSHDestinationTTYProbeTests.swift
+++ b/Tests/localvoxtralTests/SSHDestinationTTYProbeTests.swift
@@ -14,11 +14,15 @@ final class SSHDestinationTTYProbeTests: XCTestCase {
     private let surface: dev_t = 42
     private let otherTerminal: dev_t = 43
 
+    /// `ownProcessID` is a fixture value (1) rather than `getpid()`: the rule
+    /// it feeds is "this app's own ssh children are not somebody's terminal",
+    /// and a test has to be able to build a process that IS one.
     private func probe(
         deviceID: dev_t? = 42,
         processes: [SSHClientProcess]?,
         sockets: [Int32: [SSHClientSocket]] = [:],
-        socketReads: SocketReadRecorder? = nil
+        socketReads: SocketReadRecorder? = nil,
+        ownProcessID: Int32 = 1
     ) -> SSHDestinationTTYProbeResult {
         SSHDestinationTTYProbe.connection(
             onTTYDevicePath: "/dev/ttys003",
@@ -27,7 +31,8 @@ final class SSHDestinationTTYProbeTests: XCTestCase {
             readSockets: { pid in
                 socketReads?.record(pid)
                 return sockets[pid]
-            }
+            },
+            ownProcessID: ownProcessID
         )
     }
 
@@ -1395,10 +1400,16 @@ final class SSHDestinationTTYProbeTests: XCTestCase {
 
     /// A neighbor ssh to the same destination whose fd table is readable and
     /// holds NO established TCP socket: an OpenSSH ControlMaster mux client.
-    private func muxClient(pid: Int32, argv: [String] = ["ssh", "sandbox"]) -> SSHClientProcess {
+    private func muxClient(
+        pid: Int32,
+        argv: [String] = ["ssh", "sandbox"],
+        parent: Int32 = 0,
+        device: dev_t? = 43
+    ) -> SSHClientProcess {
         SSHClientProcess(
             pid: pid,
-            ttyDevice: otherTerminal,
+            parentPID: parent,
+            ttyDevice: device,
             processGroupID: pid,
             terminalForegroundGroupID: pid,
             executablePath: "/usr/bin/ssh",
@@ -1408,6 +1419,80 @@ final class SSHDestinationTTYProbeTests: XCTestCase {
 
     private var transportSocket: SSHClientSocket {
         SSHClientSocket(localPort: 51_960, peerPort: 22, peerAddress: "192.168.1.9")
+    }
+
+    func testTheSurveyCountsSocketlessAndUnreadableSiblingsSeparately() throws {
+        // The field could not tell a real ControlMaster client from an
+        // unreadable process (2026-09-06). They abstain alike and always did;
+        // they are different bugs, so they are different numbers.
+        let value = try XCTUnwrap(
+            connection(
+                probe(
+                    processes: [
+                        ssh(["ssh", "sandbox"], pid: 501),
+                        muxClient(pid: 777),
+                        muxClient(pid: 888),
+                        muxClient(pid: 999),
+                    ],
+                    sockets: [
+                        501: [transportSocket],
+                        777: [],
+                        888: [SSHClientSocket(
+                            localPort: 51_961, peerPort: 22, peerAddress: "192.168.1.9"
+                        )],
+                        // 999 absent from the map: unreadable.
+                    ]
+                )
+            )
+        )
+        XCTAssertEqual(value.siblings.considered, 3)
+        XCTAssertEqual(value.siblings.socketless, 1)
+        XCTAssertEqual(value.siblings.unreadable, 1)
+        XCTAssertTrue(value.siblings.leavesMultiplexingPossible)
+    }
+
+    func testAnSSHChildOfTHISProcessIsNeverASibling() throws {
+        // The app runs its own `ssh -N -R` RemoteForward and a herdr `ssh -L`
+        // to the very hosts this arm is about. They are OUR children by kernel
+        // ppid, they hold no interactive session, and counting one would
+        // abstain every dictation on that host. (Their argv is refused by the
+        // parser today; this stops a future forward whose argv happens to
+        // parse from resurrecting the bug.)
+        let ourPID: Int32 = 4242
+        let value = try XCTUnwrap(
+            connection(
+                probe(
+                    processes: [
+                        ssh(["ssh", "sandbox"], pid: 501),
+                        muxClient(pid: 777, parent: ourPID),
+                    ],
+                    sockets: [501: [transportSocket], 777: []],
+                    ownProcessID: ourPID
+                )
+            )
+        )
+        XCTAssertEqual(value.siblings.considered, 0, "our own forward is not a sibling")
+        XCTAssertFalse(value.siblings.leavesMultiplexingPossible)
+    }
+
+    func testATTYLessSSHIsNotASibling() throws {
+        // Machinery: an `ssh -N` forward, or `ssh host command` in a script.
+        // A ControlMaster client that could mis-join is a session in another
+        // WINDOW, so it has a controlling terminal; a tty-less one is not a
+        // surface anyone runs an agent on.
+        let value = try XCTUnwrap(
+            connection(
+                probe(
+                    processes: [
+                        ssh(["ssh", "sandbox"], pid: 501),
+                        muxClient(pid: 777, device: nil),
+                    ],
+                    sockets: [501: [transportSocket], 777: []]
+                )
+            )
+        )
+        XCTAssertEqual(value.siblings.considered, 0)
+        XCTAssertFalse(value.siblings.leavesMultiplexingPossible)
     }
 
     func testASocketlessSiblingToTheSameDestinationIsReported() throws {
@@ -1423,7 +1508,7 @@ final class SSHDestinationTTYProbeTests: XCTestCase {
                 )
             )
         )
-        XCTAssertTrue(value.hasSocketlessSiblingToDestination)
+        XCTAssertTrue(value.siblings.leavesMultiplexingPossible)
     }
 
     func testAnOrdinarySecondConnectionToTheSameDestinationIsNotASocketlessSibling() throws {
@@ -1442,7 +1527,7 @@ final class SSHDestinationTTYProbeTests: XCTestCase {
                 )
             )
         )
-        XCTAssertFalse(value.hasSocketlessSiblingToDestination)
+        XCTAssertFalse(value.siblings.leavesMultiplexingPossible)
     }
 
     func testASocketlessNeighborToANOTHERDestinationIsIrrelevant() throws {
@@ -1459,7 +1544,7 @@ final class SSHDestinationTTYProbeTests: XCTestCase {
                 )
             )
         )
-        XCTAssertFalse(value.hasSocketlessSiblingToDestination)
+        XCTAssertFalse(value.siblings.leavesMultiplexingPossible)
         XCTAssertEqual(
             recorder.pids, [501],
             "a connection to another host is not read at all — the destination "
@@ -1478,7 +1563,7 @@ final class SSHDestinationTTYProbeTests: XCTestCase {
                 )
             )
         )
-        XCTAssertTrue(value.hasSocketlessSiblingToDestination)
+        XCTAssertTrue(value.siblings.leavesMultiplexingPossible)
     }
 
     func testANeighborWithUnparseableArgvIsSkippedRatherThanCounted() throws {
@@ -1495,7 +1580,7 @@ final class SSHDestinationTTYProbeTests: XCTestCase {
                 )
             )
         )
-        XCTAssertFalse(value.hasSocketlessSiblingToDestination)
+        XCTAssertFalse(value.siblings.leavesMultiplexingPossible)
     }
 
     func testACrossUIDSocketlessNeighborIsNotCounted() throws {
@@ -1513,7 +1598,7 @@ final class SSHDestinationTTYProbeTests: XCTestCase {
                 )
             )
         )
-        XCTAssertFalse(value.hasSocketlessSiblingToDestination)
+        XCTAssertFalse(value.siblings.leavesMultiplexingPossible)
     }
 
 }

--- a/Tests/localvoxtralTests/SSHProcessSocketReaderCrossProcessTests.swift
+++ b/Tests/localvoxtralTests/SSHProcessSocketReaderCrossProcessTests.swift
@@ -1,0 +1,202 @@
+import ClaudeContextWire
+import Foundation
+import XCTest
+@testable import localvoxtral
+
+#if canImport(Darwin)
+import Darwin
+
+/// Can the reader describe ANOTHER process's established socket?
+///
+/// This is the only question that matters for the plain-ssh join, and the
+/// existing `SSHProcessSocketReaderTests` never asked it: every assertion there
+/// reads `getpid()`. A reader that works only on its own process passes all of
+/// them and then reports "no established connection on this ssh" for every real
+/// `ssh` on the machine — which is exactly what the owner's Mac reported for a
+/// live plain-ssh session whose socket the server could see (field report,
+/// 2026-09-06).
+///
+/// The fixture is a real child holding a real connection to a listener this
+/// process owns, so "the child has an established socket" is a fact the test
+/// establishes rather than assumes.
+@MainActor
+final class SSHProcessSocketReaderCrossProcessTests: XCTestCase {
+    /// A listening loopback socket on an ephemeral port, and that port.
+    private func makeListener() throws -> (descriptor: Int32, port: UInt16) {
+        let raw = Darwin.socket(AF_INET, SOCK_STREAM, 0)
+        let listener = try XCTUnwrap(raw >= 0 ? raw : nil, "socket() failed: \(errno)")
+        var address = sockaddr_in()
+        address.sin_len = UInt8(MemoryLayout<sockaddr_in>.size)
+        address.sin_family = sa_family_t(AF_INET)
+        address.sin_port = 0
+        address.sin_addr.s_addr = Darwin.inet_addr("127.0.0.1")
+        let bound = withUnsafePointer(to: &address) { pointer in
+            pointer.withMemoryRebound(to: sockaddr.self, capacity: 1) {
+                Darwin.bind(listener, $0, socklen_t(MemoryLayout<sockaddr_in>.size))
+            }
+        }
+        XCTAssertEqual(bound, 0, "bind failed: \(errno)")
+        XCTAssertEqual(Darwin.listen(listener, 4), 0, "listen failed: \(errno)")
+        var assigned = sockaddr_in()
+        var length = socklen_t(MemoryLayout<sockaddr_in>.size)
+        _ = withUnsafeMutablePointer(to: &assigned) { pointer in
+            pointer.withMemoryRebound(to: sockaddr.self, capacity: 1) {
+                Darwin.getsockname(listener, $0, &length)
+            }
+        }
+        return (listener, UInt16(bigEndian: assigned.sin_port))
+    }
+
+    /// A live child process holding one established connection to `listener`,
+    /// plus the accepted end and the child's source port.
+    private struct ChildConnection {
+        let process: Process
+        let acceptedDescriptor: Int32
+        let childPort: UInt16
+        /// Kept alive so the child does not see EOF on stdin and exit.
+        let standardInput: Pipe
+    }
+
+    /// `/usr/bin/nc` is on every macOS install and, with an open stdin, holds
+    /// the connection until it is terminated.
+    ///
+    /// The wait for the connection is a bounded `poll(2)` on the listener, not
+    /// a sleep: a live process either connects or it does not, and the deadline
+    /// only bounds how long a dead fixture may look alive (the posture
+    /// `HerdrLaneWait` documents for the same reason).
+    private func connectFromAChild(to listener: Int32, port: UInt16) throws -> ChildConnection {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/nc")
+        process.arguments = ["127.0.0.1", String(port)]
+        let standardInput = Pipe()
+        process.standardInput = standardInput
+        process.standardOutput = Pipe()
+        process.standardError = Pipe()
+        try process.run()
+
+        var descriptor = pollfd(fd: listener, events: Int16(POLLIN), revents: 0)
+        let ready = withUnsafeMutablePointer(to: &descriptor) { Darwin.poll($0, 1, 10_000) }
+        XCTAssertGreaterThan(ready, 0, "the child never connected (poll: \(errno))")
+
+        var peer = sockaddr_in()
+        var length = socklen_t(MemoryLayout<sockaddr_in>.size)
+        let accepted = withUnsafeMutablePointer(to: &peer) { pointer in
+            pointer.withMemoryRebound(to: sockaddr.self, capacity: 1) {
+                Darwin.accept(listener, $0, &length)
+            }
+        }
+        XCTAssertGreaterThanOrEqual(accepted, 0, "accept failed: \(errno)")
+        return ChildConnection(
+            process: process,
+            acceptedDescriptor: accepted,
+            childPort: UInt16(bigEndian: peer.sin_port),
+            standardInput: standardInput
+        )
+    }
+
+    private func tearDown(_ child: ChildConnection) {
+        Darwin.close(child.acceptedDescriptor)
+        child.process.terminate()
+        child.process.waitUntilExit()
+    }
+
+    func testTheReaderDescribesAnotherSameUserProcessesEstablishedSocket() throws {
+        let (listener, listenPort) = try makeListener()
+        defer { Darwin.close(listener) }
+        let child = try connectFromAChild(to: listener, port: listenPort)
+        defer { tearDown(child) }
+
+        let sockets = try XCTUnwrap(
+            SSHProcessSocketReader.establishedTCPSockets(pid: child.process.processIdentifier),
+            "another same-user process's socket table must be readable — the join "
+                + "reads the SURFACE's ssh, never its own process"
+        )
+        let match = sockets.first {
+            $0.localPort == child.childPort && $0.peerPort == listenPort
+        }
+        let described = try XCTUnwrap(
+            match,
+            "the reader must find the connection the child holds "
+                + "(client \(child.childPort) -> \(listenPort)); saw \(sockets)"
+        )
+        XCTAssertEqual(described.peerAddress, "127.0.0.1")
+    }
+
+    /// A GRANDCHILD: `nc` launched in the background by a `sh` we spawn, so the
+    /// process whose sockets are read is not one this process created.
+    ///
+    /// The distinction is the whole point. macOS's `proc_info` security policy
+    /// is not simply "same uid": a child a process spawned is not the same
+    /// access class as an unrelated process of the same user, and the join
+    /// reads `ssh` processes it never spawned. A test that only ever reads its
+    /// own child can pass while the shipped reader sees nothing.
+    private func connectFromAGrandchild(
+        to listener: Int32, port: UInt16
+    ) throws -> (shell: Process, grandchildPID: Int32, accepted: Int32, childPort: UInt16, stdin: Pipe) {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/bin/sh")
+        // `sleep | nc` rather than a bare background `nc`: a POSIX shell gives a
+        // background job /dev/null on stdin, so nc reads EOF, half-closes, and
+        // the socket sits in FIN_WAIT_2 — which is not established and made the
+        // first version of this fixture prove nothing (measured: `state=9`).
+        // The pipe keeps nc's stdin open, and `$!` after a pipeline is the LAST
+        // element's pid, i.e. nc's.
+        process.arguments = [
+            "-c", "sleep 600 | /usr/bin/nc 127.0.0.1 \(port) & echo $! >&2; wait",
+        ]
+        let standardInput = Pipe()
+        let standardError = Pipe()
+        process.standardInput = standardInput
+        process.standardOutput = Pipe()
+        process.standardError = standardError
+        try process.run()
+
+        var descriptor = pollfd(fd: listener, events: Int16(POLLIN), revents: 0)
+        let ready = withUnsafeMutablePointer(to: &descriptor) { Darwin.poll($0, 1, 10_000) }
+        XCTAssertGreaterThan(ready, 0, "the grandchild never connected (poll: \(errno))")
+
+        var peer = sockaddr_in()
+        var length = socklen_t(MemoryLayout<sockaddr_in>.size)
+        let accepted = withUnsafeMutablePointer(to: &peer) { pointer in
+            pointer.withMemoryRebound(to: sockaddr.self, capacity: 1) {
+                Darwin.accept(listener, $0, &length)
+            }
+        }
+        XCTAssertGreaterThanOrEqual(accepted, 0, "accept failed: \(errno)")
+
+        // `sh` printed the background pid before waiting, and the connection
+        // above proves it has started, so this read cannot block.
+        let announced = standardError.fileHandleForReading.availableData
+        let text = String(decoding: announced, as: UTF8.self)
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        let grandchildPID = try XCTUnwrap(Int32(text), "sh did not announce a pid: \(text)")
+        return (process, grandchildPID, accepted, UInt16(bigEndian: peer.sin_port), standardInput)
+    }
+
+    func testTheReaderDescribesAProcessItDidNotSpawn() throws {
+        let (listener, listenPort) = try makeListener()
+        defer { Darwin.close(listener) }
+        let held = try connectFromAGrandchild(to: listener, port: listenPort)
+        defer {
+            Darwin.close(held.accepted)
+            kill(held.grandchildPID, SIGTERM)
+            held.shell.terminate()
+            held.shell.waitUntilExit()
+        }
+
+        let sockets = try XCTUnwrap(
+            SSHProcessSocketReader.establishedTCPSockets(pid: held.grandchildPID),
+            "a same-user process this one did NOT spawn must still be readable"
+        )
+        let match = sockets.first {
+            $0.localPort == held.childPort && $0.peerPort == listenPort
+        }
+        XCTAssertNotNil(
+            match,
+            "the reader must find the connection a NON-child holds "
+                + "(client \(held.childPort) -> \(listenPort)); saw \(sockets)"
+        )
+    }
+
+}
+#endif

--- a/docs/agent/invariants.md
+++ b/docs/agent/invariants.md
@@ -706,12 +706,40 @@ there is not.
       socket. sshd derives `$SSH_CONNECTION` from the underlying CONNECTION,
       so B's Claude session truthfully reports A's ports — and a dictation
       into A, a plain shell with no agent in it, would join B's session. The
-      check is `SSHSurfaceConnection.hasSocketlessSiblingToDestination`: any
-      same-uid ssh CONNECTION to the same destination whose fd table is
-      readable-and-socketless (or unreadable) abstains the arm. It costs the
-      ordinary two-terminals-two-connections case nothing — those each hold a
-      socket and are told apart by their ports. Also found by review
+      check is `SSHSiblingSurvey`, carried on `SSHSurfaceConnection.siblings`:
+      the other same-uid ssh CONNECTIONS to the same destination are counted
+      by what the kernel could say about each, and any that is
+      readable-and-socketless, or unreadable at all, abstains the arm. It
+      costs the ordinary two-terminals-two-connections case nothing — those
+      each hold a socket and are told apart by their ports. Found by review
       (2026-09-05).
+
+      The survey is COUNTED rather than a boolean because the first field run
+      of this arm (2026-09-06) abstained on it and the abstention could not
+      say why: "a real ControlMaster client is open in another window" and
+      "some ssh's fd table could not be read" are the same non-join and
+      opposite fixes. They are now separate causes carrying `n of m`. Two
+      processes are excluded from the survey outright, and both exclusions are
+      about not manufacturing that abstention: an ssh whose kernel PARENT is
+      this app (its `RemoteForward` supervisor, its herdr `ssh -L` — ours, and
+      never somebody's terminal), and any ssh with no controlling terminal (a
+      mux client that could mis-join is a session in another WINDOW; a
+      tty-less ssh is machinery).
+
+      The surface's OWN two refusals are named the same way and for the same
+      reason: `this ssh holds no connection of its own (a ControlMaster client
+      or a ProxyCommand)` is the readable-and-empty case — which the field
+      also hit — and `this ssh's socket table is unreadable` means a syscall
+      failed, which
+      `SSHProcessSocketReaderCrossProcessTests` says should not happen for a
+      same-user process. That test exists because the original reader tests
+      only ever read `getpid()`: a reader that works on its own process alone
+      passes all of them and then sees nothing for every real `ssh` on the
+      machine. MEASURED on the build host 2026-09-06:
+      `proc_pidinfo(PROC_PIDLISTFDS)` + `proc_pidfdinfo(PROC_PIDFDSOCKETINFO)`
+      answer for a same-uid process this one did NOT spawn (`rc=792`,
+      `kind=SOCKINFO_TCP`, `state=TSI_S_ESTABLISHED`), so the API is not the
+      constraint and the app needs no entitlement for it.
 
   - A Claude Code "Remote Control" session (the agent runs on a machine of the
     user's, `claude.ai/code` in a browser is the UI) has no pane, no TTY, and no

--- a/docs/dogfood-builds.md
+++ b/docs/dogfood-builds.md
@@ -144,7 +144,7 @@ $ printf 'registry list\n' | nc -U ~/Library/Application\ Support/localvoxtral/d
 | `session stop` | ends it — and while a start is still connecting, cancels that instead of walking away from it |
 | `join report` | the join the LAST dictation resolved, as `ClaudeSessionJoinSummary` |
 | `surface probe` | resolves the focused surface NOW, against the live in-process registry |
-| `registry list` | the live sessions, as shapes — so "nothing registered" is distinguishable from "resolution failed" |
+| `registry list` | the live sessions, as shapes — so "nothing registered" is distinguishable from "resolution failed". For a REMOTE session it also reports whether each join arm's own inputs arrived: `remoteHerdrPane`/`remoteHerdrSocket`, `remoteCmuxSurface`, and `remoteSSHConnection`/`remoteSSHTTY`/`remoteMultiplexerLabel` for the plain-ssh arm |
 
 Bounds worth knowing before touching it:
 

--- a/integrations/claude-code/README.md
+++ b/integrations/claude-code/README.md
@@ -152,8 +152,10 @@ It deliberately does **not** join in three cases:
 * **when your `~/.ssh/config` may be sharing one connection**
   (`ControlMaster`): several terminals then run over one TCP connection and
   all report the same `$SSH_CONNECTION`, so it no longer identifies a window.
-  Detected by looking for a second `ssh` to the same host that holds no
-  connection of its own;
+  Detected two ways, each with its own reason in `--probe-surface`: the window
+  you are dictating into holds no connection of its own (it is a mux client),
+  or another `ssh` session to the same host does. If you use `ControlMaster`
+  and want this join, `ControlMaster no` for that host restores it;
 * **when anything is ambiguous**: two sessions reporting the same connection,
   two enrolled hosts matching the destination, an unreadable process table.
 


### PR DESCRIPTION
## What

The first field run of the plain-ssh join (#264) produced **no join** for a
live plain-ssh Claude session, with two different reasons from two windows:

```
remote-ssh: this destination may be carrying multiplexed ssh sessions
remote-ssh: no established connection on this ssh
```

Neither could say *why*, and the two candidate explanations — a real
ControlMaster client, or an fd table the app failed to read — call for
opposite fixes. This PR makes the arm answer that question, and clears the
reader by measurement rather than by argument.

## 1. The reader is exonerated, and now pinned cross-process

Every assertion in `SSHProcessSocketReaderTests` reads `getpid()`. A reader
that works only on its OWN process passes all of them and then sees nothing
for every real `ssh` on the machine — exactly the field symptom. That gap is
closed:

`SSHProcessSocketReaderCrossProcessTests` builds a real child (`nc`) and a real
**non-child** (a grandchild, because macOS's `proc_info` security policy is not
simply "same uid" — a process you spawned is a different access class from an
unrelated one), each holding a real connection to a listener the test owns, and
requires the reader to describe it.

Measured on the build host, 2026-09-06:

```
DIAG2 listfds-size  pid=38805 rc=360 errno=0
DIAG2 listfds-fetch rc=32 errno=0 entries=4
DIAG2 fd=3 type=2 rc=792 errno=0 kind=2 state=4      # SOCKINFO_TCP, TSI_S_ESTABLISHED
DIAG2 grandchild sockets=1
```

`proc_pidinfo(PROC_PIDLISTFDS)` + `proc_pidfdinfo(PROC_PIDFDSOCKETINFO)` answer
for a same-uid process this one did not spawn. **H1 is falsified**: the API is
not the constraint and the app needs no entitlement for it. The app is also not
sandboxed and does not use the hardened runtime (`scripts/package_app.sh` signs
with no entitlements file and no `--options runtime`), so the shipped binary is
in the same access class as the test binary.

An honest caveat about the first version of that fixture, because it is the
kind of thing that makes a test lie: a bare background `nc` gets `/dev/null` on
stdin, reads EOF, half-closes, and the socket sits in **FIN_WAIT_2** —
`state=9`, not established. It "failed" for a fixture reason. `sleep | nc`
keeps the connection established, and the comment in the file says so.

## 2. The abstention says which shape it saw

`SSHSiblingSurvey` replaces the `hasSocketlessSiblingToDestination` boolean and
counts the other ssh sessions to the destination by what the kernel could say
about each. Both still abstain — that part was right — but under their own
causes:

| before | now |
|---|---|
| `this destination may be carrying multiplexed ssh sessions` | `another ssh session to this destination holds no connection of its own (n of m)` |
|  | `another ssh session to this destination is unreadable (n of m)` |
| `no established connection on this ssh` | `this ssh holds no connection of its own (a ControlMaster client or a ProxyCommand)` |
| `socket table unreadable` | `this ssh's socket table is unreadable` |

`n of m` because "1 of 1" and "1 of 6" are different stories, and neither names
a host, a port, or a path. The surface's own readable-and-empty case is
**renamed rather than changed**: it IS the mux-client shape, and the field hit
it, so the string now says so instead of reading like an error.

## 3. Two processes leave the sibling survey

Both exclusions exist so the app cannot manufacture that abstention against
itself:

* **an ssh whose kernel parent is this app.** The `RemoteForward` supervisor
  and the herdr `ssh -L` run to the very hosts this arm is about. Their argv is
  refused by the parser today (`-N`), so this is belt and braces — it stops a
  future forward whose argv happens to parse from abstaining every dictation on
  that host. Kernel `ppid`, which no launcher gets to write.
* **an ssh with no controlling terminal.** A ControlMaster client that could
  mis-join is a session in another WINDOW, so it holds a tty. A tty-less ssh is
  machinery (`ssh -N`, `ssh host command` in a script) and counting one made
  transient helpers look like mux clients.

## 4. `registry list` reports the plain-ssh arm's inputs

`remoteSSHConnection`, `remoteSSHTTY`, `remoteMultiplexerLabel` — bools, never
the tuple, which is the join material. Same gap the herdr fields closed a day
earlier (#253): a field run could not tell "the host is on a plugin older than
1.6.0" from "the ports did not match".

## Proof

- **Unit suite green** — `./scripts/remote-build.sh test`

```
Executed 2827 tests, with 2 tests skipped and 0 failures (0 unexpected) in 50.252 (50.373) seconds
```

`grep -ci "warning:" .build/last-remote.log` → `0`.

- **Dogfood suite green** — `./scripts/remote-build.sh dogfood`

```
Executed 118 tests, with 0 failures (0 unexpected) in 1.186 (1.193) seconds
```

- **Live-herdr lane green** — `./scripts/remote-build.sh integration-herdr`
  (required: this changes the shared `SSHDestinationTTYProbe` scan)

```
Executed 11 tests, with 0 failures (0 unexpected) in 61.759 (61.761) seconds
```

- **Red/green.** All four changes reverted at once — the reader restricted to
  `pid == getpid()`, the own-children rule dropped, the tty rule dropped, the
  two sibling causes collapsed back into one:

```
Test Case '-[…PlainSSHConnectionJoinTests testAControlMasterMuxSiblingAbstainsEvenWhenThePortsAgree]' failed
Test Case '-[…PlainSSHConnectionJoinTests testAnUnreadableSiblingAbstainsUnderItsOWNCause]' failed
Test Case '-[…SSHDestinationTTYProbeTests testAnSSHChildOfTHISProcessIsNeverASibling]' failed
Test Case '-[…SSHDestinationTTYProbeTests testATTYLessSSHIsNotASibling]' failed
Test Case '-[…SSHProcessSocketReaderCrossProcessTests testTheReaderDescribesAnotherSameUserProcessesEstablishedSocket]' failed
Test Case '-[…SSHProcessSocketReaderCrossProcessTests testTheReaderDescribesAProcessItDidNotSpawn]' failed
	 Executed 2827 tests, with 2 tests skipped and 8 failures (0 unexpected)
```

  Restored → 2827/0. And the `registry list` key renamed, in the instrumented
  suite (its tests do not run in tier 0):

```
Test Case '-[…DogfoodControlServiceTests testRegistryListReportsWhetherThePlainSSHJoinsInputsArrived]' failed
Test Case '-[…DogfoodControlServiceTests testRegistryListSeparatesASessionThatReportedNoConnectionFromOneInsideAMultiplexer]' failed
	 Executed 118 tests, with 3 failures (0 unexpected)
```

  Restored → 118/0.

- **Also green on the hosted lane** — `build-test` now runs tier 0 on
  GitHub-hosted macOS (#260), so the cross-process test is proved on both
  machines by this PR's own CI.

## What this does NOT do

It does not make the owner's session join. It makes the next attempt say which
of two things is in the way. My reading of the app's own evidence now favours
**H3 (real `ControlMaster`)** over H1: `no established connection on this ssh`
means the reader worked and the surface's ssh genuinely held no TCP socket,
which for an interactive `ssh host` is the mux-client shape. The server-side
"5 alive distinct source ports" does not refute that — it is the server's count
of TCP connections, not of the Mac's terminal windows.

Two facts only the owner's Mac can give, and the exact commands:

```sh
# 1. Is ControlMaster on for that host? (This is the whole question.)
ssh -G sandbox-vpn | grep -Ei 'controlmaster|controlpath|controlpersist|proxy'

# 2. What do the ssh processes on that Mac actually hold?
#    Run while the plain-ssh claude window is open.
pgrep -u "$(id -un)" -x ssh | while read -r p; do
  echo "== pid $p =="
  ps -o pid=,ppid=,tty=,command= -p "$p"
  lsof -nP -p "$p" -a -iTCP 2>/dev/null || echo "  (no TCP)"
done
```

If (1) shows `controlmaster auto`/`ControlPath`, the arm is behaving correctly
and the honest options are: document it, or add an opt-in that trusts the
master's connection for its clients (a design question, not a bug fix). If (1)
shows no multiplexing and (2) shows the surface's ssh holding a TCP socket that
this app cannot see, then the reader IS the problem after all and the next step
is the `net.inet.tcp.pcblist_n` route — `sysctlbyname` sizes it fine on this
Mac (`rc=0 bytes=51792`), and `xsocket_n.so_last_pid` attributes each socket to
a pid without any per-process fd read.

## Docs

`docs/agent/invariants.md` (the counted survey, both exclusions, the
cross-process measurement, and why the surface's own two causes are named the
way they are), `integrations/claude-code/README.md` (both ControlMaster
detections, and `ControlMaster no` as the user's lever),
`docs/dogfood-builds.md` (the new `registry list` fields).

[run-herdr-integration]
[dogfood-package]
