### PR TITLE
Local plugin row: decode claude plugin list --json (shared decoder with the remote setup)

### DIFF
--- a/Sources/localvoxtral/ClaudeContext/ClaudePluginInstallService.swift
+++ b/Sources/localvoxtral/ClaudeContext/ClaudePluginInstallService.swift
@@ -199,14 +199,15 @@ public struct ClaudePluginInstallService: Sendable {
         return result
     }
 
-    /// stdout of `claude plugin list` for the Integrations pane's status row.
+    /// stdout of `claude plugin list --json` for the Integrations pane's
+    /// status row.
     ///
     /// Never throws for a listing that ran and failed: that is `.unknown`,
     /// not an action the pane reports. Throws only when the runner itself
     /// fails (timeout, output cap) — the same failures `perform` surfaces.
     public func pluginListOutput() throws -> String? {
         guard claudeExecutableURL != nil else { return nil }
-        let result = try runner(Invocation(arguments: ["plugin", "list"]))
+        let result = try runner(Invocation(arguments: ["plugin", "list", "--json"]))
         return result.succeeded ? result.message : nil
     }
 

--- a/Sources/localvoxtral/ClaudeContext/ClaudePluginListing.swift
+++ b/Sources/localvoxtral/ClaudeContext/ClaudePluginListing.swift
@@ -1,0 +1,37 @@
+import Foundation
+
+/// One entry of `claude plugin list --json` (Claude Code 2.1.x). Only the
+/// keys the app reads; the decoder ignores everything else the CLI adds.
+public struct ClaudePluginListEntry: Decodable, Equatable, Sendable {
+    public let id: String
+    public let version: String
+    public let scope: String?
+    public let enabled: Bool?
+
+    /// The CLI prints `"unknown"` for a version it could not read. That is
+    /// not a version.
+    public var knownVersion: String? {
+        version == "unknown" || version.isEmpty ? nil : version
+    }
+}
+
+/// Decoding rules shared by the local plugin row and the remote plugin
+/// setup, so the two never disagree about what a listing says.
+public enum ClaudePluginListing {
+    /// The decoded entries, or nil when the capture is not a JSON array of
+    /// entries. Callers treat nil as "could not read", never as "empty".
+    public static func entries(in output: String) -> [ClaudePluginListEntry]? {
+        try? JSONDecoder().decode([ClaudePluginListEntry].self, from: Data(output.utf8))
+    }
+
+    /// The entry for `reference` (`<name>@<marketplace>`, compared
+    /// case-insensitively as the CLI prints it). A user-scope entry wins
+    /// over a project/local one; among equals the first wins.
+    public static func entry(
+        for reference: String,
+        in entries: [ClaudePluginListEntry]
+    ) -> ClaudePluginListEntry? {
+        let matches = entries.filter { $0.id.caseInsensitiveCompare(reference) == .orderedSame }
+        return matches.first { $0.scope == "user" } ?? matches.first
+    }
+}

--- a/Sources/localvoxtral/ClaudeContext/ClaudePluginStatus.swift
+++ b/Sources/localvoxtral/ClaudeContext/ClaudePluginStatus.swift
@@ -2,9 +2,11 @@ import Foundation
 
 /// What the Integrations pane can say about the local Claude Code plugin.
 ///
-/// Derived from `claude plugin list`, never from Claude Code's internals: the
-/// install lives in Claude Code's own config, and the CLI's listing is the
-/// supported way to ask about it. The bundled version comes from this repo's
+/// Derived from `claude plugin list --json`, never from Claude Code's
+/// internals: the install lives in Claude Code's own config, and the CLI's
+/// machine-readable listing is the supported way to ask about it. The human
+/// listing is never parsed: its shape changed once (the version moved to its
+/// own `Version:` line) and silently took the version out of this row. The bundled version comes from this repo's
 /// own marketplace manifest (`metadata.version`), so "update available" means
 /// "this app ships a newer marketplace than the listing names" — nothing
 /// about what Claude Code would do with it.
