### PR TITLE
Remote setup: one automated flow with a one-sentence consent, no commands in the UI; status line shows lvx ●

### DIFF
--- a/Sources/ClaudeHookPublisherCore/ClaudeHookPublisher.swift
+++ b/Sources/ClaudeHookPublisherCore/ClaudeHookPublisher.swift
@@ -188,20 +188,34 @@ public struct ClaudeHookPublisher: Sendable {
     }
 
     /// The one line to print, or nil for nothing. FIXED strings only, chosen
-    /// by outcome — no wire byte, path, or id is ever interpolated,
-    /// so nothing that crossed a socket can put a byte on the terminal.
-    /// ANSI SGR is deliberate: Claude Code renders it in the status line.
-    public static func statusLineText(for outcome: StatusOutcome) -> String? {
+    /// by outcome. No wire byte, path, or id is ever interpolated, so nothing
+    /// that crossed a socket can put a byte on the terminal.
+    public static func statusLineText(
+        for outcome: StatusOutcome,
+        useColor: Bool = true
+    ) -> String? {
+        if !useColor {
+            switch outcome {
+            case .connected: return "lvx ok"
+            case .sessionUnknown: return "lvx err"
+            case .appUnreachable: return "lvx off"
+            case .unparseablePayload: return nil
+            }
+        }
         switch outcome {
         case .connected:
-            return "\u{1B}[32m\u{25CF}\u{1B}[0m localvoxtral connected"
+            return "lvx \u{1B}[32m\u{25CF}\u{1B}[0m"
         case .sessionUnknown:
-            return "\u{1B}[33m\u{25CB}\u{1B}[0m localvoxtral not connected"
+            return "lvx \u{1B}[31m\u{25CF}\u{1B}[0m"
         case .appUnreachable:
-            return "\u{1B}[2m\u{25CB} localvoxtral not running\u{1B}[0m"
+            return "lvx \u{1B}[90m\u{25CF}\u{1B}[0m"
         case .unparseablePayload:
             return nil
         }
+    }
+
+    public static func statusLineUsesColor(environment: [String: String]) -> Bool {
+        environment["NO_COLOR"] == nil && environment["TERM"]?.lowercased() != "dumb"
     }
 
     /// Safe metadata only: identity and location of the terminal, never its

--- a/Sources/localvoxtral-claude-hook/main.swift
+++ b/Sources/localvoxtral-claude-hook/main.swift
@@ -28,8 +28,8 @@ func parsedEvent(from arguments: [String]) -> String? {
 
 let arguments = Array(CommandLine.arguments.dropFirst())
 
-// Status-line mode: `localvoxtral-claude-hook --statusline`, wired by the USER
-// into Claude Code's `statusLine` setting (the app never writes that file).
+// Status-line mode: `localvoxtral-claude-hook --statusline`, wired into Claude
+// Code's `statusLine` setting after the user confirms the Settings action.
 // Reads the status-line payload, asks the broker whether this session is live,
 // and prints ONE fixed indicator line. The strings are compile-time constants
 // chosen by outcome — nothing read off the socket is ever echoed — and a
@@ -37,7 +37,10 @@ let arguments = Array(CommandLine.arguments.dropFirst())
 if arguments.contains("--statusline") {
     let payload = ClaudeHookPublisher.readBoundedStdin()
     let outcome = ClaudeHookPublisher().runStatusQuery(stdin: payload)
-    if let text = ClaudeHookPublisher.statusLineText(for: outcome) {
+    let useColor = ClaudeHookPublisher.statusLineUsesColor(
+        environment: ProcessInfo.processInfo.environment
+    )
+    if let text = ClaudeHookPublisher.statusLineText(for: outcome, useColor: useColor) {
         ClaudeHookPublisher.writeStdout(Data((text + "\n").utf8))
     }
     exit(0)

--- a/Sources/localvoxtral/ClaudeContext/ClaudeIntegrationSettingsModel.swift
+++ b/Sources/localvoxtral/ClaudeContext/ClaudeIntegrationSettingsModel.swift
@@ -202,10 +202,9 @@ public struct ClaudeShellSetupStatus: Sendable, Equatable {
 /// Every dependency is injected: no singleton reaches through this type to a
 /// real process, a real port, or a real host.
 ///
-/// The division of labour with the view is deliberate. Everything that could be
-/// wrong — a failed install, a port conflict, a token that must be shown exactly
-/// once — is decided and shaped here, where it has a test. The view renders
-/// strings.
+/// The division of labour with the view is deliberate. Failures, port
+/// conflicts, and short consent text are decided here, where they have tests.
+/// The view renders those strings without exposing generated configuration.
 @MainActor
 @Observable
 public final class ClaudeIntegrationSettingsModel {
@@ -320,23 +319,22 @@ public final class ClaudeIntegrationSettingsModel {
     /// This is the only place in the app where a plaintext token lives past the
     /// call that made it. It is `private(set)`, it is cleared by `dismissPlan`,
     /// and nothing writes it anywhere. The registry cannot reissue it — that is
-    /// the whole point of storing only hashes — so the user gets one chance to
-    /// copy it. It is not persisted locally; one-click setup only carries it in
-    /// the confirmed SSH process's stdin. Rotation is the recovery path.
+    /// the whole point of storing only hashes. It is not persisted locally;
+    /// automated setup carries it only in the confirmed SSH process's stdin.
+    /// Rotation is the recovery path.
     public struct EnrollmentPresentation: Identifiable, Equatable, Sendable {
         public var id: String { host.id }
         public var host: ClaudeRemoteHost
         public var token: String
         public var sshHostAlias: String
         public var plan: ClaudeRemoteEnrollmentService.SetupPlan
-        /// Rotation reuses this sheet; the copy differs because the user's
-        /// situation does (their remote is currently broken, on purpose).
+        /// Rotation reuses this sheet because the user's remote is currently
+        /// broken on purpose and needs the same complete setup run.
         public var isRotation: Bool
         /// False when `sshHostAlias` is the sheet's placeholder rather than an
         /// alias the user gave us — a legacy host rotated before the alias was
-        /// persisted. The commands are still copyable; what is withheld is
-        /// one-click execution, which would otherwise hand a fresh token to
-        /// whichever machine happened to answer to a guessed name.
+        /// persisted. Automated execution is withheld because it would hand a
+        /// fresh token to whichever machine answered to a guessed name.
         public var canRunRemoteSetup: Bool = true
         /// The port the snippet forwards ON THE HOST — this Mac's allocation.
         /// Carried here rather than re-read at check time so verification can
@@ -348,21 +346,12 @@ public final class ClaudeIntegrationSettingsModel {
         public var isPreview: Bool = false
     }
 
-    /// The two commands that bring one enrolled host to the plugin version this
-    /// app ships, plus the host they belong to.
-    ///
-    /// Carries no token — `claude plugin update` keeps the config the install
-    /// stored — so unlike `EnrollmentPresentation` this can be shown at any
-    /// time, which is the point: the user needs it long after the one-time
-    /// token is gone.
+    /// The generated update plan for one enrolled host.
     public struct PluginUpdatePresentation: Identifiable, Equatable, Sendable {
         public var id: String { hostID }
         public var hostID: String
-        /// The alias one-click execution would use, or nil when the host's
-        /// label is not a usable one. The alias belongs to the user's ssh
-        /// config and is never persisted, so the label is the only guess
-        /// available; when it does not qualify the commands are copy-only and
-        /// name a placeholder instead of pretending.
+        /// The alias automated execution uses, or nil for a legacy host that
+        /// must be re-enrolled before the app can safely address it.
         public var sshHostAlias: String?
         public var commands: [String]
         /// This host's regenerated ssh-config block, when the local one does
@@ -379,17 +368,8 @@ public final class ClaudeIntegrationSettingsModel {
         public var sshConfigSnippet: String?
         public var canRun: Bool { sshHostAlias != nil }
 
-        /// Everything this update consists of, in the order it must be applied.
-        ///
-        /// ONE rendering, used by all three surfaces — the panel's text, its
-        /// Copy button, and the confirmation preview. They diverged once
-        /// already: the executable path wrote the ssh block while the panel
-        /// showed and copied only the commands, so the copy-only paths (a host
-        /// with no recorded alias, and the symlink refusal that explicitly
-        /// tells the user to copy) updated the remote port and left this Mac on
-        /// 8473 — the original split brain, reachable by exactly the users most
-        /// likely to hit it. A single source is the fix; three call sites that
-        /// "should stay in sync" is what produced the bug.
+        /// Exact generated text retained as a test seam. Settings never renders
+        /// or copies it; the user-facing command reference lives in the docs.
         public var applicationText: String {
             guard let sshConfigSnippet else { return commands.joined(separator: "\n") }
             return "# 1. Replace this host's block in ~/.ssh/config on this Mac:\n"
@@ -445,7 +425,7 @@ public final class ClaudeIntegrationSettingsModel {
     public private(set) var pluginResult: String?
     public private(set) var isPerformingPluginAction = false
     public private(set) var presentedPlan: EnrollmentPresentation?
-    /// The update commands the user asked to see, for one host at a time.
+    /// The update plan for the host whose automated setup panel is open.
     public private(set) var presentedPluginUpdate: PluginUpdatePresentation?
     public private(set) var enrollmentConfirmation: EnrollmentConfirmation?
     public private(set) var enrollmentStepStatuses: [EnrollmentStepStatus] = []
@@ -1009,8 +989,8 @@ public final class ClaudeIntegrationSettingsModel {
             // fallback: name and alias are separate fields, so `prod` named
             // over alias `builder` would have sent the new token to whatever
             // answers to `prod` (review finding, PR #197). A host enrolled
-            // before the alias was persisted gets the placeholder and copy-only
-            // commands, which is honest about what we know.
+            // before the alias was persisted gets the placeholder and cannot
+            // run setup until it is re-enrolled with an explicit alias.
             let alias = enrollment.host.sshHostAlias
             let plan = try ClaudeRemoteEnrollmentService.plan(
                 host: enrollment.host,
@@ -1161,12 +1141,6 @@ public final class ClaudeIntegrationSettingsModel {
         setupManualInstructions = nil
     }
 
-    /// Show one host's plugin-update commands in its row.
-    ///
-    /// Needed because `claude plugin install` is not an update: on an installed
-    /// plugin it exits 0 and leaves the old version in place (Claude Code
-    /// 2.1.220), so re-running enrollment does nothing and a host stays on a
-    /// plugin the app has since fixed — silently, because the hooks fail open.
     // MARK: - Shell setup for the plain-ssh join
 
     /// Re-read both halves. Cheap: one `lstat`+read of one rc file, and one
@@ -1197,12 +1171,21 @@ public final class ClaudeIntegrationSettingsModel {
         )
     }
 
-    /// The exact text the user is being asked to allow, or nil when there is
-    /// no shell to write for. Shown before anything is written — the same
-    /// preview-then-consent shape as the ssh-config block.
+    /// Generated shell text retained for the writer and its test seam.
     public var shellSetupPreview: String? {
         guard let shell = loginShell() else { return nil }
         return ClaudeShellRCSetup.snippet(for: shell)
+    }
+
+    public var canApplyShellSetup: Bool { loginShell() != nil }
+
+    public var shellSetupConsentSentence: String {
+        "localvoxtral will edit \(shellRCPathForConsent()) on this Mac."
+    }
+
+    public func hostSetupConsentSentence(sshHostAlias: String) -> String {
+        "localvoxtral will edit ~/.ssh/config and \(shellRCPathForConsent()) on this Mac "
+            + "and install its plugin on \(sshHostAlias)."
     }
 
     /// Write the block. Consent is the CALLER's to obtain, immediately before.
@@ -1264,12 +1247,14 @@ public final class ClaudeIntegrationSettingsModel {
         statuslineStatus = service.status()
     }
 
-    /// The exact JSON the apply would write, for the preview sheet. Nil when
-    /// the hook binary cannot be located — the row then cannot offer Install.
+    /// Exact generated JSON retained for service tests. Settings never renders
+    /// it.
     public var statuslinePreview: String? {
         guard let hookCommand = statuslineHookCommand() else { return nil }
         return ClaudeStatuslineInstallService.preview(hookCommand: hookCommand)
     }
+
+    public var canApplyStatuslineSetup: Bool { statuslineHookCommand() != nil }
 
     public func applyStatuslineSetup() async {
         guard
@@ -1377,8 +1362,8 @@ public final class ClaudeIntegrationSettingsModel {
         // The ENROLLED alias, never the label: a host named `prod` may be
         // reached over alias `builder`, and `ssh prod …` would then update
         // whatever machine answers to that name (review finding, PR #197).
-        // Hosts enrolled before the alias was persisted have none, and get
-        // copy-only commands rather than a guess.
+        // Hosts enrolled before the alias was persisted have none and must be
+        // re-enrolled rather than targeting a guessed host.
         let alias = host.sshHostAlias.flatMap {
             ClaudeRemoteEnrollmentService.isValidHostAlias($0) ? $0 : nil
         }
@@ -1414,15 +1399,13 @@ public final class ClaudeIntegrationSettingsModel {
         )
     }
 
-    /// Exactly what `performPluginUpdate` will do, in order — and exactly what
-    /// the panel shows and copies. Same text, one source.
+    /// Exactly what `performPluginUpdate` will do, retained as a test seam.
     static func updatePreview(for presentation: PluginUpdatePresentation) -> String {
         presentation.applicationText
     }
 
-    /// Stands in for an alias we were never told. Not a valid target and not
-    /// meant to be one — it is there so the copyable commands read correctly
-    /// with an obvious blank to fill in.
+    /// Stands in for an alias we were never told. It is not a valid target and
+    /// exists only for deterministic plans used by documentation and tests.
     static let unknownAliasPlaceholder = "your-ssh-host"
 
     public func dismissPluginUpdate() {
@@ -1444,7 +1427,7 @@ public final class ClaudeIntegrationSettingsModel {
         presentedPluginUpdate = nil
     }
 
-    /// Ask before running the update commands, repeating the exact pair.
+    /// Ask before running the legacy plugin-only update path.
     public func requestPluginUpdateRun() {
         guard let presentation = presentedPluginUpdate,
               presentation.canRun,
@@ -1473,7 +1456,9 @@ public final class ClaudeIntegrationSettingsModel {
         setupManualInstructions = nil
         enrollmentConfirmation = EnrollmentConfirmation(
             action: .updateHost(hostID: presentation.hostID),
-            title: "Update this remote host?",
+            title: hostSetupConsentSentence(
+                sshHostAlias: presentation.sshHostAlias ?? Self.unknownAliasPlaceholder
+            ),
             preview: setupPreview(
                 sshConfigSnippet: presentation.sshConfigSnippet,
                 remoteCommands: presentation.commands
@@ -1502,7 +1487,7 @@ public final class ClaudeIntegrationSettingsModel {
 
     public func requestRemoteSetup() {
         guard let presentation = presentedPlan,
-              // A placeholder alias must not reach ssh: one-click would hand
+              // A placeholder alias must not reach ssh: automation would hand
               // the new token to whatever answers to a name we invented.
               presentation.canRunRemoteSetup,
               !isEnrollmentBusy,
@@ -1533,7 +1518,7 @@ public final class ClaudeIntegrationSettingsModel {
         setupManualInstructions = nil
         enrollmentConfirmation = EnrollmentConfirmation(
             action: .setupHost,
-            title: "Set up this remote host?",
+            title: hostSetupConsentSentence(sshHostAlias: presentation.sshHostAlias),
             preview: setupPreview(
                 sshConfigSnippet: presentation.plan.sshConfigSnippet,
                 remoteCommands: presentation.plan.remoteCommands
@@ -1600,6 +1585,17 @@ public final class ClaudeIntegrationSettingsModel {
                 + "\nherdr server reload-config"
         )
         return sections.joined(separator: "\n\n")
+    }
+
+    private func shellRCPathForConsent() -> String {
+        guard let shell = loginShell() else { return "your shell startup file" }
+        let relative = ClaudeShellRCSetup.relativeRCPath(for: shell) { relative in
+            FileManager.default.fileExists(
+                atPath: FileManager.default.homeDirectoryForCurrentUser
+                    .appendingPathComponent(relative).path
+            )
+        }
+        return "~/\(relative)"
     }
 
     private func performPlanAction(_ confirmation: EnrollmentConfirmation) async {
@@ -1741,11 +1737,10 @@ public final class ClaudeIntegrationSettingsModel {
             } else {
                 let shellFailure = await performAsync { try writer.apply(shell: shell) }
                 if let shellFailure {
-                    setupManualInstructions = "Add this block to your shell startup file:\n\n"
-                        + ClaudeShellRCSetup.snippet(for: shell)
+                    setupManualInstructions = "Open Details for manual shell setup."
                     markSetup(
                         .shellStartup,
-                        .skipped("The shell startup file was left unchanged; add the shown block manually.")
+                        .skipped("The shell startup file was left unchanged; see Details.")
                     )
                     Log.claudeContext.error(
                         "Claude remote setup skipped shell startup edit: \(shellFailure.describedError, privacy: .public)"
@@ -1755,9 +1750,7 @@ public final class ClaudeIntegrationSettingsModel {
                 }
             }
         } else {
-            setupManualInstructions = loginShell().map {
-                "Add this block to your shell startup file:\n\n" + ClaudeShellRCSetup.snippet(for: $0)
-            } ?? "Export LC_LVX_TTY from your Mac terminal's shell startup file."
+            setupManualInstructions = "Open Details for manual shell setup."
             markSetup(
                 .shellStartup,
                 .skipped("This login shell is not supported for automatic setup; configure it manually.")
@@ -1808,14 +1801,14 @@ public final class ClaudeIntegrationSettingsModel {
             failSetup(
                 .environmentCrossing,
                 reason: "This Mac is not sending LC_LVX_TTY for this SSH host.",
-                remedy: "Keep `SendEnv LC_LVX_TTY` in this host's ~/.ssh/config block."
+                remedy: "Open Details and follow the SSH environment setup."
             )
             return
         default:
             failSetup(
                 .environmentCrossing,
                 reason: "The remote SSH server did not accept LC_LVX_TTY.",
-                remedy: "Add `AcceptEnv LANG LC_*` to sshd_config on the host, then reload sshd."
+                remedy: "Open Details and follow the remote SSH server setup."
             )
             return
         }
@@ -1838,11 +1831,7 @@ public final class ClaudeIntegrationSettingsModel {
         case "notFound":
             markSetup(.remoteHerdr, .skipped("herdr is not installed on the remote host."))
         case "customized":
-            setupManualInstructions = [
-                setupManualInstructions,
-                "The remote herdr agents table is customized. Add this row manually:\n\n"
-                    + ClaudeRemoteEnrollmentService.herdrPanelConfigSnippet,
-            ].compactMap { $0 }.joined(separator: "\n\n")
+            setupManualInstructions = "The remote herdr table is customized; open Details to update it manually."
             markSetup(.remoteHerdr, .skipped("The existing herdr agents table was left unchanged."))
         default:
             markSetup(.remoteHerdr, .done("The remote herdr agents panel is configured."))
@@ -2241,8 +2230,7 @@ public final class ClaudeIntegrationSettingsModel {
             if case .configureHerdrPanel = action { text = "Herdr panel setup failed." }
             let detail: String
             if failure.serviceError == .herdrPanelConfigAlreadyCustomized {
-                detail = "Add this row manually:\n\n"
-                    + ClaudeRemoteEnrollmentService.herdrPanelConfigSnippet
+                detail = "Open Details for the manual herdr configuration."
             } else {
                 detail = failure.describedError
             }
@@ -2283,12 +2271,12 @@ public final class ClaudeIntegrationSettingsModel {
             return "~/.ssh/config is not valid UTF-8, so localvoxtral left it unchanged."
         case .sshConfigIsSymlink:
             return "~/.ssh/config or ~/.ssh is a symlink, likely from a dotfiles setup. "
-                + "localvoxtral won't replace the link. Use Copy and add the block "
+                + "localvoxtral won't replace the link. Open Details and add the block "
                 + "to the real file yourself."
         case .sshDirectoryNotTrusted:
             return "~/.ssh is not exclusively writable by you (wrong owner or group/world-"
-                + "writable), so localvoxtral left it unchanged. Fix its permissions "
-                + "(chmod 700 ~/.ssh) or use the Copy button."
+                + "writable), so localvoxtral left it unchanged. Open Details for the "
+                + "manual remedy."
         case .sshConfigEditingNotConfigured:
             return "Editing ~/.ssh/config is not available in this build."
         case .executionNotConfigured:
@@ -2296,8 +2284,8 @@ public final class ClaudeIntegrationSettingsModel {
         case .invalidHostAlias:
             return "The SSH host alias is invalid."
         case .herdrPanelConfigAlreadyCustomized:
-            return "The remote herdr config already has an agents table or rows key, so localvoxtral left it unchanged. Add this row manually:\n\n"
-                + ClaudeRemoteEnrollmentService.herdrPanelConfigSnippet
+            return "The remote herdr config already has an agents table or rows key, so "
+                + "localvoxtral left it unchanged. Open Details for the manual remedy."
         case .none:
             return failure.describedError
         }

--- a/Sources/localvoxtral/ClaudeContext/ClaudeRemoteEnrollmentService.swift
+++ b/Sources/localvoxtral/ClaudeContext/ClaudeRemoteEnrollmentService.swift
@@ -238,8 +238,8 @@ public struct ClaudeRemoteEnrollmentService: Sendable {
         case runnerFailed(step: Int, command: String, message: String)
         case invalidHostAlias
         /// The remote config already contains an agents table or a rows key.
-        /// Automatic merging would overwrite user intent, so Settings must show
-        /// the snippet for manual placement instead.
+        /// Automatic merging would overwrite user intent, so Settings points
+        /// to the documented manual placement instead.
         case herdrPanelConfigAlreadyCustomized
     }
 
@@ -258,7 +258,7 @@ public struct ClaudeRemoteEnrollmentService: Sendable {
 
     /// Kept next to the installer that verifies it. A manifest contract test
     /// pins this value to the remote plugin's plugin.json.
-    public static let remotePluginVersion = "1.7.0"
+    public static let remotePluginVersion = "1.8.0"
 
     /// The plugin's sensitive userConfig key. Claude Code exposes it to the
     /// plugin's COMMAND-hook shim as `CLAUDE_PLUGIN_OPTION_TOKEN`; the shim
@@ -315,8 +315,8 @@ public struct ClaudeRemoteEnrollmentService: Sendable {
     ///   - sshHostAlias: the `Host` stanza name in `~/.ssh/config`. Validated,
     ///     not escaped — an alias is a bare token and anything else is a mistake
     ///     we should surface rather than quietly rewrite.
-    ///   - token: the plaintext used to generate the copyable command and, after
-    ///     confirmation, its SSH stdin script. Not stored or logged.
+    ///   - token: the plaintext embedded in the generated documentation/test
+    ///     plan and, after consent, its SSH stdin script. Not stored or logged.
     ///   - listenerPort: the port the app listens on, HERE, on this Mac. The
     ///     forward's target.
     ///   - remoteForwardPort: the port the forward binds THERE, on the remote
@@ -466,12 +466,10 @@ public struct ClaudeRemoteEnrollmentService: Sendable {
         ]
     }
 
-    /// Bring an enrolled host to the plugin version this app ships, as a
-    /// copyable set.
+    /// Bring an enrolled host to the plugin version this app ships.
     ///
-    /// Comment-free like everything else the user pastes. What the seven `#`
-    /// lines used to say is on the docs page and in one short line beside the
-    /// panel: re-running setup is NOT an update (on Claude Code 2.1.220
+    /// The generated commands remain a documentation and test seam. The docs
+    /// explain that re-running setup is NOT an update (on Claude Code 2.1.220
     /// `plugin install` exits 0 with "already installed" and `marketplace add`
     /// does not refresh a clone it has), the stored token is preserved, and the
     /// third command only points this host at THIS Mac's allocated port —
@@ -1834,9 +1832,7 @@ public struct ClaudeRemoteEnrollmentService: Sendable {
     /// installer does (`ClaudePluginInstallService.claudeCLICandidates`), plus
     /// nvm-style node bins, and fail with an actionable message instead of
     /// dash's. POSIX sh only — the remote /bin/sh is dash on Debian-family
-    /// hosts. Token-free by construction, like the `set -eu` line: the
-    /// confirmation shows the commands the user authorizes; this is part of
-    /// how they run.
+    /// hosts. Token-free by construction, like the `set -eu` line.
     static let claudePathResolverPreamble = """
         if ! command -v claude >/dev/null 2>&1; then
           for lv_dir in "$HOME/.claude/local" "$HOME/.local/bin" "$HOME/bin" /opt/homebrew/bin /usr/local/bin "$HOME"/.nvm/versions/node/*/bin; do

--- a/Sources/localvoxtral/ClaudeContext/ClaudeShellRCSetup.swift
+++ b/Sources/localvoxtral/ClaudeContext/ClaudeShellRCSetup.swift
@@ -29,8 +29,8 @@ public enum ClaudeShellKind: String, Sendable, CaseIterable {
 /// The whole file is PURE: it turns a shell and some existing text into new
 /// text. Deciding to write anything is the caller's, exactly as it is for
 /// `ClaudeRemoteEnrollmentService.applySSHConfigSnippet` — this app never edits
-/// a user's startup file without showing the exact text first and being told
-/// yes.
+/// a user's startup file without naming the file and obtaining consent first.
+/// The exact text belongs in the linked documentation, not Settings.
 public enum ClaudeShellRCSetup {
     /// The delimiters. Idempotency and removal both ride on them, so they are
     /// content-free and must never carry a host, a path or a version: a marker

--- a/Sources/localvoxtral/ClaudeContext/ClaudeStatuslineInstallService.swift
+++ b/Sources/localvoxtral/ClaudeContext/ClaudeStatuslineInstallService.swift
@@ -9,8 +9,8 @@ import Foundation
 /// line it did not write. A foreign `statusLine` is reported, not replaced;
 /// the README shows how to call our hook from the user's own script instead.
 ///
-/// File discipline mirrors `ClaudeShellRCWriter`: preview the exact text,
-/// write only on explicit consent, refuse symlinks at every path component,
+/// File discipline mirrors `ClaudeShellRCWriter`: write only on explicit
+/// consent, refuse symlinks at every path component,
 /// refuse an unreadable file (never treat it as empty), keep an existing
 /// file's mode (0600 for a new one), write atomically, and stay idempotent
 /// (re-applying writes byte-identical bytes).
@@ -35,14 +35,8 @@ public struct ClaudeStatuslineInstallService: Sendable {
     /// ours.
     public static let statuslineFlag = "--statusline"
 
-    /// The setup sheet's explanation. A constant so tests pin the promise:
-    /// every other entry is kept, but formatting normalizes through the
-    /// JSON round-trip (pretty-printed, sorted keys) — the sheet must never
-    /// claim the file is otherwise byte-untouched.
-    public static let sheetExplanation =
-        "This adds one entry to ~/.claude/settings.json pointing at localvoxtral's publisher, "
-        + "so the Claude Code bottom bar shows whether localvoxtral is connected. "
-        + "Every other entry is kept, and formatting is normalized."
+    public static let consentSentence =
+        "localvoxtral will edit ~/.claude/settings.json on this Mac."
 
     private let fileSystem: (any ClaudeStatuslineFileSystem)?
     /// Whether an invoked path resolves to an existing executable. Injected

--- a/Sources/localvoxtral/ClaudeContext/OpencodePluginInstallService.swift
+++ b/Sources/localvoxtral/ClaudeContext/OpencodePluginInstallService.swift
@@ -29,6 +29,9 @@ import Foundation
 /// read-modify-write with no interlock, so a hand-edit landing between our
 /// read and our rename loses to our stale snapshot (last-writer-wins).
 public struct OpencodePluginInstallService: Sendable {
+    public static let consentSentence =
+        "localvoxtral will edit ~/.config/opencode/plugins/localvoxtral.js and "
+        + "~/.config/opencode/tui.json on this Mac."
     /// The entry this service owns inside `tui.json`'s `plugin` list, exactly
     /// as the plugin README documents it.
     public static let tuiPluginEntry = "./plugins/localvoxtral.js"

--- a/Sources/localvoxtral/SettingsView.swift
+++ b/Sources/localvoxtral/SettingsView.swift
@@ -1055,11 +1055,6 @@ private struct ClaudePluginInstallRow: View {
 }
 
 /// The opt-in connection indicator in Claude Code's bottom bar.
-///
-/// Install previews the exact JSON first and writes only on consent — the
-/// same shape as the shell setup, for the same reason: this edits a file the
-/// user owns. A foreign status line is never overwritten: no Install button,
-/// only a link to the recipe that runs both.
 private struct ClaudeStatuslineRow: View {
     @Bindable var model: ClaudeIntegrationSettingsModel
     @State private var isShowingSetup = false
@@ -1075,12 +1070,12 @@ private struct ClaudeStatuslineRow: View {
                 switch model.statuslineStatus {
                 case .notConfigured:
                     Button("Set up…") { isShowingSetup = true }
-                        .disabled(model.statuslinePreview == nil)
+                        .disabled(!model.canApplyStatuslineSetup)
                         .accessibilityIdentifier("integrations.claude.statusline.install")
                 case .installed, .stalePath:
                     Button("Update…") { isShowingSetup = true }
                         .disabled(
-                            model.isPerformingStatuslineAction || model.statuslinePreview == nil
+                            model.isPerformingStatuslineAction || !model.canApplyStatuslineSetup
                         )
                         .accessibilityIdentifier("integrations.claude.statusline.install")
                     Button("Remove") { Task { await model.removeStatusline() } }
@@ -1111,19 +1106,19 @@ private struct ClaudeStatuslineRow: View {
 
 /// Install/remove the opencode plugin.
 ///
-/// Acts on press: the copy target is a file this app owns, and the `tui.json`
-/// edit touches only this plugin's own list entry — everything else
-/// round-trips. Failures report one short line here and the detail in an
-/// alert (owner rule).
+/// Installation is confirmed in a consent sheet because it writes both the
+/// plugin and the user's `tui.json`. Failures report one short line here and
+/// the detail in an alert (owner rule).
 private struct OpencodePluginRow: View {
     @Bindable var model: ClaudeIntegrationSettingsModel
+    @State private var isShowingSetup = false
 
     var body: some View {
         // Stacked like the Claude Code rows: button bar plus status line.
         SettingsFieldRow(title: "opencode", layout: .stacked) {
             HStack(spacing: 8) {
-                Button("Install") {
-                    Task { await model.installOpencodePlugin() }
+                Button(model.opencodeStatus == .notInstalled ? "Set up…" : "Update…") {
+                    isShowingSetup = true
                 }
                 .disabled(model.isPerformingOpencodeAction)
                 .accessibilityIdentifier("integrations.opencode.install")
@@ -1144,6 +1139,9 @@ private struct OpencodePluginRow: View {
                 .foregroundStyle(.secondary)
                 .lineLimit(1)
                 .accessibilityIdentifier("integrations.opencode.status")
+        }
+        .sheet(isPresented: $isShowingSetup) {
+            OpencodePluginSetupSheet(model: model) { isShowingSetup = false }
         }
     }
 }
@@ -1200,7 +1198,7 @@ private struct ClaudeCmuxPasswordSettingsRow: View {
     }
 }
 
-/// Enrolled SSH hosts, and the preview-first setup for each.
+/// Enrolled SSH hosts and their automated setup flow.
 private struct ClaudeRemoteHostsSettingsRow: View {
     @Bindable var model: ClaudeIntegrationSettingsModel
     @State private var isShowingShellSetup = false
@@ -1228,7 +1226,6 @@ private struct ClaudeRemoteHostsSettingsRow: View {
                     enrollmentForm
                     listenerStatus
                     shellSetup
-                    herdrPanelSetup
                 }
             }
         }
@@ -1261,9 +1258,7 @@ private struct ClaudeRemoteHostsSettingsRow: View {
         }
     }
 
-    /// The plain-ssh join's one setup step: two short sentences and a button,
-    /// inside the group that already exists. Nothing is written until the sheet
-    /// has shown the exact text and been confirmed.
+    /// The plain-ssh join's local shell setup.
     @ViewBuilder
     private var shellSetup: some View {
         HStack(spacing: 8) {
@@ -1288,7 +1283,7 @@ private struct ClaudeRemoteHostsSettingsRow: View {
             }
             Button("Set up…") { isShowingShellSetup = true }
                 .controlSize(.small)
-                .disabled(model.shellSetupPreview == nil)
+                .disabled(!model.canApplyShellSetup)
                 .accessibilityIdentifier("claude.remote.shellSetup.setUp")
         }
     }
@@ -1384,118 +1379,54 @@ private struct ClaudeRemoteHostsSettingsRow: View {
         }
     }
 
-    /// One host's plugin-update commands, disclosed in that host's row.
-    ///
-    /// In the row rather than a new group, and confirmed and reported where the
-    /// button is (PR #194): a result the user has to go looking for is a result
-    /// they conclude never happened.
+    /// One host's automated update, kept inside that host's row.
     @ViewBuilder
     private func pluginUpdatePanel(for host: ClaudeIntegrationSettingsModel.HostRow) -> some View {
         if let update = model.presentedPluginUpdate, update.hostID == host.id {
-            // BOTH mutations, in order — not just the remote commands. The
-            // copy-only paths (no recorded alias; the symlink refusal that
-            // sends the user here) are exactly where showing only the commands
-            // recreated the split brain this feature exists to remove.
-            let commands = update.applicationText
-            let action = ClaudeIntegrationSettingsModel.EnrollmentAction.updateRemotePlugin(hostID: host.id)
-            let pendingConfirmation = model.enrollmentConfirmation.flatMap {
-                $0.action == action ? $0 : nil
-            }
             VStack(alignment: .leading, spacing: 4) {
-                HStack {
-                    Text("Update the plugin on \(host.label)").font(.caption).bold()
-                    Spacer()
-                    Button("Copy") {
-                        // No token here — the update keeps the stored one — but
-                        // concealed anyway, so a Settings copy cannot ride into
-                        // the next polish prompt's clipboard context.
-                        ConcealedPasteboardWriter.write(commands)
-                    }
-                    .controlSize(.small)
-                    Button("Close") { model.dismissPluginUpdate() }
-                        .controlSize(.small)
-                        .disabled(model.isEnrollmentBusy)
-                }
-                // The displayed block IS the confirmation preview, highlighted
-                // while the question is pending, so confirming still repeats the
-                // exact commands it authorizes.
-                Text(commands)
-                    .font(.system(size: 12, design: .monospaced))
-                    .textSelection(.enabled)
-                    .frame(maxWidth: .infinity, alignment: .leading)
-                    .padding(8)
-                    .background(
-                        pendingConfirmation != nil
-                            ? Color.orange.opacity(0.10) : Color.secondary.opacity(0.08),
-                        in: RoundedRectangle(cornerRadius: 4)
-                    )
-                if let confirmation = pendingConfirmation {
-                    Text(confirmation.title).font(.body).bold()
-                    HStack {
-                        Button("Cancel") { model.cancelEnrollmentActionConfirmation() }
-                        Button(confirmation.confirmButtonTitle) {
-                            Task { await model.confirmEnrollmentAction() }
+                Text("Update \(host.label)").font(.caption).bold()
+                if let alias = update.sshHostAlias {
+                    Text(model.hostSetupConsentSentence(sshHostAlias: alias))
+                        .font(.caption)
+                        .fixedSize(horizontal: false, vertical: true)
+                    Link("Details", destination: Self.remoteSetupDocumentationURL)
+                        .font(.caption)
+                    if !model.isEnrollmentBusy {
+                        HStack(spacing: 8) {
+                            Button("Cancel") { model.dismissPluginUpdate() }
+                                .controlSize(.small)
+                            Button("Set Up") {
+                                Task {
+                                    model.requestHostUpdateRun()
+                                    await model.confirmEnrollmentAction()
+                                }
+                            }
+                            .buttonStyle(.borderedProminent)
+                            .controlSize(.small)
+                            .accessibilityIdentifier("integrations.remote.setup.run")
                         }
-                        .buttonStyle(.borderedProminent)
                     }
-                    .controlSize(.small)
-                } else if update.canRun {
-                    HStack(spacing: 8) {
-                        Button("Run on SSH host") { model.requestPluginUpdateRun() }
-                            .controlSize(.small)
-                            .disabled(model.isEnrollmentBusy)
-                        Button("Update Host") { model.requestHostUpdateRun() }
-                            .controlSize(.small)
-                            .disabled(model.isEnrollmentBusy)
-                    }
-                    updateHostConfirmation(for: host)
                 } else {
-                    Text("Replace your-ssh-host with the alias from your ~/.ssh/config, then apply both steps above yourself. Do the ssh-config block first.")
+                    Text("Re-enroll this host before updating it because its SSH alias was not recorded.")
                         .font(.caption)
                         .foregroundStyle(.secondary)
+                    HStack(spacing: 8) {
+                        Button("Cancel") { model.dismissPluginUpdate() }
+                            .controlSize(.small)
+                        Link("Details", destination: Self.remoteSetupDocumentationURL)
+                            .font(.caption)
+                    }
                 }
-                if model.setupRun?.hostID == host.id {
-                    ClaudeSetupRunSteps(model: model, hostID: host.id)
-                }
-                if model.enrollmentResultsAction == action {
-                    ClaudeEnrollmentStepResults(statuses: model.enrollmentStepStatuses)
-                }
+                ClaudeSetupRunSteps(model: model, hostID: host.id)
             }
             .padding(.leading, 8)
             .padding(.bottom, 4)
         }
     }
 
-    /// The one-flow update's consent, inside the row whose button asked for it.
-    ///
-    /// Same shape as the plugin-update confirmation above it: the exact preview
-    /// the run will apply, then one confirming button. The run's own step list
-    /// renders below, shared with the enrollment sheet.
-    @ViewBuilder
-    private func updateHostConfirmation(
-        for host: ClaudeIntegrationSettingsModel.HostRow
-    ) -> some View {
-        let action = ClaudeIntegrationSettingsModel.EnrollmentAction.updateHost(hostID: host.id)
-        if let confirmation = model.enrollmentConfirmation,
-           confirmation.action == action {
-            Text(confirmation.title).font(.body).bold()
-            Text(confirmation.preview)
-                .font(.system(size: 12, design: .monospaced))
-                .textSelection(.enabled)
-                .frame(maxWidth: .infinity, alignment: .leading)
-                .padding(8)
-                .background(Color.orange.opacity(0.10), in: RoundedRectangle(cornerRadius: 4))
-            HStack {
-                Button("Cancel") { model.cancelEnrollmentActionConfirmation() }
-                Button(confirmation.confirmButtonTitle) {
-                    Task { await model.confirmEnrollmentAction() }
-                }
-                .buttonStyle(.borderedProminent)
-                .accessibilityIdentifier("integrations.remote.setup.run")
-            }
-            .controlSize(.small)
-        }
-    }
+    private static let remoteSetupDocumentationURL = URL(
+        string: "https://github.com/T0mSIlver/localvoxtral/blob/main/docs/remote-claude-context.md"
+    )!
 
     private var enrollmentForm: some View {
         HStack(spacing: 8) {
@@ -1530,67 +1461,6 @@ private struct ClaudeRemoteHostsSettingsRow: View {
         }
     }
 
-    @ViewBuilder
-    private var herdrPanelSetup: some View {
-        if let message = model.herdrPanelStatus.message {
-            SettingsInlineMessage(message, color: .orange)
-            Text(ClaudeRemoteEnrollmentService.herdrPanelConfigSnippet)
-                .font(.system(.caption2, design: .monospaced))
-                .textSelection(.enabled)
-                .padding(6)
-                .background(Color.secondary.opacity(0.08), in: RoundedRectangle(cornerRadius: 4))
-            ForEach(model.hosts.filter { !$0.isRevoked && $0.sshHostAlias != nil }) { host in
-                let action = ClaudeIntegrationSettingsModel.EnrollmentAction.configureHerdrPanel(
-                    hostID: host.id
-                )
-                if let confirmation = model.enrollmentConfirmation,
-                   confirmation.action == action {
-                    Text(confirmation.title).font(.caption).bold()
-                    HStack {
-                        Button("Cancel") { model.cancelEnrollmentActionConfirmation() }
-                        Button(confirmation.confirmButtonTitle) {
-                            Task { await model.confirmEnrollmentAction() }
-                        }
-                        .buttonStyle(.borderedProminent)
-                    }
-                    .controlSize(.small)
-                } else {
-                    Button("Configure on \(host.label)…") {
-                        model.requestHerdrPanelConfiguration(hostID: host.id)
-                    }
-                    .controlSize(.small)
-                }
-                if model.enrollmentResultsAction == action {
-                    ClaudeEnrollmentStepResults(statuses: model.enrollmentStepStatuses)
-                }
-            }
-        }
-    }
-}
-
-/// One action's outcome, rendered inside the section whose button ran it.
-///
-/// A pooled results area below step 2 is how a step-1 success went unseen in the
-/// field and got re-confirmed — so the caller places this, and the model's
-/// `enrollmentResultsAction` decides which caller gets to.
-private struct ClaudeEnrollmentStepResults: View {
-    let statuses: [ClaudeIntegrationSettingsModel.EnrollmentStepStatus]
-
-    var body: some View {
-        if !statuses.isEmpty {
-            // One line per step, and no command output: raw remote text is the
-            // alert's and the log's job (owner rule), and at .caption2 in a
-            // 90pt scroller nobody read it anyway.
-            VStack(alignment: .leading, spacing: 4) {
-                ForEach(statuses) { step in
-                    Text("\(step.succeeded ? "✓" : "✗") \(step.text)")
-                        .font(.body)
-                        .foregroundStyle(step.succeeded ? AnyShapeStyle(.primary) : AnyShapeStyle(.orange))
-                        .lineLimit(1)
-                }
-            }
-        }
-    }
 }
 
 /// One consented setup run, one line per step.
@@ -1603,38 +1473,39 @@ private struct ClaudeSetupRunSteps: View {
     var hostID: String
 
     var body: some View {
-        if let run = model.setupRun, run.hostID == hostID {
-            VStack(alignment: .leading, spacing: 4) {
-                ForEach(run.items) { item in
-                    HStack(spacing: 6) {
-                        Text(Self.glyph(for: item.state))
+        let activeRun = model.setupRun.flatMap { $0.hostID == hostID ? $0 : nil }
+        let items = activeRun?.items ?? RemoteHostSetupRun.Step.allCases.map {
+            RemoteHostSetupRun.Item(step: $0, state: .pending)
+        }
+        VStack(alignment: .leading, spacing: 4) {
+            ForEach(items) { item in
+                HStack(spacing: 6) {
+                    Text(Self.glyph(for: item.state))
+                        .font(.body)
+                        .foregroundStyle(
+                            Self.isFailure(item.state)
+                                ? AnyShapeStyle(.orange) : AnyShapeStyle(.primary))
+                    VStack(alignment: .leading, spacing: 1) {
+                        Text(item.step.title)
                             .font(.body)
-                            .foregroundStyle(
-                                Self.isFailure(item.state)
-                                    ? AnyShapeStyle(.orange) : AnyShapeStyle(.primary))
-                        VStack(alignment: .leading, spacing: 1) {
-                            Text(item.step.title)
-                                .font(.body)
-                            Text(Self.statusLine(for: item.state))
-                                .font(.caption)
-                                .foregroundStyle(.secondary)
-                        }
+                        Text(Self.statusLine(for: item.state))
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
                     }
-                    .lineLimit(1)
-                    .accessibilityIdentifier("integrations.remote.setup.step.\(item.step.rawValue)")
                 }
+                .lineLimit(1)
+                .accessibilityIdentifier("integrations.remote.setup.step.\(item.step.rawValue)")
             }
-            if model.isEnrollmentBusy {
-                Button("Cancel") { model.cancelSetupRun() }
-                    .controlSize(.small)
-                    .accessibilityIdentifier("integrations.remote.setup.cancel")
-            }
-            if let manual = model.setupManualInstructions {
-                Text(manual)
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
-                    .textSelection(.enabled)
-            }
+        }
+        if activeRun != nil, model.isEnrollmentBusy {
+            Button("Cancel") { model.cancelSetupRun() }
+                .controlSize(.small)
+                .accessibilityIdentifier("integrations.remote.setup.cancel")
+        }
+        if activeRun != nil, let manual = model.setupManualInstructions {
+            Text(manual)
+                .font(.caption)
+                .foregroundStyle(.secondary)
         }
     }
 
@@ -1664,12 +1535,7 @@ private struct ClaudeSetupRunSteps: View {
     }
 }
 
-/// The token, shown exactly once.
-///
-/// The registry stores only hashes, so this sheet is genuinely the user's one
-/// chance to copy the credential — there is no "show it again". The copy says so
-/// plainly, and the recovery path (rotate) is one button away in the pane behind
-/// it.
+/// One consent sentence and the six-step automated setup run.
 private struct ClaudeRemoteEnrollmentSheet: View {
     @Bindable var model: ClaudeIntegrationSettingsModel
     let presentation: ClaudeIntegrationSettingsModel.EnrollmentPresentation
@@ -1679,17 +1545,10 @@ private struct ClaudeRemoteEnrollmentSheet: View {
         string: "https://github.com/T0mSIlver/localvoxtral/blob/main/docs/remote-claude-context.md"
     )!
 
-    private var plan: ClaudeRemoteEnrollmentService.SetupPlan { presentation.plan }
-
-    /// The preview sheet exists to be photographed, so nothing in it may act.
-    /// The model refuses a preview presentation on every entry point; this only
-    /// stops the buttons looking live.
-    private var actionsDisabled: Bool { model.isEnrollmentBusy || presentation.isPreview }
-
     var body: some View {
         VStack(alignment: .leading, spacing: 14) {
             HStack(spacing: 8) {
-                Text(presentation.isRotation ? "New token for \(presentation.host.label)" : "Enroll \(presentation.host.label)")
+                Text(presentation.isRotation ? "Set up \(presentation.host.label) again" : "Set up \(presentation.host.label)")
                     .font(.headline)
                 if presentation.isPreview {
                     Text("Preview")
@@ -1701,60 +1560,20 @@ private struct ClaudeRemoteEnrollmentSheet: View {
             }
 
             if presentation.isRotation {
-                Text("The previous token stopped working immediately. This host has no access until you run step 2 again with the new token.")
+                Text("The previous token stopped working immediately. Set up this host to restore access.")
                     .font(.body)
                     .foregroundStyle(.secondary)
             }
 
-            ScrollView {
-                VStack(alignment: .leading, spacing: 16) {
-                    section(
-                        "Copy the token now",
-                        body: presentation.token,
-                        note: "It cannot be shown again. If you lose it, rotate."
-                    )
-                    setupRunSection
-                    section(
-                        "1. Add the SSH config",
-                        body: plan.sshConfigSnippet,
-                        primaryActionTitle: "Insert into ~/.ssh/config",
-                        enrollmentAction: .insertSSHConfig,
-                        action: { model.requestSSHConfigInsertion() }
-                    )
-                    // No Run button when the alias is the placeholder: this host
-                    // was enrolled before the alias was persisted, so we do not
-                    // know where to send a token. Copy still works.
-                    section(
-                        "2. Install on the host",
-                        body: plan.remoteCommands.joined(separator: "\n"),
-                        displayedBody: ClaudeIntegrationSettingsModel.redactedRemoteCommands(for: presentation),
-                        note: presentation.canRunRemoteSetup
-                            ? "The token never enters a process argument on this Mac. On the host it is in the install command arguments while it runs, and stored under ~/.claude after. Rotate if that host is shared."
-                            : "Replace \(ClaudeIntegrationSettingsModel.unknownAliasPlaceholder) with the alias from your ~/.ssh/config and run these yourself. This host was enrolled before localvoxtral recorded its alias.",
-                        primaryActionTitle: presentation.canRunRemoteSetup ? "Run on SSH host" : nil,
-                        enrollmentAction: .runRemoteSetup,
-                        action: presentation.canRunRemoteSetup ? { model.requestRemoteSetup() } : nil
-                    )
-                    section(
-                        "3. Show the dictation indicator in herdr",
-                        body: ClaudeRemoteEnrollmentService.herdrPanelConfigSnippet,
-                        note: "After confirmation, localvoxtral appends this only when no agents table or rows key exists. Otherwise it leaves the file unchanged.",
-                        primaryActionTitle: presentation.canRunRemoteSetup ? "Configure on SSH host" : nil,
-                        enrollmentAction: .configureHerdrPanel(hostID: presentation.host.id),
-                        action: presentation.canRunRemoteSetup
-                            ? { model.requestHerdrPanelConfiguration(hostID: presentation.host.id) }
-                            : nil
-                    )
-                    verificationSection
-                    section(
-                        "Update later",
-                        body: plan.updateCommands.joined(separator: "\n"),
-                        note: "Re-running step 2 does not update the plugin."
-                    )
+            Text(model.hostSetupConsentSentence(sshHostAlias: presentation.sshHostAlias))
+                .font(.body)
+                .fixedSize(horizontal: false, vertical: true)
+            Link("Details", destination: Self.documentationURL)
+                .font(.body)
 
-                    Link("Uninstall or check manually", destination: Self.documentationURL)
-                        .font(.body)
-                }
+            ScrollView {
+                ClaudeSetupRunSteps(model: model, hostID: presentation.host.id)
+                    .frame(maxWidth: .infinity, alignment: .leading)
             }
             .frame(minHeight: 280)
 
@@ -1763,167 +1582,26 @@ private struct ClaudeRemoteEnrollmentSheet: View {
                     ProgressView().controlSize(.small)
                 }
                 Spacer()
-                Button("Done", action: onDismiss).keyboardShortcut(.defaultAction)
-                    .disabled(model.isEnrollmentBusy)
+                if !model.isEnrollmentBusy {
+                    Button("Cancel", action: onDismiss)
+                        .accessibilityIdentifier("integrations.remote.setup.cancel")
+                    if presentation.canRunRemoteSetup {
+                        Button("Set Up") {
+                            Task {
+                                model.requestHostSetup()
+                                await model.confirmEnrollmentAction()
+                            }
+                        }
+                        .buttonStyle(.borderedProminent)
+                        .keyboardShortcut(.defaultAction)
+                        .disabled(presentation.isPreview)
+                        .accessibilityIdentifier("integrations.remote.setup.run")
+                    }
+                }
             }
         }
         .padding(18)
-        .frame(width: 580, height: 580)
-    }
-
-    /// The one flow: every numbered step below, in order, each self-verifying.
-    ///
-    /// Consent covers the whole run at once — the preview names what lands on
-    /// this Mac (the ssh block, the shell block) and what runs on the host —
-    /// and the run stops at the first failure with its remedy. The numbered
-    /// sections stay for copying each step by hand.
-    private var setupRunSection: some View {
-        VStack(alignment: .leading, spacing: 6) {
-            Text("Set up this host").font(.headline)
-            Text("Runs all six steps in order, stopping at the first failure with its remedy.")
-                .font(.caption)
-                .foregroundStyle(.secondary)
-            let action = ClaudeIntegrationSettingsModel.EnrollmentAction.setupHost
-            if let confirmation = model.enrollmentConfirmation,
-               confirmation.action == action {
-                Text(confirmation.preview)
-                    .font(.system(size: 12, design: .monospaced))
-                    .textSelection(.enabled)
-                    .frame(maxWidth: .infinity, alignment: .leading)
-                    .padding(8)
-                    .background(Color.orange.opacity(0.10), in: RoundedRectangle(cornerRadius: 4))
-                Text(confirmation.title).font(.body).bold()
-                HStack {
-                    Button("Cancel") { model.cancelEnrollmentActionConfirmation() }
-                    Button(confirmation.confirmButtonTitle) {
-                        Task { await model.confirmEnrollmentAction() }
-                    }
-                    .buttonStyle(.borderedProminent)
-                    .accessibilityIdentifier("integrations.remote.setup.run")
-                }
-                .controlSize(.small)
-            } else if !model.isEnrollmentBusy {
-                // Re-runnable on purpose: a failed run's remedy is usually
-                // "fix that, then run it again", and the reset (`setupRun`
-                // is cleared by `requestHostSetup`) makes the new run's list
-                // replace the old one rather than append to it.
-                Button("Run Setup", action: { model.requestHostSetup() })
-                    .buttonStyle(.borderedProminent)
-                    .controlSize(.small)
-                    .disabled(actionsDisabled || !presentation.canRunRemoteSetup)
-            }
-            ClaudeSetupRunSteps(model: model, hostID: presentation.host.id)
-        }
-    }
-
-    /// Step 3: the app runs the checks and states the verdict.
-    ///
-    /// There is nothing to copy here on purpose. The commands this replaced
-    /// needed a dozen `#` lines to explain their own output — that a forward
-    /// failure can be healthy, that HTTP 401 is the success signal — and a
-    /// person still read healthy output as broken (field report 2026-07-26).
-    /// Interpretation belongs in code.
-    private var verificationSection: some View {
-        VStack(alignment: .leading, spacing: 6) {
-            Text("4. Check the setup").font(.headline)
-            Text(
-                presentation.canRunRemoteSetup
-                    ? "Runs two read-only checks over SSH. Changes nothing."
-                    // Same reason step 2 withholds its button: with no alias on
-                    // file, checking the placeholder would report on whatever
-                    // machine answers to that name.
-                    : "Unavailable until this host's SSH alias is known. localvoxtral did not record one when it was enrolled. Re-enrol it, or run the checks from the linked page yourself."
-            )
-            .font(.caption)
-            .foregroundStyle(.secondary)
-            Button("Check setup") { Task { await model.runVerification() } }
-                .controlSize(.small)
-                .disabled(actionsDisabled || !presentation.canRunRemoteSetup)
-            ForEach(model.verificationChecks) { check in
-                VStack(alignment: .leading, spacing: 1) {
-                    Text("\(check.passed ? "✓" : "✗") \(check.title): \(check.summary)")
-                        .font(.body)
-                        .foregroundStyle(check.passed ? AnyShapeStyle(.primary) : AnyShapeStyle(.orange))
-                    if let hint = check.hint {
-                        Text(hint).font(.caption).foregroundStyle(.secondary)
-                    }
-                }
-            }
-        }
-    }
-
-    @ViewBuilder
-    private func sectionResults(for enrollmentAction: ClaudeIntegrationSettingsModel.EnrollmentAction) -> some View {
-        if model.enrollmentResultsAction == enrollmentAction {
-            ClaudeEnrollmentStepResults(statuses: model.enrollmentStepStatuses)
-        }
-    }
-
-    private func section(
-        _ title: String,
-        body: String,
-        displayedBody: String? = nil,
-        note: String? = nil,
-        primaryActionTitle: String? = nil,
-        enrollmentAction: ClaudeIntegrationSettingsModel.EnrollmentAction? = nil,
-        action: (() -> Void)? = nil
-    ) -> some View {
-        // The confirmation lives in the section whose button requested it, so
-        // "Confirm" is always next to the thing it confirms. The displayed body
-        // above the buttons IS the confirmation preview (the plan's exact
-        // snippet for step 1, the redacted commands for step 2) — highlighted
-        // while the question is pending, so the second explicit confirmation
-        // still repeats the exact text it authorizes.
-        let pendingConfirmation = model.enrollmentConfirmation.flatMap { confirmation in
-            confirmation.action == enrollmentAction ? confirmation : nil
-        }
-        return VStack(alignment: .leading, spacing: 6) {
-            Text(title).font(.headline)
-            Text(displayedBody ?? body)
-                .font(.system(size: 12, design: .monospaced))
-                .textSelection(.enabled)
-                .frame(maxWidth: .infinity, alignment: .leading)
-                .padding(8)
-                .background(
-                    pendingConfirmation != nil
-                        ? Color.orange.opacity(0.10) : Color.secondary.opacity(0.08),
-                    in: RoundedRectangle(cornerRadius: 4)
-                )
-            if let note {
-                Text(note).font(.caption).foregroundStyle(.secondary)
-            }
-            if let confirmation = pendingConfirmation {
-                Text(confirmation.title).font(.body).bold()
-                HStack {
-                    Button("Cancel") { model.cancelEnrollmentActionConfirmation() }
-                    Button(confirmation.confirmButtonTitle) {
-                        Task { await model.confirmEnrollmentAction() }
-                    }
-                    .buttonStyle(.borderedProminent)
-                }
-                .controlSize(.small)
-            } else {
-                HStack(spacing: 8) {
-                    if let primaryActionTitle, let action {
-                        Button(primaryActionTitle, action: action)
-                            .buttonStyle(.borderedProminent)
-                            .controlSize(.small)
-                            .disabled(actionsDisabled)
-                    }
-                    Button("Copy") {
-                        // Everything in this sheet embeds or accompanies the
-                        // enrollment token — concealed, so clipboard managers
-                        // and our own clipboard-context harvester skip it (F4).
-                        // Copy stays live in a preview: it mutates nothing.
-                        ConcealedPasteboardWriter.write(body)
-                    }
-                    .controlSize(.small)
-                }
-            }
-            if let enrollmentAction {
-                sectionResults(for: enrollmentAction)
-            }
-        }
+        .frame(width: 520, height: 500)
     }
 }
 
@@ -2354,49 +2032,37 @@ private struct SettingsInlineMessage: View {
     }
 }
 
-/// Preview, then consent, then write — the same shape as the enrollment
-/// sheet's ssh-config insert, for the same reason: this edits a file the user
-/// owns and did not ask us to touch.
+/// Consent for the shell startup edit.
 private struct ClaudeShellSetupSheet: View {
     @Bindable var model: ClaudeIntegrationSettingsModel
     var dismiss: () -> Void
+
+    private static let documentationURL = URL(
+        string: "https://github.com/T0mSIlver/localvoxtral/blob/main/docs/remote-claude-context.md"
+    )!
 
     var body: some View {
         VStack(alignment: .leading, spacing: 12) {
             Text("Terminal setup for plain SSH")
                 .font(.headline)
                 .accessibilityIdentifier("claude.shellSetupSheet.title")
-            Text(
-                "This adds one block to \(model.shellSetupStatus.relativeRCPath ?? "your shell startup file"), so a Claude Code session over plain SSH can be matched to the window you are dictating into. Open a new terminal window afterwards. The value is fixed when a session starts."
-            )
-            .font(.callout)
-            .fixedSize(horizontal: false, vertical: true)
-
-            if let preview = model.shellSetupPreview {
-                ScrollView {
-                    Text(preview)
-                        .font(.system(.caption2, design: .monospaced))
-                        .textSelection(.enabled)
-                        .frame(maxWidth: .infinity, alignment: .leading)
-                        .accessibilityIdentifier("claude.shellSetupSheet.preview")
-                }
-                .frame(maxHeight: 180)
-                .padding(6)
-                .background(Color.secondary.opacity(0.08), in: RoundedRectangle(cornerRadius: 4))
-            }
+            Text(model.shellSetupConsentSentence)
+                .font(.callout)
+                .fixedSize(horizontal: false, vertical: true)
+            Link("Details", destination: Self.documentationURL)
 
             HStack {
                 Spacer()
                 Button("Cancel") { dismiss() }
                     .accessibilityIdentifier("claude.shellSetupSheet.cancel")
-                Button("Add to my shell") {
+                Button("Set Up") {
                     Task {
                         await model.applyShellSetup()
                         dismiss()
                     }
                 }
                 .keyboardShortcut(.defaultAction)
-                .disabled(model.shellSetupPreview == nil)
+                .disabled(!model.canApplyShellSetup)
                 .accessibilityIdentifier("claude.shellSetupSheet.apply")
             }
         }
@@ -2405,48 +2071,74 @@ private struct ClaudeShellSetupSheet: View {
     }
 }
 
-/// Preview, then consent, then write — the same shape as the shell setup
-/// sheet, for the same reason: this edits a file the user owns and did not
-/// ask us to touch. Only ever writes the `statusLine` key; a foreign entry
-/// never reaches this sheet (the row offers no button for it).
+/// Consent for the Claude Code status-line edit.
 private struct ClaudeStatuslineSetupSheet: View {
     @Bindable var model: ClaudeIntegrationSettingsModel
     var dismiss: () -> Void
+
+    private static let documentationURL = URL(
+        string: "https://github.com/T0mSIlver/localvoxtral/blob/main/integrations/claude-code/README.md#connection-indicator-opt-in-status-line"
+    )!
 
     var body: some View {
         VStack(alignment: .leading, spacing: 12) {
             Text("Claude Code status line")
                 .font(.headline)
-            Text(ClaudeStatuslineInstallService.sheetExplanation)
-            .font(.callout)
-            .fixedSize(horizontal: false, vertical: true)
-
-            if let preview = model.statuslinePreview {
-                ScrollView {
-                    Text(preview)
-                        .font(.system(.caption2, design: .monospaced))
-                        .textSelection(.enabled)
-                        .frame(maxWidth: .infinity, alignment: .leading)
-                        .accessibilityIdentifier("integrations.statuslineSheet.preview")
-                }
-                .frame(maxHeight: 120)
-                .padding(6)
-                .background(Color.secondary.opacity(0.08), in: RoundedRectangle(cornerRadius: 4))
-            }
+            Text(ClaudeStatuslineInstallService.consentSentence)
+                .font(.callout)
+                .fixedSize(horizontal: false, vertical: true)
+            Link("Details", destination: Self.documentationURL)
 
             HStack {
                 Spacer()
                 Button("Cancel") { dismiss() }
                     .accessibilityIdentifier("integrations.statuslineSheet.cancel")
-                Button("Add status line") {
+                Button("Set Up") {
                     Task {
                         await model.applyStatuslineSetup()
                         dismiss()
                     }
                 }
                 .keyboardShortcut(.defaultAction)
-                .disabled(model.statuslinePreview == nil)
+                .disabled(!model.canApplyStatuslineSetup)
                 .accessibilityIdentifier("integrations.statuslineSheet.apply")
+            }
+        }
+        .padding(16)
+        .frame(width: 460)
+    }
+}
+
+/// Consent for the opencode plugin files.
+private struct OpencodePluginSetupSheet: View {
+    @Bindable var model: ClaudeIntegrationSettingsModel
+    var dismiss: () -> Void
+
+    private static let documentationURL = URL(
+        string: "https://github.com/T0mSIlver/localvoxtral/blob/main/integrations/opencode/README.md#install"
+    )!
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text("opencode plugin")
+                .font(.headline)
+            Text(OpencodePluginInstallService.consentSentence)
+                .font(.callout)
+                .fixedSize(horizontal: false, vertical: true)
+            Link("Details", destination: Self.documentationURL)
+
+            HStack {
+                Spacer()
+                Button("Cancel") { dismiss() }
+                    .accessibilityIdentifier("integrations.opencodeSheet.cancel")
+                Button("Set Up") {
+                    Task {
+                        await model.installOpencodePlugin()
+                        dismiss()
+                    }
+                }
+                .keyboardShortcut(.defaultAction)
+                .accessibilityIdentifier("integrations.opencodeSheet.apply")
             }
         }
         .padding(16)

--- a/Tests/localvoxtralTests/ClaudeHookPublisherTests.swift
+++ b/Tests/localvoxtralTests/ClaudeHookPublisherTests.swift
@@ -325,20 +325,35 @@ final class ClaudeHookPublisherTests: XCTestCase {
         // strings and one silence. Nothing here interpolates anything.
         XCTAssertEqual(
             ClaudeHookPublisher.statusLineText(for: .connected),
-            "\u{1B}[32m\u{25CF}\u{1B}[0m localvoxtral connected"
+            "lvx \u{1B}[32m\u{25CF}\u{1B}[0m"
         )
         XCTAssertEqual(
             ClaudeHookPublisher.statusLineText(for: .sessionUnknown),
-            "\u{1B}[33m\u{25CB}\u{1B}[0m localvoxtral not connected"
+            "lvx \u{1B}[31m\u{25CF}\u{1B}[0m"
         )
         XCTAssertEqual(
             ClaudeHookPublisher.statusLineText(for: .appUnreachable),
-            "\u{1B}[2m\u{25CB} localvoxtral not running\u{1B}[0m"
+            "lvx \u{1B}[90m\u{25CF}\u{1B}[0m"
         )
         XCTAssertNil(
             ClaudeHookPublisher.statusLineText(for: .unparseablePayload),
             "a payload we cannot attribute must render as nothing, not a guess"
         )
+    }
+
+    func testStatusLinePlainTextFallbackUsesThreeFixedStates() {
+        XCTAssertEqual(
+            ClaudeHookPublisher.statusLineText(for: .connected, useColor: false), "lvx ok"
+        )
+        XCTAssertEqual(
+            ClaudeHookPublisher.statusLineText(for: .sessionUnknown, useColor: false), "lvx err"
+        )
+        XCTAssertEqual(
+            ClaudeHookPublisher.statusLineText(for: .appUnreachable, useColor: false), "lvx off"
+        )
+        XCTAssertFalse(ClaudeHookPublisher.statusLineUsesColor(environment: ["NO_COLOR": ""]))
+        XCTAssertFalse(ClaudeHookPublisher.statusLineUsesColor(environment: ["TERM": "dumb"]))
+        XCTAssertTrue(ClaudeHookPublisher.statusLineUsesColor(environment: ["TERM": "xterm-256color"]))
     }
 }
 

--- a/Tests/localvoxtralTests/ClaudeIntegrationSettingsModelTests.swift
+++ b/Tests/localvoxtralTests/ClaudeIntegrationSettingsModelTests.swift
@@ -196,7 +196,7 @@ private struct SetupFlowScript: Sendable {
         exitCode: 0, message: "LVX_HERDR_ABSENT"
     )
     var tunnelMessage = "LVX_HTTP:401"
-    var pluginListMessage = "localvoxtral-remote 1.7.0\n"
+    var pluginListMessage = "localvoxtral-remote 1.8.0\n"
 }
 
 /// A `claude plugin list --json` capture as a login shell delivers it: a
@@ -786,7 +786,7 @@ final class ClaudeIntegrationSettingsModelTests: XCTestCase {
         )
     }
 
-    func testCustomizedHerdrPanelIsLeftUntouchedAndSurfacesTheManualSnippet() async throws {
+    func testCustomizedHerdrPanelIsLeftUntouchedAndPointsToDetailsWithoutCode() async throws {
         let registry = try makeRegistry()
         let service = ClaudeRemoteEnrollmentService(runner: { _ in
             .init(
@@ -810,15 +810,15 @@ final class ClaudeIntegrationSettingsModelTests: XCTestCase {
 
         XCTAssertEqual(model.herdrPanelStatus, .likelyNotConfigured)
         XCTAssertEqual(model.enrollmentStepStatuses.first?.text, "Herdr panel setup failed.")
-        XCTAssertTrue(
-            model.enrollmentStepStatuses.first?.detail.contains(
-                ClaudeRemoteEnrollmentService.herdrPanelConfigSnippet
-            ) == true
+        XCTAssertEqual(
+            model.enrollmentStepStatuses.first?.detail,
+            "Open Details for the manual herdr configuration."
         )
-        XCTAssertTrue(
+        XCTAssertFalse(
             model.alert?.detail.contains(ClaudeRemoteEnrollmentService.herdrPanelConfigSnippet)
                 == true
         )
+        XCTAssertTrue(model.alert?.detail.contains("Open Details") == true)
     }
 
     func testANewEnrollmentSheetDoesNotInheritThePreviousHostsStepResults() async throws {
@@ -1303,22 +1303,17 @@ final class ClaudeIntegrationSettingsModelTests: XCTestCase {
         XCTAssertTrue(model.enrollmentStepStatuses.allSatisfy(\.succeeded))
     }
 
-    /// The half of the blocker that the first fix missed: the executable path
-    /// wrote the ssh block, but the PANEL displayed and copied only the remote
-    /// commands. Both copy-only routes lead straight back to the split brain —
-    /// a host with no recorded alias can ONLY be updated by hand, and the
-    /// symlink refusal deliberately sends the user to that same Copy button.
-    /// So the copy payload has to carry both mutations, in order.
-    func testTheCopyPayloadForAnAliaslessHostCarriesTheSSHBlockToo() async throws {
+    /// The generated documentation seam keeps both halves together even when a
+    /// legacy host cannot be addressed automatically.
+    func testTheGeneratedPlanForAnAliaslessHostCarriesBothPortMutations() async throws {
         let registry = try makeRegistry()
         let filesystem = RecordingSSHConfigFileSystem()
         let service = ClaudeRemoteEnrollmentService(
             runner: { _ in .init(exitCode: 0, message: "ok") },
             sshConfigFileSystem: filesystem
         )
-        // Enrolled before aliases were recorded: copy-only, forever, until the
-        // user re-enrolls. This is the population most likely to still be on a
-        // legacy 8473 block.
+        // Enrolled before aliases were recorded. This population is the most
+        // likely to still have a legacy 8473 block.
         let enrollment = try registry.enroll(label: "buildhost")
         let model = makeModel(
             registry: registry,
@@ -1334,7 +1329,7 @@ final class ClaudeIntegrationSettingsModelTests: XCTestCase {
         let payload = update.applicationText
         XCTAssertTrue(
             payload.contains("RemoteForward 28542 127.0.0.1:8473"),
-            "a copy that omits the ssh block updates the remote and strands this Mac: \(payload)"
+            "a plan that omits the ssh block can strand this Mac: \(payload)"
         )
         XCTAssertTrue(payload.contains("--config 'port=28542'"), payload)
         // Order matters as much as presence: the block first, the remote second.
@@ -1344,9 +1339,9 @@ final class ClaudeIntegrationSettingsModelTests: XCTestCase {
         XCTAssertTrue(payload.contains("~/.ssh/config"), "and it must say where the block goes")
     }
 
-    /// The recovery path after the app refuses to write a symlinked config: the
-    /// user is told to copy, so what they copy must be enough to finish the job.
-    func testTheCopyPayloadAfterASymlinkRefusalStillCarriesTheSSHBlock() async throws {
+    /// A refusal cannot mutate either side, while the generated test seam still
+    /// describes the complete intended migration.
+    func testTheGeneratedPlanSurvivesASymlinkRefusalWithoutRunningRemoteWork() async throws {
         let registry = try makeRegistry()
         let calls = Mutex<[ClaudeRemoteEnrollmentService.Invocation]>([])
         let filesystem = RecordingSSHConfigFileSystem()
@@ -1375,18 +1370,15 @@ final class ClaudeIntegrationSettingsModelTests: XCTestCase {
         await model.confirmEnrollmentAction()
 
         XCTAssertTrue(calls.withLock { $0 }.isEmpty, "the remote must stay untouched")
-        // The panel is still open, and what it offers to copy is the whole job.
         let payload = try XCTUnwrap(model.presentedPluginUpdate).applicationText
         XCTAssertTrue(
             payload.contains("RemoteForward 28542 127.0.0.1:8473"),
-            "the refusal tells the user to copy; copying must hand them both halves: \(payload)"
+            "the retained plan must still describe both halves: \(payload)"
         )
         XCTAssertTrue(payload.contains("--config 'port=28542'"))
     }
 
-    func testThePanelTheConfirmationAndTheCopyAllShowTheSameText() async throws {
-        // Three surfaces rendered the same thing by hand once, and diverged —
-        // that divergence WAS the blocker. One source now.
+    func testThePluginUpdatePlanAndConfirmationTestSeamsUseOneSource() async throws {
         let registry = try makeRegistry()
         let service = ClaudeRemoteEnrollmentService(
             runner: { _ in .init(exitCode: 0, message: "ok") },
@@ -1411,7 +1403,7 @@ final class ClaudeIntegrationSettingsModelTests: XCTestCase {
         XCTAssertEqual(
             try XCTUnwrap(model.enrollmentConfirmation).preview,
             update.applicationText,
-            "the confirmation must be the same text the panel shows and copies"
+            "the retained confirmation seam must use the generated plan"
         )
         XCTAssertEqual(
             ClaudeIntegrationSettingsModel.updatePreview(for: update),
@@ -1517,9 +1509,9 @@ final class ClaudeIntegrationSettingsModelTests: XCTestCase {
         XCTAssertFalse(presentation.plan.updateCommands.joined().contains("ssh prod"))
     }
 
-    func testRotatingAHostEnrolledBeforeAliasesWereRecordedIsCopyOnly() async throws {
+    func testRotatingAHostEnrolledBeforeAliasesWereRecordedRequiresReenrollment() async throws {
         // No alias on file means we do not know where to send the new token,
-        // and a guess is exactly what this PR removed. Copy still works.
+        // and a guess is exactly what this path forbids.
         let registry = try makeRegistry()
         let calls = Mutex(0)
         let service = ClaudeRemoteEnrollmentService(runner: { _ in
@@ -1643,7 +1635,7 @@ final class ClaudeIntegrationSettingsModelTests: XCTestCase {
         XCTAssertNil(model.enrollmentConfirmation)
     }
 
-    func testPluginUpdateIsCopyOnlyForAHostWithNoRecordedAlias() async throws {
+    func testPluginUpdateCannotRunForAHostWithNoRecordedAlias() async throws {
         // Hosts enrolled before the alias was persisted. The row says what it
         // does not know instead of ssh-ing at a name it made up.
         let registry = try makeRegistry()
@@ -2627,6 +2619,16 @@ final class ClaudeIntegrationSettingsModelTests: XCTestCase {
         let model = shellSetupModel(fileSystem: fileSystem, crossing: .seen)
         model.refreshShellSetupStatus()
         XCTAssertEqual(model.shellSetupStatus.rc, .notApplied)
+        XCTAssertEqual(
+            model.shellSetupConsentSentence,
+            "localvoxtral will edit ~/.zshrc on this Mac."
+        )
+        XCTAssertEqual(
+            model.hostSetupConsentSentence(sshHostAlias: "builder"),
+            "localvoxtral will edit ~/.ssh/config and ~/.zshrc on this Mac and install "
+                + "its plugin on builder."
+        )
+        XCTAssertFalse(model.hostSetupConsentSentence(sshHostAlias: "builder").contains("export"))
 
         await model.applyShellSetup()
         XCTAssertEqual(fileSystem.writes, 1)
@@ -2641,26 +2643,17 @@ final class ClaudeIntegrationSettingsModelTests: XCTestCase {
     }
 
     @MainActor
-    func testTheSheetPreviewIsTheEXACTTextThatWillBeWritten() async throws {
-        // Preview-then-consent, like the ssh-config insert: what the user
-        // approved and what lands in their file must be one string, or the
-        // preview is decoration.
+    func testTheGeneratedShellBlockStillMatchesTheWriterExactly() async throws {
         let fileSystem = StubRCFileSystem(state: ClaudeShellRCState())
         let model = shellSetupModel(fileSystem: fileSystem)
         let preview = try XCTUnwrap(model.shellSetupPreview)
 
         await model.applyShellSetup()
         let written = String(decoding: fileSystem.state.data ?? Data(), as: UTF8.self)
-        // EQUALITY on the bytes the writer received, against the preview the
-        // user approved — not `contains`, and not a second call to the same
-        // generator. The earlier version compared the preview to
-        // `snippet(for: .zsh)` and then asserted the write merely CONTAINED
-        // it, which is true of any superset and could not fail (review finding
-        // n1).
         XCTAssertEqual(
             written,
             ClaudeShellRCSetup.apply(to: "", snippet: preview),
-            "what lands in the file is what the sheet showed, byte for byte"
+            "the documentation/test seam must remain byte-identical to the writer"
         )
     }
 
@@ -2671,7 +2664,8 @@ final class ClaudeIntegrationSettingsModelTests: XCTestCase {
         ))
         model.refreshShellSetupStatus()
         XCTAssertEqual(model.shellSetupStatus.rc, .unsupportedShell)
-        XCTAssertNil(model.shellSetupPreview, "the button must be disabled, not wrong")
+        XCTAssertNil(model.shellSetupPreview, "an unsupported shell must not generate a block")
+        XCTAssertFalse(model.canApplyShellSetup)
     }
 
     @MainActor
@@ -2931,7 +2925,12 @@ final class ClaudeIntegrationSettingsModelTests: XCTestCase {
             failedReason(run.items[3].state),
             "This Mac is not sending LC_LVX_TTY for this SSH host."
         )
-        XCTAssertTrue(model.alert?.detail.contains("SendEnv LC_LVX_TTY") == true)
+        XCTAssertEqual(
+            model.alert?.detail,
+            "This Mac is not sending LC_LVX_TTY for this SSH host.\n\n"
+                + "Open Details and follow the SSH environment setup."
+        )
+        XCTAssertFalse(model.alert?.detail.contains("SendEnv") == true)
         XCTAssertEqual(run.items[4].state, .pending, "herdr never ran after the env failure")
     }
 
@@ -2946,7 +2945,12 @@ final class ClaudeIntegrationSettingsModelTests: XCTestCase {
             failedReason(run.items[3].state),
             "The remote SSH server did not accept LC_LVX_TTY."
         )
-        XCTAssertTrue(model.alert?.detail.contains("AcceptEnv LANG LC_*") == true)
+        XCTAssertEqual(
+            model.alert?.detail,
+            "The remote SSH server did not accept LC_LVX_TTY.\n\n"
+                + "Open Details and follow the remote SSH server setup."
+        )
+        XCTAssertFalse(model.alert?.detail.contains("AcceptEnv") == true)
         XCTAssertTrue(recorder.all.contains { $0.argv.contains("-G") })
     }
 
@@ -2961,11 +2965,11 @@ final class ClaudeIntegrationSettingsModelTests: XCTestCase {
             run.items[4].state,
             .skipped("The existing herdr agents table was left unchanged.")
         )
-        XCTAssertTrue(
-            model.setupManualInstructions?.contains(
-                ClaudeRemoteEnrollmentService.herdrPanelConfigSnippet
-            ) == true
+        XCTAssertEqual(
+            model.setupManualInstructions,
+            "The remote herdr table is customized; open Details to update it manually."
         )
+        XCTAssertFalse(model.setupManualInstructions?.contains("[[rows]]") == true)
         XCTAssertEqual(run.items[5].state, .done("The tunnel and remote plugin checks passed."))
         XCTAssertEqual(model.hosts.first?.setupStatusText, "Setup complete.")
     }
@@ -2979,7 +2983,8 @@ final class ClaudeIntegrationSettingsModelTests: XCTestCase {
             run.items[1].state,
             .skipped("This login shell is not supported for automatic setup; configure it manually.")
         )
-        XCTAssertTrue(model.setupManualInstructions?.contains("LC_LVX_TTY") == true)
+        XCTAssertEqual(model.setupManualInstructions, "Open Details for manual shell setup.")
+        XCTAssertFalse(model.setupManualInstructions?.contains("export") == true)
         XCTAssertEqual(run.items[5].state, .done("The tunnel and remote plugin checks passed."))
     }
 

--- a/Tests/localvoxtralTests/ClaudeRemoteEnrollmentServiceTests.swift
+++ b/Tests/localvoxtralTests/ClaudeRemoteEnrollmentServiceTests.swift
@@ -984,6 +984,31 @@ final class ClaudeRemoteEnrollmentServiceTests: XCTestCase {
         )
     }
 
+    func testTheDocsPageListsEveryAutomatedSetupCommandOutsideSettings() throws {
+        let documentation = try documentation()
+        for command in [
+            "ssh -o BatchMode=yes -o ClearAllForwardings=yes -- <alias> /bin/sh -s",
+            "ssh -o BatchMode=yes -- <alias> /bin/sh -s",
+            "ssh -G -- <alias>",
+            "claude plugin list --json",
+            "claude plugin marketplace add T0mSIlver/localvoxtral",
+            "claude plugin marketplace update localvoxtral",
+            "claude plugin update localvoxtral-remote@localvoxtral",
+            "claude plugin install localvoxtral-remote@localvoxtral",
+            "printf 'LVX_TTY:%s\\n' \"${LC_LVX_TTY-}\"",
+            "command -v herdr",
+            "herdr server reload-config",
+            "command -v curl",
+            "/v1/hook/SessionStart",
+            "claude plugin list`",
+        ] {
+            XCTAssertTrue(documentation.contains(command), "missing command documentation: \(command)")
+        }
+        XCTAssertTrue(documentation.contains(ClaudeShellRCSetup.snippet(for: .zsh)))
+        XCTAssertTrue(documentation.contains(ClaudeShellRCSetup.snippet(for: .fish)))
+        XCTAssertTrue(documentation.contains(ClaudeRemoteEnrollmentService.herdrPanelConfigSnippet))
+    }
+
     // MARK: SSH config writing
 
     func testSSHConfigInsertionCreatesFreshDirectoryAndFileWithPrivatePermissions() throws {
@@ -2492,7 +2517,7 @@ final class ClaudeRemoteEnrollmentServiceTests: XCTestCase {
     func testPluginSetupDecodesTheListingAndReportsAnAlreadyCurrentPlugin() throws {
         let calls = PluginSetupCalls()
         let service = ClaudeRemoteEnrollmentService(
-            runner: pluginSetupRunner(before: "1.7.0", after: "1.7.0", calls: calls)
+            runner: pluginSetupRunner(before: "1.8.0", after: "1.8.0", calls: calls)
         )
 
         XCTAssertEqual(
@@ -2516,7 +2541,7 @@ final class ClaudeRemoteEnrollmentServiceTests: XCTestCase {
     func testPluginSetupUpdatesAStalePluginAndReadsTheNewVersionBack() throws {
         let calls = PluginSetupCalls()
         let service = ClaudeRemoteEnrollmentService(
-            runner: pluginSetupRunner(before: "1.4.0", after: "1.7.0", calls: calls)
+            runner: pluginSetupRunner(before: "1.4.0", after: "1.8.0", calls: calls)
         )
         XCTAssertEqual(
             try service.setupRemotePlugin(sshHostAlias: "builder", token: nil, remoteForwardPort: 28_511),
@@ -2530,7 +2555,7 @@ final class ClaudeRemoteEnrollmentServiceTests: XCTestCase {
     func testPluginSetupInstallsAnAbsentPluginWhenItHasAToken() throws {
         let calls = PluginSetupCalls()
         let service = ClaudeRemoteEnrollmentService(
-            runner: pluginSetupRunner(before: nil, after: "1.7.0", calls: calls)
+            runner: pluginSetupRunner(before: nil, after: "1.8.0", calls: calls)
         )
         XCTAssertEqual(
             try service.setupRemotePlugin(sshHostAlias: "builder", token: "t0k", remoteForwardPort: 28_511),
@@ -2554,7 +2579,7 @@ final class ClaudeRemoteEnrollmentServiceTests: XCTestCase {
         ) { error in
             guard case ClaudeRemoteEnrollmentService.ServiceError.commandFailed(_, _, 43, let message) = error
             else { return XCTFail("expected the read-back diagnosis, got \(error)") }
-            XCTAssertEqual(message, "The plugin reports version 1.6.0 after setup, not 1.7.0.")
+            XCTAssertEqual(message, "The plugin reports version 1.6.0 after setup, not 1.8.0.")
         }
     }
 
@@ -2562,13 +2587,13 @@ final class ClaudeRemoteEnrollmentServiceTests: XCTestCase {
         let reference = ClaudeRemoteEnrollmentService.remotePluginReference
         let twoScopes = ClaudeRemoteEnrollmentService.pluginListFrameBegin + "\n"
             + "[{\"id\":\"\(reference)\",\"version\":\"1.2.0\",\"scope\":\"project\"},"
-            + "{\"id\":\"\(reference)\",\"version\":\"1.7.0\",\"scope\":\"user\"}]\n"
+            + "{\"id\":\"\(reference)\",\"version\":\"1.8.0\",\"scope\":\"user\"}]\n"
             + ClaudeRemoteEnrollmentService.pluginListFrameEnd
         XCTAssertEqual(
             try ClaudeRemoteEnrollmentService.installedRemotePluginVersion(
                 inFramedOutput: twoScopes, reference: reference
             ),
-            "1.7.0"
+            "1.8.0"
         )
         XCTAssertNil(
             try ClaudeRemoteEnrollmentService.installedRemotePluginVersion(
@@ -2579,9 +2604,9 @@ final class ClaudeRemoteEnrollmentServiceTests: XCTestCase {
         // A version that merely contains ours is not ours.
         XCTAssertEqual(
             try ClaudeRemoteEnrollmentService.installedRemotePluginVersion(
-                inFramedOutput: Self.framedListing("11.7.0", "user"), reference: reference
+                inFramedOutput: Self.framedListing("11.8.0", "user"), reference: reference
             ),
-            "11.7.0"
+            "11.8.0"
         )
         XCTAssertThrowsError(
             try ClaudeRemoteEnrollmentService.installedRemotePluginVersion(

--- a/Tests/localvoxtralTests/ClaudeRemotePluginManifestTests.swift
+++ b/Tests/localvoxtralTests/ClaudeRemotePluginManifestTests.swift
@@ -447,7 +447,8 @@ final class ClaudeRemotePluginManifestTests: XCTestCase {
     /// (nil = no stamp at all), a status-line payload on stdin, and captures
     /// everything.
     private func runStatusLineRenderer(
-        stamp: String?
+        stamp: String?,
+        environment overrides: [String: String] = [:]
     ) throws -> (exitCode: Int32, stdout: String, stderr: String) {
         let state = FileManager.default.temporaryDirectory
             .appendingPathComponent("statusline-state-\(UUID().uuidString)")
@@ -465,6 +466,9 @@ final class ClaudeRemotePluginManifestTests: XCTestCase {
         process.arguments = [statusLineRendererURL.path]
         var environment = ProcessInfo.processInfo.environment
         environment["XDG_RUNTIME_DIR"] = state.path
+        environment.removeValue(forKey: "NO_COLOR")
+        environment["TERM"] = "xterm-256color"
+        for (key, value) in overrides { environment[key] = value }
         process.environment = environment
         return try Self.runToCompletion(process, stdin: Data(#"{"session_id":"s1"}"#.utf8))
     }
@@ -574,21 +578,21 @@ final class ClaudeRemotePluginManifestTests: XCTestCase {
         let fresh = String(Int(Date().timeIntervalSince1970))
         let stale = String(Int(Date().timeIntervalSince1970) - 3600)
         let cases: [(stamp: String?, expected: String)] = [
-            ("ok \(fresh)", "\(esc)[32m\u{25CF}\(esc)[0m localvoxtral connected\n"),
+            ("ok \(fresh)", "lvx \(esc)[32m\u{25CF}\(esc)[0m\n"),
             // A green light must expire: ok past the staleness gate demotes to
             // the dim no-recent-hooks line rather than claiming a live app.
-            ("ok \(stale)", "\(esc)[2m\u{25CB} localvoxtral no recent hooks\(esc)[0m\n"),
+            ("ok \(stale)", "lvx \(esc)[90m\u{25CF}\(esc)[0m\n"),
             // Freshness is a refinement, never a new failure mode: an epoch we
             // cannot read renders exactly as pre-gate ok did.
-            ("ok not-an-epoch", "\(esc)[32m\u{25CF}\(esc)[0m localvoxtral connected\n"),
-            ("ok", "\(esc)[32m\u{25CF}\(esc)[0m localvoxtral connected\n"),
+            ("ok not-an-epoch", "lvx \(esc)[32m\u{25CF}\(esc)[0m\n"),
+            ("ok", "lvx \(esc)[32m\u{25CF}\(esc)[0m\n"),
             // Failure states are never demoted — stale bad news is still the
             // last known truth, and staying conservative cannot mislead.
-            ("http-401 \(stale)", "\(esc)[33m\u{25CB}\(esc)[0m localvoxtral token rejected\n"),
-            ("http-503 \(fresh)", "\(esc)[33m\u{25CB}\(esc)[0m localvoxtral not connected\n"),
-            ("down \(stale)", "\(esc)[2m\u{25CB} localvoxtral unreachable\(esc)[0m\n"),
-            ("unconfigured \(fresh)", "\(esc)[33m\u{25CB}\(esc)[0m localvoxtral token not configured\n"),
-            (nil, "\(esc)[2m\u{25CB} localvoxtral no hooks yet\(esc)[0m\n"),
+            ("http-401 \(stale)", "lvx \(esc)[31m\u{25CF}\(esc)[0m\n"),
+            ("http-503 \(fresh)", "lvx \(esc)[31m\u{25CF}\(esc)[0m\n"),
+            ("down \(stale)", "lvx \(esc)[90m\u{25CF}\(esc)[0m\n"),
+            ("unconfigured \(fresh)", "lvx \(esc)[31m\u{25CF}\(esc)[0m\n"),
+            (nil, "lvx \(esc)[90m\u{25CF}\(esc)[0m\n"),
         ]
         for (stamp, expected) in cases {
             let result = try runStatusLineRenderer(stamp: stamp)
@@ -604,7 +608,7 @@ final class ClaudeRemotePluginManifestTests: XCTestCase {
         // status line. So the stamp's first token only ever SELECTS a fixed
         // string; unrecognized states render the never-heard-anything default
         // and not one byte of the file.
-        let defaultLine = "\u{1B}[2m\u{25CB} localvoxtral no hooks yet\u{1B}[0m\n"
+        let defaultLine = "lvx \u{1B}[90m\u{25CF}\u{1B}[0m\n"
         for hostile in [
             "$(uname) 1786204746",
             "ok`uname` 1786204746",
@@ -618,6 +622,20 @@ final class ClaudeRemotePluginManifestTests: XCTestCase {
                 result.stdout, defaultLine,
                 "an unrecognized stamp must render the default, never its own bytes"
             )
+            XCTAssertEqual(result.stderr, "")
+        }
+    }
+
+    func testStatusLineRendererUsesPlainTextWhenColorIsDisabled() throws {
+        let fresh = String(Int(Date().timeIntervalSince1970))
+        for (stamp, environment, expected) in [
+            ("ok \(fresh)", ["NO_COLOR": ""], "lvx ok\n"),
+            ("down \(fresh)", ["TERM": "dumb"], "lvx off\n"),
+            ("http-401 \(fresh)", ["NO_COLOR": "1"], "lvx err\n"),
+        ] {
+            let result = try runStatusLineRenderer(stamp: stamp, environment: environment)
+            XCTAssertEqual(result.exitCode, 0)
+            XCTAssertEqual(result.stdout, expected)
             XCTAssertEqual(result.stderr, "")
         }
     }

--- a/Tests/localvoxtralTests/ClaudeStatuslineInstallServiceTests.swift
+++ b/Tests/localvoxtralTests/ClaudeStatuslineInstallServiceTests.swift
@@ -248,19 +248,16 @@ final class ClaudeStatuslineInstallServiceTests: XCTestCase {
         XCTAssertEqual(parsed["command"], Self.hookCommand)
     }
 
-    func testSheetCopyStatesPreservationWithNormalization() {
-        // m4: the preview shows the entry, but Apply rewrites the whole file
-        // with normalized formatting — the sheet must promise preservation,
-        // never byte-stability.
-        XCTAssertTrue(
-            ClaudeStatuslineInstallService.sheetExplanation.contains("formatting is normalized"),
-            "the sheet names the normalization"
+    func testConsentAndApplyStatePreservationWithNormalization() {
+        XCTAssertEqual(
+            ClaudeStatuslineInstallService.consentSentence,
+            "localvoxtral will edit ~/.claude/settings.json on this Mac."
         )
         XCTAssertFalse(
-            ClaudeStatuslineInstallService.sheetExplanation.contains("left alone"),
-            "no byte-stability promise"
+            ClaudeStatuslineInstallService.consentSentence.contains(Self.hookCommand),
+            "the sheet must not render generated JSON or commands"
         )
-        // And the behaviour it describes: content preserved, bytes normalized.
+        // Apply still preserves content while normalizing bytes.
         let existing = Data("{\"z\":1,\"a\":2}".utf8)
         let updated = try? XCTUnwrap(ClaudeStatuslineInstallService.updatedSettingsData(
             existing: existing, hookCommand: Self.hookCommand

--- a/Tests/localvoxtralTests/IntegrationsSettingsModelTests.swift
+++ b/Tests/localvoxtralTests/IntegrationsSettingsModelTests.swift
@@ -9,6 +9,41 @@ import XCTest
 final class IntegrationsSettingsModelTests: XCTestCase {
     // MARK: - Harness
 
+    func testSetupSheetsRenderConsentButNoGeneratedCode() throws {
+        let repoRoot = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+        let source = try String(
+            contentsOf: repoRoot.appendingPathComponent("Sources/localvoxtral/SettingsView.swift"),
+            encoding: .utf8
+        )
+        for forbidden in [
+            "confirmation.preview",
+            "plan.remoteCommands",
+            "plan.updateCommands",
+            "plan.sshConfigSnippet",
+            "herdrPanelConfigSnippet",
+            "claude.shellSetupSheet.preview",
+            "integrations.statuslineSheet.preview",
+            "Run on SSH host",
+        ] {
+            XCTAssertFalse(source.contains(forbidden), "Settings must not render \(forbidden)")
+        }
+        XCTAssertTrue(source.contains("Link(\"Details\""))
+        XCTAssertTrue(source.contains("integrations.remote.setup.step."))
+        XCTAssertTrue(source.contains("integrations.remote.setup.run"))
+        XCTAssertTrue(source.contains("claude.remote.shellSetup.setUp"))
+        XCTAssertTrue(source.contains("claude.shellSetupSheet.apply"))
+        XCTAssertTrue(source.contains("integrations.statuslineSheet.apply"))
+        XCTAssertEqual(
+            OpencodePluginInstallService.consentSentence,
+            "localvoxtral will edit ~/.config/opencode/plugins/localvoxtral.js and "
+                + "~/.config/opencode/tui.json on this Mac."
+        )
+        XCTAssertFalse(OpencodePluginInstallService.consentSentence.contains("mkdir"))
+    }
+
     @MainActor
     private func makeModel(
         fetchPluginListOutput: @escaping @Sendable () async -> String? = { nil },

--- a/docs/agent/invariants.md
+++ b/docs/agent/invariants.md
@@ -669,14 +669,15 @@ there is not.
     wrong costs a non-join with a named cause (`no live session reports this
     terminal's tty`), never a mis-join.
 
-    The setup step is IN THE APP, and follows the ssh-config insert's shape
-    exactly: preview the literal text, write only on explicit consent,
-    idempotent by marker (`ClaudeShellRCSetup`), removable, never silent. Three
+    The setup step is IN THE APP. Its sheet names the rc file in one consent
+    sentence and links to the exact text in the docs; no command or file
+    contents render in Settings. It writes only on explicit consent, is
+    idempotent by marker (`ClaudeShellRCSetup`), removable, and never silent. Three
     login shells get a block written for them — zsh, bash, fish — chosen by
     `dscl`'s `UserShell` with `$SHELL` as a FALLBACK only (a GUI launch
     inherits `$SHELL` from launchd, which is stale after a `chsh`); anything
-    else is told to paste, because guessing at a shell's syntax is how a setup
-    step corrupts a startup file. The writer REFUSES a symlinked rc file — the
+    else is directed to the docs, because guessing at a shell's syntax is how a
+    setup step corrupts a startup file. The writer REFUSES a symlinked rc file — the
     case a dotfiles user actually hits, since an atomic rename replaces the
     link with a regular file and silently detaches their repo. It preserves an
     existing file's mode and creates a new one at 0600. The `SendEnv` half
@@ -1092,16 +1093,17 @@ there is not.
     terminal" and it is bounded by that interval; a state that claims a channel
     must be able to stop claiming it.
 
-- **Remote enrollment execution is opt-in, preview-first, and keeps the token
-  out of process arguments.** `ClaudeRemoteEnrollmentService` generates a
-  copyable plan (idempotent ssh config block, `claude plugin` commands,
-  verify/uninstall steps, caveats), and the Copy buttons remain available.
-  One-click actions require a separate confirmation that repeats the exact
-  ssh-config block or redacted command list. Local insertion replaces only the
+- **Remote enrollment execution is opt-in, consent-first, and keeps the token
+  out of process arguments.** `ClaudeRemoteEnrollmentService` generates the
+  idempotent ssh config block and remote scripts, but Settings never renders or
+  copies their text. Enrollment and host update expose only the six-step
+  `RemoteHostSetupRun`, one consent sentence naming the local files and SSH
+  alias, and a Details link to `docs/remote-claude-context.md`, where every
+  command is listed. Local insertion replaces only the
   matching host's marked block, preserves an existing config's permissions, and
   atomically renames a same-directory temporary file; a missing `~/.ssh` and
-  config are created as 0700/0600. It refuses (with the copy path as the
-  documented out) when `~/.ssh/config` or `~/.ssh` is a symlink — a rename
+  config are created as 0700/0600. It refuses and directs the user to the docs
+  when `~/.ssh/config` or `~/.ssh` is a symlink — a rename
   would replace the link and desync a dotfiles setup — or when `~/.ssh` is not
   owned by the user or is group/world-writable. Remote execution spawns only `ssh -o
   BatchMode=yes <alias> /bin/sh -s` and sends the generated token-bearing script

--- a/docs/coding-agents.md
+++ b/docs/coding-agents.md
@@ -85,7 +85,7 @@ Install is one click: **Settings → Integrations → Claude Code → "Plugin on
 this Mac" → Install or update**. The app registers its bundled plugin
 marketplace through Claude Code's own CLI. The same pane offers the opt-in
 status-line indicator (it writes exactly the `statusLine` key in
-`~/.claude/settings.json`, previewed first, never over your own script).
+`~/.claude/settings.json` after a one-sentence consent, never over your own script).
 
 **Working over SSH?** A second plugin, `localvoxtral-remote`, covers Claude
 Code sessions on other machines: its hooks POST through an SSH

--- a/docs/release-notes/v0.9.0.md
+++ b/docs/release-notes/v0.9.0.md
@@ -22,16 +22,15 @@ Terminal.app.** Inside a [herdr](https://herdr.dev) session the app asks herdr
 itself which pane is focused and binds to that pane by id. Any ambiguity —
 including two live herdr sessions — attaches nothing rather than guessing.
 
-**A plain `ssh` session joins again, and the app sets the whole thing up for
-you.** In Settings, under *Remote Claude Code over SSH*, **Run Setup** in the
-enrollment sheet — or **Update Host** in an enrolled host's row — runs one
-self-verifying flow in order: the `~/.ssh/config` block, the shell startup
-export, the remote plugin install-or-update, the check that `LC_LVX_TTY`
-actually crosses the connection, the herdr agents-panel row when herdr is
-installed, and the final Check Setup. Each step reports one short sentence and
-the run stops at the first failure with its remedy, so the step that used to
-fail silently — the value not crossing — now names its fix. The same row still
-tells you whether a remote session has actually reported its terminal yet.
+**A plain `ssh` session joins again, and remote enrollment is one automated
+flow.** In Settings, **Set Up** in the enrollment sheet, or **Update host…**
+followed by **Set Up** in an enrolled host's row, runs six steps in order: the
+`~/.ssh/config` block, the shell startup export, the remote plugin
+install-or-update, the `LC_LVX_TTY` crossing check, the herdr agents-panel row
+when herdr is installed, and the final setup check. The sheet shows one consent
+sentence naming the local files and SSH host, a **Details** link to the exact
+commands, and one progress line per step. It shows no token, command, or file
+contents.
 
 By hand, if you prefer — add this to your shell's rc file on your Mac:
 
@@ -71,7 +70,7 @@ each with a one-line status and buttons that do the whole setup, so you
 never edit a config file by hand. The Claude Code plugin row reports whether
 it is installed and whether a newer version is bundled; a new **Status
 line** row installs the bottom-bar connection indicator into
-`~/.claude/settings.json` (previewed first, and never over a status line you
+`~/.claude/settings.json` (after a one-sentence consent, and never over a status line you
 wrote yourself); and **Other agents** installs the opencode plugin — the
 bundled file plus its `tui.json` entry, both reversible from the same row.
 herdr appears there too when it is present, as a status only: its panes
@@ -80,8 +79,8 @@ already join automatically, so there is nothing to set up.
 ## Action required if you have enrolled a remote host
 
 Enrolled hosts do **not** pick up the new plugin by re-running the setup
-commands. Run this on each enrolled host to get the 1.7.x remote plugin (the
-plain-`ssh` join needs it — an older plugin publishes nothing to match on):
+commands. Run this on each enrolled host to get the 1.8.x remote plugin (the
+plain-`ssh` join needs at least 1.7.0, and 1.8.0 adds the compact status line):
 
 ```sh
 claude plugin marketplace update localvoxtral
@@ -91,7 +90,7 @@ claude plugin update localvoxtral-remote@localvoxtral
 Order matters — refreshing the marketplace clone first is what makes the second
 command an update. Your token is preserved. In the app, every row under
 **Remote Claude Code over SSH** has an **Update host…** button that shows
-these commands and can run them over SSH for you.
+one consent sentence and can run them over SSH for you.
 
 Nothing breaks if you skip it: an older plugin keeps working and simply sends
 a response the app now ignores. You just will not get the new join behaviour

--- a/docs/remote-claude-context.md
+++ b/docs/remote-claude-context.md
@@ -3,12 +3,10 @@
 Dictate into a Claude Code session that is running on another machine, and have
 localvoxtral spell your code, file names, and identifiers correctly anyway.
 
-This page is the long version. The app's enrollment sheet runs the whole
-setup as one self-verifying flow — press **Run Setup**, confirm once, and it
-stops at the first step that fails with the exact remedy — while every block
-it would write stays on the sheet, copyable, with no comments in it, for doing
-any step by hand. A **Check Setup** button runs the checks and tells you what
-they mean.
+The app's enrollment sheet runs the whole setup as one self-verifying flow.
+It shows one consent sentence, a **Details** link to this command reference,
+and one status line for each step. No token, command, or file contents appear
+in Settings.
 
 ---
 
@@ -55,20 +53,18 @@ configured.
 ## How enrollment works
 
 Enrolling a host is one flow that does everything, each step self-verifying.
-Press **Run Setup** in the enrollment sheet — or **Update Host** in an
+Press **Set Up** in the enrollment sheet, or **Update host…** and **Set Up** in an
 enrolled host's row — and it runs, in order, showing one short sentence of
 status per step and stopping at the first failure with the exact remedy:
 
 1. **Mac SSH config** — the marked `Host` block with `RemoteForward` and
-   `SendEnv LC_LVX_TTY`. Manual equivalent: copy the block from step 1 of the
-   sheet.
+   `SendEnv LC_LVX_TTY`. The exact block is below.
 2. **Mac shell startup** — the `LC_LVX_TTY` export block in your login shell's
-   rc. Manual equivalent: the block under "Terminal setup for plain SSH" in
-   Settings, or the integration README. Already applied, unsupported, or
+   rc. The exact blocks are below. Already applied, unsupported, or
    symlinked is reported, not failed.
 3. **Remote plugin** — install, or update when already present, verified by
    reading the installed version back in the same SSH session. Manual
-   equivalent: the two commands in step 2 of the sheet.
+   equivalent: the commands below.
 4. **Remote environment** — proves `LC_LVX_TTY` actually crosses by sending a
    fresh random value for that one call and comparing the echo exactly. The
    value is never logged. A mismatch names the side: no `sendenv` covering the
@@ -81,16 +77,136 @@ status per step and stopping at the first failure with the exact remedy:
 5. **Remote herdr** — when `herdr` resolves on the host, appends the
    agents-panel row (only when no agents table or rows key exists) and runs
    `herdr server reload-config`. "Not installed" and an already-customized
-   table are reported, not failed. Manual equivalent: append the TOML block
-   from the sheet, then `herdr server reload-config` on the host.
+   table are reported, not failed. The exact TOML and reload command are below.
 6. **Check Setup** — the two read-only verdicts, last, as the final status
    line.
+
+### Commands run by Set Up
+
+The app writes the two Mac files directly. For every remote script except the
+tunnel check, it starts this exact process and sends the script through stdin:
+
+```sh
+ssh -o BatchMode=yes -o ClearAllForwardings=yes -- <alias> /bin/sh -s
+```
+
+The token is only in that stdin script on this Mac. The remote plugin step runs
+`claude plugin list --json` before and after the mutation. Between those reads,
+it runs the applicable commands:
+
+```sh
+claude plugin marketplace add T0mSIlver/localvoxtral
+claude plugin marketplace update localvoxtral
+claude plugin update localvoxtral-remote@localvoxtral
+claude plugin install localvoxtral-remote@localvoxtral --config 'token=<token>' --config 'port=<this-Mac's-port>'
+```
+
+An update with no new token uses this last line instead:
+
+```sh
+claude plugin install localvoxtral-remote@localvoxtral --config 'port=<this-Mac's-port>'
+```
+
+The environment-crossing step sends this script with a fresh `LC_LVX_TTY`
+value in the SSH child's environment:
+
+```sh
+printf 'LVX_TTY:%s\n' "${LC_LVX_TTY-}"
+```
+
+If the value does not cross, the app inspects the effective local config with:
+
+```sh
+ssh -G -- <alias>
+```
+
+The herdr step uses the following commands:
+
+```sh
+set -eu
+if ! command -v herdr >/dev/null 2>&1; then
+  for lv_dir in "$HOME/.claude/local" "$HOME/.local/bin" "$HOME/bin" /opt/homebrew/bin /usr/local/bin "$HOME"/.nvm/versions/node/*/bin; do
+    if [ -x "$lv_dir/herdr" ]; then PATH="$lv_dir:$PATH"; break; fi
+  done
+fi
+if ! command -v herdr >/dev/null 2>&1; then
+  printf '%s\n' LVX_HERDR_ABSENT
+  exit 0
+fi
+lv_config=${HERDR_CONFIG_PATH:-${XDG_CONFIG_HOME:-$HOME/.config}/herdr/config.toml}
+if [ -f "$lv_config" ] && grep -Eq '^[[:space:]]*\[ui\.sidebar\.agents\][[:space:]]*(#.*)?$|^[[:space:]]*rows[[:space:]]*=' "$lv_config"; then
+  printf '%s\n' LVX_HERDR_CUSTOMIZED
+  exit 42
+fi
+mkdir -p "$(dirname "$lv_config")"
+touch "$lv_config"
+cat >> "$lv_config" <<'LOCALVOXTRAL_HERDR_PANEL'
+[ui.sidebar.agents]
+rows = [["state_icon", "workspace", "tab"], ["agent"], [{ token = "$lvmark", dim = true }]]
+LOCALVOXTRAL_HERDR_PANEL
+herdr server reload-config
+printf '%s\n' LVX_HERDR_CONFIGURED
+```
+
+The `grep` match stops the step without changing the file. The final tunnel
+check omits `ClearAllForwardings` so it can test the configured forward:
+
+```sh
+ssh -o BatchMode=yes -- <alias> /bin/sh -s
+```
+
+Its exact stdin script checks for `curl` and posts an unauthenticated `{}` body:
+
+```sh
+set -u
+command -v curl >/dev/null 2>&1 || { printf '%s\n' 'LVX_NO_CURL'; exit 0; }
+code=$(curl -s -o /dev/null -w '%{http_code}' -X POST -H 'Content-Type: application/json' -d '{}' http://127.0.0.1:<this-Mac's-port>/v1/hook/SessionStart 2>/dev/null) || code=000
+[ -n "$code" ] || code=000
+printf 'LVX_HTTP:%s\n' "$code"
+```
+
+The plugin check uses the first SSH argv above and runs `claude plugin list`
+after resolving `claude` from `PATH`, `~/.claude/local`, `~/.local/bin`,
+`~/bin`, `/opt/homebrew/bin`, `/usr/local/bin`, or
+`~/.nvm/versions/node/*/bin`. Plugin installation uses that same resolver.
 
 Removing the host reverses the Mac side — the ssh block, and the shell block
 only when no other host remains — and never lets a reversal problem block the
 removal itself: the registry entry is the off switch, and anything that could
 not be rewritten is named in an alert with its manual fix. The remote half of
 uninstalling stays manual by design ("Uninstalling" below).
+
+### Shell startup blocks
+
+For zsh and bash, the app adds this marked block to `~/.zshrc`,
+`~/.bash_profile`, or an existing `~/.bashrc`:
+
+```sh
+# localvoxtral plain-ssh join (begin)
+# Publishes this terminal's tty so localvoxtral can tell which window a
+# Claude Code session over ssh belongs to. Remove this block in
+# Settings, or by hand.
+if [ -z "${LC_LVX_TTY:-}" ] && [ -z "${SSH_TTY:-}" ]; then
+  case "$(tty 2>/dev/null)" in /dev/*) LC_LVX_TTY="$(tty)"; export LC_LVX_TTY ;; esac
+fi
+# localvoxtral plain-ssh join (end)
+```
+
+For fish, it writes `~/.config/fish/conf.d/localvoxtral.fish`:
+
+```fish
+# localvoxtral plain-ssh join (begin)
+# Publishes this terminal's tty so localvoxtral can tell which window a
+# Claude Code session over ssh belongs to. Remove this block in
+# Settings, or by hand.
+if not set -q LC_LVX_TTY; and not set -q SSH_TTY
+    set -l __lvx_tty (tty 2>/dev/null)
+    if string match -q -- '/dev/*' "$__lvx_tty"
+        set -gx LC_LVX_TTY "$__lvx_tty"
+    end
+end
+# localvoxtral plain-ssh join (end)
+```
 
 ### 1. An `~/.ssh/config` block
 
@@ -125,11 +241,10 @@ no-op instead of a duplicate `Host` stanza (OpenSSH is first-match-wins, and a
 stale duplicate above a fresh one would silently win). Everything else in your
 config is preserved byte for byte.
 
-The app will insert the block for you after a confirmation that repeats the
-exact text, or you can copy it and paste it yourself. It refuses to write when
+The app inserts the block after the one-sentence consent. It refuses to write when
 `~/.ssh/config` or `~/.ssh` is a symlink (a dotfiles setup — an atomic rename
 would replace your link) or when `~/.ssh` is not exclusively yours to write. In
-those cases, copy and paste.
+those cases, use this reference to edit the real file yourself.
 
 ### 2. The plugin on the host
 
@@ -169,14 +284,15 @@ host's processes and files can read. Practical consequences:
   where you choose, rather than letting setup run it — the exposure window is
   brief either way, but it is yours to time.
 - If you think the token was seen, **rotate it**. Rotation takes effect
-  immediately, with no grace period, and re-running step 2 with the new token is
-  the whole recovery.
+  immediately, with no grace period, and running **Set Up** with the new token
+  is the whole recovery.
 
 ### 3. A token
 
-The token is generated on enrollment and shown **once**. localvoxtral stores
-only a hash of it, so it genuinely cannot be shown again — rotation is the
-recovery path, and it takes effect immediately with no grace period.
+The token is generated on enrollment and passed straight into the consented
+setup run. It is never shown in Settings. localvoxtral stores only a hash, so
+rotation is the recovery path after an interrupted or dismissed setup. Rotation
+takes effect immediately with no grace period.
 
 What the token authorizes is narrow: a host that presents it may *contribute
 remote context*. The listener tags every session it accepts as remote no matter
@@ -204,7 +320,7 @@ unavailable. A convenience feature must never cost you your login.
 
 The price of `no` is that a failed forward is *silent*. The hooks get connection
 refused, fail open, and you simply get no context. That silence is exactly what
-step 3's **Check Setup** exists to break.
+step 6's **Check Setup** exists to break.
 
 ## The forward port is per-Mac
 
@@ -258,9 +374,9 @@ ssh-config block in the same action so the two halves can never disagree. Your
 token is preserved — `claude plugin update` keeps the stored config, and
 `--config` merges per key.
 
-Re-running step 2 is *not* an update: on Claude Code 2.1.220 `plugin install`
-exits 0 with "already installed" and `marketplace add` does not refresh a clone
-it already has.
+The update path refreshes the marketplace and calls `plugin update`; a bare
+`plugin install` is not an update. On Claude Code 2.1.220 it exits 0 with
+"already installed", and `marketplace add` does not refresh an existing clone.
 
 ## Shell history and rotation
 

--- a/integrations/claude-code/README.md
+++ b/integrations/claude-code/README.md
@@ -131,8 +131,8 @@ There are two ways it can identify your window, tried in that order.
 
 **The app can do this for you.** Settings → Integrations → Remote hosts → *Remote
 Claude Code over SSH* → **Set Up…** next to "Terminal setup for plain SSH". It
-shows the exact block first, writes it only after you say yes, is idempotent
-(a second run replaces rather than duplicates), and has a **Remove**. The row
+shows one consent sentence naming the shell file, links here for details, is
+idempotent (a second run replaces rather than duplicates), and has a **Remove**. The row
 also reports whether a remote session has actually arrived carrying the value,
 which is the half you cannot see from the file.
 
@@ -304,7 +304,7 @@ That file is yours and Claude Code owns its schema; the CLI is the
 supported interface, and a third-party app editing it is how setups get
 corrupted during an unrelated upgrade. The one exception lives one row down
 in Settings: the opt-in status-line installer writes exactly the
-`statusLine` key — previewed first, only on your press, and never over a
+`statusLine` key after a one-sentence consent, and never over a
 status line you wrote yourself (see above).
 
 If you prefer to run the commands yourself, these are the same ones the button
@@ -361,11 +361,12 @@ One glance at Claude Code's bottom bar answers the question this plugin
 otherwise leaves silent: *is localvoxtral connected to this session?*
 
 The app way: **Settings → Integrations → Claude Code → Status line →
-Set Up…**. It shows the exact JSON first and writes it only after you say
-yes — one `statusLine` entry pointing at this app's bundled
+Set Up…**. A one-sentence consent names `~/.claude/settings.json`; **Details**
+opens this section. The app writes one `statusLine` entry pointing at its bundled
 `localvoxtral-claude-hook --statusline`. Everything else in
-`~/.claude/settings.json` round-trips untouched, and **Remove** takes the
-entry back out (deleting the file when nothing else is in it). If you
+`~/.claude/settings.json` is preserved, although the JSON is rewritten with
+sorted keys and normalized formatting. **Remove** takes the entry back out
+(deleting the file when nothing else is in it). If you
 already have your own status line, the row says so and offers no Install
 button: the app never overwrites a script you wrote — combine the two with
 the recipe below instead.
@@ -379,9 +380,12 @@ three fixed lines:
 
 | Line | Meaning |
 |---|---|
-| `● localvoxtral connected` (green) | the app is running and this session's hooks are reaching it |
-| `○ localvoxtral not connected` (yellow) | the app is running but has no live record of this session — plugin not installed, or the app started after this session's last hook (it catches up on your next prompt) |
-| `○ localvoxtral not running` (dim) | nothing is listening on the socket |
+| `lvx ●` (green) | the app received this session's hooks |
+| `lvx ●` (red) | the app is listening but rejected or does not recognize this plugin session |
+| `lvx ●` (grey) | nothing is listening on the local socket |
+
+With `NO_COLOR` set or `TERM=dumb`, these render as `lvx ok`, `lvx err`, and
+`lvx off`.
 
 In `~/.claude/settings.json`:
 
@@ -538,41 +542,34 @@ exchange (any HTTP status, even a 401) clears the backoff for everything else.
 In **Settings → Integrations → Remote hosts → "Remote Claude Code over SSH"**,
 type a name and your SSH host alias and press **Enroll…**. The app issues a
 token, binds the listener immediately — there is no relaunch step — and opens a
-sheet whose **Run Setup** does all of it in one consented flow, in order, each
-step self-verifying: the SSH config block on this Mac, the shell export block,
+sheet whose **Set Up** does all of it in one consented flow, in order, each step
+self-verifying: the SSH config block on this Mac, the shell export block,
 the plugin install-or-update on the host, the `LC_LVX_TTY` crossing check, the
 herdr agents-panel row when herdr is installed, and the final Check Setup. It
-stops at the first failure with the exact remedy. **Update Host** in an
-enrolled host's row runs the same flow. The numbered sections below stay for
-copying each step by hand — the manual equivalent of every one is
+stops at the first failure with the exact remedy. **Update host…** in an
+enrolled host's row runs the same flow. The sheet shows no token, command, or
+file contents. Its **Details** link opens the complete command reference in
 [docs/remote-claude-context.md](../../docs/remote-claude-context.md#how-enrollment-works).
 The list in that row shows each enrolled host, when it was last seen,
 and gives you **Update host…**, **Rotate Token**, **Revoke** and **Remove**.
 
-Steps 1 and 2 each offer a button that does the work and a Copy button that
-does not. The button paths act **only after showing you exactly what will happen
-and asking you to confirm**: *Insert into ~/.ssh/config* previews the exact
-block (an idempotent, marker-delimited splice; the rest of the file is never
-touched) before atomically writing it, and *Run on SSH host* previews the
-commands (token redacted) before running them through `ssh -o BatchMode=yes`
-with the token fed over the remote shell's stdin — so it never appears in any
-process's argument list **on your Mac**. On the host it does, briefly:
+The consent sentence names every local file and the SSH alias the flow may
+touch. Nothing runs or is written before **Set Up**. The app runs remote work
+through `ssh -o BatchMode=yes` with the token fed over the remote shell's stdin,
+so it never appears in any process's argument list **on your Mac**. On the host
+it does, briefly:
 `claude plugin install` takes its config as a flag and has no stdin path, so
 the token is in that one command's argv while it runs and in the plugin's
 userConfig under `~/.claude` afterwards, readable by anything running as you
 there. That is true whether the app runs the command or you paste it; see
 [docs/remote-claude-context.md](../../docs/remote-claude-context.md#3-a-token).
-Nothing runs or is written without that explicit confirmation.
-
-Everything the sheet gives you to copy is exactly what you run: no `#`
-commentary, no output to interpret. Step 4 is why — instead of handing you
-probe commands and explaining their output, the app runs them and reports two
-verdicts (see below). The full reference — what the token authorizes, the
+The sheet reports one line per step instead of showing output to interpret.
+The full reference — what the token authorizes, the
 per-Mac port, multiplexer limits, uninstalling — is
 [docs/remote-claude-context.md](../../docs/remote-claude-context.md).
 
-The token is shown exactly once, because only its hash is stored. If you lose it,
-rotate — that is what rotation is for. What the four steps amount to:
+The token is never shown in Settings. Only its hash is stored on this Mac. If
+setup is interrupted, rotate the token and run **Set Up** again. The steps are:
 
 **1. Add the tunnel to `~/.ssh/config`:**
 
@@ -665,13 +662,12 @@ traffic, which is also what re-runs the status line:
 
 | Line | The last hook dial saw |
 |---|---|
-| `● localvoxtral connected` (green) | a 200 from the app, through the tunnel, within the last 15 minutes |
-| `○ localvoxtral no recent hooks` (dim) | a 200 too — but a while ago. The green light expires rather than vouch for an app that may have gone away since; your next prompt dials and restores the truth either way |
-| `○ localvoxtral unreachable` (dim) | no listener — tunnel down, Mac asleep, or the app not running |
-| `○ localvoxtral token rejected` (yellow) | a 401 — rotate the token, or finish an interrupted rotation |
-| `○ localvoxtral token not configured` (yellow) | the plugin has no `token` in its config at all |
-| `○ localvoxtral not connected` (yellow) | some other completed HTTP error |
-| `○ localvoxtral no hooks yet` (dim) | nothing — no hook has fired since this host last booted (the stamp lives in the runtime dir) |
+| `lvx ●` (green) | a 200 from the app, through the tunnel, within the last 15 minutes |
+| `lvx ●` (grey) | no recent hooks, no listener, a down tunnel, or no hook since boot |
+| `lvx ●` (red) | the token is missing or rejected, or another HTTP error indicates an outdated plugin |
+
+With `NO_COLOR` set or `TERM=dumb`, these render as `lvx ok`, `lvx off`, and
+`lvx err`.
 
 Set it up on the **remote host** (the plugin ships the renderer; Claude Code's
 versioned plugin cache is no place for a settings path, so copy it somewhere
@@ -781,12 +777,10 @@ ssh builder "claude plugin install localvoxtral-remote@localvoxtral --config 'po
 Order matters: `plugin update` installs whatever the local marketplace clone
 currently offers, so refreshing the clone first is what makes it an update at
 all. In the app, each row in **Remote Claude Code over SSH** has an **Update
-Plugin…** button that shows these two commands with a Copy button, and can run
-them over SSH after you confirm. One-click runs against the **SSH alias you
-enrolled with**, which is recorded with the host — the display name is never
-used as a substitute, since the two are separate fields and can name different
-machines. A host enrolled before localvoxtral recorded aliases has none on file:
-its commands are copy-only (and so is its rotation sheet) until you re-enroll it.
+host…** button. Its consent sentence names the local files and enrolled SSH
+alias, and **Set Up** runs the same six-step flow as enrollment. The display name
+is never used as a substitute for the alias. A host enrolled before aliases
+were recorded must be re-enrolled before the app can update it.
 Non-interactive SSH skips your login shell's
 rc, so the app's version of these commands sets `PATH` to the usual `claude`
 install locations first; add that yourself if `claude` is off the PATH a plain

--- a/integrations/claude-code/plugins/localvoxtral-remote/.claude-plugin/plugin.json
+++ b/integrations/claude-code/plugins/localvoxtral-remote/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "localvoxtral-remote",
   "description": "Publishes Claude Code session context from a REMOTE host to localvoxtral on your Mac, over an SSH RemoteForward tunnel. Command hooks running a bundled POSIX-sh shim that POSTs via curl — needs only sh and curl on the remote host, and fails open silently when either is missing.",
-  "version": "1.7.0",
+  "version": "1.8.0",
   "author": {
     "name": "localvoxtral"
   },

--- a/integrations/claude-code/plugins/localvoxtral-remote/hooks/statusline.sh
+++ b/integrations/claude-code/plugins/localvoxtral-remote/hooks/statusline.sh
@@ -48,7 +48,7 @@ fi
 # A green light must expire. `ok` is a claim about the LAST dial, and the one
 # lie this script could otherwise tell is a green dot hours after the Mac
 # went to sleep — precisely the condition the indicator exists to surface. So
-# an `ok` older than 15 minutes demotes to a dim "no recent hooks"; the next
+# an `ok` older than 15 minutes demotes to the grey offline state; the next
 # submitted prompt dials (UserPromptSubmit is backoff-exempt) and restores
 # the truth either way. Only `ok` is demoted: a stale failure state is still
 # the last known truth, and staying conservative can't mislead. Both numbers
@@ -70,20 +70,36 @@ fi
 # guarantees for %b), and the dots are literal UTF-8. printf here is safe in
 # a way it is not in post.sh: there is no secret anywhere in this process,
 # so an external printf putting its argument into an argv leaks nothing.
-# Green dot: the Mac answered 200 to this host's last hook. Everything else
-# names the failure the last dial actually saw.
+# Green means the Mac accepted this host's last hook, grey means no current
+# connection, and red means the app rejected the plugin. NO_COLOR and dumb
+# terminals get the same states as plain text.
+USE_COLOR=1
+if [ "${NO_COLOR+x}" = x ] || [ "${TERM:-}" = dumb ]; then
+  USE_COLOR=""
+fi
+
+render() {
+  STATE_NAME="$1"
+  if [ -z "$USE_COLOR" ]; then
+    printf '%s\n' "lvx $STATE_NAME"
+    return
+  fi
+  case "$STATE_NAME" in
+  ok) printf '%b\n' 'lvx \0033[32m●\0033[0m' ;;
+  off) printf '%b\n' 'lvx \0033[90m●\0033[0m' ;;
+  err) printf '%b\n' 'lvx \0033[31m●\0033[0m' ;;
+  esac
+}
+
 case "$STATE" in
 ok)
   if [ -n "$STALE" ]; then
-    printf '%b\n' '\0033[2m○ localvoxtral no recent hooks\0033[0m'
+    render off
   else
-    printf '%b\n' '\0033[32m●\0033[0m localvoxtral connected'
+    render ok
   fi
   ;;
-http-401) printf '%b\n' '\0033[33m○\0033[0m localvoxtral token rejected' ;;
-http-*) printf '%b\n' '\0033[33m○\0033[0m localvoxtral not connected' ;;
-down) printf '%b\n' '\0033[2m○ localvoxtral unreachable\0033[0m' ;;
-unconfigured) printf '%b\n' '\0033[33m○\0033[0m localvoxtral token not configured' ;;
-*) printf '%b\n' '\0033[2m○ localvoxtral no hooks yet\0033[0m' ;;
+http-401 | http-* | unconfigured) render err ;;
+*) render off ;;
 esac
 exit 0

--- a/integrations/opencode/README.md
+++ b/integrations/opencode/README.md
@@ -13,14 +13,15 @@ telemetry, and when the app is not running every write silently does nothing.
 ## Install
 
 In localvoxtral: **Settings → Integrations → Other agents → opencode →
-Install**. The app copies its bundled `localvoxtral.js` into opencode's
+Set Up…**. A one-sentence consent names both files, and **Details** opens this
+command reference. The app copies its bundled `localvoxtral.js` into opencode's
 global plugin directory and lists it in `~/.config/opencode/tui.json` —
 creating that file when it is absent, preserving everything else in it when
 it is present. **Remove** reverses both. Nothing is written until you press
 the button, and a `tui.json` whose `plugin` entry has an unexpected shape is
 left untouched rather than reshaped.
 
-If you prefer to do it by hand — the same two steps the button performs:
+The exact shell-command equivalent is:
 
 1. Copy `localvoxtral.js` into opencode's global plugin directory:
 


### PR DESCRIPTION
## What

Remote setup becomes one fully automated flow with a one-sentence consent, and no shell commands, tokens, or file contents anywhere in the UI.

- **Enrollment / Update host / shell export / status line / opencode plugin**: every writing surface now shows ONE consent sentence naming the files on this Mac and the host it will touch ("localvoxtral will edit ~/.ssh/config and ~/.zshrc on this Mac and install its plugin on sandbox-vpn."), with Cancel / Set Up and a **Details** link to the docs page that lists the exact commands (`docs/remote-claude-context.md` for ssh + shell, `integrations/claude-code/README.md` for the status line, `integrations/opencode/README.md` for opencode).
- Removed from Settings: the "Run on SSH host" action, `updateCommands`/`remoteCommands` copyables, the ssh-config snippet preview, the herdr TOML snippet, the token's one-time display, and every other monospaced command block. The six-step `RemoteHostSetupRun` list (one line per step) stays as the progress view; `EnrollmentConfirmation.preview` is kept as a model/test seam only and never rendered.
- The exact commands the app runs are now documented in `docs/remote-claude-context.md` (new "Commands run by Set Up" section + shell startup blocks), pinned by a new test that fails if a command goes missing from the docs.
- All invariants.md safety rules kept: consent before any write, symlink/unreadable-file refusals, token never in this Mac's argv (stdin only), concealed-pasteboard removals ride the same seams.
- **Status line is now `lvx ●`** in both renderers (bundled `--statusline` mode and the remote plugin's `statusline.sh`): green when the app received this session's hooks, grey when nothing is listening locally / tunnel down, red when the app rejected the plugin (bad token / outdated plugin). Plain-text fallback under `NO_COLOR` or `TERM=dumb`: `lvx ok` / `lvx off` / `lvx err`. Remote plugin bumped 1.7.0 → 1.8.0 (shim changed).
- Merged origin/main (`cbd62f2`, settings layout pass): main's pane headers, row layouts, and help copy kept; this branch's sheet changes layered on top (single conflict in `SettingsView.swift`, resolved in that direction).

## Proof

- [x] Unit suite green — `./scripts/remote-build.sh test` (after merging origin/main):

```
Test Suite 'localvoxtralPackageTests.xctest' passed at 2026-09-07 23:56:53.213.
	 Executed 3077 tests, with 2 tests skipped and 0 failures (0 unexpected) in 52.062 (52.197) seconds
```

(Pre-merge run of this branch alone: `Executed 3075 tests, with 2 tests skipped and 0 failures`.)

- Warning-free build — `grep -ci "warning:" .build/last-remote.log` → `0` (both before and after the merge).
- The four behaviour suites the change touches, with updated pins (no test deleted; preview-element pins became no-code-rendered assertions):

```
Test Suite 'ClaudeIntegrationSettingsModelTests' passed — Executed 94 tests, with 0 failures
Test Suite 'ClaudeRemotePluginManifestTests' passed — Executed 68 tests, with 0 failures
Test Suite 'ClaudeHookPublisherTests' passed — Executed 26 tests, with 0 failures
Test Suite 'IntegrationsSettingsModelTests' passed — Executed 18 tests, with 0 failures
Test Suite 'ClaudeRemoteEnrollmentServiceTests' passed — Executed 119 tests, with 0 failures
Test Suite 'ClaudeStatuslineInstallServiceTests' passed — Executed 31 tests, with 0 failures
Test Suite 'SettingsTabTests' passed (merged-from-main layout pins) — Executed 12 tests, with 0 failures
```

- New/updated pins that demonstrate the asks:
  - `IntegrationsSettingsModelTests.testSetupSheetsRenderConsentButNoGeneratedCode` — asserts `SettingsView.swift` contains no `confirmation.preview`, `plan.remoteCommands`, `plan.updateCommands`, `plan.sshConfigSnippet`, `herdrPanelConfigSnippet`, `claude.shellSetupSheet.preview`, `integrations.statuslineSheet.preview`, or "Run on SSH host", and that the Details links and the `integrations.remote.setup.*` / `claude.remote.shellSetup.*` / `claude.shellSetupSheet.*` / `integrations.statuslineSheet.*` AX identifiers survive.
  - `ClaudeHookPublisherTests.testStatusLinePlainTextFallbackUsesThreeFixedStates` + byte-for-byte colour pins — `lvx ●` green/red/grey, `lvx ok/err/off` when `NO_COLOR`/`TERM=dumb`.
  - `ClaudeRemotePluginManifestTests.testStatusLineRendererUsesPlainTextWhenColorIsDisabled` + the byte-for-byte shim table — same states through the real `statusline.sh` under a live `/bin/sh`.
  - `ClaudeRemoteEnrollmentServiceTests.testTheDocsPageListsEveryAutomatedSetupCommandOutsideSettings` — every ssh/claude/herdr command and shell block the app runs is listed in `docs/remote-claude-context.md`.
  - `sh -n` on `integrations/claude-code/plugins/localvoxtral-remote/hooks/statusline.sh` (and post.sh): syntax OK.
- Not a bug fix: no before/after failing-run pair applies (UI copy/layout restructure; the removed behaviours are covered by the absence assertions above).
- [ ] UI change: not yet verified by hand in a running app — requesting a dogfood package via the marker below; the sheets' consent text, Details links, and `lvx ●` rendering in a live Claude Code status line still need a hand-check there.

[dogfood-package]
