### PR TITLE
Remote hosts: one self-verifying setup flow (ssh block, shell export, plugin, env crossing, herdr row, check)

### DIFF
--- a/Sources/localvoxtral/ClaudeContext/ClaudeIntegrationSettingsModel.swift
+++ b/Sources/localvoxtral/ClaudeContext/ClaudeIntegrationSettingsModel.swift
@@ -1697,11 +1697,14 @@ public final class ClaudeIntegrationSettingsModel {
 
         let service = enrollmentService
         let port = remoteForwardPort
+        let snippetToApply = service.sshConfigBlockIsCurrent(port: port, hostID: hostID) == true
+            ? nil
+            : snippet
 
         markSetup(.sshConfig, .running)
         let sshAttempt = await performEnrollmentAsync {
-            if let snippet {
-                try service.insertSSHConfig(snippet: snippet, hostID: hostID)
+            if let snippetToApply {
+                try service.insertSSHConfig(snippet: snippetToApply, hostID: hostID)
             }
             return []
         }
@@ -1715,7 +1718,11 @@ public final class ClaudeIntegrationSettingsModel {
         }
         markSetup(
             .sshConfig,
-            .done(snippet == nil ? "The SSH config block is already current." : "The SSH config block is current.")
+            .done(
+                snippetToApply == nil
+                    ? "The SSH config block is already current."
+                    : "The SSH config block is current."
+            )
         )
         guard continueSetup(hostID: hostID) else { return }
 

--- a/Sources/localvoxtral/ClaudeContext/ClaudeIntegrationSettingsModel.swift
+++ b/Sources/localvoxtral/ClaudeContext/ClaudeIntegrationSettingsModel.swift
@@ -84,6 +84,55 @@ public struct ClaudeEnrollmentActionAttempt: Sendable, Equatable {
     }
 }
 
+/// One consented setup attempt for one remote host.
+public struct RemoteHostSetupRun: Sendable, Equatable {
+    public enum Step: Int, CaseIterable, Sendable, Equatable, Identifiable {
+        case sshConfig
+        case shellStartup
+        case remotePlugin
+        case environmentCrossing
+        case remoteHerdr
+        case checkSetup
+
+        public var id: Int { rawValue }
+
+        public var title: String {
+            switch self {
+            case .sshConfig: return "Mac SSH config"
+            case .shellStartup: return "Mac shell startup"
+            case .remotePlugin: return "Remote plugin"
+            case .environmentCrossing: return "Terminal environment"
+            case .remoteHerdr: return "Remote herdr"
+            case .checkSetup: return "Check setup"
+            }
+        }
+    }
+
+    public enum State: Sendable, Equatable {
+        case pending
+        case running
+        case done(String)
+        case skipped(String)
+        case failed(reason: String, remedy: String)
+    }
+
+    public struct Item: Sendable, Equatable, Identifiable {
+        public var step: Step
+        public var state: State
+        public var id: Int { step.rawValue }
+    }
+
+    public var hostID: String
+    public var startedAt: Date
+    public var items: [Item]
+
+    public init(hostID: String, startedAt: Date) {
+        self.hostID = hostID
+        self.startedAt = startedAt
+        items = Step.allCases.map { Item(step: $0, state: .pending) }
+    }
+}
+
 /// What the pane can say about the plain-ssh join's one setup step.
 ///
 /// Two facts, deliberately separate, because they fail for different reasons
@@ -193,6 +242,8 @@ public final class ClaudeIntegrationSettingsModel {
         /// A forward can only be offered where we know where to ssh. The label
         /// is not a substitute for an alias (PR #197).
         public var canHoldForward: Bool = false
+        /// Last setup outcome for this host during the current app session.
+        public var setupStatusText: String?
     }
 
     /// "Last context: 2 min ago", from a clock the caller supplies.
@@ -351,9 +402,11 @@ public final class ClaudeIntegrationSettingsModel {
     public enum EnrollmentAction: Sendable, Equatable {
         case insertSSHConfig
         case runRemoteSetup
+        case setupHost
         /// Per-host, because the pane shows one row per host and the outcome
         /// has to render in the row whose button ran it.
         case updateRemotePlugin(hostID: String)
+        case updateHost(hostID: String)
         case configureHerdrPanel(hostID: String)
     }
 
@@ -406,6 +459,10 @@ public final class ClaudeIntegrationSettingsModel {
     /// nobody asked for would spawn ssh on opening a sheet.
     public private(set) var verificationChecks: [ClaudeRemoteEnrollmentService.VerificationCheck] = []
     public private(set) var isPerformingVerification = false
+    public private(set) var setupRun: RemoteHostSetupRun?
+    public private(set) var setupManualInstructions: String?
+    private var setupCancellationRequested = false
+    private var setupSummaries: [String: String] = [:]
     public var alert: DetailAlert?
 
     /// One busy flag for the sheet, so no two actions can interleave: an
@@ -826,7 +883,8 @@ public final class ClaudeIntegrationSettingsModel {
                 forwardIsFailure: forwardState?.isFailure ?? false,
                 canHoldForward: forwards != nil
                     && !host.isRevoked
-                    && host.sshHostAlias.map(ClaudeRemoteEnrollmentService.isValidHostAlias) == true
+                    && host.sshHostAlias.map(ClaudeRemoteEnrollmentService.isValidHostAlias) == true,
+                setupStatusText: setupSummaries[host.id]
             )
         }
         refreshRejectionHint()
@@ -1017,14 +1075,63 @@ public final class ClaudeIntegrationSettingsModel {
         }
     }
 
+    /// Remove reverses the Mac side of enrollment — this host's ssh-config
+    /// block, and the shell startup block only when no other host remains —
+    /// and then revokes.
+    ///
+    /// Reversal NEVER blocks the revocation: the registry entry is the off
+    /// switch, and a host whose block could not be edited (a symlinked
+    /// `~/.ssh/config`, an unwritable rc) is exactly a host the user must be
+    /// able to turn off. A failed reversal is reported in the alert with the
+    /// manual cleanup instead; the remote uninstall commands ride along, as
+    /// the sheet and docs always offered them.
     public func remove(hostID: String) async {
         guard let registry else { return }
+        let isLastHost = registry.hosts().allSatisfy { $0.id == hostID }
+        var manualNotes: [String] = []
+
+        if enrollmentService.canEditSSHConfig {
+            let service = enrollmentService
+            let attempt = await performEnrollmentAsync {
+                try service.removeSSHConfig(hostID: hostID)
+                return []
+            }
+            if let failure = attempt.failure {
+                Log.claudeContext.error(
+                    "Claude remote host removal could not rewrite ~/.ssh/config: \(failure.describedError, privacy: .public)"
+                )
+                manualNotes.append(
+                    "This host's block is still in ~/.ssh/config.\n\n"
+                        + Self.enrollmentFailureDetail(failure, action: .insertSSHConfig)
+                )
+            }
+        }
+
+        if isLastHost, let shell = loginShell(), let writer = shellRCWriter(shell) {
+            if let failure = await performAsync({ try writer.remove() }) {
+                Log.claudeContext.error(
+                    "Claude remote host removal could not rewrite the shell startup file: \(failure.describedError, privacy: .public)"
+                )
+                manualNotes.append(
+                    "The LC_LVX_TTY block is still in your shell startup file.\n\n"
+                        + failure.describedError
+                )
+            }
+        }
+
         do {
             try registry.remove(hostID: hostID)
             // The row is going away; its open update panel must not outlive it.
             if presentedPluginUpdate?.hostID == hostID { dismissPluginUpdate() }
             refreshHosts()
             reconcileListener()
+            if !manualNotes.isEmpty {
+                alert = DetailAlert(
+                    title: "Remote host removed",
+                    detail: (manualNotes + ["Remove those blocks by hand to finish the cleanup."])
+                        .joined(separator: "\n\n")
+                )
+            }
         } catch {
             presentRegistryFailure(error, verb: "remove")
         }
@@ -1050,6 +1157,8 @@ public final class ClaudeIntegrationSettingsModel {
         enrollmentStepStatuses = []
         enrollmentResultsAction = nil
         verificationChecks = []
+        setupRun = nil
+        setupManualInstructions = nil
     }
 
     /// Show one host's plugin-update commands in its row.
@@ -1341,13 +1450,29 @@ public final class ClaudeIntegrationSettingsModel {
             title: presentation.sshConfigSnippet == nil
                 ? "Update the plugin on this SSH host?"
                 : "Update ~/.ssh/config on this Mac and the plugin on this SSH host?",
-            // Both halves, verbatim, in the order they will run. The rule that
-            // one-click actions repeat their exact text does not get weaker
-            // because an action now has two parts — it gets more important.
             preview: Self.updatePreview(for: presentation),
             confirmButtonTitle: "Confirm Update"
         )
         Log.claudeContext.info("Claude remote plugin update confirmation requested")
+    }
+
+    public func requestHostUpdateRun() {
+        guard let presentation = presentedPluginUpdate,
+              presentation.canRun,
+              !isEnrollmentBusy
+        else { return }
+        setupRun = nil
+        setupManualInstructions = nil
+        enrollmentConfirmation = EnrollmentConfirmation(
+            action: .updateHost(hostID: presentation.hostID),
+            title: "Update this remote host?",
+            preview: setupPreview(
+                sshConfigSnippet: presentation.sshConfigSnippet,
+                remoteCommands: presentation.commands
+            ),
+            confirmButtonTitle: "Update Host"
+        )
+        Log.claudeContext.info("Claude remote host update confirmation requested")
     }
 
     public func requestSSHConfigInsertion() {
@@ -1387,6 +1512,29 @@ public final class ClaudeIntegrationSettingsModel {
         Log.claudeContext.info("Claude remote setup confirmation requested")
     }
 
+    public func requestHostSetup() {
+        guard let presentation = presentedPlan,
+              presentation.canRunRemoteSetup,
+              !isEnrollmentBusy,
+              !presentation.isPreview
+        else { return }
+        enrollmentStepStatuses = []
+        enrollmentResultsAction = nil
+        verificationChecks = []
+        setupRun = nil
+        setupManualInstructions = nil
+        enrollmentConfirmation = EnrollmentConfirmation(
+            action: .setupHost,
+            title: "Set up this remote host?",
+            preview: setupPreview(
+                sshConfigSnippet: presentation.plan.sshConfigSnippet,
+                remoteCommands: presentation.plan.remoteCommands
+            ),
+            confirmButtonTitle: "Run Setup"
+        )
+        Log.claudeContext.info("Claude remote host setup confirmation requested")
+    }
+
     public func requestHerdrPanelConfiguration(hostID: String) {
         guard !isPerformingEnrollmentAction,
               let host = hosts.first(where: { $0.id == hostID }),
@@ -1414,9 +1562,36 @@ public final class ClaudeIntegrationSettingsModel {
             await performPlanAction(confirmation)
         case .updateRemotePlugin:
             await performPluginUpdate(confirmation)
+        case .setupHost, .updateHost:
+            await performSetupRun(confirmation)
         case .configureHerdrPanel:
             await performHerdrPanelConfiguration(confirmation)
         }
+    }
+
+    public func cancelSetupRun() {
+        guard setupRun != nil, isPerformingEnrollmentAction else { return }
+        setupCancellationRequested = true
+    }
+
+    private func setupPreview(
+        sshConfigSnippet: String?,
+        remoteCommands: [String]
+    ) -> String {
+        var sections: [String] = []
+        if let sshConfigSnippet {
+            sections.append("Mac ~/.ssh/config:\n\(sshConfigSnippet)")
+        }
+        if let shellSetupPreview {
+            sections.append("Mac shell startup file:\n\(shellSetupPreview)")
+        }
+        sections.append("Remote host:\n" + remoteCommands.joined(separator: "\n"))
+        sections.append(
+            "Remote herdr, when installed:\n"
+                + ClaudeRemoteEnrollmentService.herdrPanelConfigSnippet
+                + "\nherdr server reload-config"
+        )
+        return sections.joined(separator: "\n\n")
     }
 
     private func performPlanAction(_ confirmation: EnrollmentConfirmation) async {
@@ -1440,7 +1615,7 @@ public final class ClaudeIntegrationSettingsModel {
                     token: presentation.token
                 )
             }
-        case .updateRemotePlugin:
+        case .updateRemotePlugin, .setupHost, .updateHost:
             // Routed to performPluginUpdate: that action belongs to a host row,
             // has no plan and no token, and must not run against one.
             return
@@ -1484,6 +1659,251 @@ public final class ClaudeIntegrationSettingsModel {
         guard hosts.contains(where: { $0.id == hostID }) else { return }
         publish(attempt, action: confirmation.action)
         if attempt.failure == nil { herdrPanelStatus = .ok }
+    }
+
+    private func performSetupRun(_ confirmation: EnrollmentConfirmation) async {
+        let hostID: String
+        let alias: String
+        let snippet: String?
+        let token: String?
+        switch confirmation.action {
+        case .setupHost:
+            guard let presentation = presentedPlan, !presentation.isPreview else { return }
+            hostID = presentation.host.id
+            alias = presentation.sshHostAlias
+            snippet = presentation.plan.sshConfigSnippet
+            token = presentation.token
+        case .updateHost(let requestedHostID):
+            guard let presentation = presentedPluginUpdate,
+                  presentation.hostID == requestedHostID,
+                  let presentationAlias = presentation.sshHostAlias
+            else { return }
+            hostID = requestedHostID
+            alias = presentationAlias
+            snippet = presentation.sshConfigSnippet
+            token = nil
+        default:
+            return
+        }
+
+        enrollmentConfirmation = nil
+        isPerformingEnrollmentAction = true
+        setupCancellationRequested = false
+        setupManualInstructions = nil
+        setupRun = RemoteHostSetupRun(hostID: hostID, startedAt: now())
+        setupSummaries[hostID] = "Setup is running."
+        refreshHosts()
+        defer { isPerformingEnrollmentAction = false }
+
+        let service = enrollmentService
+        let port = remoteForwardPort
+
+        markSetup(.sshConfig, .running)
+        let sshAttempt = await performEnrollmentAsync {
+            if let snippet {
+                try service.insertSSHConfig(snippet: snippet, hostID: hostID)
+            }
+            return []
+        }
+        if let failure = sshAttempt.failure {
+            failSetup(
+                .sshConfig,
+                reason: "Could not update this Mac's SSH config.",
+                remedy: Self.enrollmentFailureDetail(failure, action: confirmation.action)
+            )
+            return
+        }
+        markSetup(
+            .sshConfig,
+            .done(snippet == nil ? "The SSH config block is already current." : "The SSH config block is current.")
+        )
+        guard continueSetup(hostID: hostID) else { return }
+
+        markSetup(.shellStartup, .running)
+        if let shell = loginShell(), let writer = shellRCWriter(shell) {
+            if writer.isApplied() == true {
+                markSetup(.shellStartup, .done("The shell startup block is already applied."))
+            } else {
+                let shellFailure = await performAsync { try writer.apply(shell: shell) }
+                if let shellFailure {
+                    setupManualInstructions = "Add this block to your shell startup file:\n\n"
+                        + ClaudeShellRCSetup.snippet(for: shell)
+                    markSetup(
+                        .shellStartup,
+                        .skipped("The shell startup file was left unchanged; add the shown block manually.")
+                    )
+                    Log.claudeContext.error(
+                        "Claude remote setup skipped shell startup edit: \(shellFailure.describedError, privacy: .public)"
+                    )
+                } else {
+                    markSetup(.shellStartup, .done("The shell startup block is applied."))
+                }
+            }
+        } else {
+            setupManualInstructions = loginShell().map {
+                "Add this block to your shell startup file:\n\n" + ClaudeShellRCSetup.snippet(for: $0)
+            } ?? "Export LC_LVX_TTY from your Mac terminal's shell startup file."
+            markSetup(
+                .shellStartup,
+                .skipped("This login shell is not supported for automatic setup; configure it manually.")
+            )
+        }
+        refreshShellSetupStatus()
+        guard continueSetup(hostID: hostID) else { return }
+
+        markSetup(.remotePlugin, .running)
+        let pluginAttempt = await performEnrollmentAsync {
+            let outcome = try service.setupRemotePlugin(
+                sshHostAlias: alias, token: token, remoteForwardPort: port
+            )
+            return [.init(index: 0, command: "remote plugin", message: String(describing: outcome))]
+        }
+        if let failure = pluginAttempt.failure {
+            failSetup(
+                .remotePlugin,
+                reason: "The remote plugin could not be installed or updated.",
+                remedy: Self.enrollmentFailureDetail(failure, action: confirmation.action)
+            )
+            return
+        }
+        switch pluginAttempt.steps.first?.message {
+        case "installed": markSetup(.remotePlugin, .done("The remote plugin was installed and verified."))
+        case "updated": markSetup(.remotePlugin, .done("The remote plugin was updated and verified."))
+        default: markSetup(.remotePlugin, .done("The remote plugin is already current and verified."))
+        }
+        guard continueSetup(hostID: hostID) else { return }
+
+        markSetup(.environmentCrossing, .running)
+        let environmentAttempt = await performEnrollmentAsync {
+            let outcome = try service.probeRemoteEnvironment(sshHostAlias: alias)
+            return [.init(index: 0, command: "environment probe", message: String(describing: outcome))]
+        }
+        if let failure = environmentAttempt.failure {
+            failSetup(
+                .environmentCrossing,
+                reason: "The terminal environment check could not run.",
+                remedy: Self.enrollmentFailureDetail(failure, action: confirmation.action)
+            )
+            return
+        }
+        switch environmentAttempt.steps.first?.message {
+        case "crossed":
+            markSetup(.environmentCrossing, .done("LC_LVX_TTY crossed the SSH connection."))
+        case "localSendEnvMissing":
+            failSetup(
+                .environmentCrossing,
+                reason: "This Mac is not sending LC_LVX_TTY for this SSH host.",
+                remedy: "Keep `SendEnv LC_LVX_TTY` in this host's ~/.ssh/config block."
+            )
+            return
+        default:
+            failSetup(
+                .environmentCrossing,
+                reason: "The remote SSH server did not accept LC_LVX_TTY.",
+                remedy: "Add `AcceptEnv LANG LC_*` to sshd_config on the host, then reload sshd."
+            )
+            return
+        }
+        guard continueSetup(hostID: hostID) else { return }
+
+        markSetup(.remoteHerdr, .running)
+        let herdrAttempt = await performEnrollmentAsync {
+            let outcome = try service.setupRemoteHerdr(sshHostAlias: alias)
+            return [.init(index: 0, command: "remote herdr", message: String(describing: outcome))]
+        }
+        if let failure = herdrAttempt.failure {
+            failSetup(
+                .remoteHerdr,
+                reason: "Remote herdr setup failed.",
+                remedy: Self.enrollmentFailureDetail(failure, action: .configureHerdrPanel(hostID: hostID))
+            )
+            return
+        }
+        switch herdrAttempt.steps.first?.message {
+        case "notFound":
+            markSetup(.remoteHerdr, .skipped("herdr is not installed on the remote host."))
+        case "customized":
+            setupManualInstructions = [
+                setupManualInstructions,
+                "The remote herdr agents table is customized. Add this row manually:\n\n"
+                    + ClaudeRemoteEnrollmentService.herdrPanelConfigSnippet,
+            ].compactMap { $0 }.joined(separator: "\n\n")
+            markSetup(.remoteHerdr, .skipped("The existing herdr agents table was left unchanged."))
+        default:
+            markSetup(.remoteHerdr, .done("The remote herdr agents panel is configured."))
+            herdrPanelStatus = .ok
+        }
+        guard continueSetup(hostID: hostID) else { return }
+
+        markSetup(.checkSetup, .running)
+        let listenerWasBound = listenerIsBound
+        let checkAttempt = await performVerificationAsync {
+            try service.executeVerification(
+                sshHostAlias: alias,
+                remoteForwardPort: port,
+                listenerIsBound: listenerWasBound
+            )
+        }
+        if let failure = checkAttempt.failure {
+            failSetup(
+                .checkSetup,
+                reason: "The final setup check could not run.",
+                remedy: Self.verificationFailureDetail(failure)
+            )
+            return
+        }
+        verificationChecks = ClaudeRemoteEnrollmentService.reconciled(
+            checkAttempt.checks,
+            remoteForwardPort: port,
+            listenerIsBound: listenerIsBound
+        )
+        if let failed = verificationChecks.first(where: { !$0.passed }) {
+            failSetup(
+                .checkSetup,
+                reason: failed.summary,
+                remedy: failed.hint ?? failed.detail
+            )
+            return
+        }
+        markSetup(.checkSetup, .done("The tunnel and remote plugin checks passed."))
+        setupSummaries[hostID] = "Setup complete."
+        refreshHosts()
+        Log.claudeContext.info("Claude remote host setup completed")
+    }
+
+    private func markSetup(_ step: RemoteHostSetupRun.Step, _ state: RemoteHostSetupRun.State) {
+        guard let index = setupRun?.items.firstIndex(where: { $0.step == step }) else { return }
+        setupRun?.items[index].state = state
+    }
+
+    private func failSetup(
+        _ step: RemoteHostSetupRun.Step,
+        reason: String,
+        remedy: String
+    ) {
+        markSetup(step, .failed(reason: reason, remedy: remedy))
+        if let hostID = setupRun?.hostID {
+            setupSummaries[hostID] = "Setup stopped at \(step.title)."
+        }
+        refreshHosts()
+        alert = DetailAlert(title: step.title, detail: "\(reason)\n\n\(remedy)")
+        Log.claudeContext.error(
+            "Claude remote host setup stopped at \(step.title, privacy: .public): \(reason, privacy: .public)"
+        )
+    }
+
+    private func continueSetup(hostID: String) -> Bool {
+        guard setupCancellationRequested else { return true }
+        if var run = setupRun {
+            for index in run.items.indices where run.items[index].state == .pending {
+                run.items[index].state = .skipped("Setup was cancelled.")
+            }
+            setupRun = run
+        }
+        setupSummaries[hostID] = "Setup cancelled."
+        refreshHosts()
+        Log.claudeContext.info("Claude remote host setup cancelled")
+        return false
     }
 
     private func performPluginUpdate(_ confirmation: EnrollmentConfirmation) async {
@@ -1565,14 +1985,17 @@ public final class ClaudeIntegrationSettingsModel {
                     detail: attempt.steps.first?.message ?? ""
                 )
             ]
+        case .setupHost, .updateHost:
+            break
         }
         enrollmentResultsAction = action
     }
 
     static func failureAlertTitle(for action: EnrollmentAction) -> String {
         switch action {
-        case .insertSSHConfig, .runRemoteSetup: return "Remote Claude Code setup"
+        case .insertSSHConfig, .runRemoteSetup, .setupHost: return "Remote Claude Code setup"
         case .updateRemotePlugin: return "Remote Claude Code plugin"
+        case .updateHost: return "Remote host update"
         case .configureHerdrPanel: return "Remote herdr panel"
         }
     }