@@ -28,11 +30,11 @@ public enum ClaudePluginStatus: Sendable, Equatable {
         }
     }
 
-    /// Derive the status from a `claude plugin list` capture.
+    /// Derive the status from a `claude plugin list --json` capture.
     ///
     /// - Parameters:
-    ///   - listOutput: the CLI's stdout, or nil when the CLI is missing or
-    ///     the listing failed. A nil capture is `.unknown`, never
+    ///   - listOutput: the CLI's stdout (a JSON array of entries), or nil
+    ///     when the CLI is missing or the listing failed. A nil capture is `.unknown`, never
     ///     `.notInstalled`: absence of evidence is not evidence of absence,
     ///     and claiming "not installed" would invite an install over a setup
     ///     we simply failed to read.
@@ -44,9 +46,13 @@ public enum ClaudePluginStatus: Sendable, Equatable {
         bundledVersion: String?
     ) -> ClaudePluginStatus {
         guard let listOutput else { return .unknown }
-        guard let installed = installedVersion(in: listOutput) else {
-            return listOutputContainsPlugin(in: listOutput) ? .installed(version: nil) : .notInstalled
+        // An undecodable capture is a listing we could not read, which is
+        // the same verdict as no listing at all — never "not installed".
+        guard let entries = ClaudePluginListing.entries(in: listOutput) else { return .unknown }
+        guard let entry = ClaudePluginListing.entry(for: listReference(), in: entries) else {
+            return .notInstalled
         }
+        guard let installed = entry.knownVersion else { return .installed(version: nil) }
         // m7: inequality is not ordering — a manually installed NEWER
         // marketplace must read as installed, never as an update onto an
         // older bundled one.
@@ -80,25 +86,4 @@ public enum ClaudePluginStatus: Sendable, Equatable {
         "\(pluginName)@\(marketplaceName)"
     }
 
-    static func listOutputContainsPlugin(in output: String) -> Bool {
-        output.range(of: listReference(), options: .caseInsensitive) != nil
-    }
-
-    /// The version on the listing's plugin line, when it names one. Only the
-    /// line carrying our reference is read: a version elsewhere in the output
-    /// (another plugin, a CLI banner) must never be mistaken for ours.
-    static func installedVersion(in output: String) -> String? {
-        let reference = listReference()
-        for line in output.split(whereSeparator: \.isNewline) {
-            guard line.range(of: reference, options: .caseInsensitive) != nil else { continue }
-            return firstVersionToken(in: String(line))
-        }
-        return nil
-    }
-
-    static func firstVersionToken(in line: String) -> String? {
-        let pattern = #"\d+\.\d+(?:\.\d+)?"#
-        guard let range = line.range(of: pattern, options: .regularExpression) else { return nil }
-        return String(line[range])
-    }
 }

--- a/Sources/localvoxtral/ClaudeContext/ClaudeRemoteEnrollmentService.swift
+++ b/Sources/localvoxtral/ClaudeContext/ClaudeRemoteEnrollmentService.swift
@@ -797,15 +797,6 @@ public struct ClaudeRemoteEnrollmentService: Sendable {
         )
     }
 
-    /// One entry of `claude plugin list --json`. Only the keys the version
-    /// check reads; the decoder ignores everything else the CLI adds.
-    public struct RemotePluginListEntry: Decodable, Equatable, Sendable {
-        public let id: String
-        public let version: String
-        public let scope: String?
-        public let enabled: Bool?
-    }
-
     public static let pluginListFrameBegin = "LVX_PLUGIN_LIST_BEGIN"
     public static let pluginListFrameEnd = "LVX_PLUGIN_LIST_END"
     /// A listing is a few hundred bytes per installed plugin. Anything past
@@ -854,18 +845,14 @@ public struct ClaudeRemoteEnrollmentService: Sendable {
                 message: "The host's plugin listing is larger than a listing can be."
             )
         }
