### PR TITLE
CI: fix the hosted unit-suite hang (cancel-before-suspend in test fakes) and the forensics that hid it

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -261,7 +261,14 @@ jobs:
           # generous bound is the right one. The point of the supervisor is
           # forensics on a HANG (it samples the wedged xctest before killing
           # it), not a tight performance budget.
-          ./scripts/ci/run-supervised-command.sh \
+          #
+          # NSUnbufferedIO: xctest's stdout is a pipe here, so without it the
+          # runner block-buffers and the log stops at a buffer boundary, up to
+          # several KB (dozens of test cases) BEFORE the test that hung. Four
+          # hosted hangs "always right after PolishModelCatalogTests" were
+          # that boundary, not that suite. Xcode sets the same variable for
+          # its own test runs.
+          NSUnbufferedIO=YES ./scripts/ci/run-supervised-command.sh \
             900 "$RUNNER_TEMP/localvoxtral-unit-tests.log" -- \
             swift test \
             --skip RealtimeAPIVLLMIntegrationTests \

--- a/Tests/localvoxtralTests/BackendManagerTests.swift
+++ b/Tests/localvoxtralTests/BackendManagerTests.swift
@@ -414,6 +414,36 @@ final class BackendManagerTests: XCTestCase {
         XCTAssertNil(modelPreparer.prepareCalls.last?.revision)
     }
 
