### PR TITLE
Remote plugin setup: decode claude plugin list --json instead of text-matching the human listing (fixes the exit 43 on a current host)

### DIFF
--- a/Sources/localvoxtral/ClaudeContext/ClaudeRemoteEnrollmentService.swift
+++ b/Sources/localvoxtral/ClaudeContext/ClaudeRemoteEnrollmentService.swift
@@ -799,16 +799,87 @@ public struct ClaudeRemoteEnrollmentService: Sendable {
         )
     }
 
-    /// Install or update the remote plugin, then prove the installed version
-    /// before the SSH session exits — all in ONE ssh session, so the proof
-    /// describes the install that just ran. Plugin-list output is consumed
-    /// remotely because it can contain a stored token this process cannot
-    /// redact; only our own sentinel reaches this side.
+    /// One entry of `claude plugin list --json`. Only the keys the version
+    /// check reads; the decoder ignores everything else the CLI adds.
+    public struct RemotePluginListEntry: Decodable, Equatable, Sendable {
+        public let id: String
+        public let version: String
+        public let scope: String?
+        public let enabled: Bool?
+    }
+
+    public static let pluginListFrameBegin = "LVX_PLUGIN_LIST_BEGIN"
+    public static let pluginListFrameEnd = "LVX_PLUGIN_LIST_END"
+    /// A listing is a few hundred bytes per installed plugin. Anything past
+    /// this is not a listing, and is never decoded.
+    public static let maxPluginListBytes = 256 * 1024
+
+    /// The script that prints the host's installed plugins as JSON inside a
+    /// frame. The frame is what makes the capture readable regardless of what
+    /// else the login writes to the pipe (banners, MOTD, stderr).
+    static var remotePluginListingScript: String {
+        """
+        set -eu
+        \(Self.claudePathResolverPreamble)printf '%s\\n' \(pluginListFrameBegin)
+        claude plugin list --json
+        printf '\\n%s\\n' \(pluginListFrameEnd)
+        """
+    }
+
+    /// The installed version of `reference` in a framed listing capture, or
+    /// nil when the host has no such plugin. A user-scope entry wins over a
+    /// project/local one; among equals the first entry wins. Throws when the
+    /// capture carries no frame or the frame's payload is not a JSON array of
+    /// entries — a host we could not read is a different verdict from a host
+    /// with nothing installed, and is never reported as the latter.
+    static func installedRemotePluginVersion(
+        inFramedOutput output: String,
+        reference: String
+    ) throws -> String? {
+        guard let beginRange = output.range(of: pluginListFrameBegin),
+              let endRange = output.range(
+                  of: pluginListFrameEnd, range: beginRange.upperBound..<output.endIndex
+              )
+        else {
+            throw ServiceError.runnerFailed(
+                step: 0,
+                command: "list remote plugins",
+                message: "The host did not return a plugin listing."
+            )
+        }
+        let payload = output[beginRange.upperBound..<endRange.lowerBound]
+        let data = Data(payload.utf8)
+        guard data.count <= maxPluginListBytes else {
+            throw ServiceError.runnerFailed(
+                step: 0,
+                command: "list remote plugins",
+                message: "The host's plugin listing is larger than a listing can be."
+            )
+        }
+        let entries: [RemotePluginListEntry]
+        do {
+            entries = try JSONDecoder().decode([RemotePluginListEntry].self, from: data)
+        } catch {
+            throw ServiceError.runnerFailed(
+                step: 0,
+                command: "list remote plugins",
+                message: "The host's plugin listing could not be decoded."
+            )
+        }
+        let matches = entries.filter { $0.id == reference }
+        return (matches.first { $0.scope == "user" } ?? matches.first)?.version
+    }
+
+    /// Install or update the remote plugin and prove the installed version.
     ///
