### PR TITLE
Plain-ssh join: set the shell export up from Settings

### DIFF
--- a/Sources/localvoxtral/ClaudeContext/ClaudeIntegrationSettingsModel.swift
+++ b/Sources/localvoxtral/ClaudeContext/ClaudeIntegrationSettingsModel.swift
@@ -60,6 +60,69 @@ public struct ClaudeEnrollmentActionAttempt: Sendable, Equatable {
     }
 }
 
+/// What the pane can say about the plain-ssh join's one setup step.
+///
+/// Two facts, deliberately separate, because they fail for different reasons
+/// and only the user can fix the first: is the export in the rc file, and has
+/// a session actually arrived carrying it. A block written five seconds ago
+/// proves nothing until a NEW ssh session starts, and saying so is the whole
+/// value of the second half.
+public struct ClaudeShellSetupStatus: Sendable, Equatable {
+    public enum RCState: Sendable, Equatable {
+        /// The login shell is not one this app writes for.
+        case unsupportedShell
+        case notApplied
+        case applied
+        /// The rc file could not be read, or is a symlink we will not write
+        /// through.
+        case unknown
+    }
+
+    public enum CrossingState: Sendable, Equatable {
+        /// No enrolled host has a live session at all — nothing to say yet.
+        case noSessions
+        /// Live sessions, none carrying the value: the usual "you have not
+        /// opened a new window yet".
+        case notSeen
+        case seen
+    }
+
+    public var rc: RCState
+    public var crossing: CrossingState
+    /// The rc file this app would write, relative to `$HOME` — shown so the
+    /// user knows what they are being asked to let us edit.
+    public var relativeRCPath: String?
+
+    public init(
+        rc: RCState = .unknown,
+        crossing: CrossingState = .noSessions,
+        relativeRCPath: String? = nil
+    ) {
+        self.rc = rc
+        self.crossing = crossing
+        self.relativeRCPath = relativeRCPath
+    }
+
+    /// One short sentence, per the pane's copy rule. Never restates the label,
+    /// never a path or a host.
+    public var rcSentence: String {
+        switch rc {
+        case .unsupportedShell: return "Your login shell is not one this can set up."
+        case .notApplied: return "Not set up."
+        case .applied: return "Set up."
+        case .unknown: return "Could not read your shell startup file."
+        }
+    }
+
+    public var crossingSentence: String {
+        switch crossing {
+        case .noSessions: return "No remote session has reported in yet."
+        case .notSeen: return "Open a new terminal window for it to take effect."
+        case .seen: return "A remote session is reporting its terminal."
+        }
+    }
+}
+
 /// Settings-pane state for both Claude Code integrations.
 ///
 /// `@MainActor @Observable`, per repo convention for stateful UI controllers.
