### PR TITLE
Settings: shorter headers, no focus ring on sidebar rows, horizontal button rows, one-line help

### DIFF
--- a/Sources/localvoxtral/Settings/SettingsPaneHeader.swift
+++ b/Sources/localvoxtral/Settings/SettingsPaneHeader.swift
@@ -1,28 +1,20 @@
 import SwiftUI
 
-/// Title + one-line purpose for the selected pane, above its scrolling content.
-///
-/// The subtitle exists because the sidebar row labels are short nouns: "Where
-/// speech recognition and polishing run" is the sentence that used to be missing
-/// entirely from the tabbed layout.
+/// The selected pane's title, above its scrolling content. Title only: the
+/// per-pane subtitles were narration and were removed (owner review,
+/// 2026-09-07) — what a pane does is the docs' job, and every line here
+/// pushed the first group down.
 struct SettingsPaneHeader: View {
     let tab: SettingsTab
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 2) {
-            Text(tab.title)
-                .font(.system(size: 20, weight: .semibold))
-
-            Text(tab.subtitle)
-                .font(.subheadline)
-                .foregroundStyle(.secondary)
-                .lineLimit(1)
-        }
-        .frame(maxWidth: .infinity, alignment: .leading)
-        .padding(.horizontal, 18)
-        // Matches the sidebar's inset: the window draws its content full-size
-        // under a transparent titlebar, so the header needs the same clearance.
-        .padding(.top, SettingsSidebarMetrics.topInset)
-        .padding(.bottom, 12)
+        Text(tab.title)
+            .font(.system(size: 20, weight: .semibold))
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(.horizontal, 18)
+            // Matches the sidebar's inset: the window draws its content full-size
+            // under a transparent titlebar, so the header needs the same clearance.
+            .padding(.top, SettingsSidebarMetrics.topInset)
+            .padding(.bottom, 6)
     }
 }

--- a/Sources/localvoxtral/Settings/SettingsSidebarView.swift
+++ b/Sources/localvoxtral/Settings/SettingsSidebarView.swift
@@ -157,9 +157,15 @@ private struct SettingsSidebarRow: View {
             )
         }
         .buttonStyle(.plain)
+        // No focus ring on sidebar rows (owner review, 2026-09-07): when the
+        // window becomes key, SwiftUI hands first-responder to the FIRST row
+        // (General), which then draws a blue ring while another row is
+        // selected. Disabling only the focus EFFECT keeps the button a real,
+        // keyboard-navigable, AX-pressable button — it just never paints the
+        // ring. Selection is already shown by the row's own fill.
+        .focusEffectDisabled()
         .onHover { isHovering = $0 }
         .animation(.easeInOut(duration: 0.12), value: isSelected)
-        .help(tab.subtitle)
         .accessibilityLabel(tab.title)
         .accessibilityAddTraits(isSelected ? [.isSelected] : [])
         .accessibilityIdentifier(tab.accessibilityIdentifier)

--- a/Sources/localvoxtral/Settings/SettingsSidebarView.swift
+++ b/Sources/localvoxtral/Settings/SettingsSidebarView.swift
@@ -28,17 +28,6 @@ extension SettingsTab {
         }
     }
 
