### PR TITLE
Settings copy pass: labels and one-line status, Engines rename, Report an Issue

### DIFF
--- a/Sources/localvoxtral/Backends/PolishModelCatalog.swift
+++ b/Sources/localvoxtral/Backends/PolishModelCatalog.swift
@@ -57,7 +57,7 @@ enum PolishModelCatalog {
             estimatedRAMGB: 1.2,
             samplingDefaults: nil,
             chatTemplateArguments: nil,
-            summary: "Lightest option, for constrained Macs"
+            summary: "Lightest option for constrained Macs"
         ),
         PolishModelOption(
             repoID: "mlx-community/Qwen3.5-4B-OptiQ-4bit",
@@ -70,7 +70,7 @@ enum PolishModelCatalog {
             estimatedRAMGB: 3.8,
             samplingDefaults: nil,
             chatTemplateArguments: ["enable_thinking": false],
-            summary: "For any Apple Silicon Mac"
+            summary: "Fits any Apple Silicon Mac"
         ),
         PolishModelOption(
             repoID: "mlx-community/Qwen3.5-9B-OptiQ-4bit",
@@ -81,7 +81,7 @@ enum PolishModelCatalog {
             estimatedRAMGB: 7.5,
             samplingDefaults: nil,
             chatTemplateArguments: ["enable_thinking": false],
-            summary: "For 32 GB+ Macs"
+            summary: "Needs a 32 GB or larger Mac"
         ),
     ]
 
@@ -134,7 +134,7 @@ enum PolishModelPickerSupport {
             return "Custom managed model. \(downloadState)."
         }
         return
-            "\(option.summary). \(option.sizeOnDiskGB.formatted(.number.precision(.fractionLength(1)))) GB · \(downloadState)"
+            "\(option.summary). \(option.sizeOnDiskGB.formatted(.number.precision(.fractionLength(1)))) GB, \(downloadState)"
     }
 }
 