@@ -318,6 +381,8 @@ public final class ClaudeIntegrationSettingsModel {
     /// Set by the join probe after a successful stamp whose value never
     /// appeared in the focused grid. This is inferential, not a config read.
     var herdrPanelStatus: HerdrPanelConfigurationStatus = .ok
+    /// The plain-ssh join's setup step, refreshed with the rest of the pane.
+    var shellSetupStatus = ClaudeShellSetupStatus()
 
     /// The password field's live text. Never seeded from the Keychain: the
     /// stored secret is not shown back to anyone, and an empty field on a
@@ -350,6 +415,16 @@ public final class ClaudeIntegrationSettingsModel {
     // MARK: - Dependencies
 
     private let registry: ClaudeRemoteHostRegistry?
+    /// The user's login shell, or nil for one this app will not write for.
+    /// Injected so no test spawns `dscl`.
+    private let loginShell: @Sendable () -> ClaudeShellKind?
+    /// Reads and writes the rc block for a shell. Nil disables the whole
+    /// setup step — which is what a test that forgets to inject must get, so
+    /// nothing can touch a real `~/.zshrc`.
+    private let shellRCWriter: @Sendable (ClaudeShellKind) -> ClaudeShellRCWriter?
+    /// Does any live remote session report a local tty? Nil means "no way to
+    /// ask", which reports as no sessions rather than as a failure.
+    private let liveLocalTTYReport: @Sendable () -> ClaudeShellSetupStatus.CrossingState
     private let listener: (any ClaudeRemoteListenerControlling)?
     private let pluginService: @Sendable () -> any ClaudePluginInstalling
     private let enrollmentService: ClaudeRemoteEnrollmentService
@@ -424,8 +499,16 @@ public final class ClaudeIntegrationSettingsModel {
         // still works. Production passes the allocation.
         remoteForwardPort: UInt16 = ClaudeRemoteForwardPort.legacyPort,
         cmuxPasswords: (any CmuxPasswordStoring)? = nil,
-        forwards: ClaudeRemoteForwardCoordinator? = nil
+        forwards: ClaudeRemoteForwardCoordinator? = nil,
+        loginShell: @escaping @Sendable () -> ClaudeShellKind? = { nil },
+        shellRCWriter: @escaping @Sendable (ClaudeShellKind) -> ClaudeShellRCWriter? = { _ in nil },
+        liveLocalTTYReport: @escaping @Sendable () -> ClaudeShellSetupStatus.CrossingState = {
+            .noSessions
+        }
     ) {
+        self.loginShell = loginShell
+        self.shellRCWriter = shellRCWriter
+        self.liveLocalTTYReport = liveLocalTTYReport
         self.registry = registry
         self.listener = listener
         self.pluginService = pluginService
@@ -822,6 +905,69 @@ public final class ClaudeIntegrationSettingsModel {
     /// plugin it exits 0 and leaves the old version in place (Claude Code
     /// 2.1.220), so re-running enrollment does nothing and a host stays on a
     /// plugin the app has since fixed — silently, because the hooks fail open.
+    // MARK: - Shell setup for the plain-ssh join
+
+    /// Re-read both halves. Cheap: one `lstat`+read of one rc file, and one
+    /// registry query. Called with the rest of the pane's refresh.
+    public func refreshShellSetupStatus() {
+        guard let shell = loginShell() else {
+            shellSetupStatus = ClaudeShellSetupStatus(
+                rc: .unsupportedShell, crossing: liveLocalTTYReport()
+            )
+            return
+        }
+        let writer = shellRCWriter(shell)
+        let rc: ClaudeShellSetupStatus.RCState
+        switch writer?.isApplied() {
+        case .some(true): rc = .applied
+        case .some(false): rc = .notApplied
+        case .none: rc = .unknown
+        }
+        shellSetupStatus = ClaudeShellSetupStatus(
+            rc: rc,
+            crossing: liveLocalTTYReport(),
+            relativeRCPath: ClaudeShellRCSetup.relativeRCPath(for: shell) { relative in
+                FileManager.default.fileExists(
+                    atPath: FileManager.default.homeDirectoryForCurrentUser
+                        .appendingPathComponent(relative).path
+                )
+            }
+        )
+    }
+
+    /// The exact text the user is being asked to allow, or nil when there is
+    /// no shell to write for. Shown before anything is written — the same
+    /// preview-then-consent shape as the ssh-config block.
+    public var shellSetupPreview: String? {
+        guard let shell = loginShell() else { return nil }
+        return ClaudeShellRCSetup.snippet(for: shell)
+    }
+
+    /// Write the block. Consent is the CALLER's to obtain, immediately before.
+    public func applyShellSetup() async {
+        guard let shell = loginShell(), let writer = shellRCWriter(shell) else { return }
+        await performShellRCEdit { try writer.apply(shell: shell) }
+    }
+
+    public func removeShellSetup() async {
+        guard let shell = loginShell(), let writer = shellRCWriter(shell) else { return }
+        await performShellRCEdit { try writer.remove() }
+    }
+
+    private func performShellRCEdit(_ body: @escaping @Sendable () throws -> Void) async {
+        let failure = await performAsync { try body() }
+        if let failure {
+            // The pane shows one short line; the detail belongs in the alert
+            // (owner rule), and this is the one place the symlink refusal
+            // becomes visible to a dotfiles user.
+            alert = DetailAlert(
+                title: "Could not update your shell startup file",
+                detail: failure.describedError
+            )
+        }
+        refreshShellSetupStatus()
+    }
+
     public func requestPluginUpdate(hostID: String) {
         guard !isPerformingEnrollmentAction,
               let host = hosts.first(where: { $0.id == hostID })

--- a/Sources/localvoxtral/ClaudeContext/ClaudeIntegrationSettingsModel.swift
+++ b/Sources/localvoxtral/ClaudeContext/ClaudeIntegrationSettingsModel.swift
@@ -989,11 +989,11 @@ public final class ClaudeIntegrationSettingsModel {
         // service means "cannot tell", and cannot-tell must regenerate: the
         // cost of a redundant idempotent rewrite is nothing, and the cost of
         // assuming a stale block is current is a silently dead host.
-        let alreadyForwards =
+        let alreadyCurrent =
             registry?.host(id: hostID).flatMap { host in
-                enrollmentService.sshConfigForwardsPort(remoteForwardPort, hostID: host.id)
+                enrollmentService.sshConfigBlockIsCurrent(port: remoteForwardPort, hostID: host.id)
             } ?? false
-        let snippet: String? = alreadyForwards ? nil : registry?.host(id: hostID).map { host in
+        let snippet: String? = alreadyCurrent ? nil : registry?.host(id: hostID).map { host in
             ClaudeRemoteEnrollmentService.sshConfigSnippet(
                 host: host,
                 sshHostAlias: alias ?? Self.unknownAliasPlaceholder,

--- a/Sources/localvoxtral/ClaudeContext/ClaudeRemoteEnrollmentLiveIO.swift
+++ b/Sources/localvoxtral/ClaudeContext/ClaudeRemoteEnrollmentLiveIO.swift
@@ -127,19 +127,36 @@ struct LiveClaudeShellRCFileSystem: ClaudeShellRCFileSystem {
     /// - Parameter relativePath: from `ClaudeShellRCSetup.relativeRCPath`, so
     ///   the shell rule and the file I/O cannot disagree about which file this
     ///   is.
+    private let homeURL: URL
+    private let relativePath: String
+
     init(
         relativePath: String,
         homeDirectoryURL: URL = FileManager.default.homeDirectoryForCurrentUser
     ) {
+        homeURL = homeDirectoryURL
+        self.relativePath = relativePath
         fileURL = homeDirectoryURL.appendingPathComponent(relativePath, isDirectory: false)
         directoryURL = fileURL.deletingLastPathComponent()
     }
 
     func readState() throws -> ClaudeShellRCState {
-        let directoryMetadata = ClaudeSocketGuard.metadata(ofPath: directoryURL.path)
         let fileMetadata = ClaudeSocketGuard.metadata(ofPath: fileURL.path)
+        // EVERY component from home down, not just the immediate parent. For
+        // fish the file is `~/.config/fish/conf.d/localvoxtral.fish`, and the
+        // standard dotfiles layout symlinks `~/.config` itself — checking only
+        // `conf.d` walked straight through it and planted the file in the
+        // user's repo (review finding M3). For zsh and bash the parent IS home,
+        // which is why that half of the old check was vacuous.
+        let intermediateIsSymlink = Self.anyComponentIsSymlink(
+            under: homeURL, relativePath: relativePath
+        )
         let data: Data?
-        if fileMetadata != nil, fileMetadata?.isSymlink != true {
+        if fileMetadata != nil, fileMetadata?.isSymlink != true, !intermediateIsSymlink {
+            // NOT `try?`: a file that exists and cannot be read must reach the
+            // writer as "unreadable", never as an empty file (review finding
+            // M2). `readState` reports it as existing with no data, and the
+            // writer turns that into a refusal.
             data = try? Data(contentsOf: fileURL)
         } else {
             data = nil
@@ -153,11 +170,33 @@ struct LiveClaudeShellRCFileSystem: ClaudeShellRCFileSystem {
         return ClaudeShellRCState(
             fileExists: fileMetadata != nil,
             fileIsSymlink: fileMetadata?.isSymlink == true,
-            directoryExists: directoryMetadata?.isDirectory == true,
-            directoryIsSymlink: directoryMetadata?.isSymlink == true,
+            directoryExists: ClaudeSocketGuard.metadata(ofPath: directoryURL.path)?
+                .isDirectory == true,
+            directoryIsSymlink: intermediateIsSymlink,
             data: data,
             permissions: permissions
         )
+    }
+
+    /// Is any directory between `home` and the file a symlink?
+    ///
+    /// Pure over the two arguments and `lstat`, so the fish layout is testable
+    /// against a real temp tree.
+    static func anyComponentIsSymlink(under home: URL, relativePath: String) -> Bool {
+        var current = home
+        let components = relativePath.split(separator: "/").map(String.init)
+        // The leaf is the file itself; its own symlink-ness is reported
+        // separately so the writer can name that case.
+        for component in components.dropLast() {
+            current = current.appendingPathComponent(component, isDirectory: true)
+            guard let metadata = ClaudeSocketGuard.metadata(ofPath: current.path) else {
+                // Not created yet — nothing to follow, and `createDirectory`
+                // will make it under a path we just proved link-free.
+                continue
+            }
+            if metadata.isSymlink { return true }
+        }
+        return false
     }
 
     func createDirectory(permissions: UInt16) throws {

--- a/Sources/localvoxtral/ClaudeContext/ClaudeRemoteEnrollmentLiveIO.swift
+++ b/Sources/localvoxtral/ClaudeContext/ClaudeRemoteEnrollmentLiveIO.swift
@@ -112,6 +112,165 @@ struct LiveClaudeRemoteSSHConfigFileSystem: ClaudeRemoteSSHConfigFileSystem {
     }
 }
 
+/// The user's shell rc file, with the same discipline as the ssh-config
+/// writer: `lstat` so a symlink is seen as one, `O_NOFOLLOW` on the temp file,
+/// and an atomic rename.
+///
+/// Deliberately NOT shared with that writer despite the shape: `~/.ssh` has
+/// trust rules of its own (owner and group-write checks that OpenSSH itself
+/// enforces), and an rc file has none of them. Merging the two would mean one
+/// of the two sets of rules applying where it does not belong.
+struct LiveClaudeShellRCFileSystem: ClaudeShellRCFileSystem {
+    private let fileURL: URL
+    private let directoryURL: URL
+
+    /// - Parameter relativePath: from `ClaudeShellRCSetup.relativeRCPath`, so
+    ///   the shell rule and the file I/O cannot disagree about which file this
+    ///   is.
+    init(
+        relativePath: String,
+        homeDirectoryURL: URL = FileManager.default.homeDirectoryForCurrentUser
+    ) {
+        fileURL = homeDirectoryURL.appendingPathComponent(relativePath, isDirectory: false)
+        directoryURL = fileURL.deletingLastPathComponent()
+    }
+
+    func readState() throws -> ClaudeShellRCState {
+        let directoryMetadata = ClaudeSocketGuard.metadata(ofPath: directoryURL.path)
+        let fileMetadata = ClaudeSocketGuard.metadata(ofPath: fileURL.path)
+        let data: Data?
+        if fileMetadata != nil, fileMetadata?.isSymlink != true {
+            data = try? Data(contentsOf: fileURL)
+        } else {
+            data = nil
+        }
+        var permissions: UInt16?
+        if data != nil,
+           let number = try? FileManager.default
+               .attributesOfItem(atPath: fileURL.path)[.posixPermissions] as? NSNumber {
+            permissions = number.uint16Value
+        }
+        return ClaudeShellRCState(
+            fileExists: fileMetadata != nil,
+            fileIsSymlink: fileMetadata?.isSymlink == true,
+            directoryExists: directoryMetadata?.isDirectory == true,
+            directoryIsSymlink: directoryMetadata?.isSymlink == true,
+            data: data,
+            permissions: permissions
+        )
+    }
+
+    func createDirectory(permissions: UInt16) throws {
+        try FileManager.default.createDirectory(
+            at: directoryURL,
+            withIntermediateDirectories: true,
+            attributes: [.posixPermissions: NSNumber(value: permissions)]
+        )
+    }
+
+    func atomicWrite(_ data: Data, permissions: UInt16) throws {
+        let temporaryURL = directoryURL.appendingPathComponent(
+            ".localvoxtral-rc.\(UUID().uuidString)", isDirectory: false
+        )
+        let descriptor = temporaryURL.path.withCString {
+            open($0, O_WRONLY | O_CREAT | O_EXCL | O_NOFOLLOW, 0o600)
+        }
+        guard descriptor >= 0 else { throw ShellRCPOSIXFailure(operation: "open", code: errno) }
+        var renamed = false
+        defer {
+            close(descriptor)
+            if !renamed { _ = temporaryURL.path.withCString { unlink($0) } }
+        }
+        guard fchmod(descriptor, mode_t(permissions)) == 0 else {
+            throw ShellRCPOSIXFailure(operation: "fchmod", code: errno)
+        }
+        try data.withUnsafeBytes { raw in
+            guard let baseAddress = raw.baseAddress else { return }
+            var offset = 0
+            while offset < raw.count {
+                let written = Darwin.write(
+                    descriptor, baseAddress.advanced(by: offset), raw.count - offset
+                )
+                if written == -1, errno == EINTR { continue }
+                guard written > 0 else {
+                    throw ShellRCPOSIXFailure(operation: "write", code: errno)
+                }
+                offset += written
+            }
+        }
+        guard fsync(descriptor) == 0 else {
+            throw ShellRCPOSIXFailure(operation: "fsync", code: errno)
+        }
+        let moved = temporaryURL.path.withCString { source in
+            fileURL.path.withCString { destination in rename(source, destination) }
+        }
+        guard moved == 0 else { throw ShellRCPOSIXFailure(operation: "rename", code: errno) }
+        renamed = true
+    }
+
+    private struct ShellRCPOSIXFailure: Error, CustomStringConvertible {
+        var operation: String
+        var code: Int32
+        var description: String { "\(operation) failed with errno \(code)" }
+    }
+}
+
+/// The user's login shell, from Directory Services — the same answer
+/// `chsh -s` writes and `Terminal.app` obeys.
+///
+/// `$SHELL` is the fallback and NOT the primary: this app runs from a GUI
+/// launch, where `$SHELL` is inherited from launchd and can be stale after a
+/// `chsh`. `dscl` is asked first and the environment only backs it up.
+enum ClaudeLoginShellReader {
+    /// - Parameter runDSCL: returns `dscl`'s RAW output, which `parse` reads.
+    ///   Splitting it that way keeps the parser testable without a process and
+    ///   keeps the process out of every test that forgets to inject.
+    static func loginShellPath(
+        runDSCL: () -> String? = liveDSCL,
+        environment: [String: String] = ProcessInfo.processInfo.environment
+    ) -> String? {
+        if let output = runDSCL(), let path = parse(output) {
+            return path
+        }
+        let fallback = environment["SHELL"]?.trimmingCharacters(in: .whitespacesAndNewlines)
+        return fallback?.hasPrefix("/") == true ? fallback : nil
+    }
+
+    /// `dscl . -read /Users/<me> UserShell` prints `UserShell: /bin/zsh`.
+    /// Returns that line verbatim; `parse` turns it into a path.
+    static func liveDSCL() -> String? {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/dscl")
+        process.arguments = [".", "-read", "/Users/\(NSUserName())", "UserShell"]
+        let output = Pipe()
+        process.standardOutput = output
+        process.standardError = Pipe()
+        guard (try? process.run()) != nil else { return nil }
+        // `POSIXPipeRead`, never `FileHandle.availableData` (banned repo-wide,
+        // PR #60). `dscl`'s answer is one short line, so one chunk is the whole
+        // of it; a longer answer is not one this parser would accept anyway.
+        let data = POSIXPipeRead.nextChunk(
+            fromDescriptor: output.fileHandleForReading.fileDescriptor
+        )
+        process.waitUntilExit()
+        guard process.terminationStatus == 0 else { return nil }
+        return String(data: data, encoding: .utf8)
+    }
+
+    /// `UserShell: /bin/zsh` → `/bin/zsh`.
+    static func parse(_ output: String) -> String? {
+        for line in output.split(whereSeparator: \.isNewline) {
+            let fields = line.split(separator: ":", maxSplits: 1)
+            guard fields.count == 2,
+                  fields[0].trimmingCharacters(in: .whitespaces) == "UserShell"
+            else { continue }
+            let value = fields[1].trimmingCharacters(in: .whitespaces)
+            return value.hasPrefix("/") ? value : nil
+        }
+        return nil
+    }
+}
+
 extension ClaudeRemoteEnrollmentService {
     static func live() -> ClaudeRemoteEnrollmentService {
         ClaudeRemoteEnrollmentService(

--- a/Sources/localvoxtral/ClaudeContext/ClaudeRemoteEnrollmentService.swift
+++ b/Sources/localvoxtral/ClaudeContext/ClaudeRemoteEnrollmentService.swift
@@ -616,13 +616,22 @@ public struct ClaudeRemoteEnrollmentService: Sendable {
         }
     }
 
-    /// Does this host's marked block already forward `port`?
+    /// Is this host's marked block CURRENT — everything this build would write
+    /// into it, not merely the port?
     ///
     /// `nil` means "cannot tell" — no filesystem seam, or a config we refuse to
     /// read. Callers must treat nil as "not known to match" and regenerate,
     /// never as "fine": assuming a block is current is exactly how a plugin
     /// gets a port this Mac does not forward.
-    public func sshConfigForwardsPort(_ port: UInt16, hostID: String) -> Bool? {
+    ///
+    /// It checked the `RemoteForward` port ALONE until 2026-09-06, and that was
+    /// a silent no-op on the one migration that mattered: a host enrolled
+    /// before `SendEnv LC_LVX_TTY` existed already forwards the right port, so
+    /// `Update Plugin…` skipped the local rewrite entirely and the plain-ssh
+    /// join never got the line the release notes told the user that button
+    /// would add (review finding B1). Anything the block must contain belongs
+    /// in this list, or shipping it reaches only new enrollments.
+    public func sshConfigBlockIsCurrent(port: UInt16, hostID: String) -> Bool? {
         guard let sshConfigFileSystem else { return nil }
         guard let state = try? sshConfigFileSystem.readState(),
               let data = state.configData,
@@ -636,12 +645,19 @@ public struct ClaudeRemoteEnrollmentService: Sendable {
         }), let endIndex = lines[beginIndex...].firstIndex(where: {
             $0.trimmingCharacters(in: .whitespaces) == end
         }) else { return false }
-        return lines[beginIndex...endIndex].contains { line in
+        let block = lines[beginIndex...endIndex]
+        let forwardsPort = block.contains { line in
             let fields = line.trimmingCharacters(in: .whitespaces)
                 .split(separator: " ", omittingEmptySubsequences: true)
             guard fields.count >= 2, fields[0] == "RemoteForward" else { return false }
             return fields[1] == "\(port)"
         }
+        // An exact line: `# SendEnv LC_LVX_TTY` contains the substring too, and
+        // a commented-out directive sends nothing.
+        let sendsLocalTTY = block.contains {
+            $0.trimmingCharacters(in: .whitespacesAndNewlines) == "SendEnv LC_LVX_TTY"
+        }
+        return forwardsPort && sendsLocalTTY
     }
 
     // MARK: - Execution (opt-in only)

--- a/Sources/localvoxtral/ClaudeContext/ClaudeShellRCSetup.swift
+++ b/Sources/localvoxtral/ClaudeContext/ClaudeShellRCSetup.swift
@@ -118,7 +118,15 @@ public enum ClaudeShellRCSetup {
 
     /// Is our block already in this text?
     public static func containsBlock(_ existing: String) -> Bool {
-        blockRange(in: existing.components(separatedBy: "\n")) != nil
+        if case .present = locateBlock(in: existing.components(separatedBy: "\n")) {
+            return true
+        }
+        return false
+    }
+
+    /// Does this text carry an unpaired begin marker?
+    public static func hasDamagedBlock(_ existing: String) -> Bool {
+        locateBlock(in: existing.components(separatedBy: "\n")) == .damaged
     }
 
     /// Insert or REPLACE the block, leaving everything else byte for byte.
@@ -126,38 +134,75 @@ public enum ClaudeShellRCSetup {
     /// Idempotent by delimiter, like the ssh-config writer and for a sharper
     /// reason: an rc file with two copies of this block is not merely untidy,
     /// it would run `tty` twice per shell start forever.
-    public static func apply(to existing: String, snippet: String) -> String {
+    /// - Returns: nil when the file's markers do not pair — the caller must
+    ///   refuse rather than write.
+    public static func apply(to existing: String, snippet: String) -> String? {
         let lines = existing.components(separatedBy: "\n")
-        guard let range = blockRange(in: lines) else {
+        switch locateBlock(in: lines) {
+        case .damaged:
+            return nil
+        case .absent:
             var prefix = existing
             if !prefix.isEmpty, !prefix.hasSuffix("\n") { prefix += "\n" }
             if !prefix.isEmpty, !prefix.hasSuffix("\n\n") { prefix += "\n" }
             return prefix + snippet + "\n"
+        case .present(let range):
+            var result = Array(lines[..<range.lowerBound])
+            result.append(contentsOf: snippet.components(separatedBy: "\n"))
+            result.append(contentsOf: lines[(range.upperBound + 1)...])
+            return result.joined(separator: "\n")
         }
-        var result = Array(lines[..<range.lowerBound])
-        result.append(contentsOf: snippet.components(separatedBy: "\n"))
-        result.append(contentsOf: lines[(range.upperBound + 1)...])
-        return result.joined(separator: "\n")
     }
 
     /// Remove the block, leaving everything else untouched.
-    public static func remove(from existing: String) -> String {
+    /// - Returns: nil for the same unpaired-marker case as `apply`.
+    public static func remove(from existing: String) -> String? {
         let lines = existing.components(separatedBy: "\n")
-        guard let range = blockRange(in: lines) else { return existing }
-        var result = Array(lines[..<range.lowerBound])
-        result.append(contentsOf: lines[(range.upperBound + 1)...])
-        return result.joined(separator: "\n")
+        switch locateBlock(in: lines) {
+        case .damaged:
+            return nil
+        case .absent:
+            return existing
+        case .present(let range):
+            var result = Array(lines[..<range.lowerBound])
+            result.append(contentsOf: lines[(range.upperBound + 1)...])
+            return result.joined(separator: "\n")
+        }
     }
 
-    /// The half-open line range of the block, end index INCLUSIVE of the end
-    /// marker. Matched on the trimmed line, so an indented copy still counts.
-    private static func blockRange(in lines: [String]) -> ClosedRange<Int>? {
-        guard let begin = lines.firstIndex(where: {
-            $0.trimmingCharacters(in: .whitespaces) == markerBegin
-        }), let end = lines[begin...].firstIndex(where: {
-            $0.trimmingCharacters(in: .whitespaces) == markerEnd
-        }) else { return nil }
-        return begin...end
+    /// The block's line range, end index INCLUSIVE of the end marker; or
+    /// `.damaged` when a begin marker has no end after it.
+    ///
+    /// `.damaged` is not fussiness. Appending past a dangling begin marker
+    /// leaves the file with two begins and one end, and the NEXT apply would
+    /// then replace everything between the first begin and that single end —
+    /// swallowing whatever the user wrote in between. Refusing to touch a file
+    /// whose markers do not pair is the only answer that cannot lose their
+    /// content.
+    static func locateBlock(in lines: [String]) -> BlockLocation {
+        guard let begin = lines.firstIndex(where: { isMarker($0, markerBegin) }) else {
+            return .absent
+        }
+        guard let end = lines[begin...].firstIndex(where: { isMarker($0, markerEnd) }) else {
+            return .damaged
+        }
+        return .present(begin...end)
+    }
+
+    public enum BlockLocation: Equatable {
+        case absent
+        case present(ClosedRange<Int>)
+        /// A begin marker with no end after it — a hand-edit we will not
+        /// write past.
+        case damaged
+    }
+
+    /// Trimmed of whitespace AND newlines, so an indented copy counts and a
+    /// CRLF file's `…(begin)\r` is still our marker. `.whitespaces` alone is
+    /// space and tab only, and a dotfile synced from a Windows-touched repo
+    /// would have looked marker-free — which means appending a duplicate.
+    private static func isMarker(_ line: String, _ marker: String) -> Bool {
+        line.trimmingCharacters(in: .whitespacesAndNewlines) == marker
     }
 }
 
@@ -206,6 +251,9 @@ public enum ClaudeShellRCError: Error, Equatable {
     case isSymlink
     case invalidEncoding
     case notConfigured
+    /// A begin marker with no end. Writing past it would let the NEXT apply
+    /// swallow whatever the user put in between.
+    case markersDoNotPair
 }
 
 /// Applies or removes the block in the user's rc file.
@@ -238,7 +286,7 @@ public struct ClaudeShellRCWriter: Sendable {
         try write(ClaudeShellRCSetup.remove(from:))
     }
 
-    private func write(_ transform: (String) -> String) throws {
+    private func write(_ transform: (String) -> String?) throws {
         Log.claudeContext.info("Claude shell rc edit requested")
         guard let fileSystem else {
             Log.claudeContext.error("Claude shell rc edit failed: editing not configured")
@@ -265,8 +313,11 @@ public struct ClaudeShellRCWriter: Sendable {
             // Never widen: an rc file is executed by the user's shell, so its
             // mode is a security property, and 0600 is the tightest mode that
             // still works.
+            guard let updated = transform(existing) else {
+                throw ClaudeShellRCError.markersDoNotPair
+            }
             try fileSystem.atomicWrite(
-                Data(transform(existing).utf8),
+                Data(updated.utf8),
                 permissions: state.permissions ?? 0o600
             )
             Log.claudeContext.info("Claude shell rc edit completed")

--- a/Sources/localvoxtral/ClaudeContext/ClaudeShellRCSetup.swift
+++ b/Sources/localvoxtral/ClaudeContext/ClaudeShellRCSetup.swift
@@ -118,15 +118,31 @@ public enum ClaudeShellRCSetup {
 
     /// Is our block already in this text?
     public static func containsBlock(_ existing: String) -> Bool {
-        if case .present = locateBlock(in: existing.components(separatedBy: "\n")) {
-            return true
-        }
+        if case .present = locateBlock(in: splitLines(existing)) { return true }
         return false
     }
 
     /// Does this text carry an unpaired begin marker?
     public static func hasDamagedBlock(_ existing: String) -> Bool {
-        locateBlock(in: existing.components(separatedBy: "\n")) == .damaged
+        locateBlock(in: splitLines(existing)) == .damaged
+    }
+
+    /// Lines, plus the terminator the file actually uses.
+    ///
+    /// A CRLF file spliced with LF comes back mixed (review finding m3), and
+    /// "mostly CRLF with one LF region" is a file we damaged in a way the user
+    /// will notice in their editor. The whole file is never normalized either —
+    /// that would be the same crime in the other direction.
+    static func lineTerminator(of text: String) -> String {
+        text.contains("\r\n") ? "\r\n" : "\n"
+    }
+
+    /// Split on LF and strip a trailing CR, so a CRLF file's lines compare and
+    /// rejoin like any other.
+    static func splitLines(_ text: String) -> [String] {
+        text.components(separatedBy: "\n").map { line in
+            line.hasSuffix("\r") ? String(line.dropLast()) : line
+        }
     }
 
     /// Insert or REPLACE the block, leaving everything else byte for byte.
@@ -137,63 +153,108 @@ public enum ClaudeShellRCSetup {
     /// - Returns: nil when the file's markers do not pair — the caller must
     ///   refuse rather than write.
     public static func apply(to existing: String, snippet: String) -> String? {
-        let lines = existing.components(separatedBy: "\n")
+        let terminator = lineTerminator(of: existing)
+        let lines = splitLines(existing)
         switch locateBlock(in: lines) {
         case .damaged:
             return nil
         case .absent:
             var prefix = existing
-            if !prefix.isEmpty, !prefix.hasSuffix("\n") { prefix += "\n" }
-            if !prefix.isEmpty, !prefix.hasSuffix("\n\n") { prefix += "\n" }
-            return prefix + snippet + "\n"
-        case .present(let range):
-            var result = Array(lines[..<range.lowerBound])
-            result.append(contentsOf: snippet.components(separatedBy: "\n"))
-            result.append(contentsOf: lines[(range.upperBound + 1)...])
-            return result.joined(separator: "\n")
+            if !prefix.isEmpty, !prefix.hasSuffix(terminator) { prefix += terminator }
+            if !prefix.isEmpty, !prefix.hasSuffix(terminator + terminator) {
+                prefix += terminator
+            }
+            let body = snippet.components(separatedBy: "\n").joined(separator: terminator)
+            return prefix + body + terminator
+        case .present(let ranges):
+            // Replace the FIRST block in place and drop the rest, so a file
+            // that was hand-duplicated converges to one.
+            var result: [String] = []
+            var cursor = 0
+            for (offset, range) in ranges.enumerated() {
+                result.append(contentsOf: lines[cursor..<range.lowerBound])
+                if offset == 0 {
+                    result.append(contentsOf: snippet.components(separatedBy: "\n"))
+                }
+                cursor = range.upperBound + 1
+            }
+            result.append(contentsOf: lines[cursor...])
+            return result.joined(separator: terminator)
         }
     }
 
     /// Remove the block, leaving everything else untouched.
     /// - Returns: nil for the same unpaired-marker case as `apply`.
     public static func remove(from existing: String) -> String? {
-        let lines = existing.components(separatedBy: "\n")
+        let terminator = lineTerminator(of: existing)
+        let lines = splitLines(existing)
         switch locateBlock(in: lines) {
         case .damaged:
             return nil
         case .absent:
             return existing
-        case .present(let range):
-            var result = Array(lines[..<range.lowerBound])
-            result.append(contentsOf: lines[(range.upperBound + 1)...])
-            return result.joined(separator: "\n")
+        case .present(let ranges):
+            var result: [String] = []
+            var cursor = 0
+            for range in ranges {
+                var start = range.lowerBound
+                // Take back the blank line `apply` inserted as a separator, so
+                // apply-then-remove is byte-identical to the original rather
+                // than leaving a growing gap behind (review finding m1). Only
+                // ONE, and only when it is a blank line we would have added.
+                if start > cursor, lines[start - 1].isEmpty { start -= 1 }
+                result.append(contentsOf: lines[cursor..<start])
+                cursor = range.upperBound + 1
+            }
+            result.append(contentsOf: lines[cursor...])
+            return result.joined(separator: terminator)
         }
     }
 
-    /// The block's line range, end index INCLUSIVE of the end marker; or
-    /// `.damaged` when a begin marker has no end after it.
+    /// Every complete block, in order; or `.damaged` when the markers do not
+    /// nest and pair the way we wrote them.
     ///
-    /// `.damaged` is not fussiness. Appending past a dangling begin marker
-    /// leaves the file with two begins and one end, and the NEXT apply would
-    /// then replace everything between the first begin and that single end —
-    /// swallowing whatever the user wrote in between. Refusing to touch a file
-    /// whose markers do not pair is the only answer that cannot lose their
-    /// content.
+    /// `.damaged` is not fussiness, and it took two review rounds to get its
+    /// definition right. A begin with NO end lets an append leave two begins
+    /// and one end, and the next apply then replaces everything between the
+    /// first begin and that single end. A begin followed by ANOTHER begin
+    /// before any end is the same wound already open: taking the first begin
+    /// and the first end after it spans the user's lines in between and
+    /// deletes them (review finding M1). Both are hand-edit shapes — delete an
+    /// end marker, re-paste the README block to "fix" it — and refusing to
+    /// touch such a file is the only answer that cannot lose content.
+    ///
+    /// SEVERAL complete pairs are not damage but they are not one block
+    /// either: `apply` replaces the first and would leave the rest forever,
+    /// which is the duplicate the idempotency claim exists to prevent. All of
+    /// them are replaced (review finding m2).
     static func locateBlock(in lines: [String]) -> BlockLocation {
-        guard let begin = lines.firstIndex(where: { isMarker($0, markerBegin) }) else {
-            return .absent
+        var ranges: [ClosedRange<Int>] = []
+        var openedAt: Int?
+        for (index, line) in lines.enumerated() {
+            if isMarker(line, markerBegin) {
+                guard openedAt == nil else { return .damaged }
+                openedAt = index
+                continue
+            }
+            if isMarker(line, markerEnd) {
+                guard let begin = openedAt else {
+                    // An end with no begin: also not a shape we wrote.
+                    return .damaged
+                }
+                ranges.append(begin...index)
+                openedAt = nil
+            }
         }
-        guard let end = lines[begin...].firstIndex(where: { isMarker($0, markerEnd) }) else {
-            return .damaged
-        }
-        return .present(begin...end)
+        if openedAt != nil { return .damaged }
+        return ranges.isEmpty ? .absent : .present(ranges)
     }
 
     public enum BlockLocation: Equatable {
         case absent
-        case present(ClosedRange<Int>)
-        /// A begin marker with no end after it — a hand-edit we will not
-        /// write past.
+        /// One or more complete blocks, in file order.
+        case present([ClosedRange<Int>])
+        /// Markers that do not pair — a hand-edit we will not write past.
         case damaged
     }
 
@@ -251,6 +312,10 @@ public enum ClaudeShellRCError: Error, Equatable {
     case isSymlink
     case invalidEncoding
     case notConfigured
+    /// The file EXISTS and could not be read. Never treated as empty: doing so
+    /// made a confirmed setup overwrite an unreadable `~/.zshrc` with
+    /// snippet-only bytes — total content loss, silently (review finding M2).
+    case unreadable
     /// A begin marker with no end. Writing past it would let the NEXT apply
     /// swallow whatever the user put in between.
     case markersDoNotPair
@@ -271,6 +336,9 @@ public struct ClaudeShellRCWriter: Sendable {
         guard let data = state.data, let text = String(data: data, encoding: .utf8) else {
             return state.fileExists ? nil : false
         }
+        // Damaged markers are not "applied": the writer will refuse, and the
+        // row must not offer Remove as though there were a clean block.
+        if ClaudeShellRCSetup.hasDamagedBlock(text) { return nil }
         return ClaudeShellRCSetup.containsBlock(text)
     }
 
@@ -303,6 +371,12 @@ public struct ClaudeShellRCWriter: Sendable {
                     throw ClaudeShellRCError.invalidEncoding
                 }
                 existing = decoded
+            } else if state.fileExists {
+                // A file we can see but not read is NOT an empty file. The ssh
+                // config reader beside this one propagates its read error; this
+                // one used `try?` and mapped mode-000 to "", which turned
+                // "confirm setup" into "delete my ~/.zshrc".
+                throw ClaudeShellRCError.unreadable
             } else {
                 existing = ""
             }

--- a/Sources/localvoxtral/ClaudeContext/ClaudeShellRCSetup.swift
+++ b/Sources/localvoxtral/ClaudeContext/ClaudeShellRCSetup.swift
@@ -1,0 +1,280 @@
+import Foundation
+
+/// The login shells this app will write an rc block for.
+///
+/// Three, because three is what macOS ships and what the block has to be
+/// written in: `zsh` (the default since Catalina), `bash` (still the login
+/// shell on upgraded accounts), and `fish` (whose syntax shares nothing with
+/// the other two). Anything else gets the copy-paste path — guessing at a
+/// shell's syntax is how a setup step corrupts someone's startup file.
+public enum ClaudeShellKind: String, Sendable, CaseIterable {
+    case zsh
+    case bash
+    case fish
+
+    /// The shell behind a login-shell PATH, or nil for one we will not write.
+    ///
+    /// By BASENAME, and exactly: `/bin/zsh`, `/opt/homebrew/bin/fish` and
+    /// `/usr/local/bin/bash` are all real answers from `dscl`. A path we do not
+    /// recognise is not a shell we may append POSIX to.
+    public static func detect(loginShellPath: String?) -> ClaudeShellKind? {
+        guard let loginShellPath, loginShellPath.hasPrefix("/") else { return nil }
+        let name = (loginShellPath as NSString).lastPathComponent
+        return ClaudeShellKind(rawValue: name)
+    }
+}
+
+/// Where the block goes, what it says, and how it is replaced or removed.
+///
+/// The whole file is PURE: it turns a shell and some existing text into new
+/// text. Deciding to write anything is the caller's, exactly as it is for
+/// `ClaudeRemoteEnrollmentService.applySSHConfigSnippet` — this app never edits
+/// a user's startup file without showing the exact text first and being told
+/// yes.
+public enum ClaudeShellRCSetup {
+    /// The delimiters. Idempotency and removal both ride on them, so they are
+    /// content-free and must never carry a host, a path or a version: a marker
+    /// that changes cannot find the block it wrote last time.
+    public static let markerBegin = "# localvoxtral plain-ssh join (begin)"
+    public static let markerEnd = "# localvoxtral plain-ssh join (end)"
+
+    /// The rc file this app will write for a shell, relative to `$HOME`.
+    ///
+    /// - `zsh` → `.zshrc`. Read by every interactive zsh, login or not, which
+    ///   is what a terminal window runs.
+    /// - `bash` → `.bash_profile` when it exists, else `.bashrc` when THAT
+    ///   exists, else `.bash_profile`. macOS terminals run bash as a LOGIN
+    ///   shell, which reads `.bash_profile` and not `.bashrc`; but an account
+    ///   that already keeps everything in `.bashrc` is invariably sourcing it
+    ///   from `.bash_profile`, and appending to the file the user actually
+    ///   edits is likelier to survive their next dotfile change.
+    /// - `fish` → `.config/fish/conf.d/localvoxtral.fish`. fish sources every
+    ///   file in `conf.d`, so this is the one shell where the app can own its
+    ///   own file instead of appending to the user's.
+    ///
+    /// - Parameter fileExists: injected so the bash rule is testable without a
+    ///   home directory.
+    public static func relativeRCPath(
+        for shell: ClaudeShellKind,
+        fileExists: (String) -> Bool
+    ) -> String {
+        switch shell {
+        case .zsh:
+            return ".zshrc"
+        case .bash:
+            if fileExists(".bash_profile") { return ".bash_profile" }
+            if fileExists(".bashrc") { return ".bashrc" }
+            return ".bash_profile"
+        case .fish:
+            return ".config/fish/conf.d/localvoxtral.fish"
+        }
+    }
+
+    /// The marked block, in that shell's own syntax.
+    ///
+    /// Every guard in it was measured rather than assumed (2026-09-06):
+    ///
+    /// * `$SSH_TTY` unset — export only on THIS Mac. The same rc file on a
+    ///   remote host would otherwise replace the Mac's tty with the remote pts
+    ///   and nothing would ever match.
+    /// * `$LC_LVX_TTY` unset — never overwrite what was sent to us, for the
+    ///   same reason.
+    /// * `/dev/*` — in a shell with no terminal `tty` prints `not a tty`, and
+    ///   exporting that poisons the guard above for every shell downstream.
+    /// * an `if` block rather than an `&&` chain — the chain's status becomes
+    ///   the rc file's status, and `bash --norc -c 'set -e; source rc; echo
+    ///   SURVIVED'` printed nothing and exited 1. bash sources `~/.bashrc`
+    ///   non-interactively for shells it believes sshd started, so the chain
+    ///   version could break `ssh host script` for anyone syncing dotfiles.
+    public static func snippet(for shell: ClaudeShellKind) -> String {
+        let body: String
+        switch shell {
+        case .zsh, .bash:
+            body = """
+            if [ -z "${LC_LVX_TTY:-}" ] && [ -z "${SSH_TTY:-}" ]; then
+              case "$(tty 2>/dev/null)" in /dev/*) LC_LVX_TTY="$(tty)"; export LC_LVX_TTY ;; esac
+            fi
+            """
+        case .fish:
+            // fish has no `case`/`$(...)`, and `set -q` is its "is it set".
+            body = """
+            if not set -q LC_LVX_TTY; and not set -q SSH_TTY
+                set -l __lvx_tty (tty 2>/dev/null)
+                if string match -q -- '/dev/*' "$__lvx_tty"
+                    set -gx LC_LVX_TTY "$__lvx_tty"
+                end
+            end
+            """
+        }
+        return """
+        \(markerBegin)
+        # Publishes this terminal's tty so localvoxtral can tell which window a
+        # Claude Code session over ssh belongs to. Remove this block in
+        # Settings, or by hand.
+        \(body)
+        \(markerEnd)
+        """
+    }
+
+    /// Is our block already in this text?
+    public static func containsBlock(_ existing: String) -> Bool {
+        blockRange(in: existing.components(separatedBy: "\n")) != nil
+    }
+
+    /// Insert or REPLACE the block, leaving everything else byte for byte.
+    ///
+    /// Idempotent by delimiter, like the ssh-config writer and for a sharper
+    /// reason: an rc file with two copies of this block is not merely untidy,
+    /// it would run `tty` twice per shell start forever.
+    public static func apply(to existing: String, snippet: String) -> String {
+        let lines = existing.components(separatedBy: "\n")
+        guard let range = blockRange(in: lines) else {
+            var prefix = existing
+            if !prefix.isEmpty, !prefix.hasSuffix("\n") { prefix += "\n" }
+            if !prefix.isEmpty, !prefix.hasSuffix("\n\n") { prefix += "\n" }
+            return prefix + snippet + "\n"
+        }
+        var result = Array(lines[..<range.lowerBound])
+        result.append(contentsOf: snippet.components(separatedBy: "\n"))
+        result.append(contentsOf: lines[(range.upperBound + 1)...])
+        return result.joined(separator: "\n")
+    }
+
+    /// Remove the block, leaving everything else untouched.
+    public static func remove(from existing: String) -> String {
+        let lines = existing.components(separatedBy: "\n")
+        guard let range = blockRange(in: lines) else { return existing }
+        var result = Array(lines[..<range.lowerBound])
+        result.append(contentsOf: lines[(range.upperBound + 1)...])
+        return result.joined(separator: "\n")
+    }
+
+    /// The half-open line range of the block, end index INCLUSIVE of the end
+    /// marker. Matched on the trimmed line, so an indented copy still counts.
+    private static func blockRange(in lines: [String]) -> ClosedRange<Int>? {
+        guard let begin = lines.firstIndex(where: {
+            $0.trimmingCharacters(in: .whitespaces) == markerBegin
+        }), let end = lines[begin...].firstIndex(where: {
+            $0.trimmingCharacters(in: .whitespaces) == markerEnd
+        }) else { return nil }
+        return begin...end
+    }
+}
+
+/// What the app can see about one rc file before deciding to write it.
+public struct ClaudeShellRCState: Sendable, Equatable {
+    public var fileExists: Bool
+    public var fileIsSymlink: Bool
+    public var directoryExists: Bool
+    public var directoryIsSymlink: Bool
+    public var data: Data?
+    public var permissions: UInt16?
+
+    public init(
+        fileExists: Bool = false,
+        fileIsSymlink: Bool = false,
+        directoryExists: Bool = true,
+        directoryIsSymlink: Bool = false,
+        data: Data? = nil,
+        permissions: UInt16? = nil
+    ) {
+        self.fileExists = fileExists
+        self.fileIsSymlink = fileIsSymlink
+        self.directoryExists = directoryExists
+        self.directoryIsSymlink = directoryIsSymlink
+        self.data = data
+        self.permissions = permissions
+    }
+}
+
+/// The file operations the writer needs, injected so every rule above is
+/// testable without a home directory.
+public protocol ClaudeShellRCFileSystem: Sendable {
+    func readState() throws -> ClaudeShellRCState
+    func createDirectory(permissions: UInt16) throws
+    func atomicWrite(_ data: Data, permissions: UInt16) throws
+}
+
+public enum ClaudeShellRCError: Error, Equatable {
+    /// The rc file — or a directory on the way to it — is a symlink.
+    ///
+    /// Refused rather than followed, and this is the case a dotfiles user
+    /// actually hits: `~/.zshrc` is very often a link into a repo, and an
+    /// atomic write REPLACES the link with a regular file, silently detaching
+    /// their dotfiles. Refusing costs them a copy-paste; writing costs them
+    /// their setup.
+    case isSymlink
+    case invalidEncoding
+    case notConfigured
+}
+
+/// Applies or removes the block in the user's rc file.
+public struct ClaudeShellRCWriter: Sendable {
+    private let fileSystem: (any ClaudeShellRCFileSystem)?
+
+    public init(fileSystem: (any ClaudeShellRCFileSystem)? = nil) {
+        self.fileSystem = fileSystem
+    }
+
+    /// Is the block present right now? Nil when the file cannot be read at all,
+    /// which the UI reports as unknown rather than as absent.
+    public func isApplied() -> Bool? {
+        guard let fileSystem, let state = try? fileSystem.readState() else { return nil }
+        guard let data = state.data, let text = String(data: data, encoding: .utf8) else {
+            return state.fileExists ? nil : false
+        }
+        return ClaudeShellRCSetup.containsBlock(text)
+    }
+
+    public func apply(shell: ClaudeShellKind) throws {
+        try write { existing in
+            ClaudeShellRCSetup.apply(
+                to: existing, snippet: ClaudeShellRCSetup.snippet(for: shell)
+            )
+        }
+    }
+
+    public func remove() throws {
+        try write(ClaudeShellRCSetup.remove(from:))
+    }
+
+    private func write(_ transform: (String) -> String) throws {
+        Log.claudeContext.info("Claude shell rc edit requested")
+        guard let fileSystem else {
+            Log.claudeContext.error("Claude shell rc edit failed: editing not configured")
+            throw ClaudeShellRCError.notConfigured
+        }
+        do {
+            let state = try fileSystem.readState()
+            guard !state.fileIsSymlink, !state.directoryIsSymlink else {
+                throw ClaudeShellRCError.isSymlink
+            }
+            let existing: String
+            if let data = state.data {
+                guard let decoded = String(data: data, encoding: .utf8) else {
+                    throw ClaudeShellRCError.invalidEncoding
+                }
+                existing = decoded
+            } else {
+                existing = ""
+            }
+            if !state.directoryExists {
+                try fileSystem.createDirectory(permissions: 0o700)
+            }
+            // Preserve what the file already had; a file WE create gets 0600.
+            // Never widen: an rc file is executed by the user's shell, so its
+            // mode is a security property, and 0600 is the tightest mode that
+            // still works.
+            try fileSystem.atomicWrite(
+                Data(transform(existing).utf8),
+                permissions: state.permissions ?? 0o600
+            )
+            Log.claudeContext.info("Claude shell rc edit completed")
+        } catch {
+            Log.claudeContext.error(
+                "Claude shell rc edit failed: \(String(describing: error), privacy: .public)"
+            )
+            throw error
+        }
+    }
+}

--- a/Sources/localvoxtral/SettingsView.swift
+++ b/Sources/localvoxtral/SettingsView.swift
@@ -1015,6 +1015,7 @@ private struct ClaudeCmuxPasswordSettingsRow: View {
 /// Enrolled SSH hosts, and the preview-first setup for each.
 private struct ClaudeRemoteHostsSettingsRow: View {
     @Bindable var model: ClaudeIntegrationSettingsModel
+    @State private var isShowingShellSetup = false
 
     var body: some View {
         SettingsFieldRow(title: "Remote Claude Code over SSH") {
@@ -1034,6 +1035,7 @@ private struct ClaudeRemoteHostsSettingsRow: View {
                     }
                     enrollmentForm
                     listenerStatus
+                    shellSetup
                     herdrPanelSetup
                 }
 
@@ -1064,6 +1066,42 @@ private struct ClaudeRemoteHostsSettingsRow: View {
         .onAppear {
             model.refreshHosts()
             model.refreshListenerStatus()
+            model.refreshShellSetupStatus()
+        }
+        .sheet(isPresented: $isShowingShellSetup) {
+            ClaudeShellSetupSheet(model: model) { isShowingShellSetup = false }
+        }
+    }
+
+    /// The plain-ssh join's one setup step: two short sentences and a button,
+    /// inside the group that already exists. Nothing is written until the sheet
+    /// has shown the exact text and been confirmed.
+    @ViewBuilder
+    private var shellSetup: some View {
+        HStack(spacing: 8) {
+            VStack(alignment: .leading, spacing: 1) {
+                Text("Terminal setup for plain SSH")
+                    .font(.callout)
+                    .accessibilityIdentifier("claude.remote.shellSetup.title")
+                Text(model.shellSetupStatus.rcSentence)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .accessibilityIdentifier("claude.remote.shellSetup.rcStatus")
+                Text(model.shellSetupStatus.crossingSentence)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .accessibilityIdentifier("claude.remote.shellSetup.crossingStatus")
+            }
+            Spacer()
+            if model.shellSetupStatus.rc == .applied {
+                Button("Remove") { Task { await model.removeShellSetup() } }
+                    .controlSize(.small)
+                    .accessibilityIdentifier("claude.remote.shellSetup.remove")
+            }
+            Button("Set Up…") { isShowingShellSetup = true }
+                .controlSize(.small)
+                .disabled(model.shellSetupPreview == nil)
+                .accessibilityIdentifier("claude.remote.shellSetup.setUp")
         }
     }
 
@@ -1760,5 +1798,56 @@ private struct SettingsInlineMessage: View {
             .font(.caption)
             .foregroundStyle(color)
             .fixedSize(horizontal: false, vertical: true)
+    }
+}
+
+/// Preview, then consent, then write — the same shape as the enrollment
+/// sheet's ssh-config insert, for the same reason: this edits a file the user
+/// owns and did not ask us to touch.
+private struct ClaudeShellSetupSheet: View {
+    @Bindable var model: ClaudeIntegrationSettingsModel
+    var dismiss: () -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text("Terminal setup for plain SSH")
+                .font(.headline)
+                .accessibilityIdentifier("claude.shellSetupSheet.title")
+            Text(
+                "This adds one block to \(model.shellSetupStatus.relativeRCPath ?? "your shell startup file"), so a Claude Code session over plain SSH can be matched to the window you are dictating into. Open a new terminal window afterwards — the value is fixed when a session starts."
+            )
+            .font(.callout)
+            .fixedSize(horizontal: false, vertical: true)
+
+            if let preview = model.shellSetupPreview {
+                ScrollView {
+                    Text(preview)
+                        .font(.system(.caption2, design: .monospaced))
+                        .textSelection(.enabled)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .accessibilityIdentifier("claude.shellSetupSheet.preview")
+                }
+                .frame(maxHeight: 180)
+                .padding(6)
+                .background(Color.secondary.opacity(0.08), in: RoundedRectangle(cornerRadius: 4))
+            }
+
+            HStack {
+                Spacer()
+                Button("Cancel") { dismiss() }
+                    .accessibilityIdentifier("claude.shellSetupSheet.cancel")
+                Button("Add to My Shell") {
+                    Task {
+                        await model.applyShellSetup()
+                        dismiss()
+                    }
+                }
+                .keyboardShortcut(.defaultAction)
+                .disabled(model.shellSetupPreview == nil)
+                .accessibilityIdentifier("claude.shellSetupSheet.apply")
+            }
+        }
+        .padding(16)
+        .frame(width: 460)
     }
 }

--- a/Sources/localvoxtral/localvoxtralApp.swift
+++ b/Sources/localvoxtral/localvoxtralApp.swift
@@ -673,7 +673,37 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             enrollmentService: ClaudeRemoteEnrollmentService.live(),
             remoteForwardPort: remoteForwardPort,
             cmuxPasswords: CmuxSocketPasswordStore(),
-            forwards: forwards
+            forwards: forwards,
+            // Read once per pane refresh, not cached at launch: a `chsh` while
+            // the app runs would otherwise write the wrong shell's syntax.
+            loginShell: {
+                ClaudeShellKind.detect(
+                    loginShellPath: ClaudeLoginShellReader.loginShellPath()
+                )
+            },
+            shellRCWriter: { shell in
+                ClaudeShellRCWriter(
+                    fileSystem: LiveClaudeShellRCFileSystem(
+                        relativePath: ClaudeShellRCSetup.relativeRCPath(for: shell) { relative in
+                            FileManager.default.fileExists(
+                                atPath: FileManager.default.homeDirectoryForCurrentUser
+                                    .appendingPathComponent(relative).path
+                            )
+                        }
+                    )
+                )
+            },
+            // The app-visible half of the setup step: has a session actually
+            // arrived carrying the value. Reads the registry, never a file.
+            liveLocalTTYReport: { [weak claudeSessionRegistry] in
+                guard let sessions = claudeSessionRegistry?.liveSessions(),
+                      !sessions.isEmpty
+                else { return .noSessions }
+                let remote = sessions.filter { $0.remoteSessionEnvironment != nil }
+                guard !remote.isEmpty else { return .noSessions }
+                return remote.contains { $0.remoteSessionEnvironment?.localTTY != nil }
+                    ? .seen : .notSeen
+            }
         )
 
         // Route launch through the same model that owns the Settings status.

--- a/Tests/localvoxtralTests/ClaudeIntegrationSettingsModelTests.swift
+++ b/Tests/localvoxtralTests/ClaudeIntegrationSettingsModelTests.swift
@@ -956,6 +956,89 @@ final class ClaudeIntegrationSettingsModelTests: XCTestCase {
         XCTAssertNil(model.enrollmentConfirmation)
     }
 
+    /// THE migration the release notes promise, through the shipped path.
+    ///
+    /// The owner's host was enrolled before `SendEnv LC_LVX_TTY` existed, so
+    /// its block already forwards the right port. A currency check that asked
+    /// about the PORT ALONE therefore answered "current", `requestPluginUpdate`
+    /// produced no ssh-config snippet, and `Update Plugin…` silently touched
+    /// only the remote plugin — the line the user was told that button adds
+    /// never arrived (review finding B1, 2026-09-06). The earlier test for this
+    /// fed the stale block to the pure splice and passed while the shipped path
+    /// was broken; this one goes through `requestPluginUpdate`.
+    @MainActor
+    func testUpdatePlanRewritesABlockThatHasThePortButNotSendEnv() async throws {
+        let registry = try makeRegistry()
+        let filesystem = RecordingSSHConfigFileSystem()
+        let service = ClaudeRemoteEnrollmentService(
+            runner: { _ in .init(exitCode: 0, message: "ok") },
+            sshConfigFileSystem: filesystem
+        )
+        let model = await enrolledModel(
+            label: "sandbox", alias: "sandbox-vpn", registry: registry, service: service,
+            remoteForwardPort: 28_542
+        )
+        let hostID = try XCTUnwrap(model.hosts.first).id
+
+        // Exactly the pre-#272 block: right port, no SendEnv.
+        filesystem.setConfig([
+            ClaudeRemoteEnrollmentService.blockBegin(hostID: hostID),
+            "Host sandbox-vpn",
+            "    RemoteForward 28542 127.0.0.1:8473",
+            "    ExitOnForwardFailure no",
+            ClaudeRemoteEnrollmentService.blockEnd(hostID: hostID),
+        ].joined(separator: "\n"))
+
+        model.requestPluginUpdate(hostID: hostID)
+        let update = try XCTUnwrap(model.presentedPluginUpdate)
+        let snippet = try XCTUnwrap(
+            update.sshConfigSnippet,
+            "a stale block must produce a rewrite, or Update Plugin… is a no-op on it"
+        )
+        XCTAssertTrue(
+            snippet.components(separatedBy: "\n")
+                .contains { $0.trimmingCharacters(in: .whitespaces) == "SendEnv LC_LVX_TTY" },
+            "and the rewrite must carry the line the release notes promise"
+        )
+    }
+
+    /// The other side: a block this build would write unchanged is left alone,
+    /// so the update stays a plugin action and does not churn the user's file.
+    @MainActor
+    func testUpdatePlanLeavesAnALREADYCurrentBlockAlone() async throws {
+        let registry = try makeRegistry()
+        let filesystem = RecordingSSHConfigFileSystem()
+        let service = ClaudeRemoteEnrollmentService(
+            runner: { _ in .init(exitCode: 0, message: "ok") },
+            sshConfigFileSystem: filesystem
+        )
+        let model = await enrolledModel(
+            label: "sandbox", alias: "sandbox-vpn", registry: registry, service: service,
+            remoteForwardPort: 28_542
+        )
+        let hostID = try XCTUnwrap(model.hosts.first).id
+        let host = try XCTUnwrap(registry.host(id: hostID))
+        filesystem.setConfig(
+            ClaudeRemoteEnrollmentService.applySSHConfigSnippet(
+                to: "",
+                snippet: ClaudeRemoteEnrollmentService.sshConfigSnippet(
+                    host: host,
+                    sshHostAlias: "sandbox-vpn",
+                    listenerPort: ClaudeRemoteListenerLimits.default.port,
+                    remoteForwardPort: 28_542
+                ),
+                hostID: hostID
+            )
+        )
+
+        model.requestPluginUpdate(hostID: hostID)
+        let update = try XCTUnwrap(model.presentedPluginUpdate)
+        XCTAssertNil(
+            update.sshConfigSnippet,
+            "a current block is not rewritten — the update is a plugin action then"
+        )
+    }
+
     /// Every artifact the pane hands the user must name the SAME remote port —
     /// this Mac's allocation (#215). One that names a different port than
     /// another is a tunnel to nothing, and it fails open, i.e. silently.
@@ -1870,18 +1953,27 @@ final class ClaudeIntegrationSettingsModelTests: XCTestCase {
     }
 
     @MainActor
-    func testTheSheetPreviewIsTheEXACTTextThatWillBeWritten() async {
+    func testTheSheetPreviewIsTheEXACTTextThatWillBeWritten() async throws {
         // Preview-then-consent, like the ssh-config insert: what the user
         // approved and what lands in their file must be one string, or the
         // preview is decoration.
         let fileSystem = StubRCFileSystem(state: ClaudeShellRCState())
         let model = shellSetupModel(fileSystem: fileSystem)
-        let preview = model.shellSetupPreview
-        XCTAssertEqual(preview, ClaudeShellRCSetup.snippet(for: .zsh))
+        let preview = try XCTUnwrap(model.shellSetupPreview)
 
         await model.applyShellSetup()
         let written = String(decoding: fileSystem.state.data ?? Data(), as: UTF8.self)
-        XCTAssertTrue(written.contains(try XCTUnwrap(preview)))
+        // EQUALITY on the bytes the writer received, against the preview the
+        // user approved — not `contains`, and not a second call to the same
+        // generator. The earlier version compared the preview to
+        // `snippet(for: .zsh)` and then asserted the write merely CONTAINED
+        // it, which is true of any superset and could not fail (review finding
+        // n1).
+        XCTAssertEqual(
+            written,
+            ClaudeShellRCSetup.apply(to: "", snippet: preview),
+            "what lands in the file is what the sheet showed, byte for byte"
+        )
     }
 
     @MainActor

--- a/Tests/localvoxtralTests/ClaudeIntegrationSettingsModelTests.swift
+++ b/Tests/localvoxtralTests/ClaudeIntegrationSettingsModelTests.swift
@@ -1004,7 +1004,12 @@ final class ClaudeIntegrationSettingsModelTests: XCTestCase {
             "the executed update must migrate the port, not just the panel text: \(scripts)"
         )
         XCTAssertTrue(
-            plan.sshConfigSnippet.contains("SendEnv LC_LVX_TTY"),
+            // Fresh enrollment. The UPDATE path for an ALREADY-enrolled host
+            // regenerates this same snippet and inserts it, which is what the
+            // owner's host needed — pinned in
+            // `ClaudeRemoteEnrollmentServiceTests`.
+            plan.sshConfigSnippet.components(separatedBy: "\n")
+                .contains { $0.trimmingCharacters(in: .whitespaces) == "SendEnv LC_LVX_TTY" },
             "the block must carry the terminal's tty into the session, or the "
                 + "plain-ssh join has nothing to compare: "
                 + plan.sshConfigSnippet
@@ -1783,4 +1788,130 @@ final class ClaudeIntegrationSettingsModelTests: XCTestCase {
         XCTAssertFalse(model.isRemoteAvailable)
         XCTAssertTrue(model.hosts.isEmpty)
     }
+    // MARK: - Shell setup for the plain-ssh join
+
+    private final class StubRCFileSystem: ClaudeShellRCFileSystem, @unchecked Sendable {
+        var state: ClaudeShellRCState
+        var writes = 0
+        init(state: ClaudeShellRCState) { self.state = state }
+        func readState() throws -> ClaudeShellRCState { state }
+        func createDirectory(permissions: UInt16) throws {}
+        func atomicWrite(_ data: Data, permissions: UInt16) throws {
+            writes += 1
+            state.data = data
+            state.fileExists = true
+        }
+    }
+
+    @MainActor
+    private func shellSetupModel(
+        shell: ClaudeShellKind? = .zsh,
+        fileSystem: StubRCFileSystem? = nil,
+        crossing: ClaudeShellSetupStatus.CrossingState = .noSessions
+    ) -> ClaudeIntegrationSettingsModel {
+        let stub = fileSystem
+        return ClaudeIntegrationSettingsModel(
+            registry: nil,
+            listener: nil,
+            pluginService: { StubPluginService() },
+            performAsync: { body in
+                do {
+                    try body()
+                    return nil
+                } catch {
+                    return ClaudePluginActionFailure(error)
+                }
+            },
+            loginShell: { shell },
+            shellRCWriter: { _ in stub.map { ClaudeShellRCWriter(fileSystem: $0) } },
+            liveLocalTTYReport: { crossing }
+        )
+    }
+
+    @MainActor
+    func testShellSetupReportsBothHalvesSeparately() {
+        // Two facts that fail for different reasons: the block is in the rc
+        // file, and a session has actually arrived carrying the value. A block
+        // written five seconds ago proves nothing until a NEW ssh session
+        // starts, and saying so is the point of the second half.
+        let fileSystem = StubRCFileSystem(state: ClaudeShellRCState(
+            fileExists: true, data: Data("export EDITOR=vim\n".utf8), permissions: 0o644
+        ))
+        let model = shellSetupModel(fileSystem: fileSystem, crossing: .notSeen)
+        model.refreshShellSetupStatus()
+        XCTAssertEqual(model.shellSetupStatus.rc, .notApplied)
+        XCTAssertEqual(model.shellSetupStatus.crossing, .notSeen)
+        XCTAssertEqual(model.shellSetupStatus.rcSentence, "Not set up.")
+        XCTAssertEqual(
+            model.shellSetupStatus.crossingSentence,
+            "Open a new terminal window for it to take effect."
+        )
+    }
+
+    @MainActor
+    func testApplyingTheShellSetupWritesTheBlockAndTheStatusFollows() async {
+        let fileSystem = StubRCFileSystem(state: ClaudeShellRCState(
+            fileExists: true, data: Data("export EDITOR=vim\n".utf8), permissions: 0o644
+        ))
+        let model = shellSetupModel(fileSystem: fileSystem, crossing: .seen)
+        model.refreshShellSetupStatus()
+        XCTAssertEqual(model.shellSetupStatus.rc, .notApplied)
+
+        await model.applyShellSetup()
+        XCTAssertEqual(fileSystem.writes, 1)
+        XCTAssertEqual(model.shellSetupStatus.rc, .applied, "the row reflects the write")
+        XCTAssertEqual(model.shellSetupStatus.crossingSentence,
+                       "A remote session is reporting its terminal.")
+        XCTAssertNil(model.alert)
+
+        await model.removeShellSetup()
+        XCTAssertEqual(fileSystem.writes, 2)
+        XCTAssertEqual(model.shellSetupStatus.rc, .notApplied)
+    }
+
+    @MainActor
+    func testTheSheetPreviewIsTheEXACTTextThatWillBeWritten() async {
+        // Preview-then-consent, like the ssh-config insert: what the user
+        // approved and what lands in their file must be one string, or the
+        // preview is decoration.
+        let fileSystem = StubRCFileSystem(state: ClaudeShellRCState())
+        let model = shellSetupModel(fileSystem: fileSystem)
+        let preview = model.shellSetupPreview
+        XCTAssertEqual(preview, ClaudeShellRCSetup.snippet(for: .zsh))
+
+        await model.applyShellSetup()
+        let written = String(decoding: fileSystem.state.data ?? Data(), as: UTF8.self)
+        XCTAssertTrue(written.contains(try XCTUnwrap(preview)))
+    }
+
+    @MainActor
+    func testAnUnsupportedLoginShellOffersNothingRatherThanGuessing() {
+        let model = shellSetupModel(shell: nil, fileSystem: StubRCFileSystem(
+            state: ClaudeShellRCState()
+        ))
+        model.refreshShellSetupStatus()
+        XCTAssertEqual(model.shellSetupStatus.rc, .unsupportedShell)
+        XCTAssertNil(model.shellSetupPreview, "the button must be disabled, not wrong")
+    }
+
+    @MainActor
+    func testAnUnwritableRCFileReportsUnknownRatherThanNotApplied() {
+        // "Not set up" invites a click that cannot work; "could not read"
+        // sends the user to the copy-paste path.
+        let model = shellSetupModel(fileSystem: nil)
+        model.refreshShellSetupStatus()
+        XCTAssertEqual(model.shellSetupStatus.rc, .unknown)
+    }
+
+    @MainActor
+    func testASymlinkedRCFileSurfacesAsAnAlertRatherThanSilence() async {
+        let fileSystem = StubRCFileSystem(state: ClaudeShellRCState(
+            fileExists: true, fileIsSymlink: true
+        ))
+        let model = shellSetupModel(fileSystem: fileSystem)
+        await model.applyShellSetup()
+        XCTAssertEqual(fileSystem.writes, 0, "a dotfiles symlink is never written through")
+        XCTAssertEqual(model.alert?.title, "Could not update your shell startup file")
+    }
+
 }

--- a/Tests/localvoxtralTests/ClaudeRemoteEnrollmentServiceTests.swift
+++ b/Tests/localvoxtralTests/ClaudeRemoteEnrollmentServiceTests.swift
@@ -266,7 +266,7 @@ final class ClaudeRemoteEnrollmentServiceTests: XCTestCase {
         XCTAssertLessThan(statusIndex, warningIndex)
     }
 
-    // MARK: SSH config forward state (review finding 1)
+    // MARK: SSH config block currency (review finding 1, extended 2026-09-06)
 
     func testForwardStateReportsWhetherThisHostsBlockAlreadyCarriesThePort() throws {
         let legacy = ClaudeRemoteEnrollmentService.applySSHConfigSnippet(
@@ -276,13 +276,13 @@ final class ClaudeRemoteEnrollmentServiceTests: XCTestCase {
             state: ClaudeRemoteRemoteConfigStateFixture.state(configText: legacy)
         )
         let service = ClaudeRemoteEnrollmentService(sshConfigFileSystem: filesystem)
-        XCTAssertEqual(service.sshConfigForwardsPort(8473, hostID: host.id), true)
+        XCTAssertEqual(service.sshConfigBlockIsCurrent(port: 8473, hostID: host.id), true)
         XCTAssertEqual(
-            service.sshConfigForwardsPort(28511, hostID: host.id), false,
+            service.sshConfigBlockIsCurrent(port: 28511, hostID: host.id), false,
             "a legacy block does not forward the allocated port, and saying it does is the split brain"
         )
         XCTAssertEqual(
-            service.sshConfigForwardsPort(28511, hostID: "hunknown"), false,
+            service.sshConfigBlockIsCurrent(port: 28511, hostID: "hunknown"), false,
             "no block at all is not a match either"
         )
     }
@@ -290,7 +290,48 @@ final class ClaudeRemoteEnrollmentServiceTests: XCTestCase {
     func testForwardStateIsUnknownWithoutAFilesystemSeamAndNeverGuessesTrue() throws {
         // nil means cannot tell. Callers must regenerate on nil; a `true` here
         // would let the plugin be pointed at a port nothing forwards.
-        XCTAssertNil(ClaudeRemoteEnrollmentService().sshConfigForwardsPort(28511, hostID: host.id))
+        XCTAssertNil(ClaudeRemoteEnrollmentService().sshConfigBlockIsCurrent(port: 28511, hostID: host.id))
+    }
+
+    func testABlockWithTheRIGHTPortButNoSendEnvIsNOTCurrent() throws {
+        // The owner's exact shape, and the one this check exists for now: a
+        // host enrolled before `SendEnv LC_LVX_TTY` existed already forwards
+        // the right port, so a port-only currency check reported "current" and
+        // `Update Plugin…` skipped the local rewrite — the line the release
+        // notes promise that button adds never arrived (review finding B1).
+        let stale = [
+            ClaudeRemoteEnrollmentService.blockBegin(hostID: host.id),
+            "Host sandbox-vpn",
+            "    RemoteForward 28542 127.0.0.1:8473",
+            "    ExitOnForwardFailure no",
+            ClaudeRemoteEnrollmentService.blockEnd(hostID: host.id),
+        ].joined(separator: "\n")
+        let filesystem = MemorySSHConfigFileSystem(
+            state: ClaudeRemoteRemoteConfigStateFixture.state(configText: stale)
+        )
+        let service = ClaudeRemoteEnrollmentService(sshConfigFileSystem: filesystem)
+        XCTAssertEqual(
+            service.sshConfigBlockIsCurrent(port: 28_542, hostID: host.id), false,
+            "the port matches and the block is still stale"
+        )
+    }
+
+    func testACOMMENTEDSendEnvDoesNotMakeABlockCurrent() throws {
+        // `# SendEnv LC_LVX_TTY` contains the substring and sends nothing.
+        let commented = [
+            ClaudeRemoteEnrollmentService.blockBegin(hostID: host.id),
+            "Host sandbox-vpn",
+            "    RemoteForward 28542 127.0.0.1:8473",
+            "    # SendEnv LC_LVX_TTY",
+            ClaudeRemoteEnrollmentService.blockEnd(hostID: host.id),
+        ].joined(separator: "\n")
+        let filesystem = MemorySSHConfigFileSystem(
+            state: ClaudeRemoteRemoteConfigStateFixture.state(configText: commented)
+        )
+        let service = ClaudeRemoteEnrollmentService(sshConfigFileSystem: filesystem)
+        XCTAssertEqual(
+            service.sshConfigBlockIsCurrent(port: 28_542, hostID: host.id), false
+        )
     }
 
     func testForwardStateIgnoresARemoteForwardOutsideThisHostsBlock() throws {
@@ -301,7 +342,7 @@ final class ClaudeRemoteEnrollmentServiceTests: XCTestCase {
             state: ClaudeRemoteRemoteConfigStateFixture.state(configText: foreign)
         )
         let service = ClaudeRemoteEnrollmentService(sshConfigFileSystem: filesystem)
-        XCTAssertEqual(service.sshConfigForwardsPort(28511, hostID: host.id), false)
+        XCTAssertEqual(service.sshConfigBlockIsCurrent(port: 28511, hostID: host.id), false)
     }
 
     func testTheUpdatePathMigratesAnAlreadyEnrolledHostToTheAllocatedPort() throws {

--- a/Tests/localvoxtralTests/ClaudeRemoteEnrollmentServiceTests.swift
+++ b/Tests/localvoxtralTests/ClaudeRemoteEnrollmentServiceTests.swift
@@ -1439,4 +1439,55 @@ final class ClaudeRemoteEnrollmentServiceTests: XCTestCase {
         }
         XCTAssertEqual(calls.withLock { $0 }, 0)
     }
+    // MARK: - SendEnv on an ALREADY-enrolled host
+
+    /// The owner's host was enrolled before `SendEnv LC_LVX_TTY` existed, so
+    /// the line has to reach it through the path that REGENERATES the block —
+    /// the plugin update — and not only through a fresh enrollment.
+    func testRegeneratedSnippetCarriesSendEnvAndReplacesAnOlderBlock() {
+        let host = ClaudeRemoteHost(
+            id: "h1a2b3c4",
+            label: "sandbox",
+            sshHostAlias: "sandbox-vpn",
+            createdAt: Date(timeIntervalSince1970: 1_700_000_000),
+            lastSeenAt: nil,
+            revokedAt: nil
+        )
+        let snippet = ClaudeRemoteEnrollmentService.sshConfigSnippet(
+            host: host, sshHostAlias: "sandbox-vpn", listenerPort: 8473, remoteForwardPort: 28_542
+        )
+        // An exact LINE, not a substring: `# SendEnv LC_LVX_TTY` contains the
+        // substring too, so a `contains` check passes for a commented-out
+        // directive — caught by this test's own red run, 2026-09-06.
+        XCTAssertTrue(
+            snippet.components(separatedBy: "\n")
+                .contains { $0.trimmingCharacters(in: .whitespaces) == "SendEnv LC_LVX_TTY" },
+            "the block must carry the directive, not a comment about it: \(snippet)"
+        )
+
+        // A block written before the line existed — the owner's shape.
+        let stale = [
+            ClaudeRemoteEnrollmentService.blockBegin(hostID: host.id),
+            "Host sandbox-vpn",
+            "    RemoteForward 28542 127.0.0.1:8473",
+            "    ExitOnForwardFailure no",
+            ClaudeRemoteEnrollmentService.blockEnd(hostID: host.id),
+        ].joined(separator: "\n")
+        let updated = ClaudeRemoteEnrollmentService.applySSHConfigSnippet(
+            to: "Host other\n    User someone\n\n" + stale,
+            snippet: snippet,
+            hostID: host.id
+        )
+        XCTAssertTrue(
+            updated.components(separatedBy: "\n")
+                .contains { $0.trimmingCharacters(in: .whitespaces) == "SendEnv LC_LVX_TTY" },
+            "the update must add the directive"
+        )
+        XCTAssertEqual(
+            updated.components(separatedBy: "Host sandbox-vpn").count - 1, 1,
+            "replaced, never duplicated — OpenSSH is first-match-wins"
+        )
+        XCTAssertTrue(updated.contains("Host other"), "other stanzas untouched")
+    }
+
 }

--- a/Tests/localvoxtralTests/ClaudeShellRCSetupTests.swift
+++ b/Tests/localvoxtralTests/ClaudeShellRCSetupTests.swift
@@ -118,9 +118,9 @@ final class ClaudeShellRCSetupTests: XCTestCase {
         XCTAssertEqual(result, snippet(.zsh) + "\n")
     }
 
-    func testApplyingPreservesEverythingElseAndSeparatesTheBlock() {
+    func testApplyingPreservesEverythingElseAndSeparatesTheBlock() throws {
         let existing = "export EDITOR=vim\nalias ll='ls -la'\n"
-        let result = ClaudeShellRCSetup.apply(to: existing, snippet: snippet(.zsh))
+        let result = try XCTUnwrap(ClaudeShellRCSetup.apply(to: existing, snippet: snippet(.zsh)))
         XCTAssertTrue(result.hasPrefix(existing), "the user's own lines are untouched")
         XCTAssertTrue(result.contains(snippet(.zsh)))
         XCTAssertTrue(
@@ -129,19 +129,21 @@ final class ClaudeShellRCSetupTests: XCTestCase {
         )
     }
 
-    func testApplyingTwiceIsAByteForByteNoOp() {
+    func testApplyingTwiceIsAByteForByteNoOp() throws {
         // Not tidiness: two copies would run `tty` twice on every shell start,
         // forever, and the second block's guard would then see the first's
         // export and skip — silently masking a stale value.
-        let once = ClaudeShellRCSetup.apply(to: "export EDITOR=vim\n", snippet: snippet(.zsh))
-        let twice = ClaudeShellRCSetup.apply(to: once, snippet: snippet(.zsh))
+        let once = try XCTUnwrap(
+            ClaudeShellRCSetup.apply(to: "export EDITOR=vim\n", snippet: snippet(.zsh))
+        )
+        let twice = try XCTUnwrap(ClaudeShellRCSetup.apply(to: once, snippet: snippet(.zsh)))
         XCTAssertEqual(once, twice)
         XCTAssertEqual(
             twice.components(separatedBy: ClaudeShellRCSetup.markerBegin).count - 1, 1
         )
     }
 
-    func testApplyingREPLACESAnOlderBlockRatherThanAppending() {
+    func testApplyingREPLACESAnOlderBlockRatherThanAppending() throws {
         let stale = """
         export EDITOR=vim
         \(ClaudeShellRCSetup.markerBegin)
@@ -149,7 +151,7 @@ final class ClaudeShellRCSetupTests: XCTestCase {
         \(ClaudeShellRCSetup.markerEnd)
         alias ll='ls -la'
         """
-        let result = ClaudeShellRCSetup.apply(to: stale, snippet: snippet(.zsh))
+        let result = try XCTUnwrap(ClaudeShellRCSetup.apply(to: stale, snippet: snippet(.zsh)))
         XCTAssertFalse(
             result.contains("export LC_LVX_TTY=\"$(tty)\"\n\(ClaudeShellRCSetup.markerEnd)"),
             "the old body must be gone, or a shipped fix never reaches the user"
@@ -162,10 +164,10 @@ final class ClaudeShellRCSetupTests: XCTestCase {
         )
     }
 
-    func testRemovingLeavesEverythingElseExactlyAsItWas() {
+    func testRemovingLeavesEverythingElseExactlyAsItWas() throws {
         let existing = "export EDITOR=vim\nalias ll='ls -la'\n"
-        let applied = ClaudeShellRCSetup.apply(to: existing, snippet: snippet(.zsh))
-        let removed = ClaudeShellRCSetup.remove(from: applied)
+        let applied = try XCTUnwrap(ClaudeShellRCSetup.apply(to: existing, snippet: snippet(.zsh)))
+        let removed = try XCTUnwrap(ClaudeShellRCSetup.remove(from: applied))
         XCTAssertFalse(ClaudeShellRCSetup.containsBlock(removed))
         XCTAssertTrue(removed.contains("export EDITOR=vim"))
         XCTAssertTrue(removed.contains("alias ll='ls -la'"))
@@ -176,12 +178,68 @@ final class ClaudeShellRCSetupTests: XCTestCase {
         XCTAssertEqual(ClaudeShellRCSetup.remove(from: existing), existing)
     }
 
-    func testAnIndentedMarkerIsStillOurBlock() {
+    func testAnIndentedMarkerIsStillOurBlock() throws {
         // Someone's formatter, or a copy-paste into an `if` — the block must
         // still be findable, or the next apply duplicates it.
         let indented = "    \(ClaudeShellRCSetup.markerBegin)\n    x=1\n    \(ClaudeShellRCSetup.markerEnd)\n"
         XCTAssertTrue(ClaudeShellRCSetup.containsBlock(indented))
-        XCTAssertFalse(ClaudeShellRCSetup.containsBlock(ClaudeShellRCSetup.remove(from: indented)))
+        let removed = try XCTUnwrap(ClaudeShellRCSetup.remove(from: indented))
+        XCTAssertFalse(ClaudeShellRCSetup.containsBlock(removed))
+    }
+
+    func testACRLFFileSMarkersAreStillFound() throws {
+        // `.whitespaces` is space and tab only, so a `…(begin)\r` line read
+        // with it looks marker-free — and the next apply APPENDS a duplicate.
+        // A dotfile synced from a Windows-touched repo is exactly that file.
+        // Found by self-review, 2026-09-06.
+        let crlf = "export EDITOR=vim\r\n"
+            + ClaudeShellRCSetup.markerBegin + "\r\n"
+            + "old body\r\n"
+            + ClaudeShellRCSetup.markerEnd + "\r\n"
+        XCTAssertTrue(ClaudeShellRCSetup.containsBlock(crlf))
+        let result = try XCTUnwrap(ClaudeShellRCSetup.apply(to: crlf, snippet: snippet(.zsh)))
+        XCTAssertEqual(
+            result.components(separatedBy: ClaudeShellRCSetup.markerBegin).count - 1, 1,
+            "replaced, not duplicated"
+        )
+        XCTAssertFalse(result.contains("old body"))
+    }
+
+    func testAnUNPAIREDBeginMarkerIsRefusedRatherThanWrittenPast() throws {
+        // The content-losing path, and the reason this returns nil rather than
+        // appending: a file with a dangling begin gains a SECOND begin and one
+        // end, and the next apply then replaces everything between the FIRST
+        // begin and that end — swallowing whatever the user wrote in between.
+        // Found by self-review, 2026-09-06.
+        let damaged = """
+        export EDITOR=vim
+        \(ClaudeShellRCSetup.markerBegin)
+        someone deleted the end marker
+        alias ll='ls -la'
+        """
+        XCTAssertTrue(ClaudeShellRCSetup.hasDamagedBlock(damaged))
+        XCTAssertFalse(ClaudeShellRCSetup.containsBlock(damaged))
+        XCTAssertNil(ClaudeShellRCSetup.apply(to: damaged, snippet: snippet(.zsh)))
+        XCTAssertNil(ClaudeShellRCSetup.remove(from: damaged))
+    }
+
+    func testTheWriterRefusesAFileWhoseMarkersDoNotPair() throws {
+        let damaged = ClaudeShellRCSetup.markerBegin + "\nstranded\n"
+        let fileSystem = StubRCFileSystem(state: ClaudeShellRCState(
+            fileExists: true, data: Data(damaged.utf8), permissions: 0o644
+        ))
+        let writer = ClaudeShellRCWriter(fileSystem: fileSystem)
+        XCTAssertThrowsError(try writer.apply(shell: .zsh)) { error in
+            XCTAssertEqual(error as? ClaudeShellRCError, .markersDoNotPair)
+        }
+        XCTAssertNil(fileSystem.written, "nothing may be written")
+    }
+
+    func testAFileThatIsONLYTheBlockRemovesToNothing() throws {
+        let onlyBlock = try XCTUnwrap(ClaudeShellRCSetup.apply(to: "", snippet: snippet(.zsh)))
+        let removed = try XCTUnwrap(ClaudeShellRCSetup.remove(from: onlyBlock))
+        XCTAssertFalse(ClaudeShellRCSetup.containsBlock(removed))
+        XCTAssertEqual(removed.trimmingCharacters(in: .whitespacesAndNewlines), "")
     }
 
     // MARK: - The writer's refusals

--- a/Tests/localvoxtralTests/ClaudeShellRCSetupTests.swift
+++ b/Tests/localvoxtralTests/ClaudeShellRCSetupTests.swift
@@ -165,12 +165,24 @@ final class ClaudeShellRCSetupTests: XCTestCase {
     }
 
     func testRemovingLeavesEverythingElseExactlyAsItWas() throws {
+        // EQUALITY, not `contains`. The weaker assertion hid a growing gap:
+        // `apply` inserts a blank separator line and `remove` did not take it
+        // back, so apply→remove left an extra newline every cycle (review
+        // finding m1).
         let existing = "export EDITOR=vim\nalias ll='ls -la'\n"
         let applied = try XCTUnwrap(ClaudeShellRCSetup.apply(to: existing, snippet: snippet(.zsh)))
         let removed = try XCTUnwrap(ClaudeShellRCSetup.remove(from: applied))
-        XCTAssertFalse(ClaudeShellRCSetup.containsBlock(removed))
-        XCTAssertTrue(removed.contains("export EDITOR=vim"))
-        XCTAssertTrue(removed.contains("alias ll='ls -la'"))
+        XCTAssertEqual(removed, existing, "apply then remove is a byte-for-byte round trip")
+    }
+
+    func testApplyRemoveRoundTripsRepeatedlyWithoutGrowingTheFile() throws {
+        var text = "export EDITOR=vim\nalias ll='ls -la'\n"
+        let original = text
+        for _ in 0..<5 {
+            text = try XCTUnwrap(ClaudeShellRCSetup.apply(to: text, snippet: snippet(.zsh)))
+            text = try XCTUnwrap(ClaudeShellRCSetup.remove(from: text))
+        }
+        XCTAssertEqual(text, original)
     }
 
     func testRemovingFromAFileWithNoBlockChangesNothing() {
@@ -221,6 +233,68 @@ final class ClaudeShellRCSetupTests: XCTestCase {
         XCTAssertFalse(ClaudeShellRCSetup.containsBlock(damaged))
         XCTAssertNil(ClaudeShellRCSetup.apply(to: damaged, snippet: snippet(.zsh)))
         XCTAssertNil(ClaudeShellRCSetup.remove(from: damaged))
+    }
+
+    func testADanglingBeginBeforeACompletePairIsDamagedNotSpanned() throws {
+        // The content-losing shape review finding M1 named: taking the FIRST
+        // begin and the first end AFTER it spans the user's own lines and
+        // deletes them. Reachable by hand-edit — delete an end marker, then
+        // re-paste the README block to "fix" it.
+        let damaged = [
+            ClaudeShellRCSetup.markerBegin,
+            "export EDITOR=vim",
+            ClaudeShellRCSetup.markerBegin,
+            "old body",
+            ClaudeShellRCSetup.markerEnd,
+        ].joined(separator: "\n")
+        XCTAssertTrue(ClaudeShellRCSetup.hasDamagedBlock(damaged))
+        XCTAssertNil(
+            ClaudeShellRCSetup.apply(to: damaged, snippet: snippet(.zsh)),
+            "`export EDITOR=vim` sits between the two begins and must not be deleted"
+        )
+        XCTAssertNil(ClaudeShellRCSetup.remove(from: damaged))
+    }
+
+    func testAnEndMarkerWithNoBeginIsAlsoDamaged() throws {
+        let stray = "export EDITOR=vim\n\(ClaudeShellRCSetup.markerEnd)\n"
+        XCTAssertTrue(ClaudeShellRCSetup.hasDamagedBlock(stray))
+        XCTAssertNil(ClaudeShellRCSetup.apply(to: stray, snippet: snippet(.zsh)))
+    }
+
+    func testTWOCompleteBlocksCollapseToOne() throws {
+        // The README block pasted twice by hand. Replacing only the first left
+        // the second forever, which is the duplicate the idempotency claim
+        // exists to prevent (review finding m2).
+        let doubled = snippet(.zsh) + "\nexport EDITOR=vim\n" + snippet(.zsh) + "\n"
+        let result = try XCTUnwrap(ClaudeShellRCSetup.apply(to: doubled, snippet: snippet(.zsh)))
+        XCTAssertEqual(
+            result.components(separatedBy: ClaudeShellRCSetup.markerBegin).count - 1, 1,
+            "one block afterwards, not two"
+        )
+        XCTAssertTrue(result.contains("export EDITOR=vim"), "and the user's line survives")
+    }
+
+    func testTwoCompleteBlocksAreBothRemoved() throws {
+        let doubled = snippet(.zsh) + "\nexport EDITOR=vim\n" + snippet(.zsh) + "\n"
+        let removed = try XCTUnwrap(ClaudeShellRCSetup.remove(from: doubled))
+        XCTAssertFalse(ClaudeShellRCSetup.containsBlock(removed))
+        XCTAssertTrue(removed.contains("export EDITOR=vim"))
+    }
+
+    func testACRLFFileKeepsCRLFThroughTheSplice() throws {
+        // Splicing LF into a CRLF file leaves it mixed, which the user sees in
+        // their editor (review finding m3). Asserted on BYTES.
+        let crlf = "export EDITOR=vim\r\n"
+            + ClaudeShellRCSetup.markerBegin + "\r\n"
+            + "old body\r\n"
+            + ClaudeShellRCSetup.markerEnd + "\r\n"
+        let result = try XCTUnwrap(ClaudeShellRCSetup.apply(to: crlf, snippet: snippet(.zsh)))
+        XCTAssertFalse(
+            result.replacingOccurrences(of: "\r\n", with: "").contains("\n"),
+            "no bare LF may survive in a CRLF file: \(Array(result.utf8.prefix(80)))"
+        )
+        XCTAssertTrue(result.contains("export EDITOR=vim\r\n"))
+        XCTAssertFalse(result.contains("old body"))
     }
 
     func testTheWriterRefusesAFileWhoseMarkersDoNotPair() throws {
@@ -314,6 +388,112 @@ final class ClaudeShellRCSetupTests: XCTestCase {
         try writer.remove()
         fileSystem.state.data = fileSystem.written?.data
         XCTAssertEqual(writer.isApplied(), false)
+    }
+
+    func testAnEXISTINGButUNREADABLEFileIsRefusedRatherThanTreatedAsEmpty() {
+        // `~/.zshrc` mode 000, or root-owned. Mapping that to "" made a
+        // confirmed setup overwrite it with snippet-only bytes — total content
+        // loss, silently, with the row then reporting "Set up" (review finding
+        // M2).
+        let fileSystem = StubRCFileSystem(state: ClaudeShellRCState(
+            fileExists: true, data: nil, permissions: nil
+        ))
+        let writer = ClaudeShellRCWriter(fileSystem: fileSystem)
+        XCTAssertThrowsError(try writer.apply(shell: .zsh)) { error in
+            XCTAssertEqual(error as? ClaudeShellRCError, .unreadable)
+        }
+        XCTAssertNil(fileSystem.written, "nothing may be written over a file we cannot read")
+        XCTAssertNil(writer.isApplied(), "and the row must say unknown, not `not set up`")
+    }
+
+    func testADamagedFileReportsUnknownRatherThanApplied() {
+        let damaged = ClaudeShellRCSetup.markerBegin + "\nstranded\n"
+        let fileSystem = StubRCFileSystem(state: ClaudeShellRCState(
+            fileExists: true, data: Data(damaged.utf8), permissions: 0o644
+        ))
+        XCTAssertNil(
+            ClaudeShellRCWriter(fileSystem: fileSystem).isApplied(),
+            "offering Remove for a block the writer will refuse to touch is a dead button"
+        )
+    }
+
+    // MARK: - The LIVE filesystem, against a real tree
+
+    /// Every symlink test above uses a stub state, so the live `readState` —
+    /// the code that decides what those states ARE — had no coverage at all
+    /// (review finding M3). This one builds a real temp tree.
+    func testTheLiveReaderSeesASymlinkedINTERMEDIATEDirectory() throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("lvx-rc-\(UUID().uuidString)")
+        let real = root.appendingPathComponent("dotfiles/config", isDirectory: true)
+        try FileManager.default.createDirectory(
+            at: real.appendingPathComponent("fish/conf.d", isDirectory: true),
+            withIntermediateDirectories: true
+        )
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        // `~/.config` → `~/dotfiles/config`, the standard dotfiles layout.
+        let home = root.appendingPathComponent("home", isDirectory: true)
+        try FileManager.default.createDirectory(at: home, withIntermediateDirectories: true)
+        try FileManager.default.createSymbolicLink(
+            at: home.appendingPathComponent(".config", isDirectory: true), withDestinationURL: real
+        )
+
+        let relative = ClaudeShellRCSetup.relativeRCPath(for: .fish) { _ in false }
+        XCTAssertTrue(
+            LiveClaudeShellRCFileSystem.anyComponentIsSymlink(
+                under: home, relativePath: relative
+            ),
+            "a symlinked ~/.config is a link on the way to the fish file"
+        )
+
+        let state = try LiveClaudeShellRCFileSystem(
+            relativePath: relative, homeDirectoryURL: home
+        ).readState()
+        XCTAssertTrue(state.directoryIsSymlink)
+        XCTAssertThrowsError(
+            try ClaudeShellRCWriter(
+                fileSystem: LiveClaudeShellRCFileSystem(
+                    relativePath: relative, homeDirectoryURL: home
+                )
+            ).apply(shell: .fish)
+        ) { error in
+            XCTAssertEqual(error as? ClaudeShellRCError, .isSymlink)
+        }
+        XCTAssertFalse(
+            FileManager.default.fileExists(
+                atPath: real.appendingPathComponent("fish/conf.d/localvoxtral.fish").path
+            ),
+            "nothing may be planted inside the dotfiles repo"
+        )
+    }
+
+    func testTheLiveReaderWritesAndReadsBackAThoroughlyORDINARYTree() throws {
+        // The other side: with no symlink anywhere, the real writer works and
+        // round-trips, so the refusal above is about symlinks and not about
+        // the live path being broken.
+        let home = FileManager.default.temporaryDirectory
+            .appendingPathComponent("lvx-rc-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: home, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: home) }
+        try Data("export EDITOR=vim\n".utf8)
+            .write(to: home.appendingPathComponent(".zshrc"))
+
+        let writer = ClaudeShellRCWriter(
+            fileSystem: LiveClaudeShellRCFileSystem(relativePath: ".zshrc", homeDirectoryURL: home)
+        )
+        XCTAssertEqual(writer.isApplied(), false)
+        try writer.apply(shell: .zsh)
+        XCTAssertEqual(writer.isApplied(), true)
+        let written = try String(
+            contentsOf: home.appendingPathComponent(".zshrc"), encoding: .utf8
+        )
+        XCTAssertTrue(written.hasPrefix("export EDITOR=vim\n"))
+        try writer.remove()
+        XCTAssertEqual(
+            try String(contentsOf: home.appendingPathComponent(".zshrc"), encoding: .utf8),
+            "export EDITOR=vim\n"
+        )
     }
 
     func testNonUTF8ContentIsRefusedRatherThanOverwritten() {

--- a/Tests/localvoxtralTests/ClaudeShellRCSetupTests.swift
+++ b/Tests/localvoxtralTests/ClaudeShellRCSetupTests.swift
@@ -1,0 +1,310 @@
+import Foundation
+import XCTest
+@testable import localvoxtral
+
+/// The rc-file editor for the plain-ssh join's one setup step.
+///
+/// It appends to a file the user owns and did not ask us to touch, so every
+/// rule here is about not damaging it: replace rather than duplicate, remove
+/// cleanly, preserve everything outside the markers byte for byte, and refuse
+/// outright when the file is a symlink into someone's dotfiles repo.
+final class ClaudeShellRCSetupTests: XCTestCase {
+    private func snippet(_ shell: ClaudeShellKind) -> String {
+        ClaudeShellRCSetup.snippet(for: shell)
+    }
+
+    // MARK: - Which shell, and which file
+
+    func testTheLoginShellIsDetectedByBasenameFromRealPaths() {
+        let cases: [(String?, ClaudeShellKind?)] = [
+            ("/bin/zsh", .zsh),
+            ("/bin/bash", .bash),
+            ("/usr/local/bin/bash", .bash),
+            ("/opt/homebrew/bin/fish", .fish),
+            ("/usr/local/bin/fish", .fish),
+            // Not shells this app will write POSIX (or fish) into.
+            ("/bin/ksh", nil),
+            ("/bin/sh", nil),
+            ("/usr/bin/false", nil),
+            // Not a path at all.
+            ("zsh", nil),
+            ("", nil),
+            (nil, nil),
+        ]
+        for (path, expected) in cases {
+            XCTAssertEqual(
+                ClaudeShellKind.detect(loginShellPath: path), expected,
+                "login shell \(path ?? "nil")"
+            )
+        }
+    }
+
+    func testTheRCFileFollowsMacOSConventionPerShell() {
+        XCTAssertEqual(
+            ClaudeShellRCSetup.relativeRCPath(for: .zsh) { _ in false }, ".zshrc"
+        )
+        XCTAssertEqual(
+            ClaudeShellRCSetup.relativeRCPath(for: .fish) { _ in false },
+            ".config/fish/conf.d/localvoxtral.fish"
+        )
+        // macOS terminals run bash as a LOGIN shell, which reads
+        // `.bash_profile` and never `.bashrc` — but an account that keeps
+        // everything in `.bashrc` is sourcing it from there, and appending to
+        // the file they actually edit survives their next dotfile change.
+        XCTAssertEqual(
+            ClaudeShellRCSetup.relativeRCPath(for: .bash) { $0 == ".bash_profile" },
+            ".bash_profile"
+        )
+        XCTAssertEqual(
+            ClaudeShellRCSetup.relativeRCPath(for: .bash) { $0 == ".bashrc" }, ".bashrc"
+        )
+        XCTAssertEqual(
+            ClaudeShellRCSetup.relativeRCPath(for: .bash) { _ in true }, ".bash_profile",
+            "both present: the login shell's own file wins"
+        )
+        XCTAssertEqual(
+            ClaudeShellRCSetup.relativeRCPath(for: .bash) { _ in false }, ".bash_profile",
+            "neither present: create the one a login shell reads"
+        )
+    }
+
+    // MARK: - The block itself
+
+    func testThePOSIXBlockCarriesEveryGuardThatWasMeasured() {
+        for shell in [ClaudeShellKind.zsh, .bash] {
+            let text = snippet(shell)
+            XCTAssertTrue(text.contains("[ -z \"${LC_LVX_TTY:-}\" ]"), "\(shell): already-set guard")
+            XCTAssertTrue(text.contains("[ -z \"${SSH_TTY:-}\" ]"), "\(shell): only-on-this-Mac")
+            XCTAssertTrue(
+                text.contains("case \"$(tty 2>/dev/null)\" in /dev/*"),
+                "\(shell): a tty-less shell prints `not a tty`, and exporting that "
+                    + "poisons the already-set guard for everything downstream"
+            )
+            XCTAssertTrue(
+                text.contains("if [ -z"),
+                "\(shell): an `if` block, not an `&&` chain — the chain's status becomes "
+                    + "the rc file's status and breaks `set -e` sourcing"
+            )
+            XCTAssertFalse(text.contains("set -gx"), "\(shell): that is fish syntax")
+        }
+    }
+
+    func testTheFishBlockIsFishAndNotPOSIX() {
+        let text = snippet(.fish)
+        XCTAssertTrue(text.contains("set -gx LC_LVX_TTY"))
+        XCTAssertTrue(text.contains("not set -q LC_LVX_TTY"))
+        XCTAssertTrue(text.contains("not set -q SSH_TTY"))
+        XCTAssertTrue(text.contains("string match -q -- '/dev/*'"))
+        // fish has neither, and shipping either would be a syntax error in the
+        // user's startup file — the exact damage this file exists to avoid.
+        XCTAssertFalse(text.contains("case \""))
+        XCTAssertFalse(text.contains("$(tty"))
+        XCTAssertFalse(text.contains("export "))
+    }
+
+    func testEveryShellsBlockIsDelimitedByTheSameMarkers() {
+        for shell in ClaudeShellKind.allCases {
+            let text = snippet(shell)
+            XCTAssertTrue(text.hasPrefix(ClaudeShellRCSetup.markerBegin), "\(shell)")
+            XCTAssertTrue(text.hasSuffix(ClaudeShellRCSetup.markerEnd), "\(shell)")
+            XCTAssertTrue(ClaudeShellRCSetup.containsBlock(text), "\(shell)")
+        }
+    }
+
+    // MARK: - Apply, replace, remove
+
+    func testApplyingToAnEmptyFileWritesJustTheBlock() {
+        let result = ClaudeShellRCSetup.apply(to: "", snippet: snippet(.zsh))
+        XCTAssertEqual(result, snippet(.zsh) + "\n")
+    }
+
+    func testApplyingPreservesEverythingElseAndSeparatesTheBlock() {
+        let existing = "export EDITOR=vim\nalias ll='ls -la'\n"
+        let result = ClaudeShellRCSetup.apply(to: existing, snippet: snippet(.zsh))
+        XCTAssertTrue(result.hasPrefix(existing), "the user's own lines are untouched")
+        XCTAssertTrue(result.contains(snippet(.zsh)))
+        XCTAssertTrue(
+            result.contains("alias ll='ls -la'\n\n" + ClaudeShellRCSetup.markerBegin),
+            "a blank line before the block, so it cannot fuse onto their last line"
+        )
+    }
+
+    func testApplyingTwiceIsAByteForByteNoOp() {
+        // Not tidiness: two copies would run `tty` twice on every shell start,
+        // forever, and the second block's guard would then see the first's
+        // export and skip — silently masking a stale value.
+        let once = ClaudeShellRCSetup.apply(to: "export EDITOR=vim\n", snippet: snippet(.zsh))
+        let twice = ClaudeShellRCSetup.apply(to: once, snippet: snippet(.zsh))
+        XCTAssertEqual(once, twice)
+        XCTAssertEqual(
+            twice.components(separatedBy: ClaudeShellRCSetup.markerBegin).count - 1, 1
+        )
+    }
+
+    func testApplyingREPLACESAnOlderBlockRatherThanAppending() {
+        let stale = """
+        export EDITOR=vim
+        \(ClaudeShellRCSetup.markerBegin)
+        export LC_LVX_TTY="$(tty)"
+        \(ClaudeShellRCSetup.markerEnd)
+        alias ll='ls -la'
+        """
+        let result = ClaudeShellRCSetup.apply(to: stale, snippet: snippet(.zsh))
+        XCTAssertFalse(
+            result.contains("export LC_LVX_TTY=\"$(tty)\"\n\(ClaudeShellRCSetup.markerEnd)"),
+            "the old body must be gone, or a shipped fix never reaches the user"
+        )
+        XCTAssertTrue(result.contains("case \"$(tty 2>/dev/null)\" in /dev/*"))
+        XCTAssertTrue(result.hasPrefix("export EDITOR=vim\n"))
+        XCTAssertTrue(result.hasSuffix("alias ll='ls -la'"))
+        XCTAssertEqual(
+            result.components(separatedBy: ClaudeShellRCSetup.markerBegin).count - 1, 1
+        )
+    }
+
+    func testRemovingLeavesEverythingElseExactlyAsItWas() {
+        let existing = "export EDITOR=vim\nalias ll='ls -la'\n"
+        let applied = ClaudeShellRCSetup.apply(to: existing, snippet: snippet(.zsh))
+        let removed = ClaudeShellRCSetup.remove(from: applied)
+        XCTAssertFalse(ClaudeShellRCSetup.containsBlock(removed))
+        XCTAssertTrue(removed.contains("export EDITOR=vim"))
+        XCTAssertTrue(removed.contains("alias ll='ls -la'"))
+    }
+
+    func testRemovingFromAFileWithNoBlockChangesNothing() {
+        let existing = "export EDITOR=vim\n"
+        XCTAssertEqual(ClaudeShellRCSetup.remove(from: existing), existing)
+    }
+
+    func testAnIndentedMarkerIsStillOurBlock() {
+        // Someone's formatter, or a copy-paste into an `if` — the block must
+        // still be findable, or the next apply duplicates it.
+        let indented = "    \(ClaudeShellRCSetup.markerBegin)\n    x=1\n    \(ClaudeShellRCSetup.markerEnd)\n"
+        XCTAssertTrue(ClaudeShellRCSetup.containsBlock(indented))
+        XCTAssertFalse(ClaudeShellRCSetup.containsBlock(ClaudeShellRCSetup.remove(from: indented)))
+    }
+
+    // MARK: - The writer's refusals
+
+    private final class StubRCFileSystem: ClaudeShellRCFileSystem, @unchecked Sendable {
+        var state: ClaudeShellRCState
+        var written: (data: Data, permissions: UInt16)?
+        var createdDirectory = false
+
+        init(state: ClaudeShellRCState) { self.state = state }
+
+        func readState() throws -> ClaudeShellRCState { state }
+        func createDirectory(permissions: UInt16) throws { createdDirectory = true }
+        func atomicWrite(_ data: Data, permissions: UInt16) throws {
+            written = (data, permissions)
+        }
+    }
+
+    func testWritingThroughASymlinkIsRefused() throws {
+        // The case a dotfiles user actually hits: `~/.zshrc` is very often a
+        // link into a repo, and an atomic rename REPLACES the link with a
+        // regular file — silently detaching their setup. Refusing costs them a
+        // copy-paste; writing costs them their dotfiles.
+        for state in [
+            ClaudeShellRCState(fileExists: true, fileIsSymlink: true),
+            ClaudeShellRCState(fileExists: true, directoryIsSymlink: true),
+        ] {
+            let fileSystem = StubRCFileSystem(state: state)
+            let writer = ClaudeShellRCWriter(fileSystem: fileSystem)
+            XCTAssertThrowsError(try writer.apply(shell: .zsh)) { error in
+                XCTAssertEqual(error as? ClaudeShellRCError, .isSymlink)
+            }
+            XCTAssertNil(fileSystem.written, "nothing may be written")
+        }
+    }
+
+    func testAnUnwritableSetupIsNotConfiguredRatherThanSilent() {
+        let writer = ClaudeShellRCWriter(fileSystem: nil)
+        XCTAssertThrowsError(try writer.apply(shell: .zsh)) { error in
+            XCTAssertEqual(error as? ClaudeShellRCError, .notConfigured)
+        }
+        XCTAssertNil(writer.isApplied(), "unknown, never `false`")
+    }
+
+    func testANewFileIsCreatedTightAndAnExistingOnesModeIsPreserved() throws {
+        let fresh = StubRCFileSystem(state: ClaudeShellRCState(directoryExists: false))
+        try ClaudeShellRCWriter(fileSystem: fresh).apply(shell: .fish)
+        XCTAssertEqual(fresh.written?.permissions, 0o600, "a file WE create gets the tightest mode")
+        XCTAssertTrue(fresh.createdDirectory, "fish's conf.d may not exist yet")
+
+        let existing = StubRCFileSystem(state: ClaudeShellRCState(
+            fileExists: true, data: Data("export EDITOR=vim\n".utf8), permissions: 0o644
+        ))
+        try ClaudeShellRCWriter(fileSystem: existing).apply(shell: .zsh)
+        XCTAssertEqual(
+            existing.written?.permissions, 0o644,
+            "never widen and never narrow someone's own file — preserve it"
+        )
+    }
+
+    func testIsAppliedReadsTheRealFileContents() throws {
+        let fileSystem = StubRCFileSystem(state: ClaudeShellRCState(
+            fileExists: true, data: Data("export EDITOR=vim\n".utf8), permissions: 0o644
+        ))
+        let writer = ClaudeShellRCWriter(fileSystem: fileSystem)
+        XCTAssertEqual(writer.isApplied(), false)
+
+        try writer.apply(shell: .zsh)
+        fileSystem.state.data = fileSystem.written?.data
+        XCTAssertEqual(writer.isApplied(), true)
+
+        try writer.remove()
+        fileSystem.state.data = fileSystem.written?.data
+        XCTAssertEqual(writer.isApplied(), false)
+    }
+
+    func testNonUTF8ContentIsRefusedRatherThanOverwritten() {
+        let fileSystem = StubRCFileSystem(state: ClaudeShellRCState(
+            fileExists: true, data: Data([0xFF, 0xFE, 0x00]), permissions: 0o644
+        ))
+        let writer = ClaudeShellRCWriter(fileSystem: fileSystem)
+        XCTAssertThrowsError(try writer.apply(shell: .zsh)) { error in
+            XCTAssertEqual(error as? ClaudeShellRCError, .invalidEncoding)
+        }
+        XCTAssertNil(fileSystem.written)
+    }
+
+    // MARK: - Reading the login shell
+
+    func testDSCLOutputIsParsedAndAnythingElseRefused() {
+        XCTAssertEqual(ClaudeLoginShellReader.parse("UserShell: /bin/zsh\n"), "/bin/zsh")
+        XCTAssertEqual(
+            ClaudeLoginShellReader.parse("name: tom\nUserShell: /opt/homebrew/bin/fish"),
+            "/opt/homebrew/bin/fish"
+        )
+        XCTAssertNil(ClaudeLoginShellReader.parse("UserShell: zsh"), "not a path")
+        XCTAssertNil(ClaudeLoginShellReader.parse("No such key: UserShell\n"))
+        XCTAssertNil(ClaudeLoginShellReader.parse(""))
+    }
+
+    func testTheEnvironmentIsOnlyAFallback() {
+        // The app launches from the GUI, where `$SHELL` comes from launchd and
+        // can be stale after a `chsh`. Directory Services is asked first.
+        XCTAssertEqual(
+            ClaudeLoginShellReader.loginShellPath(
+                runDSCL: { "UserShell: /bin/zsh" }, environment: ["SHELL": "/bin/bash"]
+            ),
+            "/bin/zsh"
+        )
+        XCTAssertEqual(
+            ClaudeLoginShellReader.loginShellPath(
+                runDSCL: { nil }, environment: ["SHELL": "/bin/bash"]
+            ),
+            "/bin/bash"
+        )
+        XCTAssertNil(
+            ClaudeLoginShellReader.loginShellPath(runDSCL: { nil }, environment: [:])
+        )
+        XCTAssertNil(
+            ClaudeLoginShellReader.loginShellPath(
+                runDSCL: { nil }, environment: ["SHELL": "bash"]
+            ),
+            "not a path"
+        )
+    }
+}

--- a/docs/agent/invariants.md
+++ b/docs/agent/invariants.md
@@ -669,6 +669,27 @@ there is not.
     wrong costs a non-join with a named cause (`no live session reports this
     terminal's tty`), never a mis-join.
 
+    The setup step is IN THE APP, and follows the ssh-config insert's shape
+    exactly: preview the literal text, write only on explicit consent,
+    idempotent by marker (`ClaudeShellRCSetup`), removable, never silent. Three
+    login shells get a block written for them — zsh, bash, fish — chosen by
+    `dscl`'s `UserShell` with `$SHELL` as a FALLBACK only (a GUI launch
+    inherits `$SHELL` from launchd, which is stale after a `chsh`); anything
+    else is told to paste, because guessing at a shell's syntax is how a setup
+    step corrupts a startup file. The writer REFUSES a symlinked rc file — the
+    case a dotfiles user actually hits, since an atomic rename replaces the
+    link with a regular file and silently detaches their repo. It preserves an
+    existing file's mode and creates a new one at 0600. The `SendEnv` half
+    rides the enrollment block, and reaches an ALREADY-enrolled host through
+    the plugin-update path, which regenerates that block.
+
+    The Settings row reports TWO facts because they fail for different reasons
+    and only the user can fix the first: the block is in the rc file (read
+    from disk), and a session has actually arrived carrying the value
+    (`remoteLocalTTY` on a live remote session). A block written five seconds
+    ago proves nothing until a NEW ssh session starts, and the second sentence
+    is what says so.
+
     **What IS a hazard, and the reason rules 6 and 7 exist: the tty NAME is
     recycled and the registry entry is not.** macOS hands out pty minors
     first-free (XNU `bsd/kern/tty_ptmx.c`: `ptmx_clone` scans for the first

--- a/docs/coding-agents.md
+++ b/docs/coding-agents.md
@@ -111,9 +111,10 @@ fields and the threat model.
 > context at all, and no join ever reads a window title — the TTY arm needs
 > Ghostty 1.4 or newer (or iTerm2 / Terminal.app), and there is no title
 > fallback under it. A Claude Code session in a plain `ssh host` shell on an
-> enrolled host joins through the **connection** instead: the ssh process on
-> your focused surface and the remote session have to name the same TCP
-> ports. A Claude Code **Remote Control** session — where the agent runs on a machine
+> enrolled host joins on that same tty, which your shell publishes into the
+> session — Settings offers to add the one block that does it, and unlike a
+> network-level match it works through jump hosts and shared connections. A
+> Claude Code **Remote Control** session — where the agent runs on a machine
 > of yours and [claude.ai/code](https://claude.ai/code) in a browser is the
 > UI — joins from the focused browser tab instead: its `session_…` URL is
 > matched exactly against the id the session's own hooks report (Chrome,

--- a/docs/release-notes/v0.9.0.md
+++ b/docs/release-notes/v0.9.0.md
@@ -22,8 +22,13 @@ Terminal.app.** Inside a [herdr](https://herdr.dev) session the app asks herdr
 itself which pane is focused and binds to that pane by id. Any ambiguity —
 including two live herdr sessions — attaches nothing rather than guessing.
 
-**A plain `ssh` session joins again, and one line of setup makes it work
-everywhere.** Add this to your shell's rc file on your Mac:
+**A plain `ssh` session joins again, and the app can set it up for you.**
+In Settings, under *Remote Claude Code over SSH*, **Set Up…** next to "Terminal
+setup for plain SSH" shows the exact block, writes it to your shell's startup
+file only after you confirm, and can remove it again. The same row tells you
+whether a remote session has actually reported its terminal yet.
+
+By hand, if you prefer — add this to your shell's rc file on your Mac:
 
 ```sh
 if [ -z "${LC_LVX_TTY:-}" ] && [ -z "${SSH_TTY:-}" ]; then
@@ -35,8 +40,12 @@ Your terminal's tty then travels into the remote session with the SSH session
 itself, and localvoxtral joins the window you are dictating into by comparing
 it against the window it can see. Because ssh carries environment per session,
 this works through a **jump host** (`ProxyJump`) and through **`ControlMaster`**
-— the two setups a network-level match cannot handle. Open a NEW ssh session
-after adding the line.
+— the two setups a network-level match cannot handle. Open a NEW terminal
+window afterwards, either way: the value is fixed when a session starts.
+
+If you enrolled a host before this release, run **Update Plugin…** on it — that
+also refreshes its `~/.ssh/config` block, which is where the `SendEnv` line
+lives.
 
 Without it there is still a zero-setup path: the session is matched to the TCP
 connection it arrived on. That one cannot see through a jump host or a shared

--- a/integrations/claude-code/README.md
+++ b/integrations/claude-code/README.md
@@ -129,7 +129,18 @@ There are two ways it can identify your window, tried in that order.
 
 ### 1. The tty echo (works through jump hosts and `ControlMaster`)
 
-Add one line to your shell's rc file **on your Mac**:
+**The app can do this for you.** Settings → the Claude Code pane → *Remote
+Claude Code over SSH* → **Set Up…** next to "Terminal setup for plain SSH". It
+shows the exact block first, writes it only after you say yes, is idempotent
+(a second run replaces rather than duplicates), and has a **Remove**. The row
+also reports whether a remote session has actually arrived carrying the value,
+which is the half you cannot see from the file.
+
+It refuses to write through a symlink: if your `~/.zshrc` is a link into a
+dotfiles repo, an atomic write would replace the link and detach your setup, so
+it tells you and you paste the block yourself.
+
+The manual alternative — add this to your shell's rc file **on your Mac**:
 
 ```sh
 if [ -z "${LC_LVX_TTY:-}" ] && [ -z "${SSH_TTY:-}" ]; then
@@ -235,8 +246,9 @@ Neither joins in these cases:
 If nothing joins and you expect it to, check the remote plugin version: this
 needs **1.7.0 or newer** on the remote host (`claude plugin update
 localvoxtral-remote`). `localvoxtral --probe-surface` names the exact reason.
-After adding the rc line you must open a NEW ssh session — the environment is
-fixed when the session starts.
+After adding the rc block — by hand or from Settings — you must open a NEW
+terminal window and a NEW ssh session: the environment is fixed when a session
+starts.
 
 ### What was removed (September 2026)
 


### PR DESCRIPTION
## What

The field result for #272 was that the arm behaved correctly and **the variable
never crossed**: the owner's `claude` process had no `LC_*` at all, because the
Mac side still had no rc export — he expected the app to do it. Fair. It now
does.

`ClaudeShellRCSetup` is the ssh-config insert's shape applied to a startup
file: **preview the literal text, write only on explicit consent, idempotent by
marker, removable, never silent.**

## What it writes, and where

| shell | file | why |
|---|---|---|
| zsh | `~/.zshrc` | read by every interactive zsh |
| bash | `~/.bash_profile`, else `~/.bashrc` if THAT exists | macOS terminals run bash as a *login* shell (`.bash_profile`), but an account that keeps everything in `.bashrc` is sourcing it from there and will edit that file next |
| fish | `~/.config/fish/conf.d/localvoxtral.fish` | fish sources all of `conf.d`, so the app owns its own file |
| anything else | nothing — the copy-paste path | guessing at a shell's syntax is how a setup step corrupts a startup file |

fish gets **fish syntax** (`set -q` / `set -gx` / `string match`), not POSIX —
shipping `case`/`$(...)` into a `.fish` file is a syntax error in someone's
startup. The shell comes from `dscl`'s `UserShell`, with `$SHELL` as a
**fallback only**: the app launches from the GUI, where `$SHELL` is launchd's
and is stale after a `chsh`.

## The refusals

* **A symlinked rc file is refused, not followed.** This is the case a dotfiles
  user actually hits: `~/.zshrc` is very often a link into a repo, and an
  atomic rename replaces the link with a regular file — silently detaching
  their setup. Refusing costs them a copy-paste; writing costs them their
  dotfiles. It surfaces as an alert, not silence.
* An existing file **keeps its mode**; a file we create is `0600`. Never widen,
  never narrow someone's own file.
* Non-UTF-8 content is refused rather than overwritten.

## The status row reports TWO facts

Because they fail for different reasons and only the user can fix the first:

* `Not set up.` / `Set up.` / `Could not read your shell startup file.` /
  `Your login shell is not one this can set up.`
* `No remote session has reported in yet.` /
  **`Open a new terminal window for it to take effect.`** /
  `A remote session is reporting its terminal.`

A block written five seconds ago proves nothing until a NEW ssh session starts,
and the second sentence is what says so. The row lives **inside the group that
already exists** — the pane's group structure is unchanged (owner rule,
2026-07-04) — and each line is one short sentence that does not restate its
label.

## The `SendEnv` half, for an already-enrolled host

Already in the enrollment block from #272, and it reaches a host enrolled
*before* that — the owner's — through **Update Plugin…**, which regenerates the
`~/.ssh/config` block. That path now has its own test asserting the line is
added to a stale block and the stanza is replaced rather than duplicated
(OpenSSH is first-match-wins).

## AX selectors for the UI gate

Every new element has a stable identifier:

```
claude.remote.shellSetup.title
claude.remote.shellSetup.rcStatus
claude.remote.shellSetup.crossingStatus
claude.remote.shellSetup.setUp          ← ax click opens the sheet
claude.remote.shellSetup.remove         ← only present once applied
claude.shellSetupSheet.title
claude.shellSetupSheet.preview
claude.shellSetupSheet.cancel
claude.shellSetupSheet.apply            ← ax click writes the block
```

## Proof

- **Unit suite green** — `./scripts/remote-build.sh test`

```
Executed 2904 tests, with 2 tests skipped and 0 failures (0 unexpected) in 50.820 (50.943) seconds
```

`grep -ci "warning:" .build/last-remote.log` → `0`.

- **Dogfood suite green** — `./scripts/remote-build.sh dogfood`

```
Executed 118 tests, with 0 failures (0 unexpected) in 1.235 (1.242) seconds
```

- **Red/green.** Four rules neutralised at once — `apply` appends instead of
  replacing, fish gets POSIX, the symlink refusal removed, and the enrollment
  block's `SendEnv` commented out:

```
Test Case '-[…ClaudeIntegrationSettingsModelTests testASymlinkedRCFileSurfacesAsAnAlertRatherThanSilence]' failed
Test Case '-[…ClaudeIntegrationSettingsModelTests testEveryGeneratedArtifactUsesThisMacsAllocatedRemotePort]' failed
Test Case '-[…ClaudeRemoteEnrollmentServiceTests testRegeneratedSnippetCarriesSendEnvAndReplacesAnOlderBlock]' failed
Test Case '-[…ClaudeShellRCSetupTests testApplyingREPLACESAnOlderBlockRatherThanAppending]' failed
Test Case '-[…ClaudeShellRCSetupTests testApplyingTwiceIsAByteForByteNoOp]' failed
Test Case '-[…ClaudeShellRCSetupTests testTheFishBlockIsFishAndNotPOSIX]' failed
Test Case '-[…ClaudeShellRCSetupTests testWritingThroughASymlinkIsRefused]' failed
	 Executed 2886 tests, with 2 tests skipped and 20 failures (0 unexpected)
```

  Restored → 2886/0.

- **The red run caught a weak assertion of my own**, which is the point of
  running it: `sshConfigSnippet.contains("SendEnv LC_LVX_TTY")` passed against
  a commented-out `# SendEnv LC_LVX_TTY`. Both SendEnv assertions now match an
  exact trimmed LINE. The first red run had those two tests green while the
  directive was disabled.

## Tests added

* `ClaudeShellRCSetupTests` (19) — shell detection by basename from real
  `dscl` paths (and refusal of `ksh`/`sh`/a bare name); the per-shell file
  rule including both bash orderings; every measured guard present in the POSIX
  block and fish's block being fish and not POSIX; apply to an empty file, to a
  populated one (user's lines byte-identical, blank line before the block),
  twice (exact no-op, one marker), and over a STALE block (old body gone, one
  stanza); remove; an indented marker still found; the symlink refusal for both
  file and directory; `notConfigured`; new-file `0600` vs preserved `0644`;
  `isApplied` round-tripping through real writes; non-UTF-8 refused; `dscl`
  parsing and the `$SHELL`-is-only-a-fallback rule.
* `ClaudeIntegrationSettingsModelTests` (+6) — both status halves reported
  separately; apply and remove drive the row; **the sheet's preview is the
  exact text written**; an unsupported shell offers nothing rather than
  guessing; an unreadable file reports unknown rather than "not set up" (which
  would invite a click that cannot work); a symlink surfaces as an alert.
* `ClaudeRemoteEnrollmentServiceTests` (+1) — the regenerated block carries
  `SendEnv` and replaces a stale one.

## Docs

`integrations/claude-code/README.md` (the app path first, the manual paste kept
as the alternative, the symlink caveat, and "a NEW terminal window"),
`docs/release-notes/v0.9.0.md` (the setup step, plus the note that a host
enrolled before this needs **Update Plugin…** for the `SendEnv` line),
`docs/coding-agents.md`, `docs/agent/invariants.md` (the writer's shape, the
shell-detection rule, the symlink refusal, and why the row says two things).

## Field steps for the owner

1. Open Settings → the Claude Code pane → **Remote Claude Code over SSH**.
2. Next to **Terminal setup for plain SSH**, click **Set Up…**, read the block,
   click **Add to My Shell**. The row should then read `Set up.`
3. Click **Update Plugin…** on `sandbox-vpn` — that also refreshes its
   `~/.ssh/config` block, which is where `SendEnv LC_LVX_TTY` lives, and brings
   the remote plugin to ≥ 1.7.0.
4. **Open a NEW Ghostty window** (the rc block only runs for new shells), then
   `ssh sandbox-vpn`, then `claude`. Submit one prompt.
5. The status row's second line should turn into
   `A remote session is reporting its terminal.`
6. `localvoxtral --probe-surface` in that window → `arm: remoteLocalTTY`.
   Dictate and confirm the session block is attached.

Through the UI gate, steps 2 and 3 are:

```
ax click claude.remote.shellSetup.setUp
ax click claude.shellSetupSheet.apply
```

If his `~/.zshrc` is a symlink into a dotfiles repo, step 2 will refuse with an
alert — expected, and the README's manual block is the path then.

## Adversarial review (Muse Spark 1.3 via opencode) — verdict was DO-NOT-SHIP

It found one blocker and three file-safety claims in the code and comments that
were **false**. All fixed on this branch, each red/green below. It separately
verified — and I have not touched — shell detection, both rc snippets' shell
semantics, the atomic-write path, the ssh-config splice, and the Settings-group
rule.

### BLOCKER — B1: `Update Plugin…` never delivered `SendEnv` to the host that needs it

`requestPluginUpdate` gated ssh-config regeneration on `sshConfigForwardsPort`
— the RemoteForward port **alone**. A host enrolled before
`SendEnv LC_LVX_TTY` existed already forwards the right port, so the check said
"current", `snippet` came back nil, and the update touched only the remote
plugin. `~/.ssh/config` never gained the line, silently — on exactly the
migration `docs/release-notes/v0.9.0.md` tells the user that button performs.
**The owner's host is that host.**

Worse, the test I added for this built the stale block and fed it to the *pure
splice*, so it passed while the shipped path was broken.

Fixed: `sshConfigBlockIsCurrent(port:hostID:)` requires **both** the port and an
exact `SendEnv LC_LVX_TTY` line inside the marked block (an exact line, since
`# SendEnv LC_LVX_TTY` contains the substring and sends nothing). Anything the
block must contain now belongs in that list, or shipping it reaches only new
enrollments. New tests go through `requestPluginUpdate`, and a sibling pins
that an already-current block is still left alone.

### MAJOR — M1: a dangling begin before a complete pair deleted the user's lines

`locateBlock` took the first begin and the first end *after it*. Given

```
# localvoxtral plain-ssh join (begin)
export EDITOR=vim
# localvoxtral plain-ssh join (begin)
old body
# localvoxtral plain-ssh join (end)
```

it returned one range spanning all five lines and `apply` replaced them —
destroying `export EDITOR=vim`, directly under a comment saying refusing
unpaired markers "is the only answer that cannot lose their content". Reachable
by hand-edit: delete an end marker, re-paste the README block to fix it. It now
walks the markers and returns `.damaged` for a nested begin **or** a stray end.

### MAJOR — M2: an unreadable rc file was treated as empty and overwritten

The live reader's `try? Data(contentsOf:)` swallowed `EACCES`, and the writer
mapped `data == nil` to `existing = ""`. On a mode-000 or root-owned `~/.zshrc`,
confirming Set Up… wrote **snippet-only bytes** over the original via atomic
rename — total content loss, no error, and the row then said "Set up." The
ssh-config reader beside it propagates its read error; this one did not. There
is a `.unreadable` case now and the writer refuses. `isApplied()` also returns
unknown for an unreadable *or damaged* file, so the row cannot offer a Remove
the writer will refuse.

### MAJOR — M3: a symlinked `~/.config` bypassed the symlink refusal

Only the immediate parent was `lstat`'d — for fish that is `~/.config/fish/conf.d`,
so the standard dotfiles layout (`~/.config` → `~/dotfiles/config`) was
invisible and the file was planted inside the user's repo. Every component from
home down is checked now. This is also the **first test of the live reader at
all** — every previous symlink test used a stub state, so the code that decides
what those states *are* had zero coverage. Two live tests now: a real temp tree
with a symlinked intermediate (refused, nothing planted), and an ordinary tree
that round-trips.

### MINOR / NIT

* **m1** — `remove` left the blank separator `apply` inserts, so apply→remove
  grew the file by a newline each cycle. It takes it back; the test asserts
  **equality** (it asserted `contains`), plus a five-cycle round trip.
* **m2** — two complete blocks were never collapsed; `apply` replaced the first
  and left the rest forever. All pairs are replaced now.
* **m3** — a CRLF file was spliced with LF and came back mixed. The terminator
  is detected and matched; the test asserts on bytes.
* **n1** — the preview-equals-written test compared the preview to the same
  generator and then asserted the write merely *contained* it: true of any
  superset, and the stub ignored its shell argument. It now asserts equality on
  the bytes the writer received.
* **m4 / n2–n4** — not taken, deliberately: `flock` (same last-writer-wins
  shape as the ssh writer, single-instance in practice), `Set Up…` staying
  enabled when applied (re-apply is a no-op replace), intermediate directory
  modes, and the preview/apply `chsh` TOCTOU.

### Red/green

Every fix reverted at once — the currency check back to port-only, `locateBlock`
back to first-begin/first-end, `unreadable` back to `""`, the symlink walk back
to the immediate parent, the separator not taken back, and the terminator forced
to LF:

```
Test Case '-[…ClaudeIntegrationSettingsModelTests testUpdatePlanRewritesABlockThatHasThePortButNotSendEnv]' failed
Test Case '-[…ClaudeRemoteEnrollmentServiceTests testABlockWithTheRIGHTPortButNoSendEnvIsNOTCurrent]' failed
Test Case '-[…ClaudeRemoteEnrollmentServiceTests testACOMMENTEDSendEnvDoesNotMakeABlockCurrent]' failed
Test Case '-[…ClaudeShellRCSetupTests testACRLFFileKeepsCRLFThroughTheSplice]' failed
Test Case '-[…ClaudeShellRCSetupTests testADanglingBeginBeforeACompletePairIsDamagedNotSpanned]' failed
Test Case '-[…ClaudeShellRCSetupTests testAnEndMarkerWithNoBeginIsAlsoDamaged]' failed
Test Case '-[…ClaudeShellRCSetupTests testAnEXISTINGButUNREADABLEFileIsRefusedRatherThanTreatedAsEmpty]' failed
Test Case '-[…ClaudeShellRCSetupTests testApplyRemoveRoundTripsRepeatedlyWithoutGrowingTheFile]' failed
Test Case '-[…ClaudeShellRCSetupTests testRemovingLeavesEverythingElseExactlyAsItWas]' failed
Test Case '-[…ClaudeShellRCSetupTests testTheLiveReaderSeesASymlinkedINTERMEDIATEDirectory]' failed
Test Case '-[…ClaudeShellRCSetupTests testTheLiveReaderWritesAndReadsBackAThoroughlyORDINARYTree]' failed
Test Case '-[…ClaudeShellRCSetupTests testTwoCompleteBlocksAreBothRemoved]' failed
Test Case '-[…ClaudeShellRCSetupTests testTWOCompleteBlocksCollapseToOne]' failed
	 Executed 2904 tests, with 2 tests skipped and 20 failures (0 unexpected)
```

Restored:

```
Executed 2904 tests, with 2 tests skipped and 0 failures (0 unexpected) in 50.820 (50.943) seconds
Executed 118 tests, with 0 failures (0 unexpected) in 1.235 (1.242) seconds   # dogfood
```

`grep -ci "warning:"` → `0`.

### An earlier self-review, before this one

Two providers were rate-limited when I first tried, so I attacked the writer
myself and fixed two defects of the same class: a begin marker with **no end
anywhere** fell through to the append branch (two begins, one end, and the next
apply swallows the middle), and marker matching trimmed `.whitespaces` — space
and tab only — so a CRLF file's `…(begin)\r` did not match and the next apply
appended a duplicate. Both are in the branch with their own tests; this review
then found the *nested*-begin variant of the first, which I had missed.

[dogfood-package]
