### PR TITLE
docs: record what herdr 0.9.0 federation changes for the herdr join arms

### DIFF
--- a/docs/agent/invariants.md
+++ b/docs/agent/invariants.md
@@ -151,6 +151,16 @@ there is not.
     reach a herdr socket through it. On any pane.read failure the session falls
     back to the pre-existing behavior — composite AX text, vocabulary-only,
     nothing attached.
+    KNOWN HOLE, herdr 0.9.0, issue #286: a 0.9 client can federate several
+    machines (`herdr machine add`), and while a remote machine is selected the
+    local server keeps a focused pane it has merely stopped presenting. This
+    arm still joins that pane, and every cross-check above passes on it, so the
+    failure is a WRONG join rather than an abstention. The arm must first read
+    herdr's saved machine state (`herdr machine list --json`, or
+    `<state_dir>/client/endpoints.json` with `client/endpoint-selection.json`)
+    and abstain unless Local is selected, and abstain again when more than one
+    local herdr client is running, because that selection file is global and
+    the last client to switch wins.
   - cmux (github.com/manaflow-ai/cmux — a native Swift/AppKit terminal on
     libghostty) is a join target with its OWN arm, keyed on the surface id
     cmux injects into the session environment. It is opt-in
@@ -264,6 +274,20 @@ there is not.
     focus half remains unmeasured — see the panel-binding doc's "Pinned against
     a live server" section for exactly which assumptions are covered and which
     are still documented hopes.