-        let entries: [RemotePluginListEntry]
-        do {
-            entries = try JSONDecoder().decode([RemotePluginListEntry].self, from: data)
-        } catch {
+        guard let entries = ClaudePluginListing.entries(in: String(decoding: data, as: UTF8.self)) else {
             throw ServiceError.runnerFailed(
                 step: 0,
                 command: "list remote plugins",
                 message: "The host's plugin listing could not be decoded."
             )
         }
-        let matches = entries.filter { $0.id == reference }
-        return (matches.first { $0.scope == "user" } ?? matches.first)?.version
+        return ClaudePluginListing.entry(for: reference, in: entries)?.knownVersion
     }
 
     /// Install or update the remote plugin and prove the installed version.

--- a/Tests/localvoxtralTests/IntegrationsSettingsModelTests.swift
+++ b/Tests/localvoxtralTests/IntegrationsSettingsModelTests.swift
@@ -84,7 +84,7 @@ final class IntegrationsSettingsModelTests: XCTestCase {
     func testInstalledPluginReportsItsVersion() async {
         let model = makeModel(
             fetchPluginListOutput: {
-                "localvoxtral@localvoxtral 1.4.0\nsome-other@market 2.0.0"
+                "[{\"id\":\"some-other@market\",\"version\":\"2.0.0\",\"scope\":\"user\",\"enabled\":true},{\"id\":\"localvoxtral@localvoxtral\",\"version\":\"1.4.0\",\"scope\":\"user\",\"enabled\":true}]"
             },
             bundledPluginVersion: "1.4.0"
         )
@@ -96,7 +96,7 @@ final class IntegrationsSettingsModelTests: XCTestCase {
     @MainActor
     func testOlderInstalledPluginReportsUpdateAvailable() async {
         let model = makeModel(
-            fetchPluginListOutput: { "localvoxtral@localvoxtral 1.3.0" },
+            fetchPluginListOutput: { "[{\"id\":\"localvoxtral@localvoxtral\",\"version\":\"1.3.0\",\"scope\":\"user\",\"enabled\":true}]" },
             bundledPluginVersion: "1.4.0"
         )
         await model.refreshIntegrationsStatuses()
@@ -112,7 +112,7 @@ final class IntegrationsSettingsModelTests: XCTestCase {
         // m7: a manually installed 1.5.0 over a bundled 1.4.0 is newer, not
         // stale — offering to "update" it would install the OLDER marketplace.
         let model = makeModel(
-            fetchPluginListOutput: { "localvoxtral@localvoxtral 1.5.0" },
+            fetchPluginListOutput: { "[{\"id\":\"localvoxtral@localvoxtral\",\"version\":\"1.5.0\",\"scope\":\"user\",\"enabled\":true}]" },
             bundledPluginVersion: "1.4.0"
         )
         await model.refreshIntegrationsStatuses()
@@ -123,7 +123,7 @@ final class IntegrationsSettingsModelTests: XCTestCase {
     @MainActor
     func testAbsentPluginReportsNotInstalled() async {
         let model = makeModel(
-            fetchPluginListOutput: { "some-other@market 2.0.0" },
+            fetchPluginListOutput: { "[{\"id\":\"some-other@market\",\"version\":\"2.0.0\",\"scope\":\"user\",\"enabled\":true}]" },
             bundledPluginVersion: "1.4.0"
         )
         await model.refreshIntegrationsStatuses()
@@ -146,7 +146,7 @@ final class IntegrationsSettingsModelTests: XCTestCase {
     @MainActor
     func testInstalledWithoutAVersionIsStillInstalled() async {
         let model = makeModel(
-            fetchPluginListOutput: { "localvoxtral@localvoxtral" },
+            fetchPluginListOutput: { "[{\"id\":\"localvoxtral@localvoxtral\",\"version\":\"unknown\",\"scope\":\"user\",\"enabled\":true}]" },
             bundledPluginVersion: "1.4.0"
         )
         await model.refreshIntegrationsStatuses()
@@ -159,7 +159,7 @@ final class IntegrationsSettingsModelTests: XCTestCase {
         // Only the line carrying our reference may supply a version: a CLI
         // banner or another plugin's number must never read as ours.
         let model = makeModel(
-            fetchPluginListOutput: { "claude 2.1.220\nlocalvoxtral@localvoxtral" },
+            fetchPluginListOutput: { "[{\"id\":\"claude-tools@other\",\"version\":\"2.1.220\",\"scope\":\"user\",\"enabled\":true},{\"id\":\"localvoxtral@localvoxtral\",\"version\":\"unknown\",\"scope\":\"user\",\"enabled\":true}]" },
             bundledPluginVersion: "2.1.220"
         )
         await model.refreshIntegrationsStatuses()
@@ -366,7 +366,7 @@ final class IntegrationsSettingsModelTests: XCTestCase {
 /// nil (unknown), never a throw — only the runner's own failures throw.
 ///
 /// M4: every test captures the invocation the seam received and pins it to
-/// `["plugin", "list"]` — the pane's entire plugin status rests on that argv,
+/// `["plugin", "list", "--json"]` — the pane's entire plugin status rests on that argv,
 /// and a stub discarding its input would let a wrong subcommand pass.
 final class ClaudePluginListProbeTests: XCTestCase {
     func testSuccessfulListingReturnsStdout() throws {
@@ -380,7 +380,7 @@ final class ClaudePluginListProbeTests: XCTestCase {
             }
         )
         XCTAssertEqual(try service.pluginListOutput(), "out")
-        XCTAssertEqual(catcher.invocations.map(\.arguments), [["plugin", "list"]])
+        XCTAssertEqual(catcher.invocations.map(\.arguments), [["plugin", "list", "--json"]])
     }
 
     func testFailedListingIsNil() throws {
@@ -394,7 +394,7 @@ final class ClaudePluginListProbeTests: XCTestCase {
             }
         )
         XCTAssertNil(try service.pluginListOutput())
-        XCTAssertEqual(catcher.invocations.map(\.arguments), [["plugin", "list"]])
+        XCTAssertEqual(catcher.invocations.map(\.arguments), [["plugin", "list", "--json"]])
     }
 
     func testMissingCLIIsNil() throws {


### PR DESCRIPTION
## What

The Integrations pane's local plugin row had the same blind spot #280 just fixed on the remote side: `ClaudePluginStatus` read the version off the reference line of the human `claude plugin list` output. Claude Code 2.1.x prints it on the next `Version:` line, so on every current install the row said "Installed." with no version and could never say "Update available".

Now `ClaudePluginInstallService.pluginListOutput()` runs `claude plugin list --json` and `ClaudePluginStatus.derive` decodes it. The decoding rules move into one place, `ClaudePluginListing` (entry type, the user-scope-wins selection, and the CLI's `"unknown"` version reading as no version), and the remote setup from #280 uses the same code, so the two rows can never disagree about what a listing says. An undecodable capture reads as `.unknown`, never as `.notInstalled`. The three text parsers are gone.

## Proof

- `IntegrationsSettingsModelTests` fixtures are now JSON listings in the CLI's real shape (unrelated plugin first, ours at user scope, `"unknown"` for the version-less case): installed version, older → update available, newer → installed, absent, failed listing → unknown, version-less → installed without version, another plugin's version never ours. `ClaudePluginListProbeTests` pins the argv `["plugin", "list", "--json"]`.
- `remote-build.sh test --filter IntegrationsSettingsModelTests`: 17 tests, 0 failures; `--filter ClaudePluginListProbeTests`: 3, 0 failures; `--filter ClaudeRemoteEnrollmentServiceTests` unchanged at 118 green through the shared decoder.
- Full suite: **3071 tests, 2 skipped, 0 failures**; `grep -ci "warning:" .build/last-remote.log` → 0.
- Red before: the human-listing fixtures from `main` would not decode; the argv pin `["plugin", "list"]` fails on this branch (updated in the same commit).
- LLM lane fires by path; nothing reaches the model. Field check: on the owner's Mac the row read "Installed." with no version on the previous build; a dogfood build of this branch shows the version (owner to confirm after merge, or via the gate).
