### PR TITLE
Local herdr join: abstain while a 0.9 client is showing a federated machine

### DIFF
--- a/Sources/localvoxtral/ClaudeContext/ClaudeSurfaceProbeCommand.swift
+++ b/Sources/localvoxtral/ClaudeContext/ClaudeSurfaceProbeCommand.swift
@@ -107,6 +107,8 @@ enum ClaudeSurfaceProbeCommand {
             registry: registry,
             focusedTerminalTTY: { await ttyReader.focusedTerminalTTY(bundleID: $0) },
             herdrClientProbe: { HerdrClientTTYProbe.isHerdrClient(onTTYDevicePath: $0) },
+            herdrFederation: { HerdrMachineFederationReader.live().federation() },
+            herdrClientSurfaceCount: { HerdrClientTTYProbe.clientSurfaceCount() },
             herdrPanes: HerdrSocketClient(),
             sshDestinationProbe: { SSHDestinationTTYProbe.connection(onTTYDevicePath: $0) },
             enrolledHosts: { hosts?.hosts(matchingSSHDestination: $0) ?? [] },

--- a/Sources/localvoxtral/ClaudeContext/HerdrClientTTYProbe.swift
+++ b/Sources/localvoxtral/ClaudeContext/HerdrClientTTYProbe.swift
@@ -42,5 +42,29 @@ enum HerdrClientTTYProbe {
     private static let liveProcessNames: @Sendable (dev_t) -> [String]? = { device in
         TTYProcessTable.entries(onDevice: device)?.map(\.name)
     }
+
+    /// How many terminal surfaces this user has a herdr client on, or nil when
+    /// the process table cannot be walked.
+    ///
+    /// A herdr server is a detached daemon with no controlling terminal, so
+    /// counting DEVICES that host a `herdr` process counts clients, and counts
+    /// two clients in one window as the two surfaces they are.
+    ///
+    /// One caller, the local herdr arm: herdr keeps ONE machine selection per
+    /// user rather than one per client, so with a second client on screen that
+    /// selection cannot say which machine the focused surface is showing
+    /// (issue #286). Only the count matters, never which device.
+    static func clientSurfaceCount() -> Int? {
+        clientSurfaceCount(processes: TTYProcessTable.allProcesses())
+    }
+
+    static func clientSurfaceCount(processes: [TTYProcessTable.Entry]?) -> Int? {
+        guard let processes else { return nil }
+        let user = geteuid()
+        let devices = processes.lazy
+            .filter { $0.name == "herdr" && $0.effectiveUserID == user }
+            .compactMap(\.ttyDevice)
+        return Set(devices).count
+    }
 }
 #endif

--- a/Sources/localvoxtral/ClaudeContext/HerdrClientTTYProbe.swift
+++ b/Sources/localvoxtral/ClaudeContext/HerdrClientTTYProbe.swift
@@ -46,14 +46,16 @@ enum HerdrClientTTYProbe {
     /// How many terminal surfaces this user has a herdr client on, or nil when
     /// the process table cannot be walked.
     ///
-    /// A herdr server is a detached daemon with no controlling terminal, so
-    /// counting DEVICES that host a `herdr` process counts clients, and counts
-    /// two clients in one window as the two surfaces they are.
+    /// A herdr server is a detached daemon (`setsid`, no controlling terminal),
+    /// so what this counts is clients. The unit is a JOB on a terminal device,
+    /// not a process and not a device: a client's own child processes share its
+    /// process group and count once, while two clients sharing one terminal —
+    /// suspend the first, start the second — are the two surfaces they are.
     ///
     /// One caller, the local herdr arm: herdr keeps ONE machine selection per
     /// user rather than one per client, so with a second client on screen that
     /// selection cannot say which machine the focused surface is showing
-    /// (issue #286). Only the count matters, never which device.
+    /// (issue #286). Only the count matters, never which job.
     static func clientSurfaceCount() -> Int? {
         clientSurfaceCount(processes: TTYProcessTable.allProcesses())
     }
@@ -61,10 +63,17 @@ enum HerdrClientTTYProbe {
     static func clientSurfaceCount(processes: [TTYProcessTable.Entry]?) -> Int? {
         guard let processes else { return nil }
         let user = geteuid()
-        let devices = processes.lazy
+        let jobs = processes.lazy
             .filter { $0.name == "herdr" && $0.effectiveUserID == user }
-            .compactMap(\.ttyDevice)
-        return Set(devices).count
+            .compactMap { entry in
+                entry.ttyDevice.map { ClientJob(device: $0, processGroupID: entry.processGroupID) }
+            }
+        return Set(jobs).count
+    }
+
+    private struct ClientJob: Hashable {
+        var device: dev_t
+        var processGroupID: Int32
     }
 }
 #endif

--- a/Sources/localvoxtral/ClaudeContext/HerdrMachineFederation.swift
+++ b/Sources/localvoxtral/ClaudeContext/HerdrMachineFederation.swift
@@ -100,9 +100,9 @@ struct HerdrMachineFederationReader: Sendable {
         case .unreadable:
             return .unreadable
         case .contents(let data):
-            guard let catalog = try? JSONDecoder().decode(Catalog.self, from: data) else {
-                return .unreadable
-            }
+            guard let catalog = try? JSONDecoder().decode(Catalog.self, from: data),
+                  catalog.version == Self.supportedStateVersion
+            else { return .unreadable }
             let enabled = Set(catalog.ssh?.filter(\.enabled).map(\.id) ?? [])
             guard !enabled.isEmpty else { return .notFederated }
             switch selectedProfile(
@@ -118,11 +118,13 @@ struct HerdrMachineFederationReader: Sendable {
 
     /// Which machine the client is showing, or nil for Local.
     ///
-    /// herdr resolves this the same way (`src/client/endpoint/catalog.rs`): the
-    /// selection file wins when it names an enabled profile, the catalog's own
-    /// copy answers when it does not, and anything else is Local. A selection
-    /// file that exists and cannot be decoded fails instead, because the arm
-    /// cannot tell Local from a machine without it.
+    /// herdr resolves this in `load_from_paths` (`src/client/endpoint/catalog.rs`)
+    /// and this follows it exactly. A selection file naming an enabled profile
+    /// wins. A selection file saying Local wins too, and overrides the copy the
+    /// catalog carries. Only a selection that names a profile which is gone or
+    /// disabled loses, and then the catalog's copy answers. A selection file
+    /// that exists and cannot be decoded fails instead, because with machines
+    /// saved it is the only thing that separates Local from a machine.
     private func selectedProfile(
         inClientDirectory directory: URL,
         enabledProfiles: Set<String>,
@@ -135,17 +137,25 @@ struct HerdrMachineFederationReader: Sendable {
         case .unreadable:
             return .failure(SelectionUnreadable())
         case .contents(let data):
-            guard let selection = try? JSONDecoder().decode(Selection.self, from: data) else {
-                return .failure(SelectionUnreadable())
+            guard let selection = try? JSONDecoder().decode(Selection.self, from: data),
+                  selection.version == Self.supportedStateVersion
+            else { return .failure(SelectionUnreadable()) }
+            guard let selected = selection.selectedProfile else {
+                // herdr writes null for Local, and serde reads a missing field
+                // as the same None, so both mean Local here.
+                return .success(nil)
             }
-            guard let selected = selection.selectedProfile, enabledProfiles.contains(selected) else {
-                return .success(catalogSelection)
-            }
-            return .success(selected)
+            return .success(enabledProfiles.contains(selected) ? selected : catalogSelection)
         }
     }
 
     private struct SelectionUnreadable: Error {}
+
+    /// herdr refuses any other version in its own loader and runs the client
+    /// Local-only when it does. This reader abstains instead of guessing: a
+    /// future schema that renames or reinterprets these fields would otherwise
+    /// decode as "no machines saved" and silently retire the guard.
+    private static let supportedStateVersion = 1
 
     private struct Catalog: Decodable {
         struct Profile: Decodable {
@@ -153,19 +163,23 @@ struct HerdrMachineFederationReader: Sendable {
             var enabled: Bool
         }
 
+        var version: Int
         var selectedProfile: String?
         var ssh: [Profile]?
 
         enum CodingKeys: String, CodingKey {
+            case version
             case selectedProfile = "selected_profile"
             case ssh
         }
     }
 
     private struct Selection: Decodable {
+        var version: Int
         var selectedProfile: String?
 
         enum CodingKeys: String, CodingKey {
+            case version
             case selectedProfile = "selected_profile"
         }
     }

--- a/Sources/localvoxtral/ClaudeContext/HerdrMachineFederation.swift
+++ b/Sources/localvoxtral/ClaudeContext/HerdrMachineFederation.swift
@@ -1,0 +1,211 @@
+import Foundation
+
+#if canImport(Darwin)
+import Darwin
+
+/// What herdr's saved-machine feature says about the client on this Mac.
+///
+/// herdr 0.9.0 attaches several SSH machines to ONE local client
+/// (`herdr machine add`). While a remote machine is selected, the local server
+/// keeps a focused pane it has merely stopped presenting, so `pane.current` on
+/// the local socket stops describing what the user is looking at. The local
+/// herdr arm asks this before it trusts that answer (issue #286).
+///
+/// Federation lives entirely in herdr's CLIENT: the catalog is a per-user file,
+/// no server knows about it, and the socket API exposes nothing about it. Files
+/// are therefore the only place to read it, short of running herdr's own CLI,
+/// which a GUI app cannot locate reliably.
+enum HerdrMachineFederation: Sendable, Equatable {
+    /// No saved machines. The local socket's focused pane is what the surface
+    /// displays, exactly as it was before 0.9.
+    case notFederated
+    /// Machines are saved and the client is showing Local.
+    case showingLocal
+    /// Machines are saved and the client is showing one of them.
+    case showingMachine
+    /// herdr's state is present but could not be read or decoded.
+    case unreadable
+
+    /// The more abstaining of two readings, used to merge the release and
+    /// development state directories. A user runs one of them; the other is
+    /// absent, which reads as `notFederated` and never masks the live one.
+    static func moreAbstaining(
+        _ first: HerdrMachineFederation, _ second: HerdrMachineFederation
+    ) -> HerdrMachineFederation {
+        func rank(_ value: HerdrMachineFederation) -> Int {
+            switch value {
+            case .notFederated: return 0
+            case .showingLocal: return 1
+            case .showingMachine: return 2
+            case .unreadable: return 3
+            }
+        }
+        return rank(first) >= rank(second) ? first : second
+    }
+}
+
+/// One state file as the reader found it. `absent` and `unreadable` are kept
+/// apart on purpose: a missing catalog means this user saved no machines, while
+/// a catalog that exists and cannot be read means the arm knows nothing and
+/// must abstain.
+enum HerdrStateFile: Sendable, Equatable {
+    case absent
+    case contents(Data)
+    case unreadable
+}
+
+/// Reads herdr's client-side machine catalog and machine selection.
+///
+/// The two files are `<state dir>/client/endpoints.json` (the saved machines)
+/// and `<state dir>/client/endpoint-selection.json` (the one being viewed,
+/// rewritten by the client on every switch). herdr's state directory is
+/// `$XDG_STATE_HOME/herdr` when that variable is set and `~/.local/state/herdr`
+/// otherwise, with `herdr-dev` in place of `herdr` for a development build.
+///
+/// KNOWN RESIDUAL: a GUI app does not see the user's shell environment, so a
+/// user who exports `XDG_STATE_HOME` relocates the catalog somewhere this
+/// reader cannot find, and reads back `notFederated`. That leaves them on the
+/// pre-0.9 behavior this guard exists to correct. Closing it needs herdr's own
+/// CLI, whose path a GUI app cannot resolve either.
+struct HerdrMachineFederationReader: Sendable {
+    private let clientDirectories: [URL]
+    private let readFile: @Sendable (URL) -> HerdrStateFile
+
+    init(clientDirectories: [URL], readFile: @escaping @Sendable (URL) -> HerdrStateFile) {
+        self.clientDirectories = clientDirectories
+        self.readFile = readFile
+    }
+
+    /// Production reader over this user's home directory.
+    static func live() -> HerdrMachineFederationReader {
+        HerdrMachineFederationReader(
+            clientDirectories: Self.liveClientDirectories(),
+            readFile: Self.liveReadFile
+        )
+    }
+
+    func federation() -> HerdrMachineFederation {
+        clientDirectories
+            .map(federation(inClientDirectory:))
+            .reduce(.notFederated, HerdrMachineFederation.moreAbstaining)
+    }
+
+    private func federation(inClientDirectory directory: URL) -> HerdrMachineFederation {
+        let catalogFile = readFile(directory.appendingPathComponent("endpoints.json"))
+        switch catalogFile {
+        case .absent:
+            // No catalog is the state of every herdr before 0.9 and of every
+            // 0.9 user who saved no machine. Nothing to guard against.
+            return .notFederated
+        case .unreadable:
+            return .unreadable
+        case .contents(let data):
+            guard let catalog = try? JSONDecoder().decode(Catalog.self, from: data) else {
+                return .unreadable
+            }
+            let enabled = Set(catalog.ssh?.filter(\.enabled).map(\.id) ?? [])
+            guard !enabled.isEmpty else { return .notFederated }
+            switch selectedProfile(
+                inClientDirectory: directory, enabledProfiles: enabled, catalog: catalog
+            ) {
+            case .success(let selected):
+                return selected == nil ? .showingLocal : .showingMachine
+            case .failure:
+                return .unreadable
+            }
+        }
+    }
+
+    /// Which machine the client is showing, or nil for Local.
+    ///
+    /// herdr resolves this the same way (`src/client/endpoint/catalog.rs`): the
+    /// selection file wins when it names an enabled profile, the catalog's own
+    /// copy answers when it does not, and anything else is Local. A selection
+    /// file that exists and cannot be decoded fails instead, because the arm
+    /// cannot tell Local from a machine without it.
+    private func selectedProfile(
+        inClientDirectory directory: URL,
+        enabledProfiles: Set<String>,
+        catalog: Catalog
+    ) -> Result<String?, SelectionUnreadable> {
+        let catalogSelection = catalog.selectedProfile.flatMap { enabledProfiles.contains($0) ? $0 : nil }
+        switch readFile(directory.appendingPathComponent("endpoint-selection.json")) {
+        case .absent:
+            return .success(catalogSelection)
+        case .unreadable:
+            return .failure(SelectionUnreadable())
+        case .contents(let data):
+            guard let selection = try? JSONDecoder().decode(Selection.self, from: data) else {
+                return .failure(SelectionUnreadable())
+            }
+            guard let selected = selection.selectedProfile, enabledProfiles.contains(selected) else {
+                return .success(catalogSelection)
+            }
+            return .success(selected)
+        }
+    }
+
+    private struct SelectionUnreadable: Error {}
+
+    private struct Catalog: Decodable {
+        struct Profile: Decodable {
+            var id: String
+            var enabled: Bool
+        }
+
+        var selectedProfile: String?
+        var ssh: [Profile]?
+
+        enum CodingKeys: String, CodingKey {
+            case selectedProfile = "selected_profile"
+            case ssh
+        }
+    }
+
+    private struct Selection: Decodable {
+        var selectedProfile: String?
+
+        enum CodingKeys: String, CodingKey {
+            case selectedProfile = "selected_profile"
+        }
+    }
+
+    // MARK: - Live file access
+
+    private static func liveClientDirectories() -> [URL] {
+        let state: URL
+        if let overridden = ProcessInfo.processInfo.environment["XDG_STATE_HOME"], !overridden.isEmpty {
+            state = URL(fileURLWithPath: overridden, isDirectory: true)
+        } else {
+            state = URL(fileURLWithPath: NSHomeDirectory(), isDirectory: true)
+                .appendingPathComponent(".local/state", isDirectory: true)
+        }
+        // A development build of herdr keeps its own directory, and a user
+        // running one is federated just the same.
+        return ["herdr", "herdr-dev"].map {
+            state.appendingPathComponent($0, isDirectory: true)
+                .appendingPathComponent("client", isDirectory: true)
+        }
+    }
+
+    /// Reads one state file, refusing anything that is not a plain file this
+    /// user owns. The refusals are `unreadable`, never `absent`: a path that
+    /// exists in a shape this reader does not understand is exactly the case
+    /// the arm must not treat as "no machines saved".
+    static let liveReadFile: @Sendable (URL) -> HerdrStateFile = { url in
+        // herdr caps its own catalog at 64 KiB, so a larger file is not a
+        // catalog this reader understands.
+        let maximumBytes: off_t = 64 * 1024
+        var status = stat()
+        guard lstat(url.path, &status) == 0 else {
+            return errno == ENOENT || errno == ENOTDIR ? .absent : .unreadable
+        }
+        guard status.st_mode & S_IFMT == S_IFREG,
+              status.st_uid == geteuid(),
+              status.st_size <= maximumBytes,
+              let data = try? Data(contentsOf: url, options: [.uncached])
+        else { return .unreadable }
+        return .contents(data)
+    }
+}
+#endif

--- a/Sources/localvoxtral/ClaudeContext/TerminalScreenClaudeJoin.swift
+++ b/Sources/localvoxtral/ClaudeContext/TerminalScreenClaudeJoin.swift
@@ -198,6 +198,8 @@ struct ClaudeSessionJoinResolver {
     private let focusedBrowserTabURL: (String) async -> String?
     private let focusedWindowID: (pid_t) -> CGWindowID?
     private let herdrClientProbe: @Sendable (String) -> Bool
+    private let herdrFederation: @Sendable () -> HerdrMachineFederation
+    private let herdrClientSurfaceCount: @Sendable () -> Int?
     private let herdrPanes: HerdrPaneQuerying?
     private let cmuxSurfaces: CmuxSurfaceQuerying?
     private let cmuxJoinEnabled: @MainActor () -> Bool
@@ -241,6 +243,16 @@ struct ClaudeSessionJoinResolver {
     ///     Ghostty surface to a herdr client. It DEFAULTS TO ABSTAIN: a test
     ///     that forgets to inject must never consult the live process table.
     ///     The app wires the live probe explicitly.
+    ///   - herdrFederation: reads herdr's saved-machine state, which decides
+    ///     whether the local socket's focused pane still describes what the
+    ///     surface displays (issue #286). It defaults to `.notFederated`, the
+    ///     state of every herdr before 0.9 and of every 0.9 user who saved no
+    ///     machine, so a test that does not care about federation keeps the
+    ///     pre-0.9 arm. The two abstaining values are what a test injects.
+    ///   - herdrClientSurfaceCount: how many surfaces this user has a herdr
+    ///     client on, consulted only once machines are saved. DEFAULTS TO
+    ///     ABSTAIN (nil, unknown) so a federated case cannot silently pass by
+    ///     reaching the live process table.
     ///   - herdrPanes: queries herdr's local JSON socket after that surface
     ///     binding succeeds. It likewise DEFAULTS TO ABSTAIN so a test that
     ///     forgets to inject cannot connect to a real user socket. The app is
@@ -277,6 +289,8 @@ struct ClaudeSessionJoinResolver {
             TerminalScreenAXReader.focusedWindowIdentity(applicationPID: $0)
         },
         herdrClientProbe: @escaping @Sendable (String) -> Bool = { _ in false },
+        herdrFederation: @escaping @Sendable () -> HerdrMachineFederation = { .notFederated },
+        herdrClientSurfaceCount: @escaping @Sendable () -> Int? = { nil },
         herdrPanes: HerdrPaneQuerying? = nil,
         cmuxSurfaces: CmuxSurfaceQuerying? = nil,
         cmuxJoinEnabled: @escaping @MainActor () -> Bool = { false },
@@ -311,6 +325,8 @@ struct ClaudeSessionJoinResolver {
         self.focusedBrowserTabURL = focusedBrowserTabURL
         self.focusedWindowID = focusedWindowID
         self.herdrClientProbe = herdrClientProbe
+        self.herdrFederation = herdrFederation
+        self.herdrClientSurfaceCount = herdrClientSurfaceCount
         self.herdrPanes = herdrPanes
         self.cmuxSurfaces = cmuxSurfaces
         self.cmuxJoinEnabled = cmuxJoinEnabled
@@ -556,6 +572,37 @@ struct ClaudeSessionJoinResolver {
     }
 
     private func resolveViaHerdr(target: TerminalScreenTarget) async -> ClaudeSessionJoin? {
+        // herdr 0.9 attaches several machines to one client, and while a remote
+        // machine is selected the local server keeps a focused pane it has
+        // merely stopped presenting. `pane.current` below would then describe a
+        // pane nobody is looking at, and every cross-check in this arm would
+        // pass on it, so the federation state is read BEFORE the socket
+        // question is asked at all (issue #286).
+        switch herdrFederation() {
+        case .notFederated:
+            break
+        case .showingMachine:
+            Self.abstainedHerdrJoin(outcome: "herdr is showing a federated remote machine")
+            return nil
+        case .unreadable:
+            Self.abstainedHerdrJoin(outcome: "herdr machine state unreadable")
+            return nil
+        case .showingLocal:
+            // The selection is one per USER, not one per client: the last
+            // client to switch machines wins the file
+            // (herdr `src/client/endpoint/catalog.rs`). With a second client on
+            // screen it cannot say which machine the FOCUSED surface shows, so
+            // only a lone client surface may rely on it. Gated on machines
+            // being saved, which leaves every user without them free to keep
+            // two herdr windows open.
+            guard herdrClientSurfaceCount() == 1 else {
+                Self.abstainedHerdrJoin(
+                    outcome: "machines are saved and this user has more than one herdr surface"
+                )
+                return nil
+            }
+        }
+
         let sockets = registry.liveLocalHerdrSocketPaths()
         guard sockets.count == 1, let socketPath = sockets.first else {
             Self.abstainedHerdrJoin(

--- a/Sources/localvoxtral/localvoxtralApp.swift
+++ b/Sources/localvoxtral/localvoxtralApp.swift
@@ -466,6 +466,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                 herdrClientProbe: {
                     HerdrClientTTYProbe.isHerdrClient(onTTYDevicePath: $0)
                 },
+                herdrFederation: { HerdrMachineFederationReader.live().federation() },
+                herdrClientSurfaceCount: { HerdrClientTTYProbe.clientSurfaceCount() },
                 herdrPanes: herdrClient,
                 cmuxSurfaces: CmuxSocketClient(password: { cmuxPasswords.password() }),
                 cmuxJoinEnabled: { [weak viewModel] in

--- a/Tests/localvoxtralTests/HerdrClientTTYProbeTests.swift
+++ b/Tests/localvoxtralTests/HerdrClientTTYProbeTests.swift
@@ -46,5 +46,43 @@ final class HerdrClientTTYProbeTests: XCTestCase {
             )
         )
     }
+
+    // MARK: - Counting client surfaces (issue #286)
+
+    private func entry(
+        pid: Int32, name: String, tty: dev_t?, uid: uid_t = 0
+    ) -> TTYProcessTable.Entry {
+        TTYProcessTable.Entry(
+            pid: pid, effectiveUserID: uid == 0 ? geteuid() : uid, name: name, ttyDevice: tty
+        )
+    }
+
+    // Two panes of one client are one surface, and the detached server has no
+    // controlling terminal to be counted on.
+    func testClientSurfaceCountCountsDevicesNotProcesses() {
+        let count = HerdrClientTTYProbe.clientSurfaceCount(processes: [
+            entry(pid: 1, name: "herdr", tty: dev_t(11)),
+            entry(pid: 2, name: "herdr", tty: dev_t(11)),
+            entry(pid: 3, name: "herdr", tty: dev_t(12)),
+            entry(pid: 4, name: "herdr", tty: nil),
+            entry(pid: 5, name: "zsh", tty: dev_t(13))
+        ])
+        XCTAssertEqual(count, 2)
+    }
+
+    // Another user's herdr is on another user's screen.
+    func testClientSurfaceCountIgnoresOtherUsers() {
+        let count = HerdrClientTTYProbe.clientSurfaceCount(processes: [
+            entry(pid: 1, name: "herdr", tty: dev_t(11)),
+            entry(pid: 2, name: "herdr", tty: dev_t(12), uid: geteuid() &+ 1)
+        ])
+        XCTAssertEqual(count, 1)
+    }
+
+    // An unwalkable process table is unknown, and the caller treats unknown as
+    // "not exactly one".
+    func testClientSurfaceCountIsNilWithoutAProcessTable() {
+        XCTAssertNil(HerdrClientTTYProbe.clientSurfaceCount(processes: nil))
+    }
 }
 #endif

--- a/Tests/localvoxtralTests/HerdrClientTTYProbeTests.swift
+++ b/Tests/localvoxtralTests/HerdrClientTTYProbeTests.swift
@@ -50,22 +50,36 @@ final class HerdrClientTTYProbeTests: XCTestCase {
     // MARK: - Counting client surfaces (issue #286)
 
     private func entry(
-        pid: Int32, name: String, tty: dev_t?, uid: uid_t = 0
+        pid: Int32, name: String, tty: dev_t?, uid: uid_t = 0, group: Int32 = 700
     ) -> TTYProcessTable.Entry {
         TTYProcessTable.Entry(
-            pid: pid, effectiveUserID: uid == 0 ? geteuid() : uid, name: name, ttyDevice: tty
+            pid: pid,
+            effectiveUserID: uid == 0 ? geteuid() : uid,
+            name: name,
+            ttyDevice: tty,
+            processGroupID: group
         )
     }
 
     // Two panes of one client are one surface, and the detached server has no
     // controlling terminal to be counted on.
-    func testClientSurfaceCountCountsDevicesNotProcesses() {
+    func testClientSurfaceCountCountsJobsNotProcesses() {
         let count = HerdrClientTTYProbe.clientSurfaceCount(processes: [
-            entry(pid: 1, name: "herdr", tty: dev_t(11)),
-            entry(pid: 2, name: "herdr", tty: dev_t(11)),
-            entry(pid: 3, name: "herdr", tty: dev_t(12)),
-            entry(pid: 4, name: "herdr", tty: nil),
-            entry(pid: 5, name: "zsh", tty: dev_t(13))
+            entry(pid: 1, name: "herdr", tty: dev_t(11), group: 700),
+            entry(pid: 2, name: "herdr", tty: dev_t(11), group: 700),
+            entry(pid: 3, name: "herdr", tty: dev_t(12), group: 900),
+            entry(pid: 4, name: "herdr", tty: nil, group: 1),
+            entry(pid: 5, name: "zsh", tty: dev_t(13), group: 950)
+        ])
+        XCTAssertEqual(count, 2)
+    }
+
+    // Suspend one client, start another in the same terminal: one device, two
+    // jobs, and two surfaces the single machine selection cannot speak for.
+    func testClientSurfaceCountSeesTwoJobsOnOneDevice() {
+        let count = HerdrClientTTYProbe.clientSurfaceCount(processes: [
+            entry(pid: 1, name: "herdr", tty: dev_t(11), group: 700),
+            entry(pid: 2, name: "herdr", tty: dev_t(11), group: 800)
         ])
         XCTAssertEqual(count, 2)
     }

--- a/Tests/localvoxtralTests/HerdrMachineFederationTests.swift
+++ b/Tests/localvoxtralTests/HerdrMachineFederationTests.swift
@@ -104,6 +104,41 @@ final class HerdrMachineFederationTests: XCTestCase {
         XCTAssertEqual(federation, .showingLocal)
     }
 
+    // herdr writes null for Local and that BEATS the copy the catalog carries,
+    // which is how a client that switched back to Local records it.
+    func testNullSelectionOverridesTheCatalogSelection() {
+        let federation = reader(
+            catalog: catalog(selected: profileA, profiles: [(profileA, true)]),
+            selection: json("{\"version\":1,\"selected_profile\":null}")
+        ).federation()
+        XCTAssertEqual(federation, .showingLocal)
+    }
+
+    // The startup-restore shape: the catalog carries the selection and no
+    // selection file has been written yet.
+    func testCatalogSelectionWithNoSelectionFileShowsThatMachine() {
+        let federation = reader(
+            catalog: catalog(selected: profileA, profiles: [(profileA, true)])
+        ).federation()
+        XCTAssertEqual(federation, .showingMachine)
+    }
+
+    // herdr refuses a version it does not know and runs Local-only. This reader
+    // abstains rather than decode a future schema as "no machines saved", which
+    // would retire the guard on a herdr upgrade alone.
+    func testUnknownCatalogVersionAbstains() {
+        let file = json("{\"version\":2,\"ssh\":[]}")
+        XCTAssertEqual(reader(catalog: file).federation(), .unreadable)
+    }
+
+    func testUnknownSelectionVersionAbstains() {
+        let federation = reader(
+            catalog: catalog(profiles: [(profileA, true)]),
+            selection: json("{\"version\":2,\"selected_profile\":null}")
+        ).federation()
+        XCTAssertEqual(federation, .unreadable)
+    }
+
     func testUnreadableCatalogAbstains() {
         XCTAssertEqual(reader(catalog: .unreadable).federation(), .unreadable)
     }
@@ -167,5 +202,11 @@ final class HerdrMachineFederationTests: XCTestCase {
         let asDirectory = root.appendingPathComponent("endpoint-selection.json", isDirectory: true)
         try FileManager.default.createDirectory(at: asDirectory, withIntermediateDirectories: true)
         XCTAssertEqual(HerdrMachineFederationReader.liveReadFile(asDirectory), .unreadable)
+
+        // A symlink is not the plain file this reader agreed to read, and the
+        // check is `lstat`, so it never follows one.
+        let link = root.appendingPathComponent("linked.json")
+        try FileManager.default.createSymbolicLink(at: link, withDestinationURL: file)
+        XCTAssertEqual(HerdrMachineFederationReader.liveReadFile(link), .unreadable)
     }
 }

--- a/Tests/localvoxtralTests/HerdrMachineFederationTests.swift
+++ b/Tests/localvoxtralTests/HerdrMachineFederationTests.swift
@@ -1,0 +1,171 @@
+import Foundation
+import XCTest
+@testable import localvoxtral
+
+/// What herdr's saved-machine files are allowed to mean.
+///
+/// The local herdr arm reads this to decide whether the local socket's focused
+/// pane still describes the surface in front of the user (issue #286). A wrong
+/// `notFederated` puts the arm back on the bug, so every shape that is not
+/// plainly "no machines saved" resolves to an abstaining value.
+final class HerdrMachineFederationTests: XCTestCase {
+    private let directory = URL(fileURLWithPath: "/state/herdr/client", isDirectory: true)
+
+    private func reader(
+        catalog: HerdrStateFile,
+        selection: HerdrStateFile = .absent,
+        directories: [URL]? = nil
+    ) -> HerdrMachineFederationReader {
+        let catalogPath = directory.appendingPathComponent("endpoints.json").path
+        let selectionPath = directory.appendingPathComponent("endpoint-selection.json").path
+        return HerdrMachineFederationReader(clientDirectories: directories ?? [directory]) { url in
+            switch url.path {
+            case catalogPath: return catalog
+            case selectionPath: return selection
+            default: return .absent
+            }
+        }
+    }
+
+    private func json(_ text: String) -> HerdrStateFile {
+        .contents(Data(text.utf8))
+    }
+
+    private func catalog(selected: String? = nil, profiles: [(String, Bool)]) -> HerdrStateFile {
+        let entries = profiles.map { id, enabled in
+            """
+            {"id":"\(id)","label":"box","target":"box","session":"default","enabled":\(enabled)}
+            """
+        }
+        let selectedField = selected.map { "\"selected_profile\":\"\($0)\"," } ?? ""
+        return json("{\"version\":1,\(selectedField)\"ssh\":[\(entries.joined(separator: ","))]}")
+    }
+
+    private let profileA = String(repeating: "a", count: 32)
+    private let profileB = String(repeating: "b", count: 32)
+
+    // Every herdr before 0.9, and every 0.9 user who never ran `machine add`.
+    func testNoCatalogIsNotFederated() {
+        XCTAssertEqual(reader(catalog: .absent).federation(), .notFederated)
+    }
+
+    // A selection file without a catalog names nothing, so it changes nothing.
+    func testSelectionWithoutACatalogIsNotFederated() {
+        let federation = reader(
+            catalog: .absent,
+            selection: json("{\"version\":1,\"selected_profile\":\"\(profileA)\"}")
+        ).federation()
+        XCTAssertEqual(federation, .notFederated)
+    }
+
+    // Disabled machines are not connected and cannot be selected, so they leave
+    // the arm exactly where it was.
+    func testOnlyDisabledMachinesIsNotFederated() {
+        let federation = reader(catalog: catalog(profiles: [(profileA, false)])).federation()
+        XCTAssertEqual(federation, .notFederated)
+    }
+
+    func testSavedMachineWithNoSelectionShowsLocal() {
+        let federation = reader(catalog: catalog(profiles: [(profileA, true)])).federation()
+        XCTAssertEqual(federation, .showingLocal)
+    }
+
+    func testSelectionFileNamingAnEnabledMachineShowsThatMachine() {
+        let federation = reader(
+            catalog: catalog(profiles: [(profileA, true)]),
+            selection: json("{\"version\":1,\"selected_profile\":\"\(profileA)\"}")
+        ).federation()
+        XCTAssertEqual(federation, .showingMachine)
+    }
+
+    // herdr writes `null` for Local rather than deleting the file.
+    func testSelectionFileWithANullSelectionShowsLocal() {
+        let federation = reader(
+            catalog: catalog(profiles: [(profileA, true)]),
+            selection: json("{\"version\":1,\"selected_profile\":null}")
+        ).federation()
+        XCTAssertEqual(federation, .showingLocal)
+    }
+
+    // herdr's own resolution order: a selection naming a machine that is not
+    // enabled falls back to the catalog's copy rather than to Local.
+    func testUnusableSelectionFallsBackToTheCatalogSelection() {
+        let federation = reader(
+            catalog: catalog(selected: profileA, profiles: [(profileA, true)]),
+            selection: json("{\"version\":1,\"selected_profile\":\"\(profileB)\"}")
+        ).federation()
+        XCTAssertEqual(federation, .showingMachine)
+    }
+
+    func testCatalogSelectionOfADisabledMachineShowsLocal() {
+        let federation = reader(
+            catalog: catalog(selected: profileB, profiles: [(profileA, true), (profileB, false)])
+        ).federation()
+        XCTAssertEqual(federation, .showingLocal)
+    }
+
+    func testUnreadableCatalogAbstains() {
+        XCTAssertEqual(reader(catalog: .unreadable).federation(), .unreadable)
+    }
+
+    func testUndecodableCatalogAbstains() {
+        XCTAssertEqual(reader(catalog: json("{\"version\":")).federation(), .unreadable)
+    }
+
+    // With machines saved, the selection file is the only thing that separates
+    // Local from a machine. Not reading it is not knowing.
+    func testUnreadableSelectionAbstains() {
+        let federation = reader(
+            catalog: catalog(profiles: [(profileA, true)]),
+            selection: .unreadable
+        ).federation()
+        XCTAssertEqual(federation, .unreadable)
+    }
+
+    func testUndecodableSelectionAbstains() {
+        let federation = reader(
+            catalog: catalog(profiles: [(profileA, true)]),
+            selection: json("nonsense")
+        ).federation()
+        XCTAssertEqual(federation, .unreadable)
+    }
+
+    // A release build and a development build keep separate state directories.
+    // The absent one must not vote the live one down.
+    func testTheMoreAbstainingDirectoryWins() {
+        let other = URL(fileURLWithPath: "/state/herdr-dev/client", isDirectory: true)
+        let federation = reader(
+            catalog: catalog(profiles: [(profileA, true)]),
+            selection: json("{\"version\":1,\"selected_profile\":\"\(profileA)\"}"),
+            directories: [other, directory]
+        ).federation()
+        XCTAssertEqual(federation, .showingMachine)
+    }
+
+    // MARK: - The live file read
+
+    func testLiveReadDistinguishesAbsentFromUnreadable() throws {
+        let root = URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
+            .appendingPathComponent("herdr-federation-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let missing = root.appendingPathComponent("endpoints.json")
+        XCTAssertEqual(HerdrMachineFederationReader.liveReadFile(missing), .absent)
+
+        // A path under a file rather than a directory is ENOTDIR, still absent.
+        let file = root.appendingPathComponent("plain.json")
+        try Data("{}".utf8).write(to: file)
+        XCTAssertEqual(HerdrMachineFederationReader.liveReadFile(file), .contents(Data("{}".utf8)))
+        XCTAssertEqual(
+            HerdrMachineFederationReader.liveReadFile(file.appendingPathComponent("deeper.json")),
+            .absent
+        )
+
+        // Anything that exists but is not a plain file is unreadable, never
+        // absent: the arm must not read a surprise as "no machines saved".
+        let asDirectory = root.appendingPathComponent("endpoint-selection.json", isDirectory: true)
+        try FileManager.default.createDirectory(at: asDirectory, withIntermediateDirectories: true)
+        XCTAssertEqual(HerdrMachineFederationReader.liveReadFile(asDirectory), .unreadable)
+    }
+}

--- a/Tests/localvoxtralTests/TerminalScreenClaudeJoinTests.swift
+++ b/Tests/localvoxtralTests/TerminalScreenClaudeJoinTests.swift
@@ -392,16 +392,24 @@ final class TerminalScreenClaudeJoinTests: XCTestCase {
     func testHerdrJoinAbstainsWhileTheClientShowsAFederatedMachine() async {
         let registry = makeRegistry()
         XCTAssertNotNil(registry.ingest(herdrRecord(), origin: local))
-        let join = await resolver(
+        let paneQueries = Mutex(0)
+        var panes = herdrPanes(claim: "s1")
+        panes.onFocused = { paneQueries.withLock { $0 += 1 } }
+        let join = await ClaudeSessionJoinResolver(
             registry: registry,
-            focusedTTY: "/dev/ttys-outer",
-            herdrClient: true,
-            herdrFederation: .showingMachine,
-            herdrClientSurfaceCount: 1,
-            herdrPanes: herdrPanes(claim: "s1")
+            focusedTerminalTTY: { _ in "/dev/ttys-outer" },
+            focusedWindowID: { _ in self.windowA },
+            herdrClientProbe: { _ in true },
+            herdrFederation: { .showingMachine },
+            herdrClientSurfaceCount: { 1 },
+            herdrPanes: panes
         ).resolve(target: ghostty)
 
         XCTAssertNil(join)
+        // The guard runs BEFORE the socket question, so the stale pane is never
+        // even asked for. That ordering is what keeps the answer from aging
+        // between the read and the join.
+        XCTAssertEqual(paneQueries.withLock { $0 }, 0)
     }
 
     // Unreadable state is not "no machines saved": it is not knowing, and this

--- a/Tests/localvoxtralTests/TerminalScreenClaudeJoinTests.swift
+++ b/Tests/localvoxtralTests/TerminalScreenClaudeJoinTests.swift
@@ -116,6 +116,8 @@ final class TerminalScreenClaudeJoinTests: XCTestCase {
         focusedTTY: String? = nil,
         windowID: CGWindowID? = 101,
         herdrClient: Bool = false,
+        herdrFederation: HerdrMachineFederation = .notFederated,
+        herdrClientSurfaceCount: Int? = nil,
         herdrPanes: HerdrPaneQuerying? = nil
     ) -> ClaudeSessionJoinResolver {
         ClaudeSessionJoinResolver(
@@ -123,6 +125,8 @@ final class TerminalScreenClaudeJoinTests: XCTestCase {
             focusedTerminalTTY: { _ in focusedTTY },
             focusedWindowID: { _ in windowID },
             herdrClientProbe: { _ in herdrClient },
+            herdrFederation: { herdrFederation },
+            herdrClientSurfaceCount: { herdrClientSurfaceCount },
             herdrPanes: herdrPanes
         )
     }
@@ -377,6 +381,111 @@ final class TerminalScreenClaudeJoinTests: XCTestCase {
         XCTAssertEqual(join.mechanism, .herdrPane)
         XCTAssertEqual(join.windowID, windowA)
         XCTAssertTrue(joinResolver.isStillLive(join))
+    }
+
+    // MARK: - herdr 0.9 federation (issue #286)
+
+    // The case the guard exists for. Everything this arm checks still passes
+    // (the pane is registered, the claim agrees, the pid is in the foreground
+    // list) and it must abstain anyway, because the pane belongs to a server
+    // the client has stopped presenting.
+    func testHerdrJoinAbstainsWhileTheClientShowsAFederatedMachine() async {
+        let registry = makeRegistry()
+        XCTAssertNotNil(registry.ingest(herdrRecord(), origin: local))
+        let join = await resolver(
+            registry: registry,
+            focusedTTY: "/dev/ttys-outer",
+            herdrClient: true,
+            herdrFederation: .showingMachine,
+            herdrClientSurfaceCount: 1,
+            herdrPanes: herdrPanes(claim: "s1")
+        ).resolve(target: ghostty)
+
+        XCTAssertNil(join)
+    }
+
+    // Unreadable state is not "no machines saved": it is not knowing, and this
+    // arm abstains on not knowing.
+    func testHerdrJoinAbstainsWhenTheMachineStateIsUnreadable() async {
+        let registry = makeRegistry()
+        XCTAssertNotNil(registry.ingest(herdrRecord(), origin: local))
+        let join = await resolver(
+            registry: registry,
+            focusedTTY: "/dev/ttys-outer",
+            herdrClient: true,
+            herdrFederation: .unreadable,
+            herdrClientSurfaceCount: 1,
+            herdrPanes: herdrPanes(claim: "s1")
+        ).resolve(target: ghostty)
+
+        XCTAssertNil(join)
+    }
+
+    // Machines saved, client on Local, one herdr surface: the selection speaks
+    // for the surface the user is looking at, so the join stands.
+    func testHerdrJoinsWhenMachinesAreSavedAndTheClientShowsLocal() async throws {
+        let registry = makeRegistry()
+        XCTAssertNotNil(registry.ingest(herdrRecord(), origin: local))
+        let join = await resolver(
+            registry: registry,
+            focusedTTY: "/dev/ttys-outer",
+            herdrClient: true,
+            herdrFederation: .showingLocal,
+            herdrClientSurfaceCount: 1,
+            herdrPanes: herdrPanes(claim: "s1")
+        ).resolve(target: ghostty)
+
+        XCTAssertEqual(try XCTUnwrap(join).mechanism, .herdrPane)
+    }
+
+    // Two surfaces, one selection. herdr stores the selection per user, so it
+    // cannot say which of them is showing Local.
+    func testHerdrJoinAbstainsWithMachinesSavedAndASecondHerdrSurface() async {
+        let registry = makeRegistry()
+        XCTAssertNotNil(registry.ingest(herdrRecord(), origin: local))
+        let join = await resolver(
+            registry: registry,
+            focusedTTY: "/dev/ttys-outer",
+            herdrClient: true,
+            herdrFederation: .showingLocal,
+            herdrClientSurfaceCount: 2,
+            herdrPanes: herdrPanes(claim: "s1")
+        ).resolve(target: ghostty)
+
+        XCTAssertNil(join)
+    }
+
+    // An unwalkable process table is unknown, not one.
+    func testHerdrJoinAbstainsWhenTheSurfaceCountIsUnknown() async {
+        let registry = makeRegistry()
+        XCTAssertNotNil(registry.ingest(herdrRecord(), origin: local))
+        let join = await resolver(
+            registry: registry,
+            focusedTTY: "/dev/ttys-outer",
+            herdrClient: true,
+            herdrFederation: .showingLocal,
+            herdrClientSurfaceCount: nil,
+            herdrPanes: herdrPanes(claim: "s1")
+        ).resolve(target: ghostty)
+
+        XCTAssertNil(join)
+    }
+
+    // Without saved machines the count is never asked, so two herdr windows
+    // keep working for everyone who does not use federation.
+    func testASecondHerdrSurfaceIsIrrelevantWithoutSavedMachines() async throws {
+        let registry = makeRegistry()
+        XCTAssertNotNil(registry.ingest(herdrRecord(), origin: local))
+        let join = await resolver(
+            registry: registry,
+            focusedTTY: "/dev/ttys-outer",
+            herdrClient: true,
+            herdrFederation: .notFederated,
+            herdrClientSurfaceCount: 2,
+            herdrPanes: herdrPanes(claim: "s1")
+        ).resolve(target: ghostty)
+
+        XCTAssertEqual(try XCTUnwrap(join).mechanism, .herdrPane)
     }
 
     func testHerdrPaneWithNilSessionClaimStillJoins() async throws {

--- a/docs/agent/invariants.md
+++ b/docs/agent/invariants.md
@@ -166,11 +166,16 @@ there is not.
     selection per user rather than one per client, so a second client on screen
     makes the file unable to say which machine the FOCUSED surface shows. Users
     with no saved machines keep the pre-0.9 arm, second window included.
-    RESIDUAL, and it fails OPEN: herdr's state directory moves with
+    TWO RESIDUALS, both failing OPEN. First, herdr's state directory moves with
     `XDG_STATE_HOME`, which a GUI app cannot see in the user's shell, so such a
     user reads back "no machines saved" and keeps the unguarded behavior.
-    Closing it needs herdr's own CLI, whose path a GUI app cannot resolve
-    either.
+    Second, the files describe what a client STARTING NOW would show, so they
+    lag a live client that has not caught up: a client polls the catalog once a
+    second and returns to Local when the machine it displays is removed or
+    disabled (herdr `src/client/catalog_reload.rs`), which bounds the window
+    but does not close it. Neither is closable with the file interface herdr
+    offers. The real closure is herdr reporting its active endpoint on the
+    socket, which is an upstream ask (issue #288).
   - cmux (github.com/manaflow-ai/cmux — a native Swift/AppKit terminal on
     libghostty) is a join target with its OWN arm, keyed on the surface id
     cmux injects into the session environment. It is opt-in

--- a/docs/agent/invariants.md
+++ b/docs/agent/invariants.md
@@ -151,16 +151,26 @@ there is not.
     reach a herdr socket through it. On any pane.read failure the session falls
     back to the pre-existing behavior — composite AX text, vocabulary-only,
     nothing attached.
-    KNOWN HOLE, herdr 0.9.0, issue #286: a 0.9 client can federate several
-    machines (`herdr machine add`), and while a remote machine is selected the
-    local server keeps a focused pane it has merely stopped presenting. This
-    arm still joins that pane, and every cross-check above passes on it, so the
-    failure is a WRONG join rather than an abstention. The arm must first read
-    herdr's saved machine state (`herdr machine list --json`, or
-    `<state_dir>/client/endpoints.json` with `client/endpoint-selection.json`)
-    and abstain unless Local is selected, and abstain again when more than one
-    local herdr client is running, because that selection file is global and
-    the last client to switch wins.
+    A herdr 0.9 client can federate several machines (`herdr machine add`), and
+    while a remote machine is selected the local server keeps a focused pane it
+    has merely stopped presenting. `pane.current` would then name a pane nobody
+    is looking at, and every cross-check above would pass on it, so the failure
+    would be a WRONG join rather than an abstention (issue #286). The arm
+    therefore reads herdr's saved machine state FIRST
+    (`HerdrMachineFederationReader` over `<state dir>/client/endpoints.json`
+    and `client/endpoint-selection.json`, the two files `herdr machine list`
+    itself reads) and abstains unless Local is selected. Unreadable state
+    abstains too: it is not knowing, not "no machines saved". With machines
+    saved it also requires a LONE herdr client surface
+    (`HerdrClientTTYProbe.clientSurfaceCount`), because herdr keeps one
+    selection per user rather than one per client, so a second client on screen
+    makes the file unable to say which machine the FOCUSED surface shows. Users
+    with no saved machines keep the pre-0.9 arm, second window included.
+    RESIDUAL, and it fails OPEN: herdr's state directory moves with
+    `XDG_STATE_HOME`, which a GUI app cannot see in the user's shell, so such a
+    user reads back "no machines saved" and keeps the unguarded behavior.
+    Closing it needs herdr's own CLI, whose path a GUI app cannot resolve
+    either.
   - cmux (github.com/manaflow-ai/cmux — a native Swift/AppKit terminal on
     libghostty) is a join target with its OWN arm, keyed on the surface id
     cmux injects into the session environment. It is opt-in


### PR DESCRIPTION
Closes #286.

## What

herdr 0.9.0 attaches several SSH machines to one client. While a remote machine is selected, the local herdr server keeps a focused pane it has merely stopped presenting, so `pane.current` names a pane nobody is looking at. The local herdr arm joined it anyway, with every cross-check passing on it, which made the failure a wrong join rather than an abstention.

`resolveViaHerdr` now reads herdr's saved machine state before it asks the socket anything:

- Showing a federated machine, or state that exists and cannot be read, abstains.
- With machines saved it also requires a lone herdr client surface. herdr keeps one selection per user rather than one per client (`src/client/endpoint/catalog.rs:105`), so a second client on screen makes that selection unable to say which machine the focused surface shows.
- With no machines saved nothing changes, second herdr window included: the surface count is only consulted once a catalog exists.

`HerdrMachineFederationReader` reads the same two files `herdr machine list` reads, `<state dir>/client/endpoints.json` and `client/endpoint-selection.json`, and resolves the selection the way herdr does: the selection file wins when it names an enabled profile, the catalog's own copy answers when it does not, anything else is Local. Reading files rather than running `herdr machine list --json` is deliberate: federation lives in herdr's client, no server knows about it, and a GUI app cannot reliably locate the herdr binary.

The residual is in the doc and fails open: herdr's state directory moves with `XDG_STATE_HOME`, which a GUI app does not see in the user's shell, so such a user reads back "no machines saved" and keeps the unguarded behavior.

## Proof

- [x] Unit suite green — `./scripts/remote-build.sh test`

```
Test Suite 'localvoxtralPackageTests.xctest' passed at 2026-09-08 23:57:11.950.
	 Executed 3147 tests, with 2 tests skipped and 0 failures (0 unexpected) in 52.396 (52.528) seconds
```

- [x] Bug fix: regression test added — failing before the fix, passing after.

Before, with the guard block removed from `resolveViaHerdr` and everything else identical (`./scripts/remote-build.sh test --filter TerminalScreenClaudeJoinTests`):

```
Test Case '-[localvoxtralTests.TerminalScreenClaudeJoinTests testHerdrJoinAbstainsWhenTheMachineStateIsUnreadable]' failed (0.205 seconds).
Test Case '-[localvoxtralTests.TerminalScreenClaudeJoinTests testHerdrJoinAbstainsWhenTheSurfaceCountIsUnknown]' failed (0.001 seconds).
Test Case '-[localvoxtralTests.TerminalScreenClaudeJoinTests testHerdrJoinAbstainsWhileTheClientShowsAFederatedMachine]' failed (0.001 seconds).
Test Case '-[localvoxtralTests.TerminalScreenClaudeJoinTests testHerdrJoinAbstainsWithMachinesSavedAndASecondHerdrSurface]' failed (0.000 seconds).
	 Executed 53 tests, with 4 failures (0 unexpected) in 0.223 (0.224) seconds
```

After, same filter:

```
	 Executed 53 tests, with 0 failures (0 unexpected) in 0.016 (0.017) seconds
```

The two cases that must still JOIN (`testHerdrJoinsWhenMachinesAreSavedAndTheClientShowsLocal`, `testASecondHerdrSurfaceIsIrrelevantWithoutSavedMachines`) pass in both runs, so the four failures above are the guard and not a broken arm.

No UI change. The `integration-herdr` lane is untouched by this diff; #287 covers holding these herdr 0.9 facts to a live server.