--- a/Sources/localvoxtral/ClaudeContext/ClaudeIntegrationSettingsModel.swift
+++ b/Sources/localvoxtral/ClaudeContext/ClaudeIntegrationSettingsModel.swift
@@ -1426,13 +1426,21 @@ public final class ClaudeIntegrationSettingsModel {
     static let unknownAliasPlaceholder = "your-ssh-host"
 
     public func dismissPluginUpdate() {
-        if case .updateRemotePlugin? = enrollmentResultsAction {
+        switch enrollmentResultsAction {
+        case .updateRemotePlugin?, .updateHost?:
             enrollmentStepStatuses = []
             enrollmentResultsAction = nil
+        default:
+            break
         }
-        if case .updateRemotePlugin? = enrollmentConfirmation?.action {
+        switch enrollmentConfirmation?.action {
+        case .updateRemotePlugin?, .updateHost?:
             enrollmentConfirmation = nil
+        default:
+            break
         }
+        setupRun = nil
+        setupManualInstructions = nil
         presentedPluginUpdate = nil
     }
 

--- a/Sources/localvoxtral/ClaudeContext/ClaudeRemoteEnrollmentLiveIO.swift
+++ b/Sources/localvoxtral/ClaudeContext/ClaudeRemoteEnrollmentLiveIO.swift
@@ -338,6 +338,12 @@ extension ClaudeRemoteEnrollmentService {
             let process = Process()
             process.executableURL = sshExecutableURL
             process.arguments = Array(invocation.argv.dropFirst())
+            if !invocation.environment.isEmpty {
+                process.environment = ProcessInfo.processInfo.environment.merging(
+                    invocation.environment,
+                    uniquingKeysWith: { _, requested in requested }
+                )
+            }
 
             let input = Pipe()
             process.standardInput = input

--- a/Sources/localvoxtral/ClaudeContext/ClaudeRemoteEnrollmentService.swift
+++ b/Sources/localvoxtral/ClaudeContext/ClaudeRemoteEnrollmentService.swift
@@ -660,15 +660,13 @@ public struct ClaudeRemoteEnrollmentService: Sendable {
         }) else { return false }
         let block = lines[beginIndex...endIndex]
         let forwardsPort = block.contains { line in
-            let fields = line.trimmingCharacters(in: .whitespaces)
-                .split(separator: " ", omittingEmptySubsequences: true)
+            let fields = line.split(whereSeparator: \.isWhitespace)
             guard fields.count >= 2, fields[0] == "RemoteForward" else { return false }
             return fields[1] == "\(port)"
         }
-        // An exact line: `# SendEnv LC_LVX_TTY` contains the substring too, and
-        // a commented-out directive sends nothing.
-        let sendsLocalTTY = block.contains {
-            $0.trimmingCharacters(in: .whitespacesAndNewlines) == "SendEnv LC_LVX_TTY"
+        let sendsLocalTTY = block.contains { line in
+            let fields = line.split(whereSeparator: \.isWhitespace)
+            return fields.count >= 2 && fields[0] == "SendEnv" && fields[1] == "LC_LVX_TTY"
         }
         return forwardsPort && sendsLocalTTY
     }

--- a/Sources/localvoxtral/ClaudeContext/ClaudeRemoteEnrollmentService.swift
+++ b/Sources/localvoxtral/ClaudeContext/ClaudeRemoteEnrollmentService.swift
@@ -1042,7 +1042,13 @@ public struct ClaudeRemoteEnrollmentService: Sendable {
             )
         }
         if result.message.contains("LVX_HERDR_ABSENT") { return .notFound }
-        return .configured
+        if result.message.contains("LVX_HERDR_CONFIGURED") { return .configured }
+        throw ServiceError.runnerFailed(
+            step: 0,
+            command: "configure remote herdr",
+            message: "The host did not report a herdr setup outcome. "
+                + "Check its herdr config, then run setup again."
+        )
     }
 
     private func sanitizedRunnerError(_ error: Error, command: String) -> ServiceError {

--- a/Sources/localvoxtral/ClaudeContext/ClaudeRemoteEnrollmentService.swift
+++ b/Sources/localvoxtral/ClaudeContext/ClaudeRemoteEnrollmentService.swift
@@ -156,12 +156,39 @@ public struct ClaudeRemoteEnrollmentService: Sendable {
         public var argv: [String]
         public var standardInput: Data
         public var timeout: TimeInterval
+        /// Values added to the child process environment. Used by the
+        /// SendEnv probe so its nonce never appears in argv or stdin.
+        public var environment: [String: String]
 
-        public init(argv: [String], standardInput: Data, timeout: TimeInterval) {
+        public init(
+            argv: [String],
+            standardInput: Data,
+            timeout: TimeInterval,
+            environment: [String: String] = [:]
+        ) {
             self.argv = argv
             self.standardInput = standardInput
             self.timeout = timeout
+            self.environment = environment
         }
+    }
+
+    public enum PluginSetupOutcome: Sendable, Equatable {
+        case installed
+        case updated
+        case alreadyCurrent
+    }
+
+    public enum EnvironmentCrossingOutcome: Sendable, Equatable {
+        case crossed
+        case localSendEnvMissing
+        case remoteAcceptEnvMissing
+    }
+
+    public enum HerdrSetupOutcome: Sendable, Equatable {
+        case configured
+        case notFound
+        case customized
     }
 
     public struct ExecutionStep: Sendable, Equatable {
@@ -229,6 +256,10 @@ public struct ClaudeRemoteEnrollmentService: Sendable {
     /// `.claude-plugin/marketplace.json` listing both plugins for exactly this.
     public static let repositoryMarketplaceReference = "T0mSIlver/localvoxtral"
 
+    /// Kept next to the installer that verifies it. A manifest contract test
+    /// pins this value to the remote plugin's plugin.json.
+    public static let remotePluginVersion = "1.7.0"
+
     /// The plugin's sensitive userConfig key. Claude Code exposes it to the
     /// plugin's COMMAND-hook shim as `CLAUDE_PLUGIN_OPTION_TOKEN`; the shim
     /// hands it to curl through a private header file, never an argv. (It is
@@ -257,13 +288,19 @@ public struct ClaudeRemoteEnrollmentService: Sendable {
 
     private let runner: Runner?
     private let sshConfigFileSystem: (any ClaudeRemoteSSHConfigFileSystem)?
+    private let now: @Sendable () -> Date
+    private let environmentProbeValue: @Sendable () -> String
 
     public init(
         runner: Runner? = nil,
-        sshConfigFileSystem: (any ClaudeRemoteSSHConfigFileSystem)? = nil
+        sshConfigFileSystem: (any ClaudeRemoteSSHConfigFileSystem)? = nil,
+        now: @escaping @Sendable () -> Date = Date.init,
+        environmentProbeValue: @escaping @Sendable () -> String = { UUID().uuidString }
     ) {
         self.runner = runner
         self.sshConfigFileSystem = sshConfigFileSystem
+        self.now = now
+        self.environmentProbeValue = environmentProbeValue
     }
 
     public static var remotePluginReference: String {
@@ -445,6 +482,12 @@ public struct ClaudeRemoteEnrollmentService: Sendable {
         }
     }
 
+    /// Whether this instance can edit `~/.ssh/config`. Production always wires
+    /// the live file system; a model that cannot edit also never wrote a block
+    /// through this service, so Remove Host has nothing to reverse through it
+    /// and must not treat that as a failure.
+    public var canEditSSHConfig: Bool { sshConfigFileSystem != nil }
+
     // MARK: - SSH config editing
 
     /// Insert or replace this host's block in an ssh config's text.
@@ -521,8 +564,28 @@ public struct ClaudeRemoteEnrollmentService: Sendable {
     /// disagree.
     public func insertSSHConfig(snippet: String, hostID: String) throws {
         Log.claudeContext.info("Claude remote ssh config insertion requested")
+        try writeSSHConfig(operation: "insertion") {
+            Self.applySSHConfigSnippet(to: $0, snippet: snippet, hostID: hostID)
+        }
+    }
+
+    /// Remove one marked host block through the same trust gate and atomic
+    /// writer used for enrollment.
+    public func removeSSHConfig(hostID: String) throws {
+        Log.claudeContext.info("Claude remote ssh config removal requested")
+        try writeSSHConfig(operation: "removal") {
+            Self.removeSSHConfigSnippet(from: $0, hostID: hostID)
+        }
+    }
+
+    private func writeSSHConfig(
+        operation: String,
+        transform: (String) -> String
+    ) throws {
         guard let sshConfigFileSystem else {
-            Log.claudeContext.error("Claude remote ssh config insertion failed: editing not configured")
+            Log.claudeContext.error(
+                "Claude remote ssh config \(operation, privacy: .public) failed: editing not configured"
+            )
             throw ServiceError.sshConfigEditingNotConfigured
         }
         do {
@@ -547,11 +610,7 @@ public struct ClaudeRemoteEnrollmentService: Sendable {
             } else {
                 existing = ""
             }
-            let updated = Self.applySSHConfigSnippet(
-                to: existing,
-                snippet: snippet,
-                hostID: hostID
-            )
+            let updated = transform(existing)
             if !state.directoryExists {
                 try sshConfigFileSystem.createSSHDirectory(permissions: 0o700)
             }
@@ -559,10 +618,12 @@ public struct ClaudeRemoteEnrollmentService: Sendable {
                 Data(updated.utf8),
                 permissions: state.configPermissions ?? 0o600
             )
-            Log.claudeContext.info("Claude remote ssh config insertion completed")
+            Log.claudeContext.info(
+                "Claude remote ssh config \(operation, privacy: .public) completed"
+            )
         } catch {
             Log.claudeContext.error(
-                "Claude remote ssh config insertion failed: \(String(describing: error), privacy: .public)"
+                "Claude remote ssh config \(operation, privacy: .public) failed: \(String(describing: error), privacy: .public)"
             )
             throw error
         }
@@ -740,6 +801,291 @@ public struct ClaudeRemoteEnrollmentService: Sendable {
         )
     }
 
+    /// Install or update the remote plugin, then prove the installed version
+    /// before the SSH session exits — all in ONE ssh session, so the proof
+    /// describes the install that just ran. Plugin-list output is consumed
+    /// remotely because it can contain a stored token this process cannot
+    /// redact; only our own sentinel reaches this side.
+    ///
+    /// The version check reads the line `claude plugin list` prints for our
+    /// reference (`<name>@<marketplace> <version>` — the same line
+    /// `ClaudePluginStatus.installedVersion` reads) and matches the version as
+    /// a space-delimited word, so `11.7.0` can never satisfy `1.7.0`.
+    public func setupRemotePlugin(
+        sshHostAlias: String,
+        token: String?,
+        remoteForwardPort: UInt16,
+        timeout: TimeInterval = defaultRemoteSetupTimeout
+    ) throws -> PluginSetupOutcome {
+        guard let runner else { throw ServiceError.executionNotConfigured }
+        guard Self.isValidHostAlias(sshHostAlias) else { throw ServiceError.invalidHostAlias }
+        let reference = Self.remotePluginReference
+        let tokenArguments = token.map {
+            " --config '\(Self.tokenConfigKey)=\($0)'"
+        } ?? ""
+        // Decided HERE, not on the host: an absent plugin can only be installed
+        // with a credential, and the update path deliberately has none (the
+        // one-time enrollment token is long gone). Installing tokenless would
+        // look exactly like a healthy enrollment failing open, so the script
+        // reports the absence and the run names the remedy instead.
+        let absentBranch = token == nil
+            ? """
+              printf '%s\\n' LVX_PLUGIN_ABSENT
+              exit 44
+
+            """
+            : """
+              claude plugin marketplace add \(Self.repositoryMarketplaceReference)
+              claude plugin install \(reference)\(tokenArguments) --config '\(Self.portConfigKey)=\(remoteForwardPort)'
+              lv_outcome=LVX_PLUGIN_INSTALLED
+
+            """
+        let script = """
+            set -eu
+            \(Self.claudePathResolverPreamble)lv_line=$(claude plugin list 2>&1 | grep -F '\(reference)' | head -n 1)
+            if [ -z "$lv_line" ]; then
+            \(absentBranch)else
+              lv_current=0
+              case " $lv_line " in
+                *" \(Self.remotePluginVersion) "*) lv_current=1 ;;
+              esac
+              if [ "$lv_current" -eq 0 ]; then
+                claude plugin marketplace update \(ClaudePluginAssets.marketplaceName)
+                claude plugin update \(reference)
+                lv_outcome=LVX_PLUGIN_UPDATED
+              else
+                lv_outcome=LVX_PLUGIN_ALREADY_CURRENT
+              fi
+              claude plugin install \(reference)\(tokenArguments) --config '\(Self.portConfigKey)=\(remoteForwardPort)'
+            fi
+            lv_after=$(claude plugin list 2>&1 | grep -F '\(reference)' | head -n 1)
+            case " $lv_after " in
+              *" \(Self.remotePluginVersion) "*) : ;;
+              *) exit 43 ;;
+            esac
+            printf '%s\\n' "$lv_outcome"
+            """
+        let result: RunResult
+        do {
+            result = try runner(
+                Invocation(
+                    argv: [
+                        "ssh", "-o", "BatchMode=yes", "-o", "ClearAllForwardings=yes", "--",
+                        sshHostAlias, "/bin/sh", "-s",
+                    ],
+                    standardInput: Data(script.utf8),
+                    timeout: max(timeout, 0)
+                )
+            )
+        } catch {
+            throw sanitizedRunnerError(error, command: "install and verify remote plugin")
+        }
+        if result.exitCode == 44 {
+            throw ServiceError.commandFailed(
+                step: 0,
+                command: "install and verify remote plugin",
+                exitCode: 44,
+                message: ClaudeRemoteTokenRedaction.redact(
+                    "The plugin is not installed on the host, and this run has no token to "
+                        + "give it. Rotate this host's token, then run setup again.",
+                    token: token ?? ""
+                )
+            )
+        }
+        guard result.succeeded else {
+            throw ServiceError.commandFailed(
+                step: 0,
+                command: "install and verify remote plugin",
+                exitCode: result.exitCode,
+                message: ClaudeRemoteTokenRedaction.redact(
+                    "The plugin is installed but did not report version "
+                        + Self.remotePluginVersion
+                        + " when read back in the same session.",
+                    token: token ?? ""
+                )
+            )
+        }
+        if result.message.contains("LVX_PLUGIN_INSTALLED") { return .installed }
+        if result.message.contains("LVX_PLUGIN_UPDATED") { return .updated }
+        if result.message.contains("LVX_PLUGIN_ALREADY_CURRENT") { return .alreadyCurrent }
+        throw ServiceError.runnerFailed(
+            step: 0,
+            command: "install and verify remote plugin",
+            message: "The host did not report a plugin setup outcome."
+        )
+    }
+
+    /// Prove that this process's LC_LVX_TTY value crosses sshd. The random
+    /// value exists only in the child environment and is never logged.
+    ///
+    /// The echo is FRAMED (`LVX_TTY:<value>`) and only the first framed line
+    /// is read, for the same reason every other probe frames: stderr shares
+    /// the capture pipe, and a login banner or MOTD glued to the value would
+    /// otherwise turn a healthy crossing into a "remote refused it" verdict.
+    /// The frame is never interpreted — the payload is compared by exact
+    /// equality with the minted value and nothing else.
+    public func probeRemoteEnvironment(
+        sshHostAlias: String,
+        timeout: TimeInterval = defaultVerificationTimeout
+    ) throws -> EnvironmentCrossingOutcome {
+        guard let runner else { throw ServiceError.executionNotConfigured }
+        guard Self.isValidHostAlias(sshHostAlias) else { throw ServiceError.invalidHostAlias }
+        let probe = environmentProbeValue()
+        let invocation = Invocation(
+            argv: [
+                "ssh", "-o", "BatchMode=yes", "-o", "ClearAllForwardings=yes", "--",
+                sshHostAlias, "/bin/sh", "-s",
+            ],
+            standardInput: Data("printf 'LVX_TTY:%s\\n' \"${LC_LVX_TTY-}\"\n".utf8),
+            timeout: max(timeout, 0),
+            environment: ["LC_LVX_TTY": probe]
+        )
+        let result: RunResult
+        do {
+            result = try runner(invocation)
+        } catch {
+            throw sanitizedRunnerError(error, command: "check remote environment")
+        }
+        guard result.succeeded else {
+            throw ServiceError.commandFailed(
+                step: 0,
+                command: "check remote environment",
+                exitCode: result.exitCode,
+                message: "SSH did not complete the environment check."
+            )
+        }
+        let echoed = Self.framedProbeAnswer(in: result.message)
+            .flatMap { $0.hasPrefix(Self.envProbeFramePrefix) ? String($0.dropFirst(Self.envProbeFramePrefix.count)) : nil }
+        guard echoed == probe else {
+            let configResult: RunResult
+            do {
+                configResult = try runner(
+                    Invocation(
+                        argv: ["ssh", "-G", "--", sshHostAlias],
+                        standardInput: Data(),
+                        timeout: max(timeout, 0)
+                    )
+                )
+            } catch {
+                throw sanitizedRunnerError(error, command: "inspect SSH SendEnv")
+            }
+            guard configResult.succeeded else {
+                throw ServiceError.commandFailed(
+                    step: 0,
+                    command: "inspect SSH SendEnv",
+                    exitCode: configResult.exitCode,
+                    message: "OpenSSH could not expand this host's configuration."
+                )
+            }
+            return Self.sshGOutputSendsLocalTTY(configResult.message)
+                ? .remoteAcceptEnvMissing
+                : .localSendEnvMissing
+        }
+        return .crossed
+    }
+
+    /// Configure the remote herdr panel when herdr exists. Absence and a
+    /// customized agents table are deliberate skipped outcomes, not failures.
+    public func setupRemoteHerdr(
+        sshHostAlias: String,
+        timeout: TimeInterval = defaultRemoteSetupTimeout
+    ) throws -> HerdrSetupOutcome {
+        guard Self.isValidHostAlias(sshHostAlias) else { throw ServiceError.invalidHostAlias }
+        let script = """
+            set -eu
+            if ! command -v herdr >/dev/null 2>&1; then
+              for lv_dir in "$HOME/.claude/local" "$HOME/.local/bin" "$HOME/bin" /opt/homebrew/bin /usr/local/bin "$HOME"/.nvm/versions/node/*/bin; do
+                if [ -x "$lv_dir/herdr" ]; then PATH="$lv_dir:$PATH"; break; fi
+              done
+            fi
+            if ! command -v herdr >/dev/null 2>&1; then
+              printf '%s\\n' LVX_HERDR_ABSENT
+              exit 0
+            fi
+            lv_config=${HERDR_CONFIG_PATH:-${XDG_CONFIG_HOME:-$HOME/.config}/herdr/config.toml}
+            if [ -f "$lv_config" ] && grep -Eq '^[[:space:]]*\\[ui\\.sidebar\\.agents\\][[:space:]]*(#.*)?$|^[[:space:]]*rows[[:space:]]*=' "$lv_config"; then
+              printf '%s\\n' LVX_HERDR_CUSTOMIZED
+              exit 42
+            fi
+            mkdir -p "$(dirname "$lv_config")"
+            touch "$lv_config"
+            cat >> "$lv_config" <<'LOCALVOXTRAL_HERDR_PANEL'
+            \(Self.herdrPanelConfigSnippet)
+            LOCALVOXTRAL_HERDR_PANEL
+            herdr server reload-config
+            printf '%s\\n' LVX_HERDR_CONFIGURED
+            """
+        guard let runner else { throw ServiceError.executionNotConfigured }
+        let invocation = Invocation(
+            argv: [
+                "ssh", "-o", "BatchMode=yes", "-o", "ClearAllForwardings=yes", "--",
+                sshHostAlias, "/bin/sh", "-s",
+            ],
+            standardInput: Data(script.utf8),
+            timeout: max(timeout, 0)
+        )
+        let result: RunResult
+        do {
+            result = try runner(invocation)
+        } catch {
+            throw sanitizedRunnerError(error, command: "configure remote herdr")
+        }
+        if result.exitCode == 42, result.message.contains("LVX_HERDR_CUSTOMIZED") {
+            return .customized
+        }
+        guard result.succeeded else {
+            throw ServiceError.commandFailed(
+                step: 0,
+                command: "configure remote herdr",
+                exitCode: result.exitCode,
+                message: "The remote herdr setup command failed."
+            )
+        }
+        if result.message.contains("LVX_HERDR_ABSENT") { return .notFound }
+        return .configured
+    }
+
+    private func sanitizedRunnerError(_ error: Error, command: String) -> ServiceError {
+        if let failure = error as? RunnerFailure {
+            switch failure {
+            case .timedOut(let seconds, _):
+                return .commandTimedOut(
+                    step: 0, command: command, seconds: seconds, message: "The host timed out."
+                )
+            case .outputTooLarge(let capBytes, _):
+                return .runnerFailed(
+                    step: 0,
+                    command: command,
+                    message: "The host exceeded the \(capBytes)-byte output limit."
+                )
+            }
+        }
+        return .runnerFailed(
+            step: 0, command: command, message: "The remote command could not be started."
+        )
+    }
+
+    private static func sshGOutputSendsLocalTTY(_ output: String) -> Bool {
+        output.split(whereSeparator: \.isNewline).contains { line in
+            let fields = line.split(whereSeparator: \.isWhitespace)
+            guard fields.first?.lowercased() == "sendenv" else { return false }
+            return fields.dropFirst().contains { wildcard($0, matches: "LC_LVX_TTY") }
+        }
+    }
+
+    private static func wildcard(_ pattern: Substring, matches value: String) -> Bool {
+        let parts = pattern.split(separator: "*", omittingEmptySubsequences: false)
+        if parts.count == 1 { return String(pattern) == value }
+        var remainder = value[...]
+        for (index, part) in parts.enumerated() where !part.isEmpty {
+            guard let range = remainder.range(of: part) else { return false }
+            if index == 0, range.lowerBound != remainder.startIndex { return false }
+            remainder = remainder[range.upperBound...]
+        }
+        if let last = parts.last, !last.isEmpty { return remainder.isEmpty }
+        return true
+    }
+
     /// Append localvoxtral's agents-panel row only when the remote config has
     /// no agents table and no rows key. The caller must obtain explicit consent
     /// immediately before invoking this method.
@@ -852,14 +1198,14 @@ public struct ClaudeRemoteEnrollmentService: Sendable {
             )
             throw ServiceError.invalidHostAlias
         }
-        let deadline = Date().addingTimeInterval(max(timeout, 0))
+        let deadline = now().addingTimeInterval(max(timeout, 0))
         var completed: [ExecutionStep] = []
         for (index, command) in commands.enumerated() {
             let displayCommand = ClaudeRemoteTokenRedaction.redact(
                 command.trimmingCharacters(in: .whitespaces),
                 token: token
             )
-            let remaining = max(deadline.timeIntervalSinceNow, 0)
+            let remaining = max(deadline.timeIntervalSince(now()), 0)
             guard remaining > 0 else {
                 let failure = ServiceError.commandTimedOut(
                     step: index, command: displayCommand, seconds: timeout, message: ""
@@ -1127,6 +1473,8 @@ public struct ClaudeRemoteEnrollmentService: Sendable {
     /// completely different fixes — the plugin's shim IS curl, so a host
     /// without it can never deliver context no matter how healthy the tunnel.
     static let missingCurlSentinel = "LVX_NO_CURL"
+    /// Frame carrying the env probe's echo. Payload compared by equality only.
+    static let envProbeFramePrefix = "LVX_TTY:"
 
     static func tunnelProbeScript(remoteForwardPort: UInt16) -> Data {
         Data("""

--- a/Sources/localvoxtral/ClaudeContext/ClaudeRemoteEnrollmentService.swift
+++ b/Sources/localvoxtral/ClaudeContext/ClaudeRemoteEnrollmentService.swift
@@ -954,8 +954,8 @@ public struct ClaudeRemoteEnrollmentService: Sendable {
                 message: "SSH did not complete the environment check."
             )
         }
-        let echoed = Self.framedProbeAnswer(in: result.message)
-            .flatMap { $0.hasPrefix(Self.envProbeFramePrefix) ? String($0.dropFirst(Self.envProbeFramePrefix.count)) : nil }
+        let echoed = Self.framedProbeAnswer(in: result.message, prefix: Self.envProbeFramePrefix)
+            .map { String($0.dropFirst(Self.envProbeFramePrefix.count)) }
         guard echoed == probe else {
             let configResult: RunResult
             do {
@@ -1488,11 +1488,11 @@ public struct ClaudeRemoteEnrollmentService: Sendable {
     }
 
     /// The first framed line, or nil when the probe never spoke.
-    static func framedProbeAnswer(in output: String) -> String? {
+    static func framedProbeAnswer(in output: String, prefix: String = probeFramePrefix) -> String? {
         output
             .components(separatedBy: .newlines)
             .map { $0.trimmingCharacters(in: .whitespaces) }
-            .first { $0.hasPrefix(probeFramePrefix) }
+            .first { $0.hasPrefix(prefix) }
     }
 
     /// The local half of the tunnel verdict, as its own value.

--- a/Sources/localvoxtral/ClaudeContext/ClaudeRemoteEnrollmentService.swift
+++ b/Sources/localvoxtral/ClaudeContext/ClaudeRemoteEnrollmentService.swift
@@ -892,17 +892,29 @@ public struct ClaudeRemoteEnrollmentService: Sendable {
                 )
             )
         }
-        guard result.succeeded else {
+        if result.exitCode == 43 {
             throw ServiceError.commandFailed(
                 step: 0,
                 command: "install and verify remote plugin",
-                exitCode: result.exitCode,
+                exitCode: 43,
                 message: ClaudeRemoteTokenRedaction.redact(
                     "The plugin is installed but did not report version "
                         + Self.remotePluginVersion
                         + " when read back in the same session.",
                     token: token ?? ""
                 )
+            )
+        }
+        guard result.succeeded else {
+            let message = result.exitCode == 127
+                ? "Claude CLI was not found on the remote host. "
+                    + "Install Claude Code there, or put it on the non-interactive SSH PATH."
+                : "The remote plugin setup command failed."
+            throw ServiceError.commandFailed(
+                step: 0,
+                command: "install and verify remote plugin",
+                exitCode: result.exitCode,
+                message: ClaudeRemoteTokenRedaction.redact(message, token: token ?? "")
             )
         }
         if result.message.contains("LVX_PLUGIN_INSTALLED") { return .installed }

--- a/Sources/localvoxtral/SettingsView.swift
+++ b/Sources/localvoxtral/SettingsView.swift
@@ -1352,7 +1352,7 @@ private struct ClaudeRemoteHostsSettingsRow: View {
                             }
                         }
                         Spacer()
-                        Button("Update Plugin…") { model.requestPluginUpdate(hostID: host.id) }
+                        Button("Update Host…") { model.requestPluginUpdate(hostID: host.id) }
                             .controlSize(.small)
                             .disabled(model.isEnrollmentBusy)
                         Button("Rotate Token") { Task { await model.rotate(hostID: host.id) } }

--- a/Sources/localvoxtral/SettingsView.swift
+++ b/Sources/localvoxtral/SettingsView.swift
@@ -1343,6 +1343,13 @@ private struct ClaudeRemoteHostsSettingsRow: View {
                             Text(host.statusText)
                                 .font(.caption)
                                 .foregroundStyle(.secondary)
+                            // The one-flow setup's last word for this host,
+                            // written by the run, not computed here.
+                            if let setupStatus = host.setupStatusText {
+                                Text(setupStatus)
+                                    .font(.caption)
+                                    .foregroundStyle(.secondary)
+                            }
                         }
                         Spacer()
                         Button("Update Plugin…") { model.requestPluginUpdate(hostID: host.id) }
@@ -1464,13 +1471,22 @@ private struct ClaudeRemoteHostsSettingsRow: View {
                     }
                     .controlSize(.small)
                 } else if update.canRun {
-                    Button("Run on SSH host") { model.requestPluginUpdateRun() }
-                        .controlSize(.small)
-                        .disabled(model.isEnrollmentBusy)
+                    HStack(spacing: 8) {
+                        Button("Run on SSH host") { model.requestPluginUpdateRun() }
+                            .controlSize(.small)
+                            .disabled(model.isEnrollmentBusy)
+                        Button("Update Host") { model.requestHostUpdateRun() }
+                            .controlSize(.small)
+                            .disabled(model.isEnrollmentBusy)
+                    }
+                    updateHostConfirmation(for: host)
                 } else {
                     Text("Replace your-ssh-host with the alias from your ~/.ssh/config, then apply both steps above yourself — the ssh-config block first.")
                         .font(.caption)
                         .foregroundStyle(.secondary)
+                }
+                if model.setupRun?.hostID == host.id {
+                    ClaudeSetupRunSteps(model: model, hostID: host.id)
                 }
                 if model.enrollmentResultsAction == action {
                     ClaudeEnrollmentStepResults(statuses: model.enrollmentStepStatuses)
@@ -1478,6 +1494,37 @@ private struct ClaudeRemoteHostsSettingsRow: View {
             }
             .padding(.leading, 8)
             .padding(.bottom, 4)
+        }
+    }
+
+    /// The one-flow update's consent, inside the row whose button asked for it.
+    ///
+    /// Same shape as the plugin-update confirmation above it: the exact preview
+    /// the run will apply, then one confirming button. The run's own step list
+    /// renders below, shared with the enrollment sheet.
+    @ViewBuilder
+    private func updateHostConfirmation(
+        for host: ClaudeIntegrationSettingsModel.HostRow
+    ) -> some View {
+        let action = ClaudeIntegrationSettingsModel.EnrollmentAction.updateHost(hostID: host.id)
+        if let confirmation = model.enrollmentConfirmation,
+           confirmation.action == action {
+            Text(confirmation.title).font(.body).bold()
+            Text(confirmation.preview)
+                .font(.system(size: 12, design: .monospaced))
+                .textSelection(.enabled)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(8)
+                .background(Color.orange.opacity(0.10), in: RoundedRectangle(cornerRadius: 4))
+            HStack {
+                Button("Cancel") { model.cancelEnrollmentActionConfirmation() }
+                Button(confirmation.confirmButtonTitle) {
+                    Task { await model.confirmEnrollmentAction() }
+                }
+                .buttonStyle(.borderedProminent)
+                .accessibilityIdentifier("integrations.remote.setup.run")
+            }
+            .controlSize(.small)
         }
     }
 
@@ -1577,6 +1624,77 @@ private struct ClaudeEnrollmentStepResults: View {
     }
 }
 
+/// One consented setup run, one line per step.
+///
+/// Shared by the enrollment sheet and the per-host update panel: both start the
+/// same run and both render the same six steps. The model owns every sentence;
+/// this renders strings.
+private struct ClaudeSetupRunSteps: View {
+    @Bindable var model: ClaudeIntegrationSettingsModel
+    var hostID: String
+
+    var body: some View {
+        if let run = model.setupRun, run.hostID == hostID {
+            VStack(alignment: .leading, spacing: 4) {
+                ForEach(run.items) { item in
+                    HStack(spacing: 6) {
+                        Text(Self.glyph(for: item.state))
+                            .font(.body)
+                            .foregroundStyle(
+                                Self.isFailure(item.state)
+                                    ? AnyShapeStyle(.orange) : AnyShapeStyle(.primary))
+                        VStack(alignment: .leading, spacing: 1) {
+                            Text(item.step.title)
+                                .font(.body)
+                            Text(Self.statusLine(for: item.state))
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+                        }
+                    }
+                    .lineLimit(1)
+                    .accessibilityIdentifier("integrations.remote.setup.step.\(item.step.rawValue)")
+                }
+            }
+            if model.isEnrollmentBusy {
+                Button("Cancel") { model.cancelSetupRun() }
+                    .controlSize(.small)
+                    .accessibilityIdentifier("integrations.remote.setup.cancel")
+            }
+            if let manual = model.setupManualInstructions {
+                Text(manual)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .textSelection(.enabled)
+            }
+        }
+    }
+
+    private static func glyph(for state: RemoteHostSetupRun.State) -> String {
+        switch state {
+        case .pending: return "○"
+        case .running: return "●"
+        case .done: return "✓"
+        case .skipped: return "–"
+        case .failed: return "✗"
+        }
+    }
+
+    private static func isFailure(_ state: RemoteHostSetupRun.State) -> Bool {
+        if case .failed = state { return true }
+        return false
+    }
+
+    private static func statusLine(for state: RemoteHostSetupRun.State) -> String {
+        switch state {
+        case .pending: return "Waiting."
+        case .running: return "Running."
+        case .done(let summary): return summary
+        case .skipped(let reason): return reason
+        case .failed(let reason, _): return reason
+        }
+    }
+}
+
 /// The token, shown exactly once.
 ///
 /// The registry stores only hashes, so this sheet is genuinely the user's one
@@ -1626,6 +1744,7 @@ private struct ClaudeRemoteEnrollmentSheet: View {
                         body: presentation.token,
                         note: "It cannot be shown again. If you lose it, rotate."
                     )
+                    setupRunSection
                     section(
                         "1. Add the SSH config",
                         body: plan.sshConfigSnippet,
@@ -1692,6 +1811,51 @@ private struct ClaudeRemoteEnrollmentSheet: View {
         }
         .padding(18)
         .frame(width: 580, height: 580)
+    }
+
+    /// The one flow: every numbered step below, in order, each self-verifying.
+    ///
+    /// Consent covers the whole run at once — the preview names what lands on
+    /// this Mac (the ssh block, the shell block) and what runs on the host —
+    /// and the run stops at the first failure with its remedy. The numbered
+    /// sections stay for copying each step by hand.
+    private var setupRunSection: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Text("Set up this host").font(.headline)
+            Text("Runs all six steps in order, stopping at the first failure with its remedy.")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+            let action = ClaudeIntegrationSettingsModel.EnrollmentAction.setupHost
+            if let confirmation = model.enrollmentConfirmation,
+               confirmation.action == action {
+                Text(confirmation.preview)
+                    .font(.system(size: 12, design: .monospaced))
+                    .textSelection(.enabled)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .padding(8)
+                    .background(Color.orange.opacity(0.10), in: RoundedRectangle(cornerRadius: 4))
+                Text(confirmation.title).font(.body).bold()
+                HStack {
+                    Button("Cancel") { model.cancelEnrollmentActionConfirmation() }
+                    Button(confirmation.confirmButtonTitle) {
+                        Task { await model.confirmEnrollmentAction() }
+                    }
+                    .buttonStyle(.borderedProminent)
+                    .accessibilityIdentifier("integrations.remote.setup.run")
+                }
+                .controlSize(.small)
+            } else if !model.isEnrollmentBusy {
+                // Re-runnable on purpose: a failed run's remedy is usually
+                // "fix that, then run it again", and the reset (`setupRun`
+                // is cleared by `requestHostSetup`) makes the new run's list
+                // replace the old one rather than append to it.
+                Button("Run Setup", action: { model.requestHostSetup() })
+                    .buttonStyle(.borderedProminent)
+                    .controlSize(.small)
+                    .disabled(actionsDisabled || !presentation.canRunRemoteSetup)
+            }
+            ClaudeSetupRunSteps(model: model, hostID: presentation.host.id)
+        }
     }
 
     /// Step 3: the app runs the checks and states the verdict.

--- a/Tests/localvoxtralTests/ClaudeIntegrationSettingsModelTests.swift
+++ b/Tests/localvoxtralTests/ClaudeIntegrationSettingsModelTests.swift
@@ -2758,7 +2758,7 @@ final class ClaudeIntegrationSettingsModelTests: XCTestCase {
         let rcFS = StubRCFileSystem(state: ClaudeShellRCState(
             fileExists: true, data: Data("export EDITOR=vim\n".utf8), permissions: 0o644
         ))
-        let (model, hostID, sshFS, _) = try await enrollAndRunSetup(rcFileSystem: rcFS)
+        let (model, hostID, sshFS, recorder) = try await enrollAndRunSetup(rcFileSystem: rcFS)
 
         let run = try XCTUnwrap(model.setupRun)
         XCTAssertEqual(run.hostID, hostID)
@@ -2778,6 +2778,20 @@ final class ClaudeIntegrationSettingsModelTests: XCTestCase {
         XCTAssertNil(model.alert)
         XCTAssertEqual(rcFS.writes, 1, "the shell block was written, not just reported")
         XCTAssertTrue(sshFS.configText?.contains("SendEnv LC_LVX_TTY") == true)
+        let invocationOrder = recorder.all.map { invocation in
+            let script = String(decoding: invocation.standardInput, as: UTF8.self)
+            if script.contains("LVX_PLUGIN") { return "remote plugin" }
+            if script.contains("LC_LVX_TTY") { return "environment crossing" }
+            if script.contains("LVX_HERDR") { return "remote herdr" }
+            if script.contains("SessionStart") { return "tunnel check" }
+            if script.contains("claude plugin list") { return "plugin check" }
+            return "unexpected"
+        }
+        XCTAssertEqual(
+            invocationOrder,
+            ["remote plugin", "environment crossing", "remote herdr", "tunnel check", "plugin check"],
+            "each step must finish before the next one starts"
+        )
     }
 
     @MainActor

--- a/Tests/localvoxtralTests/ClaudeIntegrationSettingsModelTests.swift
+++ b/Tests/localvoxtralTests/ClaudeIntegrationSettingsModelTests.swift
@@ -175,6 +175,38 @@ private final class StubForwarding: ClaudeRemoteForwarding {
     }
 }
 
+/// One scripted answer per ssh shape the six-step run can make. Dispatch is
+/// by shape — `ssh -G`, the env probe's stdin, the plugin/herdr sentinels,
+/// the two verification probes — so a step that never ran is visible as an
+/// invocation that never arrived. The env echo arrives framed with banner
+/// noise on both sides, as a real login shell's merged stdout/stderr would
+/// deliver it.
+private struct SetupFlowScript: Sendable {
+    var plugin = ClaudeRemoteEnrollmentService.RunResult(
+        exitCode: 0, message: "LVX_PLUGIN_INSTALLED"
+    )
+    var envEchoesBack = true
+    var sendEnvOutput = "hostname builder\nsendenv LANG LC_*\n"
+    var herdr = ClaudeRemoteEnrollmentService.RunResult(
+        exitCode: 0, message: "LVX_HERDR_ABSENT"
+    )
+    var tunnelMessage = "LVX_HTTP:401"
+    var pluginListMessage = "localvoxtral-remote 1.7.0\n"
+}
+
+/// Records every ssh invocation the run makes, from the nonisolated runner
+/// closure. File scope, not nested in the @MainActor test class: nested types
+/// inherit the enclosing actor's isolation, and `Synchronization.Mutex` is
+/// noncopyable and cannot be moved across it — the same reason every other
+/// Sendable stub in this file lives out here.
+private final class SetupFlowRecorder: @unchecked Sendable {
+    private let invocations = Mutex<[ClaudeRemoteEnrollmentService.Invocation]>([])
+    func record(_ invocation: ClaudeRemoteEnrollmentService.Invocation) {
+        invocations.withLock { $0.append(invocation) }
+    }
+    var all: [ClaudeRemoteEnrollmentService.Invocation] { invocations.withLock { $0 } }
+}
+
 @MainActor
 final class ClaudeIntegrationSettingsModelTests: XCTestCase {
     private func makeRegistry() throws -> ClaudeRemoteHostRegistry {
@@ -198,7 +230,12 @@ final class ClaudeIntegrationSettingsModelTests: XCTestCase {
         // a test that computed the allocation would only prove the derivation
         // twice.
         remoteForwardPort: UInt16 = ClaudeRemoteForwardPort.legacyPort,
-        forwards: ClaudeRemoteForwardCoordinator? = nil
+        forwards: ClaudeRemoteForwardCoordinator? = nil,
+        loginShell: @escaping @Sendable () -> ClaudeShellKind? = { nil },
+        shellRCWriter: @escaping @Sendable (ClaudeShellKind) -> ClaudeShellRCWriter? = { _ in nil },
+        liveLocalTTYReport: @escaping @Sendable () -> ClaudeShellSetupStatus.CrossingState = {
+            .noSessions
+        }
     ) -> ClaudeIntegrationSettingsModel {
         ClaudeIntegrationSettingsModel(
             registry: registry,
@@ -238,7 +275,10 @@ final class ClaudeIntegrationSettingsModelTests: XCTestCase {
             },
             now: now,
             remoteForwardPort: remoteForwardPort,
-            forwards: forwards
+            forwards: forwards,
+            loginShell: loginShell,
+            shellRCWriter: shellRCWriter,
+            liveLocalTTYReport: liveLocalTTYReport
         )
     }
 
@@ -2608,6 +2648,358 @@ final class ClaudeIntegrationSettingsModelTests: XCTestCase {
         await model.applyShellSetup()
         XCTAssertEqual(fileSystem.writes, 0, "a dotfiles symlink is never written through")
         XCTAssertEqual(model.alert?.title, "Could not update your shell startup file")
+    }
+
+    // MARK: - One-flow setup run
+
+    private func failedReason(_ state: RemoteHostSetupRun.State) -> String? {
+        if case .failed(let reason, _) = state { return reason }
+        return nil
+    }
+
+    private func setupFlowRunner(
+        script: SetupFlowScript,
+        recorder: SetupFlowRecorder
+    ) -> ClaudeRemoteEnrollmentService.Runner {
+        { invocation in
+            recorder.record(invocation)
+            let stdin = String(decoding: invocation.standardInput, as: UTF8.self)
+            if invocation.argv.contains("-G") {
+                return .init(exitCode: 0, message: script.sendEnvOutput)
+            }
+            if stdin.contains("LC_LVX_TTY") {
+                return script.envEchoesBack
+                    ? .init(
+                        exitCode: 0,
+                        message: "Welcome to builder\n"
+                            + ClaudeRemoteEnrollmentService.envProbeFramePrefix
+                            + (invocation.environment["LC_LVX_TTY"] ?? "")
+                            + "\nLast login: today\n"
+                    )
+                    : .init(exitCode: 0, message: "")
+            }
+            // Before "claude plugin list": the setup script contains both.
+            if stdin.contains("LVX_PLUGIN") { return script.plugin }
+            if stdin.contains("LVX_HERDR") { return script.herdr }
+            if stdin.contains("SessionStart") {
+                return .init(exitCode: 0, message: script.tunnelMessage)
+            }
+            if stdin.contains("claude plugin list") {
+                return .init(exitCode: 0, message: script.pluginListMessage)
+            }
+            return .init(exitCode: 1, message: "unexpected invocation")
+        }
+    }
+
+    @MainActor
+    private func setupFlowModel(
+        registry: ClaudeRemoteHostRegistry,
+        listener: StubListener,
+        service: ClaudeRemoteEnrollmentService,
+        shell: ClaudeShellKind? = .zsh,
+        rcFileSystem: StubRCFileSystem? = nil
+    ) -> ClaudeIntegrationSettingsModel {
+        let rc = rcFileSystem
+        return makeModel(
+            registry: registry,
+            listener: listener,
+            enrollmentService: service,
+            loginShell: { shell },
+            shellRCWriter: { _ in rc.map { ClaudeShellRCWriter(fileSystem: $0) } }
+        )
+    }
+
+    /// Enroll one host and confirm the one-flow setup, returning the model and
+    /// host id for assertions on the finished run.
+    @MainActor
+    private func enrollAndRunSetup(
+        script: SetupFlowScript = SetupFlowScript(),
+        shell: ClaudeShellKind? = .zsh,
+        rcFileSystem: StubRCFileSystem? = StubRCFileSystem(state: ClaudeShellRCState(
+            fileExists: true, data: Data("export EDITOR=vim\n".utf8), permissions: 0o644
+        ))
+    ) async throws -> (
+        model: ClaudeIntegrationSettingsModel,
+        hostID: String,
+        sshFS: StubSSHConfigFileSystem,
+        recorder: SetupFlowRecorder
+    ) {
+        let registry = try makeRegistry()
+        let sshFS = StubSSHConfigFileSystem()
+        let recorder = SetupFlowRecorder()
+        let service = ClaudeRemoteEnrollmentService(
+            runner: setupFlowRunner(script: script, recorder: recorder),
+            sshConfigFileSystem: sshFS
+        )
+        let listener = StubListener(hosts: registry)
+        // Bound, or the final 401 reads as a squatter and the run cannot pass.
+        listener.isListening = true
+        let model = setupFlowModel(
+            registry: registry,
+            listener: listener,
+            service: service,
+            shell: shell,
+            rcFileSystem: rcFileSystem
+        )
+        model.enrollLabel = "buildhost"
+        model.enrollSSHAlias = "builder"
+        await model.enroll()
+        let hostID = try XCTUnwrap(model.hosts.first?.id)
+        model.requestHostSetup()
+        let confirmation = try XCTUnwrap(model.enrollmentConfirmation)
+        XCTAssertTrue(confirmation.preview.contains("Mac ~/.ssh/config"))
+        XCTAssertTrue(confirmation.preview.contains("Remote host:"))
+        await model.confirmEnrollmentAction()
+        return (model, hostID, sshFS, recorder)
+    }
+
+    @MainActor
+    func testSetupRunCompletesAllSixStepsInOrder() async throws {
+        let rcFS = StubRCFileSystem(state: ClaudeShellRCState(
+            fileExists: true, data: Data("export EDITOR=vim\n".utf8), permissions: 0o644
+        ))
+        let (model, hostID, sshFS, _) = try await enrollAndRunSetup(rcFileSystem: rcFS)
+
+        let run = try XCTUnwrap(model.setupRun)
+        XCTAssertEqual(run.hostID, hostID)
+        XCTAssertEqual(run.items.map(\.step), RemoteHostSetupRun.Step.allCases)
+        XCTAssertEqual(run.items[0].state, .done("The SSH config block is current."))
+        XCTAssertEqual(run.items[1].state, .done("The shell startup block is applied."))
+        XCTAssertEqual(run.items[2].state, .done("The remote plugin was installed and verified."))
+        XCTAssertEqual(run.items[3].state, .done("LC_LVX_TTY crossed the SSH connection."))
+        XCTAssertEqual(run.items[4].state, .skipped("herdr is not installed on the remote host."))
+        XCTAssertEqual(run.items[5].state, .done("The tunnel and remote plugin checks passed."))
+        XCTAssertEqual(
+            model.hosts.first?.setupStatusText,
+            "Setup complete.",
+            "the row's sentence is the run's last word"
+        )
+        XCTAssertTrue(model.verificationChecks.allSatisfy(\.passed))
+        XCTAssertNil(model.alert)
+        XCTAssertEqual(rcFS.writes, 1, "the shell block was written, not just reported")
+        XCTAssertTrue(sshFS.configText?.contains("SendEnv LC_LVX_TTY") == true)
+    }
+
+    @MainActor
+    func testSetupRunStopsAtTheFirstFailure() async throws {
+        var script = SetupFlowScript()
+        script.plugin = .init(exitCode: 1, message: "boom")
+        let (model, _, _, recorder) = try await enrollAndRunSetup(script: script)
+
+        let run = try XCTUnwrap(model.setupRun)
+        XCTAssertEqual(failedReason(run.items[2].state), "The remote plugin could not be installed or updated.")
+        XCTAssertEqual(run.items[3].state, .pending)
+        XCTAssertEqual(run.items[4].state, .pending)
+        XCTAssertEqual(run.items[5].state, .pending)
+        XCTAssertEqual(
+            model.hosts.first?.setupStatusText,
+            "Setup stopped at Remote plugin."
+        )
+        XCTAssertEqual(model.alert?.title, "Remote plugin")
+        XCTAssertTrue(
+            recorder.all.allSatisfy { $0.environment.isEmpty },
+            "the env probe never ran after the plugin step failed"
+        )
+    }
+
+    @MainActor
+    func testSetupRunWithoutSendEnvBlamesThisMacsSSHBlock() async throws {
+        var script = SetupFlowScript()
+        script.envEchoesBack = false
+        script.sendEnvOutput = "hostname builder\nsendenv LANG\n"
+        let (model, _, _, _) = try await enrollAndRunSetup(script: script)
+
+        let run = try XCTUnwrap(model.setupRun)
+        XCTAssertEqual(
+            failedReason(run.items[3].state),
+            "This Mac is not sending LC_LVX_TTY for this SSH host."
+        )
+        XCTAssertTrue(model.alert?.detail.contains("SendEnv LC_LVX_TTY") == true)
+        XCTAssertEqual(run.items[4].state, .pending, "herdr never ran after the env failure")
+    }
+
+    @MainActor
+    func testSetupRunWithSendEnvButNoCrossingBlamesTheRemoteSshd() async throws {
+        var script = SetupFlowScript()
+        script.envEchoesBack = false
+        let (model, _, _, recorder) = try await enrollAndRunSetup(script: script)
+
+        let run = try XCTUnwrap(model.setupRun)
+        XCTAssertEqual(
+            failedReason(run.items[3].state),
+            "The remote SSH server did not accept LC_LVX_TTY."
+        )
+        XCTAssertTrue(model.alert?.detail.contains("AcceptEnv LANG LC_*") == true)
+        XCTAssertTrue(recorder.all.contains { $0.argv.contains("-G") })
+    }
+
+    @MainActor
+    func testSetupRunLeavesACustomizedHerdrTableAloneAndStillCompletes() async throws {
+        var script = SetupFlowScript()
+        script.herdr = .init(exitCode: 42, message: "LVX_HERDR_CUSTOMIZED")
+        let (model, _, _, _) = try await enrollAndRunSetup(script: script)
+
+        let run = try XCTUnwrap(model.setupRun)
+        XCTAssertEqual(
+            run.items[4].state,
+            .skipped("The existing herdr agents table was left unchanged.")
+        )
+        XCTAssertTrue(
+            model.setupManualInstructions?.contains(
+                ClaudeRemoteEnrollmentService.herdrPanelConfigSnippet
+            ) == true
+        )
+        XCTAssertEqual(run.items[5].state, .done("The tunnel and remote plugin checks passed."))
+        XCTAssertEqual(model.hosts.first?.setupStatusText, "Setup complete.")
+    }
+
+    @MainActor
+    func testSetupRunWithAnUnsupportedShellSkipsWithTheManualBlock() async throws {
+        let (model, _, _, _) = try await enrollAndRunSetup(shell: nil, rcFileSystem: nil)
+
+        let run = try XCTUnwrap(model.setupRun)
+        XCTAssertEqual(
+            run.items[1].state,
+            .skipped("This login shell is not supported for automatic setup; configure it manually.")
+        )
+        XCTAssertTrue(model.setupManualInstructions?.contains("LC_LVX_TTY") == true)
+        XCTAssertEqual(run.items[5].state, .done("The tunnel and remote plugin checks passed."))
+    }
+
+    @MainActor
+    func testUpdateHostRunsTheSameFlowWithoutAnSSHRewrite() async throws {
+        let registry = try makeRegistry()
+        let sshFS = StubSSHConfigFileSystem()
+        let recorder = SetupFlowRecorder()
+        var script = SetupFlowScript()
+        script.plugin = .init(exitCode: 0, message: "LVX_PLUGIN_UPDATED")
+        let service = ClaudeRemoteEnrollmentService(
+            runner: setupFlowRunner(script: script, recorder: recorder),
+            sshConfigFileSystem: sshFS
+        )
+        let listener = StubListener(hosts: registry)
+        listener.isListening = true
+        let model = setupFlowModel(registry: registry, listener: listener, service: service)
+        model.enrollLabel = "buildhost"
+        model.enrollSSHAlias = "builder"
+        await model.enroll()
+        let presentation = try XCTUnwrap(model.presentedPlan)
+        // The block on disk is already what this build would write.
+        sshFS.configText = ClaudeRemoteEnrollmentService.applySSHConfigSnippet(
+            to: "", snippet: presentation.plan.sshConfigSnippet, hostID: presentation.host.id
+        )
+        model.dismissPlan()
+
+        model.requestPluginUpdate(hostID: presentation.host.id)
+        let update = try XCTUnwrap(model.presentedPluginUpdate)
+        XCTAssertNil(update.sshConfigSnippet, "a current block is the update path, not a rewrite")
+        model.requestHostUpdateRun()
+        await model.confirmEnrollmentAction()
+
+        let run = try XCTUnwrap(model.setupRun)
+        XCTAssertEqual(
+            run.items[0].state,
+            .done("The SSH config block is already current.")
+        )
+        XCTAssertEqual(run.items[2].state, .done("The remote plugin was updated and verified."))
+        XCTAssertEqual(model.hosts.first?.setupStatusText, "Setup complete.")
+    }
+
+    @MainActor
+    func testRemoveReversesTheMacSideQuietlyOnSuccess() async throws {
+        let registry = try makeRegistry()
+        let sshFS = StubSSHConfigFileSystem()
+        // The rc carries our block, so reversal has something to take out.
+        let rcFS = StubRCFileSystem(state: ClaudeShellRCState(
+            fileExists: true,
+            data: ClaudeShellRCSetup.apply(
+                to: "export EDITOR=vim\n",
+                snippet: ClaudeShellRCSetup.snippet(for: .zsh)
+            ).map { Data($0.utf8) },
+            permissions: 0o644
+        ))
+        let service = ClaudeRemoteEnrollmentService(sshConfigFileSystem: sshFS)
+        let listener = StubListener(hosts: registry)
+        let model = setupFlowModel(
+            registry: registry, listener: listener, service: service, rcFileSystem: rcFS
+        )
+        model.enrollLabel = "buildhost"
+        model.enrollSSHAlias = "builder"
+        await model.enroll()
+        let hostID = try XCTUnwrap(model.hosts.first?.id)
+        let presentation = try XCTUnwrap(model.presentedPlan)
+        sshFS.configText = ClaudeRemoteEnrollmentService.applySSHConfigSnippet(
+            to: "", snippet: presentation.plan.sshConfigSnippet, hostID: hostID
+        )
+        model.dismissPlan()
+
+        await model.remove(hostID: hostID)
+
+        XCTAssertTrue(model.hosts.isEmpty)
+        XCTAssertFalse(sshFS.configText?.contains("BEGIN localvoxtral") == true)
+        XCTAssertFalse(
+            String(decoding: rcFS.state.data ?? Data(), as: UTF8.self)
+                .contains("LC_LVX_TTY"),
+            "the last host takes the shell block with it"
+        )
+        XCTAssertEqual(rcFS.writes, 1, "the reversal is a write, not a no-op claim")
+        XCTAssertNil(model.alert, "a clean reversal has nothing to say")
+    }
+
+    @MainActor
+    func testRemoveStillRevokesWhenTheSSHBlockCannotBeRewritten() async throws {
+        let registry = try makeRegistry()
+        let sshFS = RecordingSSHConfigFileSystem()
+        // The one state the writer refuses: a symlinked config, where the
+        // atomic rename would replace the user's link. Revocation must not be
+        // held hostage by it — the registry entry is the off switch.
+        sshFS.setSymlinked(true)
+        let service = ClaudeRemoteEnrollmentService(sshConfigFileSystem: sshFS)
+        let listener = StubListener(hosts: registry)
+        let model = setupFlowModel(
+            registry: registry, listener: listener, service: service, rcFileSystem: nil
+        )
+        model.enrollLabel = "buildhost"
+        model.enrollSSHAlias = "builder"
+        await model.enroll()
+        let hostID = try XCTUnwrap(model.hosts.first?.id)
+        model.dismissPlan()
+
+        await model.remove(hostID: hostID)
+
+        XCTAssertTrue(model.hosts.isEmpty, "revocation is never blocked by the reversal")
+        XCTAssertEqual(sshFS.writeCount, 0)
+        XCTAssertEqual(model.alert?.title, "Remote host removed")
+        XCTAssertTrue(
+            model.alert?.detail.contains("is a symlink") == true,
+            "the leftover block is named with its manual remedy"
+        )
+    }
+
+    @MainActor
+    func testRemoveKeepsTheShellBlockWhileAnotherHostRemains() async throws {
+        let registry = try makeRegistry()
+        let sshFS = StubSSHConfigFileSystem()
+        let rcFS = StubRCFileSystem(state: ClaudeShellRCState(
+            fileExists: true, data: Data("export EDITOR=vim\n".utf8), permissions: 0o644
+        ))
+        let service = ClaudeRemoteEnrollmentService(sshConfigFileSystem: sshFS)
+        let listener = StubListener(hosts: registry)
+        let model = setupFlowModel(
+            registry: registry, listener: listener, service: service, rcFileSystem: rcFS
+        )
+        model.enrollLabel = "buildhost"
+        model.enrollSSHAlias = "builder"
+        await model.enroll()
+        let firstID = try XCTUnwrap(model.hosts.first?.id)
+        model.enrollLabel = "devbox"
+        model.enrollSSHAlias = "devbox"
+        await model.enroll()
+
+        await model.remove(hostID: firstID)
+
+        XCTAssertEqual(model.hosts.count, 1)
+        XCTAssertEqual(rcFS.writes, 0, "a remaining host still needs the shell block")
     }
 
 }

--- a/Tests/localvoxtralTests/ClaudeIntegrationSettingsModelTests.swift
+++ b/Tests/localvoxtralTests/ClaudeIntegrationSettingsModelTests.swift
@@ -2951,6 +2951,55 @@ final class ClaudeIntegrationSettingsModelTests: XCTestCase {
     }
 
     @MainActor
+    func testDismissingAHostUpdateClearsItsConfirmationAndRetainedRun() async throws {
+        let registry = try makeRegistry()
+        let sshFS = StubSSHConfigFileSystem()
+        let recorder = SetupFlowRecorder()
+        var script = SetupFlowScript()
+        script.herdr = .init(exitCode: 42, message: "LVX_HERDR_CUSTOMIZED")
+        let service = ClaudeRemoteEnrollmentService(
+            runner: setupFlowRunner(script: script, recorder: recorder),
+            sshConfigFileSystem: sshFS
+        )
+        let listener = StubListener(hosts: registry)
+        listener.isListening = true
+        let model = setupFlowModel(registry: registry, listener: listener, service: service)
+        model.enrollLabel = "buildhost"
+        model.enrollSSHAlias = "builder"
+        await model.enroll()
+        let presentation = try XCTUnwrap(model.presentedPlan)
+        sshFS.configText = ClaudeRemoteEnrollmentService.applySSHConfigSnippet(
+            to: "",
+            snippet: presentation.plan.sshConfigSnippet,
+            hostID: presentation.host.id
+        )
+        model.dismissPlan()
+
+        model.requestPluginUpdate(hostID: presentation.host.id)
+        model.requestHostUpdateRun()
+        await model.confirmEnrollmentAction()
+        XCTAssertNotNil(model.setupRun)
+        XCTAssertNotNil(model.setupManualInstructions)
+
+        model.dismissPluginUpdate()
+
+        XCTAssertNil(model.setupRun)
+        XCTAssertNil(model.setupManualInstructions)
+        XCTAssertNil(model.presentedPluginUpdate)
+
+        model.requestPluginUpdate(hostID: presentation.host.id)
+        model.requestHostUpdateRun()
+        guard case .updateHost? = model.enrollmentConfirmation?.action else {
+            return XCTFail("expected an update-host confirmation")
+        }
+
+        model.dismissPluginUpdate()
+
+        XCTAssertNil(model.enrollmentConfirmation)
+        XCTAssertNil(model.presentedPluginUpdate)
+    }
+
+    @MainActor
     func testRemoveReversesTheMacSideQuietlyOnSuccess() async throws {
         let registry = try makeRegistry()
         let sshFS = StubSSHConfigFileSystem()

--- a/Tests/localvoxtralTests/ClaudeIntegrationSettingsModelTests.swift
+++ b/Tests/localvoxtralTests/ClaudeIntegrationSettingsModelTests.swift
@@ -2781,6 +2781,51 @@ final class ClaudeIntegrationSettingsModelTests: XCTestCase {
     }
 
     @MainActor
+    func testInitialSetupSkipsACurrentBlockInASymlinkedSSHConfig() async throws {
+        let registry = try makeRegistry()
+        let sshFS = RecordingSSHConfigFileSystem()
+        let recorder = SetupFlowRecorder()
+        let service = ClaudeRemoteEnrollmentService(
+            runner: setupFlowRunner(script: SetupFlowScript(), recorder: recorder),
+            sshConfigFileSystem: sshFS
+        )
+        let listener = StubListener(hosts: registry)
+        listener.isListening = true
+        let model = setupFlowModel(
+            registry: registry,
+            listener: listener,
+            service: service,
+            rcFileSystem: StubRCFileSystem(state: ClaudeShellRCState(
+                fileExists: true,
+                data: Data("export EDITOR=vim\n".utf8),
+                permissions: 0o644
+            ))
+        )
+        model.enrollLabel = "buildhost"
+        model.enrollSSHAlias = "builder"
+        await model.enroll()
+        let presentation = try XCTUnwrap(model.presentedPlan)
+        sshFS.setConfig(ClaudeRemoteEnrollmentService.applySSHConfigSnippet(
+            to: "",
+            snippet: presentation.plan.sshConfigSnippet,
+            hostID: presentation.host.id
+        ))
+        sshFS.setSymlinked(true)
+
+        model.requestHostSetup()
+        await model.confirmEnrollmentAction()
+
+        let run = try XCTUnwrap(model.setupRun)
+        XCTAssertEqual(
+            run.items[0].state,
+            .done("The SSH config block is already current.")
+        )
+        XCTAssertEqual(sshFS.writeCount, 0, "a current symlink target must not be replaced")
+        XCTAssertEqual(model.hosts.first?.setupStatusText, "Setup complete.")
+        XCTAssertFalse(recorder.all.isEmpty, "setup must continue after the current block")
+    }
+
+    @MainActor
     func testSetupRunStopsAtTheFirstFailure() async throws {
         var script = SetupFlowScript()
         script.plugin = .init(exitCode: 1, message: "boom")

--- a/Tests/localvoxtralTests/ClaudeRemoteEnrollmentServiceTests.swift
+++ b/Tests/localvoxtralTests/ClaudeRemoteEnrollmentServiceTests.swift
@@ -2501,6 +2501,25 @@ final class ClaudeRemoteEnrollmentServiceTests: XCTestCase {
         XCTAssertEqual(try customized.setupRemoteHerdr(sshHostAlias: "builder"), .customized)
     }
 
+    func testHerdrSetupRequiresTheConfiguredOutcomeFrame() throws {
+        let service = ClaudeRemoteEnrollmentService(runner: { _ in
+            .init(exitCode: 0, message: "")
+        })
+
+        XCTAssertThrowsError(try service.setupRemoteHerdr(sshHostAlias: "builder")) { error in
+            guard case ClaudeRemoteEnrollmentService.ServiceError
+                .runnerFailed(_, let command, let message) = error else {
+                return XCTFail("expected an unreported herdr outcome, got \(error)")
+            }
+            XCTAssertEqual(command, "configure remote herdr")
+            XCTAssertEqual(
+                message,
+                "The host did not report a herdr setup outcome. "
+                    + "Check its herdr config, then run setup again."
+            )
+        }
+    }
+
     func testRemovingTheLocalSSHBlockUsesTheSameTrustedWriter() throws {
         let applied = ClaudeRemoteEnrollmentService.applySSHConfigSnippet(
             to: "Host other\n    User me\n",

--- a/Tests/localvoxtralTests/ClaudeRemoteEnrollmentServiceTests.swift
+++ b/Tests/localvoxtralTests/ClaudeRemoteEnrollmentServiceTests.swift
@@ -452,6 +452,26 @@ final class ClaudeRemoteEnrollmentServiceTests: XCTestCase {
         )
     }
 
+    func testSSHConfigCurrencyAcceptsTabsAndRepeatedSpacesBetweenDirectiveFields() throws {
+        let current = [
+            ClaudeRemoteEnrollmentService.blockBegin(hostID: host.id),
+            "Host sandbox-vpn",
+            "\tRemoteForward\t28542\t127.0.0.1:8473",
+            "    SendEnv   LC_LVX_TTY",
+            ClaudeRemoteEnrollmentService.blockEnd(hostID: host.id),
+        ].joined(separator: "\n")
+        let filesystem = MemorySSHConfigFileSystem(
+            state: ClaudeRemoteRemoteConfigStateFixture.state(configText: current)
+        )
+        let service = ClaudeRemoteEnrollmentService(sshConfigFileSystem: filesystem)
+
+        XCTAssertEqual(
+            service.sshConfigBlockIsCurrent(port: 28_542, hostID: host.id),
+            true,
+            "OpenSSH accepts any horizontal whitespace between directive fields"
+        )
+    }
+
     func testForwardStateIgnoresARemoteForwardOutsideThisHostsBlock() throws {
         // Someone else's `RemoteForward 28511` elsewhere in the config is not
         // this host's block being current.

--- a/Tests/localvoxtralTests/ClaudeRemoteEnrollmentServiceTests.swift
+++ b/Tests/localvoxtralTests/ClaudeRemoteEnrollmentServiceTests.swift
@@ -2311,4 +2311,190 @@ final class ClaudeRemoteEnrollmentServiceTests: XCTestCase {
         )
     }
 
+    // MARK: - One-flow setup probes
+
+    func testEnvironmentProbeExportsARandomValueAndAcceptsOnlyItsExactReturn() throws {
+        let invocations = Mutex<[ClaudeRemoteEnrollmentService.Invocation]>([])
+        let service = ClaudeRemoteEnrollmentService(
+            runner: { invocation in
+                invocations.withLock { $0.append(invocation) }
+                // The frame with banner noise on both sides, exactly as the
+                // merged stdout/stderr capture would deliver it: the verdict
+                // must come from the framed line, not the raw bytes.
+                return .init(
+                    exitCode: 0,
+                    message: "Welcome to builder\n"
+                        + ClaudeRemoteEnrollmentService.envProbeFramePrefix
+                        + (invocation.environment["LC_LVX_TTY"] ?? "")
+                        + "\nLast login: today\n"
+                )
+            },
+            environmentProbeValue: { "lvx-probe-fixed-for-test" }
+        )
+
+        XCTAssertEqual(
+            try service.probeRemoteEnvironment(sshHostAlias: "builder"),
+            .crossed
+        )
+        let invocation = try XCTUnwrap(invocations.withLock { $0.first })
+        XCTAssertEqual(invocation.environment["LC_LVX_TTY"], "lvx-probe-fixed-for-test")
+        XCTAssertTrue(invocation.argv.contains("ClearAllForwardings=yes"))
+        XCTAssertFalse(invocation.argv.joined().contains("lvx-probe-fixed-for-test"))
+        XCTAssertFalse(String(decoding: invocation.standardInput, as: UTF8.self)
+            .contains("lvx-probe-fixed-for-test"))
+    }
+
+    func testEnvironmentProbeIgnoresABannerThatQuotesAWrongValue() throws {
+        // A hostile or merely chatty host can print anything around the frame;
+        // only the minted value's exact return may count, never a lookalike.
+        let service = ClaudeRemoteEnrollmentService(
+            runner: { invocation in
+                invocation.argv.contains("-G")
+                    ? .init(exitCode: 0, message: "hostname builder\nsendenv LANG LC_*\n")
+                    : .init(
+                        exitCode: 0,
+                        message: "LVX_TTY:not-the-probe-value"
+                    )
+            },
+            environmentProbeValue: { "lvx-probe-real" }
+        )
+        XCTAssertEqual(
+            try service.probeRemoteEnvironment(sshHostAlias: "builder"),
+            .remoteAcceptEnvMissing,
+            "a wrong echo is a mismatch, and the local side is sending"
+        )
+    }
+
+    func testEnvironmentProbeDistinguishesMissingSendEnvFromMissingRemoteAcceptEnv() throws {
+        let call = Mutex(0)
+        let withoutSendEnv = ClaudeRemoteEnrollmentService(
+            runner: { invocation in
+                let index = call.withLock { value -> Int in
+                    defer { value += 1 }
+                    return value
+                }
+                if index == 0 { return .init(exitCode: 0, message: "") }
+                XCTAssertEqual(invocation.argv, ["ssh", "-G", "--", "builder"])
+                return .init(exitCode: 0, message: "hostname builder\nsendenv LANG\n")
+            },
+            environmentProbeValue: { "lvx-probe-a" }
+        )
+        XCTAssertEqual(
+            try withoutSendEnv.probeRemoteEnvironment(sshHostAlias: "builder"),
+            .localSendEnvMissing
+        )
+
+        let withWildcard = ClaudeRemoteEnrollmentService(
+            runner: { invocation in
+                invocation.argv.contains("-G")
+                    ? .init(exitCode: 0, message: "hostname builder\nsendenv LANG LC_*\n")
+                    : .init(exitCode: 0, message: "")
+            },
+            environmentProbeValue: { "lvx-probe-b" }
+        )
+        XCTAssertEqual(
+            try withWildcard.probeRemoteEnvironment(sshHostAlias: "builder"),
+            .remoteAcceptEnvMissing
+        )
+    }
+
+    func testPluginSetupUpdatesAnInstalledPluginAndVerifiesItsVersionInOneSSHSession() throws {
+        let calls = Mutex<[ClaudeRemoteEnrollmentService.Invocation]>([])
+        let service = ClaudeRemoteEnrollmentService(runner: { invocation in
+            calls.withLock { $0.append(invocation) }
+            return .init(exitCode: 0, message: "LVX_PLUGIN_ALREADY_CURRENT")
+        })
+
+        XCTAssertEqual(
+            try service.setupRemotePlugin(
+                sshHostAlias: "builder", token: nil, remoteForwardPort: 28_511
+            ),
+            .alreadyCurrent
+        )
+        let recorded = calls.withLock { $0 }
+        XCTAssertEqual(recorded.count, 1, "detect, update, and version verification share one ssh session")
+        let script = String(decoding: recorded[0].standardInput, as: UTF8.self)
+        XCTAssertTrue(script.contains("claude plugin marketplace update"))
+        // The version check reads the listing line `claude plugin list` prints
+        // for our reference and matches the version as a space-delimited word
+        // (so 11.7.0 can never satisfy 1.7.0) — both before deciding AND after
+        // the install, in the same session.
+        XCTAssertTrue(
+            script.contains("grep -F '\(ClaudeRemoteEnrollmentService.remotePluginReference)' | head -n 1")
+        )
+        XCTAssertTrue(
+            script.contains("*\" \(ClaudeRemoteEnrollmentService.remotePluginVersion) \"*"),
+            "the version is matched as a word"
+        )
+        XCTAssertEqual(
+            script.components(separatedBy: "claude plugin list").count - 1,
+            2,
+            "the version is read before the decision and again after the install"
+        )
+    }
+
+    func testPluginSetupRefusesToInstallWithoutAToken() throws {
+        // The update path deliberately carries no credential. Installing
+        // tokenless would look exactly like a healthy enrollment failing open,
+        // so an absent plugin is reported for the remedy (rotate), not
+        // silently installed broken.
+        let service = ClaudeRemoteEnrollmentService(runner: { _ in
+            .init(exitCode: 44, message: "LVX_PLUGIN_ABSENT")
+        })
+
+        XCTAssertThrowsError(
+            try service.setupRemotePlugin(
+                sshHostAlias: "builder", token: nil, remoteForwardPort: 28_511
+            )
+        ) { error in
+            guard case ClaudeRemoteEnrollmentService.ServiceError
+                .commandFailed(_, _, 44, let message) = error else {
+                return XCTFail("expected exit 44 with the rotation remedy, got \(error)")
+            }
+            XCTAssertTrue(message.contains("Rotate this host's token"))
+        }
+    }
+
+    func testVerifiedPluginVersionMatchesTheRemotePluginManifest() throws {
+        let manifestURL = repositoryRoot
+            .appendingPathComponent("integrations/claude-code/plugins/localvoxtral-remote")
+            .appendingPathComponent(".claude-plugin/plugin.json")
+        let object = try JSONSerialization.jsonObject(with: Data(contentsOf: manifestURL))
+        let manifest = try XCTUnwrap(object as? [String: Any])
+        XCTAssertEqual(
+            manifest["version"] as? String,
+            ClaudeRemoteEnrollmentService.remotePluginVersion
+        )
+    }
+
+    func testHerdrSetupReportsAbsentAndRefusesAnExistingAgentsTable() throws {
+        let absent = ClaudeRemoteEnrollmentService(runner: { _ in
+            .init(exitCode: 0, message: "LVX_HERDR_ABSENT")
+        })
+        XCTAssertEqual(try absent.setupRemoteHerdr(sshHostAlias: "builder"), .notFound)
+
+        let customized = ClaudeRemoteEnrollmentService(runner: { _ in
+            .init(exitCode: 42, message: "LVX_HERDR_CUSTOMIZED")
+        })
+        XCTAssertEqual(try customized.setupRemoteHerdr(sshHostAlias: "builder"), .customized)
+    }
+
+    func testRemovingTheLocalSSHBlockUsesTheSameTrustedWriter() throws {
+        let applied = ClaudeRemoteEnrollmentService.applySSHConfigSnippet(
+            to: "Host other\n    User me\n",
+            snippet: try plan().sshConfigSnippet,
+            hostID: host.id
+        )
+        let fileSystem = MemorySSHConfigFileSystem(
+            state: ClaudeRemoteRemoteConfigStateFixture.state(configText: applied)
+        )
+        let service = ClaudeRemoteEnrollmentService(sshConfigFileSystem: fileSystem)
+
+        try service.removeSSHConfig(hostID: host.id)
+
+        let written = String(decoding: try XCTUnwrap(fileSystem.snapshot.writes.last?.data), as: UTF8.self)
+        XCTAssertFalse(written.contains("Host builder"))
+        XCTAssertTrue(written.contains("Host other"))
+    }
+
 }

--- a/Tests/localvoxtralTests/ClaudeRemoteEnrollmentServiceTests.swift
+++ b/Tests/localvoxtralTests/ClaudeRemoteEnrollmentServiceTests.swift
@@ -2533,20 +2533,50 @@ final class ClaudeRemoteEnrollmentServiceTests: XCTestCase {
     }
 
     func testHerdrSetupReportsAbsentAndRefusesAnExistingAgentsTable() throws {
-        let absent = ClaudeRemoteEnrollmentService(runner: { _ in
-            .init(exitCode: 0, message: "LVX_HERDR_ABSENT")
+        let assertInvocation: @Sendable (ClaudeRemoteEnrollmentService.Invocation) -> Void = {
+            invocation in
+            XCTAssertEqual(
+                invocation.argv,
+                [
+                    "ssh", "-o", "BatchMode=yes", "-o", "ClearAllForwardings=yes", "--",
+                    "builder", "/bin/sh", "-s",
+                ]
+            )
+            XCTAssertEqual(invocation.timeout, ClaudeRemoteEnrollmentService.defaultRemoteSetupTimeout)
+            XCTAssertTrue(invocation.environment.isEmpty)
+            let script = String(decoding: invocation.standardInput, as: UTF8.self)
+            XCTAssertTrue(script.contains("command -v herdr"))
+            XCTAssertTrue(script.contains(ClaudeRemoteEnrollmentService.herdrPanelConfigSnippet))
+            XCTAssertTrue(script.contains("herdr server reload-config"))
+            XCTAssertTrue(script.contains("LVX_HERDR_CONFIGURED"))
+        }
+        let absent = ClaudeRemoteEnrollmentService(runner: { invocation in
+            assertInvocation(invocation)
+            return .init(exitCode: 0, message: "LVX_HERDR_ABSENT")
         })
         XCTAssertEqual(try absent.setupRemoteHerdr(sshHostAlias: "builder"), .notFound)
 
-        let customized = ClaudeRemoteEnrollmentService(runner: { _ in
-            .init(exitCode: 42, message: "LVX_HERDR_CUSTOMIZED")
+        let customized = ClaudeRemoteEnrollmentService(runner: { invocation in
+            assertInvocation(invocation)
+            return .init(exitCode: 42, message: "LVX_HERDR_CUSTOMIZED")
         })
         XCTAssertEqual(try customized.setupRemoteHerdr(sshHostAlias: "builder"), .customized)
     }
 
     func testHerdrSetupRequiresTheConfiguredOutcomeFrame() throws {
-        let service = ClaudeRemoteEnrollmentService(runner: { _ in
-            .init(exitCode: 0, message: "")
+        let service = ClaudeRemoteEnrollmentService(runner: { invocation in
+            XCTAssertEqual(
+                invocation.argv,
+                [
+                    "ssh", "-o", "BatchMode=yes", "-o", "ClearAllForwardings=yes", "--",
+                    "builder", "/bin/sh", "-s",
+                ]
+            )
+            XCTAssertTrue(
+                String(decoding: invocation.standardInput, as: UTF8.self)
+                    .contains("LVX_HERDR_CONFIGURED")
+            )
+            return .init(exitCode: 0, message: "")
         })
 
         XCTAssertThrowsError(try service.setupRemoteHerdr(sshHostAlias: "builder")) { error in

--- a/Tests/localvoxtralTests/ClaudeRemoteEnrollmentServiceTests.swift
+++ b/Tests/localvoxtralTests/ClaudeRemoteEnrollmentServiceTests.swift
@@ -2365,6 +2365,28 @@ final class ClaudeRemoteEnrollmentServiceTests: XCTestCase {
         )
     }
 
+    func testEnvironmentProbeReadsFirstLVXTTYFramedLineIgnoringOtherLVXPrefixLines() throws {
+        let service = ClaudeRemoteEnrollmentService(
+            runner: { invocation in
+                .init(
+                    exitCode: 0,
+                    message: "LVX_WARNING: authorized access only\n"
+                        + "LVX_NODE=worker-42\n"
+                        + ClaudeRemoteEnrollmentService.envProbeFramePrefix
+                        + (invocation.environment["LC_LVX_TTY"] ?? "")
+                        + "\nLVX_TRAILING: ignored\n"
+                )
+            },
+            environmentProbeValue: { "lvx-probe-valid" }
+        )
+
+        XCTAssertEqual(
+            try service.probeRemoteEnvironment(sshHostAlias: "builder"),
+            .crossed,
+            "a banner line prefixed with LVX_ must not shadow the LVX_TTY: frame"
+        )
+    }
+
     func testEnvironmentProbeDistinguishesMissingSendEnvFromMissingRemoteAcceptEnv() throws {
         let call = Mutex(0)
         let withoutSendEnv = ClaudeRemoteEnrollmentService(

--- a/Tests/localvoxtralTests/ClaudeRemoteEnrollmentServiceTests.swift
+++ b/Tests/localvoxtralTests/ClaudeRemoteEnrollmentServiceTests.swift
@@ -2477,6 +2477,49 @@ final class ClaudeRemoteEnrollmentServiceTests: XCTestCase {
         }
     }
 
+    func testPluginSetupDistinguishesMissingCLICommandFailureAndVersionMismatch() throws {
+        func failure(exitCode: Int32) throws -> ClaudeRemoteEnrollmentService.ServiceError {
+            let service = ClaudeRemoteEnrollmentService(runner: { _ in
+                .init(exitCode: exitCode, message: "untrusted host output")
+            })
+            do {
+                _ = try service.setupRemotePlugin(
+                    sshHostAlias: "builder",
+                    token: "test-token",
+                    remoteForwardPort: 28_511
+                )
+                XCTFail("exit \(exitCode) must fail")
+                return .executionNotConfigured
+            } catch let error as ClaudeRemoteEnrollmentService.ServiceError {
+                return error
+            }
+        }
+
+        guard case .commandFailed(_, _, 127, let missingCLI) = try failure(exitCode: 127) else {
+            return XCTFail("expected the missing CLI diagnosis")
+        }
+        XCTAssertEqual(
+            missingCLI,
+            "Claude CLI was not found on the remote host. "
+                + "Install Claude Code there, or put it on the non-interactive SSH PATH."
+        )
+
+        guard case .commandFailed(_, _, 1, let commandFailure) = try failure(exitCode: 1) else {
+            return XCTFail("expected the generic command failure diagnosis")
+        }
+        XCTAssertEqual(commandFailure, "The remote plugin setup command failed.")
+
+        guard case .commandFailed(_, _, 43, let versionMismatch) = try failure(exitCode: 43) else {
+            return XCTFail("expected the version read-back diagnosis")
+        }
+        XCTAssertEqual(
+            versionMismatch,
+            "The plugin is installed but did not report version "
+                + ClaudeRemoteEnrollmentService.remotePluginVersion
+                + " when read back in the same session."
+        )
+    }
+
     func testVerifiedPluginVersionMatchesTheRemotePluginManifest() throws {
         let manifestURL = repositoryRoot
             .appendingPathComponent("integrations/claude-code/plugins/localvoxtral-remote")

--- a/docs/agent/invariants.md
+++ b/docs/agent/invariants.md
@@ -1136,6 +1136,20 @@ there is not.
   malicious process running as the user on the REMOTE host can still read
   `~/.claude/` and therefore the plugin's token no matter what we do. Say so
   rather than implying the token bounds it.
+- **The SendEnv probe uses a random value that is never logged and never
+  interpreted beyond equality.** `probeRemoteEnvironment` mints a fresh nonce
+  per call (a UUID by default, injected in tests), exports it into that one
+  ssh child's environment as `LC_LVX_TTY`, and compares the remote echo by
+  exact equality only. The echo travels framed (`LVX_TTY:`) and only the
+  first framed line is read, so banner or stderr noise sharing the capture
+  pipe cannot flip the verdict; the frame itself is never interpreted. The
+  value never appears in argv or stdin — where it would land in `ps`, the
+  log, or a build transcript — and never in a `Log` line, a
+  `VerificationCheck`, an alert, or an error. A mismatch reports only which
+  side refused, with its fixed remedy: no `sendenv` covering the host in
+  `ssh -G` means this Mac is not sending it; otherwise the remote sshd
+  refused it. Do not "improve" the diagnosis by quoting what came back: the
+  echo is remote output, and remote output never travels.
 - **The dogfood control socket is an accepted tradeoff, and the acceptance was
   bounded.** An instrumented build can expose a local AF_UNIX socket that
   starts dictations and reports what the context pipeline resolved

--- a/docs/release-notes/v0.9.0.md
+++ b/docs/release-notes/v0.9.0.md
@@ -22,11 +22,16 @@ Terminal.app.** Inside a [herdr](https://herdr.dev) session the app asks herdr
 itself which pane is focused and binds to that pane by id. Any ambiguity —
 including two live herdr sessions — attaches nothing rather than guessing.
 
-**A plain `ssh` session joins again, and the app can set it up for you.**
-In Settings, under *Remote Claude Code over SSH*, **Set Up…** next to "Terminal
-setup for plain SSH" shows the exact block, writes it to your shell's startup
-file only after you confirm, and can remove it again. The same row tells you
-whether a remote session has actually reported its terminal yet.
+**A plain `ssh` session joins again, and the app sets the whole thing up for
+you.** In Settings, under *Remote Claude Code over SSH*, **Run Setup** in the
+enrollment sheet — or **Update Host** in an enrolled host's row — runs one
+self-verifying flow in order: the `~/.ssh/config` block, the shell startup
+export, the remote plugin install-or-update, the check that `LC_LVX_TTY`
+actually crosses the connection, the herdr agents-panel row when herdr is
+installed, and the final Check Setup. Each step reports one short sentence and
+the run stops at the first failure with its remedy, so the step that used to
+fail silently — the value not crossing — now names its fix. The same row still
+tells you whether a remote session has actually reported its terminal yet.
 
 By hand, if you prefer — add this to your shell's rc file on your Mac:
 

--- a/docs/remote-claude-context.md
+++ b/docs/remote-claude-context.md
@@ -3,9 +3,12 @@
 Dictate into a Claude Code session that is running on another machine, and have
 localvoxtral spell your code, file names, and identifiers correctly anyway.
 
-This page is the long version. The app's enrollment sheet is deliberately short:
-four steps, no comments in anything you copy, and a **Check Setup** button that
-runs the checks and tells you what they mean.
+This page is the long version. The app's enrollment sheet runs the whole
+setup as one self-verifying flow — press **Run Setup**, confirm once, and it
+stops at the first step that fails with the exact remedy — while every block
+it would write stays on the sheet, copyable, with no comments in it, for doing
+any step by hand. A **Check Setup** button runs the checks and tells you what
+they mean.
 
 ---
 
@@ -51,7 +54,43 @@ configured.
 
 ## How enrollment works
 
-Enrolling a host does three things.
+Enrolling a host is one flow that does everything, each step self-verifying.
+Press **Run Setup** in the enrollment sheet — or **Update Host** in an
+enrolled host's row — and it runs, in order, showing one short sentence of
+status per step and stopping at the first failure with the exact remedy:
+
+1. **Mac SSH config** — the marked `Host` block with `RemoteForward` and
+   `SendEnv LC_LVX_TTY`. Manual equivalent: copy the block from step 1 of the
+   sheet.
+2. **Mac shell startup** — the `LC_LVX_TTY` export block in your login shell's
+   rc. Manual equivalent: the block under "Terminal setup for plain SSH" in
+   Settings, or the integration README. Already applied, unsupported, or
+   symlinked is reported, not failed.
+3. **Remote plugin** — install, or update when already present, verified by
+   reading the installed version back in the same SSH session. Manual
+   equivalent: the two commands in step 2 of the sheet.
+4. **Remote environment** — proves `LC_LVX_TTY` actually crosses by sending a
+   fresh random value for that one call and comparing the echo exactly. The
+   value is never logged. A mismatch names the side: no `sendenv` covering the
+   host in this Mac's `ssh -G` means step 1's block is missing; otherwise the
+   remote sshd refused it — add `AcceptEnv LANG LC_*` to `sshd_config` on that
+   host and reload sshd there, which needs root on that host and is never
+   attempted for you. Manual equivalent: from a window where the rc line ran,
+   `ssh <alias> 'echo "[$LC_LVX_TTY]"'` — empty means the value is not
+   crossing.
+5. **Remote herdr** — when `herdr` resolves on the host, appends the
+   agents-panel row (only when no agents table or rows key exists) and runs
+   `herdr server reload-config`. "Not installed" and an already-customized
+   table are reported, not failed. Manual equivalent: append the TOML block
+   from the sheet, then `herdr server reload-config` on the host.
+6. **Check Setup** — the two read-only verdicts, last, as the final status
+   line.
+
+Removing the host reverses the Mac side — the ssh block, and the shell block
+only when no other host remains — and never lets a reversal problem block the
+removal itself: the registry entry is the off switch, and anything that could
+not be rewritten is named in an alert with its manual fix. The remote half of
+uninstalling stays manual by design ("Uninstalling" below).
 
 ### 1. An `~/.ssh/config` block
 

--- a/integrations/claude-code/README.md
+++ b/integrations/claude-code/README.md
@@ -538,8 +538,15 @@ exchange (any HTTP status, even a 401) clears the backoff for everything else.
 In **Settings → Integrations → Remote hosts → "Remote Claude Code over SSH"**,
 type a name and your SSH host alias and press **Enroll…**. The app issues a
 token, binds the listener immediately — there is no relaunch step — and opens a
-sheet with four numbered steps: add the SSH config, install on the host, show
-the dictation indicator in herdr, check the setup. The list in that row shows each enrolled host, when it was last seen,
+sheet whose **Run Setup** does all of it in one consented flow, in order, each
+step self-verifying: the SSH config block on this Mac, the shell export block,
+the plugin install-or-update on the host, the `LC_LVX_TTY` crossing check, the
+herdr agents-panel row when herdr is installed, and the final Check Setup. It
+stops at the first failure with the exact remedy. **Update Host** in an
+enrolled host's row runs the same flow. The numbered sections below stay for
+copying each step by hand — the manual equivalent of every one is
+[docs/remote-claude-context.md](../../docs/remote-claude-context.md#how-enrollment-works).
+The list in that row shows each enrolled host, when it was last seen,
 and gives you **Update Plugin…**, **Rotate Token**, **Revoke** and **Remove**.
 
 Steps 1 and 2 each offer a button that does the work and a Copy button that


### PR DESCRIPTION
## What

Enrolling (or updating) a remote host is one self-verifying flow run from the enrollment sheet: Mac ssh config block, Mac shell LC_LVX_TTY export, remote plugin install-or-update (version proved back in the same session), LC_LVX_TTY crossing probe, remote herdr $lvmark panel-row offer, then Check Setup as the final verdict. Each step shows one short sentence (pending / done / skipped / failed with remedy) and the run stops at the first failure. Remove Host reverses the Mac-side edits (rc block only when no host remains). Docs (remote-claude-context.md, claude-code README, v0.9.0 notes, invariants env-probe rule) updated in the same branch.

[dogfood-package]

## Proof

- [x] Unit suite green — `./scripts/remote-build.sh test` (LV_BUILD_DIR=work/localvoxtral-enroll): `Executed 3055 tests, with 2 tests skipped and 0 failures`; `grep -ci "warning:" .build/last-remote.log` → 0
- [x] Focused suites: ClaudeRemoteEnrollmentServiceTests `Executed 110 tests, with 0 failures`; ClaudeIntegrationSettingsModelTests `Executed 92 tests, with 0 failures`; ClaudeShellRCSetupTests `Executed 33 tests, with 0 failures`
- [ ] Realtime integration green — not run (no backend/model change; app-side ssh/plugin/probe flow with runner fixtures)
- [ ] Bug fix: regression test added — N/A (feature, not a bug fix)
- [ ] UI change: enrollment sheet step list + host-row status verified via model/view-model tests (AX ids integrations.remote.setup.step.<n>, integrations.remote.setup.run|cancel); no hand-verification on a live host performed

## Review

Verdict: **FIXES COMPLETE; CI BLOCKED**. The adversarial review's five major findings, both minor findings, and the nit are fixed in separate commits. This repair task does not merge the PR. The required checks are not all green because the live-herdr fixture lost its joined pane on the original run and the one permitted rerun.

- **MAJOR-1, env-probe framing (`6426c80`)**: the probe now reads the first `LVX_TTY:` frame and ignores an earlier `LVX_WARNING: x` line. RED: `ClaudeRemoteEnrollmentServiceTests` executed 111 tests with 1 failure; `testEnvironmentProbeReadsFirstLVXTTYFramedLineIgnoringOtherLVXPrefixLines` got `localSendEnvMissing` instead of `crossed`. GREEN: executed 111 tests with 0 failures.
- **MAJOR-3, setup-time SSH block currency (`c1c6697`)**: initial setup rechecks the marked block and skips a current symlink target without invoking the rename-based writer. A needed rewrite still follows the existing symlink refusal. RED: `ClaudeIntegrationSettingsModelTests` executed 93 tests with 3 failures; `testInitialSetupSkipsACurrentBlockInASymlinkedSSHConfig` stopped at Mac SSH config. GREEN: executed 93 tests with 0 failures.
- **MAJOR-4, herdr success sentinel (`e047d54`)**: exit 0 without `LVX_HERDR_CONFIGURED` now fails with a fixed remedy. RED: `ClaudeRemoteEnrollmentServiceTests` executed 112 tests with 1 failure; `testHerdrSetupRequiresTheConfiguredOutcomeFrame` did not throw. GREEN: executed 112 tests with 0 failures.
- **MAJOR-5, remote plugin diagnostics (`139a789`)**: exit 43 alone reports a version read-back mismatch. Exit 127 says to install Claude Code or put it on the non-interactive SSH PATH, and other nonzero exits report command failure. RED: `ClaudeRemoteEnrollmentServiceTests` executed 113 tests with 2 failures in `testPluginSetupDistinguishesMissingCLICommandFailureAndVersionMismatch`. GREEN: executed 113 tests with 0 failures.
- **MAJOR-2, update-sheet dismissal (`94dc846`)**: closing the sheet clears `.updateHost` confirmations, retained setup runs, and manual instructions. RED: `ClaudeIntegrationSettingsModelTests` executed 94 tests with 3 failures in `testDismissingAHostUpdateClearsItsConfirmationAndRetainedRun`. GREEN: executed 94 tests with 0 failures.
- **MINOR-1, fixture strength (`45677e1`)**: herdr fixtures now assert argv, stdin, timeout, and environment. The six-step test asserts the chronological runner order `remote plugin`, `environment crossing`, `remote herdr`, `tunnel check`, `plugin check`. RED: not applicable because this finding hardens tests without changing product behavior. GREEN: service suite executed 113 tests with 0 failures; settings-model suite executed 94 tests with 0 failures.
- **MINOR-2, SSH directive whitespace (`5992300`)**: block currency tokenizes directives by general whitespace. RED: `ClaudeRemoteEnrollmentServiceTests` executed 114 tests with 1 failure; `testSSHConfigCurrencyAcceptsTabsAndRepeatedSpacesBetweenDirectiveFields` returned false. GREEN: executed 114 tests with 0 failures.
- **NIT-1, host-row label (`7f78a51`)**: source label changed from `Update Plugin…` to `Update Host…`. RED: source inspection found the old label. GREEN: final build and unit suite passed. Hand verification was not performed in this headless repair session.

Final proof at `7f78a51`:

- `./scripts/remote-build.sh test --filter ClaudeRemoteEnrollmentServiceTests`: executed 114 tests with 0 failures.
- `./scripts/remote-build.sh test --filter ClaudeIntegrationSettingsModelTests`: executed 94 tests with 0 failures.
- `./scripts/remote-build.sh test`: executed 3061 tests with 2 tests skipped and 0 failures.
- `grep -ci "warning:" .build/last-remote.log`: `0`.
- `./scripts/remote-build.sh integration-herdr`: executed 11 tests with 0 failures, including the live remote herdr config patch and real SSH-forward coverage.
- CI run `34139102764`: `build-test` passed. The initial `mac-lanes` attempt failed after `pane.report_metadata` returned `pane_not_found: pane w1:p1 not found` in `testAttachClientRendersNoSidebarSoItCannotEchoThePanelToken`. It overlapped the local live-herdr proof run.
- The one permitted failed-job rerun ran without overlapping worker work. Ten of eleven live-herdr tests passed, but `testPaneReadReturnsOnlyTheJoinedPanesText` failed after every `pane.read` returned `pane_not_found: pane w1:p1 not found`. No second rerun was requested.