+    func testFakePreparerCancelledBeforeSuspendingThrowsInsteadOfParking() async {
+        // Hosted unit-suite hang (run 34163270101, 2026-09-07): the test above
+        // cancels the ensure the instant it sees the prepare start, and on a
+        // loaded 3-core VM that cancellation reached the fake BEFORE it parked
+        // its resume continuation. The cancellation handler then found nothing,
+        // the continuation parked afterwards was never resumed, and the async
+        // test wrapper waited forever. A task that is already cancelled when
+        // prepare suspends must observe the termination and throw, never park.
+        let preparer = FakeModelPreparer(suspendBackendIDs: [BackendCatalog.polishd.id])
+        let request = ModelPreparationRequest(
+            backendID: BackendCatalog.polishd.id,
+            displayName: "Polish engine",
+            repoID: "org/model",
+            revision: "0000000000000000000000000000000000000000",
+            includePatterns: ["config.json"]
+        )
+        let task = Task {
+            withUnsafeCurrentTask { $0?.cancel() }
+            try await preparer.prepare(request) { _ in }
+        }
+        // Red before the fix: this await never returns (the suite is killed at
+        // the supervisor's 900 s bound with the runner parked in XCTWaiter).
+        let result = await task.result
+        guard case let .failure(error) = result else {
+            return XCTFail("prepare returned normally in a cancelled task")
+        }
+        XCTAssertTrue(error is CancellationError, "expected CancellationError, got \(error)")
+        XCTAssertEqual(preparer.terminatedBackendIDs, [BackendCatalog.polishd.id])
+    }
+
     func testStopPolishingAwaitsCancelledEnsureSoASubsequentEnsureStartsFresh() async throws {
         // Field regression (PR #99): stop cancelled the in-flight ensure but
         // returned without awaiting it, so a model switch mid-download started
@@ -879,7 +909,21 @@ private final class FakeModelPreparer: ModelPreparing, @unchecked Sendable {
         if shouldSuspend {
             try await withTaskCancellationHandler {
                 try await withCheckedThrowingContinuation { continuation in
-                    state.withLock { $0.prepareResumeContinuation = continuation }
+                    // Cancellation can land BEFORE this continuation exists:
+                    // `stop` cancels the ensure the moment the test sees the
+                    // prepare start, and on a loaded host the handler above
+                    // then runs first, finds nothing to resume, and the
+                    // continuation parked here would never be resumed (the
+                    // hosted unit-suite hang, run 34163270101). Park it only
+                    // when the task is still live; the check and the store
+                    // share the lock with the handler, so no interleaving
+                    // resumes twice or not at all.
+                    let orphaned: CheckedContinuation<Void, Error>? = state.withLock {
+                        if Task.isCancelled { return continuation }
+                        $0.prepareResumeContinuation = continuation
+                        return nil
+                    }
+                    orphaned?.resume(throwing: CancellationError())
                 }
             } onCancel: {
                 let continuation: CheckedContinuation<Void, Error>? = self.state.withLock {

--- a/Tests/localvoxtralTests/BackendProcessSupervisorTests.swift
+++ b/Tests/localvoxtralTests/BackendProcessSupervisorTests.swift
@@ -523,17 +523,24 @@ private final class StateWatcher: @unchecked Sendable {
         let id = UUID()
         return try await withTaskCancellationHandler {
             try await withCheckedThrowingContinuation { continuation in
-                let state: BackendProcessSupervisor.State? = storage.withLock { storage in
+                // Registered under the same lock the cancel handler takes, and
+                // only while the task is live: a task cancelled before this
+                // point has had its handler run against an empty waiter list,
+                // so a waiter appended now would never be resumed.
+                let outcome: Result<BackendProcessSupervisor.State, Error>? = storage.withLock { storage in
                     if let state = storage.states.first(where: predicate) {
-                        return state
+                        return .success(state)
+                    }
+                    if Task.isCancelled {
+                        return .failure(CancellationError())
                     }
                     storage.waiters.append(
                         Waiter(id: id, predicate: predicate, continuation: continuation)
                     )
                     return nil
                 }
-                if let state {
-                    continuation.resume(returning: state)
+                if let outcome {
+                    continuation.resume(with: outcome)
                 }
             }
         } onCancel: {

--- a/Tests/localvoxtralTests/PolishPromptWarmupTests.swift
+++ b/Tests/localvoxtralTests/PolishPromptWarmupTests.swift
@@ -86,9 +86,16 @@ final class PolishPromptWarmupTests: XCTestCase {
             started.fulfill()
             try await withTaskCancellationHandler {
                 try await withCheckedThrowingContinuation { continuation in
+                    // The test cancels as soon as `started` fires; on a loaded
+                    // host that cancellation can precede this store, in which
+                    // case the handler below already ran and found nothing.
+                    // Never park a continuation in a cancelled task (hosted
+                    // unit-suite hang, 2026-09-07).
                     lock.lock()
-                    self.continuation = continuation
+                    let orphaned = Task.isCancelled
+                    if !orphaned { self.continuation = continuation }
                     lock.unlock()
+                    if orphaned { continuation.resume(throwing: CancellationError()) }
                 }
             } onCancel: {
                 lock.lock()
@@ -129,9 +136,14 @@ final class PolishPromptWarmupTests: XCTestCase {
                 started.fulfill()
                 await withTaskCancellationHandler {
                     await withCheckedContinuation { continuation in
+                        // Same rule as above: a task already cancelled when
+                        // it gets here has had its handler run; resume now
+                        // instead of parking a continuation nobody holds.
                         lock.lock()
-                        self.continuation = continuation
+                        let orphaned = Task.isCancelled
+                        if !orphaned { self.continuation = continuation }
                         lock.unlock()
+                        if orphaned { continuation.resume() }
                     }
                 } onCancel: {
                     lock.lock()

--- a/scripts/ci/fixtures/build-gate-stubborn-tree.sh
+++ b/scripts/ci/fixtures/build-gate-stubborn-tree.sh
@@ -6,8 +6,21 @@ set -euo pipefail
 pid_fifo="$1"
 mode="${2:-wait}"
 trap '' TERM
-/bin/bash -c 'trap "" TERM; exec sleep 300' &
-stubborn_child=$!
+if [[ "$mode" == "escape-group" ]]; then
+  # The child moves to a process group of its own, the way `swift test`
+  # parks xctest: a descendant by ppid, invisible to group-keyed tools.
+  perl -e '$SIG{TERM} = "IGNORE"; setpgrp(0, 0); exec "sleep", "300"' &
+  stubborn_child=$!
+  # Report the pids only once the child has actually moved: perl's startup
+  # is a few ms, and a reader keyed on the group must not see the old one.
+  for _ in $(seq 1 200); do
+    [[ "$(ps -o pgid= -p "$stubborn_child" | tr -d '[:space:]')" == "$stubborn_child" ]] && break
+    sleep 0.05
+  done
+else
+  /bin/bash -c 'trap "" TERM; exec sleep 300' &
+  stubborn_child=$!
+fi
 printf '%s %s\n' "$$" "$stubborn_child" >"$pid_fifo"
 if [[ "$mode" == "exit-leader" ]]; then
   exit 0

--- a/scripts/ci/run-supervised-command.sh
+++ b/scripts/ci/run-supervised-command.sh
@@ -36,6 +36,12 @@ rm -f "$timeout_marker"
 
 command_pid=""
 command_pgid=""
+# Comma-separated live pids of the supervised tree (descendants of the
+# command pid UNION its process group), filled by the tree dump and read by
+# the sampler: `swift test` puts xctest in a process group of its OWN, so a
+# group-only sampler captured the idle driver and never the wedged runner
+# (hosted hang, 2026-09-07 run 34161722328).
+forensic_tree_pids=""
 watchdog_pid=""
 watchdog_pgid=""
 monitor_was_enabled=0
@@ -240,6 +246,7 @@ dump_tree_and_pipes_for_forensics() {
     }
   ' "$ps_file")"
   candidates_csv="$(printf '%s\n' "$tree_out" | grep '^[0-9]' | tail -n 1 || true)"
+  forensic_tree_pids="$candidates_csv"
   {
     echo "--- supervised tree (ps pid ppid pgid stat etime command) ---"
     printf '%s\n' "$tree_out" | grep -v '^[0-9]' || true
@@ -280,9 +287,20 @@ sample_group_for_forensics() {
   fi
   {
     echo ""
-    echo "=== supervisor timeout forensics: sampling process group $pgid ==="
+    echo "=== supervisor timeout forensics: sampling process group $pgid (tree pids: ${forensic_tree_pids:-none}) ==="
   } >>"$log_file"
-  for pid in $(pgrep -g "$pgid" -x xctest 2>/dev/null; pgrep -g "$pgid" 2>/dev/null); do
+  # Order: xctest anywhere in the supervised tree first (the runner is the
+  # process that hangs, and `swift test` parks it in its own process group),
+  # then the rest of the tree, then the group. Capped at 3 samples.
+  local tree_xctest="" tree_rest="" p
+  for p in ${forensic_tree_pids//,/ }; do
+    if [[ "$(ps -o comm= -p "$p" 2>/dev/null)" == *xctest* ]]; then
+      tree_xctest="$tree_xctest $p"
+    else
+      tree_rest="$tree_rest $p"
+    fi
+  done
+  for pid in $tree_xctest $tree_rest $(pgrep -g "$pgid" -x xctest 2>/dev/null; pgrep -g "$pgid" 2>/dev/null); do
     (( sampled >= 3 )) && break
     kill -0 "$pid" 2>/dev/null || continue
     case " $seen_pids " in *" $pid "*) continue ;; esac

--- a/scripts/ci/run-supervised-command.sh
+++ b/scripts/ci/run-supervised-command.sh
@@ -202,7 +202,12 @@ dump_tree_and_pipes_for_forensics() {
       ppid[$1] = $2
       pgid[$1] = $3
       ids[++n] = $1
-      full[$1] = $0
+      # ps right-aligns the pid column, so short pids arrive with leading
+      # blanks; strip them so every line reads "DESCENDANT <pid> ..." and a
+      # reader (or a grep) can key on the pid without guessing the padding.
+      line = $0
+      sub(/^[ \t]+/, "", line)
+      full[$1] = line
     }
     END {
       if (root in ppid) {

--- a/scripts/ci/run-supervised-command.sh
+++ b/scripts/ci/run-supervised-command.sh
@@ -21,8 +21,13 @@ poll_seconds="${LOCALVOXTRAL_SUPERVISOR_TERM_POLL_SECONDS:-0.1}"
 # Hard cap on each forensic `sample` (polls x 0.1 s; default 8 s): a sampler
 # stuck on a badly wedged task must never postpone the kill it precedes.
 sample_polls="${LOCALVOXTRAL_SUPERVISOR_SAMPLE_POLLS:-80}"
+# Same rule for each forensic `lsof` (default 3 s): lsof over a busy user's
+# whole process set is the one forensic command that scans hundreds of
+# processes, so it gets its own cap rather than borrowing the sampler's.
+lsof_polls="${LOCALVOXTRAL_SUPERVISOR_LSOF_POLLS:-30}"
 [[ "$term_polls" =~ ^[0-9]+$ ]] || usage
 [[ "$sample_polls" =~ ^[1-9][0-9]*$ ]] || usage
+[[ "$lsof_polls" =~ ^[1-9][0-9]*$ ]] || usage
 
 mkdir -p "$(dirname "$log_file")"
 : >"$log_file"
@@ -65,6 +70,199 @@ sample_one_bounded() {
     echo "--- sampler for pid $pid killed at the ${sample_polls}00 ms cap ---" >>"$log_file"
   fi
   wait "$sampler" 2>/dev/null || true
+}
+
+# One bounded run of ANY forensic command, appending its output to the log:
+# the same kill-at-the-cap rule as sample_one_bounded. `lsof` over a user's
+# whole process set is normally 1-3 s, but a wedged box must never turn the
+# diagnostic into a second hang.
+run_forensic_bounded() {
+  local label="$1" forensic_pid waited=0
+  shift
+  ( "$@" ) >>"$log_file" 2>&1 &
+  local forensic_pid=$!
+  while kill -0 "$forensic_pid" 2>/dev/null && (( waited < lsof_polls )); do
+    sleep 0.1
+    waited=$((waited + 1))
+  done
+  if kill -0 "$forensic_pid" 2>/dev/null; then
+    kill -KILL -- "-$forensic_pid" 2>/dev/null || kill -KILL "$forensic_pid" 2>/dev/null || true
+    echo "--- $runner killed at the ${lsof_polls}00 ms cap ---" >>"$log_file"
+  fi
+  wait "$forensic_pid" 2>/dev/null || true
+}
+
+# Cross-reference the ps snapshot file (arg 2) with the lsof -F scan on stdin
+# and print, for every pipe that the supervised tree (candidate pids, arg 1)
+# holds, every OTHER process still holding the same pipe. That outside holder
+# is the leaked grandchild keeping the driver's read() from EOF - it may long
+# since have escaped the process group and re-parented to launchd, so neither
+# pgid nor ppid can find it; only the shared pipe identifier can.
+#
+# Linux note: its lsof names every pipe "pipe" (no unique handle), so distinct
+# pipes are indistinguishable; a name held by more than eight outside pids is
+# reported once as ambiguous instead of manufacturing false matches. macOS -
+# the platform this forensics exists for - prints a unique 0x handle.
+print_shared_pipe_holders() {
+  local candidates_csv="$1" ps_file="$2"
+  lsof -n -P -w -F pftn -u "$(id -u)" 2>/dev/null | awk -v cand=",${candidates_csv}," '
+    FNR == NR {
+      if ($1 ~ /^[0-9]+$/) {
+        command = ""
+        for (i = 6; i <= NF; i++) command = command (i > 6 ? " " : "") $i
+        cmdline[$1] = command
+      }
+      next
+    }
+    /^p[0-9]+$/ { current = substr($0, 2); next }
+    /^f[0-9]+$/ { fd = substr($0, 2); next }
+    /^t[0-9A-Za-z]+$/ { type = substr($0, 2); next }
+    /^n/ {
+      name = substr($0, 2)
+      if ((type == "PIPE" || type == "pipe") && fd != "" && current != "") {
+        holders[name] = holders[name] "," current ":" fd
+      }
+      fd = ""; type = ""; name = ""
+      next
+    }
+    END {
+      for (pipe in holders) {
+        count = split(holders[pipe], list, ",")
+        in_tree = 0
+        outside = ""
+        split("", distinct)
+        for (i = 1; i <= count; i++) {
+          split(list[i], pair, ":")
+          pid = pair[1]; pfd = pair[2]
+          if (pid == "") continue
+          if (index(cand, "," pid ",") > 0) {
+            in_tree = 1
+          } else {
+            outside = outside " " pid " fd" pfd
+            distinct[pid] = 1
+          }
+        }
+        if (in_tree == 0) continue
+        n_outside = 0
+        for (pid in distinct) n_outside++
+        if (n_outside > 8) {
+          printf "pipe %s: ambiguous pipe name (%d outside holders) - not matched\n", pipe, n_outside
+          continue
+        }
+        for (pid in distinct) {
+          command = (pid in cmdline) ? cmdline[pid] : "<unknown command>"
+          printf "pipe %s ALSO HELD OUTSIDE THE SUPERVISED TREE by pid %s: %s\n", pipe, pid, command
+        }
+        if (outside != "") printf "(fd detail:%s)\n", outside
+      }
+    }
+  ' "$ps_file" -
+}
+
+# On timeout, BEFORE the samples: dump the process tree and the pipe holders.
+#
+# The 2026-09-06/07 hosted hangs (runs 34056383664, 34109063527): the log cut
+# mid-test-case, xctest was already gone from the group, and swift-package sat
+# for 12 more minutes with both libSwiftToolsSupport reader threads blocked in
+# read() - the shape of "the test process died, but a grandchild that
+# inherited its stdout/stderr still holds the pipe's write end, so the driver
+# never sees EOF and `swift test` never returns". Sampling the survivor shows
+# the symptom; this dump names the HOLDER:
+#   1. a full ps snapshot (pid, ppid, pgid, stat, etime, command),
+#   2. the supervised tree: every descendant of the command pid plus every
+#      member of its process group, tagged - descendants survive a leaked
+#      child even when the leader exited first,
+#   3. lsof: the supervised tree's fd table, and every OTHER same-uid process
+#      sharing a pipe with it - the leaked write-end holder, findable by
+#      neither pgid nor ppid once re-parented, only by the pipe identifier.
+dump_tree_and_pipes_for_forensics() {
+  local root_pid="$1" group_id="$2" ps_out ps_file tree_out candidates_csv
+  {
+    echo ""
+    echo "=== supervisor timeout forensics: process tree and pipes (root pid ${root_pid:-<gone>}, group ${group_id:-<none>}) ==="
+  } >>"$log_file"
+  if ! command -v ps >/dev/null 2>&1; then
+    echo "=== supervisor process-tree forensics skipped: ps unavailable ===" >>"$log_file"
+    return 0
+  fi
+  ps_out="$(ps -axo pid,ppid,pgid,stat,etime,command 2>/dev/null || true)"
+  if [[ -z "$ps_out" ]]; then
+    echo "=== supervisor process-tree forensics skipped: ps printed nothing ===" >>"$log_file"
+    return 0
+  fi
+
+  # The supervised tree: descendants of the command pid (ppid-walk to
+  # fixpoint) UNION the process group, each tagged. The candidate list for
+  # the lsof pass is the same set.
+  ps_file="${log_file}.forensic-ps"
+  printf '%s\n' "$ps_out" >"$ps_file"
+  tree_out="$(awk -v root="$root_pid" -v grp="$group_id" '
+    $1 !~ /^[0-9]+$/ { next }
+    {
+      ppid[$1] = $2
+      pgid[$1] = $3
+      ids[++n] = $1
+      full[$1] = $0
+    }
+    END {
+      if (root in ppid) {
+        reach[root] = 1
+        changed = 1
+        while (changed) {
+          changed = 0
+          for (i = 1; i <= n; i++) {
+            p = ids[i]
+            if (!(p in reach) && (ppid[p] in reach)) { reach[p] = 1; changed = 1 }
+          }
+        }
+      } else {
+        print "ROOT pid " root " is gone from the table - descendants may have re-parented; group and pipe evidence still apply"
+      }
+      out = ""
+      for (i = 1; i <= n; i++) {
+        p = ids[i]
+        if (p in reach) {
+          tag = (pgid[p] == grp) ? " [in pgroup]" : " [left pgroup]"
+          print "DESCENDANT " full[p] tag
+          out = out p ","
+        } else if (pgid[p] == grp) {
+          print "GROUP-ONLY " full[p]
+          out = out p ","
+        }
+      }
+      sub(/,$/, "", out)
+      print out
+    }
+  ' "$ps_file")"
+  candidates_csv="$(printf '%s\n' "$tree_out" | grep '^[0-9]' | tail -n 1 || true)"
+  {
+    echo "--- supervised tree (ps pid ppid pgid stat etime command) ---"
+    printf '%s\n' "$tree_out" | grep -v '^[0-9]' || true
+    echo "--- full ps snapshot ---"
+    printf '%s\n' "$ps_out"
+  } >>"$log_file"
+
+  if ! command -v lsof >/dev/null 2>&1; then
+    echo "=== supervisor pipe forensics skipped: lsof unavailable ===" >>"$log_file"
+    rm -f "$ps_file"
+    return 0
+  fi
+  if [[ -z "$candidates_csv" ]]; then
+    echo "=== supervisor pipe forensics skipped: no live processes in the supervised tree ===" >>"$log_file"
+    rm -f "$ps_file"
+    return 0
+  fi
+
+  {
+    echo "--- lsof fd table of the supervised tree (pids: $candidates_csv) ---"
+  } >>"$log_file"
+  run_forensic_bounded lsof lsof -n -P -w -p "$candidates_csv"
+  {
+    echo "--- processes sharing a pipe with the supervised tree (leak suspects) ---"
+  } >>"$log_file"
+  run_forensic_bounded lsof-pipe-scan print_shared_pipe_holders "$candidates_csv" "$ps_file"
+  rm -f "$ps_file"
+  return 0
 }
 
 sample_group_for_forensics() {
@@ -145,6 +343,10 @@ command_pgid=$command_pid
   # group is still alive afterwards: forensics can take seconds, and a
   # command that finished naturally inside that window must keep its real
   # exit status instead of a mislabeled 124 (PR #160 review finding).
+  group_is_alive "$command_pgid" || exit 0
+  # Tree + pipe holders first: they are cheap, and they are the only evidence
+  # that can NAME a holder which has already escaped the process group.
+  dump_tree_and_pipes_for_forensics "$command_pid" "$command_pgid"
   group_is_alive "$command_pgid" || exit 0
   sample_group_for_forensics "$command_pgid"
   group_is_alive "$command_pgid" || exit 0

--- a/scripts/ci/test-run-supervised-command.sh
+++ b/scripts/ci/test-run-supervised-command.sh
@@ -223,6 +223,49 @@ is_live_non_zombie "$stubborn_pid" && fail "tree-forensics run: descendant survi
 fixture_pid=""
 stubborn_pid=""
 
+# A descendant that has LEFT the process group must still be sampled: `swift
+# test` runs xctest in a process group of its own, so the hosted hang of
+# 2026-09-07 (run 34161722328) sampled the idle swift-package driver and
+# never the wedged runner. The tree dump tags it, and the sampler follows
+# the tree, not just the group.
+pid_fifo="$TMP_DIR/escape-pids"
+timeout_fifo="$TMP_DIR/escape-trigger"
+mkfifo "$pid_fifo" "$timeout_fifo"
+cat >"$TMP_DIR/bin/sample" <<'STUB'
+#!/usr/bin/env bash
+echo "stub-sample-of-pid-$1"
+STUB
+chmod +x "$TMP_DIR/bin/sample"
+rm -f "$TMP_DIR/bin/lsof"
+PATH="$TMP_DIR/bin:$PATH" \
+LOCALVOXTRAL_SUPERVISOR_TIMEOUT_FIFO="$timeout_fifo" \
+LOCALVOXTRAL_SUPERVISOR_TERM_POLLS=0 \
+LOCALVOXTRAL_SUPERVISOR_LSOF_POLLS=10 \
+  "$SUPERVISOR" 999 "$TMP_DIR/escape.log" -- "$FIXTURE" "$pid_fifo" escape-group &
+supervisor_pid=$!
+read -r fixture_pid stubborn_pid <"$pid_fifo"
+escaped_pgid="$(ps -o pgid= -p "$stubborn_pid" | tr -d '[:space:]')"
+[[ -n "$escaped_pgid" && "$escaped_pgid" != "$fixture_pid" ]] \
+  || fail "escape-group fixture did not leave the leader's process group (pgid $escaped_pgid)"
+printf 'fire\n' >"$timeout_fifo"
+if wait "$supervisor_pid"; then
+  fail "escape-group run unexpectedly succeeded"
+else
+  status=$?
+fi
+supervisor_pid=""
+[[ "$status" == "124" ]] || fail "escape-group run: timeout status changed from 124 to $status"
+grep -q "DESCENDANT $stubborn_pid .* \[left pgroup\]" "$TMP_DIR/escape.log" \
+  || fail "tree dump does not tag the escaped descendant as having left the group"
+grep -q "stub-sample-of-pid-$stubborn_pid" "$TMP_DIR/escape.log" \
+  || fail "sampler skipped the descendant that left the process group"
+# The escaped child is outside the group the supervisor drains; it is this
+# test's to reap.
+kill -KILL "$stubborn_pid" 2>/dev/null || true
+is_live_non_zombie "$fixture_pid" && fail "escape-group run: leader survived"
+fixture_pid=""
+stubborn_pid=""
+
 # A command that finishes naturally while forensics are running must keep
 # its real exit status — the timeout marker is only written if the group is
 # still alive after sampling (PR #160 review: the marker used to be written

--- a/scripts/ci/test-run-supervised-command.sh
+++ b/scripts/ci/test-run-supervised-command.sh
@@ -152,6 +152,77 @@ is_live_non_zombie "$stubborn_pid" && fail "hung-sampler run: descendant survive
 fixture_pid=""
 stubborn_pid=""
 
+# On timeout the supervisor must also record the PROCESS TREE (descendants of
+# the command pid plus the process group) and the PIPE HOLDERS: the
+# 2026-09-06/07 hosted hangs died with xctest gone, the swift-package driver
+# parked in read() on its test-runner pipes, and no tree evidence to name the
+# surviving write-end holder. `lsof` is stubbed with a macOS-shaped -F stream
+# where the fixture's stdout/stderr pipe (0xdeadbeefcafe) is ALSO held by this
+# test script's own pid - outside the supervised tree, exactly the leaked
+# grandchild shape. The dump must name it, and must NOT report pipes the tree
+# does not hold.
+pid_fifo="$TMP_DIR/tree-pids"
+timeout_fifo="$TMP_DIR/tree-trigger"
+mkfifo "$pid_fifo" "$timeout_fifo"
+cat >"$TMP_DIR/bin/sample" <<'STUB'
+#!/usr/bin/env bash
+echo "stub-sample-of-pid-$1"
+STUB
+chmod +x "$TMP_DIR/bin/sample"
+PATH="$TMP_DIR/bin:$PATH" \
+LOCALVOXTRAL_SUPERVISOR_TIMEOUT_FIFO="$timeout_fifo" \
+LOCALVOXTRAL_SUPERVISOR_TERM_POLLS=0 \
+LOCALVOXTRAL_SUPERVISOR_LSOF_POLLS=10 \
+  "$SUPERVISOR" 999 "$TMP_DIR/tree.log" -- "$FIXTURE" "$pid_fifo" &
+supervisor_pid=$!
+read -r fixture_pid stubborn_pid <"$pid_fifo"
+# Written after the pids are known, before the timeout fires: the stub needs
+# the REAL tree pids plus this script's pid ($$) as the outside holder.
+cat >"$TMP_DIR/bin/lsof" <<STUB
+#!/usr/bin/env bash
+case " \$* " in
+  *" -F "*)
+    for spec in "$fixture_pid:1" "$fixture_pid:2" "$stubborn_pid:1" "$stubborn_pid:2" "$$:1"; do
+      pid="\${spec%:*}"
+      fd="\${spec#*:}"
+      printf 'p%s\nf%s\ntPIPE\nn0xdeadbeefcafe\n' "\$pid" "\$fd"
+    done
+    # A pipe nobody in the supervised tree holds: must never be reported.
+    printf 'p4194304\nf1\ntPIPE\nn0x1122334455\n'
+    ;;
+  *)
+    echo "stub-lsof-readable-table-for \$*"
+    ;;
+esac
+STUB
+chmod +x "$TMP_DIR/bin/lsof"
+printf 'fire\n' >"$timeout_fifo"
+if wait "$supervisor_pid"; then
+  fail "tree-forensics run unexpectedly succeeded"
+else
+  status=$?
+fi
+supervisor_pid=""
+[[ "$status" == "124" ]] || fail "tree-forensics run: timeout status changed from 124 to $status"
+grep -q 'supervisor timeout forensics: process tree and pipes' "$TMP_DIR/tree.log" \
+  || fail "tree dump header missing from the timeout log"
+grep -q "DESCENDANT $fixture_pid .* \[in pgroup\]" "$TMP_DIR/tree.log" \
+  || fail "tree dump does not list the fixture leader as a group descendant"
+grep -q "DESCENDANT $stubborn_pid .* \[in pgroup\]" "$TMP_DIR/tree.log" \
+  || fail "tree dump does not list the stubborn child as a group descendant"
+grep -q 'lsof fd table of the supervised tree' "$TMP_DIR/tree.log" \
+  || fail "lsof fd table section missing from the timeout log"
+grep -q "pipe 0xdeadbeefcafe ALSO HELD OUTSIDE THE SUPERVISED TREE by pid $$:" "$TMP_DIR/tree.log" \
+  || fail "pipe scan did not name the outside holder pid $$"
+grep -q "by pid $$: bash" "$TMP_DIR/tree.log" \
+  || fail "pipe scan did not annotate the outside holder with its command"
+grep -q '0x1122334455' "$TMP_DIR/tree.log" \
+  && fail "pipe scan reported a pipe the supervised tree does not hold"
+is_live_non_zombie "$fixture_pid" && fail "tree-forensics run: leader survived"
+is_live_non_zombie "$stubborn_pid" && fail "tree-forensics run: descendant survived"
+fixture_pid=""
+stubborn_pid=""
+
 # A command that finishes naturally while forensics are running must keep
 # its real exit status — the timeout marker is only written if the group is
 # still alive after sampling (PR #160 review: the marker used to be written


### PR DESCRIPTION
## What

The hosted unit suite hung five times this week (exit 124 at the supervisor's 900 s bound). This PR fixes the cause and the two blind spots that hid it.

**Cause (test fakes).** Three fakes suspend with `withTaskCancellationHandler` around a stored continuation. When the test cancels the surrounding task *before* the fake reaches the store (a few-ms window, hit repeatedly on the 3-core hosted VM), Swift runs the cancel handler immediately, it finds nothing to resume, and the continuation stored afterwards is never resumed. The async test never returns, xctest sits in `XCTWaiter`, and nothing else in the process is wrong. Fixed in `BackendManagerTests.FakeModelPreparer`, both `PolishPromptWarmupTests` services, and the `BackendProcessSupervisorTests` waiter: each checks `Task.isCancelled` under the same lock the handler takes and resumes immediately instead of parking.

**Blind spot 1 (sampler).** `swift test` parks xctest in a process group of its own, so the supervisor's group-keyed sampler captured the idle `swift-package` driver and never the wedged runner. The sampler now follows the tree dump's pids (xctest first). Regression: fixture mode `escape-group` moves the child out of the group via `setpgrp`; the test asserts it is tagged `[left pgroup]` and sampled.

**Blind spot 2 (buffering).** xctest's stdout is a pipe on CI, so the log stopped at a stdio buffer boundary: every hang looked like "right after `PolishModelCatalogTests`" while the real hang was dozens of tests later (the `PolishPromptWarmupTests` fakes). The unit step now runs with `NSUnbufferedIO=YES`.

Also: the tree dump trims `ps`'s pid padding so `DESCENDANT <pid>` lines are greppable (the forensics test failed on 4-digit pids, run 34161046242).

## Proof

- Evidence run 34163270101 (with the sampler fix + unbuffered log): last line `Test Case '-[localvoxtralTests.BackendManagerTests testStopPolishingAwaitsCancelledEnsureSoASubsequentEnsureStartsFresh]' started.`, xctest sample parked in `+[XCTWaiter waitForExpectations:timeout:enforceOrder:]`, tree dump `DESCENDANT 18651 16605 18651 … xctest` (own pgid).
- Red (old fake, a throwaway bounded variant of the new test that fails instead of hanging, not committed):

```
Test Suite 'Selected tests' failed at 2026-09-08 01:40:50.945.
	 Executed 1 test, with 1 failure (0 unexpected) in 5.333 (5.333) seconds
```

- Green (fixed fakes, committed `testFakePreparerCancelledBeforeSuspendingThrowsInsteadOfParking`), `remote-build.sh test --filter <Suite>`:

```
BackendManagerTests:            Executed 28 tests, with 0 failures
BackendProcessSupervisorTests:  Executed 8 tests, with 0 failures
PolishPromptWarmupTests:        Executed 12 tests, with 0 failures
```

- `grep -ci "warning:" .build/last-remote.log` → 0.
- Supervisor regression scripts (Linux): `test-run-supervised-command.sh` red on the old sampler ("sampler skipped the descendant that left the process group"), PASS after; `test-cleanup-stale-test-processes.sh` PASS.
- Not a model/prompt/helper change: no LLM or speechd lane applies. No UI change.