--- a/Sources/localvoxtral/ClaudeContext/ClaudeIntegrationSettingsModel.swift
+++ b/Sources/localvoxtral/ClaudeContext/ClaudeIntegrationSettingsModel.swift
@@ -926,7 +926,7 @@ public final class ClaudeIntegrationSettingsModel {
         case (true, true):
             cause = "an outdated plugin or a stale token"
         case (true, false):
-            return "Rejected connections suggest an outdated plugin; use Update plugin."
+            return "Rejected connections suggest an outdated plugin; use Update host."
         case (false, true):
             return "Rejected connections suggest a stale token; rotate it and rerun setup."
         case (false, false):

--- a/Sources/localvoxtral/ClaudeContext/ClaudeIntegrationSettingsModel.swift
+++ b/Sources/localvoxtral/ClaudeContext/ClaudeIntegrationSettingsModel.swift
@@ -236,7 +236,7 @@ public final class ClaudeIntegrationSettingsModel {
 
         public var text: String {
             switch self {
-            case .idle: return "Not listening — no hosts enrolled."
+            case .idle: return "Not listening because no hosts are enrolled."
             case .listening(let port): return "Listening on 127.0.0.1:\(port)."
             case .portConflict(let port): return "Port \(port) is already in use."
             case .failed: return "Could not start listening."
@@ -249,7 +249,7 @@ public final class ClaudeIntegrationSettingsModel {
             switch self {
             case .idle, .listening: return nil
             case .portConflict(let port):
-                return "Another app — often a second copy of localvoxtral — holds \(port). "
+                return "Another app holds \(port), often a second copy of localvoxtral. "
                     + "Quit it and press Retry."
             case .failed: return "See Console for details, then press Retry."
             }
@@ -457,7 +457,7 @@ public final class ClaudeIntegrationSettingsModel {
 
     /// The herdr row's one status sentence. A constant: the row is
     /// status-only, and presence is the whole fact.
-    public static let herdrDetectedSentence = "Found — panes join automatically."
+    public static let herdrDetectedSentence = "Found; panes join automatically."
 
     /// The password field's live text. Never seeded from the Keychain: the
     /// stored secret is not shown back to anyone, and an empty field on a
@@ -868,13 +868,13 @@ public final class ClaudeIntegrationSettingsModel {
         case (true, true):
             cause = "an outdated plugin or a stale token"
         case (true, false):
-            cause = "an outdated plugin — use Update Plugin"
+            return "Rejected connections suggest an outdated plugin; use Update plugin."
         case (false, true):
-            cause = "a stale token — rotate it and re-run setup"
+            return "Rejected connections suggest a stale token; rotate it and rerun setup."
         case (false, false):
             cause = "a malformed authorization header"
         }
-        return "Rejected connections detected — a host may have \(cause)."
+        return "Rejected connections suggest \(cause)."
     }
 
     public func refreshListenerStatus() {
@@ -904,7 +904,7 @@ public final class ClaudeIntegrationSettingsModel {
         guard ClaudeRemoteEnrollmentService.isValidHostAlias(alias) else {
             alert = DetailAlert(
                 title: "Invalid SSH host",
-                detail: "“\(alias)” is not an SSH host alias. Use the name from your ~/.ssh/config — "
+                detail: "\"\(alias)\" is not an SSH host alias. Use the name from your ~/.ssh/config. "
                     + "letters, digits, dots, dashes and underscores only."
             )
             return
@@ -1345,7 +1345,7 @@ public final class ClaudeIntegrationSettingsModel {
             // one-click actions repeat their exact text does not get weaker
             // because an action now has two parts — it gets more important.
             preview: Self.updatePreview(for: presentation),
-            confirmButtonTitle: "Confirm Update"
+            confirmButtonTitle: "Confirm update"
         )
         Log.claudeContext.info("Claude remote plugin update confirmation requested")
     }
@@ -1362,7 +1362,7 @@ public final class ClaudeIntegrationSettingsModel {
             action: .insertSSHConfig,
             title: "Insert this exact block into ~/.ssh/config?",
             preview: presentation.plan.sshConfigSnippet,
-            confirmButtonTitle: "Confirm Insert"
+            confirmButtonTitle: "Confirm insert"
         )
         Log.claudeContext.info("Claude remote ssh config confirmation requested")
     }
@@ -1382,7 +1382,7 @@ public final class ClaudeIntegrationSettingsModel {
             action: .runRemoteSetup,
             title: "Run these commands on the SSH host?",
             preview: Self.redactedRemoteCommands(for: presentation),
-            confirmButtonTitle: "Confirm Run"
+            confirmButtonTitle: "Confirm run"
         )
         Log.claudeContext.info("Claude remote setup confirmation requested")
     }
@@ -1398,7 +1398,7 @@ public final class ClaudeIntegrationSettingsModel {
             action: .configureHerdrPanel(hostID: hostID),
             title: "Configure this exact herdr agents-panel row?",
             preview: ClaudeRemoteEnrollmentService.herdrPanelConfigSnippet,
-            confirmButtonTitle: "Confirm Configure"
+            confirmButtonTitle: "Confirm configuration"
         )
         Log.claudeContext.info("Claude remote herdr panel configuration confirmation requested")
     }
@@ -1844,8 +1844,8 @@ public final class ClaudeIntegrationSettingsModel {
         case .invalidSSHConfigEncoding:
             return "~/.ssh/config is not valid UTF-8, so localvoxtral left it unchanged."
         case .sshConfigIsSymlink:
-            return "~/.ssh/config (or ~/.ssh) is a symlink — likely a dotfiles setup. "
-                + "localvoxtral won't replace the link; use the Copy button and add the block "
+            return "~/.ssh/config or ~/.ssh is a symlink, likely from a dotfiles setup. "
+                + "localvoxtral won't replace the link. Use Copy and add the block "
                 + "to the real file yourself."
         case .sshDirectoryNotTrusted:
             return "~/.ssh is not exclusively writable by you (wrong owner or group/world-"
@@ -1919,7 +1919,7 @@ public final class ClaudeIntegrationSettingsModel {
            code == EADDRINUSE {
             return "localvoxtral could not bind 127.0.0.1:\(port), because something else already has it.\n\n"
                 + "This is usually a second copy of localvoxtral. Note that a squatter on this port would "
-                + "receive your remote hosts' context — it cannot authenticate them (it does not have the "
+                + "receive your remote hosts' context. It cannot authenticate them because it does not have the "
                 + "token hashes), but it does see what they send before the request is rejected. Find and "
                 + "quit whatever holds the port rather than moving off it.\n\n"
                 + "`lsof -nP -iTCP:\(port) -sTCP:LISTEN` will name the process."

--- a/Sources/localvoxtral/ClaudeContext/ClaudeRemoteEnrollmentService.swift
+++ b/Sources/localvoxtral/ClaudeContext/ClaudeRemoteEnrollmentService.swift
@@ -1322,7 +1322,7 @@ public struct ClaudeRemoteEnrollmentService: Sendable {
                     kind: .tunnel,
                     passed: false,
                     summary: "Nothing answered, and localvoxtral is not listening here.",
-                    hint: "Fix the listener on this Mac first — this check cannot tell you "
+                    hint: "Fix the listener on this Mac first. This check cannot tell you "
                         + "anything about the tunnel until it is bound.",
                     detail: "Nothing answered on the host's 127.0.0.1:\(remoteForwardPort), "
                         + "and this Mac's listener was not bound."
@@ -1405,7 +1405,7 @@ public struct ClaudeRemoteEnrollmentService: Sendable {
           done
         fi
         if ! command -v claude >/dev/null 2>&1; then
-          echo "localvoxtral: 'claude' was not found on this host's non-interactive PATH, nor in ~/.claude/local, ~/.local/bin, ~/bin, /opt/homebrew/bin, /usr/local/bin, or ~/.nvm/versions/node/*/bin. Run 'command -v claude' in a normal shell on this host, then rerun setup — or add that directory to PATH for non-interactive SSH shells." >&2
+          echo "localvoxtral: 'claude' was not found on this host's non-interactive PATH, nor in ~/.claude/local, ~/.local/bin, ~/bin, /opt/homebrew/bin, /usr/local/bin, or ~/.nvm/versions/node/*/bin. Run 'command -v claude' in a normal shell on this host. Then rerun setup or add that directory to PATH for non-interactive SSH shells." >&2
           exit 127
         fi
 

--- a/Sources/localvoxtral/ClaudeContext/ClaudeRemoteForwardSupervisor.swift
+++ b/Sources/localvoxtral/ClaudeContext/ClaudeRemoteForwardSupervisor.swift
@@ -164,7 +164,7 @@ public final class ClaudeRemoteForwardSupervisor: ClaudeRemoteForwarding {
             // "up" comes first because that is the fact that matters. The
             // clause is there so a later plain "Tunnel up." does not read as a
             // change of state.
-            case .externallyForwarded: return "Tunnel up — an ssh session already holds it."
+            case .externallyForwarded: return "Tunnel up through an existing ssh session."
             case .staleConfiguredForward: return "Old RemoteForward in ~/.ssh/config blocks this."
             case .failed: return "Tunnel stopped."
             }

--- a/Sources/localvoxtral/ClaudeContext/ClaudeStatuslineInstallService.swift
+++ b/Sources/localvoxtral/ClaudeContext/ClaudeStatuslineInstallService.swift
@@ -40,9 +40,9 @@ public struct ClaudeStatuslineInstallService: Sendable {
     /// JSON round-trip (pretty-printed, sorted keys) — the sheet must never
     /// claim the file is otherwise byte-untouched.
     public static let sheetExplanation =
-        "This adds one entry to ~/.claude/settings.json pointing at this app's publisher, "
-        + "so Claude Code's bottom bar shows whether localvoxtral is connected to the session. "
-        + "Every other entry is kept (formatting is normalized)."
+        "This adds one entry to ~/.claude/settings.json pointing at localvoxtral's publisher, "
+        + "so the Claude Code bottom bar shows whether localvoxtral is connected. "
+        + "Every other entry is kept, and formatting is normalized."
 
     private let fileSystem: (any ClaudeStatuslineFileSystem)?
     /// Whether an invoked path resolves to an existing executable. Injected
@@ -87,8 +87,8 @@ public struct ClaudeStatuslineInstallService: Sendable {
         switch status {
         case .notConfigured: return "Not installed."
         case .installed: return "Installed."
-        case .stalePath: return "Installed, path no longer exists — Update."
-        case .edited: return "Edited by you; remove it in settings.json."
+        case .stalePath: return "The installed path moved; update the status line."
+        case .edited: return "Edited in settings.json; remove it there."
         case .foreign: return "Your own status line is configured."
         case .unknown: return "Could not read your Claude settings."
         }

--- a/Sources/localvoxtral/DictationViewModel+Session.swift
+++ b/Sources/localvoxtral/DictationViewModel+Session.swift
@@ -222,7 +222,7 @@ extension DictationViewModel {
         logConnectionFailure(message: message, technicalDetails: technicalDetails)
         markRecentConnectionFailureIndicator()
         presentConnectionFailureAlert(
-            title: "Managed Backend Failed",
+            title: "Managed backend failed",
             message: message,
             technicalDetails: technicalDetails
         )

--- a/Sources/localvoxtral/DictationViewModel.swift
+++ b/Sources/localvoxtral/DictationViewModel.swift
@@ -125,9 +125,9 @@ final class DictationViewModel {
         static let requestingMicrophonePermission = "Requesting microphone permission..."
         static let waitingForAccessibilityPermission = "Waiting for Accessibility permission."
         static let pasteBlockedByAccessibilityPermission = "Paste blocked by Accessibility permission."
-        static let networkLostDictationStopped = "Network lost. Dictation stopped."
-        static let liveDictationBlockedBySecureInput = "Blocked: Secure Keyboard Entry is on."
-        static let overlayCopiedToClipboard = "Copied — paste it manually."
+        static let networkLostDictationStopped = "Dictation stopped after the network disconnected."
+        static let liveDictationBlockedBySecureInput = "Secure Keyboard Entry blocks Live Auto-Paste."
+        static let overlayCopiedToClipboard = "Copied for manual paste."
         static let noNetworkConnection = "No network connection."
         static let microphoneAccessDenied = "Microphone access denied."
         static let finalizing = "Finalizing..."
@@ -147,7 +147,7 @@ final class DictationViewModel {
     /// events, so dictated text may silently land nowhere. Warn only — the
     /// session still runs. One short sentence (popover copy rule).
     static let secureKeyboardEntryWarningMessage =
-        "Secure Keyboard Entry is on; dictated text may not appear."
+        "Secure Keyboard Entry may hide dictated text."
 
     var isDictating = false
     var isFinalizingStop = false
@@ -1414,7 +1414,7 @@ final class DictationViewModel {
         }
 
         // Owner-specified UX: required managed backends install/download/start
-        // eagerly, with progress rendered inline in Endpoints.
+        // eagerly, with progress rendered inline in Engines.
         // Failures land in the manager statuses; dictation-time ensureReady remains the
         // backstop and retry path.
         Log.backends.info(
@@ -2333,7 +2333,7 @@ final class DictationViewModel {
     }
 
     /// Reset the first-launch flag and ask the app delegate to re-present the
-    /// onboarding wizard. Invoked by the General settings pane's "Re-run Setup…".
+    /// onboarding wizard. Invoked by the General settings pane's "Re-run setup…".
     func reRunOnboarding() {
         settings.onboardingCompleted = false
         onRequestReRunOnboarding?()

--- a/Sources/localvoxtral/Onboarding/OnboardingBootstrapDriving.swift
+++ b/Sources/localvoxtral/Onboarding/OnboardingBootstrapDriving.swift
@@ -19,15 +19,6 @@ enum OnboardingItemID: String, CaseIterable, Identifiable, Sendable {
         }
     }
 
-    /// One short line describing what gets downloaded.
-    var detail: String {
-        switch self {
-        case .dictation:
-            return "the bundled dictation engine + Voxtral model"
-        case .polishing:
-            return "the polishing LLM (bundled engine)"
-        }
-    }
 }
 
 /// UI-facing state of a single onboarding download item. Deliberately decoupled
@@ -90,7 +81,7 @@ extension OnboardingItemState {
             // rather than pretending we are still checking.
             if progress.downloadedBytes > 0 {
                 let megabytes = progress.downloadedBytes / 1_048_576
-                return "Downloading model - \(megabytes) MB"
+                return "Downloading model, \(megabytes) MB"
             }
             return "Checking model..."
         }

--- a/Sources/localvoxtral/Onboarding/OnboardingTriggerSummary.swift
+++ b/Sources/localvoxtral/Onboarding/OnboardingTriggerSummary.swift
@@ -48,7 +48,7 @@ struct DictationTriggerSummary: Equatable {
 
         return DictationTriggerSummary(
             primary: "Menu bar",
-            explanation: "No shortcut is set — start dictation from the menu bar icon."
+            explanation: "No shortcut is set. Start dictation from the menu bar icon."
         )
     }
 }

--- a/Sources/localvoxtral/Onboarding/OnboardingViewModel.swift
+++ b/Sources/localvoxtral/Onboarding/OnboardingViewModel.swift
@@ -36,7 +36,7 @@ final class OnboardingViewModel {
 
     /// Set by the window controller to dismiss the wizard.
     @ObservationIgnored var onRequestClose: (() -> Void)?
-    /// Set by the window controller to open Settings on the Endpoints tab.
+    /// Set by the window controller to open Settings on the Engines tab.
     @ObservationIgnored var onOpenEndpointsSettings: (() -> Void)?
 
     init(
@@ -89,7 +89,7 @@ final class OnboardingViewModel {
     }
 
     /// The "I run my own server instead" escape hatch: point both backends at
-    /// external URLs, finish onboarding, and jump the user to the Endpoints tab.
+    /// external URLs, finish onboarding, and jump the user to the Engines tab.
     func useOwnServer() {
         driver.cancel()
         // Undo any polishing opt-in from this wizard run: leaving it enabled

--- a/Sources/localvoxtral/Onboarding/OnboardingWizardView.swift
+++ b/Sources/localvoxtral/Onboarding/OnboardingWizardView.swift
@@ -59,7 +59,7 @@ struct OnboardingWizardView: View {
 
     private var primaryActionTitle: String {
         if model.page == .downloads, !model.downloadsStarted {
-            return "Begin Download"
+            return "Begin download"
         }
         return model.isFinalPage ? "Get Started" : "Continue"
     }
@@ -106,43 +106,8 @@ private struct WelcomePage: View {
             OnboardingHeader(
                 systemImage: "waveform.circle",
                 title: "Welcome to localvoxtral",
-                subtitle:
-                    "Realtime dictation for macOS. Start dictation, speak, and text appears as you talk — right in the app you're using."
+                subtitle: "Dictate into any app from the menu bar."
             )
-
-            VStack(alignment: .leading, spacing: 12) {
-                FeatureBullet(
-                    systemImage: "menubar.arrow.up.rectangle",
-                    text: "Lives in your menu bar and opens instantly.")
-                FeatureBullet(
-                    systemImage: "bolt.horizontal.circle",
-                    text: "Streams words while you're still speaking.")
-                FeatureBullet(
-                    systemImage: "lock.laptopcomputer",
-                    text: "Runs fully on-device with the managed local engine.")
-            }
-
-            Text("This quick setup grants permissions and downloads the local engine.")
-                .font(.caption)
-                .foregroundStyle(.secondary)
-                .fixedSize(horizontal: false, vertical: true)
-        }
-    }
-}
-
-private struct FeatureBullet: View {
-    let systemImage: String
-    let text: String
-
-    var body: some View {
-        HStack(alignment: .center, spacing: 10) {
-            Image(systemName: systemImage)
-                .font(.system(size: 15))
-                .foregroundStyle(.tint)
-                .frame(width: 22)
-            Text(text)
-                .font(.system(size: 13))
-                .fixedSize(horizontal: false, vertical: true)
         }
     }
 }
@@ -157,14 +122,13 @@ private struct PermissionsPage: View {
             OnboardingHeader(
                 systemImage: "hand.raised.circle",
                 title: "Grant permissions",
-                subtitle:
-                    "localvoxtral needs the microphone to hear you, and Accessibility to type text into other apps."
+                subtitle: "Allow microphone recording and typing into other apps."
             )
 
             PermissionRowsView(viewModel: viewModel)
 
             Text(
-                "You can continue without granting these now and enable them later in Settings ▸ General."
+                "You can grant these later in Settings > General."
             )
             .font(.caption)
             .foregroundStyle(.secondary)
@@ -189,8 +153,7 @@ private struct DownloadsPage: View {
             OnboardingHeader(
                 systemImage: "arrow.down.circle",
                 title: "Set up the local engine",
-                subtitle:
-                    "localvoxtral will prepare the bundled dictation engine and download its Voxtral model. Nothing downloads until you start it below."
+                subtitle: "Start the model download when you are ready."
             )
 
             Toggle(isOn: $model.polishingConsent) {
@@ -198,7 +161,7 @@ private struct DownloadsPage: View {
                     Text("Also set up LLM polishing")
                         .font(.system(size: 13, weight: .medium))
                     Text(
-                        "Downloads a small polishing model for the built-in engine. You can decline and turn it on later in Settings."
+                        "Downloads a small polishing model. You can add it later in Settings."
                     )
                     .font(.caption)
                     .foregroundStyle(.secondary)
@@ -219,7 +182,7 @@ private struct DownloadsPage: View {
 
             if model.downloadsStarted {
                 Text(
-                    "Downloads continue in the background — you can press Continue while they finish."
+                    "You can continue while downloads finish in the background."
                 )
                 .font(.caption)
                 .foregroundStyle(.secondary)
@@ -246,9 +209,6 @@ private struct DownloadItemRow: View {
             VStack(alignment: .leading, spacing: 3) {
                 Text(item.title)
                     .font(.system(size: 13, weight: .medium))
-                Text(item.detail)
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
 
                 if case .working(let detail, let fraction) = state ?? .pending {
                     HStack(spacing: 8) {
@@ -306,7 +266,7 @@ private struct FinishPage: View {
             OnboardingHeader(
                 systemImage: "checkmark.circle",
                 title: "You're all set",
-                subtitle: "Here's how to start dictating."
+                subtitle: "Try your dictation trigger in any text field."
             )
 
             VStack(alignment: .leading, spacing: 6) {
@@ -324,14 +284,14 @@ private struct FinishPage: View {
                     .fill(Color(nsColor: .quaternarySystemFill))
             }
 
-            Text("Press it in any text field to try it out. Escape cancels a dictation.")
+            Text("Escape cancels a dictation.")
                 .font(.caption)
                 .foregroundStyle(.secondary)
                 .fixedSize(horizontal: false, vertical: true)
 
             if !summary.isModifierOnly {
                 Text(
-                    "Prefer a single key? The trigger can be just a modifier like Fn / Globe — tap it for the overlay, hold it to type live. Switch anytime in Settings ▸ Dictation."
+                    "For one-key control, choose Fn / Globe in Settings > Dictation. Tap for the overlay or hold to type live."
                 )
                 .font(.caption)
                 .foregroundStyle(.secondary)

--- a/Sources/localvoxtral/Onboarding/PermissionRowsView.swift
+++ b/Sources/localvoxtral/Onboarding/PermissionRowsView.swift
@@ -72,7 +72,7 @@ struct PermissionRowsView: View {
         case .authorized:
             return nil
         case .notDetermined:
-            return PermissionRow.Action(label: "Allow Microphone…") {
+            return PermissionRow.Action(label: "Allow microphone…") {
                 viewModel.requestMicrophonePermission()
             }
         case .denied, .restricted:
@@ -86,7 +86,7 @@ struct PermissionRowsView: View {
 
     private var accessibilityAction: PermissionRow.Action? {
         guard !viewModel.isAccessibilityTrusted else { return nil }
-        return PermissionRow.Action(label: "Grant Access") {
+        return PermissionRow.Action(label: "Grant access") {
             viewModel.requestAccessibilityPermission()
             Self.openSettings(Self.accessibilitySettingsURL)
         }

--- a/Sources/localvoxtral/OverlayBufferSessionCoordinator.swift
+++ b/Sources/localvoxtral/OverlayBufferSessionCoordinator.swift
@@ -200,7 +200,7 @@ final class OverlayBufferSessionCoordinator: OverlayBufferSessionCoordinating {
             // persistent failure panel, which keeps the text visible.
             guard copyToPasteboard(commitText) else {
                 let failureMessage =
-                    "Secure input blocked auto-paste and the clipboard copy failed — the text stays visible here."
+                    "Secure input blocked auto-paste, and the clipboard copy failed; the text remains visible."
                 stateMachine.commitFailed(
                     error: failureMessage,
                     anchor: anchorResolver.resolveAnchor()
@@ -209,7 +209,7 @@ final class OverlayBufferSessionCoordinator: OverlayBufferSessionCoordinating {
                 Log.overlay.error("overlay commit skipped: secure input active AND clipboard write failed")
                 return .failed(message: failureMessage)
             }
-            let fallbackMessage = "Secure input blocked auto-paste — text copied, paste it manually."
+            let fallbackMessage = "Secure input blocked auto-paste, so the text was copied for manual paste."
             stateMachine.commitFailed(
                 error: fallbackMessage,
                 anchor: anchorResolver.resolveAnchor()

--- a/Sources/localvoxtral/RealtimeConnectionFailure.swift
+++ b/Sources/localvoxtral/RealtimeConnectionFailure.swift
@@ -119,7 +119,7 @@ enum RealtimeConnectionFailureClassifier {
             // (kept verbatim so StatusToken mapping continues to recognize it).
             let message = "Network connection was lost while connecting to \(endpoint). Reconnect to a network and try again."
             return RealtimeConnectionFailureDescription(
-                status: "Network lost. Dictation stopped.",
+                status: "Dictation stopped after the network disconnected.",
                 message: message,
                 technicalDetails: Self.technicalDetails(
                     rawError,

--- a/Sources/localvoxtral/Settings/SettingsSidebarView.swift
+++ b/Sources/localvoxtral/Settings/SettingsSidebarView.swift
@@ -21,7 +21,7 @@ extension SettingsTab {
         switch self {
         case .general: return "General"
         case .dictation: return "Dictation"
-        case .endpoints: return "Endpoints"
+        case .endpoints: return "Engines"
         case .textProcessing: return "Text Processing"
         case .integrations: return "Integrations"
         case .about: return "About"
@@ -32,7 +32,7 @@ extension SettingsTab {
         switch self {
         case .general: return "Permissions and app-level behavior."
         case .dictation: return "How you start, stop, and see dictation."
-        case .endpoints: return "Where speech recognition and polishing run."
+        case .endpoints: return "Where dictation and polishing run."
         case .textProcessing: return "Replacements and LLM polishing of your transcript."
         case .integrations: return "What the polisher and your coding agents may see."
         case .about: return "Version, project, and diagnostics."

--- a/Sources/localvoxtral/SettingsStore.swift
+++ b/Sources/localvoxtral/SettingsStore.swift
@@ -31,14 +31,6 @@ enum DictationOutputMode: String, CaseIterable, Identifiable, Sendable {
         }
     }
 
-    var description: String {
-        switch self {
-        case .overlayBuffer:
-            return "Keeps text in an on-screen buffer until stop."
-        case .liveAutoPaste:
-            return "Streams text directly into the focused app."
-        }
-    }
 }
 
 enum DictationShortcutMode: String, CaseIterable, Identifiable {
@@ -56,14 +48,6 @@ enum DictationShortcutMode: String, CaseIterable, Identifiable {
         }
     }
 
-    var description: String {
-        switch self {
-        case .toggle:
-            return "Press once to start dictation, press again to stop."
-        case .pushToTalk:
-            return "Hold the shortcut to dictate, release to stop."
-        }
-    }
 }
 
 enum BackendMode: String, CaseIterable, Identifiable {
@@ -81,23 +65,6 @@ enum BackendMode: String, CaseIterable, Identifiable {
         }
     }
 
-    var dictationDescription: String {
-        switch self {
-        case .managedLocal:
-            return "Runs the bundled dictation engine on this Mac."
-        case .externalURL:
-            return "Use an OpenAI Realtime-compatible endpoint you run yourself."
-        }
-    }
-
-    var polishingDescription: String {
-        switch self {
-        case .managedLocal:
-            return "Runs the bundled polishing engine on this Mac."
-        case .externalURL:
-            return "Use an OpenAI-compatible chat completions endpoint you run yourself."
-        }
-    }
 }
 
 /// Metal buffer-pool cache limit for the managed dictation helper. `Auto`
@@ -335,7 +302,7 @@ final class SettingsStore {
     /// True once the user has completed (or skipped) the first-launch onboarding
     /// wizard. Resolved once at init (see `resolveOnboardingCompleted`) and
     /// persisted immediately so the wizard shows exactly once for fresh installs.
-    /// The General settings pane's "Re-run Setup…" resets it to false.
+    /// The General settings pane's "Re-run setup…" resets it to false.
     var onboardingCompleted: Bool {
         didSet { defaults.set(onboardingCompleted, forKey: Keys.onboardingCompleted) }
     }
@@ -717,7 +684,7 @@ final class SettingsStore {
         // values back off.
         //
         // The gate needs the onboarding key to be ABSENT, not merely resolved
-        // false. "Re-run Setup…" resets that flag to false on an existing
+        // false. "Re-run setup…" resets that flag to false on an existing
         // install (DictationViewModel.reRunOnboarding), so a crash or force-quit
         // before the wizard closes would otherwise leave a configured user
         // looking fresh on the next launch — and claim Right Command from them.

--- a/Sources/localvoxtral/SettingsView.swift
+++ b/Sources/localvoxtral/SettingsView.swift
@@ -2,7 +2,7 @@ import AppKit
 import SwiftUI
 
 /// Identifies each Settings tab so navigation can be driven programmatically
-/// (e.g. the onboarding "I run my own server" link jumps to Endpoints).
+/// (e.g. the onboarding "I run my own server" link jumps to Engines).
 enum SettingsTab: String, Hashable, CaseIterable, Sendable {
     case general
     case endpoints
@@ -159,18 +159,16 @@ private struct GeneralSettingsPane: View {
 
             SettingsGroup(title: "App") {
                 SettingsFieldRow(
-                    title: "Copy final segment",
-                    help: "Copies to the clipboard on stop."
+                    title: "Copy on stop"
                 ) {
                     Toggle("", isOn: $settings.autoCopyEnabled)
                         .labelsHidden()
                 }
 
                 SettingsFieldRow(
-                    title: "Setup",
-                    help: "Reopen the first-launch setup wizard for permissions and downloads."
+                    title: "Setup wizard"
                 ) {
-                    Button("Re-run Setup…") {
+                    Button("Re-run setup…") {
                         viewModel.reRunOnboarding()
                     }
                 }
@@ -289,8 +287,7 @@ private struct ConnectionSettingsPane: View {
         SettingsPage(tab: .endpoints) {
             SettingsGroup(title: "Dictation") {
                 SettingsFieldRow(
-                    title: "Mode",
-                    help: settings.dictationBackendMode.dictationDescription
+                    title: "Mode"
                 ) {
                     Picker("", selection: dictationBackendModeBinding) {
                         ForEach(BackendMode.allCases) { mode in
@@ -303,7 +300,7 @@ private struct ConnectionSettingsPane: View {
 
                 switch settings.dictationBackendMode {
                 case .externalURL:
-                    SettingsFieldRow(title: "Endpoint") {
+                    SettingsFieldRow(title: "Server URL") {
                         TextField(settings.endpointPlaceholder, text: endpointBinding)
                             .textFieldStyle(.roundedBorder)
                             .frame(maxWidth: SettingsLayout.textFieldWidth)
@@ -332,8 +329,7 @@ private struct ConnectionSettingsPane: View {
                     }
 
                     SettingsFieldRow(
-                        title: "Step interval",
-                        help: "Lower values show words sooner; higher values use less compute."
+                        title: "Step interval"
                     ) {
                         Picker("", selection: speechdStepCadenceBinding) {
                             ForEach(SpeechdStepCadence.allCases) { cadence in
@@ -353,8 +349,7 @@ private struct ConnectionSettingsPane: View {
 
             SettingsGroup(title: "Polishing") {
                 SettingsFieldRow(
-                    title: "Mode",
-                    help: settings.polishingBackendMode.polishingDescription
+                    title: "Mode"
                 ) {
                     Picker("", selection: polishingBackendModeBinding) {
                         ForEach(BackendMode.allCases) { mode in
@@ -368,10 +363,7 @@ private struct ConnectionSettingsPane: View {
                 switch settings.polishingBackendMode {
                 case .externalURL:
                     SettingsFieldRow(
-                        title: "Endpoint",
-                        help: "Enter a base URL (e.g. http://127.0.0.1:8080); "
-                            + "/v1/chat/completions is appended automatically. "
-                            + "A full …/v1/chat/completions URL still works."
+                        title: "Server URL"
                     ) {
                         TextField(
                             "http://127.0.0.1:8080",
@@ -399,7 +391,7 @@ private struct ConnectionSettingsPane: View {
                         .frame(maxWidth: SettingsLayout.textFieldWidth)
                     }
                 case .managedLocal:
-                    SettingsFieldRow(title: "Model", help: managedPolishingModelHelp) {
+                    SettingsFieldRow(title: "Model") {
                         Picker("", selection: managedPolishingModelBinding) {
                             ForEach(managedPolishingModelEntries) { entry in
                                 Text(entry.label).tag(entry.repoID)
@@ -407,6 +399,12 @@ private struct ConnectionSettingsPane: View {
                         }
                         .pickerStyle(.menu)
                         .labelsHidden()
+                    } footer: {
+                        if let managedPolishingModelHelp {
+                            Text(managedPolishingModelHelp)
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+                        }
                     }
 
                     ManagedBackendStatusRow(
@@ -473,7 +471,7 @@ private struct ManagedBackendStatusLabel: View {
         case .stopped:
             return "Stopped"
         case .failed(let summary, _):
-            return "Failed: \(summary)"
+            return "Failed. \(summary)"
         }
     }
 
@@ -495,7 +493,7 @@ private struct ManagedBackendStatusLabel: View {
             // Bytes moving but no total (CDN sent no length for some file):
             // show movement rather than pretending we are still checking.
             if progress.downloadedBytes > 0 {
-                return "Downloading model - \(Self.byteText(progress.downloadedBytes))"
+                return "Downloading model, \(Self.byteText(progress.downloadedBytes))"
             }
             // No total yet: the downloader is still resolving what (if
             // anything) needs fetching — on a warm cache this phase is all
@@ -505,7 +503,7 @@ private struct ManagedBackendStatusLabel: View {
         // Clamp: the downloader's aggregate can transiently disagree with the
         // dry-run total (retries, resumed partials); never render > 100%.
         let downloaded = min(progress.downloadedBytes, totalBytes)
-        return "Downloading model - \(Self.byteText(downloaded)) of \(Self.byteText(totalBytes))"
+        return "Downloading model, \(Self.byteText(downloaded)) of \(Self.byteText(totalBytes))"
     }
 
     private static func byteText(_ bytes: Int64) -> String {
@@ -539,8 +537,8 @@ private struct DictationSettingsPane: View {
 
     var body: some View {
         SettingsPage(tab: .dictation) {
-            SettingsGroup(title: "Start dictation with") {
-                SettingsFieldRow(title: "Trigger") {
+            SettingsGroup(title: "Trigger") {
+                SettingsFieldRow(title: "Method") {
                     Picker("", selection: Binding(
                         get: { settings.modifierOnlyHotKeyEnabled },
                         set: { newValue in
@@ -574,13 +572,13 @@ private struct DictationSettingsPane: View {
                     }
 
                     SettingsFieldRow(title: "Tap") {
-                        Text("Overlay Buffer — toggle dictation on and off.")
+                        Text("Toggles Overlay Buffer dictation.")
                             .font(.system(size: 13))
                             .foregroundStyle(.secondary)
                     }
 
                     SettingsFieldRow(title: "Hold") {
-                        Text("Live Auto-Paste — talk while held, stops on release.")
+                        Text("Streams text live while held.")
                             .font(.system(size: 13))
                             .foregroundStyle(.secondary)
                     }
@@ -678,8 +676,7 @@ private struct DictationSettingsPane: View {
                     }
 
                     SettingsFieldRow(
-                        title: "Shortcut behavior",
-                        help: settings.dictationShortcutMode.description
+                        title: "Shortcut action"
                     ) {
                         Picker("", selection: $settings.dictationShortcutMode) {
                             ForEach(DictationShortcutMode.allCases) { mode in
@@ -694,8 +691,7 @@ private struct DictationSettingsPane: View {
 
             SettingsGroup(title: "Overlay Buffer") {
                 SettingsFieldRow(
-                    title: "Font size",
-                    help: "Scales the whole dictation overlay panel."
+                    title: "Font size"
                 ) {
                     HStack(spacing: 8) {
                         Slider(
@@ -716,8 +712,7 @@ private struct DictationSettingsPane: View {
 
             SettingsGroup(title: "Menu bar") {
                 SettingsFieldRow(
-                    title: "Output mode",
-                    help: settings.dictationOutputMode.description
+                    title: "Output mode"
                 ) {
                     Picker("", selection: dictationOutputModeBinding) {
                         ForEach(DictationOutputMode.allCases) { mode in
@@ -765,7 +760,7 @@ private struct TextProcessingSettingsPane: View {
                     Toggle("", isOn: $settings.replacementDictionaryEnabled)
                         .labelsHidden()
                         .help(
-                            "In Live Auto-Paste, corrections briefly retype the last word in place. In apps that don't report the cursor position, avoid clicking elsewhere mid-dictation — a correction landing after the cursor moved can overwrite a few characters at the new position."
+                            "In Live Auto-Paste, corrections briefly retype the last word in place. In apps that do not report the cursor position, stay in place mid-dictation. A correction after a move can overwrite characters at the new position."
                         )
                 }
             }
@@ -775,7 +770,7 @@ private struct TextProcessingSettingsPane: View {
                     SettingsAvailabilityCard(
                         title: "No Overlay Buffer shortcut",
                         message:
-                            "Polishing runs on Overlay Buffer dictations. Record a shortcut in Dictation to enable it.",
+                            "Polishing runs on Overlay Buffer dictations. Record a shortcut in Dictation.",
                         systemImage: "exclamationmark.triangle.fill",
                         tint: .orange
                     )
@@ -783,8 +778,7 @@ private struct TextProcessingSettingsPane: View {
 
                 Group {
                     SettingsFieldRow(
-                        title: "Enable",
-                        help: "Overlay Buffer dictations only."
+                        title: "Enable for Overlay Buffer"
                     ) {
                         Toggle("", isOn: llmPolishingEnabledBinding)
                             .labelsHidden()
@@ -792,8 +786,7 @@ private struct TextProcessingSettingsPane: View {
 
                     SettingsFieldRow(
                         title: "Agent prompt profile in terminals",
-                        help:
-                            "Agent-tuned instructions that trust the model's technical formatting. Clipboard safety checks remain active."
+                        help: "Clipboard safety checks stay on."
                     ) {
                         Toggle("", isOn: $settings.agentPolishProfileEnabled)
                             .labelsHidden()
@@ -802,7 +795,7 @@ private struct TextProcessingSettingsPane: View {
                     SettingsFieldRow(
                         title: "Spoken clipboard paste",
                         help:
-                            "Say “paste clipboard” to insert your clipboard as a code block on commit."
+                            "Say \"paste clipboard\" to insert your clipboard as a code block on commit."
                     ) {
                         Toggle("", isOn: $settings.clipboardPayloadMacroEnabled)
                             .labelsHidden()
@@ -814,41 +807,21 @@ private struct TextProcessingSettingsPane: View {
 
             SettingsGroup(title: "Configuration") {
                 SettingsFieldRow(title: "Config folder") {
-                    Button("Open Config Folder") {
+                    Button("Open config folder") {
                         viewModel.openConfigFolder()
                     }
                 }
 
                 // Stacked: a list of file names with descriptions is a
                 // full-width block, not a control.
-                SettingsFieldRow(title: "Included files", layout: .stacked) {
+                SettingsFieldRow(title: "Files", layout: .stacked) {
                     SettingsFileNotes(notes: [
-                        SettingsFileNote(
-                            name: "replacement_dictionary.toml",
-                            description:
-                                "Replacements used in both output modes."
-                        ),
-                        SettingsFileNote(
-                            name: "llm_system_prompt.toml",
-                            description: "System prompt for polishing."
-                        ),
-                        SettingsFileNote(
-                            name: "llm_user_prompt.toml",
-                            description:
-                                "User prompt template for polishing. Remove {{replacement_dictionary}} to stop sending the dictionary to the LLM."
-                        ),
-                        SettingsFileNote(
-                            name: "llm_system_prompt_agent.toml",
-                            description: "System prompt for the agent profile in terminals."
-                        ),
-                        SettingsFileNote(
-                            name: "llm_user_prompt_agent.toml",
-                            description: "User prompt template for the agent profile."
-                        ),
-                        SettingsFileNote(
-                            name: "terminal_apps.toml",
-                            description: "Extra apps to treat as terminals."
-                        ),
+                        SettingsFileNote(name: "replacement_dictionary.toml"),
+                        SettingsFileNote(name: "llm_system_prompt.toml"),
+                        SettingsFileNote(name: "llm_user_prompt.toml"),
+                        SettingsFileNote(name: "llm_system_prompt_agent.toml"),
+                        SettingsFileNote(name: "llm_user_prompt_agent.toml"),
+                        SettingsFileNote(name: "terminal_apps.toml"),
                     ])
                 }
             }
@@ -889,7 +862,7 @@ private struct IntegrationsSettingsPane: View {
                     SettingsAvailabilityCard(
                         title: "No Overlay Buffer shortcut",
                         message:
-                            "Polishing runs on Overlay Buffer dictations. Record a shortcut in Dictation to enable it.",
+                            "Polishing runs on Overlay Buffer dictations. Record a shortcut in Dictation.",
                         systemImage: "exclamationmark.triangle.fill",
                         tint: .orange
                     )
@@ -897,9 +870,9 @@ private struct IntegrationsSettingsPane: View {
 
                 Group {
                     SettingsFieldRow(
-                        title: "Repo vocabulary from terminal",
+                        title: "Repo vocabulary",
                         help:
-                            "Reads file names from the git repo in your terminal to fix technical spellings. Local polishing endpoints only."
+                            "Reads file names from the git repo in your terminal to fix spellings. Only with a polisher on this Mac."
                     ) {
                         Toggle("", isOn: $settings.repoVocabularyEnabled)
                             .labelsHidden()
@@ -911,9 +884,9 @@ private struct IntegrationsSettingsPane: View {
                     // spellings" describes only the matcher and would be consent
                     // obtained for the smaller half.
                     SettingsFieldRow(
-                        title: "Use Claude Code terminal screen as polish context",
+                        title: "Claude Code screen",
                         help:
-                            "Reads file names and identifiers from your Claude Code terminal to fix technical spellings. When the terminal is running a Claude Code session, part of the text on screen is also sent to the polisher. Supported terminals (Ghostty, iTerm2, Terminal.app, cmux) only — in cmux this also needs the join set up below. Local polishing endpoints only."
+                            "Reads names from your Claude Code terminal to fix spellings. When that terminal runs a Claude Code session, part of the text on screen also goes to the polisher. Ghostty, iTerm2, Terminal.app and cmux only. In cmux this needs the cmux join too. Only with a polisher on this Mac."
                     ) {
                         Toggle("", isOn: $settings.terminalScreenContextEnabled)
                             .labelsHidden()
@@ -932,18 +905,18 @@ private struct IntegrationsSettingsPane: View {
                     // sends the excerpts its hooks already reported, and never
                     // causes anything on this machine to be read.
                     SettingsFieldRow(
-                        title: "Use Claude Code project files as polish context",
+                        title: "Claude Code project",
                         help:
-                            "Sends your uncommitted changes, the contents of files Claude Code recently touched, and the last request you sent that session to the polisher, so it can spell code and file names exactly. For a session on a remote host, only the session's own request and the short excerpts its hooks report are sent — no files are read from that host. Requires a Claude Code session in a supported terminal, or a Remote Control session in the focused browser tab; local polishing endpoints only."
+                            "Sends your uncommitted changes, files Claude Code recently touched, and the last request you sent that session to the polisher. For a session on a remote host, only the session request and the short excerpts its hooks report go. No files are read from that host. Needs a Claude Code session in a supported terminal or a Remote Control session in the focused browser tab. Only with a polisher on this Mac."
                     ) {
                         Toggle("", isOn: $settings.claudeRepoContextEnabled)
                             .labelsHidden()
                     }
 
                     SettingsFieldRow(
-                        title: "Use clipboard as polish context",
+                        title: "Clipboard",
                         help:
-                            "Grounds technical terms against your clipboard. Local polishing endpoints only."
+                            "Checks technical terms against your clipboard. Only with a polisher on this Mac."
                     ) {
                         Toggle("", isOn: $settings.polishClipboardContextEnabled)
                             .labelsHidden()
@@ -956,9 +929,9 @@ private struct IntegrationsSettingsPane: View {
                     // — with the user — instead of implying the app can vouch
                     // for their endpoint.
                     SettingsFieldRow(
-                        title: "Send polish context to non-local endpoints",
+                        title: "Non-local endpoints",
                         help:
-                            "Off: clipboard, screen, and project context are only ever sent to a polisher on this Mac. On: the context enabled above is also sent to the polishing endpoint you configured — enable only for an endpoint you trust, such as a server on your own network."
+                            "When off, context only ever goes to a polisher on this Mac. When on, the context enabled above also goes to the polishing endpoint you configured. Enable only for an endpoint you trust, such as a server on your own network."
                     ) {
                         Toggle("", isOn: $settings.polishContextTrustedEndpointEnabled)
                             .labelsHidden()
@@ -990,7 +963,7 @@ private struct IntegrationsSettingsPane: View {
                 SettingsFieldRow(
                     title: "Join Claude Code sessions in cmux",
                     help:
-                        "Uses cmux's automation socket to tell which session you are dictating into, and to read that one surface as context. In cmux, set Settings → Automation socket mode to Password and choose a socket password, then enter the same password below. Works for local surfaces and for sessions opened with cmux ssh."
+                        "Uses the cmux automation socket to tell which session you dictate into, and reads that surface as context. In cmux, set Automation socket mode to Password and pick a socket password, then enter the same password below. Works for local surfaces and for sessions opened with cmux ssh."
                 ) {
                     Toggle("", isOn: $settings.cmuxSurfaceJoinEnabled)
                         .labelsHidden()
@@ -1051,13 +1024,11 @@ private struct ClaudePluginInstallRow: View {
         // Stacked: the row's controls are a full button bar plus a status line,
         // which would squeeze the label to a three-line stub beside them.
         SettingsFieldRow(
-            title: "Claude Code plugin (this Mac)",
-            help:
-                "Lets localvoxtral see which Claude Code session owns your terminal, so dictation lands in the right one. Runs `claude plugin` — nothing is installed until you press this.",
+            title: "Plugin on this Mac",
             layout: .stacked
         ) {
             HStack(spacing: 8) {
-                Button("Install or Update") {
+                Button("Install or update") {
                     Task { await model.updatePlugin() }
                 }
                 .disabled(model.isPerformingPluginAction)
@@ -1103,7 +1074,7 @@ private struct ClaudeStatuslineRow: View {
             HStack(spacing: 8) {
                 switch model.statuslineStatus {
                 case .notConfigured:
-                    Button("Set Up…") { isShowingSetup = true }
+                    Button("Set up…") { isShowingSetup = true }
                         .disabled(model.statuslinePreview == nil)
                         .accessibilityIdentifier("integrations.claude.statusline.install")
                 case .installed, .stalePath:
@@ -1237,9 +1208,7 @@ private struct ClaudeRemoteHostsSettingsRow: View {
     var body: some View {
         // Stacked: host rows and the enrollment form are full-width composites.
         SettingsFieldRow(
-            title: "Remote Claude Code over SSH",
-            help:
-                "Dictate into Claude Code running on another machine. Each host gets its own token; revoking one takes effect immediately.",
+            title: "Claude Code over SSH",
             layout: .stacked
         ) {
             VStack(alignment: .leading, spacing: 8) {
@@ -1317,7 +1286,7 @@ private struct ClaudeRemoteHostsSettingsRow: View {
                     .controlSize(.small)
                     .accessibilityIdentifier("claude.remote.shellSetup.remove")
             }
-            Button("Set Up…") { isShowingShellSetup = true }
+            Button("Set up…") { isShowingShellSetup = true }
                 .controlSize(.small)
                 .disabled(model.shellSetupPreview == nil)
                 .accessibilityIdentifier("claude.remote.shellSetup.setUp")
@@ -1345,10 +1314,10 @@ private struct ClaudeRemoteHostsSettingsRow: View {
                                 .foregroundStyle(.secondary)
                         }
                         Spacer()
-                        Button("Update Plugin…") { model.requestPluginUpdate(hostID: host.id) }
+                        Button("Update plugin…") { model.requestPluginUpdate(hostID: host.id) }
                             .controlSize(.small)
                             .disabled(model.isEnrollmentBusy)
-                        Button("Rotate Token") { Task { await model.rotate(hostID: host.id) } }
+                        Button("Rotate token") { Task { await model.rotate(hostID: host.id) } }
                             .controlSize(.small)
                         if !host.isRevoked {
                             Button("Revoke") { Task { await model.revoke(hostID: host.id) } }
@@ -1468,7 +1437,7 @@ private struct ClaudeRemoteHostsSettingsRow: View {
                         .controlSize(.small)
                         .disabled(model.isEnrollmentBusy)
                 } else {
-                    Text("Replace your-ssh-host with the alias from your ~/.ssh/config, then apply both steps above yourself — the ssh-config block first.")
+                    Text("Replace your-ssh-host with the alias from your ~/.ssh/config, then apply both steps above yourself. Do the ssh-config block first.")
                         .font(.caption)
                         .foregroundStyle(.secondary)
                 }
@@ -1622,7 +1591,7 @@ private struct ClaudeRemoteEnrollmentSheet: View {
             ScrollView {
                 VStack(alignment: .leading, spacing: 16) {
                     section(
-                        "Token — copy it now",
+                        "Copy the token now",
                         body: presentation.token,
                         note: "It cannot be shown again. If you lose it, rotate."
                     )
@@ -1641,14 +1610,8 @@ private struct ClaudeRemoteEnrollmentSheet: View {
                         body: plan.remoteCommands.joined(separator: "\n"),
                         displayedBody: ClaudeIntegrationSettingsModel.redactedRemoteCommands(for: presentation),
                         note: presentation.canRunRemoteSetup
-                            // Accurate about WHERE the guarantee holds: the
-                            // token never enters an argv on this Mac, but
-                            // `claude plugin install` takes it as a flag, so on
-                            // the host it is in that command's arguments while
-                            // it runs. Overclaiming here is worse than saying
-                            // nothing (review finding, round 2).
-                            ? "The token never enters a process argument on this Mac. On the host it is in the install command's arguments while it runs, and stored under ~/.claude after — rotate if that host is shared."
-                            : "Replace \(ClaudeIntegrationSettingsModel.unknownAliasPlaceholder) with the alias from your ~/.ssh/config and run these yourself — this host was enrolled before localvoxtral recorded its alias.",
+                            ? "The token never enters a process argument on this Mac. On the host it is in the install command arguments while it runs, and stored under ~/.claude after. Rotate if that host is shared."
+                            : "Replace \(ClaudeIntegrationSettingsModel.unknownAliasPlaceholder) with the alias from your ~/.ssh/config and run these yourself. This host was enrolled before localvoxtral recorded its alias.",
                         primaryActionTitle: presentation.canRunRemoteSetup ? "Run on SSH host" : nil,
                         enrollmentAction: .runRemoteSetup,
                         action: presentation.canRunRemoteSetup ? { model.requestRemoteSetup() } : nil
@@ -1656,7 +1619,7 @@ private struct ClaudeRemoteEnrollmentSheet: View {
                     section(
                         "3. Show the dictation indicator in herdr",
                         body: ClaudeRemoteEnrollmentService.herdrPanelConfigSnippet,
-                        note: "After confirmation, localvoxtral appends this only when no agents table or rows key exists; otherwise it leaves the file unchanged.",
+                        note: "After confirmation, localvoxtral appends this only when no agents table or rows key exists. Otherwise it leaves the file unchanged.",
                         primaryActionTitle: presentation.canRunRemoteSetup ? "Configure on SSH host" : nil,
                         enrollmentAction: .configureHerdrPanel(hostID: presentation.host.id),
                         action: presentation.canRunRemoteSetup
@@ -1667,16 +1630,11 @@ private struct ClaudeRemoteEnrollmentSheet: View {
                     section(
                         "Update later",
                         body: plan.updateCommands.joined(separator: "\n"),
-                        note: "Re-running step 2 is not an update. Also offered per host in Settings, once localvoxtral ships a newer plugin."
+                        note: "Re-running step 2 does not update the plugin."
                     )
 
-                    HStack(spacing: 6) {
-                        Text("Uninstalling, caveats, and manual checks:")
-                            .font(.body)
-                            .foregroundStyle(.secondary)
-                        Link("Learn more", destination: Self.documentationURL)
-                            .font(.body)
-                    }
+                    Link("Uninstall or check manually", destination: Self.documentationURL)
+                        .font(.body)
                 }
             }
             .frame(minHeight: 280)
@@ -1710,11 +1668,11 @@ private struct ClaudeRemoteEnrollmentSheet: View {
                     // Same reason step 2 withholds its button: with no alias on
                     // file, checking the placeholder would report on whatever
                     // machine answers to that name.
-                    : "Unavailable until this host's SSH alias is known — localvoxtral did not record one when it was enrolled. Re-enrol it, or run the checks from the linked page yourself."
+                    : "Unavailable until this host's SSH alias is known. localvoxtral did not record one when it was enrolled. Re-enrol it, or run the checks from the linked page yourself."
             )
             .font(.caption)
             .foregroundStyle(.secondary)
-            Button("Check Setup") { Task { await model.runVerification() } }
+            Button("Check setup") { Task { await model.runVerification() } }
                 .controlSize(.small)
                 .disabled(actionsDisabled || !presentation.canRunRemoteSetup)
             ForEach(model.verificationChecks) { check in
@@ -1874,14 +1832,21 @@ private struct AboutSettingsPane: View {
                         destination: URL(string: "https://github.com/T0mSIlver/localvoxtral")!
                     )
                 }
+
+                SettingsFieldRow(title: "Issues") {
+                    Link(
+                        "Report an Issue",
+                        destination: URL(string: "https://github.com/T0mSIlver/localvoxtral/issues")!
+                    )
+                }
             }
 
             SettingsGroup(title: "Diagnostics") {
                 SettingsFieldRow(
-                    title: "Export",
-                    help: "Writes a redacted report to the Desktop; review before sharing."
+                    title: "Report",
+                    help: "Writes a redacted report to the Desktop. Review before sharing."
                 ) {
-                    Button("Export Diagnostics…") {
+                    Button("Export diagnostics…") {
                         viewModel.exportDiagnostics()
                     }
                 }
@@ -2192,7 +2157,6 @@ private struct SettingsHelpText: View {
 private struct SettingsFileNote: Identifiable {
     let id = UUID()
     let name: String
-    let description: String
 }
 
 private struct SettingsFileNotes: View {
@@ -2201,15 +2165,8 @@ private struct SettingsFileNotes: View {
     var body: some View {
         VStack(alignment: .leading, spacing: 10) {
             ForEach(notes) { note in
-                VStack(alignment: .leading, spacing: 2) {
-                    Text(note.name)
-                        .font(.system(size: 12, weight: .medium, design: .monospaced))
-
-                    Text(note.description)
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
-                        .fixedSize(horizontal: false, vertical: true)
-                }
+                Text(note.name)
+                    .font(.system(size: 12, weight: .medium, design: .monospaced))
             }
         }
         .frame(maxWidth: .infinity, alignment: .leading)
@@ -2246,7 +2203,7 @@ private struct ClaudeShellSetupSheet: View {
                 .font(.headline)
                 .accessibilityIdentifier("claude.shellSetupSheet.title")
             Text(
-                "This adds one block to \(model.shellSetupStatus.relativeRCPath ?? "your shell startup file"), so a Claude Code session over plain SSH can be matched to the window you are dictating into. Open a new terminal window afterwards — the value is fixed when a session starts."
+                "This adds one block to \(model.shellSetupStatus.relativeRCPath ?? "your shell startup file"), so a Claude Code session over plain SSH can be matched to the window you are dictating into. Open a new terminal window afterwards. The value is fixed when a session starts."
             )
             .font(.callout)
             .fixedSize(horizontal: false, vertical: true)
@@ -2268,7 +2225,7 @@ private struct ClaudeShellSetupSheet: View {
                 Spacer()
                 Button("Cancel") { dismiss() }
                     .accessibilityIdentifier("claude.shellSetupSheet.cancel")
-                Button("Add to My Shell") {
+                Button("Add to my shell") {
                     Task {
                         await model.applyShellSetup()
                         dismiss()
@@ -2317,7 +2274,7 @@ private struct ClaudeStatuslineSetupSheet: View {
                 Spacer()
                 Button("Cancel") { dismiss() }
                     .accessibilityIdentifier("integrations.statuslineSheet.cancel")
-                Button("Add Status Line") {
+                Button("Add status line") {
                     Task {
                         await model.applyStatuslineSetup()
                         dismiss()

--- a/Sources/localvoxtral/StatusPopoverView.swift
+++ b/Sources/localvoxtral/StatusPopoverView.swift
@@ -2,14 +2,9 @@ import AppKit
 import SwiftUI
 
 struct StatusPopoverConnectionFailurePresenter {
-    static func detail(statusText: String, lastError: String?, endpoint: String) -> String? {
+    static func detail(statusText: String) -> String? {
         guard isConnectionFailureStatus(statusText) else { return nil }
-        if statusText != "Invalid endpoint URL.",
-           lastError?.contains(endpoint) != true
-        {
-            return nil
-        }
-        return "Endpoint: \(endpoint)"
+        return "Check the engine in Settings."
     }
 
     private static func isConnectionFailureStatus(_ statusText: String) -> Bool {
@@ -19,7 +14,7 @@ struct StatusPopoverConnectionFailurePresenter {
              "Host unreachable.",
              "Connection timed out.",
              "Endpoint path rejected.",
-             "Network lost. Dictation stopped.",
+             "Dictation stopped after the network disconnected.",
              "Connection failed.":
             return true
         default:
@@ -46,29 +41,11 @@ struct StatusPopoverView: View {
         if viewModel.isConnectingRealtimeSession {
             return "Connecting..."
         }
-        return viewModel.isDictating ? "Stop Dictation" : "Start Dictation"
+        return viewModel.isDictating ? "Stop dictation" : "Start dictation"
     }
 
     private var connectionFailureDetail: String? {
-        StatusPopoverConnectionFailurePresenter.detail(
-            statusText: viewModel.statusText,
-            lastError: viewModel.lastError,
-            endpoint: sanitizedRealtimeEndpointDescription
-        )
-    }
-
-    private var sanitizedRealtimeEndpointDescription: String {
-        guard let endpoint = viewModel.settings.resolvedWebSocketURL(for: viewModel.settings.realtimeProvider) else {
-            return "<invalid endpoint>"
-        }
-        guard var components = URLComponents(url: endpoint, resolvingAgainstBaseURL: false) else {
-            return endpoint.absoluteString
-        }
-        components.user = nil
-        components.password = nil
-        components.query = nil
-        components.fragment = nil
-        return components.string ?? endpoint.absoluteString
+        StatusPopoverConnectionFailurePresenter.detail(statusText: viewModel.statusText)
     }
 
     var body: some View {
@@ -82,7 +59,7 @@ struct StatusPopoverView: View {
 
             Menu("Microphone") {
                 if viewModel.availableInputDevices.isEmpty {
-                    Text("No Input Devices")
+                    Text("No input devices")
                 } else {
                     ForEach(viewModel.availableInputDevices) { device in
                         Button {
@@ -104,7 +81,7 @@ struct StatusPopoverView: View {
             // devices, where the standard downmix applies and the choice would
             // be meaningless.
             if viewModel.selectedInputDeviceChannelCount > 2 {
-                Menu("Input Channel") {
+                Menu("Input channel") {
                     ForEach(0..<Int(viewModel.selectedInputDeviceChannelCount), id: \.self) {
                         channel in
                         Button {
@@ -120,7 +97,7 @@ struct StatusPopoverView: View {
                 }
             }
 
-            Button("Copy Latest Segment") {
+            Button("Copy latest segment") {
                 viewModel.copyLatestSegment()
             }
             .disabled(!hasLatestSegment)
@@ -130,7 +107,7 @@ struct StatusPopoverView: View {
             // only after a polish-changed commit; a one-line action, never the
             // transcript itself (owner rule: no long text in the popover).
             if viewModel.canCopyRawTranscript {
-                Button("Copy Raw Transcript") {
+                Button("Copy raw transcript") {
                     viewModel.copyRawTranscript()
                 }
             }
@@ -162,7 +139,7 @@ struct StatusPopoverView: View {
                     .frame(width: Self.contentWidth, alignment: .leading)
             }
 
-            Text("Status: \(viewModel.statusText)")
+            Text(viewModel.statusText)
                 .foregroundStyle(.secondary)
                 .lineLimit(nil)
                 .fixedSize(horizontal: false, vertical: true)
@@ -170,8 +147,8 @@ struct StatusPopoverView: View {
 
             if let connectionFailureDetail {
                 statusDetailView(connectionFailureDetail)
-            } else if let lastError = viewModel.lastError {
-                statusDetailView("Error: \(lastError)")
+            } else if viewModel.lastError != nil {
+                statusDetailView("See Console for details.")
             }
 
             Divider()

--- a/Tests/localvoxtralTests/ClaudeIntegrationSettingsModelTests.swift
+++ b/Tests/localvoxtralTests/ClaudeIntegrationSettingsModelTests.swift
@@ -1848,19 +1848,19 @@ final class ClaudeIntegrationSettingsModelTests: XCTestCase {
         XCTAssertNil(hint(ClaudeRemoteRejectionTally.Snapshot()))
         XCTAssertEqual(
             hint(ClaudeRemoteRejectionTally.Snapshot(emptyCredential: 1)),
-            "Rejected connections detected — a host may have an outdated plugin — use Update Plugin."
+            "Rejected connections suggest an outdated plugin; use Update plugin."
         )
         XCTAssertEqual(
             hint(ClaudeRemoteRejectionTally.Snapshot(unknownToken: 1)),
-            "Rejected connections detected — a host may have a stale token — rotate it and re-run setup."
+            "Rejected connections suggest a stale token; rotate it and rerun setup."
         )
         XCTAssertEqual(
             hint(ClaudeRemoteRejectionTally.Snapshot(emptyCredential: 1, unknownToken: 1)),
-            "Rejected connections detected — a host may have an outdated plugin or a stale token."
+            "Rejected connections suggest an outdated plugin or a stale token."
         )
         XCTAssertEqual(
             hint(ClaudeRemoteRejectionTally.Snapshot(malformedAuthorization: 1)),
-            "Rejected connections detected — a host may have a malformed authorization header."
+            "Rejected connections suggest a malformed authorization header."
         )
         for snapshot in [
             ClaudeRemoteRejectionTally.Snapshot(emptyCredential: 1),
@@ -1892,7 +1892,7 @@ final class ClaudeIntegrationSettingsModelTests: XCTestCase {
         model.refreshHosts()
         XCTAssertEqual(
             model.rejectionHint,
-            "Rejected connections detected — a host may have a stale token — rotate it and re-run setup."
+            "Rejected connections suggest a stale token; rotate it and rerun setup."
         )
     }
 

--- a/Tests/localvoxtralTests/ClaudeIntegrationSettingsModelTests.swift
+++ b/Tests/localvoxtralTests/ClaudeIntegrationSettingsModelTests.swift
@@ -1888,7 +1888,7 @@ final class ClaudeIntegrationSettingsModelTests: XCTestCase {
         XCTAssertNil(hint(ClaudeRemoteRejectionTally.Snapshot()))
         XCTAssertEqual(
             hint(ClaudeRemoteRejectionTally.Snapshot(emptyCredential: 1)),
-            "Rejected connections suggest an outdated plugin; use Update plugin."
+            "Rejected connections suggest an outdated plugin; use Update host."
         )
         XCTAssertEqual(
             hint(ClaudeRemoteRejectionTally.Snapshot(unknownToken: 1)),

--- a/Tests/localvoxtralTests/ClaudeRemoteForwardSupervisorTests.swift
+++ b/Tests/localvoxtralTests/ClaudeRemoteForwardSupervisorTests.swift
@@ -614,7 +614,7 @@ final class ClaudeRemoteForwardSupervisorTests: XCTestCase {
 
     func testTheExternallyForwardedCopyAsksTheUserForNothing() {
         let text = ClaudeRemoteForwardSupervisor.State.externallyForwarded.text
-        XCTAssertEqual(text, "Tunnel up — an ssh session already holds it.")
+        XCTAssertEqual(text, "Tunnel up through an existing ssh session.")
         XCTAssertLessThan(text.count, 60, "owner rule: one short sentence")
         XCTAssertFalse(
             text.lowercased().contains("close"),

--- a/Tests/localvoxtralTests/ClaudeStatuslineInstallServiceTests.swift
+++ b/Tests/localvoxtralTests/ClaudeStatuslineInstallServiceTests.swift
@@ -55,7 +55,7 @@ final class ClaudeStatuslineInstallServiceTests: XCTestCase {
         XCTAssertEqual(staleService.status(), .stalePath)
         XCTAssertEqual(
             ClaudeStatuslineInstallService.sentence(for: .stalePath),
-            "Installed, path no longer exists — Update."
+            "The installed path moved; update the status line."
         )
         let healthyService = ClaudeStatuslineInstallService(
             fileSystem: StubStatuslineFS(
@@ -181,7 +181,7 @@ final class ClaudeStatuslineInstallServiceTests: XCTestCase {
             )
             XCTAssertEqual(
                 ClaudeStatuslineInstallService.sentence(for: .edited),
-                "Edited by you; remove it in settings.json."
+                "Edited in settings.json; remove it there."
             )
             let applyFS = StubStatuslineFS(state: ClaudeStatuslineState(
                 fileExists: true, data: existing, permissions: 0o644

--- a/Tests/localvoxtralTests/DictationViewModelFailFastUXTests.swift
+++ b/Tests/localvoxtralTests/DictationViewModelFailFastUXTests.swift
@@ -117,21 +117,17 @@ final class DictationViewModelFailFastUXTests: XCTestCase {
 
         viewModel.handleConnectFailure(reason: .networkLost)
 
-        XCTAssertEqual(viewModel.statusText, "Network lost. Dictation stopped.")
+        XCTAssertEqual(viewModel.statusText, "Dictation stopped after the network disconnected.")
         XCTAssertNotNil(viewModel.lastError)
     }
 
     func testConnectionFailurePopoverDetailDoesNotRepeatStatusText() {
         let status = "Connection refused."
-        let endpoint = "ws://127.0.0.1:8001/v1/realtimeaa"
-        let detail = StatusPopoverConnectionFailurePresenter.detail(
-            statusText: status,
-            lastError: "Connection refused at \(endpoint). Make sure the backend is running and the port is correct.",
-            endpoint: endpoint
-        )
+        let detail = StatusPopoverConnectionFailurePresenter.detail(statusText: status)
 
-        XCTAssertEqual(detail, "Endpoint: \(endpoint)")
+        XCTAssertEqual(detail, "Check the engine in Settings.")
         XCTAssertFalse(detail?.contains(status) == true)
+        XCTAssertFalse(detail?.contains("://") == true)
     }
 
     // MARK: - Accessibility gate at dictation start

--- a/Tests/localvoxtralTests/IntegrationsSettingsModelTests.swift
+++ b/Tests/localvoxtralTests/IntegrationsSettingsModelTests.swift
@@ -205,7 +205,7 @@ final class IntegrationsSettingsModelTests: XCTestCase {
         XCTAssertEqual(model.statuslineStatus, .edited)
         await model.removeStatusline()
         XCTAssertEqual(
-            model.statuslineResult, "Edited by you; remove it in settings.json."
+            model.statuslineResult, "Edited in settings.json; remove it there."
         )
         XCTAssertFalse(fs.deleted, "an edited entry is never deleted")
     }
@@ -297,7 +297,7 @@ final class IntegrationsSettingsModelTests: XCTestCase {
         XCTAssertTrue(model.isHerdrDetected)
         XCTAssertEqual(
             ClaudeIntegrationSettingsModel.herdrDetectedSentence,
-            "Found — panes join automatically."
+            "Found; panes join automatically."
         )
     }
 

--- a/Tests/localvoxtralTests/RealtimeConnectionFailureTests.swift
+++ b/Tests/localvoxtralTests/RealtimeConnectionFailureTests.swift
@@ -175,7 +175,7 @@ final class RealtimeConnectionFailureTests: XCTestCase {
         )
         // Must equal StatusStrings.networkLostDictationStopped so the menu-bar /
         // popover status token mapping still recognizes it.
-        XCTAssertEqual(description.status, "Network lost. Dictation stopped.")
+        XCTAssertEqual(description.status, "Dictation stopped after the network disconnected.")
         XCTAssertTrue(description.message.contains(endpoint))
     }
 

--- a/Tests/localvoxtralTests/SettingsTabTests.swift
+++ b/Tests/localvoxtralTests/SettingsTabTests.swift
@@ -163,6 +163,11 @@ final class SettingsTabTests: XCTestCase {
         XCTAssertEqual(SettingsTab.integrations.rawValue, "integrations")
     }
 
+    func testEndpointsTabKeepsRawValueWhileDisplayingEngines() {
+        XCTAssertEqual(SettingsTab.endpoints.title, "Engines")
+        XCTAssertEqual(SettingsTab.endpoints.rawValue, "endpoints")
+    }
+
     /// Presentation order is a UX contract of its own: the coverage tests
     /// above compare Sets, so an accidental reorder (an alphabetical sort, a
     /// careless merge) would pass every other test while moving rows the user

--- a/docs/coding-agents.md
+++ b/docs/coding-agents.md
@@ -46,6 +46,11 @@ how developers talk:
 The overlay shows a **Polished** badge whenever the LLM touched your text,
 and the raw transcript stays one click away in the menu bar popover.
 
+By default, clipboard, terminal screen, and project context goes only to a
+polisher running on this Mac. To send enabled context sources to a configured
+non-local polishing endpoint, turn on **Non-local endpoints** in **Settings →
+Integrations**. Use it only with an endpoint you trust.
+
 ## Dictating into Claude Code
 
 localvoxtral ships a
@@ -76,8 +81,8 @@ while the neighboring pane stays out of the prompt:
 
 https://github.com/user-attachments/assets/15e71c26-3d8b-490f-90d0-f5c507daf5eb
 
-Install is one click: **Settings → Integrations → Claude Code → "Claude Code
-plugin (this Mac)" → Install**. The app registers its bundled plugin
+Install is one click: **Settings → Integrations → Claude Code → "Plugin on
+this Mac" → Install or update**. The app registers its bundled plugin
 marketplace through Claude Code's own CLI. The same pane offers the opt-in
 status-line indicator (it writes exactly the `statusLine` key in
 `~/.claude/settings.json`, previewed first, never over your own script).

--- a/docs/dictation.md
+++ b/docs/dictation.md
@@ -47,10 +47,14 @@ prompts are editable (see the config folder below).
 Open **Settings** from the menu bar popover:
 
 - **General** — permission status for Microphone and Accessibility (with
-  grant buttons), copy-final-segment toggle, and Re-run Setup
-- **Endpoints** — Dictation and Polishing each switch independently between
+  grant buttons), copy-on-stop toggle, and Re-run setup
+- **Engines** — Dictation and Polishing each switch independently between
   `Managed local` (a model picker for polishing, plus a status light) and
-  `External URL` (endpoint URL, model name, API key)
+  `External URL` (server URL, model name, API key). Dictation accepts an
+  OpenAI Realtime-compatible endpoint. For polishing, enter either a base URL
+  such as `http://127.0.0.1:8080` or the full chat completions URL; the app
+  appends `/v1/chat/completions` to a base URL. Lower dictation step intervals
+  show words sooner, while higher values use less compute.
 - **Dictation** — the trigger (single modifier key with tap/hold gestures, or
   per-mode keyboard shortcuts) and the menu-bar output mode
 - **Text Processing** — exact-match replacements, plus the LLM Polishing
@@ -63,8 +67,11 @@ Open **Settings** from the menu bar popover:
   (writes a redacted local report to the Desktop)
 
 The config folder at `~/Library/Application Support/localvoxtral/config`
-holds `replacement_dictionary.toml`, the LLM prompt TOMLs (including the
-agent variants), and `terminal_apps.toml`. When an update ships improved
+holds `replacement_dictionary.toml` for both output modes; the standard and
+agent `llm_system_prompt*.toml` and `llm_user_prompt*.toml` files; and
+`terminal_apps.toml` for extra terminal apps. Remove
+`{{replacement_dictionary}}` from a user prompt template to stop sending the
+dictionary to the LLM. When an update ships improved
 defaults, files you haven't edited are refreshed automatically; files you
 have edited are never touched without asking — the app offers to update them
 and keeps your versions as `.backup` files alongside.
@@ -84,11 +91,11 @@ and keeps your versions as `.backup` files alongside.
 <table>
   <tr>
     <td width="50%" align="center"><b>General</b></td>
-    <td width="50%" align="center"><b>Endpoints</b></td>
+    <td width="50%" align="center"><b>Engines</b></td>
   </tr>
   <tr>
     <td width="50%"><img src="../assets/settings-general.png" alt="localvoxtral general settings" width="100%" /></td>
-    <td width="50%"><img src="../assets/settings-endpoints.png" alt="localvoxtral endpoints settings" width="100%" /></td>
+    <td width="50%"><img src="../assets/settings-endpoints.png" alt="localvoxtral engine settings" width="100%" /></td>
   </tr>
   <tr>
     <td width="50%" align="center"><b>Dictation</b></td>

--- a/docs/under-the-hood.md
+++ b/docs/under-the-hood.md
@@ -45,7 +45,7 @@ caught before it ships.
 ## Bring your own server
 
 Prefer your own hardware? Switch Dictation or Polishing to **External URL**
-in **Settings → Endpoints**: any OpenAI Realtime-compatible server works for
+in **Settings → Engines**: any OpenAI Realtime-compatible server works for
 dictation, any chat-completions server for polishing.
 
 Example: Voxtral Realtime on vLLM (NVIDIA GPU) —

--- a/scripts/capture-readme-assets.sh
+++ b/scripts/capture-readme-assets.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 # Regenerate the README screenshots:
 #   assets/popover.png                     (menu bar menu)
 #   assets/settings-general.png            (Settings > General)
-#   assets/settings-endpoints.png          (Settings > Endpoints)
+#   assets/settings-endpoints.png          (Settings > Engines)
 #   assets/settings-dictation.png          (Settings > Dictation)
 #   assets/settings-text-processing.png    (Settings > Text Processing)
 #   assets/settings-integrations.png       (Settings > Integrations)
@@ -42,7 +42,7 @@ BUNDLE_ID="com.localvoxtral.app"
 PERSISTENT_DEFAULTS_BACKUP="${HOME}/.localvoxtral-capture-assets.pre.plist"
 PERSISTENT_DEFAULTS_BACKUP_HAD_DOMAIN="${PERSISTENT_DEFAULTS_BACKUP}.had-domain"
 ASSETS_DIR="assets"
-TAB_NAMES=("General" "Endpoints" "Dictation" "Text Processing" "Integrations")
+TAB_NAMES=("General" "Engines" "Dictation" "Text Processing" "Integrations")
 # SettingsTab raw values — the sidebar rows carry them as AXIdentifiers
 # (settings.tab.<raw>). SettingsTabTests pins both the raw values and the
 # identifier scheme.

--- a/scripts/ci/test-ui-gate.sh
+++ b/scripts/ci/test-ui-gate.sh
@@ -2811,7 +2811,7 @@ assert_allowed 'gate-log 3' 'gate-log masks token-shaped runs'
   || fail "gate-log emitted a token-shaped run verbatim"
 
 # `ax type`'s text is redacted AT WRITE TIME (it is how an API key reaches the
-# Endpoints pane), so reading the log back cannot resurrect it.
+# Engines pane), so reading the log back cannot resurrect it.
 assert_denied 'ax type role=AXTextField,title~Endpoint -- sk-secret-value' \
   'ax type with no app under test'
 assert_allowed 'gate-log 2' 'gate-log after an ax type'

--- a/scripts/mac/README.md
+++ b/scripts/mac/README.md
@@ -607,7 +607,7 @@ pick among matches deliberately.
 Everything else is denied, and **every** invocation — allowed or denied — is
 logged with a timestamp to `~/Library/Logs/localvoxtral-ui-gate.log`. The one
 thing never written there is `ax type`'s text (it is how an API key gets into
-the Endpoints pane); the log keeps the selector and `-- <redacted>`.
+the Engines pane); the log keeps the selector and `-- <redacted>`.
 
 Three refusals are load-bearing and are what the regression suite
 (`scripts/ci/test-ui-gate.sh`, in ci.yml's shell-test step) exists to hold:

--- a/scripts/ui-smoke.sh
+++ b/scripts/ui-smoke.sh
@@ -498,10 +498,10 @@ assert_tab() {
 assert_pane_scope_is_reachable
 
 assert_tab "general" "General" "Permissions"
-assert_tab "endpoints" "Endpoints" "Dictation"
+assert_tab "endpoints" "Engines" "Dictation"
 assert_tab "dictation" "Dictation" "Start dictation with"
 assert_tab "textProcessing" "Text Processing" "Replacements"
-# The polish feature toggles live on Text Processing (moved from Endpoints).
+# The polish feature toggles live on Text Processing (moved from Engines).
 assert_tab "textProcessing" "Text Processing" "Polishing"
 # The consent-grade context sources and the harness integrations live on their
 # own pane (moved off Text Processing). Asserted on the group titles, which
@@ -518,15 +518,15 @@ assert_tab "integrations" "Integrations" "opencode"
 assert_tab "about" "About" "Diagnostics"
 
 # The launch phase forces external URL modes (managed mode now eagerly spawns
-# at launch), so the Endpoints pane renders endpoint configuration fields, not
+# at launch), so the Engines pane renders endpoint configuration fields, not
 # the managed status rows. Managed-row AX coverage would need a second launch
 # that tolerates the eager spawn.
-select_tab "endpoints" "Endpoints" >/dev/null 2>&1 || true
+select_tab "endpoints" "Engines" >/dev/null 2>&1 || true
 if pane_shows_text "settings.pane.endpoints" "Endpoint" 10 \
   && pane_shows_text "settings.pane.endpoints" "API key" 10; then
-  record_pass "External-mode Endpoints pane shows endpoint configuration fields."
+  record_pass "External-mode Engines pane shows endpoint configuration fields."
 else
-  record_fail "External-mode Endpoints pane did not show endpoint configuration fields."
+  record_fail "External-mode Engines pane did not show endpoint configuration fields."
 fi
 
 quit_app


### PR DESCRIPTION
## What

Tightens copy across Settings, integration setup sheets, the menu bar popover, onboarding, and user-facing status paths. Redundant help and feature inventories are gone. Consequences, permissions, privacy boundaries, irreversible actions, and live state remain.

The display name "Endpoints" is now "Engines" while the raw `SettingsTab.endpoints` key stays unchanged. About now links to GitHub Issues.

PR #276 was not present in `origin/main` at the required pre-PR sync point. This branch still uses main's current enrollment structure and applies the copy pass to it.

[dogfood-package]

## Copy review

| Label or surface | Before | After | Rationale |
|---|---|---|---|
| Engines tab title | Endpoints | Engines | parked rename |
| Engines subtitle | Where speech recognition and polishing run. | Where dictation and polishing run. | plain language |
| General, copy toggle | Copy final segment + Copies to the clipboard on stop. | Copy on stop | restates label |
| General, setup | Setup + Reopen the first-launch setup wizard for permissions and downloads. | Setup wizard | restates label |
| General, setup button | Re-run Setup... | Re-run setup... | slop |
| Engine mode help, managed dictation | Runs the bundled dictation engine on this Mac. | (deleted) | moved to docs |
| Engine mode help, external dictation | Use an OpenAI Realtime-compatible endpoint you run yourself. | (deleted) | moved to docs |
| Engine mode help, managed polishing | Runs the bundled polishing engine on this Mac. | (deleted) | moved to docs |
| Engine mode help, external polishing | Use an OpenAI-compatible chat completions endpoint you run yourself. | (deleted) | moved to docs |
| Dictation server field | Endpoint | Server URL | clearer label |
| Polishing server field | Endpoint | Server URL | clearer label |
| Step interval help | Lower values show words sooner; higher values use less compute. | (deleted) | moved to docs |
| Polishing URL help | Enter a base URL... `/v1/chat/completions` is appended automatically... | (deleted) | moved to docs |
| Managed model status | `<summary>. <size> GB · <state>` | `<summary>. <size> GB, <state>` | slop |
| Small model summary | Lightest option, for constrained Macs | Lightest option for constrained Macs | slop |
| Default model summary | For any Apple Silicon Mac | Fits any Apple Silicon Mac | plain language |
| Large model summary | For 32 GB+ Macs | Needs a 32 GB or larger Mac | constraint |
| Backend failed status | Failed: `<summary>` | Failed. `<summary>` | slop |
| Download byte status | Downloading model - `<bytes>` | Downloading model, `<bytes>` | slop |
| Dictation trigger group | Start dictation with | Trigger | restates label |
| Dictation trigger row | Trigger | Method | restates label |
| Modifier tap | Overlay Buffer, toggle dictation on and off. | Toggles Overlay Buffer dictation. | slop |
| Modifier hold | Live Auto-Paste, talk while held, stops on release. | Streams text live while held. | slop |
| Shortcut behavior | Shortcut behavior + mode explanation | Shortcut action | restates label |
| Overlay font size help | Scales the whole dictation overlay panel. | (deleted) | restates label |
| Menu bar output help | Output mode descriptions | (deleted) | moved to docs |
| Replacement safety tooltip | Long cursor-position warning with dash clause | Two short instructions naming the overwrite risk | slop |
| Missing overlay shortcut | Polishing runs on Overlay Buffer dictations. Record a shortcut in Dictation to enable it. | Polishing runs on Overlay Buffer dictations. Record a shortcut in Dictation. | restates state |
| Polishing toggle | Enable + Overlay Buffer dictations only. | Enable for Overlay Buffer | restates label |
| Agent profile help | Uses the agent prompt in terminals. Clipboard safety checks remain active. | Clipboard safety checks stay on. | restates label |
| Spoken clipboard help | Curly-quoted command | Straight-quoted command | slop |
| Config folder button | Open Config Folder | Open config folder | slop |
| Config file list title | Included files | Files | slop |
| Config file descriptions | Six descriptions repeating adjacent filenames | (deleted) | moved to docs |
| Repo context toggle | Repo vocabulary from terminal | Repo vocabulary | restates group |
| Repo vocabulary help | Reads file names... Local polishing endpoints only. | Reads file names... Only with a polisher on this Mac. | plain language |
| Screen context toggle | Use Claude Code terminal screen as polish context | Claude Code screen | restates group |
| Screen context help | One long sentence with an em dash | Short sentences naming reads, sends, supported terminals, and locality | slop |
| Project context toggle | Use Claude Code project files as polish context | Claude Code project | restates group |
| Project context help | Dense sentence with an em dash | Short sentences naming sent data, remote limits, requirements, and locality | slop |
| Clipboard context toggle | Use clipboard as polish context | Clipboard | restates group |
| Clipboard context help | Grounds technical terms... Local polishing endpoints only. | Checks technical terms... Only with a polisher on this Mac. | plain language |
| External context toggle | Send polish context to non-local endpoints | Non-local endpoints | restates group |
| External context help | Off:/On: clauses with an em dash | Short when-off and when-on sentences plus trust warning | slop |
| cmux join help | Dense automation-socket sentence with an em dash | Short sentences naming the socket, password setup, and supported sessions | slop |
| Local Claude plugin label | Claude Code plugin (this Mac) | Plugin on this Mac | restates group |
| Local Claude plugin help | Lets localvoxtral see... Runs `claude plugin`... | (deleted) | moved to docs |
| Local Claude plugin button | Install or Update | Install or update | slop |
| Status line setup button | Set Up... | Set up... | slop |
| Remote hosts row | Remote Claude Code over SSH | Claude Code over SSH | restates group |
| Remote hosts help | Dictate into Claude Code... Each host gets its own token... | (deleted) | moved to docs |
| Plain SSH setup button | Set Up... | Set up... | slop |
| Host plugin button | Update Plugin... | Update plugin... | slop |
| Host token button | Rotate Token | Rotate token | slop |
| Manual host setup note | Em-dash instruction | Two direct sentences | slop |
| Enrollment token heading | Token, copy it now | Copy the token now | clearer action |
| Enrollment host command note | Long caveat with an em dash | Three short sentences retaining both process-argument boundaries | slop |
| Enrollment missing-alias note | Em-dash explanation | Two direct sentences | slop |
| herdr config note | Semicolon connector | Two direct sentences | slop |
| Enrollment update note | Re-running step 2 is not an update. Also offered per host in Settings... | Re-running step 2 does not update the plugin. | narration |
| Enrollment docs prompt | Uninstalling, caveats, and manual checks: Learn more | Uninstall or check manually | narration |
| Enrollment unavailable note | Em-dash explanation | Three direct sentences | slop |
| Check button | Check Setup | Check setup | slop |
| Shell setup explanation | Final em-dash clause | Three direct sentences | slop |
| Shell setup button | Add to My Shell | Add to my shell | slop |
| Status line sheet explanation | Three dense sentences | Two sentences naming the exact file change and JSON normalization | slop |
| Status line stale status | Installed, path no longer exists, Update. | The installed path moved; update the status line. | plain language |
| Status line edited status | Edited by you; remove it in settings.json. | Edited in settings.json; remove it there. | plain language |
| Status line apply button | Add Status Line | Add status line | slop |
| herdr status | Found, panes join automatically. | Found; panes join automatically. | slop |
| Listener idle status | Not listening, no hosts enrolled. | Not listening because no hosts are enrolled. | plain language |
| Listener conflict remedy | Em-dash parenthetical | Direct cause and action | slop |
| Rejected connection statuses | Em-dash cause and remedy clauses | One short sentence per rejection shape | slop |
| Existing SSH tunnel status | Tunnel up, an ssh session already holds it. | Tunnel up through an existing ssh session. | one-line status |
| Invalid SSH alias alert | Curly quotes and an em-dash constraint | Straight quotes and two direct sentences | slop |
| Enrollment confirmation buttons | Confirm Update / Insert / Run / Configure | Sentence-case action labels | slop |
| SSH symlink alert | Em-dash explanation and semicolon action | Direct sentences retaining the refusal and copy path | slop |
| Listener security alert | Em-dash caveat | Direct sentences retaining the token-hash boundary | slop |
| Remote setup hint | Em-dash connector | Two direct sentences | slop |
| Remote Claude lookup error | Em-dash action | Two direct sentences | slop |
| Managed backend alert title | Managed Backend Failed | Managed backend failed | slop |
| Network-loss status | Network lost. Dictation stopped. | Dictation stopped after the network disconnected. | one-line status |
| Secure-input live status | Blocked: Secure Keyboard Entry is on. | Secure Keyboard Entry blocks Live Auto-Paste. | one-line status |
| Clipboard fallback status | Copied, paste it manually. | Copied for manual paste. | one-line status |
| Secure-input warning | Secure Keyboard Entry is on; dictated text may not appear. | Secure Keyboard Entry may hide dictated text. | one-line status |
| Overlay copy fallback | Em-dash status | One short causal sentence | slop |
| Overlay copy failure | Em-dash status | One short sentence retaining visible-text recovery | slop |
| Popover connection detail | Endpoint: `<URL>` | Check the engine in Settings. | raw detail removed |
| Popover generic error | Error: `<raw error>` | See Console for details. | raw detail removed |
| Popover status | Status: `<status>` | `<status>` | restates label |
| Popover actions | Title Case menu and copy actions | Sentence case | slop |
| Welcome subtitle | Realtime dictation feature inventory | Dictate into any app from the menu bar. | narration |
| Welcome feature bullets | Three visible feature claims | (deleted) | narration |
| Welcome setup caption | This quick setup grants permissions and downloads the local engine. | (deleted) | narration |
| Permissions subtitle | localvoxtral needs the microphone... | Allow microphone recording and typing into other apps. | plain language |
| Deferred permission note | You can continue without granting these now... | You can grant these later in Settings > General. | slop |
| Permission buttons | Allow Microphone / Grant Access | Allow microphone / Grant access | slop |
| Download action | Begin Download | Begin download | slop |
| Download subtitle | Control inventory and "below" direction | Start the model download when you are ready. | narration |
| Download item descriptions | Descriptions repeating the adjacent item names | (deleted) | restates label |
| Optional polish model | Downloads a small polishing model for the built-in engine... | Downloads a small polishing model. You can add it later in Settings. | slop |
| Background download status | Downloads continue in the background, you can press Continue... | You can continue while downloads finish in the background. | slop |
| Finish subtitle | Here's how to start dictating. | Try your dictation trigger in any text field. | clearer action |
| Finish instruction | Press it in any text field to try it out. Escape cancels a dictation. | Escape cancels a dictation. | restates adjacent trigger |
| One-key tip | Long em-dash explanation | Two direct sentences with the Settings path | slop |
| No-shortcut summary | No shortcut is set, start dictation from the menu bar icon. | Two direct sentences | slop |
| About issue link | (absent) | Report an Issue | parked addition |
| Diagnostics row | Export + semicolon help + Export Diagnostics... | Report + two-sentence safety help + Export diagnostics... | clearer label |

Counts: 95 changed string groups, 12 deleted groups, 10 groups moved to the docs, and 1 added link. Repeated copies shared by two panes or pinned in tests count once.

## Proof

- [x] Unit suite green: `./scripts/remote-build.sh test`
  `Executed 3042 tests, with 2 tests skipped and 0 failures (0 unexpected) in 53.267 seconds.`
- [x] `SettingsTabTests`: 10 tests, 0 failures.
- [x] `ClaudeIntegrationSettingsModelTests`: 82 tests, 0 failures.
- [x] Build completed without warnings as part of each remote test run.
- [x] `bash -n scripts/ui-smoke.sh scripts/capture-readme-assets.sh`
- [ ] UI hand-check: not performed. The remote build host session available to this worker had CLI access but no interactive Settings window. Please check wrapping and spacing in all six panes, onboarding, and the enrollment sheet.
- [ ] Realtime integration: skipped. This changes display copy only and does not alter audio, request, or model behavior.
- [x] CI `build-test` passed, including the hosted unit suite, package build, and launch smoke.
- [x] CI live speechd integration passed.
- [ ] CI live herdr integration: 10 of 11 tests passed. `testAttachClientRendersNoSidebarSoItCannotEchoThePanelToken` failed because the live fixture returned `pane_not_found: pane w1:p1 not found`. The one permitted rerun produced the same external fixture failure; all other herdr tests passed again. No herdr request, response, or SSH-forward behavior changed in this copy-only patch.
- [ ] LLM and E2E lanes: skipped. No prompt, model pin, request shape, helper engine, context payload, transport, or scorer changed.