-    /// The version check reads the line `claude plugin list` prints for our
-    /// reference (`<name>@<marketplace> <version>` — the same line
-    /// `ClaudePluginStatus.installedVersion` reads) and matches the version as
-    /// a space-delimited word, so `11.7.0` can never satisfy `1.7.0`.
+    /// Three ssh calls, each with one job: a framed `claude plugin list
+    /// --json` capture that THIS side decodes (never text-matched on the
+    /// host — the human listing's shape changed once already and took every
+    /// host with it), the install or update, then a second decoded listing
+    /// as the read-back. The listing carries ids, versions, scopes and paths;
+    /// it never carries a plugin's stored config or token (verified against
+    /// Claude Code 2.1.x on 2026-09-07), so decoding it here reads nothing
+    /// this process could not redact.
     public func setupRemotePlugin(
         sshHostAlias: String,
         token: String?,
@@ -818,112 +889,116 @@ public struct ClaudeRemoteEnrollmentService: Sendable {
         guard let runner else { throw ServiceError.executionNotConfigured }
         guard Self.isValidHostAlias(sshHostAlias) else { throw ServiceError.invalidHostAlias }
         let reference = Self.remotePluginReference
+        let expected = Self.remotePluginVersion
         let tokenArguments = token.map {
             " --config '\(Self.tokenConfigKey)=\($0)'"
         } ?? ""
-        // Decided HERE, not on the host: an absent plugin can only be installed
-        // with a credential, and the update path deliberately has none (the
-        // one-time enrollment token is long gone). Installing tokenless would
-        // look exactly like a healthy enrollment failing open, so the script
-        // reports the absence and the run names the remedy instead.
-        let absentBranch = token == nil
-            ? """
-              printf '%s\\n' LVX_PLUGIN_ABSENT
-              exit 44
 
-            """
-            : """
-              claude plugin marketplace add \(Self.repositoryMarketplaceReference)
-              claude plugin install \(reference)\(tokenArguments) --config '\(Self.portConfigKey)=\(remoteForwardPort)'
-              lv_outcome=LVX_PLUGIN_INSTALLED
+        func run(_ script: String, command: String) throws -> RunResult {
+            do {
+                return try runner(
+                    Invocation(
+                        argv: [
+                            "ssh", "-o", "BatchMode=yes", "-o", "ClearAllForwardings=yes", "--",
+                            sshHostAlias, "/bin/sh", "-s",
+                        ],
+                        standardInput: Data(script.utf8),
+                        timeout: max(timeout, 0)
+                    )
+                )
+            } catch {
+                throw sanitizedRunnerError(error, command: command)
+            }
+        }
 
-            """
-        let script = """
-            set -eu
-            \(Self.claudePathResolverPreamble)lv_line=$(claude plugin list 2>&1 | grep -F '\(reference)' | head -n 1)
-            if [ -z "$lv_line" ]; then
-            \(absentBranch)else
-              lv_current=0
-              case " $lv_line " in
-                *" \(Self.remotePluginVersion) "*) lv_current=1 ;;
-              esac
-              if [ "$lv_current" -eq 0 ]; then
-                claude plugin marketplace update \(ClaudePluginAssets.marketplaceName)
+        func installedVersion(command: String) throws -> String? {
+            let result = try run(Self.remotePluginListingScript, command: command)
+            guard result.succeeded else {
+                let message = result.exitCode == 127
+                    ? "Claude CLI was not found on the remote host. "
+                        + "Install Claude Code there, or put it on the non-interactive SSH PATH."
+                    : "The remote plugin listing command failed."
+                throw ServiceError.commandFailed(
+                    step: 0,
+                    command: command,
+                    exitCode: result.exitCode,
+                    message: ClaudeRemoteTokenRedaction.redact(message, token: token ?? "")
+                )
+            }
+            return try Self.installedRemotePluginVersion(
+                inFramedOutput: result.message, reference: reference
+            )
+        }
+
+        let before = try installedVersion(command: "list remote plugins")
+
+        let mutation: String
+        let outcome: PluginSetupOutcome
+        switch before {
+        case nil:
+            // Decided HERE, not on the host: an absent plugin can only be
+            // installed with a credential, and the update path deliberately
+            // has none (the one-time enrollment token is long gone).
+            // Installing tokenless would look exactly like a healthy
+            // enrollment failing open, so the absence names the remedy.
+            guard token != nil else {
+                throw ServiceError.commandFailed(
+                    step: 0,
+                    command: "install remote plugin",
+                    exitCode: 44,
+                    message: "The plugin is not installed on the host, and this run has no token to "
+                        + "give it. Rotate this host's token, then run setup again."
+                )
+            }
+            mutation = """
+                set -eu
+                \(Self.claudePathResolverPreamble)claude plugin marketplace add \(Self.repositoryMarketplaceReference)
+                claude plugin install \(reference)\(tokenArguments) --config '\(Self.portConfigKey)=\(remoteForwardPort)'
+                """
+            outcome = .installed
+        case expected?:
+            // Current already; the install re-applies the port config only.
+            mutation = """
+                set -eu
+                \(Self.claudePathResolverPreamble)claude plugin install \(reference)\(tokenArguments) --config '\(Self.portConfigKey)=\(remoteForwardPort)'
+                """
+            outcome = .alreadyCurrent
+        default:
+            mutation = """
+                set -eu
+                \(Self.claudePathResolverPreamble)claude plugin marketplace update \(ClaudePluginAssets.marketplaceName)
                 claude plugin update \(reference)
-                lv_outcome=LVX_PLUGIN_UPDATED
-              else
-                lv_outcome=LVX_PLUGIN_ALREADY_CURRENT
-              fi
-              claude plugin install \(reference)\(tokenArguments) --config '\(Self.portConfigKey)=\(remoteForwardPort)'
-            fi
-            lv_after=$(claude plugin list 2>&1 | grep -F '\(reference)' | head -n 1)
-            case " $lv_after " in
-              *" \(Self.remotePluginVersion) "*) : ;;
-              *) exit 43 ;;
-            esac
-            printf '%s\\n' "$lv_outcome"
-            """
-        let result: RunResult
-        do {
-            result = try runner(
-                Invocation(
-                    argv: [
-                        "ssh", "-o", "BatchMode=yes", "-o", "ClearAllForwardings=yes", "--",
-                        sshHostAlias, "/bin/sh", "-s",
-                    ],
-                    standardInput: Data(script.utf8),
-                    timeout: max(timeout, 0)
-                )
-            )
-        } catch {
-            throw sanitizedRunnerError(error, command: "install and verify remote plugin")
+                claude plugin install \(reference)\(tokenArguments) --config '\(Self.portConfigKey)=\(remoteForwardPort)'
+                """
+            outcome = .updated
         }