+
+    herdr 0.9.0 CHANGED WHAT A RENDERED TOKEN PROVES, so the whole-view
+    sentence above is no longer the discriminator on a 0.9 client. That client
+    composes the agents panel itself, from every federated machine at once
+    (`src/client/shell/endpoint_agents.rs`), out of its OWN
+    `[ui.sidebar.agents]` rows (`ClientShellConfig::from_config`), and marks the
+    active machine by background color alone, which a text grid read cannot
+    see. A token stamped on machine B's pane therefore renders while the user
+    views machine A: the match proves that the surface federates that server,
+    not that it displays it. This costs nothing today, because the arm never
+    probes a surface with no ssh and a federated client has none. Anything that
+    extends the probe to those surfaces must name the machine from herdr's own
+    selection state first (issue #286) and only then use the token, which keeps
+    its freshness and mic-indicator roles.
 
     Any stamp refusal, unavailable grid, hidden/unconfigured/scrolled panel row,
     a row cut below the entropy floor, or a bounded settle timeout can only

--- a/docs/agent/remote-herdr-panel-binding.md
+++ b/docs/agent/remote-herdr-panel-binding.md
@@ -5,6 +5,12 @@ enrollment = enroll-time offer; fallback = the argv path). Supersedes the argv
 invocation signal as the PRIMARY binding for `.remoteHerdrPane` joins; the argv
 path (#228/#229) remains as fallback.
 
+AMENDED 2026-09-08: herdr 0.9.0 federates several machines into one client,
+which changes what a rendered token proves and where the row config lives. The
+mechanism and the trust argument below describe a surface that displays ONE
+server, which is still what the `.remoteHerdrPane` arm probes. Read the herdr
+0.9.0 section at the end before extending any of it.
+
 AMENDED 2026-09-05: the window-title marker mechanism was removed from the app
 entirely (owner decision). Two things in this document changed with it — the
 "Title-marker arm suppression" section is gone, and the pane-level confirmation
@@ -276,7 +282,49 @@ Unpinnable from the Mac side, and still documented hopes: that all App-mode
 clients share one server-global focus (a second whole-view client on the same
 socket disturbed the fixture's own pane rather than mirroring it, so the lane
 does not assert it), and that `terminal_observe` behaves like
-`terminal_attach` (herdr 0.8.2's CLI exposes no observe subcommand).
+`terminal_attach`.
+
+CORRECTED 2026-09-08: the second one is pinnable and was never unpinnable. The
+CLI does expose an observer, `herdr terminal session observe <target> [--cols N]
+[--rows N]`, already present at tag v0.8.2 (`src/cli.rs:43`), printing
+newline-delimited `terminal.frame` records. The lane can assert that an observer
+of a stamped pane renders no panel token, the same way it already asserts it for
+`terminal attach`, instead of hoping.
+
+## herdr 0.9.0: what federation changes here
+
+Read from source at tag v0.9.0, not yet measured against a running server.
+
+A 0.9 client can attach several machines at once (`herdr machine add`, saved in
+`<state_dir>/client/endpoints.json`, the viewed one in
+`client/endpoint-selection.json`, rewritten on every switch at
+`src/client/mod.rs:1192`, and printed by `herdr machine list --json` without a
+running server). Federation lives in the CLIENT: each machine gets its own
+connection bridged over `ssh -T <target> herdr remote-client-bridge`
+(`src/remote/saved.rs:15`), which carries the CLIENT protocol to the remote's
+`herdr-client.sock` and serves one connection at a time. It is not a route to
+the JSON API socket this document's write and read channels use, so the `ssh -L`
+forward stays.
+
+Three consequences for the mechanism above:
+
+1. The App-mode discriminator no longer separates machines. The client composes
+   the agents panel from every federated machine at once
+   (`src/client/shell/endpoint_agents.rs`), and marks the active machine by
+   background color, which a text grid read cannot see. On a 0.9 client a
+   rendered token proves that the surface federates that server, not that it
+   displays it. The machine has to come from herdr's selection state instead.
+2. The row config moves to the LOCAL machine. A client shell renders those rows
+   from its own config (`ClientShellConfig::from_config` reads
+   `config.ui.sidebar.agents`), so the enrollment-time offer to patch a remote
+   `[ui.sidebar.agents]` over ssh does not apply to a federated client. The
+   equivalent offer is a local file edit. The new built-in `machine` token can
+   sit in the same row as `$lvmark`.
+3. A server can hold focus while presenting to nobody, through the new
+   `client_shell.surface.set` method and the `surface_interest` and
+   `health_check` capabilities (`src/api/schema/server.rs`). `pane.current`
+   still answers for such a server, so a focused pane is no longer evidence
+   that anyone is looking at it. Issue #286 is the local arm's version of this.
 
 ## Out of scope (recorded follow-ups)
 


### PR DESCRIPTION
## What

herdr 0.9.0 attaches several SSH machines to one client (`herdr machine add`). Three things these docs assert stop holding on such a client, so this records them where the next change to the herdr join arms will read them.

- `invariants.md`, local herdr arm: a known hole with the guard it needs. While a remote machine is selected, the local server keeps a focused pane it has stopped presenting, and the arm joins it with every cross-check passing. Tracked in #286.
- `invariants.md` and `remote-herdr-panel-binding.md`, remote arm: a rendered panel token no longer proves the surface displays that server. A 0.9 client composes the agents panel from every federated machine (`src/client/shell/endpoint_agents.rs`) and marks the active machine by background color, which a text grid read cannot see. Harmless today, because the arm never probes a surface with no ssh and a federated client has none.
- `remote-herdr-panel-binding.md`: a new section on the 0.9 facts, including that the panel row config comes from the client's own config on a federated client (`ClientShellConfig::from_config`), so the offer to patch a remote `[ui.sidebar.agents]` over ssh does not apply there.

It also corrects one claim about what can be pinned. herdr's CLI does expose `herdr terminal session observe`, present at tag v0.8.2 (`src/cli.rs:43`), so `terminal_observe` rendering no sidebar is measurable in the `integration-herdr` lane rather than a documented hope.

All of it is read from herdr source at tag `v0.9.0` in a local checkout, and none of it is measured against a running 0.9 server. The doc says so in each place. #287 covers the lane that would measure it.

## Proof

Documentation only, no behavior change. `scripts/ci/docs-only-filter.sh` fast-paths this diff; the two files changed are both under `docs/agent/`.
