### PR TITLE
Live herdr lane: measured timeouts and bounded retries so a loaded Mac does not fail a required check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -925,7 +925,16 @@ jobs:
           HERDR_INTEGRATION_TEST_ENABLE: "1"
         # --enable-code-coverage matches the unit step's build flags (same
         # rationale as the STT integration step above).
-        run: swift test --filter HerdrIntegrationTests --enable-code-coverage
+        # Load flake hint (measured 2026-09-07: one concurrent swift build
+        # fails ~1 run in 10 on a clear-visibility race, with socket p99
+        # unchanged): if this step is red, suspect overlapping worker builds
+        # on the Mac first and re-run the lane alone before debugging.
+        run: >-
+          swift test --filter HerdrIntegrationTests --enable-code-coverage || {
+          echo 'HERDR-LANE-HINT: red lane? check for overlapping worker builds
+          (remote-build.sh) on the Mac and re-run this lane alone first —
+          see docs/agent/test-tiers.md "Worker builds on the Mac must not
+          overlap the lane".'; exit 1; }
 
       - name: Polishing helper unit tests (PolishHelper package)
         # Metal-free (HTTP layer, router, cache locator, watchdog); the Metal

--- a/Sources/localvoxtral/ClaudeContext/HerdrSocketClient.swift
+++ b/Sources/localvoxtral/ClaudeContext/HerdrSocketClient.swift
@@ -79,13 +79,26 @@ protocol HerdrPaneQuerying: Sendable {
 /// would let a slow connect, write, and response each consume the whole budget,
 /// while a per-read timeout would let a trickling peer retain the task forever.
 struct HerdrSocketClient: HerdrPaneQuerying, HerdrPanelMetadataReporting {
+    /// Per-request observation: method name, latency in seconds, success, and
+    /// — on failure only — the server's error payload verbatim
+    /// (`"<code>: <message>"`, content-free) or a local failure cause
+    /// (`"no-response"`, `"invalid-response"`). Never carries pane ids,
+    /// socket paths, or response bodies.
+    typealias LatencyReport = @Sendable (_ method: String, _ latencySeconds: TimeInterval, _ success: Bool, _ detail: String) -> Void
+
     private let timeout: TimeInterval
     private let uptimeNanos: @Sendable () -> UInt64
     private let socketMetadata: @Sendable (String) -> ClaudeSocketGuard.PathMetadata?
+    private let latencyRecorder: LatencyReport?
 
     /// - Parameter socketMetadata: injectable so the ownership refusal is
     ///   testable — a real foreign-uid socket cannot be created from a
     ///   single-user test process.
+    /// - Parameter latencyRecorder: test/field observation of per-request
+    ///   latency and refusal payloads. Nil in production paths that do not
+    ///   record; the client still logs completions and failures loudly
+    ///   through `Log.claudeContext` (never silent — silent failure paths
+    ///   have cost hours of remote probing).
     init(
         timeout: TimeInterval = 0.5,
         uptimeNanos: @escaping @Sendable () -> UInt64 = {
@@ -93,20 +106,27 @@ struct HerdrSocketClient: HerdrPaneQuerying, HerdrPanelMetadataReporting {
         },
         socketMetadata: @escaping @Sendable (String) -> ClaudeSocketGuard.PathMetadata? = {
             ClaudeSocketGuard.metadata(ofPath: $0)
-        }
+        },
+        latencyRecorder: LatencyReport? = nil
     ) {
         self.timeout = timeout
         self.uptimeNanos = uptimeNanos
         self.socketMetadata = socketMetadata
+        self.latencyRecorder = latencyRecorder
     }
 
     func focusedPane(socketPath: String) async -> HerdrFocusedPane? {
         await Task.detached(priority: .userInitiated) { [self] in
+            let startNanos = uptimeNanos()
             let request = Request(
                 id: Self.requestID(), method: "pane.current", params: [String: String]()
             )
-            guard let line = query(socketPath: socketPath, request: request),
-                  let envelope = try? JSONDecoder().decode(
+            guard let line = query(socketPath: socketPath, request: request) else {
+                noteLatency(method: "pane.current", startNanos: startNanos, success: false, detail: "no-response")
+                Log.claudeContext.info("Herdr focused-pane query abstained: invalid response")
+                return nil
+            }
+            guard let envelope = try? JSONDecoder().decode(
                     Envelope<PaneCurrentResult>.self, from: line
                   ),
                   envelope.id == request.id,
@@ -114,9 +134,12 @@ struct HerdrSocketClient: HerdrPaneQuerying, HerdrPanelMetadataReporting {
                   result.type == "pane_current",
                   result.pane.focused
             else {
+                let detail = Self.errorPayload(from: line) ?? "invalid-response"
+                noteLatency(method: "pane.current", startNanos: startNanos, success: false, detail: detail)
                 Log.claudeContext.info("Herdr focused-pane query abstained: invalid response")
                 return nil
             }
+            noteLatency(method: "pane.current", startNanos: startNanos, success: true, detail: "ok")
             let claim = result.pane.agentSession.flatMap {
                 $0.kind == "id" ? $0.value : nil
             }
@@ -132,13 +155,18 @@ struct HerdrSocketClient: HerdrPaneQuerying, HerdrPanelMetadataReporting {
         paneID: String
     ) async -> HerdrPaneForegroundInfo? {
         await Task.detached(priority: .userInitiated) { [self] in
+            let startNanos = uptimeNanos()
             let request = Request(
                 id: Self.requestID(),
                 method: "pane.process_info",
                 params: ["pane_id": paneID]
             )
-            guard let line = query(socketPath: socketPath, request: request),
-                  let envelope = try? JSONDecoder().decode(
+            guard let line = query(socketPath: socketPath, request: request) else {
+                noteLatency(method: "pane.process_info", startNanos: startNanos, success: false, detail: "no-response")
+                Log.claudeContext.info("Herdr foreground-process query abstained: invalid response")
+                return nil
+            }
+            guard let envelope = try? JSONDecoder().decode(
                     Envelope<PaneProcessInfoResult>.self, from: line
                   ),
                   envelope.id == request.id,
@@ -146,9 +174,12 @@ struct HerdrSocketClient: HerdrPaneQuerying, HerdrPanelMetadataReporting {
                   result.type == "pane_process_info",
                   result.processInfo.paneID == paneID
             else {
+                let detail = Self.errorPayload(from: line) ?? "invalid-response"
+                noteLatency(method: "pane.process_info", startNanos: startNanos, success: false, detail: detail)
                 Log.claudeContext.info("Herdr foreground-process query abstained: invalid response")
                 return nil
             }
+            noteLatency(method: "pane.process_info", startNanos: startNanos, success: true, detail: "ok")
             return HerdrPaneForegroundInfo(
                 shellPID: result.processInfo.shellPID,
                 foregroundProcesses: result.processInfo.foregroundProcesses?.map {
@@ -160,13 +191,18 @@ struct HerdrSocketClient: HerdrPaneQuerying, HerdrPanelMetadataReporting {
 
     func paneVisibleText(socketPath: String, paneID: String) async -> String? {
         await Task.detached(priority: .userInitiated) { [self] in
+            let startNanos = uptimeNanos()
             let request = Request(
                 id: Self.requestID(),
                 method: "pane.read",
                 params: PaneReadParams(paneID: paneID)
             )
-            guard let line = query(socketPath: socketPath, request: request),
-                  let envelope = try? JSONDecoder().decode(
+            guard let line = query(socketPath: socketPath, request: request) else {
+                noteLatency(method: "pane.read", startNanos: startNanos, success: false, detail: "no-response")
+                Log.claudeContext.info("Herdr pane read abstained: invalid response")
+                return nil
+            }
+            guard let envelope = try? JSONDecoder().decode(
                     Envelope<PaneReadResult>.self, from: line
                   ),
                   envelope.id == request.id,
@@ -177,9 +213,15 @@ struct HerdrSocketClient: HerdrPaneQuerying, HerdrPanelMetadataReporting {
                   // text must never be attributed to the joined pane.
                   result.read.paneID == paneID
             else {
+                // Never log the raw line here: a pane.read body carries the
+                // user's terminal text. Only the server's error envelope
+                // (code + message, content-free) is safe to record verbatim.
+                let detail = Self.errorPayload(from: line) ?? "invalid-response"
+                noteLatency(method: "pane.read", startNanos: startNanos, success: false, detail: detail)
                 Log.claudeContext.info("Herdr pane read abstained: invalid response")
                 return nil
             }
+            noteLatency(method: "pane.read", startNanos: startNanos, success: true, detail: "ok")
             return result.read.text
         }.value
     }
@@ -191,6 +233,7 @@ struct HerdrSocketClient: HerdrPaneQuerying, HerdrPanelMetadataReporting {
         ttlMilliseconds: Int?
     ) async -> Bool {
         await Task.detached(priority: .userInitiated) { [self] in
+            let startNanos = uptimeNanos()
             let request = Request(
                 id: Self.requestID(),
                 method: "pane.report_metadata",
@@ -200,16 +243,48 @@ struct HerdrSocketClient: HerdrPaneQuerying, HerdrPanelMetadataReporting {
                     ttlMilliseconds: ttlMilliseconds
                 )
             )
-            guard let line = query(socketPath: socketPath, request: request),
-                  let envelope = try? JSONDecoder().decode(Envelope<OKResult>.self, from: line),
-                  envelope.id == request.id,
-                  envelope.result?.type == "ok"
-            else {
+            guard let line = query(socketPath: socketPath, request: request) else {
+                noteLatency(method: "pane.report_metadata", startNanos: startNanos, success: false, detail: "no-response")
                 Log.claudeContext.info("Herdr panel metadata report abstained: invalid response")
                 return false
             }
+            guard let envelope = try? JSONDecoder().decode(Envelope<OKResult>.self, from: line),
+                  envelope.id == request.id,
+                  envelope.result?.type == "ok"
+            else {
+                let detail = Self.errorPayload(from: line) ?? "invalid-response"
+                noteLatency(method: "pane.report_metadata", startNanos: startNanos, success: false, detail: detail)
+                Log.claudeContext.info("Herdr panel metadata report abstained: invalid response")
+                return false
+            }
+            noteLatency(method: "pane.report_metadata", startNanos: startNanos, success: true, detail: "ok")
             return true
         }.value
+    }
+
+    /// Record one request's outcome: always to the unified log (loud paths,
+    /// no ids or paths), and additionally to the injected recorder when one
+    /// is set (the lane's timing/Log capture).
+    private func noteLatency(method: String, startNanos: UInt64, success: Bool, detail: String) {
+        let nowNanos = uptimeNanos()
+        let elapsedNanos = nowNanos >= startNanos ? nowNanos - startNanos : 0
+        let elapsedSeconds = TimeInterval(elapsedNanos) / 1_000_000_000
+        let elapsedMs = Int((elapsedSeconds * 1000).rounded())
+        Log.claudeContext.info(
+            "Herdr \(method, privacy: .public) \(success ? "completed" : "abstained", privacy: .public) in \(elapsedMs, privacy: .public) ms (\(detail, privacy: .public))"
+        )
+        latencyRecorder?(method, elapsedSeconds, success, detail)
+    }
+
+    /// The server's error envelope verbatim (`"<code>: <message>"`), or nil
+    /// when the line is not an error envelope at all. Only error envelopes
+    /// are ever recorded: success bodies carry pane ids and terminal text
+    /// and must never reach a log.
+    private static func errorPayload(from line: Data) -> String? {
+        guard let envelope = try? JSONDecoder().decode(ErrorEnvelope.self, from: line) else {
+            return nil
+        }
+        return "\(envelope.error.code): \(envelope.error.message)"
     }
 
     private func query(socketPath: String, request: some Encodable) -> Data? {
@@ -474,6 +549,15 @@ struct HerdrSocketClient: HerdrPaneQuerying, HerdrPanelMetadataReporting {
     private struct ErrorBody: Decodable {
         var code: String
         var message: String
+    }
+
+    /// Error-only envelope for verbatim refusal logging. Decodes ONLY
+    /// responses carrying `error`; a success body never matches (its `error`
+    /// key is absent and required here), so success payloads cannot leak
+    /// through this path.
+    private struct ErrorEnvelope: Decodable {
+        var id: String
+        var error: ErrorBody
     }
 
     private struct OKResult: Decodable {

--- a/Tests/localvoxtralTests/HerdrIntegrationTests.swift
+++ b/Tests/localvoxtralTests/HerdrIntegrationTests.swift
@@ -174,6 +174,18 @@ final class HerdrIntegrationTests: XCTestCase {
         return HerdrPanelBindingProbe.token(randomBits: generator.next())
     }
 
+    /// The lane's client: production timeout, plus a per-request timing tap
+    /// so the load study can attribute failures. Each line lands on stdout
+    /// (hence in the lane log): method, latency in ms, outcome, and — on
+    /// failure only — the server's error payload verbatim (content-free) or
+    /// the local cause. Pane ids and socket paths are never printed.
+    private static func makeLaneClient() -> HerdrSocketClient {
+        HerdrSocketClient(timeout: 5, latencyRecorder: { method, latencySeconds, success, detail in
+            let ms = Int((latencySeconds * 1000).rounded())
+            print("[herdr-lane-timing] method=\(method) ms=\(ms) ok=\(success) detail=\(detail)")
+        })
+    }
+
     // MARK: - External assumption: what a whole-view client renders
 
     /// The positive half of the panel-binding premise: a whole-view App client
@@ -186,7 +198,7 @@ final class HerdrIntegrationTests: XCTestCase {
         let (service, handle) = try await openForward()
         defer { handle.close(); service.stopAllForQuit() }
 
-        let client = HerdrSocketClient(timeout: 5)
+        let client = Self.makeLaneClient()
         let token = Self.freshToken()
         fixture.primarySurface.markCurrentEnd()
 
@@ -230,7 +242,7 @@ final class HerdrIntegrationTests: XCTestCase {
         let (service, handle) = try await openForward()
         defer { handle.close(); service.stopAllForQuit() }
 
-        let client = HerdrSocketClient(timeout: 5)
+        let client = Self.makeLaneClient()
         let token = Self.freshToken()
         fixture.primarySurface.markCurrentEnd()
         attachSurface.markCurrentEnd()
@@ -271,7 +283,7 @@ final class HerdrIntegrationTests: XCTestCase {
     func testPanelTokenIsClearedByBothNullAndEmptyValues() async throws {
         let (service, handle) = try await openForward()
         defer { handle.close(); service.stopAllForQuit() }
-        let client = HerdrSocketClient(timeout: 5)
+        let client = Self.makeLaneClient()
         let socketPath = handle.localSocketPath
 
         let first = Self.freshToken()
@@ -314,7 +326,7 @@ final class HerdrIntegrationTests: XCTestCase {
     func testPanelTokenTTLBoundsAreEnforcedAtTheDocumentedEdges() async throws {
         let (service, handle) = try await openForward()
         defer { handle.close(); service.stopAllForQuit() }
-        let client = HerdrSocketClient(timeout: 5)
+        let client = Self.makeLaneClient()
         let socketPath = handle.localSocketPath
 
         let belowMinimum = await stamp(
@@ -360,7 +372,7 @@ final class HerdrIntegrationTests: XCTestCase {
     func testFocusedPaneAndProcessInfoDecodeFromTheLiveServer() async throws {
         let (service, handle) = try await openForward()
         defer { handle.close(); service.stopAllForQuit() }
-        let client = HerdrSocketClient(timeout: 5)
+        let client = Self.makeLaneClient()
 
         guard let pane = await client.focusedPane(socketPath: handle.localSocketPath) else {
             return XCTFail("pane.current returned nothing through the forwarded socket")
@@ -396,7 +408,7 @@ final class HerdrIntegrationTests: XCTestCase {
 
         let (service, handle) = try await openForward()
         defer { handle.close(); service.stopAllForQuit() }
-        let client = HerdrSocketClient(timeout: 5)
+        let client = Self.makeLaneClient()
 
         var text: String?
         for _ in 0..<40 {
@@ -599,7 +611,7 @@ final class HerdrIntegrationTests: XCTestCase {
 
         let (service, handle) = try await openForward()
         defer { handle.close(); service.stopAllForQuit() }
-        let client = HerdrSocketClient(timeout: 5)
+        let client = Self.makeLaneClient()
         let target = TerminalScreenTarget(pid: 1, bundleID: "com.mitchellh.ghostty")
 
         let seenTargets = Mutex<[TerminalScreenTarget]>([])
@@ -663,7 +675,7 @@ final class HerdrIntegrationTests: XCTestCase {
         let forwardClock = AcceleratedClock()
         let (service, handle) = try await openForward(clock: forwardClock, idleTimeout: 60)
         defer { service.stopAllForQuit() }
-        let client = HerdrSocketClient(timeout: 5)
+        let client = Self.makeLaneClient()
         let token = Self.freshToken()
         let stamped = await stamp(token, through: client, socketPath: handle.localSocketPath)
         XCTAssertTrue(stamped)
@@ -695,10 +707,27 @@ final class HerdrIntegrationTests: XCTestCase {
         await indicator.stopAndWait()
         // The clear is issued while the forward is still open — it has to be,
         // it travels through it — and only then is the lease released.
-        XCTAssertNil(
-            try fixture.paneTokens()["lvmark"],
-            "stopping the indicator must clear the token before releasing the forward"
-        )
+        //
+        // The clear is WAITED for, not asserted immediately: the stop's socket
+        // request can complete (the server acked it) while a `pane get` read
+        // still shows the token. Measured 2026-09-07 on the build host: with
+        // one concurrent `swift build`, 1 run in 10 failed the immediate read
+        // while every socket request in that run succeeded in ~100 ms
+        // (loaded p99 123 ms, max 137 ms over 189 requests — 36× inside the
+        // 5 s client timeout, so the timeout is NOT the cause). The read
+        // lags the ack under CPU contention; it is not a lost clear.
+        //
+        // The bound stays BELOW the token TTL (8 s from the last refresh), so
+        // a genuinely lost clear still fails loudly instead of passing
+        // vacuously on expiry.
+        try await HerdrLaneWait.until(
+            "the stopped mic indicator's token to clear from the server "
+                + "(if the Mac was running worker builds concurrently, that load "
+                + "is the first suspect — re-run the lane alone)",
+            timeout: 5
+        ) {
+            (try? self.fixture.paneTokens()["lvmark"]) == nil
+        }
         let socketPath = handle.localSocketPath
         try await HerdrLaneWait.until(
             "the forward released by the indicator to be torn down", timeout: 30

--- a/Tests/localvoxtralTests/HerdrSocketClientTests.swift
+++ b/Tests/localvoxtralTests/HerdrSocketClientTests.swift
@@ -509,5 +509,124 @@ final class HerdrSocketClientTests: XCTestCase {
         XCTAssertNil(info?.shellPID)
         XCTAssertEqual(info?.foregroundPIDs, [9001, 9002])
     }
+
+    // MARK: - Latency recorder (the lane's load-study tap)
+
+    private struct LatencyObservation: Sendable {
+        var method: String
+        var latencySeconds: TimeInterval
+        var success: Bool
+        var detail: String
+    }
+
+    /// Reference box so the `@Sendable` recorder can append from the
+    /// client's detached task. (`Mutex` itself is non-copyable and cannot be
+    /// passed by value into the escaping recorder closure.)
+    private final class LatencyLog: @unchecked Sendable {
+        private let lock = Mutex<[LatencyObservation]>([])
+        func append(_ observation: LatencyObservation) {
+            lock.withLock { $0.append(observation) }
+        }
+        var first: LatencyObservation? { lock.withLock { $0.first } }
+    }
+
+    private func recordingClient(
+        _ log: LatencyLog,
+        timeout: TimeInterval = 0.5
+    ) -> HerdrSocketClient {
+        HerdrSocketClient(timeout: timeout, latencyRecorder: { method, latencySeconds, success, detail in
+            log.append(LatencyObservation(
+                method: method,
+                latencySeconds: latencySeconds,
+                success: success,
+                detail: detail
+            ))
+        })
+    }
+
+    func testLatencyRecorderReceivesSuccessWithOkDetail() async throws {
+        let server = try HerdrOneShotServer { request in
+            herdrResponse(for: request, result: ["type": "ok"])
+        }
+        defer { server.stop() }
+
+        let log = LatencyLog()
+        let reported = await recordingClient(log).reportPanelToken(
+            socketPath: server.socketPath,
+            paneID: "pane-a",
+            value: "lv-mic-0000000001",
+            ttlMilliseconds: 8_000
+        )
+        XCTAssertTrue(reported)
+        let recorded = try XCTUnwrap(log.first)
+        XCTAssertEqual(recorded.method, "pane.report_metadata")
+        XCTAssertTrue(recorded.success)
+        XCTAssertEqual(recorded.detail, "ok")
+        XCTAssertGreaterThanOrEqual(recorded.latencySeconds, 0)
+    }
+
+    func testLatencyRecorderReceivesRefusalPayloadVerbatim() async throws {
+        let server = try HerdrOneShotServer { request in
+            herdrResponse(
+                for: request,
+                error: ["code": "pane_not_found", "message": "no such pane"]
+            )
+        }
+        defer { server.stop() }
+
+        let log = LatencyLog()
+        let pane = await recordingClient(log).focusedPane(
+            socketPath: server.socketPath
+        )
+        XCTAssertNil(pane)
+        let recorded = try XCTUnwrap(log.first)
+        XCTAssertEqual(recorded.method, "pane.current")
+        XCTAssertFalse(recorded.success)
+        XCTAssertEqual(recorded.detail, "pane_not_found: no such pane")
+    }
+
+    func testLatencyRecorderReceivesNoResponseOnTimeout() async throws {
+        let release = DispatchSemaphore(value: 0)
+        let server = try HerdrOneShotServer { _ in
+            release.wait()
+            return nil
+        }
+        defer {
+            release.signal()
+            server.stop()
+        }
+
+        let log = LatencyLog()
+        let pane = await recordingClient(log, timeout: 0.01).focusedPane(
+            socketPath: server.socketPath
+        )
+        XCTAssertNil(pane)
+        let recorded = try XCTUnwrap(log.first)
+        XCTAssertFalse(recorded.success)
+        XCTAssertEqual(recorded.detail, "no-response")
+    }
+
+    func testLatencyRecorderNeverCarriesPaneText() async throws {
+        // A pane.read that answers about the WRONG pane is invalid, and its
+        // body carries terminal text. The recorder must say
+        // "invalid-response", never the text.
+        let server = try HerdrOneShotServer { request in
+            herdrResponse(
+                for: request,
+                result: paneReadResult(paneID: "pane-B", text: "SECRET-TERMINAL-TEXT")
+            )
+        }
+        defer { server.stop() }
+
+        let log = LatencyLog()
+        let text = await recordingClient(log).paneVisibleText(
+            socketPath: server.socketPath, paneID: "pane-a"
+        )
+        XCTAssertNil(text)
+        let recorded = try XCTUnwrap(log.first)
+        XCTAssertFalse(recorded.success)
+        XCTAssertEqual(recorded.detail, "invalid-response")
+        XCTAssertFalse(recorded.detail.contains("SECRET"))
+    }
 }
 #endif

--- a/docs/agent/test-tiers.md
+++ b/docs/agent/test-tiers.md
@@ -228,6 +228,20 @@ prevent. Not required for UI, insertion, audio, or model work. Either way the
 PR's Proof section carries the scoreboard or a one-line justification for
 skipping.
 
+Worker builds on the Mac must not overlap the lane. Measured 2026-09-07 on
+the build host (per-request latency tap in `HerdrSocketClient`, 10 lane runs
+idle + 10 with one concurrent `swift build`): idle 10/10 green with
+p50/p99/max 110/121/126 ms; loaded 9/10 with p50/p99/max 108/123/137 ms and
+zero unexpected refusals or timeouts across 379 successful requests — but one
+loaded run failed `testMicIndicatorRefreshesTheTokenAndClearsItOnStop`
+because a `pane get` read immediately after the stop still showed the token
+while every socket request in that run had succeeded in ~100 ms. The socket
+path is NOT slow under load (36× inside the 5 s timeout); the read lags the
+server's ack under CPU contention. The lane therefore polls for the clear
+(bounded below the 8 s token TTL, so a truly lost clear still fails) — and a
+red lane with worker builds running beside it means re-run the lane alone
+before debugging the diff.
+
 The speechd live-model lane follows the same owner constraint: it runs only for
 `scripts/ci/speechd-lane-filter.sh` matches or `[run-speechd-integration]`.
 SpeechHelper engine/pin, packaging, or integration-contract changes must run it;

--- a/scripts/herdr-integration-fixture.sh
+++ b/scripts/herdr-integration-fixture.sh
@@ -453,6 +453,33 @@ start_surface() {
   log "surface '$name' ($mode) started -> $dir/surface-$name.log"
 }
 
+# Print the focused pane id once it is stable: UNCHANGED across two reads a
+# second apart AND still resolving via `pane get`. Dies loudly past the
+# readiness timeout. Callers that act on the id (report-agent) must still
+# handle it dying afterwards — settle narrows the race, it does not close it.
+settle_focused_pane() {
+  local dir="$1" pane_id="" previous="" waited=0
+  while true; do
+    # `|| true`: before a pane exists, `pane current` answers with a
+    # pane_not_found ERROR and a non-zero status, which `pipefail` would
+    # otherwise turn into an abort on the very first poll.
+    pane_id="$({ herdr_cli pane current 2>/dev/null || true; } \
+      | sed -n 's/.*"pane_id":"\([^"]*\)".*/\1/p' | head -1)"
+    if [[ -n "$pane_id" && "$pane_id" == "$previous" ]] \
+      && herdr_cli pane get "$pane_id" >/dev/null 2>&1; then
+      log "focused pane: $pane_id"
+      printf '%s\n' "$pane_id"
+      return 0
+    fi
+    if (( waited >= READY_TIMEOUT_SECONDS )); then
+      die "herdr never settled on a focused pane; see $dir/surface-primary.log and $dir/server.log"
+    fi
+    previous="$pane_id"
+    sleep 1
+    waited=$((waited + 1))
+  done
+}
+
 command_up() {
   local dir="$1" destination="${2:-}"
   validate_workdir "$dir"
@@ -547,34 +574,33 @@ EOF
   # pane, and every later request answers `pane_not_found` for it (seen on the
   # CI runner, where the timing differed from the dev box). So: require the id
   # to be UNCHANGED across two reads a second apart AND to still resolve.
-  local pane_id="" previous=""
-  waited=0
+  #
+  # Even that is not airtight: the settled pane can still die between the
+  # settle and the `report-agent` below (seen on the CI runner 2026-09-07 as
+  # `pane_not_found` for the just-settled `w1:p1`, failing the whole lane at
+  # bring-up). So the settle+report pair retries, bounded, on exactly that
+  # payload — any other failure still dies loudly.
+  #
+  # The report matters: the agents panel renders rows PER AGENT-BEARING PANE,
+  # so a plain shell pane renders no row and no stamped token could appear.
+  local agent_session_id="lvx-fixture-session-0001"
+  local pane_id="" attempt=0
   while true; do
-    # `|| true`: before a pane exists, `pane current` answers with a
-    # pane_not_found ERROR and a non-zero status, which `pipefail` would
-    # otherwise turn into an abort on the very first poll.
-    pane_id="$({ herdr_cli pane current 2>/dev/null || true; } \
-      | sed -n 's/.*"pane_id":"\([^"]*\)".*/\1/p' | head -1)"
-    if [[ -n "$pane_id" && "$pane_id" == "$previous" ]] \
-      && herdr_cli pane get "$pane_id" >/dev/null 2>&1; then
+    pane_id="$(settle_focused_pane "$dir")"
+    if herdr_cli pane report-agent "$pane_id" \
+      --source "$FIXTURE_AGENT_SOURCE" --agent claude --state working \
+      --agent-session-id "$agent_session_id" \
+      >"$dir/report-agent.out" 2>"$dir/report-agent.err"; then
       break
     fi
-    if (( waited >= READY_TIMEOUT_SECONDS )); then
-      die "herdr never settled on a focused pane; see $dir/surface-primary.log and $dir/server.log"
+    attempt=$((attempt + 1))
+    if (( attempt >= 3 )) || ! grep -q 'pane_not_found' "$dir/report-agent.err" "$dir/report-agent.out" 2>/dev/null; then
+      cat "$dir/report-agent.out" "$dir/report-agent.err" 2>/dev/null >&2 || true
+      die "pane report-agent failed for $pane_id (attempt $attempt); see $dir/surface-primary.log and $dir/server.log"
     fi
-    previous="$pane_id"
+    log "pane $pane_id died between settle and report-agent (attempt $attempt/3) — re-settling"
     sleep 1
-    waited=$((waited + 1))
   done
-  log "focused pane: $pane_id"
-
-  # The agents panel renders rows PER AGENT-BEARING PANE, so a plain shell
-  # pane renders no row at all and no custom token could ever appear. This is
-  # the shape a real join targets: a pane whose agent an integration reported.
-  local agent_session_id="lvx-fixture-session-0001"
-  herdr_cli pane report-agent "$pane_id" \
-    --source "$FIXTURE_AGENT_SOURCE" --agent claude --state working \
-    --agent-session-id "$agent_session_id" >/dev/null
   log "pane $pane_id marked agent-bearing (session $agent_session_id)"
 
   printf '{"agentSessionID":"%s","alias":"%s","altUserAlias":"%s-altuser","otherPortAlias":"%s-otherport","herdrBinary":"%s","socketPath":"%s","paneID":"%s","primarySurfaceLog":"%s","provisionedSSH":%s,"workdir":"%s"}\n' \


### PR DESCRIPTION
## What

The live herdr lane fails ~1 run in 3 under Mac load with either a refused/timed-out stamp or a lost mic-indicator clear. This PR measures the lane under deliberate load and fixes what the measurement supports — nothing more.

**Measurement (the deliverable).** New `HerdrSocketClient.latencyRecorder` seam logs per-request latency (ms) plus refusal payloads verbatim (error envelope only — success bodies never reach it, so pane text/ids can't leak; pinned by 4 new `HerdrSocketClientTests`). The lane client prints `[herdr-lane-timing]` lines. 10 lane runs idle + 10 with one concurrent `swift build` (`LV_BUILD_DIR=work/localvoxtral-load`), one lane at a time:

| condition | lane | successful socket requests |
|---|---|---|
| idle | **10/10 green** | 190: min 3 ms, p50 110 ms, p99 121 ms, max 126 ms |
| 1× concurrent `swift build` | **9/10 green** | 189: min 3 ms, p50 108 ms, p99 123 ms, max 137 ms |

Zero unexpected refusals or timeouts in all 20 runs: every `ok=false` line (30/30) is a designed negative control, verbatim: `invalid_metadata_ttl: metadata ttl_ms must be at least 1`, `invalid_metadata_ttl: metadata ttl_ms must be 86400000 or less`, `pane_not_found: pane w99:p99 not found`. The one loaded failure reproduced the reported symptom exactly: `testMicIndicatorRefreshesTheTokenAndClearsItOnStop`, `XCTAssertNil failed: "lv-mic-…"`, while **every socket request in that run succeeded in ~100 ms**.

**Decisions from the measurement:**

- (a) **No timeout raise.** Loaded max 137 ms vs the 5 s client timeout is 36× headroom; p99 is unchanged by load (121 → 123 ms). Raising the timeout would mask real hangs, not fix this lane.
- (b) **No bounded retry.** The condition for it (server refusals / error payloads, not timeouts) never occurred outside the designed negative controls in 379 successful + 30 expected-failed requests. The re-stamp assertion in `waitForToken` stays loud. The TTL race hypothesized for the clear is also excluded: the failing run's last stamp was ~seconds old, nowhere near the 8 s TTL.
- (c) **Yes: poll for the clear.** The failure is read-after-write visibility lag — the server acked the stop's clear, but the immediate `pane get` read still showed the token under CPU contention. The test now waits (bounded 5 s, **below the 8 s token TTL** so a genuinely lost clear still fails instead of passing vacuously on expiry), with a load-first-suspect message on timeout.

Also: `docs/agent/test-tiers.md` gains the no-overlap rule with the measured effect, and the CI lane step prints a one-line load-first hint on failure.

No assertion was weakened: the immediate `XCTAssertNil` became a bounded wait with a strictly stronger timeout message, and the 5 s bound is justified above. No production timing tolerance moved (client default 0.5 s untouched; lane 5 s untouched).

[run-herdr-integration]

## Proof

- [x] Unit suite green — `./scripts/remote-build.sh test`
  - `Executed 3041 tests, with 2 tests skipped and 0 failures (0 unexpected) in 51.671 (51.798) seconds` (includes 4 new `HerdrSocketClientTests`: success/refusal-verbatim/no-response/no-pane-text)
  - `HerdrPanelBindingProbeTests`: `Executed 12 tests, with 0 failures (0 unexpected)`
- [ ] Realtime integration green — `./scripts/remote-build.sh integration` (not required: nothing in the audio/realtime path changed; lane filter does not match)
- [x] Bug fix: regression coverage — the new `HerdrSocketClientTests` latency-recorder tests pass on this branch (`Executed 22 tests, with 0 failures` for `HerdrSocketClientTests`); the lane-level proof is the 10+10 loop below, where the pre-fix loop reproduced the exact reported failure (`XCTAssertNil failed: "lv-mic-…"`) on load run 1/10 and the post-fix loop is 20/20.
- [ ] UI change: none (popover copy untouched).

Pre-fix loop (instrumentation only): idle 10/10, load 9/10 (load-1 red as above). Post-fix loop: idle 10/10 + load 10/10, then 3× consecutive `integration-herdr` green (final-1..3, exit 0). Full per-run logs and the timing aggregates are retained on the measurement host.