-        if result.exitCode == 44 {
-            throw ServiceError.commandFailed(
-                step: 0,
-                command: "install and verify remote plugin",
-                exitCode: 44,
-                message: ClaudeRemoteTokenRedaction.redact(
-                    "The plugin is not installed on the host, and this run has no token to "
-                        + "give it. Rotate this host's token, then run setup again.",
-                    token: token ?? ""
-                )
-            )
-        }
-        if result.exitCode == 43 {
-            throw ServiceError.commandFailed(
-                step: 0,
-                command: "install and verify remote plugin",
-                exitCode: 43,
-                message: ClaudeRemoteTokenRedaction.redact(
-                    "The plugin is installed but did not report version "
-                        + Self.remotePluginVersion
-                        + " when read back in the same session.",
-                    token: token ?? ""
-                )
-            )
-        }
-        guard result.succeeded else {
-            let message = result.exitCode == 127
+
+        let mutationResult = try run(mutation, command: "install and verify remote plugin")
+        guard mutationResult.succeeded else {
+            let message = mutationResult.exitCode == 127
                 ? "Claude CLI was not found on the remote host. "
                     + "Install Claude Code there, or put it on the non-interactive SSH PATH."
                 : "The remote plugin setup command failed."
             throw ServiceError.commandFailed(
                 step: 0,
                 command: "install and verify remote plugin",
-                exitCode: result.exitCode,
+                exitCode: mutationResult.exitCode,
                 message: ClaudeRemoteTokenRedaction.redact(message, token: token ?? "")
             )
         }
-        if result.message.contains("LVX_PLUGIN_INSTALLED") { return .installed }
-        if result.message.contains("LVX_PLUGIN_UPDATED") { return .updated }
-        if result.message.contains("LVX_PLUGIN_ALREADY_CURRENT") { return .alreadyCurrent }
-        throw ServiceError.runnerFailed(
-            step: 0,
-            command: "install and verify remote plugin",
-            message: "The host did not report a plugin setup outcome."
-        )
+
+        let after = try installedVersion(command: "verify remote plugin")
+        guard after == expected else {
+            throw ServiceError.commandFailed(
+                step: 0,
+                command: "install and verify remote plugin",
+                exitCode: 43,
+                message: "The plugin reports version \(after ?? "none") after setup, not \(expected)."
+            )
+        }
+        return outcome
     }
+
 
     /// Prove that this process's LC_LVX_TTY value crosses sshd. The random
     /// value exists only in the child environment and is never logged.

