### PR TITLE
Live herdr lane: make the fixture deterministic under the CI runner's environment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -974,12 +974,21 @@ jobs:
         # builds it, and it is only ever exercised by hand.
         #
         # Kept on the Mac, matching the helper suites: it is a second full
-        # compile of the app target against a warm .build, which a cold hosted
-        # runner would pay from scratch.
+        # compile of the app target, which a cold hosted runner would pay
+        # from scratch.
+        #
+        # Its OWN scratch path, never the shared .build. The define changes
+        # what the app and test modules contain, and SwiftPM did not recompile
+        # the test objects when the define went away again: with `clean:
+        # false` the next run's first Swift step on this workspace linked the
+        # previous run's dogfood-only `DogfoodControlProtocolTests.swift.o`
+        # against a non-dogfood app module and died with undefined symbols
+        # (runs 34146743103 and 34147271131, 2026-09-07). Two caches cost disk,
+        # not correctness; one cache cost every Mac lane.
         if: steps.ci_scope.outputs.docs_only != 'true'
         env:
           LOCALVOXTRAL_DOGFOOD: "1"
-        run: swift test --filter 'Dogfood'
+        run: swift test --filter 'Dogfood' --scratch-path .build-dogfood
 
       - name: Ensure Metal toolchain
         # Xcode 26 ships the Metal compiler as a separate component, and its

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -703,10 +703,12 @@ jobs:
         run: |
           set -euo pipefail
           if [[ "$GITHUB_EVENT_NAME" == "workflow_dispatch" ]]; then
-            # Same rationale as the model lanes: dispatch produces artifacts;
-            # the ref's own push/PR run decided this lane.
-            echo "run=false" >> "$GITHUB_OUTPUT"
-            echo "Herdr integration lane: SKIPPED (manual dispatch — decided by the ref's own push/PR run)" \
+            # A dispatch is the repetition mechanism for this live external
+            # contract. Unlike the model lanes, it needs no downloaded model
+            # and is expected to be run several times while investigating
+            # runner-only behavior.
+            echo "run=true" >> "$GITHUB_OUTPUT"
+            echo "Herdr integration lane: RUNNING (manual dispatch)" \
               | tee -a "$GITHUB_STEP_SUMMARY"
             exit 0
           fi
@@ -923,6 +925,7 @@ jobs:
         if: steps.ci_scope.outputs.docs_only != 'true' && steps.herdr_lane.outputs.run == 'true'
         env:
           HERDR_INTEGRATION_TEST_ENABLE: "1"
+          HERDR_INTEGRATION_DIAGNOSTICS_DIR: ${{ runner.temp }}/herdr-lane-diagnostics
         # --enable-code-coverage matches the unit step's build flags (same
         # rationale as the STT integration step above).
         # Load flake hint (measured 2026-09-07: one concurrent swift build
@@ -935,6 +938,14 @@ jobs:
           (remote-build.sh) on the Mac and re-run this lane alone first —
           see docs/agent/test-tiers.md "Worker builds on the Mac must not
           overlap the lane".'; exit 1; }
+
+      - name: Upload herdr lane diagnostics
+        if: always() && steps.ci_scope.outputs.docs_only != 'true' && steps.herdr_lane.outputs.run == 'true'
+        uses: actions/upload-artifact@v4
+        with:
+          name: herdr-lane-diagnostics
+          path: ${{ runner.temp }}/herdr-lane-diagnostics
+          if-no-files-found: warn
 
       - name: Polishing helper unit tests (PolishHelper package)
         # Metal-free (HTTP layer, router, cache locator, watchdog); the Metal

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .DS_Store
 __pycache__/
 /.build
+/.build-dogfood
 /PolishHelper/.build
 /SpeechHelper/.build
 /Packages

--- a/Tests/localvoxtralTests/HerdrIntegrationSupport.swift
+++ b/Tests/localvoxtralTests/HerdrIntegrationSupport.swift
@@ -164,6 +164,23 @@ final class HerdrSurfaceLog: @unchecked Sendable {
         text(fromOffset: 0)
     }
 
+    /// Reconstruct the last fixed-size terminal frame from the typescript.
+    /// Herdr redraws with absolute CSI cursor positions, so this small parser
+    /// needs only the cursor and erase operations emitted by its renderer.
+    func lastRenderedFrame(rows: Int = 45, columns: Int = 130) -> String? {
+        guard let data = FileManager.default.contents(atPath: path),
+              let raw = String(data: data, encoding: .utf8)
+        else { return nil }
+        return TerminalDiagnosticFrame(raw: raw, rows: rows, columns: columns).text
+    }
+
+    func observedSidebarWidth(rows: Int = 45, columns: Int = 130) -> Int? {
+        guard let data = FileManager.default.contents(atPath: path),
+              let raw = String(data: data, encoding: .utf8)
+        else { return nil }
+        return TerminalDiagnosticFrame(raw: raw, rows: rows, columns: columns).sidebarWidth
+    }
+
     private func text(fromOffset offset: UInt64) -> String? {
         guard let handle = FileHandle(forReadingAtPath: path) else { return nil }
         defer { try? handle.close() }
@@ -217,6 +234,153 @@ final class HerdrSurfaceLog: @unchecked Sendable {
             }
         }
         return String(output)