-    var subtitle: String {
-        switch self {
-        case .general: return "Permissions and app-level behavior."
-        case .dictation: return "How you start, stop, and see dictation."
-        case .endpoints: return "Where dictation and polishing run."
-        case .textProcessing: return "Replacements and LLM polishing of your transcript."
-        case .integrations: return "What the polisher and your coding agents may see."
-        case .about: return "Version, project, and diagnostics."
-        }
-    }
-
     var systemImage: String {
         switch self {
         case .general: return "gearshape.fill"

--- a/Sources/localvoxtral/SettingsView.swift
+++ b/Sources/localvoxtral/SettingsView.swift
@@ -918,7 +918,7 @@ private struct IntegrationsSettingsPane: View {
 
                     SettingsFieldRow(
                         title: "Clipboard",
-                        help: "Sends technical terms from your clipboard to the polisher."
+                        help: "Sends a capped excerpt of your clipboard to the polisher."
                     ) {
                         Toggle("", isOn: $settings.polishClipboardContextEnabled)
                             .labelsHidden()
@@ -1245,15 +1245,20 @@ private struct ClaudeRemoteHostsSettingsRow: View {
         }
     }
 
-    /// The plain-ssh join's one setup step, on one line: title + status
-    /// leading, the small buttons trailing. The two facts the status carries
-    /// (is the export in the rc file; has a new session arrived carrying it)
-    /// stay separate texts for the drills, separated by a middle dot.
-    /// Nothing is written until the sheet has shown the exact text and been
-    /// confirmed.
+    /// The plain-ssh join's one setup step: title + status leading, the small
+    /// buttons trailing on the TITLE'S line (the outer stack is
+    /// baseline-aligned, so a wrapped status never drags the buttons down).
+    /// The status may wrap to a SECOND line rather than truncate — the
+    /// crossing sentence ("Open a new terminal window for it to take
+    /// effect.") is an instruction, and an instruction must never be
+    /// ellipsized (owner rule, PR #282 review). The two facts the status
+    /// carries (is the export in the rc file; has a new session arrived
+    /// carrying it) stay separate texts for the drills, separated by a
+    /// middle dot. Nothing is written until the sheet has shown the exact
+    /// text and been confirmed.
     @ViewBuilder
     private var shellSetup: some View {
-        HStack(spacing: 8) {
+        HStack(alignment: .firstTextBaseline, spacing: 8) {
             HStack(alignment: .firstTextBaseline, spacing: 8) {
                 Text("Terminal setup for plain SSH")
                     .font(.callout)
@@ -1270,7 +1275,11 @@ private struct ClaudeRemoteHostsSettingsRow: View {
                 }
                 .font(.caption)
                 .foregroundStyle(.secondary)
-                .lineLimit(1)
+                // Two lines, not an ellipsis: lineLimit(2) lets the status
+                // wrap, fixedSize(horizontal: false, vertical: true) lets the
+                // row actually grow to the wrapped height inside the stack.
+                .lineLimit(2)
+                .fixedSize(horizontal: false, vertical: true)
             }
 
             Spacer(minLength: 8)
@@ -1302,7 +1311,16 @@ private struct ClaudeRemoteHostsSettingsRow: View {
                         // The transient post-run status is the only thing that
                         // ever adds a second line.
                         HStack(alignment: .firstTextBaseline, spacing: 6) {
-                            Text(host.label).font(.callout)
+                            // Labels run to the registry's 64-character cap:
+                            // one line, truncating from the middle so head and
+                            // tail stay readable, at a priority BELOW the
+                            // status — a long name must never squeeze
+                            // "Last context: …" off its full line.
+                            Text(host.label)
+                                .font(.callout)
+                                .lineLimit(1)
+                                .truncationMode(.middle)
+                                .layoutPriority(0)
 
                             // Rendered by the model against its injected clock —
                             // "Last context: 2 min ago" — and refreshed with the
@@ -1312,6 +1330,7 @@ private struct ClaudeRemoteHostsSettingsRow: View {
                                 .font(.caption)
                                 .foregroundStyle(.secondary)
                                 .lineLimit(1)
+                                .layoutPriority(1)
                         }
 
                         Spacer(minLength: 8)
@@ -1535,10 +1554,14 @@ private struct ClaudeRemoteHostsSettingsRow: View {
             }
         }
         if let remedy = model.listenerStatus.remedy {
+            // Wrap, never truncate — the remedy is an instruction ("Quit it
+            // and press Retry."), same rule as the shell-setup crossing
+            // sentence (PR #282 review).
             Text(remedy)
                 .font(.caption)
                 .foregroundStyle(.secondary)
-                .lineLimit(1)
+                .lineLimit(2)
+                .fixedSize(horizontal: false, vertical: true)
         }
     }
 

--- a/Sources/localvoxtral/SettingsView.swift
+++ b/Sources/localvoxtral/SettingsView.swift
@@ -401,9 +401,7 @@ private struct ConnectionSettingsPane: View {
                         .labelsHidden()
                     } footer: {
                         if let managedPolishingModelHelp {
-                            Text(managedPolishingModelHelp)
-                                .font(.caption)
-                                .foregroundStyle(.secondary)
+                            SettingsHelpText(managedPolishingModelHelp)
                         }
                     }
 
@@ -837,9 +835,29 @@ private struct TextProcessingSettingsPane: View {
 /// options next to "Exact match". The four groups here are STATIC — a toggle
 /// switches a group's content, never the number or identity of the groups
 /// (owner rule, 2026-07-04).
+///
+/// Copy rule (owner review, 2026-09-07): each toggle's help is ONE line
+/// stating what leaves the machine — the consequence, nothing else. The full
+/// terms live in `docs/coding-agents.md` behind each group's Learn more link.
 private struct IntegrationsSettingsPane: View {
     @Bindable var settings: SettingsStore
     let viewModel: DictationViewModel
+
+    /// Where each group's Learn more link lands. Repo pages, not relative
+    /// links: Settings is a shipped app, not a doc site.
+    private enum LearnMore {
+        static let polishContext = URL(
+            string:
+                "https://github.com/T0mSIlver/localvoxtral/blob/main/docs/coding-agents.md#polish-context-what-each-toggle-sends"
+        )!
+        static let claudeCode = URL(
+            string:
+                "https://github.com/T0mSIlver/localvoxtral/blob/main/integrations/claude-code/README.md#which-terminal-am-i-dictating-into"
+        )!
+        static let remoteHosts = URL(
+            string: "https://github.com/T0mSIlver/localvoxtral/blob/main/docs/remote-claude-context.md"
+        )!
+    }
 
     /// Read ONCE, when the pane is constructed — like every other `debug.`
     /// default, this is a screenshot affordance, not a preference that may
@@ -857,7 +875,7 @@ private struct IntegrationsSettingsPane: View {
 
     var body: some View {
         SettingsPage(tab: .integrations) {
-            SettingsGroup(title: "Polish context") {
+            SettingsGroup(title: "Polish context", learnMoreURL: LearnMore.polishContext) {
                 if !isLLMPolishingReachable {
                     SettingsAvailabilityCard(
                         title: "No Overlay Buffer shortcut",
@@ -869,45 +887,30 @@ private struct IntegrationsSettingsPane: View {
                 }
 
                 Group {
+                    // Each help line names the SEND — the consequence of the
+                    // toggle — and nothing else. The full terms (supported
+                    // terminals, the remote-session clause, the locality
+                    // default and how "Non-local endpoints" relaxes it) are in
+                    // docs/coding-agents.md, one Learn more away.
                     SettingsFieldRow(
                         title: "Repo vocabulary",
-                        help:
-                            "Reads file names from the git repo in your terminal to fix spellings. Only with a polisher on this Mac."
+                        help: "Sends file names from the repo in your terminal to the polisher."
                     ) {
                         Toggle("", isOn: $settings.repoVocabularyEnabled)
                             .labelsHidden()
                     }
 
-                    // Names the send, not just the benefit: when the pane is
-                    // joined to a live Claude Code session, part of what is on
-                    // screen is attached to the prompt verbatim. "Fixes
-                    // spellings" describes only the matcher and would be consent
-                    // obtained for the smaller half.
                     SettingsFieldRow(
                         title: "Claude Code screen",
-                        help:
-                            "Reads names from your Claude Code terminal to fix spellings. When that terminal runs a Claude Code session, part of the text on screen also goes to the polisher. Ghostty, iTerm2, Terminal.app and cmux only. In cmux this needs the cmux join too. Only with a polisher on this Mac."
+                        help: "Sends the text on screen in your Claude Code terminal to the polisher."
                     ) {
                         Toggle("", isOn: $settings.terminalScreenContextEnabled)
                             .labelsHidden()
                     }
 
-                    // Says what is SENT, not just what is gained: this toggle
-                    // attaches file contents and diffs, which the vocabulary
-                    // toggle above does not. Someone who agreed to "spell my
-                    // filenames right" has not thereby agreed to this.
-                    //
-                    // All four things the toggle actually sends are named. The
-                    // prior request is the one a user would least expect from a
-                    // label about "project files", and it is their own typed
-                    // words. The remote clause is worded to describe what the
-                    // SESSION carries, not a second behavior: a remote session
-                    // sends the excerpts its hooks already reported, and never
-                    // causes anything on this machine to be read.
                     SettingsFieldRow(
                         title: "Claude Code project",
-                        help:
-                            "Sends your uncommitted changes, files Claude Code recently touched, and the last request you sent that session to the polisher. For a session on a remote host, only the session request and the short excerpts its hooks report go. No files are read from that host. Needs a Claude Code session in a supported terminal or a Remote Control session in the focused browser tab. Only with a polisher on this Mac."
+                        help: "Sends your uncommitted changes, recent files, and last prompt to the polisher."
                     ) {
                         Toggle("", isOn: $settings.claudeRepoContextEnabled)
                             .labelsHidden()
@@ -915,23 +918,15 @@ private struct IntegrationsSettingsPane: View {
 
                     SettingsFieldRow(
                         title: "Clipboard",
-                        help:
-                            "Checks technical terms against your clipboard. Only with a polisher on this Mac."
+                        help: "Sends technical terms from your clipboard to the polisher."
                     ) {
                         Toggle("", isOn: $settings.polishClipboardContextEnabled)
                             .labelsHidden()
                     }
 
-                    // Names the trade in full: every "local polishing endpoints
-                    // only" promise above is exactly what this toggle relaxes,
-                    // so the help text says which content classes ride and where
-                    // they go. "You trust" puts the judgment where it now lives
-                    // — with the user — instead of implying the app can vouch
-                    // for their endpoint.
                     SettingsFieldRow(
                         title: "Non-local endpoints",
-                        help:
-                            "When off, context only ever goes to a polisher on this Mac. When on, the context enabled above also goes to the polishing endpoint you configured. Enable only for an endpoint you trust, such as a server on your own network."
+                        help: "Also sends the context enabled above to your non-local polishing endpoint."
                     ) {
                         Toggle("", isOn: $settings.polishContextTrustedEndpointEnabled)
                             .labelsHidden()
@@ -945,25 +940,20 @@ private struct IntegrationsSettingsPane: View {
             // the security off switch for an already-bound listener, and
             // plugin/session setup is independent of the current hotkey
             // configuration.
-            SettingsGroup(title: "Claude Code") {
+            SettingsGroup(title: "Claude Code", learnMoreURL: LearnMore.claudeCode) {
                 if let claude = viewModel.claudeIntegrationSettings {
                     ClaudePluginInstallRow(model: claude)
                     ClaudeStatuslineRow(model: claude)
                 }
 
-                // Not in Polish context above: this is a JOIN arm — it decides which session you are dictating
-                // into — and it works with no Overlay Buffer shortcut recorded.
-                //
-                // Names the prerequisite AND the send. cmux exposes no
-                // accessible text, so the socket is the only way to read the
-                // pane the user is dictating into — and that socket refuses
-                // everyone by default, which is a setup step in ANOTHER app
-                // that the user has to know about or this toggle will look
-                // broken.
+                // Not in Polish context above: this is a JOIN arm — it decides
+                // which session you are dictating into — and it works with no
+                // Overlay Buffer shortcut recorded. The two-step cmux setup
+                // (socket password mode, then this password) is in the group's
+                // Learn more page.
                 SettingsFieldRow(
                     title: "Join Claude Code sessions in cmux",
-                    help:
-                        "Uses the cmux automation socket to tell which session you dictate into, and reads that surface as context. In cmux, set Automation socket mode to Password and pick a socket password, then enter the same password below. Works for local surfaces and for sessions opened with cmux ssh."
+                    help: "Reads the cmux pane you dictate into, via cmux's automation socket."
                 ) {
                     Toggle("", isOn: $settings.cmuxSurfaceJoinEnabled)
                         .labelsHidden()
@@ -971,7 +961,8 @@ private struct IntegrationsSettingsPane: View {
 
                 if let claude = viewModel.claudeIntegrationSettings {
                     // Directly under the toggle whose prerequisite it is: the
-                    // help text above tells the user to enter it "below".
+                    // README's two-step setup ends with "enter the same
+                    // password below".
                     ClaudeCmuxPasswordSettingsRow(model: claude)
                 }
             }
@@ -979,7 +970,7 @@ private struct IntegrationsSettingsPane: View {
             // The integration model is built once at launch and cleared only on
             // terminate, so the `if let` is not a mode: in a running app both
             // groups above and this one always have their rows.
-            SettingsGroup(title: "Remote hosts") {
+            SettingsGroup(title: "Remote hosts", learnMoreURL: LearnMore.remoteHosts) {
                 if let claude = viewModel.claudeIntegrationSettings {
                     ClaudeRemoteHostsSettingsRow(model: claude)
                 }
@@ -1014,18 +1005,19 @@ private struct IntegrationsSettingsPane: View {
 /// Install/update the LOCAL Claude Code plugin.
 ///
 /// One explicit action, never anything at launch: putting a plugin into someone
-/// else's Claude Code is their decision. The result is one short line here; the
-/// CLI's actual output goes to an alert and the log (owner rule: no long text in
-/// the pane).
+/// else's Claude Code is their decision. The result is one short line next to
+/// the label; the CLI's actual output goes to an alert and the log (owner
+/// rule: no long text in the pane).
 private struct ClaudePluginInstallRow: View {
     @Bindable var model: ClaudeIntegrationSettingsModel
 
     var body: some View {
-        // Stacked: the row's controls are a full button bar plus a status line,
-        // which would squeeze the label to a three-line stub beside them.
+        // One line (owner review, 2026-09-07): "label + status" leading, the
+        // small buttons in the row's trailing column.
         SettingsFieldRow(
             title: "Plugin on this Mac",
-            layout: .stacked
+            status: model.pluginResult ?? model.localPluginSentence,
+            statusAccessibilityIdentifier: "integrations.claude.plugin.status"
         ) {
             HStack(spacing: 8) {
                 Button("Install or update") {
@@ -1044,12 +1036,7 @@ private struct ClaudePluginInstallRow: View {
                     ProgressView().controlSize(.small)
                 }
             }
-
-            Text(model.pluginResult ?? model.localPluginSentence)
-                .font(.callout)
-                .foregroundStyle(.secondary)
-                .lineLimit(1)
-                .accessibilityIdentifier("integrations.claude.plugin.status")
+            .controlSize(.small)
         }
     }
 }
@@ -1069,8 +1056,12 @@ private struct ClaudeStatuslineRow: View {
     )!
 
     var body: some View {
-        // Stacked like the plugin row above: button bar plus status line.
-        SettingsFieldRow(title: "Status line", layout: .stacked) {
+        // One line like the plugin row: status leads, small buttons trail.
+        SettingsFieldRow(
+            title: "Status line",
+            status: model.statuslineResult ?? model.statuslineSentence,
+            statusAccessibilityIdentifier: "integrations.claude.statusline.status"
+        ) {
             HStack(spacing: 8) {
                 switch model.statuslineStatus {
                 case .notConfigured:
@@ -1096,12 +1087,7 @@ private struct ClaudeStatuslineRow: View {
                     ProgressView().controlSize(.small)
                 }
             }
-
-            Text(model.statuslineResult ?? model.statuslineSentence)
-                .font(.callout)
-                .foregroundStyle(.secondary)
-                .lineLimit(1)
-                .accessibilityIdentifier("integrations.claude.statusline.status")
+            .controlSize(.small)
         }
         .sheet(isPresented: $isShowingSetup) {
             ClaudeStatuslineSetupSheet(model: model) { isShowingSetup = false }
@@ -1119,8 +1105,12 @@ private struct OpencodePluginRow: View {
     @Bindable var model: ClaudeIntegrationSettingsModel
 
     var body: some View {
-        // Stacked like the Claude Code rows: button bar plus status line.
-        SettingsFieldRow(title: "opencode", layout: .stacked) {
+        // One line like the Claude Code rows above.
+        SettingsFieldRow(
+            title: "opencode",
+            status: model.opencodeResult ?? model.opencodeSentence,
+            statusAccessibilityIdentifier: "integrations.opencode.status"
+        ) {
             HStack(spacing: 8) {
                 Button("Install") {
                     Task { await model.installOpencodePlugin() }
@@ -1138,12 +1128,7 @@ private struct OpencodePluginRow: View {
                     ProgressView().controlSize(.small)
                 }
             }
-
-            Text(model.opencodeResult ?? model.opencodeSentence)
-                .font(.callout)
-                .foregroundStyle(.secondary)
-                .lineLimit(1)
-                .accessibilityIdentifier("integrations.opencode.status")
+            .controlSize(.small)
         }
     }
 }
@@ -1152,12 +1137,12 @@ private struct OpencodePluginRow: View {
 /// row is status-only, and hidden entirely until something reports herdr.
 private struct HerdrPresenceRow: View {
     var body: some View {
-        SettingsFieldRow(title: "herdr") {
-            Text(ClaudeIntegrationSettingsModel.herdrDetectedSentence)
-                .font(.callout)
-                .foregroundStyle(.secondary)
-                .lineLimit(1)
-                .accessibilityIdentifier("integrations.herdr.status")
+        SettingsFieldRow(
+            title: "herdr",
+            status: ClaudeIntegrationSettingsModel.herdrDetectedSentence,
+            statusAccessibilityIdentifier: "integrations.herdr.status"
+        ) {
+            EmptyView()
         }
     }
 }
@@ -1173,8 +1158,7 @@ private struct ClaudeCmuxPasswordSettingsRow: View {
     var body: some View {
         SettingsFieldRow(
             title: "cmux socket password",
-            help:
-                "Stored in your Keychain and sent only to cmux's local socket. Save an empty field to remove it."
+            help: "Stored in your Keychain, sent only to cmux's local socket."
         ) {
             HStack(alignment: .center, spacing: 8) {
                 SecureField("cmux socket password", text: $model.cmuxPasswordField)
@@ -1261,26 +1245,36 @@ private struct ClaudeRemoteHostsSettingsRow: View {
         }
     }
 
-    /// The plain-ssh join's one setup step: two short sentences and a button,
-    /// inside the group that already exists. Nothing is written until the sheet
-    /// has shown the exact text and been confirmed.
+    /// The plain-ssh join's one setup step, on one line: title + status
+    /// leading, the small buttons trailing. The two facts the status carries
+    /// (is the export in the rc file; has a new session arrived carrying it)
+    /// stay separate texts for the drills, separated by a middle dot.
+    /// Nothing is written until the sheet has shown the exact text and been
+    /// confirmed.
     @ViewBuilder
     private var shellSetup: some View {
         HStack(spacing: 8) {
-            VStack(alignment: .leading, spacing: 1) {
+            HStack(alignment: .firstTextBaseline, spacing: 8) {
                 Text("Terminal setup for plain SSH")
                     .font(.callout)
                     .accessibilityIdentifier("claude.remote.shellSetup.title")
-                Text(model.shellSetupStatus.rcSentence)
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
-                    .accessibilityIdentifier("claude.remote.shellSetup.rcStatus")
-                Text(model.shellSetupStatus.crossingSentence)
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
-                    .accessibilityIdentifier("claude.remote.shellSetup.crossingStatus")
+
+                HStack(alignment: .firstTextBaseline, spacing: 4) {
+                    Text(model.shellSetupStatus.rcSentence)
+                        .accessibilityIdentifier("claude.remote.shellSetup.rcStatus")
+                    Text("·")
+                        .accessibilityHidden(true)
+                        .foregroundStyle(.tertiary)
+                    Text(model.shellSetupStatus.crossingSentence)
+                        .accessibilityIdentifier("claude.remote.shellSetup.crossingStatus")
+                }
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .lineLimit(1)
             }
-            Spacer()
+
+            Spacer(minLength: 8)
+
             if model.shellSetupStatus.rc == .applied {
                 Button("Remove") { Task { await model.removeShellSetup() } }
                     .controlSize(.small)
@@ -1303,8 +1297,13 @@ private struct ClaudeRemoteHostsSettingsRow: View {
             VStack(alignment: .leading, spacing: 4) {
                 ForEach(model.hosts) { host in
                     HStack(spacing: 8) {
-                        VStack(alignment: .leading, spacing: 1) {
+                        // One line per host (owner review, 2026-09-07): label +
+                        // "last context" leading, the small buttons trailing.
+                        // The transient post-run status is the only thing that
+                        // ever adds a second line.
+                        HStack(alignment: .firstTextBaseline, spacing: 6) {
                             Text(host.label).font(.callout)
+
                             // Rendered by the model against its injected clock —
                             // "Last context: 2 min ago" — and refreshed with the
                             // rest of the section. A tunnel that quietly stopped
@@ -1312,35 +1311,48 @@ private struct ClaudeRemoteHostsSettingsRow: View {
                             Text(host.statusText)
                                 .font(.caption)
                                 .foregroundStyle(.secondary)
-                            // The one-flow setup's last word for this host,
-                            // written by the run, not computed here.
-                            if let setupStatus = host.setupStatusText {
-                                Text(setupStatus)
-                                    .font(.caption)
-                                    .foregroundStyle(.secondary)
-                            }
+                                .lineLimit(1)
                         }
-                        Spacer()
-                        Button("Update host…") { model.requestPluginUpdate(hostID: host.id) }
-                            .controlSize(.small)
-                            .disabled(model.isEnrollmentBusy)
-                        Button("Rotate token") { Task { await model.rotate(hostID: host.id) } }
-                            .controlSize(.small)
-                        if !host.isRevoked {
-                            Button("Revoke") { Task { await model.revoke(hostID: host.id) } }
+
+                        Spacer(minLength: 8)
+
+                        HStack(spacing: 8) {
+                            Button("Update host…") { model.requestPluginUpdate(hostID: host.id) }
                                 .controlSize(.small)
+                                .disabled(model.isEnrollmentBusy)
+                            Button("Rotate token") { Task { await model.rotate(hostID: host.id) } }
+                                .controlSize(.small)
+                            if !host.isRevoked {
+                                Button("Revoke") { Task { await model.revoke(hostID: host.id) } }
+                                    .controlSize(.small)
+                            }
+                            Button("Remove") { Task { await model.remove(hostID: host.id) } }
+                                .controlSize(.small)
+                                // Removing the row an action is reporting into is
+                                // handled (the late-result guard drops the outcome),
+                                // but offering it mid-run is still offering a race.
+                                .disabled(model.isEnrollmentBusy)
                         }
-                        Button("Remove") { Task { await model.remove(hostID: host.id) } }
-                            .controlSize(.small)
-                            // Removing the row an action is reporting into is
-                            // handled (the late-result guard drops the outcome),
-                            // but offering it mid-run is still offering a race.
-                            .disabled(model.isEnrollmentBusy)
                     }
+
+                    hostSetupStatus(host.setupStatusText)
+
                     persistentForwardRow(for: host)
                     pluginUpdatePanel(for: host)
                 }
             }
+        }
+    }
+
+    /// The one-flow setup's last word for this host, written by the run, not
+    /// computed here. Transient: the row is one line until a run has spoken.
+    @ViewBuilder
+    private func hostSetupStatus(_ text: String?) -> some View {
+        if let text {
+            Text(text)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .lineLimit(1)
         }
     }
 
@@ -1516,7 +1528,7 @@ private struct ClaudeRemoteHostsSettingsRow: View {
             Text(model.listenerStatus.text)
                 .font(.caption)
                 .foregroundStyle(model.listenerStatus.isFailure ? .orange : .secondary)
-                .lineLimit(2)
+                .lineLimit(1)
             if model.listenerStatus.isFailure {
                 Button("Retry") { model.retryListener() }
                     .controlSize(.small)
@@ -1526,7 +1538,7 @@ private struct ClaudeRemoteHostsSettingsRow: View {
             Text(remedy)
                 .font(.caption)
                 .foregroundStyle(.secondary)
-                .lineLimit(3)
+                .lineLimit(1)
         }
     }
 
@@ -2046,12 +2058,25 @@ private struct SettingsPage<Content: View>: View {
 
 private struct SettingsGroup<Content: View>: View {
     let title: String
+    /// When set, the group's header row carries ONE "Learn more" link to this
+    /// page (owner review, 2026-09-07): details a row's one-line help can no
+    /// longer carry live in the docs, not repeated under every toggle.
+    var learnMoreURL: URL?
     @ViewBuilder var content: Content
 
     var body: some View {
         VStack(alignment: .leading, spacing: SettingsLayout.sectionSpacing) {
-            Text(title)
-                .font(.headline)
+            HStack(alignment: .firstTextBaseline) {
+                Text(title)
+                    .font(.headline)
+
+                if let learnMoreURL {
+                    Spacer(minLength: 12)
+                    Link("Learn more", destination: learnMoreURL)
+                        .font(.callout)
+                }
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
 
             VStack(alignment: .leading, spacing: 0) {
                 content
@@ -2185,11 +2210,20 @@ private struct SettingsFieldRow<Content: View, Footer: View>: View {
     /// `content`: a row cannot pull a nested view out of its control column, and
     /// the whole point is that this text is NOT in that column.
     ///
-    /// This is the STATIC explanation of what the row does. Anything that
-    /// changes with the row's state — "Not set.", a validation error, "Password
-    /// saved." — belongs in `footer:` instead, which is the same shape of line
-    /// but built from a view rather than a string.
+    /// This is the STATIC explanation of what the row does, ONE line at
+    /// `.callout` (owner review, 2026-09-07: readable size, secondary colour,
+    /// never a wall of text — the details live in the docs behind the group's
+    /// Learn more link). Anything that changes with the row's state — "Not
+    /// set.", a validation error, "Password saved." — belongs in `status` or
+    /// `footer:` instead.
     var help: String?
+    /// One-line dynamic status, rendered next to the label in the LEADING
+    /// column so a row with buttons reads "label + status … [buttons]" on a
+    /// single line instead of stacking them into a tall row.
+    var status: String?
+    /// Drill anchor for `status`, preserved from the stacked layout the rows
+    /// used before the horizontal rework.
+    var statusAccessibilityIdentifier: String?
     var layout: SettingsFieldRowLayout
     /// How the label sits against the control in an `.inline` row. See
     /// `inlineRow` for why the default is `.center`.
@@ -2209,6 +2243,8 @@ private struct SettingsFieldRow<Content: View, Footer: View>: View {
     init(
         title: String,
         help: String? = nil,
+        status: String? = nil,
+        statusAccessibilityIdentifier: String? = nil,
         layout: SettingsFieldRowLayout = .inline,
         controlAlignment: VerticalAlignment = .center,
         @ViewBuilder content: () -> Content,
@@ -2216,6 +2252,8 @@ private struct SettingsFieldRow<Content: View, Footer: View>: View {
     ) {
         self.title = title
         self.help = help
+        self.status = status
+        self.statusAccessibilityIdentifier = statusAccessibilityIdentifier
         self.layout = layout
         self.controlAlignment = controlAlignment
         self.content = content()
@@ -2226,12 +2264,16 @@ private struct SettingsFieldRow<Content: View, Footer: View>: View {
     init(
         title: String,
         help: String? = nil,
+        status: String? = nil,
+        statusAccessibilityIdentifier: String? = nil,
         layout: SettingsFieldRowLayout = .inline,
         controlAlignment: VerticalAlignment = .center,
         @ViewBuilder content: () -> Content
     ) where Footer == EmptyView {
         self.title = title
         self.help = help
+        self.status = status
+        self.statusAccessibilityIdentifier = statusAccessibilityIdentifier
         self.layout = layout
         self.controlAlignment = controlAlignment
         self.content = content()
@@ -2270,6 +2312,23 @@ private struct SettingsFieldRow<Content: View, Footer: View>: View {
             .fixedSize(horizontal: false, vertical: true)
     }
 
+    /// The row's one-line status. The drill anchor is applied only when the
+    /// row names one: an unconditional `.accessibilityIdentifier("")` would
+    /// put empty ids in every AX dump.
+    @ViewBuilder
+    private func statusText(_ text: String) -> some View {
+        let base = Text(text)
+            .font(.callout)
+            .foregroundStyle(.secondary)
+            .lineLimit(1)
+
+        if let statusAccessibilityIdentifier {
+            base.accessibilityIdentifier(statusAccessibilityIdentifier)
+        } else {
+            base
+        }
+    }
+
     private var inlineRow: some View {
         // Centered by default, top-aligned only where a row asks for it. The
         // default used to be `.top`, which is right for a tall composite control
@@ -2278,9 +2337,18 @@ private struct SettingsFieldRow<Content: View, Footer: View>: View {
         // misaligned against System Settings (PR #201 review). A row with a
         // genuinely tall control passes `controlAlignment: .top`.
         HStack(alignment: controlAlignment, spacing: SettingsLayout.rowSpacing) {
-            label
-                .frame(maxWidth: .infinity, alignment: .leading)
-                .layoutPriority(0)
+            // "Label + one-line status" on the left (owner review, 2026-09-07):
+            // baselines aligned, the status truncates rather than wrapping so a
+            // row with buttons stays one line tall.
+            HStack(alignment: .firstTextBaseline, spacing: 8) {
+                label
+
+                if let status {
+                    statusText(status)
+                }
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .layoutPriority(0)
 
             VStack(alignment: .trailing, spacing: 6) {
                 content
@@ -2310,9 +2378,14 @@ private struct SettingsHelpText: View {
     }
 
     var body: some View {
+        // ONE line, at a readable size (owner review, 2026-09-07): `.callout`
+        // in secondary colour, truncating rather than wrapping, so no row can
+        // grow a wall of text under its control. What does not fit lives in
+        // the docs behind the group's Learn more link.
         Text(text)
-            .font(.caption)
+            .font(.callout)
             .foregroundStyle(.secondary)
+            .lineLimit(1)
             .fixedSize(horizontal: false, vertical: true)
             .frame(maxWidth: .infinity, alignment: .leading)
     }

--- a/Tests/localvoxtralTests/SettingsTabTests.swift
+++ b/Tests/localvoxtralTests/SettingsTabTests.swift
@@ -42,7 +42,6 @@ final class SettingsTabTests: XCTestCase {
     func testEveryTabHasCompleteChrome() {
         for tab in SettingsTab.allCases {
             XCTAssertFalse(tab.title.isEmpty, "\(tab.rawValue) has no title")
-            XCTAssertFalse(tab.subtitle.isEmpty, "\(tab.rawValue) has no subtitle")
             XCTAssertFalse(tab.systemImage.isEmpty, "\(tab.rawValue) has no SF Symbol")
             XCTAssertFalse(
                 tab.accessibilityIdentifier.isEmpty,
@@ -55,17 +54,32 @@ final class SettingsTabTests: XCTestCase {
         }
     }
 
-    func testSubtitlesAreOneLineSentences() {
-        for tab in SettingsTab.allCases {
-            XCTAssertFalse(
-                tab.subtitle.contains("\n"),
-                "\(tab.rawValue) subtitle must be a single line"
-            )
-            XCTAssertTrue(
-                tab.subtitle.hasSuffix("."),
-                "\(tab.rawValue) subtitle must read as a sentence"
-            )
-        }
+    /// The pane header is the title only (owner review, 2026-09-07): every
+    /// pane subtitle ("What the polisher and your coding agents may see." and
+    /// siblings) was narration and was deleted so the first group starts
+    /// higher. Pins the deletion at the source, the same way the script-pinning
+    /// tests below hold the AX drills, so a future "helpful" subtitle cannot
+    /// silently return.
+    func testPaneHeaderIsTitleOnly() throws {
+        let repoRoot = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()  // SettingsTabTests.swift
+            .deletingLastPathComponent()  // localvoxtralTests
+            .deletingLastPathComponent()  // Tests
+        let headerSource = try String(
+            contentsOf: repoRoot.appendingPathComponent(
+                "Sources/localvoxtral/Settings/SettingsPaneHeader.swift"
+            ),
+            encoding: .utf8
+        )
+
+        XCTAssertFalse(
+            headerSource.contains("tab.subtitle"),
+            "pane subtitles were deleted by owner review; put new explanations in the docs, not the header"
+        )
+        XCTAssertFalse(
+            headerSource.contains(".subheadline"),
+            "the header renders exactly one line: the tab title"
+        )
     }
 
     func testAccessibilityIdentifiersUseTheDrillScheme() {

--- a/Tests/localvoxtralTests/SettingsTabTests.swift
+++ b/Tests/localvoxtralTests/SettingsTabTests.swift
@@ -138,6 +138,20 @@ final class SettingsTabTests: XCTestCase {
         )
     }
 
+    /// `SettingsView.swift` source, for the copy/layout pins above. Read from
+    /// the repo rather than inlined constants so the assertion runs against
+    /// what actually ships.
+    private static func settingsViewSource() throws -> String {
+        let repoRoot = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()  // SettingsTabTests.swift
+            .deletingLastPathComponent()  // localvoxtralTests
+            .deletingLastPathComponent()  // Tests
+        return try String(
+            contentsOf: repoRoot.appendingPathComponent("Sources/localvoxtral/SettingsView.swift"),
+            encoding: .utf8
+        )
+    }
+
     /// First double-quoted argument of every top-level `<call> "<arg>" ...`
     /// line. Skips the function's own definition line (`<call>() {`).
     private static func firstQuotedArguments(ofCalls call: String, in script: String) -> Set<String> {
@@ -168,6 +182,102 @@ final class SettingsTabTests: XCTestCase {
                 + "if the script was reformatted, teach the parser the new shape"
         )
         return entries
+    }
+
+    /// The clipboard toggle's help must name the real payload: a capped,
+    /// sanitized EXCERPT of the clipboard attached to the polish prompt
+    /// (`PolishContextClipboardReader`). "Technical terms" understated what
+    /// leaves the machine (an independent review of PR #282 caught it), so
+    /// the line is pinned here the same way the header source is pinned
+    /// above — against the understatement returning.
+    func testClipboardHelpNamesTheExcerptNotTechnicalTerms() throws {
+        let source = try Self.settingsViewSource()
+
+        let title = try XCTUnwrap(
+            source.range(of: "title: \"Clipboard\""),
+            "the Clipboard toggle row is gone from SettingsView.swift"
+        )
+        // The row's `help:` argument is the next one after its title.
+        let afterTitle = source[title.upperBound...]
+        let helpOpening = try XCTUnwrap(
+            afterTitle.range(of: "help: \""),
+            "the Clipboard toggle has no help line"
+        )
+        let helpLine = afterTitle[helpOpening.upperBound...].prefix(while: { $0 != "\n" })
+
+        XCTAssertTrue(
+            helpLine.contains("excerpt"),
+            "clipboard help must say an excerpt of the clipboard is sent, was: \(helpLine)"
+        )
+        XCTAssertFalse(
+            helpLine.contains("technical terms"),
+            "\"technical terms\" understates the payload — a capped excerpt of the whole "
+                + "clipboard goes to the polisher, not just terms; was: \(helpLine)"
+        )
+    }
+
+    /// Layout rules for the Integrations remote rows (PR #282 review), pinned
+    /// at the source because no render seam exists for them (no `#Preview`,
+    /// no view-inspector dependency):
+    ///
+    /// - the plain-SSH setup status is an INSTRUCTION ("Open a new terminal
+    ///   window for it to take effect.") and must wrap to a second line
+    ///   (`lineLimit(2)` + `fixedSize(horizontal: false, vertical: true)`),
+    ///   never truncate;
+    /// - a host label (up to the registry's 64-character cap) must not squeeze
+    ///   "Last context: …" off its line: the label truncates from the middle
+    ///   at a layout priority below the status's.
+    func testRemoteRowsWrapInstructionsAndCapHostLabels() throws {
+        let source = try Self.settingsViewSource()
+
+        let shellSetup = try XCTUnwrap(
+            source.range(of: "private var shellSetup: some View {"),
+            "the plain-SSH setup row (shellSetup) moved — update this test's anchor"
+        )
+        // Up to the next member (hostList) = the shellSetup body.
+        let nextMember = try XCTUnwrap(
+            source.range(
+                of: "private var hostList",
+                range: shellSetup.upperBound..<source.endIndex
+            ),
+            "hostList no longer follows shellSetup — update this test's anchor"
+        )
+        let row = source[shellSetup.lowerBound..<nextMember.lowerBound]
+        XCTAssertTrue(
+            row.contains(".lineLimit(2)"),
+            "the shell-setup status may wrap to a second line instead of truncating"
+        )
+        XCTAssertTrue(
+            row.contains(".fixedSize(horizontal: false, vertical: true)"),
+            "the shell-setup status needs fixedSize to actually take its second line"
+        )
+
+        let label = try XCTUnwrap(
+            source.range(of: "Text(host.label)"),
+            "the host-row label (Text(host.label)) moved — update this test's anchor"
+        )
+        let labelModifiers = source[label.upperBound...].prefix(300)
+        XCTAssertTrue(
+            labelModifiers.contains(".lineLimit(1)"),
+            "a 64-char host label must be one line, not an unbounded wrap"
+        )
+        XCTAssertTrue(
+            labelModifiers.contains(".truncationMode(.middle)"),
+            "a long host label should truncate from the middle (head and tail stay readable)"
+        )
+        let status = try XCTUnwrap(
+            source.range(of: "Text(host.statusText)"),
+            "the host-row status (Text(host.statusText)) moved — update this test's anchor"
+        )
+        let statusModifiers = source[status.upperBound...].prefix(300)
+        XCTAssertTrue(
+            statusModifiers.contains(".lineLimit(1)"),
+            "the \"Last context\" status keeps one full line"
+        )
+        XCTAssertTrue(
+            statusModifiers.contains(".layoutPriority(1)"),
+            "the status outranks the label when width runs out"
+        )
     }
 
     /// The Context → Integrations rename (this tab never shipped, so the raw

--- a/docs/coding-agents.md
+++ b/docs/coding-agents.md
@@ -73,8 +73,8 @@ toggle that relaxes that.
   its hooks report go; no files are read from that host. Needs a Claude Code
   session in a supported terminal, or a Remote Control session in the focused
   browser tab.
-- **Clipboard** — checks technical terms against your clipboard to ground
-  spellings.
+- **Clipboard** — sends an excerpt of your clipboard text to the polisher,
+  sanitized and length-capped, used only as a spelling reference.
 - **Non-local endpoints** — when on, the context enabled above also goes to
   the polishing endpoint you configured. Enable it only for an endpoint you
   trust, such as a server on your own network.

--- a/docs/coding-agents.md
+++ b/docs/coding-agents.md
@@ -51,6 +51,42 @@ polisher running on this Mac. To send enabled context sources to a configured
 non-local polishing endpoint, turn on **Non-local endpoints** in **Settings →
 Integrations**. Use it only with an endpoint you trust.
 
+## Polish context: what each toggle sends
+
+Each **Settings → Integrations → Polish context** row states its consequence
+in one line; this section is the full text behind those lines.
+
+The first four sources share one default: they run only while the polisher
+runs on this Mac (the bundled helper). **Non-local endpoints** is the single
+toggle that relaxes that.
+
+- **Repo vocabulary** — reads file names from the git repo in your terminal
+  (one sandboxed `git ls-files`) so near-miss spellings resolve to real names.
+- **Claude Code screen** — reads file and identifier names from your Claude
+  Code terminal to fix spellings. When that terminal runs a Claude Code
+  session, part of the text on screen also goes to the polisher, verbatim.
+  Ghostty, iTerm2, Terminal.app, and cmux only; in cmux this needs the cmux
+  join as well (see the next section).
+- **Claude Code project** — sends your uncommitted changes, the files Claude
+  Code recently touched, and the last request you sent that session. For a
+  session on a remote host, only the session request and the short excerpts
+  its hooks report go; no files are read from that host. Needs a Claude Code
+  session in a supported terminal, or a Remote Control session in the focused
+  browser tab.
+- **Clipboard** — checks technical terms against your clipboard to ground
+  spellings.
+- **Non-local endpoints** — when on, the context enabled above also goes to
+  the polishing endpoint you configured. Enable it only for an endpoint you
+  trust, such as a server on your own network.
+
+The **Join Claude Code sessions in cmux** toggle (in the Claude Code group)
+and its **cmux socket password** row are covered in the
+[plugin README](../integrations/claude-code/README.md#which-terminal-am-i-dictating-into):
+the join uses cmux's automation socket to tell which session you are dictating
+into and reads that surface as context, for local surfaces and for sessions
+opened with `cmux ssh`. The socket password is stored in your Keychain and
+sent only to cmux's local socket; saving an empty field removes it.
+
 ## Dictating into Claude Code
 
 localvoxtral ships a

--- a/docs/dictation.md
+++ b/docs/dictation.md
@@ -62,7 +62,10 @@ Open **Settings** from the menu bar popover:
 - **Integrations** — what the polisher may see (repo vocabulary, terminal
   screen, Claude Code project files, clipboard), one row per harness with
   in-app setup: the Claude Code plugin and status line, remote SSH hosts, the
-  opencode plugin, and herdr presence
+  opencode plugin, and herdr presence. Each row's help is one line naming
+  what leaves this Mac; the full terms per toggle are in
+  [Terminals & coding agents](coding-agents.md#polish-context-what-each-toggle-sends),
+  and each group's **Learn more** link opens the relevant page
 - **About** — version, link to the repository, and Export Diagnostics
   (writes a redacted local report to the Desktop)
 

--- a/integrations/claude-code/README.md
+++ b/integrations/claude-code/README.md
@@ -81,7 +81,7 @@ default:
  2. In localvoxtral, enable **Settings → Integrations → Claude Code → "Join
     Claude Code sessions in cmux"** and enter the same password in **cmux
    socket password**. It is stored in your Keychain and sent only to cmux's
-   local socket.
+   local socket; saving an empty field removes the stored password.
 
 If the socket refuses the app, the settings row says
 `cmux socket requires password mode.` and the dictation joins nothing —

--- a/scripts/ui-smoke.sh
+++ b/scripts/ui-smoke.sh
@@ -499,7 +499,9 @@ assert_pane_scope_is_reachable
 
 assert_tab "general" "General" "Permissions"
 assert_tab "endpoints" "Engines" "Dictation"
-assert_tab "dictation" "Dictation" "Start dictation with"
+# "Trigger" is the Dictation pane's first group title; the pre-#278 needle
+# ("Start dictation with") named copy that no longer exists.
+assert_tab "dictation" "Dictation" "Trigger"
 assert_tab "textProcessing" "Text Processing" "Replacements"
 # The polish feature toggles live on Text Processing (moved from Engines).
 assert_tab "textProcessing" "Text Processing" "Polishing"
@@ -507,7 +509,9 @@ assert_tab "textProcessing" "Text Processing" "Polishing"
 # own pane (moved off Text Processing). Asserted on the group titles, which
 # exist nowhere else.
 assert_tab "integrations" "Integrations" "Polish context"
-assert_tab "integrations" "Integrations" "Remote Claude Code over SSH"
+# Renamed to "Claude Code over SSH" in the #278 copy pass; the old needle
+# ("Remote Claude Code over SSH") no longer exists in the pane.
+assert_tab "integrations" "Integrations" "Claude Code over SSH"
 # The cmux join toggle binds $settings.cmuxSurfaceJoinEnabled in its new home;
 # without this, the row could be deleted or rebound with every lane green.
 assert_tab "integrations" "Integrations" "Join Claude Code sessions in cmux"


### PR DESCRIPTION
## What

Owner screenshot review, four asks, no group/sidebar restructuring (that is the next worker's diff):

1. **Pane header is the title only.** All six pane subtitles ("What the polisher and your coding agents may see." etc.) are deleted — from the header, from the `SettingsTab` enum, and from the sidebar row tooltip that repeated them. The header's bottom padding drops 12 → 6, so the first group starts higher. `SettingsTabTests` pins the header source against a subtitle coming back.
2. **No focus ring on sidebar rows.** When the window becomes key, SwiftUI hands first responder to the first sidebar button, so General drew a blue ring while Integrations was selected. `focusEffectDisabled()` on the row buttons removes only the ring: the rows stay real buttons (the AX drill presses them via `AXPress` by AXIdentifier, and its title fallback requires `AXButton`).
3. **Rows with buttons use the trailing column.** Plugin, status line, opencode, the remote-host rows, and shell setup now read "label + one-line status … [small right-aligned buttons]" on a single line; the status sentence only wraps when it cannot fit, and the transient post-run host status is the only second line any of these rows can grow. `SettingsFieldRow` grows the `status:` slot for the idiom; the per-row status AX identifiers (`integrations.claude.plugin.status`, …, `claude.remote.shellSetup.rcStatus`/`crossingStatus`) move with the text and are unchanged as strings.
4. **One-line help everywhere.** Every Integrations consent toggle's help is one line at `.callout` (secondary, truncating instead of wrapping) stating what leaves the machine — nothing else. The full terms moved to `docs/coding-agents.md` ("Polish context: what each toggle sends") and the plugin README, reached through a single **Learn more** link per group (Polish context, Claude Code, Remote hosts). `SettingsHelpText` enforces the same one-line rule for the other panes' help (Engines' model footer included); General/Dictation/Text Processing help was already single-line and only picked up the size change.

`scripts/ui-smoke.sh`: `bash -n` clean; all eleven `assert_tab` needles verified against the new pane copy. Two needles had already drifted dead in #278 and are fixed to current copy ("Start dictation with" → "Trigger", "Remote Claude Code over SSH" → "Claude Code over SSH"); the other nine are unchanged and still present.

[dogfood-package]

## Proof

- [x] Unit suite green — `./scripts/remote-build.sh test`:

```
Test Suite 'localvoxtralPackageTests.xctest' passed at 2026-09-07 23:11:25.781.
	 Executed 3071 tests, with 2 tests skipped and 0 failures (0 unexpected) in 54.031 (54.167) seconds
```

- Warning count on the same run: `grep -ci "warning:" .build/last-remote.log` → `0`
- Named suites from the same run, all passed:

```
Test Suite 'SettingsTabTests' passed … (incl. testPaneHeaderIsTitleOnly, testEveryTabHasCompleteChrome, testAutomationScriptsDrillExactlyTheTabsTheEnumDefines)
Test Suite 'ClaudeIntegrationSettingsModelTests' passed
Test Suite 'IntegrationsSettingsModelTests' passed
```

- `bash -n scripts/ui-smoke.sh` → exit 0
- Realtime integration lane: not run locally — no backend, prompt, model, or helper change in this diff (SwiftUI settings surface + docs only); the tier-0/tier-1 lanes on this push cover it.
- UI change, verified by hand: **not hand-verified in a GUI from this worktree** (Linux-side edit worker; the Mac host is at 1 GiB free disk, so no `package` run was risked on it). What holds the change instead: the AX identifiers and drill needles above are pinned by unit tests, `focusEffectDisabled()` is documented to change rendering only (not focusability or role), and the tier-2 nightly UI smoke exercises every needle this PR touches — note that lane is currently blocked by a **pre-existing** runner TCC failure on `main` (run 34161210709 fails at "TCC preflight failed", before any assertion runs). The `[dogfood-package]` build from this PR is the intended hand-check vehicle for the screenshots that motivated the asks.

## Changed strings (before → after)

Pane headers — subtitle line deleted on every pane (title unchanged, still AX-readable):

| Pane | Before (subtitle) | After |
|---|---|---|
| General | Permissions and app-level behavior. | *(deleted)* |
| Dictation | How you start, stop, and see dictation. | *(deleted)* |
| Engines | Where dictation and polishing run. | *(deleted)* |
| Text Processing | Replacements and LLM polishing of your transcript. | *(deleted)* |
| Integrations | What the polisher and your coding agents may see. | *(deleted)* |
| About | Version, project, and diagnostics. | *(deleted)* |

Integrations help lines (now one line, `.callout`, secondary; full text moved to the linked docs):

| Row | Before | After |
|---|---|---|
| Repo vocabulary | Reads file names from the git repo in your terminal to fix spellings. Only with a polisher on this Mac. | Sends file names from the repo in your terminal to the polisher. |
| Claude Code screen | Reads names from your Claude Code terminal to fix spellings. When that terminal runs a Claude Code session, part of the text on screen also goes to the polisher. Ghostty, iTerm2, Terminal.app and cmux only. In cmux this needs the cmux join too. Only with a polisher on this Mac. | Sends the text on screen in your Claude Code terminal to the polisher. |
| Claude Code project | Sends your uncommitted changes, files Claude Code recently touched, and the last request you sent that session to the polisher. For a session on a remote host, only the session request and the short excerpts its hooks report go. No files are read from that host. Needs a Claude Code session in a supported terminal or a Remote Control session in the focused browser tab. Only with a polisher on this Mac. | Sends your uncommitted changes, recent files, and last prompt to the polisher. |
| Clipboard | Checks technical terms against your clipboard. Only with a polisher on this Mac. | Sends a capped excerpt of your clipboard to the polisher. (further corrected by review — see Review fixes) |
| Non-local endpoints | When off, context only ever goes to a polisher on this Mac. When on, the context enabled above also goes to the polishing endpoint you configured. Enable only for an endpoint you trust, such as a server on your own network. | Also sends the context enabled above to your non-local polishing endpoint. |
| Join Claude Code sessions in cmux | Uses the cmux automation socket to tell which session you dictate into, and reads that surface as context. In cmux, set Automation socket mode to Password and pick a socket password, then enter the same password below. Works for local surfaces and for sessions opened with cmux ssh. | Reads the cmux pane you dictate into, via cmux's automation socket. |
| cmux socket password | Stored in your Keychain and sent only to cmux's local socket. Save an empty field to remove it. | Stored in your Keychain, sent only to cmux's local socket. |

Presentation-only changes (same strings, new placement): the plugin/status-line/opencode/herdr status sentences and the shell-setup rc/crossing sentences now render beside their labels (`.callout`/`.caption` secondary, one line) instead of under the buttons; host rows show `label` + `Last context: …` on one line. Group headers gained a **Learn more** link (Polish context / Claude Code / Remote hosts). Help text font `.caption` → `.callout` with `lineLimit(1)` pane-wide; the sidebar row tooltip (which showed the deleted subtitle) is gone. No model-owned sentence changed — `ClaudeIntegrationSettingsModelTests` and `IntegrationsSettingsModelTests` pass untouched.

`scripts/ui-smoke.sh` needles: "Start dictation with" → "Trigger", "Remote Claude Code over SSH" → "Claude Code over SSH" (both had been dead since #278); all other needles unchanged.


## Review fixes

An independent review of this PR found three defects; all fixed in f6e3796.

1. **HIGH — clipboard help understated the payload.** "Sends technical terms from your clipboard to the polisher." was not true: `PolishContextClipboardReader` attaches a capped, sanitized EXCERPT of the whole clipboard to the polish prompt (fence-neutralized, rendered length capped by `PolishContextBudget`). The help line now reads **"Sends a capped excerpt of your clipboard to the polisher."**, and the docs row behind the group's Learn more link (`docs/coding-agents.md`, "Polish context: what each toggle sends") now says an excerpt of the clipboard text is sent, sanitized and length-capped, used only as a spelling reference. New `SettingsTabTests.testClipboardHelpNamesTheExcerptNotTechnicalTerms` pins the line (contains "excerpt", not "technical terms") so the understatement cannot return.
2. **MEDIUM — plain-SSH setup row truncated an instruction.** At the fixed window width, title + two status sentences + Remove + Set up… exceeded the row, and `.lineLimit(1)` ellipsized "Open a new terminal window for it to take effect.". Per the owner rule: the status now wraps to a second line (`lineLimit(2)` + `.fixedSize(horizontal: false, vertical: true)`) instead of truncating, and the outer `HStack` is baseline-aligned so the buttons stay on the title's line. The listener remedy line ("Quit it and press Retry." / "See Console for details, then press Retry.") — the pane's only other status that is an instruction rather than a state word — got the same treatment; state-word statuses (host setup results, tunnel states, plugin/status-line sentences) keep the one-line contract.
3. **MEDIUM — long host labels squeezed "Last context: …" off the line.** Labels run to the registry's 64-character cap (`ClaudeRemoteHostRegistry.sanitizeLabel(maxLength: 64)`) and had no line limit, so a long label pushed the status to minimum width. The label now has `lineLimit(1)` + `.truncationMode(.middle)` at `layoutPriority(0)`, below the status's `lineLimit(1)` at `layoutPriority(1)`: "Last context" always keeps one full line, and a long name middle-truncates with head and tail readable.

How the layout rules were verified: no render seam exists for these rows (no `#Preview` in the target, no view-inspector dependency — only the enrollment sheet has a preview arm), so both rules are pinned at the source by the new `SettingsTabTests.testRemoteRowsWrapInstructionsAndCapHostLabels` — red before the fix, green after — the same mechanism `testPaneHeaderIsTitleOnly` uses for the header. As with the rest of this PR, the GUI hand-check vehicle remains the `[dogfood-package]` build.

Proof (same tier-0 lane):

Red — test added first, copy/layout unfixed (`./scripts/remote-build.sh test --filter SettingsTabTests`):

```
Test Case '-[localvoxtralTests.SettingsTabTests testClipboardHelpNamesTheExcerptNotTechnicalTerms]' started.
Tests/localvoxtralTests/SettingsTabTests.swift:208: error: -[localvoxtralTests.SettingsTabTests testClipboardHelpNamesTheExcerptNotTechnicalTerms] : XCTAssertTrue failed - clipboard help must say an excerpt of the clipboard is sent, was: Sends technical terms from your clipboard to the polisher."
Tests/localvoxtralTests/SettingsTabTests.swift:212: error: -[localvoxtralTests.SettingsTabTests testClipboardHelpNamesTheExcerptNotTechnicalTerms] : XCTAssertFalse failed - "technical terms" understates the payload — a capped excerpt of the whole clipboard goes to the polisher, not just terms; was: Sends technical terms from your clipboard to the polisher."
Test Case '-[localvoxtralTests.SettingsTabTests testClipboardHelpNamesTheExcerptNotTechnicalTerms]' failed (0.220 seconds).
Tests/localvoxtralTests/SettingsTabTests.swift:246: error: -[localvoxtralTests.SettingsTabTests testRemoteRowsWrapInstructionsAndCapHostLabels] : XCTAssertTrue failed - the shell-setup status may wrap to a second line instead of truncating
Tests/localvoxtralTests/SettingsTabTests.swift:250: error: -[localvoxtralTests.SettingsTabTests testRemoteRowsWrapInstructionsAndCapHostLabels] : XCTAssertTrue failed - the shell-setup status needs fixedSize to actually take its second line
Tests/localvoxtralTests/SettingsTabTests.swift:260: error: -[localvoxtralTests.SettingsTabTests testRemoteRowsWrapInstructionsAndCapHostLabels] : XCTAssertTrue failed - a 64-char host label must be one line, not an unbounded wrap
Tests/localvoxtralTests/SettingsTabTests.swift:264: error: -[localvoxtralTests.SettingsTabTests testRemoteRowsWrapInstructionsAndCapHostLabels] : XCTAssertTrue failed - a long host label should truncate from the middle (head and tail stay readable)
Tests/localvoxtralTests/SettingsTabTests.swift:277: error: -[localvoxtralTests.SettingsTabTests testRemoteRowsWrapInstructionsAndCapHostLabels] : XCTAssertTrue failed - the status outranks the label when width runs out
Test Suite 'SettingsTabTests' failed at 2026-09-07 23:36:11.100.
	 Executed 12 tests, with 7 failures (0 unexpected) in 0.230 (0.231) seconds
```

Green — after the fixes (same command):

```
Test Case '-[localvoxtralTests.SettingsTabTests testClipboardHelpNamesTheExcerptNotTechnicalTerms]' passed (0.001 seconds).
Test Case '-[localvoxtralTests.SettingsTabTests testRemoteRowsWrapInstructionsAndCapHostLabels]' passed (0.004 seconds).
Test Suite 'SettingsTabTests' passed at 2026-09-07 23:37:34.746.
	 Executed 12 tests, with 0 failures (0 unexpected) in 0.007 (0.008) seconds
```

(One intermediate run caught the layout pin's modifier window being ~100 characters too short to reach `.layoutPriority(1)` at the file's indentation; the window was widened — same assertions, nothing weakened or deleted.)

Full unit suite after the fixes (`./scripts/remote-build.sh test`):

```
Test Suite 'localvoxtralPackageTests.xctest' passed at 2026-09-07 23:38:43.655.
	 Executed 3073 tests, with 2 tests skipped and 0 failures (0 unexpected) in 54.666 (54.811) seconds
```

- Warning count on that run: `grep -ci "warning:" .build/last-remote.log` → `0`
- Conditional lanes: still untriggered by the same justification as above — no prompt, model, sampling, helper, or eval-corpus change in this diff (SwiftUI settings surface + docs only).