--- a/Tests/localvoxtralTests/ClaudeIntegrationSettingsModelTests.swift
+++ b/Tests/localvoxtralTests/ClaudeIntegrationSettingsModelTests.swift
@@ -182,9 +182,14 @@ private final class StubForwarding: ClaudeRemoteForwarding {
 /// noise on both sides, as a real login shell's merged stdout/stderr would
 /// deliver it.
 private struct SetupFlowScript: Sendable {
-    var plugin = ClaudeRemoteEnrollmentService.RunResult(
-        exitCode: 0, message: "LVX_PLUGIN_INSTALLED"
-    )
+    /// The install/update call's result. Its message is never read: the
+    /// outcome comes from the two decoded listings around it.
+    var plugin = ClaudeRemoteEnrollmentService.RunResult(exitCode: 0, message: "")
+    /// What `claude plugin list --json` reports for our plugin before and
+    /// after the install call; nil = not installed. The defaults model a
+    /// fresh host: nothing before, the shipped version after the install.
+    var pluginVersionBefore: String?
+    var pluginVersionAfter: String? = ClaudeRemoteEnrollmentService.remotePluginVersion
     var envEchoesBack = true
     var sendEnvOutput = "hostname builder\nsendenv LANG LC_*\n"
     var herdr = ClaudeRemoteEnrollmentService.RunResult(
@@ -192,6 +197,45 @@ private struct SetupFlowScript: Sendable {
     )
     var tunnelMessage = "LVX_HTTP:401"
     var pluginListMessage = "localvoxtral-remote 1.7.0\n"
+}
+
+/// A `claude plugin list --json` capture as a login shell delivers it: a
+/// banner before the frame, the CLI's own array (a second, unrelated plugin
+/// first, ours at user scope), and the frame end after it. `version == nil`
+/// lists only the unrelated plugin.
+private func framedPluginListing(version: String?) -> String {
+    let ours = version.map {
+        """
+          ,
+          {
+            "id": "\(ClaudeRemoteEnrollmentService.remotePluginReference)",
+            "version": "\($0)",
+            "scope": "user",
+            "enabled": true,
+            "installPath": "/home/dev/.claude/plugins/cache/localvoxtral/localvoxtral-remote/\($0)",
+            "installedAt": "2026-07-27T20:59:23.439Z",
+            "lastUpdated": "2026-09-07T13:27:31.000Z"
+          }
+        """
+    } ?? ""
+    return """
+        Welcome to builder
+        \(ClaudeRemoteEnrollmentService.pluginListFrameBegin)
+        [
+          {
+            "id": "frontend-design@claude-plugins-official",
+            "version": "unknown",
+            "scope": "project",
+            "enabled": false,
+            "installPath": "/home/dev/.claude/plugins/cache/claude-plugins-official/frontend-design/unknown",
+            "installedAt": "2026-07-01T15:07:39.195Z",
+            "lastUpdated": "2026-07-01T15:07:39.195Z",
+            "projectPath": "/home/dev/work/other"
+          }\(ours)
+        ]
+        \(ClaudeRemoteEnrollmentService.pluginListFrameEnd)
+        Last login: today
+        """
 }
 
 /// Records every ssh invocation the run makes, from the nonisolated runner
@@ -2661,7 +2705,8 @@ final class ClaudeIntegrationSettingsModelTests: XCTestCase {
         script: SetupFlowScript,
         recorder: SetupFlowRecorder
     ) -> ClaudeRemoteEnrollmentService.Runner {
-        { invocation in
+        let listingCalls = Mutex(0)
+        return { invocation in
             recorder.record(invocation)
             let stdin = String(decoding: invocation.standardInput, as: UTF8.self)
             if invocation.argv.contains("-G") {
@@ -2678,8 +2723,17 @@ final class ClaudeIntegrationSettingsModelTests: XCTestCase {
                     )
                     : .init(exitCode: 0, message: "")
             }
-            // Before "claude plugin list": the setup script contains both.
-            if stdin.contains("LVX_PLUGIN") { return script.plugin }
+            // The framed JSON listing runs twice: before the install call
+            // (decides install / update / current) and after it (read-back).
+            if stdin.contains(ClaudeRemoteEnrollmentService.pluginListFrameBegin) {
+                let isReadBack = listingCalls.withLock { calls -> Bool in
+                    calls += 1
+                    return calls > 1
+                }
+                let version = isReadBack ? script.pluginVersionAfter : script.pluginVersionBefore
+                return .init(exitCode: 0, message: framedPluginListing(version: version))
+            }
+            if stdin.contains("claude plugin install") { return script.plugin }
             if stdin.contains("LVX_HERDR") { return script.herdr }
             if stdin.contains("SessionStart") {
                 return .init(exitCode: 0, message: script.tunnelMessage)
@@ -2780,7 +2834,8 @@ final class ClaudeIntegrationSettingsModelTests: XCTestCase {
         XCTAssertTrue(sshFS.configText?.contains("SendEnv LC_LVX_TTY") == true)
         let invocationOrder = recorder.all.map { invocation in
             let script = String(decoding: invocation.standardInput, as: UTF8.self)
-            if script.contains("LVX_PLUGIN") { return "remote plugin" }
+            if script.contains(ClaudeRemoteEnrollmentService.pluginListFrameBegin) { return "plugin listing" }
+            if script.contains("claude plugin install") { return "remote plugin" }
             if script.contains("LC_LVX_TTY") { return "environment crossing" }
             if script.contains("LVX_HERDR") { return "remote herdr" }
             if script.contains("SessionStart") { return "tunnel check" }
@@ -2789,7 +2844,10 @@ final class ClaudeIntegrationSettingsModelTests: XCTestCase {
         }
         XCTAssertEqual(
             invocationOrder,
-            ["remote plugin", "environment crossing", "remote herdr", "tunnel check", "plugin check"],
+            [
+                "plugin listing", "remote plugin", "plugin listing",
+                "environment crossing", "remote herdr", "tunnel check", "plugin check",
+            ],
             "each step must finish before the next one starts"
         )
     }
@@ -2931,7 +2989,7 @@ final class ClaudeIntegrationSettingsModelTests: XCTestCase {
         let sshFS = StubSSHConfigFileSystem()
         let recorder = SetupFlowRecorder()
         var script = SetupFlowScript()
-        script.plugin = .init(exitCode: 0, message: "LVX_PLUGIN_UPDATED")
+        script.pluginVersionBefore = "1.6.0"
         let service = ClaudeRemoteEnrollmentService(
             runner: setupFlowRunner(script: script, recorder: recorder),
             sshConfigFileSystem: sshFS

--- a/Tests/localvoxtralTests/ClaudeRemoteEnrollmentServiceTests.swift
+++ b/Tests/localvoxtralTests/ClaudeRemoteEnrollmentServiceTests.swift
@@ -2440,38 +2440,162 @@ final class ClaudeRemoteEnrollmentServiceTests: XCTestCase {
         )
     }
 
-    func testPluginSetupUpdatesAnInstalledPluginAndVerifiesItsVersionInOneSSHSession() throws {
-        let calls = Mutex<[ClaudeRemoteEnrollmentService.Invocation]>([])
-        let service = ClaudeRemoteEnrollmentService(runner: { invocation in
-            calls.withLock { $0.append(invocation) }
-            return .init(exitCode: 0, message: "LVX_PLUGIN_ALREADY_CURRENT")
-        })
+    /// The listing a real `claude plugin list --json` prints (Claude Code
+    /// 2.1.x), framed by the listing script, with a banner on each side as a
+    /// login shell's merged pipe delivers it.
+    private static func framedListing(_ version: String?, _ scope: String) -> String {
+        let ours = version.map {
+            """
+            ,{"id":"\(ClaudeRemoteEnrollmentService.remotePluginReference)","version":"\($0)","scope":"\(scope)","enabled":true,"installPath":"/home/dev/.claude/plugins/cache/localvoxtral/localvoxtral-remote/\($0)","installedAt":"2026-07-27T20:59:23.439Z","lastUpdated":"2026-09-07T13:27:31.000Z"}
+            """
+        } ?? ""
+        return "Welcome to builder\n"
+            + ClaudeRemoteEnrollmentService.pluginListFrameBegin + "\n"
+            + "[{\"id\":\"frontend-design@claude-plugins-official\",\"version\":\"unknown\",\"scope\":\"project\",\"enabled\":false,\"installPath\":\"/x\",\"installedAt\":\"2026-07-01T15:07:39.195Z\",\"lastUpdated\":\"2026-07-01T15:07:39.195Z\",\"projectPath\":\"/home/dev/work/other\"}"
+            + ours + "]\n"
+            + ClaudeRemoteEnrollmentService.pluginListFrameEnd + "\nLast login: today\n"
+    }
+
+    /// Records the ssh invocations a plugin setup makes, from the
+    /// nonisolated runner closure.
+    private final class PluginSetupCalls: Sendable {
+        private let storage = Mutex<[ClaudeRemoteEnrollmentService.Invocation]>([])
+        private let listings = Mutex(0)
+        func record(_ invocation: ClaudeRemoteEnrollmentService.Invocation) {
+            storage.withLock { $0.append(invocation) }
+        }
+        /// 1 for the first listing, 2 for the read-back.
+        func nextListing() -> Int { listings.withLock { $0 += 1; return $0 } }
+        var all: [ClaudeRemoteEnrollmentService.Invocation] { storage.withLock { $0 } }
+        var scripts: [String] { all.map { String(decoding: $0.standardInput, as: UTF8.self) } }
+    }
+
+    /// Answers the three-call plugin setup: listing, install call, listing.
+    private func pluginSetupRunner(
+        before: String?,
+        after: String?,
+        install: ClaudeRemoteEnrollmentService.RunResult = .init(exitCode: 0, message: ""),
+        calls: PluginSetupCalls
+    ) -> ClaudeRemoteEnrollmentService.Runner {
+        let listing = Self.framedListing
+        return { invocation in
+            calls.record(invocation)
+            let stdin = String(decoding: invocation.standardInput, as: UTF8.self)
+            if stdin.contains(ClaudeRemoteEnrollmentService.pluginListFrameBegin) {
+                let n = calls.nextListing()
+                return .init(exitCode: 0, message: listing(n == 1 ? before : after, "user"))
+            }
+            return install
+        }
+    }
+
+    func testPluginSetupDecodesTheListingAndReportsAnAlreadyCurrentPlugin() throws {
+        let calls = PluginSetupCalls()
+        let service = ClaudeRemoteEnrollmentService(
+            runner: pluginSetupRunner(before: "1.7.0", after: "1.7.0", calls: calls)
+        )
 
         XCTAssertEqual(
-            try service.setupRemotePlugin(
-                sshHostAlias: "builder", token: nil, remoteForwardPort: 28_511
-            ),
-            .alreadyCurrent
+            try service.setupRemotePlugin(sshHostAlias: "builder", token: nil, remoteForwardPort: 28_511),
+            ClaudeRemoteEnrollmentService.PluginSetupOutcome.alreadyCurrent
         )
-        let recorded = calls.withLock { $0 }
-        XCTAssertEqual(recorded.count, 1, "detect, update, and version verification share one ssh session")
-        let script = String(decoding: recorded[0].standardInput, as: UTF8.self)
-        XCTAssertTrue(script.contains("claude plugin marketplace update"))
-        // The version check reads the listing line `claude plugin list` prints
-        // for our reference and matches the version as a space-delimited word
-        // (so 11.7.0 can never satisfy 1.7.0) — both before deciding AND after
-        // the install, in the same session.
-        XCTAssertTrue(
-            script.contains("grep -F '\(ClaudeRemoteEnrollmentService.remotePluginReference)' | head -n 1")
-        )
-        XCTAssertTrue(
-            script.contains("*\" \(ClaudeRemoteEnrollmentService.remotePluginVersion) \"*"),
-            "the version is matched as a word"
+        XCTAssertEqual(calls.all.count, 3, "listing, install call, listing")
+        let scripts = calls.scripts
+        XCTAssertTrue(scripts[0].contains("claude plugin list --json"))
+        XCTAssertTrue(scripts[1].contains("claude plugin install"))
+        XCTAssertFalse(scripts[1].contains("claude plugin update"), "a current plugin is not updated")
+        XCTAssertTrue(scripts[2].contains("claude plugin list --json"))
+        // Nothing on the host matches text: the decision and the read-back
+        // are decoded here from the JSON the CLI prints.
+        for script in scripts {
+            XCTAssertFalse(script.contains("grep"), "no text matching on the host")
+            XCTAssertFalse(script.contains("case \""), "no text matching on the host")
+        }
+    }
+
+    func testPluginSetupUpdatesAStalePluginAndReadsTheNewVersionBack() throws {
+        let calls = PluginSetupCalls()
+        let service = ClaudeRemoteEnrollmentService(
+            runner: pluginSetupRunner(before: "1.4.0", after: "1.7.0", calls: calls)
         )
         XCTAssertEqual(
-            script.components(separatedBy: "claude plugin list").count - 1,
-            2,
-            "the version is read before the decision and again after the install"
+            try service.setupRemotePlugin(sshHostAlias: "builder", token: nil, remoteForwardPort: 28_511),
+            ClaudeRemoteEnrollmentService.PluginSetupOutcome.updated
+        )
+        let script = calls.scripts[1]
+        XCTAssertTrue(script.contains("claude plugin marketplace update"))
+        XCTAssertTrue(script.contains("claude plugin update"))
+    }
+
+    func testPluginSetupInstallsAnAbsentPluginWhenItHasAToken() throws {
+        let calls = PluginSetupCalls()
+        let service = ClaudeRemoteEnrollmentService(
+            runner: pluginSetupRunner(before: nil, after: "1.7.0", calls: calls)
+        )
+        XCTAssertEqual(
+            try service.setupRemotePlugin(sshHostAlias: "builder", token: "t0k", remoteForwardPort: 28_511),
+            ClaudeRemoteEnrollmentService.PluginSetupOutcome.installed
+        )
+        let script = calls.scripts[1]
+        XCTAssertTrue(script.contains("claude plugin marketplace add"))
+        XCTAssertTrue(script.contains("--config 'token=t0k'"))
+    }
+
+    func testPluginSetupReadBackNamesTheVersionItFound() throws {
+        // The field failure of 2026-09-07: the plugin was current, but the
+        // check read the human listing's reference line, which no longer
+        // carries the version, and reported a mismatch on every host.
+        let calls = PluginSetupCalls()
+        let service = ClaudeRemoteEnrollmentService(
+            runner: pluginSetupRunner(before: "1.6.0", after: "1.6.0", calls: calls)
+        )
+        XCTAssertThrowsError(
+            try service.setupRemotePlugin(sshHostAlias: "builder", token: nil, remoteForwardPort: 28_511)
+        ) { error in
+            guard case ClaudeRemoteEnrollmentService.ServiceError.commandFailed(_, _, 43, let message) = error
+            else { return XCTFail("expected the read-back diagnosis, got \(error)") }
+            XCTAssertEqual(message, "The plugin reports version 1.6.0 after setup, not 1.7.0.")
+        }
+    }
+
+    func testPluginListingDecoderPrefersTheUserScopeEntryAndRefusesUnreadableCaptures() throws {
+        let reference = ClaudeRemoteEnrollmentService.remotePluginReference
+        let twoScopes = ClaudeRemoteEnrollmentService.pluginListFrameBegin + "\n"
+            + "[{\"id\":\"\(reference)\",\"version\":\"1.2.0\",\"scope\":\"project\"},"
+            + "{\"id\":\"\(reference)\",\"version\":\"1.7.0\",\"scope\":\"user\"}]\n"
+            + ClaudeRemoteEnrollmentService.pluginListFrameEnd
+        XCTAssertEqual(
+            try ClaudeRemoteEnrollmentService.installedRemotePluginVersion(
+                inFramedOutput: twoScopes, reference: reference
+            ),
+            "1.7.0"
+        )
+        XCTAssertNil(
+            try ClaudeRemoteEnrollmentService.installedRemotePluginVersion(
+                inFramedOutput: Self.framedListing(nil, "user"), reference: reference
+            ),
+            "an unrelated plugin is not ours"
+        )
+        // A version that merely contains ours is not ours.
+        XCTAssertEqual(
+            try ClaudeRemoteEnrollmentService.installedRemotePluginVersion(
+                inFramedOutput: Self.framedListing("11.7.0", "user"), reference: reference
+            ),
+            "11.7.0"
+        )
+        XCTAssertThrowsError(
+            try ClaudeRemoteEnrollmentService.installedRemotePluginVersion(
+                inFramedOutput: "Welcome\n[]\n", reference: reference
+            ),
+            "no frame is an unreadable host, not an absent plugin"
+        )
+        XCTAssertThrowsError(
+            try ClaudeRemoteEnrollmentService.installedRemotePluginVersion(
+                inFramedOutput: ClaudeRemoteEnrollmentService.pluginListFrameBegin + "\nnot json\n"
+                    + ClaudeRemoteEnrollmentService.pluginListFrameEnd,
+                reference: reference
+            ),
+            "an undecodable frame is an unreadable host"
         )
     }
 
@@ -2480,42 +2604,44 @@ final class ClaudeRemoteEnrollmentServiceTests: XCTestCase {
         // tokenless would look exactly like a healthy enrollment failing open,
         // so an absent plugin is reported for the remedy (rotate), not
         // silently installed broken.
-        let service = ClaudeRemoteEnrollmentService(runner: { _ in
-            .init(exitCode: 44, message: "LVX_PLUGIN_ABSENT")
-        })
-
+        let calls = PluginSetupCalls()
+        let service = ClaudeRemoteEnrollmentService(
+            runner: pluginSetupRunner(before: nil, after: nil, calls: calls)
+        )
         XCTAssertThrowsError(
-            try service.setupRemotePlugin(
-                sshHostAlias: "builder", token: nil, remoteForwardPort: 28_511
-            )
+            try service.setupRemotePlugin(sshHostAlias: "builder", token: nil, remoteForwardPort: 28_511)
         ) { error in
-            guard case ClaudeRemoteEnrollmentService.ServiceError
-                .commandFailed(_, _, 44, let message) = error else {
-                return XCTFail("expected exit 44 with the rotation remedy, got \(error)")
-            }
+            guard case ClaudeRemoteEnrollmentService.ServiceError.commandFailed(_, _, 44, let message) = error
+            else { return XCTFail("expected exit 44 with the rotation remedy, got \(error)") }
             XCTAssertTrue(message.contains("Rotate this host's token"))
         }
+        XCTAssertEqual(calls.all.count, 1, "nothing is installed without a token")
     }
 
-    func testPluginSetupDistinguishesMissingCLICommandFailureAndVersionMismatch() throws {
-        func failure(exitCode: Int32) throws -> ClaudeRemoteEnrollmentService.ServiceError {
-            let service = ClaudeRemoteEnrollmentService(runner: { _ in
-                .init(exitCode: exitCode, message: "untrusted host output")
+    func testPluginSetupDistinguishesMissingCLIFromAFailedInstall() throws {
+        func failure(listingExit: Int32, installExit: Int32) throws -> ClaudeRemoteEnrollmentService.ServiceError {
+            let calls = PluginSetupCalls()
+            let service = ClaudeRemoteEnrollmentService(runner: { invocation in
+                calls.record(invocation)
+                let stdin = String(decoding: invocation.standardInput, as: UTF8.self)
+                if stdin.contains(ClaudeRemoteEnrollmentService.pluginListFrameBegin) {
+                    _ = calls.nextListing()
+                    return listingExit == 0
+                        ? .init(exitCode: 0, message: Self.framedListing("1.6.0", "user"))
+                        : .init(exitCode: listingExit, message: "untrusted host output")
+                }
+                return .init(exitCode: installExit, message: "untrusted host output")
             })
             do {
-                _ = try service.setupRemotePlugin(
-                    sshHostAlias: "builder",
-                    token: "test-token",
-                    remoteForwardPort: 28_511
-                )
-                XCTFail("exit \(exitCode) must fail")
+                _ = try service.setupRemotePlugin(sshHostAlias: "builder", token: "test-token", remoteForwardPort: 28_511)
+                XCTFail("must fail")
                 return .executionNotConfigured
             } catch let error as ClaudeRemoteEnrollmentService.ServiceError {
                 return error
             }
         }
 
-        guard case .commandFailed(_, _, 127, let missingCLI) = try failure(exitCode: 127) else {
+        guard case .commandFailed(_, _, 127, let missingCLI) = try failure(listingExit: 127, installExit: 0) else {
             return XCTFail("expected the missing CLI diagnosis")
         }
         XCTAssertEqual(
@@ -2523,21 +2649,10 @@ final class ClaudeRemoteEnrollmentServiceTests: XCTestCase {
             "Claude CLI was not found on the remote host. "
                 + "Install Claude Code there, or put it on the non-interactive SSH PATH."
         )
-
-        guard case .commandFailed(_, _, 1, let commandFailure) = try failure(exitCode: 1) else {
-            return XCTFail("expected the generic command failure diagnosis")
+        guard case .commandFailed(_, _, 1, let installFailure) = try failure(listingExit: 0, installExit: 1) else {
+            return XCTFail("expected the install failure diagnosis")
         }
-        XCTAssertEqual(commandFailure, "The remote plugin setup command failed.")
-
-        guard case .commandFailed(_, _, 43, let versionMismatch) = try failure(exitCode: 43) else {
-            return XCTFail("expected the version read-back diagnosis")
-        }
-        XCTAssertEqual(
-            versionMismatch,
-            "The plugin is installed but did not report version "
-                + ClaudeRemoteEnrollmentService.remotePluginVersion
-                + " when read back in the same session."
-        )
+        XCTAssertEqual(installFailure, "The remote plugin setup command failed.")
     }
 
     func testVerifiedPluginVersionMatchesTheRemotePluginManifest() throws {


### PR DESCRIPTION
## What

Field report from the owner's Mac, first use of the one-flow setup (#276) against an enrolled host whose plugin was already 1.7.0:

> The remote plugin could not be installed or updated. SSH setup exited with code 43. The plugin is installed but did not report version 1.7.0 when read back in the same session.

The step decided "current or stale" by grepping the reference line of the human `claude plugin list` output for the version as a word. Claude Code 2.1.x prints the version on the NEXT line (`Version: 1.7.0`), so the reference line never matched: every host read as stale, was updated needlessly, and then failed the identical read-back with exit 43. The host was fine; the check was reading the wrong thing.

**Now the host prints structured data and this side decodes it.** `claude plugin list --json` (Claude Code's own machine-readable listing) runs inside a frame (`LVX_PLUGIN_LIST_BEGIN` / `LVX_PLUGIN_LIST_END`, so banners and MOTD around it cannot break the capture), and the app decodes the array with `JSONDecoder`, picks the entry whose `id` equals our reference (a `user`-scope entry wins over project/local), and compares `version` by string equality. No text matching on the host at all. The step is three ssh calls with one job each: listing → decide (absent / current / stale) → install or update → listing as the read-back. An unframed or undecodable capture is a distinct error ("could not read the host"), never reported as "not installed". The listing carries ids, versions, scopes and paths and no plugin config or token (verified against the real output on the enrolled host), so decoding it here reads nothing this process could not redact.

The read-back error now names what it found: "The plugin reports version 1.6.0 after setup, not 1.7.0."

## Proof

- Real `claude plugin list --json` output from the enrolled host is the test fixture shape (an unrelated project-scope plugin first, ours at user scope, banner lines on both sides).
- New tests, `ClaudeRemoteEnrollmentServiceTests`: decoded current plugin → `.alreadyCurrent` with no `plugin update` in the install call and no `grep`/`case` anywhere in any script; stale → `.updated` with marketplace update + plugin update; absent with a token → `.installed`; absent without a token → exit 44 remedy after ONE call; stale after setup → exit 43 naming both versions (the field failure's shape, now diagnosable); decoder prefers the user-scope entry, does not mistake `11.7.0` for `1.7.0`, refuses an unframed or non-JSON capture instead of reporting absence; missing CLI (127) vs failed install (1) still distinguished.
- `ClaudeIntegrationSettingsModelTests`: the six-step flow's fixtures answer the framed listing before and after; the in-order test now pins `listing → install → listing → env probe → herdr → tunnel → check`; a fresh host installs, an outdated enrolled host updates.
- `remote-build.sh test --filter ClaudeRemoteEnrollmentServiceTests`: 118 tests, 0 failures. `--filter ClaudeIntegrationSettingsModelTests`: 94 tests, 0 failures. Full suite: **3071 tests, 2 skipped, 0 failures**; `grep -ci "warning:" .build/last-remote.log` → 0.
- Red before: on `main`, `testPluginSetupDecodesTheListingAndReportsAnAlreadyCurrentPlugin` cannot pass (the service never emits the frame and matches text), and the field run above is the production reproduction.
- Not run: the LLM lane fires by path (`ClaudeContext/*`); nothing here reaches the model. herdr lane: nothing here changes what the app says to herdr.