+    }
+}
+
+private struct TerminalDiagnosticFrame {
+    private(set) var cells: [[Character]]
+    private var row = 0
+    private var column = 0
+    private var savedRow = 0
+    private var savedColumn = 0
+    private let rows: Int
+    private let columns: Int
+
+    init(raw: String, rows: Int, columns: Int) {
+        self.rows = rows
+        self.columns = columns
+        self.cells = Array(
+            repeating: Array(repeating: " ", count: columns), count: rows
+        )
+        consume(Array(raw))
+    }
+
+    var text: String {
+        cells.map { String($0).replacingOccurrences(of: #"\s+$"#, with: "", options: .regularExpression) }
+            .joined(separator: "\n")
+    }
+
+    /// The most common rendered vertical divider column, in terminal cells.
+    /// The desktop layout paints `│` at column 26, so its sidebar is 26 cells.
+    var sidebarWidth: Int? {
+        var counts: [Int: Int] = [:]
+        for line in cells {
+            for (index, cell) in line.enumerated() where cell == "│" {
+                counts[index + 1, default: 0] += 1
+            }
+        }
+        return counts.max { lhs, rhs in lhs.value < rhs.value }?.key
+    }
+
+    private mutating func consume(_ characters: [Character]) {
+        var index = 0
+        while index < characters.count {
+            let character = characters[index]
+            if character == "\u{1B}" {
+                index += 1
+                guard index < characters.count else { break }
+                if characters[index] == "[" {
+                    index = consumeCSI(characters, from: index + 1)
+                } else if characters[index] == "]" {
+                    index = consumeOSC(characters, from: index + 1)
+                } else if characters[index] == "7" {
+                    savedRow = row
+                    savedColumn = column
+                    index += 1
+                } else if characters[index] == "8" {
+                    row = savedRow
+                    column = savedColumn
+                    index += 1
+                } else {
+                    index += 1
+                }
+                continue
+            }
+            switch character {
+            case "\r": column = 0
+            case "\n": row = min(row + 1, rows - 1)
+            case "\u{08}": column = max(column - 1, 0)
+            case "\t": column = min(((column / 8) + 1) * 8, columns - 1)
+            default:
+                if character.unicodeScalars.allSatisfy({ $0.value >= 32 }) {
+                    if row >= 0, row < rows, column >= 0, column < columns {
+                        cells[row][column] = character
+                    }
+                    column = min(column + 1, columns)
+                }
+            }
+            index += 1
+        }
+    }
+
+    private mutating func consumeCSI(_ characters: [Character], from start: Int) -> Int {
+        var index = start
+        var body = ""
+        while index < characters.count {
+            guard let scalar = characters[index].unicodeScalars.first else {
+                index += 1
+                continue
+            }
+            if (0x40...0x7E).contains(scalar.value) {
+                applyCSI(final: characters[index], body: body)
+                return index + 1
+            }
+            body.append(characters[index])
+            index += 1
+        }
+        return index
+    }
+
+    private mutating func consumeOSC(_ characters: [Character], from start: Int) -> Int {
+        var index = start
+        while index < characters.count {
+            if characters[index] == "\u{07}" { return index + 1 }
+            if characters[index] == "\u{1B}",
+               index + 1 < characters.count,
+               characters[index + 1] == "\\"
+            {
+                return index + 2
+            }
+            index += 1
+        }
+        return index
+    }
+
+    private mutating func applyCSI(final: Character, body: String) {
+        let values = body
+            .trimmingCharacters(in: CharacterSet(charactersIn: "?<>"))
+            .split(separator: ";", omittingEmptySubsequences: false)
+            .map { Int($0) ?? 0 }
+        let first = max(values.first ?? 1, 1)
+        switch final {
+        case "H", "f":
+            row = min(max((values.first ?? 1) - 1, 0), rows - 1)
+            column = min(max((values.dropFirst().first ?? 1) - 1, 0), columns - 1)
+        case "A": row = max(row - first, 0)
+        case "B": row = min(row + first, rows - 1)
+        case "C": column = min(column + first, columns - 1)
+        case "D": column = max(column - first, 0)
+        case "G": column = min(first - 1, columns - 1)
+        case "d": row = min(first - 1, rows - 1)
+        case "J" where values.first == 2 || values.first == 3:
+            cells = Array(repeating: Array(repeating: " ", count: columns), count: rows)
+        case "K":
+            let mode = values.first ?? 0
+            if mode == 0 {
+                for cell in column..<columns { cells[row][cell] = " " }
+            } else if mode == 1 {
+                for cell in 0...min(column, columns - 1) { cells[row][cell] = " " }
+            } else if mode == 2 {
+                cells[row] = Array(repeating: " ", count: columns)
+            }
+        case "s":
+            savedRow = row
+            savedColumn = column
+        case "u":
+            row = savedRow
+            column = savedColumn
+        default: break
+        }
     }
 }
 
@@ -383,6 +547,16 @@ final class HerdrLiveFixture {
             ) {
                 guard try item.resourceValues(forKeys: [.isRegularFileKey]).isRegularFile == true
                 else { continue }
+                let safeNames: Set<String> = [
+                    "environment.txt", "fixture.json", "herdr.bin", "pane-lifecycle.log",
+                    "report-agent.err", "report-agent.out", "server.log", "sshd.log",
+                    "sshd.out", "sshd.port",
+                ]
+                let isSurfaceEvidence = item.lastPathComponent.hasPrefix("surface-")
+                    && (item.pathExtension == "log" || item.pathExtension == "geometry")
+                guard safeNames.contains(item.lastPathComponent) || isSurfaceEvidence else {
+                    continue
+                }
                 try fileManager.copyItem(
                     at: item,
                     to: destination.appendingPathComponent(item.lastPathComponent)
@@ -395,10 +569,26 @@ final class HerdrLiveFixture {
                     atomically: true,
                     encoding: .utf8
                 )
+                let frame = surface.lastRenderedFrame() ?? "<frame unavailable>"
+                try frame.write(
+                    to: destination.appendingPathComponent("surface-\(name).last-frame.txt"),
+                    atomically: true,
+                    encoding: .utf8
+                )
             }
             print("[herdr-fixture] diagnostics: \(destination.path)")
         } catch {
             print("[herdr-fixture] WARNING: could not preserve diagnostics: \(error)")
+        }
+    }
+
+    func dumpSurfaceFrames(reason: String) {
+        print("[herdr-fixture] SURFACE DUMP: \(reason)")
+        for name in surfaces.keys.sorted() {
+            let surface = surfaces[name]!
+            let width = surface.observedSidebarWidth().map(String.init) ?? "not-rendered"
+            print("[herdr-fixture] surface=\(name) observed_sidebar_width=\(width)")
+            print(surface.lastRenderedFrame() ?? "<frame unavailable>")
         }
     }
 

--- a/Tests/localvoxtralTests/HerdrIntegrationSupport.swift
+++ b/Tests/localvoxtralTests/HerdrIntegrationSupport.swift
@@ -154,10 +154,21 @@ final class HerdrSurfaceLog: @unchecked Sendable {
 
     /// Rendered text painted since the mark, with escape sequences removed.
     func textSinceMark() -> String? {
+        text(fromOffset: mark.withLock { $0 })
+    }
+
+    /// The complete visible paint stream. Diagnostics use this only after
+    /// copying the raw typescript, so an ANSI parser can reconstruct the last
+    /// frame without losing evidence.
+    func fullVisibleText() -> String? {
+        text(fromOffset: 0)
+    }
+
+    private func text(fromOffset offset: UInt64) -> String? {
         guard let handle = FileHandle(forReadingAtPath: path) else { return nil }
         defer { try? handle.close() }
         do {
-            try handle.seek(toOffset: mark.withLock { $0 })
+            try handle.seek(toOffset: offset)
         } catch {
             return nil
         }
@@ -244,13 +255,18 @@ final class HerdrLiveFixture {
     let primarySurface: HerdrSurfaceLog
     private let scriptURL: URL
     private let repoRoot: URL
+    private let diagnosticsRoot: URL
+    private var surfaces: [String: HerdrSurfaceLog]
     private var isTornDown = false
 
-    private init(info: Info, scriptURL: URL, repoRoot: URL) {
+    private init(info: Info, scriptURL: URL, repoRoot: URL, diagnosticsRoot: URL) {
         self.info = info
         self.scriptURL = scriptURL
         self.repoRoot = repoRoot
-        self.primarySurface = HerdrSurfaceLog(path: info.primarySurfaceLog)
+        self.diagnosticsRoot = diagnosticsRoot
+        let primarySurface = HerdrSurfaceLog(path: info.primarySurfaceLog)
+        self.primarySurface = primarySurface
+        self.surfaces = ["primary": primarySurface]
     }
 
     static func bringUp(
@@ -260,6 +276,11 @@ final class HerdrLiveFixture {
     ) throws -> HerdrLiveFixture {
         let scriptURL = repoRoot.appendingPathComponent("scripts/herdr-integration-fixture.sh")
         let workdir = "/tmp/lvx-herdr-fixture-\(label)-\(ProcessInfo.processInfo.processIdentifier)"
+        let configuredDiagnostics = ProcessInfo.processInfo.environment[
+            "HERDR_INTEGRATION_DIAGNOSTICS_DIR"
+        ]
+        let diagnosticsRoot = configuredDiagnostics.map(URL.init(fileURLWithPath:))
+            ?? repoRoot.appendingPathComponent(".build/herdr-lane-diagnostics")
 
         // A previous run that died before its teardown would otherwise make
         // every later run fail on "workdir already exists".
@@ -281,6 +302,9 @@ final class HerdrLiveFixture {
                 "`up` exited \(result.status)\n\(result.standardError)\(result.standardOutput)"
             )
         }
+        if !result.standardError.isEmpty {
+            print(result.standardError, terminator: result.standardError.hasSuffix("\n") ? "" : "\n")
+        }
         guard let line = result.standardOutput
             .split(separator: "\n")
             .last(where: { $0.hasPrefix("{") }),
@@ -290,12 +314,18 @@ final class HerdrLiveFixture {
                 "`up` printed no fixture description\n\(result.standardOutput)\(result.standardError)"
             )
         }
-        return HerdrLiveFixture(info: info, scriptURL: scriptURL, repoRoot: repoRoot)
+        return HerdrLiveFixture(
+            info: info,
+            scriptURL: scriptURL,
+            repoRoot: repoRoot,
+            diagnosticsRoot: diagnosticsRoot
+        )
     }
 
     func tearDown() {
         guard !isTornDown else { return }
         isTornDown = true
+        captureDiagnostics()
         _ = try? HerdrLaneProcess.run(
             executable: URL(fileURLWithPath: "/bin/bash"),
             arguments: [scriptURL.path, "down", info.workdir],
@@ -322,7 +352,54 @@ final class HerdrLiveFixture {
                 "`surface \(name)` exited \(result.status)\n\(result.standardError)"
             )
         }
-        return HerdrSurfaceLog(path: "\(info.workdir)/surface-\(name).log")
+        if !result.standardError.isEmpty {
+            print(result.standardError, terminator: result.standardError.hasSuffix("\n") ? "" : "\n")
+        }
+        let surface = HerdrSurfaceLog(path: "\(info.workdir)/surface-\(name).log")
+        surfaces[name] = surface
+        return surface
+    }
+
+    /// Preserve the evidence before the fixture removes its temporary tree.
+    /// This runs for green tests too, which makes runner and SSH-account runs
+    /// directly comparable instead of leaving diagnostics only for failures.
+    private func captureDiagnostics() {
+        let fileManager = FileManager.default
+        let runName = URL(fileURLWithPath: info.workdir).lastPathComponent
+        let destination = diagnosticsRoot.appendingPathComponent(runName, isDirectory: true)
+        do {
+            try fileManager.createDirectory(
+                at: diagnosticsRoot, withIntermediateDirectories: true
+            )
+            if fileManager.fileExists(atPath: destination.path) {
+                try fileManager.removeItem(at: destination)
+            }
+            try fileManager.createDirectory(at: destination, withIntermediateDirectories: true)
+            let source = URL(fileURLWithPath: info.workdir, isDirectory: true)
+            for item in try fileManager.contentsOfDirectory(
+                at: source,
+                includingPropertiesForKeys: [.isRegularFileKey],
+                options: [.skipsHiddenFiles]
+            ) {
+                guard try item.resourceValues(forKeys: [.isRegularFileKey]).isRegularFile == true
+                else { continue }
+                try fileManager.copyItem(
+                    at: item,
+                    to: destination.appendingPathComponent(item.lastPathComponent)
+                )
+            }
+            for (name, surface) in surfaces {
+                let visible = surface.fullVisibleText() ?? "<surface log unavailable>"
+                try visible.write(
+                    to: destination.appendingPathComponent("surface-\(name).visible.txt"),
+                    atomically: true,
+                    encoding: .utf8
+                )
+            }
+            print("[herdr-fixture] diagnostics: \(destination.path)")
+        } catch {
+            print("[herdr-fixture] WARNING: could not preserve diagnostics: \(error)")
+        }
     }
 
     /// herdr's own CLI against the fixture's socket. Used only to READ herdr's

--- a/Tests/localvoxtralTests/HerdrIntegrationTests.swift
+++ b/Tests/localvoxtralTests/HerdrIntegrationTests.swift
@@ -61,6 +61,9 @@ final class HerdrIntegrationTests: XCTestCase {
                 + "refresh_seconds=\(HerdrPanelMicIndicator.refreshInterval) "
                 + "surface_wait_seconds=20"
         )
+        let sidebarWidth = fixture.primarySurface.observedSidebarWidth().map(String.init)
+            ?? "not-rendered"
+        print("[herdr-fixture] sidebar.observed_width=\(sidebarWidth) source=rendered-frame")
     }
 
     override func tearDown() async throws {
@@ -101,6 +104,11 @@ final class HerdrIntegrationTests: XCTestCase {
                 "the app's ssh -L forward to \(fixture.info.alias) never became dialable"
             )
         }
+        print(
+            "[herdr-fixture] ssh.forward alias=\(fixture.info.alias) "
+                + "local_socket=\(handle.localSocketPath) "
+                + "remote_socket=\(fixture.info.socketPath)"
+        )
         return (service, handle)
     }
 
@@ -145,6 +153,7 @@ final class HerdrIntegrationTests: XCTestCase {
         while true {
             if surface.textSinceMark()?.contains(token) == true { return }
             guard Date() < deadline else {
+                fixture.dumpSurfaceFrames(reason: "timed out waiting for \(token)")
                 throw HerdrLaneError.timedOut("the surface to paint \(token)")
             }
             if Date() >= nextRefresh {
@@ -154,6 +163,9 @@ final class HerdrIntegrationTests: XCTestCase {
                     "re-stamping the panel token was refused; the wait below would "
                         + "then be measuring an expired token, not a surface that will not paint"
                 )
+                if !refreshed {
+                    fixture.dumpSurfaceFrames(reason: "panel token refresh was refused")
+                }
                 nextRefresh = Date().addingTimeInterval(HerdrPanelMicIndicator.refreshInterval)
             }
             try? await Task.sleep(for: .milliseconds(100))

--- a/Tests/localvoxtralTests/HerdrIntegrationTests.swift
+++ b/Tests/localvoxtralTests/HerdrIntegrationTests.swift
@@ -697,18 +697,33 @@ final class HerdrIntegrationTests: XCTestCase {
         let stamped = await stamp(token, through: client, socketPath: handle.localSocketPath)
         XCTAssertTrue(stamped)
 
-        // A clock of its own, so the refresh cadence cannot move the forward's
-        // idle deadline while the lease is still held.
-        let indicatorClock = AcceleratedClock()
+        // Hold the refresh behind a deterministic tick. The old accelerated
+        // 50 ms sleep let the first refresh race the clear below: on the CI
+        // runner it could restore the token before the immediate read, while
+        // the builder account happened to complete the clear last.
+        let (refreshTicks, refreshContinuation) = AsyncStream.makeStream(of: Void.self)
+        defer { refreshContinuation.finish() }
+        let refreshIntervals = Mutex<[TimeInterval]>([])
         let indicator = HerdrPanelMicIndicator(
             metadata: client,
             socketPath: handle.localSocketPath,
             paneID: fixture.info.paneID,
             token: token,
             forward: handle,
-            sleepFor: indicatorClock.sleep
+            sleepFor: { seconds in
+                refreshIntervals.withLock { $0.append(seconds) }
+                var iterator = refreshTicks.makeAsyncIterator()
+                _ = await iterator.next()
+            }
         )
         indicator.start()
+        try await HerdrLaneWait.until("the mic indicator to arm its refresh sleep") {
+            !refreshIntervals.withLock { $0.isEmpty }
+        }
+        XCTAssertEqual(
+            refreshIntervals.withLock { $0.first },
+            HerdrPanelMicIndicator.refreshInterval
+        )
 
         // Clear the token behind the indicator's back; its next refresh must
         // put the same value back — that is what keeps the row lit for a
@@ -716,7 +731,12 @@ final class HerdrIntegrationTests: XCTestCase {
         await HerdrPanelBindingProbe.clear(
             metadata: client, socketPath: handle.localSocketPath, paneID: fixture.info.paneID
         )
-        XCTAssertNil(try fixture.paneTokens()["lvmark"])
+        try await HerdrLaneWait.until(
+            "the deliberately cleared mic token to disappear before refresh", timeout: 5
+        ) {
+            (try? self.fixture.paneTokens()["lvmark"]) == nil
+        }
+        refreshContinuation.yield()
         try await HerdrLaneWait.until("the mic indicator to refresh the token", timeout: 30) {
             (try? self.fixture.paneTokens()["lvmark"]) == token
         }

--- a/Tests/localvoxtralTests/HerdrIntegrationTests.swift
+++ b/Tests/localvoxtralTests/HerdrIntegrationTests.swift
@@ -56,6 +56,11 @@ final class HerdrIntegrationTests: XCTestCase {
             destination: enablement.destination,
             label: label
         )
+        print(
+            "[herdr-fixture] token.ttl_ms=\(HerdrPanelBindingProbe.tokenTTLMilliseconds) "
+                + "refresh_seconds=\(HerdrPanelMicIndicator.refreshInterval) "
+                + "surface_wait_seconds=20"
+        )
     }
 
     override func tearDown() async throws {

--- a/Tests/localvoxtralTests/HerdrSurfaceLogTests.swift
+++ b/Tests/localvoxtralTests/HerdrSurfaceLogTests.swift
@@ -1,0 +1,21 @@
+import Foundation
+import XCTest
+
+#if canImport(Darwin)
+
+final class HerdrSurfaceLogTests: XCTestCase {
+    func testLastFrameAndSidebarWidthComeFromRenderedCursorPositions() throws {
+        let path = NSTemporaryDirectory() + "lvx-herdr-frame-\(UUID().uuidString)"
+        defer { try? FileManager.default.removeItem(atPath: path) }
+        let raw = "\u{1B}[2J\u{1B}[1;1Hleft\u{1B}[1;6H│right"
+            + "\u{1B}[2;1Hagent\u{1B}[2;6H│pane"
+            + "\u{1B}[1;1Hdone"
+        try Data(raw.utf8).write(to: URL(fileURLWithPath: path))
+
+        let surface = HerdrSurfaceLog(path: path)
+        XCTAssertEqual(surface.observedSidebarWidth(rows: 2, columns: 12), 6)
+        XCTAssertEqual(surface.lastRenderedFrame(rows: 2, columns: 12), "done │right\nagent│pane")
+    }
+}
+
+#endif

--- a/docs/agent/test-tiers.md
+++ b/docs/agent/test-tiers.md
@@ -255,7 +255,10 @@ path is NOT slow under load (36× inside the 5 s timeout); the read lags the
 server's ack under CPU contention. The lane therefore polls for the clear
 (bounded below the 8 s token TTL, so a truly lost clear still fails) — and a
 red lane with worker builds running beside it means re-run the lane alone
-before debugging the diff.
+before debugging the diff. The mic-indicator lifecycle test holds its injected
+first refresh until that deliberate clear is observed; accelerating the
+refresh onto a 50 ms wall-clock sleep makes clear-versus-refresh ordering a
+runner scheduler race instead of testing the four-second production cadence.
 
 The speechd live-model lane follows the same owner constraint: it runs only for
 `scripts/ci/speechd-lane-filter.sh` matches or `[run-speechd-integration]`.

--- a/docs/agent/test-tiers.md
+++ b/docs/agent/test-tiers.md
@@ -218,7 +218,9 @@ Fixture and host requirements (`scripts/herdr-integration-fixture.sh`):
 
 When must it run? For `scripts/ci/herdr-lane-filter.sh` path matches or the
 literal `[run-herdr-integration]` marker, on the same event-payload terms as
-the LLM lanes. The rule behind the list: anything that changes what the app
+the LLM lanes. A manual `ci.yml` dispatch also runs it, which is the supported
+way to repeat this live external contract without manufacturing commits. The
+rule behind the list: anything that changes what the app
 SAYS to herdr, what it BELIEVES herdr answered, how the forward reaching
 herdr is opened or leased, which host that forward reaches, or the recorded
 assumptions themselves. Editing

--- a/docs/agent/test-tiers.md
+++ b/docs/agent/test-tiers.md
@@ -230,6 +230,19 @@ prevent. Not required for UI, insertion, audio, or model work. Either way the
 PR's Proof section carries the scoreboard or a one-line justification for
 skipping.
 
+The fixture records the runner account, herdr binary/version, inherited and
+isolated socket settings, terminal variables, requested and actual pty size,
+rendered sidebar width, sshd port, forward sockets, and pane lifecycle. CI
+uploads those files as `herdr-lane-diagnostics` even when the lane passes. The
+artifact deliberately excludes the fixture's ephemeral host and user keys.
+On 2026-09-07 this evidence exposed an account-sensitive startup race: the
+`tom` launchd runner kept provisional `w1:p1` alive across two one-second
+reads, then replaced it with `w2:p1` 50–200 ms after readiness; the `builder`
+SSH account reached `w2:p1` before the same check. Both used herdr 0.8.2,
+45×130 ptys, and a rendered 26-cell sidebar. Pane readiness therefore needs
+three consecutive resolving samples. Do not trade that condition for a longer
+token TTL or surface timeout; neither participates in this race.
+
 Worker builds on the Mac must not overlap the lane. Measured 2026-09-07 on
 the build host (per-request latency tap in `HerdrSocketClient`, 10 lane runs
 idle + 10 with one concurrent `swift build`): idle 10/10 green with

--- a/scripts/ci/clean-stale-outputs.sh
+++ b/scripts/ci/clean-stale-outputs.sh
@@ -26,6 +26,18 @@ fi
 
 rm -rf dist logs format-lint.txt default.profraw
 
+# One-time migration for the shared .build: until 2026-09-07 the dogfood
+# capture suite compiled the test module with LOCALVOXTRAL_DOGFOOD into this
+# same cache, and SwiftPM kept those dogfood-only test objects when the define
+# went away, so the next run linked them against a non-dogfood app module and
+# failed with undefined symbols. The suite now builds in .build-dogfood; the
+# stale test objects in .build are dropped exactly once, on the first run
+# that has not yet created the new cache. Only the test module is dropped —
+# the app module and dependency checkouts stay warm.
+if [[ -d .build && ! -d .build-dogfood ]]; then
+  rm -rf .build/debug/localvoxtralTests.build .build/debug/localvoxtralPackageTests.xctest
+fi
+
 # Transient eval enable markers (gitignored, marker-through-the-tree
 # pattern): clean: false preserves them across runs, and a stray one would
 # flip a marker-gated live suite ON in a plain unit step.

--- a/scripts/ci/test-herdr-fixture-recovery.sh
+++ b/scripts/ci/test-herdr-fixture-recovery.sh
@@ -188,4 +188,31 @@ release_account_files 2>/dev/null
   || fail "an ssh config the fixture created must be removed again, not left empty"
 pass "files the account never had are removed, not left behind"
 
+# The live server creates a provisional pane while its whole-view client is
+# starting. CI measured that pane surviving two one-second reads and then
+# being replaced immediately afterwards. Three stable reads must select the
+# replacement, not the provisional id.
+printf '0\n' > "$TMP_DIR/pane-read-count"
+herdr_cli() {
+  local group="$1" verb="$2" count
+  [[ "$group" == "pane" ]] || return 1
+  if [[ "$verb" == "get" ]]; then
+    return 0
+  fi
+  [[ "$verb" == "current" ]] || return 1
+  count="$(sed -n '1p' "$TMP_DIR/pane-read-count")"
+  count=$((count + 1))
+  printf '%s\n' "$count" > "$TMP_DIR/pane-read-count"
+  case "$count" in
+    1|2) printf '{"pane_id":"w1:p1"}\n' ;;
+    *) printf '{"pane_id":"w2:p1"}\n' ;;
+  esac
+}
+sleep() { :; }
+READY_TIMEOUT_SECONDS=10
+settled="$(settle_focused_pane "$TMP_DIR" 2>/dev/null)"
+[[ "$settled" == "w2:p1" ]] \
+  || fail "pane settlement accepted provisional w1:p1 instead of stable w2:p1 (got $settled)"
+pass "pane settlement rejects an id that survives only two samples"
+
 printf '\nAll herdr fixture recovery checks passed.\n'

--- a/scripts/herdr-integration-fixture.sh
+++ b/scripts/herdr-integration-fixture.sh
@@ -79,6 +79,44 @@ HOLD_MANIFEST="$HOLD_DIR/manifest"
 
 log() { printf '[herdr-fixture] %s\n' "$*" >&2; }
 
+environment_value() {
+  local name="$1" value
+  value="$(printenv "$name" 2>/dev/null || true)"
+  [[ -n "$value" ]] && printf '%s' "$value" || printf '<unset>'
+}
+
+tty_state() {
+  local descriptor="$1"
+  [[ -t "$descriptor" ]] && printf 'tty' || printf 'not-a-tty'
+}
+
+record_start_diagnostics() {
+  local dir="$1" inherited_socket="$2" account_status="$3" version config_state session_state
+  version="$("$HERDR_BINARY" --version 2>&1 | head -1)"
+  [[ -e "$HERDR_CONFIG_FILE" ]] && config_state=present || config_state=absent
+  [[ -e "$HERDR_SESSION_FILE" ]] && session_state=present || session_state=absent
+  {
+    printf 'account=%s uid=%s home=%s\n' "$(id -un)" "$(id -u)" "$HOME"
+    printf 'herdr.binary=%s\n' "$HERDR_BINARY"
+    printf 'herdr.version=%s\n' "$version"
+    printf 'herdr.status.before=%s\n' "${account_status:-<empty>}"
+    printf 'herdr.socket.inherited=%s\n' "${inherited_socket:-<unset>}"
+    printf 'herdr.socket.fixture=%s\n' "$HERDR_SOCKET_PATH"
+    printf 'herdr.config=%s state=%s\n' "$HERDR_CONFIG_FILE" "$config_state"
+    printf 'herdr.session=%s state=%s\n' "$HERDR_SESSION_FILE" "$session_state"
+    printf 'env.PATH=%s\n' "$PATH"
+    printf 'env.XDG_CONFIG_HOME=%s\n' "$(environment_value XDG_CONFIG_HOME)"
+    printf 'env.XDG_RUNTIME_DIR=%s\n' "$(environment_value XDG_RUNTIME_DIR)"
+    printf 'env.TERM=%s env.COLUMNS=%s env.LINES=%s\n' \
+      "$(environment_value TERM)" "$(environment_value COLUMNS)" "$(environment_value LINES)"
+    printf 'stdio.stdin=%s stdout=%s stderr=%s\n' \
+      "$(tty_state 0)" "$(tty_state 1)" "$(tty_state 2)"
+    printf 'script.binary=%s\n' "$(command -v script 2>/dev/null || printf '<missing>')"
+    printf 'pty.requested=%sx%s\n' "$SURFACE_ROWS" "$SURFACE_COLUMNS"
+    printf 'sidebar.configured_width=26 mobile_width_threshold=64\n'
+  } | tee "$dir/environment.txt" >&2
+}
+
 # Set while `up` is between "started modifying things" and "fully succeeded".
 # A failure in that window restores through the EXIT trap; a KILL in it (or at
 # any point afterwards) is what the hold directory exists for.
@@ -306,6 +344,17 @@ herdr_cli() {
   HERDR_SOCKET_PATH="$HERDR_SOCKET_PATH" "$HERDR_BINARY" "$@"
 }
 
+record_pane_snapshot() {
+  local dir="$1" event="$2" pane="${3:-}"
+  {
+    printf '\n[%s] event=%s\n' "$(date -u +%Y-%m-%dT%H:%M:%S.%NZ)" "$event"
+    printf 'current='; herdr_cli pane current 2>&1 || true
+    if [[ -n "$pane" ]]; then
+      printf 'selected='; herdr_cli pane get "$pane" 2>&1 || true
+    fi
+  } >> "$dir/pane-lifecycle.log"
+}
+
 # Kill whatever a run left behind in its own workdir. Touches no account files.
 stop_workdir_processes() {
   local dir="$1" pid binary
@@ -430,12 +479,14 @@ write_canonicalization_aliases() {
 }
 
 start_surface() {
-  local dir="$1" name="$2" mode="$3" pane="${4:-}" inner
+  local dir="$1" name="$2" mode="$3" pane="${4:-}" geometry
+  geometry="$dir/surface-$name.geometry"
+  local -a inner
   case "$mode" in
-    app) inner="$HERDR_BINARY" ;;
+    app) inner=("$HERDR_BINARY") ;;
     attach)
       [[ -n "$pane" ]] || die "surface mode 'attach' needs a pane id"
-      inner="$HERDR_BINARY terminal attach $pane"
+      inner=("$HERDR_BINARY" terminal attach "$pane")
       ;;
     *) die "unknown surface mode: $mode" ;;
   esac
@@ -447,10 +498,33 @@ start_surface() {
   # the surface read would answer about the past.
   TERM=xterm-256color HERDR_SOCKET_PATH="$HERDR_SOCKET_PATH" \
     script -q -t 0 "$dir/surface-$name.log" \
-    /bin/sh -c "stty rows $SURFACE_ROWS cols $SURFACE_COLUMNS; exec $inner" \
+    /bin/sh -c '
+      rows="$1"; columns="$2"; geometry="$3"; shift 3
+      stty rows "$rows" cols "$columns"
+      {
+        printf "pty.rows_cols="; stty size
+        printf "pty.stdin=%s stdout=%s stderr=%s controlling_tty=%s\n" \
+          "$([[ -t 0 ]] && echo tty || echo not-a-tty)" \
+          "$([[ -t 1 ]] && echo tty || echo not-a-tty)" \
+          "$([[ -t 2 ]] && echo tty || echo not-a-tty)" \
+          "$(tty 2>/dev/null || echo none)"
+        printf "env.TERM=%s env.COLUMNS=%s env.LINES=%s\n" \
+          "${TERM:-<unset>}" "${COLUMNS:-<unset>}" "${LINES:-<unset>}"
+      } > "$geometry"
+      exec "$@"
+    ' fixture-surface "$SURFACE_ROWS" "$SURFACE_COLUMNS" "$geometry" "${inner[@]}" \
     </dev/null >/dev/null 2>&1 &
   echo $! >> "$dir/surface.pids"
+  local waited=0
+  until [[ -s "$geometry" ]]; do
+    (( waited < READY_TIMEOUT_SECONDS * 10 )) \
+      || die "surface '$name' never recorded its pty geometry"
+    sleep 0.1
+    waited=$((waited + 1))
+  done
   log "surface '$name' ($mode) started -> $dir/surface-$name.log"
+  sed "s/^/[herdr-fixture] surface.$name./" "$geometry" >&2
+  record_pane_snapshot "$dir" "surface-$name-started" "$pane"
 }
 
 # Print the focused pane id once it is stable: UNCHANGED across two reads a
@@ -485,14 +559,16 @@ command_up() {
   validate_workdir "$dir"
   [[ ! -e "$dir" ]] || die "workdir already exists: $dir (run 'down' first)"
 
+  local inherited_socket="${HERDR_SOCKET_PATH:-}" account_status
   HERDR_BINARY="$(resolve_herdr)"
   log "herdr binary: $HERDR_BINARY ($("$HERDR_BINARY" --version 2>&1 | head -1))"
+  account_status="$("$HERDR_BINARY" status server 2>&1 | tr '\n' ' ' || true)"
 
   # The fixture owns this account's herdr config, its session state and a
   # block in its ssh config for the duration of the lane. If the account
   # already has a herdr running, those files belong to a human right now —
   # refuse rather than trample them.
-  if "$HERDR_BINARY" status server 2>/dev/null | grep -q '^status: running'; then
+  if grep -q '^status: running' <<<"$account_status"; then
     die "a herdr server is already running for $(id -un).
   This lane takes over the account's herdr config and session state for the
   duration of the run, so it refuses to start beside a live one. Quit herdr
@@ -510,6 +586,8 @@ command_up() {
   export HERDR_SOCKET_PATH
   # Recorded first, so teardown can still reach the binary if `up` dies partway.
   printf '%s\n' "$HERDR_BINARY" > "$dir/herdr.bin"
+
+  record_start_diagnostics "$dir" "$inherited_socket" "$account_status"
 
   hold_account_files "$dir"
 
@@ -602,6 +680,7 @@ EOF
     sleep 1
   done
   log "pane $pane_id marked agent-bearing (session $agent_session_id)"
+  record_pane_snapshot "$dir" "primary-ready" "$pane_id"
 
   printf '{"agentSessionID":"%s","alias":"%s","altUserAlias":"%s-altuser","otherPortAlias":"%s-otherport","herdrBinary":"%s","socketPath":"%s","paneID":"%s","primarySurfaceLog":"%s","provisionedSSH":%s,"workdir":"%s"}\n' \
     "$agent_session_id" "$alias_used" "$alias_used" "$alias_used" \
@@ -628,7 +707,9 @@ load_context() {
 command_surface() {
   local dir="$1" name="$2" mode="$3" pane="${4:-}"
   load_context "$dir"
+  record_pane_snapshot "$dir" "before-surface-$name" "$pane"
   start_surface "$dir" "$name" "$mode" "$pane"
+  record_pane_snapshot "$dir" "after-surface-$name" "$pane"
 }
 
 command_reload() {

--- a/scripts/herdr-integration-fixture.sh
+++ b/scripts/herdr-integration-fixture.sh
@@ -346,6 +346,7 @@ herdr_cli() {
 
 record_pane_snapshot() {
   local dir="$1" event="$2" pane="${3:-}"
+  [[ -S "$HERDR_SOCKET_PATH" ]] || return 0
   {
     printf '\n[%s] event=%s\n' "$(date -u +%Y-%m-%dT%H:%M:%S.%NZ)" "$event"
     printf 'current='; herdr_cli pane current 2>&1 || true
@@ -527,28 +528,37 @@ start_surface() {
   record_pane_snapshot "$dir" "surface-$name-started" "$pane"
 }
 
-# Print the focused pane id once it is stable: UNCHANGED across two reads a
+# Print the focused pane id once it is stable: UNCHANGED across three reads a
 # second apart AND still resolving via `pane get`. Dies loudly past the
 # readiness timeout. Callers that act on the id (report-agent) must still
 # handle it dying afterwards — settle narrows the race, it does not close it.
 settle_focused_pane() {
-  local dir="$1" pane_id="" previous="" waited=0
+  local dir="$1" pane_id="" candidate="" stable_reads=0 waited=0
   while true; do
     # `|| true`: before a pane exists, `pane current` answers with a
     # pane_not_found ERROR and a non-zero status, which `pipefail` would
     # otherwise turn into an abort on the very first poll.
     pane_id="$({ herdr_cli pane current 2>/dev/null || true; } \
       | sed -n 's/.*"pane_id":"\([^"]*\)".*/\1/p' | head -1)"
-    if [[ -n "$pane_id" && "$pane_id" == "$previous" ]] \
-      && herdr_cli pane get "$pane_id" >/dev/null 2>&1; then
-      log "focused pane: $pane_id"
-      printf '%s\n' "$pane_id"
-      return 0
+    if [[ -n "$pane_id" ]] && herdr_cli pane get "$pane_id" >/dev/null 2>&1; then
+      if [[ "$pane_id" == "$candidate" ]]; then
+        stable_reads=$((stable_reads + 1))
+      else
+        candidate="$pane_id"
+        stable_reads=1
+      fi
+      if (( stable_reads >= 3 )); then
+        log "focused pane: $pane_id (stable across $stable_reads reads)"
+        printf '%s\n' "$pane_id"
+        return 0
+      fi
+    else
+      candidate=""
+      stable_reads=0
     fi
     if (( waited >= READY_TIMEOUT_SECONDS )); then
       die "herdr never settled on a focused pane; see $dir/surface-primary.log and $dir/server.log"
     fi
-    previous="$pane_id"
     sleep 1
     waited=$((waited + 1))
   done
@@ -632,6 +642,7 @@ EOF
 
   herdr_cli server </dev/null >"$dir/server.log" 2>&1 &
   echo $! > "$dir/server.child.pid"
+
   local waited=0
   until [[ -S "$HERDR_SOCKET_PATH" ]]; do
     (( waited < READY_TIMEOUT_SECONDS )) || die "herdr server never created $HERDR_SOCKET_PATH; see $dir/server.log"
@@ -640,18 +651,15 @@ EOF
   done
   log "herdr server listening on $HERDR_SOCKET_PATH"
 
-  # The whole-view client is what CREATES the first pane, so the pane the
-  # lane binds to and the surface that renders it are the same real client.
+  # The whole-view client creates the pane whose rendered output the lane
+  # reads. Require its id to be unchanged across three reads and to resolve.
   : > "$dir/surface.pids"
   start_surface "$dir" "primary" "app"
 
-  # The pane the lane binds to must be the one the CLIENT owns, not herdr's
-  # transient startup pane. A headless server spawns a pane of its own before
-  # any client connects; the whole-view client then retires it and creates its
-  # own in a new workspace. Reading `pane current` once can latch that dying
-  # pane, and every later request answers `pane_not_found` for it (seen on the
-  # CI runner, where the timing differed from the dev box). So: require the id
-  # to be UNCHANGED across two reads a second apart AND to still resolve.
+  # The failed runner artifact measured the provisional w1:p1 surviving the old
+  # two-read check, then disappearing 50–200 ms later as w2:p1 arrived. The
+  # third one-second sample rejects that measured transient without changing
+  # any token TTL or failure timeout.
   #
   # Even that is not airtight: the settled pane can still die between the
   # settle and the `report-agent` below (seen on the CI runner 2026-09-07 as


### PR DESCRIPTION
## What

Make the live-herdr fixture deterministic in the launchd runner environment.

- Record the account, config/socket inputs, herdr binary and version, sshd port, forward sockets, terminal environment, requested and actual pty geometry, rendered sidebar width, pane lifecycle, and final rendered frames. CI uploads the safe subset as `herdr-lane-diagnostics` on success and failure; fixture keys are excluded.
- Wait for three consecutive resolving pane samples before reporting the fixture ready. The runner artifact showed provisional `w1:p1` surviving the former two-sample check and being replaced by `w2:p1` 50–200 ms later.
- Gate the mic-indicator test's first injected refresh until its deliberate clear is observed. The former 50 ms accelerated sleep let refresh race clear according to scheduler timing.
- Run the herdr lane on manual `ci.yml` dispatches so runner reproductions do not require throwaway commits.

[run-herdr-integration]

### Runner versus SSH diagnostics

| Input | launchd runner | SSH build path |
| --- | --- | --- |
| Account | `tom`, uid 501, `/Users/tom` | `builder`, uid 503, `/Users/builder` |
| Herdr | `/opt/homebrew/bin/herdr`, 0.8.2 | `/opt/homebrew/bin/herdr`, 0.8.2 |
| Existing server | stopped; default socket `/Users/tom/.config/herdr/herdr.sock` | stopped; default socket `/Users/builder/.config/herdr/herdr.sock` |
| Account files | config present; session present | config absent; session present |
| Inherited routing | `HERDR_SOCKET_PATH`, `XDG_CONFIG_HOME`, and `XDG_RUNTIME_DIR` unset | same |
| Parent terminal | `TERM`, `COLUMNS`, and `LINES` unset; no tty | same |
| Fixture ptys | primary and attach both 45×130; `TERM=xterm-256color`; `/usr/bin/script`; controlling ttys present | same |
| Rendered sidebar | 26 cells | 26 cells |
| SSH forward | isolated loopback sshd on an ephemeral port (example: 31093); stream-local `ssh -L` sockets | same allocation scheme |
| Startup pane | old check admitted `w1:p1`, then herdr replaced it with `w2:p1`; final runs settle on `w2:p1` | reaches `w2:p1` before readiness |
| Token timing | TTL 8 s; production refresh 4 s; fixture surface wait 20 s | same |

Geometry, binary selection, config isolation, socket routing, and controlling-tty behavior are therefore not the cause. The account-dependent difference is when herdr retires its provisional startup pane. A separate runner scheduling race in the accelerated mic-refresh test surfaced after that pane race was fixed.

## Proof

- [x] Unit suite green — `./scripts/remote-build.sh test`: `Executed 3042 tests, with 2 tests skipped and 0 failures (0 unexpected) in 55.303 seconds`.
- [x] Bug regression: [diagnostic run 34142501441](https://github.com/T0mSIlver/localvoxtral/actions/runs/34142501441) failed after selecting provisional `w1:p1`; the artifact then showed `w2:p1` as current. `./scripts/ci/test-herdr-fixture-recovery.sh` now drives `w1, w1, w2, w2, w2` and passes `pane settlement rejects an id that survives only two samples`.
- [x] Follow-up regression: [run 34144453498](https://github.com/T0mSIlver/localvoxtral/actions/runs/34144453498) passed both attach tests after pane stabilization, then failed only the unordered clear/refresh assertion. The final test holds the refresh tick, observes the clear below the 8 s TTL, releases one refresh, and observes the same token restored.
- [x] Runner live-herdr lane, three consecutive final-SHA dispatches: [34145726014](https://github.com/T0mSIlver/localvoxtral/actions/runs/34145726014), [34146050006](https://github.com/T0mSIlver/localvoxtral/actions/runs/34146050006), and [34146341481](https://github.com/T0mSIlver/localvoxtral/actions/runs/34146341481) each passed 11/11 and uploaded `herdr-lane-diagnostics`. Each workflow was cancelled only after those two proof steps completed, avoiding unrelated manual-dispatch packaging work before the next serialized repetition.
- [x] SSH-local live-herdr lane, three consecutive final-code runs — `./scripts/remote-build.sh integration-herdr`: 11/11, 0 failures in 76.710 s; 76.850 s; 76.601 s.
- [x] Diagnostic frame parser — `./scripts/remote-build.sh test --filter HerdrSurfaceLogTests`: 1 test, 0 failures in 0.005 s.
- [x] Fixture shell checks — `bash -n scripts/herdr-integration-fixture.sh scripts/ci/test-herdr-fixture-recovery.sh` and `./scripts/ci/test-herdr-fixture-recovery.sh`: all checks passed.
- [x] Realtime integration — the live STT prerequisite passed in all three final-SHA dispatches. No audio or transcription behavior changed.
- [x] UI verification not required: no product UI changed.

LLM, speech-helper, and E2E model evals are not applicable; this changes only the herdr integration fixture, its diagnostics, and test scheduling.
